### PR TITLE
fix: Section nested in BottomSheet overflows the sheet

### DIFF
--- a/.changeset/bottomsheet-container-padding-escape.md
+++ b/.changeset/bottomsheet-container-padding-escape.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] A `Section` nested inside a `BottomSheet` no longer overflows the sheet when an ancestor of the sheet's trigger sets `--container-padding-*` (e.g. a page container, or another `Section`). `Section` escapes its parent's padding via a negative margin driven by those CSS variables; a `BottomSheet` is a fixed-position overlay but is still a DOM descendant of whatever container opened it, so it inherited those vars even though it has visually left the container's box, and a nested `Section` escaped padding that was never actually there. `BottomSheetPanel` now resets `--container-padding-*` to `0px` for its own descendants, the same way `Section`'s own inner wrapper already resets it for its children.
+
+@HelloOjasMutreja

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -122,6 +122,18 @@ const styles = stylex.create({
     '@media (prefers-reduced-motion: reduce)': {
       transitionDuration: '0.01s',
     },
+    // The sheet is a fixed-position overlay, but it is still a DOM descendant
+    // of whatever container opened it, so it inherits that container's
+    // `--container-padding-*` vars even though it has visually left the
+    // container's box. A nested Section reads those vars to escape its
+    // parent's padding (see Section.tsx's nestedStyles), so without this
+    // reset a Section inside the sheet "escapes" padding that was never
+    // visually there and overflows the sheet. Reset to 0 here, the same way
+    // Section's own inner wrapper resets for its descendants.
+    '--container-padding-inline-start': '0px',
+    '--container-padding-inline-end': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
   },
   sheetClosing: {
     transform: 'translateY(100%)',


### PR DESCRIPTION
Fixes #5208.

## Problem

`Section` escapes its parent's container padding via a negative margin driven by `--container-padding-*` CSS custom properties (`Section.tsx`'s `nestedStyles.outer`), which is correct when a `Section` is nested directly in a padded page container.

`BottomSheet` is a fixed-position overlay, but it's still a DOM descendant of whatever container opened it, so it inherits those `--container-padding-*` vars from that ancestor even though the sheet has visually left the container's box. A `Section` nested inside the sheet then "escapes" padding that was never actually there, overflowing the sheet on both edges.

Reproduced live with a `padding=4` `Section` wrapping a `BottomSheet` that has a nested `padding=4` `Section`: the inner Section measured 672px inside a 640px sheet (304..976 vs the sheet's 320..960), matching the issue's own reported numbers exactly.

## Fix

`BottomSheetPanel` now resets `--container-padding-*` to `0px` for its own descendants, the same way `Section`'s own inner wrapper already resets it for its children. Any overlay that leaves its parent's visual box while staying a DOM descendant of it likely needs the same treatment (Dialog, Popover), but I've kept this fix scoped to the reported component; happy to follow up on the others if that's wanted.

## Verification

Live-verified against a temporary Storybook harness reproducing the issue's exact repro (padded `Section` > `BottomSheet` > padded `Section`):

- Before this fix: inner Section's `getBoundingClientRect()` = 672px wide, offset -16px/+16px past the 640px sheet panel on each side.
- After this fix: inner Section renders flush with the sheet panel's edges, no overflow.

Screenshots below overlay the sheet panel (red) and the inner Section (blue) so the overflow (or lack of it) is visible even though both surfaces are the same background color:

**Before:**
![before](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5208-bottomsheet-overflow/5208-before.png)

**After:**
![after](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/issue-5208-bottomsheet-overflow/5208-after.png)

The temporary story used for this was not committed. Existing `BottomSheet` test suites (180 tests across 5 files) pass unchanged. Typecheck and lint pass locally.
