### PR TITLE
fix: reserve the scrollbar's width while scroll is locked

### DIFF
--- a/.changeset/scroll-lock-scrollbar-gutter.md
+++ b/.changeset/scroll-lock-scrollbar-gutter.md
@@ -1,0 +1,18 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Opening a Dialog, BottomSheet, Lightbox, or MobileNav no longer shifts the page sideways when the browser has a classic scrollbar
+
+@imdreamrunner
+
+Locking background scroll hides the document's scrollbar. Where that scrollbar
+takes layout space — Windows/Linux desktop, and macOS set to always show scroll
+bars — hiding it widened the layout viewport by its width (~15px), so the whole
+page reflowed sideways behind the overlay and back again on close.
+
+Both scroll locks now measure that width before they hide the scrollbar and
+reserve it as padding for the duration of the lock. Overlay scrollbars measure
+0 and are untouched. The reserved width is published as
+`--astryx-scrollbar-gutter` so `position: fixed` chrome, which body padding
+can't hold, can compensate too.

--- a/.changeset/scroll-lock-scrollbar-gutter.md
+++ b/.changeset/scroll-lock-scrollbar-gutter.md
@@ -11,8 +11,9 @@ takes layout space — Windows/Linux desktop, and macOS set to always show scrol
 bars — hiding it widened the layout viewport by its width (~15px), so the whole
 page reflowed sideways behind the overlay and back again on close.
 
-Both scroll locks now measure that width before they hide the scrollbar and
-reserve it as padding for the duration of the lock. Overlay scrollbars measure
-0 and are untouched. The reserved width is published as
-`--astryx-scrollbar-gutter` so `position: fixed` chrome, which body padding
-can't hold, can compensate too.
+Both scroll locks now hold that gutter open with `scrollbar-gutter: stable` for
+the duration of the lock, which keeps `position: fixed` chrome (sticky headers,
+toast viewports) still as well as in-flow content. Pages with no space-taking
+scrollbar, and pages that already set `scrollbar-gutter` themselves, are left
+alone. Engines without `scrollbar-gutter` support fall back to padding the
+measured difference.

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -23,6 +23,7 @@
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/MobileNav/index.ts (exports if types change)
+ * - /packages/core/src/hooks/scrollbarGutter.ts (shared scroll-lock gutter)
  * - /packages/cli/assets/templates/blocks/components/MobileNav/ (showcase blocks)
  */
 
@@ -47,6 +48,11 @@ import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {Heading} from '../Heading/Heading';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
+import {
+  reserveScrollbarGutter,
+  releaseScrollbarGutter,
+  type ScrollbarGutterSnapshot,
+} from '../hooks/scrollbarGutter';
 import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -396,6 +402,15 @@ export function MobileNav({
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const gutterRef = useRef<ScrollbarGutterSnapshot | null>(null);
+
+  // Gives back the width reserved for the (now hidden) document scrollbar.
+  const releaseGutter = useCallback(() => {
+    if (gutterRef.current) {
+      releaseScrollbarGutter(document.documentElement, gutterRef.current);
+      gutterRef.current = null;
+    }
+  }, []);
   // Resolved side — computed from trigger position when side='auto'
   const [resolvedSide, setResolvedSide] = useState<'start' | 'end'>(
     side === 'auto' ? 'end' : side,
@@ -444,9 +459,13 @@ export function MobileNav({
       // Prevent background scrolling and iOS pull-to-refresh.
       // overflow: clip avoids creating a scroll container (unlike hidden),
       // so there's no scroll bounce and no need to save/restore scroll position.
+      // Reserve the classic scrollbar's width first (measured while it's still
+      // there) so clipping it away doesn't reflow the page sideways.
+      gutterRef.current ??= reserveScrollbarGutter(document.documentElement);
       document.documentElement.style.overflow = 'clip';
     } else if (dialog.open) {
       document.documentElement.style.overflow = '';
+      releaseGutter();
 
       closeTimeoutRef.current = setTimeout(() => {
         dialog.close();
@@ -459,8 +478,9 @@ export function MobileNav({
         closeTimeoutRef.current = null;
       }
       document.documentElement.style.overflow = '';
+      releaseGutter();
     };
-  }, [isOpen]);
+  }, [isOpen, releaseGutter]);
 
   // Close the native dialog on unmount if it's still open. Inside AppShell the
   // drawer is mounted in an <Activity> that switches to mode="hidden" when the

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -49,9 +49,8 @@ import {Icon} from '../Icon';
 import {Heading} from '../Heading/Heading';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {
-  reserveScrollbarGutter,
-  releaseScrollbarGutter,
-  type ScrollbarGutterSnapshot,
+  holdScrollbarGutter,
+  type ScrollbarGutterHold,
 } from '../hooks/scrollbarGutter';
 import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
@@ -402,12 +401,12 @@ export function MobileNav({
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
-  const gutterRef = useRef<ScrollbarGutterSnapshot | null>(null);
+  const gutterRef = useRef<ScrollbarGutterHold | null>(null);
 
-  // Gives back the width reserved for the (now hidden) document scrollbar.
+  // Gives back the gutter held open in place of the hidden scrollbar.
   const releaseGutter = useCallback(() => {
     if (gutterRef.current) {
-      releaseScrollbarGutter(document.documentElement, gutterRef.current);
+      gutterRef.current.release();
       gutterRef.current = null;
     }
   }, []);
@@ -453,16 +452,18 @@ export function MobileNav({
     }
 
     if (isOpen) {
+      // Taken first: every mutation below is one that can hide the scrollbar,
+      // and the gutter has to be measured while it is still there.
+      gutterRef.current ??= holdScrollbarGutter(document.documentElement);
+
       if (!dialog.open) {
         dialog.showModal();
       }
       // Prevent background scrolling and iOS pull-to-refresh.
       // overflow: clip avoids creating a scroll container (unlike hidden),
       // so there's no scroll bounce and no need to save/restore scroll position.
-      // Reserve the classic scrollbar's width first (measured while it's still
-      // there) so clipping it away doesn't reflow the page sideways.
-      gutterRef.current ??= reserveScrollbarGutter(document.documentElement);
       document.documentElement.style.overflow = 'clip';
+      gutterRef.current.settle();
     } else if (dialog.open) {
       document.documentElement.style.overflow = '';
       releaseGutter();

--- a/packages/core/src/MobileNav/MobileNavScrollbarGutter.test.tsx
+++ b/packages/core/src/MobileNav/MobileNavScrollbarGutter.test.tsx
@@ -1,0 +1,113 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file MobileNavScrollbarGutter.test.tsx
+ * @input Uses vitest, @testing-library/react, MobileNav, a stubbed viewport
+ * @output Unit tests for the scrollbar gutter MobileNav reserves while open
+ * @position Testing; guards MobileNav.tsx against the open-drawer page shift
+ *
+ * MobileNav clips the document to lock background scroll, which hides a
+ * classic scrollbar and widens the layout viewport by its width — the page
+ * behind the drawer jumps sideways. The clip has to be paired with a
+ * reservation of that width.
+ *
+ * SYNC: When MobileNav.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, beforeAll, afterEach} from 'vitest';
+import {render, cleanup} from '@testing-library/react';
+import {MobileNav} from './MobileNav';
+
+beforeAll(() => {
+  // jsdom doesn't implement showModal/close on <dialog>
+  HTMLDialogElement.prototype.showModal =
+    HTMLDialogElement.prototype.showModal ||
+    function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  HTMLDialogElement.prototype.close =
+    HTMLDialogElement.prototype.close ||
+    function (this: HTMLDialogElement) {
+      this.removeAttribute('open');
+    };
+});
+
+/** jsdom does no layout, so both halves of the measurement are stubbed. */
+function stubViewport(innerWidth: number, clientWidth: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    value: innerWidth,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(document.documentElement, 'clientWidth', {
+    value: clientWidth,
+    configurable: true,
+  });
+}
+
+const gutterVar = () =>
+  document.documentElement.style.getPropertyValue('--astryx-scrollbar-gutter');
+
+describe('MobileNav scrollbar gutter', () => {
+  afterEach(() => {
+    cleanup();
+    document.documentElement.style.cssText = '';
+    // @ts-expect-error -- drop the viewport stub so jsdom's own value comes back
+    delete document.documentElement.clientWidth;
+  });
+
+  it('reserves the hidden scrollbar width while the drawer is open', () => {
+    stubViewport(1024, 1009);
+
+    const view = render(
+      <MobileNav isOpen={true} onOpenChange={() => {}}>
+        <span>Nav content</span>
+      </MobileNav>,
+    );
+
+    expect(document.documentElement.style.overflow).toBe('clip');
+    expect(document.documentElement.style.paddingRight).toBe('15px');
+    expect(gutterVar()).toBe('15px');
+
+    view.unmount();
+
+    expect(document.documentElement.style.overflow).toBe('');
+    expect(document.documentElement.style.paddingRight).toBe('');
+    expect(gutterVar()).toBe('');
+  });
+
+  it('gives the reserved width back when the drawer closes', () => {
+    stubViewport(1024, 1009);
+
+    const view = render(
+      <MobileNav isOpen={true} onOpenChange={() => {}}>
+        <span>Nav content</span>
+      </MobileNav>,
+    );
+
+    expect(document.documentElement.style.paddingRight).toBe('15px');
+
+    view.rerender(
+      <MobileNav isOpen={false} onOpenChange={() => {}}>
+        <span>Nav content</span>
+      </MobileNav>,
+    );
+
+    expect(document.documentElement.style.paddingRight).toBe('');
+    expect(gutterVar()).toBe('');
+  });
+
+  it('reserves nothing when the scrollbar is an overlay one', () => {
+    stubViewport(1024, 1024);
+
+    render(
+      <MobileNav isOpen={true} onOpenChange={() => {}}>
+        <span>Nav content</span>
+      </MobileNav>,
+    );
+
+    expect(document.documentElement.style.overflow).toBe('clip');
+    expect(document.documentElement.style.paddingRight).toBe('');
+    expect(gutterVar()).toBe('');
+  });
+});

--- a/packages/core/src/MobileNav/MobileNavScrollbarGutter.test.tsx
+++ b/packages/core/src/MobileNav/MobileNavScrollbarGutter.test.tsx
@@ -8,8 +8,8 @@
  *
  * MobileNav clips the document to lock background scroll, which hides a
  * classic scrollbar and widens the layout viewport by its width — the page
- * behind the drawer jumps sideways. The clip has to be paired with a
- * reservation of that width.
+ * behind the drawer jumps sideways. The clip has to be paired with holding
+ * that gutter open.
  *
  * SYNC: When MobileNav.tsx changes, update tests to match new behavior
  */
@@ -45,8 +45,7 @@ function stubViewport(innerWidth: number, clientWidth: number) {
   });
 }
 
-const gutterVar = () =>
-  document.documentElement.style.getPropertyValue('--astryx-scrollbar-gutter');
+const rootGutter = () => document.documentElement.style.scrollbarGutter;
 
 describe('MobileNav scrollbar gutter', () => {
   afterEach(() => {
@@ -56,7 +55,7 @@ describe('MobileNav scrollbar gutter', () => {
     delete document.documentElement.clientWidth;
   });
 
-  it('reserves the hidden scrollbar width while the drawer is open', () => {
+  it('holds the gutter open while the drawer is open', () => {
     stubViewport(1024, 1009);
 
     const view = render(
@@ -66,17 +65,15 @@ describe('MobileNav scrollbar gutter', () => {
     );
 
     expect(document.documentElement.style.overflow).toBe('clip');
-    expect(document.documentElement.style.paddingRight).toBe('15px');
-    expect(gutterVar()).toBe('15px');
+    expect(rootGutter()).toBe('stable');
 
     view.unmount();
 
     expect(document.documentElement.style.overflow).toBe('');
-    expect(document.documentElement.style.paddingRight).toBe('');
-    expect(gutterVar()).toBe('');
+    expect(rootGutter()).toBe('');
   });
 
-  it('gives the reserved width back when the drawer closes', () => {
+  it('gives the gutter back when the drawer closes', () => {
     stubViewport(1024, 1009);
 
     const view = render(
@@ -85,7 +82,7 @@ describe('MobileNav scrollbar gutter', () => {
       </MobileNav>,
     );
 
-    expect(document.documentElement.style.paddingRight).toBe('15px');
+    expect(rootGutter()).toBe('stable');
 
     view.rerender(
       <MobileNav isOpen={false} onOpenChange={() => {}}>
@@ -93,11 +90,10 @@ describe('MobileNav scrollbar gutter', () => {
       </MobileNav>,
     );
 
-    expect(document.documentElement.style.paddingRight).toBe('');
-    expect(gutterVar()).toBe('');
+    expect(rootGutter()).toBe('');
   });
 
-  it('reserves nothing when the scrollbar is an overlay one', () => {
+  it('holds nothing when the scrollbar is an overlay one', () => {
     stubViewport(1024, 1024);
 
     render(
@@ -107,7 +103,7 @@ describe('MobileNav scrollbar gutter', () => {
     );
 
     expect(document.documentElement.style.overflow).toBe('clip');
+    expect(rootGutter()).toBe('');
     expect(document.documentElement.style.paddingRight).toBe('');
-    expect(gutterVar()).toBe('');
   });
 });

--- a/packages/core/src/hooks/scrollbarGutter.test.ts
+++ b/packages/core/src/hooks/scrollbarGutter.test.ts
@@ -2,33 +2,30 @@
 
 /**
  * @file scrollbarGutter.test.ts
- * @input Uses vitest and a stubbed viewport (window.innerWidth vs
- *   documentElement.clientWidth)
- * @output Unit tests for measure/reserve/releaseScrollbarGutter
+ * @input Uses vitest and a stubbed viewport + element box (jsdom does no layout)
+ * @output Unit tests for holdScrollbarGutter
  * @position Testing; validates scrollbarGutter.ts implementation
  *
  * SYNC: When scrollbarGutter.ts changes, update tests to match new behavior
  */
 
 import {afterEach, describe, expect, it} from 'vitest';
-import {
-  SCROLLBAR_GUTTER_VAR,
-  measureScrollbarGutter,
-  releaseScrollbarGutter,
-  reserveScrollbarGutter,
-} from './scrollbarGutter';
+import {holdScrollbarGutter} from './scrollbarGutter';
 
 /**
- * jsdom does no layout, so `documentElement.clientWidth` is 0 there. Stub the
- * pair the measurement reads: a 15px classic scrollbar is `innerWidth` 1024
- * against a 1009px layout viewport.
+ * jsdom does no layout, so both halves of the measurement are stubbed: the
+ * viewport (`innerWidth` vs `documentElement.clientWidth`) and the element's
+ * own box, which `widths` reads from and a test flips to simulate the lock
+ * widening it.
  */
-function stubViewport({
+function stub({
   innerWidth,
   clientWidth,
+  widths,
 }: {
   innerWidth: number;
   clientWidth: number;
+  widths?: () => number;
 }) {
   Object.defineProperty(window, 'innerWidth', {
     value: innerWidth,
@@ -39,99 +36,132 @@ function stubViewport({
     value: clientWidth,
     configurable: true,
   });
+  if (widths) {
+    document.body.getBoundingClientRect = () => ({width: widths()}) as DOMRect;
+  }
 }
 
-describe('scrollbarGutter', () => {
+const rootGutter = () => document.documentElement.style.scrollbarGutter;
+
+describe('holdScrollbarGutter', () => {
   afterEach(() => {
     document.body.style.cssText = '';
     document.documentElement.style.cssText = '';
     // @ts-expect-error -- drop the stubs so jsdom's own values come back
     delete document.documentElement.clientWidth;
+    // @ts-expect-error -- restore the prototype's implementation
+    delete document.body.getBoundingClientRect;
   });
 
-  describe('measureScrollbarGutter', () => {
-    it('measures a classic scrollbar as the gap between the window and the layout viewport', () => {
-      stubViewport({innerWidth: 1024, clientWidth: 1009});
-      expect(measureScrollbarGutter()).toBe(15);
-    });
+  it('holds the gutter open when a space-taking scrollbar is about to be hidden', () => {
+    // A 1024px window over a 1009px layout viewport = a 15px classic scrollbar.
+    stub({innerWidth: 1024, clientWidth: 1009});
 
-    it('measures 0 for overlay scrollbars, which take no layout space', () => {
-      stubViewport({innerWidth: 1024, clientWidth: 1024});
-      expect(measureScrollbarGutter()).toBe(0);
-    });
+    const hold = holdScrollbarGutter(document.body);
 
-    it('measures 0 when there is no layout to measure', () => {
-      stubViewport({innerWidth: 1024, clientWidth: 0});
-      expect(measureScrollbarGutter()).toBe(0);
-    });
+    expect(rootGutter()).toBe('stable');
+
+    hold.settle();
+    hold.release();
+
+    expect(rootGutter()).toBe('');
   });
 
-  describe('reserveScrollbarGutter', () => {
-    it('reserves the scrollbar width as padding and publishes it as a custom property', () => {
-      stubViewport({innerWidth: 1024, clientWidth: 1009});
+  it('leaves an overlay scrollbar alone — there is no gutter to hold', () => {
+    stub({innerWidth: 1024, clientWidth: 1024});
 
-      const snapshot = reserveScrollbarGutter(document.body);
+    const hold = holdScrollbarGutter(document.body);
+    hold.settle();
 
-      expect(document.body.style.paddingRight).toBe('15px');
-      expect(
-        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
-      ).toBe('15px');
+    expect(rootGutter()).toBe('');
+    expect(document.body.style.paddingRight).toBe('');
 
-      releaseScrollbarGutter(document.body, snapshot);
+    hold.release();
+  });
 
-      expect(document.body.style.paddingRight).toBe('');
-      expect(
-        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
-      ).toBe('');
-    });
+  it('does not pad when holding the gutter kept the element still', () => {
+    stub({innerWidth: 1024, clientWidth: 1009, widths: () => 1009});
 
-    it("adds to the page's own padding instead of replacing it", () => {
-      stubViewport({innerWidth: 1024, clientWidth: 1009});
-      document.body.style.paddingRight = '24px';
+    const hold = holdScrollbarGutter(document.body);
+    hold.settle();
 
-      const snapshot = reserveScrollbarGutter(document.body);
+    expect(rootGutter()).toBe('stable');
+    expect(document.body.style.paddingRight).toBe('');
 
-      expect(document.body.style.paddingRight).toBe('39px');
+    hold.release();
+  });
 
-      releaseScrollbarGutter(document.body, snapshot);
+  it('falls back to padding when the element grew anyway', () => {
+    // What an engine without scrollbar-gutter support does: the gutter request
+    // is ignored, the scrollbar goes away, and the element widens by 15px.
+    let width = 1009;
+    stub({innerWidth: 1024, clientWidth: 1009, widths: () => width});
 
-      expect(document.body.style.paddingRight).toBe('24px');
-    });
+    const hold = holdScrollbarGutter(document.body);
+    width = 1024;
+    hold.settle();
 
-    it('leaves the element alone when the scrollbar takes no space', () => {
-      stubViewport({innerWidth: 1024, clientWidth: 1024});
+    expect(document.body.style.paddingRight).toBe('15px');
 
-      const snapshot = reserveScrollbarGutter(document.body);
+    hold.release();
 
-      expect(document.body.style.paddingRight).toBe('');
-      expect(
-        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
-      ).toBe('');
+    expect(document.body.style.paddingRight).toBe('');
+  });
 
-      releaseScrollbarGutter(document.body, snapshot);
+  it("adds to the page's own padding instead of replacing it", () => {
+    let width = 1009;
+    stub({innerWidth: 1024, clientWidth: 1009, widths: () => width});
+    document.body.style.paddingRight = '24px';
 
-      expect(document.body.style.paddingRight).toBe('');
-    });
+    const hold = holdScrollbarGutter(document.body);
+    width = 1024;
+    hold.settle();
 
-    it('keeps the outer reservation intact when a nested lock releases', () => {
-      stubViewport({innerWidth: 1024, clientWidth: 1009});
+    expect(document.body.style.paddingRight).toBe('39px');
 
-      const outer = reserveScrollbarGutter(document.body);
-      // The scrollbar is already hidden by the time an overlay opens on top of
-      // another one, so the inner lock measures nothing to reserve.
-      stubViewport({innerWidth: 1024, clientWidth: 1024});
-      const inner = reserveScrollbarGutter(document.body);
+    hold.release();
 
-      releaseScrollbarGutter(document.body, inner);
+    expect(document.body.style.paddingRight).toBe('24px');
+  });
 
-      expect(document.body.style.paddingRight).toBe('15px');
-      expect(
-        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
-      ).toBe('15px');
+  it('restores the page\u2019s own scrollbar-gutter rather than clearing it', () => {
+    stub({innerWidth: 1024, clientWidth: 1009});
+    document.documentElement.style.scrollbarGutter = 'stable both-edges';
 
-      releaseScrollbarGutter(document.body, outer);
+    const hold = holdScrollbarGutter(document.body);
 
-      expect(document.body.style.paddingRight).toBe('');
-    });
+    expect(rootGutter()).toBe('stable');
+
+    hold.settle();
+    hold.release();
+
+    expect(rootGutter()).toBe('stable both-edges');
+  });
+
+  it('settles once, however many times it is called', () => {
+    let width = 1009;
+    stub({innerWidth: 1024, clientWidth: 1009, widths: () => width});
+
+    const hold = holdScrollbarGutter(document.body);
+    width = 1024;
+    hold.settle();
+    hold.settle();
+    hold.settle();
+
+    expect(document.body.style.paddingRight).toBe('15px');
+
+    hold.release();
+  });
+
+  it('does nothing where there is no layout to measure', () => {
+    stub({innerWidth: 1024, clientWidth: 0});
+
+    const hold = holdScrollbarGutter(document.body);
+    hold.settle();
+
+    expect(rootGutter()).toBe('');
+    expect(document.body.style.paddingRight).toBe('');
+
+    hold.release();
   });
 });

--- a/packages/core/src/hooks/scrollbarGutter.test.ts
+++ b/packages/core/src/hooks/scrollbarGutter.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file scrollbarGutter.test.ts
+ * @input Uses vitest and a stubbed viewport (window.innerWidth vs
+ *   documentElement.clientWidth)
+ * @output Unit tests for measure/reserve/releaseScrollbarGutter
+ * @position Testing; validates scrollbarGutter.ts implementation
+ *
+ * SYNC: When scrollbarGutter.ts changes, update tests to match new behavior
+ */
+
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+  SCROLLBAR_GUTTER_VAR,
+  measureScrollbarGutter,
+  releaseScrollbarGutter,
+  reserveScrollbarGutter,
+} from './scrollbarGutter';
+
+/**
+ * jsdom does no layout, so `documentElement.clientWidth` is 0 there. Stub the
+ * pair the measurement reads: a 15px classic scrollbar is `innerWidth` 1024
+ * against a 1009px layout viewport.
+ */
+function stubViewport({
+  innerWidth,
+  clientWidth,
+}: {
+  innerWidth: number;
+  clientWidth: number;
+}) {
+  Object.defineProperty(window, 'innerWidth', {
+    value: innerWidth,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(document.documentElement, 'clientWidth', {
+    value: clientWidth,
+    configurable: true,
+  });
+}
+
+describe('scrollbarGutter', () => {
+  afterEach(() => {
+    document.body.style.cssText = '';
+    document.documentElement.style.cssText = '';
+    // @ts-expect-error -- drop the stubs so jsdom's own values come back
+    delete document.documentElement.clientWidth;
+  });
+
+  describe('measureScrollbarGutter', () => {
+    it('measures a classic scrollbar as the gap between the window and the layout viewport', () => {
+      stubViewport({innerWidth: 1024, clientWidth: 1009});
+      expect(measureScrollbarGutter()).toBe(15);
+    });
+
+    it('measures 0 for overlay scrollbars, which take no layout space', () => {
+      stubViewport({innerWidth: 1024, clientWidth: 1024});
+      expect(measureScrollbarGutter()).toBe(0);
+    });
+
+    it('measures 0 when there is no layout to measure', () => {
+      stubViewport({innerWidth: 1024, clientWidth: 0});
+      expect(measureScrollbarGutter()).toBe(0);
+    });
+  });
+
+  describe('reserveScrollbarGutter', () => {
+    it('reserves the scrollbar width as padding and publishes it as a custom property', () => {
+      stubViewport({innerWidth: 1024, clientWidth: 1009});
+
+      const snapshot = reserveScrollbarGutter(document.body);
+
+      expect(document.body.style.paddingRight).toBe('15px');
+      expect(
+        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
+      ).toBe('15px');
+
+      releaseScrollbarGutter(document.body, snapshot);
+
+      expect(document.body.style.paddingRight).toBe('');
+      expect(
+        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
+      ).toBe('');
+    });
+
+    it("adds to the page's own padding instead of replacing it", () => {
+      stubViewport({innerWidth: 1024, clientWidth: 1009});
+      document.body.style.paddingRight = '24px';
+
+      const snapshot = reserveScrollbarGutter(document.body);
+
+      expect(document.body.style.paddingRight).toBe('39px');
+
+      releaseScrollbarGutter(document.body, snapshot);
+
+      expect(document.body.style.paddingRight).toBe('24px');
+    });
+
+    it('leaves the element alone when the scrollbar takes no space', () => {
+      stubViewport({innerWidth: 1024, clientWidth: 1024});
+
+      const snapshot = reserveScrollbarGutter(document.body);
+
+      expect(document.body.style.paddingRight).toBe('');
+      expect(
+        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
+      ).toBe('');
+
+      releaseScrollbarGutter(document.body, snapshot);
+
+      expect(document.body.style.paddingRight).toBe('');
+    });
+
+    it('keeps the outer reservation intact when a nested lock releases', () => {
+      stubViewport({innerWidth: 1024, clientWidth: 1009});
+
+      const outer = reserveScrollbarGutter(document.body);
+      // The scrollbar is already hidden by the time an overlay opens on top of
+      // another one, so the inner lock measures nothing to reserve.
+      stubViewport({innerWidth: 1024, clientWidth: 1024});
+      const inner = reserveScrollbarGutter(document.body);
+
+      releaseScrollbarGutter(document.body, inner);
+
+      expect(document.body.style.paddingRight).toBe('15px');
+      expect(
+        document.documentElement.style.getPropertyValue(SCROLLBAR_GUTTER_VAR),
+      ).toBe('15px');
+
+      releaseScrollbarGutter(document.body, outer);
+
+      expect(document.body.style.paddingRight).toBe('');
+    });
+  });
+});

--- a/packages/core/src/hooks/scrollbarGutter.ts
+++ b/packages/core/src/hooks/scrollbarGutter.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file scrollbarGutter.ts
+ * @input An element to compensate, plus viewport metrics (window.innerWidth vs
+ *   document.documentElement.clientWidth)
+ * @output Exports SCROLLBAR_GUTTER_VAR, measureScrollbarGutter,
+ *   reserveScrollbarGutter, releaseScrollbarGutter
+ * @position Internal hook utility; used by useScrollLock and MobileNav so that
+ *   locking background scroll does not resize the layout viewport.
+ *
+ * Locking scroll hides the document's scrollbar. Where that scrollbar is a
+ * classic (space-taking) one — Windows/Linux desktop, and macOS set to
+ * "Always" show scroll bars — hiding it widens the layout viewport by the
+ * scrollbar's width and the whole page jumps sideways behind the overlay.
+ * These helpers reserve that width back as padding on whichever element the
+ * lock pins, so the content box keeps its pre-lock size.
+ *
+ * Overlay scrollbars (mobile, default macOS) measure 0 and are left alone.
+ */
+
+/**
+ * Custom property holding the reserved gutter width while a scroll lock is
+ * active (`0px` is not set — the property is simply absent when unlocked).
+ *
+ * Padding on the pinned element only compensates content in the document
+ * flow. `position: fixed` chrome (sticky headers, toast viewports) is laid out
+ * against the viewport itself and has to compensate explicitly:
+ *
+ * ```
+ * paddingRight: 'var(--astryx-scrollbar-gutter, 0px)'
+ * ```
+ */
+export const SCROLLBAR_GUTTER_VAR = '--astryx-scrollbar-gutter';
+
+export interface ScrollbarGutterSnapshot {
+  /** The element's inline `padding-right` before the lock. */
+  paddingRight: string;
+  /** Whether this lock is the one that reserved the gutter. */
+  reserved: boolean;
+}
+
+/**
+ * Width of the document's classic scrollbar, in pixels; `0` when the scrollbar
+ * is an overlay one (or when there is no scrollbar at all).
+ *
+ * Must be read *before* the scroll lock's styles are applied — afterwards the
+ * scrollbar is already gone and the difference measures 0.
+ */
+export function measureScrollbarGutter(): number {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return 0;
+  }
+
+  const viewportWidth = document.documentElement.clientWidth;
+
+  // 0 means "no layout to measure" (jsdom, and any non-visual environment),
+  // not "the scrollbar is as wide as the window".
+  if (viewportWidth === 0) {
+    return 0;
+  }
+
+  return Math.max(0, window.innerWidth - viewportWidth);
+}
+
+/**
+ * Reserves the scrollbar's width as extra `padding-right` on `element`, so
+ * hiding the scrollbar doesn't widen the content box.
+ *
+ * Physical `padding-right`, not logical `padding-inline-end`: where the
+ * document's scrollbar sits is a UA decision, not a writing-mode one. Chromium
+ * keeps the root scrollbar at the physical right edge even in RTL documents,
+ * where compensating the inline-end edge measurably moved RTL content by the
+ * gutter width instead of holding it still.
+ *
+ * Returns a snapshot to hand back to {@link releaseScrollbarGutter}.
+ */
+export function reserveScrollbarGutter(
+  element: HTMLElement,
+): ScrollbarGutterSnapshot {
+  const paddingRight = element.style.paddingRight;
+  const gutter = measureScrollbarGutter();
+
+  if (gutter === 0) {
+    return {paddingRight, reserved: false};
+  }
+
+  const existing =
+    Number.parseFloat(window.getComputedStyle(element).paddingRight || '0') ||
+    0;
+
+  element.style.paddingRight = `${existing + gutter}px`;
+  document.documentElement.style.setProperty(
+    SCROLLBAR_GUTTER_VAR,
+    `${gutter}px`,
+  );
+
+  return {paddingRight, reserved: true};
+}
+
+/** Undoes {@link reserveScrollbarGutter}, restoring the inline padding. */
+export function releaseScrollbarGutter(
+  element: HTMLElement,
+  snapshot: ScrollbarGutterSnapshot,
+): void {
+  if (!snapshot.reserved) {
+    return;
+  }
+
+  element.style.paddingRight = snapshot.paddingRight;
+  document.documentElement.style.removeProperty(SCROLLBAR_GUTTER_VAR);
+}

--- a/packages/core/src/hooks/scrollbarGutter.ts
+++ b/packages/core/src/hooks/scrollbarGutter.ts
@@ -2,10 +2,8 @@
 
 /**
  * @file scrollbarGutter.ts
- * @input An element to compensate, plus viewport metrics (window.innerWidth vs
- *   document.documentElement.clientWidth)
- * @output Exports SCROLLBAR_GUTTER_VAR, measureScrollbarGutter,
- *   reserveScrollbarGutter, releaseScrollbarGutter
+ * @input The element a scroll lock pins, plus live layout measurements
+ * @output Exports holdScrollbarGutter and the ScrollbarGutterHold it returns
  * @position Internal hook utility; used by useScrollLock and MobileNav so that
  *   locking background scroll does not resize the layout viewport.
  *
@@ -13,100 +11,111 @@
  * classic (space-taking) one — Windows/Linux desktop, and macOS set to
  * "Always" show scroll bars — hiding it widens the layout viewport by the
  * scrollbar's width and the whole page jumps sideways behind the overlay.
- * These helpers reserve that width back as padding on whichever element the
- * lock pins, so the content box keeps its pre-lock size.
  *
- * Overlay scrollbars (mobile, default macOS) measure 0 and are left alone.
+ * The fix is `scrollbar-gutter: stable`, which holds the gutter open once the
+ * scrollbar goes away. Being a real layout change it holds `position: fixed`
+ * chrome (sticky headers, toast viewports) as well as in-flow content, which
+ * padding fundamentally cannot: fixed elements resolve against the viewport,
+ * not against the padded element.
+ *
+ * Padding is kept only as a fallback for engines without `scrollbar-gutter`
+ * (Safari shipped it in 18.2), and it is applied by measuring whether the
+ * element actually moved rather than by assuming it did.
  */
 
-/**
- * Custom property holding the reserved gutter width while a scroll lock is
- * active (`0px` is not set — the property is simply absent when unlocked).
- *
- * Padding on the pinned element only compensates content in the document
- * flow. `position: fixed` chrome (sticky headers, toast viewports) is laid out
- * against the viewport itself and has to compensate explicitly:
- *
- * ```
- * paddingRight: 'var(--astryx-scrollbar-gutter, 0px)'
- * ```
- */
-export const SCROLLBAR_GUTTER_VAR = '--astryx-scrollbar-gutter';
+const NOOP: ScrollbarGutterHold = {
+  settle() {},
+  release() {},
+};
 
-export interface ScrollbarGutterSnapshot {
-  /** The element's inline `padding-right` before the lock. */
-  paddingRight: string;
-  /** Whether this lock is the one that reserved the gutter. */
-  reserved: boolean;
+export interface ScrollbarGutterHold {
+  /**
+   * Call once the lock's own styles are applied: measures whether the element
+   * grew anyway and, only then, pads the difference away.
+   */
+  settle(): void;
+  /** Call on unlock: restores everything this hold changed. */
+  release(): void;
 }
 
 /**
- * Width of the document's classic scrollbar, in pixels; `0` when the scrollbar
- * is an overlay one (or when there is no scrollbar at all).
+ * Keeps `element`'s content box the width it is right now, across a scroll
+ * lock that is about to hide the document's scrollbar.
  *
- * Must be read *before* the scroll lock's styles are applied — afterwards the
- * scrollbar is already gone and the difference measures 0.
+ * Call it *before* applying the lock's styles, then {@link
+ * ScrollbarGutterHold.settle} immediately after, and {@link
+ * ScrollbarGutterHold.release} on unlock:
+ *
+ * ```
+ * const hold = holdScrollbarGutter(document.body);
+ * body.style.position = 'fixed';
+ * hold.settle();
+ * ```
+ *
+ * Overlay scrollbars (mobile, default macOS) take no layout space, so there is
+ * nothing to hold and nothing is touched.
  */
-export function measureScrollbarGutter(): number {
+export function holdScrollbarGutter(element: HTMLElement): ScrollbarGutterHold {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return 0;
+    return NOOP;
   }
 
-  const viewportWidth = document.documentElement.clientWidth;
+  const root = document.documentElement;
+  const viewportWidth = root.clientWidth;
 
   // 0 means "no layout to measure" (jsdom, and any non-visual environment),
   // not "the scrollbar is as wide as the window".
   if (viewportWidth === 0) {
-    return 0;
+    return NOOP;
   }
 
-  return Math.max(0, window.innerWidth - viewportWidth);
-}
+  const previousGutter = root.style.scrollbarGutter;
+  const previousPadding = element.style.paddingRight;
+  const widthBefore = element.getBoundingClientRect().width;
 
-/**
- * Reserves the scrollbar's width as extra `padding-right` on `element`, so
- * hiding the scrollbar doesn't widen the content box.
- *
- * Physical `padding-right`, not logical `padding-inline-end`: where the
- * document's scrollbar sits is a UA decision, not a writing-mode one. Chromium
- * keeps the root scrollbar at the physical right edge even in RTL documents,
- * where compensating the inline-end edge measurably moved RTL content by the
- * gutter width instead of holding it still.
- *
- * Returns a snapshot to hand back to {@link releaseScrollbarGutter}.
- */
-export function reserveScrollbarGutter(
-  element: HTMLElement,
-): ScrollbarGutterSnapshot {
-  const paddingRight = element.style.paddingRight;
-  const gutter = measureScrollbarGutter();
+  let heldGutter = false;
+  let padded = false;
+  let settled = false;
 
-  if (gutter === 0) {
-    return {paddingRight, reserved: false};
+  // Only when a space-taking scrollbar is actually there. Holding the gutter
+  // open on a page that never had one would carve out 15px that was never
+  // reserved — the same shift, in the other direction.
+  if (window.innerWidth > viewportWidth) {
+    root.style.scrollbarGutter = 'stable';
+    heldGutter = true;
   }
 
-  const existing =
-    Number.parseFloat(window.getComputedStyle(element).paddingRight || '0') ||
-    0;
+  return {
+    settle() {
+      if (settled) {
+        return;
+      }
+      settled = true;
 
-  element.style.paddingRight = `${existing + gutter}px`;
-  document.documentElement.style.setProperty(
-    SCROLLBAR_GUTTER_VAR,
-    `${gutter}px`,
-  );
+      // What the lock actually did to this element, rather than what we
+      // assumed it would do. 0 on any engine where the gutter held — and on a
+      // page that already sets `scrollbar-gutter: stable` itself, where the
+      // scrollbar was never taking the space back.
+      const grew = element.getBoundingClientRect().width - widthBefore;
+      if (grew <= 0) {
+        return;
+      }
 
-  return {paddingRight, reserved: true};
-}
+      const existing =
+        Number.parseFloat(window.getComputedStyle(element).paddingRight) || 0;
+      element.style.paddingRight = `${existing + grew}px`;
+      padded = true;
+    },
 
-/** Undoes {@link reserveScrollbarGutter}, restoring the inline padding. */
-export function releaseScrollbarGutter(
-  element: HTMLElement,
-  snapshot: ScrollbarGutterSnapshot,
-): void {
-  if (!snapshot.reserved) {
-    return;
-  }
-
-  element.style.paddingRight = snapshot.paddingRight;
-  document.documentElement.style.removeProperty(SCROLLBAR_GUTTER_VAR);
+    release() {
+      if (padded) {
+        element.style.paddingRight = previousPadding;
+        padded = false;
+      }
+      if (heldGutter) {
+        root.style.scrollbarGutter = previousGutter;
+        heldGutter = false;
+      }
+    },
+  };
 }

--- a/packages/core/src/hooks/useScrollLock.doc.mjs
+++ b/packages/core/src/hooks/useScrollLock.doc.mjs
@@ -4,7 +4,7 @@
 export const docs = {
   name: 'useScrollLock',
   displayName: 'useScrollLock',
-  keywords: ['scroll', 'lock', 'modal', 'dialog', 'body', 'prevent', 'background', 'ios', 'safari', 'fixed', 'scrollbar', 'gutter', 'layout shift'],
+  keywords: ['scroll', 'lock', 'modal', 'dialog', 'body', 'prevent', 'background', 'ios', 'safari', 'fixed', 'scrollbar', 'gutter', 'layout shift', 'reflow'],
   params: [
     {
       name: 'isLocked',
@@ -16,11 +16,10 @@ export const docs = {
   returns: [],
   usage: {
     description:
-      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked. Pinning hides the document scrollbar, so where that scrollbar takes layout space (desktop) its width is reserved as body padding for the duration of the lock and the page does not shift sideways.',
+      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked. Pinning hides the document scrollbar, so where that scrollbar takes layout space (desktop) the hook holds its gutter open with scrollbar-gutter: stable for the duration of the lock — the page, including any position: fixed chrome, does not shift sideways.',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals or dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass the same boolean that controls dialog visibility (e.g., isOpen) as the isLocked parameter.' },
-      { guidance: true, description: 'Compensate your own position: fixed chrome with padding-right: var(--astryx-scrollbar-gutter, 0px) — the hook sets that custom property while locked, and body padding only holds content that is in the document flow.' },
       { guidance: false, description: 'Use for non-modal overlays like popovers or tooltips; users should be able to scroll away from those.' },
     ],
   },
@@ -33,17 +32,16 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').HookTranslationDoc} */
 export const docsDense = {
   description:
-    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Reserves the hidden scrollbar\'s width as body padding so the page does not shift sideways.',
+    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways.',
   paramDescriptions: {
     isLocked: 'whether body scroll should be locked.',
   },
   usage: {
     description:
-      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Reserves the hidden scrollbar\'s width as body padding so the page does not shift sideways.',
+      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways.',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals / dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass same boolean that controls dialog visibility (e.g. isOpen) as isLocked parameter.' },
-      { guidance: true, description: 'Compensate own position: fixed chrome w/ padding-right: var(--astryx-scrollbar-gutter, 0px) — hook sets that custom property while locked; body padding only holds in-flow content.' },
       { guidance: false, description: 'Use for non-modal overlays like popovers / tooltips; users should be able to scroll away from those.' },
     ],
   },

--- a/packages/core/src/hooks/useScrollLock.doc.mjs
+++ b/packages/core/src/hooks/useScrollLock.doc.mjs
@@ -4,7 +4,7 @@
 export const docs = {
   name: 'useScrollLock',
   displayName: 'useScrollLock',
-  keywords: ['scroll', 'lock', 'modal', 'dialog', 'body', 'prevent', 'background', 'ios', 'safari', 'fixed'],
+  keywords: ['scroll', 'lock', 'modal', 'dialog', 'body', 'prevent', 'background', 'ios', 'safari', 'fixed', 'scrollbar', 'gutter', 'layout shift'],
   params: [
     {
       name: 'isLocked',
@@ -16,10 +16,11 @@ export const docs = {
   returns: [],
   usage: {
     description:
-      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked.',
+      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked. Pinning hides the document scrollbar, so where that scrollbar takes layout space (desktop) its width is reserved as body padding for the duration of the lock and the page does not shift sideways.',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals or dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass the same boolean that controls dialog visibility (e.g., isOpen) as the isLocked parameter.' },
+      { guidance: true, description: 'Compensate your own position: fixed chrome with padding-right: var(--astryx-scrollbar-gutter, 0px) — the hook sets that custom property while locked, and body padding only holds content that is in the document flow.' },
       { guidance: false, description: 'Use for non-modal overlays like popovers or tooltips; users should be able to scroll away from those.' },
     ],
   },
@@ -32,16 +33,17 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').HookTranslationDoc} */
 export const docsDense = {
   description:
-    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked.',
+    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Reserves the hidden scrollbar\'s width as body padding so the page does not shift sideways.',
   paramDescriptions: {
     isLocked: 'whether body scroll should be locked.',
   },
   usage: {
     description:
-      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked.',
+      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Reserves the hidden scrollbar\'s width as body padding so the page does not shift sideways.',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals / dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass same boolean that controls dialog visibility (e.g. isOpen) as isLocked parameter.' },
+      { guidance: true, description: 'Compensate own position: fixed chrome w/ padding-right: var(--astryx-scrollbar-gutter, 0px) — hook sets that custom property while locked; body padding only holds in-flow content.' },
       { guidance: false, description: 'Use for non-modal overlays like popovers / tooltips; users should be able to scroll away from those.' },
     ],
   },

--- a/packages/core/src/hooks/useScrollLock.test.ts
+++ b/packages/core/src/hooks/useScrollLock.test.ts
@@ -73,7 +73,7 @@ describe('useScrollLock', () => {
     expect(document.body.style.right).toBe('');
   });
 
-  it('holds the page still by reserving the width of the scrollbar it hides', () => {
+  it('holds the page still across the scrollbar it hides', () => {
     // A 1024px window over a 1009px layout viewport = a 15px classic
     // scrollbar. Pinning the body hides it, which would widen the page by
     // those 15px and reflow everything sideways.
@@ -90,24 +90,14 @@ describe('useScrollLock', () => {
 
     const lock = renderHook(() => useScrollLock(true));
 
-    expect(document.body.style.paddingRight).toBe('15px');
-    expect(
-      document.documentElement.style.getPropertyValue(
-        '--astryx-scrollbar-gutter',
-      ),
-    ).toBe('15px');
+    expect(document.documentElement.style.scrollbarGutter).toBe('stable');
 
     lock.unmount();
 
-    expect(document.body.style.paddingRight).toBe('');
-    expect(
-      document.documentElement.style.getPropertyValue(
-        '--astryx-scrollbar-gutter',
-      ),
-    ).toBe('');
+    expect(document.documentElement.style.scrollbarGutter).toBe('');
   });
 
-  it('leaves padding alone when the scrollbar is an overlay one', () => {
+  it('leaves the page alone when the scrollbar is an overlay one', () => {
     Object.defineProperty(window, 'innerWidth', {
       value: 1024,
       configurable: true,
@@ -121,8 +111,35 @@ describe('useScrollLock', () => {
 
     const lock = renderHook(() => useScrollLock(true));
 
+    expect(document.documentElement.style.scrollbarGutter).toBe('');
     expect(document.body.style.paddingRight).toBe('');
 
     lock.unmount();
+  });
+
+  it('holds the gutter for the outermost overlay only, and gives it back once', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1009,
+      configurable: true,
+    });
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const first = renderHook(() => useScrollLock(true));
+    const second = renderHook(() => useScrollLock(true));
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+
+    first.unmount();
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+
+    second.unmount();
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('');
   });
 });

--- a/packages/core/src/hooks/useScrollLock.test.ts
+++ b/packages/core/src/hooks/useScrollLock.test.ts
@@ -17,6 +17,9 @@ describe('useScrollLock', () => {
   afterEach(() => {
     cleanup();
     document.body.style.cssText = '';
+    document.documentElement.style.cssText = '';
+    // @ts-expect-error -- drop the viewport stub so jsdom's own value comes back
+    delete document.documentElement.clientWidth;
     vi.restoreAllMocks();
   });
 
@@ -68,5 +71,58 @@ describe('useScrollLock', () => {
     expect(document.body.style.top).toBe('');
     expect(document.body.style.left).toBe('');
     expect(document.body.style.right).toBe('');
+  });
+
+  it('holds the page still by reserving the width of the scrollbar it hides', () => {
+    // A 1024px window over a 1009px layout viewport = a 15px classic
+    // scrollbar. Pinning the body hides it, which would widen the page by
+    // those 15px and reflow everything sideways.
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1009,
+      configurable: true,
+    });
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const lock = renderHook(() => useScrollLock(true));
+
+    expect(document.body.style.paddingRight).toBe('15px');
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--astryx-scrollbar-gutter',
+      ),
+    ).toBe('15px');
+
+    lock.unmount();
+
+    expect(document.body.style.paddingRight).toBe('');
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--astryx-scrollbar-gutter',
+      ),
+    ).toBe('');
+  });
+
+  it('leaves padding alone when the scrollbar is an overlay one', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1024,
+      configurable: true,
+    });
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const lock = renderHook(() => useScrollLock(true));
+
+    expect(document.body.style.paddingRight).toBe('');
+
+    lock.unmount();
   });
 });

--- a/packages/core/src/hooks/useScrollLock.ts
+++ b/packages/core/src/hooks/useScrollLock.ts
@@ -17,11 +17,7 @@
  */
 
 import {useEffect} from 'react';
-import {
-  reserveScrollbarGutter,
-  releaseScrollbarGutter,
-  type ScrollbarGutterSnapshot,
-} from './scrollbarGutter';
+import {holdScrollbarGutter, type ScrollbarGutterHold} from './scrollbarGutter';
 
 interface ScrollLockSnapshot {
   scrollX: number;
@@ -31,7 +27,7 @@ interface ScrollLockSnapshot {
   top: string;
   left: string;
   right: string;
-  gutter: ScrollbarGutterSnapshot;
+  gutter: ScrollbarGutterHold;
 }
 
 let lockCount = 0;
@@ -45,9 +41,9 @@ let originalBodyState: ScrollLockSnapshot | null = null;
  * does not prevent body scroll behind modals. Restores scroll position
  * on unlock.
  *
- * Pinning hides the document scrollbar, so the width a classic scrollbar
- * occupied is reserved as body padding for the duration of the lock — without
- * it the page reflows sideways by ~15px the moment an overlay opens.
+ * Pinning also hides the document's scrollbar, so the gutter that scrollbar
+ * occupied is held open for the duration of the lock — without it the page
+ * reflows sideways by ~15px the moment an overlay opens.
  *
  * @example
  * ```
@@ -66,8 +62,8 @@ export function useScrollLock(isLocked: boolean): void {
       const scrollX = window.scrollX;
       const scrollY = window.scrollY;
 
-      // Measured before the pinning styles below hide the scrollbar.
-      const gutter = reserveScrollbarGutter(body);
+      // Taken before the pinning styles below hide the scrollbar.
+      const gutter = holdScrollbarGutter(body);
 
       originalBodyState = {
         scrollX,
@@ -85,6 +81,8 @@ export function useScrollLock(isLocked: boolean): void {
       body.style.top = `-${scrollY}px`;
       body.style.left = '0';
       body.style.right = '0';
+
+      gutter.settle();
     }
 
     lockCount += 1;
@@ -104,7 +102,7 @@ export function useScrollLock(isLocked: boolean): void {
       body.style.top = state.top;
       body.style.left = state.left;
       body.style.right = state.right;
-      releaseScrollbarGutter(body, state.gutter);
+      state.gutter.release();
       window.scrollTo(state.scrollX, state.scrollY);
     };
   }, [isLocked]);

--- a/packages/core/src/hooks/useScrollLock.ts
+++ b/packages/core/src/hooks/useScrollLock.ts
@@ -13,9 +13,15 @@
  *
  * SYNC: When modified, update:
  * - /packages/core/src/hooks/index.ts
+ * - /packages/core/src/hooks/scrollbarGutter.ts
  */
 
 import {useEffect} from 'react';
+import {
+  reserveScrollbarGutter,
+  releaseScrollbarGutter,
+  type ScrollbarGutterSnapshot,
+} from './scrollbarGutter';
 
 interface ScrollLockSnapshot {
   scrollX: number;
@@ -25,6 +31,7 @@ interface ScrollLockSnapshot {
   top: string;
   left: string;
   right: string;
+  gutter: ScrollbarGutterSnapshot;
 }
 
 let lockCount = 0;
@@ -37,6 +44,10 @@ let originalBodyState: ScrollLockSnapshot | null = null;
  * which is necessary for iOS Safari where `overscroll-behavior: contain`
  * does not prevent body scroll behind modals. Restores scroll position
  * on unlock.
+ *
+ * Pinning hides the document scrollbar, so the width a classic scrollbar
+ * occupied is reserved as body padding for the duration of the lock — without
+ * it the page reflows sideways by ~15px the moment an overlay opens.
  *
  * @example
  * ```
@@ -55,6 +66,9 @@ export function useScrollLock(isLocked: boolean): void {
       const scrollX = window.scrollX;
       const scrollY = window.scrollY;
 
+      // Measured before the pinning styles below hide the scrollbar.
+      const gutter = reserveScrollbarGutter(body);
+
       originalBodyState = {
         scrollX,
         scrollY,
@@ -63,6 +77,7 @@ export function useScrollLock(isLocked: boolean): void {
         top: body.style.top,
         left: body.style.left,
         right: body.style.right,
+        gutter,
       };
 
       body.style.overflow = 'hidden';
@@ -89,6 +104,7 @@ export function useScrollLock(isLocked: boolean): void {
       body.style.top = state.top;
       body.style.left = state.left;
       body.style.right = state.right;
+      releaseScrollbarGutter(body, state.gutter);
       window.scrollTo(state.scrollX, state.scrollY);
     };
   }, [isLocked]);


### PR DESCRIPTION
## The bug

Opening a `Dialog`, `BottomSheet`, `Lightbox`, `Drawer`, or `MobileNav` locks background scroll, and locking hides the document's scrollbar. Where that scrollbar takes layout space — Windows/Linux desktop, and macOS set to *always* show scroll bars — hiding it widens the layout viewport by the scrollbar's width, so the page behind the overlay reflows sideways by ~15px, then back again on close.

Two independent lock implementations both had it:

- `useScrollLock` (Dialog, BottomSheet, Lightbox, lab's Drawer) pins the body with `position: fixed` + `overflow: hidden`.
- `MobileNav` clips the document with `documentElement.style.overflow = 'clip'`.

## The fix

Hold the gutter open with `scrollbar-gutter: stable` for the duration of the lock.

It's a real layout change rather than a compensation, so it holds **`position: fixed` chrome** — a toast viewport, a sticky dock — as well as in-flow content. Padding the pinned element cannot: fixed elements resolve against the viewport, not against the padded element, so they keep jumping.

It's applied only when a space-taking scrollbar is actually present. Holding the gutter open on a page that never had one would carve out 15px that was never reserved — the same shift, in the other direction.

Padding survives only as a fallback for engines without `scrollbar-gutter` (Safari shipped it in 18.2). It's applied by measuring whether the element actually moved, not by assuming it did — which is also what keeps a page that already sets `scrollbar-gutter: stable` from being double-compensated.

## Test plan

Real-browser matrix (Playwright + Chromium), rendering the built `Dialog` / `BottomSheet` / `MobileNav` and measuring both an in-flow row and a `position: fixed` element before / during / after each overlay. **30/30 hold at Δ 0px and fully restore** — 3 overlays × 5 page shapes × 2 scrollbar modes:

| page shape | classic scrollbars | overlay scrollbars |
|---|---|---|
| tall, plain | in-flow 0px, fixed 0px ✅ | ✅ |
| tall, app sets `html{scrollbar-gutter:stable}` | ✅ | ✅ |
| tall, app already pads the body 24px | ✅ | ✅ |
| tall, RTL | ✅ | ✅ |
| short (no scrollbar at all) | ✅ | ✅ |

For reference, the same harness on `main` (classic scrollbars, tall plain page): in-flow **+15px**, fixed **+15px**, for all three overlays.

Unit coverage for the helper (`scrollbarGutter.test.ts`), the hook (`useScrollLock.test.ts`), and the drawer (`MobileNavScrollbarGutter.test.tsx`): the gutter is held and given back, overlay scrollbars are left alone, the page's own `scrollbar-gutter` value is restored rather than cleared, nested locks hold once, the padding fallback fires only when the element moved anyway, and it adds to the page's existing padding instead of replacing it.

Gates: `pnpm lint:strict` (0 errors, 56 pre-existing warnings), `pnpm test` (7,321 in `packages/core` + `packages/lab`; 2,781 in `packages/cli` + `apps`), `pnpm build`.

## Note on browser support

`scrollbar-gutter` is Chrome 94+, Firefox 97+, Safari 18.2+. Older Safari falls to the padding path, which fixes in-flow content and leaves fixed chrome shifting — the same behavior as today, never worse. Safari's default is overlay scrollbars, where there is no shift to fix in the first place.