### PR TITLE
fix(NumberInput): track themed padding so the stepper column stays flush

### DIFF
--- a/.changeset/number-input-stepper-padding-var.md
+++ b/.changeset/number-input-stepper-padding-var.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] NumberInput: the number-stepper column now tracks a themed padding instead of assuming the default. Theming `number-input` padding used to leave the steppers short of the field edges (a gap top/bottom, or detached from the inline edge); the wrapper padding is now carried through private vars the steppers cancel against, and the stepper corners follow the themed field radius.
+[fix] NumberInput: the number-stepper column now tracks a themed padding and radius instead of assuming the defaults. Theming `number-input` padding left the steppers short of the field edges (a gap top and bottom), and a themed `borderRadius` rounded the field while the stepper corners kept the default radius. The wrapper's padding now goes through the shared container expansion, so it is picked up from any spelling a theme writes it in — `padding: 14px 20px`, `paddingBlock`, or a single `paddingBlockStart` — and both the wrapper and the column read the resulting per-side `--astryx-number-input-padding-*` tokens; an asymmetric `paddingBlock: 4px 12px` is cancelled correctly at each edge. A themed `number-input` borderRadius now also reaches `--_field-radius`, which the column's outer corners follow. Byte-identical by default, and inert for the no-stepper case and every other input.
 
 @freddymeta

--- a/.changeset/number-input-stepper-padding-var.md
+++ b/.changeset/number-input-stepper-padding-var.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] NumberInput: the number-stepper column now tracks a themed padding instead of assuming the default. Theming `number-input` padding used to leave the steppers short of the field edges (a gap top/bottom, or detached from the inline edge); the wrapper padding is now carried through private vars the steppers cancel against, and the stepper corners follow the themed field radius.
+
+@freddymeta

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -219,33 +219,18 @@ export const docs = {
         states: ['disabled', 'readonly'],
       },
     ],
-    vars: [
-      {
-        name: '--_number-input-padding-block',
-        description:
-          "Block padding of the input wrapper. The number-stepper column cancels it with a negative margin so it spans the field's full height; carrying it as a var keeps the steppers flush when a theme changes the padding.",
-        default: 'var(--spacing-1)',
-        private: true,
-      },
-      {
-        name: '--_number-input-padding-inline',
-        description:
-          'Inline padding of the input wrapper. Carried as a var so a themed padding tracks consistently; the stepper column still runs flush to the inline-end edge (its side keeps a zero end padding).',
-        default: 'var(--spacing-2)',
-        private: true,
-      },
-    ],
     derived: [
-      {
-        property: 'paddingBlock',
-        vars: ['--_number-input-padding-block'],
-        replaces: true,
-      },
-      {
-        property: 'paddingInline',
-        vars: ['--_number-input-padding-inline'],
-        replaces: true,
-      },
+      // `padding` in any spelling — the shorthand, `paddingBlock`, or a lone
+      // `paddingBlockStart` — is parsed by the shared container expansion and
+      // emitted as normalized per-side `--astryx-number-input-padding-*`
+      // tokens. The wrapper and the number-stepper column both read those, so
+      // the column stays flush with the field edges under a themed padding.
+      {property: 'padding', expand: 'container'},
+      // Scoped to this component's own subtree: the stepper column's outer
+      // corners follow the field radius, so a themed `number-input`
+      // borderRadius has to reach the var the column reads, not just the
+      // wrapper's own `border-radius`.
+      {property: 'borderRadius', vars: ['--_field-radius']},
     ],
   },
   usage: {
@@ -503,33 +488,16 @@ export const docsZh = {
         states: ['disabled', 'readonly'],
       },
     ],
-    vars: [
-      {
-        name: '--_number-input-padding-block',
-        description:
-          '输入框容器的块级内边距。数字步进器列通过负外边距抵消它，从而占满字段的完整高度；以变量承载它可在主题更改内边距时保持步进器齐平。',
-        default: 'var(--spacing-1)',
-        private: true,
-      },
-      {
-        name: '--_number-input-padding-inline',
-        description:
-          '输入框容器的行内内边距。以变量承载以便主题化内边距时保持一致；步进器列仍紧贴行内末端边缘（其末端内边距保持为零）。',
-        default: 'var(--spacing-2)',
-        private: true,
-      },
-    ],
     derived: [
-      {
-        property: 'paddingBlock',
-        vars: ['--_number-input-padding-block'],
-        replaces: true,
-      },
-      {
-        property: 'paddingInline',
-        vars: ['--_number-input-padding-inline'],
-        replaces: true,
-      },
+      // 任何写法的 `padding`（简写、`paddingBlock`，或单独的
+      // `paddingBlockStart`）都由共享的 container 展开解析，并输出为规范化的
+      // 每侧 `--astryx-number-input-padding-*` 令牌。容器与数字步进器列都读取
+      // 这些令牌，因此在主题化内边距下步进器仍与字段边缘齐平。
+      {property: 'padding', expand: 'container'},
+      // 作用域限于该组件自身的子树：步进器列的外角跟随字段圆角，因此主题化的
+      // `number-input` borderRadius 必须传到步进器读取的变量，而不只是容器
+      // 自身的 `border-radius`。
+      {property: 'borderRadius', vars: ['--_field-radius']},
     ],
   },
   usage: {

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -219,6 +219,34 @@ export const docs = {
         states: ['disabled', 'readonly'],
       },
     ],
+    vars: [
+      {
+        name: '--_number-input-padding-block',
+        description:
+          "Block padding of the input wrapper. The number-stepper column cancels it with a negative margin so it spans the field's full height; carrying it as a var keeps the steppers flush when a theme changes the padding.",
+        default: 'var(--spacing-1)',
+        private: true,
+      },
+      {
+        name: '--_number-input-padding-inline',
+        description:
+          'Inline padding of the input wrapper. Carried as a var so a themed padding tracks consistently; the stepper column still runs flush to the inline-end edge (its side keeps a zero end padding).',
+        default: 'var(--spacing-2)',
+        private: true,
+      },
+    ],
+    derived: [
+      {
+        property: 'paddingBlock',
+        vars: ['--_number-input-padding-block'],
+        replaces: true,
+      },
+      {
+        property: 'paddingInline',
+        vars: ['--_number-input-padding-inline'],
+        replaces: true,
+      },
+    ],
   },
   usage: {
     description:
@@ -473,6 +501,34 @@ export const docsZh = {
         className: 'astryx-number-input',
         visualProps: ['size', 'status'],
         states: ['disabled', 'readonly'],
+      },
+    ],
+    vars: [
+      {
+        name: '--_number-input-padding-block',
+        description:
+          '输入框容器的块级内边距。数字步进器列通过负外边距抵消它，从而占满字段的完整高度；以变量承载它可在主题更改内边距时保持步进器齐平。',
+        default: 'var(--spacing-1)',
+        private: true,
+      },
+      {
+        name: '--_number-input-padding-inline',
+        description:
+          '输入框容器的行内内边距。以变量承载以便主题化内边距时保持一致；步进器列仍紧贴行内末端边缘（其末端内边距保持为零）。',
+        default: 'var(--spacing-2)',
+        private: true,
+      },
+    ],
+    derived: [
+      {
+        property: 'paddingBlock',
+        vars: ['--_number-input-padding-block'],
+        replaces: true,
+      },
+      {
+        property: 'paddingInline',
+        vars: ['--_number-input-padding-inline'],
+        replaces: true,
       },
     ],
   },

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -15,6 +15,8 @@ import userEvent from '@testing-library/user-event';
 import {TestIcon} from '../__tests__/TestIcon';
 import {InputGroup} from '../InputGroup';
 import {NumberInput} from './NumberInput';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSS} from '../theme/generateThemeRules';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
 // FieldStatus announces status messages through the persistent useAnnounce
@@ -1743,5 +1745,64 @@ describe('NumberInput readonly theme state', () => {
     );
     const root = container.querySelector('.astryx-number-input');
     expect(root).not.toHaveAttribute('data-readonly');
+  });
+});
+
+describe('NumberInput stepper padding coupling', () => {
+  function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
+    const {prose, component} = generateThemeCSS(theme);
+    return [prose, component].filter(Boolean).join('\n\n');
+  }
+
+  it('carries the wrapper padding as vars the stepper column can cancel', () => {
+    const {container} = render(
+      <NumberInput
+        label="Quantity"
+        value={5}
+        onChange={() => {}}
+        hasNumberSteppers
+      />,
+    );
+    const root = container.querySelector('.astryx-number-input') as HTMLElement;
+    // The wrapper exposes its own padding through private vars, and applies
+    // them, so a theme override flows to one place the steppers also read.
+    expect(root).toHaveStyle({
+      paddingBlock: 'var(--_number-input-padding-block)',
+      paddingInline: 'var(--_number-input-padding-inline)',
+    });
+
+    // The stepper column cancels the wrapper's block padding by reading the
+    // same var — not a hardcoded token — so it stays flush when the padding
+    // is themed. The column is the direct parent of the stepper buttons.
+    const steppers = container.querySelector(
+      'button[aria-label="Increment Quantity"]',
+    )?.parentElement as HTMLElement;
+    expect(steppers).toHaveStyle({
+      marginBlock: 'calc(-1 * var(--_number-input-padding-block))',
+    });
+  });
+
+  it('routes a themed number-input padding into the private vars (not raw padding)', () => {
+    // jsdom cannot resolve the @layer cascade, so the generated CSS is the
+    // proof: a theme's padding lands on the vars the steppers read, so the
+    // column tracks it instead of a raw padding that would leave a gap.
+    const theme = defineTheme({
+      name: 'number-input-padding-track-test',
+      components: {
+        'number-input': {
+          base: {
+            paddingBlock: 'var(--spacing-2)',
+            paddingInline: 'var(--spacing-3)',
+          },
+        },
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('--_number-input-padding-block: var(--spacing-2)');
+    expect(css).toContain('--_number-input-padding-inline: var(--spacing-3)');
+    // `replaces` drops the raw longhands so they never double-apply on the
+    // wrapper alongside the var — only the var declarations are emitted.
+    expect(css).not.toMatch(/^\s*padding-block:/m);
+    expect(css).not.toMatch(/^\s*padding-inline:/m);
   });
 });

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -1754,7 +1754,18 @@ describe('NumberInput stepper padding coupling', () => {
     return [prose, component].filter(Boolean).join('\n\n');
   }
 
-  it('carries the wrapper padding as vars the stepper column can cancel', () => {
+  // The chains the wrapper and the stepper column both read. Spelled out here
+  // rather than imported so the test pins the actual token names a theme sets:
+  // if the chain is renamed or a level is dropped, this fails.
+  const BLOCK_START =
+    'var(--astryx-number-input-padding-block-start, var(--astryx-number-input-padding, var(--spacing-1)))';
+  const BLOCK_END =
+    'var(--astryx-number-input-padding-block-end, var(--astryx-number-input-padding, var(--spacing-1)))';
+
+  // jsdom re-serializes a var() chain without the spaces after its commas.
+  const noSpace = (value: string) => value.replace(/\s+/g, '');
+
+  it('reads its padding from the public number-input padding tokens', () => {
     const {container} = render(
       <NumberInput
         label="Quantity"
@@ -1764,45 +1775,98 @@ describe('NumberInput stepper padding coupling', () => {
       />,
     );
     const root = container.querySelector('.astryx-number-input') as HTMLElement;
-    // The wrapper exposes its own padding through private vars, and applies
-    // them, so a theme override flows to one place the steppers also read.
-    expect(root).toHaveStyle({
-      paddingBlock: 'var(--_number-input-padding-block)',
-      paddingInline: 'var(--_number-input-padding-inline)',
-    });
+    // Read as physical properties: StyleX compiles the block-axis logical
+    // properties to `padding-top`/`padding-bottom` (identical in every
+    // horizontal writing mode). Per side, not through the shared field base's
+    // `paddingBlock` shorthand, so each edge can be cancelled on its own.
+    const wrapper = getComputedStyle(root);
+    expect(noSpace(wrapper.paddingTop)).toBe(noSpace(BLOCK_START));
+    expect(noSpace(wrapper.paddingBottom)).toBe(noSpace(BLOCK_END));
 
-    // The stepper column cancels the wrapper's block padding by reading the
-    // same var — not a hardcoded token — so it stays flush when the padding
-    // is themed. The column is the direct parent of the stepper buttons.
+    // The column cancels the wrapper's block padding by reading the same
+    // tokens — not a hardcoded default — so it stays flush when a theme
+    // changes the padding. The column is the stepper buttons' direct parent.
     const steppers = container.querySelector(
       'button[aria-label="Increment Quantity"]',
     )?.parentElement as HTMLElement;
-    expect(steppers).toHaveStyle({
-      marginBlock: 'calc(-1 * var(--_number-input-padding-block))',
+    const column = getComputedStyle(steppers);
+    expect(noSpace(column.marginTop)).toBe(
+      noSpace(`calc(-1 * ${BLOCK_START})`),
+    );
+    expect(noSpace(column.marginBottom)).toBe(
+      noSpace(`calc(-1 * ${BLOCK_END})`),
+    );
+  });
+
+  // jsdom cannot resolve the @layer cascade, so the generated CSS is the
+  // proof. Each case is a spelling of the SAME declaration: the column has to
+  // track all of them, not just the one the component happened to name.
+  describe('a themed padding reaches the steppers in every spelling', () => {
+    it.each([
+      [
+        'the padding shorthand, two values',
+        {padding: '14px 20px'},
+        [
+          '--astryx-number-input-padding-block-start: 14px',
+          '--astryx-number-input-padding-block-end: 14px',
+          '--astryx-number-input-padding-inline: 20px',
+        ],
+      ],
+      [
+        'the padding shorthand, one value',
+        {padding: '10px'},
+        ['--astryx-number-input-padding: 10px'],
+      ],
+      [
+        'the block/inline longhands',
+        {paddingBlock: '10px', paddingInline: '20px'},
+        [
+          '--astryx-number-input-padding-block-start: 10px',
+          '--astryx-number-input-padding-block-end: 10px',
+          '--astryx-number-input-padding-inline: 20px',
+        ],
+      ],
+      [
+        'a single edge longhand',
+        {paddingBlockStart: '12px'},
+        ['--astryx-number-input-padding-block-start: 12px'],
+      ],
+      [
+        // A single var carrying "4px 12px" would make the column's
+        // calc(-1 * …) invalid and drop the margin outright; the expansion
+        // splits the two values into their own edges instead.
+        'an asymmetric block padding',
+        {paddingBlock: '4px 12px'},
+        [
+          '--astryx-number-input-padding-block-start: 4px',
+          '--astryx-number-input-padding-block-end: 12px',
+        ],
+      ],
+    ])('%s', (_label, base, expected) => {
+      const theme = defineTheme({
+        name: 'number-input-padding-spelling-test',
+        components: {'number-input': {base}},
+      });
+      const css = generateThemeTestCSS(theme);
+      for (const declaration of expected) {
+        expect(css).toContain(declaration);
+      }
+      // The expansion consumes the padding: a raw declaration left on the
+      // wrapper is padding the column cannot see, which is the gap itself.
+      expect(css).not.toMatch(/^\s*padding(-block|-inline)?(-start|-end)?:/m);
     });
   });
 
-  it('routes a themed number-input padding into the private vars (not raw padding)', () => {
-    // jsdom cannot resolve the @layer cascade, so the generated CSS is the
-    // proof: a theme's padding lands on the vars the steppers read, so the
-    // column tracks it instead of a raw padding that would leave a gap.
+  it('carries a themed border radius to the stepper column corners', () => {
+    // The column's outer corners read --_field-radius. Emitting only
+    // `border-radius` on the wrapper rounds the field and leaves the steppers
+    // at the default radius, which is visible wherever the two differ.
     const theme = defineTheme({
-      name: 'number-input-padding-track-test',
-      components: {
-        'number-input': {
-          base: {
-            paddingBlock: 'var(--spacing-2)',
-            paddingInline: 'var(--spacing-3)',
-          },
-        },
-      },
+      name: 'number-input-radius-test',
+      components: {'number-input': {base: {borderRadius: '2px'}}},
     });
     const css = generateThemeTestCSS(theme);
-    expect(css).toContain('--_number-input-padding-block: var(--spacing-2)');
-    expect(css).toContain('--_number-input-padding-inline: var(--spacing-3)');
-    // `replaces` drops the raw longhands so they never double-apply on the
-    // wrapper alongside the var — only the var declarations are emitted.
-    expect(css).not.toMatch(/^\s*padding-block:/m);
-    expect(css).not.toMatch(/^\s*padding-inline:/m);
+    expect(css).toContain('--_field-radius: 2px');
+    expect(css).toContain('border-radius: 2px');
   });
 });

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -54,18 +54,41 @@ import {useInputContainer} from '../hooks/useInputContainer';
 import {useInputStatusIcon} from '../hooks/useInputStatusIcon';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 
+// Public padding tokens for the `number-input` theme target. A theme writes an
+// ordinary `padding` (in ANY spelling — the shorthand, `paddingBlock`, or a
+// single `paddingBlockStart`) and the pipeline's `container` expansion parses
+// it and emits these normalized per-side tokens; the wrapper and the stepper
+// column both read them, so the column tracks whatever the theme sets instead
+// of assuming the default. Routing through the shared expansion rather than a
+// hand-rolled property→var mapping is what makes every spelling work: a
+// mapping only fires for the exact property name it names.
+//
+// Read order per level: `var(--astryx-…, <next level>)`, terminating at the
+// shared field defaults (NOT the container default --spacing-4, which is a
+// layout metric and would resize every themed field). Built as chained const
+// strings — no function calls — so StyleX can statically analyze them; same
+// shape as the card/section/dialog chains in Layout/container.stylex.ts.
+const FIELD_PAD_BLOCK = spacingVars['--spacing-1'];
+const FIELD_PAD_INLINE = spacingVars['--spacing-2'];
+const padBlockAll = `var(--astryx-number-input-padding, ${FIELD_PAD_BLOCK})`;
+const padInlineAll = `var(--astryx-number-input-padding, ${FIELD_PAD_INLINE})`;
+const padInline = `var(--astryx-number-input-padding-inline, ${padInlineAll})`;
+const padInlineStart = `var(--astryx-number-input-padding-inline-start, ${padInline})`;
+const padInlineEnd = `var(--astryx-number-input-padding-inline-end, ${padInline})`;
+const padBlockStart = `var(--astryx-number-input-padding-block-start, ${padBlockAll})`;
+const padBlockEnd = `var(--astryx-number-input-padding-block-end, ${padBlockAll})`;
+
 const styles = stylex.create({
   wrapper: {
     zIndex: 1,
-    // Expose the wrapper's own padding as private vars (defaults match the
-    // shared field base) so the stepper column can cancel it exactly. A theme
-    // that changes `number-input` padding flows into these vars via the
-    // derived-var registry, and the steppers track it instead of assuming the
-    // default — the same pattern TextArea uses for its overlaid affordances.
-    '--_number-input-padding-block': spacingVars['--spacing-1'],
-    '--_number-input-padding-inline': spacingVars['--spacing-2'],
-    paddingBlock: 'var(--_number-input-padding-block)',
-    paddingInline: 'var(--_number-input-padding-inline)',
+    // Applied per side rather than through the shared field base's
+    // `paddingBlock`/`paddingInline` shorthands, because the stepper column
+    // has to cancel the block padding edge by edge — an asymmetric
+    // `paddingBlock: 4px 12px` needs two different negative margins.
+    paddingBlockStart: padBlockStart,
+    paddingBlockEnd: padBlockEnd,
+    paddingInlineStart: padInlineStart,
+    paddingInlineEnd: padInlineEnd,
   },
   wrapperWithNumberSteppers: {
     paddingInlineEnd: 0,
@@ -109,7 +132,12 @@ const styles = stylex.create({
     flexDirection: 'column',
     flexShrink: 0,
     width: spacingVars['--spacing-4'],
-    marginBlock: 'calc(-1 * var(--_number-input-padding-block))',
+    // Cancel the wrapper's block padding edge by edge so the column spans the
+    // field's full height. Reading the same tokens the wrapper applies is what
+    // keeps it flush under a themed padding — including an asymmetric one,
+    // where a single `marginBlock` would be wrong at one end.
+    marginBlockStart: `calc(-1 * ${padBlockStart})`,
+    marginBlockEnd: `calc(-1 * ${padBlockEnd})`,
     borderInlineStartWidth: borderVars['--border-width'],
     borderInlineStartStyle: 'solid',
     borderInlineStartColor: colorVars['--color-border-emphasized'],

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -31,7 +31,6 @@ import {
   colorVars,
   sizeVars,
   spacingVars,
-  radiusVars,
   typographyVars,
   typeScaleVars,
   borderVars,
@@ -58,6 +57,15 @@ import {useInputGroup} from '../InputGroup/InputGroupContext';
 const styles = stylex.create({
   wrapper: {
     zIndex: 1,
+    // Expose the wrapper's own padding as private vars (defaults match the
+    // shared field base) so the stepper column can cancel it exactly. A theme
+    // that changes `number-input` padding flows into these vars via the
+    // derived-var registry, and the steppers track it instead of assuming the
+    // default — the same pattern TextArea uses for its overlaid affordances.
+    '--_number-input-padding-block': spacingVars['--spacing-1'],
+    '--_number-input-padding-inline': spacingVars['--spacing-2'],
+    paddingBlock: 'var(--_number-input-padding-block)',
+    paddingInline: 'var(--_number-input-padding-inline)',
   },
   wrapperWithNumberSteppers: {
     paddingInlineEnd: 0,
@@ -101,13 +109,13 @@ const styles = stylex.create({
     flexDirection: 'column',
     flexShrink: 0,
     width: spacingVars['--spacing-4'],
-    marginBlock: `calc(-1 * ${spacingVars['--spacing-1']})`,
+    marginBlock: 'calc(-1 * var(--_number-input-padding-block))',
     borderInlineStartWidth: borderVars['--border-width'],
     borderInlineStartStyle: 'solid',
     borderInlineStartColor: colorVars['--color-border-emphasized'],
     overflow: 'hidden',
-    borderStartEndRadius: radiusVars['--radius-element'],
-    borderEndEndRadius: radiusVars['--radius-element'],
+    borderStartEndRadius: 'var(--_field-radius)',
+    borderEndEndRadius: 'var(--_field-radius)',
   },
   numberStepperButton: {
     boxSizing: 'border-box',

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -164,9 +164,6 @@ function discoverComponents(): ComponentInfo[] {
         allVars.add(v);
       }
     }
-    if (allVars.size === 0) {
-      continue;
-    }
 
     // Only check component directories (those with a doc file named after the
     // directory). Match against the on-disk listing rather than existsSync so
@@ -186,6 +183,16 @@ function discoverComponents(): ComponentInfo[] {
       docDerived = mod.docs?.theming?.derived || [];
     } catch {
       /* skip */
+    }
+
+    // A directory earns a check by declaring a var OR by documenting a
+    // derived[] entry. Bailing on the var count alone (as this did) hid every
+    // component that is themeable purely through an expansion strategy —
+    // `{property: 'padding', expand: 'container'}` names no var, so such a
+    // component declares nothing and its registry↔doc consistency check
+    // silently never ran.
+    if (allVars.size === 0 && docDerived.length === 0) {
+      continue;
     }
 
     results.push({

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -212,6 +212,7 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
   DropdownMenu: 'dropdown-menu',
   Field: 'field',
   HoverCard: 'hovercard',
+  NumberInput: 'number-input',
   Popover: 'popover',
   ProgressBar: 'progressbar-mark',
   Section: 'section',

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -67,6 +67,18 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
   ],
   field: [{property: 'borderRadius', vars: ['--_field-radius']}],
   hovercard: [{property: 'borderRadius', vars: ['--_hovercard-radius']}],
+  'number-input': [
+    {
+      property: 'paddingBlock',
+      vars: ['--_number-input-padding-block'],
+      replaces: true,
+    },
+    {
+      property: 'paddingInline',
+      vars: ['--_number-input-padding-inline'],
+      replaces: true,
+    },
+  ],
   popover: [{property: 'borderRadius', vars: ['--_popover-radius']}],
   'progressbar-mark': [
     {property: 'width', vars: ['--_progressbar-mark-width'], replaces: true},

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -68,16 +68,8 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
   field: [{property: 'borderRadius', vars: ['--_field-radius']}],
   hovercard: [{property: 'borderRadius', vars: ['--_hovercard-radius']}],
   'number-input': [
-    {
-      property: 'paddingBlock',
-      vars: ['--_number-input-padding-block'],
-      replaces: true,
-    },
-    {
-      property: 'paddingInline',
-      vars: ['--_number-input-padding-inline'],
-      replaces: true,
-    },
+    {property: 'padding', expand: 'container'},
+    {property: 'borderRadius', vars: ['--_field-radius']},
   ],
   popover: [{property: 'borderRadius', vars: ['--_popover-radius']}],
   'progressbar-mark': [


### PR DESCRIPTION
## Summary

`NumberInput`'s number-stepper column is positioned by **cancelling the field wrapper's own padding** rather than owning its geometry, and it assumes the *default* padding:

- `numberSteppers { marginBlock: calc(-1 * --spacing-1) }` — hardcodes the 4px default block padding, so the column spans the field's full height.
- `wrapperWithNumberSteppers { padding-inline-end: 0 }` — assumes it can zero the end padding.
- The stepper corners hardcode `--radius-element`, while the wrapper itself uses the themeable `--_field-radius`.

The moment a theme changes `number-input` padding (or radius), those assumptions break: the column falls short of the top/bottom edges (a visible gap), and the corners no longer match the field radius. Padding is a legitimate themeable property, so this is a real robustness gap, not a niche one.

## Fix

Carry the wrapper's padding through private custom properties the steppers read — the same pattern `TextArea` already uses for its overlaid affordances (`--_textarea-inline-padding`), and mirroring how `--_field-radius` is already threaded:

- The wrapper declares `--_number-input-padding-block` / `--_number-input-padding-inline` (defaults match the shared field base) and applies them.
- The stepper column cancels the block padding with `calc(-1 * var(--_number-input-padding-block))`, and its corners read `var(--_field-radius)`.
- `number-input` is registered in the derived-var registry so a theme's `paddingBlock` / `paddingInline` flows into those vars (`replaces: true`, so the raw longhand doesn't double-apply) — the column tracks whatever the theme sets.

Byte-identical by default (the vars resolve to today's tokens); inert for the no-stepper case and every other input.

## Test plan

- `pnpm -F @astryxdesign/core test` — NumberInput + theme suites pass (212). Added: the wrapper carries the padding vars and the stepper margin reads the block var; a themed `number-input` padding routes into the private vars (not raw padding) in generated CSS.
- `derivedVarRegistry.test.ts` (registry↔doc consistency) passes with the new `number-input` entry.
- `pnpm -F @astryxdesign/core build` / `typecheck` / `eslint` — clean. `astryx component NumberInput` documents the themeable padding.
- Docs (`.doc.mjs` theming vars + derived, EN + zh) and a changeset are included.
