### PR TITLE
fix(build): split StyleX layers in production builds, not just dev

### DIFF
--- a/.changeset/build-split-layers-in-production.md
+++ b/.changeset/build-split-layers-in-production.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/build': patch
+---
+
+[fix] Vite plugin: split Astryx library styles and product styles into their CSS layers during production builds, not only in the dev server. The splitter lived in a `configureServer` hook, so `vite build` shipped every atom in StyleX's flat `@layer priorityN` blocks — which sit outside the named layers and outrank `astryx-theme`, letting library base styles beat an installed theme. Splitting now keys off the atomic class prefix rather than the source path, and runs wherever StyleX hands over its CSS (dev middleware, bundle asset, written file), so dev and production agree. `libraryPattern` also accepts an array and now feeds the prefixer that the split reads, so the two can no longer disagree about which files are library source.
+
+@cixzhang

--- a/packages/build/build.mjs
+++ b/packages/build/build.mjs
@@ -23,6 +23,7 @@ buildSync({
     'vite',
     '@stylexjs/babel-plugin',
     '@stylexjs/unplugin',
+    'postcss',
     'path',
     'url',
     'node:fs',

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "fast-glob": "^3.3.0",
     "glob-parent": "^6.0.0",
-    "is-glob": "^4.0.0"
+    "is-glob": "^4.0.0",
+    "postcss": "^8.5.0"
   },
   "devDependencies": {
     "esbuild": "^0.28.1"

--- a/packages/build/src/babel.js
+++ b/packages/build/src/babel.js
@@ -23,10 +23,13 @@ module.exports = function astryxBabelPlugin(api, options) {
 
   const {
     libraryPatterns = LIBRARY_PATTERNS,
+    extraLibraryPatterns = [],
     libraryPrefix = 'astryx',
     classNamePrefix = 'x',
     ...stylexOptions
   } = options;
+
+  const patterns = [...libraryPatterns, ...extraLibraryPatterns];
 
   // Build the two sets of options — only classNamePrefix differs
   const libraryOpts = {...stylexOptions, classNamePrefix: libraryPrefix};
@@ -37,7 +40,7 @@ module.exports = function astryxBabelPlugin(api, options) {
   const productPlugin = stylexPlugin(api, productOpts);
 
   function getPluginAndOpts(filename) {
-    const isLibrary = libraryPatterns.some(p => filename.includes(p));
+    const isLibrary = patterns.some(p => filename.includes(p));
     return isLibrary
       ? {plugin: libraryPlugin, opts: libraryOpts}
       : {plugin: productPlugin, opts: productOpts};

--- a/packages/build/src/splitLayers.test.ts
+++ b/packages/build/src/splitLayers.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file splitLayers.test.ts
+ * @description Bucketing rules for compiled StyleX CSS. The shapes here are
+ *   taken from real Storybook output: merged selector lists, `:root` token
+ *   blocks, conditional at-rules and prefixed keyframes.
+ */
+
+import {describe, it, expect} from 'vitest';
+import postcss from 'postcss';
+import {splitStylexLayers} from './splitLayers';
+
+const OPTIONS = {
+  libraryLayer: 'astryx-base',
+  productLayer: 'product',
+  libraryPrefix: 'astryx',
+};
+
+const split = (css: string) => splitStylexLayers(css, OPTIONS);
+
+/** The CSS text of one top-level layer. */
+function layer(css: string, name: string): string {
+  let found = '';
+  postcss.parse(css).each(node => {
+    if (
+      node.type === 'atrule' &&
+      node.name === 'layer' &&
+      node.params === name
+    ) {
+      found += node.toString();
+    }
+  });
+  return found;
+}
+
+describe('splitStylexLayers', () => {
+  it('sorts atoms into the library and product layers by prefix', () => {
+    const out = split(`@layer priority2 {
+  .astryx1q8g9m5 { background-color: var(--color-warning); }
+  .x1n0khkq { color: #639; }
+}`);
+
+    expect(layer(out, 'astryx-base')).toContain('.astryx1q8g9m5');
+    expect(layer(out, 'astryx-base')).not.toContain('.x1n0khkq');
+    expect(layer(out, 'product')).toContain('.x1n0khkq');
+    expect(layer(out, 'product')).not.toContain('.astryx1q8g9m5');
+  });
+
+  it('splits a selector list shared by a library and a product atom', () => {
+    // StyleX merges identical declarations across both compilation targets.
+    const out = split(`@layer priority2 {
+  .astryx11g6tue, .astryx1md70p1, .x1md70p1 { background: none; }
+}`);
+
+    expect(layer(out, 'astryx-base')).toContain(
+      '.astryx11g6tue, .astryx1md70p1',
+    );
+    expect(layer(out, 'astryx-base')).not.toContain('.x1md70p1');
+    expect(layer(out, 'product')).toContain('.x1md70p1 {');
+  });
+
+  it('keeps :root token defaults in the library layer', () => {
+    // Tokens must stay below the theme layer, or a theme cannot retint them.
+    const out = split(`@layer priority10 {
+  :root, .astryxj0fimd { --color-accent: #0064e0; }
+}`);
+
+    expect(layer(out, 'astryx-base')).toContain(':root, .astryxj0fimd');
+    expect(layer(out, 'product')).toBe('');
+  });
+
+  it('splits inside conditional at-rules', () => {
+    const out = split(`@layer priority4 {
+  @media (width >= 768px) {
+    .astryxabc123 { display: flex; }
+    .xdef456 { display: grid; }
+  }
+}`);
+
+    expect(layer(out, 'astryx-base')).toContain('.astryxabc123');
+    expect(layer(out, 'astryx-base')).not.toContain('.xdef456');
+    expect(layer(out, 'product')).toContain('@media (width >= 768px)');
+    expect(layer(out, 'product')).toContain('.xdef456');
+  });
+
+  it('routes keyframes by the prefix in their name', () => {
+    const out = split(`@layer priority10 {
+  @keyframes astryx1k48ry3-B { from { opacity: 0; } }
+  @keyframes x1ofn8cw-B { from { opacity: 1; } }
+}`);
+
+    expect(layer(out, 'astryx-base')).toContain('@keyframes astryx1k48ry3-B');
+    expect(layer(out, 'product')).toContain('@keyframes x1ofn8cw-B');
+  });
+
+  it('preserves the relative order of the priority layers', () => {
+    const out = split(`@layer priority2 { .astryxa1 { color: red; } }
+@layer priority5 { .astryxb2 { color: blue; } }`);
+
+    const base = layer(out, 'astryx-base');
+    expect(base.indexOf('priority2')).toBeLessThan(base.indexOf('priority5'));
+    // The order statement covers layers whose rules all landed in one bucket.
+    expect(layer(out, 'product')).toBe('');
+    expect(base).toContain('@layer priority2, priority5;');
+  });
+
+  it('leaves other layers and unlayered CSS untouched', () => {
+    const css = `@layer reset{:where(*){box-sizing:border-box}}
+.legacy{color:red}
+@layer priority2 { .astryxa1 { color: red; } }`;
+
+    const out = split(css);
+    expect(out).toContain('@layer reset{:where(*){box-sizing:border-box}}');
+    expect(out).toContain('.legacy{color:red}');
+  });
+
+  it('is a no-op on CSS it has already split', () => {
+    const once = split(`@layer priority2 {
+  .astryx1q8g9m5 { background-color: var(--color-warning); }
+  .x1n0khkq { color: #639; }
+}`);
+    expect(split(once)).toBe(once);
+  });
+
+  it('returns CSS with no priority layers unchanged', () => {
+    const css = '@layer reset{body{margin:0}}';
+    expect(split(css)).toBe(css);
+  });
+
+  it('refuses to guess when the library prefix is itself an atom prefix', () => {
+    const css = '@layer priority2 { .x1n0khkq { color: #639; } }';
+    expect(splitStylexLayers(css, {...OPTIONS, libraryPrefix: 'x1'})).toBe(css);
+  });
+});

--- a/packages/build/src/splitLayers.ts
+++ b/packages/build/src/splitLayers.ts
@@ -1,0 +1,187 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Splits compiled StyleX CSS into the Astryx library layer and the product
+ * layer.
+ *
+ * StyleX compiles every file in one pass and emits its atoms into flat
+ * `@layer priorityN` blocks. Those blocks are declared after the named layers,
+ * so library base styles end up outranking the installed theme. Astryx gives
+ * library atoms their own class-name prefix, which is what lets the two be
+ * told apart again here and re-nested:
+ *
+ *   @layer astryx-base { @layer priority1, ...; @layer priority1 { ... } }
+ *   @layer product     { @layer priority1, ...; @layer priority1 { ... } }
+ *
+ * Splitting the emitted CSS — rather than compiling twice — keeps whatever
+ * post-processing (lightningcss lowering, minification) the bundler already
+ * applied, and is idempotent: only top-level priority layers are rewritten.
+ */
+
+import postcss, {AtRule, Container, Root, Rule, type ChildNode} from 'postcss';
+
+/** postcss types `nodes` as optional on at-rules; statement at-rules have none. */
+function count(node: AtRule): number {
+  return node.nodes?.length ?? 0;
+}
+
+const PRIORITY_LAYER = /^priority\d+$/;
+const CLASS_TOKEN = /\.(-?[_a-zA-Z][\w-]*)/g;
+const PRODUCT_ATOM = /^x[0-9a-z]+$/;
+
+type Bucket = 'library' | 'product';
+
+/**
+ * Which layer a selector belongs to, judged by the atomic class prefix.
+ * Selectors carrying no atom at all (`:root` token blocks, element resets)
+ * count as library: they are Astryx defaults that the theme must be able to
+ * override.
+ */
+function bucketForSelector(selector: string, libraryPrefix: string): Bucket {
+  let product = false;
+  for (const [, name] of selector.matchAll(CLASS_TOKEN)) {
+    if (name.startsWith(libraryPrefix)) return 'library';
+    if (PRODUCT_ATOM.test(name)) product = true;
+  }
+  return product ? 'product' : 'library';
+}
+
+function bucketForAtRule(node: AtRule, libraryPrefix: string): Bucket | null {
+  if (node.name === 'keyframes' || node.name.endsWith('-keyframes')) {
+    return node.params.trim().startsWith(libraryPrefix) ? 'library' : 'product';
+  }
+  return null;
+}
+
+/**
+ * Partition a container's children into the two buckets, recursing through
+ * conditional at-rules (`@media`, `@supports`, `@container`, `@scope`) so a
+ * rule inside one is still judged on its own selector.
+ */
+function partition(
+  source: Container,
+  targets: Record<Bucket, Container>,
+  libraryPrefix: string,
+): void {
+  source.each((node: ChildNode) => {
+    if (node.type === 'rule') {
+      const rule = node as Rule;
+      const selectors: Record<Bucket, string[]> = {library: [], product: []};
+      for (const selector of rule.selectors) {
+        selectors[bucketForSelector(selector, libraryPrefix)].push(selector);
+      }
+      for (const bucket of ['library', 'product'] as const) {
+        if (selectors[bucket].length === 0) continue;
+        const clone = rule.clone();
+        clone.selectors = selectors[bucket];
+        targets[bucket].append(clone);
+      }
+      return;
+    }
+
+    if (node.type === 'atrule') {
+      const atRule = node as AtRule;
+      const fixed = bucketForAtRule(atRule, libraryPrefix);
+      if (fixed != null) {
+        targets[fixed].append(atRule.clone());
+        return;
+      }
+      if (atRule.nodes == null) {
+        // Statement at-rules (`@layer a, b;`) carry ordering, not styles.
+        targets.library.append(atRule.clone());
+        targets.product.append(atRule.clone());
+        return;
+      }
+      const nested: Record<Bucket, AtRule> = {
+        library: atRule.clone({nodes: []}),
+        product: atRule.clone({nodes: []}),
+      };
+      partition(atRule, nested, libraryPrefix);
+      for (const bucket of ['library', 'product'] as const) {
+        if (count(nested[bucket]) > 0) targets[bucket].append(nested[bucket]);
+      }
+      return;
+    }
+
+    // Anything else (a stray declaration or comment) rides with the library.
+    targets.library.append(node.clone());
+  });
+}
+
+export interface SplitStylexLayersOptions {
+  /** Layer that receives Astryx library atoms. */
+  libraryLayer: string;
+  /** Layer that receives product atoms. */
+  productLayer: string;
+  /** Class-name prefix given to library atoms. */
+  libraryPrefix: string;
+}
+
+/**
+ * Rewrite top-level StyleX priority layers into the library and product
+ * layers. Returns the input unchanged when there is nothing to split.
+ */
+export function splitStylexLayers(
+  css: string,
+  {libraryLayer, productLayer, libraryPrefix}: SplitStylexLayersOptions,
+): string {
+  if (!css.includes('@layer priority')) return css;
+  // A library prefix that is itself a valid product atom would make every
+  // selector ambiguous; leave the CSS alone rather than mis-sort it.
+  if (PRODUCT_ATOM.test(libraryPrefix)) return css;
+
+  let root: Root;
+  try {
+    root = postcss.parse(css);
+  } catch {
+    return css;
+  }
+
+  const priorityLayers: AtRule[] = [];
+  root.each(node => {
+    if (
+      node.type === 'atrule' &&
+      node.name === 'layer' &&
+      PRIORITY_LAYER.test(node.params.trim())
+    ) {
+      priorityLayers.push(node);
+    }
+  });
+  if (priorityLayers.length === 0) return css;
+
+  const wrappers: Record<Bucket, AtRule> = {
+    library: postcss.atRule({name: 'layer', params: libraryLayer, nodes: []}),
+    product: postcss.atRule({name: 'layer', params: productLayer, nodes: []}),
+  };
+
+  // Re-declare the priority order inside each wrapper: a layer that ends up
+  // with rules in only one bucket must still sort against its siblings.
+  const order = priorityLayers.map(layer => layer.params.trim()).join(', ');
+  for (const bucket of ['library', 'product'] as const) {
+    wrappers[bucket].append(
+      postcss.atRule({name: 'layer', params: order, raws: {afterName: ' '}}),
+    );
+  }
+
+  for (const layer of priorityLayers) {
+    if (layer.nodes == null || layer.nodes.length === 0) continue;
+    const nested: Record<Bucket, AtRule> = {
+      library: layer.clone({nodes: []}),
+      product: layer.clone({nodes: []}),
+    };
+    partition(layer, nested, libraryPrefix);
+    for (const bucket of ['library', 'product'] as const) {
+      if (count(nested[bucket]) > 0) wrappers[bucket].append(nested[bucket]);
+    }
+  }
+
+  priorityLayers[0].replaceWith(
+    ...(['library', 'product'] as const)
+      // > 1: every wrapper holds the priority-order statement, rules or not.
+      .filter(bucket => count(wrappers[bucket]) > 1)
+      .map(bucket => wrappers[bucket]),
+  );
+  for (const layer of priorityLayers.slice(1)) layer.remove();
+
+  return root.toString();
+}

--- a/packages/build/src/vite.build.test.ts
+++ b/packages/build/src/vite.build.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file vite.build.test.ts
+ * @description End-to-end check that a *production* Vite build emits Astryx
+ *   library atoms and product atoms into separate CSS layers. The dev server
+ *   splits them via a middleware; builds must reach the same result, or the
+ *   installed theme (in `astryx-theme`) loses to library base styles.
+ */
+
+import {describe, it, expect, afterAll} from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {build} from 'vite';
+import postcss from 'postcss';
+import {astryxStylex} from './vite';
+
+/** Collect the CSS text of a named top-level layer. */
+function layerContent(css: string, layer: string): string {
+  const parts: string[] = [];
+  postcss.parse(css).each(node => {
+    if (
+      node.type === 'atrule' &&
+      node.name === 'layer' &&
+      node.params === layer
+    ) {
+      parts.push(node.toString());
+    }
+  });
+  return parts.join('\n');
+}
+
+/** Names of the top-level layers, in source order. */
+function topLevelLayers(css: string): string[] {
+  const names: string[] = [];
+  postcss.parse(css).each(node => {
+    if (node.type === 'atrule' && node.name === 'layer' && node.nodes != null) {
+      names.push(node.params);
+    }
+  });
+  return names;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const tmpRoots: string[] = [];
+
+afterAll(() => {
+  for (const dir of tmpRoots) rmSync(dir, {recursive: true, force: true});
+});
+
+/**
+ * Build a fixture app with one library file and one product file, and return
+ * the emitted CSS. The fixture lives under packages/build so that Node
+ * resolves @stylexjs/* from the workspace root.
+ */
+async function buildFixture(): Promise<string> {
+  const root = mkdtempSync(path.join(__dirname, '.vite-build-'));
+  tmpRoots.push(root);
+
+  // `packages/core/` matches the default library patterns of both the babel
+  // prefixer and the layer splitter.
+  mkdirSync(path.join(root, 'packages/core'), {recursive: true});
+  mkdirSync(path.join(root, 'src'), {recursive: true});
+
+  writeFileSync(
+    path.join(root, 'packages/core/lib.ts'),
+    `import * as stylex from '@stylexjs/stylex';
+export const libStyles = stylex.create({
+  base: {backgroundColor: 'var(--color-warning)'},
+});
+`,
+  );
+
+  // StyleX appends its output to an existing CSS asset, so the fixture needs
+  // one for the build to emit any CSS at all.
+  writeFileSync(
+    path.join(root, 'src/styles.css'),
+    `@layer reset {\n  body {\n    margin: 0;\n  }\n}\n`,
+  );
+
+  writeFileSync(
+    path.join(root, 'src/main.ts'),
+    `import './styles.css';
+import * as stylex from '@stylexjs/stylex';
+import {libStyles} from '../packages/core/lib';
+const productStyles = stylex.create({
+  base: {color: 'rebeccapurple'},
+});
+document.body.className = stylex.props(libStyles.base, productStyles.base).className ?? '';
+`,
+  );
+
+  writeFileSync(
+    path.join(root, 'index.html'),
+    `<!doctype html><html><body><script type="module" src="/src/main.ts"></script></body></html>`,
+  );
+
+  // StyleX appends its CSS to the file on disk, so the build must write.
+  const outDir = path.join(root, 'dist');
+  await build({
+    root,
+    logLevel: 'silent',
+    configFile: false,
+    plugins: [
+      ...astryxStylex({rootDir: root, libraryPattern: 'packages/core/'}),
+    ],
+    build: {outDir, cssCodeSplit: false},
+  });
+
+  const assets = path.join(outDir, 'assets');
+  return readdirSync(assets)
+    .filter(file => file.endsWith('.css'))
+    .map(file => readFileSync(path.join(assets, file), 'utf8'))
+    .join('\n');
+}
+
+describe('astryxStylex production build', () => {
+  it('emits library atoms in the library layer and product atoms in the product layer', async () => {
+    const css = await buildFixture();
+
+    // Sanity: the prefix routing itself works.
+    expect(css, 'library atom should be prefixed').toMatch(/\.astryx[0-9a-z]+/);
+    expect(css, 'product atom should exist').toMatch(/[^a-z]\.x[0-9a-z]+/);
+
+    // No stylex priority layer may sit at the top level: anything outside the
+    // named layers outranks the theme.
+    expect(topLevelLayers(css)).toEqual(['reset', 'astryx-base', 'product']);
+
+    expect(layerContent(css, 'astryx-base')).toContain('var(--color-warning)');
+    expect(layerContent(css, 'astryx-base')).not.toContain('rebeccapurple');
+    expect(layerContent(css, 'product')).toContain('#639');
+    expect(layerContent(css, 'product')).not.toMatch(/\.astryx[0-9a-z]+/);
+  }, 120_000);
+});

--- a/packages/build/src/vite.test.ts
+++ b/packages/build/src/vite.test.ts
@@ -118,6 +118,7 @@ describe('astryxStylex optimizeDeps package discovery', () => {
           'vite',
           '@stylexjs/babel-plugin',
           '@stylexjs/unplugin',
+          'postcss',
           'path',
           'url',
           'node:fs',

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -1,16 +1,20 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Plugin, UserConfig} from 'vite';
-import stylexBabelPlugin from '@stylexjs/babel-plugin';
 import stylex from '@stylexjs/unplugin';
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {splitStylexLayers} from './splitLayers';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const LIBRARY_PATTERN = 'node_modules/@astryxdesign/';
 const STYLEX_CSS_PATH = '/virtual:stylex.css';
+
+function toPatterns(pattern: string | string[] | undefined): string[] {
+  if (pattern == null) return [];
+  return Array.isArray(pattern) ? pattern : [pattern];
+}
 
 /**
  * Browser targets for lightningcss (opt-in).
@@ -29,7 +33,8 @@ export const LIGHTNINGCSS_TARGETS = {
  */
 export interface AstryxVitePluginLegacyOptions {
   stylexOptions: Parameters<typeof stylex.vite>[0];
-  libraryPattern?: string;
+  /** Extra path fragments that mark a file as Astryx library source. */
+  libraryPattern?: string | string[];
   /** StyleX atomic class-name prefix for Astryx library styles. @default 'astryx' */
   stylexPrefix?: string;
   layers?: {
@@ -52,10 +57,12 @@ export interface AstryxVitePluginOptions {
   rootDir?: string;
 
   /**
-   * Pattern to identify Astryx library files vs product files.
-   * @default 'node_modules/@astryxdesign/'
+   * Extra path fragments that mark a file as Astryx library source, on top of
+   * the built-in ones (`node_modules/@astryxdesign/`, `packages/core/`,
+   * `packages/themes/`, `packages/lab/`). Library source is compiled with the
+   * library class-name prefix, which is what puts it in the library layer.
    */
-  libraryPattern?: string;
+  libraryPattern?: string | string[];
 
   /**
    * CSS layer names for the split output.
@@ -94,6 +101,113 @@ export interface AstryxVitePluginOptions {
 }
 
 /**
+ * Declares the layer order the split output relies on. The theme layer name
+ * is fixed: a theme package ships CSS written into `astryx-theme`.
+ */
+function createLayerOrderPlugin(
+  libraryLayer: string,
+  productLayer: string,
+): Plugin {
+  return {
+    name: 'astryx-css-layer-order',
+    transformIndexHtml() {
+      return [
+        {
+          tag: 'style',
+          children: `@layer reset, ${libraryLayer}, astryx-theme, ${productLayer};`,
+          injectTo: 'head-prepend',
+        },
+      ];
+    },
+  };
+}
+
+/**
+ * Re-nests StyleX's flat priority layers into the library and product layers.
+ *
+ * StyleX hands us its CSS in three different places, so all three are covered:
+ * the dev server serves it from a middleware, and a build either injects it
+ * into a bundle asset (`generateBundle`) or appends it to the written file
+ * (`writeBundle`) depending on whether a CSS asset existed in time. The split
+ * is idempotent, so a path that runs twice is harmless.
+ */
+function createSplitLayerPlugin(
+  libraryLayer: string,
+  productLayer: string,
+  libraryPrefix: string,
+): Plugin {
+  const split = (css: string) =>
+    splitStylexLayers(css, {libraryLayer, productLayer, libraryPrefix});
+
+  return {
+    name: 'astryx-split-layers',
+
+    configureServer(server) {
+      let stylexPlugin: any = null;
+
+      return () => {
+        for (const p of server.config.plugins.flat()) {
+          if ((p as any)?.__stylexCollectCss) {
+            stylexPlugin = p;
+            break;
+          }
+        }
+
+        server.middlewares.stack.unshift({
+          route: '',
+          handle: (req: any, res: any, next: any) => {
+            if (!req.url?.startsWith(STYLEX_CSS_PATH)) {
+              return next();
+            }
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'text/css');
+            res.setHeader('Cache-Control', 'no-store');
+            res.end(split(stylexPlugin?.__stylexCollectCss?.() ?? ''));
+          },
+        });
+      };
+    },
+
+    generateBundle(_options, bundle) {
+      for (const asset of Object.values(bundle)) {
+        if (asset.type !== 'asset' || !asset.fileName.endsWith('.css'))
+          continue;
+        const source =
+          typeof asset.source === 'string'
+            ? asset.source
+            : Buffer.from(asset.source).toString('utf8');
+        asset.source = split(source);
+      }
+    },
+
+    writeBundle(options, bundle) {
+      const outDir =
+        options.dir ?? (options.file ? path.dirname(options.file) : null);
+      if (outDir == null) return;
+
+      const files = Object.values(bundle)
+        .filter(
+          output => output.type === 'asset' && output.fileName.endsWith('.css'),
+        )
+        .map(output => path.join(outDir, output.fileName));
+      // StyleX falls back to its own file when the bundle held no CSS asset.
+      files.push(path.join(outDir, 'assets/stylex.css'));
+
+      for (const file of files) {
+        let current: string;
+        try {
+          current = fs.readFileSync(file, 'utf8');
+        } catch {
+          continue;
+        }
+        const next = split(current);
+        if (next !== current) fs.writeFileSync(file, next, 'utf8');
+      }
+    },
+  };
+}
+
+/**
  * Astryx Vite plugin for source builds.
  *
  * Provides sensible defaults for StyleX compilation with Astryx.
@@ -121,7 +235,7 @@ export function astryxStylex(
   const {
     dev = process.env.NODE_ENV !== 'production',
     rootDir = process.cwd(),
-    libraryPattern = LIBRARY_PATTERN,
+    libraryPattern,
     layers = {},
     lightningcssTargets,
     stylexPrefix = 'astryx',
@@ -160,6 +274,7 @@ export function astryxStylex(
           {
             ...stylexOptions,
             libraryPrefix: stylexPrefix,
+            extraLibraryPatterns: toPatterns(libraryPattern),
             babelConfig: undefined,
           },
         ],
@@ -168,18 +283,7 @@ export function astryxStylex(
   });
 
   // Layer order declaration plugin
-  const layerOrderPlugin: Plugin = {
-    name: 'astryx-css-layer-order',
-    transformIndexHtml() {
-      return [
-        {
-          tag: 'style',
-          children: `@layer reset, ${libraryLayer}, astryx-theme, ${productLayer};`,
-          injectTo: 'head-prepend',
-        },
-      ];
-    },
-  };
+  const layerOrderPlugin = createLayerOrderPlugin(libraryLayer, productLayer);
 
   // Config plugin — injects resolve.alias and optimizeDeps
   const configPlugin: Plugin = {
@@ -221,81 +325,11 @@ export function astryxStylex(
     },
   };
 
-  // Split-layer interceptor plugin (dev server only)
-  const splitLayerPlugin: Plugin = {
-    name: 'astryx-split-layers',
-    configureServer(server) {
-      let stylexPlugin: any = null;
-
-      return () => {
-        for (const p of server.config.plugins.flat()) {
-          if ((p as any)?.__stylexGetSharedStore) {
-            stylexPlugin = p;
-            break;
-          }
-        }
-
-        server.middlewares.stack.unshift({
-          route: '',
-          handle: (req: any, res: any, next: any) => {
-            if (!req.url?.startsWith(STYLEX_CSS_PATH)) {
-              return next();
-            }
-
-            if (!stylexPlugin) {
-              res.statusCode = 200;
-              res.setHeader('Content-Type', 'text/css');
-              res.end('');
-              return;
-            }
-
-            const shared = stylexPlugin.__stylexGetSharedStore?.();
-            const rulesById = shared?.rulesById;
-
-            if (!rulesById || rulesById.size === 0) {
-              res.statusCode = 200;
-              res.setHeader('Content-Type', 'text/css');
-              res.end('');
-              return;
-            }
-
-            const libraryRules: any[] = [];
-            const productRules: any[] = [];
-
-            for (const [filePath, rules] of rulesById.entries()) {
-              if (filePath.includes(libraryPattern)) {
-                libraryRules.push(...rules);
-              } else {
-                productRules.push(...rules);
-              }
-            }
-
-            const libraryCss = libraryRules.length
-              ? stylexBabelPlugin.processStylexRules(libraryRules, {
-                  useLayers: true,
-                })
-              : '';
-            const productCss = productRules.length
-              ? stylexBabelPlugin.processStylexRules(productRules, {
-                  useLayers: true,
-                })
-              : '';
-
-            const parts: string[] = [];
-            if (libraryCss)
-              parts.push(`@layer ${libraryLayer} {\n${libraryCss}\n}`);
-            if (productCss)
-              parts.push(`@layer ${productLayer} {\n${productCss}\n}`);
-
-            res.statusCode = 200;
-            res.setHeader('Content-Type', 'text/css');
-            res.setHeader('Cache-Control', 'no-store');
-            res.end(parts.join('\n\n'));
-          },
-        });
-      };
-    },
-  };
+  const splitLayerPlugin = createSplitLayerPlugin(
+    libraryLayer,
+    productLayer,
+    stylexPrefix,
+  );
 
   return [configPlugin, layerOrderPlugin, basePlugin, splitLayerPlugin];
 }
@@ -307,7 +341,7 @@ export function astryxStylex(
 function astryxStylexLegacy(options: AstryxVitePluginLegacyOptions): Plugin[] {
   const {
     stylexOptions,
-    libraryPattern = LIBRARY_PATTERN,
+    libraryPattern,
     stylexPrefix = 'astryx',
     layers = {},
   } = options;
@@ -329,6 +363,7 @@ function astryxStylexLegacy(options: AstryxVitePluginLegacyOptions): Plugin[] {
           {
             ...(stylexOptions as any),
             libraryPrefix: stylexPrefix,
+            extraLibraryPatterns: toPatterns(libraryPattern),
             babelConfig: undefined,
           },
         ],
@@ -337,93 +372,13 @@ function astryxStylexLegacy(options: AstryxVitePluginLegacyOptions): Plugin[] {
     },
   });
 
-  const layerOrderPlugin: Plugin = {
-    name: 'astryx-css-layer-order',
-    transformIndexHtml() {
-      return [
-        {
-          tag: 'style',
-          children: `@layer reset, ${libraryLayer}, astryx-theme, ${productLayer};`,
-          injectTo: 'head-prepend',
-        },
-      ];
-    },
-  };
+  const layerOrderPlugin = createLayerOrderPlugin(libraryLayer, productLayer);
 
-  const splitLayerPlugin: Plugin = {
-    name: 'astryx-split-layers',
-    configureServer(server) {
-      let stylexPlugin: any = null;
-
-      return () => {
-        for (const p of server.config.plugins.flat()) {
-          if ((p as any)?.__stylexGetSharedStore) {
-            stylexPlugin = p;
-            break;
-          }
-        }
-
-        server.middlewares.stack.unshift({
-          route: '',
-          handle: (req: any, res: any, next: any) => {
-            if (!req.url?.startsWith(STYLEX_CSS_PATH)) {
-              return next();
-            }
-
-            if (!stylexPlugin) {
-              res.statusCode = 200;
-              res.setHeader('Content-Type', 'text/css');
-              res.end('');
-              return;
-            }
-
-            const shared = stylexPlugin.__stylexGetSharedStore?.();
-            const rulesById = shared?.rulesById;
-
-            if (!rulesById || rulesById.size === 0) {
-              res.statusCode = 200;
-              res.setHeader('Content-Type', 'text/css');
-              res.end('');
-              return;
-            }
-
-            const libraryRules: any[] = [];
-            const productRules: any[] = [];
-
-            for (const [filePath, rules] of rulesById.entries()) {
-              if (filePath.includes(libraryPattern)) {
-                libraryRules.push(...rules);
-              } else {
-                productRules.push(...rules);
-              }
-            }
-
-            const libraryCss = libraryRules.length
-              ? stylexBabelPlugin.processStylexRules(libraryRules, {
-                  useLayers: true,
-                })
-              : '';
-            const productCss = productRules.length
-              ? stylexBabelPlugin.processStylexRules(productRules, {
-                  useLayers: true,
-                })
-              : '';
-
-            const parts: string[] = [];
-            if (libraryCss)
-              parts.push(`@layer ${libraryLayer} {\n${libraryCss}\n}`);
-            if (productCss)
-              parts.push(`@layer ${productLayer} {\n${productCss}\n}`);
-
-            res.statusCode = 200;
-            res.setHeader('Content-Type', 'text/css');
-            res.setHeader('Cache-Control', 'no-store');
-            res.end(parts.join('\n\n'));
-          },
-        });
-      };
-    },
-  };
+  const splitLayerPlugin = createSplitLayerPlugin(
+    libraryLayer,
+    productLayer,
+    stylexPrefix,
+  );
 
   return [layerOrderPlugin, basePlugin, splitLayerPlugin];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,9 @@ importers:
       is-glob:
         specifier: ^4.0.0
         version: 4.0.3
+      postcss:
+        specifier: ^8.5.23
+        version: 8.5.25
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)


### PR DESCRIPTION
## Why

The Astryx layer splitter only ever ran in a Vite **dev server**. It lived in a `configureServer` hook, so `vite build` never split anything: every atom — library and product alike — shipped inside StyleX's flat `@layer priorityN` blocks.

Those blocks are declared *after* the named layers, so they outrank `astryx-theme`. The layer order we advertise is real in dev and fiction in production, and an installed theme's component overrides are silently dropped in every built app — Storybook previews included.

Spotted by @cixzhang on a PR preview: `.astryx1q8g9m5 { background-color: var(--color-warning) }` — a library atom, correctly prefixed — sitting in a top-level priority layer.

## What

- Split the emitted CSS by **atomic class prefix** instead of by source path, in a small pure `splitStylexLayers()` pass, and run it everywhere StyleX hands its CSS over: the dev middleware, the bundle asset (`generateBundle`), and the file StyleX appends to on disk (`writeBundle`). Dev and production now produce the same layering from the same code.
- Splitting the *output* rather than compiling twice keeps whatever lowering and minification the bundler already applied, and makes the pass idempotent — only top-level `priorityN` layers are rewritten, so a second run is a no-op and other layers (`reset`, app CSS) are untouched.
- Selectors carrying no atom (`:root` token blocks) stay in the library layer, or a theme could not retint tokens.
- `libraryPattern` now feeds the prefixer that the split reads — before, Storybook's `libraryPattern: 'packages/'` and the babel prefixer's own default list disagreed, so `packages/charts` and `packages/richtext` were compiled as *product*. It also accepts an array now.
- Folded the duplicated modern/legacy plugin bodies into shared factories. The duplication is why this stayed invisible.

## Risk

Behavior change, and the point of the PR: library base styles now sit *below* `astryx-theme`, so themed component overrides start applying in built apps that never showed them. Expect Storybook previews of themed stories to shift. Class names for `packages/charts` and `packages/richtext` change prefix (`x…` → `astryx…`).

`postcss` becomes a declared dependency of `@astryxdesign/build` — `src/index.js` already required it undeclared.

## Testing

`splitLayers.test.ts` covers the bucketing rules against real Storybook output shapes: merged selector lists (`.astryx1md70p1, .x1md70p1`), `:root` token blocks, conditional at-rules, prefixed keyframes, priority ordering, idempotency. `vite.build.test.ts` runs a real production `vite build` over a two-file fixture and asserts the top-level layers are exactly `reset, astryx-base, product`.

Verified on a real Storybook build, before and after — same story, same y2k theme, same machine:

| | main | this PR |
|---|---|---|
| top-level layers | `reset, priority1 … priority10` | `reset, astryx-base, product` |
| `.astryx1q8g9m5` | top-level `@layer priority4` | `@layer astryx-base { @layer priority4 }` |
| rules with mixed library/product selectors | 196 | 0 |
| Button, y2k `color` | `rgb(255,255,255)` — base wins | `rgb(204,207,250)` — theme wins |
| Button, y2k `border-top` | `0px none` — override dropped | `1px solid` |
