### PR TITLE
fix(core): apply PowerSearch menu width

### DIFF
--- a/.changeset/powersearch-applies-menuwidth-to-its-main-field--ffyn.md
+++ b/.changeset/powersearch-applies-menuwidth-to-its-main-field--ffyn.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] PowerSearch applies menuWidth to its main field and search menu (#5237)
+[fix] PowerSearch now applies `menuWidth` to the initial field and search menu without letting it shrink below the input width. Value menus shown after selecting a field are unchanged. (#5237)
 @nynexman4464

--- a/.changeset/powersearch-applies-menuwidth-to-its-main-field--ffyn.md
+++ b/.changeset/powersearch-applies-menuwidth-to-its-main-field--ffyn.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] PowerSearch applies menuWidth to its main field and search menu (#5237)
+@nynexman4464

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -473,6 +473,10 @@ const meta: Meta<typeof PowerSearch> = {
       description:
         'Value results shown after selecting a field, such as people in the Owner picker.',
     },
+    menuWidth: {
+      control: 'number',
+      description: 'Main field/search menu width in pixels.',
+    },
     popoverSaveButtonLabel: {control: 'text'},
     size: {
       control: 'radio',
@@ -590,6 +594,7 @@ export const IssueTracker: Story = {
     hasAutoFocus: true,
     maxSearchResults: 2,
     maxOperatorMenuItems: 2,
+    menuWidth: 700,
   },
   parameters: {
     docs: {
@@ -601,7 +606,7 @@ export const IssueTracker: Story = {
   },
   decorators: [
     Story => (
-      <div style={{width: 700, minHeight: 420}}>
+      <div style={{width: 500, minHeight: 420}}>
         <Story />
       </div>
     ),

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -126,6 +126,12 @@ export const docs = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number',
+      description:
+        'Width in pixels for the main field/search menu. Does not affect field value editors.',
+    },
+    {
       name: 'popoverSaveButtonLabel',
       type: 'string',
       description: 'Label for the save button in the edit popover.',
@@ -345,6 +351,11 @@ export const docsZh = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number',
+      description: '主字段/搜索菜单的像素宽度。不影响字段值编辑器。',
+    },
+    {
       name: 'popoverSaveButtonLabel',
       type: 'string',
       description: '编辑弹出窗口中保存按钮的标签。',
@@ -464,6 +475,7 @@ export const docsDense = {
       'Max suggestions in string/entity value typeaheads; excludes main field search + enum menus.',
     maxSearchResults:
       'Max ranked results for a non-empty query; excludes value editors.',
+    menuWidth: 'Main field/search menu width in pixels.',
     popoverSaveButtonLabel: 'Label for save button in edit popover.',
     timezoneID: 'Timezone ID for date formatting (e.g. "America/New_York").',
     handleRef:

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -576,7 +576,7 @@ describe('field menu sizing', () => {
   };
 
   async function openMenu(
-    props?: {maxSearchResults?: number},
+    props?: {maxSearchResults?: number; menuWidth?: number},
     config: PowerSearchConfig = manyFields,
   ) {
     const user = userEvent.setup();
@@ -638,6 +638,16 @@ describe('field menu sizing', () => {
   it('does not apply maxSearchResults while browsing', async () => {
     await openMenu({maxSearchResults: 3});
     expect(optionCount()).toBe(FIELD_COUNT);
+  });
+
+  it('applies menuWidth to the main field menu', async () => {
+    await openMenu({menuWidth: 480});
+    const listbox = screen.getByRole('listbox', {hidden: true});
+    const popover = listbox.closest('[popover]');
+    expect(popover).not.toBeNull();
+    expect((popover as HTMLElement).style.getPropertyValue('--x-width')).toBe(
+      '480px',
+    );
   });
 });
 

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -561,6 +561,7 @@ export function PowerSearch({
   onBlur,
   status,
   statusVariant = 'attached',
+  menuWidth,
   maxTokenLength = 40,
   maxOperatorMenuItems,
   maxSearchResults = DEFAULT_MAX_SEARCH_RESULTS,
@@ -1067,6 +1068,7 @@ export function PowerSearch({
           renderToken={renderToken}
           renderItem={renderItem}
           maxMenuItems={MAX_BROWSE_MENU_ITEMS}
+          menuWidth={menuWidth}
           placeholder={filters.length === 0 ? placeholder : ''}
           hasAutoFocus={hasAutoFocus}
           hasClear={hasClear && !isReadOnly}

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -136,6 +136,11 @@ export const docs = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number',
+      description: 'Fixed dropdown width in pixels. The menu never shrinks below its anchor width.',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: 'Text shown when search returns no results.',
@@ -385,6 +390,11 @@ export const docsZh = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number',
+      description: '下拉菜单的固定像素宽度。菜单不会小于其锚点宽度。',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: '\u641c\u7d22\u65e0\u7ed3\u679c\u65f6\u663e\u793a\u7684\u6587\u672c\u3002',
@@ -506,6 +516,7 @@ export const docsDense = {
     labelTooltip: 'Tooltip on label.',
     hasEntriesOnFocus: 'Show bootstrap results on focus before typing.',
     maxMenuItems: 'Max dropdown items to display.',
+    menuWidth: 'Fixed dropdown width in pixels.',
     emptySearchResultsText: 'Text when search returns no results.',
     hasAutoFocus: 'Auto-focus input on mount.',
     size: 'Input+token size.',

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -156,6 +156,8 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
   hasEntriesOnFocus?: boolean;
   /** Max dropdown items. @default 10 */
   maxMenuItems?: number;
+  /** Fixed dropdown width in pixels. Never shrinks below the input width. */
+  menuWidth?: number;
   /** Text shown when no results found. @default 'No results found' */
   emptySearchResultsText?: string;
   /** Whether the input is disabled. @default false */
@@ -393,6 +395,7 @@ export function Tokenizer<T extends SearchableItem>({
   placeholder,
   hasEntriesOnFocus,
   maxMenuItems,
+  menuWidth,
   emptySearchResultsText,
   isDisabled = false,
   htmlName,
@@ -778,6 +781,7 @@ export function Tokenizer<T extends SearchableItem>({
         placeholder={value.length === 0 ? placeholder : ''}
         hasEntriesOnFocus={isAtMax ? false : hasEntriesOnFocus}
         maxMenuItems={maxMenuItems}
+        menuWidth={menuWidth}
         emptySearchResultsText={emptySearchResultsText}
         isDisabled={isDisabled}
         isFocusableDisabled={showsDisabledMessage}

--- a/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
+++ b/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
@@ -61,6 +61,11 @@ export const docs = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number',
+      description: 'Fixed dropdown width in pixels. The menu never shrinks below its anchor width.',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: 'Text shown when search returns no results.',
@@ -170,6 +175,11 @@ export const docsZh = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number',
+      description: '下拉菜单的固定像素宽度。菜单不会小于其锚点宽度。',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: '搜索无结果时显示的文本。',
@@ -253,6 +263,7 @@ export const docsDense = {
     placeholder: 'Input placeholder.',
     hasEntriesOnFocus: 'Bootstrap results on focus.',
     maxMenuItems: 'Max dropdown items.',
+    menuWidth: 'Fixed dropdown width in pixels.',
     emptySearchResultsText: 'Text when no results.',
     isDisabled: 'Whether input disabled.',
     hasAutoFocus: 'Auto-focus on mount.',

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -94,6 +94,9 @@ export interface BaseTypeaheadProps<T extends SearchableItem> extends Omit<
    */
   maxMenuItems?: number;
 
+  /** Fixed dropdown width in pixels. Never shrinks below the anchor width. */
+  menuWidth?: number;
+
   /**
    * Text shown when no results found.
    * @default 'No results found'
@@ -227,6 +230,9 @@ const styles = stylex.create({
   popover: {
     minWidth: 'anchor-size(width)',
   },
+  popoverCustomWidth: (width: number) => ({
+    width: `${width}px`,
+  }),
   groupHeading: {
     paddingInline: spacingVars['--spacing-2'],
     paddingBlockStart: spacingVars['--spacing-2'],
@@ -326,6 +332,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   placeholder: placeholderFromProps,
   hasEntriesOnFocus = false,
   maxMenuItems = 10,
+  menuWidth,
   emptySearchResultsText: emptySearchResultsTextFromProps,
   isDisabled = false,
   isFocusableDisabled = false,
@@ -914,7 +921,10 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
           placement: 'below',
           alignment: 'start',
           offset: spacingVars['--spacing-1'],
-          xstyle: styles.popover,
+          xstyle: [
+            styles.popover,
+            menuWidth != null && styles.popoverCustomWidth(menuWidth),
+          ],
         },
       )}
     </>


### PR DESCRIPTION
## Summary

- make the existing `PowerSearch.menuWidth` prop control the main field/search menu
- forward the width through Tokenizer to BaseTypeahead
- preserve the current default and never shrink the menu below its anchor width
- expose the width alongside both result-limit controls in the realistic issue-tracker Storybook story

Stacked on #5235 so all three PowerSearch fixes remain independently reviewable.

Fixes #5236.

## Test plan

- Added an integration test asserting `menuWidth={480}` reaches the main menu surface.
- Verified the test fails without the wiring (`expected '' to be '480px'`).
- `pnpm test`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm check:sync`
- `pnpm check:i18n-catalog`
