### PR TITLE
fix(Table): mirror the row-expansion chevron under RTL

### DIFF
--- a/.changeset/table-row-expansion-rtl-chevron.md
+++ b/.changeset/table-row-expansion-rtl-chevron.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Table`'s row-expansion chevron now mirrors correctly under RTL. It previously rotated on expand with no RTL handling at all, so the directional glyph pointed the same way regardless of text direction, matching the pattern already used by `TreeListItem`'s chevron.
+
+@HelloOjasMutreja

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -23,6 +23,7 @@ import {spacingVars, colorVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {resolveContextActions} from '../../tableContextMenu';
 import {useTranslator} from '../../../i18n';
+import {rtlStyles} from '../../../utils';
 import type {
   TablePlugin,
   TableColumn,
@@ -92,8 +93,20 @@ const expansionStyles = stylex.create({
       color: colorVars['--color-icon-primary'],
     },
   },
+  // The RTL mirror is folded into each state's transform rather than living
+  // on a parent span, matching TreeListItem's chevron (both are `transform`,
+  // so on one element the later value would win).
   chevronExpanded: {
-    transform: 'rotate(90deg)',
+    transform: {
+      default: 'rotate(90deg)',
+      ':is([dir="rtl"] *)': 'scaleX(-1) rotate(90deg)',
+    },
+  },
+  chevronCollapsed: {
+    transform: {
+      default: 'rotate(0deg)',
+      ':is([dir="rtl"] *)': 'scaleX(-1) rotate(0deg)',
+    },
   },
   expandedRow: {
     backgroundColor: colorVars['--color-background-muted'],
@@ -121,7 +134,9 @@ function ExpansionChevron({
       type="button"
       {...stylex.props(
         expansionStyles.chevronButton,
-        isExpanded && expansionStyles.chevronExpanded,
+        isExpanded
+          ? expansionStyles.chevronExpanded
+          : expansionStyles.chevronCollapsed,
       )}
       onClick={e => {
         e.stopPropagation();
@@ -249,6 +264,9 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
                   icon={isExpanded ? 'chevronDown' : 'chevronRight'}
                   size="xsm"
                   aria-hidden
+                  // chevronDown needs no mirroring; chevronRight (collapsed,
+                  // pointing toward the reveal direction) does.
+                  xstyle={!isExpanded && rtlStyles.mirror}
                 />
               ),
               onSelect: () => onToggle(key),


### PR DESCRIPTION
## Summary

Closes the `tablerowexpansion` finding in #5141 (weekly full-suite RTL audit, D1 icon-mirror).

## Evidence

`useTableRowExpansion.tsx`'s chevron rotated on expand with zero RTL handling:

```ts
chevronExpanded: {
  transform: 'rotate(90deg)',
},
```

No `:is([dir="rtl"] *)` variant at all, so the directional glyph pointed the same way regardless of text direction.

## What I checked before fixing

`TreeListItem.tsx`'s chevron is the exact same shape (rotate + directional glyph) and already handles this correctly:

```ts
chevronExpanded: {
  transform: {
    default: 'rotate(90deg)',
    ':is([dir="rtl"] *)': 'scaleX(-1) rotate(90deg)',
  },
},
```

with a comment explaining why the mirror is folded into each state's own transform rather than living on a separate wrapper: both are `transform`, so on one element the later declaration would win.

## Fix

Applied the identical pattern to `TableRowExpansion`'s chevron: `chevronExpanded`/`chevronCollapsed` variants, applied unconditionally based on state (matching `TreeListItem`'s JSX callsite pattern) instead of the previous `isExpanded && expansionStyles.chevronExpanded`.

Also fixed a second, separate chevron in the same file: the row's context-menu action icon swaps between `chevronDown` (expanded, no mirroring needed since down is direction-agnostic) and `chevronRight` (collapsed, directional) instead of rotating. Applied `rtlStyles.mirror` to the collapsed state, matching the convention already used for static directional chevrons in `Pagination`, `Carousel`, `Lightbox`, and `Calendar`.

## On the `treelist` finding in #5141

Checked: `TreeListItem.tsx` is the only chevron render site anywhere under `TreeList/`, and it already has the exact fold-into-transform mirror pattern (landed in #4838, well before this audit run). I couldn't find anything to fix there. The audit's `treelist` finding may be stale relative to that PR, or probing a state (e.g. an item this specific run's story couldn't expand) that a source-level check can't reproduce. Flagging this rather than guessing at a fix for code that already looks correct.

## Test notes

Existing `useTableRowExpansion.test.tsx` suite (13 tests) passes unchanged. This codebase verifies RTL mirroring via the separate Storybook-based `rtl-audit.mjs` tool rather than per-component unit tests (confirmed: even `TreeListItem`, the reference-correct implementation, has no RTL-specific unit test), so I didn't invent a new test type here, staying consistent with that convention. Verification is source-level: the new code is an exact match of `TreeListItem`'s already-shipped, already-audited-clean pattern.

## Test plan

- [x] `vitest run` on `useTableRowExpansion.test.tsx`: 13/13 passing (no regression)
- [x] `eslint` clean on touched file
- [x] `tsc --noEmit`: no new errors (four pre-existing, unrelated `renderExpanded` errors confirmed present on unmodified `upstream/main` too)
- [x] Changeset added
- [x] Pattern verified against `TreeListItem.tsx`'s identical, already-shipped fix
