### PR TITLE
fix(core): keep the ResizeHandle grab zone on the handle

### DIFF
--- a/.changeset/resize-handle-grab-zone-cross-axis.md
+++ b/.changeset/resize-handle-grab-zone-cross-axis.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ResizeHandle: dragging the lower half of a tall handle works again. The invisible grab zone is stretched along the handle, but the offset that biases it onto the pill also carried the pill's own `-50%` centering shift — so the zone slid half the handle's length off the divider. On a full-height panel at 1440x900 the 16x900 hit box sat at y=-434, leaving everything below the pill's centre dead: a pointerdown on the visible grip's centre, or anywhere lower, started no drag at all. The dead region grew with the panel, and the same shift stranded the grab zone sideways on vertical handles. The bias now moves the zone along the pill's axis only.
+
+@cixzhang

--- a/packages/core/src/Resizable/ResizeHandle.test.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.test.tsx
@@ -344,6 +344,28 @@ describe('ResizeHandle', () => {
     expect(hitArea.className).not.toContain('hitAreaOffsetX');
   });
 
+  // The grab zone is stretched along the handle by its 0/0 insets, so anything
+  // that moves it across the handle displaces the whole zone off the divider —
+  // a percentage does it by half the handle's length, so the taller the panel
+  // the larger the dead region, and nothing about it is visible on screen.
+  it.each([
+    ['horizontal' as const, 'translateX'],
+    ['vertical' as const, 'translateY'],
+  ])('offsets the %s grab zone along the pill axis only', (direction, axis) => {
+    render(<Harness handleProps={{direction, pillPlacement: 'start'}} />);
+    const hitArea = getSeparator().firstElementChild as HTMLElement;
+    const translates = (hitArea.getAttribute('style') ?? '')
+      .split(';')
+      .map(decl => decl.split(/:(.*)/s)[1]?.trim() ?? '')
+      .filter(value => value.startsWith('translate'));
+
+    // Both the LTR and RTL declarations of the horizontal offset.
+    expect(translates.length).toBeGreaterThan(0);
+    for (const translate of translates) {
+      expect(translate.startsWith(`${axis}(`)).toBe(true);
+    }
+  });
+
   // --- Prop composition (ordering choice: handler sits after {...props}) ---
 
   it('runs a consumer onKeyDown alongside keyboard resizing', () => {

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -219,16 +219,22 @@ const dynamicStyles = stylex.create({
   // directions because the pill's own offset is physical. Mixing the previous
   // divider-relative `50%` anchor with a percentage translate stranded the grab
   // zone to one side under RTL; this construction keeps it on the pill.
+  //
+  // Only the offset axis is translated. Unlike the pill — a small box anchored
+  // at the divider's midpoint, so it needs a −50% self-shift to centre — the
+  // grab zone is STRETCHED along the handle by hitAreaHorizontal/Vertical's
+  // 0/0 insets, so it is already in place on that axis. A percentage there
+  // would displace it by half the handle's own length, growing with the panel.
   hitAreaOffsetX: (dir: number) => ({
     insetInlineStart: 0,
     transform: {
-      default: `translate(calc(${dir} * (3px + ${spacingVars['--spacing-1']}) - 6.5px), -50%)`,
-      ':is([dir="rtl"] *)': `translate(calc(${dir} * (3px + ${spacingVars['--spacing-1']}) + 6.5px), -50%)`,
+      default: `translateX(calc(${dir} * (3px + ${spacingVars['--spacing-1']}) - 6.5px))`,
+      ':is([dir="rtl"] *)': `translateX(calc(${dir} * (3px + ${spacingVars['--spacing-1']}) + 6.5px))`,
     },
   }),
   hitAreaOffsetY: (dir: number) => ({
     insetBlockStart: 0,
-    transform: `translate(-50%, calc(${dir} * (3px + ${spacingVars['--spacing-1']}) - 6.5px))`,
+    transform: `translateY(calc(${dir} * (3px + ${spacingVars['--spacing-1']}) - 6.5px))`,
   }),
   pillOffsetX: (dir: number) => ({
     insetInlineStart: 0,


### PR DESCRIPTION
## Why

A pointerdown on the visible pill grip of a tall `ResizeHandle` does nothing. The grab zone — the invisible child that carries `onPointerDown` — is anchored half the handle's length above the divider, so on a full-height panel everything from the pill's centre downward is dead. People who grab the pill land in its top half and mostly never notice; anything that aims at the pill's centre misses every time. The zone is invisible, and the dead region grows with the panel.

## What

The bias that pulls the grab zone onto an off-centre pill reused the pill's transform wholesale, including the `-50%` self-shift the pill needs to centre itself on its `top: 50%` anchor. The grab zone has no such anchor — it is stretched along the handle by its `0`/`0` insets — so that percentage was a pure displacement of half the handle's own length. It now translates along the pill's axis only. Vertical handles carried the mirror of the same bug, stranded sideways by half the handle's width.

## Risk

Low, and contained to the biased-pill branch. `pillPlacement="center"` never used this construction and measures identically before and after. The offset that aligns the zone with the pill along the pill's own axis — including its RTL sign flip — is untouched; only the cross-axis component is gone.

## Testing

Chromium, full-height panel, comparing the grab zone's box with the painted pill and probing `elementFromPoint` at ten points down the handle. "Offset" is the grab zone's centre minus the divider's centre on the cross axis; a drag starts at the painted pill's centre.

| case | offset before | after | drag from pill centre |
|---|---|---|---|
| horizontal, 900px viewport | −450px, lower half dead | 0px, whole handle live | 250 → 250, now 250 → 310 |
| horizontal, 600px viewport | −300px | 0px | dead → resizes |
| horizontal, 1200px viewport | −600px | 0px | dead → resizes |
| horizontal, 900px, page scrolled 300px | −450px | 0px | dead → resizes |
| horizontal, reversed (pill on the end side) | −450px | 0px | dead → resizes |
| horizontal, RTL | −450px | 0px | dead → resizes |
| horizontal, `pillPlacement="center"` | 0px | 0px | resizes, unchanged |
| vertical, 1440px wide | −720px | 0px | resizes (pill sat inside the surviving half) |
| vertical, 800px wide | −400px | 0px | resizes |

At 1440x900 the hit box measured 16x900 at y=−434 while the handle ran 16→916; it now shares the handle's box exactly, and the alignment with the pill along the offset axis stays at 0px in every case above.

Two unit tests are added; both fail on the current code and pass on this branch. `pnpm -F @astryxdesign/core typecheck` and the Resizable suite are green.
