### PR TITLE
feat(core): per-edge padding — paddingBlockStart/End and paddingInlineStart/End on Section, Stack and Center

### DIFF
--- a/.changeset/section-stack-center-block-edge-padding.md
+++ b/.changeset/section-stack-center-block-edge-padding.md
@@ -1,0 +1,18 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] `Section`, `Stack` (with `HStack` / `VStack`) and `Center` accept `paddingBlockStart` and `paddingBlockEnd`, so the top and bottom edges can take different spacing steps without an `xstyle` escape hatch. Each takes the same spacing scale as `padding` and wins over `paddingBlock` and `padding` on its own edge only — every other edge keeps the value it already had.
+
+```tsx
+// A section under a sticky header: tight above, roomy below.
+<Section padding={6} paddingBlockStart={2}>
+  …
+</Section>
+```
+
+On `Section` the matching `--container-padding-block-start` / `--container-padding-block-end` custom property moves with the prop, so bleed children (`Table`, `Divider`, a nested `Section`) keep compensating against the padding actually applied.
+
+Existing code is unaffected: `padding` and `paddingBlock` still set both block edges, and their generated class output is unchanged.
+
+@imdreamrunner

--- a/.changeset/section-stack-center-block-edge-padding.md
+++ b/.changeset/section-stack-center-block-edge-padding.md
@@ -2,17 +2,23 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] `Section`, `Stack` (with `HStack` / `VStack`) and `Center` accept `paddingBlockStart` and `paddingBlockEnd`, so the top and bottom edges can take different spacing steps without an `xstyle` escape hatch. Each takes the same spacing scale as `padding` and wins over `paddingBlock` and `padding` on its own edge only — every other edge keeps the value it already had.
+[feat] `Section`, `Stack` (with `HStack` / `VStack`) and `Center` accept a padding prop for each of the four edges — `paddingBlockStart`, `paddingBlockEnd`, `paddingInlineStart` and `paddingInlineEnd` — so an edge can take its own spacing step without an `xstyle` escape hatch. `Section` also gains the `paddingInline` axis prop it was missing, so all three components now expose the same seven-prop set.
+
+Each prop takes the same spacing scale as `padding`, and resolution is most-specific-wins, per edge:
+
+> edge prop → axis prop (`paddingInline` / `paddingBlock`) → `padding`
+
+An edge prop changes its own edge and leaves the other three alone.
 
 ```tsx
-// A section under a sticky header: tight above, roomy below.
-<Section padding={6} paddingBlockStart={2}>
-  …
-</Section>
+<Section padding={6} paddingBlockStart={2}>…</Section>   // tight top, 24px elsewhere
+<Stack padding={4} paddingInlineEnd={0}>…</Stack>         // flush trailing edge
 ```
 
-On `Section` the matching `--container-padding-block-start` / `--container-padding-block-end` custom property moves with the prop, so bleed children (`Table`, `Divider`, a nested `Section`) keep compensating against the padding actually applied.
+The inline props are logical, so `paddingInlineStart` is the left edge in LTR and the right edge in RTL.
 
-Existing code is unaffected: `padding` and `paddingBlock` still set both block edges, and their generated class output is unchanged.
+On `Section` the matching `--container-padding-*` custom property moves with the prop, so bleed children (`Table`, `Divider`, a nested `Section`) keep compensating against the padding actually applied.
+
+Existing code is unaffected: `padding`, `paddingInline` and `paddingBlock` behave exactly as before, and their generated class output is unchanged.
 
 @imdreamrunner

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -89,6 +89,18 @@ const meta: Meta<typeof Center> = {
       description:
         'Inline (horizontal) padding; overrides padding on that axis',
     },
+    paddingInlineStart: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Inline-start (left in LTR) padding; overrides paddingInline/padding on that edge',
+    },
+    paddingInlineEnd: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Inline-end (right in LTR) padding; overrides paddingInline/padding on that edge',
+    },
     paddingBlock: {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
@@ -252,13 +264,14 @@ export const Padding: Story = {
   ),
 };
 
-export const PaddingPerBlockEdge: Story = {
+export const PaddingPerEdge: Story = {
   args: {
     axis: 'both',
     width: '100%',
     height: 200,
     padding: 6,
     paddingBlockEnd: 0,
+    paddingInlineStart: 2,
     children: null,
   },
   render: args => (

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -94,6 +94,18 @@ const meta: Meta<typeof Center> = {
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description: 'Block (vertical) padding; overrides padding on that axis',
     },
+    paddingBlockStart: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Block-start (top) padding; overrides paddingBlock/padding on that edge',
+    },
+    paddingBlockEnd: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Block-end (bottom) padding; overrides paddingBlock/padding on that edge',
+    },
   },
 };
 
@@ -234,6 +246,26 @@ export const Padding: Story = {
       <Center {...args} xstyle={styles.paddingOutline}>
         <div {...stylex.props(styles.fillArea)}>
           <Box>Inset by padding on the spacing scale</Box>
+        </div>
+      </Center>
+    </Section>
+  ),
+};
+
+export const PaddingPerBlockEdge: Story = {
+  args: {
+    axis: 'both',
+    width: '100%',
+    height: 200,
+    padding: 6,
+    paddingBlockEnd: 0,
+    children: null,
+  },
+  render: args => (
+    <Section variant="muted" width="100%">
+      <Center {...args} xstyle={styles.paddingOutline}>
+        <div {...stylex.props(styles.fillArea)}>
+          <Box>Roomy above, flush below — only the block-end edge moved</Box>
         </div>
       </Center>
     </Section>

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -267,7 +267,7 @@ export const NestedPaddingInheritance: Story = {
   ),
 };
 
-export const AsymmetricBlockPadding: Story = {
+export const AsymmetricPadding: Story = {
   render: () => (
     <div {...stylex.props(styles.storyWrapper)}>
       <div>
@@ -312,6 +312,34 @@ export const AsymmetricBlockPadding: Story = {
           <p {...stylex.props(styles.text)}>
             paddingBlockEnd wins over paddingBlock on its own edge: 24px top,
             4px bottom, inline padding from the theme default.
+          </p>
+        </Section>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>
+          padding=6 + paddingInlineStart=2 (tight leading edge)
+        </h4>
+        <Section variant="muted" width={350} padding={6} paddingInlineStart={2}>
+          <p {...stylex.props(styles.text)}>
+            Only the inline-start edge moves to 8px — the left edge in LTR, the
+            right edge in RTL. The other three stay at 24px.
+          </p>
+        </Section>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>
+          one prop per edge (1 / 2 / 3 / 4)
+        </h4>
+        <Section
+          variant="muted"
+          width={350}
+          paddingInlineStart={1}
+          paddingInlineEnd={2}
+          paddingBlockStart={3}
+          paddingBlockEnd={4}>
+          <p {...stylex.props(styles.text)}>
+            All four edges resolved independently: 4px leading, 8px trailing,
+            12px top, 16px bottom.
           </p>
         </Section>
       </div>

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -189,8 +189,8 @@ export const PageLayout: Story = {
             <VStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Main Content</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
-                This demonstrates how Layout can be used to create page
-                layouts with header, sidebar, and content areas.
+                This demonstrates how Layout can be used to create page layouts
+                with header, sidebar, and content areas.
               </p>
             </VStack>
           </LayoutContent>
@@ -261,6 +261,58 @@ export const NestedPaddingInheritance: Story = {
               compensation and content inset use 8px.
             </p>
           </Section>
+        </Section>
+      </div>
+    </div>
+  ),
+};
+
+export const AsymmetricBlockPadding: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>padding=6 (all edges 24px)</h4>
+        <Section variant="muted" width={350} padding={6}>
+          <p {...stylex.props(styles.text)}>
+            The baseline: every edge takes the same spacing step.
+          </p>
+        </Section>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>
+          padding=6 + paddingBlockStart=2 (tight above)
+        </h4>
+        <Section variant="muted" width={350} padding={6} paddingBlockStart={2}>
+          <p {...stylex.props(styles.text)}>
+            Only the top edge moves to 8px. Both inline edges and the bottom
+            edge stay at 24px — the shape you want under a sticky header.
+          </p>
+        </Section>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>
+          padding=6 + paddingBlockEnd=0 (flush bottom)
+        </h4>
+        <Section variant="muted" width={350} padding={6} paddingBlockEnd={0}>
+          <p {...stylex.props(styles.text)}>
+            The bottom edge goes to 0 so content can sit flush against a
+            following section, with the inline inset preserved.
+          </p>
+        </Section>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>
+          paddingBlock=6 + paddingBlockEnd=1 (edge beats axis)
+        </h4>
+        <Section
+          variant="muted"
+          width={350}
+          paddingBlock={6}
+          paddingBlockEnd={1}>
+          <p {...stylex.props(styles.text)}>
+            paddingBlockEnd wins over paddingBlock on its own edge: 24px top,
+            4px bottom, inline padding from the theme default.
+          </p>
         </Section>
       </div>
     </div>

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -149,6 +149,18 @@ const meta: Meta<typeof Stack> = {
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description: 'Block (vertical) padding; overrides padding on that axis',
     },
+    paddingBlockStart: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Block-start (top) padding; overrides paddingBlock/padding on that edge',
+    },
+    paddingBlockEnd: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Block-end (bottom) padding; overrides paddingBlock/padding on that edge',
+    },
     isScrollable: {
       control: 'boolean',
       description: 'Enables scrollable overflow (overflow: auto)',
@@ -692,6 +704,21 @@ export const PaddingPerAxis: Story = {
     gap: 2,
     paddingInline: 6,
     paddingBlock: 2,
+  },
+  render: args => (
+    <Stack {...args} xstyle={styles.container}>
+      <Box>Item 1</Box>
+      <Box>Item 2</Box>
+      <Box>Item 3</Box>
+    </Stack>
+  ),
+};
+
+export const PaddingPerBlockEdge: Story = {
+  args: {
+    gap: 2,
+    padding: 6,
+    paddingBlockStart: 1,
   },
   render: args => (
     <Stack {...args} xstyle={styles.container}>

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -144,6 +144,18 @@ const meta: Meta<typeof Stack> = {
       description:
         'Inline (horizontal) padding; overrides padding on that axis',
     },
+    paddingInlineStart: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Inline-start (left in LTR) padding; overrides paddingInline/padding on that edge',
+    },
+    paddingInlineEnd: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Inline-end (right in LTR) padding; overrides paddingInline/padding on that edge',
+    },
     paddingBlock: {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
@@ -714,11 +726,12 @@ export const PaddingPerAxis: Story = {
   ),
 };
 
-export const PaddingPerBlockEdge: Story = {
+export const PaddingPerEdge: Story = {
   args: {
     gap: 2,
     padding: 6,
     paddingBlockStart: 1,
+    paddingInlineEnd: 2,
   },
   render: args => (
     <Stack {...args} xstyle={styles.container}>

--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -55,6 +55,18 @@ export const docs = {
         'Block (vertical) padding, using the spacing scale. Overrides padding on the block axis when both are set.',
     },
     {
+      name: 'paddingBlockStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description:
+        'Block-start (top) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+    },
+    {
+      name: 'paddingBlockEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description:
+        'Block-end (bottom) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+    },
+    {
       name: 'isInline',
       type: 'boolean',
       description: 'Use inline-flex (useful for text/icons).',
@@ -129,6 +141,16 @@ export const docsZh = {
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description: '块（垂直）内边距，使用间距刻度。两者同时设置时在块轴上覆盖 padding。',
     },
+    {
+      name: 'paddingBlockStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '块起始（顶部）内边距，使用间距刻度。仅在该边上覆盖 paddingBlock 和 padding。',
+    },
+    {
+      name: 'paddingBlockEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '块结束（底部）内边距，使用间距刻度。仅在该边上覆盖 paddingBlock 和 padding。',
+    },
     {name: 'isInline', type: 'boolean', description: '使用 inline-flex（适用于文本/图标）。', default: 'false'},
     {name: 'children', type: 'ReactNode', description: '要居中的内容。'},
     {
@@ -172,6 +194,8 @@ export const docsDense = {
       'inner padding on all sides (spacing step: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10)',
     paddingInline: 'inline (horizontal) padding; overrides padding on that axis',
     paddingBlock: 'block (vertical) padding; overrides padding on that axis',
+    paddingBlockStart: 'block-start (top) padding; overrides paddingBlock/padding on that edge',
+    paddingBlockEnd: 'block-end (bottom) padding; overrides paddingBlock/padding on that edge',
     isInline: 'use inline-flex for text/icons',
     children: 'content to center',
     xstyle: 'StyleX styles for layout (margins, positioning, sizing); must be stylex.create() value',

--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -49,6 +49,18 @@ export const docs = {
         'Inline (horizontal) padding, using the spacing scale. Overrides padding on the inline axis when both are set.',
     },
     {
+      name: 'paddingInlineStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description:
+        'Inline-start padding, using the spacing scale (left in LTR, right in RTL). Overrides paddingInline and padding on that edge only.',
+    },
+    {
+      name: 'paddingInlineEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description:
+        'Inline-end padding, using the spacing scale (right in LTR, left in RTL). Overrides paddingInline and padding on that edge only.',
+    },
+    {
       name: 'paddingBlock',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
@@ -137,6 +149,16 @@ export const docsZh = {
       description: '行内（水平）内边距，使用间距刻度。两者同时设置时在行内轴上覆盖 padding。',
     },
     {
+      name: 'paddingInlineStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '行内起始内边距，使用间距刻度（LTR 中为左侧，RTL 中为右侧）。仅在该边上覆盖 paddingInline 和 padding。',
+    },
+    {
+      name: 'paddingInlineEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '行内结束内边距，使用间距刻度（LTR 中为右侧，RTL 中为左侧）。仅在该边上覆盖 paddingInline 和 padding。',
+    },
+    {
       name: 'paddingBlock',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description: '块（垂直）内边距，使用间距刻度。两者同时设置时在块轴上覆盖 padding。',
@@ -193,6 +215,8 @@ export const docsDense = {
     padding:
       'inner padding on all sides (spacing step: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10)',
     paddingInline: 'inline (horizontal) padding; overrides padding on that axis',
+    paddingInlineStart: 'inline-start padding (left in LTR); overrides paddingInline/padding on that edge',
+    paddingInlineEnd: 'inline-end padding (right in LTR); overrides paddingInline/padding on that edge',
     paddingBlock: 'block (vertical) padding; overrides padding on that axis',
     paddingBlockStart: 'block-start (top) padding; overrides paddingBlock/padding on that edge',
     paddingBlockEnd: 'block-end (bottom) padding; overrides paddingBlock/padding on that edge',

--- a/packages/core/src/Center/Center.test.tsx
+++ b/packages/core/src/Center/Center.test.tsx
@@ -13,6 +13,22 @@ import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Center} from './Center';
 
+/**
+ * The functional class output, as an order-insensitive set. StyleX's dev
+ * runtime also emits readable debug classes naming the style object a
+ * declaration came from ("padding__paddingBlockStyles.2"); those record
+ * provenance rather than applied CSS and survive even when the declaration
+ * they name loses a merge, so they are dropped here.
+ */
+function classSet(el: HTMLElement): Set<string> {
+  return new Set(
+    el.className
+      .split(' ')
+      .filter(Boolean)
+      .filter(c => !c.includes('__') && !c.includes('.')),
+  );
+}
+
 describe('Center', () => {
   it('renders and centers children (both axes by default)', () => {
     render(
@@ -206,5 +222,71 @@ describe('Center', () => {
     );
     const element = screen.getByTestId('center');
     expect(element.tagName).toBe('DIV');
+  });
+
+  it('applies a class when paddingBlockStart is set on its own', () => {
+    const {rerender} = render(
+      <Center data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const baseline = screen.getByTestId('center').className;
+    rerender(
+      <Center paddingBlockStart={2} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(screen.getByTestId('center').className).not.toBe(baseline);
+  });
+
+  it('lets paddingBlockStart/paddingBlockEnd override only their own edge', () => {
+    // padding={4} + paddingBlockStart={2} must equal spelling every edge out:
+    // both inline edges and the block-end edge stay at 4.
+    const {rerender} = render(
+      <Center padding={4} paddingBlockStart={2} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const perEdge = classSet(screen.getByTestId('center'));
+    rerender(
+      <Center
+        paddingInline={4}
+        paddingBlockStart={2}
+        paddingBlockEnd={4}
+        data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(perEdge).toEqual(classSet(screen.getByTestId('center')));
+  });
+
+  it('gives paddingBlockEnd precedence over paddingBlock', () => {
+    const {rerender} = render(
+      <Center paddingBlock={6} paddingBlockEnd={0} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const overridden = classSet(screen.getByTestId('center'));
+    rerender(
+      <Center paddingBlockStart={6} paddingBlockEnd={0} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(overridden).toEqual(classSet(screen.getByTestId('center')));
+  });
+
+  it('leaves padding/paddingBlock output unchanged when no edge prop is set', () => {
+    const {rerender} = render(
+      <Center padding={3} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const uniform = classSet(screen.getByTestId('center'));
+    rerender(
+      <Center paddingInline={3} paddingBlock={3} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(uniform).toEqual(classSet(screen.getByTestId('center')));
   });
 });

--- a/packages/core/src/Center/Center.test.tsx
+++ b/packages/core/src/Center/Center.test.tsx
@@ -289,4 +289,80 @@ describe('Center', () => {
     );
     expect(uniform).toEqual(classSet(screen.getByTestId('center')));
   });
+
+  it('applies a class when paddingInlineStart is set on its own', () => {
+    const {rerender} = render(
+      <Center data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const baseline = screen.getByTestId('center').className;
+    rerender(
+      <Center paddingInlineStart={2} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(screen.getByTestId('center').className).not.toBe(baseline);
+  });
+
+  it('lets paddingInlineStart/paddingInlineEnd override only their own edge', () => {
+    const {rerender} = render(
+      <Center padding={4} paddingInlineStart={2} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const perEdge = classSet(screen.getByTestId('center'));
+    rerender(
+      <Center
+        paddingInlineStart={2}
+        paddingInlineEnd={4}
+        paddingBlock={4}
+        data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(perEdge).toEqual(classSet(screen.getByTestId('center')));
+  });
+
+  it('gives paddingInlineEnd precedence over paddingInline', () => {
+    const {rerender} = render(
+      <Center paddingInline={6} paddingInlineEnd={0} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const overridden = classSet(screen.getByTestId('center'));
+    rerender(
+      <Center paddingInlineStart={6} paddingInlineEnd={0} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(overridden).toEqual(classSet(screen.getByTestId('center')));
+  });
+
+  it('resolves all four edges independently', () => {
+    // One prop per edge, each a different step: the four-edge spelling and the
+    // shorthand-plus-overrides spelling must agree.
+    const {rerender} = render(
+      <Center
+        paddingInlineStart={1}
+        paddingInlineEnd={2}
+        paddingBlockStart={3}
+        paddingBlockEnd={4}
+        data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const explicit = classSet(screen.getByTestId('center'));
+    rerender(
+      <Center
+        padding={4}
+        paddingInlineStart={1}
+        paddingInlineEnd={2}
+        paddingBlockStart={3}
+        data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(explicit).toEqual(classSet(screen.getByTestId('center')));
+  });
 });

--- a/packages/core/src/Center/Center.tsx
+++ b/packages/core/src/Center/Center.tsx
@@ -18,7 +18,8 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {
-  paddingInlineStyles,
+  paddingInlineStartStyles,
+  paddingInlineEndStyles,
   paddingBlockStartStyles,
   paddingBlockEndStyles,
 } from '../Layout/padding.stylex';
@@ -108,6 +109,20 @@ export interface CenterProps extends BaseProps<HTMLDivElement> {
   paddingInline?: SpacingStep;
 
   /**
+   * Inline-start padding, using the spacing scale. Logical: the left edge in
+   * LTR, the right edge in RTL.
+   * Overrides `paddingInline` and `padding` on that edge only.
+   */
+  paddingInlineStart?: SpacingStep;
+
+  /**
+   * Inline-end padding, using the spacing scale. Logical: the right edge in
+   * LTR, the left edge in RTL.
+   * Overrides `paddingInline` and `padding` on that edge only.
+   */
+  paddingInlineEnd?: SpacingStep;
+
+  /**
    * Block (vertical) padding, using the spacing scale.
    * Overrides `padding` on the block axis when both are set.
    */
@@ -158,6 +173,8 @@ export function Center({
   minHeight,
   padding,
   paddingInline,
+  paddingInlineStart,
+  paddingInlineEnd,
   paddingBlock,
   paddingBlockStart,
   paddingBlockEnd,
@@ -169,10 +186,11 @@ export function Center({
   ref,
   ...props
 }: CenterProps) {
-  // Resolve padding to per-edge values: `padding` sets every edge;
-  // `paddingInline` / `paddingBlock` take precedence on their own axis, and
-  // `paddingBlockStart` / `paddingBlockEnd` take precedence on their own edge.
-  const resolvedPaddingInline = paddingInline ?? padding;
+  // Resolve padding to per-edge values. Most specific wins, per edge:
+  // edge prop -> axis prop -> `padding`.
+  const resolvedPaddingInlineStart =
+    paddingInlineStart ?? paddingInline ?? padding;
+  const resolvedPaddingInlineEnd = paddingInlineEnd ?? paddingInline ?? padding;
   const resolvedPaddingBlockStart =
     paddingBlockStart ?? paddingBlock ?? padding;
   const resolvedPaddingBlockEnd = paddingBlockEnd ?? paddingBlock ?? padding;
@@ -189,8 +207,10 @@ export function Center({
         maxWidth ?? null,
         minHeight ?? null,
       ),
-      resolvedPaddingInline != null &&
-        paddingInlineStyles[resolvedPaddingInline],
+      resolvedPaddingInlineStart != null &&
+        paddingInlineStartStyles[resolvedPaddingInlineStart],
+      resolvedPaddingInlineEnd != null &&
+        paddingInlineEndStyles[resolvedPaddingInlineEnd],
       resolvedPaddingBlockStart != null &&
         paddingBlockStartStyles[resolvedPaddingBlockStart],
       resolvedPaddingBlockEnd != null &&

--- a/packages/core/src/Center/Center.tsx
+++ b/packages/core/src/Center/Center.tsx
@@ -19,7 +19,8 @@ import * as stylex from '@stylexjs/stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {
   paddingInlineStyles,
-  paddingBlockStyles,
+  paddingBlockStartStyles,
+  paddingBlockEndStyles,
 } from '../Layout/padding.stylex';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
@@ -113,6 +114,18 @@ export interface CenterProps extends BaseProps<HTMLDivElement> {
   paddingBlock?: SpacingStep;
 
   /**
+   * Block-start (top) padding, using the spacing scale.
+   * Overrides `paddingBlock` and `padding` on that edge only.
+   */
+  paddingBlockStart?: SpacingStep;
+
+  /**
+   * Block-end (bottom) padding, using the spacing scale.
+   * Overrides `paddingBlock` and `padding` on that edge only.
+   */
+  paddingBlockEnd?: SpacingStep;
+
+  /**
    * Whether to make the container inline-flex (useful for text/icons).
    * @default false
    */
@@ -146,6 +159,8 @@ export function Center({
   padding,
   paddingInline,
   paddingBlock,
+  paddingBlockStart,
+  paddingBlockEnd,
   isInline = false,
   children,
   xstyle,
@@ -154,10 +169,13 @@ export function Center({
   ref,
   ...props
 }: CenterProps) {
-  // Resolve padding to per-axis values: `padding` sets both axes; `paddingInline`
-  // / `paddingBlock` take precedence on their own axis when provided.
+  // Resolve padding to per-edge values: `padding` sets every edge;
+  // `paddingInline` / `paddingBlock` take precedence on their own axis, and
+  // `paddingBlockStart` / `paddingBlockEnd` take precedence on their own edge.
   const resolvedPaddingInline = paddingInline ?? padding;
-  const resolvedPaddingBlock = paddingBlock ?? padding;
+  const resolvedPaddingBlockStart =
+    paddingBlockStart ?? paddingBlock ?? padding;
+  const resolvedPaddingBlockEnd = paddingBlockEnd ?? paddingBlock ?? padding;
 
   const stylexProps = mergeProps(
     themeProps('center', {axis}),
@@ -173,7 +191,10 @@ export function Center({
       ),
       resolvedPaddingInline != null &&
         paddingInlineStyles[resolvedPaddingInline],
-      resolvedPaddingBlock != null && paddingBlockStyles[resolvedPaddingBlock],
+      resolvedPaddingBlockStart != null &&
+        paddingBlockStartStyles[resolvedPaddingBlockStart],
+      resolvedPaddingBlockEnd != null &&
+        paddingBlockEndStyles[resolvedPaddingBlockEnd],
       xstyle,
     ),
     className,

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -326,6 +326,82 @@ export const paddingBlockStyles = stylex.create({
 });
 
 /**
+ * Inline-start-only padding override styles.
+ * Use when a component needs to override the inline-start edge independently
+ * of inline-end. Logical, so it follows the writing direction (left in LTR,
+ * right in RTL).
+ */
+export const paddingInlineStartStyles = stylex.create({
+  0: {paddingInlineStart: spacingVars['--spacing-0']},
+  0.5: {paddingInlineStart: spacingVars['--spacing-0-5']},
+  1: {paddingInlineStart: spacingVars['--spacing-1']},
+  1.5: {paddingInlineStart: spacingVars['--spacing-1-5']},
+  2: {paddingInlineStart: spacingVars['--spacing-2']},
+  3: {paddingInlineStart: spacingVars['--spacing-3']},
+  4: {paddingInlineStart: spacingVars['--spacing-4']},
+  5: {paddingInlineStart: spacingVars['--spacing-5']},
+  6: {paddingInlineStart: spacingVars['--spacing-6']},
+  8: {paddingInlineStart: spacingVars['--spacing-8']},
+  10: {paddingInlineStart: spacingVars['--spacing-10']},
+});
+
+/**
+ * Inline-end-only padding override styles.
+ * The inline-end counterpart of paddingInlineStartStyles.
+ */
+export const paddingInlineEndStyles = stylex.create({
+  0: {paddingInlineEnd: spacingVars['--spacing-0']},
+  0.5: {paddingInlineEnd: spacingVars['--spacing-0-5']},
+  1: {paddingInlineEnd: spacingVars['--spacing-1']},
+  1.5: {paddingInlineEnd: spacingVars['--spacing-1-5']},
+  2: {paddingInlineEnd: spacingVars['--spacing-2']},
+  3: {paddingInlineEnd: spacingVars['--spacing-3']},
+  4: {paddingInlineEnd: spacingVars['--spacing-4']},
+  5: {paddingInlineEnd: spacingVars['--spacing-5']},
+  6: {paddingInlineEnd: spacingVars['--spacing-6']},
+  8: {paddingInlineEnd: spacingVars['--spacing-8']},
+  10: {paddingInlineEnd: spacingVars['--spacing-10']},
+});
+
+/**
+ * Container padding inline-start CSS variable style, set independently of
+ * inline-end so a per-edge override keeps edge-compensating children (Card,
+ * Divider, a nested Section) compensating against the padding actually
+ * applied on that edge.
+ */
+export const containerPaddingInlineStartVarStyles = stylex.create({
+  0: {'--container-padding-inline-start': spacingVars['--spacing-0']},
+  0.5: {'--container-padding-inline-start': spacingVars['--spacing-0-5']},
+  1: {'--container-padding-inline-start': spacingVars['--spacing-1']},
+  1.5: {'--container-padding-inline-start': spacingVars['--spacing-1-5']},
+  2: {'--container-padding-inline-start': spacingVars['--spacing-2']},
+  3: {'--container-padding-inline-start': spacingVars['--spacing-3']},
+  4: {'--container-padding-inline-start': spacingVars['--spacing-4']},
+  5: {'--container-padding-inline-start': spacingVars['--spacing-5']},
+  6: {'--container-padding-inline-start': spacingVars['--spacing-6']},
+  8: {'--container-padding-inline-start': spacingVars['--spacing-8']},
+  10: {'--container-padding-inline-start': spacingVars['--spacing-10']},
+});
+
+/**
+ * Container padding inline-end CSS variable style, the counterpart of
+ * containerPaddingInlineStartVarStyles.
+ */
+export const containerPaddingInlineEndVarStyles = stylex.create({
+  0: {'--container-padding-inline-end': spacingVars['--spacing-0']},
+  0.5: {'--container-padding-inline-end': spacingVars['--spacing-0-5']},
+  1: {'--container-padding-inline-end': spacingVars['--spacing-1']},
+  1.5: {'--container-padding-inline-end': spacingVars['--spacing-1-5']},
+  2: {'--container-padding-inline-end': spacingVars['--spacing-2']},
+  3: {'--container-padding-inline-end': spacingVars['--spacing-3']},
+  4: {'--container-padding-inline-end': spacingVars['--spacing-4']},
+  5: {'--container-padding-inline-end': spacingVars['--spacing-5']},
+  6: {'--container-padding-inline-end': spacingVars['--spacing-6']},
+  8: {'--container-padding-inline-end': spacingVars['--spacing-8']},
+  10: {'--container-padding-inline-end': spacingVars['--spacing-10']},
+});
+
+/**
  * Block-start-only padding override styles.
  * Use when a component needs to override the block-start (top) edge
  * independently of block-end — e.g. a section that sits under a sticky

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -326,6 +326,44 @@ export const paddingBlockStyles = stylex.create({
 });
 
 /**
+ * Block-start-only padding override styles.
+ * Use when a component needs to override the block-start (top) edge
+ * independently of block-end — e.g. a section that sits under a sticky
+ * header and needs less padding above than below.
+ */
+export const paddingBlockStartStyles = stylex.create({
+  0: {paddingBlockStart: spacingVars['--spacing-0']},
+  0.5: {paddingBlockStart: spacingVars['--spacing-0-5']},
+  1: {paddingBlockStart: spacingVars['--spacing-1']},
+  1.5: {paddingBlockStart: spacingVars['--spacing-1-5']},
+  2: {paddingBlockStart: spacingVars['--spacing-2']},
+  3: {paddingBlockStart: spacingVars['--spacing-3']},
+  4: {paddingBlockStart: spacingVars['--spacing-4']},
+  5: {paddingBlockStart: spacingVars['--spacing-5']},
+  6: {paddingBlockStart: spacingVars['--spacing-6']},
+  8: {paddingBlockStart: spacingVars['--spacing-8']},
+  10: {paddingBlockStart: spacingVars['--spacing-10']},
+});
+
+/**
+ * Block-end-only padding override styles.
+ * The block-end counterpart of paddingBlockStartStyles.
+ */
+export const paddingBlockEndStyles = stylex.create({
+  0: {paddingBlockEnd: spacingVars['--spacing-0']},
+  0.5: {paddingBlockEnd: spacingVars['--spacing-0-5']},
+  1: {paddingBlockEnd: spacingVars['--spacing-1']},
+  1.5: {paddingBlockEnd: spacingVars['--spacing-1-5']},
+  2: {paddingBlockEnd: spacingVars['--spacing-2']},
+  3: {paddingBlockEnd: spacingVars['--spacing-3']},
+  4: {paddingBlockEnd: spacingVars['--spacing-4']},
+  5: {paddingBlockEnd: spacingVars['--spacing-5']},
+  6: {paddingBlockEnd: spacingVars['--spacing-6']},
+  8: {paddingBlockEnd: spacingVars['--spacing-8']},
+  10: {paddingBlockEnd: spacingVars['--spacing-10']},
+});
+
+/**
  * Propagation styles for --astryx-section-padding.
  * When a parent section sets explicit padding, this propagates the value
  * through the CSS custom property cascade so nested sections that use

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -54,6 +54,21 @@ export const docs = {
       default: '4',
     },
     {
+      name: 'paddingInline',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: 'Inline (horizontal) padding override. Overrides only the inline-axis padding while preserving block padding from `padding` or the container theme default. Accepts the spacing scale (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10).',
+    },
+    {
+      name: 'paddingInlineStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: 'Inline-start padding override (left in LTR, right in RTL). Overrides paddingInline and padding on that edge only.',
+    },
+    {
+      name: 'paddingInlineEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: 'Inline-end padding override (right in LTR, left in RTL). Overrides paddingInline and padding on that edge only.',
+    },
+    {
       name: 'paddingBlock',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description: 'Block (vertical) padding override. Overrides only the block-axis padding while preserving inline padding from `padding` or the container theme default. Accepts the spacing scale (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10).',
@@ -146,6 +161,21 @@ export const docsZh = {
       default: '4',
     },
     {
+      name: 'paddingInline',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '行内（水平）方向内边距覆盖。仅覆盖行内轴内边距，同时保留来自 padding 或容器主题默认值的块内边距。使用间距比例（0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10）。',
+    },
+    {
+      name: 'paddingInlineStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '行内起始内边距覆盖（LTR 中为左侧，RTL 中为右侧）。仅在该边上覆盖 paddingInline 和 padding。',
+    },
+    {
+      name: 'paddingInlineEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '行内结束内边距覆盖（LTR 中为右侧，RTL 中为左侧）。仅在该边上覆盖 paddingInline 和 padding。',
+    },
+    {
       name: 'paddingBlock',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description: '块（垂直）方向内边距覆盖。仅覆盖块轴内边距，同时保留来自 padding 或容器主题默认值的行内内边距。使用间距比例（0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10）。',
@@ -212,6 +242,9 @@ export const docsDense = {
     children: 'Content rendered inside section.',
     dividers: 'Which sides of section have divider borders.',
     padding: 'Internal padding via spacing scale; 0 for edge-to-edge content.',
+    paddingInline: 'Inline-axis padding override; preserves block padding from padding/theme.',
+    paddingInlineStart: 'Inline-start (left in LTR) padding override; wins over paddingInline/padding on that edge.',
+    paddingInlineEnd: 'Inline-end (right in LTR) padding override; wins over paddingInline/padding on that edge.',
     paddingBlock: 'Block-axis padding override; preserves inline padding from padding/theme.',
     paddingBlockStart: 'Block-start (top) padding override; wins over paddingBlock/padding on that edge.',
     paddingBlockEnd: 'Block-end (bottom) padding override; wins over paddingBlock/padding on that edge.',

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -59,6 +59,16 @@ export const docs = {
       description: 'Block (vertical) padding override. Overrides only the block-axis padding while preserving inline padding from `padding` or the container theme default. Accepts the spacing scale (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10).',
     },
     {
+      name: 'paddingBlockStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: 'Block-start (top) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+    },
+    {
+      name: 'paddingBlockEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: 'Block-end (bottom) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object.',
@@ -141,6 +151,16 @@ export const docsZh = {
       description: '块（垂直）方向内边距覆盖。仅覆盖块轴内边距，同时保留来自 padding 或容器主题默认值的行内内边距。使用间距比例（0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10）。',
     },
     {
+      name: 'paddingBlockStart',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '块起始（顶部）内边距，使用间距刻度。仅在该边上覆盖 paddingBlock 和 padding。',
+    },
+    {
+      name: 'paddingBlockEnd',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: '块结束（底部）内边距，使用间距刻度。仅在该边上覆盖 paddingBlock 和 padding。',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: '用于布局自定义的 StyleX 样式（外边距、定位、尺寸）。必须是 stylex.create() 的值，不能是内联样式对象。',
@@ -193,6 +213,8 @@ export const docsDense = {
     dividers: 'Which sides of section have divider borders.',
     padding: 'Internal padding via spacing scale; 0 for edge-to-edge content.',
     paddingBlock: 'Block-axis padding override; preserves inline padding from padding/theme.',
+    paddingBlockStart: 'Block-start (top) padding override; wins over paddingBlock/padding on that edge.',
+    paddingBlockEnd: 'Block-end (bottom) padding override; wins over paddingBlock/padding on that edge.',
     xstyle: 'StyleX styles for layout customization; must be stylex.create() value.',
   },
 };

--- a/packages/core/src/Section/Section.test.tsx
+++ b/packages/core/src/Section/Section.test.tsx
@@ -266,4 +266,99 @@ describe('Section', () => {
     // The inline-axis classes are shared by both renders.
     expect(uniform.size - removed.length).toBeGreaterThan(0);
   });
+
+  it('applies a class when paddingInlineStart is set on its own', () => {
+    const {container, rerender} = render(<Section>Content</Section>);
+    const baseline = (
+      container.firstElementChild!.firstElementChild as HTMLElement
+    ).className;
+    rerender(<Section paddingInlineStart={2}>Content</Section>);
+    expect(
+      (container.firstElementChild!.firstElementChild as HTMLElement).className,
+    ).not.toBe(baseline);
+  });
+
+  it('treats paddingInline as the two inline edge props set to the same step', () => {
+    const {container, rerender} = render(
+      <Section paddingInline={2}>Content</Section>,
+    );
+    const axis = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    rerender(
+      <Section paddingInlineStart={2} paddingInlineEnd={2}>
+        Content
+      </Section>,
+    );
+    expect(axis).toEqual(
+      classSet(container.firstElementChild!.firstElementChild as HTMLElement),
+    );
+  });
+
+  it('gives paddingInlineEnd precedence over paddingInline', () => {
+    const {container, rerender} = render(
+      <Section paddingInline={2} paddingInlineEnd={8}>
+        Content
+      </Section>,
+    );
+    const overridden = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    rerender(
+      <Section paddingInlineStart={2} paddingInlineEnd={8}>
+        Content
+      </Section>,
+    );
+    expect(overridden).toEqual(
+      classSet(container.firstElementChild!.firstElementChild as HTMLElement),
+    );
+  });
+
+  it('keeps block padding when only an inline edge is overridden', () => {
+    const {container, rerender} = render(
+      <Section padding={6}>Content</Section>,
+    );
+    const uniform = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    rerender(
+      <Section padding={6} paddingInlineStart={0}>
+        Content
+      </Section>,
+    );
+    const overridden = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    const removed = [...uniform].filter(c => !overridden.has(c));
+    const added = [...overridden].filter(c => !uniform.has(c));
+    expect(removed.length).toBeGreaterThan(0);
+    expect(added.length).toBeGreaterThan(0);
+    // The block-axis classes survive the inline-edge override.
+    expect(uniform.size - removed.length).toBeGreaterThan(0);
+  });
+
+  it('moves the inline container vars with a per-edge override', () => {
+    // Section drives --container-padding-inline-start/end for bleed children.
+    // A per-edge override must move only the matching var, so a nested Section
+    // or a bleeding Divider compensates against the real padding.
+    const {container, rerender} = render(
+      <Section padding={6} paddingInlineStart={2}>
+        Content
+      </Section>,
+    );
+    const startOverride = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    rerender(
+      <Section padding={6} paddingInlineEnd={2}>
+        Content
+      </Section>,
+    );
+    const endOverride = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    // Overriding opposite edges by the same step must not produce identical
+    // output — each edge carries its own padding class and its own var class.
+    expect(startOverride).not.toEqual(endOverride);
+  });
 });

--- a/packages/core/src/Section/Section.test.tsx
+++ b/packages/core/src/Section/Section.test.tsx
@@ -4,6 +4,22 @@ import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Section} from './Section';
 
+/**
+ * The functional class output, as an order-insensitive set. StyleX's dev
+ * runtime also emits readable debug classes naming the style object a
+ * declaration came from ("padding__paddingBlockStyles.2"); those record
+ * provenance rather than applied CSS and survive even when the declaration
+ * they name loses a merge, so they are dropped here.
+ */
+function classSet(el: HTMLElement): Set<string> {
+  return new Set(
+    el.className
+      .split(' ')
+      .filter(Boolean)
+      .filter(c => !c.includes('__') && !c.includes('.')),
+  );
+}
+
 describe('Section', () => {
   it('renders with default props', () => {
     const {container} = render(<Section>Default section</Section>);
@@ -175,5 +191,79 @@ describe('Section', () => {
     );
     expect(screen.getByTestId('inner')).toBeInTheDocument();
     expect(screen.getByText('Inner')).toBeInTheDocument();
+  });
+
+  it('applies a class when paddingBlockStart is set on its own', () => {
+    const {container, rerender} = render(<Section>Content</Section>);
+    const baseline = (
+      container.firstElementChild!.firstElementChild as HTMLElement
+    ).className;
+    rerender(<Section paddingBlockStart={2}>Content</Section>);
+    const withEdge = (
+      container.firstElementChild!.firstElementChild as HTMLElement
+    ).className;
+    expect(withEdge).not.toBe(baseline);
+  });
+
+  it('treats paddingBlock as the two edge props set to the same step', () => {
+    const {container, rerender} = render(
+      <Section paddingBlock={2}>Content</Section>,
+    );
+    const axis = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    rerender(
+      <Section paddingBlockStart={2} paddingBlockEnd={2}>
+        Content
+      </Section>,
+    );
+    expect(axis).toEqual(
+      classSet(container.firstElementChild!.firstElementChild as HTMLElement),
+    );
+  });
+
+  it('gives paddingBlockEnd precedence over paddingBlock', () => {
+    const {container, rerender} = render(
+      <Section paddingBlock={2} paddingBlockEnd={8}>
+        Content
+      </Section>,
+    );
+    const overridden = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    rerender(
+      <Section paddingBlockStart={2} paddingBlockEnd={8}>
+        Content
+      </Section>,
+    );
+    expect(overridden).toEqual(
+      classSet(container.firstElementChild!.firstElementChild as HTMLElement),
+    );
+  });
+
+  it('keeps inline padding when only a block edge is overridden', () => {
+    // padding={6} sets all four edges; paddingBlockStart={0} may only move the
+    // top edge, so the inline classes must survive unchanged.
+    const {container, rerender} = render(
+      <Section padding={6}>Content</Section>,
+    );
+    const uniform = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    rerender(
+      <Section padding={6} paddingBlockStart={0}>
+        Content
+      </Section>,
+    );
+    const overridden = classSet(
+      container.firstElementChild!.firstElementChild as HTMLElement,
+    );
+    // Everything the uniform render dropped is block-start related.
+    const removed = [...uniform].filter(c => !overridden.has(c));
+    const added = [...overridden].filter(c => !uniform.has(c));
+    expect(removed.length).toBeGreaterThan(0);
+    expect(added.length).toBeGreaterThan(0);
+    // The inline-axis classes are shared by both renders.
+    expect(uniform.size - removed.length).toBeGreaterThan(0);
   });
 });

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -22,6 +22,8 @@ import type {SpacingToken} from '../Layout/container.stylex';
 import {
   paddingStyles,
   paddingBlockStyles,
+  paddingBlockStartStyles,
+  paddingBlockEndStyles,
   containerPaddingInlineVarStyles,
   containerPaddingBlockStartVarStyles,
   containerPaddingBlockEndVarStyles,
@@ -182,6 +184,20 @@ export interface SectionProps extends BaseProps<HTMLElement> {
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    */
   paddingBlock?: SpacingStep;
+  /**
+   * Block-start (top) padding override. Takes precedence over `paddingBlock`
+   * and `padding` on that edge only; the block-end edge and both inline edges
+   * are left alone.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  paddingBlockStart?: SpacingStep;
+  /**
+   * Block-end (bottom) padding override. Takes precedence over `paddingBlock`
+   * and `padding` on that edge only; the block-start edge and both inline
+   * edges are left alone.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  paddingBlockEnd?: SpacingStep;
 }
 
 /**
@@ -212,6 +228,8 @@ export function Section({
   dividers,
   padding,
   paddingBlock,
+  paddingBlockStart,
+  paddingBlockEnd,
   xstyle,
   className,
   style,
@@ -280,6 +298,17 @@ export function Section({
               containerPaddingBlockStartVarStyles[paddingBlock],
             paddingBlock != null &&
               containerPaddingBlockEndVarStyles[paddingBlock],
+            // Per-edge overrides come last so they win over `paddingBlock`
+            // and `padding` on their own edge. The matching container var is
+            // updated alongside so bleed children (Table, Divider, nested
+            // Section) compensate against the padding actually applied.
+            paddingBlockStart != null &&
+              paddingBlockStartStyles[paddingBlockStart],
+            paddingBlockStart != null &&
+              containerPaddingBlockStartVarStyles[paddingBlockStart],
+            paddingBlockEnd != null && paddingBlockEndStyles[paddingBlockEnd],
+            paddingBlockEnd != null &&
+              containerPaddingBlockEndVarStyles[paddingBlockEnd],
             variantStyles[variant],
             dividers?.includes('top') && dividerStyles.top,
             dividers?.includes('bottom') && dividerStyles.bottom,

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -21,10 +21,15 @@ import {container} from '../Layout/container.stylex';
 import type {SpacingToken} from '../Layout/container.stylex';
 import {
   paddingStyles,
+  paddingInlineStyles,
+  paddingInlineStartStyles,
+  paddingInlineEndStyles,
   paddingBlockStyles,
   paddingBlockStartStyles,
   paddingBlockEndStyles,
   containerPaddingInlineVarStyles,
+  containerPaddingInlineStartVarStyles,
+  containerPaddingInlineEndVarStyles,
   containerPaddingBlockStartVarStyles,
   containerPaddingBlockEndVarStyles,
   sectionPaddingPropagationStyles,
@@ -178,6 +183,27 @@ export interface SectionProps extends BaseProps<HTMLElement> {
    */
   padding?: SpacingStep;
   /**
+   * Inline (horizontal) padding override. When set, overrides only the inline
+   * axis padding while preserving block padding from `padding` or the
+   * container theme default.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  paddingInline?: SpacingStep;
+  /**
+   * Inline-start padding override. Logical: the left edge in LTR, the right
+   * edge in RTL. Takes precedence over `paddingInline` and `padding` on that
+   * edge only; every other edge is left alone.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  paddingInlineStart?: SpacingStep;
+  /**
+   * Inline-end padding override. Logical: the right edge in LTR, the left
+   * edge in RTL. Takes precedence over `paddingInline` and `padding` on that
+   * edge only; every other edge is left alone.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  paddingInlineEnd?: SpacingStep;
+  /**
    * Block (vertical) padding override. When set, overrides only the block
    * axis padding while preserving inline padding from `padding` or the
    * container theme default.
@@ -227,6 +253,9 @@ export function Section({
   children,
   dividers,
   padding,
+  paddingInline,
+  paddingInlineStart,
+  paddingInlineEnd,
   paddingBlock,
   paddingBlockStart,
   paddingBlockEnd,
@@ -293,6 +322,9 @@ export function Section({
               containerPaddingBlockEndVarStyles[effectivePadding],
             !useThemeDefault &&
               sectionPaddingPropagationStyles[effectivePadding],
+            paddingInline != null && paddingInlineStyles[paddingInline],
+            paddingInline != null &&
+              containerPaddingInlineVarStyles[paddingInline],
             paddingBlock != null && paddingBlockStyles[paddingBlock],
             paddingBlock != null &&
               containerPaddingBlockStartVarStyles[paddingBlock],
@@ -309,6 +341,14 @@ export function Section({
             paddingBlockEnd != null && paddingBlockEndStyles[paddingBlockEnd],
             paddingBlockEnd != null &&
               containerPaddingBlockEndVarStyles[paddingBlockEnd],
+            paddingInlineStart != null &&
+              paddingInlineStartStyles[paddingInlineStart],
+            paddingInlineStart != null &&
+              containerPaddingInlineStartVarStyles[paddingInlineStart],
+            paddingInlineEnd != null &&
+              paddingInlineEndStyles[paddingInlineEnd],
+            paddingInlineEnd != null &&
+              containerPaddingInlineEndVarStyles[paddingInlineEnd],
             variantStyles[variant],
             dividers?.includes('top') && dividerStyles.top,
             dividers?.includes('bottom') && dividerStyles.bottom,

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -53,6 +53,18 @@ export const docs = {
             'Block (vertical) padding. Overrides padding on the block axis when both are set.',
         },
         {
+          name: 'paddingBlockStart',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Block-start (top) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+        },
+        {
+          name: 'paddingBlockEnd',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Block-end (bottom) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+        },
+        {
           name: 'isScrollable',
           type: 'boolean',
           description:
@@ -157,6 +169,18 @@ export const docs = {
             'Block (vertical) padding, using the spacing scale. Overrides padding on the block axis when both are set.',
         },
         {
+          name: 'paddingBlockStart',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Block-start (top) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+        },
+        {
+          name: 'paddingBlockEnd',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Block-end (bottom) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+        },
+        {
           name: 'isScrollable',
           type: 'boolean',
           description:
@@ -258,6 +282,18 @@ export const docs = {
           type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
           description:
             'Block (vertical) padding, using the spacing scale. Overrides padding on the block axis when both are set.',
+        },
+        {
+          name: 'paddingBlockStart',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Block-start (top) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+        },
+        {
+          name: 'paddingBlockEnd',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Block-end (bottom) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
         },
         {
           name: 'isScrollable',

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -47,6 +47,18 @@ export const docs = {
             'Inline (horizontal) padding. Overrides padding on the inline axis when both are set.',
         },
         {
+          name: 'paddingInlineStart',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inline-start padding, using the spacing scale (left in LTR, right in RTL). Overrides paddingInline and padding on that edge only.',
+        },
+        {
+          name: 'paddingInlineEnd',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inline-end padding, using the spacing scale (right in LTR, left in RTL). Overrides paddingInline and padding on that edge only.',
+        },
+        {
           name: 'paddingBlock',
           type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
           description:
@@ -163,6 +175,18 @@ export const docs = {
             'Inline (horizontal) padding, using the spacing scale. Overrides padding on the inline axis when both are set.',
         },
         {
+          name: 'paddingInlineStart',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inline-start padding, using the spacing scale (left in LTR, right in RTL). Overrides paddingInline and padding on that edge only.',
+        },
+        {
+          name: 'paddingInlineEnd',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inline-end padding, using the spacing scale (right in LTR, left in RTL). Overrides paddingInline and padding on that edge only.',
+        },
+        {
           name: 'paddingBlock',
           type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
           description:
@@ -276,6 +300,18 @@ export const docs = {
           type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
           description:
             'Inline (horizontal) padding, using the spacing scale. Overrides padding on the inline axis when both are set.',
+        },
+        {
+          name: 'paddingInlineStart',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inline-start padding, using the spacing scale (left in LTR, right in RTL). Overrides paddingInline and padding on that edge only.',
+        },
+        {
+          name: 'paddingInlineEnd',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inline-end padding, using the spacing scale (right in LTR, left in RTL). Overrides paddingInline and padding on that edge only.',
         },
         {
           name: 'paddingBlock',

--- a/packages/core/src/Stack/Stack.test.tsx
+++ b/packages/core/src/Stack/Stack.test.tsx
@@ -13,6 +13,22 @@ import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Stack} from './Stack';
 
+/**
+ * The functional class output, as an order-insensitive set. StyleX's dev
+ * runtime also emits readable debug classes naming the style object a
+ * declaration came from ("padding__paddingBlockStyles.2"); those record
+ * provenance rather than applied CSS and survive even when the declaration
+ * they name loses a merge, so they are dropped here.
+ */
+function classSet(el: HTMLElement): Set<string> {
+  return new Set(
+    el.className
+      .split(' ')
+      .filter(Boolean)
+      .filter(c => !c.includes('__') && !c.includes('.')),
+  );
+}
+
 describe('Stack', () => {
   it('defaults to vertical direction', () => {
     render(
@@ -313,5 +329,69 @@ describe('Stack', () => {
     );
     const withScroll = screen.getByTestId('stack').className;
     expect(withScroll).not.toBe(withoutScroll);
+  });
+
+  it('applies a class when paddingBlockStart is set on its own', () => {
+    const {rerender} = render(
+      <Stack data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const baseline = screen.getByTestId('stack').className;
+    rerender(
+      <Stack paddingBlockStart={2} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(screen.getByTestId('stack').className).not.toBe(baseline);
+  });
+
+  it('lets paddingBlockStart/paddingBlockEnd override only their own edge', () => {
+    const {rerender} = render(
+      <Stack padding={4} paddingBlockStart={2} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const perEdge = classSet(screen.getByTestId('stack'));
+    rerender(
+      <Stack
+        paddingInline={4}
+        paddingBlockStart={2}
+        paddingBlockEnd={4}
+        data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(perEdge).toEqual(classSet(screen.getByTestId('stack')));
+  });
+
+  it('gives paddingBlockEnd precedence over paddingBlock', () => {
+    const {rerender} = render(
+      <Stack paddingBlock={6} paddingBlockEnd={0} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const overridden = classSet(screen.getByTestId('stack'));
+    rerender(
+      <Stack paddingBlockStart={6} paddingBlockEnd={0} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(overridden).toEqual(classSet(screen.getByTestId('stack')));
+  });
+
+  it('leaves padding/paddingBlock output unchanged when no edge prop is set', () => {
+    const {rerender} = render(
+      <Stack padding={3} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const uniform = classSet(screen.getByTestId('stack'));
+    rerender(
+      <Stack paddingInline={3} paddingBlock={3} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(uniform).toEqual(classSet(screen.getByTestId('stack')));
   });
 });

--- a/packages/core/src/Stack/Stack.test.tsx
+++ b/packages/core/src/Stack/Stack.test.tsx
@@ -394,4 +394,80 @@ describe('Stack', () => {
     );
     expect(uniform).toEqual(classSet(screen.getByTestId('stack')));
   });
+
+  it('applies a class when paddingInlineStart is set on its own', () => {
+    const {rerender} = render(
+      <Stack data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const baseline = screen.getByTestId('stack').className;
+    rerender(
+      <Stack paddingInlineStart={2} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(screen.getByTestId('stack').className).not.toBe(baseline);
+  });
+
+  it('lets paddingInlineStart/paddingInlineEnd override only their own edge', () => {
+    const {rerender} = render(
+      <Stack padding={4} paddingInlineStart={2} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const perEdge = classSet(screen.getByTestId('stack'));
+    rerender(
+      <Stack
+        paddingInlineStart={2}
+        paddingInlineEnd={4}
+        paddingBlock={4}
+        data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(perEdge).toEqual(classSet(screen.getByTestId('stack')));
+  });
+
+  it('gives paddingInlineEnd precedence over paddingInline', () => {
+    const {rerender} = render(
+      <Stack paddingInline={6} paddingInlineEnd={0} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const overridden = classSet(screen.getByTestId('stack'));
+    rerender(
+      <Stack paddingInlineStart={6} paddingInlineEnd={0} data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(overridden).toEqual(classSet(screen.getByTestId('stack')));
+  });
+
+  it('resolves all four edges independently', () => {
+    // One prop per edge, each a different step: the four-edge spelling and the
+    // shorthand-plus-overrides spelling must agree.
+    const {rerender} = render(
+      <Stack
+        paddingInlineStart={1}
+        paddingInlineEnd={2}
+        paddingBlockStart={3}
+        paddingBlockEnd={4}
+        data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    const explicit = classSet(screen.getByTestId('stack'));
+    rerender(
+      <Stack
+        padding={4}
+        paddingInlineStart={1}
+        paddingInlineEnd={2}
+        paddingBlockStart={3}
+        data-testid="stack">
+        <div>Content</div>
+      </Stack>,
+    );
+    expect(explicit).toEqual(classSet(screen.getByTestId('stack')));
+  });
 });

--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -25,7 +25,8 @@ import {
 } from './stack.stylex';
 import type {SizeValue} from '../utils/types';
 import {
-  paddingInlineStyles,
+  paddingInlineStartStyles,
+  paddingInlineEndStyles,
   paddingBlockStartStyles,
   paddingBlockEndStyles,
 } from '../Layout/padding.stylex';
@@ -142,6 +143,20 @@ export interface StackProps extends BaseProps<HTMLElement> {
   paddingInline?: SpacingStep;
 
   /**
+   * Inline-start padding, using the spacing scale. Logical: the left edge in
+   * LTR, the right edge in RTL.
+   * Overrides `paddingInline` and `padding` on that edge only.
+   */
+  paddingInlineStart?: SpacingStep;
+
+  /**
+   * Inline-end padding, using the spacing scale. Logical: the right edge in
+   * LTR, the left edge in RTL.
+   * Overrides `paddingInline` and `padding` on that edge only.
+   */
+  paddingInlineEnd?: SpacingStep;
+
+  /**
    * Block (vertical) padding, using the spacing scale.
    * Overrides `padding` on the block axis when both are set.
    */
@@ -224,6 +239,8 @@ export function Stack({
   gap,
   padding,
   paddingInline,
+  paddingInlineStart,
+  paddingInlineEnd,
   paddingBlock,
   paddingBlockStart,
   paddingBlockEnd,
@@ -257,10 +274,11 @@ export function Stack({
       ? (resolvedVAlign as StackCrossAlignment | undefined)
       : (resolvedHAlign as StackCrossAlignment | undefined);
 
-  // Resolve padding to per-edge values: `padding` sets every edge;
-  // `paddingInline` / `paddingBlock` take precedence on their own axis, and
-  // `paddingBlockStart` / `paddingBlockEnd` take precedence on their own edge.
-  const resolvedPaddingInline = paddingInline ?? padding;
+  // Resolve padding to per-edge values. Most specific wins, per edge:
+  // edge prop -> axis prop -> `padding`.
+  const resolvedPaddingInlineStart =
+    paddingInlineStart ?? paddingInline ?? padding;
+  const resolvedPaddingInlineEnd = paddingInlineEnd ?? paddingInline ?? padding;
   const resolvedPaddingBlockStart =
     paddingBlockStart ?? paddingBlock ?? padding;
   const resolvedPaddingBlockEnd = paddingBlockEnd ?? paddingBlock ?? padding;
@@ -273,7 +291,10 @@ export function Stack({
       gap,
       wrap,
     }),
-    resolvedPaddingInline != null && paddingInlineStyles[resolvedPaddingInline],
+    resolvedPaddingInlineStart != null &&
+      paddingInlineStartStyles[resolvedPaddingInlineStart],
+    resolvedPaddingInlineEnd != null &&
+      paddingInlineEndStyles[resolvedPaddingInlineEnd],
     resolvedPaddingBlockStart != null &&
       paddingBlockStartStyles[resolvedPaddingBlockStart],
     resolvedPaddingBlockEnd != null &&

--- a/packages/core/src/Stack/Stack.tsx
+++ b/packages/core/src/Stack/Stack.tsx
@@ -26,7 +26,8 @@ import {
 import type {SizeValue} from '../utils/types';
 import {
   paddingInlineStyles,
-  paddingBlockStyles,
+  paddingBlockStartStyles,
+  paddingBlockEndStyles,
 } from '../Layout/padding.stylex';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
@@ -147,6 +148,18 @@ export interface StackProps extends BaseProps<HTMLElement> {
   paddingBlock?: SpacingStep;
 
   /**
+   * Block-start (top) padding, using the spacing scale.
+   * Overrides `paddingBlock` and `padding` on that edge only.
+   */
+  paddingBlockStart?: SpacingStep;
+
+  /**
+   * Block-end (bottom) padding, using the spacing scale.
+   * Overrides `paddingBlock` and `padding` on that edge only.
+   */
+  paddingBlockEnd?: SpacingStep;
+
+  /**
    * Enables scrollable overflow (`overflow: auto`) for the stack.
    *
    * Matches the `isScrollable` prop on `LayoutContent` and `LayoutPanel`.
@@ -212,6 +225,8 @@ export function Stack({
   padding,
   paddingInline,
   paddingBlock,
+  paddingBlockStart,
+  paddingBlockEnd,
   isScrollable,
   width,
   height,
@@ -242,10 +257,13 @@ export function Stack({
       ? (resolvedVAlign as StackCrossAlignment | undefined)
       : (resolvedHAlign as StackCrossAlignment | undefined);
 
-  // Resolve padding to per-axis values: `padding` sets both axes; `paddingInline`
-  // / `paddingBlock` take precedence on their own axis when provided.
+  // Resolve padding to per-edge values: `padding` sets every edge;
+  // `paddingInline` / `paddingBlock` take precedence on their own axis, and
+  // `paddingBlockStart` / `paddingBlockEnd` take precedence on their own edge.
   const resolvedPaddingInline = paddingInline ?? padding;
-  const resolvedPaddingBlock = paddingBlock ?? padding;
+  const resolvedPaddingBlockStart =
+    paddingBlockStart ?? paddingBlock ?? padding;
+  const resolvedPaddingBlockEnd = paddingBlockEnd ?? paddingBlock ?? padding;
 
   const stylexProps = stylex.props(
     ...stack({
@@ -256,7 +274,10 @@ export function Stack({
       wrap,
     }),
     resolvedPaddingInline != null && paddingInlineStyles[resolvedPaddingInline],
-    resolvedPaddingBlock != null && paddingBlockStyles[resolvedPaddingBlock],
+    resolvedPaddingBlockStart != null &&
+      paddingBlockStartStyles[resolvedPaddingBlockStart],
+    resolvedPaddingBlockEnd != null &&
+      paddingBlockEndStyles[resolvedPaddingBlockEnd],
     isScrollable && overflowStyles.scrollable,
     xstyle,
   );


### PR DESCRIPTION
## Problem

Padding on the layout components is axis-granular and stops there. `padding` sets all four edges, `paddingInline` sets left+right together, `paddingBlock` sets top+bottom together. There is no way to give one edge its own value.

So any asymmetry has to leave the spacing scale entirely:

```tsx
// today
const styles = stylex.create({tightTop: {paddingBlockStart: spacingVars['--spacing-2']}});
<Section padding={6} xstyle={styles.tightTop}>…</Section>
```

That escape hatch costs a `stylex.create` block per site, is invisible to the theme layer, and on `Section` is actively wrong — it moves the padding without moving the `--container-padding-*` custom property, so bleed children (`Table`, `Divider`, a nested `Section`) compensate against a stale number.

The asymmetries themselves are ordinary: a section under a sticky header wants less room above than below; content that should sit flush against the next section wants `0` on one edge; a nav rail wants a tight leading edge and a normal trailing one.

`Section` had a second, smaller version of the same gap — it has `paddingBlock` but **no `paddingInline`**, the only one of the three components missing its inline axis prop.

## Proposal

One prop per edge, on the three layout components that already take axis padding — **Section**, **Stack** (and therefore `HStack` / `VStack`), and **Center**:

`paddingBlockStart` · `paddingBlockEnd` · `paddingInlineStart` · `paddingInlineEnd`

plus `paddingInline` on `Section`, so all three expose the same seven-prop set.

```tsx
<Section padding={6} paddingBlockStart={2}>…</Section>   // tight top, 24px elsewhere
<Stack padding={4} paddingInlineEnd={0}>…</Stack>         // flush trailing edge
<Center paddingBlock={6} paddingBlockEnd={1}>…</Center>   // edge beats axis
```

Same spacing scale as `padding` (`0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10`), same CSS-logical naming the codebase already uses, and one resolution rule for every edge:

> **edge prop → axis prop → `padding`. Most specific wins, per edge.**

An edge prop changes its own edge and leaves the other three alone. This is the precedence `paddingInline` / `paddingBlock` already establish, extended one level down — it is the CSS longhand cascade a reader would predict.

The inline props are logical, not physical: `paddingInlineStart` is the left edge in LTR and the right edge in RTL. Verified, not assumed — see the RTL table below.

### Why not the alternatives

- **A `padding` shorthand tuple** (`padding={[2, 6]}`) — reads as CSS shorthand but is a second spelling for a value the props already express, breaks the "one prop, one spacing step" shape every layout prop shares, and can't be a `select` control in Storybook.
- **Leave it to `xstyle`** — the status quo, and on Section it silently desynchronizes the container vars.
- **Edge props on Section without adding `paddingInline`** — would leave Section able to set one inline edge but not both at once, an edge override with no axis prop under it. Adding the axis prop is one map lookup and removes the rung gap.
- **Extend to `Grid` / `FormLayout` / `Layout`** — out of scope. Grid and FormLayout have no padding props at all (Grid has `gap`, which is space *between* items). `Layout` has `padding` but no axis props, so edge props there would skip the same rung this PR just closed on Section; giving it the full ladder is a bigger change than this one.

## Implementation

- `padding.stylex.ts` gains four single-edge maps (`paddingInlineStartStyles`, `paddingInlineEndStyles`, `paddingBlockStartStyles`, `paddingBlockEndStyles`) and two container-var maps (`containerPaddingInlineStartVarStyles`, `containerPaddingInlineEndVarStyles`).
- The two inline container vars **already existed and were already read separately** by `Card`, `ClickableCard`, `Divider` and `Layout` — only the setter map was combined. Per-edge inline is the model the CSS already assumed.
- **Stack** and **Center** compose the four edge maps instead of the two axis maps. StyleX already emitted per-property atomic classes, so **existing `padding` / `paddingInline` / `paddingBlock` usage produces identical class output** — asserted as class-set equality (`padding={3}` ≡ `paddingInline={3} paddingBlock={3}`), not just claimed.
- **Section** moves the matching `--container-padding-*` custom property per edge alongside the padding, so bleed children keep compensating against the padding actually applied. This is the part `xstyle` cannot do, and the main reason the props belong in the component.

## Verification

Gates: `pnpm lint:strict` (0 errors, 56 pre-existing warnings), `pnpm test` (10,113 tests), `pnpm build` — all green.

New tests assert semantics rather than "renders without error": each component checks that an edge prop changes the output, that the shorthand-plus-override spelling is **class-for-class identical** to spelling every edge out, that an edge prop beats its axis prop, that all four edges resolve independently, and that untouched usage is unchanged. On Section there is an extra test that overriding opposite edges by the same step does *not* collapse to the same output — that is the container-var wiring.

Measured in headless Chromium against the built `astryx.css`, reading `getComputedStyle`, in both directions:

**`dir="ltr"`** — top / bottom / inline-start / inline-end

| case | measured |
|---|---|
| `Section padding={6}` | 24 / 24 / 24 / 24 |
| `Section padding={6} paddingInlineStart={2}` | 24 / 24 / **8** / 24 |
| `Section padding={6} paddingInlineEnd={0}` | 24 / 24 / 24 / **0** |
| `Section` one prop per edge (1/2/3/4) | **12 / 16 / 4 / 8** |
| `Section paddingInline={6} paddingInlineEnd={1}` | 16 / 16 / 24 / **4** *(block from theme default)* |
| `Stack padding={6} paddingInlineStart={2}` | 24 / 24 / **8** / 24 |
| `Center padding={6} paddingInlineEnd={0}` | 24 / 24 / 24 / **0** |

**`dir="rtl"`** — the logical values above are byte-identical; the physical edges swap, which is the point:

| case | physical left / right in LTR | physical left / right in RTL |
|---|---|---|
| `Section padding={6} paddingInlineStart={2}` | 8 / 24 | **24 / 8** |
| `Section padding={6} paddingInlineEnd={0}` | 24 / 0 | **0 / 24** |
| `Section` one prop per edge | 4 / 8 | **8 / 4** |

Docs (`docs` / `docsZh` / `docsDense`), Storybook argTypes and a per-edge story on each component are included; `check:sync` is clean.

## Relation to #3223

#3223 derives a standard layout prop set and lists spacing as `padding` + `paddingBlock` / `paddingInline`. This extends that row one level down on both axes, using the precedence the standard already implies, and closes one of the inconsistencies #3223 catalogues (Section missing `paddingInline`). If #3223 lands a different vocabulary, this is a rename, not a rethink.
