### PR TITLE
fix(core): tighten the Bottom Sheet grab handle bar to 24px

### DIFF
--- a/.changeset/bottom-sheet-handle-24px.md
+++ b/.changeset/bottom-sheet-handle-24px.md
@@ -1,0 +1,12 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Bottom Sheet: tighten the grab handle bar to 24px
+
+The drag area above the sheet's content was 48px tall, which read as an empty
+band between the sheet's top edge and its first line of content. It is now
+24px (`--spacing-6`), keeping the pill centered and giving the content back
+the other 24px of the sheet's height budget.
+
+@imdreamrunner

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -137,7 +137,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    height: spacingVars['--spacing-12'],
+    height: spacingVars['--spacing-6'],
     touchAction: 'none',
     cursor: 'grab',
   },


### PR DESCRIPTION
## Summary

The Bottom Sheet's drag area — the band above the content that holds the grab
pill — was `--spacing-12` (48px) tall. That reads as an empty gap between the
sheet's top edge and its first line of content. This drops it to `--spacing-6`
(24px).

The pill itself is unchanged (`--size-element-lg` × 4px, centered); only the
bar's height moves, so the content gains 24px of the sheet's height budget.

## Changes

- `packages/core/src/BottomSheet/BottomSheetPanel.tsx` — `handleBar.height`:
  `--spacing-12` → `--spacing-6`.

Nothing else keyed off this value: the 48px constants in the sheet
(`OVERSCROLL_PADDING`, `MOBILE_KEYBOARD_BOTTOM_CLEARANCE`, `DETENT_DEDUP_PX`,
`FLICK_MIN_DISTANCE`) are unrelated to the handle, and the panel is a flex
column, so the body absorbs the freed space.

## Test plan

- `pnpm exec vitest run packages/core/src/BottomSheet` — 180 tests pass.
- `pnpm test` — full suite passes except the known `packages/cli`
  load-flake (10 tests time out only in the full run; `vitest run --project
  node packages/cli` passes 2724/2724).
- `pnpm lint:strict` — 0 errors (56 pre-existing warnings).
- `pnpm build` — clean; `packages/core/dist/astryx.css` emits
  `height:var(--spacing-6)` for the handle bar.
- Measured in headless Chromium against the built CSS: the handle bar's
  computed height is `24px`, pill unchanged.
