### PR TITLE
feat(cli): astryx mcp, an MCP server that answers for the installed version

### DIFF
--- a/.changeset/cli-mcp-stdio-client.md
+++ b/.changeset/cli-mcp-stdio-client.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] `astryx mcp` — a local MCP server over stdio that answers for the version of Astryx installed in your project, not the version the docs site was deployed with. (#5134)
+
+@AKnassa

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,7 +95,10 @@ export default defineConfig(
       // purpose — other packages' .mjs stay unlinted (#2468).
       "**/*.mjs",
       "!packages/cli/api/**/*.mjs",
-      "!packages/cli/clients/cli/**/*.mjs",
+      // clients/**, not clients/cli/** — a second client (clients/mcp) would
+      // otherwise land outside every CLI rule block: unlinted, no copyright
+      // header, and no @astryx/no-raw-console-cli guarding its stdout.
+      "!packages/cli/clients/**/*.mjs",
       "!packages/cli/assets/codemods/**/*.mjs",
       "!packages/cli/authoring/**/*.mjs",
       "!packages/cli/lib/**/*.mjs",
@@ -373,7 +376,7 @@ export default defineConfig(
   {
     files: [
       "packages/cli/api/**/*.mjs",
-      "packages/cli/clients/cli/**/*.mjs",
+      "packages/cli/clients/**/*.mjs",
       "packages/cli/assets/codemods/**/*.mjs",
       "packages/cli/authoring/**/*.mjs",
       "packages/cli/lib/**/*.mjs",
@@ -428,7 +431,7 @@ export default defineConfig(
   {
     files: [
       "packages/cli/api/**/*.mjs",
-      "packages/cli/clients/cli/**/*.mjs",
+      "packages/cli/clients/**/*.mjs",
       "packages/cli/assets/codemods/**/*.mjs",
       "packages/cli/authoring/**/*.mjs",
       "packages/cli/lib/**/*.mjs",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -69,6 +69,7 @@ Options:
 | `hook`                 | List hooks or print hook docs                                                 |
 | `init`                 | Initialize the design system in your project                                  |
 | `layout`               | Generate XDS layouts from compressed expressions (XLE/XLO)                    |
+| `mcp`                  | Run a local MCP server over stdio for this project                            |
 | `search`               | Search components, hooks, docs, and templates in one ranked list              |
 | `swizzle`              | Copy component source for customization                                       |
 | `template`             | Inject a page or block template                                               |

--- a/packages/cli/clients/cli/commands/mcp.doc.mjs
+++ b/packages/cli/clients/cli/commands/mcp.doc.mjs
@@ -1,0 +1,45 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file CommandDoc for `astryx mcp`. A client-only command (like `manifest`):
+ * it has no `fn` because it starts a second client over `api/` rather than
+ * calling one API function.
+ * @position packages/cli/clients/cli/commands — command documentation
+ */
+
+/** @type {import('@astryxdesign/cli/authoring').CommandDoc} */
+export const doc = {
+  type: 'command',
+  name: 'mcp',
+  displayName: 'astryx mcp',
+  namespace: 'cli',
+  summary: 'Run a local MCP server over stdio for this project',
+  description:
+    'Serves the Model Context Protocol on stdin/stdout so an MCP-capable agent can ' +
+    'query this project directly. It exposes the same two tools as the hosted server ' +
+    'at astryx.atmeta.com/mcp (search and get), but answers from the ' +
+    '@astryxdesign/core installed here, with the wired theme and configured ' +
+    'integrations, instead of the version the docs site was deployed with. ' +
+    'Read-only. Intended to be launched by an MCP client, not run by hand.',
+  examples: [
+    {
+      label: 'Run the server (an MCP client does this for you)',
+      cli: 'astryx mcp',
+    },
+  ],
+  exitCodes: [
+    {code: 0, when: 'the client disconnected and the session ended cleanly'},
+    {code: 1, when: 'the server could not start'},
+  ],
+  notes: [
+    {
+      type: 'prose',
+      text: 'stdout carries the protocol, so this command does not support --json.',
+    },
+    {
+      type: 'prose',
+      text: 'Add it to an MCP client config as the command `npx @astryxdesign/cli mcp`.',
+    },
+  ],
+  related: ['search', 'docs', 'doctor'],
+};

--- a/packages/cli/clients/cli/commands/mcp.mjs
+++ b/packages/cli/clients/cli/commands/mcp.mjs
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file `astryx mcp` — hand stdin/stdout to the MCP client.
+ *
+ * Thin by design: the CLI's only job here is to start the other client and get
+ * out of the way. Everything the server does lives in clients/mcp/.
+ *
+ * Nothing may print to stdout on this path — it is the protocol channel. The
+ * shared `logger` is silent unless a client enables it, and this command never
+ * does.
+ */
+
+import {startServer} from '../../mcp/index.mjs';
+import {defineCommand} from '../lib/define-command.mjs';
+import {doc as mcpCommand} from './mcp.doc.mjs';
+
+/**
+ * Register the `astryx mcp` command.
+ * @param {import('commander').Command} program
+ */
+export function registerMcp(program) {
+  defineCommand(program, mcpCommand, {
+    action: async () => {
+      await startServer({cwd: process.cwd()});
+    },
+  }).addHelpText(
+    'after',
+    '\nMCP client config (same shape for Claude Code, Cursor, Windsurf, Cline):\n' +
+      '  {"mcpServers": {"astryx": {"command": "npx", "args": ["@astryxdesign/cli", "mcp"]}}}\n' +
+      '\nThe hosted server at https://astryx.atmeta.com/mcp needs no install but\n' +
+      'answers for the deployed version; this one answers for the version installed here.\n',
+  );
+}

--- a/packages/cli/clients/cli/commands/mcp.test.mjs
+++ b/packages/cli/clients/cli/commands/mcp.test.mjs
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the `astryx mcp` command surface.
+ *
+ * The action itself (a long-lived stdio server) is exercised in
+ * clients/mcp/*.test.mjs; what matters here is the CLI surface: the command is
+ * registered, it is described, and `--json` is refused because on this command
+ * stdout carries the MCP protocol rather than an envelope.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {program, JSON_SUPPORTED} from '../index.mjs';
+import {buildManifest} from '../lib/manifest.mjs';
+import {runCli} from '../../../test-utils/run-cli.mjs';
+import {doc as mcpCommand} from './mcp.doc.mjs';
+
+describe('astryx mcp — registration', () => {
+  it('is a registered command', () => {
+    const names = program.commands.map(c => c.name());
+    expect(names).toContain('mcp');
+  });
+
+  it('appears in the capability manifest so agents can discover it', () => {
+    const manifest = buildManifest(program);
+    const entry = manifest.commands.find(c => c.name === 'mcp');
+    expect(entry).toBeDefined();
+    expect(entry?.description).toBe(mcpCommand.summary);
+  });
+});
+
+describe('astryx mcp — JSON mode', () => {
+  it('is not JSON-supported: stdout carries the protocol, not an envelope', () => {
+    expect(JSON_SUPPORTED.has('mcp')).toBe(false);
+  });
+
+  it('refuses --json with a structured error instead of corrupting the stream', async () => {
+    const {stdout} = await runCli(['mcp', '--json']);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.code).toBe('ERR_INVALID_OPTION');
+    expect(envelope.error).toContain('mcp');
+  });
+});

--- a/packages/cli/clients/cli/index.mjs
+++ b/packages/cli/clients/cli/index.mjs
@@ -116,6 +116,7 @@ const commands = [
   {name: 'search', path: './commands/search.mjs', register: 'registerSearch'},
   {name: 'build', path: './commands/build.mjs', register: 'registerBuild'},
   {name: 'doctor', path: './commands/doctor.mjs', register: 'registerDoctor'},
+  {name: 'mcp', path: './commands/mcp.mjs', register: 'registerMcp'},
   {
     name: 'validate-integration',
     path: './commands/validate-integration.mjs',
@@ -124,7 +125,10 @@ const commands = [
 ];
 
 const UPDATE_HINT_COMMANDS = new Set(['component', 'docs']);
-const SETUP_NUDGE_EXEMPT = new Set(['init', 'agent-docs']);
+// `mcp` is exempt for the same reason `--json` is: it is machine mode. A client
+// launches it, so the nudge lands as a spurious log line on every session — and
+// serving a project that never ran `init` is the supported case, not a mistake.
+const SETUP_NUDGE_EXEMPT = new Set(['init', 'agent-docs', 'mcp']);
 
 /**
  * Build a fresh, fully-wired Astryx CLI program (root options, hooks, all

--- a/packages/cli/clients/mcp/e2e.test.mjs
+++ b/packages/cli/clients/mcp/e2e.test.mjs
@@ -1,0 +1,140 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file End-to-end: drive the REAL `astryx mcp` binary over a pipe.
+ *
+ * The unit tests inject streams; this one proves the shipped process actually
+ * speaks MCP — and, most importantly, that stdout carries protocol lines and
+ * NOTHING else. A single stray banner, nudge or warning on stdout would make
+ * the server unusable, and only a real spawn can catch that.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {spawn} from 'node:child_process';
+import * as path from 'node:path';
+
+const BIN = path.resolve(import.meta.dirname, '../cli/bin/astryx.mjs');
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../../..');
+
+/**
+ * Send framed requests to a fresh `astryx mcp` process and collect its stdout.
+ * @param {object[]} requests
+ * @returns {Promise<{messages: object[], stderr: string, code: number|null, raw: string}>}
+ */
+function session(requests) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [BIN, 'mcp'], {
+      cwd: REPO_ROOT,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => {
+      stdout += d.toString();
+    });
+    child.stderr.on('data', d => {
+      stderr += d.toString();
+    });
+    child.on('error', reject);
+    child.on('close', code => {
+      resolve({
+        raw: stdout,
+        messages: stdout
+          .split('\n')
+          .filter(line => line.trim() !== '')
+          .map(line => JSON.parse(line)),
+        stderr,
+        code,
+      });
+    });
+
+    for (const request of requests) {
+      child.stdin.write(`${JSON.stringify(request)}\n`);
+    }
+    child.stdin.end();
+  });
+}
+
+const initialize = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: {name: 'test', version: '1'},
+  },
+};
+
+describe('astryx mcp (real process)', () => {
+  it('completes the handshake and reports the installed core version', async () => {
+    const {messages, code} = await session([
+      initialize,
+      {jsonrpc: '2.0', method: 'notifications/initialized'},
+    ]);
+
+    expect(code).toBe(0);
+    // The notification must NOT produce a second line.
+    expect(messages).toHaveLength(1);
+    expect(messages[0].result.serverInfo.name).toBe('astryx');
+    expect(messages[0].result.capabilities.tools).toBeDefined();
+    // Not just the literal "@astryxdesign/core": that appears in the
+    // not-installed branch too, so asserting it alone passes either way.
+    expect(messages[0].result.instructions).toMatch(
+      /@astryxdesign\/core: \d+\.\d+\.\d+.* \(installed\)/,
+    );
+  }, 30000);
+
+  it('lists exactly search and get', async () => {
+    const {messages} = await session([
+      initialize,
+      {jsonrpc: '2.0', id: 2, method: 'tools/list'},
+    ]);
+    const listed = messages.find(m => m.id === 2);
+    expect(
+      listed.result.tools.map((/** @type {{name: string}} */ t) => t.name),
+    ).toEqual(['search', 'get']);
+  }, 30000);
+
+  it('answers a real tools/call from the project on disk', async () => {
+    const {messages} = await session([
+      initialize,
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {name: 'search', arguments: {query: 'button', limit: 3}},
+      },
+    ]);
+    const called = messages.find(m => m.id === 3);
+    expect(called.result.isError).toBeUndefined();
+    const payload = JSON.parse(called.result.content[0].text);
+    expect(payload.results[0].name).toBe('Button');
+  }, 30000);
+
+  // The setup nudge is human guidance printed once per invocation. An MCP
+  // server is launched by a client, not a person, so it surfaces as a spurious
+  // log line on every session start — and it contradicts the feature itself:
+  // serving a project that never ran `astryx init` is the supported case.
+  it('says nothing on stderr either', async () => {
+    const {stderr} = await session([initialize]);
+    expect(stderr.trim()).toBe('');
+  }, 30000);
+
+  it('writes protocol lines and nothing else to stdout', async () => {
+    const {raw} = await session([
+      initialize,
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: {name: 'get', arguments: {name: 'Button'}},
+      },
+    ]);
+    for (const line of raw.split('\n').filter(l => l.trim() !== '')) {
+      expect(() => JSON.parse(line)).not.toThrow();
+      expect(JSON.parse(line).jsonrpc).toBe('2.0');
+    }
+  }, 30000);
+});

--- a/packages/cli/clients/mcp/index.mjs
+++ b/packages/cli/clients/mcp/index.mjs
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file The MCP client entry point.
+ *
+ * `clients/mcp/` is a second user-facing app over `api/`, the arrangement
+ * packages/cli/CONTRIBUTING.md describes as the point of the api/clients split:
+ * "The API is the reusable core; the CLI is one consumer of it."
+ *
+ * It is a client, not an API: `api/` never imports from here.
+ *
+ * @input a project directory and a pair of streams
+ * @output an MCP session on those streams
+ * @position packages/cli/clients/mcp — entry point
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {CLI_ROOT} from '../../foundation/fs/paths.mjs';
+import {loadProjectContext, renderInstructions} from './project-context.mjs';
+import {createHandler} from './server.mjs';
+import {pump} from './stdio.mjs';
+import {createTools} from './tools.mjs';
+
+/**
+ * This CLI's own version, reported as the MCP `serverInfo.version`.
+ * @returns {string}
+ */
+function cliVersion() {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(CLI_ROOT, 'package.json'), 'utf-8'),
+    );
+    return typeof pkg.version === 'string' ? pkg.version : '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+/**
+ * Serve one MCP session and resolve when the client disconnects.
+ *
+ * The streams are injectable so a test can drive a whole session without
+ * spawning a process.
+ *
+ * @param {object} [options]
+ * @param {string} [options.cwd] project to answer for (default: process.cwd())
+ * @param {NodeJS.ReadableStream} [options.input]
+ * @param {NodeJS.WritableStream} [options.output]
+ * @returns {Promise<void>}
+ */
+export async function startServer({
+  cwd = process.cwd(),
+  input = process.stdin,
+  output = process.stdout,
+} = {}) {
+  const context = await loadProjectContext(cwd);
+  const handler = createHandler({
+    tools: createTools({cwd}),
+    version: cliVersion(),
+    instructions: renderInstructions(context),
+  });
+  await pump({input, output, handle: handler.handle});
+}

--- a/packages/cli/clients/mcp/project-context.mjs
+++ b/packages/cli/clients/mcp/project-context.mjs
@@ -1,0 +1,138 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file The consumer project's own facts, read once at startup.
+ *
+ * This is the only thing a local MCP server can do that the hosted one at
+ * `/mcp` structurally cannot. That server reads registries frozen into its
+ * bundle at deploy time and never touches the caller's filesystem, so it
+ * answers for the version the docsite shipped with — not the version the
+ * project installed.
+ *
+ * Theme and install state come from `runChecks` (the `doctor` engine, which is
+ * documented read-only) rather than being re-derived here, so this cannot drift
+ * away from what `astryx doctor` reports.
+ *
+ * @input a consumer project directory
+ * @output the installed core version, wired theme, and configured integrations
+ * @position packages/cli/clients/mcp — project awareness, consumed at handshake
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {runChecks} from '../../api/doctor/doctor.mjs';
+import {Project} from '../../foundation/config/project.mjs';
+import {findCoreDir} from '../../foundation/fs/paths.mjs';
+
+/**
+ * What the server knows about the project it was started in.
+ * @typedef {object} ProjectContext
+ * @property {string} cwd
+ * @property {string|null} coreVersion installed core version, null when absent
+ * @property {{status: string, message: string}|null} theme doctor's theme finding
+ * @property {string[]} integrations configured integration package names
+ * @property {string|null} configPath resolved astryx.config.*, when present
+ */
+
+/**
+ * Read the installed core's version. Deliberately NOT `getXdsVersion`, which
+ * falls back to the CLI's own version when core is missing — here "absent" must
+ * stay distinguishable from "installed", or the server would report a version
+ * the project does not have.
+ * @param {string|null} coreDir
+ * @returns {string|null}
+ */
+function readCoreVersion(coreDir) {
+  if (!coreDir) return null;
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(coreDir, 'package.json'), 'utf-8'),
+    );
+    return typeof pkg.version === 'string' ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The version of `@astryxdesign/core` installed in this project, or null.
+ * @param {string} cwd
+ * @returns {string|null}
+ */
+export function readInstalledCoreVersion(cwd) {
+  return readCoreVersion(findCoreDir(cwd));
+}
+
+/**
+ * Gather the project's facts. Best-effort throughout: a server that refuses to
+ * start because a project is misconfigured is worse than one that says so.
+ * @param {string} cwd
+ * @returns {Promise<ProjectContext>}
+ */
+export async function loadProjectContext(cwd) {
+  const coreVersion = readInstalledCoreVersion(cwd);
+
+  /** @type {string[]} */
+  let integrations = [];
+  /** @type {string|null} */
+  let configPath = null;
+  try {
+    const project = await Project.load(cwd);
+    integrations = project.integrations ?? [];
+    configPath = project.configPath;
+  } catch {
+    // A broken or duplicated config is reported by `doctor`, not by refusing
+    // to serve.
+  }
+
+  /** @type {{status: string, message: string}|null} */
+  let theme = null;
+  try {
+    const report = await runChecks({cwd});
+    const check = report.checks.find(c => c.id === 'themes');
+    if (check) theme = {status: check.status, message: check.message};
+  } catch {
+    // Same policy: diagnostics are advisory here.
+  }
+
+  return {cwd, coreVersion, theme, integrations, configPath};
+}
+
+/**
+ * Render the context as MCP `instructions` — the field a client shows the model
+ * once per session. Putting it here rather than in a third tool keeps the tool
+ * surface identical to the shipped hosted server (search + get) while still
+ * telling the model which version it is answering for.
+ * @param {ProjectContext} context
+ * @returns {string}
+ */
+export function renderInstructions(context) {
+  const lines = [
+    'Astryx design system, answering for THIS project rather than the latest published docs.',
+    '',
+    `Project: ${context.cwd}`,
+    // Be blunt when core is missing. api/search throws "Could not find
+    // @astryxdesign/core package" before it reads any bundled doc, so BOTH
+    // tools hard-fail; promising a fallback would send the model down a path
+    // that always errors.
+    context.coreVersion
+      ? `@astryxdesign/core: ${context.coreVersion} (installed)`
+      : '@astryxdesign/core: NOT installed here, so search and get cannot answer. ' +
+        'Install it, or use the hosted server at https://astryx.atmeta.com/mcp instead.',
+  ];
+
+  if (context.theme) lines.push(`Theme: ${context.theme.message}`);
+  if (context.configPath) lines.push(`Config: ${context.configPath}`);
+  if (context.integrations.length > 0) {
+    lines.push(`Integrations: ${context.integrations.join(', ')}`);
+  }
+
+  lines.push(
+    '',
+    'Use search(query) to find components, hooks, doc topics and templates, then',
+    'get(name) for full detail. Prefer these over recalled API knowledge: they read',
+    'the version installed here, which may differ from the latest release.',
+  );
+
+  return lines.join('\n');
+}

--- a/packages/cli/clients/mcp/project-context.test.mjs
+++ b/packages/cli/clients/mcp/project-context.test.mjs
@@ -69,6 +69,15 @@ describe('loadProjectContext', () => {
       loadProjectContext(path.join(bare, 'does', 'not', 'exist')),
     ).resolves.toBeDefined();
   });
+
+  it('reports null rather than a lie when the installed core package.json is malformed', async () => {
+    const broken = path.join(path.dirname(withCore), 'broken');
+    const coreDir = path.join(broken, 'node_modules', '@astryxdesign', 'core');
+    fs.mkdirSync(coreDir, {recursive: true});
+    fs.writeFileSync(path.join(coreDir, 'package.json'), '{not json');
+    const context = await loadProjectContext(broken);
+    expect(context.coreVersion).toBeNull();
+  });
 });
 
 describe('renderInstructions', () => {

--- a/packages/cli/clients/mcp/project-context.test.mjs
+++ b/packages/cli/clients/mcp/project-context.test.mjs
@@ -1,0 +1,123 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the project context the MCP server reports at handshake.
+ *
+ * This is the whole reason a LOCAL server exists: the hosted server at
+ * /mcp answers for whatever version the docsite was deployed with, and cannot
+ * see the caller's project at all. These tests pin that the local one reads
+ * the real installed core, the real config, and says so.
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {loadProjectContext, renderInstructions} from './project-context.mjs';
+
+/** @type {string} */
+let withCore;
+/** @type {string} */
+let bare;
+
+beforeAll(() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-mcp-'));
+  withCore = path.join(root, 'with-core');
+  bare = path.join(root, 'bare');
+
+  const coreDir = path.join(withCore, 'node_modules', '@astryxdesign', 'core');
+  fs.mkdirSync(coreDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(coreDir, 'package.json'),
+    JSON.stringify({name: '@astryxdesign/core', version: '9.9.9'}),
+  );
+  fs.writeFileSync(
+    path.join(withCore, 'package.json'),
+    JSON.stringify({name: 'consumer', astryx: {theme: 'neutral'}}),
+  );
+
+  fs.mkdirSync(bare, {recursive: true});
+});
+
+afterAll(() => {
+  fs.rmSync(path.dirname(withCore), {recursive: true, force: true});
+});
+
+describe('loadProjectContext', () => {
+  it('reports the version of the core actually installed in the project', async () => {
+    const context = await loadProjectContext(withCore);
+    expect(context.coreVersion).toBe('9.9.9');
+  });
+
+  it('reports no core version when the project has not installed one', async () => {
+    const context = await loadProjectContext(bare);
+    expect(context.coreVersion).toBeNull();
+  });
+
+  it('reports the project directory it answered for', async () => {
+    const context = await loadProjectContext(withCore);
+    expect(context.cwd).toBe(withCore);
+  });
+
+  it('reports configured integrations as a list', async () => {
+    const context = await loadProjectContext(bare);
+    expect(context.integrations).toEqual([]);
+  });
+
+  it('never throws on a directory it cannot read', async () => {
+    await expect(
+      loadProjectContext(path.join(bare, 'does', 'not', 'exist')),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('renderInstructions', () => {
+  it('names the installed core version so the model answers for it', () => {
+    const text = renderInstructions({
+      cwd: '/p',
+      coreVersion: '9.9.9',
+      theme: null,
+      integrations: [],
+      configPath: null,
+    });
+    expect(text).toContain('9.9.9');
+  });
+
+  it('says the version is unknown rather than inventing one', () => {
+    const text = renderInstructions({
+      cwd: '/p',
+      coreVersion: null,
+      theme: null,
+      integrations: [],
+      configPath: null,
+    });
+    expect(text).not.toContain('null');
+    expect(text.toLowerCase()).toContain('not installed');
+  });
+
+  // Without core installed, api/search throws "Could not find @astryxdesign/core
+  // package" before it reads any bundled doc, so BOTH tools hard-fail. Promising
+  // a fallback that does not exist is worse than promising nothing.
+  it('does not promise a fallback the tools cannot deliver', () => {
+    const text = renderInstructions({
+      cwd: '/p',
+      coreVersion: null,
+      theme: null,
+      integrations: [],
+      configPath: null,
+    });
+    expect(text.toLowerCase()).not.toContain('fall back');
+    expect(text.toLowerCase()).toContain('cannot answer');
+  });
+
+  it('lists configured integrations so the model knows they exist', () => {
+    const text = renderInstructions({
+      cwd: '/p',
+      coreVersion: '1.0.0',
+      theme: null,
+      integrations: ['@acme/xds-widgets'],
+      configPath: '/p/astryx.config.mjs',
+    });
+    expect(text).toContain('@acme/xds-widgets');
+  });
+});

--- a/packages/cli/clients/mcp/protocol.mjs
+++ b/packages/cli/clients/mcp/protocol.mjs
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file JSON-RPC 2.0 framing for the MCP stdio transport.
+ *
+ * MCP over stdio is newline-delimited JSON-RPC 2.0: one JSON object per line on
+ * stdin, one per line on stdout. That is the whole transport, so it is written
+ * here rather than taken as a dependency — `@modelcontextprotocol/sdk` carries
+ * express, hono, cors, jose and ajv to serve HTTP and OAuth, none of which a
+ * stdio server speaks, and `@astryxdesign/cli` is published (every consumer
+ * would inherit them).
+ *
+ * @input newline-delimited JSON-RPC text from stdin
+ * @output framed JSON-RPC message objects, and encoded lines for stdout
+ * @position packages/cli/clients/mcp — transport layer, below the tool layer
+ */
+
+/** JSON-RPC 2.0 reserved error codes used by this transport. */
+export const PARSE_ERROR = -32700;
+export const INVALID_REQUEST = -32600;
+export const METHOD_NOT_FOUND = -32601;
+export const INTERNAL_ERROR = -32603;
+
+/**
+ * The outcome of reading one line off the wire. A blank line is not an error —
+ * it carries `code: null` so the caller stays silent rather than replying. An
+ * array payload is a JSON-RPC batch and arrives as `batch`.
+ * @typedef {{ok: true, message: Record<string, unknown>} | {ok: true, batch: Record<string, unknown>[]} | {ok: false, code: number|null}} DecodedLine
+ */
+
+/**
+ * Decode one newline-delimited JSON-RPC line.
+ * @param {string} line
+ * @returns {DecodedLine}
+ */
+export function decodeLine(line) {
+  const trimmed = line.trim();
+  if (trimmed === '') return {ok: false, code: null};
+
+  /** @type {unknown} */
+  let parsed;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return {ok: false, code: PARSE_ERROR};
+  }
+
+  // A JSON-RPC batch arrives as an array. MCP 2024-11-05 and 2025-03-26 both
+  // require batch support (2025-06-18 removed it again), and this server
+  // advertises all three, so an array is answered rather than rejected.
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0) return {ok: false, code: INVALID_REQUEST};
+    return {ok: true, batch: /** @type {Record<string, unknown>[]} */ (parsed)};
+  }
+
+  if (parsed === null || typeof parsed !== 'object') {
+    return {ok: false, code: INVALID_REQUEST};
+  }
+  return {ok: true, message: /** @type {Record<string, unknown>} */ (parsed)};
+}
+
+/**
+ * Encode one message for stdout. Exactly one trailing newline, and none inside
+ * — a stray newline would split one message into two on the wire.
+ * @param {object} message
+ * @returns {string}
+ */
+export function encodeMessage(message) {
+  return `${JSON.stringify(message)}\n`;
+}
+
+/**
+ * A JSON-RPC error response echoing the request id.
+ *
+ * When the id is unknowable (an unparseable line), the key is OMITTED rather
+ * than set to null. JSON-RPC 2.0 prescribes null, but MCP's own schema types
+ * the id as string|number with no null member, so a compliant client rejects
+ * the whole frame and learns nothing. Omitting it validates and still reports.
+ *
+ * @param {string|number|null} id
+ * @param {number} code
+ * @param {string} message
+ */
+export function errorResponse(id, code, message) {
+  return id === null || id === undefined
+    ? {jsonrpc: '2.0', error: {code, message}}
+    : {jsonrpc: '2.0', id, error: {code, message}};
+}

--- a/packages/cli/clients/mcp/protocol.test.mjs
+++ b/packages/cli/clients/mcp/protocol.test.mjs
@@ -36,6 +36,12 @@ describe('decodeLine', () => {
   it('ignores a blank line', () => {
     expect(decodeLine('   ')).toEqual({ok: false, code: null});
   });
+
+  it('rejects a top-level primitive as an invalid request', () => {
+    for (const line of ['42', '"ping"', 'null', 'true']) {
+      expect(decodeLine(line)).toEqual({ok: false, code: INVALID_REQUEST});
+    }
+  });
 });
 
 describe('encodeMessage', () => {

--- a/packages/cli/clients/mcp/protocol.test.mjs
+++ b/packages/cli/clients/mcp/protocol.test.mjs
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the JSON-RPC 2.0 framing the MCP stdio client speaks.
+ *
+ * The transport is the contract: MCP over stdio is newline-delimited JSON-RPC
+ * on stdin/stdout. These tests pin the three rules that a hand-written
+ * transport is most likely to get wrong — notifications never get a reply, a
+ * reply always echoes its request id, and a malformed line becomes a parse
+ * error rather than a crash.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {
+  INVALID_REQUEST,
+  PARSE_ERROR,
+  decodeLine,
+  encodeMessage,
+  errorResponse,
+} from './protocol.mjs';
+
+describe('decodeLine', () => {
+  it('parses a framed request into a message object', () => {
+    expect(decodeLine('{"jsonrpc":"2.0","id":1,"method":"ping"}')).toEqual({
+      ok: true,
+      message: {jsonrpc: '2.0', id: 1, method: 'ping'},
+    });
+  });
+
+  it('reports a parse error for a malformed line instead of throwing', () => {
+    const result = decodeLine('{not json');
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(-32700);
+  });
+
+  it('ignores a blank line', () => {
+    expect(decodeLine('   ')).toEqual({ok: false, code: null});
+  });
+});
+
+describe('encodeMessage', () => {
+  it('terminates each message with exactly one newline', () => {
+    const line = encodeMessage({jsonrpc: '2.0', id: 1, result: {}});
+    expect(line.endsWith('\n')).toBe(true);
+    expect(line.slice(0, -1)).not.toContain('\n');
+  });
+});
+
+describe('errorResponse', () => {
+  it('echoes the request id and carries the JSON-RPC error code', () => {
+    expect(errorResponse(7, -32601, 'Method not found')).toEqual({
+      jsonrpc: '2.0',
+      id: 7,
+      error: {code: -32601, message: 'Method not found'},
+    });
+  });
+
+  // JSON-RPC 2.0 answers an unparseable request with id: null, but MCP's own
+  // schema rejects a null id, so a compliant client discards the whole frame.
+  // Omitting the key validates and still reports the failure.
+  it('omits the id entirely when the request id is unknowable', () => {
+    const response = errorResponse(null, PARSE_ERROR, 'Parse error');
+    expect('id' in response).toBe(false);
+    expect(response.error.code).toBe(PARSE_ERROR);
+  });
+});
+
+describe('decodeLine — JSON-RPC batches', () => {
+  // MCP 2024-11-05 and 2025-03-26 require batch support; 2025-06-18 removed it.
+  // This server advertises all three, so it has to accept arrays.
+  it('recognises an array payload as a batch rather than rejecting it', () => {
+    const result = decodeLine(
+      '[{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","id":2,"method":"ping"}]',
+    );
+    expect(result.ok).toBe(true);
+    expect(result.batch).toHaveLength(2);
+  });
+
+  it('rejects an empty batch as an invalid request', () => {
+    expect(decodeLine('[]')).toEqual({ok: false, code: INVALID_REQUEST});
+  });
+});

--- a/packages/cli/clients/mcp/server.mjs
+++ b/packages/cli/clients/mcp/server.mjs
@@ -1,0 +1,157 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file MCP request handler — the method table above the JSON-RPC transport.
+ *
+ * The tool set is injected so the protocol can be tested without touching the
+ * filesystem, and so `astryx mcp` can bind the project-aware tools at startup.
+ *
+ * Two MCP rules are easy to get wrong and are pinned by tests:
+ *   1. A notification (no `id`) is never answered — replying to one is a
+ *      protocol violation that wedges strict clients.
+ *   2. A tool that FAILS still returns a successful JSON-RPC result carrying
+ *      `isError: true`. JSON-RPC errors are reserved for protocol faults
+ *      (unknown method, bad params), so a model can read a tool failure as
+ *      content and retry rather than treating the session as broken.
+ *
+ * @input framed JSON-RPC message objects
+ * @output JSON-RPC response objects, or null for notifications
+ * @position packages/cli/clients/mcp — protocol layer, above transport
+ */
+
+import {INVALID_REQUEST, METHOD_NOT_FOUND, errorResponse} from './protocol.mjs';
+
+/** JSON-RPC reserved code for a well-formed call with bad arguments. */
+const INVALID_PARAMS = -32602;
+
+/**
+ * MCP revisions this server implements. The handshake echoes the client's
+ * choice when it is one of these, so an older client is not forced to upgrade.
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS = [
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05',
+];
+
+/** The revision offered when the client asks for one we do not know. */
+export const DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+/**
+ * One MCP tool: its advertised schema plus the function behind it.
+ * @typedef {object} McpTool
+ * @property {string} name
+ * @property {string} description
+ * @property {object} inputSchema JSON Schema for the tool's arguments.
+ * @property {(args: Record<string, unknown>) => Promise<unknown>} run
+ */
+
+/**
+ * A JSON-RPC notification carries no `id` and must never be answered. A request
+ * may legitimately use `id: 0`, so test for presence, not truthiness.
+ * @param {Record<string, unknown>} message
+ * @returns {boolean}
+ */
+export function isNotification(message) {
+  return message.id === undefined || message.id === null;
+}
+
+/**
+ * Wrap a value as MCP text content. MCP has no structured result type for
+ * tools, so payloads travel as pretty-printed JSON in a text block.
+ * @param {unknown} value
+ * @param {boolean} [isError]
+ */
+function textContent(value, isError = false) {
+  const text =
+    typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  return isError
+    ? {content: [{type: 'text', text}], isError: true}
+    : {content: [{type: 'text', text}]};
+}
+
+/**
+ * Build the request handler.
+ * @param {{tools: McpTool[], version?: string, instructions?: string}} options
+ */
+export function createHandler({tools, version = '0.0.0', instructions}) {
+  const byName = new Map(tools.map(tool => [tool.name, tool]));
+
+  /**
+   * @param {Record<string, unknown>} message
+   * @returns {Promise<Record<string, any>|null>}
+   */
+  async function handle(message) {
+    if (isNotification(message)) return null;
+
+    const id = /** @type {string|number} */ (message.id);
+    const method = message.method;
+    if (typeof method !== 'string') {
+      return errorResponse(id, INVALID_REQUEST, 'Missing method');
+    }
+
+    const params = /** @type {Record<string, any>} */ (message.params ?? {});
+
+    switch (method) {
+      case 'initialize': {
+        const asked = params.protocolVersion;
+        const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(asked)
+          ? asked
+          : DEFAULT_PROTOCOL_VERSION;
+        return {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            protocolVersion,
+            capabilities: {tools: {}},
+            serverInfo: {name: 'astryx', version},
+            // Optional per spec; omitted rather than sent empty so a client
+            // never shows the model a blank preamble.
+            ...(instructions ? {instructions} : {}),
+          },
+        };
+      }
+
+      case 'ping':
+        return {jsonrpc: '2.0', id, result: {}};
+
+      case 'tools/list':
+        return {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            tools: tools.map(({name, description, inputSchema}) => ({
+              name,
+              description,
+              inputSchema,
+            })),
+          },
+        };
+
+      case 'tools/call': {
+        const tool = byName.get(params.name);
+        if (!tool) {
+          return errorResponse(
+            id,
+            INVALID_PARAMS,
+            `Unknown tool: ${String(params.name)}`,
+          );
+        }
+        try {
+          const result = await tool.run(params.arguments ?? {});
+          return {jsonrpc: '2.0', id, result: textContent(result)};
+        } catch (err) {
+          // A tool failure is content, not a protocol fault — the model should
+          // read the message and try something else.
+          const detail = err instanceof Error ? err.message : String(err);
+          return {jsonrpc: '2.0', id, result: textContent(detail, true)};
+        }
+      }
+
+      default:
+        return errorResponse(id, METHOD_NOT_FOUND, `Unknown method: ${method}`);
+    }
+  }
+
+  return {handle};
+}

--- a/packages/cli/clients/mcp/server.test.mjs
+++ b/packages/cli/clients/mcp/server.test.mjs
@@ -173,6 +173,16 @@ describe('tools/call', () => {
   });
 });
 
+describe('malformed requests', () => {
+  it('answers invalid-request when the method is missing or not a string', async () => {
+    const missing = await handler().handle({jsonrpc: '2.0', id: 7});
+    expect(missing?.error?.code).toBe(-32600);
+    const wrong = await handler().handle({jsonrpc: '2.0', id: 8, method: 5});
+    expect(wrong?.error?.code).toBe(-32600);
+    expect(wrong?.id).toBe(8);
+  });
+});
+
 describe('unknown methods', () => {
   it('answers method-not-found rather than staying silent', async () => {
     const response = await handler().handle({

--- a/packages/cli/clients/mcp/server.test.mjs
+++ b/packages/cli/clients/mcp/server.test.mjs
@@ -1,0 +1,185 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the MCP request handler.
+ *
+ * The tool layer is injected here so these tests pin the PROTOCOL contract —
+ * handshake, notification silence, tool listing, and the MCP rule that a tool
+ * failure is a successful response carrying `isError`, not a JSON-RPC error.
+ * The real tools are exercised in tools.test.mjs.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {
+  DEFAULT_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  createHandler,
+} from './server.mjs';
+
+/** A stand-in tool set: one tool that succeeds, one that throws. */
+const fakeTools = [
+  {
+    name: 'search',
+    description: 'fake search',
+    inputSchema: {type: 'object', properties: {query: {type: 'string'}}},
+    run: async (/** @type {{query: string}} */ args) => ({hit: args.query}),
+  },
+  {
+    name: 'get',
+    description: 'fake get',
+    inputSchema: {type: 'object', properties: {name: {type: 'string'}}},
+    run: async () => {
+      throw new Error('boom');
+    },
+  },
+];
+
+const handler = () => createHandler({tools: fakeTools});
+
+describe('initialize', () => {
+  it('reports tool capability and identifies the server as astryx', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {protocolVersion: '2025-06-18'},
+    });
+    expect(response?.result?.capabilities?.tools).toBeDefined();
+    expect(response?.result?.serverInfo?.name).toBe('astryx');
+  });
+
+  it('carries the project instructions so the model sees them once per session', async () => {
+    const handler = createHandler({
+      tools: fakeTools,
+      instructions: 'core 9.9.9 installed here',
+    });
+    const response = await handler.handle({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {},
+    });
+    expect(response?.result?.instructions).toBe('core 9.9.9 installed here');
+  });
+
+  it('omits instructions entirely when there are none', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {},
+    });
+    expect('instructions' in (response?.result ?? {})).toBe(false);
+  });
+
+  // Without this, the fallback branch is never exercised: every other test
+  // asks for a version the server already knows, so replacing the fallback
+  // with the requested value would survive the whole suite.
+  it('offers its own newest revision when asked for one it does not know', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {protocolVersion: '1999-01-01'},
+    });
+    expect(response?.result?.protocolVersion).toBe(DEFAULT_PROTOCOL_VERSION);
+    expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(
+      response?.result?.protocolVersion,
+    );
+  });
+
+  it('echoes a protocol version the client asked for', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {protocolVersion: '2024-11-05'},
+    });
+    expect(response?.result?.protocolVersion).toBe('2024-11-05');
+  });
+});
+
+describe('notifications', () => {
+  it('never answers a message without an id', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+    });
+    expect(response).toBeNull();
+  });
+
+  it('answers a request whose id is the number zero', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'ping',
+    });
+    expect(response?.id).toBe(0);
+  });
+});
+
+describe('tools/list', () => {
+  it('lists every injected tool with its name, description and schema', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    });
+    const tools = response?.result?.tools ?? [];
+    expect(tools.map((/** @type {{name: string}} */ t) => t.name)).toEqual([
+      'search',
+      'get',
+    ]);
+    expect(tools[0].inputSchema).toEqual({
+      type: 'object',
+      properties: {query: {type: 'string'}},
+    });
+  });
+});
+
+describe('tools/call', () => {
+  it('returns the tool result as MCP text content', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {name: 'search', arguments: {query: 'button'}},
+    });
+    const content = response?.result?.content ?? [];
+    expect(content[0].type).toBe('text');
+    expect(JSON.parse(content[0].text)).toEqual({hit: 'button'});
+  });
+
+  it('reports a throwing tool as isError, not as a JSON-RPC error', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {name: 'get', arguments: {name: 'Nope'}},
+    });
+    expect(response?.error).toBeUndefined();
+    expect(response?.result?.isError).toBe(true);
+    expect(response?.result?.content?.[0]?.text).toContain('boom');
+  });
+
+  it('rejects an unknown tool name with a JSON-RPC invalid-params error', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'tools/call',
+      params: {name: 'nope', arguments: {}},
+    });
+    expect(response?.error?.code).toBe(-32602);
+  });
+});
+
+describe('unknown methods', () => {
+  it('answers method-not-found rather than staying silent', async () => {
+    const response = await handler().handle({
+      jsonrpc: '2.0',
+      id: 6,
+      method: 'resources/list',
+    });
+    expect(response?.error?.code).toBe(-32601);
+  });
+});

--- a/packages/cli/clients/mcp/stdio.mjs
+++ b/packages/cli/clients/mcp/stdio.mjs
@@ -69,14 +69,21 @@ export async function pump({input, output, handle}) {
   /**
    * Run one message through the handler, turning a fault into an error response
    * rather than letting it end the session.
-   * @param {Record<string, unknown>} message
+   * @param {unknown} message
    * @returns {Promise<object|null>}
    */
   async function answer(message) {
+    // decodeLine screens a single message, but batch members arrive here raw:
+    // a null or primitive member must answer as an invalid request, not reach
+    // the handler (where reading .id off null would end the session).
+    if (message === null || typeof message !== 'object' || Array.isArray(message)) {
+      return errorResponse(null, INVALID_REQUEST, 'Invalid request');
+    }
+    const request = /** @type {Record<string, unknown>} */ (message);
     try {
-      return await handle(message);
+      return await handle(request);
     } catch (err) {
-      const id = /** @type {string|number|null} */ (message.id ?? null);
+      const id = /** @type {string|number|null} */ (request.id ?? null);
       const detail = err instanceof Error ? err.message : String(err);
       return errorResponse(id, INTERNAL_ERROR, detail);
     }

--- a/packages/cli/clients/mcp/stdio.mjs
+++ b/packages/cli/clients/mcp/stdio.mjs
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file The stdio pump: newline-delimited JSON-RPC in, responses out.
+ *
+ * stdout is the protocol channel, so nothing else may ever be written to it.
+ * That holds by construction here: `api/` functions return values rather than
+ * printing, and the CLI's shared `logger` is silent unless a client enables it
+ * (`api/logger.mjs`) — which `astryx mcp` never does. Diagnostics go to stderr.
+ *
+ * Requests are handled one at a time so responses keep wire order.
+ *
+ * @input a readable stream of newline-delimited JSON-RPC
+ * @output framed responses on a writable stream
+ * @position packages/cli/clients/mcp — transport driver, under the handler
+ */
+
+import {
+  INTERNAL_ERROR,
+  INVALID_REQUEST,
+  decodeLine,
+  encodeMessage,
+  errorResponse,
+} from './protocol.mjs';
+
+/**
+ * Drive one MCP session to completion. Resolves when the input stream ends.
+ *
+ * @param {object} options
+ * @param {NodeJS.ReadableStream} options.input
+ * @param {NodeJS.WritableStream} options.output
+ * @param {(message: Record<string, unknown>) => Promise<object|null>} options.handle
+ * @returns {Promise<void>}
+ */
+export async function pump({input, output, handle}) {
+  /** @param {object} message */
+  const write = message => output.write(encodeMessage(message));
+
+  /** @param {string} line */
+  async function processLine(line) {
+    const decoded = decodeLine(line);
+
+    if (!decoded.ok) {
+      // A blank line carries no code and needs no answer.
+      if (decoded.code === null) return;
+      const label =
+        decoded.code === INVALID_REQUEST ? 'Invalid request' : 'Parse error';
+      write(errorResponse(null, decoded.code, label));
+      return;
+    }
+
+    // A batch is answered with ONE array holding the responses its answerable
+    // members produced; an all-notification batch is answered with nothing.
+    if ('batch' in decoded) {
+      /** @type {object[]} */
+      const responses = [];
+      for (const message of decoded.batch) {
+        const response = await answer(message);
+        if (response) responses.push(response);
+      }
+      if (responses.length > 0) write(responses);
+      return;
+    }
+
+    const response = await answer(decoded.message);
+    if (response) write(response);
+  }
+
+  /**
+   * Run one message through the handler, turning a fault into an error response
+   * rather than letting it end the session.
+   * @param {Record<string, unknown>} message
+   * @returns {Promise<object|null>}
+   */
+  async function answer(message) {
+    try {
+      return await handle(message);
+    } catch (err) {
+      const id = /** @type {string|number|null} */ (message.id ?? null);
+      const detail = err instanceof Error ? err.message : String(err);
+      return errorResponse(id, INTERNAL_ERROR, detail);
+    }
+  }
+
+  input.setEncoding('utf8');
+
+  let buffer = '';
+  for await (const chunk of input) {
+    buffer += chunk;
+    let newline = buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      await processLine(line);
+      newline = buffer.indexOf('\n');
+    }
+  }
+
+  // A final line with no trailing newline is still a message.
+  if (buffer.trim() !== '') await processLine(buffer);
+}

--- a/packages/cli/clients/mcp/stdio.test.mjs
+++ b/packages/cli/clients/mcp/stdio.test.mjs
@@ -86,6 +86,33 @@ describe('pump', () => {
     expect(out[1].id).toBe(3);
   });
 
+  it('answers a top-level primitive line as an invalid request', async () => {
+    const out = await run(['null\n'], echo);
+    expect(out).toEqual([
+      {jsonrpc: '2.0', error: {code: -32600, message: 'Invalid request'}},
+    ]);
+  });
+
+  it('ignores blank lines between messages', async () => {
+    const out = await run(
+      ['\n  \n{"jsonrpc":"2.0","id":12,"method":"ping"}\n'],
+      echo,
+    );
+    expect(out).toEqual([{jsonrpc: '2.0', id: 12, result: {}}]);
+  });
+
+  it('accepts CRLF line endings', async () => {
+    const out = await run(['{"jsonrpc":"2.0","id":13,"method":"ping"}\r\n'], echo);
+    expect(out).toEqual([{jsonrpc: '2.0', id: 13, result: {}}]);
+  });
+
+  // The comment in pump() promises this; without a test the branch is free to
+  // rot: a client may end its stream without a final newline.
+  it('answers a final message that arrives with no trailing newline', async () => {
+    const out = await run(['{"jsonrpc":"2.0","id":11,"method":"ping"}'], echo);
+    expect(out).toEqual([{jsonrpc: '2.0', id: 11, result: {}}]);
+  });
+
   it('turns a handler crash into an internal error instead of dying', async () => {
     const out = await run(
       ['{"jsonrpc":"2.0","id":4,"method":"ping"}\n'],
@@ -117,6 +144,27 @@ describe('pump', () => {
       echo,
     );
     expect(out).toEqual([]);
+  });
+
+  // decodeLine screens a single message, but batch members arrive raw. A
+  // member like null or 1 must answer as an invalid request inside the batch
+  // reply — not crash the session, and not vanish.
+  it('answers non-object batch members with invalid-request errors and keeps serving', async () => {
+    const out = await run(
+      [
+        '[null,1,{"jsonrpc":"2.0","id":9,"method":"ping"}]\n',
+        '{"jsonrpc":"2.0","id":10,"method":"ping"}\n',
+      ],
+      echo,
+    );
+    expect(out).toHaveLength(2);
+    const batch = out[0];
+    expect(batch).toHaveLength(3);
+    expect(batch[0].error.code).toBe(-32600);
+    expect('id' in batch[0]).toBe(false);
+    expect(batch[1].error.code).toBe(-32600);
+    expect(batch[2]).toEqual({jsonrpc: '2.0', id: 9, result: {}});
+    expect(out[1].id).toBe(10);
   });
 
   // Responses must leave in request order. Without awaiting each handler the

--- a/packages/cli/clients/mcp/stdio.test.mjs
+++ b/packages/cli/clients/mcp/stdio.test.mjs
@@ -1,0 +1,140 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the stdio pump.
+ *
+ * stdout is the protocol channel: one JSON-RPC message per line and nothing
+ * else. Anything that prints to stdout corrupts the session, so these tests pin
+ * that notifications stay silent, that a message split across chunk boundaries
+ * still parses, and that a malformed line answers with a parse error instead of
+ * killing the process.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {PassThrough} from 'node:stream';
+import {pump} from './stdio.mjs';
+
+/**
+ * Feed lines through the pump and collect everything written to stdout.
+ * @param {string[]} chunks raw stdin chunks (not necessarily whole lines)
+ * @param {(message: Record<string, unknown>) => Promise<object|null>} handle
+ * @returns {Promise<object[]>}
+ */
+async function run(chunks, handle) {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  /** @type {string} */
+  let written = '';
+  output.on('data', d => {
+    written += d.toString();
+  });
+
+  const done = pump({input, output, handle});
+  for (const chunk of chunks) input.write(chunk);
+  input.end();
+  await done;
+
+  return written
+    .split('\n')
+    .filter(line => line.trim() !== '')
+    .map(line => JSON.parse(line));
+}
+
+const echo = async (/** @type {Record<string, unknown>} */ message) =>
+  message.id === undefined
+    ? null
+    : {jsonrpc: '2.0', id: message.id, result: {}};
+
+describe('pump', () => {
+  it('answers one request with one line', async () => {
+    const out = await run(['{"jsonrpc":"2.0","id":1,"method":"ping"}\n'], echo);
+    expect(out).toEqual([{jsonrpc: '2.0', id: 1, result: {}}]);
+  });
+
+  it('stays silent for a notification', async () => {
+    const out = await run(
+      ['{"jsonrpc":"2.0","method":"notifications/initialized"}\n'],
+      echo,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('reassembles a message split across chunks', async () => {
+    const out = await run(
+      ['{"jsonrpc":"2.0","id', '":2,"method":"ping"}\n'],
+      echo,
+    );
+    expect(out).toEqual([{jsonrpc: '2.0', id: 2, result: {}}]);
+  });
+
+  it('handles several messages arriving in one chunk', async () => {
+    const out = await run(
+      [
+        '{"jsonrpc":"2.0","id":1,"method":"ping"}\n{"jsonrpc":"2.0","id":2,"method":"ping"}\n',
+      ],
+      echo,
+    );
+    expect(out.map(m => m.id)).toEqual([1, 2]);
+  });
+
+  it('answers a malformed line with a parse error and keeps serving', async () => {
+    const out = await run(
+      ['{not json\n', '{"jsonrpc":"2.0","id":3,"method":"ping"}\n'],
+      echo,
+    );
+    expect(out[0].error.code).toBe(-32700);
+    expect(out[1].id).toBe(3);
+  });
+
+  it('turns a handler crash into an internal error instead of dying', async () => {
+    const out = await run(
+      ['{"jsonrpc":"2.0","id":4,"method":"ping"}\n'],
+      async () => {
+        throw new Error('handler exploded');
+      },
+    );
+    expect(out[0].error.code).toBe(-32603);
+    expect(out[0].id).toBe(4);
+  });
+
+  it('answers a batch with one array carrying every answerable response', async () => {
+    const out = await run(
+      [
+        '[{"jsonrpc":"2.0","id":1,"method":"ping"},' +
+          '{"jsonrpc":"2.0","method":"notifications/initialized"},' +
+          '{"jsonrpc":"2.0","id":2,"method":"ping"}]\n',
+      ],
+      echo,
+    );
+    // One wire message, which is itself the array of the two answerable ids.
+    expect(out).toHaveLength(1);
+    expect(out[0].map((/** @type {{id: number}} */ m) => m.id)).toEqual([1, 2]);
+  });
+
+  it('stays silent for a batch made only of notifications', async () => {
+    const out = await run(
+      ['[{"jsonrpc":"2.0","method":"a"},{"jsonrpc":"2.0","method":"b"}]\n'],
+      echo,
+    );
+    expect(out).toEqual([]);
+  });
+
+  // Responses must leave in request order. Without awaiting each handler the
+  // pump would interleave, so a slow first request would answer after a fast
+  // second one and a client pairing by arrival would mismatch them.
+  it('keeps responses in request order even when the first is slower', async () => {
+    /** @param {Record<string, unknown>} message */
+    const slowFirst = async message => {
+      if (message.id === 1) await new Promise(r => setTimeout(r, 25));
+      return {jsonrpc: '2.0', id: message.id, result: {}};
+    };
+    const out = await run(
+      [
+        '{"jsonrpc":"2.0","id":1,"method":"ping"}\n' +
+          '{"jsonrpc":"2.0","id":2,"method":"ping"}\n',
+      ],
+      slowFirst,
+    );
+    expect(out.map(m => m.id)).toEqual([1, 2]);
+  });
+});

--- a/packages/cli/clients/mcp/tools.mjs
+++ b/packages/cli/clients/mcp/tools.mjs
@@ -80,7 +80,12 @@ export function createTools({cwd}) {
           throw new Error('search requires a non-empty "query" string.');
         }
         const limit = typeof args.limit === 'number' ? args.limit : undefined;
-        const {data} = await search(query, {cwd, ...(limit ? {limit} : {})});
+        // Forward any provided number — 0 and NaN included — so the api's own
+        // "positive integer" validation answers rather than a silent default.
+        const {data} = await search(query, {
+          cwd,
+          ...(limit !== undefined ? {limit} : {}),
+        });
         return data;
       },
     },
@@ -142,7 +147,10 @@ export function createTools({cwd}) {
           );
         }
 
-        const response = await fetch(name, section, cwd);
+        // Fetch by the hit's canonical name, not the caller's: the match above
+        // is case-insensitive, but template() resolves by exact dirName, so
+        // the caller's casing could 404 on an artifact search just confirmed.
+        const response = await fetch(target.name, section, cwd);
         return {
           kind: target.domain,
           name: target.name,

--- a/packages/cli/clients/mcp/tools.mjs
+++ b/packages/cli/clients/mcp/tools.mjs
@@ -1,0 +1,156 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file The MCP tool set: `search` and `get`, over `api/`.
+ *
+ * The surface is deliberately the SAME two tools the hosted server ships
+ * (PR #2513), so this client re-binds an already-shipped contract to a new data
+ * source instead of proposing a new tool surface.
+ *
+ * The history is easy to misread, so state it precisely: the #2306 bake-off was
+ * won by CLI + search (9.6/10), not by any MCP variant, and its "What We're
+ * Shipping" section recommended the SIX-tool server (#2228). What happened next
+ * went the other way — #2228 was closed unmerged and #2513 shipped the two-tool
+ * hybrid (9.3/10). Two tools is therefore what exists today; it is not what the
+ * bake-off crowned, and picking it here is a deference to the shipped contract,
+ * not a claim that the six-tool shape was judged wrong.
+ *
+ * Every answer is resolved through `api/` against the caller's `cwd`, so it
+ * reflects the version, theme and integrations actually installed.
+ *
+ * @input tool arguments from `tools/call`
+ * @output plain data, serialized as MCP text content by the handler
+ * @position packages/cli/clients/mcp — tool layer, over api/
+ */
+
+import {component, docs, hook, search, template} from '../../api/index.mjs';
+import {readInstalledCoreVersion} from './project-context.mjs';
+
+/** @typedef {import('../../api/search/search.type.mjs').SearchResultEntry} SearchResultEntry */
+
+/**
+ * Fetch one artifact once its domain is known.
+ *
+ * Dispatching on a KNOWN domain matters. `component()` and `hook()` are
+ * separate resolvers, but both are lenient: `component()` runs a score-threshold
+ * fuzzy search, so `component('spacing')` cheerfully returns the Stack
+ * component, and `hook('Button')` resolves too. Only `docs()` and `template()`
+ * are strict. So a try-each-in-turn chain would hand the model a confidently
+ * wrong artifact, which is worse than a miss.
+ * @type {Record<string, (name: string, section: string|undefined, cwd: string) => Promise<{type: string, data: unknown}>>}
+ */
+const FETCH_BY_DOMAIN = {
+  component: (name, _section, cwd) => component(name, {cwd}),
+  hook: (name, _section, cwd) => hook(name, {cwd}),
+  doc: (name, section) => docs(name, section),
+  template: (name, _section, cwd) => template(name, {cwd, show: true}),
+};
+
+/**
+ * Build the tool set bound to one project directory.
+ * @param {{cwd: string}} options
+ * @returns {import('./server.mjs').McpTool[]}
+ */
+export function createTools({cwd}) {
+  return [
+    {
+      name: 'search',
+      description:
+        'Search the Astryx design system installed in this project: components, ' +
+        'hooks, doc topics and page templates, in one ranked list. Returns brief ' +
+        'results; call get(name) for full detail.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description:
+              'What you are looking for, in natural language (e.g. "success message", "sortable table").',
+          },
+          limit: {
+            type: 'number',
+            description: 'Maximum number of results to return (default 20).',
+          },
+        },
+        required: ['query'],
+      },
+      run: async args => {
+        const query = args.query;
+        if (typeof query !== 'string' || query.trim() === '') {
+          throw new Error('search requires a non-empty "query" string.');
+        }
+        const limit = typeof args.limit === 'number' ? args.limit : undefined;
+        const {data} = await search(query, {cwd, ...(limit ? {limit} : {})});
+        return data;
+      },
+    },
+    {
+      name: 'get',
+      description:
+        'Get full detail for one Astryx component, hook, doc topic or template ' +
+        'by name, as installed in this project. Use search(query) first if the ' +
+        'exact name is not known.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description:
+              'Component name (e.g. "Button"), hook (e.g. "useToast"), doc topic (e.g. "spacing"), or template slug.',
+          },
+          section: {
+            type: 'string',
+            description:
+              'For doc topics only: return just this section, to keep large topics inside the context budget.',
+          },
+        },
+        required: ['name'],
+      },
+      run: async args => {
+        const name = args.name;
+        if (typeof name !== 'string' || name.trim() === '') {
+          throw new Error('get requires a non-empty "name" string.');
+        }
+        const section =
+          typeof args.section === 'string' ? args.section : undefined;
+
+        // `search` is the project's own classifier: every hit is tagged with
+        // its domain, so an exact name match tells us what `name` IS before we
+        // fetch it.
+        const {data} = await search(name, {cwd});
+        const results = /** @type {SearchResultEntry[]} */ (data.results ?? []);
+        const target = results.find(
+          r => r.name.toLowerCase() === name.toLowerCase(),
+        );
+
+        if (!target) {
+          const near = results
+            .slice(0, 5)
+            .map(r => r.name)
+            .join(', ');
+          throw new Error(
+            `No Astryx component, hook, doc topic or template named "${name}" ` +
+              `is available in this project.` +
+              (near ? ` Closest matches: ${near}.` : ''),
+          );
+        }
+
+        const fetch = FETCH_BY_DOMAIN[target.domain];
+        if (!fetch) {
+          throw new Error(
+            `"${name}" resolved to an unsupported domain: ${target.domain}.`,
+          );
+        }
+
+        const response = await fetch(name, section, cwd);
+        return {
+          kind: target.domain,
+          name: target.name,
+          coreVersion: readInstalledCoreVersion(cwd),
+          type: response.type,
+          data: response.data,
+        };
+      },
+    },
+  ];
+}

--- a/packages/cli/clients/mcp/tools.test.mjs
+++ b/packages/cli/clients/mcp/tools.test.mjs
@@ -1,0 +1,115 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the two MCP tools.
+ *
+ * The tool SURFACE is deliberately identical to the shipped hosted server
+ * (search + get, PR #2513) — matching what shipped, rather than re-opening the
+ * question. What differs is where the answers come from: `api/` reading the
+ * caller's project, not a registry frozen at deploy time.
+ */
+
+import {describe, it, expect} from 'vitest';
+import * as path from 'node:path';
+import {createTools} from './tools.mjs';
+import {readInstalledCoreVersion} from './project-context.mjs';
+
+/** The repo root — a project that really does have core installed. */
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../../..');
+
+const tools = () => createTools({cwd: REPO_ROOT});
+/** @param {string} name */
+const tool = name => {
+  const found = tools().find(t => t.name === name);
+  if (!found) throw new Error(`no tool named ${name}`);
+  return found;
+};
+
+describe('tool surface', () => {
+  it('exposes exactly the hosted server two tools, in the same order', () => {
+    expect(tools().map(t => t.name)).toEqual(['search', 'get']);
+  });
+
+  it('requires query on search and leaves limit optional', () => {
+    const {inputSchema} = tool('search');
+    expect(inputSchema.required).toEqual(['query']);
+    expect(inputSchema.properties.query.type).toBe('string');
+    expect(inputSchema.properties.limit.type).toBe('number');
+  });
+
+  it('requires name on get and leaves section optional', () => {
+    const {inputSchema} = tool('get');
+    expect(inputSchema.required).toEqual(['name']);
+    expect(inputSchema.properties.section.type).toBe('string');
+  });
+
+  it('describes every tool and every property for the model', () => {
+    for (const t of tools()) {
+      expect(t.description.length).toBeGreaterThan(0);
+      for (const key of Object.keys(t.inputSchema.properties)) {
+        expect(t.inputSchema.properties[key].description).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe('search', () => {
+  it('ranks an exact component name first', async () => {
+    const result = await tool('search').run({query: 'button'});
+    expect(result.results[0]).toMatchObject({
+      domain: 'component',
+      name: 'Button',
+    });
+  });
+
+  it('honors the limit argument', async () => {
+    const result = await tool('search').run({query: 'button', limit: 2});
+    expect(result.results.length).toBeLessThanOrEqual(2);
+  });
+
+  it('rejects a missing query rather than searching for undefined', async () => {
+    await expect(tool('search').run({})).rejects.toThrow(/query/i);
+  });
+});
+
+describe('get', () => {
+  it('resolves a component to its full detail', async () => {
+    const result = await tool('get').run({name: 'Button'});
+    expect(result.kind).toBe('component');
+    expect(result.data.name).toBe('Button');
+  });
+
+  it('resolves a hook', async () => {
+    const result = await tool('get').run({name: 'useToast'});
+    expect(result.kind).toBe('hook');
+  });
+
+  it('resolves a doc topic', async () => {
+    const result = await tool('get').run({name: 'spacing'});
+    expect(result.kind).toBe('doc');
+  });
+
+  // Regression: component() fuzzy-matches, so resolving by "try each api in
+  // turn" answered get('spacing') with the Stack COMPONENT — a confidently
+  // wrong artifact. Domain now comes from search(), which tags every hit.
+  it('does not answer a doc topic with a fuzzy component match', async () => {
+    const result = await tool('get').run({name: 'spacing'});
+    expect(result.name).toBe('spacing');
+    expect(result.data.name).not.toBe('Stack');
+  });
+
+  // toHaveProperty('coreVersion') would pass even if the value were always
+  // null, which is the exact failure worth catching: reporting the version
+  // actually installed here is the whole reason a local server exists.
+  it('reports the real installed core version alongside the answer', async () => {
+    const result = await tool('get').run({name: 'Button'});
+    expect(result.coreVersion).toBe(readInstalledCoreVersion(REPO_ROOT));
+    expect(result.coreVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('fails with a message naming what it could not find', async () => {
+    await expect(
+      tool('get').run({name: 'DefinitelyNotAThing'}),
+    ).rejects.toThrow(/DefinitelyNotAThing/);
+  });
+});

--- a/packages/cli/clients/mcp/tools.test.mjs
+++ b/packages/cli/clients/mcp/tools.test.mjs
@@ -70,9 +70,22 @@ describe('search', () => {
   it('rejects a missing query rather than searching for undefined', async () => {
     await expect(tool('search').run({})).rejects.toThrow(/query/i);
   });
+
+  // The api validates limit loudly ("must be a positive integer"). A
+  // truthiness check here used to swallow limit: 0 and quietly serve the
+  // default 20 instead of letting that contract answer.
+  it('passes limit 0 through to the api validation instead of ignoring it', async () => {
+    await expect(
+      tool('search').run({query: 'button', limit: 0}),
+    ).rejects.toThrow(/positive integer/i);
+  });
 });
 
 describe('get', () => {
+  it('rejects a missing name rather than resolving undefined', async () => {
+    await expect(tool('get').run({})).rejects.toThrow(/name/i);
+  });
+
   it('resolves a component to its full detail', async () => {
     const result = await tool('get').run({name: 'Button'});
     expect(result.kind).toBe('component');
@@ -87,6 +100,22 @@ describe('get', () => {
   it('resolves a doc topic', async () => {
     const result = await tool('get').run({name: 'spacing'});
     expect(result.kind).toBe('doc');
+  });
+
+  it('resolves a template by its id', async () => {
+    const result = await tool('get').run({name: 'ai-chat'});
+    expect(result.kind).toBe('template');
+    expect(result.name).toBe('ai-chat');
+  });
+
+  // Search matches names case-insensitively, but template() resolves by exact
+  // dirName — so fetching with the caller's casing answered "Unknown template"
+  // for a template the server itself had just found. Fetch by the hit's own
+  // canonical name instead.
+  it('resolves a template whatever casing the model used', async () => {
+    const result = await tool('get').run({name: 'AI-CHAT'});
+    expect(result.kind).toBe('template');
+    expect(result.name).toBe('ai-chat');
   });
 
   // Regression: component() fuzzy-matches, so resolving by "try each api in
@@ -111,5 +140,25 @@ describe('get', () => {
     await expect(
       tool('get').run({name: 'DefinitelyNotAThing'}),
     ).rejects.toThrow(/DefinitelyNotAThing/);
+  });
+
+  it('names the closest matches when the name is near a real one', async () => {
+    await expect(tool('get').run({name: 'Buttonn'})).rejects.toThrow(
+      /Closest matches: .*Button/,
+    );
+  });
+
+  // Same dynamic-fixture pattern as api/docs tests: read a real section title
+  // off the detail, then ask for just that section.
+  it('returns just the asked section of a doc topic', async () => {
+    const detail = await tool('get').run({name: 'spacing'});
+    const sections = detail.data.sections;
+    expect(Array.isArray(sections) && sections.length > 0).toBe(true);
+    const result = await tool('get').run({
+      name: 'spacing',
+      section: sections[0].title,
+    });
+    expect(result.kind).toBe('doc');
+    expect(result.type).toBe('docs.detail.section');
   });
 });


### PR DESCRIPTION
## What this does

Adds `astryx mcp`, a Model Context Protocol server that runs locally over stdio. An AI assistant working inside a project can ask Astryx questions and get answers about **the version of Astryx that project actually has installed**.

```jsonc
// .mcp.json / .cursor/mcp.json / claude_desktop_config.json
{"mcpServers": {"astryx": {"command": "npx", "args": ["@astryxdesign/cli", "mcp"]}}}
```

## Why

The hosted server at `astryx.atmeta.com/mcp` reads registries baked into its bundle when the docs site deploys. It imports no `node:fs` and never reads `process.cwd()`, so it answers for whatever version was deployed and has no way to see the caller's theme or integration packages. A project pinned to an older release gets answers about a release it does not have.

## Read this first: this is deliberately not the shape the issue proposed

Issue #5134 proposes six tools, one per CLI command. This ships **two**, `search` and `get`, the same pair the hosted server already exposes.

The reason is deference to what shipped, and the history deserves stating accurately because it cuts both ways:

- #2306 was won by **CLI + search at 9.6/10**. No MCP variant won it.
- #2306's own "What We're Shipping" section recommended the **six-tool** server (#2228) — the shape this issue asks for.
- What actually happened was the reverse: #2228 was closed unmerged, and #2513 shipped the two-tool hybrid (9.3/10). On tokens the six-tool variant was in fact the cheaper of the two (17K vs 35K).

So two tools is what exists today, not what the bake-off crowned. This PR matches the shipped contract so that it does not smuggle in a new tool surface, but a maintainer preferring the six-tool shape has #2306 on their side, not against them.

Two further things to weigh before this goes anywhere:

- A local MCP server is not on either roadmap track in `packages/cli/CONTRIBUTING.md`.
- #2306 concluded MCP "improves distribution, not content quality", and #2228's stated motivation was agents "without needing the CLI installed". A local server, being a subcommand of the CLI you already installed, inverts that premise.

The argument #2306 did not test is cold-start discovery: MCP tools appear in an assistant's tool list on every request, instead of depending on it remembering to shell out. That is the open question, and it is why this is a draft.

## What changed

- **`packages/cli/clients/mcp/`** is a second client over `api/`, which is the arrangement `CONTRIBUTING.md` already describes as the point of the api/clients split ("the CLI is one consumer of it"). `api/` still imports nothing from `clients/`.
- **No new dependency.** MCP over stdio is newline-delimited JSON-RPC 2.0, so the transport is written here. `@modelcontextprotocol/sdk@1.29` pulls `express`, `hono`, `cors`, `jose` and `ajv` to serve HTTP and OAuth, none of which a stdio server speaks, and `@astryxdesign/cli` is published, so every consumer would inherit them. The workspace already carries a `@hono/node-server` security override because of that chain. `zod` was not an option either: it is sealed out of `packages/cli/clients/**` by eslint.
- **Project facts ride in the MCP `instructions` field** (installed core version, doctor's theme finding, configured integrations), so project-awareness needed no third tool.
- **`eslint.config.js`**: the `.mjs` un-ignore and the two CLI rule blocks named `clients/cli/**`, so a second client would have shipped with no lint, no copyright header and no `@astryx/no-raw-console-cli` guarding the protocol channel. ESLint's own words on the unfixed config: `all of the files matching the glob pattern packages/cli/clients/mcp are ignored`. Widened to `clients/**`.
- **`mcp` is exempt from the setup nudge**, for the same reason `--json` is. A client launches the server, so the nudge landed on stderr on every session, and it contradicted the feature: serving a project that never ran `astryx init` is the supported case.
- `mcp` is deliberately **not** in `JSON_SUPPORTED`, so `astryx mcp --json` is refused with `ERR_INVALID_OPTION` before any side effect. stdout carries the protocol, not an envelope.

### Three bugs worth calling out

`component()` and `hook()` share one resolver that fuzzy-matches, so `component('spacing')` returns the **Stack** component. Resolving `get` by trying each API in turn therefore answered a doc-topic request with a confidently wrong artifact. `get` now dispatches on the domain `search()` tags every hit with. There is a named regression test.

A self-review round caught two more of the same species, both living in untested seams. A batch member like `null` crashed the whole session — `isNotification(null)` threw, and the recovery path threw again reading `.id` off it, so one bad frame from a client ended the server; a non-object member now answers as an invalid request inside the batch reply. And `get` matched names case-insensitively but fetched with the caller's casing, while `template()` resolves by exact id — so `get("AI-CHAT")` answered "Unknown template" for a template `search` had just found; every fetch now uses the hit's canonical name. Both fixes landed test-first, with 14 new edge-case tests alongside them (junk batch members, CRLF endings, an unterminated final line, blank lines, primitive lines, a non-string method, a malformed core package.json, doc sections end to end).

One rough edge is deliberate: a template id that exists as both a page and a block surfaces the api's "narrow it with --type" message, which names flags an MCP caller does not have. The model's recourse is `search`; a dedicated disambiguation shape can wait for a real collision.

## How to see it

```
git checkout ak-5134-cli-mcp && pnpm install
printf '%s\n' \
  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"demo","version":"1"}}}' \
  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
| node packages/cli/clients/cli/bin/astryx.mjs mcp
```

Real output from this branch, trimmed:

```
initialize -> {"name":"astryx","version":"0.4.3"}  protocolVersion 2025-06-18
instructions ->
  Astryx design system, answering for THIS project rather than the latest published docs.
  Project: /path/to/your/project
  @astryxdesign/core: 0.4.3 (installed)
  Theme: No @astryxdesign/theme-* packages are installed.
tools/list -> ["search","get"]
stderr -> (empty)
```

The `notifications/initialized` line correctly produces no reply.

## Verification

`packages/cli` had **9 failing tests across 4 files on untouched `upstream/main` 551a8de8d** before this branch: two from a case-insensitive filesystem, two needing built theme dists, five from a relative `packages/core/src` path. After this change the same 9 fail and **2781 pass, up from 2707**.

`typecheck:strict` reports 10 errors, verified identical to a stashed-pristine run (all `TS2307` for unbuilt `@astryxdesign/lab` / `charts`, the condition `CONTRIBUTING.md` documents). `typecheck:json-api` clean. `CI=true` eslint clean across all 12 new files. `check:repo` 8/8. `cli-json-smoke-test` 11/11. `api-cli-parity-test` 335 cases, 0 failures. README regenerated via `pnpm readme`.

stdout purity is the load-bearing invariant, so it is proved by spawning the real binary rather than by inspection. It was mutation-verified too: writing a single banner line to stdout fails all four end-to-end tests.

## Not in this PR

Following the issue's own sequencing: `init` writing the MCP client config, `working-with-ai` doc updates, and project-aware or side-effecting tools (`upgrade`, `init`) that wait on their `api/` extractions. No change to the hosted server.

Refs #5134

