### PR TITLE
docs(layout): rewrite as an outside-in build sequence with tiered guidance

### DIFF
--- a/apps/docsite/src/components/docs/ReferenceDocView.tsx
+++ b/apps/docsite/src/components/docs/ReferenceDocView.tsx
@@ -84,10 +84,14 @@ function buildOutline(sections: DocSection[]): {
   return {sectionIds, blockIds, outline};
 }
 
-function isBestPracticesSection(section: DocSection): boolean {
-  return section.content.every(
-    b => b.type === 'list' && (b.style === 'do' || b.style === 'dont'),
+function isGuidanceList(block: DocSection['content'][number] | undefined) {
+  return (
+    block?.type === 'list' && (block.style === 'do' || block.style === 'dont')
   );
+}
+
+function isBestPracticesSection(section: DocSection): boolean {
+  return section.content.every(isGuidanceList);
 }
 
 function BestPracticesSection({
@@ -161,6 +165,28 @@ export function ReferenceDocView({
                         </AnchorHeading>
                       );
                     }
+                  }
+                  // A run of do/dont lists is one badge table, so guidance
+                  // keeps its Do/Don't label outside all-guidance sections.
+                  if (isGuidanceList(block)) {
+                    if (isGuidanceList(section.content[blockIndex - 1])) {
+                      return null;
+                    }
+                    const items: {guidance: boolean; description: string}[] =
+                      [];
+                    for (let j = blockIndex; j < section.content.length; j++) {
+                      const run = section.content[j];
+                      if (!isGuidanceList(run)) {break;}
+                      for (const item of run.items ?? []) {
+                        items.push({
+                          guidance: run.style === 'do',
+                          description: item,
+                        });
+                      }
+                    }
+                    return (
+                      <BestPracticesBlock key={blockIndex} items={items} />
+                    );
                   }
                   return (
                     <ContentBlockRenderer key={blockIndex} block={block} />

--- a/packages/cli/assets/docs/layout.doc.dense.mjs
+++ b/packages/cli/assets/docs/layout.doc.dense.mjs
@@ -4,124 +4,267 @@
 
 export const docsDense = {
   description:
-    'frame-first app layout: shell choice, region budgets, nav choice, sections vs rows vs cards',
+    'outside-in app layout in 4 phases: frame -> structure -> space -> ship. each phase ends in a do/dont table.',
   sections: [
+    // ===== FRAME =====
     {
-      section: 'Frame First',
-      title: 'Frame First',
+      section: 'Frame: Pick the shell',
+      title: 'Frame: Pick the shell',
       content: [
         {
           type: 'prose',
-          text: 'decide frame before content. content-first (Card-wrapped sections in a scroll column) = prototype look.',
+          text: 'phase 1/4 frame. start from the frame, not content. content-first (Card-wrapped sections in a scroll column) = prototype look.',
         },
         {
           type: 'list',
           items: [
             'pick frame: AppShell (nav apps) | Layout+LayoutPanel+LayoutContent (multi-pane tools) | plain column (docs/forms)',
-            'budget regions in px first: side nav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
-            'interior spacing = spacing token, never raw px. px is only for structural widths (nav 256, inspector 380)',
-            'container policy per region: dense data = rows; dashboards/galleries = card grids',
-            'write responsive contract up front',
+            'budget regions px first: side nav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
+            'raw px = structural widths only; interior spacing = tokens',
+            'set container policy (rows vs card grid) + responsive contract before content',
           ],
         },
         null,
       ],
     },
     {
-      section: 'App Archetypes',
-      title: 'App Archetypes',
+      section: 'Frame: Match the archetype',
+      title: 'Frame: Match the archetype',
       content: [
         {
           type: 'prose',
-          text: 'container choice tracks archetype, not preference. table = pointer to the template you inherit, not a spec.',
+          text: 'match frame + container policy to app type. container choice tracks archetype, not preference. each row points to a template to inherit.',
         },
         null,
         {
           type: 'prose',
-          text: 'start from matching template (astryx template --list), study with --skeleton, inherit its nav pairing.',
+          text: 'start from the matching template (npx astryx template --list), read --skeleton, inherit its nav pairing.',
         },
       ],
     },
     {
-      section: 'Choosing Navigation',
-      title: 'Choosing Navigation',
+      section: 'Frame: Choose navigation',
+      title: 'Frame: Choose navigation',
       content: [
         {
           type: 'prose',
-          text: 'choose nav from countable signals, not preference: destination count, grouping, hierarchy depth. inherit template pairing first.',
+          text: 'decide from countable signals (destination count, grouping, depth), not preference. inherit template pairing first.',
         },
         null,
         {
           type: 'prose',
-          text: 'default side/left nav (>5 dests, grouping, customizable, collapsible). top nav only if <=5 dests + no grouping + control-heavy. top+left only for a real suite/ecosystem layer.',
+          text: 'default left nav; top only if <=5 destinations and no grouping; top+left only for a real ecosystem layer.',
         },
       ],
     },
     {
-      section: 'Containers',
-      title: 'Containers',
+      section: "Frame: Do & Don't",
+      title: "Frame: Do & Don't",
+      content: [
+        {
+          type: 'list',
+          items: [
+            'decide frame + per-region px budgets before content',
+            'choose nav from signals or inherit template pairing',
+            'raw px for structural widths; interior = tokens',
+          ],
+        },
+        {
+          type: 'list',
+          items: [
+            'build content-first, Card-wrapping each section',
+            'top+left nav when the ecosystem layer is thin',
+            'break template nav pairing without a reason',
+          ],
+        },
+      ],
+    },
+    // ===== STRUCTURE =====
+    {
+      section: 'Structure: Set hierarchy',
+      title: 'Structure: Set hierarchy',
       content: [
         {
           type: 'prose',
-          text: 'grouping ladder weakest->strongest: spacing, divider, Section, Card. use the weakest that reads as a group. Card-by-default = the generic-AI-prototype look.',
+          text: 'phase 2/4 structure. one lead per region. name lead/support/tertiary, make ranks look different. rank via type+color; drop weight before size.',
         },
-        null,
+        {
+          type: 'list',
+          items: [
+            'lead: Heading, or Text weight="semibold" color="primary"',
+            'support: Text color="secondary"',
+            'tertiary/meta: Text type="supporting-text"/color="disabled"; StatusDot/Token over prose',
+          ],
+        },
         {
           type: 'prose',
-          text: 'decision: collection of records = rows (Table columnar | List/Item single-line, edge-to-edge, 32-40px). self-contained widget or hard boundary = Card. everything else = Section. ceiling: one bordered container, no cards-in-cards, no card soup.',
+          text: 'squint test: read lead, then support, then groups, in order. everything at once = raise contrast (weight/color/spacing), not borders.',
         },
       ],
     },
     {
-      section: 'Spacing & Alignment',
-      title: 'Spacing & Alignment',
+      section: 'Structure: Choose a container',
+      title: 'Structure: Choose a container',
       content: [
         {
           type: 'prose',
-          text: 'container owns structural space (region padding + child gap); children set gap/margin 0. interior spacing = token (Section padding default 4 = 16px).',
+          text: 'strength ladder: spacing < divider < Section < Card. use the weakest that reads as a group. default-Card = generic prototype look.',
+        },
+        null,
+        {
+          type: 'prose',
+          text: 'Card = widget container, not list-item wrapper. dense data = rows (Table columnar, List single-line), edge-to-edge, 32-40px. ceiling: 1 bordered level, no cards-in-cards.',
         },
         {
           type: 'prose',
-          text: 'optical alignment: one content line per region (16px default). hold the line constant, not the padding: container_inset = content_line - component built-in inset. plain text = full inset; padded components (List/Tab/Menu/nav ~8px, Table cells ~12-16px) = set Section padding={0} so label lands on the line and hover bg bleeds to edge. double-padding (both container + component pad) indents rows past the heading.',
+          text: 'test: records -> rows; self-contained widget or hard boundary -> Card; everything else -> Section.',
+        },
+      ],
+    },
+    {
+      section: 'Structure: Panels and inspectors',
+      title: 'Structure: Panels and inspectors',
+      content: [
+        {
+          type: 'prose',
+          text: 'master-detail: select a row -> fixed-width inspector, no navigation away. LayoutPanel end slot + width budget + resizable; overlay content below ~1024px.',
         },
         null,
       ],
     },
     {
-      section: 'Panels and Inspectors',
-      title: 'Panels and Inspectors',
+      section: "Structure: Do & Don't",
+      title: "Structure: Do & Don't",
+      content: [
+        {
+          type: 'list',
+          items: [
+            'one lead per region; rank via weight+color; one primary action',
+            'default Section; weakest container that reads as a group',
+            'collections = rows (Table/List), edge-to-edge with dividers',
+            'inspector on select; overlay below ~1024px',
+          ],
+        },
+        {
+          type: 'list',
+          items: [
+            'card soup: each record in its own Card',
+            'cards-in-cards, or full-width Cards as page structure',
+            'two competing primary actions in one region',
+            'Badge as decoration; use StatusDot/Token for status',
+          ],
+        },
+      ],
+    },
+    // ===== SPACE =====
+    {
+      section: 'Space: Align to one line',
+      title: 'Space: Align to one line',
       content: [
         {
           type: 'prose',
-          text: 'master-detail: row select opens fixed-width inspector (LayoutPanel end slot + width budget + resizable/useResizable). overlay content <=1024px, do not compress.',
+          text: 'phase 3/4 space. container owns padding + child gaps; children zero their margins. interior spacing = token (Section padding 4 = 16px).',
+        },
+        {
+          type: 'prose',
+          text: 'one content line per region (16px default). hold the line, not the padding: container_inset = content_line - component built-in inset. text=0 inset (full padding); List/Tab/Menu/nav ~8px, Table cells ~12-16px -> Section padding={0}, component owns inset. label on line, hover bleeds to edge.',
+        },
+        null,
+        {
+          type: 'prose',
+          text: 'squint: draw one left line; every label touches it, only hover/selected cross it. list indented past its heading = double padding. keep one inset owner.',
+        },
+      ],
+    },
+    {
+      section: 'Space: Set the rhythm',
+      title: 'Space: Set the rhythm',
+      content: [
+        {
+          type: 'prose',
+          text: 'grouping via contrast, not one repeated gap. tight binds, generous separates: gap={1}-{2} within an item, {4}-{6} between sections. the jump is what reads.',
+        },
+        {
+          type: 'prose',
+          text: 'use in-between 4px steps (gap={3}=12px, {5}=20px); do not round all to {2}/{4}. verify: name the groups from spacing alone with borders removed; cannot = intervals too uniform.',
+        },
+      ],
+    },
+    {
+      section: 'Space: Match density and size',
+      title: 'Space: Match density and size',
+      content: [
+        {
+          type: 'prose',
+          text: 'density by use: compact = high-volume fast scan (logs/monitors); balanced = default Table/List; spacious = low-frequency/high-stakes. set deliberately.',
+        },
+        {
+          type: 'prose',
+          text: 'ONE size per row/container. all controls in a row share size (sm/md/lg) or heights lose their baseline and read broken. pick row size once; pair with density (compact->sm, spacious->md/lg).',
+        },
+      ],
+    },
+    {
+      section: "Space: Do & Don't",
+      title: "Space: Do & Don't",
+      content: [
+        {
+          type: 'list',
+          items: [
+            'container owns padding; children zero margins',
+            'one content line: text on line, hover bleeds to edge',
+            'contrast tight vs generous gaps',
+            'use in-between 4px steps',
+            'one control size per row; density by use frequency',
+          ],
+        },
+        {
+          type: 'list',
+          items: [
+            'double padding (component past its heading); keep one inset owner',
+            'raw px for interior spacing; tokens only',
+            'one repeated gap everywhere',
+            'mixed sm/md/lg controls in one row',
+          ],
+        },
+      ],
+    },
+    // ===== SHIP =====
+    {
+      section: 'Ship: Responsive contract',
+      title: 'Ship: Responsive contract',
+      content: [
+        {
+          type: 'prose',
+          text: 'phase 4/4 ship. declare breakpoints as a contract at the frame root; pair each line with the prop/hook that enforces it. typical: full frame >1024px; inspector overlays <=1024px; nav -> MobileNav <=768px.',
         },
         null,
       ],
     },
     {
-      section: 'Responsive Contract',
-      title: 'Responsive Contract',
+      section: 'Ship: Before you ship',
+      title: 'Ship: Before you ship',
       content: [
         {
-          type: 'prose',
-          text: 'declare breakpoint behavior as comment at frame root; pair every line with its enforcing prop/hook so the comment cannot drift.',
-        },
-        null,
-      ],
-    },
-    {
-      section: 'Before You Ship',
-      title: 'Before You Ship',
-      content: [
-        {
-          type: 'prose',
-          text: 'self-review named anti-patterns: card soup, dashboard-by-default, double padding, magic-number spacing, flexbox soup, comment-only responsive contract.',
+          type: 'list',
+          items: [
+            '<=1 bordered level; Section before Card',
+            'collections = rows; Cards = widgets/hard boundaries',
+            'interior = tokens; one padding token across header/body/footer',
+            'every label on one left content line',
+            'nav matches template pairing or the signals',
+            'each responsive-contract line names a mechanism',
+          ],
         },
         {
-          type: 'prose',
-          text: 'checks: <=1 bordered container; collections = rows; spacing = tokens (one padding token per region); one content line (no double padding); nav from template pairing; each contract line names a mechanism.',
+          type: 'list',
+          items: [
+            'card soup, or card grid because app type was unclear',
+            'double padding, or magic-number px interior spacing',
+            'flexbox soup instead of Grid/Layout/FormLayout',
+            'breakpoint comment with no prop/hook wiring it',
+          ],
         },
-        null,
       ],
     },
   ],

--- a/packages/cli/assets/docs/layout.doc.dense.mjs
+++ b/packages/cli/assets/docs/layout.doc.dense.mjs
@@ -6,61 +6,54 @@ export const docsDense = {
   description:
     'outside-in app layout in 4 phases: frame -> structure -> space -> ship. each phase ends in a do/dont table.',
   sections: [
-    // ===== FRAME =====
     {
-      section: 'Frame: Pick the shell',
-      title: 'Frame: Pick the shell',
+      section: 'Frame',
+      title: 'Frame',
       content: [
+        // Pick the shell
+        null,
         {
           type: 'prose',
-          text: 'phase 1/4 frame. start from the frame, not content. content-first (Card-wrapped sections in a scroll column) = prototype look.',
+          text: 'pick the shell + budget its regions in px before any content exists.',
         },
         {
           type: 'list',
           items: [
             'pick frame: AppShell (nav apps) | Layout+LayoutPanel+LayoutContent (multi-pane tools) | plain column (docs/forms)',
-            'budget regions px first: side nav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
+            'budget each region px: side nav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
             'raw px = structural widths only; interior spacing = tokens',
             'set container policy (rows vs card grid) + responsive contract before content',
           ],
         },
         null,
-      ],
-    },
-    {
-      section: 'Frame: Match the archetype',
-      title: 'Frame: Match the archetype',
-      content: [
         {
           type: 'prose',
-          text: 'match frame + container policy to app type. container choice tracks archetype, not preference. each row points to a template to inherit.',
+          text: 'verify: every region has a px budget + a container policy written down before any content.',
+        },
+        // Match the archetype
+        null,
+        {
+          type: 'prose',
+          text: 'match frame + container policy to app type. container choice tracks archetype, not preference.',
         },
         null,
         {
           type: 'prose',
-          text: 'start from the matching template (npx astryx template --list), read --skeleton, inherit its nav pairing.',
+          text: 'verify: start from the matching template (npx astryx template --list, read --skeleton), inherit its nav pairing.',
         },
-      ],
-    },
-    {
-      section: 'Frame: Choose navigation',
-      title: 'Frame: Choose navigation',
-      content: [
+        // Choose navigation
+        null,
         {
           type: 'prose',
-          text: 'decide from countable signals (destination count, grouping, depth), not preference. inherit template pairing first.',
+          text: 'nav left open? decide from countable signals: destination count, grouping, hierarchy depth.',
         },
         null,
         {
           type: 'prose',
-          text: 'default left nav; top only if <=5 destinations and no grouping; top+left only for a real ecosystem layer.',
+          text: 'verify: left nav unless <=5 destinations and no grouping; top+left only above a real ecosystem layer.',
         },
-      ],
-    },
-    {
-      section: "Frame: Do & Don't",
-      title: "Frame: Do & Don't",
-      content: [
+        // Do & Don't
+        null,
         {
           type: 'list',
           items: [
@@ -79,14 +72,15 @@ export const docsDense = {
         },
       ],
     },
-    // ===== STRUCTURE =====
     {
-      section: 'Structure: Set hierarchy',
-      title: 'Structure: Set hierarchy',
+      section: 'Structure',
+      title: 'Structure',
       content: [
+        // Set hierarchy
+        null,
         {
           type: 'prose',
-          text: 'phase 2/4 structure. one lead per region. name lead/support/tertiary, make ranks look different. rank via type+color; drop weight before size.',
+          text: 'one lead per region. separate lead/support/tertiary via type+color; drop weight before size.',
         },
         {
           type: 'list',
@@ -98,44 +92,32 @@ export const docsDense = {
         },
         {
           type: 'prose',
-          text: 'squint test: read lead, then support, then groups, in order. everything at once = raise contrast (weight/color/spacing), not borders.',
+          text: 'squint test: read lead, then support, then groups, in order. everything at once = raise contrast (weight/color), not borders.',
         },
-      ],
-    },
-    {
-      section: 'Structure: Choose a container',
-      title: 'Structure: Choose a container',
-      content: [
+        // Choose a container
+        null,
         {
           type: 'prose',
-          text: 'strength ladder: spacing < divider < Section < Card. use the weakest that reads as a group. default-Card = generic prototype look.',
+          text: 'weakest container that reads as a group, escalate only when it fails: spacing < divider < Section < Card.',
         },
         null,
         {
           type: 'prose',
-          text: 'Card = widget container, not list-item wrapper. dense data = rows (Table columnar, List single-line), edge-to-edge, 32-40px. ceiling: 1 bordered level, no cards-in-cards.',
+          text: 'test: records -> rows (Table columnar, List single-line, edge-to-edge, 32-40px); self-contained widget or hard boundary -> Card; everything else -> Section.',
         },
+        // Panels and inspectors
+        null,
         {
           type: 'prose',
-          text: 'test: records -> rows; self-contained widget or hard boundary -> Card; everything else -> Section.',
-        },
-      ],
-    },
-    {
-      section: 'Structure: Panels and inspectors',
-      title: 'Structure: Panels and inspectors',
-      content: [
-        {
-          type: 'prose',
-          text: 'master-detail: select a row -> fixed-width inspector, no navigation away. LayoutPanel end slot + width budget + resizable; overlay content below ~1024px.',
+          text: 'master-detail: select a row -> fixed-width inspector, no navigation away. LayoutPanel end slot + width budget + resizable.',
         },
         null,
-      ],
-    },
-    {
-      section: "Structure: Do & Don't",
-      title: "Structure: Do & Don't",
-      content: [
+        {
+          type: 'prose',
+          text: 'verify: below ~1024px the panel overlays the content region instead of compressing it.',
+        },
+        // Do & Don't
+        null,
         {
           type: 'list',
           items: [
@@ -156,58 +138,67 @@ export const docsDense = {
         },
       ],
     },
-    // ===== SPACE =====
     {
-      section: 'Space: Align to one line',
-      title: 'Space: Align to one line',
+      section: 'Space',
+      title: 'Space',
       content: [
+        // Align to one line
+        null,
         {
           type: 'prose',
-          text: 'phase 3/4 space. container owns padding + child gaps; children zero their margins. interior spacing = token (Section padding 4 = 16px).',
+          text: 'container owns padding + child gaps; children zero margins; interior spacing = token. one content line per region, hold the line not the padding: container_inset = content_line - component_intrinsic_inset.',
         },
         {
-          type: 'prose',
-          text: 'one content line per region (16px default). hold the line, not the padding: container_inset = content_line - component built-in inset. text=0 inset (full padding); List/Tab/Menu/nav ~8px, Table cells ~12-16px -> Section padding={0}, component owns inset. label on line, hover bleeds to edge.',
+          type: 'list',
+          items: [
+            'Text/Heading: 0 inset -> container takes full padding (Section padding={4} = 16px line)',
+            'List/Tab/Menu/nav items: ~8px built in -> Section padding={0}, component owns inset',
+            'Table cells: 12-16px built in -> Section padding={0}, cell owns inset',
+          ],
         },
         null,
         {
           type: 'prose',
-          text: 'squint: draw one left line; every label touches it, only hover/selected cross it. list indented past its heading = double padding. keep one inset owner.',
+          text: 'verify: draw one vertical line down the left. every label touches it; only hover/selected backgrounds cross it.',
         },
-      ],
-    },
-    {
-      section: 'Space: Set the rhythm',
-      title: 'Space: Set the rhythm',
-      content: [
+        // Set the rhythm
+        null,
         {
           type: 'prose',
-          text: 'grouping via contrast, not one repeated gap. tight binds, generous separates: gap={1}-{2} within an item, {4}-{6} between sections. the jump is what reads.',
+          text: 'grouping = contrast between tight and generous gaps, not one repeated value. same step everywhere = proximity does no work.',
         },
         {
-          type: 'prose',
-          text: 'use in-between 4px steps (gap={3}=12px, {5}=20px); do not round all to {2}/{4}. verify: name the groups from spacing alone with borders removed; cannot = intervals too uniform.',
-        },
-      ],
-    },
-    {
-      section: 'Space: Match density and size',
-      title: 'Space: Match density and size',
-      content: [
-        {
-          type: 'prose',
-          text: 'density by use: compact = high-volume fast scan (logs/monitors); balanced = default Table/List; spacious = low-frequency/high-stakes. set deliberately.',
+          type: 'list',
+          items: [
+            'tight binds: gap={1}-{2} inside an item or field',
+            'generous separates: gap={4}-{6} between sections',
+            'in-between 4px steps tune cadence: gap={3}=12px, gap={5}=20px. do not round all to {2}/{4}',
+          ],
         },
         {
           type: 'prose',
-          text: 'ONE size per row/container. all controls in a row share size (sm/md/lg) or heights lose their baseline and read broken. pick row size once; pair with density (compact->sm, spacious->md/lg).',
+          text: 'verify: borders removed, you can still name the groups from spacing alone. cannot = intervals too uniform.',
         },
-      ],
-    },
-    {
-      section: "Space: Do & Don't",
-      title: "Space: Do & Don't",
-      content: [
+        // Match density and size
+        null,
+        {
+          type: 'prose',
+          text: 'density by use frequency; every control in a row shares one size so heights share a baseline.',
+        },
+        {
+          type: 'list',
+          items: [
+            'density="compact": high-volume, fast scan (logs, monitors, large datasets)',
+            'density="balanced": most Table/List surfaces',
+            'density="spacious": low-frequency or high-stakes rows (settings, short selection list)',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'verify: one size per row (sm/md/lg), paired with density: compact -> sm, spacious -> md/lg.',
+        },
+        // Do & Don't
+        null,
         {
           type: 'list',
           items: [
@@ -229,22 +220,23 @@ export const docsDense = {
         },
       ],
     },
-    // ===== SHIP =====
     {
-      section: 'Ship: Responsive contract',
-      title: 'Ship: Responsive contract',
+      section: 'Ship',
+      title: 'Ship',
       content: [
+        // Responsive contract
+        null,
         {
           type: 'prose',
-          text: 'phase 4/4 ship. declare breakpoints as a contract at the frame root; pair each line with the prop/hook that enforces it. typical: full frame >1024px; inspector overlays <=1024px; nav -> MobileNav <=768px.',
+          text: 'declare breakpoints as a contract at the frame root; pair each line with the prop/hook that enforces it.',
         },
         null,
-      ],
-    },
-    {
-      section: 'Ship: Before you ship',
-      title: 'Ship: Before you ship',
-      content: [
+        {
+          type: 'prose',
+          text: 'verify: every contract line names a mechanism, so the comment cannot drift from the behavior.',
+        },
+        // Before you ship
+        null,
         {
           type: 'list',
           items: [

--- a/packages/cli/assets/docs/layout.doc.dense.mjs
+++ b/packages/cli/assets/docs/layout.doc.dense.mjs
@@ -4,7 +4,7 @@
 
 export const docsDense = {
   description:
-    'outside-in app layout in 4 phases: frame -> structure -> space -> ship. each phase ends in a do/dont table.',
+    'outside-in app layout: scaffold -> structure -> spacing -> breakpoints.',
   sections: [
     {
       section: 'Overview',
@@ -17,89 +17,69 @@ export const docsDense = {
         {
           type: 'list',
           items: [
-            'frame: pick shell, budget regions in px, choose nav',
+            'scaffold: pick shell, budget regions, choose nav',
             'structure: rank content per region, pick the weakest container that groups it',
-            'space: hold one content line per region, then tune gaps + density',
-            'ship: declare the responsive contract, run the checklist',
+            'spacing: hold one content line per region, then tune gaps + density',
+            'breakpoints: decide what each region does as width changes',
           ],
         },
         {
           type: 'prose',
-          text: 'every sub-section: rule -> how (props) -> one example -> the test. skip to your phase.',
+          text: 'decides layout, not component APIs. npx astryx build "<idea>" = closest template for your app type. npx astryx component <Name> = props.',
         },
       ],
     },
     {
-      section: 'Frame',
-      title: 'Frame',
+      section: 'Scaffold',
+      title: 'Scaffold',
       content: [
-        // Pick the shell
+        // Shell
         null,
         {
           type: 'prose',
-          text: 'pick the shell + budget its regions in px before any content exists.',
+          text: 'pick the shell + budget its regions before any content exists. structural widths are the one place raw px belongs; everything inside uses the scale.',
         },
         {
           type: 'list',
           items: [
             'pick frame: AppShell (nav apps) | Layout + LayoutPanel in a start/end slot (multi-pane tools) | plain column (docs/forms)',
-            'budget each region px: SideNav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
-            'raw px = structural widths only; interior spacing = tokens',
-            'set container policy (rows or card grid) + responsive contract before content',
+            'give every fixed region a width budget, so none negotiates for space at render time',
+            'read content to set fill vs capped: tables/charts/boards fill; prose/forms/lists cap via Layout contentWidth',
+            'set container policy (rows or card grid) before writing content',
           ],
         },
         null,
         {
           type: 'prose',
-          text: 'verify: every region has a px budget + a container policy written down before any content.',
+          text: 'verify: every region has a width budget + fill-or-capped + a container policy written down before any content.',
         },
-        // Match the archetype
+        // Navigation
         null,
         {
           type: 'prose',
-          text: 'match frame + container policy to app type. container choice tracks archetype, not preference.',
+          text: 'nav left open? default SideNav: it absorbs destinations you have not planned yet. app type + destination count are guiding indicators, not determining rules.',
         },
         {
           type: 'list',
           items: [
-            'tracker/work tool (issues, tickets, CRM): AppShell + SideNav, inspector LayoutPanel on select. rows only, zero cards',
-            'console/observability (metrics, logs, deploys): AppShell + SideNav, or TopNav + TabList. card grid for widgets, Table elsewhere',
-            'messaging/feed: column frame of rail, nav, stream, panel. rows + bubbles, no cards in stream',
-            'media library/gallery: AppShell + TopNav over grid content. card grid via ClickableCard, dense meta rows in detail',
-            'settings/forms: AppShell + SideNav, or settings template. Sections + FormLayout; Card only for dangerous/billing',
-          ],
-        },
-        null,
-        {
-          type: 'prose',
-          text: 'verify: start from the matching template (npx astryx template --list, read --skeleton), inherit its nav pairing.',
-        },
-        // Choose navigation
-        null,
-        {
-          type: 'prose',
-          text: 'nav left open? decide from countable signals: destination count, grouping, hierarchy depth.',
-        },
-        {
-          type: 'list',
-          items: [
-            'SideNav (default): >~5 destinations, need grouping, customizable, items carry secondary actions, or must collapse',
-            'TopNav: <=5 destinations, context must stay visible, or control/filter-heavy page w/ shallow nav',
+            'SideNav (default): need grouping, customizable, items carry secondary actions, or must collapse. trackers, consoles, settings usually start here',
+            'TopNav: shallow nav you expect to stay shallow, context must stay visible, or control/filter-heavy page; + TabList for a 2nd level. media libraries often sit over grid content',
             'both: a genuine suite. TopNav = ecosystem concerns (context switcher, global search), SideNav = product nav',
+            'neither: messaging/feeds use a column frame of rail, nav, stream, panel',
           ],
         },
         null,
         {
           type: 'prose',
-          text: 'verify: SideNav unless <=5 destinations and no grouping; two bars only above a real ecosystem layer.',
+          text: 'verify: you can state the reason in one sentence, and it still holds if the nav doubles. npx astryx build "<idea>" names the closest template, --skeleton shows the pairing wired up.',
         },
-        // Do & Don't
+        // Best practices
         null,
         {
           type: 'list',
           items: [
-            'decide frame + per-region px budgets before content',
-            'choose nav from signals or inherit template pairing',
+            'decide frame + region width budgets + fill-or-capped before content',
+            'state the reason for the nav choice, or inherit template pairing',
             'raw px for structural widths; interior = tokens',
           ],
         },
@@ -107,6 +87,7 @@ export const docsDense = {
           type: 'list',
           items: [
             'build content-first, Card-wrapping each section',
+            'stretch prose/forms/lists across a wide region instead of capping with contentWidth',
             'SideNav when the nav is really filters/controls, or must hold wide elements like breadcrumbs',
             'TopNav when top-slot ownership is unclear, or hierarchy is deep or still growing',
             'both bars when the ecosystem layer is thin',
@@ -119,81 +100,108 @@ export const docsDense = {
       section: 'Structure',
       title: 'Structure',
       content: [
-        // Set hierarchy
+        // Type hierarchy
         null,
         {
           type: 'prose',
-          text: 'one lead per region. separate lead/support/tertiary via type+color; drop weight before size.',
+          text: 'one lead per region, then rank with weight+color, not size. two text colors only: primary + secondary, nothing dimmer. body copy needs no props.',
         },
         {
           type: 'list',
           items: [
-            'lead: Heading, or Text weight="semibold" color="primary"',
-            'support: Text color="secondary"',
-            'tertiary/meta: Text type="supporting"/color="disabled"; StatusDot/Token over prose',
+            'body (default): plain Text, no type/color/size prop',
+            'lead: Heading at the level matching page depth, or body Text at a heavier weight',
+            'support: step to secondary color, not to a smaller size',
+            'meta: the supporting type, or StatusDot/Token instead of prose',
           ],
         },
         null,
         {
           type: 'prose',
-          text: 'squint test: read lead, then support, then groups, in order. everything at once = raise contrast (weight/color), not borders.',
+          text: 'squint test: read lead, then support, then groups, in order. everything at once = raise contrast (weight/color), not borders and not smaller text.',
         },
-        // Choose a container
+        // Containers
         null,
         {
           type: 'prose',
-          text: 'weakest container that reads as a group, escalate only when it fails. list runs weakest to strongest.',
+          text: 'weakest container that reads as a group, escalate only when it fails. weakest to strongest:',
         },
         {
           type: 'list',
           items: [
             'spacing/gap: related items inside one group. the default rhythm',
             'Divider: peers in a dense list/toolbar, or fencing a header from a scrollable body',
-            'Section: default page-structure unit, related content under a heading. no border, hierarchy from spacing',
-            'Card: self-contained widget (KPI tile, chart, gallery entry) or hard boundary. never a list-item wrapper',
+            'Section: default page-structure unit, related content under a heading. no border',
+            'Card: self-contained widget (KPI tile, chart, gallery entry) or hard boundary',
           ],
         },
         null,
         {
           type: 'prose',
-          text: 'test: records -> rows (Table columnar, List single-line, edge-to-edge, 32-40px); self-contained widget or hard boundary -> Card; everything else -> Section.',
+          text: 'test: records -> rows (Table columnar, List single-line); self-contained widget or hard boundary -> Card; everything else -> Section.',
         },
-        // Panels and inspectors
+        // Headers and footers
         null,
         {
           type: 'prose',
-          text: 'master-detail: select a row -> fixed-width inspector, no navigation away.',
+          text: 'a region can pin a header/footer while its body scrolls. both are Layout slots, and padding set once on Layout reaches all three, so header/body/footer share one content line.',
         },
         {
           type: 'list',
           items: [
-            'LayoutPanel in the end slot of Layout, width budget 340-420px',
+            'LayoutHeader in the header slot: region title + its primary action',
+            'Toolbar instead of LayoutHeader when the header carries interactive controls',
+            'LayoutFooter in the footer slot: actions that commit the work + must stay reachable',
+            'defaultHasDividers on Layout fences both at once, rather than hasDivider per slot',
+          ],
+        },
+        null,
+        {
+          type: 'prose',
+          text: 'verify: scroll the body. header + footer stay put, dividers run full-bleed, all three still share one left content line.',
+        },
+        // Side panels
+        null,
+        {
+          type: 'prose',
+          text: 'master-detail: select a row -> fixed-width side panel, no navigation away.',
+        },
+        {
+          type: 'list',
+          items: [
+            'LayoutPanel in the start or end slot of Layout, holding a fixed width budget',
             'hasDivider fences it from content; isScrollable so long detail scrolls on its own',
-            'user-adjustable width: drive w/ useResizable(), place a ResizeHandle next to the panel',
+            'user-adjustable width: useResizable() + ResizeHandle on the panel inner edge. after the panel in a start slot, before it in an end slot w/ isReversed',
+            'the handle then owns the divider, so the panel sets hasDivider={false}',
             'EmptyState when nothing is selected, so the region never collapses',
           ],
         },
         null,
         {
           type: 'prose',
-          text: 'verify: at narrow widths the inspector yields width instead of squeezing content (see Ship).',
+          text: 'verify: at narrow widths the panel yields width instead of squeezing content (see Breakpoints), and only one element between the regions draws a border.',
         },
-        // Do & Don't
+        // Best practices
         null,
         {
           type: 'list',
           items: [
             'one lead per region; rank via weight+color; one primary action',
+            'leave body copy at its defaults; demote via weight+color, not size',
             'default Section; weakest container that reads as a group',
             'collections = rows (Table/List), edge-to-edge with dividers',
-            'inspector on select; it yields width at narrow sizes',
+            'side panel on select; it yields width at narrow sizes',
           ],
         },
         {
           type: 'list',
           items: [
+            'grey + shrink body copy, so a whole region reads as metadata',
+            'the disabled color for content; it fails contrast, it is for disabled controls',
             'card soup: each record in its own Card',
             'cards-in-cards, or full-width Cards as page structure',
+            'a header/footer rebuilt inside the body, where it scrolls away with the rows',
+            'flexbox soup instead of Grid/Layout/Section/FormLayout',
             'two competing primary actions in one region',
             'Badge as decoration; use StatusDot/Token for status',
           ],
@@ -201,10 +209,10 @@ export const docsDense = {
       ],
     },
     {
-      section: 'Space',
-      title: 'Space',
+      section: 'Spacing',
+      title: 'Spacing',
       content: [
-        // Align to one line
+        // Alignment
         null,
         {
           type: 'prose',
@@ -213,9 +221,9 @@ export const docsDense = {
         {
           type: 'list',
           items: [
-            'Text/Heading: 0 inset -> container takes full padding (Section padding={4} = 16px line)',
-            'List/Tab/Menu/nav items: ~8px built in -> Section padding={0}, component owns inset',
-            'Table cells: 12-16px built in -> Section padding={0}, cell owns inset',
+            'Text/Heading carry no inset -> container takes the full padding',
+            'List/Tab/Menu/nav items carry a small inset -> container gives up padding, component owns the line',
+            'Table cells carry a larger inset -> container gives up padding, cell owns the line',
           ],
         },
         null,
@@ -223,7 +231,7 @@ export const docsDense = {
           type: 'prose',
           text: 'verify: draw one vertical line down the left. every label touches it; only hover/selected backgrounds cross it.',
         },
-        // Set the rhythm
+        // Rhythm
         null,
         {
           type: 'prose',
@@ -232,17 +240,17 @@ export const docsDense = {
         {
           type: 'list',
           items: [
-            'tight binds: gap={1}-{2} inside an item or field',
-            'generous separates: gap={4}-{6} between sections',
-            'in-between 4px steps tune cadence: gap={3}=12px, gap={5}=20px. do not round all to {2}/{4}',
+            'tight gaps bind: the smallest steps, inside an item or field',
+            'generous gaps separate: several steps up, between sections',
+            'reach for the in-between steps to tune cadence, not the same two values everywhere',
           ],
         },
         null,
         {
           type: 'prose',
-          text: 'verify: borders removed, you can still name the groups from spacing alone. cannot = intervals too uniform.',
+          text: 'verify: borders removed, you can still name the groups from spacing alone. cannot = intervals too uniform. form fields excepted: FormLayout owns their spacing.',
         },
-        // Match density and size
+        // Density and size
         null,
         {
           type: 'prose',
@@ -251,25 +259,25 @@ export const docsDense = {
         {
           type: 'list',
           items: [
-            'density="compact": high-volume, fast scan (logs, monitors, large datasets)',
-            'density="balanced": most Table/List surfaces',
-            'density="spacious": low-frequency or high-stakes rows (settings, short selection list)',
+            'compact: high-volume, fast scan (logs, monitors, large datasets)',
+            'balanced: most Table/List surfaces',
+            'spacious: low-frequency or high-stakes rows (settings, short selection list)',
           ],
         },
         null,
         {
           type: 'prose',
-          text: 'verify: one size per row (sm/md/lg), paired with density: compact -> sm, spacious -> md/lg.',
+          text: 'verify: one size per row, paired with the density of the region it sits in.',
         },
-        // Do & Don't
+        // Best practices
         null,
         {
           type: 'list',
           items: [
             'container owns padding; children zero margins',
             'one content line: text on line, hover bleeds to edge',
+            'one padding token across region header/body/footer',
             'contrast tight vs generous gaps',
-            'use in-between 4px steps',
             'one control size per row; density by use frequency',
           ],
         },
@@ -279,27 +287,28 @@ export const docsDense = {
             'double padding (component past its heading); keep one inset owner',
             'raw px for interior spacing; tokens only',
             'one repeated gap everywhere',
-            'mixed sm/md/lg controls in one row',
+            'mixed control sizes in one row',
           ],
         },
       ],
     },
     {
-      section: 'Ship',
-      title: 'Ship',
+      section: 'Breakpoints',
+      title: 'Breakpoints',
       content: [
         // Responsive contract
         null,
         {
           type: 'prose',
-          text: 'declare breakpoints as a contract at the frame root; pair each line with the prop/hook that enforces it.',
+          text: 'lock what each region does as width changes; pair each contract line with the prop/hook that enforces it.',
         },
         {
           type: 'list',
           items: [
-            '>768: SideNav holds its budget, content flexes, inspector holds 380',
-            '<=768: nav collapses to MobileNav via AppShell mobileNav breakpoint ("md"=768, "lg"=1024)',
-            '<=1024: inspector stops competing for width. swap for Dialog/BottomSheet via useMediaQuery',
+            'divide: how many regions survive at each width',
+            'reveal: which regions earn their width only when there is room, opening on demand below that',
+            'resize: content flexes, fixed regions hold their budgets, text capped by contentWidth so line length holds',
+            'swap: nav -> MobileNav at the AppShell mobileNav breakpoint; side panel -> Dialog/BottomSheet via useMediaQuery',
           ],
         },
         null,
@@ -307,26 +316,22 @@ export const docsDense = {
           type: 'prose',
           text: 'verify: every contract line names a mechanism, so the comment cannot drift from the behavior.',
         },
-        // Before you ship
+        // Best practices
         null,
         {
           type: 'list',
           items: [
-            '<=1 bordered level; Section before Card',
-            'collections = rows; Cards = widgets/hard boundaries',
-            'interior = tokens; one padding token across header/body/footer',
-            'every label on one left content line',
-            'nav matches template pairing or the signals',
-            'each responsive-contract line names a mechanism',
+            'write the contract down for every region before calling the layout done',
+            'decide per region: revealed, resized, or swapped at each width',
+            'drop a region rather than let it fight for width it lacks',
           ],
         },
         {
           type: 'list',
           items: [
-            'card soup, or card grid because app type was unclear',
-            'double padding, or magic-number px interior spacing',
-            'flexbox soup instead of Grid/Layout/FormLayout',
-            'breakpoint comment with no prop/hook wiring it',
+            '3 regions at a width where none has usable space',
+            'shrink every region uniformly instead of swapping/dropping one',
+            'a CSS breakpoint the contract comment never mentions',
           ],
         },
       ],

--- a/packages/cli/assets/docs/layout.doc.dense.mjs
+++ b/packages/cli/assets/docs/layout.doc.dense.mjs
@@ -7,6 +7,29 @@ export const docsDense = {
     'outside-in app layout in 4 phases: frame -> structure -> space -> ship. each phase ends in a do/dont table.',
   sections: [
     {
+      section: 'Overview',
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'build outside-in. settle the shell + region budgets before any content, then work inward. content-first drifts into a padded column of cards, each section inventing its own container.',
+        },
+        {
+          type: 'list',
+          items: [
+            'frame: pick shell, budget regions in px, choose nav',
+            'structure: rank content per region, pick the weakest container that groups it',
+            'space: hold one content line per region, then tune gaps + density',
+            'ship: declare the responsive contract, run the checklist',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'every sub-section: rule -> how (props) -> one example -> the test. skip to your phase.',
+        },
+      ],
+    },
+    {
       section: 'Frame',
       title: 'Frame',
       content: [
@@ -19,10 +42,10 @@ export const docsDense = {
         {
           type: 'list',
           items: [
-            'pick frame: AppShell (nav apps) | Layout+LayoutPanel+LayoutContent (multi-pane tools) | plain column (docs/forms)',
-            'budget each region px: side nav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
+            'pick frame: AppShell (nav apps) | Layout + LayoutPanel in a start/end slot (multi-pane tools) | plain column (docs/forms)',
+            'budget each region px: SideNav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
             'raw px = structural widths only; interior spacing = tokens',
-            'set container policy (rows vs card grid) + responsive contract before content',
+            'set container policy (rows or card grid) + responsive contract before content',
           ],
         },
         null,
@@ -36,6 +59,16 @@ export const docsDense = {
           type: 'prose',
           text: 'match frame + container policy to app type. container choice tracks archetype, not preference.',
         },
+        {
+          type: 'list',
+          items: [
+            'tracker/work tool (issues, tickets, CRM): AppShell + SideNav, inspector LayoutPanel on select. rows only, zero cards',
+            'console/observability (metrics, logs, deploys): AppShell + SideNav, or TopNav + TabList. card grid for widgets, Table elsewhere',
+            'messaging/feed: column frame of rail, nav, stream, panel. rows + bubbles, no cards in stream',
+            'media library/gallery: AppShell + TopNav over grid content. card grid via ClickableCard, dense meta rows in detail',
+            'settings/forms: AppShell + SideNav, or settings template. Sections + FormLayout; Card only for dangerous/billing',
+          ],
+        },
         null,
         {
           type: 'prose',
@@ -47,10 +80,18 @@ export const docsDense = {
           type: 'prose',
           text: 'nav left open? decide from countable signals: destination count, grouping, hierarchy depth.',
         },
+        {
+          type: 'list',
+          items: [
+            'SideNav (default): >~5 destinations, need grouping, customizable, items carry secondary actions, or must collapse',
+            'TopNav: <=5 destinations, context must stay visible, or control/filter-heavy page w/ shallow nav',
+            'both: a genuine suite. TopNav = ecosystem concerns (context switcher, global search), SideNav = product nav',
+          ],
+        },
         null,
         {
           type: 'prose',
-          text: 'verify: left nav unless <=5 destinations and no grouping; top+left only above a real ecosystem layer.',
+          text: 'verify: SideNav unless <=5 destinations and no grouping; two bars only above a real ecosystem layer.',
         },
         // Do & Don't
         null,
@@ -66,7 +107,9 @@ export const docsDense = {
           type: 'list',
           items: [
             'build content-first, Card-wrapping each section',
-            'top+left nav when the ecosystem layer is thin',
+            'SideNav when the nav is really filters/controls, or must hold wide elements like breadcrumbs',
+            'TopNav when top-slot ownership is unclear, or hierarchy is deep or still growing',
+            'both bars when the ecosystem layer is thin',
             'break template nav pairing without a reason',
           ],
         },
@@ -87,9 +130,10 @@ export const docsDense = {
           items: [
             'lead: Heading, or Text weight="semibold" color="primary"',
             'support: Text color="secondary"',
-            'tertiary/meta: Text type="supporting-text"/color="disabled"; StatusDot/Token over prose',
+            'tertiary/meta: Text type="supporting"/color="disabled"; StatusDot/Token over prose',
           ],
         },
+        null,
         {
           type: 'prose',
           text: 'squint test: read lead, then support, then groups, in order. everything at once = raise contrast (weight/color), not borders.',
@@ -98,7 +142,16 @@ export const docsDense = {
         null,
         {
           type: 'prose',
-          text: 'weakest container that reads as a group, escalate only when it fails: spacing < divider < Section < Card.',
+          text: 'weakest container that reads as a group, escalate only when it fails. list runs weakest to strongest.',
+        },
+        {
+          type: 'list',
+          items: [
+            'spacing/gap: related items inside one group. the default rhythm',
+            'Divider: peers in a dense list/toolbar, or fencing a header from a scrollable body',
+            'Section: default page-structure unit, related content under a heading. no border, hierarchy from spacing',
+            'Card: self-contained widget (KPI tile, chart, gallery entry) or hard boundary. never a list-item wrapper',
+          ],
         },
         null,
         {
@@ -109,12 +162,21 @@ export const docsDense = {
         null,
         {
           type: 'prose',
-          text: 'master-detail: select a row -> fixed-width inspector, no navigation away. LayoutPanel end slot + width budget + resizable.',
+          text: 'master-detail: select a row -> fixed-width inspector, no navigation away.',
+        },
+        {
+          type: 'list',
+          items: [
+            'LayoutPanel in the end slot of Layout, width budget 340-420px',
+            'hasDivider fences it from content; isScrollable so long detail scrolls on its own',
+            'user-adjustable width: drive w/ useResizable(), place a ResizeHandle next to the panel',
+            'EmptyState when nothing is selected, so the region never collapses',
+          ],
         },
         null,
         {
           type: 'prose',
-          text: 'verify: below ~1024px the panel overlays the content region instead of compressing it.',
+          text: 'verify: at narrow widths the inspector yields width instead of squeezing content (see Ship).',
         },
         // Do & Don't
         null,
@@ -124,7 +186,7 @@ export const docsDense = {
             'one lead per region; rank via weight+color; one primary action',
             'default Section; weakest container that reads as a group',
             'collections = rows (Table/List), edge-to-edge with dividers',
-            'inspector on select; overlay below ~1024px',
+            'inspector on select; it yields width at narrow sizes',
           ],
         },
         {
@@ -175,6 +237,7 @@ export const docsDense = {
             'in-between 4px steps tune cadence: gap={3}=12px, gap={5}=20px. do not round all to {2}/{4}',
           ],
         },
+        null,
         {
           type: 'prose',
           text: 'verify: borders removed, you can still name the groups from spacing alone. cannot = intervals too uniform.',
@@ -193,6 +256,7 @@ export const docsDense = {
             'density="spacious": low-frequency or high-stakes rows (settings, short selection list)',
           ],
         },
+        null,
         {
           type: 'prose',
           text: 'verify: one size per row (sm/md/lg), paired with density: compact -> sm, spacious -> md/lg.',
@@ -229,6 +293,14 @@ export const docsDense = {
         {
           type: 'prose',
           text: 'declare breakpoints as a contract at the frame root; pair each line with the prop/hook that enforces it.',
+        },
+        {
+          type: 'list',
+          items: [
+            '>768: SideNav holds its budget, content flexes, inspector holds 380',
+            '<=768: nav collapses to MobileNav via AppShell mobileNav breakpoint ("md"=768, "lg"=1024)',
+            '<=1024: inspector stops competing for width. swap for Dialog/BottomSheet via useMediaQuery',
+          ],
         },
         null,
         {

--- a/packages/cli/assets/docs/layout.doc.dense.mjs
+++ b/packages/cli/assets/docs/layout.doc.dense.mjs
@@ -4,7 +4,7 @@
 
 export const docsDense = {
   description:
-    'frame-first app layout: shell choice, region budgets, cards vs rows',
+    'frame-first app layout: shell choice, region budgets, nav choice, sections vs rows vs cards',
   sections: [
     {
       section: 'Frame First',
@@ -19,6 +19,7 @@ export const docsDense = {
           items: [
             'pick frame: AppShell (nav apps) | Layout+LayoutPanel+LayoutContent (multi-pane tools) | plain column (docs/forms)',
             'budget regions in px first: side nav 240-280, rail 64-72, inspector 340-420, facet rail 220-260',
+            'interior spacing = spacing token, never raw px. px is only for structural widths (nav 256, inspector 380)',
             'container policy per region: dense data = rows; dashboards/galleries = card grids',
             'write responsive contract up front',
           ],
@@ -32,41 +33,58 @@ export const docsDense = {
       content: [
         {
           type: 'prose',
-          text: 'container choice tracks archetype, not preference.',
+          text: 'container choice tracks archetype, not preference. table = pointer to the template you inherit, not a spec.',
         },
         null,
         {
           type: 'prose',
-          text: 'start from matching template (astryx template --list), study with --skeleton.',
+          text: 'start from matching template (astryx template --list), study with --skeleton, inherit its nav pairing.',
         },
       ],
     },
     {
-      section: 'Cards vs Rows',
-      title: 'Cards vs Rows',
+      section: 'Choosing Navigation',
+      title: 'Choosing Navigation',
       content: [
         {
           type: 'prose',
-          text: 'Card = widget container, NOT list-item wrapper. dense/scannable/selectable data = rows: Table (columnar) or List/Item (single-line), edge-to-edge, 32-40px rows, dividers.',
+          text: 'choose nav from countable signals, not preference: destination count, grouping, hierarchy depth. inherit template pairing first.',
+        },
+        null,
+        {
+          type: 'prose',
+          text: 'default side/left nav (>5 dests, grouping, customizable, collapsible). top nav only if <=5 dests + no grouping + control-heavy. top+left only for a real suite/ecosystem layer.',
+        },
+      ],
+    },
+    {
+      section: 'Containers',
+      title: 'Containers',
+      content: [
+        {
+          type: 'prose',
+          text: 'grouping ladder weakest->strongest: spacing, divider, Section, Card. use the weakest that reads as a group. Card-by-default = the generic-AI-prototype look.',
+        },
+        null,
+        {
+          type: 'prose',
+          text: 'decision: collection of records = rows (Table columnar | List/Item single-line, edge-to-edge, 32-40px). self-contained widget or hard boundary = Card. everything else = Section. ceiling: one bordered container, no cards-in-cards, no card soup.',
+        },
+      ],
+    },
+    {
+      section: 'Spacing & Alignment',
+      title: 'Spacing & Alignment',
+      content: [
+        {
+          type: 'prose',
+          text: 'container owns structural space (region padding + child gap); children set gap/margin 0. interior spacing = token (Section padding default 4 = 16px).',
         },
         {
-          type: 'list',
-          items: [
-            'Table+plugins: hosts, deployments, monitors, users',
-            'List/Item rows: issues, files, conversations',
-            'Card: KPI tiles, chart panels, gallery entries, settings groups',
-            'EmptyState for zero-match',
-          ],
+          type: 'prose',
+          text: 'optical alignment: one content line per region (16px default). hold the line constant, not the padding: container_inset = content_line - component built-in inset. plain text = full inset; padded components (List/Tab/Menu/nav ~8px, Table cells ~12-16px) = set Section padding={0} so label lands on the line and hover bg bleeds to edge. double-padding (both container + component pad) indents rows past the heading.',
         },
-        {
-          type: 'list',
-          items: [
-            'no Card-wrapped list items (card soup)',
-            'no stacked full-width Cards as page structure',
-            'no Cards in Cards',
-            'no decorative Badge: counts/enums only; StatusDot/Token for status',
-          ],
-        },
+        null,
       ],
     },
     {
@@ -86,7 +104,22 @@ export const docsDense = {
       content: [
         {
           type: 'prose',
-          text: 'declare breakpoint behavior as comment at frame root: which regions collapse/overlay/drop at which widths.',
+          text: 'declare breakpoint behavior as comment at frame root; pair every line with its enforcing prop/hook so the comment cannot drift.',
+        },
+        null,
+      ],
+    },
+    {
+      section: 'Before You Ship',
+      title: 'Before You Ship',
+      content: [
+        {
+          type: 'prose',
+          text: 'self-review named anti-patterns: card soup, dashboard-by-default, double padding, magic-number spacing, flexbox soup, comment-only responsive contract.',
+        },
+        {
+          type: 'prose',
+          text: 'checks: <=1 bordered container; collections = rows; spacing = tokens (one padding token per region); one content line (no double padding); nav from template pairing; each contract line names a mechanism.',
         },
         null,
       ],

--- a/packages/cli/assets/docs/layout.doc.mjs
+++ b/packages/cli/assets/docs/layout.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   title: 'Layout',
   category: 'guide',
   description:
-    'Frame-first app layout: choosing a shell, budgeting regions, and when to use cards vs rows.',
+    'Frame-first app layout: choosing a shell, budgeting regions, choosing navigation, and when to use sections, rows, or cards.',
 
   sections: [
     {
@@ -23,7 +23,8 @@ export const docs = {
           items: [
             'Pick the frame: AppShell (top nav and/or side nav apps), Layout + LayoutPanel + LayoutContent (multi-pane tools like explorers and consoles), or a plain content column (documents, marketing, forms)',
             'Budget regions in px before filling them: side nav 240–280, icon rail 64–72, detail/inspector panel 340–420, filter/facet rail 220–260',
-            'Decide the container policy per region: dense data renders as rows; widget dashboards and galleries render as card grids (see Cards vs Rows)',
+            'Interior spacing is a spacing token, never raw px. Raw px is only for the structural width budgets above (nav 256, inspector 380); everything inside a region uses the spacing scale (see Spacing & Alignment)',
+            'Decide the container policy per region: dense data renders as rows; widget dashboards and galleries render as card grids (see Containers)',
             'Write the responsive contract up front: which regions collapse, overlay, or drop at which breakpoints (see Responsive Contract)',
           ],
         },
@@ -48,7 +49,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Match the frame and container policy to the kind of app you are building. These recipes are distilled from product-scale apps built with the design system; container choice tracks the archetype, not personal preference.',
+          text: 'Match the frame and container policy to the kind of app you are building. These recipes are distilled from product-scale apps built with the design system; container choice tracks the archetype, not personal preference. Treat the table as a pointer to the template you inherit from, not a spec to reimplement.',
         },
         {
           type: 'table',
@@ -83,24 +84,93 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Start from a template that matches the archetype (`npx astryx template --list`), then study its structure with `--skeleton` before customizing.',
+          text: 'Start from a template that matches the archetype (`npx astryx template --list`), study its structure with `--skeleton`, and inherit its navigation pairing before customizing. Deviate from the pairing only with a stated reason (see Choosing Navigation).',
         },
       ],
     },
     {
-      title: 'Cards vs Rows',
+      title: 'Choosing Navigation',
       content: [
         {
           type: 'prose',
-          text: 'Card is a widget container, not a list-item wrapper. The fastest way to make an app look like a generic AI prototype is to wrap every record in a Card with a Badge. Dense data (anything the user scans, filters, or selects) belongs in rows: Table for columnar data, List/Item for single-line records, edge-to-edge with dividers and 32–40px row height.',
+          text: 'When the frame gives you a navigation choice, decide from countable signals (number of destinations, whether they need grouping, how deep the hierarchy is), not from preference. Inherit the pairing from the matching template first; this section is for when you genuinely have to choose.',
+        },
+        {
+          type: 'table',
+          headers: ['Nav', 'Choose when', 'Avoid when'],
+          rows: [
+            [
+              'Side / left nav (default)',
+              'More than ~5 destinations, destinations need grouping, nav is user-customizable, items carry secondary actions, or nav should collapse',
+              'The primary navigation is really filters or controls (e.g. a calendar), or the nav must hold wide elements like breadcrumbs',
+            ],
+            [
+              'Top nav',
+              '5 or fewer top-level destinations, context must stay always-visible, and the page is control- or filter-heavy with shallow page nav',
+              'Ownership of the top slots is unclear, or the hierarchy is deep or still growing',
+            ],
+            [
+              'Top + left',
+              'A genuine suite or ecosystem: top carries ecosystem-wide concerns (context switcher, global search, shared settings), left carries product nav',
+              'The ecosystem layer is thin, so a second nav bar just wastes space',
+            ],
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'Procedure: start with a left nav; switch to top only if you have 5 or fewer destinations and no grouping; add top + left only when there is a real ecosystem layer above the product.',
+        },
+      ],
+    },
+    {
+      title: 'Containers',
+      content: [
+        {
+          type: 'prose',
+          text: 'Grouping has a strength ladder: spacing, divider, Section, Card. Reach for the weakest tool that reads as a group and escalate only when it fails. Reaching for a Card by default is the single biggest cause of the generic-AI-prototype look.',
+        },
+        {
+          type: 'table',
+          headers: ['Tool', 'Use for', 'Strength'],
+          rows: [
+            [
+              'spacing / gap',
+              'Separating related items inside one group. The default rhythm.',
+              'weakest',
+            ],
+            [
+              'Divider',
+              'Separating peers in a dense list or toolbar, or fencing a header from a scrollable body, when whitespace alone is ambiguous.',
+              'low',
+            ],
+            [
+              'Section',
+              'The default page-structure unit: related content under a heading. No border needed; hierarchy comes from spacing.',
+              'medium',
+            ],
+            [
+              'Card',
+              'A self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical or dangerous content (billing, delete).',
+              'strongest',
+            ],
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'Card is a widget container, not a list-item wrapper. Dense data (anything the user scans, filters, or selects) belongs in rows: Table for columnar data, List/Item for single-line records, edge-to-edge with dividers and 32–40px rows. Ceiling: one level of bordered container. No cards inside cards.',
+        },
+        {
+          type: 'prose',
+          text: 'Decision test: (1) a collection of records? render rows. (2) a self-contained widget, or content that needs a hard visual boundary? use a Card. (3) everything else, which is most things, is a Section.',
         },
         {
           type: 'list',
           style: 'do',
           items: [
+            'Default to Section (heading + spacing) for page structure; most "wrap this in a Card" instincts should be a Section',
             'Table (with selection/sorting plugins) for columnar records: hosts, deployments, monitors, users',
             'List/Item rows for scannable single-line records: issues, files, conversations',
-            'Card for self-contained widgets: KPI tiles, chart panels, gallery entries, settings groups',
+            'Card only for self-contained widgets (KPI tiles, chart panels, gallery entries) or a hard boundary around critical content',
             'EmptyState inside the region when a filter matches nothing',
           ],
         },
@@ -109,10 +179,40 @@ export const docs = {
           style: 'dont',
           items: [
             'Wrapping each list item in a Card (card soup)',
-            'Stacking full-width Cards as a substitute for page structure',
-            'Nesting Cards inside Cards',
+            'Stacking full-width Cards as a substitute for page structure; that is what Sections and dividers are for',
+            'Nesting Cards inside Cards, or using a Card for primary content unless it needs a hard boundary',
             'Using Badge as decoration: reserve it for counts and enumerated states; use StatusDot or Token for status and metadata',
           ],
+        },
+      ],
+    },
+    {
+      title: 'Spacing & Alignment',
+      content: [
+        {
+          type: 'prose',
+          text: 'The container owns structural space: the padding around a region and the gap between its children. Children set their own gaps and margins to 0 and inherit rhythm from the container, so spacing never drifts child to child. Interior spacing is always a spacing token (Section padding defaults to 4 = 16px); raw px is reserved for structural width budgets like nav 256. Use the same padding token across a region header, body, and footer so hierarchy comes from rhythm, not from borders.',
+        },
+        {
+          type: 'prose',
+          text: 'Optical alignment: pick one content line per region: the left edge that every heading, paragraph, and row label aligns to (16px is a good default). Hold the content line constant, not the container padding. For each element: container_inset = content_line minus the element built-in inset. Plain text has zero built-in inset, so it takes the full padding. Components carry their own inset (List, Tab, Menu, and nav items reserve ~8px for hit area and hover background; Table cells reserve ~12–16px), so reduce the container by that amount: set the Section to padding={0} and let the component cells define the margin, or drop the padding a step. Done right, the label lands on the content line while the hover/selected background bleeds to the region edge.',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'One content line: absorb a component built-in inset',
+          code: `// Target content line = 16px. Heading has 0 built-in inset; the list item has ~8px.
+// Full inset for text, reduced inset for the padded component, so both labels align at 16px.
+<Section padding={4}>            {/* 16px: heading label sits at 16 */}
+  <Heading>Members</Heading>
+</Section>
+<Section padding={0}>            {/* 0: the List owns the inset */}
+  <List>{/* item label sits at 16, hover background bleeds to the edge */}</List>
+</Section>`,
+        },
+        {
+          type: 'prose',
+          text: 'Verify by squinting: draw one vertical line down the left of the region. Every text label should touch it; only hover or selected backgrounds should extend past it. If a table or list is indented past its own Section heading, you double-padded; remove one owner of the inset. Either the Section pads and the component runs edge-to-edge, or the component owns the inset and the Section runs to 0, never both.',
         },
       ],
     },
@@ -143,7 +243,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Declare breakpoint behavior as a contract before building, and keep it in a comment at the frame root. A typical contract: full frame above 1024px; inspector panels overlay the content column at 1024px and below; the side nav collapses into MobileNav at 768px and below. Deciding this up front keeps every region change intentional instead of emergent.',
+          text: 'Declare breakpoint behavior as a contract before building, and keep it in a comment at the frame root. Pair every line with the mechanism that enforces it (a prop or hook) so the comment cannot drift from the behavior. A typical contract: full frame above 1024px; inspector panels overlay the content column at 1024px and below; the side nav collapses into MobileNav at 768px and below.',
         },
         {
           type: 'code',
@@ -151,8 +251,41 @@ export const docs = {
           label: 'Contract comment at the frame root',
           code: `// Responsive contract:
 //   > 1024px  nav 256 | content | inspector 380
-//   <= 1024px inspector overlays content (position: absolute, end-aligned)
-//   <= 768px  nav collapses into MobileNav drawer; toolbar actions wrap`,
+//   <= 1024px inspector overlays content   (LayoutPanel overlay mode)
+//   <= 768px  nav collapses to MobileNav    (AppShell mobileNav prop)`,
+        },
+      ],
+    },
+    {
+      title: 'Before You Ship',
+      content: [
+        {
+          type: 'prose',
+          text: 'Self-review against these named failure modes; a labeled anti-pattern is far easier to catch in your own output than an abstract principle.',
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Card soup: every record wrapped in its own Card instead of rendered as rows',
+            'Dashboard-by-default: a Card grid used because the app type was unclear, not because the content is widgets',
+            'Double padding: a table or list indented past its Section heading because both the container and the component pad',
+            'Magic-number spacing: raw px for interior spacing instead of tokens (px is only for structural widths)',
+            'Flexbox soup: ad-hoc nested flexboxes instead of Grid, Layout, or FormLayout for structure',
+            'Comment-only responsive contract: a breakpoint comment with no prop or hook actually wiring the behavior',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'One level of bordered container at most; default to Section before Card',
+            'Collections render as rows; Cards are widgets or hard boundaries only',
+            'Interior spacing uses tokens; one padding token across a region header, body, and footer',
+            'Every text label in a region shares one left content line (no double padding)',
+            'Navigation chosen from the template pairing, or from the Choosing Navigation signals',
+            'Each responsive-contract line names a mechanism (prop or hook), not just a comment',
+          ],
         },
       ],
     },

--- a/packages/cli/assets/docs/layout.doc.mjs
+++ b/packages/cli/assets/docs/layout.doc.mjs
@@ -7,25 +7,25 @@ export const docs = {
   title: 'Layout',
   category: 'guide',
   description:
-    'Frame-first app layout: choosing a shell, budgeting regions, choosing navigation, and when to use sections, rows, or cards.',
+    'Build an app layout outside-in: frame the regions, structure the content, tune the spacing, then ship. Grouped into four phases, each closing with a Do and Don\'t table.',
 
   sections: [
+    // ===== FRAME =====
     {
-      title: 'Frame First',
+      title: 'Frame: Pick the shell',
       content: [
         {
           type: 'prose',
-          text: 'Decide the frame before writing any content. Real applications are built top-down: pick the shell, name its regions, give each region an explicit size budget, then fill regions with content. Content-first layout (writing sections and wrapping each one in a Card) produces a padded scroll column that reads as a prototype, not a product.',
+          text: 'Phase 1 of four: Frame. Start every layout from the frame, not the content. Pick the shell, name its regions, give each an explicit width budget, then fill them. Content-first layout (writing sections and wrapping each in a Card) produces a padded scroll column that reads as a prototype, not a product.',
         },
         {
           type: 'list',
           style: 'ordered',
           items: [
-            'Pick the frame: AppShell (top nav and/or side nav apps), Layout + LayoutPanel + LayoutContent (multi-pane tools like explorers and consoles), or a plain content column (documents, marketing, forms)',
+            'Pick the frame: AppShell (top and/or side nav apps), Layout + LayoutPanel + LayoutContent (multi-pane tools like explorers and consoles), or a plain content column (documents, marketing, forms)',
             'Budget regions in px before filling them: side nav 240–280, icon rail 64–72, detail/inspector panel 340–420, filter/facet rail 220–260',
-            'Interior spacing is a spacing token, never raw px. Raw px is only for the structural width budgets above (nav 256, inspector 380); everything inside a region uses the spacing scale (see Spacing & Alignment)',
-            'Decide the container policy per region: dense data renders as rows; widget dashboards and galleries render as card grids (see Containers)',
-            'Write the responsive contract up front: which regions collapse, overlay, or drop at which breakpoints (see Responsive Contract)',
+            'Keep raw px for these structural widths only; everything inside a region uses the spacing scale (see Space)',
+            'Set the container policy per region (rows vs card grid) and the responsive contract before writing content',
           ],
         },
         {
@@ -45,11 +45,11 @@ export const docs = {
       ],
     },
     {
-      title: 'App Archetypes',
+      title: 'Frame: Match the archetype',
       content: [
         {
           type: 'prose',
-          text: 'Match the frame and container policy to the kind of app you are building. These recipes are distilled from product-scale apps built with the design system; container choice tracks the archetype, not personal preference. Treat the table as a pointer to the template you inherit from, not a spec to reimplement.',
+          text: 'Match the frame and container policy to the kind of app you are building. These pairings come from product-scale apps built with the design system; container choice tracks the archetype, not preference. Treat each row as a pointer to the template you inherit from, not a spec to reimplement.',
         },
         {
           type: 'table',
@@ -73,27 +73,27 @@ export const docs = {
             [
               'Media library / gallery',
               'AppShell + TopNav; grid content',
-              'Card grid (ClickableCard) with dense metadata rows in detail views',
+              'Card grid (ClickableCard); dense metadata rows in detail',
             ],
             [
               'Settings / forms',
               'AppShell + SideNav or settings template',
-              'Sections with FormLayout; Card only to group dangerous or billing actions',
+              'Sections with FormLayout; Card only for dangerous or billing actions',
             ],
           ],
         },
         {
           type: 'prose',
-          text: 'Start from a template that matches the archetype (`npx astryx template --list`), study its structure with `--skeleton`, and inherit its navigation pairing before customizing. Deviate from the pairing only with a stated reason (see Choosing Navigation).',
+          text: 'Start from the matching template (`npx astryx template --list`), study its structure with `--skeleton`, and inherit its navigation pairing before customizing.',
         },
       ],
     },
     {
-      title: 'Choosing Navigation',
+      title: 'Frame: Choose navigation',
       content: [
         {
           type: 'prose',
-          text: 'When the frame gives you a navigation choice, decide from countable signals (number of destinations, whether they need grouping, how deep the hierarchy is), not from preference. Inherit the pairing from the matching template first; this section is for when you genuinely have to choose.',
+          text: 'When the frame leaves navigation open, decide from countable signals (how many destinations, whether they need grouping, how deep the hierarchy), not from preference. Inherit the template pairing first; this section is for when you genuinely have to choose.',
         },
         {
           type: 'table',
@@ -101,127 +101,106 @@ export const docs = {
           rows: [
             [
               'Side / left nav (default)',
-              'More than ~5 destinations, destinations need grouping, nav is user-customizable, items carry secondary actions, or nav should collapse',
-              'The primary navigation is really filters or controls (e.g. a calendar), or the nav must hold wide elements like breadcrumbs',
+              'More than ~5 destinations, they need grouping, nav is customizable, items carry secondary actions, or nav should collapse',
+              'The primary nav is really filters or controls, or it must hold wide elements like breadcrumbs',
             ],
             [
               'Top nav',
-              '5 or fewer top-level destinations, context must stay always-visible, and the page is control- or filter-heavy with shallow page nav',
+              '5 or fewer destinations, context must stay always-visible, page is control- or filter-heavy with shallow nav',
               'Ownership of the top slots is unclear, or the hierarchy is deep or still growing',
             ],
             [
               'Top + left',
-              'A genuine suite or ecosystem: top carries ecosystem-wide concerns (context switcher, global search, shared settings), left carries product nav',
-              'The ecosystem layer is thin, so a second nav bar just wastes space',
+              'A genuine suite: top carries ecosystem-wide concerns (context switcher, global search), left carries product nav',
+              'The ecosystem layer is thin, so a second bar just wastes space',
             ],
           ],
         },
         {
           type: 'prose',
-          text: 'Procedure: start with a left nav; switch to top only if you have 5 or fewer destinations and no grouping; add top + left only when there is a real ecosystem layer above the product.',
+          text: 'Default to a left nav; switch to top only with 5 or fewer destinations and no grouping; add top + left only when a real ecosystem layer sits above the product.',
         },
       ],
     },
     {
-      title: 'Containers',
+      title: "Frame: Do & Don't",
       content: [
-        {
-          type: 'prose',
-          text: 'Grouping has a strength ladder: spacing, divider, Section, Card. Reach for the weakest tool that reads as a group and escalate only when it fails. Reaching for a Card by default is the single biggest cause of the generic-AI-prototype look.',
-        },
-        {
-          type: 'table',
-          headers: ['Tool', 'Use for', 'Strength'],
-          rows: [
-            [
-              'spacing / gap',
-              'Separating related items inside one group. The default rhythm.',
-              'weakest',
-            ],
-            [
-              'Divider',
-              'Separating peers in a dense list or toolbar, or fencing a header from a scrollable body, when whitespace alone is ambiguous.',
-              'low',
-            ],
-            [
-              'Section',
-              'The default page-structure unit: related content under a heading. No border needed; hierarchy comes from spacing.',
-              'medium',
-            ],
-            [
-              'Card',
-              'A self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical or dangerous content (billing, delete).',
-              'strongest',
-            ],
-          ],
-        },
-        {
-          type: 'prose',
-          text: 'Card is a widget container, not a list-item wrapper. Dense data (anything the user scans, filters, or selects) belongs in rows: Table for columnar data, List/Item for single-line records, edge-to-edge with dividers and 32–40px rows. Ceiling: one level of bordered container. No cards inside cards.',
-        },
-        {
-          type: 'prose',
-          text: 'Decision test: (1) a collection of records? render rows. (2) a self-contained widget, or content that needs a hard visual boundary? use a Card. (3) everything else, which is most things, is a Section.',
-        },
         {
           type: 'list',
           style: 'do',
           items: [
-            'Default to Section (heading + spacing) for page structure; most "wrap this in a Card" instincts should be a Section',
-            'Table (with selection/sorting plugins) for columnar records: hosts, deployments, monitors, users',
-            'List/Item rows for scannable single-line records: issues, files, conversations',
-            'Card only for self-contained widgets (KPI tiles, chart panels, gallery entries) or a hard boundary around critical content',
-            'EmptyState inside the region when a filter matches nothing',
+            'Decide the frame and per-region px budgets before any content exists',
+            'Choose navigation from countable signals, or inherit the template pairing',
+            'Reserve raw px for structural widths; interior spacing uses tokens',
           ],
         },
         {
           type: 'list',
           style: 'dont',
           items: [
-            'Wrapping each list item in a Card (card soup)',
-            'Stacking full-width Cards as a substitute for page structure; that is what Sections and dividers are for',
-            'Nesting Cards inside Cards, or using a Card for primary content unless it needs a hard boundary',
-            'Using Badge as decoration: reserve it for counts and enumerated states; use StatusDot or Token for status and metadata',
+            'Build content-first and wrap each section in a Card, producing a padded scroll column',
+            'Add a top + left nav when the ecosystem layer is thin',
+            'Deviate from the template navigation pairing without a stated reason',
           ],
         },
       ],
     },
+    // ===== STRUCTURE =====
     {
-      title: 'Spacing & Alignment',
+      title: 'Structure: Set hierarchy',
       content: [
         {
           type: 'prose',
-          text: 'The container owns structural space: the padding around a region and the gap between its children. Children set their own gaps and margins to 0 and inherit rhythm from the container, so spacing never drifts child to child. Interior spacing is always a spacing token (Section padding defaults to 4 = 16px); raw px is reserved for structural width budgets like nav 256. Use the same padding token across a region header, body, and footer so hierarchy comes from rhythm, not from borders.',
+          text: 'Phase 2 of four: Structure. Give every region one clear lead. Name what leads, what supports, and what is tertiary, then make the ranks look different; equal weight everywhere reads as a template. Express rank with type and color, and drop weight before you drop size.',
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Lead: Heading (level reflects page depth), or Text weight="semibold" color="primary"',
+            'Support: Text color="secondary"',
+            'Tertiary and metadata: Text type="supporting-text" or color="disabled"; StatusDot or Token over prose',
+          ],
         },
         {
           type: 'prose',
-          text: 'Optical alignment: pick one content line per region: the left edge that every heading, paragraph, and row label aligns to (16px is a good default). Hold the content line constant, not the container padding. For each element: container_inset = content_line minus the element built-in inset. Plain text has zero built-in inset, so it takes the full padding. Components carry their own inset (List, Tab, Menu, and nav items reserve ~8px for hit area and hover background; Table cells reserve ~12–16px), so reduce the container by that amount: set the Section to padding={0} and let the component cells define the margin, or drop the padding a step. Done right, the label lands on the content line while the hover/selected background bleeds to the region edge.',
-        },
-        {
-          type: 'code',
-          lang: 'tsx',
-          label: 'One content line: absorb a component built-in inset',
-          code: `// Target content line = 16px. Heading has 0 built-in inset; the list item has ~8px.
-// Full inset for text, reduced inset for the padded component, so both labels align at 16px.
-<Section padding={4}>            {/* 16px: heading label sits at 16 */}
-  <Heading>Members</Heading>
-</Section>
-<Section padding={0}>            {/* 0: the List owns the inset */}
-  <List>{/* item label sits at 16, hover background bleeds to the edge */}</List>
-</Section>`,
-        },
-        {
-          type: 'prose',
-          text: 'Verify by squinting: draw one vertical line down the left of the region. Every text label should touch it; only hover or selected backgrounds should extend past it. If a table or list is indented past its own Section heading, you double-padded; remove one owner of the inset. Either the Section pads and the component runs edge-to-edge, or the component owns the inset and the Section runs to 0, never both.',
+          text: 'Squint test: blurred, you should still read the lead, then the support, then the groups, in that order. If everything reads at once, raise the contrast between ranks through weight, color, and spacing, not borders.',
         },
       ],
     },
     {
-      title: 'Panels and Inspectors',
+      title: 'Structure: Choose a container',
       content: [
         {
           type: 'prose',
-          text: 'Master-detail is the backbone of tool UIs: selecting a row opens a fixed-width inspector panel rather than navigating away. Use LayoutPanel in the end slot with an explicit width budget; add resizable (useResizable) for user control, and let the panel overlay the content region below ~1024px instead of compressing it.',
+          text: 'Grouping has a strength ladder: spacing, divider, Section, Card. Reach for the weakest tool that reads as a group and escalate only when it fails. Defaulting to a Card is the single biggest cause of the generic-prototype look.',
+        },
+        {
+          type: 'table',
+          headers: ['Tool', 'Use for', 'Strength'],
+          rows: [
+            ['spacing / gap', 'Separating related items inside one group. The default rhythm.', 'weakest'],
+            ['Divider', 'Separating peers in a dense list or toolbar, or fencing a header from a scrollable body.', 'low'],
+            ['Section', 'The default page-structure unit: related content under a heading. No border; hierarchy from spacing.', 'medium'],
+            ['Card', 'A self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical content.', 'strongest'],
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'Card is a widget container, not a list-item wrapper. Dense data (anything the user scans, filters, or selects) belongs in rows: Table for columnar data, List for single-line records, edge-to-edge with dividers and 32–40px rows. Ceiling: one level of bordered container, no cards inside cards.',
+        },
+        {
+          type: 'prose',
+          text: 'Decision test: a collection of records renders as rows; a self-contained widget or content that needs a hard boundary is a Card; everything else, which is most things, is a Section.',
+        },
+      ],
+    },
+    {
+      title: 'Structure: Panels and inspectors',
+      content: [
+        {
+          type: 'prose',
+          text: 'Master-detail is the backbone of tool UIs: selecting a row opens a fixed-width inspector rather than navigating away. Use LayoutPanel in the end slot with an explicit width budget, add resizable for user control, and let the panel overlay the content below ~1024px instead of compressing it.',
         },
         {
           type: 'code',
@@ -239,11 +218,119 @@ export const docs = {
       ],
     },
     {
-      title: 'Responsive Contract',
+      title: "Structure: Do & Don't",
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Give each region one lead; rank with weight and color; one primary action per region',
+            'Default to Section; use the weakest container that reads as a group',
+            'Render collections as rows (Table or List), edge-to-edge with dividers',
+            'Open a fixed-width inspector on select; overlay it below ~1024px',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Card soup: each record wrapped in its own Card instead of rendered as rows',
+            'Cards inside Cards, or full-width Cards stacked as page structure',
+            'Two competing primary actions in one region',
+            'Badge as decoration; use StatusDot or Token for status and metadata',
+          ],
+        },
+      ],
+    },
+    // ===== SPACE =====
+    {
+      title: 'Space: Align to one line',
       content: [
         {
           type: 'prose',
-          text: 'Declare breakpoint behavior as a contract before building, and keep it in a comment at the frame root. Pair every line with the mechanism that enforces it (a prop or hook) so the comment cannot drift from the behavior. A typical contract: full frame above 1024px; inspector panels overlay the content column at 1024px and below; the side nav collapses into MobileNav at 768px and below.',
+          text: 'Phase 3 of four: Space. The container owns structural space: the padding around a region and the gap between its children. Children zero their own margins and inherit the container rhythm, so spacing never drifts child to child. Interior spacing is always a token (Section padding defaults to 4 = 16px).',
+        },
+        {
+          type: 'prose',
+          text: 'Pick one content line per region: the left edge every heading, label, and row aligns to (16px is a good default). Hold the content line constant, not the padding, with container_inset = content_line minus the component built-in inset. Plain text has zero inset and takes the full padding; List, Tab, Menu, and nav items reserve ~8px and Table cells ~12–16px, so set those to Section padding={0} and let the component own the inset. The label lands on the line while the hover background bleeds to the edge.',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'One content line: absorb a component built-in inset',
+          code: `// Target content line = 16px. Heading has 0 inset; the list item has ~8px.
+<Section padding={4}>            {/* 16px: heading label sits at 16 */}
+  <Heading>Members</Heading>
+</Section>
+<Section padding={0}>            {/* 0: the List owns the inset */}
+  <List>{/* item label sits at 16, hover background bleeds to the edge */}</List>
+</Section>`,
+        },
+        {
+          type: 'prose',
+          text: 'Squint and draw one vertical line down the left of the region: every label should touch it, and only hover or selected backgrounds should cross it. If a list is indented past its own heading, you double-padded; keep one owner of the inset, never both.',
+        },
+      ],
+    },
+    {
+      title: 'Space: Set the rhythm',
+      content: [
+        {
+          type: 'prose',
+          text: 'Spacing groups through contrast, not one repeated value. Tight space binds related items; generous space separates groups. If every gap is the same step, proximity does no work. Keep intra-group gaps small and inter-group gaps a step or two larger (gap={1}–{2} within an item, {4}–{6} between sections); the jump is what reads.',
+        },
+        {
+          type: 'prose',
+          text: 'Use the in-between steps. The scale is 4px-based (gap={3} = 12px, {5} = 20px) so you can tune a cadence an 8px-only scale cannot hit; do not round everything to {2} or {4}. Verify: with every border removed, you can still name the groups from spacing alone. If you cannot, the intervals are too uniform.',
+        },
+      ],
+    },
+    {
+      title: 'Space: Match density and size',
+      content: [
+        {
+          type: 'prose',
+          text: 'Match density to how a region is used: density="compact" for high-volume regions the user scans fast (logs, monitors, large datasets), density="balanced" for most Table and List surfaces, density="spacious" for low-frequency or high-stakes rows (settings, a short selection list). Set it deliberately rather than accepting the default.',
+        },
+        {
+          type: 'prose',
+          text: 'One size per row, one size per container. Every interactive element in a row shares the same size (sm, md, or lg): a sm Button next to an md Selector next to an md TextInput reads as broken even when each is fine on its own, because the heights do not share a baseline. Pick the row size once, and pair it with density (compact with sm, spacious with md or lg).',
+        },
+      ],
+    },
+    {
+      title: "Space: Do & Don't",
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Let the container own padding; children zero their own margins',
+            'Hold one content line per region: text on the line, hover backgrounds bleed to the edge',
+            'Contrast tight and generous gaps so grouping reads without borders',
+            'Use the in-between 4px steps to tune cadence',
+            'One control size per row; match density to use frequency',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Double padding: a component indented past its Section heading (keep one inset owner)',
+            'Raw px for interior spacing; tokens only, px is for structural widths',
+            'One repeated gap everywhere, which flattens grouping',
+            'Mixed sm, md, and lg controls in a single row',
+          ],
+        },
+      ],
+    },
+    // ===== SHIP =====
+    {
+      title: 'Ship: Responsive contract',
+      content: [
+        {
+          type: 'prose',
+          text: 'Phase 4 of four: Ship. Declare breakpoint behavior as a contract before building, and keep it in a comment at the frame root. Pair every line with the mechanism that enforces it (a prop or hook) so the comment cannot drift from the behavior. A typical contract: full frame above 1024px; inspectors overlay the content at 1024px and below; the side nav collapses to MobileNav at 768px and below.',
         },
         {
           type: 'code',
@@ -257,34 +344,28 @@ export const docs = {
       ],
     },
     {
-      title: 'Before You Ship',
+      title: 'Ship: Before you ship',
       content: [
         {
-          type: 'prose',
-          text: 'Self-review against these named failure modes; a labeled anti-pattern is far easier to catch in your own output than an abstract principle.',
+          type: 'list',
+          style: 'do',
+          items: [
+            'One level of bordered container at most; Section before Card',
+            'Collections render as rows; Cards are widgets or hard boundaries only',
+            'Interior spacing uses tokens; one padding token across a region header, body, and footer',
+            'Every label in a region shares one left content line',
+            'Navigation matches the template pairing or the Choose navigation signals',
+            'Each responsive-contract line names a mechanism, not just a comment',
+          ],
         },
         {
           type: 'list',
           style: 'dont',
           items: [
-            'Card soup: every record wrapped in its own Card instead of rendered as rows',
-            'Dashboard-by-default: a Card grid used because the app type was unclear, not because the content is widgets',
-            'Double padding: a table or list indented past its Section heading because both the container and the component pad',
-            'Magic-number spacing: raw px for interior spacing instead of tokens (px is only for structural widths)',
-            'Flexbox soup: ad-hoc nested flexboxes instead of Grid, Layout, or FormLayout for structure',
-            'Comment-only responsive contract: a breakpoint comment with no prop or hook actually wiring the behavior',
-          ],
-        },
-        {
-          type: 'list',
-          style: 'do',
-          items: [
-            'One level of bordered container at most; default to Section before Card',
-            'Collections render as rows; Cards are widgets or hard boundaries only',
-            'Interior spacing uses tokens; one padding token across a region header, body, and footer',
-            'Every text label in a region shares one left content line (no double padding)',
-            'Navigation chosen from the template pairing, or from the Choosing Navigation signals',
-            'Each responsive-contract line names a mechanism (prop or hook), not just a comment',
+            'Card soup, or a card grid chosen because the app type was unclear',
+            'Double padding, or magic-number px for interior spacing',
+            'Flexbox soup: nested ad-hoc flexboxes instead of Grid, Layout, or FormLayout',
+            'A breakpoint comment with no prop or hook wiring the behavior',
           ],
         },
       ],

--- a/packages/cli/assets/docs/layout.doc.mjs
+++ b/packages/cli/assets/docs/layout.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   title: 'Layout',
   category: 'guide',
   description:
-    'Build an app layout outside-in: frame the regions, structure the content, tune the spacing, then ship. Four phases, each closing with a Do and Don\'t table.',
+    'Build an app layout outside-in: scaffold the regions, structure the content, tune the spacing, then adapt across widths.',
 
   sections: [
     {
@@ -21,100 +21,74 @@ export const docs = {
           type: 'list',
           style: 'ordered',
           items: [
-            'Frame: pick the shell, budget each region in px, and choose navigation',
+            'Scaffold: pick the shell, budget each region, and choose navigation',
             'Structure: rank the content in each region, then pick the weakest container that groups it',
-            'Space: hold one content line per region, then tune gaps and density',
-            'Ship: declare the responsive contract and run the checklist',
+            'Spacing: hold one content line per region, then tune gaps and density',
+            'Breakpoints: decide what each region does as width changes',
           ],
         },
         {
           type: 'prose',
-          text: 'Every sub-section reads the same way: the rule, how to apply it, one example, then the test that tells you it worked. Skip to the phase you are in.',
+          text: 'This guide decides layout, not component APIs. Run `npx astryx build "<idea>"` to start from the closest template for your app type, and `npx astryx component <Name>` for a component\'s props.',
         },
       ],
     },
     {
-      title: 'Frame',
+      title: 'Scaffold',
       content: [
-        {type: 'heading', level: 3, text: 'Pick the shell'},
+        {type: 'heading', level: 3, text: 'Shell'},
         {
           type: 'prose',
-          text: 'Pick the shell and budget its regions in px before any content exists.',
+          text: 'Pick the shell and budget its regions before any content exists. Structural widths are the one place raw px belongs; everything inside them uses the spacing scale.',
         },
         {
           type: 'list',
           style: 'ordered',
           items: [
-            'Pick the frame: AppShell (nav apps), Layout with LayoutPanel in a start or end slot (multi-pane tools), or a plain content column (documents, forms)',
-            'Budget each region in px: SideNav 240–280, icon rail 64–72, inspector 340–420, filter rail 220–260',
-            'Keep raw px for these structural widths only; interior spacing uses the scale (see Space)',
-            'Set each region container policy (rows or card grid) and the responsive contract before writing content',
+            'Pick the frame: AppShell for nav apps, Layout with LayoutPanel in a start or end slot for multi-pane tools, or a plain content column for documents and forms',
+            'Give every fixed region a width budget, so no region has to negotiate for space at render time',
+            'Read the content to set fill or capped: tables, charts, and boards fill their region; prose, forms, and lists cap with Layout contentWidth so lines never over-stretch',
+            'Set each region container policy, rows or card grid, before writing content',
           ],
         },
         {
           type: 'code',
           lang: 'tsx',
           label: 'A three-region tool frame',
-          code: `// nav 256 | content flex | inspector 380
+          code: `// Recommended budgets: SideNav 240–280, icon rail 64–72,
+// side panel 340–420, filter rail 220–260.
 <AppShell sideNav={<SideNav>{/* nav items */}</SideNav>}>
   <Layout
-    content={<LayoutContent>{/* dense list or table */}</LayoutContent>}
-    end={<LayoutPanel width={380} hasDivider>{/* inspector */}</LayoutPanel>}
+    content={<LayoutContent>{/* table fills its region */}</LayoutContent>}
+    end={<LayoutPanel width={380} hasDivider>{/* detail */}</LayoutPanel>}
   />
-</AppShell>`,
+</AppShell>
+
+// Capped instead: 640 suits text and forms, 960 mixed content.
+// Dividers stay full-bleed.
+<Layout
+  contentWidth={640}
+  content={<LayoutContent>{/* settings form */}</LayoutContent>}
+/>`,
         },
         {
           type: 'prose',
-          text: 'Verify: every region has a px budget and a container policy written down before any content exists.',
+          text: 'Verify: every region has a width budget, a fill-or-capped decision, and a container policy written down before any content exists.',
         },
 
-        {type: 'heading', level: 3, text: 'Match the archetype'},
+        {type: 'heading', level: 3, text: 'Navigation'},
         {
           type: 'prose',
-          text: 'Match the frame and container policy to your app type; container choice tracks the archetype, not preference.',
+          text: 'When the frame leaves navigation open, default to SideNav: it absorbs destinations you have not planned yet. App type and destination count are guiding indicators, not determining rules.',
         },
         {
           type: 'list',
           style: 'unordered',
           items: [
-            'Tracker (issues, tickets, CRM): AppShell with SideNav, inspector on select. Rows only, zero cards',
-            'Console (metrics, logs, deploys): AppShell with SideNav, or TopNav plus TabList. Card grid for widgets, Table elsewhere',
-            'Messaging or feed: column frame of rail, nav, stream, panel. Rows and bubbles, never cards in the stream',
-            'Media library: AppShell with TopNav over grid content. Card grid via ClickableCard, dense metadata rows in detail',
-            'Settings or forms: AppShell with SideNav, or the settings template. Sections with FormLayout; Card only for destructive or billing actions',
-          ],
-        },
-        {
-          type: 'code',
-          lang: 'tsx',
-          label: 'Same records, two container policies',
-          code: `// Tracker: records are rows, edge-to-edge, no Card.
-<Section padding={0}>
-  <List hasDividers>{/* ListItem per record */}</List>
-</Section>
-
-// Console: only self-contained widgets get a Card.
-<Grid columns={{minWidth: 280}} gap={4}>
-  {widgets.map(w => <Card key={w.id}>{w.chart}</Card>)}
-</Grid>`,
-        },
-        {
-          type: 'prose',
-          text: 'Verify: start from the matching template (`npx astryx template --list`, read `--skeleton`) and inherit its navigation pairing.',
-        },
-
-        {type: 'heading', level: 3, text: 'Choose navigation'},
-        {
-          type: 'prose',
-          text: 'When the frame leaves navigation open, decide from countable signals: destination count, grouping, hierarchy depth.',
-        },
-        {
-          type: 'list',
-          style: 'unordered',
-          items: [
-            'SideNav, the default: more than ~5 destinations, grouping needed, customizable nav, items with secondary actions, or nav that collapses',
-            'TopNav: 5 or fewer destinations, context that must stay visible, or a control- and filter-heavy page with shallow nav',
+            'SideNav, the default: grouping needed, customizable nav, items with secondary actions, or nav that collapses. Trackers, consoles, and settings usually start here',
+            'TopNav: a shallow nav you expect to stay shallow, context that must stay visible, or a control- and filter-heavy page; add a TabList for a second level. Media libraries often sit here, over grid content',
             'Both: a genuine suite, where TopNav carries ecosystem-wide concerns (context switcher, global search) and SideNav carries product nav',
+            'Neither: messaging and feeds use a column frame of rail, nav, stream, and panel',
           ],
         },
         {
@@ -124,7 +98,7 @@ export const docs = {
           code: `// Default: product nav on the side.
 <AppShell sideNav={<SideNav>{/* items */}</SideNav>} />
 
-// Shallow and control-heavy: 5 or fewer destinations on top.
+// Shallow, stable nav on a control-heavy page.
 <AppShell topNav={<TopNav>{/* items */}</TopNav>} />
 
 // Suite: ecosystem concerns on top, product nav on the side.
@@ -132,16 +106,16 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Verify: SideNav unless you have 5 or fewer destinations and no grouping; two bars only above a real ecosystem layer.',
+          text: 'Verify: you can state the reason in one sentence, and the choice still holds if the nav doubles in size. `npx astryx build "<idea>"` names the closest template, and its `--skeleton` shows the pairing already wired up.',
         },
 
-        {type: 'heading', level: 3, text: "Do & Don't"},
+        {type: 'heading', level: 3, text: 'Best practices'},
         {
           type: 'list',
           style: 'do',
           items: [
-            'Decide the frame and per-region px budgets before any content exists',
-            'Choose navigation from countable signals, or inherit the template pairing',
+            'Decide the frame, region width budgets, and fill or capped before any content exists',
+            'State the reason for the navigation choice, or inherit the template pairing',
             'Reserve raw px for structural widths; interior spacing uses tokens',
           ],
         },
@@ -150,6 +124,7 @@ export const docs = {
           style: 'dont',
           items: [
             'Build content-first and wrap each section in a Card, producing a padded scroll column',
+            'Stretch prose, forms, or lists across a wide region instead of capping with contentWidth',
             'SideNav when the nav is really filters or controls, or must hold wide elements like breadcrumbs',
             'TopNav when top-slot ownership is unclear, or the hierarchy is deep or still growing',
             'Both bars when the ecosystem layer is thin, so the second only wastes space',
@@ -161,25 +136,30 @@ export const docs = {
     {
       title: 'Structure',
       content: [
-        {type: 'heading', level: 3, text: 'Set hierarchy'},
+        {type: 'heading', level: 3, text: 'Type hierarchy'},
         {
           type: 'prose',
-          text: 'Give every region one lead, then separate lead, support, and tertiary with type and color; drop weight before size.',
+          text: 'Give every region one lead, then rank the rest with weight and color rather than size. Content uses two text colors, primary and secondary, and nothing dimmer: body copy needs no props at all.',
         },
         {
           type: 'list',
           style: 'unordered',
           items: [
-            'Lead: Heading (level reflects page depth), or Text weight="semibold" color="primary"',
-            'Support: Text color="secondary"',
-            'Tertiary and metadata: Text type="supporting" or color="disabled"; StatusDot or Token over prose',
+            'Body, the default: plain Text with no type, color, or size prop',
+            'Lead: Heading at the level matching page depth, or body Text at a heavier weight',
+            'Support: step to the secondary color, not to a smaller size',
+            'Metadata: the supporting type, or a StatusDot or Token instead of prose',
           ],
         },
         {
           type: 'code',
           lang: 'tsx',
-          label: 'One row, three ranks',
-          code: `<HStack gap={2}>
+          label: 'Body copy, then one row of four ranks',
+          code: `// Body copy takes no props. Text already defaults to body
+// size in the primary color.
+<Text>Credentials rotate every 90 days</Text>
+
+<HStack gap={2}>
   <Text weight="semibold">Payments API</Text>
   <StatusDot variant="success" label="Healthy" />
   <Text color="secondary">v2.14</Text>
@@ -188,13 +168,13 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Squint test: blurred, you read lead, then support, then groups, in that order. If everything reads at once, raise contrast with weight and color, not borders.',
+          text: 'Squint test: blurred, you read lead, then support, then groups, in that order. If everything reads at once, raise contrast with weight and color, not borders and not smaller text.',
         },
 
-        {type: 'heading', level: 3, text: 'Choose a container'},
+        {type: 'heading', level: 3, text: 'Containers'},
         {
           type: 'prose',
-          text: 'Reach for the weakest container that reads as a group, and escalate only when it fails. This list runs weakest to strongest.',
+          text: 'Reach for the weakest container that reads as a group, and escalate only when it fails. Weakest to strongest:',
         },
         {
           type: 'list',
@@ -202,8 +182,8 @@ export const docs = {
           items: [
             'spacing and gap: related items inside one group. The default rhythm',
             'Divider: peers in a dense list or toolbar, or fencing a header from a scrollable body',
-            'Section: the default page-structure unit, related content under a heading. No border; hierarchy comes from spacing',
-            'Card: a self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical content. Never a list-item wrapper',
+            'Section: the default page-structure unit, related content under a heading. No border',
+            'Card: a self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical content',
           ],
         },
         {
@@ -211,6 +191,7 @@ export const docs = {
           lang: 'tsx',
           label: 'Section as the default unit',
           code: `// Records are rows in one Section, not one Card each.
+// Recommended row height: 32–40px.
 <Section padding={0}>
   <List header={<Heading level={3}>Members</Heading>} hasDividers>
     {/* ListItem per member */}
@@ -219,59 +200,109 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Decision test: a collection of records renders as rows (Table for columnar, List for single-line, edge-to-edge with dividers, 32–40px); a self-contained widget or hard boundary is a Card; everything else is a Section.',
+          text: 'Decision test: records render as rows, Table for columnar and List for single-line; a self-contained widget or hard boundary is a Card; everything else is a Section.',
         },
 
-        {type: 'heading', level: 3, text: 'Panels and inspectors'},
+        {type: 'heading', level: 3, text: 'Headers and footers'},
         {
           type: 'prose',
-          text: 'Master-detail: selecting a row opens a fixed-width inspector instead of navigating away.',
+          text: 'A region can pin a header or footer while its body scrolls. Both are Layout slots, and padding set once on Layout reaches all three, so header, body, and footer share one content line.',
         },
         {
           type: 'list',
           style: 'unordered',
           items: [
-            'LayoutPanel in the end slot of Layout, with a width budget of 340–420px',
+            'LayoutHeader in the header slot: the region title and its primary action',
+            'Toolbar instead of LayoutHeader when the header carries interactive controls',
+            'LayoutFooter in the footer slot: actions that commit the work and must stay reachable',
+            'defaultHasDividers on Layout fences both at once, rather than hasDivider per slot',
+          ],
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Pinned header and footer around a scrolling body',
+          code: `// padding on Layout reaches every slot, so all three align.
+<Layout
+  padding={4}
+  defaultHasDividers
+  header={<LayoutHeader>{/* title + primary action */}</LayoutHeader>}
+  content={<LayoutContent>{/* rows */}</LayoutContent>}
+  footer={<LayoutFooter>{/* Save and Cancel */}</LayoutFooter>}
+/>`,
+        },
+        {
+          type: 'prose',
+          text: 'Verify: scroll the body. The header and footer stay put, their dividers run full-bleed, and all three still share one left content line.',
+        },
+
+        {type: 'heading', level: 3, text: 'Side panels'},
+        {
+          type: 'prose',
+          text: 'Master-detail: selecting a row opens a fixed-width side panel instead of navigating away.',
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'LayoutPanel in the start or end slot of Layout, holding a fixed width budget',
             'hasDivider to fence it from the content region; isScrollable so long detail scrolls on its own',
-            'For user-adjustable width, drive it with useResizable() and place a ResizeHandle next to the panel',
+            'For user-adjustable width, pair useResizable() with a ResizeHandle on the panel inner edge: after the panel in a start slot, before it in an end slot with isReversed',
+            'The handle then owns the divider, so the panel sets hasDivider={false}',
             'Render an EmptyState when nothing is selected, so the region never collapses',
           ],
         },
         {
           type: 'code',
           lang: 'tsx',
-          label: 'Inspector in the end slot',
-          code: `<Layout
+          label: 'Fixed panel, then the resizable form',
+          code: `// Recommended panel width: 340–420.
+<Layout
   content={<LayoutContent>{/* rows */}</LayoutContent>}
   end={
     <LayoutPanel width={380} hasDivider isScrollable label="Details">
       {/* detail fields, or EmptyState when nothing is selected */}
     </LayoutPanel>
   }
-/>`,
+/>
+
+// Resizable: handle first in an end slot, and isReversed so
+// dragging left widens the panel.
+end={
+  <>
+    <ResizeHandle isReversed hasDivider resizable={panel.props}
+      label="Resize details" />
+    <LayoutPanel width={panel.size} hasDivider={false} />
+  </>
+}`,
         },
         {
           type: 'prose',
-          text: 'Verify: at narrow widths the inspector gives up its width instead of squeezing the content region (see the responsive contract in Ship).',
+          text: 'Verify: at narrow widths the panel yields width instead of squeezing content (see Breakpoints), and only one element between the regions draws a border.',
         },
 
-        {type: 'heading', level: 3, text: "Do & Don't"},
+        {type: 'heading', level: 3, text: 'Best practices'},
         {
           type: 'list',
           style: 'do',
           items: [
-            'Give each region one lead; rank with weight and color; one primary action per region',
+            'One lead per region; rank with weight and color; one primary action',
+            'Leave body copy at its defaults; demote by weight and color, not size',
             'Default to Section; use the weakest container that reads as a group',
             'Render collections as rows (Table or List), edge-to-edge with dividers',
-            'Open a fixed-width inspector on select, and let it yield width at narrow sizes',
+            'Open a fixed-width side panel on select; let it yield width at narrow sizes',
           ],
         },
         {
           type: 'list',
           style: 'dont',
           items: [
+            'Grey and shrink body copy, so a whole region reads as secondary metadata',
+            'The disabled color for content; it fails contrast and is for disabled controls',
             'Card soup: each record wrapped in its own Card instead of rendered as rows',
             'Cards inside Cards, or full-width Cards stacked as page structure',
+            'A header or footer rebuilt inside the body, where it scrolls away with the rows',
+            'Flexbox soup: nested ad-hoc flexboxes instead of Grid, Layout, Section, or FormLayout',
             'Two competing primary actions in one region',
             'Badge as decoration; use StatusDot or Token for status and metadata',
           ],
@@ -279,9 +310,9 @@ export const docs = {
       ],
     },
     {
-      title: 'Space',
+      title: 'Spacing',
       content: [
-        {type: 'heading', level: 3, text: 'Align to one line'},
+        {type: 'heading', level: 3, text: 'Alignment'},
         {
           type: 'prose',
           text: 'The container owns padding and child gaps; children zero their margins, and interior spacing is always a token. Pick one content line per region and hold it constant, not the padding: `container_inset = content_line - component_intrinsic_inset`.',
@@ -290,9 +321,9 @@ export const docs = {
           type: 'list',
           style: 'unordered',
           items: [
-            'Text and Heading: 0 inset, so the container takes the full padding (Section padding={4} = a 16px line)',
-            'List, Tab, Menu, nav items: ~8px built in, so Section padding={0} and the component owns the inset',
-            'Table cells: 12–16px built in, so Section padding={0} and the cell owns the inset',
+            'Text and Heading carry no inset, so the container takes the full padding',
+            'List, Tab, Menu, and nav items carry a small inset, so the container gives up its padding and the component owns the line',
+            'Table cells carry a larger inset, so the container gives up its padding and the cell owns the line',
           ],
         },
         {
@@ -302,7 +333,9 @@ export const docs = {
           code: `// Target content line = 16px.
 // Heading has 0 inset, so the Section takes the full padding.
 <Section padding={4}><Heading level={3}>Members</Heading></Section>
-// List has ~8px built in, so the Section gives up its padding.
+
+// List has ~8px built in, Table cells 12–16px, so the Section
+// gives up its padding and the component owns the inset.
 <Section padding={0}><List>{/* items */}</List></Section>`,
         },
         {
@@ -310,7 +343,7 @@ export const docs = {
           text: 'Verify: draw one vertical line down the left of the region. Every label touches it; only hover and selected backgrounds cross it.',
         },
 
-        {type: 'heading', level: 3, text: 'Set the rhythm'},
+        {type: 'heading', level: 3, text: 'Rhythm'},
         {
           type: 'prose',
           text: 'Grouping comes from contrast between tight and generous gaps, not one repeated value. If every gap is the same step, proximity does no work.',
@@ -319,29 +352,31 @@ export const docs = {
           type: 'list',
           style: 'unordered',
           items: [
-            'Tight binds: gap={1}–{2} inside an item or field',
-            'Generous separates: gap={4}–{6} between sections',
-            'Use the in-between 4px steps to tune cadence: gap={3} = 12px, gap={5} = 20px. Do not round everything to {2} or {4}',
+            'Tight gaps bind: the smallest steps, used inside an item or field',
+            'Generous gaps separate: several steps up, used between sections',
+            'Reach for the in-between steps to tune cadence, rather than rounding everything to the same two values',
           ],
         },
         {
           type: 'code',
           lang: 'tsx',
           label: 'Tight inside, generous between',
-          code: `<VStack gap={6}>
+          code: `// Tight binds at gap={1}–{2}, generous separates at gap={4}–{6}.
+// In-between steps tune cadence: gap={3} = 12px, gap={5} = 20px.
+<VStack gap={6}>
   <VStack gap={1}>
     <Text weight="semibold">Retention</Text>
-    <Text color="secondary">How long logs are kept</Text>
+    <Text color="secondary">Logs are kept for 30 days</Text>
   </VStack>
-  <VStack gap={1}>{/* next field */}</VStack>
+  <VStack gap={1}>{/* next label and value */}</VStack>
 </VStack>`,
         },
         {
           type: 'prose',
-          text: 'Verify: with every border removed, you can still name the groups from spacing alone. If you cannot, the intervals are too uniform.',
+          text: 'Verify: with every border removed, you can still name the groups from spacing alone. If you cannot, the intervals are too uniform. Form fields are the exception: FormLayout owns their spacing.',
         },
 
-        {type: 'heading', level: 3, text: 'Match density and size'},
+        {type: 'heading', level: 3, text: 'Density and size'},
         {
           type: 'prose',
           text: 'Match density to how often a region is used, and give every control in a row the same size so heights share a baseline.',
@@ -350,34 +385,34 @@ export const docs = {
           type: 'list',
           style: 'unordered',
           items: [
-            'density="compact": high-volume regions scanned fast (logs, monitors, large datasets)',
-            'density="balanced": most Table and List surfaces',
-            'density="spacious": low-frequency or high-stakes rows (settings, a short selection list)',
+            'Compact: high-volume regions scanned fast, like logs, monitors, and large datasets',
+            'Balanced: most Table and List surfaces',
+            'Spacious: low-frequency or high-stakes rows, like settings or a short selection list',
           ],
         },
         {
           type: 'code',
           lang: 'tsx',
           label: 'Density paired with control size',
-          code: `<Table data={rows} columns={columns} density="compact" hasHover />
-
-// Every control inside a compact row is size="sm".
+          code: `// Pair density with one control size: compact with sm,
+// balanced with sm or md, spacious with md or lg.
+<Table data={rows} columns={columns} density="compact" hasHover />
 <Button label="Retry" size="sm" variant="ghost" />`,
         },
         {
           type: 'prose',
-          text: 'Verify: every interactive element in a row shares one size (sm, md, or lg), paired with the density: compact with sm, spacious with md or lg.',
+          text: 'Verify: every interactive element in a row shares one size, and that size is paired with the density of the region it sits in.',
         },
 
-        {type: 'heading', level: 3, text: "Do & Don't"},
+        {type: 'heading', level: 3, text: 'Best practices'},
         {
           type: 'list',
           style: 'do',
           items: [
             'Let the container own padding; children zero their own margins',
             'Hold one content line per region: text on the line, hover backgrounds bleed to the edge',
+            'Hold one padding token across a region header, body, and footer',
             'Contrast tight and generous gaps so grouping reads without borders',
-            'Use the in-between 4px steps to tune cadence',
             'One control size per row; match density to use frequency',
           ],
         },
@@ -388,35 +423,38 @@ export const docs = {
             'Double padding: a component indented past its Section heading (keep one inset owner)',
             'Raw px for interior spacing; tokens only, px is for structural widths',
             'One repeated gap everywhere, which flattens grouping',
-            'Mixed sm, md, and lg controls in a single row',
+            'Mixed control sizes in a single row',
           ],
         },
       ],
     },
     {
-      title: 'Ship',
+      title: 'Breakpoints',
       content: [
         {type: 'heading', level: 3, text: 'Responsive contract'},
         {
           type: 'prose',
-          text: 'Declare breakpoint behavior as a contract in a comment at the frame root, and pair every line with the prop or hook that enforces it.',
+          text: 'Lock what each region does as width changes, and pair every line of the contract with the prop or hook that enforces it.',
         },
         {
           type: 'list',
           style: 'unordered',
           items: [
-            'Above 768px: SideNav holds its budget, content flexes, the inspector holds 380',
-            'At 768px: navigation collapses to MobileNav, via the AppShell mobileNav breakpoint ("md" = 768, "lg" = 1024)',
-            'At 1024px: the inspector stops competing for width. Swap it for a Dialog or BottomSheet, driven by useMediaQuery',
+            'Divide: how many regions survive at each width',
+            'Reveal: which regions earn their width only when there is room, and open on demand below that',
+            'Resize: content flexes while fixed regions hold their budgets, and text stays capped by contentWidth so line length holds',
+            'Swap: navigation becomes MobileNav at the AppShell mobileNav breakpoint; the side panel becomes a Dialog or BottomSheet, driven by useMediaQuery',
           ],
         },
         {
           type: 'code',
           lang: 'tsx',
           label: 'Contract wired to props',
-          code: `//   >768   SideNav 256 | content | inspector 380
-//   <=768  nav collapses to MobileNav   (mobileNav breakpoint)
-//   <=1024 inspector moves to a Dialog  (useMediaQuery)
+          code: `// Recommended thresholds: 3 regions above 1024, 2 from 768,
+// 1 below. Text reads best at 40–60 characters per line.
+//   >1024  SideNav 256 | content | side panel 380
+//   <=1024 panel moves to a Dialog     (useMediaQuery)
+//   <=768  nav collapses to MobileNav   (mobileNav "md")
 const isNarrow = useMediaQuery('(max-width: 1024px)');
 
 <AppShell sideNav={<SideNav />} mobileNav={{breakpoint: 'md'}}>
@@ -431,27 +469,23 @@ const isNarrow = useMediaQuery('(max-width: 1024px)');
           text: 'Verify: every contract line names a mechanism, so the comment cannot drift from the behavior.',
         },
 
-        {type: 'heading', level: 3, text: 'Before you ship'},
+        {type: 'heading', level: 3, text: 'Best practices'},
         {
           type: 'list',
           style: 'do',
           items: [
-            'One level of bordered container at most; Section before Card',
-            'Collections render as rows; Cards are widgets or hard boundaries only',
-            'Interior spacing uses tokens; one padding token across a region header, body, and footer',
-            'Every label in a region shares one left content line',
-            'Navigation matches the template pairing or the Choose navigation signals',
-            'Each responsive-contract line names a mechanism, not just a comment',
+            'Write the contract down for every region before you call the layout done',
+            'Decide per region whether it is revealed, resized, or swapped at each width',
+            'Drop a region rather than let it compete for width it does not have',
           ],
         },
         {
           type: 'list',
           style: 'dont',
           items: [
-            'Card soup, or a card grid chosen because the app type was unclear',
-            'Double padding, or magic-number px for interior spacing',
-            'Flexbox soup: nested ad-hoc flexboxes instead of Grid, Layout, or FormLayout',
-            'A breakpoint comment with no prop or hook wiring the behavior',
+            'Hold three regions at a width where none of them has usable space',
+            'Shrink every region uniformly instead of swapping or dropping one',
+            'Wire a breakpoint in CSS that the contract comment never mentions',
           ],
         },
       ],

--- a/packages/cli/assets/docs/layout.doc.mjs
+++ b/packages/cli/assets/docs/layout.doc.mjs
@@ -7,9 +7,32 @@ export const docs = {
   title: 'Layout',
   category: 'guide',
   description:
-    'Build an app layout outside-in: frame the regions, structure the content, tune the spacing, then ship. Grouped into four phases, each closing with a Do and Don\'t table.',
+    'Build an app layout outside-in: frame the regions, structure the content, tune the spacing, then ship. Four phases, each closing with a Do and Don\'t table.',
 
   sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'Build a layout outside-in. Settle the shell and its region budgets before any content exists, then work inward. Content-first layouts drift into a padded column of cards, because every section ends up inventing its own container.',
+        },
+        {
+          type: 'list',
+          style: 'ordered',
+          items: [
+            'Frame: pick the shell, budget each region in px, and choose navigation',
+            'Structure: rank the content in each region, then pick the weakest container that groups it',
+            'Space: hold one content line per region, then tune gaps and density',
+            'Ship: declare the responsive contract and run the checklist',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'Every sub-section reads the same way: the rule, how to apply it, one example, then the test that tells you it worked. Skip to the phase you are in.',
+        },
+      ],
+    },
     {
       title: 'Frame',
       content: [
@@ -22,24 +45,22 @@ export const docs = {
           type: 'list',
           style: 'ordered',
           items: [
-            'Pick the frame: AppShell (nav apps), Layout + LayoutPanel + LayoutContent (multi-pane tools like explorers and consoles), or a plain content column (documents, forms)',
-            'Budget each region in px: side nav 240–280, icon rail 64–72, inspector 340–420, filter rail 220–260',
+            'Pick the frame: AppShell (nav apps), Layout with LayoutPanel in a start or end slot (multi-pane tools), or a plain content column (documents, forms)',
+            'Budget each region in px: SideNav 240–280, icon rail 64–72, inspector 340–420, filter rail 220–260',
             'Keep raw px for these structural widths only; interior spacing uses the scale (see Space)',
-            'Set each region container policy (rows vs card grid) and the responsive contract before writing content',
+            'Set each region container policy (rows or card grid) and the responsive contract before writing content',
           ],
         },
         {
           type: 'code',
           lang: 'tsx',
           label: 'A three-region tool frame',
-          code: `// Frame: nav 256 | content flex | inspector 380 (resizable)
-<AppShell sideNav={<SideNav>{/* nav items */}</SideNav>} contentPadding={0}>
-  <Layout>
-    <LayoutContent>{/* dense list or table, edge-to-edge */}</LayoutContent>
-    <LayoutPanel width={380} resizable={{minSizePx: 320, maxSizePx: 480}} hasDivider>
-      {/* inspector for the selected row */}
-    </LayoutPanel>
-  </Layout>
+          code: `// nav 256 | content flex | inspector 380
+<AppShell sideNav={<SideNav>{/* nav items */}</SideNav>}>
+  <Layout
+    content={<LayoutContent>{/* dense list or table */}</LayoutContent>}
+    end={<LayoutPanel width={380} hasDivider>{/* inspector */}</LayoutPanel>}
+  />
 </AppShell>`,
         },
         {
@@ -53,35 +74,29 @@ export const docs = {
           text: 'Match the frame and container policy to your app type; container choice tracks the archetype, not preference.',
         },
         {
-          type: 'table',
-          headers: ['Archetype', 'Frame', 'Container policy'],
-          rows: [
-            [
-              'Tracker / work tool (issues, tickets, CRM)',
-              'AppShell + SideNav; inspector LayoutPanel on select',
-              'Rows only. Grouped edge-to-edge lists, zero cards',
-            ],
-            [
-              'Console / observability (metrics, logs, deploys)',
-              'AppShell + SideNav or TopNav + TabList',
-              'Card grid for dashboard widgets; Table for everything else',
-            ],
-            [
-              'Messaging / feed',
-              'Column frame: rail + sidebar + stream + panel',
-              'Rows and bubbles. No cards in the stream',
-            ],
-            [
-              'Media library / gallery',
-              'AppShell + TopNav; grid content',
-              'Card grid (ClickableCard); dense metadata rows in detail',
-            ],
-            [
-              'Settings / forms',
-              'AppShell + SideNav or settings template',
-              'Sections with FormLayout; Card only for dangerous or billing actions',
-            ],
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Tracker (issues, tickets, CRM): AppShell with SideNav, inspector on select. Rows only, zero cards',
+            'Console (metrics, logs, deploys): AppShell with SideNav, or TopNav plus TabList. Card grid for widgets, Table elsewhere',
+            'Messaging or feed: column frame of rail, nav, stream, panel. Rows and bubbles, never cards in the stream',
+            'Media library: AppShell with TopNav over grid content. Card grid via ClickableCard, dense metadata rows in detail',
+            'Settings or forms: AppShell with SideNav, or the settings template. Sections with FormLayout; Card only for destructive or billing actions',
           ],
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Same records, two container policies',
+          code: `// Tracker: records are rows, edge-to-edge, no Card.
+<Section padding={0}>
+  <List hasDividers>{/* ListItem per record */}</List>
+</Section>
+
+// Console: only self-contained widgets get a Card.
+<Grid columns={{minWidth: 280}} gap={4}>
+  {widgets.map(w => <Card key={w.id}>{w.chart}</Card>)}
+</Grid>`,
         },
         {
           type: 'prose',
@@ -94,29 +109,30 @@ export const docs = {
           text: 'When the frame leaves navigation open, decide from countable signals: destination count, grouping, hierarchy depth.',
         },
         {
-          type: 'table',
-          headers: ['Nav', 'Choose when', 'Avoid when'],
-          rows: [
-            [
-              'Side / left nav (default)',
-              'More than ~5 destinations, they need grouping, nav is customizable, items carry secondary actions, or nav should collapse',
-              'The primary nav is really filters or controls, or it must hold wide elements like breadcrumbs',
-            ],
-            [
-              'Top nav',
-              '5 or fewer destinations, context must stay always-visible, page is control- or filter-heavy with shallow nav',
-              'Ownership of the top slots is unclear, or the hierarchy is deep or still growing',
-            ],
-            [
-              'Top + left',
-              'A genuine suite: top carries ecosystem-wide concerns (context switcher, global search), left carries product nav',
-              'The ecosystem layer is thin, so a second bar just wastes space',
-            ],
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'SideNav, the default: more than ~5 destinations, grouping needed, customizable nav, items with secondary actions, or nav that collapses',
+            'TopNav: 5 or fewer destinations, context that must stay visible, or a control- and filter-heavy page with shallow nav',
+            'Both: a genuine suite, where TopNav carries ecosystem-wide concerns (context switcher, global search) and SideNav carries product nav',
           ],
         },
         {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Navigation passed to AppShell',
+          code: `// Default: product nav on the side.
+<AppShell sideNav={<SideNav>{/* items */}</SideNav>} />
+
+// Shallow and control-heavy: 5 or fewer destinations on top.
+<AppShell topNav={<TopNav>{/* items */}</TopNav>} />
+
+// Suite: ecosystem concerns on top, product nav on the side.
+<AppShell topNav={<TopNav />} sideNav={<SideNav />} />`,
+        },
+        {
           type: 'prose',
-          text: 'Verify: left nav unless you have 5 or fewer destinations and no grouping; top + left only above a real ecosystem layer.',
+          text: 'Verify: SideNav unless you have 5 or fewer destinations and no grouping; two bars only above a real ecosystem layer.',
         },
 
         {type: 'heading', level: 3, text: "Do & Don't"},
@@ -134,7 +150,9 @@ export const docs = {
           style: 'dont',
           items: [
             'Build content-first and wrap each section in a Card, producing a padded scroll column',
-            'Add a top + left nav when the ecosystem layer is thin',
+            'SideNav when the nav is really filters or controls, or must hold wide elements like breadcrumbs',
+            'TopNav when top-slot ownership is unclear, or the hierarchy is deep or still growing',
+            'Both bars when the ecosystem layer is thin, so the second only wastes space',
             'Deviate from the template navigation pairing without a stated reason',
           ],
         },
@@ -154,8 +172,19 @@ export const docs = {
           items: [
             'Lead: Heading (level reflects page depth), or Text weight="semibold" color="primary"',
             'Support: Text color="secondary"',
-            'Tertiary and metadata: Text type="supporting-text" or color="disabled"; StatusDot or Token over prose',
+            'Tertiary and metadata: Text type="supporting" or color="disabled"; StatusDot or Token over prose',
           ],
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'One row, three ranks',
+          code: `<HStack gap={2}>
+  <Text weight="semibold">Payments API</Text>
+  <StatusDot variant="success" label="Healthy" />
+  <Text color="secondary">v2.14</Text>
+  <Text type="supporting">edited 3h ago</Text>
+</HStack>`,
         },
         {
           type: 'prose',
@@ -165,17 +194,28 @@ export const docs = {
         {type: 'heading', level: 3, text: 'Choose a container'},
         {
           type: 'prose',
-          text: 'Reach for the weakest container that reads as a group and escalate only when it fails: spacing, Divider, Section, Card.',
+          text: 'Reach for the weakest container that reads as a group, and escalate only when it fails. This list runs weakest to strongest.',
         },
         {
-          type: 'table',
-          headers: ['Tool', 'Use for', 'Strength'],
-          rows: [
-            ['spacing / gap', 'Related items inside one group. The default rhythm.', 'weakest'],
-            ['Divider', 'Peers in a dense list or toolbar, or fencing a header from a scrollable body.', 'low'],
-            ['Section', 'The default page-structure unit: related content under a heading. No border; hierarchy from spacing.', 'medium'],
-            ['Card', 'A self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical content. Not a list-item wrapper.', 'strongest'],
+          type: 'list',
+          style: 'ordered',
+          items: [
+            'spacing and gap: related items inside one group. The default rhythm',
+            'Divider: peers in a dense list or toolbar, or fencing a header from a scrollable body',
+            'Section: the default page-structure unit, related content under a heading. No border; hierarchy comes from spacing',
+            'Card: a self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical content. Never a list-item wrapper',
           ],
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Section as the default unit',
+          code: `// Records are rows in one Section, not one Card each.
+<Section padding={0}>
+  <List header={<Heading level={3}>Members</Heading>} hasDividers>
+    {/* ListItem per member */}
+  </List>
+</Section>`,
         },
         {
           type: 'prose',
@@ -185,24 +225,34 @@ export const docs = {
         {type: 'heading', level: 3, text: 'Panels and inspectors'},
         {
           type: 'prose',
-          text: 'Master-detail: selecting a row opens a fixed-width inspector instead of navigating away. Use LayoutPanel in the end slot with an explicit width budget, plus resizable for user control.',
+          text: 'Master-detail: selecting a row opens a fixed-width inspector instead of navigating away.',
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'LayoutPanel in the end slot of Layout, with a width budget of 340–420px',
+            'hasDivider to fence it from the content region; isScrollable so long detail scrolls on its own',
+            'For user-adjustable width, drive it with useResizable() and place a ResizeHandle next to the panel',
+            'Render an EmptyState when nothing is selected, so the region never collapses',
+          ],
         },
         {
           type: 'code',
           lang: 'tsx',
-          label: 'Inspector that overlays at narrow widths',
-          code: `<LayoutPanel
-  width={380}
-  hasDivider
-  isScrollable
-  label="Details"
-  resizable={{minSizePx: 320, maxSizePx: 480, autoSaveId: 'inspector'}}>
-  {selected ? <DetailFields item={selected} /> : <EmptyState title="Nothing selected" />}
-</LayoutPanel>`,
+          label: 'Inspector in the end slot',
+          code: `<Layout
+  content={<LayoutContent>{/* rows */}</LayoutContent>}
+  end={
+    <LayoutPanel width={380} hasDivider isScrollable label="Details">
+      {/* detail fields, or EmptyState when nothing is selected */}
+    </LayoutPanel>
+  }
+/>`,
         },
         {
           type: 'prose',
-          text: 'Verify: below ~1024px the panel overlays the content region instead of compressing it.',
+          text: 'Verify: at narrow widths the inspector gives up its width instead of squeezing the content region (see the responsive contract in Ship).',
         },
 
         {type: 'heading', level: 3, text: "Do & Don't"},
@@ -213,7 +263,7 @@ export const docs = {
             'Give each region one lead; rank with weight and color; one primary action per region',
             'Default to Section; use the weakest container that reads as a group',
             'Render collections as rows (Table or List), edge-to-edge with dividers',
-            'Open a fixed-width inspector on select; overlay it below ~1024px',
+            'Open a fixed-width inspector on select, and let it yield width at narrow sizes',
           ],
         },
         {
@@ -250,8 +300,10 @@ export const docs = {
           lang: 'tsx',
           label: 'One content line, two inset owners',
           code: `// Target content line = 16px.
-<Section padding={4}><Heading>Members</Heading></Section>  {/* 0 inset */}
-<Section padding={0}><List>{/* items */}</List></Section>  {/* ~8px inset */}`,
+// Heading has 0 inset, so the Section takes the full padding.
+<Section padding={4}><Heading level={3}>Members</Heading></Section>
+// List has ~8px built in, so the Section gives up its padding.
+<Section padding={0}><List>{/* items */}</List></Section>`,
         },
         {
           type: 'prose',
@@ -273,6 +325,18 @@ export const docs = {
           ],
         },
         {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Tight inside, generous between',
+          code: `<VStack gap={6}>
+  <VStack gap={1}>
+    <Text weight="semibold">Retention</Text>
+    <Text color="secondary">How long logs are kept</Text>
+  </VStack>
+  <VStack gap={1}>{/* next field */}</VStack>
+</VStack>`,
+        },
+        {
           type: 'prose',
           text: 'Verify: with every border removed, you can still name the groups from spacing alone. If you cannot, the intervals are too uniform.',
         },
@@ -290,6 +354,15 @@ export const docs = {
             'density="balanced": most Table and List surfaces',
             'density="spacious": low-frequency or high-stakes rows (settings, a short selection list)',
           ],
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Density paired with control size',
+          code: `<Table data={rows} columns={columns} density="compact" hasHover />
+
+// Every control inside a compact row is size="sm".
+<Button label="Retry" size="sm" variant="ghost" />`,
         },
         {
           type: 'prose',
@@ -329,13 +402,29 @@ export const docs = {
           text: 'Declare breakpoint behavior as a contract in a comment at the frame root, and pair every line with the prop or hook that enforces it.',
         },
         {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Above 768px: SideNav holds its budget, content flexes, the inspector holds 380',
+            'At 768px: navigation collapses to MobileNav, via the AppShell mobileNav breakpoint ("md" = 768, "lg" = 1024)',
+            'At 1024px: the inspector stops competing for width. Swap it for a Dialog or BottomSheet, driven by useMediaQuery',
+          ],
+        },
+        {
           type: 'code',
           lang: 'tsx',
-          label: 'Contract comment at the frame root',
-          code: `// Responsive contract:
-//   > 1024px  nav 256 | content | inspector 380
-//   <= 1024px inspector overlays content   (LayoutPanel overlay mode)
-//   <= 768px  nav collapses to MobileNav    (AppShell mobileNav prop)`,
+          label: 'Contract wired to props',
+          code: `//   >768   SideNav 256 | content | inspector 380
+//   <=768  nav collapses to MobileNav   (mobileNav breakpoint)
+//   <=1024 inspector moves to a Dialog  (useMediaQuery)
+const isNarrow = useMediaQuery('(max-width: 1024px)');
+
+<AppShell sideNav={<SideNav />} mobileNav={{breakpoint: 'md'}}>
+  <Layout
+    content={<LayoutContent>{/* rows */}</LayoutContent>}
+    end={isNarrow ? undefined : <LayoutPanel width={380} hasDivider />}
+  />
+</AppShell>`,
         },
         {
           type: 'prose',

--- a/packages/cli/assets/docs/layout.doc.mjs
+++ b/packages/cli/assets/docs/layout.doc.mjs
@@ -10,22 +10,22 @@ export const docs = {
     'Build an app layout outside-in: frame the regions, structure the content, tune the spacing, then ship. Grouped into four phases, each closing with a Do and Don\'t table.',
 
   sections: [
-    // ===== FRAME =====
     {
-      title: 'Frame: Pick the shell',
+      title: 'Frame',
       content: [
+        {type: 'heading', level: 3, text: 'Pick the shell'},
         {
           type: 'prose',
-          text: 'Phase 1 of four: Frame. Start every layout from the frame, not the content. Pick the shell, name its regions, give each an explicit width budget, then fill them. Content-first layout (writing sections and wrapping each in a Card) produces a padded scroll column that reads as a prototype, not a product.',
+          text: 'Pick the shell and budget its regions in px before any content exists.',
         },
         {
           type: 'list',
           style: 'ordered',
           items: [
-            'Pick the frame: AppShell (top and/or side nav apps), Layout + LayoutPanel + LayoutContent (multi-pane tools like explorers and consoles), or a plain content column (documents, marketing, forms)',
-            'Budget regions in px before filling them: side nav 240–280, icon rail 64–72, detail/inspector panel 340–420, filter/facet rail 220–260',
-            'Keep raw px for these structural widths only; everything inside a region uses the spacing scale (see Space)',
-            'Set the container policy per region (rows vs card grid) and the responsive contract before writing content',
+            'Pick the frame: AppShell (nav apps), Layout + LayoutPanel + LayoutContent (multi-pane tools like explorers and consoles), or a plain content column (documents, forms)',
+            'Budget each region in px: side nav 240–280, icon rail 64–72, inspector 340–420, filter rail 220–260',
+            'Keep raw px for these structural widths only; interior spacing uses the scale (see Space)',
+            'Set each region container policy (rows vs card grid) and the responsive contract before writing content',
           ],
         },
         {
@@ -42,14 +42,15 @@ export const docs = {
   </Layout>
 </AppShell>`,
         },
-      ],
-    },
-    {
-      title: 'Frame: Match the archetype',
-      content: [
         {
           type: 'prose',
-          text: 'Match the frame and container policy to the kind of app you are building. These pairings come from product-scale apps built with the design system; container choice tracks the archetype, not preference. Treat each row as a pointer to the template you inherit from, not a spec to reimplement.',
+          text: 'Verify: every region has a px budget and a container policy written down before any content exists.',
+        },
+
+        {type: 'heading', level: 3, text: 'Match the archetype'},
+        {
+          type: 'prose',
+          text: 'Match the frame and container policy to your app type; container choice tracks the archetype, not preference.',
         },
         {
           type: 'table',
@@ -84,16 +85,13 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Start from the matching template (`npx astryx template --list`), study its structure with `--skeleton`, and inherit its navigation pairing before customizing.',
+          text: 'Verify: start from the matching template (`npx astryx template --list`, read `--skeleton`) and inherit its navigation pairing.',
         },
-      ],
-    },
-    {
-      title: 'Frame: Choose navigation',
-      content: [
+
+        {type: 'heading', level: 3, text: 'Choose navigation'},
         {
           type: 'prose',
-          text: 'When the frame leaves navigation open, decide from countable signals (how many destinations, whether they need grouping, how deep the hierarchy), not from preference. Inherit the template pairing first; this section is for when you genuinely have to choose.',
+          text: 'When the frame leaves navigation open, decide from countable signals: destination count, grouping, hierarchy depth.',
         },
         {
           type: 'table',
@@ -118,13 +116,10 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Default to a left nav; switch to top only with 5 or fewer destinations and no grouping; add top + left only when a real ecosystem layer sits above the product.',
+          text: 'Verify: left nav unless you have 5 or fewer destinations and no grouping; top + left only above a real ecosystem layer.',
         },
-      ],
-    },
-    {
-      title: "Frame: Do & Don't",
-      content: [
+
+        {type: 'heading', level: 3, text: "Do & Don't"},
         {
           type: 'list',
           style: 'do',
@@ -145,13 +140,13 @@ export const docs = {
         },
       ],
     },
-    // ===== STRUCTURE =====
     {
-      title: 'Structure: Set hierarchy',
+      title: 'Structure',
       content: [
+        {type: 'heading', level: 3, text: 'Set hierarchy'},
         {
           type: 'prose',
-          text: 'Phase 2 of four: Structure. Give every region one clear lead. Name what leads, what supports, and what is tertiary, then make the ranks look different; equal weight everywhere reads as a template. Express rank with type and color, and drop weight before you drop size.',
+          text: 'Give every region one lead, then separate lead, support, and tertiary with type and color; drop weight before size.',
         },
         {
           type: 'list',
@@ -164,43 +159,33 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Squint test: blurred, you should still read the lead, then the support, then the groups, in that order. If everything reads at once, raise the contrast between ranks through weight, color, and spacing, not borders.',
+          text: 'Squint test: blurred, you read lead, then support, then groups, in that order. If everything reads at once, raise contrast with weight and color, not borders.',
         },
-      ],
-    },
-    {
-      title: 'Structure: Choose a container',
-      content: [
+
+        {type: 'heading', level: 3, text: 'Choose a container'},
         {
           type: 'prose',
-          text: 'Grouping has a strength ladder: spacing, divider, Section, Card. Reach for the weakest tool that reads as a group and escalate only when it fails. Defaulting to a Card is the single biggest cause of the generic-prototype look.',
+          text: 'Reach for the weakest container that reads as a group and escalate only when it fails: spacing, Divider, Section, Card.',
         },
         {
           type: 'table',
           headers: ['Tool', 'Use for', 'Strength'],
           rows: [
-            ['spacing / gap', 'Separating related items inside one group. The default rhythm.', 'weakest'],
-            ['Divider', 'Separating peers in a dense list or toolbar, or fencing a header from a scrollable body.', 'low'],
+            ['spacing / gap', 'Related items inside one group. The default rhythm.', 'weakest'],
+            ['Divider', 'Peers in a dense list or toolbar, or fencing a header from a scrollable body.', 'low'],
             ['Section', 'The default page-structure unit: related content under a heading. No border; hierarchy from spacing.', 'medium'],
-            ['Card', 'A self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical content.', 'strongest'],
+            ['Card', 'A self-contained widget (KPI tile, chart, gallery entry), or a hard boundary around critical content. Not a list-item wrapper.', 'strongest'],
           ],
         },
         {
           type: 'prose',
-          text: 'Card is a widget container, not a list-item wrapper. Dense data (anything the user scans, filters, or selects) belongs in rows: Table for columnar data, List for single-line records, edge-to-edge with dividers and 32–40px rows. Ceiling: one level of bordered container, no cards inside cards.',
+          text: 'Decision test: a collection of records renders as rows (Table for columnar, List for single-line, edge-to-edge with dividers, 32–40px); a self-contained widget or hard boundary is a Card; everything else is a Section.',
         },
+
+        {type: 'heading', level: 3, text: 'Panels and inspectors'},
         {
           type: 'prose',
-          text: 'Decision test: a collection of records renders as rows; a self-contained widget or content that needs a hard boundary is a Card; everything else, which is most things, is a Section.',
-        },
-      ],
-    },
-    {
-      title: 'Structure: Panels and inspectors',
-      content: [
-        {
-          type: 'prose',
-          text: 'Master-detail is the backbone of tool UIs: selecting a row opens a fixed-width inspector rather than navigating away. Use LayoutPanel in the end slot with an explicit width budget, add resizable for user control, and let the panel overlay the content below ~1024px instead of compressing it.',
+          text: 'Master-detail: selecting a row opens a fixed-width inspector instead of navigating away. Use LayoutPanel in the end slot with an explicit width budget, plus resizable for user control.',
         },
         {
           type: 'code',
@@ -215,11 +200,12 @@ export const docs = {
   {selected ? <DetailFields item={selected} /> : <EmptyState title="Nothing selected" />}
 </LayoutPanel>`,
         },
-      ],
-    },
-    {
-      title: "Structure: Do & Don't",
-      content: [
+        {
+          type: 'prose',
+          text: 'Verify: below ~1024px the panel overlays the content region instead of compressing it.',
+        },
+
+        {type: 'heading', level: 3, text: "Do & Don't"},
         {
           type: 'list',
           style: 'do',
@@ -242,65 +228,75 @@ export const docs = {
         },
       ],
     },
-    // ===== SPACE =====
     {
-      title: 'Space: Align to one line',
+      title: 'Space',
       content: [
+        {type: 'heading', level: 3, text: 'Align to one line'},
         {
           type: 'prose',
-          text: 'Phase 3 of four: Space. The container owns structural space: the padding around a region and the gap between its children. Children zero their own margins and inherit the container rhythm, so spacing never drifts child to child. Interior spacing is always a token (Section padding defaults to 4 = 16px).',
+          text: 'The container owns padding and child gaps; children zero their margins, and interior spacing is always a token. Pick one content line per region and hold it constant, not the padding: `container_inset = content_line - component_intrinsic_inset`.',
         },
         {
-          type: 'prose',
-          text: 'Pick one content line per region: the left edge every heading, label, and row aligns to (16px is a good default). Hold the content line constant, not the padding, with container_inset = content_line minus the component built-in inset. Plain text has zero inset and takes the full padding; List, Tab, Menu, and nav items reserve ~8px and Table cells ~12–16px, so set those to Section padding={0} and let the component own the inset. The label lands on the line while the hover background bleeds to the edge.',
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Text and Heading: 0 inset, so the container takes the full padding (Section padding={4} = a 16px line)',
+            'List, Tab, Menu, nav items: ~8px built in, so Section padding={0} and the component owns the inset',
+            'Table cells: 12–16px built in, so Section padding={0} and the cell owns the inset',
+          ],
         },
         {
           type: 'code',
           lang: 'tsx',
-          label: 'One content line: absorb a component built-in inset',
-          code: `// Target content line = 16px. Heading has 0 inset; the list item has ~8px.
-<Section padding={4}>            {/* 16px: heading label sits at 16 */}
-  <Heading>Members</Heading>
-</Section>
-<Section padding={0}>            {/* 0: the List owns the inset */}
-  <List>{/* item label sits at 16, hover background bleeds to the edge */}</List>
-</Section>`,
+          label: 'One content line, two inset owners',
+          code: `// Target content line = 16px.
+<Section padding={4}><Heading>Members</Heading></Section>  {/* 0 inset */}
+<Section padding={0}><List>{/* items */}</List></Section>  {/* ~8px inset */}`,
         },
         {
           type: 'prose',
-          text: 'Squint and draw one vertical line down the left of the region: every label should touch it, and only hover or selected backgrounds should cross it. If a list is indented past its own heading, you double-padded; keep one owner of the inset, never both.',
+          text: 'Verify: draw one vertical line down the left of the region. Every label touches it; only hover and selected backgrounds cross it.',
         },
-      ],
-    },
-    {
-      title: 'Space: Set the rhythm',
-      content: [
+
+        {type: 'heading', level: 3, text: 'Set the rhythm'},
         {
           type: 'prose',
-          text: 'Spacing groups through contrast, not one repeated value. Tight space binds related items; generous space separates groups. If every gap is the same step, proximity does no work. Keep intra-group gaps small and inter-group gaps a step or two larger (gap={1}–{2} within an item, {4}–{6} between sections); the jump is what reads.',
+          text: 'Grouping comes from contrast between tight and generous gaps, not one repeated value. If every gap is the same step, proximity does no work.',
         },
         {
-          type: 'prose',
-          text: 'Use the in-between steps. The scale is 4px-based (gap={3} = 12px, {5} = 20px) so you can tune a cadence an 8px-only scale cannot hit; do not round everything to {2} or {4}. Verify: with every border removed, you can still name the groups from spacing alone. If you cannot, the intervals are too uniform.',
-        },
-      ],
-    },
-    {
-      title: 'Space: Match density and size',
-      content: [
-        {
-          type: 'prose',
-          text: 'Match density to how a region is used: density="compact" for high-volume regions the user scans fast (logs, monitors, large datasets), density="balanced" for most Table and List surfaces, density="spacious" for low-frequency or high-stakes rows (settings, a short selection list). Set it deliberately rather than accepting the default.',
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Tight binds: gap={1}–{2} inside an item or field',
+            'Generous separates: gap={4}–{6} between sections',
+            'Use the in-between 4px steps to tune cadence: gap={3} = 12px, gap={5} = 20px. Do not round everything to {2} or {4}',
+          ],
         },
         {
           type: 'prose',
-          text: 'One size per row, one size per container. Every interactive element in a row shares the same size (sm, md, or lg): a sm Button next to an md Selector next to an md TextInput reads as broken even when each is fine on its own, because the heights do not share a baseline. Pick the row size once, and pair it with density (compact with sm, spacious with md or lg).',
+          text: 'Verify: with every border removed, you can still name the groups from spacing alone. If you cannot, the intervals are too uniform.',
         },
-      ],
-    },
-    {
-      title: "Space: Do & Don't",
-      content: [
+
+        {type: 'heading', level: 3, text: 'Match density and size'},
+        {
+          type: 'prose',
+          text: 'Match density to how often a region is used, and give every control in a row the same size so heights share a baseline.',
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'density="compact": high-volume regions scanned fast (logs, monitors, large datasets)',
+            'density="balanced": most Table and List surfaces',
+            'density="spacious": low-frequency or high-stakes rows (settings, a short selection list)',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'Verify: every interactive element in a row shares one size (sm, md, or lg), paired with the density: compact with sm, spacious with md or lg.',
+        },
+
+        {type: 'heading', level: 3, text: "Do & Don't"},
         {
           type: 'list',
           style: 'do',
@@ -324,13 +320,13 @@ export const docs = {
         },
       ],
     },
-    // ===== SHIP =====
     {
-      title: 'Ship: Responsive contract',
+      title: 'Ship',
       content: [
+        {type: 'heading', level: 3, text: 'Responsive contract'},
         {
           type: 'prose',
-          text: 'Phase 4 of four: Ship. Declare breakpoint behavior as a contract before building, and keep it in a comment at the frame root. Pair every line with the mechanism that enforces it (a prop or hook) so the comment cannot drift from the behavior. A typical contract: full frame above 1024px; inspectors overlay the content at 1024px and below; the side nav collapses to MobileNav at 768px and below.',
+          text: 'Declare breakpoint behavior as a contract in a comment at the frame root, and pair every line with the prop or hook that enforces it.',
         },
         {
           type: 'code',
@@ -341,11 +337,12 @@ export const docs = {
 //   <= 1024px inspector overlays content   (LayoutPanel overlay mode)
 //   <= 768px  nav collapses to MobileNav    (AppShell mobileNav prop)`,
         },
-      ],
-    },
-    {
-      title: 'Ship: Before you ship',
-      content: [
+        {
+          type: 'prose',
+          text: 'Verify: every contract line names a mechanism, so the comment cannot drift from the behavior.',
+        },
+
+        {type: 'heading', level: 3, text: 'Before you ship'},
         {
           type: 'list',
           style: 'do',

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -93,6 +93,24 @@ export const docs = {
       description: 'Height behavior: fill the container or grow with content.',
       default: "'fill'",
     },
+    {
+      name: 'contentWidth',
+      type: 'number | string',
+      description:
+        'Maximum width of the content within each slot (header, content, footer, panels), centered when narrower than the available space. Dividers stay full-bleed. Numbers are pixels, strings are used as-is (e.g. `60ch`). Common page widths: 640 for forms, settings, and text-focused pages; 960 for content pages and wider layouts.',
+    },
+    {
+      name: 'padding',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description:
+        "Padding at the layout's outer edges using the spacing scale.",
+    },
+    {
+      name: 'defaultHasDividers',
+      type: 'boolean',
+      description:
+        "Default divider visibility for LayoutHeader and LayoutFooter children. Headers and footers that don't pass `hasDivider` use this value; when unset, nested layouts inherit from their parent context.",
+    },
   ],
   components: [
     {name: 'LayoutHeader'},


### PR DESCRIPTION
## What

Rewrites the **Layout** guide (`astryx docs layout`, [docs page](https://astryx.atmeta.com/docs/layout)) into an
outside-in build sequence with a repeating shape, so an agent reading it top to
bottom lands on the same layout decisions a designer would.

Compared against what is live today, the guide goes from five flat sections with
no internal structure to four build phases with fourteen named sub-sections, and
from three code examples to ten.

## Why

The live guide is thin in the places where agents actually guess. It never names
the mechanism for responsive behavior, never gives a region a width, and never
states the alignment rule, so an agent has to invent all three. The A/B test
below shows exactly that happening: given the live guide, the agent hand-rolled
its own `matchMedia` subscription because it could not find `useMediaQuery`, and
its table text landed 8px off the page heading.

## Structure: live vs this PR

| | Live (`main`) | This PR |
|---|---|---|
| Sections | 5 flat | 5 (Overview + 4 phases) |
| Sub-sections | 0 | 14 |
| Code examples | 3 (21 lines) | 10 (100 lines) |
| Do / Don't items | 4 / 4 | 16 / 21 |
| Tables | 1 | 0 (converted to lists) |
| Words | 548 | 1,691 |

The four phases, outside-in, named to match
[Material 3's layout vocabulary](https://m3.material.io/foundations/layout/layout-overview/overview):

- **Scaffold**: Shell, Navigation, Best practices
- **Structure**: Type hierarchy, Containers, Headers and footers, Side panels, Best practices
- **Spacing**: Alignment, Rhythm, Density and size, Best practices
- **Breakpoints**: Responsive contract, Best practices

`Breakpoints` sits last so nothing references a phase the reader has not reached
yet. Every sub-section title is a noun, so the on-this-page outline reads as a
table of contents rather than a list of commands.

## Three tiers, so a rule is distinguishable from a suggestion

The single biggest readability change. Every section now separates:

1. **Principles** in prose. Always true, no numbers.
2. **Recommended values** in code blocks and their comments. Tunable. Region
   budgets, capped widths, gap steps, and density pairings all moved here out of
   prose.
3. **Rules** in the Do / Don't tables, and nowhere else.

Previously a sentence like "side nav 240-280" read with the same authority as
"one primary action per region", and only one of those is a rule.

Each phase closes with a section that is *only* do/dont lists, so the docsite
renders it as the same green/red table used on component docs
(`isBestPracticesSection` -> `BestPracticesBlock`) and the CLI renders `+`/`x`
bullets. No schema change. Renamed from "Do & Don't" to **Best practices** to
match the seven other reference docs that already use that name.

## New guidance not on the live page

- **Alignment**: hold one content line per region, not one padding value, via
  `container_inset = content_line - component_intrinsic_inset`. Names which
  components carry their own inset.
- **Headers and footers**: `LayoutHeader` / `LayoutFooter` as `Layout` slots,
  when `Toolbar` replaces a header, and how one `padding` on `Layout` reaches all
  three slots.
- **Side panels**: `ResizeHandle` placement on the panel's inner edge, including
  `isReversed` for `end`-slot panels, and which element owns the divider.
- **Type hierarchy**: body copy takes no props. Two accessible text colors only
  (`primary`, `secondary`); `disabled` fails contrast and is reserved for
  disabled controls.
- **Rhythm**: grouping comes from contrast between tight and generous gaps, not
  one repeated value.
- **Density and size**: match `density` to use frequency, one control `size` per
  row so heights share a baseline.
- **Navigation**: app type and destination count are guiding indicators, not
  deterministic thresholds.

Also documents `contentWidth`, `padding`, and `defaultHasDividers` on
`Layout.doc.mjs`. All three already existed on the component but were missing
from its doc, so `astryx component Layout` never surfaced them. The guide points
readers at `contentWidth` to cap prose and form regions, which only works if the
prop is discoverable.

## Proof: A/B vibe test

Same prompt, same tooling, same model, two arms. The only variable is the layout
doc text.

**Setup**, following the five fairness invariants in
`internal/vibe-tests/README.md`:

- Prompt: `wd-4` ("TodoTracker") verbatim from `test-sets/default.json`, the
  existing todo-list prompt in the battery. `expectedComponents` withheld from
  both arms per invariant 3.
- Both arms: fresh context-free subagents, identical instructions, identical
  access to `astryx component <Name> --dense`, identical house rules.
- Arm A reads the **live** doc (`origin/main`); Arm B reads **this PR's** doc.
  Each arm received the doc exactly as `astryx docs layout` renders it, 737 vs
  2,345 words of rendered text including code blocks. Both arms were instructed
  not to run `astryx docs layout` themselves, so the working tree could not leak
  the new doc into Arm A.
- Rendered and screenshotted through the repo's own pipeline
  (`build-previews.ts` then `screenshot-previews.ts`), Chromium at 1280x800 and
  375x812.

### Result: both arms are good, and they diverge on the parts the live doc omits

Both produced a real app with zero `tsc` errors, zero `<div>`, zero `xstyle`,
zero raw StyleX, and no `Card` misuse. The live guide's frame-first advice is
already doing its job on card soup. The differences are everywhere it stays
silent:

| | Arm A (live doc) | Arm B (this PR) |
|---|---|---|
| **Content line spread** | **8px** | **0px** |
| Responsive mechanism | hand-rolled `matchMedia` + `useSyncExternalStore` | `useMediaQuery` |
| Nav collapse | none | `mobileNav={{breakpoint: 'md'}}` |
| `contentWidth` / `defaultHasDividers` | not used | used |
| Pending marker | ad hoc spinner | `Token` |
| `tsc` errors | 0 | 0 |

**Content line** is measured, not eyeballed. Left edge of the `h1`, the first
column header, the first body cell, and the footer text, in the rendered page:

- Arm A: 260, 268, 268, 260 -> **8px spread**. The table's intrinsic cell inset
  was never compensated, which is precisely the failure the new Alignment
  section exists to prevent.
- Arm B: 276, 276, 276, 276 -> **0px spread**.

Arm B's agent reported measuring this itself while building, because the doc gave
it a test to run.

**Desktop, 1280x800.** Arm A left, Arm B right:

<table>
<tr>
<td width="50%"><img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/pr/5164/vibe-ab/live-doc-desktop.png" alt="Arm A, live doc, desktop"></td>
<td width="50%"><img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/pr/5164/vibe-ab/new-doc-desktop.png" alt="Arm B, this PR, desktop"></td>
</tr>
</table>

**Mobile, 375x812.** This is where the missing breakpoint guidance shows. Arm A
kept all five columns and truncated every title to "Add keyboard...". Arm B
dropped the Created column so titles stay readable:

<table>
<tr>
<td width="50%"><img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/pr/5164/vibe-ab/live-doc-mobile.png" alt="Arm A, live doc, mobile"></td>
<td width="50%"><img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/pr/5164/vibe-ab/new-doc-mobile.png" alt="Arm B, this PR, mobile"></td>
</tr>
</table>

### Limits of this test

Worth stating plainly: n=1 per arm, one prompt, one model. This is an existence
proof that the added guidance changes specific decisions, not a statistical
result. Both arms cleared the bar the live doc already sets. Arm B also surfaced
two genuine problems the doc should own, filed as follow-ups rather than fixed
here: a `LayoutContent` top-padding conflict under a divider-less `LayoutHeader`,
and a collision between the recommended 32-40px row height and `balanced`
density with `sm` controls.

## Notes

- Dense variant (`layout.doc.dense.mjs`) stays index-aligned with the full doc,
  verified section keys, block counts, and per-index types, so
  `astryx docs layout --dense` matches. Renaming a section title required
  updating the overlay's `section` matcher key.
- Docsite: 377 tests pass. CLI suite has 9 pre-existing failures in component
  search, theme manifest, and hook discovery; none read this doc.
- Doc-only change, no changeset, consistent with prior doc-only commits to
  `packages/core/src/**/*.doc.mjs` such as `docs(core): document the seven hooks
  missing from the hooks doc`.
- No em dashes in prose per the deslop rubric; en dashes only for numeric ranges.
- Also fixes a pre-existing docsite bug where consecutive do/dont lists in a
  nested section rendered without their green/red badges. It affected
  `theme.doc.mjs` too.
