### PR TITLE
fix(core,lab): stop the container padding system at every overlay boundary

### DIFF
--- a/.changeset/overlay-padding-var-isolation.md
+++ b/.changeset/overlay-padding-var-isolation.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Stop the container padding system at every overlay boundary. Follow-up to #5209, which zeroed `--container-padding-*` on four overlay roots and closed the visible overflow in #5208.
+
+Two gaps remained. The variables descendants ADD (`--layout-padding-*`, and a Section's propagated padding) still crossed the boundary, so an unpadded `Section` inside an overlay took the page's padding instead of the theme default — 40px where 16px was meant. And `Lightbox`, `ContextMenu` and `HoverCard` were never covered.
+
+The reset now lives in one place (`overlayPaddingReset`, exported from `@astryxdesign/core/Layout`) instead of being hand-copied per overlay, and moved onto the `useLayer` root, which covers every layer surface at once. Values descendants subtract are zeroed; values they add are cleared to `initial` so readers fall through to their own default rather than losing their padding.
+
+Section's padding propagation moved from the public `--astryx-section-padding` token to a private `--_section-padding-propagated`. The two carried different authority under one name — a theme's value versus one ancestor's — and an overlay could not drop the inherited one without blanking the theme's. Propagated values still win over the theme for nested sections, so behavior is unchanged. Themes are unaffected: `--astryx-section-padding` remains the public token and still reaches inside overlays.
+
+@imdreamrunner

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -43,6 +43,7 @@ import {
   spacingVars,
 } from '../theme/tokens.stylex';
 import {mergeProps, themeProps} from '../utils';
+import {overlayPaddingReset} from '../Layout/padding.stylex';
 import {
   isValidSnapPoint,
   resolveSnapPoints,
@@ -111,10 +112,6 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 640,
     backgroundColor: colorVars['--color-background-surface'],
-    '--container-padding-inline-start': '0px',
-    '--container-padding-inline-end': '0px',
-    '--container-padding-block-start': '0px',
-    '--container-padding-block-end': '0px',
     borderStartStartRadius: radiusVars['--radius-container'],
     borderStartEndRadius: radiusVars['--radius-container'],
     boxShadow: shadowVars['--shadow-high'],
@@ -584,6 +581,7 @@ export function BottomSheetPanel({
         themeProps('bottom-sheet'),
         stylex.props(
           styles.sheet,
+          overlayPaddingReset.reset,
           height === 'hug' ? styles.hugHeight : styles.budget,
           isClosing && styles.sheetClosing,
           isFading && styles.sheetFading,

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -44,6 +44,7 @@ import {
   containerPaddingBlockStartVarStyles,
   containerPaddingBlockEndVarStyles,
   spacingStepToToken,
+  overlayPaddingReset,
 } from '../Layout/padding.stylex';
 import type {SpacingStep} from '../utils/types';
 import {mergeProps, mergeRefs} from '../utils';
@@ -129,10 +130,6 @@ const styles = stylex.create({
     border: 'none',
     backgroundColor: colorVars['--color-background-surface'],
     '--_dialog-radius': radiusVars['--radius-container'],
-    '--container-padding-inline-start': '0px',
-    '--container-padding-inline-end': '0px',
-    '--container-padding-block-start': '0px',
-    '--container-padding-block-end': '0px',
     borderRadius: 'var(--_dialog-radius)',
     boxShadow: shadowVars['--shadow-high'],
     display: 'none',
@@ -188,10 +185,6 @@ const styles = stylex.create({
     border: 'none',
     backgroundColor: colorVars['--color-background-surface'],
     '--_dialog-radius': radiusVars['--radius-container'],
-    '--container-padding-inline-start': '0px',
-    '--container-padding-inline-end': '0px',
-    '--container-padding-block-start': '0px',
-    '--container-padding-block-end': '0px',
     borderRadius: 'var(--_dialog-radius)',
     boxShadow: shadowVars['--shadow-high'],
     display: 'flex',
@@ -618,6 +611,7 @@ export function Dialog({
           themeProps('dialog', {variant}),
           stylex.props(
             styles.inlineWrapper,
+            overlayPaddingReset.reset,
             !isFullscreen && dynamicStyles.sizing(width, maxHeight),
             isFullscreen && styles.fullscreen,
             xstyle,
@@ -644,6 +638,7 @@ export function Dialog({
         themeProps('dialog', {variant}),
         focusOutlineProps.focusVisible(
           styles.dialog,
+          overlayPaddingReset.reset,
           isOpen && styles.open,
           styles.backdrop,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -29,6 +29,7 @@ import {createPortal} from 'react-dom';
 import {addAnchorName, removeAnchorName} from './anchorName';
 import {resolveLayerPortalTarget} from './layerHost';
 import {typeScaleVars, typographyVars} from '../theme/tokens.stylex';
+import {overlayPaddingReset} from '../Layout/padding.stylex';
 
 const styles = stylex.create({
   // Base reset for all layers
@@ -771,7 +772,12 @@ export function useLayer(
             : styles.offsetInline(toCssLength(offset))
           : null;
 
-      const stylexResult = stylex.props(styles.base, offsetStyle, xstyle);
+      const stylexResult = stylex.props(
+        styles.base,
+        overlayPaddingReset.reset,
+        offsetStyle,
+        xstyle,
+      );
       const combinedClassName = extraClassName
         ? `${extraClassName} ${stylexResult.className ?? ''}`
         : stylexResult.className;
@@ -835,7 +841,12 @@ export function useLayer(
         left: x,
       };
 
-      const stylexResult = stylex.props(styles.base, styles.fixed, xstyle);
+      const stylexResult = stylex.props(
+        styles.base,
+        overlayPaddingReset.reset,
+        styles.fixed,
+        xstyle,
+      );
       const combinedClassName = extraClassName
         ? `${extraClassName} ${stylexResult.className ?? ''}`
         : stylexResult.className;

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -28,8 +28,10 @@
  * }
  * ```
  *
- * Internal variables (`--layout-padding-inner-x`, `--container-padding-*`)
- * are implementation details and must not be referenced by themes.
+ * Internal variables (`--layout-padding-inner-x`, `--container-padding-*`,
+ * `--_section-padding-propagated`) are implementation details and must not be
+ * referenced by themes. They also do not cross an overlay boundary — see
+ * `overlayPaddingReset` in padding.stylex.ts.
  *
  * SYNC: When modified, update /packages/core/src/Layout/Layout.doc.mjs
  */
@@ -105,7 +107,13 @@ const cardBlockEnd = `var(--astryx-card-padding-block-end, ${cardShorthand})`;
 // Section padding chains: --astryx-* then the next specificity level, terminating
 // at --spacing-4. Built as chained const strings (no function calls) so StyleX
 // can statically analyze them; see naming.ts for the prefix policy.
-const sectionShorthand = `var(--astryx-section-padding, ${SP4})`;
+// `--_section-padding-propagated` (set by an ancestor Section with explicit
+// padding) is read AHEAD of the public theme token, so a propagated value
+// still wins over the theme for nested sections. Splitting the two names is
+// what lets an overlay drop the inherited value at its boundary while keeping
+// the theme's — see `overlayPaddingReset` in padding.stylex.ts.
+const sectionThemeShorthand = `var(--astryx-section-padding, ${SP4})`;
+const sectionShorthand = `var(--_section-padding-propagated, ${sectionThemeShorthand})`;
 const sectionInline = `var(--astryx-section-padding-inline, ${sectionShorthand})`;
 const sectionInlineStart = `var(--astryx-section-padding-inline-start, ${sectionInline})`;
 const sectionInlineEnd = `var(--astryx-section-padding-inline-end, ${sectionInline})`;

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -19,6 +19,10 @@ export type {
   SpacingToken,
 } from './container.stylex';
 
+// Overlay padding-variable reset (applied on overlay roots so the container
+// padding system does not cross a fixed/top-layer boundary)
+export {overlayPaddingReset} from './padding.stylex';
+
 // Edge compensation utility
 export {edgeCompSlot, EDGE_COMP_ATTR} from './edgeCompensation.stylex';
 

--- a/packages/core/src/Layout/overlayPaddingReset.test.tsx
+++ b/packages/core/src/Layout/overlayPaddingReset.test.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file overlayPaddingReset.test.tsx
+ * @input Uses vitest, @testing-library/react, overlay components from core
+ * @output Tests that overlay roots stop the container padding system at their
+ *   boundary, and that the public theme token still crosses it
+ * @position Layout tests; validates overlayPaddingReset in padding.stylex.ts
+ *
+ * The container padding system talks to descendants through INHERITED custom
+ * properties, but an overlay leaves its parent's visual box while staying a DOM
+ * descendant of it. Every overlay root therefore has to stop those values (see
+ * #5208: a Section in a 640px sheet rendered 672px wide).
+ *
+ * jsdom does no layout, so these assert on the custom properties themselves —
+ * the definitions the layout is computed from. The widths they stand in for are
+ * verified in a browser; see the PR description.
+ *
+ * SYNC: When an overlay is added, add it to OVERLAYS below.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {render, screen} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {Dialog} from '../Dialog';
+import {BottomSheet} from '../BottomSheet';
+import {MobileNav} from '../MobileNav';
+import {Lightbox} from '../Lightbox';
+import {Popover} from '../Popover';
+import {Section} from '../Section';
+
+// jsdom implements neither the <dialog> methods nor matchMedia.
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/**
+ * Values descendants SUBTRACT (bleed margins). The overlay root has no padding
+ * of its own to escape, so these must read a literal zero.
+ */
+const SUBTRACTED = [
+  '--container-padding-inline-start',
+  '--container-padding-inline-end',
+  '--container-padding-block-start',
+  '--container-padding-block-end',
+];
+
+/**
+ * Values descendants ADD. These must be guaranteed-invalid (`initial`) rather
+ * than zero, so readers fall through to their own default instead of losing
+ * their padding — a computed empty string is what `initial` looks like here.
+ */
+const CLEARED = [
+  '--layout-padding-outer-x',
+  '--layout-padding-outer-y',
+  '--layout-padding-inner-x',
+  '--layout-padding-inner-y',
+  '--_section-padding-propagated',
+];
+
+/** What a cleared custom property reads back as. See the assertion below. */
+const CLEARED_READBACK = ['', 'initial'];
+
+/** Each overlay, rendered open inside a page Section that leaks 40px. */
+const OVERLAYS: {
+  name: string;
+  render: (child: ReactNode) => ReactNode;
+  root: () => HTMLElement;
+}[] = [
+  {
+    name: 'Dialog',
+    render: child => (
+      <Dialog isOpen onOpenChange={() => {}}>
+        {child}
+      </Dialog>
+    ),
+    root: () => screen.getByRole('dialog'),
+  },
+  {
+    name: 'BottomSheet',
+    render: child => (
+      <BottomSheet isOpen onOpenChange={() => {}} label="S">
+        {child}
+      </BottomSheet>
+    ),
+    root: () =>
+      document.querySelector<HTMLElement>(
+        '.astryx-bottom-sheet',
+      ) as HTMLElement,
+  },
+  {
+    name: 'MobileNav',
+    render: child => (
+      <MobileNav isOpen onOpenChange={() => {}} label="N">
+        {child}
+      </MobileNav>
+    ),
+    root: () => screen.getByRole('dialog'),
+  },
+  {
+    name: 'Lightbox',
+    render: () => (
+      <Lightbox
+        isOpen
+        onOpenChange={() => {}}
+        media={{src: 'a.png', alt: 'a'}}
+      />
+    ),
+    root: () => screen.getByRole('dialog'),
+  },
+  {
+    name: 'Popover (useLayer surface)',
+    render: child => (
+      <Popover isOpen onOpenChange={() => {}} label="P" content={child}>
+        <button type="button">t</button>
+      </Popover>
+    ),
+    root: () => document.querySelector<HTMLElement>('[popover]') as HTMLElement,
+  },
+];
+
+describe('overlayPaddingReset', () => {
+  describe.each(OVERLAYS)('$name', ({render: renderOverlay, root}) => {
+    it('zeroes the values descendants subtract', () => {
+      render(<Section padding={10}>{renderOverlay(<div>c</div>)}</Section>);
+      const computed = getComputedStyle(root());
+      for (const name of SUBTRACTED) {
+        expect(computed.getPropertyValue(name), name).toBe('0px');
+      }
+    });
+
+    it('clears the values descendants add, so they fall to their default', () => {
+      render(<Section padding={10}>{renderOverlay(<div>c</div>)}</Section>);
+      const computed = getComputedStyle(root());
+      for (const name of CLEARED) {
+        // A browser resolves `initial` on a custom property to the
+        // guaranteed-invalid value and reports '' here; jsdom does not
+        // implement that and echoes the keyword. Either proves the
+        // declaration landed — and neither is the leaked '40px'.
+        expect(CLEARED_READBACK, name).toContain(
+          computed.getPropertyValue(name),
+        );
+      }
+    });
+  });
+
+  it('does not clear the public theme token', () => {
+    // The reset clears the PRIVATE propagation var only. The public
+    // `--astryx-section-padding` is theme surface, set once at the theme root,
+    // so it has to keep reaching inside every overlay — clearing it would
+    // blank a theme's section padding in every dialog. That is the whole
+    // reason the two names were split, and it is the mistake a later
+    // "simplification" would most plausibly make.
+    //
+    // jsdom does not inherit custom properties, so the cascade cannot show
+    // this; assert it where it is decided instead. (Verified in a browser: a
+    // theme's 20px still reaches a Section inside a Dialog nested under a
+    // 40px page Section.)
+    const source = readFileSync(join(__dirname, 'padding.stylex.ts'), 'utf8');
+    const reset = source.slice(
+      source.indexOf('export const overlayPaddingReset'),
+    );
+    expect(reset).toContain("'--_section-padding-propagated': 'initial'");
+    expect(reset).not.toContain('--astryx-section-padding');
+  });
+
+  it("stops an ancestor Section's propagated padding at the boundary", () => {
+    // The page Section propagates 40px. Without the reset it would reach the
+    // Section inside the overlay, which would pad itself 40px instead of the
+    // theme default — the second half of #5208.
+    render(
+      <Section padding={10}>
+        <Dialog isOpen onOpenChange={() => {}}>
+          <div data-testid="content">c</div>
+        </Dialog>
+      </Section>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(CLEARED_READBACK).toContain(
+      getComputedStyle(dialog).getPropertyValue(
+        '--_section-padding-propagated',
+      ),
+    );
+    // ...while the page Section outside the overlay still propagates it.
+    // (jsdom does not resolve the token reference to its 40px value.)
+    const pageSection = document.querySelector<HTMLElement>('.astryx-section');
+    expect(
+      getComputedStyle(pageSection as HTMLElement).getPropertyValue(
+        '--_section-padding-propagated',
+      ),
+    ).toBe('var(--spacing-10)');
+  });
+});

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -440,21 +440,87 @@ export const paddingBlockEndStyles = stylex.create({
 });
 
 /**
- * Propagation styles for --astryx-section-padding.
+ * Propagation styles for `--_section-padding-propagated`.
  * When a parent section sets explicit padding, this propagates the value
  * through the CSS custom property cascade so nested sections that use
  * useThemeDefault inherit the parent's padding instead of the theme default.
+ *
+ * This is deliberately NOT the public `--astryx-section-padding` token. The
+ * two carry different authority: the public token is the THEME's section
+ * padding, set once at the theme root, while this one is one ancestor
+ * Section's padding, propagated down the tree. An overlay has to drop the
+ * inherited value at its boundary (see {@link overlayPaddingReset}) without
+ * dropping the theme's — impossible while both live under one name.
+ * `container.stylex.ts` reads this ahead of the public token, so a propagated
+ * value still wins over the theme for nested sections, as before.
  */
 export const sectionPaddingPropagationStyles = stylex.create({
-  0: {'--astryx-section-padding': spacingVars['--spacing-0']},
-  0.5: {'--astryx-section-padding': spacingVars['--spacing-0-5']},
-  1: {'--astryx-section-padding': spacingVars['--spacing-1']},
-  1.5: {'--astryx-section-padding': spacingVars['--spacing-1-5']},
-  2: {'--astryx-section-padding': spacingVars['--spacing-2']},
-  3: {'--astryx-section-padding': spacingVars['--spacing-3']},
-  4: {'--astryx-section-padding': spacingVars['--spacing-4']},
-  5: {'--astryx-section-padding': spacingVars['--spacing-5']},
-  6: {'--astryx-section-padding': spacingVars['--spacing-6']},
-  8: {'--astryx-section-padding': spacingVars['--spacing-8']},
-  10: {'--astryx-section-padding': spacingVars['--spacing-10']},
+  0: {'--_section-padding-propagated': spacingVars['--spacing-0']},
+  0.5: {'--_section-padding-propagated': spacingVars['--spacing-0-5']},
+  1: {'--_section-padding-propagated': spacingVars['--spacing-1']},
+  1.5: {'--_section-padding-propagated': spacingVars['--spacing-1-5']},
+  2: {'--_section-padding-propagated': spacingVars['--spacing-2']},
+  3: {'--_section-padding-propagated': spacingVars['--spacing-3']},
+  4: {'--_section-padding-propagated': spacingVars['--spacing-4']},
+  5: {'--_section-padding-propagated': spacingVars['--spacing-5']},
+  6: {'--_section-padding-propagated': spacingVars['--spacing-6']},
+  8: {'--_section-padding-propagated': spacingVars['--spacing-8']},
+  10: {'--_section-padding-propagated': spacingVars['--spacing-10']},
+});
+
+/**
+ * Padding-variable reset for overlay roots (Dialog, BottomSheet, Drawer,
+ * MobileNav, Lightbox, and every layer surface).
+ *
+ * ## Why an overlay needs this
+ *
+ * The container padding system talks to descendants through inherited custom
+ * properties: a padded container announces its padding, and children read the
+ * value either to apply it or to cancel it with a negative margin
+ * (`Section`, `Divider`, `Layout`, `Table`).
+ *
+ * Inheritance follows the DOM, but an overlay leaves its parent's visual box —
+ * a fixed/top-layer `<dialog>` is a DOM descendant of the padded page while
+ * being nowhere near it on screen. It inherits values describing padding that
+ * is not there, and its content compensates against phantom space: a `Section`
+ * inside a 640px sheet rendered 672px wide and hung off both edges (#5208).
+ *
+ * Two families leak, and they need opposite treatments:
+ *
+ * - `--container-padding-*` -> `0px`. Descendants SUBTRACT these (bleed
+ *   margins). The overlay root has no padding of its own to escape, so the
+ *   honest answer is zero. Nested containers that do set padding (a Dialog's
+ *   content wrapper) re-announce their own values below this point, so
+ *   legitimate edge-to-edge bleed inside the overlay is unaffected.
+ * - `--layout-padding-*` and `--_section-padding-propagated` -> `initial`.
+ *   Descendants ADD these, so zeroing them would strip padding rather than
+ *   restore it. `initial` makes each guaranteed-invalid, so readers fall
+ *   through their own `var(…, fallback)` chain and land on the theme default —
+ *   which is what an overlay at the top of the tree should show.
+ *
+ * `initial` is also why propagation moved off `--astryx-section-padding`: that
+ * name is public theme surface, set at the theme root, and making it invalid
+ * here would blank the theme's own section padding inside every overlay.
+ *
+ * Apply on the overlay's outermost styled element.
+ *
+ * @example
+ * ```
+ * <dialog {...stylex.props(styles.dialog, overlayPaddingReset.reset)} />
+ * ```
+ */
+export const overlayPaddingReset = stylex.create({
+  reset: {
+    // Subtracted by descendants — the overlay root has no padding to escape.
+    '--container-padding-inline-start': '0px',
+    '--container-padding-inline-end': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
+    // Added by descendants — fall through to each reader's own default.
+    '--layout-padding-outer-x': 'initial',
+    '--layout-padding-outer-y': 'initial',
+    '--layout-padding-inner-x': 'initial',
+    '--layout-padding-inner-y': 'initial',
+    '--_section-padding-propagated': 'initial',
+  },
 });

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -36,6 +36,7 @@ import {mergeProps, mergeRefs, rtlStyles} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
+import {overlayPaddingReset} from '../Layout/padding.stylex';
 import {useTranslator} from '../i18n';
 
 /**
@@ -588,7 +589,7 @@ export function Lightbox({
       aria-label={currentItem.alt || t('@astryx.lightbox.mediaViewer')}
       {...mergeProps(
         themeProps('lightbox'),
-        stylex.props(styles.dialog, xstyle),
+        stylex.props(styles.dialog, overlayPaddingReset.reset, xstyle),
         className,
         style,
       )}

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -53,6 +53,7 @@ import {
   type ScrollbarGutterHold,
 } from '../hooks/scrollbarGutter';
 import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
+import {overlayPaddingReset} from '../Layout/padding.stylex';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
@@ -144,10 +145,6 @@ const styles = stylex.create({
     flexDirection: 'column',
     backgroundColor: colorVars['--color-background-surface'],
     boxSizing: 'border-box',
-    '--container-padding-inline-start': '0px',
-    '--container-padding-inline-end': '0px',
-    '--container-padding-block-start': '0px',
-    '--container-padding-block-end': '0px',
     overflow: 'hidden',
     transitionProperty: 'transform',
     transitionDuration: durationVars['--duration-medium'],
@@ -570,6 +567,7 @@ export function MobileNav({
         themeProps('mobile-nav', {side: resolvedSide}),
         stylex.props(
           styles.dialog,
+          overlayPaddingReset.reset,
           isOpen && styles.open,
           styles.backdrop,
           isOpen && styles.backdropOpen,

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -40,10 +40,6 @@ const styles = stylex.create({
   // Consumers that need a raw positioned layer should use useLayer instead.
   surface: {
     backgroundColor: colorVars['--color-background-popover'],
-    '--container-padding-inline-start': '0px',
-    '--container-padding-inline-end': '0px',
-    '--container-padding-block-start': '0px',
-    '--container-padding-block-end': '0px',
     borderRadius: radiusVars['--radius-container'],
     boxShadow: shadowVars['--shadow-low'],
   },

--- a/packages/core/src/Section/Section.test.tsx
+++ b/packages/core/src/Section/Section.test.tsx
@@ -167,15 +167,27 @@ describe('Section', () => {
     expect(screen.getByTestId('custom-section')).toBeInTheDocument();
   });
 
-  it('propagates explicit padding to nested sections via --astryx-section-padding', () => {
+  it('propagates explicit padding to nested sections via --_section-padding-propagated', () => {
     const {container} = render(
       <Section padding={6}>
         <Section data-testid="inner">Inner</Section>
       </Section>,
     );
-    // Outer section's inner div should set --astryx-section-padding
-    const outerInner = container.firstElementChild!.firstElementChild!;
-    expect(outerInner.className).toBeDefined();
+    // The outer section's inner div announces its padding on the PRIVATE
+    // propagation var, not the public `--astryx-section-padding` theme token —
+    // the split is what lets an overlay drop an inherited value at its
+    // boundary while keeping the theme's (see overlayPaddingReset).
+    const outerInner = container.firstElementChild!
+      .firstElementChild! as HTMLElement;
+    expect(
+      getComputedStyle(outerInner).getPropertyValue(
+        '--_section-padding-propagated',
+      ),
+      // jsdom does not resolve the token reference to its 24px value.
+    ).toBe('var(--spacing-6)');
+    expect(
+      getComputedStyle(outerInner).getPropertyValue('--astryx-section-padding'),
+    ).toBe('');
     // Inner section should render without error
     expect(screen.getByTestId('inner')).toBeInTheDocument();
     expect(screen.getByText('Inner')).toBeInTheDocument();

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -85,6 +85,9 @@ const STRUCTURAL_VARS = new Set([
   '--table-row-overlay',
   '--separator-display',
   '--astryx-section-padding',
+  // Private counterpart of the public token above: one ancestor Section's
+  // padding, propagated down the tree. Structural, never authored by a theme.
+  '--_section-padding-propagated',
 ]);
 
 /**

--- a/packages/lab/src/Drawer/Drawer.tsx
+++ b/packages/lab/src/Drawer/Drawer.tsx
@@ -58,6 +58,7 @@ import {Icon} from '@astryxdesign/core/Icon';
 import {IconButton} from '@astryxdesign/core/IconButton';
 import {useScrollLock, useDevWarning} from '@astryxdesign/core/hooks';
 import {mergeProps, mergeRefs, themeProps} from '@astryxdesign/core/utils';
+import {overlayPaddingReset} from '@astryxdesign/core/Layout';
 
 // =============================================================================
 // LIFO stacking registry (internal)
@@ -123,10 +124,6 @@ const styles = stylex.create({
     overflow: 'hidden',
     overscrollBehavior: 'contain',
     outline: 'none',
-    '--container-padding-inline-start': '0px',
-    '--container-padding-inline-end': '0px',
-    '--container-padding-block-start': '0px',
-    '--container-padding-block-end': '0px',
     // Closed state. `display` participates in the transition with
     // allow-discrete so it flips to none only after the slide-out finishes
     // (@starting-style covers the none -> flex entry). max-width animates
@@ -670,6 +667,7 @@ export function Drawer({
         themeProps('drawer', {side}),
         stylex.props(
           styles.dialog,
+          overlayPaddingReset.reset,
           sideStyle,
           isSheet
             ? dynamicStyles.blockSize(sizeValue)


### PR DESCRIPTION
Follow-up to #5209. **Stacked on it** — the first three commits here are #5209's; this PR's own change is the last commit, and the diff cleans up once #5209 merges.

#5209 zeroed `--container-padding-*` on four overlay roots and closed the visible overflow in #5208. Two gaps remained.

### 1. Only half the leak was closed

The container padding system talks to descendants through **inherited** custom properties, but an overlay leaves its parent's visual box while staying a DOM descendant of it. Two families cross that boundary, and they pull in opposite directions:

| variable family | descendants… | leak symptom |
|---|---|---|
| `--container-padding-*` | **subtract** it (bleed margins) | content overflows by the page's padding — #5208, fixed by #5209 |
| `--layout-padding-*`, section propagation | **add** it | content over-padded — **still broken** |

So after #5209 an *unpadded* `Section` inside an overlay under `<Section padding={10}>` renders at 40px instead of the 16px theme default. Measured, before this PR:

```
                      baseline (top level)   under a 40px page Section
Section in a Dialog          16px                     40px   ✗
Section in a BottomSheet     16px                     40px   ✗
```

Zeroing these would be wrong — they're *added*, so `0px` strips padding rather than restoring it. They're cleared to `initial` instead, which makes each guaranteed-invalid so readers fall through their own `var(…, fallback)` chain to the theme default. After this PR both columns read 16px.

### 2. Three overlays were never covered

`Lightbox` (its own `<dialog>`), and `ContextMenu` + `HoverCard` (they call `useLayer` directly, so `usePopover`'s surface reset missed them).

Rather than hand-copy the block a seventh time, the reset moved to **`useLayer`'s root** — which covers every layer surface at once, including `hasSurface: false` consumers that the surface style never reached — and is exported once as `overlayPaddingReset` from `@astryxdesign/core/Layout` for the `<dialog>`-based overlays. Net: the four-line block goes from six hand-copied sites to one definition.

### The `--astryx-section-padding` split

`Section` propagated its explicit padding on the **public** `--astryx-section-padding` token, the same name themes set at the theme root. One name, two authorities — a theme's value and one ancestor's — so an overlay could not drop the inherited one without blanking the theme's inside every dialog.

Propagation moved to a private `--_section-padding-propagated`, read *ahead* of the public token, so a propagated value still wins over the theme for nested sections. **No behavior change** and themes are untouched: `--astryx-section-padding` is still the public token and still reaches inside overlays. Verified in a browser — a theme's 20px reaches a `Section` inside a `Dialog` nested under a 40px page `Section`, while the 40px does not.

## Verification

Measured in Chromium against a built `@astryxdesign/core`, each overlay open inside `<Section padding={10}>` (40px):

| | before | after |
|---|---|---|
| Section in a Dialog / BottomSheet | 40px padding | **16px** (matches top-level baseline) |
| Section in a Popover | 40px | **16px** |
| Lightbox root `--container-padding-inline-start` | 40px inherited | **0px** |
| theme's `--astryx-section-padding` inside a Dialog | 20px | **20px** (unchanged) |
| Section in a 640px sheet (#5208 repro) | 640px | **640px** (unchanged — #5209's fix holds) |

`packages/core/src/Layout/overlayPaddingReset.test.tsx` covers Dialog, BottomSheet, MobileNav, Lightbox and the layer surface. The tests discriminate: emptying the reset fails all 12.

Full suite 530 files / 10,778 tests green; `pnpm lint:strict` clean (56 pre-existing warnings); `pnpm build` produces no drift.

Two jsdom limits worth knowing, both noted at the assertions: it echoes the `initial` keyword instead of resolving it to the guaranteed-invalid value, and it does not inherit custom properties — so the theme-token invariant is guarded at its source (the reset must not name the public token) and verified in a browser.
