### PR TITLE
fix(NumberInput): commit an out-of-range entry at the nearest bound

### DIFF
--- a/.changeset/numberinput-clamp-to-bound.md
+++ b/.changeset/numberinput-clamp-to-bound.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] NumberInput: an entry past `min`/`max` now commits at the nearest bound on blur or Enter instead of falling back to the last in-range prefix — typing 100 into a 1–2 field lands on 2, not 1. Pagination inherits this.
+
+@cixzhang

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -128,12 +128,14 @@ export const docs = {
     {
       name: 'min',
       type: 'number | null',
-      description: 'Minimum value allowed.',
+      description:
+        'Minimum value allowed. A smaller entry commits at this value on blur or Enter.',
     },
     {
       name: 'max',
       type: 'number | null',
-      description: 'Maximum value allowed.',
+      description:
+        'Maximum value allowed. A larger entry commits at this value on blur or Enter.',
     },
     {
       name: 'step',
@@ -410,12 +412,12 @@ export const docsZh = {
     {
       name: 'min',
       type: 'number | null',
-      description: '允许的最小值。',
+      description: '允许的最小值。更小的输入会在失焦或按 Enter 时提交为该值。',
     },
     {
       name: 'max',
       type: 'number | null',
-      description: '允许的最大值。',
+      description: '允许的最大值。更大的输入会在失焦或按 Enter 时提交为该值。',
     },
     {
       name: 'step',

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -653,6 +653,30 @@ describe('NumberInput', () => {
       expect(input).toHaveValue('2');
     });
 
+    it('shows the clamped value in the field after Enter', async () => {
+      const user = userEvent.setup();
+      function ControlledNumberInput() {
+        const [value, setValue] = useState<number | null>(null);
+        return (
+          <NumberInput
+            label="Rating"
+            value={value}
+            onChange={setValue}
+            min={1}
+            max={5}
+          />
+        );
+      }
+      render(<ControlledNumberInput />);
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '10{Enter}');
+
+      // Still focused: the field must not keep showing the rejected entry.
+      expect(input).toHaveValue('5');
+    });
+
     it('reverts an entry that is not a usable number', async () => {
       const user = userEvent.setup();
       const handleChange = vi.fn();

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -699,6 +699,73 @@ describe('NumberInput', () => {
       expect(handleChange).not.toHaveBeenCalled();
       expect(input).toHaveValue('');
     });
+
+    it('rounds a fractional max inwards for an integer-only field', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Count"
+          value={null}
+          onChange={handleChange}
+          max={9.5}
+          isIntegerOnly
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '20');
+      handleChange.mockClear();
+      await user.tab();
+
+      expect(handleChange).toHaveBeenCalledWith(9);
+    });
+
+    it('rounds a fractional min inwards for an integer-only field', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Count"
+          value={null}
+          onChange={handleChange}
+          min={0.5}
+          isIntegerOnly
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '0');
+      handleChange.mockClear();
+      await user.tab();
+
+      expect(handleChange).toHaveBeenCalledWith(1);
+    });
+
+    it('does not clamp when no value can satisfy both bounds', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Count"
+          value={null}
+          onChange={handleChange}
+          min={5}
+          max={2}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '10');
+      handleChange.mockClear();
+      await user.tab();
+
+      expect(handleChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('');
+    });
   });
 
   describe('status prop', () => {

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -10,6 +10,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {useState} from 'react';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TestIcon} from '../__tests__/TestIcon';
@@ -537,6 +538,142 @@ describe('NumberInput', () => {
       await user.keyboard('{Enter}');
 
       expect(handleEnter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('range clamping on commit', () => {
+    it('commits an over-max entry at max on blur', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Page"
+          value={null}
+          onChange={handleChange}
+          min={1}
+          max={2}
+          isIntegerOnly
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '100');
+      handleChange.mockClear();
+      await user.tab();
+
+      expect(handleChange).toHaveBeenCalledWith(2);
+    });
+
+    it('commits an over-max entry at max on Enter', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Rating"
+          value={null}
+          onChange={handleChange}
+          max={5}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '10');
+      handleChange.mockClear();
+      await user.keyboard('{Enter}');
+
+      expect(handleChange).toHaveBeenCalledWith(5);
+    });
+
+    it('commits a below-min entry at min', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Age"
+          value={null}
+          onChange={handleChange}
+          min={0}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '-5');
+      await user.tab();
+
+      expect(handleChange).toHaveBeenCalledWith(0);
+    });
+
+    it('does not clamp while typing', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Rating"
+          value={null}
+          onChange={handleChange}
+          max={5}
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '10');
+
+      // The entry stays exactly as typed until it is committed.
+      expect(input).toHaveValue('10');
+      expect(handleChange).not.toHaveBeenCalledWith(5);
+    });
+
+    it('displays the clamped value after commit', async () => {
+      const user = userEvent.setup();
+      function ControlledNumberInput() {
+        const [value, setValue] = useState<number>(1);
+        return (
+          <NumberInput
+            label="Page"
+            value={value}
+            onChange={setValue}
+            min={1}
+            max={2}
+            isIntegerOnly
+          />
+        );
+      }
+      render(<ControlledNumberInput />);
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.clear(input);
+      await user.type(input, '100');
+      await user.tab();
+
+      expect(input).toHaveValue('2');
+    });
+
+    it('reverts an entry that is not a usable number', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <NumberInput
+          label="Count"
+          value={null}
+          onChange={handleChange}
+          max={10}
+          isIntegerOnly
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '12.5');
+      handleChange.mockClear();
+      await user.tab();
+
+      expect(handleChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('');
     });
   });
 

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -351,10 +351,12 @@ interface NumberInputPropsBase extends Omit<
   autoComplete?: string;
   /**
    * The minimum value allowed.
+   * A smaller entry commits at this value on blur or Enter.
    */
   min?: number | null;
   /**
    * The maximum value allowed.
+   * A larger entry commits at this value on blur or Enter.
    */
   max?: number | null;
   /**
@@ -429,15 +431,12 @@ export type NumberInputProps =
   NumberInputPropsNonClearable | NumberInputPropsClearable;
 
 /**
- * Read the typed or pasted text as a number, then apply the field's
- * constraints.
- * Returns null if the input is not a valid number or fails validation.
+ * Read the typed or pasted text as a number, applying the shape rules (finite,
+ * and integral when `isIntegerOnly`) but not the min/max range.
  */
-function parseNumberInput(
+function parseNumericInput(
   input: string,
   options: {
-    min?: number | null;
-    max?: number | null;
     isIntegerOnly?: boolean;
     locale?: Locale;
   },
@@ -452,8 +451,28 @@ function parseNumberInput(
     return null;
   }
 
-  // Check integer constraint
   if (options.isIntegerOnly && !Number.isInteger(num)) {
+    return null;
+  }
+
+  return num;
+}
+
+/**
+ * Parse and validate a string input as a number.
+ * Returns null if the input is not a valid number or fails validation.
+ */
+function parseNumberInput(
+  input: string,
+  options: {
+    min?: number | null;
+    max?: number | null;
+    isIntegerOnly?: boolean;
+    locale?: Locale;
+  },
+): number | null {
+  const num = parseNumericInput(input, options);
+  if (num === null) {
     return null;
   }
 
@@ -465,6 +484,38 @@ function parseNumberInput(
   // Check max constraint
   if (options.max != null && num > options.max) {
     return null;
+  }
+
+  return num;
+}
+
+/**
+ * Parse a string input for commit (blur/Enter), clamping an out-of-range
+ * number to the nearest bound.
+ *
+ * Rejecting an out-of-range entry outright leaves the last in-range prefix
+ * committed, so typing 100 into a [1, 2] field lands on 1; the nearest bound
+ * is what the entry actually asked for.
+ */
+function parseNumberInputForCommit(
+  input: string,
+  options: {
+    min?: number | null;
+    max?: number | null;
+    isIntegerOnly?: boolean;
+    locale?: Locale;
+  },
+): number | null {
+  const num = parseNumericInput(input, options);
+  if (num === null) {
+    return null;
+  }
+
+  if (options.min != null && num < options.min) {
+    return options.min;
+  }
+  if (options.max != null && num > options.max) {
+    return options.max;
   }
 
   return num;
@@ -664,6 +715,12 @@ export function NumberInput({
     [isIntegerOnly, locale, max, min],
   );
 
+  const parseInputForCommit = useCallback(
+    (text: string) =>
+      parseNumberInputForCommit(text, {min, max, isIntegerOnly, locale}),
+    [isIntegerOnly, locale, max, min],
+  );
+
   const formattedValue = useMemo(() => {
     if (value == null) {
       return '';
@@ -732,7 +789,7 @@ export function NumberInput({
             onChange(null);
           }
         } else {
-          const parsed = parseInput(pendingInput);
+          const parsed = parseInputForCommit(pendingInput);
           if (parsed !== null && parsed !== value) {
             onChange(parsed);
           }
@@ -744,7 +801,7 @@ export function NumberInput({
       setIsFocused(false);
       onBlur?.(e);
     },
-    [pendingInput, value, onChange, parseInput, onBlur, hasClear],
+    [pendingInput, value, onChange, parseInputForCommit, onBlur, hasClear],
   );
 
   const valueForStepping = useMemo(() => {
@@ -820,7 +877,7 @@ export function NumberInput({
               onChange(null);
             }
           } else {
-            const parsed = parseInput(pendingInput);
+            const parsed = parseInputForCommit(pendingInput);
             if (parsed !== null && parsed !== value) {
               onChange(parsed);
             }
@@ -834,7 +891,7 @@ export function NumberInput({
       pendingInput,
       value,
       onChange,
-      parseInput,
+      parseInputForCommit,
       onEnter,
       onKeyDown,
       hasClear,

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -721,6 +721,11 @@ export function NumberInput({
     [isIntegerOnly, locale, max, min],
   );
 
+  const parseNumeric = useCallback(
+    (text: string) => parseNumericInput(text, {isIntegerOnly, locale}),
+    [isIntegerOnly, locale],
+  );
+
   const formattedValue = useMemo(() => {
     if (value == null) {
       return '';
@@ -878,8 +883,15 @@ export function NumberInput({
             }
           } else {
             const parsed = parseInputForCommit(pendingInput);
-            if (parsed !== null && parsed !== value) {
-              onChange(parsed);
+            if (parsed !== null) {
+              // Enter otherwise keeps the pending text, which would leave a
+              // clamped entry showing the number that was not committed.
+              if (parsed !== parseNumeric(pendingInput)) {
+                setPendingInput(null);
+              }
+              if (parsed !== value) {
+                onChange(parsed);
+              }
             }
           }
         }
@@ -892,6 +904,7 @@ export function NumberInput({
       value,
       onChange,
       parseInputForCommit,
+      parseNumeric,
       onEnter,
       onKeyDown,
       hasClear,

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -511,14 +511,41 @@ function parseNumberInputForCommit(
     return null;
   }
 
-  if (options.min != null && num < options.min) {
-    return options.min;
+  // The bound itself has to satisfy the field's own shape rule, or an
+  // integer-only field commits the fractional `max` it was handed. Round
+  // inwards, the same way stepping from empty does.
+  const {min, max} = getCommittableBounds(options);
+  // No number satisfies both, so there is nothing to clamp to.
+  if (min != null && max != null && min > max) {
+    return null;
   }
-  if (options.max != null && num > options.max) {
-    return options.max;
+
+  if (min != null && num < min) {
+    return min;
+  }
+  if (max != null && num > max) {
+    return max;
   }
 
   return num;
+}
+
+function getCommittableBounds({
+  min,
+  max,
+  isIntegerOnly,
+}: {
+  min?: number | null;
+  max?: number | null;
+  isIntegerOnly?: boolean;
+}): {min: number | null; max: number | null} {
+  if (!isIntegerOnly) {
+    return {min: min ?? null, max: max ?? null};
+  }
+  return {
+    min: min == null ? null : Math.ceil(min),
+    max: max == null ? null : Math.floor(max),
+  };
 }
 
 type StepDirection = -1 | 1;

--- a/packages/core/src/Pagination/Pagination.test.tsx
+++ b/packages/core/src/Pagination/Pagination.test.tsx
@@ -613,7 +613,7 @@ describe('Pagination', () => {
       expect(box).toHaveAttribute('aria-valuemax', '10');
     });
 
-    it('commits a typed page on Enter and rejects an over-range entry', async () => {
+    it('commits a typed page on Enter and clamps an over-range entry', async () => {
       const user = userEvent.setup();
       const onChange = vi.fn();
       render(
@@ -633,9 +633,10 @@ describe('Pagination', () => {
       onChange.mockClear();
       await user.clear(box);
       // The box is a NumberInput bounded to [1, totalPages]: an over-max entry
-      // is rejected and never navigates past the last page.
+      // lands on the last page rather than navigating past it.
       await user.type(box, '99{Enter}');
       expect(onChange).not.toHaveBeenCalledWith(99);
+      expect(onChange).toHaveBeenCalledWith(10);
     });
 
     it('commits on blur', async () => {


### PR DESCRIPTION
## Why

Reported by @aldentan: with a `max` set, typing a number past it leaves the *first digit or two* committed instead of the max. With `max={2}`, typing `100` lands on **1**. Pagination shows this as jumping to page 1 rather than the last page — the previous treatment (clamp to max) is more intuitive, and that's what people expect from a bounded field.

The cause: every keystroke commits if it parses in range, so `1` commits, then `10` and `100` are rejected outright and the stale `1` is what survives the blur.

## What

`min`/`max` violations now clamp to the nearest bound **at commit time** — blur and Enter. Typing is deliberately untouched: the entry stays exactly as typed (and styled invalid) until committed, so nothing rewrites the field mid-edit. Text that isn't a usable number (`abc`, or a decimal under `isIntegerOnly`) still reverts, unchanged.

The bound is put through the field's own shape rule before it is committed, so an `isIntegerOnly` field handed a fractional bound rounds inwards (`max={9.5}` commits 9, not 9.5), and a range no number can satisfy (`min` above `max`) reverts rather than committing outside both ends.

Enter also clears the pending text when the commit clamped. That is more than cosmetic: before, Enter left the field reading `100` on a value of 1, with `aria-invalid` still set and an assertive "Invalid number" still announced, and no way out but retyping.

Pagination inherits the fix — it already delegates all bounding to NumberInput.

## Risk

Behavior change on commit, patch-level: an out-of-range entry that previously reverted now fires `onChange` with the bound. Consumers relying on "reject and revert" for range violations would see a value they didn't before. The committed bound always satisfies both the range and `isIntegerOnly`, so it can't produce a value the field's own rules reject.

Not fixed here: the per-keystroke commit itself, so someone on page 3 typing `10` still visits page 1 for one keystroke before landing on 10. Pre-existing, and a larger change to where the commit lives.

## Testing

- `range clamping on commit` suite: over-max on blur, over-max on Enter, below-min, no clamping while typing, displayed value after commit, non-numeric entries still reverting, fractional bounds rounded inwards under `isIntegerOnly`, and an unsatisfiable range reverting. Each new case fails without the change.
- Updated the Pagination over-range test to assert page 10 rather than only "not 99".
- `NumberInput` + `Pagination`: 364 tests pass.
- Verified in Chrome against local Storybook (screenshots in the comments).
