### PR TITLE
fix(core): a bottom-edge pull-up no longer hijacks a fully expanded Bottom Sheet

### DIFF
--- a/.changeset/bottom-sheet-scroll-drag-handoff.md
+++ b/.changeset/bottom-sheet-scroll-drag-handoff.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BottomSheet: an upward pull at the bottom of scrolled content no longer hijacks the gesture when the sheet is already fully expanded. It used to hand off to a sheet drag with nowhere to expand to, producing a rubber-band the release threw straight back, and — because the handoff swallows the rest of the gesture — leaving the content unscrollable until the finger lifted, so dragging back down collapsed the sheet instead of scrolling. The bottom edge now hands off only when a taller detent exists.
+
+@imdreamrunner

--- a/packages/core/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/core/src/BottomSheet/useSheetGestures.test.ts
@@ -549,7 +549,7 @@ describe('useSheetGestures', () => {
       expect(hook.result.current.isDragging).toBe(true);
     });
 
-    it('promotes a bottom pull-up (touch) into a sheet drag', () => {
+    it('promotes a bottom pull-up (touch) into a sheet drag that travels', () => {
       const {hook} = setup({snapHeights: () => [200]});
       // scrolled to the bottom: scrollTop + clientHeight === scrollHeight
       const el = makeScroller({
@@ -559,11 +559,67 @@ describe('useSheetGestures', () => {
       });
       act(() => hook.result.current.sheetRef(el));
       act(() => hook.result.current.bodyProps.ref(el));
+      // Settle at the lower detent first, so expanding has somewhere to go.
+      down(hook, 0, 0, el);
+      move(hook, 180, 700, el);
+      up(hook, 180, 1100, el);
+      expect(hook.result.current.settledOffset).toBe(200);
+
       act(() => {
         touch(el, 'touchstart', 300);
         touch(el, 'touchmove', 250); // pull up
       });
       expect(hook.result.current.isDragging).toBe(true);
+      // The handoff is only worth taking if the sheet follows the finger:
+      // 50px of pull expands 50px toward the tallest detent.
+      expect(hook.result.current.dragOffset).toBe(150);
+    });
+
+    it('leaves a bottom pull-up with the scroller at the tallest detent', () => {
+      // Regression: the sheet is already fully expanded, so an upward pull has
+      // nowhere to expand to. Promoting it produced a rubber-band the release
+      // threw straight back, and stole the gesture from the scroller.
+      const {hook} = setup({snapHeights: () => [200]});
+      const el = makeScroller({
+        scrollTop: 600,
+        clientHeight: 200,
+        scrollHeight: 800,
+      });
+      act(() => hook.result.current.sheetRef(el));
+      act(() => hook.result.current.bodyProps.ref(el));
+      expect(hook.result.current.settledOffset).toBe(0);
+
+      act(() => {
+        touch(el, 'touchstart', 300);
+        touch(el, 'touchmove', 250); // pull up
+      });
+      expect(hook.result.current.isDragging).toBe(false);
+      expect(hook.result.current.dragOffset).toBe(0);
+    });
+
+    it('does not preventDefault a bottom pull-up at the tallest detent', () => {
+      // The captured gesture was the worse half of the bug: once promoted,
+      // every later touchmove was preventDefault()ed, so reversing downward to
+      // scroll back collapsed the sheet instead of scrolling.
+      const {hook} = setup({snapHeights: () => [200]});
+      const el = makeScroller({
+        scrollTop: 600,
+        clientHeight: 200,
+        scrollHeight: 800,
+      });
+      act(() => hook.result.current.sheetRef(el));
+      act(() => hook.result.current.bodyProps.ref(el));
+
+      let pullUp: Event | undefined;
+      let reverseDown: Event | undefined;
+      act(() => {
+        touch(el, 'touchstart', 300);
+        pullUp = touch(el, 'touchmove', 250);
+        reverseDown = touch(el, 'touchmove', 400);
+      });
+      expect(pullUp?.defaultPrevented).toBe(false);
+      expect(reverseDown?.defaultPrevented).toBe(false);
+      expect(hook.result.current.isDragging).toBe(false);
     });
 
     it('finishes the active drag when another ended touch is listed first', () => {

--- a/packages/core/src/BottomSheet/useSheetGestures.ts
+++ b/packages/core/src/BottomSheet/useSheetGestures.ts
@@ -968,7 +968,15 @@ export function useSheetGestures({
         return;
       }
       const top = atTop(scroller);
-      const bottom = atBottom(scroller);
+      // The bottom edge hands off so the sheet can EXPAND, so it is only a
+      // handoff when a taller detent exists. Already at the tallest, an
+      // upward pull has nowhere to travel: promoting it would trade the
+      // user's scroll for a rubber-band the release throws straight back, and
+      // — because promotion preventDefault()s the rest of the gesture — would
+      // strand the scroller for as long as the finger stays down, so reversing
+      // downward to scroll back would collapse the sheet instead. Leave the
+      // gesture with the content.
+      const bottom = atBottom(scroller) && activeOffsetRef.current > 0;
       if (!top && !bottom) {
         touchDragRef.current = null;
         return;


### PR DESCRIPTION
## Summary

At its tallest detent, a Bottom Sheet with scrolled content stole an upward
pull that belonged to the scroller. The sheet lifted a little, stopped short of
the finger, and sprang back — and for the rest of that gesture the content
could not scroll at all.

`onTouchStart` armed the bottom edge for handoff whenever the scroller was at
its end, without asking whether the sheet had anywhere to expand to. At the
tallest detent `baseOffset === 0`, so every upward pixel landed in the
rubber-band branch of `handlePointerMove` (`OVERSCROLL_RESISTANCE = 0.35`,
capped at `OVERSCROLL_MAX = 48`) and `settleFromDrag` returned it to 0. The
measured lift was exactly `min(0.35 × d, 48)`, thrown back over ~225ms.

**The worse half is the captured gesture.** Once promoted, `dragStateRef` is
set and every later `touchmove` is `preventDefault()`ed, so native scrolling
stays dead until the finger lifts. Overshoot the end of a list by a few pixels,
drag back to scroll, and the sheet collapses a detent instead — from a mid
detent the same gesture drove the sheet to `top: 810` on a 900px viewport, one
nudge from dismissal.

The bottom edge hands off so the sheet can **expand**, so it is only a handoff
when a taller detent exists:

```ts
const bottom = atBottom(scroller) && activeOffsetRef.current > 0;
```

`activeOffsetRef` is refreshed every render and equals `settledOffset` when no
drag is in flight, so it is the live answer to "is there room to expand" — no
new state, no stale closure.

## Measured

Capped-height story, 500×900, content scrolled to the bottom:

| finger up | lift before | lift after |
|---|---|---|
| 20px | 7px | 0px |
| 80px | 28px | 0px |
| 320px | 48px | 0px |

One gesture, fully open: pull up 60px, then reverse down 300px.

| | before | after |
|---|---|---|
| sheet top | 342 → 450 (collapsed a detent) | 342 (stays) |
| scrollTop | 367 → 367 (dead) | 367 → 0 (scrolls) |

Unchanged and re-verified: top-edge pull-down collapse, mid-detent
expand-by-pull-up (450 → 342), fully-open + at-top + finger-up scrolling, and
`scrollPreservationInset` healing. Same on the hug-height story.

## Risk

Public API unchanged. One deliberate behavior change beyond the bug: on a sheet
whose content does not scroll at all, `atTop` and `atBottom` are both true, so
an upward pull used to rubber-band there too. It no longer does. The body
already sets `overscrollBehavior: 'none'`, so "no bounce at the end" is the
established choice here, and the grab handle remains the affordance for moving
the sheet. Happy to restore the bounce for that case if reviewers prefer it.

**Touch-only.** The pointer path never armed the bottom edge —
`handleBodyPointerDown` returns early when `scrollTop > 0` — so mouse-driven
harnesses cannot see any of this, before or after.

## Testing

`useSheetGestures.test.ts` — the existing case asserted only
`isDragging === true`, which the bug satisfied: the promotion was real, the
travel was worthless. It now asserts the sheet actually follows the finger, and
two regressions pin the tallest detent:

- `promotes a bottom pull-up (touch) into a sheet drag that travels` — settles
  at a lower detent first, then asserts `dragOffset` tracks the finger 1:1
- `leaves a bottom pull-up with the scroller at the tallest detent`
- `does not preventDefault a bottom pull-up at the tallest detent` — pins the
  reversal case via `defaultPrevented`

Both regressions fail on the unfixed source and pass with the fix.

- `vitest run packages/core/src/BottomSheet/` — 142 pass
- `pnpm check:repo`, eslint, `tsc --noEmit` — clean
- Browser: real CDP touch events at 500×900 against both long-content stories

## Scope

This PR only stops the sheet from taking a gesture it cannot use. The
scroll-to-the-bottom-then-pull-up handoff is unchanged and verified: at a mid
detent with content at its end, an upward pull tracks the finger 1:1 (40px →
40.0, 60px → 60.0, 80px → 80.0) and settles expanded. Direct expansion from any
scroll position remains the grab handle's job.

Whether an upward drag should expand a sheet *beyond* its opening height is a
separate question, tracked in #5087.
