### PR TITLE
fix(core): bound PowerSearch field browsing at 1,000

### DIFF
--- a/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
+++ b/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] PowerSearch shows the full field list while browsing and supports overriding the typed suggestion cap (#5233)
+@nynexman4464

--- a/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
+++ b/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] PowerSearch shows up to 1,000 fields while browsing and adds a separate override for ranked main-search results (#5233)
+[fix] PowerSearch now shows up to 1,000 configured fields when the search box is empty, instead of stopping at 10. Typed searches still show 10 ranked results by default; use `maxSearchResults` to change only that limit. (#5233)
 @nynexman4464

--- a/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
+++ b/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] PowerSearch shows the full field list while browsing and supports overriding the typed suggestion cap (#5233)
+[fix] PowerSearch shows the full field list while browsing and adds a separate override for ranked main-search results (#5233)
 @nynexman4464

--- a/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
+++ b/.changeset/powersearch-shows-the-full-field-list-while-brow-5j66.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] PowerSearch shows the full field list while browsing and adds a separate override for ranked main-search results (#5233)
+[fix] PowerSearch shows up to 1,000 fields while browsing and adds a separate override for ranked main-search results (#5233)
 @nynexman4464

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -111,6 +111,13 @@ export const docs = {
       default: '10',
     },
     {
+      name: 'maxMenuItems',
+      type: 'number',
+      description:
+        'Max fields suggested while typing. Browsing the field list (empty query) always shows every field.',
+      default: '10',
+    },
+    {
       name: 'popoverSaveButtonLabel',
       type: 'string',
       description: 'Label for the save button in the edit popover.',
@@ -309,6 +316,12 @@ export const docsZh = {
       default: '10',
     },
     {
+      name: 'maxMenuItems',
+      type: 'number',
+      description: '输入时建议的最大字段数。浏览字段列表（空查询）时始终显示所有字段。',
+      default: '10',
+    },
+    {
       name: 'popoverSaveButtonLabel',
       type: 'string',
       description: '编辑弹出窗口中保存按钮的标签。',
@@ -390,6 +403,7 @@ export const docsDense = {
     maxTokenLength: 'Max char length for filter value display in tokens.',
     maxOperatorMenuItems:
       'Max suggestions in string/entity value typeaheads; excludes main field search + enum menus.',
+    maxMenuItems: 'Max fields suggested while typing; browsing shows all.',
     popoverSaveButtonLabel: 'Label for save button in edit popover.',
     timezoneID: 'Timezone ID for date formatting (e.g. "America/New_York").',
     handleRef: 'Imperative handle w/ focusTypeahead() + blurTypeahead() methods.',

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -122,7 +122,7 @@ export const docs = {
       name: 'maxSearchResults',
       type: 'number',
       description:
-        'Max ranked results for a non-empty query. Does not affect a field value editor. Browsing with an empty query shows every field.',
+        'Max ranked results for a non-empty query. Does not affect a field value editor. Browsing with an empty query shows up to 1,000 fields.',
       default: '10',
     },
     {
@@ -341,7 +341,7 @@ export const docsZh = {
       name: 'maxSearchResults',
       type: 'number',
       description:
-        '非空查询的最大排名结果数。不影响字段值编辑器。使用空查询浏览时显示所有字段。',
+        '非空查询的最大排名结果数。不影响字段值编辑器。使用空查询浏览时最多显示 1,000 个字段。',
       default: '10',
     },
     {

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -6,7 +6,17 @@ export const docs = {
   name: 'PowerSearch',
   displayName: 'Power Search',
   category: 'Data Input',
-  keywords: ["powersearch","search","searchbar","filter","filterbar","faceted","querybuilder","structured","omnibar"],
+  keywords: [
+    'powersearch',
+    'search',
+    'searchbar',
+    'filter',
+    'filterbar',
+    'faceted',
+    'querybuilder',
+    'structured',
+    'omnibar',
+  ],
   props: [
     {
       name: 'config',
@@ -43,8 +53,7 @@ export const docs = {
     {
       name: 'placeholder',
       type: 'string',
-      description:
-        'Placeholder text shown when no filters are selected.',
+      description: 'Placeholder text shown when no filters are selected.',
       default: "'Search...'",
     },
     {
@@ -80,8 +89,7 @@ export const docs = {
     {
       name: 'status',
       type: "{type: 'warning' | 'error' | 'success', message?: string}",
-      description:
-        'Validation status object with type and optional message.',
+      description: 'Validation status object with type and optional message.',
     },
     {
       name: 'startIcon',
@@ -111,10 +119,10 @@ export const docs = {
       default: '10',
     },
     {
-      name: 'maxMenuItems',
+      name: 'maxSearchResults',
       type: 'number',
       description:
-        'Max fields suggested while typing. Browsing the field list (empty query) always shows every field.',
+        'Max ranked results for a non-empty query. Does not affect a field value editor. Browsing with an empty query shows every field.',
       default: '10',
     },
     {
@@ -193,16 +201,30 @@ export const docs = {
     description:
       'PowerSearch is a structured filter bar where each token represents a field, operator, and value. Use it for complex multi-dimensional filtering when users need to combine multiple search criteria. For simple single-field search, use a text input instead.',
     bestPractices: [
-      { guidance: true, description: 'Define clear, descriptive field names and aliases so users can quickly find the filter they need.' },
-      { guidance: true, description: 'Provide a result count to give users feedback on how their filters affect the data set.' },
-      { guidance: false, description: 'Use PowerSearch for simple keyword searches; a standard text input is more appropriate for single-field lookups.' },
-      { guidance: false, description: 'Wrap a disabled PowerSearch in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.' },
+      {
+        guidance: true,
+        description:
+          'Define clear, descriptive field names and aliases so users can quickly find the filter they need.',
+      },
+      {
+        guidance: true,
+        description:
+          'Provide a result count to give users feedback on how their filters affect the data set.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use PowerSearch for simple keyword searches; a standard text input is more appropriate for single-field lookups.',
+      },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled PowerSearch in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
+      },
     ],
   },
   theming: {
-    targets: [
-      {className: 'astryx-power-search'},
-    ],
+    targets: [{className: 'astryx-power-search'}],
   },
 };
 
@@ -316,9 +338,10 @@ export const docsZh = {
       default: '10',
     },
     {
-      name: 'maxMenuItems',
+      name: 'maxSearchResults',
       type: 'number',
-      description: '输入时建议的最大字段数。浏览字段列表（空查询）时始终显示所有字段。',
+      description:
+        '非空查询的最大排名结果数。不影响字段值编辑器。使用空查询浏览时显示所有字段。',
       default: '10',
     },
     {
@@ -335,7 +358,8 @@ export const docsZh = {
     {
       name: 'handleRef',
       type: 'Ref<PowerSearchHandle>',
-      description: '提供 focusTypeahead() 和 blurTypeahead() 方法的命令式句柄。',
+      description:
+        '提供 focusTypeahead() 和 blurTypeahead() 方法的命令式句柄。',
     },
     {
       name: 'endContent',
@@ -364,10 +388,26 @@ export const docsZh = {
     description:
       'PowerSearch is a structured filter bar where each token represents a field, operator, and value. Use it for complex multi-dimensional filtering when users need to combine multiple search criteria. For simple single-field search, use a text input instead.',
     bestPractices: [
-      { guidance: true, description: 'Define clear, descriptive field names and aliases so users can quickly find the filter they need.' },
-      { guidance: true, description: 'Provide a result count to give users feedback on how their filters affect the data set.' },
-      { guidance: false, description: 'Use PowerSearch for simple keyword searches; a standard text input is more appropriate for single-field lookups.' },
-      { guidance: false, description: 'Wrap a disabled PowerSearch in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.' },
+      {
+        guidance: true,
+        description:
+          'Define clear, descriptive field names and aliases so users can quickly find the filter they need.',
+      },
+      {
+        guidance: true,
+        description:
+          'Provide a result count to give users feedback on how their filters affect the data set.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use PowerSearch for simple keyword searches; a standard text input is more appropriate for single-field lookups.',
+      },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled PowerSearch in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
+      },
     ],
   },
 };
@@ -380,16 +420,33 @@ export const docsDense = {
     description:
       'PowerSearch is a structured filter bar where each token represents a field, operator, and value. Use it for complex multi-dimensional filtering when users need to combine multiple search criteria. For simple single-field search, use a text input instead.',
     bestPractices: [
-      { guidance: true, description: 'Define clear, descriptive field names and aliases so users can quickly find the filter they need.' },
-      { guidance: true, description: 'Provide a result count to give users feedback on how their filters affect the data set.' },
-      { guidance: false, description: 'Use PowerSearch for simple keyword searches; a standard text input is more appropriate for single-field lookups.' },
-      { guidance: false, description: 'Wrap a disabled PowerSearch in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.' },
+      {
+        guidance: true,
+        description:
+          'Define clear, descriptive field names and aliases so users can quickly find the filter they need.',
+      },
+      {
+        guidance: true,
+        description:
+          'Provide a result count to give users feedback on how their filters affect the data set.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use PowerSearch for simple keyword searches; a standard text input is more appropriate for single-field lookups.',
+      },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled PowerSearch in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
+      },
     ],
   },
   propDescriptions: {
     config: 'Configuration defining available fields, operators, value types.',
     filters: 'Currently active filters.',
-    onChange: "Called on filter change. changeType is 'add', 'edit', or 'remove'. index is affected filter position.",
+    onChange:
+      "Called on filter change. changeType is 'add', 'edit', or 'remove'. index is affected filter position.",
     label: 'Accessible label for search input.',
     isLabelHidden: 'Visually hides label while keeping accessible.',
     placeholder: 'Text shown when no filters selected.',
@@ -398,18 +455,25 @@ export const docsDense = {
     isReadOnly: 'Prevent adding, editing, or removing filters.',
     isDisabled: 'Disables entire component.',
     status: 'Validation status object w/ type + optional message.',
-    startIcon: 'Icon at input start, before filter tokens. Forwarded to internal Tokenizer.',
-    statusVariant: 'How status message is placed: attached overlaps below input; detached floats below w/ spacing.',
+    startIcon:
+      'Icon at input start, before filter tokens. Forwarded to internal Tokenizer.',
+    statusVariant:
+      'How status message is placed: attached overlaps below input; detached floats below w/ spacing.',
     maxTokenLength: 'Max char length for filter value display in tokens.',
     maxOperatorMenuItems:
       'Max suggestions in string/entity value typeaheads; excludes main field search + enum menus.',
-    maxMenuItems: 'Max fields suggested while typing; browsing shows all.',
+    maxSearchResults:
+      'Max ranked results for a non-empty query; excludes value editors.',
     popoverSaveButtonLabel: 'Label for save button in edit popover.',
     timezoneID: 'Timezone ID for date formatting (e.g. "America/New_York").',
-    handleRef: 'Imperative handle w/ focusTypeahead() + blurTypeahead() methods.',
-    endContent: 'Content at end of input row. Useful for action buttons or controls.',
-    resultCount: 'Result count matching current filters. Number formatted as "N results"; string displayed as-is.',
+    handleRef:
+      'Imperative handle w/ focusTypeahead() + blurTypeahead() methods.',
+    endContent:
+      'Content at end of input row. Useful for action buttons or controls.',
+    resultCount:
+      'Result count matching current filters. Number formatted as "N results"; string displayed as-is.',
     size: 'Search input+token size.',
-    xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
+    xstyle:
+      'StyleX styles for layout customization. Must be stylex.create() value.',
   },
 };

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -575,11 +575,14 @@ describe('field menu sizing', () => {
     })),
   };
 
-  async function openMenu(props?: {maxSearchResults?: number}) {
+  async function openMenu(
+    props?: {maxSearchResults?: number},
+    config: PowerSearchConfig = manyFields,
+  ) {
     const user = userEvent.setup();
     render(
       <PowerSearch
-        config={manyFields}
+        config={config}
         filters={[]}
         onChange={() => {}}
         {...props}
@@ -595,9 +598,24 @@ describe('field menu sizing', () => {
   const optionCount = () =>
     screen.getAllByRole('option', {hidden: true}).length;
 
-  it('shows every field while browsing', async () => {
+  it('shows every field in a normal field list while browsing', async () => {
     await openMenu();
     expect(optionCount()).toBe(FIELD_COUNT);
+  });
+
+  it('caps an extreme field list at the 1,000-row browsing ceiling', async () => {
+    const extremeConfig: PowerSearchConfig = {
+      name: 'ExtremeFields',
+      fields: Array.from({length: 1001}, (_, i) => ({
+        key: `extreme_${i}`,
+        label: `Extreme ${i}`,
+        defaultOperator: 'is',
+        operators: [{key: 'is', label: 'is', value: {type: 'string'} as const}],
+      })),
+    };
+
+    await openMenu(undefined, extremeConfig);
+    expect(optionCount()).toBe(1000);
   });
 
   it('caps ranked results while typing', async () => {
@@ -617,7 +635,7 @@ describe('field menu sizing', () => {
     });
   });
 
-  it('never truncates browsing, whatever maxSearchResults says', async () => {
+  it('does not apply maxSearchResults while browsing', async () => {
     await openMenu({maxSearchResults: 3});
     expect(optionCount()).toBe(FIELD_COUNT);
   });

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -575,7 +575,7 @@ describe('field menu sizing', () => {
     })),
   };
 
-  async function openMenu(props?: {maxMenuItems?: number}) {
+  async function openMenu(props?: {maxSearchResults?: number}) {
     const user = userEvent.setup();
     render(
       <PowerSearch
@@ -609,16 +609,16 @@ describe('field menu sizing', () => {
     });
   });
 
-  it('caps ranked results at maxMenuItems while typing', async () => {
-    const user = await openMenu({maxMenuItems: 3});
+  it('caps ranked results at maxSearchResults while typing', async () => {
+    const user = await openMenu({maxSearchResults: 3});
     await user.type(screen.getByRole('combobox'), 'zebra');
     await waitFor(() => {
       expect(optionCount()).toBe(3);
     });
   });
 
-  it('never truncates browsing, whatever maxMenuItems says', async () => {
-    await openMenu({maxMenuItems: 3});
+  it('never truncates browsing, whatever maxSearchResults says', async () => {
+    await openMenu({maxSearchResults: 3});
     expect(optionCount()).toBe(FIELD_COUNT);
   });
 });

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -562,3 +562,63 @@ describe('maxOperatorMenuItems', () => {
     });
   });
 });
+
+describe('field menu sizing', () => {
+  const FIELD_COUNT = 25;
+  const manyFields: PowerSearchConfig = {
+    name: 'ManyFields',
+    fields: Array.from({length: FIELD_COUNT}, (_, i) => ({
+      key: `field_${i}`,
+      label: `Zebra ${String(i).padStart(2, '0')}`,
+      defaultOperator: 'is',
+      operators: [{key: 'is', label: 'is', value: {type: 'string'} as const}],
+    })),
+  };
+
+  async function openMenu(props?: {maxMenuItems?: number}) {
+    const user = userEvent.setup();
+    render(
+      <PowerSearch
+        config={manyFields}
+        filters={[]}
+        onChange={() => {}}
+        {...props}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+    await waitFor(() => {
+      expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
+    });
+    return user;
+  }
+
+  const optionCount = () =>
+    screen.getAllByRole('option', {hidden: true}).length;
+
+  it('shows every field while browsing', async () => {
+    await openMenu();
+    expect(optionCount()).toBe(FIELD_COUNT);
+  });
+
+  it('caps ranked results while typing', async () => {
+    const user = await openMenu();
+    // "zebra" matches every field label.
+    await user.type(screen.getByRole('combobox'), 'zebra');
+    await waitFor(() => {
+      expect(optionCount()).toBe(10);
+    });
+  });
+
+  it('caps ranked results at maxMenuItems while typing', async () => {
+    const user = await openMenu({maxMenuItems: 3});
+    await user.type(screen.getByRole('combobox'), 'zebra');
+    await waitFor(() => {
+      expect(optionCount()).toBe(3);
+    });
+  });
+
+  it('never truncates browsing, whatever maxMenuItems says', async () => {
+    await openMenu({maxMenuItems: 3});
+    expect(optionCount()).toBe(FIELD_COUNT);
+  });
+});

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -80,8 +80,8 @@ import {useMergedRefs} from '../hooks/useMergedRefs';
 // =============================================================================
 
 // Ranked suggestions shown for a non-empty query. The field list itself is
-// never capped -- see the maxMenuItems prop.
-const DEFAULT_MAX_MENU_ITEMS = 10;
+// never capped -- see the maxSearchResults prop.
+const DEFAULT_MAX_SEARCH_RESULTS = 10;
 
 // The source caps typed results itself, so the dropdown must not cap again --
 // its own default of 10 would truncate the field list while browsing.
@@ -417,10 +417,11 @@ export interface PowerSearchProps extends Omit<
   /** Max suggestions in string and entity value typeaheads. @default 10 */
   maxOperatorMenuItems?: number;
   /**
-   * Max fields suggested while typing. Browsing the field list (empty query)
-   * always shows every field. @default 10
+   * Max ranked results shown for a non-empty query. This does not affect the
+   * value editor shown after selecting a field. Browsing the field list with
+   * an empty query always shows every field. @default 10
    */
-  maxMenuItems?: number;
+  maxSearchResults?: number;
   /** Label for the save button in edit popover. @default 'Apply' */
   popoverSaveButtonLabel?: string;
   /** Timezone ID for date formatting. */
@@ -562,7 +563,7 @@ export function PowerSearch({
   statusVariant = 'attached',
   maxTokenLength = 40,
   maxOperatorMenuItems,
-  maxMenuItems = DEFAULT_MAX_MENU_ITEMS,
+  maxSearchResults = DEFAULT_MAX_SEARCH_RESULTS,
   popoverSaveButtonLabel: popoverSaveButtonLabelFromProps,
   timezoneID,
   tokenOverflowBehavior,
@@ -579,7 +580,7 @@ export function PowerSearch({
 }: PowerSearchProps) {
   const size = useSize(sizeProp, 'md');
   const config = useInternalConfig(configProp);
-  const searchSource = usePowerSearchSource(config, maxMenuItems);
+  const searchSource = usePowerSearchSource(config, maxSearchResults);
   const t = useTranslator();
   const locale = useLocale();
   const label = labelFromProps ?? t('@astryx.powersearch.label');

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -79,6 +79,14 @@ import {useMergedRefs} from '../hooks/useMergedRefs';
 // Icon mapping for typeahead entries
 // =============================================================================
 
+// Ranked suggestions shown for a non-empty query. The field list itself is
+// never capped -- see the maxMenuItems prop.
+const DEFAULT_MAX_MENU_ITEMS = 10;
+
+// The source caps typed results itself, so the dropdown must not cap again --
+// its own default of 10 would truncate the field list while browsing.
+const VIEW_MENU_ITEMS_UNCAPPED = Number.POSITIVE_INFINITY;
+
 const OPERATOR_VALUE_TYPE_TO_ICON: Record<string, IconName> = {
   string: 'search',
   string_list: 'search',
@@ -408,6 +416,11 @@ export interface PowerSearchProps extends Omit<
   maxTokenLength?: number;
   /** Max suggestions in string and entity value typeaheads. @default 10 */
   maxOperatorMenuItems?: number;
+  /**
+   * Max fields suggested while typing. Browsing the field list (empty query)
+   * always shows every field. @default 10
+   */
+  maxMenuItems?: number;
   /** Label for the save button in edit popover. @default 'Apply' */
   popoverSaveButtonLabel?: string;
   /** Timezone ID for date formatting. */
@@ -549,6 +562,7 @@ export function PowerSearch({
   statusVariant = 'attached',
   maxTokenLength = 40,
   maxOperatorMenuItems,
+  maxMenuItems = DEFAULT_MAX_MENU_ITEMS,
   popoverSaveButtonLabel: popoverSaveButtonLabelFromProps,
   timezoneID,
   tokenOverflowBehavior,
@@ -565,7 +579,7 @@ export function PowerSearch({
 }: PowerSearchProps) {
   const size = useSize(sizeProp, 'md');
   const config = useInternalConfig(configProp);
-  const searchSource = usePowerSearchSource(config);
+  const searchSource = usePowerSearchSource(config, maxMenuItems);
   const t = useTranslator();
   const locale = useLocale();
   const label = labelFromProps ?? t('@astryx.powersearch.label');
@@ -1051,6 +1065,7 @@ export function PowerSearch({
           onChange={handleTokenizerChange}
           renderToken={renderToken}
           renderItem={renderItem}
+          maxMenuItems={VIEW_MENU_ITEMS_UNCAPPED}
           placeholder={filters.length === 0 ? placeholder : ''}
           hasAutoFocus={hasAutoFocus}
           hasClear={hasClear && !isReadOnly}

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -83,9 +83,9 @@ import {useMergedRefs} from '../hooks/useMergedRefs';
 // never capped -- see the maxSearchResults prop.
 const DEFAULT_MAX_SEARCH_RESULTS = 10;
 
-// The source caps typed results itself, so the dropdown must not cap again --
-// its own default of 10 would truncate the field list while browsing.
-const VIEW_MENU_ITEMS_UNCAPPED = Number.POSITIVE_INFINITY;
+// Empty-query browsing gets a high safety ceiling, matching XDS. This shows
+// every practical field list without allowing an accidental unbounded DOM.
+const MAX_BROWSE_MENU_ITEMS = 1000;
 
 const OPERATOR_VALUE_TYPE_TO_ICON: Record<string, IconName> = {
   string: 'search',
@@ -419,7 +419,7 @@ export interface PowerSearchProps extends Omit<
   /**
    * Max ranked results shown for a non-empty query. This does not affect the
    * value editor shown after selecting a field. Browsing the field list with
-   * an empty query always shows every field. @default 10
+   * an empty query shows up to 1,000 fields. @default 10
    */
   maxSearchResults?: number;
   /** Label for the save button in edit popover. @default 'Apply' */
@@ -1066,7 +1066,7 @@ export function PowerSearch({
           onChange={handleTokenizerChange}
           renderToken={renderToken}
           renderItem={renderItem}
-          maxMenuItems={VIEW_MENU_ITEMS_UNCAPPED}
+          maxMenuItems={MAX_BROWSE_MENU_ITEMS}
           placeholder={filters.length === 0 ? placeholder : ''}
           hasAutoFocus={hasAutoFocus}
           hasClear={hasClear && !isReadOnly}

--- a/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
@@ -21,10 +21,15 @@ import type {
 // Helpers
 // =============================================================================
 
-function createSource(config: PowerSearchConfig) {
+function createSource(
+  config: PowerSearchConfig,
+  // Uncapped by default so these tests exercise matching and ranking rather
+  // than the typed-result cap, which has its own test below.
+  maxTypedResults: number = Number.POSITIVE_INFINITY,
+) {
   const {result} = renderHook(() => {
     const internal = useInternalConfig(config);
-    return usePowerSearchSource(internal);
+    return usePowerSearchSource(internal, maxTypedResults);
   });
   return result.current;
 }
@@ -537,5 +542,27 @@ describe('usePowerSearchSource', () => {
       const aux = valueItem!.auxiliaryData as PowerSearchAuxData;
       expect(aux.filterValue).toEqual({type: 'enum_list', value: ['bug']});
     });
+  });
+});
+
+describe('typed-result cap', () => {
+  const manyFields: PowerSearchConfig = {
+    name: 'many',
+    fields: Array.from({length: 25}, (_, i) => ({
+      key: `field_${i}`,
+      label: `Zebra ${String(i).padStart(2, '0')}`,
+      operators: [{key: 'is', label: 'is', value: {type: 'string'} as const}],
+    })),
+  };
+
+  it('caps results for a typed query', () => {
+    const source = createSource(manyFields, 10);
+    expect(source.search('zebra')).toHaveLength(10);
+  });
+
+  it('never caps the field list for an empty query', () => {
+    const source = createSource(manyFields, 10);
+    expect(syncBootstrap(source)).toHaveLength(25);
+    expect(source.search('')).toHaveLength(25);
   });
 });

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -21,8 +21,8 @@ import type {PowerSearchItem, PowerSearchOperator, FilterValue} from './types';
 
 /**
  * @param maxTypedResults Cap applied to ranked results for a non-empty query.
- *   Browsing (empty query) is never capped: the field list is the config, and
- *   truncating it hides fields the user has no way to discover.
+ *   The source never truncates empty-query browsing; PowerSearch's view applies
+ *   a separate 1,000-row safety ceiling.
  */
 export function usePowerSearchSource(
   config: InternalConfig,

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -19,8 +19,14 @@ import {resolveOperatorLabel} from './resolveOperatorLabel';
 import type {InternalConfig} from './useInternalConfig';
 import type {PowerSearchItem, PowerSearchOperator, FilterValue} from './types';
 
+/**
+ * @param maxTypedResults Cap applied to ranked results for a non-empty query.
+ *   Browsing (empty query) is never capped: the field list is the config, and
+ *   truncating it hides fields the user has no way to discover.
+ */
 export function usePowerSearchSource(
   config: InternalConfig,
+  maxTypedResults: number,
 ): SearchSource<PowerSearchItem> {
   const t = useTranslator();
   return useMemo(() => {
@@ -198,14 +204,14 @@ export function usePowerSearchSource(
           }
         }
 
-        return results;
+        return results.slice(0, maxTypedResults);
       },
 
       bootstrap(): PowerSearchItem[] {
         return allItems;
       },
     };
-  }, [config, t]);
+  }, [config, t, maxTypedResults]);
 }
 
 interface ValueMatch {


### PR DESCRIPTION
## Summary

PowerSearch used the typeahead's generic 10-item default for both typed results and empty-query field browsing. This made configured fields after the first 10 inaccessible until users searched for them.

This change:

- shows up to 1,000 configured fields while browsing with an empty query, matching the established safety ceiling in the predecessor component
- keeps ranked results capped at 10 by default for non-empty queries
- adds `maxSearchResults` to override the ranked-result cap without affecting browsing or field value editors

Fixes #5232.

## Test plan

- Added integration coverage for normal field browsing, the 1,000-row browsing ceiling, the default typed cap, and an explicit `maxSearchResults` override.
- Added search-source coverage proving only non-empty queries are capped at the source level.
- Verified the regression tests fail if browsing falls back to 10 items or becomes unbounded.
- Ran the focused PowerSearch tests, core typecheck, and repository checks locally.
- Full GitHub CI passes.
