### PR TITLE
fix(core): Slider vertical track hit area below WCAG minimum on touch

### DIFF
--- a/.changeset/slider-vertical-touch-target.md
+++ b/.changeset/slider-vertical-touch-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Slider`'s vertical orientation now floors its tap target to the WCAG 2.5.8 AA 24px minimum on coarse-pointer (touch) devices, matching the horizontal orientation's existing floor from #4963. The horizontal fix only covered `minBlockSize` (its narrow axis, height); the vertical orientation's narrow axis is width, which had no such floor, so a vertical `Slider` embedded in a width-constrained layout kept a 20px-wide tap target on touch.
+
+@HelloOjasMutreja

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -189,6 +189,15 @@ const styles = stylex.create({
   trackContainerVertical: {
     width: THUMB_SIZE,
     height: 160,
+    // Inline-axis counterpart of trackContainerHorizontal's minBlockSize
+    // above: the same WCAG 2.5.8 AA 24px floor, applied to whichever axis is
+    // the narrow one for this orientation. The rail, filled track, and thumb
+    // all center on the inline axis, so only the invisible tappable area
+    // grows.
+    minInlineSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
     flexDirection: 'column',
     justifyContent: 'center',
     cursor: 'pointer',


### PR DESCRIPTION
Fixes #5169.

## Problem

#4963 floored `Slider`'s tap target to the WCAG 2.5.8 AA 24px minimum on coarse pointers via `minBlockSize` on `trackContainerHorizontal`, but `trackContainerVertical` had no equivalent. `orientation="vertical"` is a public, documented prop, and the same single `trackContainer` div (with `onPointerDown`/`onPointerMove`/`onPointerUp`) is the tap target for both orientations, so a vertical Slider kept a 20px-wide tap target on touch, below the WCAG minimum, in exactly the layouts where it matters (a vertical Slider narrow enough that its container doesn't already exceed 24px on its own).

## Fix

Added the inline-axis counterpart, same coarse-pointer gate, exactly as suggested in the issue:

```ts
trackContainerVertical: {
  width: THUMB_SIZE,
  height: 160,
  minInlineSize: {
    default: null,
    '@media (pointer: coarse)': '24px',
  },
  flexDirection: 'column',
  justifyContent: 'center',
  cursor: 'pointer',
},
```

The rail, filled track, and thumb are all centered on the inline axis already, so widening the container doesn't move anything visible.

## Verification

A subtlety worth calling out: the default `Core/Slider` `VerticalOrientation` Storybook story has no outer width constraint, and `trackContainer`'s base style sets `flexGrow: 1`. In that unconstrained story, the container already stretches to ~268px regardless of this fix, which would make a before/after comparison there look identical and prove nothing. The bug (and the fix) only actually shows up when the Slider's own width is constrained below 24px by its layout, so I measured and screenshotted against a temporary story wrapping the vertical Slider in a `width: 20` container, matching how a narrow real-world usage (e.g. a slim sidebar control) would actually be sized:

- Before this fix: `getBoundingClientRect().width` = **20px**, `getComputedStyle().minWidth` = `auto`.
- After this fix: `getBoundingClientRect().width` = **24px**, `getComputedStyle().minWidth` = `24px`.

Both measured with `window.matchMedia('(pointer: coarse)').matches === true` confirmed (Playwright context with `hasTouch`/`isMobile`).

![before](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5169-slider-touch-target/5169-vertical-before.png)
![after](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5169-slider-touch-target/5169-vertical-after.png)

The visible difference is subtle (a few px on the track's own outline) since the rail/thumb stay centered as intended; the overlay's red outline traces the actual tap-target box in each. The temporary story used for this was not committed.

No jsdom unit test added, for the same reason as the horizontal fix in #4963 and the sibling touch-target fix in #5170/#5192: jsdom does not evaluate real `@media (pointer: coarse)` queries against actual computed layout, so a test asserting on class names wouldn't exercise the real bug. Existing `Slider.test.tsx` suite (51 tests) still passes unchanged. Typecheck and lint pass locally.
