### PR TITLE
docs: replace em dashes in DateRangeInput and FormLayout prop descriptions

### DIFF
--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -102,7 +102,7 @@ export const docs = {
       name: 'maxRangeSpan',
       type: 'number',
       description:
-        'Maximum days a selected range may span, counting both endpoints (`7` = a 7-day window, start + 6). Once a start is picked, days beyond this distance are disabled so the range cannot stretch past the cap. Rolling window relative to the start — for fixed calendar bounds use `min`/`max`. Constrains selection only; it never rewrites a `value` already wider than the cap (flag that with `status`).',
+        'Maximum days a selected range may span, counting both endpoints (`7` = a 7-day window, start + 6). Once a start is picked, days beyond this distance are disabled so the range cannot stretch past the cap. Rolling window relative to the start; for fixed calendar bounds use `min`/`max`. Constrains selection only; it never rewrites a `value` already wider than the cap (flag that with `status`).',
     },
     {
       name: 'minRangeSpan',

--- a/packages/core/src/FormLayout/FormLayout.doc.mjs
+++ b/packages/core/src/FormLayout/FormLayout.doc.mjs
@@ -20,7 +20,7 @@ export const docs = {
       name: 'defaultOptionality',
       type: "'optional' | 'required'",
       description:
-        'The state the form treats as its default, so only the exception shows an optional/required indicator. With "optional", only fields marked isRequired show an indicator; with "required", only fields marked isOptional do. A field that restates the default shows nothing. Under "required" the unmarked fields also expose aria-required so screen readers match the visual default — aria-required only, never the native required attribute. Leave unset for today\'s per-field behavior.',
+        'The state the form treats as its default, so only the exception shows an optional/required indicator. With "optional", only fields marked isRequired show an indicator; with "required", only fields marked isOptional do. A field that restates the default shows nothing. Under "required" the unmarked fields also expose aria-required so screen readers match the visual default; aria-required only, never the native required attribute. Leave unset for today\'s per-field behavior.',
     },
     {
       name: 'children',


### PR DESCRIPTION
## What

Two AI-slop typographic tells (check 17, sub A1) in component prop descriptions, replaced with plain punctuation. Prose only; meaning preserved.

- `DateRangeInput.doc.mjs` (maxRangeSpan): `Rolling window relative to the start — for fixed calendar bounds` becomes `... relative to the start; for fixed calendar bounds`. Two independent clauses, so a semicolon.
- `FormLayout.doc.mjs` (defaultOptionality): `match the visual default — aria-required only, never` becomes `match the visual default; aria-required only, never`.

Both props exist on current main (added by #5145 and #4791). Renders verified via `astryx component <Name> --props`.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] CLI `--props` output verified
- [x] Prose strings only; meaning preserved

Night Watch — Doc Reviewer