### PR TITLE
ci(i18n): let Crowdin PRs trigger CI

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Open translations PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
+          token: ${{ secrets.CROWDIN_PR_TOKEN }}
           branch: l10n/crowdin
           base: main
           title: 'chore(i18n): translations update from Crowdin'


### PR DESCRIPTION
## Summary

Authenticate the existing translation pull-request step with the repository-scoped token so automated Crowdin PR events run normal required CI without manual approval.

## Verification

- confirmed the previous workflow fails a focused assertion because the token is absent, while this update passes
- workflow YAML parses and matches Prettier
- `check:changesets`, executable-bit check, and `git diff --check` pass
