### PR TITLE
fix(cli): alias @xds/core imports that collide with local bindings when dropping the XDS prefix

### DIFF
--- a/packages/cli/assets/codemods/transforms/v0.1.0/__tests__/drop-xds-prefix-imports.test.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.1.0/__tests__/drop-xds-prefix-imports.test.mjs
@@ -212,4 +212,95 @@ describe('drop-xds-prefix-imports', () => {
     const output = await applyTransform(input);
     expect(output).toBe(input);
   });
+
+  it('aliases a component wrapper collision in place (XDS -> Astryx), leaving the local fn untouched', async () => {
+    const input = [
+      `import {XDSLinkProvider} from '@xds/core/Link';`,
+      `export default function LinkProvider({children}) {`,
+      `  return <XDSLinkProvider component={NextLink}>{children}</XDSLinkProvider>;`,
+      `}`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    // Import aliased in place, local wrapper + its name untouched.
+    expect(output).toContain('import {LinkProvider as AstryxLinkProvider}');
+    expect(output).toContain('function LinkProvider({children})');
+    // JSX rewritten to the alias -> no self-recursion.
+    expect(output).toContain('<AstryxLinkProvider component={NextLink}>');
+    expect(output).not.toContain('XDSLinkProvider');
+    // No duplicate bare LinkProvider import.
+    expect(output).not.toMatch(/import \{LinkProvider\}/);
+  });
+
+  it('aliases a hook collision as use<Astryx>Name (not <Astryx>use)', async () => {
+    const input = [
+      `import {useXDSToast} from '@xds/core';`,
+      `function useToast() {`,
+      `  return useXDSToast();`,
+      `}`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('import {useToast as useAstryxToast}');
+    expect(output).toContain('function useToast()');
+    expect(output).toContain('return useAstryxToast();');
+    expect(output).not.toContain('useXDSToast');
+    // Must not produce the malformed `Astryxuse...` form.
+    expect(output).not.toContain('AstryxuseToast');
+  });
+
+  it('aliases on collision with a local default import binding', async () => {
+    const input = [
+      `import Link from 'next/link';`,
+      `import {XDSLink} from '@xds/core';`,
+      `export const a = <XDSLink href="/" />;`,
+      `export const b = <Link href="/" />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('import {Link as AstryxLink}');
+    expect(output).toContain(`import Link from 'next/link';`);
+    expect(output).toContain('<AstryxLink href="/" />');
+    expect(output).toContain('<Link href="/" />');
+    expect(output).not.toContain('XDSLink');
+  });
+
+  it('aliases on collision with a local type alias', async () => {
+    const input = [
+      `import type {XDSTab} from '@xds/core';`,
+      `type Tab = {id: string};`,
+      `const active: XDSTab = null as any;`,
+      `const local: Tab = {id: '1'};`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('Tab as AstryxTab');
+    expect(output).toContain('type Tab = {id: string};');
+    expect(output).toContain('const active: AstryxTab');
+    expect(output).toContain('const local: Tab');
+    expect(output).not.toContain('XDSTab');
+  });
+
+  it('aliases on collision with a local interface', async () => {
+    const input = [
+      `import type {XDSTheme} from '@xds/core';`,
+      `interface Theme {}`,
+      `const t: XDSTheme = null as any;`,
+      `const local: Theme = {};`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    expect(output).toContain('Theme as AstryxTheme');
+    expect(output).toContain('interface Theme {}');
+    expect(output).toContain('const t: AstryxTheme');
+    expect(output).not.toContain('XDSTheme');
+  });
+
+  it('still bare-renames when there is NO colliding local binding', async () => {
+    const input = [
+      `import {XDSButton} from '@xds/core';`,
+      `export const App = () => <XDSButton label="Hi" />;`,
+    ].join('\n');
+    const output = await applyTransform(input);
+    // No local `Button` binding -> existing blind bare-rename behavior kept.
+    expect(output).toContain(`import {Button} from '@xds/core';`);
+    expect(output).toContain('<Button label="Hi" />');
+    expect(output).not.toContain('AstryxButton');
+    expect(output).not.toContain('XDSButton');
+  });
 });

--- a/packages/cli/assets/codemods/transforms/v0.1.0/drop-xds-prefix-imports.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.1.0/drop-xds-prefix-imports.mjs
@@ -65,6 +65,22 @@ export const meta = {
 const XDS_CORE_SOURCE = /^@xds\/core(\/.*)?$/;
 
 /**
+ * Compute a collision alias for an XDS-prefixed identifier by replacing the
+ * `XDS` segment IN PLACE with `Astryx` (as opposed to prefixing the bare name).
+ * This keeps hook names well-formed:
+ *
+ *   XDSButton       -> AstryxButton
+ *   XDSLinkProvider -> AstryxLinkProvider
+ *   useXDSToast     -> useAstryxToast   (NOT AstryxuseToast)
+ *
+ * Only the first `XDS` occurrence is replaced, matching how `bareName` strips a
+ * single leading prefix.
+ */
+function aliasName(/** @type {any} */ name) {
+  return name.replace('XDS', 'Astryx');
+}
+
+/**
  * Compute the bare (unprefixed) name for an XDS-prefixed identifier.
  * Returns null if the name is not XDS-prefixed in a renameable way.
  */
@@ -190,7 +206,12 @@ export default function transformer(file, api) {
     if (!node) return;
     if (
       (node.type === 'FunctionDeclaration' ||
-        node.type === 'ClassDeclaration') &&
+        node.type === 'ClassDeclaration' ||
+        // Type-only bindings share the module namespace for our purposes: a
+        // `type Tab`/`interface Theme` collides with an un-prefixed `XDSTab`/
+        // `XDSTheme` type import and would create a duplicate declaration.
+        node.type === 'TSTypeAliasDeclaration' ||
+        node.type === 'TSInterfaceDeclaration') &&
       node.id
     ) {
       existingBindings.add(node.id.name);
@@ -239,10 +260,13 @@ export default function transformer(file, api) {
       if (bare !== importedName && existingBindings.has(bare)) {
         // COLLISION: the bare name is already a top-level binding in this file
         // (e.g. a local `export function CodeBlock` alongside imported
-        // `XDSCodeBlock`). Un-prefixing directly would create a duplicate
-        // declaration, so alias the import to `Astryx<Name>` and rename the
+        // `XDSCodeBlock`, or a `type Tab` alongside `XDSTab`). Un-prefixing
+        // directly would create a duplicate declaration (TS2451), so alias the
+        // import by replacing `XDS` with `Astryx` in place and rename the
         // import's references to that alias, leaving the local binding intact.
-        const alias = `Astryx${bare}`;
+        // In-place replacement keeps hooks well-formed: `useXDSToast` becomes
+        // `useAstryxToast`, not `AstryxuseToast`.
+        const alias = aliasName(importedName);
         localRenames.set(importedName, alias);
         existingBindings.add(alias);
         hasChanges = true;


### PR DESCRIPTION
## What

The `drop-xds-prefix-imports` codemod un-prefixes `@xds/core` imports (`XDSButton` → `Button`, `useXDSTheme` → `useTheme`) and rewrites every reference to the new bare name. It already has collision handling: when the bare name clashes with a local top-level binding it aliases the import to keep the two distinct. But two collision cases still slipped through and broke consumer builds:

1. **Type-only collisions were not detected.** A local `type Tab` / `interface Theme` next to an imported `XDSTab` / `XDSTheme` was blindly un-prefixed to `Tab` / `Theme`, producing a duplicate declaration — `TS2451: Cannot redeclare block-scoped variable`.

2. **The alias mangled hook names.** The alias was built as `Astryx<bare>`, so `useXDSToast` → bare `useToast` → `AstryxuseToast`, which isn't a valid hook name (React only treats `use`-prefixed identifiers as hooks). The same wrapper idiom also caused runtime self-recursion, e.g.:

   ```tsx
   import {XDSLinkProvider} from '@xds/core/Link';
   export default function LinkProvider({children}) {   // local wrapper, same bare name
     return <XDSLinkProvider component={NextLink}>{children}</XDSLinkProvider>;
   }
   ```

   Un-prefixing straight to `LinkProvider` gives you `import {LinkProvider}` next to `function LinkProvider`, and the JSX inside the wrapper now points at the local function — a duplicate binding plus infinite recursion.

## How

- Collect `TSTypeAliasDeclaration` and `TSInterfaceDeclaration` ids into the existing-bindings set alongside functions/classes/vars/imports, so type/interface collisions are caught.
- Derive the collision alias by replacing `XDS` with `Astryx` **in place** on the imported name rather than prefixing the bare name. This keeps hooks well-formed:
  - `XDSLinkProvider` → `AstryxLinkProvider`
  - `useXDSToast` → `useAstryxToast` (not `AstryxuseToast`)
- On collision, emit `import {<bare> as <alias>}` and rewrite the prefixed references to the alias, leaving the local binding and its own references untouched.
- Non-colliding imports keep the existing plain bare-rename behavior — unchanged.

Erring toward over-aliasing here is safe (a correct, distinct alias); under-aliasing is what breaks the build, so the collision check stays a broad program-scope binding scan rather than full scope resolution.

## Blast radius

This is the local-wrapper / same-name idiom that shows up across the fleet — roughly **88 apps / 143 files** where a wrapper component, hook, type, interface, or re-imported symbol shares the bare name of an `@xds/core` export (`function AppShell` + `XDSAppShell`, `type Tab` + `XDSTab`, `import Link from 'next/link'` + `XDSLink`, etc.). Those are exactly the files that were hitting TS2451 / wrapper self-recursion after the codemod ran.

## Test plan

New codemod tests (all green, alongside the existing suite):

- component wrapper collision (`XDSLinkProvider` + local `function LinkProvider`) → `LinkProvider as AstryxLinkProvider`, local fn untouched, JSX rewritten to the alias
- hook collision (`useXDSToast` + local `useToast`) → `useToast as useAstryxToast` (asserts it is *not* `AstryxuseToast`)
- default-import collision (`import Link from 'next/link'` + `XDSLink`) → `Link as AstryxLink`
- type-alias collision (`type Tab` + `XDSTab`) → `Tab as AstryxTab`
- interface collision (`interface Theme` + `XDSTheme`) → `Theme as AstryxTheme`
- regression: no local `Button` → still bare-renames `XDSButton` → `Button` (no alias)

`vitest run` on the file: 23 passed.