### PR TITLE
fix(core): let the Bottom Sheet be dragged up from its scroll area on iOS

### DIFF
--- a/.changeset/bottom-sheet-ios-pointer-id-collision.md
+++ b/.changeset/bottom-sheet-ios-pointer-id-collision.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BottomSheet: a pull up from the scroll area now expands the sheet on iOS. Below the tallest detent, dragging up inside the content did nothing on a real device while the grab handle worked — the sheet took the gesture and then froze for the rest of the pull. iOS Safari raises PointerEvents for a finger under the same numeric id it puts in `Touch.identifier`, so the drag the touch path started was keyed to a live pointer: `beginDrag` captured that pointer, WebKit handed the capture straight back, and the `lostpointercapture` a millisecond later cancelled the drag. Touch-driven drags are now marked as such — they take no pointer capture, and `lostpointercapture`, `pointercancel` and `pointermove` for that same finger no longer cancel, end or double-drive them. Browsers that keep the two id spaces apart were never affected, which is why this only showed up on device.
+
+@imdreamrunner

--- a/packages/core/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/core/src/BottomSheet/useSheetGestures.test.ts
@@ -726,6 +726,51 @@ describe('useSheetGestures', () => {
       return el;
     }
 
+    // iOS Safari raises PointerEvents for a finger under the SAME numeric id
+    // it puts in `Touch.identifier`, so a drag the touch path starts is keyed
+    // to a live pointer. WebKit takes that pointer's capture straight back,
+    // and the `lostpointercapture` that follows used to cancel the drag one
+    // event after it began — leaving the sheet inert for the rest of the pull
+    // while the handle still worked. Every browser that keeps the two id
+    // spaces apart hides this, which is why it only showed up on device.
+    it('survives a lostpointercapture for the finger driving it', () => {
+      const {hook} = setup({snapHeights: () => [200]});
+      const el = midDetentScroller(hook, 600); // parked at the content end
+      act(() => {
+        touch(el, 'touchstart', 500, 7);
+        touch(el, 'touchmove', 450, 7); // promotes at the armed bottom edge
+      });
+      expect(hook.result.current.isDragging).toBe(true);
+      act(() => {
+        hook.result.current.bodyProps.onLostPointerCapture(
+          pointerEvent(450, 0, el, 7), // same id as the touch: iOS does this
+        );
+      });
+      expect(hook.result.current.isDragging).toBe(true);
+      act(() => {
+        touch(el, 'touchmove', 400, 7);
+      });
+      // 100px of pull past the touchstart, from the 200px detent.
+      expect(hook.result.current.dragOffset).toBe(100);
+    });
+
+    // `pointercancel` for that same finger arrives the moment WebKit claims
+    // the gesture. Ending the drag on it settles the sheet mid-pull.
+    it('does not end the touch drag on a pointercancel for that finger', () => {
+      const {hook} = setup({snapHeights: () => [200]});
+      const el = midDetentScroller(hook, 600);
+      act(() => {
+        touch(el, 'touchstart', 500, 7);
+        touch(el, 'touchmove', 450, 7);
+      });
+      act(() => {
+        hook.result.current.bodyProps.onPointerCancel(
+          pointerEvent(450, 0, el, 7),
+        );
+      });
+      expect(hook.result.current.isDragging).toBe(true);
+    });
+
     it('hands off when the content runs out under a moving finger', () => {
       const {hook} = setup({snapHeights: () => [200]});
       const el = midDetentScroller(hook, 300); // finger lands mid-content

--- a/packages/core/src/BottomSheet/useSheetGestures.ts
+++ b/packages/core/src/BottomSheet/useSheetGestures.ts
@@ -82,6 +82,19 @@ const DISMISS_OVERSHOOT_RATIO = 0.4;
 // Within this many px of a detent, the live drag is magnetically eased toward
 // it so it "clicks" into place instead of hovering just off the mark.
 const MAGNET_RANGE = 40;
+// The touch path drives the sheet through the same machinery the pointer path
+// uses, by handing it a pointer-shaped object built from a `Touch`. On iOS
+// Safari that object is indistinguishable from the real thing: WebKit raises
+// PointerEvents for a finger under the SAME numeric id it puts in
+// `Touch.identifier`, so such a drag is keyed to a live pointer and the
+// handlers that guard a mouse drag fire against it. Mark the synthetic object
+// so they can tell the two apart.
+type SyntheticTouchPointer = ReactPointerEvent & {syntheticTouch?: true};
+
+function isSyntheticTouch(event: ReactPointerEvent): boolean {
+  return (event as SyntheticTouchPointer).syntheticTouch === true;
+}
+
 // Rubber-band factor for dragging up past fully-open, capped at OVERSCROLL_MAX
 // (the sheet reserves that much bottom padding for the lift to reveal).
 const OVERSCROLL_RESISTANCE = 0.35;
@@ -434,6 +447,10 @@ export function useSheetGestures({
 
   // Live drag bookkeeping (refs so pointermove doesn't churn renders).
   const dragStateRef = useRef<{
+    // Whether the touch path drives this drag. Such a drag holds no pointer
+    // capture and takes its events from `touchmove`, so every real-pointer
+    // handler has to leave it alone.
+    syntheticTouch: boolean;
     pointerId: number;
     startCoord: number;
     lastCoord: number;
@@ -855,7 +872,16 @@ export function useSheetGestures({
   const beginDrag = useCallback(
     (event: ReactPointerEvent, sheetHeight: number, startCoord?: number) => {
       const target = event.currentTarget as HTMLElement;
-      target.setPointerCapture?.(event.pointerId);
+      const syntheticTouch = isSyntheticTouch(event);
+      // Never capture for a touch drag. The id came from `Touch.identifier`,
+      // which on iOS names a live pointer: the capture succeeds, WebKit takes
+      // it straight back for its own gesture handling, and the
+      // `lostpointercapture` a millisecond later cancels the drag that just
+      // started. Touch drags need no capture — the listener is on the
+      // scroller itself.
+      if (!syntheticTouch) {
+        target.setPointerCapture?.(event.pointerId);
+      }
       // `startCoord` lets a body-overscroll drag anchor at the original
       // pointer-down position (not the promotion point), so the first frame's
       // delta reflects the full pull distance.
@@ -863,6 +889,7 @@ export function useSheetGestures({
       const naturalEndGap = naturalEndGapFor(bodyNodeRef.current);
       const baseLayoutOffset = settledLayoutOffsetRef.current;
       dragStateRef.current = {
+        syntheticTouch,
         pointerId: event.pointerId,
         startCoord: start,
         lastCoord: event.clientY,
@@ -917,6 +944,12 @@ export function useSheetGestures({
 
   const handleLostPointerCapture = useCallback(
     (event: ReactPointerEvent) => {
+      // A touch drag never took capture, so this is WebKit reclaiming its own
+      // pointer for the finger doing the dragging — not the drag losing its
+      // grip.
+      if (dragStateRef.current?.syntheticTouch) {
+        return;
+      }
       if (dragStateRef.current?.pointerId === event.pointerId) {
         cancelDrag();
       }
@@ -928,6 +961,11 @@ export function useSheetGestures({
     (event: ReactPointerEvent) => {
       const state = dragStateRef.current;
       if (!state || state.pointerId !== event.pointerId) {
+        return;
+      }
+      // Same finger, real pointer event: the touch path already drove this
+      // move. Let it own the drag rather than driving it twice.
+      if (state.syntheticTouch && !isSyntheticTouch(event)) {
         return;
       }
       const delta = event.clientY - state.startCoord;
@@ -991,12 +1029,20 @@ export function useSheetGestures({
       if (!state || state.pointerId !== event.pointerId) {
         return;
       }
+      // `pointercancel` fires for the finger the moment WebKit claims the
+      // gesture; ending a touch drag on it settles the sheet mid-pull. The
+      // touchend handler is what finishes a touch drag.
+      if (state.syntheticTouch && !isSyntheticTouch(event)) {
+        return;
+      }
       const target = event.currentTarget as HTMLElement;
       const delta = event.clientY - state.startCoord;
       const offset = Math.max(0, state.baseOffset + delta);
       const dir = delta === 0 ? 0 : delta > 0 ? 1 : -1;
       dragStateRef.current = null;
-      target.releasePointerCapture?.(event.pointerId);
+      if (!state.syntheticTouch) {
+        target.releasePointerCapture?.(event.pointerId);
+      }
       setIsDragging(false);
       settleFromDrag(
         offset,
@@ -1067,6 +1113,11 @@ export function useSheetGestures({
   const handleBodyEnd = useCallback(
     (event: ReactPointerEvent) => {
       armedBodyRef.current = null;
+      // The pointerup/pointercancel for a finger already driving a touch drag
+      // arrives here carrying that drag's own id; touchend ends those.
+      if (dragStateRef.current?.syntheticTouch) {
+        return;
+      }
       if (dragStateRef.current) {
         endDrag(event);
       }
@@ -1118,6 +1169,7 @@ export function useSheetGestures({
   const bodyRef = useCallback((node: HTMLElement | null) => {
     const asPointer = (touch: Touch, target: HTMLElement) =>
       ({
+        syntheticTouch: true,
         pointerId: touch.identifier,
         clientY: touch.clientY,
         timeStamp: Date.now(),


### PR DESCRIPTION
# fix(core): let the Bottom Sheet be dragged up from its scroll area on iOS

## The bug

With the sheet resting below its tallest detent, a pull up **inside the
scrolling content** does nothing on a real device. The grab handle drags the
same sheet perfectly. Reported as "I can drag up using the little bar, but I
can't drag up using the scroll area."

Not a gating or geometry problem — the sheet *does* take the gesture, and then
loses it one event later.

## Root cause: `Touch.identifier` and `PointerEvent.pointerId` are the same
number on iOS

The body's touch path drives the shared drag machinery by handing it a
pointer-shaped object built from a `Touch`. On WebKit the id it copies out of
`touch.identifier` **names a live pointer** — so the drag is keyed to a real
one, and the handlers that exist to protect a *mouse* drag fire against it.

Instrumented, one gesture on iOS 26.5 / Safari 26.5 (iPhone 17 Simulator),
`@astryxdesign/core@0.4.3-canary.00bed29`, sheet at the 0.5 detent, content
parked at its end:

```
touchstart                      y=638  scrollTop=271/271
touchmove #1  -> armed-edge promotion, preventDefault, beginDrag
  gotpointercapture   pointerId=-1239851261   <- the Touch.identifier, exactly
  setPointerCapture   has=true
  beginDrag           startCoord=638
  lostpointercapture  pointerId=-1239851261  dragId=-1239851261  willCancel=TRUE
  cancelDrag                                  <- 0 ms after the drag began
touchmove #2..#50               drag gone; the sheet ignores the rest of the pull
```

`beginDrag` calls `setPointerCapture(event.pointerId)`. Because that id is a
real pointer the capture *succeeds*; WebKit reclaims it immediately for its own
gesture handling; `handleLostPointerCapture` sees a matching id and cancels.
The promotion had already nulled `touchDragRef`, so nothing re-arms and the
remaining ~50 moves do nothing.

### Why nothing caught this

- **Chromium keeps the two id spaces apart** (small, separate sequences), so
  under DevTools touch emulation the synthetic id never matches a live pointer
  and no `lostpointercapture` ever arrives. Every scripted repro to date was
  Chromium.
- **The unit tests can't see it**: `makeTarget()` stubs
  `el.setPointerCapture = vi.fn()`, so capture never happens and jsdom never
  fires the cancelling event.
- **The handle keeps working** — it runs on real pointer events, which
  legitimately hold the capture.
- **The mid-gesture content-end handoff (#5172) usually survives** only by
  timing: it promotes *after* WebKit has already fired `pointercancel` +
  `lostpointercapture` for that finger at scroll commit, so there is no live
  capture left to lose. The armed-edge path promotes on the **first** move,
  while the pointer is still live, and loses the race every time.

## The fix

Mark the pointer-shaped objects the touch path synthesises, and keep
real-pointer handling off the drags they start:

- **No capture for a touch drag.** It is driven by `touchmove` on the scroller
  itself and never needed one.
- **`lostpointercapture` is ignored** for such a drag — it is WebKit reclaiming
  its own pointer, not the drag losing its grip.
- **`pointercancel` / `pointerup` for that finger no longer end it.** They
  arrive carrying the drag's own id; `touchend` is what finishes a touch drag.
  (Ending on `pointercancel` would settle the sheet mid-pull.)
- **A real `pointermove` for that finger no longer double-drives it.**

## Verification

New unit tests dispatch `onLostPointerCapture` and `onPointerCancel` with a
`pointerId` equal to the touch identifier — the collision, reproduced in jsdom.
Both **fail on `main`** (`expected false to be true`) and pass here, so CI holds
this without a device.

On an iPhone 17 Simulator (iOS 26.5), one continuous touch per case, sheet at
the 0.5 detent. Numbers are the scrolling body's height: 309 = mid detent,
395 = fully open. The "after" column is a build of this branch's source, not a
hand-patched bundle.

| case | before | after |
|---|---|---|
| fresh touch at the content end, pull up | 309 -> **309** (inert) | 309 -> **395** |
| scroll to the end mid-gesture, keep pulling (#5172) | 309 -> 395 | 309 -> 395 |
| top-edge pull-down in the body | 395 -> 309 | 395 -> 309 |
| ordinary mid-content scroll | scrolls, sheet still | unchanged |
| grab-handle drag | works | works |

Only the reported case changes.

`packages/core/src/BottomSheet` suite 163/163; `tsc --noEmit` clean;
`lint:strict` 0 errors.
