### PR TITLE
fix(core): float the Bottom Sheet grab handle so content sits closer to the top

### DIFF
--- a/.changeset/bottom-sheet-floating-handle.md
+++ b/.changeset/bottom-sheet-floating-handle.md
@@ -1,0 +1,18 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Bottom Sheet: float the grab handle so content sits closer to the top
+
+The drag area above the sheet's content was a 48px row in the sheet's flex
+column, pushing everything below it down by its full height and reading as an
+empty band above the first line of content.
+
+The bar is now 24px and floats over the content: the scrolling area starts at
+the sheet's top edge and rides up under the pill, so a heading sits 24px
+closer to the top. The pill is 4px tall centered in the band, so it occupies
+only 10-14px from the edge — inside the top padding a content wrapper already
+provides — and a surface gradient behind it keeps it legible over whatever
+sits or scrolls beneath.
+
+@imdreamrunner

--- a/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
@@ -237,4 +237,45 @@ describe('BottomSheetPanel', () => {
     expect(panelRef).toHaveBeenLastCalledWith(null);
     expect(panelRef).toHaveBeenCalledTimes(2);
   });
+
+  it('floats the handle bar over content that starts at the sheet top edge', () => {
+    renderPanel({kind: 'open', entering: false});
+
+    const bar = getPanel().querySelector<HTMLElement>(
+      'div[aria-hidden="true"]',
+    );
+    if (bar == null) {
+      throw new Error('handle bar not found');
+    }
+    const body = bar.nextElementSibling as HTMLElement;
+
+    // Out of flow: the bar costs the content no layout space. That is the
+    // point of it -- the content sits closer to the sheet's top edge, and
+    // scrolled content passes beneath the pill rather than stopping at a
+    // hard edge.
+    expect(getComputedStyle(bar).position).toBe('absolute');
+
+    // So the body must not reserve room for it. A top padding here would
+    // push the content back down and undo the change.
+    expect(getComputedStyle(body).paddingTop).toBe('');
+  });
+
+  // The pill is only legible over the content riding up beneath it because
+  // the bar carries a backdrop; without it, text runs straight through the
+  // pill. jsdom's StyleX runtime does not inject the rule, so assert on the
+  // style definition itself (same approach as AspectRatio's reset.css tests).
+  it('backs the floating handle bar with a surface gradient', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const source = fs.readFileSync(
+      path.resolve(__dirname, './BottomSheetPanel.tsx'),
+      'utf-8',
+    );
+
+    const handleBar = source.match(/handleBar: \{([\s\S]*?)\n {2}\},/);
+    expect(handleBar).not.toBeNull();
+    expect(handleBar![1]).toContain("position: 'absolute'");
+    expect(handleBar![1]).toContain('linear-gradient(to bottom');
+    expect(handleBar![1]).toContain("colorVars['--color-background-surface']");
+  });
 });

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -64,6 +64,11 @@ export type {BottomSheetSnapPoint};
 const OVERSCROLL_PADDING = 48;
 const MOBILE_KEYBOARD_BOTTOM_CLEARANCE = 48;
 const TRANSITION_BACKSTOP_BUFFER_MS = 50;
+// The floating handle bar's height. The bar is out of flow, so this is not
+// layout space the content pays for -- the pill (4px, centered) lands 10-14px
+// from the sheet's top edge, inside the space a content wrapper's own top
+// padding already provides.
+const HANDLE_BAR_HEIGHT = spacingVars['--spacing-6'];
 
 // Measure the same viewport the height budgets are written against. Those are
 // `dvh`, which the virtual keyboard does not shrink, so reading
@@ -97,6 +102,9 @@ const styles = stylex.create({
   sheet: {
     pointerEvents: 'auto',
     boxSizing: 'border-box',
+    // Containing block for the floating handle bar, which is lifted out of
+    // flow so the scrolling body reaches the sheet's top edge.
+    position: 'relative',
     display: 'flex',
     flexDirection: 'column',
     minHeight: 0,
@@ -133,11 +141,23 @@ const styles = stylex.create({
     pointerEvents: 'none',
   },
   handleBar: {
-    flexShrink: 0,
+    // Floats over the body rather than taking a row in the flex column. The
+    // content starts at the sheet's top edge and rides up under the pill --
+    // both moving it closer to the top and letting scrolled content pass
+    // beneath instead of stopping at a hard edge.
+    position: 'absolute',
+    insetBlockStart: 0,
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
+    zIndex: 1,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    height: spacingVars['--spacing-12'],
+    height: HANDLE_BAR_HEIGHT,
+    // Keeps the pill legible over whatever sits or scrolls under it: opaque
+    // surface behind the pill itself, fading out across the lower half so the
+    // content emerging below has no visible cut line.
+    backgroundImage: `linear-gradient(to bottom, ${colorVars['--color-background-surface']} 60%, transparent)`,
     touchAction: 'none',
     cursor: 'grab',
   },
@@ -154,6 +174,10 @@ const styles = stylex.create({
     overflowY: 'auto',
     overscrollBehavior: 'none',
     touchAction: 'pan-y',
+    // No reserve for the handle bar: it floats, so the content starts at the
+    // sheet's top edge and rides up under the pill. The pill is 4px centered
+    // in a 24px band, so it occupies only 10-14px from the edge -- inside the
+    // space a content wrapper's own top padding already provides.
     paddingBlockEnd: 0,
   },
   tallKeyboardBody: {


### PR DESCRIPTION
> Supersedes #5220, which took the same 48px band down to 24px but kept it in
> flow. This does that *and* floats it, which is what actually moves the
> content up. #5220 is closed; its height change is folded in here.

## Summary

The drag area above the sheet's content was a 48px row in the sheet's flex
column, so everything below it was pushed down by its full height and it read
as an empty band above the first line of content.

The bar is now 24px and floats over the content: the scrolling area starts at
the sheet's top edge and rides up under the pill, so **a heading sits 24px
closer to the top**.

Scrolled content also passes beneath the pill and fades out under a gradient
rather than stopping at a hard edge, but the main effect is at rest: content
moves up.

| | at rest | scrolled |
|---|---|---|
| With `<Section padding={4}>` (the stories' pattern) | [shot](https://pxl.cl/cst0W) | [shot](https://pxl.cl/cst11) |
| Bare content, no wrapper (the `doc.mjs` pattern) | [shot](https://pxl.cl/cst1d) | |

Heading top, measured from the sheet's top edge at 390x760:

| | before | after |
|---|---|---|
| With `Section padding={4}` | 57px | **33px** |
| Bare content | 41px | **17px** |

## Why the pill does not land on the content

The bar reserves no layout space, so nothing pushes the content down — but the
pill still needs somewhere to sit. It is 4px tall and centered in the 24px
band, so it occupies only **10–14px** from the sheet's edge. A content
wrapper's own top padding (16px for `Section padding={4}`) already covers that,
and even bare content clears it on the first line's leading.

Where content does reach the pill — anything scrolled, or a flush-topped
element like an image — the bar's `linear-gradient` backdrop (opaque surface
through the pill, fading to transparent) keeps it legible.

## Changes

- `BottomSheetPanel.tsx`
  - `handleBar` — 48px → 24px, `position: absolute` at the top inline edges,
    `zIndex: 1`, plus the gradient backdrop.
  - `sheet` gains `position: relative` (containing block for the bar).
  - `body` — unchanged padding; the comment records that a top reserve here
    would undo the change.
- `BottomSheetPanel.test.tsx` — two guards: the body must never carry top
  padding (that would push content back down), and the bar must keep its
  gradient (asserted against the style definition, since jsdom's StyleX
  runtime does not inject the rule — same approach as `AspectRatio`'s
  `reset.css` tests).

Nothing else keyed off the old 48px: the other 48px constants in the sheet
(`OVERSCROLL_PADDING`, `MOBILE_KEYBOARD_BOTTOM_CLEARANCE`, `DETENT_DEDUP_PX`,
`FLICK_MIN_DISTANCE`) are unrelated to the handle. Height budgets are
unaffected — the bar leaving the flow gives its space to the body, so the
panel's content box is unchanged. Gestures are unaffected: #5172 already hands
the sheet the pull at `scrollTop` 0.

## Known behaviour change

The bar carries `touchAction: 'none'` and now sits above scrollable content, so
once content is scrolled, a pointer landing in the top 24px drags the sheet
rather than scrolling it. That matches iOS Maps and is intentional, but it is a
real change and worth a reviewer's eye.

## Test plan

- `pnpm exec vitest run packages/core` — 6930 pass (258 files), including the
  two new guards.
- `pnpm lint:strict` — 0 errors (56 pre-existing warnings).
- `pnpm build` — clean; `astryx.css` carries the gradient and no top padding
  on the body.
- Headless Chromium against the built CSS at 390x420: body computes
  `padding-top: 0px`, pill occupies 10–14px from the sheet edge, heading at
  33px (padded) / 17px (bare). Screenshots above.
