### PR TITLE
docs(cli): use the standard Section wrapper in Bottom Sheet examples

### DIFF
--- a/.changeset/bottom-sheet-examples-section.md
+++ b/.changeset/bottom-sheet-examples-section.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Use the standard `<Section padding={4}>` wrapper in every Bottom Sheet example. Four of them padded the sheet body by hand — three with an inline `style={{padding: 'var(--spacing-4)'}}` and one with `<VStack padding={4}>` — because a `Section` there used to overflow the sheet (#5208). With that fixed, they match the pattern the showcase examples already use. Rendering is pixel-identical.
+
+@imdreamrunner

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetHeights.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetHeights.doc.mjs
@@ -15,6 +15,7 @@ export const doc = {
     'Button',
     'Divider',
     'Heading',
+    'Section',
     'Stack',
     'Text',
   ],

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetHeights.tsx
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetHeights.tsx
@@ -10,6 +10,7 @@ import {
 import {Button} from '@astryxdesign/core/Button';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Heading} from '@astryxdesign/core/Heading';
+import {Section} from '@astryxdesign/core/Section';
 import {HStack, VStack} from '@astryxdesign/core/Stack';
 import {Text} from '@astryxdesign/core/Text';
 
@@ -34,12 +35,14 @@ export default function BottomSheetHeights() {
         onOpenChange={isOpen => !isOpen && setHeight(null)}
         label={`${height ?? 'Hug'} height`}
         height={height ?? 'hug'}>
-        <VStack gap={4} style={{padding: 'var(--spacing-4)'}}>
-          <Heading level={3}>{height ?? 'Hug'} height</Heading>
-          <Divider />
-          <Text type="body">{descriptions[height ?? 'hug']}</Text>
-          <Button label="Close" onClick={() => setHeight(null)} />
-        </VStack>
+        <Section padding={4}>
+          <VStack gap={4}>
+            <Heading level={3}>{height ?? 'Hug'} height</Heading>
+            <Divider />
+            <Text type="body">{descriptions[height ?? 'hug']}</Text>
+            <Button label="Close" onClick={() => setHeight(null)} />
+          </VStack>
+        </Section>
       </BottomSheet>
     </>
   );

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetMobileKeyboard.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetMobileKeyboard.doc.mjs
@@ -15,6 +15,7 @@ export const doc = {
     'Button',
     'Divider',
     'Heading',
+    'Section',
     'Stack',
     'Text',
     'TextArea',

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetMobileKeyboard.tsx
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetMobileKeyboard.tsx
@@ -7,6 +7,7 @@ import {BottomSheet} from '@astryxdesign/core/BottomSheet';
 import {Button} from '@astryxdesign/core/Button';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Heading} from '@astryxdesign/core/Heading';
+import {Section} from '@astryxdesign/core/Section';
 import {VStack} from '@astryxdesign/core/Stack';
 import {Text} from '@astryxdesign/core/Text';
 import {TextArea} from '@astryxdesign/core/TextArea';
@@ -51,48 +52,50 @@ export default function BottomSheetMobileKeyboard() {
             event.preventDefault();
             setIsOpen(false);
           }}>
-          <VStack gap={4} style={{padding: 'var(--spacing-4)'}}>
-            <Heading level={3}>Edit profile</Heading>
-            <Divider />
-            <Text type="supporting" color="secondary">
-              Focus fields throughout the form to see them remain visible above
-              the mobile keyboard.
-            </Text>
-            <TextInput
-              label="Name"
-              value={values.name}
-              onChange={update('name')}
-            />
-            <TextInput
-              label="Email"
-              type="email"
-              value={values.email}
-              onChange={update('email')}
-            />
-            <TextInput
-              label="Company"
-              value={values.company}
-              onChange={update('company')}
-            />
-            <TextInput
-              label="Role"
-              value={values.role}
-              onChange={update('role')}
-            />
-            <TextArea
-              label="Bio"
-              rows={5}
-              value={values.bio}
-              onChange={update('bio')}
-            />
-            <TextArea
-              label="Notes"
-              rows={5}
-              value={values.notes}
-              onChange={update('notes')}
-            />
-            <Button label="Save profile" type="submit" />
-          </VStack>
+          <Section padding={4}>
+            <VStack gap={4}>
+              <Heading level={3}>Edit profile</Heading>
+              <Divider />
+              <Text type="supporting" color="secondary">
+                Focus fields throughout the form to see them remain visible
+                above the mobile keyboard.
+              </Text>
+              <TextInput
+                label="Name"
+                value={values.name}
+                onChange={update('name')}
+              />
+              <TextInput
+                label="Email"
+                type="email"
+                value={values.email}
+                onChange={update('email')}
+              />
+              <TextInput
+                label="Company"
+                value={values.company}
+                onChange={update('company')}
+              />
+              <TextInput
+                label="Role"
+                value={values.role}
+                onChange={update('role')}
+              />
+              <TextArea
+                label="Bio"
+                rows={5}
+                value={values.bio}
+                onChange={update('bio')}
+              />
+              <TextArea
+                label="Notes"
+                rows={5}
+                value={values.notes}
+                onChange={update('notes')}
+              />
+              <Button label="Save profile" type="submit" />
+            </VStack>
+          </Section>
         </form>
       </BottomSheet>
     </>

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetNoScrim.tsx
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetNoScrim.tsx
@@ -33,14 +33,16 @@ export default function BottomSheetNoScrim() {
         label="Place details"
         height="hug"
         hasScrim={false}>
-        <VStack gap={4} style={{padding: 'var(--spacing-4)'}}>
-          <Heading level={3}>Central Park</Heading>
-          <Divider />
-          <Text type="body">
-            The page remains visible and interactive behind this sheet.
-          </Text>
-          <Button label="Close details" onClick={() => setIsOpen(false)} />
-        </VStack>
+        <Section padding={4}>
+          <VStack gap={4}>
+            <Heading level={3}>Central Park</Heading>
+            <Divider />
+            <Text type="body">
+              The page remains visible and interactive behind this sheet.
+            </Text>
+            <Button label="Close details" onClick={() => setIsOpen(false)} />
+          </VStack>
+        </Section>
       </BottomSheet>
     </Section>
   );

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetSnapPoints.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetSnapPoints.doc.mjs
@@ -17,6 +17,7 @@ export const doc = {
     'Heading',
     'Icon',
     'Item',
+    'Section',
     'Stack',
     'Text',
   ],

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetSnapPoints.tsx
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetSnapPoints.tsx
@@ -12,6 +12,7 @@ import {Divider} from '@astryxdesign/core/Divider';
 import {Heading} from '@astryxdesign/core/Heading';
 import {Icon} from '@astryxdesign/core/Icon';
 import {Item} from '@astryxdesign/core/Item';
+import {Section} from '@astryxdesign/core/Section';
 import {HStack, VStack} from '@astryxdesign/core/Stack';
 import {Text} from '@astryxdesign/core/Text';
 import {
@@ -122,33 +123,35 @@ export default function BottomSheetSnapPoints() {
         label="Directions to the Ferry Building"
         height="tall"
         snapPoints={SNAP_POINTS}>
-        <VStack gap={4} padding={4}>
-          <VStack gap={1}>
-            <Heading level={3}>Ferry Building</Heading>
-            <HStack gap={2}>
-              <Text type="label">18 min</Text>
-              <Text type="supporting">3.7 mi · arrive 9:41 AM</Text>
-            </HStack>
+        <Section padding={4}>
+          <VStack gap={4}>
+            <VStack gap={1}>
+              <Heading level={3}>Ferry Building</Heading>
+              <HStack gap={2}>
+                <Text type="label">18 min</Text>
+                <Text type="supporting">3.7 mi · arrive 9:41 AM</Text>
+              </HStack>
+            </VStack>
+            <Divider />
+            <VStack gap={0}>
+              {steps.map(step => (
+                <Item
+                  key={step.label}
+                  startContent={<Icon icon={step.icon} size="sm" />}
+                  label={step.label}
+                  description={step.detail}
+                  endContent={<Text type="supporting">{step.distance}</Text>}
+                />
+              ))}
+            </VStack>
+            <Divider />
+            <Button
+              label="Start"
+              onClick={() => setIsOpen(false)}
+              variant="primary"
+            />
           </VStack>
-          <Divider />
-          <VStack gap={0}>
-            {steps.map(step => (
-              <Item
-                key={step.label}
-                startContent={<Icon icon={step.icon} size="sm" />}
-                label={step.label}
-                description={step.detail}
-                endContent={<Text type="supporting">{step.distance}</Text>}
-              />
-            ))}
-          </VStack>
-          <Divider />
-          <Button
-            label="Start"
-            onClick={() => setIsOpen(false)}
-            variant="primary"
-          />
-        </VStack>
+        </Section>
       </BottomSheet>
     </>
   );


### PR DESCRIPTION
Removes the #5208 workaround from the Bottom Sheet examples. **Stacked on #5231** (which is stacked on #5209) — only the last commit belongs to this PR, and the diff cleans up as those merge.

### What the examples were doing

Four of the six Bottom Sheet examples padded the sheet body by hand instead of using a `Section`, in two flavors:

```tsx
// BottomSheetHeights, BottomSheetMobileKeyboard, BottomSheetNoScrim
<VStack gap={4} style={{padding: 'var(--spacing-4)'}}>

// BottomSheetSnapPoints
<VStack gap={4} padding={4}>
```

The other two — `BottomSheetShowcase` and all three sheets in `BottomSheetSwitcherShowcase` — already use the house pattern:

```tsx
<Section padding={4}>
  <VStack gap={4}>
```

The split wasn't taste. A `Section` inside a sheet used to escape padding that wasn't visually there and hang off both edges (#5208), so these four reached for something without escape behavior. `BottomSheetNoScrim` shows the mechanism plainly: its own page wrapper is a `<Section padding={4}>`, which is exactly the value that leaked into the sheet.

With the boundary fixed, all four use the standard wrapper. Every Bottom Sheet example now reads the same way, and none reaches for an inline style with a raw token string.

### Rendering is unchanged

Rendered the real example components in Chromium at 2x, opened each sheet, and diffed before/after:

| example | differing pixels |
|---|---|
| BottomSheetSnapPoints | **0** / 1,444,800 |
| BottomSheetNoScrim | **0** / 1,444,800 |
| BottomSheetHeights | **0** / 1,444,800 |

Sheet body is 420px inside a 420px sheet in all three (no overflow), with 16px padding as before.

One thing I checked rather than assumed: `Divider`'s edge-to-edge behavior is **opt-in** via `isFullBleed` (default `false`), so moving a `Divider` inside a `Section` does not silently turn the separators into full-bleed rules. That's why the diffs are exactly zero rather than merely close.

`componentsUsed` updated in the three affected `.doc.mjs` files. `pnpm lint` clean, `packages/cli` suite 198 files / 2,724 tests green, `pnpm build` produces no drift.
