### PR TITLE
fix(Switch): keep accent for the on state and mute the off track

### DIFF
--- a/.changeset/switch-off-state-muted.md
+++ b/.changeset/switch-off-state-muted.md
@@ -1,0 +1,10 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/theme-stone': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] Switch: only the on state paints an accent fill. The off track is now a muted step off the surface, with the thumb carrying the state contrast, so "off" can never read as filled — in Butter and Y2K dark it was measuring 1.0:1 and 1.1:1 against the on state. Both off colours derive from the surface and the theme's own text colour, so the thumb clears 3:1 against its track (WCAG 1.4.11) in every theme instead of none. Neutral and Stone no longer need their `--color-background-gray` switch overrides.
+
+@cixzhang

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -572,20 +572,6 @@ export const neutralTheme = defineTheme({
     // dark T20). Verified all six combinations clear AA non-text 3:1.
     // =========================================================================
 
-    // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
-    // =========================================================================
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-border-emphasized)',
-      },
-    },
-
     progressbar: {
       base: {
         // Track uses --color-background-muted; override it to

--- a/packages/cli/assets/templates/themes/stone/stoneTheme.ts
+++ b/packages/cli/assets/templates/themes/stone/stoneTheme.ts
@@ -345,16 +345,6 @@ export const stoneTheme = defineTheme({
       },
     },
 
-    // Switch off-state track reads --color-background-gray by default.
-    // Redefine it inside the switch scope to --color-skeleton, matching
-    // the ProgressBar track. The on-state reads --color-accent (unaffected);
-    // disabled-off also picks up --color-skeleton for consistency.
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-skeleton)',
-      },
-    },
-
     // FieldStatus surface matches badge — see badge override above.
     'field-status': {
       'type:success': {

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -129,6 +129,15 @@ const labelWrapperSizeStyles = stylex.create({
   },
 });
 
+// Off state: the track stays a muted step off the surface so only the on state
+// is a filled, accented pill, and the thumb carries the contrast instead. Both
+// are mixed from the surface the control sits on toward the theme's own text
+// colour, so no palette can land them on top of each other — 1.4.11 asks 3:1
+// of the thumb against its track, and a track and thumb picked from separate
+// tokens converged in every theme we measured.
+const offTrackColor = `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-text-primary']} 12%)`;
+const offThumbColor = `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-text-primary']} 68%)`;
+
 const styles = stylex.create({
   container: {
     display: 'flex',
@@ -237,7 +246,7 @@ const styles = stylex.create({
   // State-dependent colors with ancestor hover behavior
   trackOff: {
     backgroundColor: {
-      default: colorVars['--color-background-gray'],
+      default: offTrackColor,
       // Off = empty (Canvas) track; on = Highlight track, so the two states
       // stay distinguishable under forced colors.
       '@media (forced-colors: active)': 'Canvas',
@@ -248,7 +257,7 @@ const styles = stylex.create({
       // white track (white-on-white). Gating on `forced-colors: none` keeps
       // the tint out of forced colors and lets the system-color track stand.
       [stylex.when.ancestor(':hover', switchScope)]: {
-        '@media (hover: hover) and (forced-colors: none)': `color-mix(in srgb, ${colorVars['--color-background-gray']}, ${colorVars['--color-tint-hover']} 5%)`,
+        '@media (hover: hover) and (forced-colors: none)': `color-mix(in srgb, ${offTrackColor}, ${colorVars['--color-tint-hover']} 5%)`,
       },
     },
   },
@@ -273,7 +282,7 @@ const styles = stylex.create({
     },
   },
   trackDisabledOff: {
-    backgroundColor: colorVars['--color-background-gray'],
+    backgroundColor: offTrackColor,
   },
   thumb: {
     display: 'flex',
@@ -288,14 +297,21 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   // The thumb fill lives on the on/off styles (not the shared thumb style)
-  // because forced colors needs a per-state system color: CanvasText on the
-  // empty off track, HighlightText on the Highlight on track. Sizing stays in
+  // because each state needs its own: off is the only contrast the muted
+  // track carries, on rides an accent fill. Forced colors needs a per-state
+  // system color for the same reason — CanvasText on the empty off track,
+  // HighlightText on the Highlight on track. Sizing stays in
   // thumbOffSizeStyles/thumbOnSizeStyles; only the fill is state-dependent.
   thumbOff: {
     backgroundColor: {
-      default: colorVars['--color-background-surface'],
+      default: offThumbColor,
       '@media (forced-colors: active)': 'CanvasText',
     },
+    // The loading spinner draws in the inherited currentColor while off (see
+    // the Spinner call below): the off thumb's fill flips polarity between
+    // light and dark, and the surface it was mixed from is the one colour
+    // guaranteed to sit opposite it in both.
+    color: colorVars['--color-background-surface'],
   },
   thumbOn: {
     backgroundColor: {
@@ -613,7 +629,7 @@ export function Switch({
               isOn ? styles.thumbOn : styles.thumbOff,
             ),
           )}>
-          {isBusy && <Spinner size="sm" />}
+          {isBusy && <Spinner size="sm" shade={isOn ? 'default' : 'inherit'} />}
         </div>
       </div>
       {isBusy && <VisuallyHidden role="status">Loading</VisuallyHidden>}

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -572,20 +572,6 @@ export const neutralTheme = defineTheme({
     // dark T20). Verified all six combinations clear AA non-text 3:1.
     // =========================================================================
 
-    // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
-    // =========================================================================
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-border-emphasized)',
-      },
-    },
-
     progressbar: {
       base: {
         // Track uses --color-background-muted; override it to

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -345,16 +345,6 @@ export const stoneTheme = defineTheme({
       },
     },
 
-    // Switch off-state track reads --color-background-gray by default.
-    // Redefine it inside the switch scope to --color-skeleton, matching
-    // the ProgressBar track. The on-state reads --color-accent (unaffected);
-    // disabled-off also picks up --color-skeleton for consistency.
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-skeleton)',
-      },
-    },
-
     // FieldStatus surface matches badge — see badge override above.
     'field-status': {
       'type:success': {


### PR DESCRIPTION
## Why

Only the **on** state should read as a filled, accented control. Today the off track paints `--color-background-gray` — a categorical gray with nothing tying it to the switch — and in two themes it comes out *brighter and more filled-looking than the on state*, because both keep a light gray in their dark slot:

| theme · mode | off track | on track | off : on |
| --- | --- | --- | --- |
| butter · dark | `#f0edd4` | `#fdee8c` | **1.00:1** |
| y2k · dark | `#ede0d4` | `#edeffc` | **1.13:1** |

The same split hits the thumb, which paints `--color-background-surface`: two independently chosen neutrals, so they converge. Sampled from rendered Chrome pixels, the thumb clears the 3:1 WCAG 1.4.11 asks of its track in **2 of 16** theme/mode combinations — including 1.55:1 with no theme at all.

## What

Both off colours are mixed from the surface the control sits on toward the theme's own text colour:

```
track  color-mix(in srgb, var(--color-background-surface), var(--color-text-primary) 12%)
thumb  color-mix(in srgb, var(--color-background-surface), var(--color-text-primary) 68%)
```

12% keeps the track muted — a channel, not a fill — and the thumb carries the contrast the muted track can't. Derived from one pair of tokens, track and thumb cannot converge in any palette, and the result is what the forced-colors path already drew: a plain Canvas track with a CanvasText thumb.

Neutral's and Stone's switch overrides of `--color-background-gray` were reaching for the same thing and cleared neither bar; they're removed, along with their copies in the CLI theme templates.

## Risk

Visual change to every off switch: the knob goes from surface-coloured to a mid-tone. The on state is untouched. The busy spinner in the off thumb switches to `shade="inherit"` against a surface-coloured `color`, since the thumb's fill now flips polarity between light and dark.

## Testing

788 core + theme tests pass. Measured across 8 themes × 2 modes from screenshot pixels (never `getComputedStyle` — the alpha and `color-mix` values only mean something composited):

| | before | after |
| --- | --- | --- |
| worst off : on | 1.00:1 (butter dark) | 3.87:1 |
| worst thumb : off track | 1.15:1 (chocolate dark) | 3.25:1 (matcha light) |
| combos with thumb ≥ 3:1 | 2 / 16 | 16 / 16 |
