### PR TITLE
fix(core): floor the vertical Slider's touch hit area to 24px too

### DIFF
--- a/.changeset/slider-vertical-touch-target.md
+++ b/.changeset/slider-vertical-touch-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Slider` with `orientation="vertical"` now gets the same 24px touch hit area the horizontal one got: its track was still only 20px wide on coarse pointers, under the WCAG 2.5.8 AA minimum. The whole track is the tap target for both orientations — the fix that floored the horizontal track's block size did nothing for vertical, whose short axis is the inline one — so the inline size is now floored to 24px on touch, with the same `@media (pointer: coarse)` gate. The rail, fill, marks and thumb all center on the inline 50%, so nothing visible moves and desktop is untouched.
+
+@imdreamrunner

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -189,6 +189,16 @@ const styles = stylex.create({
   trackContainerVertical: {
     width: THUMB_SIZE,
     height: 160,
+    // Same tap target, rotated: the vertical track is the thing you press, and
+    // it is only THUMB_SIZE (20px) wide. `minBlockSize` above floors the
+    // horizontal track's short axis; here the short axis is the inline one
+    // (the block size is already 160px), so floor that instead. The rail,
+    // fill, marks and thumb all center on the inline 50%, so they stay put;
+    // only the invisible tappable area grows. Desktop is unchanged.
+    minInlineSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
     flexDirection: 'column',
     justifyContent: 'center',
     cursor: 'pointer',


### PR DESCRIPTION
## What

Fixes #5169 — `orientation="vertical"` never got the touch hit area #4963 gave the horizontal Slider. Its track is still **20 CSS px wide** on coarse pointers, under the WCAG 2.5.8 AA 24px minimum.

## How

#4963 floored the track container's **block** size, which is the horizontal slider's short axis. A vertical slider's block size is already 160px; its short axis is the **inline** one, so `min-block-size` does nothing for it.

Both orientations share one tap target — a single `trackContainer` carries `onPointerDown`/`Move`/`Up`, and `getValueFromPosition` has a vertical branch — so the interaction model #4963 described applies unchanged: the track is what you press, the thumb is not the primary target. The fix is the inline-axis counterpart behind the same gate:

```ts
trackContainerVertical: {
  width: THUMB_SIZE,
  height: 160,
  minInlineSize: {
    default: null,
    '@media (pointer: coarse)': '24px',
  },
  ...
},
```

The rail, fill, marks and thumb are all centered on the inline 50% (`rtlStyles.centerInline('0px')`, and `left: 50%` + a centering translate for the thumb), so nothing visible moves — only the invisible tappable area grows. Fine pointers are untouched, and `min-*` only ever grows a dimension.

## Testing

Measured `getBoundingClientRect` in Chromium under both pointer modes, same method as #4963. The measured case is a content-sized vertical slider with a hidden label — the case where the container is exactly the track. (With a visible label the row is already wider than 24px, because `trackContainer` has `flex-grow: 1`; the floor is what covers the narrow case.)

| Element | Fine (desktop) | Coarse (touch) |
| --- | --- | --- |
| Vertical track container (real target) | 20×160 | **24**×160 |
| Vertical thumb (visual) | 20×20 | 20×20 (unchanged) |
| Vertical rail (visual) | 4×160 | 4×160 (unchanged) |
| Vertical rail/thumb center, from container edge | 10px | 12px — still centered |
| Horizontal track container (regression check) | 380×20 | 380×24 (as before) |

Confirmed the rule ships in the compiled `astryx.css` (StyleX emits `min-inline-size` as `min-width`): `@media (pointer: coarse){...{min-width:24px}}`, on the class the vertical track container carries.

`pnpm lint:strict` (0 errors), `pnpm test` (10666 tests, 526 files, all pass) and `pnpm build` are clean.

One layout note, the same trade the horizontal fix made: on a touch device a content-sized vertical slider's field box is 24px wide instead of 20px (horizontal grows 20px → 24px in height the same way). Nothing inside it moves relative to the box.
