### PR TITLE
fix(cli): wire state into the Bottom Sheet showcase checkboxes

### DIFF
--- a/.changeset/bottom-sheet-showcase-checkbox-state.md
+++ b/.changeset/bottom-sheet-showcase-checkbox-state.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Bottom Sheet showcase block: the filter checkboxes are interactive again.
+
+`CheckboxInput` is fully controlled — `value` is required and the input only moves when the owner updates it. The showcase passed a literal `value={false}` with no `onChange`, so the three filters ("In stock", "On sale", "Free shipping") rendered but could never be toggled: on the docs site the first thing a reader tries in a Bottom Sheet does nothing, and anyone copying the block inherits three dead controls. Each filter now has its own `useState` and `onChange`, matching the checkbox wiring already used in the Bottom Sheet Switcher showcase.
+
+@imdreamrunner

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetShowcase.tsx
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetShowcase.tsx
@@ -13,6 +13,9 @@ import {VStack} from '@astryxdesign/core/Stack';
 
 export default function BottomSheetShowcase() {
   const [isOpen, setIsOpen] = useState(false);
+  const [inStock, setInStock] = useState(false);
+  const [onSale, setOnSale] = useState(false);
+  const [freeShipping, setFreeShipping] = useState(false);
 
   return (
     <>
@@ -23,9 +26,21 @@ export default function BottomSheetShowcase() {
             <Heading level={3}>Filters</Heading>
             <Divider />
             <VStack gap={2}>
-              <CheckboxInput label="In stock" value={false} />
-              <CheckboxInput label="On sale" value={false} />
-              <CheckboxInput label="Free shipping" value={false} />
+              <CheckboxInput
+                label="In stock"
+                value={inStock}
+                onChange={setInStock}
+              />
+              <CheckboxInput
+                label="On sale"
+                value={onSale}
+                onChange={setOnSale}
+              />
+              <CheckboxInput
+                label="Free shipping"
+                value={freeShipping}
+                onChange={setFreeShipping}
+              />
             </VStack>
             <Button label="Apply" onClick={() => setIsOpen(false)} />
           </VStack>


### PR DESCRIPTION
## What's broken

The Bottom Sheet showcase block — the example on the component page, and the block `astryx template` hands out — renders three filter checkboxes:

```tsx
<CheckboxInput label="In stock" value={false} />
<CheckboxInput label="On sale" value={false} />
<CheckboxInput label="Free shipping" value={false} />
```

`CheckboxInput` is fully controlled: `value` is required and the box only moves when its owner updates it. With a literal `value={false}` and no `onChange`, all three are inert. Open the sheet on the docs site and click a filter and nothing happens — the first thing a reader tries inside a Bottom Sheet is dead — and anyone copying the block inherits three dead controls.

Visible on the canary docs site at https://astryx-canary.vercel.app/components/BottomSheet (the page is canary-only until the promote release ships).

## The fix

Each filter gets its own `useState` and `onChange`. That is the wiring the sibling `BottomSheetSwitcherShowcase` already uses for its three checkboxes, so the two Bottom Sheet examples now teach the same thing. No component change — the block is example code only.

I scanned every `.tsx` under `packages/cli/assets/templates` for a controlled input passed a literal `value` with no `onChange`: this showcase was the only occurrence.

## Checks

- `pnpm check:changesets`, `check:sync`, `check:use-client`, `check:cli-structure` — pass
- `eslint` (strict) and `prettier --check` on the touched files — clean
- Changeset added (`[fix]`, `@astryxdesign/cli` patch)

## Possible follow-up (not in this PR)

Nothing catches this class of bug: a controlled input given a literal `value={true|false}` and no `onChange` is always inert. A small `internal/eslint-plugin-astryx` rule scoped to `packages/cli/assets/templates/**` would keep shipped examples from teaching dead UI.
