### PR TITLE
feat(SegmentedControl): collapsibleLabels — a strip that goes icon-only when the labels do not fit

### DIFF
--- a/.changeset/segmented-control-collapsible-labels.md
+++ b/.changeset/segmented-control-collapsible-labels.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] SegmentedControl: `collapsibleLabels` collapses the strip to icons when the labels do not fit, keeping each label as the segment's accessible name and tooltip.
+
+@cixzhang

--- a/apps/storybook/stories/SegmentedControl.stories.tsx
+++ b/apps/storybook/stories/SegmentedControl.stories.tsx
@@ -11,6 +11,10 @@ import {
   Squares2X2Icon,
   ListBulletIcon,
   TableCellsIcon,
+  SunIcon,
+  MoonIcon,
+  ComputerDesktopIcon,
+  SwatchIcon,
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof SegmentedControl> = {
@@ -226,6 +230,75 @@ export const DisabledWithMessage: Story = {
         <SegmentedControlItem value="active" label="Active" />
         <SegmentedControlItem value="completed" label="Completed" />
       </SegmentedControl>
+    );
+  },
+};
+
+export const CollapsibleLabels: Story = {
+  render: () => {
+    const [value, setValue] = useState('light');
+    const [isCollapsed, setIsCollapsed] = useState(false);
+    const items = [
+      {value: 'light', label: 'Light', icon: SunIcon},
+      {value: 'dark', label: 'Dark', icon: MoonIcon},
+      {value: 'system', label: 'System', icon: ComputerDesktopIcon},
+      {value: 'custom', label: 'Custom', icon: SwatchIcon},
+    ];
+    return (
+      <div
+        data-testid="collapse-demo"
+        style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
+        <div
+          data-testid="hug-container"
+          style={{
+            resize: 'horizontal',
+            overflow: 'auto',
+            border: '1px dashed #999',
+            padding: '12px',
+            width: '100%',
+          }}>
+          <SegmentedControl
+            value={value}
+            onChange={setValue}
+            label="Theme"
+            collapsibleLabels={{onCollapsedChange: setIsCollapsed}}>
+            {items.map(item => (
+              <SegmentedControlItem
+                key={item.value}
+                value={item.value}
+                label={item.label}
+                icon={<Icon icon={item.icon} color="inherit" />}
+              />
+            ))}
+          </SegmentedControl>
+        </div>
+        <div
+          data-testid="fill-container"
+          style={{
+            border: '1px dashed #999',
+            padding: '12px',
+            width: '100%',
+          }}>
+          <SegmentedControl
+            value={value}
+            onChange={setValue}
+            label="Theme (fill)"
+            layout="fill"
+            collapsibleLabels>
+            {items.map(item => (
+              <SegmentedControlItem
+                key={item.value}
+                value={item.value}
+                label={item.label}
+                icon={<Icon icon={item.icon} color="inherit" />}
+              />
+            ))}
+          </SegmentedControl>
+        </div>
+        <div data-testid="collapse-state" style={{fontSize: '12px', color: '#666'}}>
+          collapsed: {String(isCollapsed)}
+        </div>
+      </div>
     );
   },
 };

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -72,6 +72,13 @@ export const docs = {
         'Explains why the control is disabled. Applies to the whole-group disabled state (isDisabled), not per segment. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the control focusable via aria-disabled (selection stays blocked). Use this instead of wrapping a disabled SegmentedControl in Tooltip. Disabled controls swallow the hover events an external Tooltip needs.',
     },
     {
+      name: 'collapsibleLabels',
+      type: 'boolean | {isCollapsed?: boolean; onCollapsedChange?: (isCollapsed: boolean) => void}',
+      description:
+        'Collapse item labels to icons when the strip does not have room for them; the label stays the accessible name and becomes the tooltip. true measures the fit (no breakpoint); {isCollapsed} lets the caller decide instead. A fill strip measures itself, a hug strip measures its parent. Items without an icon keep their label.',
+      default: 'false',
+    },
+    {
       name: 'children',
       type: 'ReactNode',
       description: 'SegmentedControlItem children.',
@@ -104,6 +111,7 @@ export const docs = {
       {guidance: false, description: 'Use for page-level navigation; use TabList instead. TabList is a navigation component, while SegmentedControl is an input that always has exactly one selected option.'},
       {guidance: false, description: 'Use for simple on/off states; use ToggleButton instead. ToggleButton can be toggled on or off independently, while SegmentedControl enforces a single selection from a group.'},
       {guidance: false, description: 'Wrap a disabled SegmentedControl in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.'},
+      {guidance: true, description: 'Give every item an icon before using collapsibleLabels; an item with no icon keeps its label, so a mixed strip collapses unevenly.'},
     ],
   },
 };
@@ -142,6 +150,7 @@ export const docsDense = {
     label: 'aria-label for radio group (never rendered)',
     size: 'size variant',
     layout: 'hug (default) sizes to content; fill stretches equally',
+    collapsibleLabels: 'collapses labels to icons when they do not fit; name and tooltip keep the label',
     isDisabled: 'disables entire control',
     children: 'SegmentedControlItem children',
     xstyle: 'additional StyleX styles for container',

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -9,8 +9,9 @@
  * SYNC: When SegmentedControl components change, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach, beforeAll, afterAll} from 'vitest';
+import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
+import type {ComponentProps} from 'react';
 import userEvent from '@testing-library/user-event';
 import {SegmentedControl} from './SegmentedControl';
 import {SegmentedControlItem} from './SegmentedControlItem';
@@ -837,5 +838,233 @@ describe('forced colors (WCAG 1.4.11)', () => {
     // HighlightText text on a white surface. forced-color-adjust: none makes
     // both render as authored.
     expect(getAllInjectedCss()).toContain('forced-color-adjust: none;');
+  });
+});
+
+// The collapse is a measurement, and jsdom has no layout: these tests install a
+// ResizeObserver stub and a scrollWidth/clientWidth pair driven by the rendered
+// content, so the real fit math runs. `scrollWidth` reports the labelled width
+// only while a label is actually rendered — that is what makes the
+// remembered-natural-width path (grow back, and stay collapsed when the room is
+// still short) testable rather than trivially true.
+describe('collapsibleLabels', () => {
+  const LABELLED_WIDTH = 400;
+  const ICON_ONLY_WIDTH = 160;
+
+  const originalResizeObserver = (
+    globalThis as unknown as {ResizeObserver?: unknown}
+  ).ResizeObserver;
+  const originalScrollWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'scrollWidth',
+  );
+  const originalClientWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'clientWidth',
+  );
+
+  let notify: ((entries: {target: Element}[]) => void) | null = null;
+
+  class StubResizeObserver {
+    constructor(callback: (entries: {target: Element}[]) => void) {
+      notify = callback;
+    }
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  const TestIcon = () => <span data-testid="icon" />;
+
+  function resize(element: Element, width: number) {
+    element.setAttribute('data-w', String(width));
+    act(() => {
+      notify?.([{target: element}]);
+    });
+  }
+
+  beforeAll(() => {
+    (globalThis as unknown as {ResizeObserver: unknown}).ResizeObserver =
+      StubResizeObserver;
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get(this: HTMLElement): number {
+        if (this.getAttribute('role') !== 'radiogroup') {
+          return 0;
+        }
+        return this.textContent?.trim()
+          ? LABELLED_WIDTH
+          : ICON_ONLY_WIDTH;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      get(this: HTMLElement): number {
+        return Number(this.getAttribute('data-w') ?? 0);
+      },
+    });
+  });
+
+  afterAll(() => {
+    (globalThis as unknown as {ResizeObserver?: unknown}).ResizeObserver =
+      originalResizeObserver;
+    if (originalScrollWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollWidth',
+        originalScrollWidth,
+      );
+    }
+    if (originalClientWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientWidth',
+        originalClientWidth,
+      );
+    }
+  });
+
+  function renderStrip(
+    props: Partial<ComponentProps<typeof SegmentedControl>> = {},
+    parentWidth = 200,
+  ) {
+    const result = render(
+      <div data-testid="parent" data-w={String(parentWidth)}>
+        <SegmentedControl
+          value="light"
+          onChange={() => {}}
+          label="Theme"
+          collapsibleLabels
+          {...props}>
+          <SegmentedControlItem
+            value="light"
+            label="Light"
+            icon={<TestIcon />}
+          />
+          <SegmentedControlItem value="dark" label="Dark" icon={<TestIcon />} />
+        </SegmentedControl>
+      </div>,
+    );
+    return {...result, parent: screen.getByTestId('parent')};
+  }
+
+  /** The text a sighted reader sees on a segment (the tooltip layer renders the
+   * same string elsewhere in the tree, so a document-wide text query would find
+   * a label that is not on screen). */
+  function segmentText(name: string): string {
+    return screen.getByRole('radio', {name}).textContent ?? '';
+  }
+
+  it('collapses to icons when the labelled strip needs more room than it has', () => {
+    renderStrip();
+
+    expect(segmentText('Light')).toBe('');
+    expect(segmentText('Dark')).toBe('');
+    expect(screen.getAllByTestId('icon')).toHaveLength(2);
+  });
+
+  it('keeps every accessible name through the collapse', () => {
+    renderStrip();
+
+    expect(screen.getByRole('radio', {name: 'Light'})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Dark'})).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', {name: 'Theme'})).toBeInTheDocument();
+  });
+
+  it('leaves the labels up when they fit', () => {
+    renderStrip({}, 600);
+
+    expect(screen.getByText('Light')).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Light'})).not.toHaveAttribute(
+      'aria-label',
+    );
+  });
+
+  it('grows back when the room returns, and stays collapsed while it has not', () => {
+    const {parent} = renderStrip();
+    expect(segmentText('Light')).toBe('');
+
+    // Still short of the 400px the labels need — the strip must not read its
+    // own collapsed width as the width it needs.
+    resize(parent, 300);
+    expect(segmentText('Light')).toBe('');
+
+    resize(parent, 600);
+    expect(segmentText('Light')).toBe('Light');
+  });
+
+  it('reports the decision through onCollapsedChange', () => {
+    const onCollapsedChange = vi.fn();
+    renderStrip({collapsibleLabels: {onCollapsedChange}});
+
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders what a controlled caller asks for, measurement or not', () => {
+    renderStrip({collapsibleLabels: {isCollapsed: false}}, 100);
+
+    expect(screen.getByText('Light')).toBeInTheDocument();
+  });
+
+  it('gives a collapsed item its label as a tooltip', () => {
+    renderStrip();
+
+    expect(screen.getByRole('radio', {name: 'Light'})).toHaveAttribute(
+      'aria-describedby',
+    );
+  });
+
+  it('leaves a caller-hidden label alone — no tooltip, same as before', () => {
+    render(
+      <SegmentedControl value="light" onChange={() => {}} label="Theme">
+        <SegmentedControlItem
+          value="light"
+          label="Light"
+          icon={<TestIcon />}
+          isLabelHidden
+        />
+      </SegmentedControl>,
+    );
+
+    const radio = screen.getByRole('radio', {name: 'Light'});
+    expect(radio).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('keeps the label on an item that has no icon — an empty segment is not a state', () => {
+    render(
+      <div data-testid="parent" data-w="200">
+        <SegmentedControl
+          value="light"
+          onChange={() => {}}
+          label="Theme"
+          collapsibleLabels>
+          <SegmentedControlItem
+            value="light"
+            label="Light"
+            icon={<TestIcon />}
+          />
+          <SegmentedControlItem value="custom" label="Custom" />
+        </SegmentedControl>
+      </div>,
+    );
+
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Custom'})).toBeInTheDocument();
+  });
+
+  it('does nothing at all when the prop is absent', () => {
+    render(
+      <div data-testid="parent" data-w="100">
+        <SegmentedControl value="light" onChange={() => {}} label="Theme">
+          <SegmentedControlItem
+            value="light"
+            label="Light"
+            icon={<TestIcon />}
+          />
+        </SegmentedControl>
+      </div>,
+    );
+
+    expect(screen.getByText('Light')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.tsx
@@ -12,6 +12,7 @@
  * - /packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
  * - /packages/core/src/SegmentedControl/index.ts
  * - /packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+ * - /packages/core/src/SegmentedControl/useLabelCollapse.ts
  * - /packages/cli/assets/templates/blocks/components/SegmentedControl/ (showcase blocks)
  */
 
@@ -19,6 +20,7 @@ import React, {useMemo, useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../theme/tokens.stylex';
 import {SegmentedControlContext} from './SegmentedControlContext';
+import {useLabelCollapse} from './useLabelCollapse';
 import {useListFocus} from '../hooks/useListFocus';
 import {useKeyboardHint} from '../hooks/useKeyboardHint';
 import {useTooltip} from '../Tooltip';
@@ -78,9 +80,36 @@ export interface SegmentedControlProps extends Omit<
    */
   disabledMessage?: string;
   /**
+   * Collapse every item's label to its icon when the strip does not have the
+   * room for the labels. The label stays the item's accessible name and becomes
+   * its tooltip, so nothing is lost but the pixels. Off by default.
+   *
+   * - `true` — the strip measures itself: labels are up while they fit and
+   *   collapse when they do not. There is no breakpoint; the trigger is the
+   *   width the labelled strip actually needs versus the width it has.
+   * - `{isCollapsed}` — the caller decides and the strip never measures.
+   * - `{onCollapsedChange}` — observe the measured decision.
+   *
+   * A `'fill'` strip measures its own box; a `'hug'` strip measures its parent,
+   * so give it a parent with a width of its own rather than a shrink-to-fit one.
+   * An item with no icon keeps its label — an empty segment is not a state worth
+   * rendering.
+   */
+  collapsibleLabels?: boolean | SegmentedControlCollapsibleLabelsConfig;
+  /**
    * SegmentedControlItem children.
    */
   children: ReactNode;
+}
+
+export interface SegmentedControlCollapsibleLabelsConfig {
+  /**
+   * Controlled collapse state. When set, the strip renders what it is told and
+   * never measures.
+   */
+  isCollapsed?: boolean;
+  /** Fired when the measured collapse state changes. */
+  onCollapsedChange?: (isCollapsed: boolean) => void;
 }
 
 // =============================================================================
@@ -149,6 +178,7 @@ export function SegmentedControl({
   layout = 'hug',
   isDisabled = false,
   disabledMessage,
+  collapsibleLabels = false,
   children,
   xstyle,
   className,
@@ -159,6 +189,16 @@ export function SegmentedControl({
   ...rest
 }: SegmentedControlProps) {
   const size = useSize(sizeProp, 'md');
+
+  const collapsibleLabelsConfig =
+    typeof collapsibleLabels === 'object' ? collapsibleLabels : {};
+  const {isCollapsed: areLabelsCollapsed, ref: labelCollapseRef} =
+    useLabelCollapse({
+      isEnabled: !!collapsibleLabels,
+      isCollapsed: collapsibleLabelsConfig.isCollapsed,
+      onCollapsedChange: collapsibleLabelsConfig.onCollapsedChange,
+      layout,
+    });
 
   // Disabled-reason tooltip. Applies to the whole-group disabled state. Disabled
   // controls swallow pointer events, so the tooltip listeners attach to the
@@ -252,14 +292,28 @@ export function SegmentedControl({
       layout,
       isDisabled,
       hasDisabledMessage: showsDisabledMessage,
+      areLabelsCollapsed,
     }),
-    [value, onChange, size, layout, isDisabled, showsDisabledMessage],
+    [
+      value,
+      onChange,
+      size,
+      layout,
+      isDisabled,
+      showsDisabledMessage,
+      areLabelsCollapsed,
+    ],
   );
 
   return (
     <SegmentedControlContext value={contextValue}>
       <div
-        ref={useMergedRefs(ref, listRef, disabledMessageTooltip.ref)}
+        ref={useMergedRefs(
+          ref,
+          listRef,
+          disabledMessageTooltip.ref,
+          labelCollapseRef,
+        )}
         {...rest}
         role="radiogroup"
         aria-label={label}

--- a/packages/core/src/SegmentedControl/SegmentedControlContext.ts
+++ b/packages/core/src/SegmentedControl/SegmentedControlContext.ts
@@ -29,6 +29,12 @@ export interface SegmentedControlContextValue {
    * tooltip is keyboard-discoverable; selection is still blocked.
    */
   hasDisabledMessage?: boolean;
+  /**
+   * True while the group has collapsed its items to icons (`collapsibleLabels`).
+   * Items keep their label as the accessible name and gain a tooltip; an item
+   * with no icon keeps its visible label, since it would otherwise render empty.
+   */
+  areLabelsCollapsed?: boolean;
 }
 
 export const SegmentedControlContext =

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.doc.mjs
@@ -32,7 +32,7 @@ export const docs = {
     {
       name: 'isLabelHidden',
       type: 'boolean',
-      description: 'Whether the label is visually hidden. When true, only the icon is displayed and label is used as aria-label.',
+      description: 'Whether the label is visually hidden. When true, only the icon is displayed and label is used as aria-label. The group-level collapsibleLabels prop does the same thing responsively, and adds a tooltip.',
       default: 'false',
     },
     {

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/assets/templates/blocks/components/SegmentedControl/ (showcase blocks)
  */
 
-import React, {type ReactNode} from 'react';
+import React, {useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -33,6 +33,9 @@ import {mergeProps, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineProps} from '../utils/focusOutline.stylex';
+import {Tooltip} from '../Tooltip';
+import {useDevWarning} from '../hooks/useDevWarning';
+import {useMergedRefs} from '../hooks/useMergedRefs';
 
 export interface SegmentedControlItemProps extends BaseProps<HTMLButtonElement> {
   ref?: React.Ref<HTMLButtonElement>;
@@ -194,6 +197,18 @@ export function SegmentedControlItem({
   ...rest
 }: SegmentedControlItemProps) {
   const ctx = useSegmentedControlContext();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // A group collapse only has somewhere to go on an item that has an icon; an
+  // item without one keeps its label rather than rendering an empty segment.
+  const isCollapsedByGroup = !!ctx.areLabelsCollapsed && icon != null;
+  const isLabelVisuallyHidden = isLabelHidden || isCollapsedByGroup;
+
+  useDevWarning(
+    'SegmentedControlItem',
+    `"${label}" has no icon, so it keeps its visible label while the group collapses to icons. Give every item an icon when using collapsibleLabels.`,
+    !!ctx.areLabelsCollapsed && icon == null,
+  );
 
   const isSelected = ctx.value === value;
   const isItemDisabled = isDisabled || ctx.isDisabled;
@@ -219,45 +234,51 @@ export function SegmentedControlItem({
   ) : null;
 
   return (
-    <button
-      ref={ref}
-      {...rest}
-      type="button"
-      role="radio"
-      aria-checked={isSelected}
-      aria-disabled={isItemDisabled || undefined}
-      aria-label={isLabelHidden ? label : undefined}
-      data-value={value}
-      // Disabled items (including when the whole group is disabled) are not tab
-      // stops — otherwise the selected segment stays keyboard-focusable but is
-      // silently dead (arrows and activation are no-ops) (navigation-13). The
-      // exception is a whole-group disabledMessage, where the selected segment
-      // stays focusable so the reason tooltip is keyboard-discoverable.
-      tabIndex={
-        (isSelected && !isItemDisabled) || keepsSelectedFocusable ? 0 : -1
-      }
-      onClick={handleClick}
-      {...mergeProps(
-        themeProps('segmented-control-item', {
-          size,
-          selected: isSelected ? 'selected' : null,
-          disabled: isItemDisabled ? 'disabled' : null,
-        }),
-        focusOutlineProps.focusVisible(
-          styles.base,
-          sizeStyles[size],
-          isFill && styles.fill,
-          isSelected && styles.selected,
-          !isSelected && !isItemDisabled && styles.hover,
-          isItemDisabled && styles.disabled,
-          xstyle,
-        ),
-      )}>
-      {iconElement}
-      {!isLabelHidden && (
-        <span {...stylex.props(styles.labelText)}>{label}</span>
-      )}
-    </button>
+    <>
+      <button
+        ref={useMergedRefs(ref, buttonRef)}
+        {...rest}
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        aria-disabled={isItemDisabled || undefined}
+        aria-label={isLabelVisuallyHidden ? label : undefined}
+        data-value={value}
+        // Disabled items (including when the whole group is disabled) are not tab
+        // stops — otherwise the selected segment stays keyboard-focusable but is
+        // silently dead (arrows and activation are no-ops) (navigation-13). The
+        // exception is a whole-group disabledMessage, where the selected segment
+        // stays focusable so the reason tooltip is keyboard-discoverable.
+        tabIndex={
+          (isSelected && !isItemDisabled) || keepsSelectedFocusable ? 0 : -1
+        }
+        onClick={handleClick}
+        {...mergeProps(
+          themeProps('segmented-control-item', {
+            size,
+            selected: isSelected ? 'selected' : null,
+            disabled: isItemDisabled ? 'disabled' : null,
+          }),
+          focusOutlineProps.focusVisible(
+            styles.base,
+            sizeStyles[size],
+            isFill && styles.fill,
+            isSelected && styles.selected,
+            !isSelected && !isItemDisabled && styles.hover,
+            isItemDisabled && styles.disabled,
+            xstyle,
+          ),
+        )}>
+        {iconElement}
+        {!isLabelVisuallyHidden && (
+          <span {...stylex.props(styles.labelText)}>{label}</span>
+        )}
+      </button>
+      {/* When the *component* takes the label away, it owes the reader a way to
+          get it back. A caller-set isLabelHidden is the caller's decision and
+          keeps today's behavior: no tooltip unless they add one. */}
+      {isCollapsedByGroup && <Tooltip content={label} anchorRef={buttonRef} />}
+    </>
   );
 }
 

--- a/packages/core/src/SegmentedControl/index.ts
+++ b/packages/core/src/SegmentedControl/index.ts
@@ -12,7 +12,10 @@
  */
 
 export {SegmentedControl} from './SegmentedControl';
-export type {SegmentedControlProps} from './SegmentedControl';
+export type {
+  SegmentedControlProps,
+  SegmentedControlCollapsibleLabelsConfig,
+} from './SegmentedControl';
 
 export {SegmentedControlItem} from './SegmentedControlItem';
 export type {SegmentedControlItemProps} from './SegmentedControlItem';

--- a/packages/core/src/SegmentedControl/useLabelCollapse.ts
+++ b/packages/core/src/SegmentedControl/useLabelCollapse.ts
@@ -62,6 +62,16 @@ export function useLabelCollapse({
   const [element, setElement] = useState<HTMLDivElement | null>(null);
   const [measuredCollapsed, setMeasuredCollapsed] = useState(false);
 
+  // Turning the feature off (or handing over to a controlled caller) drops the
+  // measured verdict, so re-enabling starts from labels-up and measures again
+  // rather than trusting a reading taken at some other size.
+  const [wasMeasuring, setWasMeasuring] = useState(isEnabled && !isControlled);
+  const isMeasuring = isEnabled && !isControlled;
+  if (wasMeasuring !== isMeasuring) {
+    setWasMeasuring(isMeasuring);
+    setMeasuredCollapsed(false);
+  }
+
   const isCollapsed = isControlled
     ? controlledCollapsed
     : isEnabled && measuredCollapsed;
@@ -110,8 +120,7 @@ export function useLabelCollapse({
   }, [element, layout]);
 
   useIsomorphicLayoutEffect(() => {
-    if (!isEnabled || isControlled) {
-      setMeasuredCollapsed(false);
+    if (!isMeasuring) {
       naturalWidthRef.current = null;
       return;
     }
@@ -129,7 +138,7 @@ export function useLabelCollapse({
         unobserveResize(parent);
       }
     };
-  }, [isEnabled, isControlled, element, measure]);
+  }, [isMeasuring, element, measure]);
 
   return {ref: setElement, isCollapsed};
 }

--- a/packages/core/src/SegmentedControl/useLabelCollapse.ts
+++ b/packages/core/src/SegmentedControl/useLabelCollapse.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useLabelCollapse.ts
+ * @input Uses React state/refs, sharedResizeObserver, useIsomorphicLayoutEffect
+ * @output Exports useLabelCollapse — fit-measured icon-only collapse
+ * @position Internal hook; consumed by SegmentedControl.tsx
+ *
+ * The strip collapses on a measured fact — the labelled strip needs more room
+ * than its container has — rather than on a breakpoint, so no width is baked
+ * into the component and none has to be invented by the caller.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/SegmentedControl/SegmentedControl.tsx
+ * - /packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+ */
+
+import {useCallback, useRef, useState} from 'react';
+import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
+import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
+import type {SegmentedControlLayout} from './SegmentedControlContext';
+
+/** Sub-pixel layout rounding must not read as an overflow. */
+const FIT_TOLERANCE_PX = 1;
+
+export interface UseLabelCollapseOptions {
+  /** Whether collapsing is enabled at all. */
+  isEnabled: boolean;
+  /** Controlled state. When set, the strip never measures. */
+  isCollapsed?: boolean;
+  /** Fired when the measured decision changes. */
+  onCollapsedChange?: (isCollapsed: boolean) => void;
+  /** Layout mode of the strip — decides where the available width comes from. */
+  layout: SegmentedControlLayout;
+}
+
+export interface UseLabelCollapseReturn {
+  /** Attach to the strip element. */
+  ref: (element: HTMLDivElement | null) => void;
+  /** Whether labels should currently be collapsed to icons. */
+  isCollapsed: boolean;
+}
+
+function contentWidth(element: HTMLElement): number {
+  const {paddingLeft, paddingRight} = getComputedStyle(element);
+  return (
+    element.clientWidth -
+    (parseFloat(paddingLeft) || 0) -
+    (parseFloat(paddingRight) || 0)
+  );
+}
+
+export function useLabelCollapse({
+  isEnabled,
+  isCollapsed: controlledCollapsed,
+  onCollapsedChange,
+  layout,
+}: UseLabelCollapseOptions): UseLabelCollapseReturn {
+  const isControlled = controlledCollapsed !== undefined;
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+  const [measuredCollapsed, setMeasuredCollapsed] = useState(false);
+
+  const isCollapsed = isControlled
+    ? controlledCollapsed
+    : isEnabled && measuredCollapsed;
+
+  const isCollapsedRef = useRef(isCollapsed);
+  isCollapsedRef.current = isCollapsed;
+  const onCollapsedChangeRef = useRef(onCollapsedChange);
+  onCollapsedChangeRef.current = onCollapsedChange;
+
+  // The width the strip needs with its labels. Once collapsed that number is
+  // no longer in the DOM to read, so it is remembered from the last measurement
+  // taken while the labels were up — which is also what lets the strip grow
+  // back when the room returns.
+  const naturalWidthRef = useRef<number | null>(null);
+
+  const measure = useCallback(() => {
+    if (!element) {
+      return;
+    }
+    if (!isCollapsedRef.current) {
+      naturalWidthRef.current = element.scrollWidth;
+    }
+    const naturalWidth = naturalWidthRef.current;
+    if (naturalWidth == null) {
+      return;
+    }
+
+    // 'fill' spans its container, so its own box still reports the available
+    // width after the labels go. 'hug' shrinks to its content, so the question
+    // has to be put to the parent instead.
+    const parent = element.parentElement;
+    const available =
+      layout === 'fill' || parent == null
+        ? element.clientWidth
+        : contentWidth(parent);
+    if (available <= 0) {
+      return;
+    }
+
+    const next = naturalWidth > available + FIT_TOLERANCE_PX;
+    if (next !== isCollapsedRef.current) {
+      isCollapsedRef.current = next;
+      setMeasuredCollapsed(next);
+      onCollapsedChangeRef.current?.(next);
+    }
+  }, [element, layout]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!isEnabled || isControlled) {
+      setMeasuredCollapsed(false);
+      naturalWidthRef.current = null;
+      return;
+    }
+    if (element == null || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const parent = element.parentElement;
+    observeResize(element, measure);
+    if (parent) {
+      observeResize(parent, measure);
+    }
+    return () => {
+      unobserveResize(element);
+      if (parent) {
+        unobserveResize(parent);
+      }
+    };
+  }, [isEnabled, isControlled, element, measure]);
+
+  return {ref: setElement, isCollapsed};
+}


### PR DESCRIPTION
## Why

A four-choice theme picker (Light / Dark / System / Custom, each an icon plus a
label) inside a settings dialog needs its labels when there is room and its
icons when there is not. `isLabelHidden` cannot express that: it is per item and
fixed at render, so a strip is icon-only always or labelled always. The only way
through the public API is a JS media query feeding a boolean into every item —
re-rendering the group on resize to express something layout already knows, and
keyed to the viewport when the constraint is the dialog. The app in the report
kept its own segmented control rather than do that.

## What

`collapsibleLabels` on the group. Off by default, and absent means today's
behavior byte for byte.

```tsx
<SegmentedControl value={theme} onChange={setTheme} label="Theme" collapsibleLabels>
  <SegmentedControlItem value="light" label="Light" icon={<Icon icon={SunIcon} />} />
  …
</SegmentedControl>
```

- `true` — the strip measures itself and collapses every label to its icon when
  the labelled strip needs more room than it has.
- `{isCollapsed}` — the caller decides; the strip never measures.
- `{onCollapsedChange}` — observe the decision.

Through the collapse the label stays the segment's accessible name and becomes
its tooltip, so nothing is lost but the pixels. An item with no icon keeps its
label (an empty segment is not a state worth rendering) and says so once in dev.

## The API decision

**How does a strip decide it is narrow? It doesn't — it decides whether the
labels fit, which is a measurement, not a threshold.** The trigger is the width
the labelled strip needs versus the width its container gives it. No breakpoint
is baked into the component, and none has to be invented by the caller.

Rejected, and why:

- **A group-level static `isLabelHidden`.** Simple and honest, but it only moves
  the caller's problem up one level: they still need a media query, still
  re-render on resize, and still answer "how narrow is narrow" with a number
  that has nothing to do with the labels they actually wrote. It is also already
  reachable — `{isCollapsed: true}` — so the axis is not lost.
- **A container query with a breakpoint inside the component.** This is the
  support burden the report warns about: the strip would change shape at a width
  nobody declared. [#4930](https://github.com/facebook/astryx/pull/4930) is the
  house evidence — given a raw number, every reader invents a different one, and
  the fix there was to *name* the condition rather than publish a pixel. A
  container query also cannot take its threshold from a prop (no `var()` in the
  condition), so the number would have to be ours.
- **Overflow-driven collapse à la
  [#4868](https://github.com/facebook/astryx/pull/4868) / `OverflowList`.** Wrong
  shape: a radio group cannot move segments into a menu — all four choices must
  stay on screen and stay selectable. Its hidden inert measurement copy also
  duplicates every `role="radio"` inside the group, which is precisely the
  roving-focus hazard that PR had to fix for Toolbar.

What it borrows instead is `SideNav`'s collapsed rail, the pattern the system
already ships for "this became an icon": `boolean | config` prop on the
container, `aria-label` plus a tooltip on the icon-only control.

## Risk

Low and opt-in, but three things worth knowing:

- **It measures.** One shared `ResizeObserver` (the existing
  `sharedResizeObserver`), two observed elements per strip, a layout read on
  resize. The natural width is remembered from the last labelled measurement,
  which is what lets the strip grow back and what keeps it from reading its own
  collapsed width as the width it needs.
- **A `'hug'` strip measures its parent** (a hug box shrinks with its content, so
  its own width answers nothing). Give it a parent with a width of its own; a
  shrink-to-fit parent will collapse and stay collapsed. `'fill'` measures
  itself and has no such caveat.
- **The tooltip sets `aria-describedby`,** so a collapsed segment reports name
  *and* description as the same string. That is `SideNav`'s shipped behavior
  today; deduping it belongs in `Tooltip`, not here.

## Testing

11 new tests (52 in the file, 6684 in core, all green), and Chromium at
320/375/480/768/1280 against the new `CollapsibleLabels` story.

| viewport | available | strip needs | state | item widths |
|---|---|---|---|---|
| 320 | 288px | 352px | icons | 40 / 40 / 40 / 40 |
| 375 | 343px | 352px | icons | 40 / 40 / 40 / 40 |
| 480 | 448px | 352px | labels | 78 / 75 / 93 / 95 |
| 768 | 736px | 352px | labels | 78 / 75 / 93 / 95 |
| 1280 | 1248px | 352px | labels | 78 / 75 / 93 / 95 |

Bisected, the flip is one pixel wide and exactly where the arithmetic says:
labels at 351px available, icons at 350px, against the 352px the labelled strip
needs. The `'fill'` twin in the same story crosses within 3px of it, with no
clipped or wrapped label at any width on the way down.

Accessibility, read from Chrome's accessibility tree (not the markup) at every
width above: `radiogroup "Theme"` with `radio "Light" (checked)`, `radio "Dark"`,
`radio "System"`, `radio "Custom"` — identical collapsed and expanded, none
ignored. Hovering a collapsed segment opens its tooltip ("Light"), and
`ArrowRight` still moves and selects (`Dark` checked and focused) while
icon-only.

Not done: the count badge of the sibling report is untouched. This collapse
hides the label text only, so a badge would survive it — but whether an
icon-plus-badge segment folds the count into its accessible name is that
change's call, not this one.