### PR TITLE
fix(core): close only the top-most layer on Escape

### DIFF
--- a/.changeset/escape-topmost-layer-dialog.md
+++ b/.changeset/escape-topmost-layer-dialog.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Lightbox, MobileNav: one Escape press closes the layer itself instead of the Dialog it was opened from. Both now claim the press at their own `<dialog>` element, so it never reaches the host's listener or the browser's close request, and both still defer to a focus-trapped layer (popover, menu) above them.
+
+@AKnassa

--- a/packages/core/src/Lightbox/Lightbox.test.tsx
+++ b/packages/core/src/Lightbox/Lightbox.test.tsx
@@ -3,6 +3,8 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {Lightbox} from './Lightbox';
+import {Dialog} from '../Dialog';
+import {useFocusTrap} from '../hooks/useFocusTrap';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {InternationalizationProvider} from '../i18n';
 
@@ -674,5 +676,149 @@ describe('Lightbox', () => {
       fireEvent.click(screen.getByRole('img', {hidden: true}));
       expect(onOpenChange).not.toHaveBeenCalled();
     });
+  });
+});
+
+/**
+ * Regression coverage for #5168 — a Lightbox opened from inside a Dialog used
+ * to hand its Escape press to the Dialog: the press bubbled from the Lightbox
+ * `<dialog>` up to the Dialog's element-level keydown listener, which called
+ * `preventDefault()` (killing the browser close request that would have
+ * dismissed the Lightbox) and closed itself. The Dialog vanished and the
+ * Lightbox stayed on screen.
+ */
+describe('Lightbox layered over a Dialog', () => {
+  function renderNested() {
+    const onLightboxOpenChange = vi.fn();
+    const onDialogOpenChange = vi.fn();
+    render(
+      <Dialog isOpen onOpenChange={onDialogOpenChange} aria-label="Host dialog">
+        <Lightbox
+          isOpen
+          onOpenChange={onLightboxOpenChange}
+          media={{src: '/photo.jpg', alt: 'Photo'}}
+        />
+      </Dialog>,
+    );
+
+    // Document order puts the wrapping Dialog first; assert the nesting the
+    // regression depends on rather than trusting the order.
+    const dialogs = Array.from(document.querySelectorAll('dialog'));
+    expect(dialogs).toHaveLength(2);
+    const [hostDialog, lightbox] = dialogs;
+    expect(hostDialog.contains(lightbox)).toBe(true);
+
+    return {hostDialog, lightbox, onLightboxOpenChange, onDialogOpenChange};
+  }
+
+  function pressEscape(target: Element): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(event);
+    return event;
+  }
+
+  it('closes the Lightbox and leaves the Dialog open', () => {
+    const {lightbox, onLightboxOpenChange, onDialogOpenChange} = renderNested();
+
+    pressEscape(lightbox);
+
+    expect(onLightboxOpenChange).toHaveBeenCalledWith(false);
+    expect(onDialogOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('consumes the press instead of letting it travel to the layers above', () => {
+    const {lightbox} = renderNested();
+    const reachedDocument = vi.fn();
+    document.addEventListener('keydown', reachedDocument);
+
+    // Two ways a single press reaches a second layer: it keeps bubbling to
+    // document-level listeners, or the browser turns the un-consumed default
+    // into a close request and fires `cancel` on the top-most open dialog.
+    // Claiming the press at the Lightbox element shuts both down.
+    const event = pressEscape(lightbox);
+
+    document.removeEventListener('keydown', reachedDocument);
+    expect(reachedDocument).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('closes on Escape when it is the only layer', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Lightbox
+        isOpen
+        onOpenChange={onOpenChange}
+        media={{src: '/photo.jpg', alt: 'Photo'}}
+      />,
+    );
+    const lightbox = document.querySelector('dialog')!;
+
+    pressEscape(lightbox);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('defers to a focus-trapped layer opened on top of it', () => {
+    const onOpenChange = vi.fn();
+    const onEscape = vi.fn();
+
+    function TrappedLayer() {
+      const {containerRef} = useFocusTrap<HTMLDivElement>({
+        isActive: true,
+        onEscape,
+      });
+      return <div ref={containerRef} data-testid="trapped" />;
+    }
+
+    render(
+      <>
+        <Lightbox
+          isOpen
+          onOpenChange={onOpenChange}
+          media={{src: '/photo.jpg', alt: 'Photo'}}
+        />
+        <TrappedLayer />
+      </>,
+    );
+    const lightbox = document.querySelector('dialog')!;
+
+    pressEscape(lightbox);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(onEscape).toHaveBeenCalled();
+  });
+
+  it('ignores a close request raised while a focus-trapped layer is open', () => {
+    const onOpenChange = vi.fn();
+
+    function TrappedLayer() {
+      const {containerRef} = useFocusTrap<HTMLDivElement>({
+        isActive: true,
+        onEscape: () => {},
+      });
+      return <div ref={containerRef} data-testid="trapped" />;
+    }
+
+    render(
+      <>
+        <Lightbox
+          isOpen
+          onOpenChange={onOpenChange}
+          media={{src: '/photo.jpg', alt: 'Photo'}}
+        />
+        <TrappedLayer />
+      </>,
+    );
+    const lightbox = document.querySelector('dialog')!;
+
+    // The trapped layer let the press through to the browser, which aims its
+    // close request at the top-most open dialog — this one. It is not ours.
+    lightbox.dispatchEvent(new Event('cancel', {cancelable: true}));
+
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -4,7 +4,8 @@
 
 /**
  * @file Lightbox.tsx
- * @input Uses React, native dialog, StyleX, IconButton, theme tokens
+ * @input Uses React, native dialog, StyleX, IconButton, theme tokens,
+ *   hasActiveFocusTrapEscape
  * @output Exports Lightbox component, LightboxProps, LightboxMedia
  * @position Core implementation; consumed by index.ts
  *
@@ -31,12 +32,14 @@ import {Icon} from '../Icon';
 import {IconButton} from '../IconButton';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {useScrollLock} from '../hooks/useScrollLock';
+import {hasActiveFocusTrapEscape} from '../hooks/useFocusTrap';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {mergeProps, mergeRefs, rtlStyles} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
+import {isImeKeyEvent} from '../utils/ime';
 
 /**
  * Media type for lightbox items.
@@ -408,10 +411,43 @@ export function Lightbox({
     onOpenChange(false);
   }, [onOpenChange]);
 
-  // Escape key
+  // Escape key. Claimed at the dialog element rather than left to the browser's
+  // close request: a Lightbox opened from inside another modal is a DOM
+  // descendant of it, so an unclaimed press bubbles on to the host's own
+  // element-level listener, which closes the host and consumes the default —
+  // the close request that would have dismissed this Lightbox never arrives,
+  // leaving the wrong layer on screen (#5168). A focus-trapped layer (popover,
+  // menu) sitting on top of us still wins the press.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!isOpen || !dialog) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      if (isImeKeyEvent(event) || hasActiveFocusTrapEscape()) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      handleClose();
+    };
+
+    dialog.addEventListener('keydown', handleKeyDown);
+    return () => dialog.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleClose]);
+
+  // Fallback for a close request the keydown listener above never saw, e.g. a
+  // press that landed outside this dialog's subtree.
   const handleCancel = useCallback(
     (e: React.SyntheticEvent) => {
       e.preventDefault();
+      if (hasActiveFocusTrapEscape()) {
+        return;
+      }
       handleClose();
     },
     [handleClose],

--- a/packages/core/src/MobileNav/MobileNav.test.tsx
+++ b/packages/core/src/MobileNav/MobileNav.test.tsx
@@ -12,6 +12,8 @@
 import {describe, it, expect, vi, beforeAll} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {MobileNav} from './MobileNav';
+import {Dialog} from '../Dialog';
+import {useFocusTrap} from '../hooks/useFocusTrap';
 
 // jsdom doesn't implement showModal/close on <dialog>, so we mock them
 beforeAll(() => {
@@ -133,10 +135,7 @@ describe('MobileNav', () => {
 
   it('forwards data-testid', () => {
     render(
-      <MobileNav
-        isOpen={true}
-        onOpenChange={() => {}}
-        data-testid="custom-nav">
+      <MobileNav isOpen={true} onOpenChange={() => {}} data-testid="custom-nav">
         <span>Content</span>
       </MobileNav>,
     );
@@ -202,10 +201,7 @@ describe('MobileNav', () => {
 
   it('uses native dialog element', () => {
     render(
-      <MobileNav
-        isOpen={true}
-        onOpenChange={() => {}}
-        data-testid="mobile-nav">
+      <MobileNav isOpen={true} onOpenChange={() => {}} data-testid="mobile-nav">
         <span>Content</span>
       </MobileNav>,
     );
@@ -251,14 +247,143 @@ describe('MobileNav', () => {
     expect(dialog).not.toHaveAttribute('open');
 
     rerender(
-      <MobileNav
-        isOpen={true}
-        onOpenChange={() => {}}
-        data-testid="mobile-nav">
+      <MobileNav isOpen={true} onOpenChange={() => {}} data-testid="mobile-nav">
         <span>Content</span>
       </MobileNav>,
     );
 
     expect(dialog).toHaveAttribute('open');
+  });
+});
+
+/**
+ * Regression coverage for #5168 — a MobileNav opened from inside a Dialog used
+ * to hand its Escape press to the Dialog: the press bubbled from the MobileNav
+ * `<dialog>` up to the Dialog's element-level keydown listener, which called
+ * `preventDefault()` (killing the browser close request that would have
+ * dismissed the nav) and closed itself. The Dialog vanished and the nav stayed
+ * on screen.
+ */
+describe('MobileNav layered over a Dialog', () => {
+  function pressEscape(target: Element): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(event);
+    return event;
+  }
+
+  function renderNested() {
+    const onNavOpenChange = vi.fn();
+    const onDialogOpenChange = vi.fn();
+    render(
+      <Dialog isOpen onOpenChange={onDialogOpenChange} aria-label="Host dialog">
+        <MobileNav isOpen onOpenChange={onNavOpenChange}>
+          <span>Nav content</span>
+        </MobileNav>
+      </Dialog>,
+    );
+
+    // Document order puts the wrapping Dialog first; assert the nesting the
+    // regression depends on rather than trusting the order.
+    const dialogs = Array.from(document.querySelectorAll('dialog'));
+    expect(dialogs).toHaveLength(2);
+    const [hostDialog, nav] = dialogs;
+    expect(hostDialog.contains(nav)).toBe(true);
+
+    return {hostDialog, nav, onNavOpenChange, onDialogOpenChange};
+  }
+
+  it('closes the nav and leaves the Dialog open', () => {
+    const {nav, onNavOpenChange, onDialogOpenChange} = renderNested();
+
+    pressEscape(nav);
+
+    expect(onNavOpenChange).toHaveBeenCalledWith(false);
+    expect(onDialogOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('consumes the press instead of letting it travel to the layers above', () => {
+    const {nav} = renderNested();
+    const reachedDocument = vi.fn();
+    document.addEventListener('keydown', reachedDocument);
+
+    // Two ways a single press reaches a second layer: it keeps bubbling to
+    // document-level listeners, or the browser turns the un-consumed default
+    // into a close request and fires `cancel` on the top-most open dialog.
+    // Claiming the press at the nav element shuts both down.
+    const event = pressEscape(nav);
+
+    document.removeEventListener('keydown', reachedDocument);
+    expect(reachedDocument).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('closes on Escape when it is the only layer', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <MobileNav isOpen onOpenChange={onOpenChange}>
+        <span>Nav content</span>
+      </MobileNav>,
+    );
+    const nav = document.querySelector('dialog')!;
+
+    pressEscape(nav);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('defers to a focus-trapped layer opened inside it', () => {
+    const onOpenChange = vi.fn();
+    const onEscape = vi.fn();
+
+    // Stands in for a DropdownMenu or Popover opened from a nav row: those
+    // register on the focus-trap Escape stack and must win the press.
+    function TrappedLayer() {
+      const {containerRef} = useFocusTrap<HTMLDivElement>({
+        isActive: true,
+        onEscape,
+      });
+      return <div ref={containerRef} data-testid="trapped" />;
+    }
+
+    render(
+      <MobileNav isOpen onOpenChange={onOpenChange}>
+        <TrappedLayer />
+      </MobileNav>,
+    );
+    const trapped = screen.getByTestId('trapped');
+
+    pressEscape(trapped);
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(onEscape).toHaveBeenCalled();
+  });
+
+  it('ignores a close request raised while a focus-trapped layer is open', () => {
+    const onOpenChange = vi.fn();
+
+    function TrappedLayer() {
+      const {containerRef} = useFocusTrap<HTMLDivElement>({
+        isActive: true,
+        onEscape: () => {},
+      });
+      return <div ref={containerRef} data-testid="trapped" />;
+    }
+
+    render(
+      <MobileNav isOpen onOpenChange={onOpenChange}>
+        <TrappedLayer />
+      </MobileNav>,
+    );
+    const nav = document.querySelector('dialog')!;
+
+    // The trapped layer let the press through to the browser, which aims its
+    // close request at the top-most open dialog — this one. It is not ours.
+    nav.dispatchEvent(new Event('cancel', {cancelable: true}));
+
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -19,7 +19,7 @@
  * - `::backdrop` pseudo-element
  * - Body scroll lock
  * - Focus trapping
- * - Escape key handling via `cancel` event
+ * - Escape key handling, claimed at the dialog element
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/MobileNav/index.ts (exports if types change)
@@ -51,6 +51,8 @@ import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import {hasActiveFocusTrapEscape} from '../hooks/useFocusTrap';
+import {isImeKeyEvent} from '../utils/ime';
 
 // =============================================================================
 // Styles
@@ -481,10 +483,43 @@ export function MobileNav({
     };
   }, []);
 
-  // Handle native cancel event (Escape key) — prevent default and route through onOpenChange
+  // Escape key. Claimed at the dialog element rather than left to the browser's
+  // close request: a nav opened from inside another modal is a DOM descendant
+  // of it, so an unclaimed press bubbles on to the host's own element-level
+  // listener, which closes the host and consumes the default — the close
+  // request that would have dismissed this nav never arrives, leaving the wrong
+  // layer on screen (#5168). A focus-trapped layer (a menu or popover opened
+  // from a nav row) sitting on top of us still wins the press.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!isOpen || !dialog) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      if (isImeKeyEvent(event) || hasActiveFocusTrapEscape()) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      onOpenChange(false);
+    };
+
+    dialog.addEventListener('keydown', handleKeyDown);
+    return () => dialog.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onOpenChange]);
+
+  // Fallback for a close request the keydown listener above never saw, e.g. a
+  // press that landed outside this dialog's subtree.
   const handleCancel = useCallback(
     (event: React.SyntheticEvent<HTMLDialogElement>) => {
       event.preventDefault();
+      if (hasActiveFocusTrapEscape()) {
+        return;
+      }
       onOpenChange(false);
     },
     [onOpenChange],

--- a/packages/lab/src/InfoTip/InfoTip.test.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {InfoTip} from './InfoTip';
+import {Dialog} from '@astryxdesign/core/Dialog';
 
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;
@@ -165,5 +166,100 @@ describe('InfoTip', () => {
   it('renders ReactNode tooltip content', () => {
     render(<InfoTip content={<span data-testid="rich-content">Rich</span>} />);
     expect(screen.getByTestId('rich-content')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Regression coverage for #5168 — an InfoTip inside a Dialog dismissed both
+ * layers on one Escape. The trigger stopped propagation from a React handler,
+ * which React dispatches at the root container — long after the press has
+ * already bubbled through the Dialog's own element-level listener. The Dialog
+ * closed alongside the tip.
+ */
+describe('InfoTip inside a Dialog', () => {
+  beforeAll(() => {
+    // jsdom has no modal dialog; Dialog only needs open/close to be observable.
+    HTMLDialogElement.prototype.showModal = vi.fn(function (
+      this: HTMLDialogElement,
+    ) {
+      this.setAttribute('open', '');
+    });
+    HTMLDialogElement.prototype.close = vi.fn(function (
+      this: HTMLDialogElement,
+    ) {
+      this.removeAttribute('open');
+    });
+  });
+
+  async function renderNested() {
+    const onDialogOpenChange = vi.fn();
+    render(
+      <Dialog isOpen onOpenChange={onDialogOpenChange} aria-label="Host dialog">
+        <InfoTip content="Helpful context" />
+      </Dialog>,
+    );
+    const trigger = screen.getByRole('button', {name: 'More information'});
+    const layer = screen.getByRole('tooltip', {hidden: true});
+
+    focusTrigger(trigger);
+    await waitFor(() => {
+      expect(popoverOpenState.get(layer)).toBe(true);
+    });
+
+    return {trigger, layer, onDialogOpenChange};
+  }
+
+  it('dismisses the tooltip and leaves the Dialog open', async () => {
+    const {trigger, layer, onDialogOpenChange} = await renderNested();
+
+    fireEvent.keyDown(trigger, {key: 'Escape'});
+
+    await waitFor(() => {
+      expect(popoverOpenState.get(layer)).toBe(false);
+    });
+    expect(onDialogOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('consumes the press before it reaches the dialog element', async () => {
+    const {trigger} = await renderNested();
+    const hostDialog = document.querySelector('dialog')!;
+    const reachedDialog = vi.fn();
+    hostDialog.addEventListener('keydown', reachedDialog);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    trigger.dispatchEvent(event);
+
+    hostDialog.removeEventListener('keydown', reachedDialog);
+    // Stopping propagation from a React handler is too late: React dispatches
+    // at the root container, above the dialog element whose own listener has
+    // already run. The press has to be claimed natively at the trigger.
+    expect(reachedDialog).not.toHaveBeenCalled();
+    // An un-consumed Escape also becomes a browser close request, which fires
+    // `cancel` on the dialog behind the tip.
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('leaves Escape alone when no tooltip is showing', async () => {
+    const onDialogOpenChange = vi.fn();
+    render(
+      <Dialog isOpen onOpenChange={onDialogOpenChange} aria-label="Host dialog">
+        <InfoTip content="Helpful context" />
+      </Dialog>,
+    );
+    const trigger = screen.getByRole('button', {name: 'More information'});
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    trigger.dispatchEvent(event);
+
+    // Nothing was dismissed, so the press belongs to the Dialog.
+    expect(onDialogOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/lab/src/InfoTip/InfoTip.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.tsx
@@ -14,7 +14,7 @@
  * - /packages/lab/src/InfoTip/index.ts (exports if types change)
  */
 
-import {useCallback, useRef, useState, type ReactNode} from 'react';
+import {useCallback, useEffect, useRef, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import {Icon, type IconSize} from '@astryxdesign/core/Icon';
@@ -111,17 +111,34 @@ export function InfoTip({
     isOpenRef.current = isOpen;
   }, []);
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (event.key === 'Escape' && isOpenRef.current) {
-        // Only swallow Escape when it actually dismissed the tooltip, so an
-        // enclosing dialog still closes on the next press.
-        event.stopPropagation();
-        setIsDismissed(true);
+  // Escape dismissal is claimed with a native listener on the trigger, not a
+  // React `onKeyDown`. React dispatches synthetic events at the root container,
+  // by which point an enclosing dialog's own element-level listener has already
+  // run and closed it, and the browser has already taken the un-consumed press
+  // as a close request for the layer behind — so one press dismissed both the
+  // tip and the dialog hosting it (#5168). Only presses that actually dismiss a
+  // showing tooltip are claimed; otherwise the press belongs to the layer
+  // behind, and is left alone.
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || !isOpenRef.current) {
+        return;
       }
-    },
-    [],
-  );
+      event.preventDefault();
+      event.stopPropagation();
+      setIsDismissed(true);
+    };
+
+    trigger.addEventListener('keydown', handleKeyDown);
+    return () => trigger.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
   const handleReset = useCallback(() => {
     setIsDismissed(false);
@@ -133,9 +150,9 @@ export function InfoTip({
       isOpen={isDismissed ? false : undefined}
       onOpenChange={handleOpenChange}>
       <button
+        ref={triggerRef}
         type="button"
         aria-label={label}
-        onKeyDown={handleKeyDown}
         onBlur={handleReset}
         onMouseLeave={handleReset}
         {...stylex.props(focusOutlineStyles.focusVisible, styles.trigger)}>


### PR DESCRIPTION
Fixes #5168.

## What this does

One press of Escape now closes the thing you actually have open on top — a Lightbox, the mobile navigation drawer, or a lab InfoTip — instead of closing the window sitting behind it.

## Why

Open a photo viewer from inside a dialog and press Escape: the dialog disappeared and the photo viewer stayed on screen. Same with the mobile nav. With an InfoTip, the little help bubble *and* the dialog both closed at once. Each of those leaves you somewhere you didn't ask to be — and for keyboard-only users, Escape is the main way out of a layer.

## What changed

- **Lightbox** and **MobileNav** now take the Escape press for themselves, so it never reaches the dialog behind them.
- **InfoTip** (lab) takes the press only when a tip is actually showing; otherwise Escape belongs to whatever is behind it.
- All three still step aside for a menu or popover opened on top of them — that layer still wins the press.
- 13 new tests, one changeset.

## How to see it

Open a Dialog; from inside it open a Lightbox (or a MobileNav, or focus an InfoTip until the tip shows). Press Escape once — only the inner layer should close.

Measured in Chromium 149 against a Storybook harness, one press per row:

| Layer | Before | After |
| --- | --- | --- |
| Lightbox over Dialog | dialog closed, lightbox stayed open | only the Lightbox closes |
| MobileNav over Dialog | dialog closed, nav stayed open | only the nav closes |
| InfoTip in Dialog | both closed | only the tip closes |

No pixels change, so there are no before/after screenshots — the whole difference is what one key press does.

## Under the hood, for reviewers

All three render inside the host Dialog's DOM subtree, and Dialog listens for `keydown` on its own `<dialog>` element. An unclaimed press bubbles from the inner layer straight into that listener, which closes the Dialog and calls `preventDefault()` — consuming the browser's close request, so the close request that would have dismissed the inner layer never arrives. InfoTip stopped propagation from a React `onKeyDown`, which React dispatches at the root container, above the dialog element whose listener has already run; both layers closed.

Lightbox and MobileNav now attach a `keydown` listener to their own `<dialog>` and consume Escape there — the same shape Dialog already uses, including its `hasActiveFocusTrapEscape()` gate. Their `cancel` handlers gain the same gate, for the case where a trapped layer let the press through and the browser aims its close request at the top-most dialog. InfoTip swaps its React handler for a native listener on the trigger.

## Notes

- Deliberately per-component, and it touches **none** of the files in #4881 (the shared dismissal stack). When that lands and collapses `Dialog`, `useFocusTrap`, `usePopover`, `useTooltip` and `useHoverCard` into `useLayerDismissal`, these three should register with it. What's here is the "or at minimum" gate the issue names, and it fixes `main` today.
- `packages/core/src/MobileNav/MobileNav.test.tsx` is prettier-dirty on `main`. The edit itself is purely additive; the three reformatted `<MobileNav>` blocks in the diff came from the repo's own lint-staged hook at commit time.
- `pnpm lint:strict` 0 errors, `pnpm build` green for core and lab. Full suite 10,669 passing — the 2 failures in `packages/cli` are the pre-existing macOS case-insensitive-filesystem tests, reproduced on a clean tree.
