### PR TITLE
audit(Blockquote): drop the contentinfo landmark, guard the cite slot, wrap long words

### DIFF
--- a/.changeset/blockquote-attribution-landmark.md
+++ b/.changeset/blockquote-attribution-landmark.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Blockquote: the `cite` attribution renders as a bare `<cite>` instead of being wrapped in a `<footer>`, which was becoming a `contentinfo` document landmark. Also guards the slot with `isRenderable`, so `cite={condition && author}` no longer emits an empty `<cite>`, and wraps long unbroken words instead of overflowing.
+
+@cixzhang

--- a/apps/storybook/stories/Blockquote.stories.tsx
+++ b/apps/storybook/stories/Blockquote.stories.tsx
@@ -1,11 +1,27 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
 import {Blockquote} from '@astryxdesign/core/Blockquote';
 import {Card} from '@astryxdesign/core/Card';
 import {Section} from '@astryxdesign/core/Section';
 import {VStack} from '@astryxdesign/core/Layout';
 import {Text} from '@astryxdesign/core/Text';
+import {
+  spacingVars,
+  typeScaleVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  pullQuote: {
+    fontSize: typeScaleVars['--text-large-size'],
+    lineHeight: typeScaleVars['--text-large-leading'],
+    marginBlock: spacingVars['--spacing-4'],
+  },
+  narrow: {
+    maxWidth: '280px',
+  },
+});
 
 const meta: Meta<typeof Blockquote> = {
   title: 'Core/Blockquote',
@@ -100,6 +116,58 @@ export const MultipleParagraphs: Story = {
               hardware.
             </Text>
           </VStack>
+        </Blockquote>
+      </Card>
+    </Section>
+  ),
+};
+
+export const PullQuoteWithXstyle: Story = {
+  render: () => (
+    <Section variant="muted">
+      <Card>
+        <VStack gap={3}>
+          <Text type="body">
+            xstyle carries layout and type overrides onto the blockquote itself,
+            with no wrapper element.
+          </Text>
+          <Blockquote cite="Alan Kay" xstyle={styles.pullQuote}>
+            The best way to predict the future is to invent it.
+          </Blockquote>
+        </VStack>
+      </Card>
+    </Section>
+  ),
+};
+
+export const LongContent: Story = {
+  render: () => (
+    <Section variant="muted">
+      <Card>
+        <VStack gap={3}>
+          <Blockquote cite="A source with a notably long attribution line that has to wrap">
+            A long quotation that runs past a single line, so the rule on the
+            inline-start edge and the wrapped text stay aligned all the way
+            down. Long attributions wrap the same way underneath.
+          </Blockquote>
+          <Blockquote>
+            An unbroken token such as
+            https://www.example.com/research/2026/design-systems/the-very-long-report-slug/appendix
+            wraps instead of overflowing.
+          </Blockquote>
+        </VStack>
+      </Card>
+    </Section>
+  ),
+};
+
+export const NarrowContainer: Story = {
+  render: () => (
+    <Section variant="muted">
+      <Card xstyle={styles.narrow}>
+        <Blockquote cite="Steve Jobs">
+          Design is not just what it looks like and feels like. Design is how it
+          works.
         </Blockquote>
       </Card>
     </Section>

--- a/packages/core/src/Blockquote/Blockquote.doc.mjs
+++ b/packages/core/src/Blockquote/Blockquote.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
     {
       name: 'cite',
       type: 'ReactNode',
-      description: 'Optional attribution for the quote. Rendered in a <footer> with <cite>.',
+      description: 'Optional attribution for the quote. Rendered in a <cite> element after the quoted content.',
     },
     {
       name: 'xstyle',
@@ -28,17 +28,31 @@ export const docs = {
         'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.',
     },
   ],
+  playground: {
+    defaults: {
+      children:
+        'Design is not just what it looks like and feels like. Design is how it works.',
+      cite: 'Steve Jobs',
+    },
+  },
   theming: {
     targets: [
       {className: 'astryx-blockquote', visualProps: []},
     ],
   },
   usage: {
-    description: 'A styled quotation block with an accent-colored left border and secondary text color. Use to highlight quoted content, testimonials, or excerpts.',
+    description: 'A quotation block with a rule on its inline-start edge and secondary text color. Use to highlight quoted content, testimonials, or excerpts. The rule and padding are logical, so they move to the right edge in right-to-left locales.',
+    anatomy: [
+      {name: 'Rule', required: true, description: 'The border on the inline-start edge, drawn with --color-border-emphasized.'},
+      {name: 'Quotation', required: true, description: 'The quoted content, passed as children. Renders inside the <blockquote> element.'},
+      {name: 'Attribution', required: false, description: 'The source, passed as cite. Renders as a <cite> element below the quotation.'},
+    ],
     bestPractices: [
       { guidance: true, description: 'Use for quoted text, testimonials, or highlighted excerpts from external sources.' },
       { guidance: true, description: 'Provide a cite prop when the source of the quote is known.' },
+      { guidance: true, description: 'Pass the source through cite rather than typing it into children, so it renders as a semantic <cite> element that assistive technology can distinguish from the quotation.' },
       { guidance: false, description: 'Use for callout boxes or informational notes; use Banner for those.' },
+      { guidance: false, description: 'Wrap the attribution in your own <footer>. A <footer> inside a <blockquote> becomes a contentinfo document landmark, and a page with several quotes then reports several page footers.' },
     ],
   },
 };
@@ -57,7 +71,7 @@ export const docsZh = {
     {
       name: 'cite',
       type: 'ReactNode',
-      description: '引用的可选出处。在 <footer> 中以 <cite> 渲染。',
+      description: '引用的可选出处。在引用内容之后以 <cite> 元素渲染。',
     },
     {
       name: 'xstyle',
@@ -72,29 +86,38 @@ export const docsZh = {
     ],
   },
   usage: {
-    description: '带有强调色左边框和次要文本颜色的引用块。用于突出显示引用内容、推荐语或摘录。',
+    description: '带有行首边框和次要文本颜色的引用块。用于突出显示引用内容、推荐语或摘录。边框和内边距使用逻辑属性，因此在从右到左的语言环境中会移到右侧。',
+    anatomy: [
+      {name: '边框', required: true, description: '行首边缘的边框，使用 --color-border-emphasized 绘制。'},
+      {name: '引用内容', required: true, description: '通过 children 传入的引用内容，渲染在 <blockquote> 元素内。'},
+      {name: '出处', required: false, description: '通过 cite 传入的来源，在引用内容下方以 <cite> 元素渲染。'},
+    ],
     bestPractices: [
       { guidance: true, description: '用于引用文本、推荐语或来自外部来源的高亮摘录。' },
       { guidance: true, description: '当引用来源已知时，提供 cite 属性。' },
+      { guidance: true, description: '通过 cite 传入来源，而不是写在 children 里，这样它会渲染为语义化的 <cite> 元素，辅助技术可以将其与引用内容区分开。' },
       { guidance: false, description: '用于提示框或信息说明，应使用 Banner。' },
+      { guidance: false, description: '自行用 <footer> 包裹出处。<blockquote> 内的 <footer> 会成为 contentinfo 文档地标，页面上有多个引用时就会报告多个页脚。' },
     ],
   },
 };
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
-  description: 'styled quotation block w/ accent left border, secondary text, optional citation',
+  description: 'quotation block w/ inline-start rule, secondary text, optional citation',
   usage: {
-    description: 'A styled quotation block with an accent-colored left border and secondary text color. Use to highlight quoted content, testimonials, or excerpts.',
+    description: 'A quotation block with a rule on its inline-start edge and secondary text color. Use to highlight quoted content, testimonials, or excerpts.',
     bestPractices: [
       { guidance: true, description: 'Use for quoted text, testimonials, or highlighted excerpts.' },
       { guidance: true, description: 'Provide cite when source is known.' },
+      { guidance: true, description: 'Pass the source via cite, not inside children.' },
       { guidance: false, description: 'Use for callouts/notes; use Banner instead.' },
+      { guidance: false, description: 'Wrap the attribution in <footer>; it becomes a contentinfo landmark.' },
     ],
   },
   propDescriptions: {
     children: 'blockquote content',
-    cite: 'optional attribution rendered in <footer><cite>',
+    cite: 'optional attribution rendered as <cite> after the quote',
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/Blockquote/Blockquote.test.tsx
+++ b/packages/core/src/Blockquote/Blockquote.test.tsx
@@ -11,6 +11,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
+import {renderToString} from 'react-dom/server';
 import {Blockquote} from './Blockquote';
 
 describe('Blockquote', () => {
@@ -31,7 +32,6 @@ describe('Blockquote', () => {
   it('renders without cite by default', () => {
     render(<Blockquote data-testid="bq">Quote</Blockquote>);
     const element = screen.getByTestId('bq');
-    expect(element.querySelector('footer')).toBeNull();
     expect(element.querySelector('cite')).toBeNull();
   });
 
@@ -42,11 +42,32 @@ describe('Blockquote', () => {
       </Blockquote>,
     );
     const element = screen.getByTestId('bq');
-    const footer = element.querySelector('footer');
-    expect(footer).toBeInTheDocument();
     const cite = element.querySelector('cite');
     expect(cite).toBeInTheDocument();
     expect(cite).toHaveTextContent('Steve Jobs');
+  });
+
+  it('never wraps the attribution in a landmark element', () => {
+    render(
+      <Blockquote cite="Steve Jobs" data-testid="bq">
+        Quote
+      </Blockquote>,
+    );
+    const element = screen.getByTestId('bq');
+    expect(element.querySelector('footer')).toBeNull();
+    expect(screen.queryByRole('contentinfo')).toBeNull();
+  });
+
+  it.each([
+    ['false', false],
+    ['an empty string', ''],
+  ])('renders no cite element when cite is %s', (_label, cite) => {
+    render(
+      <Blockquote cite={cite} data-testid="bq">
+        Quote
+      </Blockquote>,
+    );
+    expect(screen.getByTestId('bq').querySelector('cite')).toBeNull();
   });
 
   it('renders cite as ReactNode', () => {
@@ -86,5 +107,15 @@ describe('Blockquote', () => {
       </Blockquote>,
     );
     expect(screen.getByTestId('child-p')).toBeInTheDocument();
+  });
+
+  it('renders on the server', () => {
+    const html = renderToString(
+      <Blockquote cite="Steve Jobs">Design is how it works.</Blockquote>,
+    );
+    expect(html).toContain('<blockquote');
+    expect(html).toContain('astryx-blockquote');
+    expect(html).toContain('<cite');
+    expect(html).toContain('Steve Jobs');
   });
 });

--- a/packages/core/src/Blockquote/Blockquote.tsx
+++ b/packages/core/src/Blockquote/Blockquote.tsx
@@ -17,7 +17,7 @@ import type {ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {isRenderable, mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 
 export interface BlockquoteProps extends BaseProps<HTMLQuoteElement> {
@@ -26,7 +26,8 @@ export interface BlockquoteProps extends BaseProps<HTMLQuoteElement> {
   /** Content of the blockquote */
   children: ReactNode;
   /**
-   * Optional attribution for the quote. Rendered in a <footer> with <cite>.
+   * Optional attribution for the quote. Rendered in a `<cite>` element after
+   * the quoted content.
    */
   cite?: ReactNode;
 }
@@ -38,6 +39,7 @@ const styles = stylex.create({
     borderInlineStartColor: colorVars['--color-border-emphasized'],
     paddingInlineStart: spacingVars['--spacing-4'],
     color: colorVars['--color-text-secondary'],
+    overflowWrap: 'break-word',
     marginInlineStart: 0,
     marginInlineEnd: 0,
     marginBlockStart: 0,
@@ -55,8 +57,8 @@ const styles = stylex.create({
 /**
  * Blockquote component for displaying quoted content.
  *
- * Renders a semantic `<blockquote>` with an accent-colored left border
- * and secondary text color, matching the Astryx visual language.
+ * Renders a semantic `<blockquote>` with an inline-start rule and secondary
+ * text color, matching the Astryx visual language.
  *
  * @example
  * ```
@@ -83,11 +85,11 @@ export function Blockquote({
       )}
       {...props}>
       {children}
-      {cite != null && (
-        <footer>
-          <cite {...stylex.props(styles.cite)}>{cite}</cite>
-        </footer>
-      )}
+      {/*
+        A bare <cite>, never wrapped in <footer>: <blockquote> is a sectioning
+        root, so a <footer> inside it maps to a contentinfo document landmark.
+      */}
+      {isRenderable(cite) && <cite {...stylex.props(styles.cite)}>{cite}</cite>}
     </blockquote>
   );
 }


### PR DESCRIPTION
Nightly component audit of `core/Blockquote` against [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) **v1.4**, at `b3dd679619`.

| | Score | Grade | Open BLOCKs |
|---|---|---|---|
| Before | 79.7 | C | 1 |
| After | 89.4 | B | 0 |

Pre-fix score is already in the ledger: [`ed9b5538e2`](https://github.com/facebook/astryx/wiki/_compare/ed9b5538e273a33c0247a76e2d1b852b77f3343a). **The post-fix score is not recorded yet**; it is held until this PR is on `main`, and will be written then.

Blockquote is 95 source lines with two props. Most of the rubric does not apply to it, so four sections fall under the one-third non-vacuous threshold and are marked `limited` with their weight redistributed: a11y (3 of 19 items produce a verdict), code health (4 of 21), i18n and RTL (5 of 18), responsive (2 of 11). Sections were not padded to fill the night, and inapplicable items are N/A rather than scored as passes.

## What moved

| Section | Before | After | Why |
|---|---|---|---|
| §1 Accessibility (`limited`) | 3.0 | 4.5 | The `contentinfo` landmark is gone |
| §4 Behavior | 3.5 | 4.5 | Overflow fixed, adversarial finding fixed |
| §6 Testing | 3.5 | 4.5 | Server render asserted, 8 tests to 12 |
| §7 Code health (`limited`) | 3.5 | 5.0 | `isRenderable` replaces the bare nullish guard |
| §8 Docs | 3.0 | 4.5 | Six doc gaps closed, prose corrected |
| §9 i18n and RTL (`limited`) | 4.5 | 4.5 | Long-string story now exists |
| §10 Responsive (`limited`) | 4.0 | 4.5 | No overflow at 320px, narrow story added |

§2 Theming 4.5, §3 API 4.5, §5a 4.5 and §5b 4.0 are unchanged.

## Fixed

### The attribution rendered a `contentinfo` document landmark (BLOCK, §1 A2)

`Blockquote.tsx:87` wrapped the `cite` attribution in a bare `<footer>`. `<blockquote>` is a sectioning root, not sectioning content, so HTML-AAM does not scope that `<footer>` away: it maps to a `contentinfo` landmark, the "footer of the document" landmark.

Measured in Chromium through CDP `Accessibility.getFullAXTree`: three quotes carrying `cite` produced three non-ignored `role=contentinfo` nodes. On a page that also has a real footer, axe reports two violations and the node it prints is Blockquote's own `<footer>`:

```
landmark-no-duplicate-contentinfo (moderate)
  <footer><cite class="astryx1lliihq ...
landmark-unique (moderate)
  <footer><cite class="astryx1lliihq ...
```

The victim is not hypothetical. `packages/cli/assets/templates/blocks/components/Blockquote/BlockquoteTestimonials.tsx` ships three quotes with `cite` in one block, and that is the code consumers copy.

`pnpm a11y:audit --components Blockquote` was green before this PR and is green after it. It missed this because every Blockquote story rendered a single isolated quote, so no second landmark existed for the duplicate rule to fire against. That is the §6 3/5 anchor exactly: axe green partly because the stories are too thin to reach the interesting states.

Fix: render the `<cite>` directly. After, `Accessibility.getFullAXTree` reports **0** `contentinfo` nodes, and the two axe landmark violations are gone. The rendered geometry is byte-identical: root rect `x40 y40 w820 h52` and cite rect `x58 y72 w802 h20` before and after, with `margin-block-start: 8px` on the cite unchanged, because the `<footer>` carried no border or padding and the cite's margin was collapsing through it.

### A falsy `cite` emitted an empty `<cite>` (FIX, §7 C12)

`cite != null` passes for `false`, `true` and `''`, so the ordinary consumer shape `cite={condition && author}` rendered `<footer><cite></cite></footer>`. `@astryx/no-nullish-jsx-guard` already flagged `Blockquote.tsx:86` and named the remedy; the rule is `warn` in both lint tiers, so nothing failed on it.

Now guarded with `isRenderable`. Measured after: `cite={false}` and `cite=""` both render `innerHTML` of just the quote, with no `<cite>` element. Rendered height was 0 either way, so this was DOM and accessibility-tree noise rather than a visible gap. `lint:strict` warnings go from 56 to 55 and Blockquote no longer appears.

### A long unbroken word overflowed its own box (FIX, §4 B10, §10 R1)

At a 320px viewport a 107-character word gave the blockquote `scrollWidth 813` against `clientWidth 238`; a long URL gave `373` against `238`. No document-level horizontal scroll, so this was cosmetic overflow rather than an unreachable control. `overflow-wrap` resolved to `normal`, while `Markdown`, `Code`, `ChatMessageBubble` and `Tooltip` all set `break-word` on their long-form text.

Now `overflowWrap: 'break-word'` on the root. Measured after, both cases: `scrollWidth 238` equals `clientWidth 238`, no overflow.

### No server render test after #4407 (FIX, §6 V12)

[#4407](https://github.com/facebook/astryx/pull/4407) dropped `'use client'` from this file and nothing asserted the result. Verified with a real `renderToString` that it does render on the server, and added that as a test rather than leaving the claim to `check-use-client.mjs`.

### Docs (FIX, §8 X3, X4, X10, X11, X12, X16)

- The overview said "accent-colored left border". The rule is `--color-border-emphasized`, a neutral border token measuring `rgb(212,212,212)` in light and `rgb(82,82,82)` in dark, and it is a logical inline-start border that moves to the right edge in RTL. Corrected in the English, Chinese and dense docs and in the component JSDoc.
- `usage.anatomy` was absent (X4). Added, with the three parts.
- One "don't" where the convention is two or more (X3). Added a second, and a third "do" carrying accessibility guidance (X16), including not to re-wrap the attribution in a `<footer>`.
- `xstyle` was documented but no story touched it, so prop-to-story coverage was 2 of 3 (X10). A pull-quote story now exercises it.
- No long-text, narrow-container or overflow story (X11, X12, §10 R11). Added `LongContent` and `NarrowContainer`. The a11y and RTL sweeps only see what a story renders.
- `playground.defaults` was absent on a component whose `children` are required, so the playground opened blank (X19). Added.

## Needs review

Everything below is a decision rather than a correction, so this pass did not touch it.

**The attribution still sits inside the `<blockquote>`.** The HTML spec says attribution "must be placed outside the blockquote element", with `<figure>` plus `<figcaption>` as the worked example. The accessibility tree confirms the consequence: the blockquote subtree exposes both the quotation StaticText and "Steve Jobs". Moving to a figure changes the rendered structure and the component's theming surface, which is an API decision.

**`cite` reuses a native attribute name with a different meaning (§3 P33, NIT).** `<blockquote cite>` is natively a URL pointing at the source. Here `cite` is a `ReactNode` rendered as visible text. `BaseProps` extends `React.HTMLAttributes`, which never carried `cite`, so there is nothing to `Omit` and no type collision, but there is also no way for a consumer to set the standards-correct source URL. P33's remedy is to keep the semantic name, and `cite` is not a semantic name distinct from the attribute, it is the attribute name. Renaming a public prop or adding one is not a fix-pass call.

**The attribution is a raw `<cite>` rather than `Text as="cite"` (§2 T29).** Composing `Text` would give the attribution the system's supporting-text treatment and a second theme target. It would also add `astryx-text` to the rendered classes, which changes the theming surface.

**The rule's width comes from `spacingVars['--spacing-0-5']` (§2 T3, NIT).** It is a token, but a spacing token used as a border width. `borderVars['--border-width']` exists and is 1px, and the design here wants 2px, so closing this properly means adding a border-width token, which is a system decision. `Section.tsx:95` uses a raw `1` for the same job, so the house is not consistent today either.

**Measure runs past 75ch.** At the story's 820px width and 16px body the line is roughly 102 characters, above the §5a D6 guideline. `Text` sets no measure either, so this is a system-level layout question rather than a Blockquote defect.

**No `play:` functions in the stories (§6 V14, NIT).** There is no interactive flow to exercise.

## Not scored against this component

`defineTheme` component overrides do not reach Blockquote. Injecting the exact CSS `generateThemeCSS` emits, `@layer astryx-theme { @scope([data-astryx-theme="neutral"]) to ([data-astryx-theme]) { .astryx-blockquote { ... } } }`, changes nothing: `color`, `border-inline-start-color` and `padding-inline-start` all keep their StyleX values. The identical rule with the `@layer` wrapper removed wins all three. The page carries two disjoint layer statements, `@layer reset, astryx-base, astryx-theme, product;` and `@layer priority1;`.

That is [#5095](https://github.com/facebook/astryx/issues/5095), found by last night's Banner audit and reproduced here on a structurally unrelated component. It is not a Blockquote defect and is not scored.

Token-level theming does reach the component: under the `y2k` theme the rule moves to 3px, padding to 24px, and both colours change.

## Evidence

Screenshots: all 26 after and 22 before captures live on the orphan branch [`assets/pr-5144`](https://github.com/facebook/astryx/tree/assets/pr-5144), under `before/` and `after/`, alongside the raw `measurements.json` for each pass.

**The landmark fix is visually a no-op.** Root rect `x40 y40 w820 h52` and cite rect `x58 y72 w802 h20`, identical before and after.

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/before/Blockquote__withCitation__rest__light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__withCitation__rest__light.png) |
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/before/Blockquote__withCitation__rest__dark.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__withCitation__rest__dark.png) |

**Long unbroken word at 320px.** `scrollWidth 813` against `clientWidth 238`, then `238` against `238`.

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/before/Blockquote__edge__longWord__320.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__edge__longWord__320.png) |

**Long URL at 320px.** `373` against `238`, then `238` against `238`.

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/before/Blockquote__edge__longUrl__320.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__edge__longUrl__320.png) |

**`cite={condition && author}` with the condition false.** An empty `<cite>` in the DOM, then no element at all.

| Before | After |
|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/before/Blockquote__edge__citeOnlyFalsy__light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__edge__citeFalsy__light.png) |

**RTL and the `y2k` custom theme**, unchanged by this PR and captured to show they stay correct.

| RTL before | RTL after | y2k before | y2k after |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/before/Blockquote__withCitation__rest__rtl.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__withCitation__rest__rtl.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/before/Blockquote__withCitation__rest__y2k.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__withCitation__rest__y2k.png) |

**New stories.**

| Pull quote via `xstyle` | Long content | Narrow container |
|---|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__pull-quote-with-xstyle__rest__light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__long-content__rest__light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5144/after/Blockquote__narrow-container__rest__light.png) |


Also measured, without a picture:

- **Contrast.** Light: text and cite `rgb(82,82,82)` on `rgb(255,255,255)` is 7.81:1. Dark: `rgb(163,163,163)` on `rgb(27,27,27)` is 6.83:1. Both clear WCAG AA for body text. The decorative rule is 1.48:1 light and 2.20:1 dark, which carries no text or control requirement.
- **Type.** Body 16px with line-height 1.5; cite 12px with line-height 1.67, exactly at the legibility floor rather than below it. The 16-to-12 step is 1.33x, above the scale ratio.
- **RTL.** Under `dir=rtl` the rule moves to the right edge: `border-left 0px`, `border-right 2px`, `padding-left 0px`, `padding-right 16px`. `pnpm rtl:audit --filter Blockquote` is 0 fail, 0 surprise.
- **Custom theme.** `y2k` renders at 3px rule, 24px padding, `rgb(103,93,82)` text.

## Checks

- `pnpm lint:strict`: 0 errors, 55 warnings, down from 56, with no Blockquote line.
- `pnpm test`: 2 failed, 10571 passed. Both failures are `packages/cli` case-insensitive-filesystem tests (`component.test.mjs` name resolution, `hook-discovery.test.mjs`) that fail identically on `b3dd679619` with these changes stashed. Blockquote's own suite goes from 8 tests to 12, all green.
- `pnpm build`: exit 0.
- `pnpm a11y:audit --components Blockquote`: 0 violations across all 8 stories, 0 new baseline entries.
- `pnpm rtl:audit --filter Blockquote`: 0 fail, 0 surprise.
- `pnpm check:sync`, `check:changesets`, `check-use-client.mjs`, `sync-exports --check`, `typecheck:docs`, docsite `generate` and `test`: all clean.

## §5b is graded numerically

The judgment rows (D3, D13, D15, D16) were assessed from measured geometry, computed contrast ratios, token signatures and the resolved type scale, not by looking at the images. That caps §5b at 4 of 5, as it has been for every previous run.

Night Watch — Component Auditor
