### PR TITLE
ci(i18n): download Crowdin translations nightly

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -3,10 +3,9 @@
 # Crowdin download — pull translated locale files from Crowdin and open a PR
 # against main.
 #
-# TRIGGER: workflow_dispatch ONLY for now, so a maintainer can smoke-test the
-# full flow (download → prettier → PR) before we automate it. A follow-up PR
-# will add a cron schedule once we're confident the PR that comes out looks
-# right end-to-end.
+# TRIGGER: nightly plus manual dispatch. Each run downloads nonempty translated
+# locale files and opens (or updates) a reviewable PR; when nothing changed,
+# create-pull-request is a no-op.
 #
 # Why not use Crowdin's built-in PR creation? Its PR flow is limited (title/
 # body/labels), so we let the Crowdin action land translations on a staging
@@ -17,6 +16,9 @@ name: Crowdin Download
 
 on:
   workflow_dispatch:
+  schedule:
+    # 06:00 UTC — overnight in US time zones; opens a PR only when translations changed.
+    - cron: '0 6 * * *'
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Run the existing Crowdin download workflow nightly at 06:00 UTC, while keeping the manual dispatch available.

The workflow downloads nonempty translated locale files and opens or updates the reviewable `l10n/crowdin` pull request. When Crowdin has no changes, `create-pull-request` is a no-op.

## Verification

- manually dispatched the existing workflow on `main`: [run 32154225166](https://github.com/facebook/astryx/actions/runs/32154225166) passed end to end
- the run opened [#5185](https://github.com/facebook/astryx/pull/5185) with all 29 translated locale files
- workflow YAML parses and matches Prettier
- `check:changesets`, executable-bit check, and `git diff --check` pass
