### PR TITLE
fix: Escape dismisses only the top-most overlay for Lightbox/MobileNav

### DIFF
--- a/.changeset/escape-key-wrong-layer.md
+++ b/.changeset/escape-key-wrong-layer.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Escape now dismisses only the top-most overlay when a `Lightbox` or `MobileNav` is layered on top of a `Dialog`. `Dialog` already deferred to any popover-style overlay via the shared focus-trap Escape stack, but `Lightbox` and `MobileNav` never registered on it, so a single Escape press closed the `Dialog` underneath instead of the overlay on top. Both now register on the shared stack while open (via the new `useEscapeStackEntry` hook), so `Dialog` correctly defers to them.
+
+Also fixes `InfoTip` (lab): dismissing its own tooltip on Escape only called `stopPropagation`, not `preventDefault`, so a `Dialog` behind it still closed via its native top-layer close-watcher on the same press.
+
+@HelloOjasMutreja

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -31,6 +31,7 @@ import {Icon} from '../Icon';
 import {IconButton} from '../IconButton';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {useScrollLock} from '../hooks/useScrollLock';
+import {useEscapeStackEntry} from '../hooks/useFocusTrap';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {mergeProps, mergeRefs, rtlStyles} from '../utils';
 import type {BaseProps} from '../BaseProps';
@@ -350,6 +351,13 @@ export function Lightbox({
 
   // Scroll lock
   useScrollLock(isOpen);
+
+  // Register on the shared Escape stack while open so a Dialog (or other
+  // overlay) layered underneath correctly defers to this Lightbox instead of
+  // closing itself on the same Escape press. The Lightbox's own dismissal is
+  // still handled natively below via the dialog's `cancel` event.
+  const getEscapeContainer = useCallback(() => dialogRef.current, []);
+  useEscapeStackEntry(isOpen, getEscapeContainer);
 
   // Reset zoom on image change
   useEffect(() => {

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -52,6 +52,7 @@ import {
   holdScrollbarGutter,
   type ScrollbarGutterHold,
 } from '../hooks/scrollbarGutter';
+import {useEscapeStackEntry} from '../hooks/useFocusTrap';
 import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import {overlayPaddingReset} from '../Layout/padding.stylex';
 import type {BaseProps} from '../BaseProps';
@@ -535,6 +536,13 @@ export function MobileNav({
       }
     };
   }, []);
+
+  // Register on the shared Escape stack while open so a Dialog (or other
+  // overlay) layered underneath correctly defers to this drawer instead of
+  // closing itself on the same Escape press. The drawer's own dismissal is
+  // still handled natively below via the dialog's `cancel` event.
+  const getEscapeContainer = useCallback(() => dialogRef.current, []);
+  useEscapeStackEntry(isOpen, getEscapeContainer);
 
   // Handle native cancel event (Escape key) — prevent default and route through onOpenChange
   const handleCancel = useCallback(

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -11,7 +11,11 @@
  * SYNC: When modified, update this header
  */
 
-export {hasActiveFocusTrapEscape, useFocusTrap} from './useFocusTrap';
+export {
+  hasActiveFocusTrapEscape,
+  useEscapeStackEntry,
+  useFocusTrap,
+} from './useFocusTrap';
 export type {UseFocusTrapOptions, UseFocusTrapReturn} from './useFocusTrap';
 
 /**

--- a/packages/core/src/hooks/useFocusTrap.test.tsx
+++ b/packages/core/src/hooks/useFocusTrap.test.tsx
@@ -9,10 +9,15 @@
  * SYNC: When useFocusTrap.ts changes, update tests to match new behavior
  */
 
+import {useEffect, useRef} from 'react';
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, cleanup} from '@testing-library/react';
 import {FOCUSABLE_SELECTOR} from './focusableSelector';
-import {useFocusTrap} from './useFocusTrap';
+import {
+  hasActiveFocusTrapEscape,
+  useEscapeStackEntry,
+  useFocusTrap,
+} from './useFocusTrap';
 
 function Trap({children}: {children: React.ReactNode}) {
   const {containerRef, focusFirst} = useFocusTrap<HTMLDivElement>({
@@ -328,6 +333,74 @@ describe('useFocusTrap Escape coordination', () => {
     );
     fireEvent.keyDown(document, {key: 'Escape'});
     expect(onEscape).not.toHaveBeenCalled();
+  });
+});
+
+describe('useEscapeStackEntry', () => {
+  function StackEntry({isActive}: {isActive: boolean}) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    useEscapeStackEntry(isActive, () => containerRef.current);
+    return <div ref={containerRef} data-testid="entry" />;
+  }
+
+  it('registers a presence while active, seen via hasActiveFocusTrapEscape', () => {
+    expect(hasActiveFocusTrapEscape()).toBe(false);
+    render(<StackEntry isActive />);
+    expect(hasActiveFocusTrapEscape()).toBe(true);
+    cleanup();
+    expect(hasActiveFocusTrapEscape()).toBe(false);
+  });
+
+  it('does not register while inactive', () => {
+    render(<StackEntry isActive={false} />);
+    expect(hasActiveFocusTrapEscape()).toBe(false);
+    cleanup();
+  });
+
+  it('removes its entry when isActive flips to false without unmounting', () => {
+    const {rerender} = render(<StackEntry isActive />);
+    expect(hasActiveFocusTrapEscape()).toBe(true);
+    rerender(<StackEntry isActive={false} />);
+    expect(hasActiveFocusTrapEscape()).toBe(false);
+    cleanup();
+  });
+
+  it('makes an unrelated Dialog-style consumer defer while it is active, matching Lightbox/MobileNav over a native Dialog (#5168)', () => {
+    const dialogEscape = vi.fn();
+    // Simulates Dialog's own Escape handling, which only consults
+    // hasActiveFocusTrapEscape() as a boolean gate rather than joining the
+    // stack itself (see Dialog.tsx).
+    function DialogLike() {
+      useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+          if (event.key === 'Escape' && !hasActiveFocusTrapEscape()) {
+            dialogEscape();
+          }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+      }, []);
+      return null;
+    }
+
+    const {rerender} = render(
+      <>
+        <DialogLike />
+        <StackEntry isActive />
+      </>,
+    );
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(dialogEscape).not.toHaveBeenCalled();
+
+    // Once the overlay on top closes, Dialog is free to respond again.
+    rerender(
+      <>
+        <DialogLike />
+        <StackEntry isActive={false} />
+      </>,
+    );
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(dialogEscape).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -96,6 +96,33 @@ export function hasActiveFocusTrapEscape(): boolean {
 }
 
 /**
+ * Registers a presence on the shared Escape stack while `isActive`, without
+ * pulling in the rest of `useFocusTrap`'s JS focus-trap/Tab-wrapping
+ * machinery. For overlays that already trap focus and dismiss on Escape
+ * natively (e.g. a `<dialog>` opened with `showModal()`, which gets a native
+ * top-layer `cancel` event for free), this is enough to make
+ * `hasActiveFocusTrapEscape()` — and so an outer Dialog's own Escape
+ * handling — correctly defer to them instead of closing itself first.
+ *
+ * This does not call `onEscape` itself; the overlay's own native Escape
+ * handling stays in charge of its own dismissal. Registering only makes the
+ * overlay visible to *other* layers coordinating through this same stack.
+ */
+export function useEscapeStackEntry(
+  isActive: boolean,
+  getContainer: () => HTMLElement | null,
+): void {
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+    const handler = () => {};
+    pushEscapeHandler({handler, getContainer});
+    return () => removeEscapeHandler(handler);
+  }, [isActive, getContainer]);
+}
+
+/**
  * Whether an element is currently perceivable/focusable — excludes ones hidden
  * via `display:none`/`visibility:hidden` or inside an `inert`/`hidden` subtree,
  * which the browser skips for Tab, and ones inside an `aria-hidden="true"`

--- a/packages/lab/src/InfoTip/InfoTip.test.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.test.tsx
@@ -134,6 +134,28 @@ describe('InfoTip', () => {
     });
   });
 
+  it('prevents default on the Escape that dismisses it, so an ancestor dialog does not also close on the same press', async () => {
+    render(<InfoTip content="Helpful context" />);
+    const trigger = screen.getByRole('button', {name: 'More information'});
+    const layer = screen.getByRole('tooltip', {hidden: true});
+
+    focusTrigger(trigger);
+    await waitFor(() => {
+      expect(popoverOpenState.get(layer)).toBe(true);
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      trigger.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   it('re-opens after Escape once the trigger is left and re-hovered', async () => {
     render(<InfoTip content="Helpful context" />);
     const trigger = screen.getByRole('button', {name: 'More information'});

--- a/packages/lab/src/InfoTip/InfoTip.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.tsx
@@ -115,7 +115,14 @@ export function InfoTip({
     (event: React.KeyboardEvent<HTMLButtonElement>) => {
       if (event.key === 'Escape' && isOpenRef.current) {
         // Only swallow Escape when it actually dismissed the tooltip, so an
-        // enclosing dialog still closes on the next press.
+        // enclosing dialog still closes on the next press. preventDefault is
+        // required too, not just stopPropagation: a native <dialog> ancestor
+        // (e.g. Dialog) closes via its own top-layer close-watcher, which
+        // reacts to the physical keydown's default action independently of
+        // React's synthetic event bubbling — without it, dismissing the
+        // tooltip and closing the dialog underneath both happened on the
+        // same press.
+        event.preventDefault();
         event.stopPropagation();
         setIsDismissed(true);
       }


### PR DESCRIPTION
Fixes #5168.

## Problem

`Dialog` already defers to any popover-style overlay layered on top of it via a shared "focus-trap Escape stack" (`hasActiveFocusTrapEscape()` in `useFocusTrap.ts`), so pressing Escape with a `Popover`/`DropdownMenu` open inside a `Dialog` correctly dismisses only the top layer. `Lightbox` and `MobileNav` never registered on that same stack, even though both also open as native top-layer `<dialog>` elements. Reproduced live: with a `Dialog` open and a `Lightbox` open on top of it, one Escape press closed the `Dialog` underneath while the `Lightbox` on top stayed open, exactly backwards from expected.

Root cause: `Dialog`'s own document-level Escape handler only checks `hasActiveFocusTrapEscape()` as a boolean gate. Since `Lightbox`/`MobileNav` never pushed anything onto that stack, the gate read "nothing active" even while one of them was genuinely the top-most overlay, so `Dialog` closed itself via its own JS handler instead of deferring.

Separately, lab's `InfoTip` had a related but distinct bug: its own Escape handling called `stopPropagation()` to dismiss its tooltip, but never `preventDefault()`. `stopPropagation()` on the React synthetic event stops the shared stack's document listener from seeing the press, but does not stop the browser's own native top-layer close-watcher, which processes Escape independently. Result: an ancestor `Dialog` still closed on the same press.

## Fix

Added `useEscapeStackEntry(isActive, getContainer)`, a small hook extracted from `useFocusTrap`'s existing stack registration logic, exported alongside `hasActiveFocusTrapEscape`. It only pushes/removes a presence on the shared stack; it does not attach its own Escape handling or pull in `useFocusTrap`'s JS focus-trap/Tab-wrapping machinery, since `Lightbox` and `MobileNav` already trap focus and dismiss on Escape natively via `dialog.showModal()`/the `cancel` event. Wired into both.

For `InfoTip`, added the missing `preventDefault()` alongside the existing `stopPropagation()`.

## Verification

- `useFocusTrap.test.tsx`: added a `useEscapeStackEntry` suite (registration/removal across mount, unmount, and `isActive` toggling, plus a test simulating Dialog's own gate to confirm it correctly defers while the hook is active and responds again once it isn't).
- `InfoTip.test.tsx`: added a test asserting `event.defaultPrevented` is `true` on the Escape that dismisses the tooltip.
- Existing `Lightbox`, `MobileNav`, and `useFocusTrap` suites still pass unchanged.
- Live-verified against a temporary Storybook harness (Dialog + Lightbox both open): confirmed the original bug before this fix (Dialog closed, Lightbox stayed open on one Escape press), then confirmed after this fix that Dialog's own JS-driven self-close no longer fires.
- One thing I could **not** fully verify end-to-end in this environment: whether the browser's native `<dialog>` close-watcher then correctly targets the true top-most dialog (Lightbox) once Dialog stops intercepting. My browser automation session runs with `document.visibilityState: "hidden"` (not compositing frames), and Chrome gates the native close-watcher's default action on real page visibility, confirmed by testing a `Lightbox` alone (no `Dialog` involved) also not self-closing on a synthetic Escape in this same session. This is a tooling limitation, not something in question about the fix itself: the mechanism it relies on (native `<dialog>` top-layer close-watcher plus `preventDefault()` suppression) is the same one `Dialog` and every other native-`<dialog>` consumer in this codebase already depend on, and is inherently outside jsdom's/this automation session's reach, similar in kind to why this class of bug wasn't caught by unit tests in the first place.

Typecheck, lint, and the full affected test suites (`useFocusTrap`, `Lightbox`, `MobileNav`, `InfoTip`) pass locally.
