### PR TITLE
feat(SegmentedControl): SegmentedControlItem takes a count, named for screen readers

### DIFF
--- a/.changeset/segmented-control-item-count.md
+++ b/.changeset/segmented-control-item-count.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] `SegmentedControlItem` takes a `count` — the tally a tab strip needs to say how many rows each choice holds ("Needs me 12"), rendered inside the segment so it stays within the hit target and the `layout="fill"` widths. The number is `aria-hidden` and `countLabel` names what it counts, so the segment announces "Needs me, 12 sessions" instead of the bare "Needs me 12" a screen reader would otherwise read. It renders at every width, including an icon-only segment (`isLabelHidden`), and stays out of the selected segment's bold weight.
+
+@cixzhang

--- a/apps/storybook/stories/SegmentedControl.stories.tsx
+++ b/apps/storybook/stories/SegmentedControl.stories.tsx
@@ -236,6 +236,7 @@ export const DisabledWithMessage: Story = {
 export const WithCounts: Story = {
   args: {
     size: 'md',
+    isDisabled: false,
   },
   render: args => {
     const [value, setValue] = useState('needs-me');
@@ -244,7 +245,8 @@ export const WithCounts: Story = {
         value={value}
         onChange={setValue}
         label="Sessions"
-        size={args.size}>
+        size={args.size}
+        isDisabled={args.isDisabled}>
         <SegmentedControlItem
           value="needs-me"
           label="Needs me"

--- a/apps/storybook/stories/SegmentedControl.stories.tsx
+++ b/apps/storybook/stories/SegmentedControl.stories.tsx
@@ -229,3 +229,130 @@ export const DisabledWithMessage: Story = {
     );
   },
 };
+
+// A tab strip whose counts are the point: the viewer scans them to decide where
+// to go. The number is aria-hidden and countLabel names it, so the segment
+// announces "Needs me, 12 sessions" rather than "Needs me 12".
+export const WithCounts: Story = {
+  args: {
+    size: 'md',
+  },
+  render: args => {
+    const [value, setValue] = useState('needs-me');
+    return (
+      <SegmentedControl
+        value={value}
+        onChange={setValue}
+        label="Sessions"
+        size={args.size}>
+        <SegmentedControlItem
+          value="needs-me"
+          label="Needs me"
+          count={12}
+          countLabel="sessions"
+        />
+        <SegmentedControlItem
+          value="running"
+          label="Running"
+          count={3}
+          countLabel="sessions"
+        />
+        <SegmentedControlItem
+          value="finished"
+          label="Recently finished"
+          count={148}
+          countLabel="sessions"
+        />
+        <SegmentedControlItem
+          value="archived"
+          label="Archived"
+          count={0}
+          countLabel="sessions"
+        />
+      </SegmentedControl>
+    );
+  },
+};
+
+// Counts survive an icon-only strip: the label hides, the count does not, and
+// the accessible name still carries both.
+export const IconOnlyWithCounts: Story = {
+  args: {
+    size: 'md',
+  },
+  render: args => {
+    const [value, setValue] = useState('grid');
+    return (
+      <SegmentedControl
+        value={value}
+        onChange={setValue}
+        label="View mode"
+        size={args.size}>
+        <SegmentedControlItem
+          value="grid"
+          label="Grid"
+          isLabelHidden
+          icon={<Icon icon={Squares2X2Icon} color="inherit" />}
+          count={24}
+          countLabel="items"
+        />
+        <SegmentedControlItem
+          value="list"
+          label="List"
+          isLabelHidden
+          icon={<Icon icon={ListBulletIcon} color="inherit" />}
+          count={8}
+          countLabel="items"
+        />
+        <SegmentedControlItem
+          value="table"
+          label="Table"
+          isLabelHidden
+          icon={<Icon icon={TableCellsIcon} color="inherit" />}
+          count={132}
+          countLabel="items"
+        />
+      </SegmentedControl>
+    );
+  },
+};
+
+// layout="fill" divides the width equally; counts must not break that or the
+// segments' alignment as the numbers change width.
+export const CountsFillLayout: Story = {
+  render: () => {
+    const [value, setValue] = useState('needs-me');
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: '16px'}}>
+        {[520, 380, 280].map(width => (
+          <div key={width} style={{width}}>
+            <SegmentedControl
+              value={value}
+              onChange={setValue}
+              label="Sessions"
+              layout="fill">
+              <SegmentedControlItem
+                value="needs-me"
+                label="Needs me"
+                count={12}
+                countLabel="sessions"
+              />
+              <SegmentedControlItem
+                value="running"
+                label="Running"
+                count={3}
+                countLabel="sessions"
+              />
+              <SegmentedControlItem
+                value="finished"
+                label="Finished"
+                count={148}
+                countLabel="sessions"
+              />
+            </SegmentedControl>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -17,6 +17,7 @@ export const docs = {
     targets: [
       {className: 'astryx-segmented-control', visualProps: ['size']},
       {className: 'astryx-segmented-control-item', visualProps: ['size'], states: ['selected', 'disabled']},
+      {className: 'astryx-segmented-control-item-count', visualProps: ['size'], states: ['selected', 'disabled']},
     ],
     vars: [
       {name: '--_segmented-control-radius', description: 'Border radius of the segmented control', default: 'var(--radius-element)', private: true},

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -839,3 +839,121 @@ describe('forced colors (WCAG 1.4.11)', () => {
     expect(getAllInjectedCss()).toContain('forced-color-adjust: none;');
   });
 });
+
+describe('SegmentedControlItem count', () => {
+  it('renders the count and folds it into the accessible name', () => {
+    render(
+      <SegmentedControl value="needs-me" onChange={() => {}} label="Sessions">
+        <SegmentedControlItem
+          value="needs-me"
+          label="Needs me"
+          count={12}
+          countLabel="sessions"
+        />
+        <SegmentedControlItem
+          value="running"
+          label="Running"
+          count={3}
+          countLabel="sessions"
+        />
+      </SegmentedControl>,
+    );
+
+    expect(
+      screen.getByRole('radio', {name: 'Needs me, 12 sessions'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', {name: 'Running, 3 sessions'}),
+    ).toBeInTheDocument();
+    // Hidden from the name computed off the button's contents, so the number
+    // is announced once — as a quantity of something, not a trailing digit.
+    expect(screen.getByText('12')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByText('12').className).toContain(
+      'segmented-control-item-count',
+    );
+  });
+
+  it('names the segment without a noun when countLabel is omitted', () => {
+    render(
+      <SegmentedControl value="all" onChange={() => {}} label="Sessions">
+        <SegmentedControlItem value="all" label="All" count={7} />
+      </SegmentedControl>,
+    );
+
+    expect(screen.getByRole('radio', {name: 'All, 7'})).toBeInTheDocument();
+  });
+
+  it('keeps the count visible and named when the label is hidden', () => {
+    render(
+      <SegmentedControl value="needs-me" onChange={() => {}} label="Sessions">
+        <SegmentedControlItem
+          value="needs-me"
+          label="Needs me"
+          count={12}
+          countLabel="sessions"
+          isLabelHidden
+          icon={<span data-testid="icon">N</span>}
+        />
+      </SegmentedControl>,
+    );
+
+    expect(
+      screen.getByRole('radio', {name: 'Needs me, 12 sessions'}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.queryByText('Needs me')).not.toBeInTheDocument();
+  });
+
+  it('renders a zero count rather than suppressing it', () => {
+    render(
+      <SegmentedControl value="archived" onChange={() => {}} label="Sessions">
+        <SegmentedControlItem
+          value="archived"
+          label="Archived"
+          count={0}
+          countLabel="sessions"
+        />
+      </SegmentedControl>,
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', {name: 'Archived, 0 sessions'}),
+    ).toBeInTheDocument();
+  });
+
+  it('leaves an uncounted segment named by its label alone', () => {
+    render(
+      <SegmentedControl value="grid" onChange={() => {}} label="View mode">
+        <SegmentedControlItem value="grid" label="Grid" />
+      </SegmentedControl>,
+    );
+
+    const radio = screen.getByRole('radio', {name: 'Grid'});
+    expect(radio).not.toHaveAttribute('aria-label');
+  });
+
+  it('still selects when a counted segment is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl value="needs-me" onChange={onChange} label="Sessions">
+        <SegmentedControlItem
+          value="needs-me"
+          label="Needs me"
+          count={12}
+          countLabel="sessions"
+        />
+        <SegmentedControlItem
+          value="running"
+          label="Running"
+          count={3}
+          countLabel="sessions"
+        />
+      </SegmentedControl>,
+    );
+
+    await user.click(screen.getByRole('radio', {name: 'Running, 3 sessions'}));
+    expect(onChange).toHaveBeenCalledWith('running');
+  });
+});

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.doc.mjs
@@ -50,6 +50,16 @@ export const docs = {
       ],
     },
     {
+      name: 'count',
+      type: 'number',
+      description: 'How many items this segment holds, rendered after the label and shown even when isLabelHidden makes the segment icon-only. Hidden from assistive technology and folded into the accessible name instead (pair it with countLabel). Rendered as given, 0 included; pass undefined for no count.',
+    },
+    {
+      name: 'countLabel',
+      type: 'string',
+      description: 'What count counts, used to build the accessible name — "Inbox, 12 unread". Without it the name is just "Inbox, 12". Ignored when count is not set.',
+    },
+    {
       name: 'isDisabled',
       type: 'boolean',
       description: 'Whether this individual item is disabled.',
@@ -68,6 +78,8 @@ export const docsZh = {
     label: '该分段的无障碍标签。除非 isLabelHidden 为 true，否则渲染为可见文本。',
     isLabelHidden: '是否在视觉上隐藏标签。为 true 时仅显示图标，label 用作 aria-label。',
     icon: '显示在标签前的图标元素。',
+    count: '该分段包含的条目数，渲染在标签之后（即使 isLabelHidden 为 true 也会显示）。数字对辅助技术隐藏，改为并入无障碍名称，请搭配 countLabel 使用。',
+    countLabel: 'count 所计数的对象，用于构建无障碍名称，例如“收件箱，12 条未读”。',
     isDisabled: '是否禁用该单个项。',
   },
 };

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -56,6 +56,28 @@ export interface SegmentedControlItemProps extends BaseProps<HTMLButtonElement> 
    */
   icon?: ReactNode;
   /**
+   * How many items this segment holds, rendered after the label. Shown at every
+   * width, including when `isLabelHidden` leaves the segment icon-only.
+   *
+   * The number itself is hidden from assistive technology and folded into the
+   * segment's accessible name instead, so pair it with `countLabel` to say what
+   * it counts. Every value is rendered as given, `0` included — pass
+   * `undefined` for a segment that should show no count.
+   *
+   * @example
+   * ```
+   * <SegmentedControlItem value="inbox" label="Inbox" count={12} countLabel="unread" />
+   * ```
+   */
+  count?: number;
+  /**
+   * What `count` counts, used to build the accessible name: `label`, then the
+   * count and this noun — "Inbox, 12 unread". Without it the name is just
+   * "Inbox, 12", which leaves a screen reader user to guess. Ignored when
+   * `count` is not set.
+   */
+  countLabel?: string;
+  /**
    * Whether this individual item is disabled.
    * @default false
    */
@@ -143,6 +165,27 @@ const styles = stylex.create({
     textOverflow: 'ellipsis',
     minWidth: 0,
   },
+  count: {
+    flexShrink: 0,
+    // Tabular figures keep the counts in a strip on one vertical rhythm, so a
+    // segment doesn't reflow by a fraction of a character as its number ticks.
+    fontVariantNumeric: 'tabular-nums',
+    fontSize: typeScaleVars['--text-supporting-size'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-secondary'],
+  },
+  countSelected: {
+    // The selected segment sets forced-color-adjust: none, which children
+    // inherit — so under forced colors the authored secondary gray would paint
+    // on the Highlight fill and vanish. Follow the label onto HighlightText.
+    color: {
+      default: colorVars['--color-text-secondary'],
+      '@media (forced-colors: active)': 'HighlightText',
+    },
+  },
+  countDisabled: {
+    color: colorVars['--color-text-disabled'],
+  },
 });
 
 const CONCENTRIC_RADIUS =
@@ -188,6 +231,8 @@ export function SegmentedControlItem({
   label,
   isLabelHidden = false,
   icon,
+  count,
+  countLabel,
   isDisabled = false,
   onClick: onClickProp,
   xstyle,
@@ -218,6 +263,36 @@ export function SegmentedControlItem({
     <span {...stylex.props(styles.icon, iconSizeStyles[size])}>{icon}</span>
   ) : null;
 
+  // The count reaches assistive technology through the segment's name, not as
+  // a bare trailing number: "Inbox 12" says nothing about what 12 is. Naming
+  // the segment explicitly also keeps the count out of the name computed from
+  // the button's contents, so it is announced once, as a quantity of something.
+  const hasCount = count != null;
+  const accessibleName = hasCount
+    ? `${label}, ${count}${countLabel == null ? '' : ` ${countLabel}`}`
+    : isLabelHidden
+      ? label
+      : undefined;
+
+  const countElement = hasCount ? (
+    <span
+      aria-hidden="true"
+      {...mergeProps(
+        themeProps('segmented-control-item-count', {
+          size,
+          selected: isSelected ? 'selected' : null,
+          disabled: isItemDisabled ? 'disabled' : null,
+        }),
+        stylex.props(
+          styles.count,
+          isSelected && styles.countSelected,
+          isItemDisabled && styles.countDisabled,
+        ),
+      )}>
+      {count}
+    </span>
+  ) : null;
+
   return (
     <button
       ref={ref}
@@ -226,7 +301,7 @@ export function SegmentedControlItem({
       role="radio"
       aria-checked={isSelected}
       aria-disabled={isItemDisabled || undefined}
-      aria-label={isLabelHidden ? label : undefined}
+      aria-label={accessibleName}
       data-value={value}
       // Disabled items (including when the whole group is disabled) are not tab
       // stops — otherwise the selected segment stays keyboard-focusable but is
@@ -257,6 +332,7 @@ export function SegmentedControlItem({
       {!isLabelHidden && (
         <span {...stylex.props(styles.labelText)}>{label}</span>
       )}
+      {countElement}
     </button>
   );
 }


### PR DESCRIPTION
**Why.** A tab strip whose choices hold different numbers of rows has to say so — "Needs me" empty and "Needs me 12" are different messages, and the counts are what a viewer scans to decide where to go. `SegmentedControlItem` had no affordance for one, so a product that shows row counts in a tab strip forked a private copy of the whole control rather than lose the number, and that app now runs two segmented controls side by side: ours on a sidebar sort axis, its own fork on the tab strip.

**What.** `SegmentedControlItem` takes `count` — a number rendered after the label, inside the segment, so it stays within the hit target and the `layout="fill"` widths — and `countLabel`, what that number counts. The number is `aria-hidden` and the segment's accessible name is composed instead: "Needs me, 12 sessions". It renders at every size and every width, including an icon-only segment (`isLabelHidden`), stays out of the selected segment's bold weight, and has its own theming target (`astryx-segmented-control-item-count`). Story, tests and changeset included.

**The API decision.** A count is a number, so it is a prop, not a slot: `count?: number` plus `countLabel?: string`.

- *A `badge` / `endContent` slot* is the sibling pattern — `Tab`, `SideNavItem` and `ListItem` all take `endContent`, and I would have copied it if the accessible name weren't the whole problem. Slot content joins the button's name as a trailing digit ("Inbox 12"), and a component that receives a `ReactNode` cannot know what the number means, so it cannot fix that — every consumer has to. A slot also invites arbitrary content into a radio's name and hit target. Where content genuinely is arbitrary, `endContent` can still be added later beside `count`, matching `Tab`; typing this one as a number does not foreclose it.
- *Composition via children* isn't on the table: the item takes `label` as a prop rather than children, and content inside a `role="radio"` lands in its accessible name anyway.
- The cost of a number-typed prop, taken knowingly: no "99+", no formatted or non-numeric badge. If that need is demonstrated, the answer is the `endContent` slot, not widening `count` to `ReactNode`.
- `count={0}` renders "0". Suppressing a value the consumer passed is a design recipe living in the API; `count={n || undefined}` is the quiet-at-zero recipe, and it stays the caller's call.

**Risk.** Both props are optional and nothing renders differently without them. Two behavioral notes: a segment with a count now carries an explicit `aria-label` (the name still begins with the visible label, so Label-in-Name holds), and the count consumes width, so a long label in a squeezed `layout="fill"` strip wraps about 60px earlier than before — three counts, ~20px each. The wrapping itself is existing behavior (the segment sets no `whiteSpace: nowrap`) and I left it alone, because [#5137](https://github.com/facebook/astryx/pull/5137) — responsive icon-only labels on this same component — is being drafted in that territory and an icon-only narrow mode is the real answer for it.

**Testing.** 336 tests pass across the SegmentedControl and theming-target suites, 7 of them new: name composition with and without `countLabel`, the hidden-label case, zero, the uncounted case, and selection still firing from a counted segment. Verified in real Chromium at 900/520/420/360/320/280/240px in light and dark — segment heights stay equal (28px at every width, counts on or off), nothing clips, the count is optically centered against its label, and Chromium's own accessibility tree reads "Needs me, 12 sessions [checked]" rather than "Needs me 12". Count contrast against the track: 7.8:1 selected and 6.8:1 unselected in light, 6.0:1 and 4.4:1 in dark. That last figure is the existing `--color-text-secondary`-on-track pairing the unselected *label* already uses — the count matches its label exactly — and it sits just under AA; flagging it rather than changing a token here.
