### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,12 @@
+# Normalize line endings to LF on checkout regardless of the client's own
+# core.autocrlf. Without this, a Windows checkout with the (Git-default)
+# core.autocrlf=true gets CRLF line endings, which silently breaks any script
+# that regenerates a checked-in file and diffs it byte-for-byte against the
+# LF content Prettier/Node actually wrote. For example,
+# scripts/generate-cldr-weekdays.mjs --check fails on every Windows machine
+# with default settings, regardless of whether the data is actually stale.
+* text=auto eol=lf
+
 # Vendored shadcn components — treat as binary (no diffs, no linguist stats)
 internal/vibe-tests/.baseline/components/ui/** linguist-generated=true binary
 


### PR DESCRIPTION
Not tied to a filed issue; found while shipping an unrelated fix, when `scripts/generate-cldr-weekdays.mjs --check` (from the recently-merged Calendar CLDR PR) failed on a completely default Windows checkout, immediately after running the generator itself.

## Root cause

The check does:

```js
const actual = fs.readFileSync(OUTPUT_FILE, 'utf8');
if (actual !== expected) { /* report stale */ }
```

`expected` is built from a template literal plus Prettier's `format()`, both of which always emit `\n`. `actual` is read exactly as the file sits on disk. Git's default `core.autocrlf=true` on Windows converts checked-in LF files to CRLF on checkout, so `actual` has CRLF line endings while `expected` has LF. The byte-for-byte comparison then fails on every default Windows checkout, regardless of whether the data is actually stale.

Confirmed: forcing a fresh LF checkout of the same file (bypassing `autocrlf`) makes the exact same check pass immediately, with zero real content difference. This isn't specific to the CLDR script either, it's a latent risk for any current or future script that does a similar regenerate-and-diff check.

## Fix

Add a `.gitattributes` rule forcing LF line endings on checkout for all text files:

```
* text=auto eol=lf
```

This is the standard fix for this exact class of problem (also used by many JS/TS monorepos), and normalizes checkouts going forward for every Windows contributor without needing anyone to change their local `core.autocrlf`. It doesn't touch any already-committed blob content, only how files are materialized on checkout/add from here on.

## Verification

`node scripts/generate-cldr-weekdays.mjs --check` passes on a normal checkout. Ran the full `BottomSheet` suite (180 tests) as a sanity check that nothing else regressed; unaffected as expected, since this only changes checkout-time line-ending handling. No changeset since this touches no published package.
