### PR TITLE
docs(banner): backfill two missing dense best-practice bullets

### DIFF
--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -221,6 +221,8 @@ export const docsDense = {
       {guidance: true, description: 'Keep titles short: "Payment failed" not "There was a problem processing your payment."'},
       {guidance: false, description: 'Use for auto-dismissing messages; use Toast instead.'},
       {guidance: false, description: 'Stack multiple banners of the same status; combine into one.'},
+      {guidance: true, description: 'Error/warning render role="alert", info/success role="status"; mount an alert banner on an event, not first paint, so assistive tech announces it.'},
+      {guidance: false, description: 'Rely on status color or icon alone; state the status in the title text, since the icon is decorative to a screen reader.'},
     ],
     anatomy: [
       {name: 'Icon', required: true, description: 'Set automatically from status.'},


### PR DESCRIPTION
## What

The English `usage.bestPractices` on Banner has 8 entries, but the `docsDense` overlay had only 6. The dense overlay covered the first six English bullets in order and stopped, so `astryx component Banner --lang dense` silently dropped the last two:

- the accessibility bullet (`role="alert"` vs `role="status"`, mount an alert banner on an event rather than first paint)
- the color-alone anti-pattern (state the status in the title text; the icon is decorative to a screen reader)

The English list grew in #5096 without the dense overlay being extended, so the check-13 count-parity rule (dense must match English length, order, and per-position guidance flag) started failing.

This adds compressed versions of both bullets, preserving English order and the `guidance` true/false flags 1:1. No English or Chinese prose changes.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `astryx component Banner --lang dense` renders both bullets (Do/Don't) in order
- [x] Dense bestPractices count now matches English (8 vs 8), guidance flags aligned

---
Night Watch — Doc Reviewer