### PR TITLE
fix(core): keep the page still when the mobile keyboard reveals a Bottom Sheet field

### DIFF
--- a/.changeset/bottomsheet-keeps-the-page-still-when-the-mobile-xlk2.md
+++ b/.changeset/bottomsheet-keeps-the-page-still-when-the-mobile-xlk2.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] BottomSheet keeps the page still when the mobile keyboard reveals a field the browser focused itself
+[fix] BottomSheet keeps the page still when the mobile keyboard reveals a field the browser focused itself (#5158)
 @imdreamrunner

--- a/.changeset/bottomsheet-keeps-the-page-still-when-the-mobile-xlk2.md
+++ b/.changeset/bottomsheet-keeps-the-page-still-when-the-mobile-xlk2.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BottomSheet keeps the page still when the mobile keyboard reveals a field the browser focused itself
+@imdreamrunner

--- a/packages/core/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/core/src/BottomSheet/BottomSheet.doc.mjs
@@ -99,7 +99,7 @@ export const docs = {
       name: 'height',
       type: "'hug' | 'capped' | 'tall' | number | string",
       description:
-        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height. Only a fully expanded 'tall' sheet provides mobile-keyboard accommodation; shorter Tall detents, Hug, Capped, numeric, and CSS-length heights do not move, do not add keyboard scroll space, and leave the browser's own focus reveal in place — on iOS that reveal can pan the page.",
+        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height. Only a fully expanded 'tall' sheet provides mobile-keyboard accommodation; shorter Tall detents, Hug, Capped, numeric, and CSS-length heights do not move, do not add keyboard scroll space, and leave the browser's own focus reveal in place — on iOS that reveal can shift the whole page.",
       default: "'capped'",
     },
     {

--- a/packages/core/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/core/src/BottomSheet/BottomSheet.doc.mjs
@@ -99,7 +99,7 @@ export const docs = {
       name: 'height',
       type: "'hug' | 'capped' | 'tall' | number | string",
       description:
-        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height. Only a fully expanded 'tall' sheet provides mobile-keyboard accommodation; shorter Tall detents, Hug, Capped, numeric, and CSS-length heights do not move, do not add keyboard scroll space, and leave the browser's own focus reveal in place — on iOS that reveal can shift the whole page.",
+        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height. Only a fully expanded 'tall' sheet provides mobile-keyboard accommodation: it stays put and scrolls each focused control above the keyboard. Hug, Capped, numeric and CSS-length heights never do, and a Tall sheet stops doing it the moment the user drags it to a shorter detent — resuming when they drag it back. Outside that state the sheet neither moves nor adds keyboard scroll space, and the browser's own focus reveal is left in place; on iOS that reveal can shift the whole page.",
       default: "'capped'",
     },
     {

--- a/packages/core/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/core/src/BottomSheet/BottomSheet.doc.mjs
@@ -99,7 +99,7 @@ export const docs = {
       name: 'height',
       type: "'hug' | 'capped' | 'tall' | number | string",
       description:
-        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height. Only a fully expanded 'tall' sheet provides mobile-keyboard accommodation; shorter Tall detents, Hug, Capped, numeric, and CSS-length heights do not move or add keyboard scroll space.",
+        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height. Only a fully expanded 'tall' sheet provides mobile-keyboard accommodation; shorter Tall detents, Hug, Capped, numeric, and CSS-length heights do not move, do not add keyboard scroll space, and leave the browser's own focus reveal in place — on iOS that reveal can pan the page.",
       default: "'capped'",
     },
     {

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -1061,133 +1061,16 @@ describe('BottomSheet', () => {
   });
 
   describe('mobile keyboard', () => {
-    it('prevents native touch focus panning without moving focus early or duplicating events', () => {
+    it('claims a transition between fields and delivers it with preventScroll', () => {
       mockIOSWebKit();
-      const onFocus = vi.fn();
-      const onBlur = vi.fn();
       render(
         <BottomSheet
           isOpen
           onOpenChange={() => {}}
           label="Add a comment"
           height="tall">
-          <input
-            aria-label="Comment"
-            onPointerDown={event => event.stopPropagation()}
-            onFocus={onFocus}
-            onBlur={onBlur}
-          />
-        </BottomSheet>,
-      );
-      const sheet = getSheet();
-      const input = screen.getByRole('textbox', {name: 'Comment'});
-      const focus = vi.spyOn(input, 'focus');
-      sheet.focus();
-
-      // Pointerdown may still become a scroll gesture, so it must not move
-      // focus or open the keyboard early.
-      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
-      expect(focus).not.toHaveBeenCalled();
-      expect(onFocus).not.toHaveBeenCalled();
-      expect(document.activeElement).toBe(sheet);
-
-      // Pointerup confirms a tap and prevents focus panning. The subsequent
-      // native click remains responsible for caret placement.
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
-      expect(focus).toHaveBeenCalledTimes(1);
-      expect(focus).toHaveBeenCalledWith({preventScroll: true});
-      expect(document.activeElement).toBe(input);
-      expect(onFocus).toHaveBeenCalledTimes(1);
-      expect(onBlur).not.toHaveBeenCalled();
-
-      // The native click still runs for caret placement and must not produce a
-      // second focus transition.
-      fireEvent.click(input);
-      expect(onFocus).toHaveBeenCalledTimes(1);
-      expect(onBlur).not.toHaveBeenCalled();
-    });
-
-    it('does not focus when a touch becomes a scroll gesture', () => {
-      mockIOSWebKit();
-      const onPreviousBlur = vi.fn();
-      render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <button type="button" onBlur={onPreviousBlur}>
-            Previous action
-          </button>
+          <input aria-label="Title" />
           <input aria-label="Comment" />
-        </BottomSheet>,
-      );
-      const body = getBody();
-      const previous = screen.getByRole('button', {name: 'Previous action'});
-      const input = screen.getByRole('textbox', {name: 'Comment'});
-      const focus = vi.spyOn(input, 'focus');
-      body.scrollTop = 20;
-      previous.focus();
-
-      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
-      fireTouchPointer(input, 'pointermove', {x: 20, y: 240});
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 240});
-
-      expect(focus).not.toHaveBeenCalled();
-      expect(document.activeElement).toBe(previous);
-      expect(onPreviousBlur).not.toHaveBeenCalled();
-    });
-
-    it('does not focus when pointer activation is canceled', () => {
-      mockIOSWebKit();
-      const onFocus = vi.fn();
-      const onPreviousBlur = vi.fn();
-      render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <button type="button" onBlur={onPreviousBlur}>
-            Previous action
-          </button>
-          <input
-            aria-label="Comment"
-            onPointerDown={event => event.preventDefault()}
-            onFocus={onFocus}
-          />
-        </BottomSheet>,
-      );
-      const previous = screen.getByRole('button', {name: 'Previous action'});
-      const input = screen.getByRole('textbox', {name: 'Comment'});
-      const focus = vi.spyOn(input, 'focus');
-      previous.focus();
-
-      const pointerDownAllowed = fireTouchPointer(input, 'pointerdown', {
-        x: 20,
-        y: 200,
-      });
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
-
-      expect(pointerDownAllowed).toBe(false);
-      expect(focus).not.toHaveBeenCalled();
-      expect(document.activeElement).toBe(previous);
-      expect(onFocus).not.toHaveBeenCalled();
-      expect(onPreviousBlur).not.toHaveBeenCalled();
-    });
-
-    it('prevents input-to-input focus panning without duplicating focus or blur events', () => {
-      mockIOSWebKit();
-      const onTitleBlur = vi.fn();
-      const onCommentFocus = vi.fn();
-      render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <input aria-label="Title" onBlur={onTitleBlur} />
-          <input aria-label="Comment" onFocus={onCommentFocus} />
         </BottomSheet>,
       );
       const title = screen.getByRole('textbox', {name: 'Title'});
@@ -1195,42 +1078,95 @@ describe('BottomSheet', () => {
       title.focus();
       const focus = vi.spyOn(comment, 'focus');
 
-      fireTouchPointer(comment, 'pointerdown', {x: 20, y: 200});
-      fireTouchPointer(comment, 'pointerup', {x: 20, y: 200});
+      // The keyboard's Next, Tab, and a programmatic focus() all arrive as this
+      // one transition, named by relatedTarget on the outgoing blur.
+      fireEvent.blur(title, {relatedTarget: comment});
 
+      // Delivered by us, with the browser's reveal refused.
       expect(focus).toHaveBeenCalledWith({preventScroll: true});
-      expect(document.activeElement).toBe(comment);
-      expect(onTitleBlur).toHaveBeenCalledTimes(1);
-      expect(onCommentFocus).toHaveBeenCalledTimes(1);
-
-      fireEvent.click(comment);
-      expect(onTitleBlur).toHaveBeenCalledTimes(1);
-      expect(onCommentFocus).toHaveBeenCalledTimes(1);
     });
 
-    it('does not duplicate callbacks during programmatic input-to-input focus', () => {
+    it('does not re-deliver a transition it has already claimed', () => {
       mockIOSWebKit();
-      const onTitleBlur = vi.fn();
-      const onCommentFocus = vi.fn();
       render(
         <BottomSheet
           isOpen
           onOpenChange={() => {}}
           label="Add a comment"
           height="tall">
-          <input aria-label="Title" onBlur={onTitleBlur} />
-          <input aria-label="Comment" onFocus={onCommentFocus} />
+          <input aria-label="Title" />
+          <input aria-label="Comment" />
         </BottomSheet>,
       );
       const title = screen.getByRole('textbox', {name: 'Title'});
       const comment = screen.getByRole('textbox', {name: 'Comment'});
-
       title.focus();
-      comment.focus();
+      const focus = vi.spyOn(comment, 'focus');
 
+      // Delivering the focus makes the browser run its own transition, whose
+      // blur re-enters the handler naming the same destination. Exactly one
+      // delivery must come out of that — a consumer's onFocus is one event, and
+      // measured on iOS the counts match an unclaimed transition exactly.
+      fireEvent.blur(title, {relatedTarget: comment});
+
+      expect(focus).toHaveBeenCalledTimes(1);
       expect(document.activeElement).toBe(comment);
-      expect(onTitleBlur).toHaveBeenCalledTimes(1);
-      expect(onCommentFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('parks focus on the sheet when the keyboard Done button takes it', () => {
+      mockIOSWebKit();
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const sheet = getSheet();
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      input.focus();
+      const sheetFocus = vi.spyOn(sheet, 'focus');
+
+      // Done dismisses the keyboard and drops focus on the body. Left there,
+      // the field is still document.activeElement on the next tap, so no
+      // transition fires and the browser reveals it its own way. Parking focus
+      // on the sheet keeps the next tap a transition this hook can claim.
+      fireEvent.blur(input, {relatedTarget: null});
+
+      expect(sheetFocus).toHaveBeenCalledWith({preventScroll: true});
+    });
+
+    it('contains overscroll while the sheet owns focus transitions', () => {
+      mockIOSWebKit();
+      const {unmount} = render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+
+      // A scroll that runs out of room in any nested scroller chains to the
+      // document and takes the fixed sheet with it. Current iOS latches this
+      // at touchstart, too late for a listener, so it ships as a stylesheet.
+      const style = [...document.head.querySelectorAll('style')].find(node =>
+        node.textContent?.includes('overscroll-behavior'),
+      );
+      expect(style?.textContent).toBe(
+        '@layer {*{overscroll-behavior:contain}}',
+      );
+
+      unmount();
+
+      expect(
+        [...document.head.querySelectorAll('style')].some(node =>
+          node.textContent?.includes('overscroll-behavior'),
+        ),
+      ).toBe(false);
     });
 
     it('does not alter ordinary desktop focus when the viewport is unobstructed', () => {
@@ -1852,7 +1788,7 @@ describe('BottomSheet', () => {
       Object.defineProperty(window, 'scrollY', {configurable: true, value: 0});
     });
 
-    it('reaches a browser-driven destination before its native reveal can pan', () => {
+    it('delivers a browser-driven transition itself, then reveals the field', () => {
       mockIOSWebKit();
       mockVisualViewport(500);
       render(
@@ -1902,15 +1838,15 @@ describe('BottomSheet', () => {
       );
       expect(scrolls).toEqual([]);
 
-      // A keyboard accessory "Next", a Tab, or a programmatic focus gives
-      // nowhere to pass preventScroll: WebKit reveals the destination itself
-      // once focus lands, and pans the visual viewport to do it. The
-      // destination has to be in the safe area before that, which means
-      // scrolling instantly and while focus is still in flight.
-      comment.focus();
+      // A keyboard accessory "Next" or a Tab arrives as a blur naming the
+      // destination. We deliver that focus with preventScroll — refusing the
+      // browser's reveal — and then reveal the field ourselves, inside the
+      // sheet.
+      fireEvent.blur(title, {relatedTarget: comment});
 
+      expect(document.activeElement).toBe(comment);
       expect(scrolls).toEqual([
-        {top: 248, behavior: 'instant', focusLanded: false},
+        {top: 248, behavior: 'smooth', focusLanded: true},
       ]);
       expect(body.scrollTop).toBe(248);
     });
@@ -1934,7 +1870,11 @@ describe('BottomSheet', () => {
       const scrolls: number[] = [];
       Object.defineProperty(body, 'scrollBy', {
         configurable: true,
+        // Apply the scroll, as the real scroller would: a reveal that has
+        // already happened must read as no distance left to travel, otherwise
+        // every later reveal looks like a fresh one.
         value: (options: ScrollToOptions) => {
+          body.scrollTop += options.top ?? 0;
           scrolls.push(options.top ?? 0);
         },
       });
@@ -1944,20 +1884,22 @@ describe('BottomSheet', () => {
       vi.spyOn(title, 'getBoundingClientRect').mockReturnValue(
         rect({top: 150, bottom: 190}),
       );
-      // Below the body's visible area, so the head start would move it if it
-      // ran at all — with no keyboard, only the reveal path may.
-      vi.spyOn(comment, 'getBoundingClientRect').mockReturnValue(
-        rect({top: 860, bottom: 900}),
+      // Below the body's visible area, so a reveal has somewhere to travel.
+      vi.spyOn(comment, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 860 - body.scrollTop, bottom: 900 - body.scrollTop}),
       );
 
       title.focus();
       scrolls.length = 0;
-      comment.focus();
+      const scrollTo = vi.mocked(window.scrollTo);
+      scrollTo.mockClear();
+      fireEvent.blur(title, {relatedTarget: comment});
 
-      // The focusout head start exists to beat a keyboard reveal. With no
-      // keyboard there is no reveal to beat, so the transition stays on the
-      // existing focusin path: one scroll, not two, and not one taken early.
+      // With no keyboard there is no clearance to leave and nothing to race,
+      // but the control still has to end up visible — brought there once, by
+      // the sheet's own scroller, with the page left alone.
       expect(scrolls).toEqual([100]);
+      expect(scrollTo).not.toHaveBeenCalled();
     });
 
     it('holds the keyboard scroll range through a pan, on the blur path', () => {
@@ -2054,159 +1996,16 @@ describe('BottomSheet', () => {
         inset,
       );
 
-      // And the next browser-driven focus still gets its head start: taken
-      // before focus lands, and far enough to clear the keyboard.
+      // And the next browser-driven transition is still claimed and revealed,
+      // by a distance measured against the unshifted keyboard boundary.
       scrolls.length = 0;
-      comment.focus();
+      fireEvent.blur(title, {relatedTarget: comment});
 
+      expect(document.activeElement).toBe(comment);
       expect(scrolls[0]).toEqual({
         top: 740 - (500 - 48),
-        focusLanded: false,
+        focusLanded: true,
       });
-    });
-
-    it('re-arms after a pointerup the page swallowed', () => {
-      mockIOSWebKit();
-      render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <input aria-label="Comment" />
-        </BottomSheet>,
-      );
-      const input = screen.getByRole('textbox', {name: 'Comment'});
-      // The pointerup listener is on document in the bubble phase, so a
-      // consumer can stop it and strand the armed tap.
-      const swallow = (event: Event) => event.stopPropagation();
-      input.addEventListener('pointerup', swallow);
-
-      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
-      input.removeEventListener('pointerup', swallow);
-
-      // A stranded arming must not lock out later taps. The next contact is a
-      // fresh pointer — a real one always is — and has to be protected.
-      const focus = vi.spyOn(input, 'focus');
-      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200, pointerId: 7});
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 200, pointerId: 7});
-
-      expect(focus).toHaveBeenCalledWith({preventScroll: true});
-    });
-
-    it('leaves a tap on its own gentle reveal, with no head start', () => {
-      const layoutBottom = window.innerHeight;
-      mockIOSWebKit();
-      mockVisualViewport(500);
-      render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <input aria-label="Title" />
-          <input aria-label="Comment" />
-        </BottomSheet>,
-      );
-      const body = getBody();
-      const title = screen.getByRole('textbox', {name: 'Title'});
-      const comment = screen.getByRole('textbox', {name: 'Comment'});
-      const scrolls: {behavior?: ScrollBehavior; focusLanded: boolean}[] = [];
-      Object.defineProperty(body, 'scrollBy', {
-        configurable: true,
-        value: (options: ScrollToOptions) => {
-          body.scrollTop += options.top ?? 0;
-          scrolls.push({
-            behavior: options.behavior,
-            focusLanded: document.activeElement === comment,
-          });
-        },
-      });
-      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
-        rect({top: 100, bottom: layoutBottom}),
-      );
-      vi.spyOn(title, 'getBoundingClientRect').mockReturnValue(
-        rect({top: 150, bottom: 190}),
-      );
-      vi.spyOn(comment, 'getBoundingClientRect').mockImplementation(() =>
-        rect({top: 700 - body.scrollTop, bottom: 740 - body.scrollTop}),
-      );
-      title.focus();
-      scrolls.length = 0;
-
-      fireTouchPointer(comment, 'pointerdown', {x: 20, y: 700});
-      fireTouchPointer(comment, 'pointerup', {x: 20, y: 700});
-
-      // A tap is already covered — it focused with preventScroll, so there is
-      // no native reveal to beat. It should keep the reveal it has always had:
-      // after focus, and animated. Taking the head start here would turn every
-      // tap between fields into a snap.
-      expect(scrolls).toEqual([{behavior: 'smooth', focusLanded: true}]);
-    });
-
-    it('keeps a tap protected when a second contact lands mid-gesture', () => {
-      mockIOSWebKit();
-      render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <input aria-label="Comment" />
-        </BottomSheet>,
-      );
-      const input = screen.getByRole('textbox', {name: 'Comment'});
-      const focus = vi.spyOn(input, 'focus');
-
-      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
-      // A thumb resting on the page, a palm, a second finger anywhere: not the
-      // contact that is tapping the field, and it must not disarm that tap.
-      fireTouchPointer(document.body, 'pointerdown', {
-        x: 300,
-        y: 700,
-        pointerId: 2,
-        isPrimary: false,
-      });
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
-
-      expect(focus).toHaveBeenCalledWith({preventScroll: true});
-      expect(document.activeElement).toBe(input);
-    });
-
-    it('keeps a tap protected when a second contact lifts first', () => {
-      mockIOSWebKit();
-      render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <input aria-label="Comment" />
-        </BottomSheet>,
-      );
-      const input = screen.getByRole('textbox', {name: 'Comment'});
-      const focus = vi.spyOn(input, 'focus');
-
-      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
-      fireTouchPointer(document.body, 'pointerdown', {
-        x: 300,
-        y: 700,
-        pointerId: 2,
-        isPrimary: false,
-      });
-      // The other end of the same gesture: the resting thumb lifts before the
-      // finger on the field does. That pointerup is not this tap ending.
-      fireTouchPointer(document.body, 'pointerup', {
-        x: 300,
-        y: 700,
-        pointerId: 2,
-        isPrimary: false,
-      });
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
-
-      expect(focus).toHaveBeenCalledWith({preventScroll: true});
-      expect(document.activeElement).toBe(input);
     });
   });
 

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -1852,23 +1852,33 @@ describe('BottomSheet', () => {
       const body = getBody();
       const title = screen.getByRole('textbox', {name: 'Title'});
       const comment = screen.getByRole('textbox', {name: 'Comment'});
+      const scrolls: number[] = [];
+      Object.defineProperty(body, 'scrollBy', {
+        configurable: true,
+        value: (options: ScrollToOptions) => {
+          scrolls.push(options.top ?? 0);
+        },
+      });
       vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
         rect({top: 100, bottom: 800}),
       );
       vi.spyOn(title, 'getBoundingClientRect').mockReturnValue(
         rect({top: 150, bottom: 190}),
       );
+      // Below the body's visible area, so the head start would move it if it
+      // ran at all — with no keyboard, only the reveal path may.
       vi.spyOn(comment, 'getBoundingClientRect').mockReturnValue(
-        rect({top: 660, bottom: 700}),
+        rect({top: 860, bottom: 900}),
       );
 
       title.focus();
+      scrolls.length = 0;
       comment.focus();
 
-      // With no keyboard measured there is no reveal to beat, and a hardware
-      // keyboard or desktop Tab must not shift a control that is already
-      // visible.
-      expect(body.scrollTop).toBe(0);
+      // The focusout head start exists to beat a keyboard reveal. With no
+      // keyboard there is no reveal to beat, so the transition stays on the
+      // existing focusin path: one scroll, not two, and not one taken early.
+      expect(scrolls).toEqual([100]);
     });
 
     it('does not mistake a panned visual viewport for a dismissed keyboard', () => {
@@ -1908,6 +1918,36 @@ describe('BottomSheet', () => {
       expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
         '80px',
       );
+    });
+
+    it('re-arms after a pointerup the page swallowed', () => {
+      mockIOSWebKit();
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      // The pointerup listener is on document in the bubble phase, so a
+      // consumer can stop it and strand the armed tap.
+      const swallow = (event: Event) => event.stopPropagation();
+      input.addEventListener('pointerup', swallow);
+
+      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
+      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
+      input.removeEventListener('pointerup', swallow);
+
+      // A stranded arming must not lock out later taps. The next contact is a
+      // fresh pointer — a real one always is — and has to be protected.
+      const focus = vi.spyOn(input, 'focus');
+      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200, pointerId: 7});
+      fireTouchPointer(input, 'pointerup', {x: 20, y: 200, pointerId: 7});
+
+      expect(focus).toHaveBeenCalledWith({preventScroll: true});
     });
 
     it('keeps a tap protected when a second contact lands mid-gesture', () => {

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -1773,6 +1773,85 @@ describe('BottomSheet', () => {
       );
     });
 
+    it('puts back a document scroll the browser makes to reveal a field', () => {
+      mockVisualViewport(377);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 57, bottom: 714}),
+      );
+      vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 600 - body.scrollTop, bottom: 640 - body.scrollTop}),
+      );
+      input.focus();
+      const scrollTo = vi.mocked(window.scrollTo);
+      scrollTo.mockClear();
+      const scrolledBy = body.scrollTop;
+
+      // The page numbers an iPhone 17 produces when the browser reveals a
+      // focused field in a scroll-locked, fixed sheet: it scrolls the DOCUMENT,
+      // and the sheet — fixed — travels with it.
+      Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        value: 337,
+      });
+      fireEvent.scroll(window);
+
+      expect(scrollTo).toHaveBeenCalledWith(0, 0);
+      // …and the control is still inside the safe area afterwards: the sheet's
+      // own scroller holds it there, so putting the document back does not
+      // hide what the browser was trying to reveal.
+      expect(input.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+        377 - 48,
+      );
+      expect(body.scrollTop).toBe(scrolledBy);
+      Object.defineProperty(window, 'scrollY', {configurable: true, value: 0});
+    });
+
+    it('leaves the document alone when no keyboard is measured', () => {
+      mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 57, bottom: 700}),
+      );
+      vi.spyOn(input, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 600, bottom: 640}),
+      );
+      input.focus();
+      const scrollTo = vi.mocked(window.scrollTo);
+      scrollTo.mockClear();
+
+      // An ordinary page scroll with no keyboard up is the user's, not the
+      // browser's, and a non-modal sheet leaves the page scrollable.
+      Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        value: 120,
+      });
+      fireEvent.scroll(window);
+
+      expect(scrollTo).not.toHaveBeenCalled();
+      Object.defineProperty(window, 'scrollY', {configurable: true, value: 0});
+    });
+
     it('reaches a browser-driven destination before its native reveal can pan', () => {
       mockIOSWebKit();
       mockVisualViewport(500);

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -1910,7 +1910,7 @@ describe('BottomSheet', () => {
       comment.focus();
 
       expect(scrolls).toEqual([
-        {top: 248, behavior: 'auto', focusLanded: false},
+        {top: 248, behavior: 'instant', focusLanded: false},
       ]);
       expect(body.scrollTop).toBe(248);
     });
@@ -1960,7 +1960,13 @@ describe('BottomSheet', () => {
       expect(scrolls).toEqual([100]);
     });
 
-    it('does not mistake a panned visual viewport for a dismissed keyboard', () => {
+    it('holds the keyboard scroll range through a pan, on the blur path', () => {
+      // A fully expanded Tall sheet — the only shape this hook runs in — is
+      // pinned to the layout viewport bottom, so the body's bottom IS
+      // innerHeight. Giving it a cushion below that would hide every bug in
+      // this file: the cushion, not the measurement, would keep the overlap
+      // positive under a pan.
+      const layoutBottom = window.innerHeight;
       const viewport = mockVisualViewport(500);
       render(
         <BottomSheet
@@ -1974,29 +1980,89 @@ describe('BottomSheet', () => {
       const body = getBody();
       const input = screen.getByRole('textbox', {name: 'Comment'});
       vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
-        rect({top: 100, bottom: 800}),
+        rect({top: 100, bottom: layoutBottom}),
       );
       vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
         rect({top: 660 - body.scrollTop, bottom: 700 - body.scrollTop}),
       );
       input.focus();
-      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '348px',
-      );
+      const inset = body.style.getPropertyValue('--_sheet-keyboard-inset');
+      expect(inset).toBe(`${layoutBottom - (500 - 48)}px`);
 
-      // iOS pans the viewport up to reveal a field: the same 500px of visible
-      // page, now offset so its bottom edge coincides with the layout viewport
-      // bottom — while the keyboard is still on screen. Read the bottom and
-      // that looks exactly like recovery, which would drop the scroll range
-      // out from under the field. The height is what stays honest: the body's
-      // 800px bottom still sits 32px below the visible region, so 48px of
-      // clearance leaves an 80px inset.
+      // The browser pans the page up to reveal a field: the same 500px of
+      // visible page, now offset so its bottom edge coincides with the layout
+      // viewport bottom — with the keyboard still on screen. Read the bottom
+      // and that is indistinguishable from the keyboard closing.
       viewport.offsetTop = window.innerHeight - 500;
       input.blur();
 
+      // The keyboard did not change size, so neither does the scroll range.
       expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '80px',
+        inset,
       );
+    });
+
+    it('keeps defending a pinned sheet after the browser has panned it once', () => {
+      // The regression that made the device symptom permanent: one pan read as
+      // "no keyboard" cleared the inset AND cleared hasKeyboardLayout, which
+      // disarms the head start below — so every subsequent reveal panned, and
+      // the sheet never recovered.
+      const layoutBottom = window.innerHeight;
+      mockIOSWebKit();
+      const viewport = mockVisualViewport(500);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Title" />
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const title = screen.getByRole('textbox', {name: 'Title'});
+      const comment = screen.getByRole('textbox', {name: 'Comment'});
+      const scrolls: {top: number; focusLanded: boolean}[] = [];
+      Object.defineProperty(body, 'scrollBy', {
+        configurable: true,
+        value: (options: ScrollToOptions) => {
+          body.scrollTop += options.top ?? 0;
+          scrolls.push({
+            top: options.top ?? 0,
+            focusLanded: document.activeElement === comment,
+          });
+        },
+      });
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 100, bottom: layoutBottom}),
+      );
+      vi.spyOn(title, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 150, bottom: 190}),
+      );
+      vi.spyOn(comment, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 700 - body.scrollTop, bottom: 740 - body.scrollTop}),
+      );
+
+      title.focus();
+      const inset = body.style.getPropertyValue('--_sheet-keyboard-inset');
+      expect(inset).toBe(`${layoutBottom - (500 - 48)}px`);
+
+      viewport.offsetTop = layoutBottom - 500;
+      void act(() => viewport.dispatchEvent(new Event('resize')));
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
+        inset,
+      );
+
+      // And the next browser-driven focus still gets its head start: taken
+      // before focus lands, and far enough to clear the keyboard.
+      scrolls.length = 0;
+      comment.focus();
+
+      expect(scrolls[0]).toEqual({
+        top: 740 - (500 - 48),
+        focusLanded: false,
+      });
     });
 
     it('re-arms after a pointerup the page swallowed', () => {
@@ -2029,6 +2095,56 @@ describe('BottomSheet', () => {
       expect(focus).toHaveBeenCalledWith({preventScroll: true});
     });
 
+    it('leaves a tap on its own gentle reveal, with no head start', () => {
+      const layoutBottom = window.innerHeight;
+      mockIOSWebKit();
+      mockVisualViewport(500);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Title" />
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const title = screen.getByRole('textbox', {name: 'Title'});
+      const comment = screen.getByRole('textbox', {name: 'Comment'});
+      const scrolls: {behavior?: ScrollBehavior; focusLanded: boolean}[] = [];
+      Object.defineProperty(body, 'scrollBy', {
+        configurable: true,
+        value: (options: ScrollToOptions) => {
+          body.scrollTop += options.top ?? 0;
+          scrolls.push({
+            behavior: options.behavior,
+            focusLanded: document.activeElement === comment,
+          });
+        },
+      });
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 100, bottom: layoutBottom}),
+      );
+      vi.spyOn(title, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 150, bottom: 190}),
+      );
+      vi.spyOn(comment, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 700 - body.scrollTop, bottom: 740 - body.scrollTop}),
+      );
+      title.focus();
+      scrolls.length = 0;
+
+      fireTouchPointer(comment, 'pointerdown', {x: 20, y: 700});
+      fireTouchPointer(comment, 'pointerup', {x: 20, y: 700});
+
+      // A tap is already covered — it focused with preventScroll, so there is
+      // no native reveal to beat. It should keep the reveal it has always had:
+      // after focus, and animated. Taking the head start here would turn every
+      // tap between fields into a snap.
+      expect(scrolls).toEqual([{behavior: 'smooth', focusLanded: true}]);
+    });
+
     it('keeps a tap protected when a second contact lands mid-gesture', () => {
       mockIOSWebKit();
       render(
@@ -2047,6 +2163,41 @@ describe('BottomSheet', () => {
       // A thumb resting on the page, a palm, a second finger anywhere: not the
       // contact that is tapping the field, and it must not disarm that tap.
       fireTouchPointer(document.body, 'pointerdown', {
+        x: 300,
+        y: 700,
+        pointerId: 2,
+        isPrimary: false,
+      });
+      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
+
+      expect(focus).toHaveBeenCalledWith({preventScroll: true});
+      expect(document.activeElement).toBe(input);
+    });
+
+    it('keeps a tap protected when a second contact lifts first', () => {
+      mockIOSWebKit();
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      const focus = vi.spyOn(input, 'focus');
+
+      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
+      fireTouchPointer(document.body, 'pointerdown', {
+        x: 300,
+        y: 700,
+        pointerId: 2,
+        isPrimary: false,
+      });
+      // The other end of the same gesture: the resting thumb lifts before the
+      // finger on the field does. That pointerup is not this tap ending.
+      fireTouchPointer(document.body, 'pointerup', {
         x: 300,
         y: 700,
         pointerId: 2,

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -222,14 +222,19 @@ function drag(handle: HTMLElement, points: {y: number}[]) {
 function fireTouchPointer(
   target: Element,
   type: 'pointerdown' | 'pointermove' | 'pointerup',
-  {x, y}: {x: number; y: number},
+  {
+    x,
+    y,
+    pointerId = 1,
+    isPrimary = true,
+  }: {x: number; y: number; pointerId?: number; isPrimary?: boolean},
 ) {
   const event = new Event(type, {bubbles: true, cancelable: true});
   Object.defineProperties(event, {
     clientX: {value: x},
     clientY: {value: y},
-    isPrimary: {value: true},
-    pointerId: {value: 1},
+    isPrimary: {value: isPrimary},
+    pointerId: {value: pointerId},
     pointerType: {value: 'touch'},
   });
   return fireEvent(target, event);
@@ -1766,6 +1771,172 @@ describe('BottomSheet', () => {
       expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
         '0px',
       );
+    });
+
+    it('reaches a browser-driven destination before its native reveal can pan', () => {
+      mockIOSWebKit();
+      mockVisualViewport(500);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Title" />
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const title = screen.getByRole('textbox', {name: 'Title'});
+      const comment = screen.getByRole('textbox', {name: 'Comment'});
+      const scrolls: {
+        top: number;
+        behavior?: ScrollBehavior;
+        focusLanded: boolean;
+      }[] = [];
+      Object.defineProperty(body, 'scrollBy', {
+        configurable: true,
+        value: (options: ScrollToOptions) => {
+          body.scrollTop += options.top ?? 0;
+          scrolls.push({
+            top: options.top ?? 0,
+            behavior: options.behavior,
+            focusLanded: document.activeElement === comment,
+          });
+        },
+      });
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 100, bottom: 800}),
+      );
+      vi.spyOn(title, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 150 - body.scrollTop, bottom: 190 - body.scrollTop}),
+      );
+      vi.spyOn(comment, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 660 - body.scrollTop, bottom: 700 - body.scrollTop}),
+      );
+
+      // The first field opens the keyboard and is already inside the safe
+      // area, so nothing has to move for it.
+      title.focus();
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
+        '348px',
+      );
+      expect(scrolls).toEqual([]);
+
+      // A keyboard accessory "Next", a Tab, or a programmatic focus gives
+      // nowhere to pass preventScroll: WebKit reveals the destination itself
+      // once focus lands, and pans the visual viewport to do it. The
+      // destination has to be in the safe area before that, which means
+      // scrolling instantly and while focus is still in flight.
+      comment.focus();
+
+      expect(scrolls).toEqual([
+        {top: 248, behavior: 'auto', focusLanded: false},
+      ]);
+      expect(body.scrollTop).toBe(248);
+    });
+
+    it('does not scroll a browser-driven transition when the viewport is unobstructed', () => {
+      mockIOSWebKit();
+      mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Title" />
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const title = screen.getByRole('textbox', {name: 'Title'});
+      const comment = screen.getByRole('textbox', {name: 'Comment'});
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 100, bottom: 800}),
+      );
+      vi.spyOn(title, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 150, bottom: 190}),
+      );
+      vi.spyOn(comment, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 660, bottom: 700}),
+      );
+
+      title.focus();
+      comment.focus();
+
+      // With no keyboard measured there is no reveal to beat, and a hardware
+      // keyboard or desktop Tab must not shift a control that is already
+      // visible.
+      expect(body.scrollTop).toBe(0);
+    });
+
+    it('does not mistake a panned visual viewport for a dismissed keyboard', () => {
+      const viewport = mockVisualViewport(500);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 100, bottom: 800}),
+      );
+      vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 660 - body.scrollTop, bottom: 700 - body.scrollTop}),
+      );
+      input.focus();
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
+        '348px',
+      );
+
+      // iOS pans the viewport up to reveal a field: the same 500px of visible
+      // page, now offset so its bottom edge coincides with the layout viewport
+      // bottom — while the keyboard is still on screen. Read the bottom and
+      // that looks exactly like recovery, which would drop the scroll range
+      // out from under the field. The height is what stays honest: the body's
+      // 800px bottom still sits 32px below the visible region, so 48px of
+      // clearance leaves an 80px inset.
+      viewport.offsetTop = window.innerHeight - 500;
+      input.blur();
+
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
+        '80px',
+      );
+    });
+
+    it('keeps a tap protected when a second contact lands mid-gesture', () => {
+      mockIOSWebKit();
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      const focus = vi.spyOn(input, 'focus');
+
+      fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
+      // A thumb resting on the page, a palm, a second finger anywhere: not the
+      // contact that is tapping the field, and it must not disarm that tap.
+      fireTouchPointer(document.body, 'pointerdown', {
+        x: 300,
+        y: 700,
+        pointerId: 2,
+        isPrimary: false,
+      });
+      fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
+
+      expect(focus).toHaveBeenCalledWith({preventScroll: true});
+      expect(document.activeElement).toBe(input);
     });
   });
 

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -222,19 +222,14 @@ function drag(handle: HTMLElement, points: {y: number}[]) {
 function fireTouchPointer(
   target: Element,
   type: 'pointerdown' | 'pointermove' | 'pointerup',
-  {
-    x,
-    y,
-    pointerId = 1,
-    isPrimary = true,
-  }: {x: number; y: number; pointerId?: number; isPrimary?: boolean},
+  {x, y}: {x: number; y: number},
 ) {
   const event = new Event(type, {bubbles: true, cancelable: true});
   Object.defineProperties(event, {
     clientX: {value: x},
     clientY: {value: y},
-    isPrimary: {value: isPrimary},
-    pointerId: {value: pointerId},
+    isPrimary: {value: true},
+    pointerId: {value: 1},
     pointerType: {value: 'touch'},
   });
   return fireEvent(target, event);
@@ -1086,31 +1081,29 @@ describe('BottomSheet', () => {
       expect(focus).toHaveBeenCalledWith({preventScroll: true});
     });
 
-    it('does not re-deliver a transition it has already claimed', () => {
+    it('does not park focus on a sheet that is closing', () => {
       mockIOSWebKit();
-      render(
+      const content = (isOpen: boolean) => (
         <BottomSheet
-          isOpen
+          isOpen={isOpen}
           onOpenChange={() => {}}
           label="Add a comment"
           height="tall">
-          <input aria-label="Title" />
           <input aria-label="Comment" />
-        </BottomSheet>,
+        </BottomSheet>
       );
-      const title = screen.getByRole('textbox', {name: 'Title'});
-      const comment = screen.getByRole('textbox', {name: 'Comment'});
-      title.focus();
-      const focus = vi.spyOn(comment, 'focus');
+      const {rerender} = render(content(true));
+      const sheet = getSheet();
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      input.focus();
+      const sheetFocus = vi.spyOn(sheet, 'focus');
 
-      // Delivering the focus makes the browser run its own transition, whose
-      // blur re-enters the handler naming the same destination. Exactly one
-      // delivery must come out of that — a consumer's onFocus is one event, and
-      // measured on iOS the counts match an unclaimed transition exactly.
-      fireEvent.blur(title, {relatedTarget: comment});
+      // Closing blurs the field as well, and that blur names no destination —
+      // the same shape as Done. There is no next tap to keep claimable here,
+      // and the host is about to hand focus back to whatever opened the sheet.
+      void act(() => rerender(content(false)));
 
-      expect(focus).toHaveBeenCalledTimes(1);
-      expect(document.activeElement).toBe(comment);
+      expect(sheetFocus).not.toHaveBeenCalled();
     });
 
     it('parks focus on the sheet when the keyboard Done button takes it', () => {
@@ -1136,37 +1129,6 @@ describe('BottomSheet', () => {
       fireEvent.blur(input, {relatedTarget: null});
 
       expect(sheetFocus).toHaveBeenCalledWith({preventScroll: true});
-    });
-
-    it('contains overscroll while the sheet owns focus transitions', () => {
-      mockIOSWebKit();
-      const {unmount} = render(
-        <BottomSheet
-          isOpen
-          onOpenChange={() => {}}
-          label="Add a comment"
-          height="tall">
-          <input aria-label="Comment" />
-        </BottomSheet>,
-      );
-
-      // A scroll that runs out of room in any nested scroller chains to the
-      // document and takes the fixed sheet with it. Current iOS latches this
-      // at touchstart, too late for a listener, so it ships as a stylesheet.
-      const style = [...document.head.querySelectorAll('style')].find(node =>
-        node.textContent?.includes('overscroll-behavior'),
-      );
-      expect(style?.textContent).toBe(
-        '@layer {*{overscroll-behavior:contain}}',
-      );
-
-      unmount();
-
-      expect(
-        [...document.head.querySelectorAll('style')].some(node =>
-          node.textContent?.includes('overscroll-behavior'),
-        ),
-      ).toBe(false);
     });
 
     it('does not alter ordinary desktop focus when the viewport is unobstructed', () => {
@@ -1900,6 +1862,43 @@ describe('BottomSheet', () => {
       // the sheet's own scroller, with the page left alone.
       expect(scrolls).toEqual([100]);
       expect(scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('leaves the page alone behind a non-modal sheet', () => {
+      const layoutBottom = window.innerHeight;
+      mockVisualViewport(500);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall"
+          hasScrim={false}>
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const body = getBody();
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 100, bottom: layoutBottom}),
+      );
+      vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
+        rect({top: 600 - body.scrollTop, bottom: 640 - body.scrollTop}),
+      );
+      input.focus();
+      const scrollTo = vi.mocked(window.scrollTo);
+      scrollTo.mockClear();
+
+      // Without a scrim the page behind stays scrollable, so a document scroll
+      // is the user's. Putting it back would fight them.
+      Object.defineProperty(window, 'scrollY', {
+        configurable: true,
+        value: 200,
+      });
+      fireEvent.scroll(window);
+
+      expect(scrollTo).not.toHaveBeenCalled();
+      Object.defineProperty(window, 'scrollY', {configurable: true, value: 0});
     });
 
     it('holds the keyboard scroll range through a pan, on the blur path', () => {

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -219,22 +219,6 @@ function drag(handle: HTMLElement, points: {y: number}[]) {
   fireEvent.pointerUp(handle, {pointerId: 1, clientY: last.y});
 }
 
-function fireTouchPointer(
-  target: Element,
-  type: 'pointerdown' | 'pointermove' | 'pointerup',
-  {x, y}: {x: number; y: number},
-) {
-  const event = new Event(type, {bubbles: true, cancelable: true});
-  Object.defineProperties(event, {
-    clientX: {value: x},
-    clientY: {value: y},
-    isPrimary: {value: true},
-    pointerId: {value: 1},
-    pointerType: {value: 'touch'},
-  });
-  return fireEvent(target, event);
-}
-
 function fireTimedPointer(
   target: Element,
   type: 'pointerdown' | 'pointermove' | 'pointerup',
@@ -1106,6 +1090,31 @@ describe('BottomSheet', () => {
       expect(sheetFocus).not.toHaveBeenCalled();
     });
 
+    it('autofocuses a field without letting the browser reveal it', () => {
+      mockIOSWebKit();
+      const focus = vi.spyOn(HTMLInputElement.prototype, 'focus');
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
+          <input aria-label="Comment" data-autofocus />
+        </BottomSheet>,
+      );
+      // A prototype spy outlives this test unless it is put back by hand.
+      const calls = [...focus.mock.calls];
+      focus.mockRestore();
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+
+      // Opening focuses the field itself, so there is no transition to claim —
+      // nothing was focused to blur. The presenting call has to refuse the
+      // reveal on its own, or the browser scrolls the page to show a field the
+      // sheet was about to show anyway.
+      expect(document.activeElement).toBe(input);
+      expect(calls).toContainEqual([{preventScroll: true}]);
+    });
+
     it('parks focus on the sheet when the keyboard Done button takes it', () => {
       mockIOSWebKit();
       render(
@@ -1319,8 +1328,9 @@ describe('BottomSheet', () => {
       );
       viewport.height = 500;
       const focus = vi.spyOn(input, 'focus');
-      fireTouchPointer(input, 'pointerdown', {x: 20, y: 700});
-      fireTouchPointer(input, 'pointerup', {x: 20, y: 700});
+      // A transition the browser would drive: at a shorter detent the hook
+      // must not claim it, so nothing focuses the field but the caller.
+      fireEvent.blur(sheet, {relatedTarget: input});
       expect(focus).not.toHaveBeenCalled();
 
       focus.mockRestore();
@@ -1370,8 +1380,8 @@ describe('BottomSheet', () => {
         body.scrollTop = 20;
 
         fireEvent.touchStart(input);
-        fireTouchPointer(input, 'pointerdown', {x: 20, y: 200});
-        fireTouchPointer(input, 'pointerup', {x: 20, y: 200});
+        // These heights opt out, so a browser-driven transition is left alone.
+        fireEvent.blur(sheet, {relatedTarget: input});
         fireEvent.pointerDown(input, {pointerId: 1, clientY: 200});
         body.scrollTop = 120;
         fireEvent.focus(input, {relatedTarget: null});

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -169,6 +169,10 @@ function panelStateForSwitcherPhase(
   }
 }
 
+// preventScroll on both: presenting a sheet must not scroll the page to reveal
+// what it just focused. For an autofocused field that reveal is the mobile
+// keyboard's, and it moves the document under a fixed sheet; useMobileKeyboard
+// brings the field into view within the sheet instead.
 function focusPanel(panel: HTMLElement | null, isModal: boolean): void {
   const activeElement = document.activeElement;
   if (activeElement != null && panel?.contains(activeElement)) {
@@ -176,9 +180,9 @@ function focusPanel(panel: HTMLElement | null, isModal: boolean): void {
   }
   const autofocus = panel?.querySelector<HTMLElement>('[data-autofocus]');
   if (autofocus != null) {
-    autofocus.focus();
+    autofocus.focus({preventScroll: true});
   } else if (isModal) {
-    panel?.focus();
+    panel?.focus({preventScroll: true});
   }
 }
 

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -330,6 +330,7 @@ function StandaloneBottomSheet({
           state={panelState}
           height={height}
           isSwipeDismissAllowed={purpose === 'info'}
+          isPageScrollLocked={shouldPresent && hasScrim}
           xstyle={xstyle}
           onDismiss={dismissOnLightInteraction}
           onScrimOpacity={handleScrimOpacity}
@@ -484,6 +485,7 @@ function SwitcherBottomSheetItem({
         state={panelState}
         height={height}
         isSwipeDismissAllowed={purpose === 'info'}
+        isPageScrollLocked={hasScrim}
         xstyle={xstyle}
         onDismiss={dismissOnSwipe}
         onScrimOpacity={handleScrimOpacity}

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -16,6 +16,7 @@
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/BottomSheet/BottomSheet.tsx
  * - /packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
+ * - /packages/core/src/BottomSheet/useMobileKeyboard.ts
  * - /packages/core/src/BottomSheet/useSheetGestures.ts
  */
 
@@ -171,6 +172,8 @@ interface BottomSheetPanelProps extends BaseProps<HTMLDivElement> {
   height: BottomSheetHeight | number | string;
   children: ReactNode;
   isSwipeDismissAllowed?: boolean;
+  /** Whether the host has locked page scrolling (a modal, scrim-backed sheet). */
+  isPageScrollLocked?: boolean;
   onDismiss: () => void;
   onScrimOpacity: (opacity: number) => void;
   onElementChange?: (element: HTMLDivElement | null) => void;
@@ -298,6 +301,7 @@ export function BottomSheetPanel({
   tabIndex,
   xstyle,
   isSwipeDismissAllowed = true,
+  isPageScrollLocked = false,
   onDismiss,
   onScrimOpacity,
   onElementChange,
@@ -372,6 +376,7 @@ export function BottomSheetPanel({
     bottomClearance: MOBILE_KEYBOARD_BOTTOM_CLEARANCE,
     isEnabled: height === 'tall',
     isFullyExpanded: settledOffset === 0,
+    isPageScrollLocked,
     isSheetTraveling: isDragging && dragOffset !== settledOffset,
     isOpen: isInteractive,
     isPresented,

--- a/packages/core/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -320,14 +320,12 @@ export function useMobileKeyboard({
     // still owns caret placement. Holding the original pointerdown event lets
     // consumer preventDefault calls remain authoritative after capture.
     const rememberPointerFocusScroll = (event: PointerEvent) => {
-      // A second contact — a resting thumb, a palm, a finger anywhere else on
-      // the page — must not disarm the one already mid-tap on a field. Without
-      // this, that tap's pointerup finds nothing pending, falls through to the
-      // browser's own focus, and the reveal pans the page.
-      if (
-        pendingTouchFocus != null &&
-        event.pointerId !== pendingTouchFocus.pointerId
-      ) {
+      // Only the primary contact can arm below, but a secondary one — a
+      // resting thumb, a palm, a second finger anywhere on the page — would
+      // still fall through and null out the arming of the finger already
+      // mid-tap on a field. Its pointerup would then find nothing pending and
+      // hand the focus back to the browser, whose reveal pans the page.
+      if (event.isPrimary === false) {
         return;
       }
       const control = findTextEntryControl(event.target, body);
@@ -405,20 +403,17 @@ export function useMobileKeyboard({
         pendingFocusScroll = null;
         return;
       }
-      // Snapshots restore what a scroll container scrolled, and that is not
-      // what a browser-driven transition costs us here. When WebKit reveals a
-      // destination sitting behind the keyboard it pans the visual viewport,
-      // and nothing can put that back: offsetTop is read-only, the dialog is
-      // fixed, and the page beneath it is scroll-locked. So reach the
-      // destination first and leave the reveal with nothing to do. It has to
-      // be instant to win that race, and it only runs while a keyboard is
-      // actually measured, so unobstructed desktop and hardware-keyboard focus
-      // keeps behaving exactly as before.
+      // A snapshot restores what a scroll container scrolled, which is not what
+      // this transition costs: WebKit reveals a destination behind the keyboard
+      // by panning the visual viewport, and offsetTop is read-only. So reach the
+      // destination first — instantly, to win the race — and leave the reveal
+      // nothing to do. Gated on a measured keyboard to keep unobstructed focus
+      // on the existing reveal path alone.
       if (hasKeyboardLayoutRef.current) {
         scrollControlIntoSafeArea(control, false);
       }
-      // Snapshot after that scroll, never before: the restore below is meant to
-      // undo the browser's reveal, not our own head start.
+      // Snapshot after that scroll: the restore below undoes the browser's
+      // reveal, not our own head start.
       pendingFocusScroll = captureFocusScroll(control);
     };
     const restoreFocusScroll = (event: FocusEvent) => {

--- a/packages/core/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -348,7 +348,6 @@ export function useMobileKeyboard({
         isActiveRef.current &&
         isFullyExpandedRef.current &&
         event.pointerType === 'touch' &&
-        event.isPrimary !== false &&
         control &&
         control !== document.activeElement
           ? {

--- a/packages/core/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -92,23 +92,27 @@ function captureFocusScroll(target: HTMLElement): FocusScrollSnapshot {
   };
 }
 
-function getVisualViewportBounds(): {top: number; bottom: number} {
-  const viewport = window.visualViewport;
-  const top = viewport?.offsetTop ?? 0;
+// Where the keyboard starts, in client coordinates. The keyboard covers the
+// bottom of the LAYOUT viewport, so its top edge sits at `visualViewport.height`
+// — and stays there when the browser pans the page to reveal a field, because a
+// pan slides the window over the page without moving the keyboard.
+//
+// Reading `offsetTop + height` instead makes the obstruction appear to shrink as
+// the pan grows. A fully expanded Tall sheet — the only shape this hook runs in
+// — is pinned to the layout viewport bottom, so at full pan the obstruction
+// reads as zero: the sheet concludes the keyboard is gone, drops the scroll
+// range it added, and disarms the defenses that would have caught the next pan.
+// One pan then latches the sheet into the unprotected behavior for good.
+function getUnobstructedBounds(): {top: number; bottom: number} {
   return {
-    top,
-    bottom: top + (viewport?.height ?? window.innerHeight),
+    top: 0,
+    bottom: window.visualViewport?.height ?? window.innerHeight,
   };
 }
 
-// The keyboard is gone once the visual viewport is as tall as the layout
-// viewport again. Height is the only pan-invariant signal for that: while iOS
-// holds the viewport panned up to reveal a field, the viewport's *bottom*
-// already sits at the layout viewport bottom with the keyboard still on
-// screen, so reading the bottom mistakes a pan for a dismissal.
+// The keyboard is gone once the visible band reaches the layout viewport bottom.
 function isVisualViewportRecovered(): boolean {
-  const height = window.visualViewport?.height ?? window.innerHeight;
-  return height >= window.innerHeight - 0.5;
+  return getUnobstructedBounds().bottom >= window.innerHeight - 0.5;
 }
 
 function isIOSWebKit(): boolean {
@@ -262,7 +266,10 @@ export function useMobileKeyboard({
         window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       body.scrollBy({
         top: distance,
-        behavior: smoothly && !reduceMotion ? 'smooth' : 'auto',
+        // Not 'auto': that defers to the element's computed `scroll-behavior`,
+        // so a consumer's `scroll-behavior: smooth` would animate a scroll this
+        // hook needs to land in the same frame.
+        behavior: smoothly && !reduceMotion ? 'smooth' : 'instant',
       });
     };
 
@@ -275,7 +282,7 @@ export function useMobileKeyboard({
     ) => {
       const measuredBodyRect = body.getBoundingClientRect();
       const measuredControlRect = control.getBoundingClientRect();
-      const viewport = getVisualViewportBounds();
+      const viewport = getUnobstructedBounds();
       const overlap = Math.max(0, measuredBodyRect.bottom - viewport.bottom);
       const clearance = overlap > 0 ? bottomClearance : 0;
       const safeTop = Math.max(measuredBodyRect.top, viewport.top);
@@ -295,7 +302,7 @@ export function useMobileKeyboard({
     };
 
     const applyKeyboardGeometry = (geometry: KeyboardGeometry) => {
-      const viewport = getVisualViewportBounds();
+      const viewport = getUnobstructedBounds();
       // A collapsed detent can extend the body below the layout viewport even
       // after the keyboard closes, so body overlap alone cannot identify
       // recovery. Once the visual viewport is full height again, release the
@@ -377,11 +384,17 @@ export function useMobileKeyboard({
     };
     const preventTouchFocusScroll = (event: PointerEvent) => {
       const pending = pendingTouchFocus;
+      // A lift by some other contact — the resting thumb, the palm — is not
+      // this tap ending. Leave the arming alone: consuming it here is the same
+      // disarm the pointerdown guard above prevents, at the other end of the
+      // gesture.
+      if (pending != null && pending.pointerId !== event.pointerId) {
+        return;
+      }
       pendingTouchFocus = null;
       if (
         !pending ||
         !isFullyExpandedRef.current ||
-        pending.pointerId !== event.pointerId ||
         pending.pointerDown.defaultPrevented ||
         event.defaultPrevented ||
         findTextEntryControl(event.target, body) !== pending.control ||
@@ -407,11 +420,16 @@ export function useMobileKeyboard({
       }
       // A snapshot restores what a scroll container scrolled, which is not what
       // this transition costs: WebKit reveals a destination behind the keyboard
-      // by panning the visual viewport, and offsetTop is read-only. So reach the
-      // destination first — instantly, to win the race — and leave the reveal
-      // nothing to do. Gated on a measured keyboard to keep unobstructed focus
-      // on the existing reveal path alone.
-      if (hasKeyboardLayoutRef.current) {
+      // by scrolling the page under a fixed sheet. Reach the destination first —
+      // in the same frame, so the reveal finds nothing left to do.
+      //
+      // The tap path is excluded: preventTouchFocusScroll has already focused
+      // with preventScroll there, so a head start would only replace that
+      // path's gentle post-focus glide with a snap.
+      if (
+        hasKeyboardLayoutRef.current &&
+        pendingPointerFocusScroll?.target !== control
+      ) {
         scrollControlIntoSafeArea(control, false);
       }
       // Snapshot after that scroll: the restore below undoes the browser's
@@ -452,7 +470,7 @@ export function useMobileKeyboard({
       retainKeyboardLayoutRef.current = false;
 
       const measuredBodyRect = body.getBoundingClientRect();
-      const viewport = getVisualViewportBounds();
+      const viewport = getUnobstructedBounds();
       const overlap = Math.max(0, measuredBodyRect.bottom - viewport.bottom);
       // The extra clearance leaves room for mobile suggestion UI, but only
       // while the visual viewport actually overlaps the sheet. With no

--- a/packages/core/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -14,16 +14,18 @@
  * sheet blurs the field and dismisses the keyboard.
  *
  * Every route into a field also has to reach it without the browser revealing
- * it for us: on iOS that reveal pans the visual viewport, which shifts the
- * whole page out from under a stationary sheet. A tap is pre-empted by focusing
- * with preventScroll; a transition the browser drives itself cannot be, so the
- * destination is scrolled into the safe area before focus lands instead.
+ * it for us. On iOS that reveal scrolls the DOCUMENT, and a fixed sheet travels
+ * with it, so the whole page lurches. The reveal is attached to the focus
+ * operation, which is where it can be refused: take the focus transition over
+ * on the capture-phase blur, deliver it with preventScroll, and bring the
+ * control into view with the sheet's own scroller afterwards. Every route in —
+ * a tap, the keyboard's Next, Tab, a programmatic focus() — passes through that
+ * one transition.
  */
 
 import {useEffect, useRef, type RefObject} from 'react';
 
 const MOBILE_KEYBOARD_INSET_VAR = '--_sheet-keyboard-inset';
-const TOUCH_FOCUS_MOVE_THRESHOLD = 10;
 const NON_TEXT_INPUT_TYPES = new Set([
   'button',
   'checkbox',
@@ -52,57 +54,6 @@ interface KeyboardGeometry {
   bodyBottom: number;
 }
 
-interface FocusScrollSnapshot {
-  target: HTMLElement;
-  elements: {
-    element: HTMLElement;
-    scrollLeft: number;
-    scrollTop: number;
-  }[];
-  windowX: number;
-  windowY: number;
-}
-
-interface PendingTouchFocus {
-  clientX: number;
-  clientY: number;
-  control: HTMLElement;
-  pointerDown: PointerEvent;
-  pointerId: number;
-}
-
-function captureFocusScroll(target: HTMLElement): FocusScrollSnapshot {
-  const elements: FocusScrollSnapshot['elements'] = [];
-  for (
-    let element = target.parentElement;
-    element;
-    element = element.parentElement
-  ) {
-    elements.push({
-      element,
-      scrollLeft: element.scrollLeft,
-      scrollTop: element.scrollTop,
-    });
-  }
-  return {
-    target,
-    elements,
-    windowX: window.scrollX,
-    windowY: window.scrollY,
-  };
-}
-
-// Where the keyboard starts, in client coordinates. The keyboard covers the
-// bottom of the LAYOUT viewport, so its top edge sits at `visualViewport.height`
-// — and stays there when the browser pans the page to reveal a field, because a
-// pan slides the window over the page without moving the keyboard.
-//
-// Reading `offsetTop + height` instead makes the obstruction appear to shrink as
-// the pan grows. A fully expanded Tall sheet — the only shape this hook runs in
-// — is pinned to the layout viewport bottom, so at full pan the obstruction
-// reads as zero: the sheet concludes the keyboard is gone, drops the scroll
-// range it added, and disarms the defenses that would have caught the next pan.
-// One pan then latches the sheet into the unprotected behavior for good.
 function getUnobstructedBounds(): {top: number; bottom: number} {
   return {
     top: 0,
@@ -226,10 +177,7 @@ export function useMobileKeyboard({
 
     let keyboardGeometry: KeyboardGeometry | null = null;
     let documentScrollAtKeyboard: {x: number; y: number} | null = null;
-    let pendingFocusScroll: FocusScrollSnapshot | null = null;
-    let pendingPointerFocusScroll: FocusScrollSnapshot | null = null;
-    let pendingTouchFocus: PendingTouchFocus | null = null;
-    const preventFocusScroll = isIOSWebKit();
+    const ownsFocusTransitions = isIOSWebKit();
 
     const clearKeyboardLayout = () => {
       body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, '0px');
@@ -237,23 +185,6 @@ export function useMobileKeyboard({
       documentScrollAtKeyboard = null;
       hasKeyboardLayoutRef.current = false;
       retainKeyboardLayoutRef.current = false;
-    };
-
-    const restoreScrollSnapshot = (snapshot: FocusScrollSnapshot) => {
-      for (const {element, scrollLeft, scrollTop} of snapshot.elements) {
-        if (element.scrollLeft !== scrollLeft) {
-          element.scrollLeft = scrollLeft;
-        }
-        if (element.scrollTop !== scrollTop) {
-          element.scrollTop = scrollTop;
-        }
-      }
-      if (
-        window.scrollX !== snapshot.windowX ||
-        window.scrollY !== snapshot.windowY
-      ) {
-        window.scrollTo(snapshot.windowX, snapshot.windowY);
-      }
     };
 
     const scrollBodyBy = (distance: number, smoothly: boolean) => {
@@ -324,129 +255,47 @@ export function useMobileKeyboard({
       body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, `${inset}px`);
     };
 
-    // Wait until pointerup confirms a touch was a tap, then focus before the
-    // native click so preventScroll suppresses page panning while the click
-    // still owns caret placement. Holding the original pointerdown event lets
-    // consumer preventDefault calls remain authoritative after capture.
-    const rememberPointerFocusScroll = (event: PointerEvent) => {
-      // Only the primary contact can arm below, but a secondary one — a
-      // resting thumb, a palm, a second finger anywhere on the page — would
-      // still fall through and null out the arming of the finger already
-      // mid-tap on a field. Its pointerup would then find nothing pending and
-      // hand the focus back to the browser, whose reveal pans the page.
-      if (event.isPrimary === false) {
+    // Take the focus transition over before the browser performs it.
+    //
+    // `blur` is dispatched in the capture phase ahead of the browser's own
+    // focus step, and it names the destination in `relatedTarget`. Focusing it
+    // here with preventScroll settles the transition: the browser's step finds
+    // the element already active, so it dispatches nothing further and there is
+    // no reveal to race. Then bring the control into view with the sheet's own
+    // scroller, which never moves anything outside the sheet.
+    let isClaimingFocus = false;
+    const claimFocusTransition = (event: FocusEvent) => {
+      // Delivering the focus below makes the browser run its own transition,
+      // whose blur re-enters here naming the same destination. Claiming that
+      // one too would deliver the focus a second time.
+      if (!isFullyExpandedRef.current || isClaimingFocus) {
         return;
       }
-      const control = findTextEntryControl(event.target, body);
-      pendingPointerFocusScroll =
-        isFullyExpandedRef.current &&
-        control &&
-        control !== document.activeElement
-          ? captureFocusScroll(control)
-          : null;
-      pendingTouchFocus =
-        isActiveRef.current &&
-        isFullyExpandedRef.current &&
-        event.pointerType === 'touch' &&
-        control &&
-        control !== document.activeElement
-          ? {
-              clientX: event.clientX,
-              clientY: event.clientY,
-              control,
-              pointerDown: event,
-              pointerId: event.pointerId,
-            }
-          : null;
-    };
-    const clearPendingTouchFocus = () => {
-      if (pendingPointerFocusScroll?.target === pendingTouchFocus?.control) {
-        pendingPointerFocusScroll = null;
-      }
-      pendingTouchFocus = null;
-    };
-    const handlePointerMove = (event: PointerEvent) => {
-      if (
-        pendingTouchFocus?.pointerId === event.pointerId &&
-        Math.hypot(
-          event.clientX - pendingTouchFocus.clientX,
-          event.clientY - pendingTouchFocus.clientY,
-        ) > TOUCH_FOCUS_MOVE_THRESHOLD
-      ) {
-        clearPendingTouchFocus();
-      }
-    };
-    const handlePointerCancel = (event: PointerEvent) => {
-      if (pendingTouchFocus?.pointerId === event.pointerId) {
-        clearPendingTouchFocus();
-      }
-    };
-    const preventTouchFocusScroll = (event: PointerEvent) => {
-      const pending = pendingTouchFocus;
-      // A lift by some other contact — the resting thumb, the palm — is not
-      // this tap ending. Leave the arming alone: consuming it here is the same
-      // disarm the pointerdown guard above prevents, at the other end of the
-      // gesture.
-      if (pending != null && pending.pointerId !== event.pointerId) {
-        return;
-      }
-      pendingTouchFocus = null;
-      if (
-        !pending ||
-        !isFullyExpandedRef.current ||
-        pending.pointerDown.defaultPrevented ||
-        event.defaultPrevented ||
-        findTextEntryControl(event.target, body) !== pending.control ||
-        document.activeElement === pending.control
-      ) {
-        if (pendingPointerFocusScroll?.target === pending?.control) {
-          pendingPointerFocusScroll = null;
+      const destination = findTextEntryControl(event.relatedTarget, body);
+      if (destination) {
+        if (destination !== document.activeElement) {
+          // Revealing the field is not this handler's job: focusing it raises
+          // focusin, and the viewport resize that follows the keyboard raises
+          // another — both already schedule the reveal below, which knows the
+          // safe area and scrolls only the sheet's own body.
+          isClaimingFocus = true;
+          try {
+            destination.focus({preventScroll: true});
+          } finally {
+            isClaimingFocus = false;
+          }
         }
         return;
       }
 
-      pending.control.focus({preventScroll: true});
-    };
-
-    // Keyboard and programmatic focus transitions cannot supply preventScroll.
-    // Restore their pre-focus scroll positions without re-entering the focus
-    // lifecycle, so consumer focus and blur callbacks remain single events.
-    const rememberFocusScroll = (event: FocusEvent) => {
-      const control = findTextEntryControl(event.relatedTarget, body);
-      if (!isFullyExpandedRef.current || !control) {
-        pendingFocusScroll = null;
-        return;
-      }
-      // A snapshot restores what a scroll container scrolled, which is not what
-      // this transition costs: WebKit reveals a destination behind the keyboard
-      // by scrolling the page under a fixed sheet. Reach the destination first —
-      // in the same frame, so the reveal finds nothing left to do.
-      //
-      // The tap path is excluded: preventTouchFocusScroll has already focused
-      // with preventScroll there, so a head start would only replace that
-      // path's gentle post-focus glide with a snap.
-      if (
-        hasKeyboardLayoutRef.current &&
-        pendingPointerFocusScroll?.target !== control
-      ) {
-        scrollControlIntoSafeArea(control, false);
-      }
-      // Snapshot after that scroll: the restore below undoes the browser's
-      // reveal, not our own head start.
-      pendingFocusScroll = captureFocusScroll(control);
-    };
-    const restoreFocusScroll = (event: FocusEvent) => {
-      const control = findTextEntryControl(event.target, body);
-      const snapshot =
-        pendingFocusScroll?.target === control
-          ? pendingFocusScroll
-          : pendingPointerFocusScroll?.target === control
-            ? pendingPointerFocusScroll
-            : null;
-      pendingFocusScroll = null;
-      pendingPointerFocusScroll = null;
-      if (snapshot?.target === control) {
-        restoreScrollSnapshot(snapshot);
+      // Focus left for nothing — the keyboard's Done button parks it on the
+      // body. Park it on the sheet instead, so re-tapping the same field is
+      // still a transition this handler sees. Left on the body, the field is
+      // already `document.activeElement` on the next tap, no blur fires, and
+      // the browser reveals it its own way.
+      const origin = findTextEntryControl(event.target, body);
+      if (origin && !event.relatedTarget) {
+        sheet?.focus({preventScroll: true});
       }
     };
 
@@ -608,17 +457,20 @@ export function useMobileKeyboard({
     };
 
     const viewport = window.visualViewport;
-    if (preventFocusScroll) {
-      document.addEventListener(
-        'pointerdown',
-        rememberPointerFocusScroll,
-        true,
-      );
-      document.addEventListener('pointermove', handlePointerMove, true);
-      document.addEventListener('pointercancel', handlePointerCancel, true);
-      document.addEventListener('pointerup', preventTouchFocusScroll);
-      document.addEventListener('focusout', rememberFocusScroll);
-      body.addEventListener('focus', restoreFocusScroll, true);
+    let containmentStyle: HTMLStyleElement | null = null;
+    if (ownsFocusTransitions) {
+      // Capture phase, and `blur` rather than `focusout`: both are dispatched
+      // before the browser's own focus step, which is the only window in which
+      // the transition can still be claimed.
+      document.addEventListener('blur', claimFocusTransition, true);
+
+      // A scroll that reaches the end of any nested scroller chains to the
+      // document, which moves the fixed sheet with it. Current iOS latches
+      // this at touchstart, too late for a listener to add — so it ships as a
+      // stylesheet, in its own layer so a consumer's own rules still win.
+      containmentStyle = document.createElement('style');
+      containmentStyle.textContent = '@layer {*{overscroll-behavior:contain}}';
+      document.head.prepend(containmentStyle);
     }
     body.addEventListener('focusin', handleFocusIn);
     body.addEventListener('focusout', handleFocusOut);
@@ -640,21 +492,9 @@ export function useMobileKeyboard({
 
     return () => {
       cancelAnimationFrame(animationFrame);
-      if (preventFocusScroll) {
-        document.removeEventListener(
-          'pointerdown',
-          rememberPointerFocusScroll,
-          true,
-        );
-        document.removeEventListener('pointermove', handlePointerMove, true);
-        document.removeEventListener(
-          'pointercancel',
-          handlePointerCancel,
-          true,
-        );
-        document.removeEventListener('pointerup', preventTouchFocusScroll);
-        document.removeEventListener('focusout', rememberFocusScroll);
-        body.removeEventListener('focus', restoreFocusScroll, true);
+      if (ownsFocusTransitions) {
+        document.removeEventListener('blur', claimFocusTransition, true);
+        containmentStyle?.remove();
       }
       body.removeEventListener('focusin', handleFocusIn);
       body.removeEventListener('focusout', handleFocusOut);

--- a/packages/core/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -44,6 +44,7 @@ interface UseMobileKeyboardOptions {
   bottomClearance: number;
   isEnabled: boolean;
   isFullyExpanded: boolean;
+  isPageScrollLocked: boolean;
   isSheetTraveling: boolean;
   isOpen: boolean;
   isPresented: boolean;
@@ -54,16 +55,13 @@ interface KeyboardGeometry {
   bodyBottom: number;
 }
 
-function getUnobstructedBounds(): {top: number; bottom: number} {
-  return {
-    top: 0,
-    bottom: window.visualViewport?.height ?? window.innerHeight,
-  };
+function getObstructionTop(): number {
+  return window.visualViewport?.height ?? window.innerHeight;
 }
 
 // The keyboard is gone once the visible band reaches the layout viewport bottom.
 function isVisualViewportRecovered(): boolean {
-  return getUnobstructedBounds().bottom >= window.innerHeight - 0.5;
+  return getObstructionTop() >= window.innerHeight - 0.5;
 }
 
 function isIOSWebKit(): boolean {
@@ -118,6 +116,7 @@ export function useMobileKeyboard({
   bottomClearance,
   isEnabled,
   isFullyExpanded,
+  isPageScrollLocked,
   isSheetTraveling,
   isOpen,
   isPresented,
@@ -125,10 +124,10 @@ export function useMobileKeyboard({
 }: UseMobileKeyboardOptions): void {
   const hasKeyboardLayoutRef = useRef(false);
   const retainKeyboardLayoutRef = useRef(false);
-  const isActiveRef = useRef(isOpen);
   const isFullyExpandedRef = useRef(isFullyExpanded);
-  isActiveRef.current = isOpen;
+  const isOpenRef = useRef(isOpen);
   isFullyExpandedRef.current = isFullyExpanded;
+  isOpenRef.current = isOpen;
 
   useEffect(() => {
     if (!isEnabled || !isSheetTraveling) {
@@ -204,22 +203,21 @@ export function useMobileKeyboard({
       });
     };
 
-    // Scroll `control` into the part of the body the keyboard leaves visible.
-    // Reads live geometry every time, so it serves both the reveal after focus
-    // lands and the head start taken before a transition the browser drives.
+    // Scroll `control` into the part of the body the keyboard leaves visible,
+    // reading live geometry each time.
     const scrollControlIntoSafeArea = (
       control: HTMLElement,
       smoothly: boolean,
     ) => {
       const measuredBodyRect = body.getBoundingClientRect();
       const measuredControlRect = control.getBoundingClientRect();
-      const viewport = getUnobstructedBounds();
-      const overlap = Math.max(0, measuredBodyRect.bottom - viewport.bottom);
+      const obstructionTop = getObstructionTop();
+      const overlap = Math.max(0, measuredBodyRect.bottom - obstructionTop);
       const clearance = overlap > 0 ? bottomClearance : 0;
-      const safeTop = Math.max(measuredBodyRect.top, viewport.top);
+      const safeTop = measuredBodyRect.top;
       const safeBottom = Math.min(
         measuredBodyRect.bottom,
-        viewport.bottom - clearance,
+        obstructionTop - clearance,
       );
       if (safeBottom <= safeTop) {
         return;
@@ -233,7 +231,7 @@ export function useMobileKeyboard({
     };
 
     const applyKeyboardGeometry = (geometry: KeyboardGeometry) => {
-      const viewport = getUnobstructedBounds();
+      const obstructionTop = getObstructionTop();
       // A collapsed detent can extend the body below the layout viewport even
       // after the keyboard closes, so body overlap alone cannot identify
       // recovery. Once the visual viewport is full height again, release the
@@ -242,7 +240,7 @@ export function useMobileKeyboard({
         clearKeyboardLayout();
         return;
       }
-      const overlap = Math.max(0, geometry.bodyBottom - viewport.bottom);
+      const overlap = Math.max(0, geometry.bodyBottom - obstructionTop);
       if (overlap === 0) {
         clearKeyboardLayout();
         return;
@@ -250,7 +248,7 @@ export function useMobileKeyboard({
 
       const inset = Math.max(
         0,
-        geometry.bodyBottom - (viewport.bottom - bottomClearance),
+        geometry.bodyBottom - (obstructionTop - bottomClearance),
       );
       body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, `${inset}px`);
     };
@@ -260,15 +258,10 @@ export function useMobileKeyboard({
     // `blur` is dispatched in the capture phase ahead of the browser's own
     // focus step, and it names the destination in `relatedTarget`. Focusing it
     // here with preventScroll settles the transition: the browser's step finds
-    // the element already active, so it dispatches nothing further and there is
-    // no reveal to race. Then bring the control into view with the sheet's own
-    // scroller, which never moves anything outside the sheet.
-    let isClaimingFocus = false;
+    // the element already active, so it dispatches nothing further and has
+    // nothing to reveal.
     const claimFocusTransition = (event: FocusEvent) => {
-      // Delivering the focus below makes the browser run its own transition,
-      // whose blur re-enters here naming the same destination. Claiming that
-      // one too would deliver the focus a second time.
-      if (!isFullyExpandedRef.current || isClaimingFocus) {
+      if (!isFullyExpandedRef.current) {
         return;
       }
       const destination = findTextEntryControl(event.relatedTarget, body);
@@ -278,12 +271,7 @@ export function useMobileKeyboard({
           // focusin, and the viewport resize that follows the keyboard raises
           // another — both already schedule the reveal below, which knows the
           // safe area and scrolls only the sheet's own body.
-          isClaimingFocus = true;
-          try {
-            destination.focus({preventScroll: true});
-          } finally {
-            isClaimingFocus = false;
-          }
+          destination.focus({preventScroll: true});
         }
         return;
       }
@@ -293,8 +281,12 @@ export function useMobileKeyboard({
       // still a transition this handler sees. Left on the body, the field is
       // already `document.activeElement` on the next tap, no blur fires, and
       // the browser reveals it its own way.
+      //
+      // Only while the sheet is open: closing blurs the field too, and there
+      // is no next tap to keep claimable — the host restores focus to whatever
+      // opened the sheet.
       const origin = findTextEntryControl(event.target, body);
-      if (origin && !event.relatedTarget) {
+      if (isOpenRef.current && origin && !event.relatedTarget) {
         sheet?.focus({preventScroll: true});
       }
     };
@@ -318,8 +310,8 @@ export function useMobileKeyboard({
       retainKeyboardLayoutRef.current = false;
 
       const measuredBodyRect = body.getBoundingClientRect();
-      const viewport = getUnobstructedBounds();
-      const overlap = Math.max(0, measuredBodyRect.bottom - viewport.bottom);
+      const obstructionTop = getObstructionTop();
+      const overlap = Math.max(0, measuredBodyRect.bottom - obstructionTop);
       // The extra clearance leaves room for mobile suggestion UI, but only
       // while the visual viewport actually overlaps the sheet. With no
       // obstruction, ordinary desktop and hardware-keyboard focus must not
@@ -335,14 +327,14 @@ export function useMobileKeyboard({
       // the position handleDocumentScroll returns to. Captured on the
       // transition only — a reveal that runs after the browser has already
       // scrolled would otherwise record the shifted position as correct.
-      if (overlap > 0 && !hasKeyboardLayoutRef.current) {
+      if (isPageScrollLocked && overlap > 0 && !hasKeyboardLayoutRef.current) {
         documentScrollAtKeyboard = {x: window.scrollX, y: window.scrollY};
       }
       hasKeyboardLayoutRef.current = overlap > 0;
 
       const inset =
         overlap > 0
-          ? Math.max(0, measuredBodyRect.bottom - (viewport.bottom - clearance))
+          ? Math.max(0, measuredBodyRect.bottom - (obstructionTop - clearance))
           : 0;
       body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, `${inset}px`);
 
@@ -355,17 +347,14 @@ export function useMobileKeyboard({
       animationFrame = requestAnimationFrame(revealFocusedControl);
     };
 
-    // useScrollLock pins the body, which stops the user scrolling the page but
-    // not the browser: to reveal a focused control the browser scrolls the
-    // DOCUMENT, and every fixed-position element travels with it — the sheet,
-    // its scrim, the page behind. That is the whole-page shift, and because it
-    // is a real document scroll it can simply be put back, on the event that
-    // reports it, before the frame is painted. Then bring the control into
-    // view with the sheet's own scroller, which moves nothing outside the
-    // sheet. This catches every route in — tap, keyboard Next, programmatic
-    // focus, and the reveal the browser performs when the app is resumed with
-    // a field still focused — because it corrects the outcome rather than
-    // racing the cause.
+    // Resuming the app re-reveals the focused field with no focus event to
+    // claim, so the reveal above never runs and the document scrolls — taking
+    // the fixed sheet with it. Put that scroll back on the event that reports
+    // it and re-reveal inside the sheet.
+    //
+    // Only while the page is locked, which is the only state in which a
+    // document scroll cannot be the user's own: behind a non-modal sheet the
+    // page stays scrollable, and reverting there would fight them.
     const handleDocumentScroll = () => {
       const expected = documentScrollAtKeyboard;
       if (
@@ -457,20 +446,11 @@ export function useMobileKeyboard({
     };
 
     const viewport = window.visualViewport;
-    let containmentStyle: HTMLStyleElement | null = null;
     if (ownsFocusTransitions) {
-      // Capture phase, and `blur` rather than `focusout`: both are dispatched
-      // before the browser's own focus step, which is the only window in which
-      // the transition can still be claimed.
+      // `blur` does not bubble, so the capture phase is the only place to hear
+      // every one of them — and it runs before the browser's own focus step,
+      // which is the only window in which the transition can still be claimed.
       document.addEventListener('blur', claimFocusTransition, true);
-
-      // A scroll that reaches the end of any nested scroller chains to the
-      // document, which moves the fixed sheet with it. Current iOS latches
-      // this at touchstart, too late for a listener to add — so it ships as a
-      // stylesheet, in its own layer so a consumer's own rules still win.
-      containmentStyle = document.createElement('style');
-      containmentStyle.textContent = '@layer {*{overscroll-behavior:contain}}';
-      document.head.prepend(containmentStyle);
     }
     body.addEventListener('focusin', handleFocusIn);
     body.addEventListener('focusout', handleFocusOut);
@@ -494,7 +474,6 @@ export function useMobileKeyboard({
       cancelAnimationFrame(animationFrame);
       if (ownsFocusTransitions) {
         document.removeEventListener('blur', claimFocusTransition, true);
-        containmentStyle?.remove();
       }
       body.removeEventListener('focusin', handleFocusIn);
       body.removeEventListener('focusout', handleFocusOut);
@@ -509,5 +488,12 @@ export function useMobileKeyboard({
       hasKeyboardLayoutRef.current = false;
       retainKeyboardLayoutRef.current = false;
     };
-  }, [bodyRef, bottomClearance, isEnabled, isPresented, sheetRef]);
+  }, [
+    bodyRef,
+    bottomClearance,
+    isEnabled,
+    isPageScrollLocked,
+    isPresented,
+    sheetRef,
+  ]);
 }

--- a/packages/core/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -12,6 +12,12 @@
  * scroll range while leaving the sheet itself stationary. Shorter detents and
  * other heights opt out entirely. Starting Tall-sheet travel or closing the
  * sheet blurs the field and dismisses the keyboard.
+ *
+ * Every route into a field also has to reach it without the browser revealing
+ * it for us: on iOS that reveal pans the visual viewport, which shifts the
+ * whole page out from under a stationary sheet. A tap is pre-empted by focusing
+ * with preventScroll; a transition the browser drives itself cannot be, so the
+ * destination is scrolled into the safe area before focus lands instead.
  */
 
 import {useEffect, useRef, type RefObject} from 'react';
@@ -93,6 +99,16 @@ function getVisualViewportBounds(): {top: number; bottom: number} {
     top,
     bottom: top + (viewport?.height ?? window.innerHeight),
   };
+}
+
+// The keyboard is gone once the visual viewport is as tall as the layout
+// viewport again. Height is the only pan-invariant signal for that: while iOS
+// holds the viewport panned up to reveal a field, the viewport's *bottom*
+// already sits at the layout viewport bottom with the keyboard still on
+// screen, so reading the bottom mistakes a pan for a dismissal.
+function isVisualViewportRecovered(): boolean {
+  const height = window.visualViewport?.height ?? window.innerHeight;
+  return height >= window.innerHeight - 0.5;
 }
 
 function isIOSWebKit(): boolean {
@@ -248,13 +264,41 @@ export function useMobileKeyboard({
       });
     };
 
+    // Scroll `control` into the part of the body the keyboard leaves visible.
+    // Reads live geometry every time, so it serves both the reveal after focus
+    // lands and the head start taken before a transition the browser drives.
+    const scrollControlIntoSafeArea = (
+      control: HTMLElement,
+      smoothly: boolean,
+    ) => {
+      const measuredBodyRect = body.getBoundingClientRect();
+      const measuredControlRect = control.getBoundingClientRect();
+      const viewport = getVisualViewportBounds();
+      const overlap = Math.max(0, measuredBodyRect.bottom - viewport.bottom);
+      const clearance = overlap > 0 ? bottomClearance : 0;
+      const safeTop = Math.max(measuredBodyRect.top, viewport.top);
+      const safeBottom = Math.min(
+        measuredBodyRect.bottom,
+        viewport.bottom - clearance,
+      );
+      if (safeBottom <= safeTop) {
+        return;
+      }
+
+      if (measuredControlRect.bottom > safeBottom) {
+        scrollBodyBy(measuredControlRect.bottom - safeBottom, smoothly);
+      } else if (measuredControlRect.top < safeTop) {
+        scrollBodyBy(measuredControlRect.top - safeTop, smoothly);
+      }
+    };
+
     const applyKeyboardGeometry = (geometry: KeyboardGeometry) => {
       const viewport = getVisualViewportBounds();
       // A collapsed detent can extend the body below the layout viewport even
       // after the keyboard closes, so body overlap alone cannot identify
-      // recovery. Once the visual viewport reaches the layout viewport bottom,
-      // release the retained keyboard layout unconditionally.
-      if (viewport.bottom >= window.innerHeight - 0.5) {
+      // recovery. Once the visual viewport is full height again, release the
+      // retained keyboard layout unconditionally.
+      if (isVisualViewportRecovered()) {
         clearKeyboardLayout();
         return;
       }
@@ -276,6 +320,16 @@ export function useMobileKeyboard({
     // still owns caret placement. Holding the original pointerdown event lets
     // consumer preventDefault calls remain authoritative after capture.
     const rememberPointerFocusScroll = (event: PointerEvent) => {
+      // A second contact — a resting thumb, a palm, a finger anywhere else on
+      // the page — must not disarm the one already mid-tap on a field. Without
+      // this, that tap's pointerup finds nothing pending, falls through to the
+      // browser's own focus, and the reveal pans the page.
+      if (
+        pendingTouchFocus != null &&
+        event.pointerId !== pendingTouchFocus.pointerId
+      ) {
+        return;
+      }
       const control = findTextEntryControl(event.target, body);
       pendingPointerFocusScroll =
         isFullyExpandedRef.current &&
@@ -351,6 +405,20 @@ export function useMobileKeyboard({
         pendingFocusScroll = null;
         return;
       }
+      // Snapshots restore what a scroll container scrolled, and that is not
+      // what a browser-driven transition costs us here. When WebKit reveals a
+      // destination sitting behind the keyboard it pans the visual viewport,
+      // and nothing can put that back: offsetTop is read-only, the dialog is
+      // fixed, and the page beneath it is scroll-locked. So reach the
+      // destination first and leave the reveal with nothing to do. It has to
+      // be instant to win that race, and it only runs while a keyboard is
+      // actually measured, so unobstructed desktop and hardware-keyboard focus
+      // keeps behaving exactly as before.
+      if (hasKeyboardLayoutRef.current) {
+        scrollControlIntoSafeArea(control, false);
+      }
+      // Snapshot after that scroll, never before: the restore below is meant to
+      // undo the browser's reveal, not our own head start.
       pendingFocusScroll = captureFocusScroll(control);
     };
     const restoreFocusScroll = (event: FocusEvent) => {
@@ -387,7 +455,6 @@ export function useMobileKeyboard({
       retainKeyboardLayoutRef.current = false;
 
       const measuredBodyRect = body.getBoundingClientRect();
-      const measuredFocusedRect = activeElement.getBoundingClientRect();
       const viewport = getVisualViewportBounds();
       const overlap = Math.max(0, measuredBodyRect.bottom - viewport.bottom);
       // The extra clearance leaves room for mobile suggestion UI, but only
@@ -409,20 +476,7 @@ export function useMobileKeyboard({
           : 0;
       body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, `${inset}px`);
 
-      const safeTop = Math.max(measuredBodyRect.top, viewport.top);
-      const safeBottom = Math.min(
-        measuredBodyRect.bottom,
-        viewport.bottom - clearance,
-      );
-      if (safeBottom <= safeTop) {
-        return;
-      }
-
-      if (measuredFocusedRect.bottom > safeBottom) {
-        scrollBodyBy(measuredFocusedRect.bottom - safeBottom, overlap > 0);
-      } else if (measuredFocusedRect.top < safeTop) {
-        scrollBodyBy(measuredFocusedRect.top - safeTop, overlap > 0);
-      }
+      scrollControlIntoSafeArea(activeElement, overlap > 0);
     };
 
     let animationFrame = 0;

--- a/packages/core/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -221,6 +221,7 @@ export function useMobileKeyboard({
     }
 
     let keyboardGeometry: KeyboardGeometry | null = null;
+    let documentScrollAtKeyboard: {x: number; y: number} | null = null;
     let pendingFocusScroll: FocusScrollSnapshot | null = null;
     let pendingPointerFocusScroll: FocusScrollSnapshot | null = null;
     let pendingTouchFocus: PendingTouchFocus | null = null;
@@ -229,6 +230,7 @@ export function useMobileKeyboard({
     const clearKeyboardLayout = () => {
       body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, '0px');
       keyboardGeometry = null;
+      documentScrollAtKeyboard = null;
       hasKeyboardLayoutRef.current = false;
       retainKeyboardLayoutRef.current = false;
     };
@@ -463,6 +465,13 @@ export function useMobileKeyboard({
               bodyBottom: measuredBodyRect.bottom,
             }
           : null;
+      // Where the document sits with the keyboard up and nothing yet shifted:
+      // the position handleDocumentScroll returns to. Captured on the
+      // transition only — a reveal that runs after the browser has already
+      // scrolled would otherwise record the shifted position as correct.
+      if (overlap > 0 && !hasKeyboardLayoutRef.current) {
+        documentScrollAtKeyboard = {x: window.scrollX, y: window.scrollY};
+      }
       hasKeyboardLayoutRef.current = overlap > 0;
 
       const inset =
@@ -478,6 +487,36 @@ export function useMobileKeyboard({
     const scheduleReveal = () => {
       cancelAnimationFrame(animationFrame);
       animationFrame = requestAnimationFrame(revealFocusedControl);
+    };
+
+    // useScrollLock pins the body, which stops the user scrolling the page but
+    // not the browser: to reveal a focused control the browser scrolls the
+    // DOCUMENT, and every fixed-position element travels with it — the sheet,
+    // its scrim, the page behind. That is the whole-page shift, and because it
+    // is a real document scroll it can simply be put back, on the event that
+    // reports it, before the frame is painted. Then bring the control into
+    // view with the sheet's own scroller, which moves nothing outside the
+    // sheet. This catches every route in — tap, keyboard Next, programmatic
+    // focus, and the reveal the browser performs when the app is resumed with
+    // a field still focused — because it corrects the outcome rather than
+    // racing the cause.
+    const handleDocumentScroll = () => {
+      const expected = documentScrollAtKeyboard;
+      if (
+        expected == null ||
+        (window.scrollX === expected.x && window.scrollY === expected.y)
+      ) {
+        return;
+      }
+      window.scrollTo(expected.x, expected.y);
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLElement &&
+        body.contains(activeElement) &&
+        isTextEntryControl(activeElement)
+      ) {
+        scrollControlIntoSafeArea(activeElement, false);
+      }
     };
 
     const resizeObserver =
@@ -569,6 +608,7 @@ export function useMobileKeyboard({
     sheet?.addEventListener('transitionend', handleSheetTransitionEnd);
     viewport?.addEventListener('resize', scheduleReveal);
     viewport?.addEventListener('scroll', scheduleReveal);
+    window.addEventListener('scroll', handleDocumentScroll);
     window.addEventListener('resize', scheduleReveal);
     mutationObserver?.observe(body, {
       attributes: true,
@@ -604,6 +644,7 @@ export function useMobileKeyboard({
       sheet?.removeEventListener('transitionend', handleSheetTransitionEnd);
       viewport?.removeEventListener('resize', scheduleReveal);
       viewport?.removeEventListener('scroll', scheduleReveal);
+      window.removeEventListener('scroll', handleDocumentScroll);
       window.removeEventListener('resize', scheduleReveal);
       resizeObserver?.disconnect();
       mutationObserver?.disconnect();


### PR DESCRIPTION
## The bug

A Tall Bottom Sheet holding a form is pinned to the viewport, so it should not
move while you type. On iOS it moved: focus a field low in the form and the
whole page lurched upward, taking the sheet's header and scrim off screen with
it. It reproduced roughly one time in ten, which read as flaky rather than as a
specific unhandled case.

It is not flaky. Three separate things were wrong.

## 1. The reveal is attached to focus — claim the transition

The browser reveals a newly focused field by scrolling the **document**, and a
`position: fixed` sheet rides along. Earlier revisions of this PR tried to get
in front of that scroll, and to undo it afterwards. Both are races: the reveal
runs on the compositor, so a main-thread correction can land a frame late and
read as *a pan followed by a snap back*.

The reveal is attached to the **focus operation**, which is where it can be
refused. `blur` is dispatched in the capture phase ahead of the browser's own
focus step and names the destination in `relatedTarget`:

```ts
document.addEventListener('blur', event => {
  const destination = findTextEntryControl(event.relatedTarget, body);
  if (destination && destination !== document.activeElement) {
    destination.focus({preventScroll: true});   // transition settled here
  }
}, true);
```

The browser's focus step then finds the element already active, dispatches
nothing, and has nothing to reveal. A tap, the keyboard's Next, Tab and a
programmatic `focus()` all arrive as that one transition — so the separately
special-cased tap path is gone, along with its pending-tap state machine,
movement threshold and multi-touch guards.

Revealing the field is left to the existing `focusin` / viewport-resize path,
which already knows the safe area and scrolls only the sheet's own body.

Presenting a sheet that **autofocuses** a field is not a transition — nothing
was focused, so no blur names it. `focusPanel` therefore passes `preventScroll`
itself; the sheet was about to show that field anyway, and the hook brings it
into view within the sheet.

A blur that names **no** destination is the keyboard's Done button. Left alone,
focus lands on the body, the field stays `document.activeElement`, and the next
tap on it produces no transition at all — so the browser reveals it its own way.
Focus is parked on the sheet instead, keeping that tap claimable. Only while the
sheet is open: closing blurs the field too, and there the host is restoring
focus to whatever opened the sheet.

### This is #5043's B1, re-tested rather than honoured

#5043 rejected blur-phase `focus({preventScroll: true})` for double-firing
`focus`/`blur` (finding `B1`). Measured on an iPhone 17 simulator, counting real
events with the mechanism on and off:

| transition | off | on |
|---|---|---|
| tap A → tap B | 1 focus / 1 blur each | **identical** |
| accessory-bar Previous, then Next | 1 each | **identical** |
| programmatic `a.focus(); b.focus()` | 1 each | **identical** |

B1 does not reproduce in WebKit.

## 2. The keyboard boundary was read in a way a shift corrupts

`visualViewport.offsetTop + visualViewport.height` was the "where does the
keyboard start" measure in four places. It is wrong the moment the page is
shifted: the shift slides the window over the page, but the keyboard stays where
it is, so the obstruction appears to shrink as the shift grows.

A fully expanded Tall sheet is pinned to the layout viewport bottom, so
`bodyBottom == innerHeight`. At full shift that expression also equals
`innerHeight`, so the overlap computes as **zero**: the sheet concluded the
keyboard was gone, dropped the scroll range it had added, and cleared the flag
that arms the defences. One shift latched it into the unprotected behaviour
permanently — which is exactly the reported symptom that Next works down a form
until something shifts once, and never recovers after.

Measured with `bodyBottom = innerHeight = 768` and a 500px keyboard: **316px →
0px**. Every reader now takes `visualViewport.height` alone, which a shift does
not change. Identical when nothing is shifted.

## 3. Putting back a document scroll (a net, for one case)

App resume raises **no focus event at all**: leave Safari with a field focused,
come back, and the browser reveals it again with nothing to claim. The
document's own `scroll` event is the earliest signal, so the scroll is put back
there, synchronously, and the field re-revealed inside the sheet.

This runs **only while the page is locked** — the one state in which a document
scroll cannot be the user's own. Behind a non-modal sheet (`hasScrim={false}`)
the page stays scrollable by design, and an earlier revision of this PR reverted
the user's own scrolling there; the host now passes `isPageScrollLocked`.

## Scope: fully expanded Tall only

Prevention lives behind the same gates as keyboard accommodation —
`height="tall"` at full expansion, iOS WebKit. A `capped` sheet (the default),
or a Tall sheet dragged to a shorter detent, still lets the browser reveal the
field its own way. That is a deliberate decision for now, and the `height` prop
docs now say so rather than only promising no keyboard scroll space.

## Tests

`packages/core/src/BottomSheet` — 161 passing, 10 new, 5 removed with the tap
machinery they covered. Every guard the fix adds fails a test when removed:

| Remove this | and this test fails |
|---|---|
| the claim listener | claims a transition between fields… (+4 more) |
| `preventScroll` on the claim | claims a transition between fields and delivers it with preventScroll |
| Done-button parking | parks focus on the sheet when the keyboard Done button takes it |
| the open-sheet gate on parking | does not park focus on a sheet that is closing |
| the scroll-lock gate on the net | leaves the page alone behind a non-modal sheet |
| the document-scroll net | puts back a document scroll the browser makes to reveal a field |
| shift-invariant boundary | holds the keyboard scroll range through a pan · keeps defending a pinned sheet after the browser has panned it once |
| `preventScroll` in `focusPanel` | autofocuses a field without letting the browser reveal it |
| the full-expansion gate | does not accommodate the keyboard at a shorter Tall detent |

`pnpm lint:strict` (0 errors) and `pnpm build` are clean. On `pnpm test`,
10,668 of 10,671 pass; one failure passes on re-run, and the two that persist —
CLI name resolution and hook discovery — are the same two `main` fails on this
machine, both case-insensitive-filesystem artifacts.

## Device evidence

The real story driven on an iPhone 17 simulator (iOS 26.5). Sheet top edge
decoded from the scrim boundary in each screenshot; 376px is the unshifted
position:

| | sheet top |
|---|---|
| field focused, keyboard up | 376px |
| after six accessory-bar Nexts | 376px |
| **scrolled to the end, last field of eleven focused** | **376px** |
| four accessory-bar Previous from there | 376px |
| across an app switch | 376px |

Pre-fix the same sequence put the sheet top off screen entirely — no scrim
boundary left to find — and it stayed there. Whole-frame comparison across the
app switch: 4.3% of pixels differed pre-fix, 0.0% with it.

The deep end of the form is included above: the last field sits above the
keyboard with the submit button still visible, and nothing moved.

**Still worth a physical-device pass** for what the simulator does not model:
Safari with browser UI expanded vs collapsed, PWA standalone, and a real
software keyboard's timing. Test
`/iframe.html?id=core-bottomsheet--mobile-keyboard` directly — focus-scroll
prevention does not work inside an iframe, so the Storybook manager shell gives
a false negative.

## Measured, not assumed

**Caret placement.** Claiming the focus ahead of the click could cost the tap's
caret position, so it was measured in Mobile Safari — tap into the middle of a
populated field with a prior field focused:

| | caret offset |
|---|---|
| claim on | 40 of 40 |
| claim off (native) | 40 of 40 |

Identical: the click's hit test still owns the caret. A tap into a field that is
already focused cannot be affected at all, since the claim no-ops when the
destination is already active.

## Deliberately not in this PR

Found while investigating, each its own change:

- **React's `autoFocus` on a field inside a sheet** (`<TextInput hasAutoFocus />`
  emits both it and `data-autofocus`). React applies it at `commitMount`, before
  any effect runs, so no listener this hook installs can exist yet and
  `focusPanel` early-returns because focus is already inside the panel. Not
  reachable from a hook; closing it means the sheet owning autofocus itself.
- **The first focus into a non-modal sheet** (`hasScrim={false}`). Focus starts
  on the body, so there is no blur to claim. Parking focus on the panel would
  close it, but non-modal sheets deliberately leave focus alone — "the
  background stays interactive, so the sheet must not grab focus" is existing,
  tested behavior. The page is not scroll-locked in that shape either, so a
  document scroll there is ordinary page scrolling rather than a fixed sheet
  being dragged off screen.

- **`<select>` and password fields.** `isTextEntryControl` does not match
  `<select>`, whose iOS picker also shrinks the viewport; prevention is
  unreliable for password inputs without `autocomplete="current-password"`.
- **Chromium.** The claim is gated on iOS WebKit. A similar race exists on
  Android and needs its own validation.
- **Caret-driven reveal while typing** in a tall `TextArea` — WebKit follows the
  caret, this hook reveals the element.
- **Re-tapping a field the keyboard was dismissed from without a blur** (iPad's
  hide-keyboard chevron, attaching a hardware keyboard). Measured: that re-tap
  produces **zero** focus events of any kind, so no blur-based mechanism can
  reach it — whatever covers it has to be a pointer or touch path.
- **The inset flaps on resume.** The keyboard is dismissed while the app is
  backgrounded and re-presented on return, so the hook sees no-keyboard and then
  keyboard again: the body's extra scroll range goes 385px → 0 → 385px in ~130
  ms. The page stays still through it, but the flap itself is avoidable.
- **`overscroll-behavior: contain` on nested scrollers.** Scroll chaining is a
  different mechanism from the focus reveal, and nothing here was shown to need
  it; a revision of this PR carried a global rule for it and dropped it as
  unproven. Worth revisiting with a case that fails without it.
- **Drag smoothness.** Reported separately while testing this: the live drag
  routes every pointer move through React state, and the detent magnet means the
  sheet deliberately lags the finger. Neither is touched here.

## Risk

Confined to `useMobileKeyboard`, plus one private prop threaded through
`BottomSheetPanel`. Within the hook, everything but the boundary reading is
gated on iOS WebKit, and all of it on `height="tall"` at full expansion. The 151
pre-existing Bottom Sheet tests pass unchanged.
