### PR TITLE
fix(ci): don't let a transient 503 silently drop the review-required gate

### DIFF
--- a/.github/workflows/review-clear.yml
+++ b/.github/workflows/review-clear.yml
@@ -43,6 +43,9 @@ jobs:
         env:
           ENG_OWNERS: ${{ vars.ENGOWNERS }}
         with:
+          # See review-signal.yml — a transient 503 on the status POST must not
+          # be the last word on whether the gate clears.
+          retries: 3
           script: |
             const { owner, repo } = context.repo;
             const run = context.payload.workflow_run;
@@ -140,15 +143,11 @@ jobs:
                 core.warning(`Could not remove ${CODE} (may already be gone): ${e.message}`);
               }
             }
-            try {
-              await github.rest.repos.createCommitStatus({
-                owner, repo, sha: headSha, context: 'review-required',
-                state: 'success', description: 'Cleared by code-owner approval.',
-              });
-              core.info(`review-required status → success on #${prNumber}.`);
-            } catch (e) {
-              core.warning(`Could not set review-required status: ${e.message}`);
-            }
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: headSha, context: 'review-required',
+              state: 'success', description: 'Cleared by code-owner approval.',
+            });
+            core.info(`review-required status → success on #${prNumber}.`);
             // Neutralize stale check-run(s) of the same name so the rollup isn't
             // dragged to failure by a pre-status action_required leftover.
             try {

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -109,6 +109,10 @@ jobs:
           ENG_OWNERS: ${{ vars.ENGOWNERS }}
           DESIGN_OWNERS: ${{ vars.DESIGNOWNERS }}
         with:
+          # api.github.com 503s intermittently; an unretried one used to leave a
+          # PR with no review-required status at all, blocked forever on
+          # "Expected — waiting for status" (#5149, #5152).
+          retries: 3
           script: |
             const { owner, repo } = context.repo;
             const CODE = process.env.CODE_LABEL;
@@ -201,15 +205,11 @@ jobs:
                   }
                 }
               }
-              try {
-                await github.rest.repos.createCommitStatus({
-                  owner, repo, sha: pr.head.sha,
-                  context: 'review-required', state: 'success',
-                  description: 'Automated (bot) PR — exempt from review gates.',
-                });
-              } catch (e) {
-                core.warning(`Could not set review-required status: ${e.message}`);
-              }
+              await github.rest.repos.createCommitStatus({
+                owner, repo, sha: pr.head.sha,
+                context: 'review-required', state: 'success',
+                description: 'Automated (bot) PR — exempt from review gates.',
+              });
               return;
             }
 
@@ -504,21 +504,21 @@ jobs:
             // (branch protection passes only success); an owner's code approval
             // flips it to success.
             const gateReasons = codeGated ? codeReasons : [];
-            try {
-              await github.rest.repos.createCommitStatus({
-                owner,
-                repo,
-                sha: pr.head.sha,
-                context: 'review-required',
-                state: codeGated ? 'pending' : 'success',
-                description: codeGated
-                  ? `Waiting on code review: ${gateReasons.join(', ')}`.slice(0, 140)
-                  : 'No code review required.',
-              });
-              core.info(`review-required status: ${codeGated ? 'pending' : 'success'}`);
-            } catch (e) {
-              core.warning(`Could not set review-required status: ${e.message}`);
-            }
+            // Never swallow a failure here: the status IS the gate, so a PR
+            // whose POST failed is blocked on a status that will never arrive.
+            // Throwing marks the run red and lets the per-PR catch continue a
+            // backfill; re-run the workflow to retry.
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha: pr.head.sha,
+              context: 'review-required',
+              state: codeGated ? 'pending' : 'success',
+              description: codeGated
+                ? `Waiting on code review: ${gateReasons.join(', ')}`.slice(0, 140)
+                : 'No code review required.',
+            });
+            core.info(`review-required status: ${codeGated ? 'pending' : 'success'}`);
             // Neutralize any stale "review-required" CHECK RUN left over from the
             // pre-status gate. Such a leftover (conclusion action_required) drags
             // the status rollup to FAILURE even though we now gate via a commit


### PR DESCRIPTION
## Problem

`review-signal.yml` posts the `review-required` commit status that branch protection gates on. The POST was wrapped in a `try/catch` that downgraded any failure to `core.warning` — so when `api.github.com` returned a 503, the job finished **green** having never posted the status, and branch protection sat on *"Expected — waiting for status to be reported"* indefinitely.

From #5149's run ([job log](https://github.com/facebook/astryx/actions/runs/32037881199)):

```
author=@ejhammond eng=true design=false
code: false (-)
POST /repos/facebook/astryx/statuses/6ad347b0… - 503 …
##[warning]Could not set review-required status: No server is currently available…
```

The gate decision was *correct* (eng owner → no review needed); only the delivery failed. Three PRs were stuck this way — [#5149](https://github.com/facebook/astryx/pull/5149), [#5152](https://github.com/facebook/astryx/pull/5152), [#5035](https://github.com/facebook/astryx/pull/5035) — with no red run anywhere to point at. It reads as "I lost my permissions", which is what makes it expensive: nothing in the UI says the status is *missing* rather than *unsatisfied*.

## Fix

1. **`retries: 3`** on both `github-script` steps. The action ships an octokit retry plugin that defaults to `retries: 0`; 4xx that we rely on (404/422 from `removeLabel`, etc.) are already in `retry-exempt-status-codes`, so this retries exactly the transient 5xx class.
2. **Stop swallowing the status POST.** All three sites (`review-signal` bot path, `review-signal` main path, `review-clear`) now let a failure propagate. In `review-signal` it lands in the existing per-PR `try/catch`, which keeps a backfill going across the other PRs and then `setFailed`s the run — so a dropped gate is visible instead of silent.

Deliberately unchanged: everything about how the gate *decides*. Same buckets, same detection, same clearing rules.

## Test plan

- `node --check` on both extracted inline scripts; YAML parses.
- The stuck PRs were recovered with the documented lever, `workflow_dispatch` with a PR number, and all three now carry a status: #5149 `success`, #5152 `success`, #5035 `pending — core change` (correctly gated: design-owner author, core runtime change).
- ⚠️ **`pull_request_target` workflows run from the base ref, so this PR cannot exercise its own change.** It takes effect on the first PR event after landing. The retry path specifically only shows up under a real 503.

## Adjacent, not fixed here

The reviews read in `review-signal.yml` swallows failures the same way:

```
##[warning]Could not read reviews: Not Found …
```

That one is worse in kind — it doesn't drop the status, it computes `codeApproved=false` from a failed read and posts a **wrong** `pending`, blocking a PR that was already approved. It also fired on #5149's run. Same 503-ish flakiness, retries will reduce it, but the swallow deserves its own change and its own thinking about what to do when the read fails (leaving the gate untouched is probably right). Happy to follow up if you want it.
