### PR TITLE
fix(core): animate the Dialog exit

### DIFF
--- a/.changeset/dialog-exit-animation.md
+++ b/.changeset/dialog-exit-animation.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Dialog: animates out instead of vanishing in a single frame — the entrance played in reverse, with the scrim fading on the same curve. Reduced motion still closes instantly.
+
+@cixzhang

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -29,6 +29,7 @@ import {
   useId,
   useMemo,
   useRef,
+  useState,
   type ReactNode,
 } from 'react';
 import type {BaseProps} from '../BaseProps';
@@ -153,6 +154,25 @@ export const dialogFullscreenSafeAreaPaddingContract = {
   },
 } as const;
 
+// The entrance run backwards, so the dialog retreats toward the element that
+// opened it (motion docs: "when you do animate exit, match the entrance").
+const exitDirectional = stylex.keyframes({
+  from: {opacity: 1, transform: 'translate(0, 0) scale(1)'},
+  to: {
+    opacity: 0,
+    transform:
+      'translate(var(--dialog-dir-x, 0px), var(--dialog-dir-y, 16px)) scale(0.95)',
+  },
+});
+
+// The scrim leaves on the same curve as the panel. Without this it stays
+// opaque for the whole exit and then snaps, which reads as a grey flash after
+// the dialog has already faded out.
+const exitBackdrop = stylex.keyframes({
+  from: {opacity: 1},
+  to: {opacity: 0},
+});
+
 /**
  * Dialog styles using native <dialog> element
  * Uses ::backdrop pseudo-element for overlay
@@ -175,6 +195,11 @@ const styles = stylex.create({
     animationDuration: durationVars['--duration-medium-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards' as const,
+    // Read back by resolveExitDelay() to time dialog.close() to the end of the
+    // slide-out. Declared here (not only in `exiting`) so the value is
+    // readable from the still-open dialog, and as a token so a theme that
+    // retimes its motion scale retimes the close with it.
+    '--dialog-exit-duration': durationVars['--duration-medium-min'],
   },
   // Applied via isOpen prop — avoids :where([open]) attribute selectors
   // which have zero specificity and can lose to default styles depending
@@ -188,6 +213,29 @@ const styles = stylex.create({
     animationName: {
       default: enterDirectional,
       '@media (prefers-reduced-motion: reduce)': 'none',
+    },
+  },
+  // Applied while the dialog is closing: `isOpen` has already gone false, so
+  // `open` is off and the element would otherwise be display:none in the same
+  // frame. Keeps it rendered for the length of the slide-out.
+  exiting: {
+    display: 'flex',
+    animationName: {
+      default: exitDirectional,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
+    animationDuration: 'var(--dialog-exit-duration)',
+    // `both`: hold the entrance's end state until the first frame runs, and
+    // the faded-out state after it, so neither edge flashes at full opacity.
+    animationFillMode: 'both' as const,
+    '::backdrop': {
+      animationName: {
+        default: exitBackdrop,
+        '@media (prefers-reduced-motion: reduce)': 'none',
+      },
+      animationDuration: 'var(--dialog-exit-duration)',
+      animationTimingFunction: easeVars['--ease-standard'],
+      animationFillMode: 'both' as const,
     },
   },
   // Backdrop using ::backdrop pseudo-element
@@ -295,6 +343,54 @@ const dynamicStyles = stylex.create({
  */
 function formatPosition(value: number | string): string {
   return typeof value === 'number' ? `${value}px` : value;
+}
+
+// =============================================================================
+// Close timing
+// =============================================================================
+
+/** Longest the dialog stays modal after `isOpen` goes false, whatever the theme asks for. */
+const MAX_EXIT_DELAY_MS = 400;
+
+/**
+ * `--dialog-exit-duration` in ms; null when it can't be read as a duration.
+ *
+ * Custom properties are not normalised on read, so this comes back as authored
+ * (`"310ms"`), and a theme is free to author seconds instead. Outside a real
+ * browser the declaration doesn't exist and the value is the empty string.
+ *
+ * @internal Exported for unit tests.
+ */
+export function parseExitDurationMs(value: string): number | null {
+  const trimmed = value.trim();
+  const ms = Number.parseFloat(trimmed);
+  if (!Number.isFinite(ms)) {
+    return null;
+  }
+  return trimmed.endsWith('ms') ? ms : trimmed.endsWith('s') ? ms * 1000 : null;
+}
+
+/**
+ * How long to hold the open `<dialog>` so the exit animation can play.
+ *
+ * Zero — close in the same tick, exactly as the dialog behaved before there
+ * was an exit animation — whenever there is no animation to wait for: reduced
+ * motion, a theme that zeroes the duration, or a context where the property
+ * can't be read at all (jsdom, an unresolved `var()`). Degrading to the old
+ * instant close is always safe here; unlike MobileNav's `display` hold, an
+ * early close only costs the animation, it can't strand the page inert.
+ */
+function resolveExitDelay(dialog: HTMLDialogElement): number {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return 0;
+  }
+  const duration = parseExitDurationMs(
+    window.getComputedStyle(dialog).getPropertyValue('--dialog-exit-duration'),
+  );
+  if (duration === null || duration <= 0) {
+    return 0;
+  }
+  return Math.min(MAX_EXIT_DELAY_MS, duration);
 }
 
 /**
@@ -495,6 +591,19 @@ export function Dialog({
   // for directional animation origin and focus restoration on close.
   const triggerElementRef = useRef<HTMLElement | null>(null);
 
+  // `isOpen` has gone false but the dialog is still on screen, playing its
+  // exit animation. Derived during render rather than in an effect: the exit
+  // style has to land in the same commit that drops `open`, or the dialog
+  // blinks out for a frame before it starts animating (measured: one frame at
+  // display:none, then the fade).
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  const [isExiting, setIsExiting] = useState(false);
+  if (wasOpen !== isOpen) {
+    setWasOpen(isOpen);
+    setIsExiting(wasOpen);
+  }
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Derive dismissal behavior from purpose
   const allowEscape = purpose !== 'required';
   const allowBackdropClick = purpose === 'info';
@@ -507,6 +616,11 @@ export function Dialog({
     const dialog = dialogRef.current;
     if (!dialog) {
       return;
+    }
+
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
     }
 
     if (isOpen) {
@@ -538,17 +652,56 @@ export function Dialog({
       }
     } else {
       if (dialog.open) {
-        dialog.close();
+        // Hold the open dialog for the length of the exit animation, then
+        // close. Focus is restored after close() because an open modal makes
+        // the rest of the document inert — focusing the trigger any earlier
+        // silently fails.
+        const delay = resolveExitDelay(dialog);
+        const finishClose = () => {
+          closeTimeoutRef.current = null;
+          setIsExiting(false);
+          dialog.close();
+          triggerElementRef.current?.focus();
+          triggerElementRef.current = null;
+        };
+
+        if (delay <= 0) {
+          finishClose();
+          return;
+        }
+
+        closeTimeoutRef.current = setTimeout(finishClose, delay);
+      } else {
+        triggerElementRef.current?.focus();
+        triggerElementRef.current = null;
       }
-      // Return focus to the element that opened the dialog
-      triggerElementRef.current?.focus();
-      triggerElementRef.current = null;
     }
+
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+    };
   }, [isOpen, isInline]);
 
-  // Lock body scroll when dialog is open (iOS Safari workaround)
+  // Close the dialog if it unmounts mid-exit: the pending close() is cancelled
+  // with the effect above, and leaving the element `open` would skip
+  // showModal() on the next open (same failure MobileNav guards against).
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    return () => {
+      if (dialog?.open) {
+        dialog.close();
+      }
+    };
+  }, []);
+
+  // Lock body scroll while the dialog is up (iOS Safari workaround), including
+  // its exit animation — unpinning the body early would scroll the page back
+  // underneath a dialog that is still on screen.
   // Skip for inline rendering — no modal overlay to compensate for.
-  useScrollLock(isOpen && !isInline);
+  useScrollLock((isOpen || isExiting) && !isInline);
 
   // Join the shared layer dismissal stack. The stack owns the Escape listener
   // and routes each press to the top-most layer, so this dialog does not listen
@@ -709,6 +862,7 @@ export function Dialog({
           styles.dialog,
           overlayPaddingReset.reset,
           isOpen && styles.open,
+          isExiting && styles.exiting,
           styles.backdrop,
           standardSizing &&
             dynamicStyles.sizing(

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -195,11 +195,6 @@ const styles = stylex.create({
     animationDuration: durationVars['--duration-medium-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards' as const,
-    // Read back by resolveExitDelay() to time dialog.close() to the end of the
-    // slide-out. Declared here (not only in `exiting`) so the value is
-    // readable from the still-open dialog, and as a token so a theme that
-    // retimes its motion scale retimes the close with it.
-    '--dialog-exit-duration': durationVars['--duration-medium-min'],
   },
   // Applied via isOpen prop — avoids :where([open]) attribute selectors
   // which have zero specificity and can lose to default styles depending
@@ -224,7 +219,10 @@ const styles = stylex.create({
       default: exitDirectional,
       '@media (prefers-reduced-motion: reduce)': 'none',
     },
-    animationDuration: 'var(--dialog-exit-duration)',
+    // Read back by resolveExitDelay() to time dialog.close() to the end of the
+    // slide-out — a theme that retimes its motion scale retimes the close with
+    // it.
+    animationDuration: durationVars['--duration-medium-min'],
     // `both`: hold the entrance's end state until the first frame runs, and
     // the faded-out state after it, so neither edge flashes at full opacity.
     animationFillMode: 'both' as const,
@@ -233,7 +231,7 @@ const styles = stylex.create({
         default: exitBackdrop,
         '@media (prefers-reduced-motion: reduce)': 'none',
       },
-      animationDuration: 'var(--dialog-exit-duration)',
+      animationDuration: durationVars['--duration-medium-min'],
       animationTimingFunction: easeVars['--ease-standard'],
       animationFillMode: 'both' as const,
     },
@@ -353,16 +351,16 @@ function formatPosition(value: number | string): string {
 const MAX_EXIT_DELAY_MS = 400;
 
 /**
- * `--dialog-exit-duration` in ms; null when it can't be read as a duration.
+ * A CSS `<time>` in ms; null when the value isn't one.
  *
- * Custom properties are not normalised on read, so this comes back as authored
- * (`"310ms"`), and a theme is free to author seconds instead. Outside a real
- * browser the declaration doesn't exist and the value is the empty string.
+ * Browsers serialise computed times in seconds — an authored `310ms` reads
+ * back as `"0.31s"` — and a list gives one entry per animation. Outside a real
+ * browser there is no StyleX-authored CSS at all and the value is empty.
  *
  * @internal Exported for unit tests.
  */
 export function parseExitDurationMs(value: string): number | null {
-  const trimmed = value.trim();
+  const trimmed = value.split(',')[0]?.trim() ?? '';
   const ms = Number.parseFloat(trimmed);
   if (!Number.isFinite(ms)) {
     return null;
@@ -373,9 +371,13 @@ export function parseExitDurationMs(value: string): number | null {
 /**
  * How long to hold the open `<dialog>` so the exit animation can play.
  *
+ * Read off the dialog once the `exiting` style is on it, so the hold is
+ * whatever that animation actually runs for — including a theme that retimes
+ * the motion scale underneath it.
+ *
  * Zero — close in the same tick, exactly as the dialog behaved before there
  * was an exit animation — whenever there is no animation to wait for: reduced
- * motion, a theme that zeroes the duration, or a context where the property
+ * motion, a theme that zeroes the duration, or a context where the duration
  * can't be read at all (jsdom, an unresolved `var()`). Degrading to the old
  * instant close is always safe here; unlike MobileNav's `display` hold, an
  * early close only costs the animation, it can't strand the page inert.
@@ -385,7 +387,7 @@ function resolveExitDelay(dialog: HTMLDialogElement): number {
     return 0;
   }
   const duration = parseExitDurationMs(
-    window.getComputedStyle(dialog).getPropertyValue('--dialog-exit-duration'),
+    window.getComputedStyle(dialog).animationDuration,
   );
   if (duration === null || duration <= 0) {
     return 0;
@@ -602,7 +604,6 @@ export function Dialog({
     setWasOpen(isOpen);
     setIsExiting(wasOpen);
   }
-  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Derive dismissal behavior from purpose
   const allowEscape = purpose !== 'required';
@@ -616,11 +617,6 @@ export function Dialog({
     const dialog = dialogRef.current;
     if (!dialog) {
       return;
-    }
-
-    if (closeTimeoutRef.current) {
-      clearTimeout(closeTimeoutRef.current);
-      closeTimeoutRef.current = null;
     }
 
     if (isOpen) {
@@ -650,40 +646,50 @@ export function Dialog({
           autofocusTarget.focus();
         }
       }
-    } else {
-      if (dialog.open) {
-        // Hold the open dialog for the length of the exit animation, then
-        // close. Focus is restored after close() because an open modal makes
-        // the rest of the document inert — focusing the trigger any earlier
-        // silently fails.
-        const delay = resolveExitDelay(dialog);
-        const finishClose = () => {
-          closeTimeoutRef.current = null;
-          setIsExiting(false);
-          dialog.close();
-          triggerElementRef.current?.focus();
-          triggerElementRef.current = null;
-        };
+    } else if (!dialog.open) {
+      // Never opened, or already closed by the exit effect below.
+      triggerElementRef.current?.focus();
+      triggerElementRef.current = null;
+    }
+  }, [isOpen, isInline]);
 
-        if (delay <= 0) {
-          finishClose();
-          return;
-        }
-
-        closeTimeoutRef.current = setTimeout(finishClose, delay);
-      } else {
-        triggerElementRef.current?.focus();
-        triggerElementRef.current = null;
-      }
+  // Hold the open dialog while it animates out, then close. The hold is read
+  // from the dialog only once `exiting` is on it — that is what makes it the
+  // exit's duration and not the entrance's — so this is its own effect rather
+  // than a branch of the one above.
+  //
+  // Focus goes back to the trigger after close(), never before: an open modal
+  // makes the rest of the document inert, so focusing the trigger any earlier
+  // silently fails.
+  useEffect(() => {
+    if (isInline || !isExiting) {
+      return;
+    }
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+    if (!dialog.open) {
+      setIsExiting(false);
+      return;
     }
 
-    return () => {
-      if (closeTimeoutRef.current) {
-        clearTimeout(closeTimeoutRef.current);
-        closeTimeoutRef.current = null;
-      }
+    const finishClose = () => {
+      setIsExiting(false);
+      dialog.close();
+      triggerElementRef.current?.focus();
+      triggerElementRef.current = null;
     };
-  }, [isOpen, isInline]);
+
+    const delay = resolveExitDelay(dialog);
+    if (delay <= 0) {
+      finishClose();
+      return;
+    }
+
+    const timeout = setTimeout(finishClose, delay);
+    return () => clearTimeout(timeout);
+  }, [isExiting, isInline]);
 
   // Close the dialog if it unmounts mid-exit: the pending close() is cancelled
   // with the effect above, and leaving the element `open` would skip

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -670,11 +670,15 @@ export function Dialog({
       return;
     }
     if (!dialog.open) {
+      // Nothing to animate out — the dialog was closed by something other than
+      // this effect (a native form submit, say). Retire the exit style, or it
+      // would keep a closed dialog displayed.
       setIsExiting(false);
       return;
     }
 
     const finishClose = () => {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- the exit is over; this render is what retires the exit style
       setIsExiting(false);
       dialog.close();
       triggerElementRef.current?.focus();

--- a/packages/core/src/Dialog/DialogExitAnimation.test.tsx
+++ b/packages/core/src/Dialog/DialogExitAnimation.test.tsx
@@ -15,8 +15,9 @@
  * SYNC: When the close timing in Dialog.tsx changes, update these tests.
  */
 
+import {useState} from 'react';
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {render, screen, act} from '@testing-library/react';
+import {render, screen, act, fireEvent} from '@testing-library/react';
 import {Dialog, parseExitDurationMs} from './Dialog';
 
 const EXIT_MS = 250;
@@ -182,5 +183,46 @@ describe('Dialog exit animation', () => {
     act(() => unmount());
 
     expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('lets a second Escape dismiss the parent while the inner dialog exits', () => {
+    const onOuterChange = vi.fn();
+    const onInnerChange = vi.fn();
+
+    function NestedDialogs() {
+      const [isOuterOpen, setIsOuterOpen] = useState(true);
+      const [isInnerOpen, setIsInnerOpen] = useState(true);
+      return (
+        <Dialog
+          isOpen={isOuterOpen}
+          onOpenChange={next => {
+            onOuterChange(next);
+            setIsOuterOpen(next);
+          }}
+          aria-label="Outer dialog">
+          <Dialog
+            isOpen={isInnerOpen}
+            onOpenChange={next => {
+              onInnerChange(next);
+              setIsInnerOpen(next);
+            }}
+            aria-label="Inner dialog">
+            Content
+          </Dialog>
+        </Dialog>
+      );
+    }
+
+    mockExitDuration(`${EXIT_MS}ms`);
+    render(<NestedDialogs />);
+
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(onInnerChange).toHaveBeenCalledTimes(1);
+    expect(onOuterChange).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(onInnerChange).toHaveBeenCalledTimes(1);
+    expect(onOuterChange).toHaveBeenCalledOnce();
+    expect(onOuterChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/core/src/Dialog/DialogExitAnimation.test.tsx
+++ b/packages/core/src/Dialog/DialogExitAnimation.test.tsx
@@ -21,17 +21,13 @@ import {Dialog, parseExitDurationMs} from './Dialog';
 
 const EXIT_MS = 250;
 
+// jsdom resolves no StyleX CSS, so the exit animation's own duration — what
+// the component reads to time the close — has to be stood in for.
 function mockExitDuration(value: string) {
   const real = window.getComputedStyle.bind(window);
   vi.spyOn(window, 'getComputedStyle').mockImplementation((el, pseudo) => {
     const style = real(el, pseudo);
-    return {
-      ...style,
-      getPropertyValue: (prop: string) =>
-        prop === '--dialog-exit-duration'
-          ? value
-          : style.getPropertyValue(prop),
-    };
+    return {...style, animationDuration: value};
   });
 }
 
@@ -39,7 +35,7 @@ function mockReducedMotion(reduce: boolean) {
   const real = window.matchMedia.bind(window);
   vi.spyOn(window, 'matchMedia').mockImplementation(query =>
     query.includes('prefers-reduced-motion')
-      ? ({...real(query), matches: reduce})
+      ? {...real(query), matches: reduce}
       : real(query),
   );
 }
@@ -75,6 +71,7 @@ describe('parseExitDurationMs', () => {
     ['0.31s', 310],
     [' 250ms ', 250],
     ['0ms', 0],
+    ['0.31s, 0.31s', 310],
   ])('reads %s', (input, expected) => {
     expect(parseExitDurationMs(input)).toBe(expected);
   });

--- a/packages/core/src/Dialog/DialogExitAnimation.test.tsx
+++ b/packages/core/src/Dialog/DialogExitAnimation.test.tsx
@@ -1,0 +1,189 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file DialogExitAnimation.test.tsx
+ * @input Uses vitest, @testing-library/react, Dialog
+ * @output Unit tests for the hold between `isOpen` going false and close()
+ * @position Testing; validates the exit-animation timing in Dialog.tsx
+ *
+ * jsdom cannot run the animation itself — the frame-by-frame evidence that the
+ * dialog fades and retreats lives in the PR. What is testable here is the
+ * contract around it: how long the open <dialog> is held, that the hold is
+ * skipped whenever there is no animation to wait for, and that focus goes back
+ * to the trigger only once the dialog has actually closed.
+ *
+ * SYNC: When the close timing in Dialog.tsx changes, update these tests.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, act} from '@testing-library/react';
+import {Dialog, parseExitDurationMs} from './Dialog';
+
+const EXIT_MS = 250;
+
+function mockExitDuration(value: string) {
+  const real = window.getComputedStyle.bind(window);
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((el, pseudo) => {
+    const style = real(el, pseudo);
+    return {
+      ...style,
+      getPropertyValue: (prop: string) =>
+        prop === '--dialog-exit-duration'
+          ? value
+          : style.getPropertyValue(prop),
+    };
+  });
+}
+
+function mockReducedMotion(reduce: boolean) {
+  const real = window.matchMedia.bind(window);
+  vi.spyOn(window, 'matchMedia').mockImplementation(query =>
+    query.includes('prefers-reduced-motion')
+      ? ({...real(query), matches: reduce})
+      : real(query),
+  );
+}
+
+function DialogUnderTest({isOpen}: {isOpen: boolean}) {
+  return (
+    <Dialog isOpen={isOpen} onOpenChange={() => {}} aria-label="Test dialog">
+      Content
+    </Dialog>
+  );
+}
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('parseExitDurationMs', () => {
+  it.each([
+    ['250ms', 250],
+    ['0.31s', 310],
+    [' 250ms ', 250],
+    ['0ms', 0],
+  ])('reads %s', (input, expected) => {
+    expect(parseExitDurationMs(input)).toBe(expected);
+  });
+
+  it.each(['', 'var(--duration-medium-min)', '250', 'none'])(
+    'returns null for %s',
+    input => {
+      expect(parseExitDurationMs(input)).toBeNull();
+    },
+  );
+});
+
+describe('Dialog exit animation', () => {
+  it('holds the open dialog for the exit duration, then closes', () => {
+    mockExitDuration(`${EXIT_MS}ms`);
+    const {rerender} = render(<DialogUnderTest isOpen={true} />);
+    const dialog = screen.getByRole('dialog');
+
+    act(() => rerender(<DialogUnderTest isOpen={false} />));
+    expect(dialog).toHaveAttribute('open');
+
+    act(() => void vi.advanceTimersByTime(EXIT_MS - 1));
+    expect(dialog).toHaveAttribute('open');
+
+    act(() => void vi.advanceTimersByTime(1));
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('restores focus to the trigger only after the dialog has closed', () => {
+    mockExitDuration(`${EXIT_MS}ms`);
+    function Harness({isOpen}: {isOpen: boolean}) {
+      return (
+        <>
+          <button type="button" data-testid="trigger">
+            Open
+          </button>
+          <Dialog isOpen={isOpen} onOpenChange={() => {}} aria-label="Test">
+            <button type="button" data-autofocus data-testid="inside">
+              Inside
+            </button>
+          </Dialog>
+        </>
+      );
+    }
+    const {rerender} = render(<Harness isOpen={false} />);
+    const trigger = screen.getByTestId('trigger');
+    act(() => trigger.focus());
+
+    act(() => rerender(<Harness isOpen={true} />));
+    expect(document.activeElement).toBe(screen.getByTestId('inside'));
+
+    act(() => rerender(<Harness isOpen={false} />));
+    expect(document.activeElement).toBe(screen.getByTestId('inside'));
+
+    act(() => void vi.advanceTimersByTime(EXIT_MS));
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('closes in the same tick when the duration cannot be read', () => {
+    // No StyleX-authored CSS outside a browser, so this is what jsdom and any
+    // unresolved var() get: the pre-animation behaviour, unchanged.
+    const {rerender} = render(<DialogUnderTest isOpen={true} />);
+    const dialog = screen.getByRole('dialog');
+
+    act(() => rerender(<DialogUnderTest isOpen={false} />));
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('closes in the same tick under prefers-reduced-motion', () => {
+    mockExitDuration(`${EXIT_MS}ms`);
+    mockReducedMotion(true);
+    const {rerender} = render(<DialogUnderTest isOpen={true} />);
+    const dialog = screen.getByRole('dialog');
+
+    act(() => rerender(<DialogUnderTest isOpen={false} />));
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('caps the hold so a long theme duration cannot strand the dialog open', () => {
+    mockExitDuration('5s');
+    const {rerender} = render(<DialogUnderTest isOpen={true} />);
+    const dialog = screen.getByRole('dialog');
+
+    act(() => rerender(<DialogUnderTest isOpen={false} />));
+    act(() => void vi.advanceTimersByTime(400));
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('cancels the pending close when the dialog is reopened mid-exit', () => {
+    mockExitDuration(`${EXIT_MS}ms`);
+    const {rerender} = render(<DialogUnderTest isOpen={true} />);
+    const dialog = screen.getByRole('dialog');
+
+    act(() => rerender(<DialogUnderTest isOpen={false} />));
+    act(() => void vi.advanceTimersByTime(EXIT_MS / 2));
+    act(() => rerender(<DialogUnderTest isOpen={true} />));
+    act(() => void vi.advanceTimersByTime(EXIT_MS));
+
+    expect(dialog).toHaveAttribute('open');
+  });
+
+  it('closes the dialog when it unmounts mid-exit', () => {
+    mockExitDuration(`${EXIT_MS}ms`);
+    const {rerender, unmount} = render(<DialogUnderTest isOpen={true} />);
+    const dialog = screen.getByRole('dialog');
+
+    act(() => rerender(<DialogUnderTest isOpen={false} />));
+    act(() => unmount());
+
+    expect(dialog).not.toHaveAttribute('open');
+  });
+});


### PR DESCRIPTION
## Why

`Dialog`'s entrance animates — it fades and scales in from the direction of its trigger, over `--duration-medium-max`. Its dismissal did not: the open/close effect called `dialog.close()` the moment `isOpen` went false, and `HTMLDialogElement.close()` is immediate.

Measured on `main` at the Storybook default theme, per animation frame in Chromium: the entrance spends **26 frames / ~490ms** interpolating opacity and scale, and the exit spends **zero** — one frame at `display: flex`, the next at `display: none`. Our own motion guidance names this exact case ("animate the exit ... like a panel closing or a dialog dismissing to reveal what's underneath", and "when you do animate exit, match the entrance"), and `MobileNav` in this same package already holds its close so its slide-out can play.

This is the first half of the gap in the gap report below. See "Not addressed" for the rest.

## What

Hold the open `<dialog>` for the length of an exit animation, then close it.

- The exit is the entrance run backwards — opacity to 0, scale to 0.95, translating back toward the element that opened the dialog — at `--duration-medium-min`, the motion scale's "quick exit" band, rather than the entrance's dramatic one.
- The scrim fades on the same curve. Without that it stayed fully opaque for the whole exit and then snapped, which reads as a grey flash after the panel has already gone.
- The hold is read off the dialog's own computed `animationDuration` once the exit style is on it, so a theme that retimes its motion scale retimes the close with it. It is capped at 400ms.
- The hold is skipped entirely — same-tick close, byte-for-byte the old behaviour — under `prefers-reduced-motion`, when a theme zeroes the duration, and anywhere the duration cannot be read (jsdom, an unresolved `var()`).
- The body scroll lock now spans the exit too; releasing it while the dialog was still on screen would scroll the page underneath it.

Whether the dialog is exiting is derived during render, not in an effect: deciding it in an effect costs a commit, and the dialog was measurably blinking out for one frame before it began to animate.

## Risk

The real change is that a dismissed dialog stays modal ~300ms longer than it used to. For that window the page behind is still inert and focus has not yet returned to the trigger. `AlertDialog` and `CommandPalette` inherit it, since both are `Dialog` underneath.

Two things bound it: the cap, and the fact that every path which cannot see a real animation degrades to the old instant close — including every jsdom test in this repo, which is why the suite is unchanged and also why unit tests cannot cover the held path. That path is covered by frame-level measurement in a browser instead (below).

Consumers that unmount the dialog the instant `isOpen` goes false still get no exit animation; nothing regresses for them, they just see no change.

[#4865](https://github.com/facebook/astryx/pull/4865) and [#4881](https://github.com/facebook/astryx/pull/4881) both touch `Dialog.tsx`, in its Escape/dismissal machinery rather than its open/close effect — textually adjacent, semantically disjoint, but whichever lands second will want a look.

## Testing

Chromium, per animation frame, Storybook `core-dialog--default`:

| | before | after |
|---|---|---|
| exit frames with the dialog partly faded | 0 | 12 |
| dialog still on screen after dismissal | 0ms | ~215ms, then closed |
| `prefers-reduced-motion: reduce` | closes at once | closes at once, no partial frame |

Also checked in Chromium: nested dialogs peel off one Escape at a time and the outer one is immediately usable after the inner one goes (the delayed close does not strand the page inert); `AlertDialog`'s confirm still fires and unpins the body; scroll position survives a dialog on both a scrolling document (500 → 500) and a fixed app shell with an inner scroller (745 → 745).

`DialogExitAnimation.test.tsx` covers the contract around the animation: the length of the hold, the cap, both skip paths, reopening mid-exit, unmounting mid-exit, and focus returning to the trigger only after the dialog has actually closed. Full `core` + `lab` suites: 7209 passed.

## Not addressed

Two of the three things the report asks for are deliberately left out.

**The scroll lock has no opt-out, and this PR does not add one.** The follow-up measurement already withdrew the damage claim, and I reproduced that: in a fixed-height app shell the lock moves the inner scroller by 0px, and the body's border box is unchanged to the pixel. What is left is a toggle with no measured use case, which is the shape [API Conventions](https://github.com/facebook/astryx/wiki/API-Conventions#escape-hatches) tells us not to add ("prefer enforced good practices over toggles ... unless there's a real use case for disabling it"). Flagged for @cixzhang rather than decided here.

**There is no `drawer` variant here, and I don't think `Dialog` should grow one.** `Drawer` already exists in `@astryxdesign/lab`: edge-anchored to any of the four sides, directional enter *and* exit, LIFO Escape stack, optional scrim. At 390x844, `side="end"` renders 0,0,390,844 in the top layer — the full-screen phone panel the report wanted. That is a system-design call for the TL, so it is a question for the TL, not a PR.
