### PR TITLE
fix: RTL touch hit target displaced from Checkbox, Radio, Switch

### DIFF
--- a/.changeset/rtl-touch-hit-target-displaced.md
+++ b/.changeset/rtl-touch-hit-target-displaced.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `CheckboxInput`, `RadioListItem`, and `Switch` no longer displace their coarse-pointer (touch) hit target away from the visible control under RTL. The invisible native input is centered with a logical `insetInlineStart: 50%` paired with a physical `translate(-50%, -50%)`; under RTL the logical inset resolves from the opposite edge while the transform stays physical, so the two no longer canceled out and the actual tap target moved a full control-width away from what's visible. The transform now flips its X direction under RTL, matching the pattern `Slider`'s thumb already uses for the same class of problem.
+
+@HelloOjasMutreja

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -97,9 +97,16 @@ const styles = stylex.create({
       default: null,
       '@media (pointer: coarse)': '50%',
     },
+    // The input is positioned via logical `insetInlineStart`, which resolves
+    // from the right edge under RTL. The centering translate is a physical
+    // (screen-space) transform, so it must flip its X direction under RTL to
+    // keep the input centered over the visible indicator (#5170).
     transform: {
       default: null,
-      '@media (pointer: coarse)': 'translate(-50%, -50%)',
+      '@media (pointer: coarse)': {
+        default: 'translate(-50%, -50%)',
+        ':is([dir="rtl"] *)': 'translate(50%, -50%)',
+      },
     },
   },
   inputDisabled: {

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -67,9 +67,16 @@ const styles = stylex.create({
       default: null,
       '@media (pointer: coarse)': '50%',
     },
+    // The input is positioned via logical `insetInlineStart`, which resolves
+    // from the right edge under RTL. The centering translate is a physical
+    // (screen-space) transform, so it must flip its X direction under RTL to
+    // keep the input centered over the visible indicator (#5170).
     transform: {
       default: null,
-      '@media (pointer: coarse)': 'translate(-50%, -50%)',
+      '@media (pointer: coarse)': {
+        default: 'translate(-50%, -50%)',
+        ':is([dir="rtl"] *)': 'translate(50%, -50%)',
+      },
     },
   },
   inputDisabled: {

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -178,9 +178,16 @@ const styles = stylex.create({
       default: null,
       '@media (pointer: coarse)': '50%',
     },
+    // The input is positioned via logical `insetInlineStart`, which resolves
+    // from the right edge under RTL. The centering translate is a physical
+    // (screen-space) transform, so it must flip its X direction under RTL to
+    // keep the input centered over the visible track (#5170).
     transform: {
       default: null,
-      '@media (pointer: coarse)': 'translate(-50%, -50%)',
+      '@media (pointer: coarse)': {
+        default: 'translate(-50%, -50%)',
+        ':is([dir="rtl"] *)': 'translate(50%, -50%)',
+      },
     },
   },
   inputDisabled: {


### PR DESCRIPTION
Fixes #5170.

## Problem

`CheckboxInput`, `RadioListItem`, and `Switch` all center their invisible native `<input>` over the visible control on coarse-pointer (touch) devices with:

```ts
insetInlineStart: '50%',
transform: 'translate(-50%, -50%)',
```

`insetInlineStart` is logical: it resolves from the container's right edge under RTL. The centering `translate()` is always physical (there is no logical form of `transform`), so it keeps shifting left regardless of direction. In LTR the two operations cancel out correctly. In RTL they compound instead of canceling: verified live, a 24px input in a 20px `CheckboxInput` wrapper ends up at `-26px` relative to the wrapper (matching the issue's own math) instead of centered, so tapping the visible indicator misses the actual input entirely.

## Fix

Flip the transform's X direction under RTL with `:is([dir="rtl"] *)`, matching the pattern `Slider`'s thumb already uses for this exact combination (logical position + physical centering transform):

```ts
transform: {
  default: null,
  '@media (pointer: coarse)': {
    default: 'translate(-50%, -50%)',
    ':is([dir="rtl"] *)': 'translate(50%, -50%)',
  },
},
```

Applied identically to `CheckboxInput.tsx`, `RadioListItem.tsx`, and `Switch.tsx`, since all three share the exact same positioning block.

## Verification

Live-verified against the real `Core/CheckboxInput`, `Core/RadioList`, and `Core/Switch` Storybook stories with `direction: rtl` and coarse-pointer emulated (`hasTouch`/`isMobile` in a Playwright context, confirmed `window.matchMedia('(pointer: coarse)').matches === true` in each case):

- `CheckboxInput`, before this fix, `getBoundingClientRect()` showed the native input's center offset **-24px** from the wrapper's center. After this fix, offset is **0px**.
- The same displacement/centering pattern held for `RadioListItem` and `Switch`.

Screenshots below overlay the actual native-input hit target (red, solid) against the visible control (blue, dashed), captured with the same technique, so the normally-invisible input's real bounds are visible:

**CheckboxInput, RTL, before → after:**

![checkbox before](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5170-rtl-hit-target/5170-checkbox-rtl-before.png)
![checkbox after](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5170-rtl-hit-target/5170-checkbox-rtl.png)

**RadioListItem, RTL, before → after:**

![radio before](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5170-rtl-hit-target/5170-radio-rtl-before.png)
![radio after](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5170-rtl-hit-target/5170-radio-rtl.png)

**Switch, RTL, before → after:**

![switch before](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5170-rtl-hit-target/5170-switch-rtl-before.png)
![switch after](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5170-rtl-hit-target/5170-switch-rtl.png)

I didn't add a jsdom unit test for this: jsdom does not evaluate real `@media (pointer: coarse)` queries or the `:is([dir="rtl"] *)` compound selector against actual layout, so a unit test asserting on class names would not exercise the real bug (the same reason this codebase's RTL correctness is verified via the separate live/Playwright-based `rtl-audit` tool rather than per-component jsdom specs, e.g. `TreeListItem`, `Table` row-expansion). Existing `CheckboxInput`, `RadioList`, and `Switch` unit suites still pass unchanged. Typecheck and lint pass locally.
