### PR TITLE
fix(core): keep tooltip status button interactive in TextArea trailing slot

### DIFF
--- a/.changeset/textarea-tooltip-status-pointer-events.md
+++ b/.changeset/textarea-tooltip-status-pointer-events.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Inputs (`statusVariant="tooltip"`): the focusable status button now opens its tooltip on hover inside `TextArea`, whose absolutely-positioned trailing slot is `pointer-events: none`. Keyboard focus already worked; pointer hover did not.
+
+@freddymeta

--- a/packages/core/src/hooks/useInputStatusIcon.test.tsx
+++ b/packages/core/src/hooks/useInputStatusIcon.test.tsx
@@ -159,6 +159,25 @@ describe('useInputStatusIcon — no dangling aria-describedby (WCAG 1.3.1)', () 
     ).not.toBeInTheDocument();
     expectNoDanglingDescribedBy(container);
   });
+
+  it('keeps the tooltip status button interactive inside a non-interactive trailing slot', () => {
+    // TextArea positions its trailing slot as an absolute overlay with
+    // `pointer-events: none` (correct for the decorative spinner/icon it was
+    // built for). The focusable status button owns its own interactivity so
+    // hover still opens the tooltip there — keyboard focus always worked, the
+    // pointer path did not until the button set `pointer-events: auto`.
+    render(
+      <TextArea
+        label="Field"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Message'}}
+        statusVariant="tooltip"
+      />,
+    );
+    const statusButton = screen.getByRole('button', {name: 'Error details'});
+    expect(statusButton).toHaveStyle({pointerEvents: 'auto'});
+  });
 });
 
 describe('useInputStatusIcon — input-status-icon theme target', () => {

--- a/packages/core/src/hooks/useInputStatusIcon.tsx
+++ b/packages/core/src/hooks/useInputStatusIcon.tsx
@@ -82,6 +82,13 @@ const styles = stylex.create({
     background: 'none',
     color: 'inherit',
     cursor: 'pointer',
+    // Own the interactivity so the tooltip opens on hover even when the field
+    // renders this affordance inside a non-interactive trailing slot. TextArea
+    // positions its end slot as an absolute overlay with `pointer-events: none`
+    // (right for the decorative spinner/icon it was built for), which otherwise
+    // swallows this button's hover — keyboard focus still worked, pointer did
+    // not.
+    pointerEvents: 'auto',
     borderRadius: radiusVars['--radius-full'],
     // Not the shared offset: this button sits inside the field, and measured at
     // the standard 3px its ring crosses the field border.


### PR DESCRIPTION
## Summary

When an input's `statusVariant="tooltip"`, the on-field status icon becomes a focusable `<button>` that reveals the status message on hover, keyboard focus, or tap (via `useInputStatusIcon`). In `TextArea`, hover never opened that tooltip — only keyboard focus did.

**Root cause:** `TextArea` is multi-line, so it positions its trailing content (`endSlot`) as an absolute overlay with `pointer-events: none` — correct for the decorative spinner and the plain status icon it was originally built for, but it also swallowed pointer events for the *interactive* tooltip button introduced with the tooltip status variant. The single-line inputs render the status affordance in normal flow, so they were unaffected.

**Fix:** the status button now declares `pointer-events: auto` on itself in `useInputStatusIcon`, so the interactive control owns its own interactivity regardless of the slot it's rendered into. This fixes `TextArea` and is inert for every other input (they never disabled pointer events on the slot).

## Test plan

- `pnpm -F @astryxdesign/core test` — `useInputStatusIcon` and `TextArea` suites pass. Added a test asserting the tooltip status button resolves to `pointer-events: auto` inside `TextArea`.
- `pnpm -F @astryxdesign/core typecheck` / `eslint` — clean.
- No API or markup change; a11y behavior (focusable button, tab order, focus ring, described-by wiring) is unchanged — only the pointer path is restored.
