### PR TITLE
feat(core): give StatusDot the same colour variants Badge exposes

### DIFF
--- a/.changeset/statusdot-hue-variants.md
+++ b/.changeset/statusdot-hue-variants.md
@@ -1,0 +1,24 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[feat] StatusDot: the nine hue variants — `blue`, `cyan`, `green`, `orange`, `pink`, `purple`, `red`, `teal`, `yellow`
+
+The dot had the five sentiment variants and nothing else, so a consumer
+colouring dots by category rather than by health — a legend key, a project
+colour, a tab strip's per-section marker — had no variant to reach for and
+fell back to overriding the fill. `Badge` already carries exactly this set
+under exactly these names; the dot now matches it, so the two agree when they
+sit in the same row.
+
+The dot paints from the solid `--color-text-<hue>` stop, not the
+`--color-background-<hue>` wash `Badge` fills its pill with: the wash is 20%
+alpha, and on an 8px shape it lands at 1.2–1.5:1 against the page instead of
+the ≥8.3:1 the solid stop holds in both colour schemes. A user-supplied `icon`
+paints from the surface as ink, the same pairing `neutral` already uses,
+measured at ≥8.3:1 on every hue in both schemes.
+
+No new tokens, and no change to the five existing variants.
+
+@cixzhang

--- a/apps/storybook/stories/StatusDot.stories.tsx
+++ b/apps/storybook/stories/StatusDot.stories.tsx
@@ -3,6 +3,18 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {StatusDot} from '@astryxdesign/core/StatusDot';
 
+const HUES = [
+  'blue',
+  'cyan',
+  'green',
+  'orange',
+  'pink',
+  'purple',
+  'red',
+  'teal',
+  'yellow',
+] as const;
+
 const meta: Meta<typeof StatusDot> = {
   title: 'Core/StatusDot',
   component: StatusDot,
@@ -10,8 +22,8 @@ const meta: Meta<typeof StatusDot> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['success', 'warning', 'error', 'accent', 'neutral'],
-      description: 'Semantic color variant',
+      options: ['success', 'warning', 'error', 'accent', 'neutral', ...HUES],
+      description: 'Colour variant — five semantic, nine hues',
     },
     label: {
       control: 'text',
@@ -46,6 +58,24 @@ export const Variants: Story = {
       <StatusDot variant="error" label="Negative" />
       <StatusDot variant="accent" label="Info" />
       <StatusDot variant="neutral" label="Neutral" />
+    </div>
+  ),
+};
+
+export const Hues: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The nine non-semantic hues, the same set `Badge` exposes. They carry no built-in meaning — use them to categorise, and keep the semantic variants for status.',
+      },
+    },
+  },
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+      {HUES.map(hue => (
+        <StatusDot key={hue} variant={hue} label={hue} />
+      ))}
     </div>
   ),
 };
@@ -132,6 +162,7 @@ export const WithIcon: Story = {
     <div style={{display: 'flex', gap: '24px', alignItems: 'center'}}>
       <StatusDot variant="success" label="Verified" icon={<DiamondIcon />} />
       <StatusDot variant="accent" label="Featured" icon={<DiamondIcon />} />
+      <StatusDot variant="purple" label="Design" icon={<DiamondIcon />} />
       <span style={{fontSize: '11px'}}>icon carries the status as a shape</span>
     </div>
   ),

--- a/packages/cli/assets/templates/blocks/components/StatusDot/StatusDotVariants.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/StatusDot/StatusDotVariants.doc.mjs
@@ -6,9 +6,10 @@ export const doc = {
   exampleFor: 'StatusDot',
   name: 'StatusDot — Variants',
   displayName: 'StatusDot — Variants',
-  description: 'All five semantic color variants displayed in a row.',
+  description:
+    'The five semantic color variants, with the nine non-semantic hues below them.',
   isReady: true,
   aspectRatio: 16 / 9,
   scale: 1,
-  componentsUsed: ['StatusDot', 'HStack'],
+  componentsUsed: ['StatusDot', 'HStack', 'VStack'],
 };

--- a/packages/cli/assets/templates/blocks/components/StatusDot/StatusDotVariants.tsx
+++ b/packages/cli/assets/templates/blocks/components/StatusDot/StatusDotVariants.tsx
@@ -3,16 +3,35 @@
 'use client';
 
 import {StatusDot} from '@astryxdesign/core/StatusDot';
-import {HStack} from '@astryxdesign/core/Layout';
+import {HStack, VStack} from '@astryxdesign/core/Layout';
+
+const HUES = [
+  'blue',
+  'cyan',
+  'green',
+  'orange',
+  'pink',
+  'purple',
+  'red',
+  'teal',
+  'yellow',
+] as const;
 
 export default function StatusDotVariants() {
   return (
-    <HStack gap={2} vAlign="center">
-      <StatusDot variant="success" label="Positive" />
-      <StatusDot variant="warning" label="Warning" />
-      <StatusDot variant="error" label="Negative" />
-      <StatusDot variant="accent" label="Info" />
-      <StatusDot variant="neutral" label="Neutral" />
-    </HStack>
+    <VStack gap={3}>
+      <HStack gap={2} vAlign="center">
+        <StatusDot variant="success" label="Positive" />
+        <StatusDot variant="warning" label="Warning" />
+        <StatusDot variant="error" label="Negative" />
+        <StatusDot variant="accent" label="Info" />
+        <StatusDot variant="neutral" label="Neutral" />
+      </HStack>
+      <HStack gap={2} vAlign="center">
+        {HUES.map(hue => (
+          <StatusDot key={hue} variant={hue} label={hue} />
+        ))}
+      </HStack>
+    </VStack>
   );
 }

--- a/packages/core/src/StatusDot/StatusDot.doc.mjs
+++ b/packages/core/src/StatusDot/StatusDot.doc.mjs
@@ -10,8 +10,9 @@ export const docs = {
   props: [
     {
       name: 'variant',
-      type: "'success' | 'warning' | 'error' | 'accent' | 'neutral'",
-      description: 'Semantic color variant.',
+      type: "'success' | 'warning' | 'error' | 'accent' | 'neutral' | 'blue' | 'cyan' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'",
+      description:
+        'Color variant. Five semantic (success, warning, error, accent, neutral) plus nine non-semantic hues for categorization, the same set Badge exposes.',
       required: true,
     },
     {
@@ -53,7 +54,7 @@ export const docs = {
   },
   usage: {
     description:
-      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
+      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants, nine non-semantic hues for categorization, and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
       { guidance: true, description: 'Use StatusDot as a binary present/absent signal; avoid encoding many distinct states in a single dot, since color and size alone cannot reliably distinguish them.' },
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
@@ -61,6 +62,7 @@ export const docs = {
       { guidance: true, description: 'Pair the dot with an icon that carries the status as a distinct shape when it must stand on its own without adjacent text, so meaning survives without color.' },
       { guidance: true, description: 'If you can\'t add a label or an icon, make sure the status is conveyed elsewhere accessibly (e.g. adjacent text, a table column, or a live region).' },
       { guidance: false, description: 'Rely on color alone to communicate status; StatusDot is not fully accessible in isolation, so the builder must make the status distinguishable in context via a label, an icon, or an accessible alternative.' },
+      { guidance: true, description: 'Reach for a hue variant only when the dot categorizes (a project color, a legend key); keep the semantic variants for reporting health.' },
       { guidance: false, description: 'Use the pulse animation for purely decorative purposes; reserve it for states that require immediate attention.' },
     ],
   },
@@ -73,8 +75,9 @@ export const docsZh = {
   props: [
     {
       name: 'variant',
-      type: "'success' | 'warning' | 'error' | 'accent' | 'neutral'",
-      description: '语义颜色变体。',
+      type: "'success' | 'warning' | 'error' | 'accent' | 'neutral' | 'blue' | 'cyan' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'",
+      description:
+        '颜色变体。五个语义变体（success、warning、error、accent、neutral），外加九个用于分类的非语义色相，与 Badge 提供的集合相同。',
       required: true,
     },
     {
@@ -110,7 +113,7 @@ export const docsZh = {
   },
   usage: {
     description:
-      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
+      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants, nine non-semantic hues for categorization, and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
       { guidance: true, description: 'Use StatusDot as a binary present/absent signal; avoid encoding many distinct states in a single dot, since color and size alone cannot reliably distinguish them.' },
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
@@ -118,6 +121,7 @@ export const docsZh = {
       { guidance: true, description: 'Pair the dot with an icon that carries the status as a distinct shape when it must stand on its own without adjacent text, so meaning survives without color.' },
       { guidance: true, description: 'If you can\'t add a label or an icon, make sure the status is conveyed elsewhere accessibly (e.g. adjacent text, a table column, or a live region).' },
       { guidance: false, description: 'Rely on color alone to communicate status; StatusDot is not fully accessible in isolation, so the builder must make the status distinguishable in context via a label, an icon, or an accessible alternative.' },
+      { guidance: true, description: 'Reach for a hue variant only when the dot categorizes (a project color, a legend key); keep the semantic variants for reporting health.' },
       { guidance: false, description: 'Use the pulse animation for purely decorative purposes; reserve it for states that require immediate attention.' },
     ],
   },
@@ -128,7 +132,7 @@ export const docsDense = {
   description: 'Small colored dot indicator for status display (online/offline, severity, etc).',
   usage: {
     description:
-      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
+      'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants, nine non-semantic hues for categorization, and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
       { guidance: true, description: 'Use StatusDot as a binary present/absent signal; avoid encoding many distinct states in a single dot, since color and size alone cannot reliably distinguish them.' },
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
@@ -136,11 +140,12 @@ export const docsDense = {
       { guidance: true, description: 'Pair the dot with an icon that carries the status as a distinct shape when it must stand on its own without adjacent text, so meaning survives without color.' },
       { guidance: true, description: 'If you can\'t add a label or an icon, make sure the status is conveyed elsewhere accessibly (e.g. adjacent text, a table column, or a live region).' },
       { guidance: false, description: 'Rely on color alone to communicate status; StatusDot is not fully accessible in isolation, so the builder must make the status distinguishable in context via a label, an icon, or an accessible alternative.' },
+      { guidance: true, description: 'Reach for a hue variant only when the dot categorizes (a project color, a legend key); keep the semantic variants for reporting health.' },
       { guidance: false, description: 'Use the pulse animation for purely decorative purposes; reserve it for states that require immediate attention.' },
     ],
   },
   propDescriptions: {
-    variant: 'Semantic color variant.',
+    variant: 'Color variant: five semantic plus nine non-semantic hues (same set as Badge).',
     label: 'Accessible label via aria-label.',
     isPulsing: 'Pulse animation; respects prefers-reduced-motion: reduce.',
     tooltip: 'Tooltip text on hover to explain status meaning.',

--- a/packages/core/src/StatusDot/StatusDot.test.tsx
+++ b/packages/core/src/StatusDot/StatusDot.test.tsx
@@ -6,6 +6,28 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {StatusDot} from './StatusDot';
 
+const SEMANTIC_VARIANTS = [
+  'success',
+  'warning',
+  'error',
+  'accent',
+  'neutral',
+] as const;
+
+const HUE_VARIANTS = [
+  'blue',
+  'cyan',
+  'green',
+  'orange',
+  'pink',
+  'purple',
+  'red',
+  'teal',
+  'yellow',
+] as const;
+
+const ALL_VARIANTS = [...SEMANTIC_VARIANTS, ...HUE_VARIANTS];
+
 /** Renders a StatusDot and returns its root element. */
 function renderDot(props: React.ComponentProps<typeof StatusDot>) {
   render(<StatusDot {...props} />);
@@ -26,15 +48,7 @@ describe('StatusDot', () => {
   });
 
   it('renders with all variant types', () => {
-    const variants = [
-      'success',
-      'warning',
-      'error',
-      'accent',
-      'neutral',
-    ] as const;
-
-    for (const variant of variants) {
+    for (const variant of ALL_VARIANTS) {
       const {unmount} = render(<StatusDot variant={variant} label={variant} />);
       expect(screen.getByRole('img', {name: variant})).toBeInTheDocument();
       unmount();
@@ -89,14 +103,7 @@ describe('StatusDot', () => {
     // per-variant glyph. Making the status accessible in context (label,
     // icon, or an accessible alternative) is the builder's responsibility;
     // see the usage guidance.
-    const variants = [
-      'success',
-      'warning',
-      'error',
-      'accent',
-      'neutral',
-    ] as const;
-    for (const variant of variants) {
+    for (const variant of ALL_VARIANTS) {
       const dot = renderDot({variant, label: `plain-${variant}`});
       expect(dot.childElementCount, variant).toBe(0);
     }
@@ -165,18 +172,71 @@ describe('StatusDot', () => {
         expect(dot.className).toContain(cls);
       }
     });
+
+    // StyleX resolves token keys at build time, so the expected pairing is
+    // spelled out per hue rather than indexed by name.
+    const huePlates = stylex.create({
+      blue: {
+        backgroundColor: colorVars['--color-text-blue'],
+        color: colorVars['--color-background-surface'],
+      },
+      cyan: {
+        backgroundColor: colorVars['--color-text-cyan'],
+        color: colorVars['--color-background-surface'],
+      },
+      green: {
+        backgroundColor: colorVars['--color-text-green'],
+        color: colorVars['--color-background-surface'],
+      },
+      orange: {
+        backgroundColor: colorVars['--color-text-orange'],
+        color: colorVars['--color-background-surface'],
+      },
+      pink: {
+        backgroundColor: colorVars['--color-text-pink'],
+        color: colorVars['--color-background-surface'],
+      },
+      purple: {
+        backgroundColor: colorVars['--color-text-purple'],
+        color: colorVars['--color-background-surface'],
+      },
+      red: {
+        backgroundColor: colorVars['--color-text-red'],
+        color: colorVars['--color-background-surface'],
+      },
+      teal: {
+        backgroundColor: colorVars['--color-text-teal'],
+        color: colorVars['--color-background-surface'],
+      },
+      yellow: {
+        backgroundColor: colorVars['--color-text-yellow'],
+        color: colorVars['--color-background-surface'],
+      },
+    });
+
+    it.each(HUE_VARIANTS)(
+      'paints the %s hue from its solid text stop, with the surface as ink',
+      hue => {
+        // The hues have no `--color-on-*` pairing, so they take neutral's
+        // shape. The regression this guards: Badge's `--color-background-*`
+        // wash is 20% alpha, which on an 8px dot lands at 1.2-1.5:1 against
+        // the page instead of the >=8.3:1 the solid stop holds in both
+        // schemes.
+        const dot = renderDot({variant: hue, label: hue});
+        const atomicClasses = (stylex.props(huePlates[hue]).className ?? '')
+          .split(' ')
+          .filter(cls => !cls.includes('__'));
+        expect(atomicClasses.length).toBeGreaterThan(0);
+        for (const cls of atomicClasses) {
+          expect(dot.className).toContain(cls);
+        }
+      },
+    );
   });
 
   describe('accessible name (label reaches AT without hover)', () => {
     it('exposes the status label as the accessible name for every variant, without a tooltip', () => {
-      const variants = [
-        'success',
-        'warning',
-        'error',
-        'accent',
-        'neutral',
-      ] as const;
-      for (const variant of variants) {
+      for (const variant of ALL_VARIANTS) {
         const {unmount} = render(
           <StatusDot variant={variant} label={`Status: ${variant}`} />,
         );

--- a/packages/core/src/StatusDot/StatusDot.tsx
+++ b/packages/core/src/StatusDot/StatusDot.tsx
@@ -84,6 +84,16 @@ const styles = stylex.create({
  * colour: on-warning is a fixed dark ink, which keeps an icon legible on the
  * yellow plate (~9.6:1) where a light surface ink lands near 2:1. Neutral has
  * no `--color-on-*` token; its mid-grey plate takes the surface ink.
+ *
+ * The nine hues (Badge's non-semantic set) have no `--color-on-*` pairing
+ * either, so they take neutral's shape: a foreground-ramp plate with the
+ * surface as ink. `--color-text-<hue>` is the stop that flips polarity with
+ * the colour scheme, so both contrasts hold in light and dark — plate against
+ * the page ≥8.3:1, surface ink on the plate the same ≥8.3:1 (worst case
+ * purple, dark). The other two stops fail an 8px dot: the
+ * `--color-background-<hue>` wash Badge fills its pill with is 20% alpha and
+ * lands at 1.2–1.5:1 on the page, and mid-tone `--color-icon-<hue>` misses
+ * the 3:1 non-text bar in light mode for yellow (1.7:1) and cyan (2.7:1).
  */
 const variants = stylex.create({
   success: {
@@ -106,6 +116,42 @@ const variants = stylex.create({
     backgroundColor: colorVars['--color-icon-secondary'],
     color: colorVars['--color-background-surface'],
   },
+  blue: {
+    backgroundColor: colorVars['--color-text-blue'],
+    color: colorVars['--color-background-surface'],
+  },
+  cyan: {
+    backgroundColor: colorVars['--color-text-cyan'],
+    color: colorVars['--color-background-surface'],
+  },
+  green: {
+    backgroundColor: colorVars['--color-text-green'],
+    color: colorVars['--color-background-surface'],
+  },
+  orange: {
+    backgroundColor: colorVars['--color-text-orange'],
+    color: colorVars['--color-background-surface'],
+  },
+  pink: {
+    backgroundColor: colorVars['--color-text-pink'],
+    color: colorVars['--color-background-surface'],
+  },
+  purple: {
+    backgroundColor: colorVars['--color-text-purple'],
+    color: colorVars['--color-background-surface'],
+  },
+  red: {
+    backgroundColor: colorVars['--color-text-red'],
+    color: colorVars['--color-background-surface'],
+  },
+  teal: {
+    backgroundColor: colorVars['--color-text-teal'],
+    color: colorVars['--color-background-surface'],
+  },
+  yellow: {
+    backgroundColor: colorVars['--color-text-yellow'],
+    color: colorVars['--color-background-surface'],
+  },
 });
 
 /**
@@ -118,7 +164,10 @@ export interface StatusDotProps extends BaseProps<HTMLSpanElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLSpanElement>;
   /**
-   * The semantic color variant.
+   * The colour variant. Five are semantic (`success`, `warning`, `error`,
+   * `accent`, `neutral`); the nine hues (`blue`, `cyan`, `green`, `orange`,
+   * `pink`, `purple`, `red`, `teal`, `yellow`) carry no built-in meaning and
+   * are for categorising — the same set, under the same names, as `Badge`.
    */
   variant: StatusDotVariant;
   /**
@@ -177,6 +226,7 @@ export interface StatusDotProps extends BaseProps<HTMLSpanElement> {
  * <StatusDot variant="success" label="Live" isPulsing />
  * <StatusDot variant="success" label="Online" tooltip="Online" />
  * <StatusDot variant="success" label="Verified" icon={<CheckIcon />} />
+ * <StatusDot variant="purple" label="Design" />
  * ```
  */
 export function StatusDot({

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -28,6 +28,15 @@ export interface StatusDotVariantMap {
   error: true;
   accent: true;
   neutral: true;
+  blue: true;
+  cyan: true;
+  green: true;
+  orange: true;
+  pink: true;
+  purple: true;
+  red: true;
+  teal: true;
+  yellow: true;
 }
 
 export {StatusDot} from './StatusDot';


### PR DESCRIPTION
> **Draft — not mergeable as it stands.** The implementation is complete and
> green, but measurement across the bundled themes found the fill it depends on
> is not safe in three of them. The numbers are below; the design question they
> raise is the reason this is still a draft.

## Why

`StatusDot` has the five sentiment variants and nothing else. A consumer
colouring dots by **category** rather than by health — a legend key, a project
colour, a per-section marker in a tab strip — has no variant to reach for, and
ends up overriding the fill from outside the component.

`Badge` already carries a nine-hue non-semantic set for exactly this. This adds
the same set to the dot, under the same names, so the two agree when they sit
in the same row.

## What

`blue`, `cyan`, `green`, `orange`, `pink`, `purple`, `red`, `teal`, `yellow` —
added to `StatusDotVariantMap`, so they widen `StatusDotVariant` and stay
augmentable. The five existing variants are untouched and **no tokens were
added**.

Each hue paints from the solid `--color-text-<hue>` stop, with the surface
colour as ink for a passed `icon` — the pairing `neutral` already uses.

## The blocker

An 8px dot is a filled shape: it needs 3:1 against the page (WCAG 2.1 SC
1.4.11). The hue ramp has four stops and **none of them is a fill**. Measured
in Chromium, against the surface the dot sits on:

| Stop | Fails at 3:1 in |
|---|---|
| `--color-background-<hue>` (20% wash) | almost everywhere — 1.2–1.5:1 at this size |
| `--color-border-<hue>` | five theme/scheme pairs, all nine hues |
| `--color-icon-<hue>` | light mode of four themes |
| `--color-text-<hue>` (what this PR uses) | three themes, all nine hues |

The last row is the one that matters. It holds where the ramp flips polarity
with the colour scheme:

| Theme | sentiment variants (min) | hues (min) |
|---|---|---|
| neutral light | 4.74:1 | 8.83:1 |
| neutral dark | 6.00:1 | 10.14:1 |
| y2k dark | 7.91:1 | **1.06:1** |
| butter dark | 6.81:1 | **1.40:1** |
| gothic (dark only) | 7.03:1 | **1.37:1** |

Those three themes tune the hue ramp to the contract `Badge` relies on — the
wash is the plate, `--color-text-<hue>` is ink *on that plate* — and they do
not flip it per scheme, because they only have the one. So the stop that reads
as a fill in the base tokens reads as ink-on-dark there, and the dot
disappears. The sentiment variants are fine in the same themes, so this is not
the pre-existing "warning is 1.5:1 in neutral light" problem — the hues would
be materially worse than what the component ships today.

## The question this raises

Every stop in the hue ramp is defined against something *else* — a wash to sit
on, a page to be read on, a plate to be inked onto. There is no per-hue value
whose contract is "the hue as a fill that reads against the page", which is
what a dot needs and what a theme author would have to supply.

That leaves three options, and picking one is a system-level call rather than a
component one:

1. **Give the ramp a fill stop.** Solves it once for every consumer of a hue as
   a shape, not just this dot.
2. **Make every theme own its dots.** `.astryx-statusdot` already carries
   `data-variant`, so a theme *can* fix this — but the three bundled themes
   would each need a nine-entry block, and a third-party theme would break
   silently until someone noticed.
3. **Don't put the hues on the dot.** The categorical ramp stays a
   plate-and-ink ramp, and colouring a dot by category stays outside the
   component.

## Testing

`pnpm test`, typecheck and lint clean. New tests assert the plate/ink pairing
per hue against a StyleX probe; the existing per-variant tests now run over all
fourteen. Every variant was rendered in Chromium in both schemes, plain and
with an icon, and re-measured under each bundled theme — that is where the
blocker above came from.
