### PR TITLE
fix(BottomSheet): follow the viewport when it changes under a resting sheet

### DIFF
--- a/.changeset/bottom-sheet-viewport-resize.md
+++ b/.changeset/bottom-sheet-viewport-resize.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BottomSheet: a sheet resting at a detent now follows the viewport. Its detents were resolved to pixels at gesture time and never revisited, so rotating the device or resizing the window left the sheet frozen at the old geometry — a half-height sheet covering three quarters of a shorter window, and a peek detent whose slide-down could exceed the new viewport entirely, leaving a modal dialog on screen with no sheet in it. Snap fractions are also read from the layout viewport now, so the mobile keyboard no longer moves the detents out from under the sheet it is measuring.
+
+@imdreamrunner

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -121,6 +121,14 @@ function mockVisualViewport(height: number, offsetTop = 0) {
   return viewport;
 }
 
+// The layout viewport — `100dvh`, `window.innerHeight` — which is what the
+// sheet's height budget and its detents are measured against. Deliberately
+// separate from the visual viewport above: the mobile keyboard shrinks that
+// one and leaves this one alone, and the sheet has to tell them apart.
+function mockWindowHeight(height: number) {
+  vi.stubGlobal('innerHeight', height);
+}
+
 function mockIOSWebKit() {
   const navigatorMock = Object.create(window.navigator);
   Object.defineProperties(navigatorMock, {
@@ -618,6 +626,7 @@ describe('BottomSheet', () => {
     it('keeps the full layout height at the peek detent', () => {
       const observers = mockResizeObserverInstances();
       mockVisualViewport(800);
+      mockWindowHeight(800);
       render(
         <BottomSheet
           isOpen
@@ -668,6 +677,7 @@ describe('BottomSheet', () => {
     it('swaps height for transform without a transition when released on a detent', () => {
       const observers = mockResizeObserverInstances();
       mockVisualViewport(800);
+      mockWindowHeight(800);
       render(
         <BottomSheet
           isOpen
@@ -720,6 +730,7 @@ describe('BottomSheet', () => {
     it('uses transforms while dragging and resizes to the visible snapped height', () => {
       const observers = mockResizeObserverInstances();
       mockVisualViewport(800);
+      mockWindowHeight(800);
       render(
         <BottomSheet
           isOpen
@@ -796,6 +807,7 @@ describe('BottomSheet', () => {
     it('reconciles the snapped height immediately when transitions are disabled', () => {
       const observers = mockResizeObserverInstances();
       mockVisualViewport(800);
+      mockWindowHeight(800);
       render(
         <BottomSheet
           isOpen
@@ -828,6 +840,7 @@ describe('BottomSheet', () => {
     it('restores the maximum height before an upward drag and reconciles at snap', () => {
       const observers = mockResizeObserverInstances();
       mockVisualViewport(800);
+      mockWindowHeight(800);
       render(
         <BottomSheet
           isOpen
@@ -892,6 +905,7 @@ describe('BottomSheet', () => {
     it('keeps the settled height stable while dismissing', () => {
       const observers = mockResizeObserverInstances();
       mockVisualViewport(800);
+      mockWindowHeight(800);
       render(<ExitHarness />);
       const sheet = getSheet();
       const sheetObserver = observers.find(instance =>
@@ -927,6 +941,117 @@ describe('BottomSheet', () => {
         );
       });
       expect(sheet.style.height).toBe('448px');
+    });
+
+    it('re-resolves the settled detent when the window resizes', () => {
+      const observers = mockResizeObserverInstances();
+      mockVisualViewport(800);
+      mockWindowHeight(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Release notes"
+          height="tall">
+          Content
+        </BottomSheet>,
+      );
+      const sheet = getSheet();
+      const sheetObserver = observers.find(instance =>
+        instance.observed.has(sheet),
+      );
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(784, 736)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+
+      // Settle on the half-height detent: 784 - 48 - 400 = 336px of travel.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 336});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 336});
+      const reconciliationFrames: FrameRequestCallback[] = [];
+      vi.mocked(requestAnimationFrame).mockImplementation(callback => {
+        reconciliationFrames.push(callback);
+        return reconciliationFrames.length;
+      });
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      act(() => reconciliationFrames.splice(0).forEach(frame => frame(0)));
+      // 448px of layout height shows 400px of sheet: half the 800px window.
+      expect(sheet.style.height).toBe('448px');
+
+      // Shrink the window. The sheet's budget is `92dvh`, so its border box
+      // follows: 0.92 * 600 + the 48px reserve = 600px.
+      vi.spyOn(sheet, 'getBoundingClientRect').mockImplementation(() =>
+        rect({
+          top: 0,
+          bottom: sheet.style.height
+            ? Number.parseFloat(sheet.style.height)
+            : 600,
+        }),
+      );
+      mockWindowHeight(600);
+      act(() => {
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      // Still the half-height detent, re-resolved against the new window:
+      // 348px of layout height shows 300px, half of 600. Before this, the
+      // sheet kept its 448px and showed 400px — three quarters of the window.
+      expect(sheet.style.height).toBe('348px');
+      expect(sheet.style.transform).toBe('');
+      // Re-anchoring is not a gesture, so it does not animate.
+      expect(sheet.style.transition).toBe('none');
+      act(() => reconciliationFrames.splice(0).forEach(frame => frame(0)));
+      expect(sheet.style.transition).toBe('');
+    });
+
+    it('keeps its detents when the keyboard shrinks the visual viewport', () => {
+      const observers = mockResizeObserverInstances();
+      const viewport = mockVisualViewport(800);
+      mockWindowHeight(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Release notes"
+          height="tall">
+          Content
+        </BottomSheet>,
+      );
+      const sheet = getSheet();
+      const sheetObserver = observers.find(instance =>
+        instance.observed.has(sheet),
+      );
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(784, 736)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 336});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 336});
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.height).toBe('448px');
+
+      // The keyboard opens: the visual viewport shrinks, the layout viewport
+      // the sheet is measured in does not.
+      act(() => {
+        viewport.height = 500;
+        viewport.dispatchEvent(new Event('resize'));
+      });
+      expect(sheet.style.height).toBe('448px');
+
+      // The next drag still snaps to the window's detents, not to fractions
+      // of the space the keyboard left over.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 3000, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 4000, y: 288});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 5000, y: 288});
+      // The peek of an 800px window: 736 - 112 = 624px of travel.
+      expect(sheet.style.transform).toBe('translateY(624px)');
     });
   });
 
@@ -1105,6 +1230,7 @@ describe('BottomSheet', () => {
 
     it('does not alter ordinary desktop focus when the viewport is unobstructed', () => {
       mockVisualViewport(800);
+      mockWindowHeight(800);
       const onFocus = vi.fn();
       render(
         <BottomSheet
@@ -1218,6 +1344,7 @@ describe('BottomSheet', () => {
 
     it('does not add clearance or scroll when the viewport is unobstructed', () => {
       mockVisualViewport(800);
+      mockWindowHeight(800);
       render(
         <BottomSheet
           isOpen
@@ -1248,6 +1375,7 @@ describe('BottomSheet', () => {
       mockIOSWebKit();
       const observers = mockResizeObserverInstances();
       const viewport = mockVisualViewport(800);
+      mockWindowHeight(800);
       render(
         <BottomSheet
           isOpen

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -61,8 +61,13 @@ function defaultSnapHeights(): number[] {
   if (typeof window === 'undefined') {
     return [];
   }
-  const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
-  return SNAP_FRACTIONS.map(fraction => fraction * viewportHeight);
+  // Measure the same viewport the height budgets are written against. Those
+  // are `dvh`, which the virtual keyboard does not shrink, so reading
+  // `visualViewport` here made the two disagree by exactly the keyboard's
+  // height: every detent moved while the sheet it was measuring did not. A
+  // keyboard is `useMobileKeyboard`'s business — it holds the sheet still and
+  // scrolls the body — and it does not redefine the sheet's detents.
+  return SNAP_FRACTIONS.map(fraction => fraction * window.innerHeight);
 }
 
 const styles = stylex.create({

--- a/packages/core/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/core/src/BottomSheet/useSheetGestures.test.ts
@@ -612,4 +612,166 @@ describe('useSheetGestures', () => {
       expect(hook.result.current.isDragging).toBe(false);
     });
   });
+
+  describe('viewport resize', () => {
+    // The panel pins the sheet's height in px at a resizing detent; everywhere
+    // else the height comes from CSS (`92dvh`), which follows the viewport.
+    // Model both, so a measurement taken while pinned reads the pin back —
+    // that is the trap the hook has to work around.
+    const SNAP_FRACTIONS = [0.14, 0.5, 0.92];
+    const RESERVED_BELOW_FLOOR = 48;
+
+    function viewportHarness(initialViewport: number) {
+      let viewport = initialViewport;
+      const el = document.createElement('div');
+      el.setPointerCapture = vi.fn();
+      el.releasePointerCapture = vi.fn();
+      el.getBoundingClientRect = () =>
+        ({
+          height: el.style.height
+            ? Number.parseFloat(el.style.height)
+            : 0.92 * viewport + RESERVED_BELOW_FLOOR,
+        }) as DOMRect;
+
+      const onSnap = vi.fn();
+      const {hook} = setup({
+        offscreenBlockEndInset: RESERVED_BELOW_FLOOR,
+        snapHeights: () => SNAP_FRACTIONS.map(f => f * viewport),
+        onSnap,
+      });
+      act(() => hook.result.current.sheetRef(el));
+
+      // What BottomSheetPanel renders at rest.
+      const paint = () => {
+        const {sheetHeight, settledLayoutOffset} = hook.result.current;
+        el.style.height =
+          settledLayoutOffset > 0
+            ? `${sheetHeight - settledLayoutOffset}px`
+            : '';
+      };
+      const dragTo = (offset: number) => {
+        // Anchor anywhere; what matters is the delta from where it rests, so
+        // this drags in whichever direction the target detent lies.
+        const anchor = 1000;
+        const delta = offset - hook.result.current.settledOffset;
+        act(() =>
+          hook.result.current.handleProps.onPointerDown(
+            pointerEvent(anchor, 0, el),
+          ),
+        );
+        // Slow: well under the flick threshold, so the release settles.
+        act(() =>
+          hook.result.current.handleProps.onPointerMove(
+            pointerEvent(anchor + delta, 2000, el),
+          ),
+        );
+        act(() =>
+          hook.result.current.handleProps.onPointerUp(
+            pointerEvent(anchor + delta, 2400, el),
+          ),
+        );
+        // The panel resolves the settle when the transform transition ends.
+        act(() => hook.result.current.completeScrollAreaSettle());
+        paint();
+      };
+      const resizeTo = (next: number) => {
+        viewport = next;
+        act(() => {
+          window.dispatchEvent(new Event('resize'));
+        });
+        paint();
+      };
+      // What the user sees: the border box, less the part reserved below the
+      // viewport floor and the part translated past it.
+      const visibleHeight = () =>
+        hook.result.current.sheetHeight -
+        RESERVED_BELOW_FLOOR -
+        hook.result.current.settledOffset;
+
+      return {hook, el, onSnap, dragTo, resizeTo, visibleHeight};
+    }
+
+    it('re-resolves the settled detent against the new viewport', () => {
+      // 900px viewport: detents at 0 / 378 / 702, so the half-height stop
+      // shows 450px of sheet.
+      const {hook, dragTo, resizeTo, visibleHeight, onSnap} =
+        viewportHarness(900);
+      dragTo(378);
+      expect(hook.result.current.settledOffset).toBe(378);
+      expect(visibleHeight()).toBe(450);
+
+      resizeTo(600);
+
+      // Still the half-height stop, now half of 600 — not the 450px (75% of
+      // the window) it was frozen at before.
+      expect(visibleHeight()).toBe(300);
+      expect(hook.result.current.settledOffset).toBe(252);
+      expect(onSnap).toHaveBeenLastCalledWith(300);
+    });
+
+    it('keeps the peek detent on screen when the viewport shrinks', () => {
+      const {hook, dragTo, resizeTo, visibleHeight} = viewportHarness(900);
+      dragTo(702);
+      expect(hook.result.current.settledOffset).toBe(702);
+      // The peek keeps its full height and slides, so its offset is the whole
+      // of its travel — and 702px of travel does not fit in a 600px window.
+      expect(hook.result.current.settledLayoutOffset).toBe(0);
+
+      resizeTo(600);
+
+      expect(hook.result.current.settledOffset).toBe(468);
+      expect(hook.result.current.settledOffset).toBeLessThan(
+        hook.result.current.sheetHeight,
+      );
+      expect(visibleHeight()).toBe(84);
+    });
+
+    it('refreshes the fully open height the next drag measures against', () => {
+      const {hook, dragTo, resizeTo} = viewportHarness(900);
+      dragTo(378);
+      expect(hook.result.current.sheetHeight).toBe(876);
+
+      resizeTo(600);
+
+      // Measured through the pinned height the panel had written for the old
+      // viewport, so this is the natural budget and not the stale pin.
+      expect(hook.result.current.sheetHeight).toBe(600);
+
+      // Dragging back up lands on fully open rather than overshooting past it
+      // toward where fully open used to be.
+      dragTo(0);
+      expect(hook.result.current.settledOffset).toBe(0);
+      expect(hook.result.current.settledLayoutOffset).toBe(0);
+    });
+
+    it('leaves a drag in progress alone', () => {
+      const {hook, el} = viewportHarness(900);
+      act(() =>
+        hook.result.current.handleProps.onPointerDown(pointerEvent(0, 0, el)),
+      );
+      act(() =>
+        hook.result.current.handleProps.onPointerMove(
+          pointerEvent(200, 2000, el),
+        ),
+      );
+
+      act(() => {
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      expect(hook.result.current.isDragging).toBe(true);
+      expect(hook.result.current.sheetHeight).toBe(876);
+      expect(hook.result.current.settledOffset).toBe(0);
+    });
+
+    it('stops re-resolving once the sheet closes', () => {
+      const {hook, dragTo, resizeTo} = viewportHarness(900);
+      dragTo(378);
+      act(() => hook.rerender({isOpen: false, onDismiss: vi.fn()}));
+
+      resizeTo(600);
+
+      expect(hook.result.current.sheetHeight).toBe(876);
+    });
+  });
 });

--- a/packages/core/src/BottomSheet/useSheetGestures.ts
+++ b/packages/core/src/BottomSheet/useSheetGestures.ts
@@ -21,6 +21,12 @@
  * render whose visible geometry is identical. The peek detent keeps the full
  * height and slides below the viewport instead of reflowing to a sliver.
  *
+ * Those are pixels, and the detents behind them are viewport fractions, so a
+ * sheet at rest re-resolves its detent on `resize` / `orientationchange` and
+ * re-anchors to the new geometry without animating. The detent it returns to
+ * is tracked by index: the pixels stop meaning the same thing when the
+ * viewport changes, the stop the user chose does not.
+ *
  * Kept private to BottomSheet: a dismiss edge + detents on a bottom-anchored
  * surface are inherently sheet concepts. It is not a general primitive and is
  * intentionally not exported.
@@ -122,6 +128,20 @@ function renderedBlockEndPadding(element: HTMLElement): number {
   return Number.isFinite(value) ? value : 0;
 }
 
+// How much further the body could scroll on its own, ignoring the padding the
+// hook adds to preserve scroll position across a height change.
+function naturalEndGapFor(body: HTMLElement | null): number {
+  if (!body) {
+    return 0;
+  }
+  const renderedInset = renderedBlockEndPadding(body);
+  const naturalMaxScrollTop = Math.max(
+    0,
+    body.scrollHeight - body.clientHeight - renderedInset,
+  );
+  return naturalMaxScrollTop - body.scrollTop;
+}
+
 function visibleHeightForOffset(
   sheetHeight: number,
   offset: number,
@@ -149,11 +169,11 @@ export interface UseSheetGesturesOptions {
   onDismiss: () => void;
   /**
    * Resolver for candidate visible detent heights in px below the fully open
-   * visible height. Called lazily at the start of each drag so the values stay
-   * current (e.g. after rotation or virtual-keyboard opening) without a
-   * persistent resize listener. The fully open height is always the tallest
-   * detent. Omit for a single-height sheet (a drag then only dismisses or
-   * springs back).
+   * visible height. Called at the start of each drag, and again whenever the
+   * viewport changes while the sheet rests, so the detents track the window
+   * (rotation, a resized desktop window, collapsing browser chrome). The fully
+   * open height is always the tallest detent. Omit for a single-height sheet
+   * (a drag then only dismisses or springs back).
    */
   snapHeights?: () => number[];
   /** Notified when the settled visible detent height (px) changes. */
@@ -284,6 +304,11 @@ export function useSheetGestures({
   // peek (see isPeekOffset), which keep the full height and use a transform.
   const [settledLayoutOffset, setSettledLayoutOffset] = useState(0);
   const settledLayoutOffsetRef = useRef(0);
+  // WHICH detent the sheet rests on, as an index into the resolved list. The
+  // offsets themselves are pixels derived from the viewport, so they stop
+  // meaning the same thing the moment the viewport changes; the index survives
+  // that and lets a resize re-resolve the same stop against the new geometry.
+  const settledDetentIndexRef = useRef(0);
   const [settlingLayoutOffset, setSettlingLayoutOffset] = useState<
     number | null
   >(null);
@@ -474,6 +499,7 @@ export function useSheetGestures({
       // eslint-disable-next-line @eslint-react/set-state-in-effect -- resets gesture state on controlled reopen
       setIsScrollAreaReconciling(false);
       recordSettledLayoutOffset(0);
+      settledDetentIndexRef.current = 0;
       scrollPreservationInsetRef.current = 0;
       settlingLayoutOffsetRef.current = null;
       pendingScrollPreservationInsetRef.current = null;
@@ -509,6 +535,118 @@ export function useSheetGestures({
       snapHeightsRef.current?.() ?? [],
     );
   }, []);
+
+  // The height the sheet WOULD have fully open, right now. While it rests at a
+  // resizing detent the element carries a pixel height computed for whatever
+  // the viewport was then, so measuring it directly just reads that stale
+  // number back. Drop the inline height for the measurement and put it back in
+  // the same synchronous block — the browser cannot paint in between, so this
+  // is invisible — and the natural CSS budget is what gets measured.
+  const measureFullyOpenHeight = useCallback((): number => {
+    const element = sheetElRef.current;
+    if (!element) {
+      return sheetHeightRef.current;
+    }
+    const inlineHeight = element.style.height;
+    if (inlineHeight === '') {
+      return element.getBoundingClientRect().height;
+    }
+    element.style.height = '';
+    const height = element.getBoundingClientRect().height;
+    element.style.height = inlineHeight;
+    return height;
+  }, []);
+
+  // Detents are viewport fractions, but a settled sheet holds them as pixels:
+  // an offset to translate by, and a layout height to render. Both are read
+  // once, at gesture time. Without this, a viewport change leaves the sheet
+  // frozen at the old pixel geometry — a "half height" sheet showing 75% of a
+  // shorter window, a peek detent whose slide-down is taller than the whole
+  // window (so the sheet leaves the screen while its dialog stays modal), and
+  // a stale fully-open height for the next drag to overshoot past.
+  //
+  // Re-resolve the SAME detent — by index, the one thing that survives the
+  // units changing — against the new geometry, and re-anchor without
+  // animating: the viewport moved, not the user's finger, so there is no
+  // gesture to continue and nothing to ease.
+  useEffect(() => {
+    if (!isOpen || typeof window === 'undefined') {
+      return;
+    }
+    const handleViewportChange = () => {
+      // A live drag re-measures on its own, and a settle in flight owns the
+      // layout until it lands.
+      if (
+        dragStateRef.current != null ||
+        settlingLayoutOffsetRef.current != null
+      ) {
+        return;
+      }
+      const height = measureFullyOpenHeight();
+      if (height <= 0) {
+        return;
+      }
+      const offsets = detentOffsets(height);
+      const index = Math.min(settledDetentIndexRef.current, offsets.length - 1);
+      const target = offsets[index];
+      const targetLayoutOffset = isPeekOffset(target, offsets) ? 0 : target;
+      const baseLayoutOffset = settledLayoutOffsetRef.current;
+      if (
+        height === sheetHeightRef.current &&
+        Math.abs(target - activeOffsetRef.current) <= 0.5 &&
+        Math.abs(targetLayoutOffset - baseLayoutOffset) <= 0.5
+      ) {
+        return;
+      }
+
+      sheetHeightRef.current = height;
+      setSheetHeight(height);
+      settledDetentIndexRef.current = index;
+      prepareScrollAreaSettle(
+        baseLayoutOffset,
+        target,
+        targetLayoutOffset,
+        target,
+        baseLayoutOffset,
+        naturalEndGapFor(bodyNodeRef.current),
+        false,
+      );
+      recordSettledLayoutOffset(targetLayoutOffset);
+      setSettledOffset(target);
+      onSnapRef.current?.(
+        visibleHeightForOffset(
+          height,
+          target,
+          offscreenBlockEndInsetRef.current,
+        ),
+      );
+      const maxOffset = offsets[offsets.length - 1];
+      const shortestDetentHeight = visibleHeightForOffset(
+        height,
+        maxOffset,
+        offscreenBlockEndInsetRef.current,
+      );
+      onScrimOpacityRef.current?.(
+        scrimOpacityForOffset(
+          target,
+          offsets,
+          maxOffset + shortestDetentHeight * DISMISS_OVERSHOOT_RATIO,
+        ),
+      );
+    };
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('orientationchange', handleViewportChange);
+    return () => {
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('orientationchange', handleViewportChange);
+    };
+  }, [
+    detentOffsets,
+    isOpen,
+    measureFullyOpenHeight,
+    prepareScrollAreaSettle,
+    recordSettledLayoutOffset,
+  ]);
 
   const cancelDrag = useCallback(
     (target?: HTMLElement) => {
@@ -605,6 +743,7 @@ export function useSheetGestures({
           true,
         );
         recordSettledLayoutOffset(targetLayoutOffset);
+        settledDetentIndexRef.current = Math.max(0, offsets.indexOf(target));
         setSettledOffset(target);
         onSnapRef.current?.(
           visibleHeightForOffset(
@@ -653,6 +792,7 @@ export function useSheetGestures({
           true,
         );
         recordSettledLayoutOffset(0);
+        settledDetentIndexRef.current = 0;
         setDragOffset(0);
         setSettledOffset(0);
         onSnapRef.current?.(
@@ -695,12 +835,7 @@ export function useSheetGestures({
       // pointer-down position (not the promotion point), so the first frame's
       // delta reflects the full pull distance.
       const start = startCoord ?? event.clientY;
-      const body = bodyNodeRef.current;
-      const renderedInset = body ? renderedBlockEndPadding(body) : 0;
-      const naturalMaxScrollTop = body
-        ? Math.max(0, body.scrollHeight - body.clientHeight - renderedInset)
-        : 0;
-      const naturalEndGap = body ? naturalMaxScrollTop - body.scrollTop : 0;
+      const naturalEndGap = naturalEndGapFor(bodyNodeRef.current);
       const baseLayoutOffset = settledLayoutOffsetRef.current;
       dragStateRef.current = {
         pointerId: event.pointerId,


### PR DESCRIPTION
## The bug

`BottomSheet` reads the viewport **once, at gesture time**, and stores the
result in **absolute pixels**.

- `defaultSnapHeights()` samples the viewport and turns the snap fractions into
  px (`BottomSheetPanel.tsx`).
- It is only ever called from `detentOffsets()`, and that is only called from
  drag paths — `handlePointerMove`, `settleFromDrag`, `cancelDrag`. There was no
  resize listener anywhere in the gesture path.
- The resting detent then lives as a px offset (`settledOffset` /
  `settledLayoutOffset`) rendered as a px `height`, so a parked sheet is no
  longer `dvh`-driven at all.
- `recordSheetHeight()` discards every `ResizeObserver` report while
  `activeOffsetRef.current > 0` — i.e. exactly while parked at a detent.

`useSheetGestures`' own docs promised the opposite: detents "stay correct across
rotation / viewport changes", and the lazy resolution keeps values current
"after rotation or virtual-keyboard opening". True for the *next drag*, never
for the sheet already on screen.

### What that does (measured in Chrome, `Core/BottomSheet` → Tall sheet, 500px wide)

**1. A parked sheet keeps its old pixel height.**

| | viewport | visible sheet | |
|---|---|---|---|
| dragged to the mid detent | 900 | 450 | 50% ✓ |
| resized, untouched | 600 | 450 | **75%** |
| resized, untouched | 1200 | 450 | **37.5%** |

It only heals on a drag back to fully open, or a close and reopen.

**2. Peek detent + shrink → the sheet leaves the screen.** Peek keeps its full
height and slides down by an offset computed for the old viewport (702px),
which is taller than the whole new window:

```
parked at peek       vh= 900  visible= 126
viewport -> 1200     vh=1200  visible= 402   (should be 168)
viewport ->  600     vh= 600  visible=-150   top edge 150px BELOW the window
```

`<dialog>` is still `open`, still `:modal`, backdrop still painted, page behind
still unclickable — a dimmed, blocked page with no sheet on it. Escape is the
only way out.

**3. The next drag measures against the stale fully-open height.** After
shrinking 900→600 and dragging up from the mid detent, the sheet travels
**110px above the top of the window and takes the grab handle with it**.
`OVERSCROLL_MAX` doesn't catch it, because the drag is still "below" the stale
fully-open reference.

**4. The two viewport units disagreed.** The budget is `92dvh`, which the
virtual keyboard does not shrink; the snap fractions were of
`visualViewport.height`, which it does. With a 300px keyboard at 500×900 the
same two drags settled at 552/300 instead of 450/126, and a spurious fourth
detent appeared just below fully open (0.92 × 600 = 552 < the 828px sheet).
This hit the advertised flow: `useMobileKeyboard` blurs the field when travel
starts, so the keyboard retracts *during* the gesture and the sheet settles onto
detents computed for a viewport that no longer exists.

## The fix

**Re-resolve the settled detent when the viewport changes, and re-anchor without
animating** — the viewport moved, not the user's finger, so there is no gesture
to continue and nothing to ease. A live drag or an in-flight settle is left
alone; so is a closed sheet.

**Track the detent by index.** The pixels stop meaning the same thing when the
viewport changes; the stop the user chose does not. The index is recorded
wherever the sheet settles and clamped to the new list, so the peek stays the
peek and the half-height stop stays half of whatever the window now is.

**Measure the fully open height through the pin.** The panel writes a px height
at a resizing detent, so measuring the element just reads that stale number
back. `measureFullyOpenHeight()` drops the inline height, measures, and restores
it in the same synchronous block — the browser cannot paint in between, so it is
invisible — and the natural CSS budget is what gets measured.

**Read snap fractions from the layout viewport** (`window.innerHeight`), the
same viewport `dvh` is written against. The keyboard now moves neither the
budget nor the detents, which is what `useMobileKeyboard` already assumes: it
holds the sheet still and scrolls the body.

`scrollAreaSizing`, the peek's transform-only slide, and the transition-free
reconciliation are all untouched — the resize path reuses
`prepareScrollAreaSettle(..., shouldAnimate: false)`, the same machinery a
release on a detent already used.

### After

| | viewport | visible sheet | |
|---|---|---|---|
| mid detent | 900 | 450 | 50% ✓ |
| resized | 600 | 300 | 50% ✓ |
| resized | 1200 | 600 | 50% ✓ |
| peek | 900 → 1200 → 600 | 126 → 168 → 84 | 14% throughout ✓ |

The handle no longer leaves the screen on the drag after a resize (worst top
edge 45px, inside the rubber band, vs −110px before), and the keyboard case
settles at 450/126 with and without a 300px keyboard.

## Tests

Five behavioral tests, all of which fail on `main` and pass here:

- `useSheetGestures` — re-resolves the settled detent against the new viewport;
  keeps the peek on screen when the viewport shrinks; refreshes the fully open
  height the next drag measures against.
- `BottomSheet` — re-resolves the settled detent when the window resizes (end to
  end, asserting the rendered height, transform, and that the re-anchor does not
  animate); keeps its detents when the keyboard shrinks the visual viewport.

Two more assert the non-regressions the fix must not break: a drag in progress
is left alone, and a closed sheet stops re-resolving.

The existing suite needed one mechanical change: `mockVisualViewport(800)` was
standing in for the whole viewport, so those tests now also set the layout
viewport with a new `mockWindowHeight(800)`. The keyboard tests that mock a
500px *visual* viewport deliberately leave the layout viewport alone — that is
the case this PR is separating.

`pnpm lint:strict` clean, `pnpm build` clean, `packages/core/src/BottomSheet`
147/147. Full-suite failures are pre-existing and unrelated (two CLI
name-resolution tests fail identically on `main`; TransferList/Table.perf are
timing-flaky and vary run to run).

## Notes for review

- Detent identity is an index, so a viewport change that changes how
  `computeDetentOffsets` de-dupes could shift which stop the index names. With
  proportional fractions the list length is stable; a content-hugging sheet
  whose hug height crosses `DETENT_DEDUP_PX` relative to a snap point is the
  edge case, and it clamps rather than throwing.
- The alternative to all of this is to stop holding detents in pixels at all —
  render the resting height as a `dvh` fraction and pin px only during a
  gesture, so the browser reflows on resize for free. That is a larger change to
  the layout/transform split, and worth discussing against
  #5087, which is deciding these semantics.
