### PR TITLE
feat(ci): check ICU plural categories in the i18n catalog gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@eslint-react/eslint-plugin": "^5.10.4",
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",
+    "@formatjs/icu-messageformat-parser": "^3.5.12",
     "@playwright/test": "^1.61.1",
     "@testing-library/user-event": "^14.5.0",
     "@types/node": "^25.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
+      '@formatjs/icu-messageformat-parser':
+        specifier: ^3.5.12
+        version: 3.5.12
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1

--- a/scripts/check-i18n-catalog.mjs
+++ b/scripts/check-i18n-catalog.mjs
@@ -13,11 +13,14 @@
  *      keys fail (see LOCALE_MISSING_KEYS_ARE_FATAL for the missing direction).
  *   3. Every en.json entry carries a non-empty `description` — the only
  *      context a Crowdin translator gets.
+ *   4. Every message parses as ICU, and every plural branch it declares is a
+ *      category the locale can actually select.
  *
  * Deliberately NOT checked: catalog keys with no call site. A shipped key is
  * public surface (consumers override any key through `overrides`), so an
  * "unused" key is legitimate and pruning one is a breaking change. Do not add
- * that check.
+ * that check. Placeholder parity between a translation and its en source is
+ * also not checked yet — a separate comparison, worth its own change.
  *
  * Key references come from the TypeScript AST, reusing the call-site
  * definition in internal/eslint-plugin-astryx/i18n-key-format.js — a `t()` /
@@ -25,12 +28,18 @@
  * gate and that lint rule cannot disagree about what a key reference is. A
  * reference whose key is not statically knowable is reported as unverifiable
  * rather than passed or failed silently.
+ *
+ * Plural categories come from `Intl.PluralRules` at check time, never from a
+ * table in this file: CLDR retires categories (Hebrew's `many` is gone from
+ * current data), and a hardcoded set would then fail correct catalogs. It also
+ * means the check inherits the ICU data of whatever Node runs it.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {createRequire} from 'node:module';
+import {parse, TYPE} from '@formatjs/icu-messageformat-parser';
 
 const require = createRequire(import.meta.url);
 const ts = require('typescript');
@@ -275,6 +284,118 @@ function compareLocale(enKeys, localeKeys) {
   };
 }
 
+/**
+ * The plural categories a locale can actually select, cardinal and ordinal,
+ * as `Intl` sees them — the same data `intl-messageformat` selects with at
+ * runtime.
+ *
+ * Returns null when ICU has no data for the tag, which it answers by silently
+ * resolving to the default locale: `he-IL` resolves to `he`, but `xx-YY`
+ * resolves to `en-US` and would report every non-English category as dead.
+ * Comparing the language subtag catches that; the caller skips the locale
+ * rather than reporting against English rules.
+ *
+ * @param {string} tag  BCP-47 tag, from the locale filename
+ * @returns {{cardinal: Set<string>, ordinal: Set<string>} | null}
+ */
+function pluralCategoriesFor(tag) {
+  try {
+    const cardinal = new Intl.PluralRules(tag);
+    const ordinal = new Intl.PluralRules(tag, {type: 'ordinal'});
+    const resolved = cardinal.resolvedOptions().locale;
+    if (new Intl.Locale(tag).language !== new Intl.Locale(resolved).language) {
+      return null;
+    }
+    return {
+      cardinal: new Set(cardinal.resolvedOptions().pluralCategories),
+      ordinal: new Set(ordinal.resolvedOptions().pluralCategories),
+    };
+  } catch {
+    // Malformed tag — not a locale question, and the filename is ours to fix.
+    return null;
+  }
+}
+
+/** Every plural/selectordinal node in a parsed message, including those nested
+ * inside another plural's branches, a `select`, or a rich-text tag. */
+function forEachPluralNode(nodes, visit) {
+  for (const node of nodes) {
+    if (node.type === TYPE.plural) visit(node);
+    if (node.options) {
+      for (const option of Object.values(node.options)) {
+        forEachPluralNode(option.value, visit);
+      }
+    }
+    if (node.children) forEachPluralNode(node.children, visit);
+  }
+}
+
+/**
+ * Parse every message in one catalog and check its plural branches against the
+ * locale's own categories.
+ *
+ * A branch outside the category set is unreachable: `intl-messageformat` asks
+ * `Intl.PluralRules` which category a number is and falls back to `other` when
+ * the message has no branch for it, so the dead branch's wording never renders
+ * and the count silently reads as `other`. The parser itself rejects a plural
+ * with no `other`, so that arrives here as a parse error.
+ *
+ * The parser is the reason this is not a regex: `{g, select, many {…}}` is not
+ * a plural, `selectordinal` is scored against the ordinal categories (Hebrew
+ * has one cardinal set and a single-category ordinal one), `=0` is an exact
+ * match rather than a category, and quoted braces are not syntax at all.
+ *
+ * @param {object} catalog  parsed locale JSON
+ * @param {string} tag      BCP-47 tag for that catalog
+ * @returns {{parseErrors: string[], deadBranches: string[],
+ *            unsupportedLocale: boolean}}
+ */
+function auditPluralCategories(catalog, tag) {
+  const categories = pluralCategoriesFor(tag);
+  if (categories === null) {
+    return {parseErrors: [], deadBranches: [], unsupportedLocale: true};
+  }
+
+  const parseErrors = [];
+  const deadBranches = [];
+
+  for (const [key, entry] of Object.entries(catalog)) {
+    const message =
+      entry !== null && typeof entry === 'object'
+        ? entry.defaultMessage
+        : entry;
+    // Entry shape is validateSourceCatalog's to report; skip, don't double-report.
+    if (typeof message !== 'string') continue;
+
+    let ast;
+    try {
+      ast = parse(message);
+    } catch (error) {
+      parseErrors.push(`${key}: ${String(error.message).split('\n')[0]}`);
+      continue;
+    }
+
+    forEachPluralNode(ast, node => {
+      const valid =
+        node.pluralType === 'ordinal'
+          ? categories.ordinal
+          : categories.cardinal;
+      for (const branch of Object.keys(node.options)) {
+        // `=0` / `=1` match an exact value, not a category — always reachable.
+        if (branch.startsWith('=')) continue;
+        if (!valid.has(branch)) {
+          deadBranches.push(
+            `${key}: "${branch}" is not a ${node.pluralType} category of ${tag} ` +
+              `(${[...valid].join(', ')})`,
+          );
+        }
+      }
+    });
+  }
+
+  return {parseErrors, deadBranches, unsupportedLocale: false};
+}
+
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
@@ -319,11 +440,13 @@ function main() {
     });
   }
 
-  // 2. Locale parity
+  // 2. Locale parity + 4. ICU plural categories
   const localeFiles = fs
     .readdirSync(path.join(ROOT, LOCALES_DIR))
     .filter(f => f.endsWith('.json') && !NOT_A_SHIPPED_LOCALE.has(f))
     .sort();
+
+  const skippedLocales = [];
 
   for (const file of localeFiles) {
     const localeCatalog = readJson(path.join(ROOT, LOCALES_DIR, file));
@@ -343,6 +466,25 @@ function main() {
         notes.push(summary);
       }
     }
+
+    const {parseErrors, deadBranches, unsupportedLocale} =
+      auditPluralCategories(localeCatalog, path.basename(file, '.json'));
+    if (unsupportedLocale) {
+      skippedLocales.push(file);
+    }
+    if (parseErrors.length > 0) {
+      errors.push({
+        title: `${file}: ${parseErrors.length} message(s) are not valid ICU`,
+        lines: parseErrors,
+        hint: 'These throw when formatted. Fix the string in Crowdin so the next download carries the correction.',
+      });
+    }
+    // A dead branch in a translation is Crowdin's content, and it degrades to
+    // `other` rather than breaking — a note, on the same reasoning as
+    // LOCALE_MISSING_KEYS_ARE_FATAL. In en.json it is an error; see below.
+    for (const line of deadBranches) {
+      notes.push(`${file}: unreachable plural branch — ${line}`);
+    }
   }
 
   // 3. Translator context
@@ -353,6 +495,31 @@ function main() {
       lines: catalogProblems,
       hint: 'A description is the only context a Crowdin translator gets.',
     });
+  }
+
+  // 4. The source catalog's own ICU. Authored here, so both findings are fatal:
+  // a dead branch in en.json is wording a reader will never see, and it is also
+  // what every translation is modelled on.
+  const en = auditPluralCategories(catalog, 'en');
+  if (en.parseErrors.length > 0) {
+    errors.push({
+      title: `en.json: ${en.parseErrors.length} message(s) are not valid ICU`,
+      lines: en.parseErrors,
+      hint: 'These throw when formatted.',
+    });
+  }
+  if (en.deadBranches.length > 0) {
+    errors.push({
+      title: `en.json: ${en.deadBranches.length} unreachable plural branch(es)`,
+      lines: en.deadBranches,
+      hint: 'Intl.PluralRules never selects this category for the locale, so the branch is dead and the count renders as `other`.',
+    });
+  }
+
+  if (skippedLocales.length > 0) {
+    notes.push(
+      `plural categories unchecked for ${skippedLocales.join(', ')} — this Node's ICU has no data for the tag`,
+    );
   }
 
   if (unverifiable.length > 0) {
@@ -376,7 +543,8 @@ function main() {
 
   console.log(
     `✓ check:i18n-catalog — ${seen.size} key(s) over ${refCount} reference(s) resolve; ` +
-      `${enKeys.size} en entries described; ${localeFiles.length} locale(s) consistent`,
+      `${enKeys.size} en entries described; ${localeFiles.length} locale(s) consistent; ` +
+      `ICU plurals checked against CLDR ${process.versions.cldr}`,
   );
   for (const note of notes) console.log(`  · ${note}`);
 }
@@ -386,4 +554,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main();
 }
 
-export {extractKeyRefs, validateSourceCatalog, compareLocale};
+export {
+  extractKeyRefs,
+  validateSourceCatalog,
+  compareLocale,
+  auditPluralCategories,
+};

--- a/scripts/check-i18n-catalog.test.mjs
+++ b/scripts/check-i18n-catalog.test.mjs
@@ -14,6 +14,7 @@ import {
   extractKeyRefs,
   validateSourceCatalog,
   compareLocale,
+  auditPluralCategories,
 } from './check-i18n-catalog.mjs';
 
 const keys = source => extractKeyRefs(source, 'Test.tsx').refs.map(r => r.key);
@@ -189,5 +190,95 @@ describe('compareLocale', () => {
       missing: ['@astryx.a.two'],
       extra: ['@astryx.a.stale'],
     });
+  });
+});
+
+describe('auditPluralCategories', () => {
+  const catalog = message => ({
+    '@astryx.a.count': {defaultMessage: message, description: 'ctx'},
+  });
+  const audit = (message, tag) => auditPluralCategories(catalog(message), tag);
+
+  it('accepts a plural whose branches the locale selects', () => {
+    const {parseErrors, deadBranches} = audit(
+      '{c, plural, one {item} other {items}}',
+      'en',
+    );
+    expect({parseErrors, deadBranches}).toEqual({
+      parseErrors: [],
+      deadBranches: [],
+    });
+  });
+
+  it("accepts a category en lacks but the locale has — he's `two`", () => {
+    expect(
+      audit('{c, plural, one {א} two {ב} other {ג}}', 'he-IL').deadBranches,
+    ).toEqual([]);
+  });
+
+  it('reports a category the locale never selects', () => {
+    // Hebrew dropped `many` from CLDR, so this branch can never render.
+    const {deadBranches} = audit(
+      '{c, plural, one {א} two {ב} many {ד} other {ג}}',
+      'he-IL',
+    );
+    expect(deadBranches).toHaveLength(1);
+    expect(deadBranches[0]).toContain('"many" is not a cardinal category');
+  });
+
+  it('scores selectordinal against the ordinal categories, not the cardinal ones', () => {
+    // `two` is a cardinal category of en and an ordinal one; `many` is neither.
+    expect(
+      audit('{c, selectordinal, two {2nd} other {th}}', 'en').deadBranches,
+    ).toEqual([]);
+    expect(
+      audit('{c, selectordinal, many {th} other {th}}', 'en').deadBranches,
+    ).toHaveLength(1);
+  });
+
+  it('does not mistake a select option for a plural category', () => {
+    expect(
+      audit('{who, select, many {a crowd} other {someone}}', 'he-IL')
+        .deadBranches,
+    ).toEqual([]);
+  });
+
+  it('exempts an exact `=N` match, which is not a category', () => {
+    expect(
+      audit('{c, plural, =0 {none} one {one} other {some}}', 'en').deadBranches,
+    ).toEqual([]);
+  });
+
+  it('descends into a nested plural', () => {
+    const {deadBranches} = audit(
+      '{a, plural, one {{b, plural, many {x} other {y}}} other {z}}',
+      'en',
+    );
+    expect(deadBranches).toHaveLength(1);
+    expect(deadBranches[0]).toContain('"many"');
+  });
+
+  it('reports a message that is not valid ICU', () => {
+    const {parseErrors} = audit('{c, plural, one {a} other {b}', 'en');
+    expect(parseErrors).toHaveLength(1);
+    expect(parseErrors[0]).toContain('@astryx.a.count');
+  });
+
+  it('reports a plural with no `other` — the parser rejects it', () => {
+    expect(audit('{c, plural, one {a} two {b}}', 'he-IL').parseErrors).toEqual([
+      '@astryx.a.count: MISSING_OTHER_CLAUSE',
+    ]);
+  });
+
+  it('skips a locale this Node has no plural data for, rather than scoring it against en', () => {
+    const result = audit('{c, plural, one {a} other {b}}', 'xx-YY');
+    expect(result.unsupportedLocale).toBe(true);
+    expect(result.deadBranches).toEqual([]);
+  });
+
+  it('leaves entry-shape problems to validateSourceCatalog', () => {
+    expect(
+      auditPluralCategories({'@astryx.a.count': {description: 'ctx'}}, 'en'),
+    ).toEqual({parseErrors: [], deadBranches: [], unsupportedLocale: false});
   });
 });


### PR DESCRIPTION
`check:i18n-catalog` compared key sets only. A plural branch naming a category the locale never selects passed unnoticed — and such a branch is dead code: `intl-messageformat` asks `Intl.PluralRules` which category a number falls in and drops to `other` when the message has no branch for it, so the translator's wording never renders.

Crowdin is about to make this concrete. On 2026-08-26 it drops the `many` category for Hebrew to match current CLDR (one/two/many/other → one/two/other). Our Hebrew catalog is already one/two/other and current ICU already agrees, so nothing changes for us — but nothing was watching either, and the next language CLDR revises would land the same way.

## What the gate does now

Every message in every catalog is parsed with the same ICU parser the runtime uses, and each plural branch is checked against the categories `Intl.PluralRules` reports for that locale.

Categories are read at check time, never hardcoded — a CLDR table in the repo is exactly what breaks when CLDR moves, and it would then fail catalogs that are correct. The check also inherits the ICU data of whatever Node runs it, which is the same data the app will use.

Using the parser rather than a regex is what makes the rest correct: `{who, select, many {…}}` is not a plural, `selectordinal` is scored against the ordinal categories (Hebrew has three cardinal categories and one ordinal), `=0` is an exact match rather than a category, quoted braces are not syntax, and a plural nested inside another branch is still found.

## Severity

- **Unreachable branch in `en.json` — error.** We author it, and every translation is modelled on it.
- **Unreachable branch in a translation — note.** Crowdin owns that content and it degrades to `other`; failing here would red every translations PR, the same reasoning that makes untranslated keys a note.
- **A message that does not parse — error, anywhere.** It throws when formatted.

Not included: placeholder parity between a translation and its English source. That is a different comparison and worth its own change.

## Test plan

- `pnpm check:i18n-catalog` passes on all 29 shipped locales plus `en` — 7,404 messages parse, zero dead branches.
- Each new rule was removed in turn to confirm its test fails and nothing else does: cardinal/ordinal split, the `=N` exemption, the unsupported-locale guard, nested descent, and plural-vs-`select`.
- Injected into real catalogs, then reverted: a `many` branch in Hebrew reports the dead branch and exits 0; an unbalanced brace in Hebrew reports `EXPECT_ARGUMENT_CLOSING_BRACE` and exits 1; a `few` branch in `en.json` exits 1.
- `pnpm lint:strict` clean. Full `pnpm test` matches `main`'s failures on this machine (all in `packages/cli`, timeouts under load); the one difference passes on its own.