### PR TITLE
feat(markdown): renderBlock — give overrides the source line range of each block

### DIFF
--- a/.changeset/markdown-render-block.md
+++ b/.changeset/markdown-render-block.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Markdown: `renderBlock` wraps each rendered block with the source line range it came from, so rendered markdown can carry diff, change, or blame indicators. Parsing is unchanged unless the prop is set.
+
+@cixzhang

--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -445,3 +445,126 @@ export const InlinePlugins: Story = {
     );
   },
 };
+
+const SPEC_BEFORE = [
+  '# Session file viewer',
+  '',
+  'Renders a file an agent wrote during the session.',
+  '',
+  '## Supported types',
+  '',
+  '- Plain text',
+  '- Source code, syntax highlighted',
+  '- Images',
+  '',
+  '## Open questions',
+  '',
+  '> How do we show a file that changed twice in one session?',
+  '',
+  '```ts',
+  'type FileView = {path: string; body: string};',
+  '```',
+].join('\n');
+
+const SPEC_AFTER = [
+  '# Session file viewer',
+  '',
+  'Renders a file an agent wrote during the session.',
+  '',
+  '## Supported types',
+  '',
+  '- Plain text',
+  '- Source code, syntax highlighted',
+  '- **Markdown**, rendered as prose (`.md`)',
+  '- Images',
+  '',
+  '## Open questions',
+  '',
+  '> How do we show a file that changed twice in one session?',
+  '> Mark the second change only, or both?',
+  '',
+  '```ts',
+  'type FileView = {path: string; body: string; language?: string};',
+  '```',
+].join('\n');
+
+/** Line numbers (1-based) in `after` that are new or rewritten. */
+function changedLines(before: string, after: string): Set<number> {
+  const a = before.split('\n');
+  const b = after.split('\n');
+  // Longest common subsequence over lines — the same shape a real diff uses.
+  const lcs: number[][] = Array.from({length: a.length + 1}, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      lcs[i][j] =
+        a[i] === b[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+  const changed = new Set<number>();
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      i++;
+    } else {
+      changed.add(j + 1);
+      j++;
+    }
+  }
+  while (j < b.length) {
+    changed.add(++j);
+  }
+  return changed;
+}
+
+export const DiffIndicators: Story = {
+  name: 'Diff Indicators',
+  render: () => {
+    const changed = changedLines(SPEC_BEFORE, SPEC_AFTER);
+
+    return (
+      <div style={{maxWidth: 680, display: 'grid', gap: 16}}>
+        <Text variant="body-secondary">
+          The same document, rendered as prose, with the lines a diff reports as
+          added or rewritten marked in place.
+        </Text>
+        <Markdown
+          renderBlock={(block, children) => {
+            const isChanged = Array.from(
+              {length: block.position.endLine - block.position.startLine + 1},
+              (_unused, offset) => block.position.startLine + offset,
+            ).some(line => changed.has(line));
+            // A container's range covers its children, so tinting it would
+            // paint bullets that did not change; let the children carry it.
+            if (
+              !isChanged ||
+              block.type === 'list' ||
+              block.type === 'blockquote'
+            ) {
+              return children;
+            }
+            return (
+              <div
+                data-changed={block.type}
+                style={{
+                  background: 'var(--color-success-muted)',
+                  borderInlineStart: '2px solid var(--color-success)',
+                  paddingInlineStart: 8,
+                }}>
+                {children}
+              </div>
+            );
+          }}>
+          {SPEC_AFTER}
+        </Markdown>
+      </div>
+    );
+  },
+};

--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -531,7 +531,7 @@ export const DiffIndicators: Story = {
 
     return (
       <div style={{maxWidth: 680, display: 'grid', gap: 16}}>
-        <Text variant="body-secondary">
+        <Text type="supporting">
           The same document, rendered as prose, with the lines a diff reports as
           added or rewritten marked in place.
         </Text>

--- a/packages/core/src/Markdown/Markdown.doc.mjs
+++ b/packages/core/src/Markdown/Markdown.doc.mjs
@@ -97,6 +97,12 @@ export const docs = {
         "Opt-in autolinking of bare URLs and emails. 'gfm' applies GitHub-Flavored Markdown autolink-literal rules: bare https?://..., www...., <scheme:url>, <email>, and user@host all become links. Trailing sentence punctuation and unbalanced trailing close-parens are excluded; matches inside code spans, code blocks, existing links, and image alt text are skipped. Default behavior (option unset) is unchanged.",
     },
     {
+      name: 'renderBlock',
+      type: '(block: MarkdownBlock, children: ReactNode) => ReactNode',
+      description:
+        'Wraps every rendered block, given the source line range it came from ({type, position: {startLine, endLine}, depth}). Use for source-anchored decoration such as diff or change indicators, where rendered text is not a sound key. Runs for nested blocks too, so a changed list item can be marked on its own.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -192,6 +198,22 @@ import {Text} from '@astryxdesign/core/Text';
 <Markdown autolink="gfm">
   {'Visit https://example.com or email contact@example.com. ' +
     'You can also bracket links: <https://docs.example.com>.'}
+</Markdown>;
+`,
+    },
+    {
+      label: 'Diff indicators',
+      code: `
+// changedLines comes from a line diff of the old and new source.
+<Markdown
+  renderBlock={(block, children) =>
+    changedLines.has(block.position.startLine) ? (
+      <div className="changed">{children}</div>
+    ) : (
+      children
+    )
+  }>
+  {source}
 </Markdown>;
 `,
     },
@@ -299,6 +321,12 @@ export const docsZh = {
       type: "'gfm'",
       description:
         "可选的裸 URL 和电子邮箱自动链接。设为 'gfm' 启用 GitHub Flavored Markdown 自动链接规则：裸 https?://、www.、<scheme:url>、<email> 以及 user@host 都会变成链接。末尾句末标点和不平衡的末尾右括号会被排除；代码块、现有链接和图片替代文本内部的匹配会被跳过。默认为关闭。",
+    },
+    {
+      name: 'renderBlock',
+      type: '(block: MarkdownBlock, children: ReactNode) => ReactNode',
+      description:
+        '包裹每个渲染的块，并提供它在源文本中的行范围（{type, position: {startLine, endLine}, depth}）。适用于基于源位置的标注，例如差异/变更指示器——渲染后的文本不足以作为可靠的匹配依据。嵌套块同样会调用，因此可以单独标记被修改的列表项。',
     },
     {
       name: 'xstyle',

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -770,7 +770,7 @@ describe('Markdown renderBlock', () => {
     const stripIds = (html: string) => html.replace(/_r_[0-9a-z]+_/g, '_id_');
     const plain = render(<Markdown>{DOC}</Markdown>);
     const wrapped = render(
-      <Markdown renderBlock={async (_block, children) => children}>{DOC}</Markdown>,
+      <Markdown renderBlock={(_block, children) => children}>{DOC}</Markdown>,
     );
     expect(stripIds(wrapped.container.innerHTML)).toBe(
       stripIds(plain.container.innerHTML),
@@ -781,7 +781,7 @@ describe('Markdown renderBlock', () => {
     const seen: string[] = [];
     render(
       <Markdown
-        renderBlock={async (block, children) => {
+        renderBlock={(block, children) => {
           seen.push(
             `${block.type}:${block.position.startLine}-${block.position.endLine}@${block.depth}`,
           );
@@ -822,7 +822,7 @@ describe('Markdown renderBlock', () => {
 
     render(
       <Markdown
-        renderBlock={async (block, children) =>
+        renderBlock={(block, children) =>
           // Mark the innermost changed block only: a changed bullet marks the
           // bullet, not the whole list.
           isChanged(block) ? (
@@ -836,7 +836,7 @@ describe('Markdown renderBlock', () => {
     );
 
     const marked = Array.from(
-      document.querySelectorAll('[data-changed]'),
+      document.querySelectorAll<HTMLElement>('[data-changed]'),
     );
     // Document order: the list wrapper, then the changed bullet inside it,
     // then the code block. The unchanged bullet carries no mark of its own.
@@ -859,7 +859,7 @@ describe('Markdown renderBlock', () => {
         components={{
           heading: ({children}) => <h2 data-custom-heading>{children}</h2>,
         }}
-        renderBlock={async (block, children) =>
+        renderBlock={(block, children) =>
           block.type === 'heading' ? (
             <section data-wrapped>{children}</section>
           ) : (

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -750,3 +750,127 @@ describe('inlinePlugins', () => {
     });
   });
 });
+
+describe('Markdown renderBlock', () => {
+  const DOC = [
+    '# Spec', // 1
+    '',
+    'Intro paragraph.', // 3
+    '',
+    '- unchanged bullet', // 5
+    '- rewritten bullet', // 6
+    '',
+    '```ts', // 8
+    'const answer = 42;', // 9
+    '```', // 10
+  ].join('\n');
+
+  it('renders identical markup when the renderer passes children through', () => {
+    // React's generated ids differ between the two renders; nothing else may.
+    const stripIds = (html: string) => html.replace(/_r_[0-9a-z]+_/g, '_id_');
+    const plain = render(<Markdown>{DOC}</Markdown>);
+    const wrapped = render(
+      <Markdown renderBlock={async (_block, children) => children}>{DOC}</Markdown>,
+    );
+    expect(stripIds(wrapped.container.innerHTML)).toBe(
+      stripIds(plain.container.innerHTML),
+    );
+  });
+
+  it('reports the source range and depth of every block', () => {
+    const seen: string[] = [];
+    render(
+      <Markdown
+        renderBlock={async (block, children) => {
+          seen.push(
+            `${block.type}:${block.position.startLine}-${block.position.endLine}@${block.depth}`,
+          );
+          return children;
+        }}>
+        {DOC}
+      </Markdown>,
+    );
+    expect(seen).toEqual([
+      'heading:1-1@0',
+      'paragraph:3-3@0',
+      'paragraph:5-5@1',
+      'paragraph:6-6@1',
+      'list:5-6@0',
+      'codeblock:8-10@0',
+    ]);
+  });
+
+  it('drives the diff-indicator use case end to end', () => {
+    // A diff gives changed SOURCE LINE numbers; the renderer marks the blocks
+    // those lines fall in. Here line 6 (a bullet) and line 9 (inside the code
+    // block) changed.
+    const changed = new Set([6, 9]);
+    const isChanged = (block: {
+      position: {startLine: number; endLine: number};
+    }) => {
+      for (
+        let line = block.position.startLine;
+        line <= block.position.endLine;
+        line++
+      ) {
+        if (changed.has(line)) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    render(
+      <Markdown
+        renderBlock={async (block, children) =>
+          // Mark the innermost changed block only: a changed bullet marks the
+          // bullet, not the whole list.
+          isChanged(block) ? (
+            <div data-changed={`${block.type}-${block.depth}`}>{children}</div>
+          ) : (
+            children
+          )
+        }>
+        {DOC}
+      </Markdown>,
+    );
+
+    const marked = Array.from(
+      document.querySelectorAll('[data-changed]'),
+    );
+    // Document order: the list wrapper, then the changed bullet inside it,
+    // then the code block. The unchanged bullet carries no mark of its own.
+    expect(marked.map(el => [el.dataset.changed, el.textContent])).toEqual([
+      ['list-0', 'unchanged bulletrewritten bullet'],
+      ['paragraph-1', 'rewritten bullet'],
+      ['codeblock-0', expect.stringContaining('const answer = 42;')],
+    ]);
+    expect(screen.getByText('unchanged bullet').closest('[data-changed]')).toBe(
+      marked[0],
+    );
+    expect(screen.getByText('Intro paragraph.').closest('[data-changed]')).toBe(
+      null,
+    );
+  });
+
+  it('composes with component overrides rather than replacing them', () => {
+    render(
+      <Markdown
+        components={{
+          heading: ({children}) => <h2 data-custom-heading>{children}</h2>,
+        }}
+        renderBlock={async (block, children) =>
+          block.type === 'heading' ? (
+            <section data-wrapped>{children}</section>
+          ) : (
+            children
+          )
+        }>
+        {DOC}
+      </Markdown>,
+    );
+    const heading = screen.getByText('Spec');
+    expect(heading).toHaveAttribute('data-custom-heading');
+    expect(heading.parentElement).toHaveAttribute('data-wrapped');
+  });
+});

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -57,7 +57,12 @@ import {
   slugify,
   uniqueSlug,
 } from './parser';
-import type {BlockNode, InlineNode, IncrementalState} from './parser';
+import type {
+  BlockNode,
+  InlineNode,
+  IncrementalState,
+  MarkdownSourcePosition,
+} from './parser';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator, type TranslatorFn} from '../i18n';
 
@@ -126,6 +131,27 @@ export interface MarkdownComponents {
   hr?: React.ComponentType<object>;
 }
 
+/** The markdown construct a block came from — not a DOM tag name. */
+export type MarkdownBlockType = BlockNode['type'];
+
+/** What `renderBlock` is told about the block it is wrapping. */
+export interface MarkdownBlock {
+  type: MarkdownBlockType;
+  /** 1-based, inclusive range of source lines this block was parsed from. */
+  position: MarkdownSourcePosition;
+  /** 0 at the top level; 1+ for a block inside a blockquote or list item. */
+  depth: number;
+}
+
+/**
+ * Wraps one rendered block. Return `children` to leave it alone, or wrap it
+ * to attach a decoration keyed off the block's source lines.
+ */
+export type MarkdownBlockRenderer = (
+  block: MarkdownBlock,
+  children: React.ReactNode,
+) => React.ReactNode;
+
 export interface MarkdownProps extends BaseProps<HTMLElement> {
   ref?: React.Ref<HTMLDivElement> | React.Ref<HTMLSpanElement>;
   children: string;
@@ -181,6 +207,31 @@ export interface MarkdownProps extends BaseProps<HTMLElement> {
    */
   contentAlign?: 'start' | 'center';
   components?: Partial<MarkdownComponents>;
+  /**
+   * Wrap every rendered block, given the source line range it came from.
+   * Runs for nested blocks too (a paragraph inside a list item reports its
+   * own lines), so `depth` distinguishes them.
+   *
+   * This is the hook for source-anchored decoration — diff and change
+   * indicators, review comments, blame — where the mapping has to be to
+   * source lines, since rendered text is not unique. Enabling it turns on
+   * position tracking in the parser; without it, parsing is unchanged.
+   *
+   * @example
+   * ```tsx
+   * <Markdown
+   *   renderBlock={(block, children) =>
+   *     changedLines.has(block.position.startLine) ? (
+   *       <div className="changed">{children}</div>
+   *     ) : (
+   *       children
+   *     )
+   *   }>
+   *   {source}
+   * </Markdown>
+   * ```
+   */
+  renderBlock?: MarkdownBlockRenderer;
   /**
    * Plugins that transform text patterns into custom React elements.
    * Applied to text nodes after parsing — code blocks and inline code
@@ -1041,6 +1092,20 @@ function computeTableColumnMinWidths(node: {
   });
 }
 
+/** The renderer plus the current nesting depth, threaded through recursion. */
+type BlockRenderContext = {render: MarkdownBlockRenderer; depth: number};
+
+function descend(
+  ctx: BlockRenderContext | undefined,
+): BlockRenderContext | undefined {
+  return ctx && {render: ctx.render, depth: ctx.depth + 1};
+}
+
+/**
+ * Renders one block, then hands it to the consumer's `renderBlock` (when
+ * there is one) with the block's source range. Wrapping happens here — the
+ * one place every block, nested ones included, passes through.
+ */
 function renderBlock(
   node: BlockNode,
   index: number,
@@ -1056,6 +1121,56 @@ function renderBlock(
   inlinePlugins: MarkdownInlinePlugin[] | undefined,
   components: Partial<MarkdownComponents> | undefined,
   t: TranslatorFn,
+  blockCtx: BlockRenderContext | undefined,
+  headingIdMap?: ReadonlyMap<BlockNode, string>,
+): SyncReactNode {
+  const element = renderBlockElement(
+    node,
+    index,
+    blockCount,
+    density,
+    headingLevelStart,
+    onLinkClick,
+    cursor,
+    citationCtx,
+    contentWidthValue,
+    contentAlign,
+    linkComponent,
+    inlinePlugins,
+    components,
+    t,
+    blockCtx,
+    headingIdMap,
+  );
+  if (blockCtx == null || node.position == null) {
+    return element;
+  }
+  return (
+    <Fragment key={index}>
+      {blockCtx.render(
+        {type: node.type, position: node.position, depth: blockCtx.depth},
+        element,
+      )}
+    </Fragment>
+  );
+}
+
+function renderBlockElement(
+  node: BlockNode,
+  index: number,
+  blockCount: number,
+  density: 'default' | 'compact',
+  headingLevelStart: 1 | 2 | 3 | 4 | 5 | 6,
+  onLinkClick: MarkdownProps['onLinkClick'] | undefined,
+  cursor: StreamingCursor,
+  citationCtx: CitationContext | null,
+  contentWidthValue: string | null,
+  contentAlign: 'start' | 'center',
+  linkComponent: LinkComponentType = 'a',
+  inlinePlugins: MarkdownInlinePlugin[] | undefined,
+  components: Partial<MarkdownComponents> | undefined,
+  t: TranslatorFn,
+  blockCtx: BlockRenderContext | undefined,
   headingIdMap?: ReadonlyMap<BlockNode, string>,
 ): SyncReactNode {
   const blockAlignMargin = BLOCK_ALIGN_MARGIN[contentAlign];
@@ -1227,6 +1342,7 @@ function renderBlock(
             inlinePlugins,
             components,
             t,
+            descend(blockCtx),
           ),
         );
         return <BlockquoteComp key={index}>{bqC}</BlockquoteComp>;
@@ -1262,12 +1378,38 @@ function renderBlock(
               inlinePlugins,
               components,
               t,
+              descend(blockCtx),
             ),
           )}
         </Blockquote>
       );
     }
     case 'list': {
+      // A single-paragraph item renders as an inline label, so it never
+      // reaches renderBlock through the recursion — decorate it here, with
+      // the same shape a multi-block item's paragraph would report.
+      const decorateItemLabel = (
+        item: ListItemNode,
+        label: SyncReactNode,
+      ): SyncReactNode => {
+        const first = item.children[0];
+        if (blockCtx == null || first?.position == null) {
+          return label;
+        }
+        return (
+          <Fragment>
+            {blockCtx.render(
+              {
+                type: first.type,
+                position: first.position,
+                depth: blockCtx.depth + 1,
+              },
+              label,
+            )}
+          </Fragment>
+        );
+      };
+
       // Detect task lists: all items have a checked state
       const isTaskList =
         node.items.length > 0 && node.items.every(item => item.checked != null);
@@ -1336,6 +1478,7 @@ function renderBlock(
                         inlinePlugins,
                         components,
                         t,
+                        descend(blockCtx),
                       ),
                     )}
                   </>
@@ -1346,7 +1489,7 @@ function renderBlock(
                     // eslint-disable-next-line @eslint-react/no-array-index-key -- markdown task items are rendered from positional AST nodes
                     key={i}
                     value={`task-${i}`}
-                    label={label}
+                    label={decorateItemLabel(item, label)}
                   />
                 );
               })}
@@ -1418,6 +1561,7 @@ function renderBlock(
                       inlinePlugins,
                       components,
                       t,
+                      descend(blockCtx),
                     ),
                   )}
                 </>
@@ -1427,7 +1571,7 @@ function renderBlock(
                 <ListItem
                   // eslint-disable-next-line @eslint-react/no-array-index-key -- markdown list items are rendered from positional AST nodes
                   key={i}
-                  label={label}
+                  label={decorateItemLabel(item, label)}
                 />
               );
             })}
@@ -1616,6 +1760,7 @@ export function Markdown({
   contentWidth = 680,
   contentAlign = 'start',
   components,
+  renderBlock: renderBlockProp,
   inlinePlugins,
   autolink,
   xstyle,
@@ -1632,9 +1777,13 @@ export function Markdown({
   );
 
   const parseOptions = useMemo(
-    () => ({sourceIds, autolink}),
-    [sourceIds, autolink],
+    () => ({sourceIds, autolink, trackPosition: renderBlockProp != null}),
+    [sourceIds, autolink, renderBlockProp],
   );
+
+  const blockCtx: BlockRenderContext | undefined = renderBlockProp
+    ? {render: renderBlockProp, depth: 0}
+    : undefined;
 
   // Smooth bursty streamed chunks into a steady character-by-character reveal.
   // When not streaming, the hook returns children unchanged (no-op).
@@ -1804,6 +1953,7 @@ export function Markdown({
           inlinePlugins,
           components,
           t,
+          blockCtx,
           headingIdMap,
         ),
       )}

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -61,6 +61,7 @@ import type {
   BlockNode,
   InlineNode,
   IncrementalState,
+  ListItemNode,
   MarkdownSourcePosition,
 } from './parser';
 import {themeProps} from '../utils/themeProps';
@@ -146,11 +147,15 @@ export interface MarkdownBlock {
 /**
  * Wraps one rendered block. Return `children` to leave it alone, or wrap it
  * to attach a decoration keyed off the block's source lines.
+ *
+ * Nodes here are the synchronous subset of `ReactNode`: React 19 types admit
+ * a Promise, which would make every `=> children` implementation a function
+ * "returning a promise" and get it auto-fixed to `async` by lint.
  */
 export type MarkdownBlockRenderer = (
   block: MarkdownBlock,
-  children: React.ReactNode,
-) => React.ReactNode;
+  children: SyncReactNode,
+) => SyncReactNode;
 
 export interface MarkdownProps extends BaseProps<HTMLElement> {
   ref?: React.Ref<HTMLDivElement> | React.Ref<HTMLSpanElement>;

--- a/packages/core/src/Markdown/index.ts
+++ b/packages/core/src/Markdown/index.ts
@@ -14,6 +14,9 @@ export type {
   MarkdownSource,
   MarkdownComponents,
   MarkdownInlinePlugin,
+  MarkdownBlock,
+  MarkdownBlockType,
+  MarkdownBlockRenderer,
 } from './Markdown';
 
 export {
@@ -24,6 +27,7 @@ export {
 } from './parser';
 export type {
   BlockNode,
+  MarkdownSourcePosition,
   InlineNode,
   ListItemNode,
   TableCellNode,

--- a/packages/core/src/Markdown/parser.test.ts
+++ b/packages/core/src/Markdown/parser.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {parseMarkdown, parseInline} from './parser';
+import {
+  parseMarkdown,
+  parseInline,
+  parseMarkdownIncremental,
+  createIncrementalState,
+} from './parser';
 import type {InlineNode} from './parser';
 
 describe('parseInline', () => {
@@ -1207,5 +1212,144 @@ describe('link reference definitions', () => {
     const {links, blocks} = paragraphLinks('an array like [1, 2, 3] here');
     expect(links).toEqual([]);
     expect(blocks[0].type).toBe('paragraph');
+  });
+});
+
+describe('source positions (trackPosition)', () => {
+  const DOC = [
+    '[home]: https://example.com', // 1 — stripped from the parsed text
+    '',
+    '# Release notes', // 3
+    '',
+    'An intro paragraph that', // 5
+    'wraps onto a second line.', // 6
+    '',
+    '- first bullet', // 8
+    '- second bullet', // 9
+    '  with a continuation', // 10
+    '',
+    '> a quoted line', // 12
+    '> and another', // 13
+    '',
+    '```js', // 15
+    'const x = 1;', // 16
+    '', // 17 — blank line inside the fence
+    '# not a heading', // 18
+    '```', // 19
+    '',
+    '| a | b |', // 21
+    '| --- | --- |', // 22
+    '| 1 | 2 |', // 23
+    '',
+    '---', // 25
+    '',
+    'Read the [home] page.', // 27
+  ].join('\n');
+
+  const at = (position: {startLine: number; endLine: number} | undefined) => {
+    if (position == null) {
+      throw new Error('expected a position');
+    }
+    return DOC.split('\n')
+      .slice(position.startLine - 1, position.endLine)
+      .join('\n');
+  };
+
+  it('omits position unless asked', () => {
+    const blocks = parseMarkdown(DOC);
+    expect(blocks.every(block => block.position === undefined)).toBe(true);
+  });
+
+  it('maps every top-level block to its source lines', () => {
+    const blocks = parseMarkdown(DOC, {trackPosition: true});
+    expect(blocks.map(block => [block.type, block.position])).toEqual([
+      ['heading', {startLine: 3, endLine: 3}],
+      ['paragraph', {startLine: 5, endLine: 6}],
+      ['list', {startLine: 8, endLine: 10}],
+      ['blockquote', {startLine: 12, endLine: 13}],
+      ['codeblock', {startLine: 15, endLine: 19}],
+      ['table', {startLine: 21, endLine: 23}],
+      ['hr', {startLine: 25, endLine: 25}],
+      ['paragraph', {startLine: 27, endLine: 27}],
+    ]);
+  });
+
+  it('points at the text the reader sees, not an off-by-one neighbour', () => {
+    const blocks = parseMarkdown(DOC, {trackPosition: true});
+    expect(at(blocks[0].position)).toBe('# Release notes');
+    expect(at(blocks[4].position)).toBe(
+      '```js\nconst x = 1;\n\n# not a heading\n```',
+    );
+    expect(at(blocks[6].position)).toBe('---');
+    expect(at(blocks[7].position)).toBe('Read the [home] page.');
+  });
+
+  it('gives nested blocks their line in the original document', () => {
+    const blocks = parseMarkdown(DOC, {trackPosition: true});
+    const list = blocks[2];
+    const quote = blocks[3];
+    if (list.type !== 'list' || quote.type !== 'blockquote') {
+      throw new Error('unexpected block types');
+    }
+    expect(list.items.map(item => item.children[0].position)).toEqual([
+      {startLine: 8, endLine: 8},
+      {startLine: 9, endLine: 10},
+    ]);
+    expect(quote.children[0].position).toEqual({startLine: 12, endLine: 13});
+  });
+
+  it('keeps deeply nested content aligned', () => {
+    const doc = [
+      '- outer', // 1
+      '  - inner one', // 2
+      '  - inner two', // 3
+      '',
+      '> - quoted bullet', // 5
+      '>', // 6
+      '>   ```', // 7
+      '>   code', // 8
+      '>   ```', // 9
+    ].join('\n');
+    const blocks = parseMarkdown(doc, {trackPosition: true});
+    const outer = blocks[0];
+    if (outer.type !== 'list') {
+      throw new Error('expected a list');
+    }
+    const nested = outer.items[0].children[1];
+    expect(nested.type).toBe('list');
+    expect(nested.position).toEqual({startLine: 2, endLine: 3});
+
+    const quote = blocks[1];
+    if (quote.type !== 'blockquote') {
+      throw new Error('expected a blockquote');
+    }
+    const quotedList = quote.children[0];
+    if (quotedList.type !== 'list') {
+      throw new Error('expected a list inside the quote');
+    }
+    expect(quotedList.position).toEqual({startLine: 5, endLine: 5});
+    expect(quotedList.items[0].children[0].position).toEqual({
+      startLine: 5,
+      endLine: 5,
+    });
+    expect(quote.position).toEqual({startLine: 5, endLine: 9});
+    expect(quote.children[1].position).toEqual({startLine: 7, endLine: 9});
+  });
+
+  it('counts stripped link definitions as source lines', () => {
+    // The definition line produces no block but still occupies line 1, so
+    // everything after it must not slide up by one.
+    const blocks = parseMarkdown(DOC, {trackPosition: true});
+    expect(blocks[0].position?.startLine).toBe(3);
+  });
+
+  it('is stable under streaming (incremental) parsing', () => {
+    const state = createIncrementalState();
+    const streamed = parseMarkdownIncremental(DOC, state, {
+      trackPosition: true,
+    });
+    expect(streamed.map(block => block.position)).toEqual(
+      parseMarkdown(DOC, {trackPosition: true}).map(block => block.position),
+    );
   });
 });

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -24,7 +24,20 @@ export type InlineNode =
   | {type: 'citation'; sourceId: string}
   | {type: 'break'};
 
-export type BlockNode =
+/**
+ * Where a block came from in the source markdown: a 1-based, inclusive range
+ * of source lines. Only the line range is exposed — not byte offsets, and not
+ * the parser's internal indices — because a source range is what line-oriented
+ * consumers (diffs, blame, review comments) speak in.
+ */
+export type MarkdownSourcePosition = {
+  /** 1-based line number of the block's first source line. */
+  startLine: number;
+  /** 1-based line number of the block's last source line, inclusive. */
+  endLine: number;
+};
+
+type BlockNodeKind =
   | {type: 'heading'; level: 1 | 2 | 3 | 4 | 5 | 6; children: InlineNode[]}
   | {type: 'paragraph'; children: InlineNode[]}
   | {type: 'codeblock'; language: string; content: string}
@@ -46,6 +59,11 @@ export type BlockNode =
     }
   | {type: 'hr'}
   | {type: 'image'; src: string; alt: string};
+
+export type BlockNode = BlockNodeKind & {
+  /** Source line range. Present only when parsing with `trackPosition`. */
+  position?: MarkdownSourcePosition;
+};
 
 export type ListItemNode = {checked?: boolean; children: BlockNode[]};
 export type TableCellNode = {children: InlineNode[]};
@@ -78,6 +96,12 @@ export type ParseOptions = {
    * suffix is not rejected (Astryx accepts any plausible TLD shape).
    */
   autolink?: 'gfm';
+  /**
+   * Record a `position` (source line range) on every block node. Off by
+   * default: it costs an allocation per block and adds a field that
+   * structural comparisons of the AST would otherwise not see.
+   */
+  trackPosition?: boolean;
 };
 
 type ResolvedOptions = {
@@ -109,7 +133,44 @@ function resolveOptions(
     return {sourceIds: arg as ReadonlySet<string>, autolink: undefined};
   }
   const opts = arg as ParseOptions;
-  return {sourceIds: opts.sourceIds, autolink: opts.autolink};
+  return {
+    sourceIds: opts.sourceIds,
+    autolink: opts.autolink,
+    trackPosition: opts.trackPosition,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Source positions
+// ---------------------------------------------------------------------------
+
+/**
+ * Source line number (1-based) for each line of the text being parsed, or
+ * null when position tracking is off. Recursive parses (blockquote bodies,
+ * list-item bodies) re-slice this so a nested block reports the line it
+ * occupies in the ORIGINAL document, not in the de-indented fragment the
+ * recursion actually parses.
+ */
+type LineNumbers = ReadonlyArray<number> | null;
+
+function makePosition(
+  lineNumbers: LineNumbers,
+  startIndex: number,
+  endIndex: number,
+): MarkdownSourcePosition | undefined {
+  if (lineNumbers == null || startIndex >= lineNumbers.length) {
+    return undefined;
+  }
+  const last = Math.min(Math.max(endIndex, startIndex), lineNumbers.length - 1);
+  return {startLine: lineNumbers[startIndex], endLine: lineNumbers[last]};
+}
+
+/** Attach a position to a freshly-built block, or return it untouched. */
+function positioned(
+  node: BlockNodeKind,
+  position: MarkdownSourcePosition | undefined,
+): BlockNode {
+  return position == null ? node : {...node, position};
 }
 
 // ---------------------------------------------------------------------------
@@ -174,6 +235,8 @@ function matchLinkDefinition(
 function extractLinkDefinitions(input: string): {
   defs: ReadonlyMap<string, string>;
   cleaned: string;
+  /** Per source line: whether it survived into `cleaned`. */
+  keep: ReadonlyArray<boolean>;
 } {
   const lines = input.split('\n');
   const defs = new Map<string, string>();
@@ -233,10 +296,10 @@ function extractLinkDefinitions(input: string): {
   }
 
   if (defs.size === 0) {
-    return {defs, cleaned: input};
+    return {defs, cleaned: input, keep};
   }
   const cleaned = lines.filter((_, index) => keep[index]).join('\n');
-  return {defs, cleaned};
+  return {defs, cleaned, keep};
 }
 
 /** Order-independent signature of a link-definition set, for cache checks. */
@@ -1115,6 +1178,7 @@ function parseTable(
   lines: string[],
   lineIndex: number,
   opts: ResolvedOptions,
+  lineNumbers: LineNumbers,
 ): {node: BlockNode; nextIndex: number} {
   const headers: TableCellNode[] = splitTableRow(lines[lineIndex]).map(
     cell => ({children: parseInlineEntry(cell, opts)}),
@@ -1148,7 +1212,10 @@ function parseTable(
     rowIndex++;
   }
   return {
-    node: {type: 'table', headers, alignments, rows},
+    node: positioned(
+      {type: 'table', headers, alignments, rows},
+      makePosition(lineNumbers, lineIndex, rowIndex - 1),
+    ),
     nextIndex: rowIndex,
   };
 }
@@ -1158,6 +1225,7 @@ function parseList(
   startIndex: number,
   ordered: boolean,
   opts: ResolvedOptions,
+  lineNumbers: LineNumbers,
 ): {node: BlockNode; nextIndex: number} {
   const items: ListItemNode[] = [];
   const baseIndent = getIndent(lines[startIndex]);
@@ -1177,7 +1245,9 @@ function parseList(
 
   let loose = false;
   let index = startIndex;
+  let lastContentIndex = startIndex;
   while (index < lines.length && itemPattern.test(lines[index])) {
+    const itemStart = index;
     const content = ordered
       ? lines[index].replace(new RegExp(`^ *\\d+${escDelim} `), '')
       : lines[index].replace(/^ *[-*+] /, '');
@@ -1213,7 +1283,18 @@ function parseList(
       itemText += '\n' + deindented.join('\n');
     }
 
-    items.push({checked, children: parseMarkdownImpl(itemText, opts)});
+    items.push({
+      checked,
+      // The item body is line-for-line the item's own source lines (the
+      // marker line, then its de-indented continuations), so the recursion
+      // gets that exact slice of source line numbers.
+      children: parseMarkdownImpl(
+        itemText,
+        opts,
+        lineNumbers ? lineNumbers.slice(itemStart, index) : null,
+      ),
+    });
+    lastContentIndex = index - 1;
 
     // CommonMark loose list: blank line(s) between items of the same style
     // and indent still form one list. Skip the blanks and continue if the
@@ -1232,14 +1313,17 @@ function parseList(
     }
   }
   return {
-    node: {
-      type: 'list',
-      ordered,
-      start,
-      delimiter: ordered ? (delim as '.' | ')') : undefined,
-      loose: loose || undefined,
-      items,
-    },
+    node: positioned(
+      {
+        type: 'list',
+        ordered,
+        start,
+        delimiter: ordered ? (delim as '.' | ')') : undefined,
+        loose: loose || undefined,
+        items,
+      },
+      makePosition(lineNumbers, startIndex, lastContentIndex),
+    ),
     nextIndex: index,
   };
 }
@@ -1266,6 +1350,12 @@ export function parseMarkdown(
 function parseMarkdownImpl(
   input: string,
   baseOpts: ResolvedOptions,
+  /**
+   * Source line numbers for `input`'s lines, when the caller is a recursive
+   * parse of a document fragment. Null/omitted at the document root, where
+   * line N of `input` simply is line N of the source.
+   */
+  lineMap?: LineNumbers,
 ): BlockNode[] {
   // Collect this input's link reference definitions and strip their lines,
   // then merge them with any definitions inherited from an enclosing parse
@@ -1274,7 +1364,7 @@ function parseMarkdownImpl(
   // definitions win on conflict, matching CommonMark's first-definition-wins
   // in document order; locally-nested definitions still resolve within this
   // parse.
-  const {defs, cleaned} = extractLinkDefinitions(input);
+  const {defs, cleaned, keep} = extractLinkDefinitions(input);
   const inherited = baseOpts.linkDefs;
   let linkDefs: ReadonlyMap<string, string> | undefined;
   if (defs.size === 0) {
@@ -1287,6 +1377,17 @@ function parseMarkdownImpl(
   const opts: ResolvedOptions =
     linkDefs != null ? {...baseOpts, linkDefs} : baseOpts;
   const lines = cleaned.split('\n');
+  // Source line number per line of `cleaned` — stripped link definitions shift
+  // everything after them, so this is built from `keep` rather than assumed.
+  let lineNumbers: number[] | null = null;
+  if (opts.trackPosition) {
+    lineNumbers = [];
+    for (let i = 0; i < keep.length; i++) {
+      if (keep[i]) {
+        lineNumbers.push(lineMap ? lineMap[i] : i + 1);
+      }
+    }
+  }
   const blocks: BlockNode[] = [];
   let index = 0;
 
@@ -1303,31 +1404,44 @@ function parseMarkdownImpl(
       const fence = fenceMatch[1];
       const language = fenceMatch[2] || 'plaintext';
       const codeLines: string[] = [];
+      const fenceStart = index;
       index++;
       while (index < lines.length && !lines[index].startsWith(fence)) {
         codeLines.push(lines[index]);
         index++;
       }
       index++; // skip closing fence
-      blocks.push({type: 'codeblock', language, content: codeLines.join('\n')});
+      blocks.push(
+        positioned(
+          {type: 'codeblock', language, content: codeLines.join('\n')},
+          makePosition(lineNumbers, fenceStart, index - 1),
+        ),
+      );
       continue;
     }
 
     // --- Heading ---
     const headingMatch = line.match(/^(#{1,6}) +(.*)/);
     if (headingMatch) {
-      blocks.push({
-        type: 'heading',
-        level: headingMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6,
-        children: parseInlineEntry(headingMatch[2], opts),
-      });
+      blocks.push(
+        positioned(
+          {
+            type: 'heading',
+            level: headingMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6,
+            children: parseInlineEntry(headingMatch[2], opts),
+          },
+          makePosition(lineNumbers, index, index),
+        ),
+      );
       index++;
       continue;
     }
 
     // --- HR (must precede list check to handle `- - -`, `* * *`, `_ _ _`) ---
     if (isHorizontalRule(line)) {
-      blocks.push({type: 'hr'});
+      blocks.push(
+        positioned({type: 'hr'}, makePosition(lineNumbers, index, index)),
+      );
       index++;
       continue;
     }
@@ -1335,7 +1449,12 @@ function parseMarkdownImpl(
     // --- Standalone image ---
     const imageMatch = line.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
     if (imageMatch && line.trim() === imageMatch[0]) {
-      blocks.push({type: 'image', alt: imageMatch[1], src: imageMatch[2]});
+      blocks.push(
+        positioned(
+          {type: 'image', alt: imageMatch[1], src: imageMatch[2]},
+          makePosition(lineNumbers, index, index),
+        ),
+      );
       index++;
       continue;
     }
@@ -1346,7 +1465,7 @@ function parseMarkdownImpl(
       line.includes('|') &&
       isTableSeparator(lines[index + 1])
     ) {
-      const tableResult = parseTable(lines, index, opts);
+      const tableResult = parseTable(lines, index, opts, lineNumbers);
       blocks.push(tableResult.node);
       index = tableResult.nextIndex;
       continue;
@@ -1354,6 +1473,7 @@ function parseMarkdownImpl(
 
     // --- Blockquote ---
     if (line.startsWith('> ') || line === '>') {
+      const quoteStart = index;
       const quoteLines: string[] = [];
       while (
         index < lines.length &&
@@ -1362,16 +1482,25 @@ function parseMarkdownImpl(
         quoteLines.push(lines[index].replace(/^> ?/, ''));
         index++;
       }
-      blocks.push({
-        type: 'blockquote',
-        children: parseMarkdownImpl(quoteLines.join('\n'), opts),
-      });
+      blocks.push(
+        positioned(
+          {
+            type: 'blockquote',
+            children: parseMarkdownImpl(
+              quoteLines.join('\n'),
+              opts,
+              lineNumbers ? lineNumbers.slice(quoteStart, index) : null,
+            ),
+          },
+          makePosition(lineNumbers, quoteStart, index - 1),
+        ),
+      );
       continue;
     }
 
     // --- Unordered list ---
     if (/^ {0,9}[-*+] /.test(line)) {
-      const listResult = parseList(lines, index, false, opts);
+      const listResult = parseList(lines, index, false, opts, lineNumbers);
       blocks.push(listResult.node);
       index = listResult.nextIndex;
       continue;
@@ -1379,13 +1508,14 @@ function parseMarkdownImpl(
 
     // --- Ordered list ---
     if (/^ {0,9}\d+[.)] /.test(line)) {
-      const listResult = parseList(lines, index, true, opts);
+      const listResult = parseList(lines, index, true, opts, lineNumbers);
       blocks.push(listResult.node);
       index = listResult.nextIndex;
       continue;
     }
 
     // --- Paragraph ---
+    const paraStart = index;
     const paraLines: string[] = [line];
     index++;
     while (
@@ -1396,10 +1526,15 @@ function parseMarkdownImpl(
       paraLines.push(lines[index]);
       index++;
     }
-    blocks.push({
-      type: 'paragraph',
-      children: parseInlineEntry(paraLines.join('\n'), opts),
-    });
+    blocks.push(
+      positioned(
+        {
+          type: 'paragraph',
+          children: parseInlineEntry(paraLines.join('\n'), opts),
+        },
+        makePosition(lineNumbers, paraStart, index - 1),
+      ),
+    );
   }
   return blocks;
 }
@@ -1757,6 +1892,19 @@ export function parseMarkdownIncremental(
     state.settledUpTo = 0;
     state.linkDefsKey = undefined;
     return [];
+  }
+
+  // Position tracking and incremental reuse do not mix: the cache is keyed on
+  // text slices, and a slice's blocks carry line numbers relative to the slice.
+  // Streaming a document while also reporting source lines is rare enough
+  // (positions serve static views — diffs, blame) that a full re-parse is the
+  // honest trade rather than a second, cache-aware line-offset path.
+  if (opts.trackPosition) {
+    state.prevInput = input;
+    state.settledText = '';
+    state.settledBlocks = [];
+    state.settledUpTo = 0;
+    return parseMarkdownImpl(input, opts);
   }
 
   // Link reference definitions are document-global and usually stream in

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -107,6 +107,7 @@ export type ParseOptions = {
 type ResolvedOptions = {
   readonly sourceIds: ReadonlySet<string> | undefined;
   readonly autolink: 'gfm' | undefined;
+  readonly trackPosition?: boolean;
   /**
    * Link reference definitions (`[label]: url`) collected from the whole
    * document, keyed by normalized label. Internal only — populated by the


### PR DESCRIPTION
## Why

A file viewer wants to render a changed markdown file as prose and mark which blocks were added or rewritten — the way a rich code-review UI shows a changed document — instead of dropping the reader into a raw `+`/`-` column. That mapping is expressed in **source line ranges**, and today no override in `Markdown` receives any source information, so there is no sound way to say "this rendered paragraph is lines 12–18". Matching on rendered text collides on repeated blocks; pre-splitting the source per hunk breaks any list or table that straddles a hunk boundary.

Worth stating, because the gap report assumed otherwise: Astryx's `Markdown` does **not** use remark/mdast. `parser.ts` is a hand-rolled line parser whose nodes carry no `position` at all, so this is not "surface what the parser already knows" — the positions had to be computed and threaded through the recursive parses (blockquote bodies, list-item bodies) and through link-reference stripping, which removes source lines.

## What

- Parser: opt-in `trackPosition` records `position: {startLine, endLine}` (1-based, inclusive) on every block node. Off by default, so parsing cost and AST shape are unchanged for everyone else.
- Component: `renderBlock?: (block, children) => node` wraps each rendered block, given `{type, position, depth}`. It runs for nested blocks too, so a single rewritten bullet can be marked without tinting its whole list; `depth` distinguishes them. Single-paragraph list items — which render as an inline label and so never reach the block recursion — are decorated at the same shape, otherwise per-bullet indicators would silently not work.

## The API surface, and what it deliberately does not expose

`renderBlock` was chosen over the two obvious alternatives:

- **Pass the AST node** (or a `node` prop on each override). Maximally useful, and it makes `BlockNode`'s shape a render-contract we can never change — for a use case that needs two integers.
- **Add `position` to the nine `MarkdownComponents` overrides.** Two mechanisms for one job, and it still doesn't cover the blocks most likely to carry an indicator: there is no `list` or `table` override to put it on. One decorator that sees *every* block, including lists and tables, is smaller and more complete.

Deliberately not exposed: the AST node, byte offsets, columns, per-table-row and per-table-cell ranges (a changed row marks the table), and any new component-override types. `MarkdownBlockType` is the block-kind union, which `BlockNode` already exports today.

## Risk

Anything shipped here is public API. The surface is two integers plus a block-kind string and a depth — the smallest thing that drives the use case — and it is additive: omit the prop and both parsing and markup are byte-identical (asserted in a test). One trade recorded in code: with `trackPosition` on, streaming skips the incremental cache and re-parses, because cached blocks carry line numbers relative to a text slice. Positions serve static views, so a second cache-aware offset path was not worth its bug surface.

The renderer's node types are the synchronous subset of `ReactNode`. React 19's `ReactNode` admits a Promise, which makes `(block, children) => children` read as "returns a promise" and get auto-fixed to `async` by lint — caught here by that autofix silently rewriting the tests.

## Testing

- Parser: line ranges for headings, lazy-continued paragraphs, lists, blockquotes, a fenced block containing a blank line and a `#` line, tables, `hr`; nested blocks reporting original-document lines; ranges verified by slicing the source back out (off-by-one guard); shifted lines after a stripped link definition; streaming parity.
- Component: renders identical markup when the renderer passes children through, reported ranges and depths for a whole document, the diff-indicator path end to end (changed lines in → the right blocks marked, the untouched bullet and intro not), and composition with existing `components` overrides.
- Storybook: `Core/Markdown → Diff Indicators` runs a real LCS line diff of a before/after spec and marks the result. Verified in Chromium, not just jsdom: the rewritten bullet, the added quote line and the changed code block are marked; the unchanged bullets, heading and intro are not.
