### PR TITLE
fix: hold the scrollbar gutter while an overlay is open

### DIFF
--- a/.changeset/css-first-scrollbar-gutter.md
+++ b/.changeset/css-first-scrollbar-gutter.md
@@ -1,0 +1,23 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Hold the scrollbar gutter while an overlay is open, so the page behind it doesn't shift sideways
+
+@imdreamrunner
+
+Refines the fix from #5219. Locking background scroll hides the document's
+scrollbar; where that scrollbar takes layout space (Windows/Linux desktop, and
+macOS set to always show scroll bars) the layout viewport widened by its width
+and the page jumped ~15px behind the overlay.
+
+Dialog, BottomSheet, Lightbox, Drawer and MobileNav now hold that gutter with
+`scrollbar-gutter: stable`, applied for the duration of the lock and removed on
+close. Being a real layout change it holds `position: fixed` chrome — toast
+viewports, sticky docks — which the padding compensation it replaces could not:
+fixed elements resolve against the viewport, not against the padded element.
+
+Nothing is applied where there is no gutter to hold. Overlay scrollbars (mobile,
+and macOS by default) take no layout space, and neither does a page too short to
+scroll — so a one-screen marketing page renders exactly as before, full-bleed to
+the edge.

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -48,10 +48,7 @@ import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {Heading} from '../Heading/Heading';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
-import {
-  holdScrollbarGutter,
-  type ScrollbarGutterHold,
-} from '../hooks/scrollbarGutter';
+import {holdScrollbarGutter} from '../hooks/scrollbarGutter';
 import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -438,14 +435,12 @@ export function MobileNav({
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
-  const gutterRef = useRef<ScrollbarGutterHold | null>(null);
+  const releaseGutterRef = useRef<(() => void) | null>(null);
 
   // Gives back the gutter held open in place of the hidden scrollbar.
   const releaseGutter = useCallback(() => {
-    if (gutterRef.current) {
-      gutterRef.current.release();
-      gutterRef.current = null;
-    }
+    releaseGutterRef.current?.();
+    releaseGutterRef.current = null;
   }, []);
   // Resolved side — computed from trigger position when side='auto'
   const [resolvedSide, setResolvedSide] = useState<'start' | 'end'>(
@@ -489,9 +484,9 @@ export function MobileNav({
     }
 
     if (isOpen) {
-      // Taken first: every mutation below is one that can hide the scrollbar,
-      // and the gutter has to be measured while it is still there.
-      gutterRef.current ??= holdScrollbarGutter(document.documentElement);
+      // Taken first: the mutations below hide the scrollbar, and the gutter
+      // has to be measured while it is still there.
+      releaseGutterRef.current ??= holdScrollbarGutter();
 
       if (!dialog.open) {
         dialog.showModal();
@@ -500,7 +495,6 @@ export function MobileNav({
       // overflow: clip avoids creating a scroll container (unlike hidden),
       // so there's no scroll bounce and no need to save/restore scroll position.
       document.documentElement.style.overflow = 'clip';
-      gutterRef.current.settle();
     } else if (dialog.open) {
       document.documentElement.style.overflow = '';
       releaseGutter();

--- a/packages/core/src/MobileNav/MobileNavScrollbarGutter.test.tsx
+++ b/packages/core/src/MobileNav/MobileNavScrollbarGutter.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file MobileNavScrollbarGutter.test.tsx
  * @input Uses vitest, @testing-library/react, MobileNav, a stubbed viewport
- * @output Unit tests for the scrollbar gutter MobileNav reserves while open
+ * @output Unit tests for the scrollbar gutter MobileNav holds while open
  * @position Testing; guards MobileNav.tsx against the open-drawer page shift
  *
  * MobileNav clips the document to lock background scroll, which hides a
@@ -45,7 +45,7 @@ function stubViewport(innerWidth: number, clientWidth: number) {
   });
 }
 
-const rootGutter = () => document.documentElement.style.scrollbarGutter;
+const gutter = () => document.documentElement.style.scrollbarGutter;
 
 describe('MobileNav scrollbar gutter', () => {
   afterEach(() => {
@@ -65,12 +65,12 @@ describe('MobileNav scrollbar gutter', () => {
     );
 
     expect(document.documentElement.style.overflow).toBe('clip');
-    expect(rootGutter()).toBe('stable');
+    expect(gutter()).toBe('stable');
 
     view.unmount();
 
     expect(document.documentElement.style.overflow).toBe('');
-    expect(rootGutter()).toBe('');
+    expect(gutter()).toBe('');
   });
 
   it('gives the gutter back when the drawer closes', () => {
@@ -82,7 +82,7 @@ describe('MobileNav scrollbar gutter', () => {
       </MobileNav>,
     );
 
-    expect(rootGutter()).toBe('stable');
+    expect(gutter()).toBe('stable');
 
     view.rerender(
       <MobileNav isOpen={false} onOpenChange={() => {}}>
@@ -90,10 +90,10 @@ describe('MobileNav scrollbar gutter', () => {
       </MobileNav>,
     );
 
-    expect(rootGutter()).toBe('');
+    expect(gutter()).toBe('');
   });
 
-  it('holds nothing when the scrollbar is an overlay one', () => {
+  it('holds nothing when the scrollbar takes no space', () => {
     stubViewport(1024, 1024);
 
     render(
@@ -103,7 +103,6 @@ describe('MobileNav scrollbar gutter', () => {
     );
 
     expect(document.documentElement.style.overflow).toBe('clip');
-    expect(rootGutter()).toBe('');
-    expect(document.documentElement.style.paddingRight).toBe('');
+    expect(gutter()).toBe('');
   });
 });

--- a/packages/core/src/hooks/scrollbarGutter.test.ts
+++ b/packages/core/src/hooks/scrollbarGutter.test.ts
@@ -2,7 +2,7 @@
 
 /**
  * @file scrollbarGutter.test.ts
- * @input Uses vitest and a stubbed viewport + element box (jsdom does no layout)
+ * @input Uses vitest and a stubbed viewport (jsdom does no layout)
  * @output Unit tests for holdScrollbarGutter
  * @position Testing; validates scrollbarGutter.ts implementation
  *
@@ -13,20 +13,11 @@ import {afterEach, describe, expect, it} from 'vitest';
 import {holdScrollbarGutter} from './scrollbarGutter';
 
 /**
- * jsdom does no layout, so both halves of the measurement are stubbed: the
- * viewport (`innerWidth` vs `documentElement.clientWidth`) and the element's
- * own box, which `widths` reads from and a test flips to simulate the lock
- * widening it.
+ * jsdom does no layout, so `documentElement.clientWidth` is 0 there. Stub the
+ * pair the check reads: a 15px classic scrollbar is `innerWidth` 1024 against
+ * a 1009px layout viewport.
  */
-function stub({
-  innerWidth,
-  clientWidth,
-  widths,
-}: {
-  innerWidth: number;
-  clientWidth: number;
-  widths?: () => number;
-}) {
+function stubViewport(innerWidth: number, clientWidth: number) {
   Object.defineProperty(window, 'innerWidth', {
     value: innerWidth,
     configurable: true,
@@ -36,132 +27,126 @@ function stub({
     value: clientWidth,
     configurable: true,
   });
-  if (widths) {
-    document.body.getBoundingClientRect = () => ({width: widths()}) as DOMRect;
-  }
 }
 
-const rootGutter = () => document.documentElement.style.scrollbarGutter;
+const gutter = () => document.documentElement.style.scrollbarGutter;
 
 describe('holdScrollbarGutter', () => {
   afterEach(() => {
-    document.body.style.cssText = '';
     document.documentElement.style.cssText = '';
-    // @ts-expect-error -- drop the stubs so jsdom's own values come back
+    // @ts-expect-error -- drop the stub so jsdom's own value comes back
     delete document.documentElement.clientWidth;
-    // @ts-expect-error -- restore the prototype's implementation
-    delete document.body.getBoundingClientRect;
   });
 
-  it('holds the gutter open when a space-taking scrollbar is about to be hidden', () => {
-    // A 1024px window over a 1009px layout viewport = a 15px classic scrollbar.
-    stub({innerWidth: 1024, clientWidth: 1009});
+  it('holds the gutter while a space-taking scrollbar is being hidden', () => {
+    stubViewport(1024, 1009);
 
-    const hold = holdScrollbarGutter(document.body);
+    const release = holdScrollbarGutter();
 
-    expect(rootGutter()).toBe('stable');
+    expect(gutter()).toBe('stable');
 
-    hold.settle();
-    hold.release();
+    release();
 
-    expect(rootGutter()).toBe('');
+    expect(gutter()).toBe('');
   });
 
-  it('leaves an overlay scrollbar alone — there is no gutter to hold', () => {
-    stub({innerWidth: 1024, clientWidth: 1024});
+  it('does nothing for an overlay scrollbar, which takes no space', () => {
+    stubViewport(1024, 1024);
 
-    const hold = holdScrollbarGutter(document.body);
-    hold.settle();
+    const release = holdScrollbarGutter();
 
-    expect(rootGutter()).toBe('');
-    expect(document.body.style.paddingRight).toBe('');
+    expect(gutter()).toBe('');
 
-    hold.release();
+    release();
+
+    expect(gutter()).toBe('');
   });
 
-  it('does not pad when holding the gutter kept the element still', () => {
-    stub({innerWidth: 1024, clientWidth: 1009, widths: () => 1009});
+  it('does nothing on a page too short to scroll', () => {
+    // No scrollbar means nothing is hidden, so nothing shifts — and reserving
+    // a gutter here would narrow the page instead of holding it still.
+    stubViewport(1024, 1024);
 
-    const hold = holdScrollbarGutter(document.body);
-    hold.settle();
+    const release = holdScrollbarGutter();
 
-    expect(rootGutter()).toBe('stable');
-    expect(document.body.style.paddingRight).toBe('');
+    expect(gutter()).toBe('');
 
-    hold.release();
-  });
-
-  it('falls back to padding when the element grew anyway', () => {
-    // What an engine without scrollbar-gutter support does: the gutter request
-    // is ignored, the scrollbar goes away, and the element widens by 15px.
-    let width = 1009;
-    stub({innerWidth: 1024, clientWidth: 1009, widths: () => width});
-
-    const hold = holdScrollbarGutter(document.body);
-    width = 1024;
-    hold.settle();
-
-    expect(document.body.style.paddingRight).toBe('15px');
-
-    hold.release();
-
-    expect(document.body.style.paddingRight).toBe('');
-  });
-
-  it("adds to the page's own padding instead of replacing it", () => {
-    let width = 1009;
-    stub({innerWidth: 1024, clientWidth: 1009, widths: () => width});
-    document.body.style.paddingRight = '24px';
-
-    const hold = holdScrollbarGutter(document.body);
-    width = 1024;
-    hold.settle();
-
-    expect(document.body.style.paddingRight).toBe('39px');
-
-    hold.release();
-
-    expect(document.body.style.paddingRight).toBe('24px');
-  });
-
-  it('restores the page\u2019s own scrollbar-gutter rather than clearing it', () => {
-    stub({innerWidth: 1024, clientWidth: 1009});
-    document.documentElement.style.scrollbarGutter = 'stable both-edges';
-
-    const hold = holdScrollbarGutter(document.body);
-
-    expect(rootGutter()).toBe('stable');
-
-    hold.settle();
-    hold.release();
-
-    expect(rootGutter()).toBe('stable both-edges');
-  });
-
-  it('settles once, however many times it is called', () => {
-    let width = 1009;
-    stub({innerWidth: 1024, clientWidth: 1009, widths: () => width});
-
-    const hold = holdScrollbarGutter(document.body);
-    width = 1024;
-    hold.settle();
-    hold.settle();
-    hold.settle();
-
-    expect(document.body.style.paddingRight).toBe('15px');
-
-    hold.release();
+    release();
   });
 
   it('does nothing where there is no layout to measure', () => {
-    stub({innerWidth: 1024, clientWidth: 0});
+    stubViewport(1024, 0);
 
-    const hold = holdScrollbarGutter(document.body);
-    hold.settle();
+    const release = holdScrollbarGutter();
 
-    expect(rootGutter()).toBe('');
-    expect(document.body.style.paddingRight).toBe('');
+    expect(gutter()).toBe('');
 
-    hold.release();
+    release();
+  });
+
+  it('holds once for nested overlays and gives it back on the last release', () => {
+    stubViewport(1024, 1009);
+
+    const first = holdScrollbarGutter();
+    // The scrollbar is already hidden by the time a second overlay opens.
+    stubViewport(1024, 1024);
+    const second = holdScrollbarGutter();
+
+    expect(gutter()).toBe('stable');
+
+    first.call(null);
+
+    expect(gutter()).toBe('stable');
+
+    second();
+
+    expect(gutter()).toBe('');
+  });
+
+  it('is unaffected by releasing out of order', () => {
+    stubViewport(1024, 1009);
+
+    const first = holdScrollbarGutter();
+    const second = holdScrollbarGutter();
+
+    second();
+
+    expect(gutter()).toBe('stable');
+
+    first();
+
+    expect(gutter()).toBe('');
+  });
+
+  it('ignores a disposer called more than once', () => {
+    stubViewport(1024, 1009);
+
+    const first = holdScrollbarGutter();
+    const second = holdScrollbarGutter();
+
+    first();
+    first();
+    first();
+
+    // The double-releases must not have dropped the count below the second
+    // overlay's own hold.
+    expect(gutter()).toBe('stable');
+
+    second();
+
+    expect(gutter()).toBe('');
+  });
+
+  it("restores the page's own scrollbar-gutter rather than clearing it", () => {
+    stubViewport(1024, 1009);
+    document.documentElement.style.scrollbarGutter = 'stable both-edges';
+
+    const release = holdScrollbarGutter();
+
+    expect(gutter()).toBe('stable');
+
+    release();
+
+    expect(gutter()).toBe('stable both-edges');
   });
 });

--- a/packages/core/src/hooks/scrollbarGutter.ts
+++ b/packages/core/src/hooks/scrollbarGutter.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+'use client';
+
 /**
  * @file scrollbarGutter.ts
- * @input The element a scroll lock pins, plus live layout measurements
- * @output Exports holdScrollbarGutter and the ScrollbarGutterHold it returns
+ * @input Live viewport metrics (window.innerWidth vs documentElement.clientWidth)
+ * @output Exports holdScrollbarGutter
  * @position Internal hook utility; used by useScrollLock and MobileNav so that
  *   locking background scroll does not resize the layout viewport.
  *
@@ -12,110 +14,88 @@
  * "Always" show scroll bars — hiding it widens the layout viewport by the
  * scrollbar's width and the whole page jumps sideways behind the overlay.
  *
- * The fix is `scrollbar-gutter: stable`, which holds the gutter open once the
+ * The fix is `scrollbar-gutter: stable`, which holds that space once the
  * scrollbar goes away. Being a real layout change it holds `position: fixed`
  * chrome (sticky headers, toast viewports) as well as in-flow content, which
  * padding fundamentally cannot: fixed elements resolve against the viewport,
  * not against the padded element.
  *
- * Padding is kept only as a fallback for engines without `scrollbar-gutter`
- * (Safari shipped it in 18.2), and it is applied by measuring whether the
- * element actually moved rather than by assuming it did.
+ * Applied dynamically, for the duration of the lock only. A static rule in
+ * reset.css would also work, but it reserves the gutter for the whole life of
+ * every document — including pages too short to scroll, which never had the
+ * shift in the first place. On a short full-bleed page (a one-screen marketing
+ * page) that permanently narrows the layout by the scrollbar's width and pulls
+ * full-bleed art off the right edge.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
  */
 
-const NOOP: ScrollbarGutterHold = {
-  settle() {},
-  release() {},
-};
+/** Balanced by the disposer `holdScrollbarGutter` returns. */
+let holdCount = 0;
 
-export interface ScrollbarGutterHold {
-  /**
-   * Call once the lock's own styles are applied: measures whether the element
-   * grew anyway and, only then, pads the difference away.
-   */
-  settle(): void;
-  /** Call on unlock: restores everything this hold changed. */
-  release(): void;
-}
+/** The value to put back once the last hold is released. */
+let restoreTo: string | null = null;
+
+const NOOP = () => {};
 
 /**
- * Keeps `element`'s content box the width it is right now, across a scroll
- * lock that is about to hide the document's scrollbar.
+ * Holds the layout viewport at its current width across a scroll lock that is
+ * about to hide the document's scrollbar. Returns a disposer that gives the
+ * gutter back; calling it more than once is safe.
  *
- * Call it *before* applying the lock's styles, then {@link
- * ScrollbarGutterHold.settle} immediately after, and {@link
- * ScrollbarGutterHold.release} on unlock:
+ * Call it *before* applying the lock's own styles — the measurement has to see
+ * the scrollbar while it is still there:
  *
  * ```
- * const hold = holdScrollbarGutter(document.body);
+ * const release = holdScrollbarGutter();
  * body.style.position = 'fixed';
- * hold.settle();
+ * // …later
+ * release();
  * ```
  *
- * Overlay scrollbars (mobile, default macOS) take no layout space, so there is
- * nothing to hold and nothing is touched.
+ * Nested overlays share one hold: the gutter is taken by the first and given
+ * back by the last, in whatever order they close.
+ *
+ * Does nothing where there is no gutter to hold — overlay scrollbars (mobile,
+ * and macOS by default) take no layout space, and neither does a page too
+ * short to scroll.
  */
-export function holdScrollbarGutter(element: HTMLElement): ScrollbarGutterHold {
+export function holdScrollbarGutter(): () => void {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
     return NOOP;
   }
 
   const root = document.documentElement;
-  const viewportWidth = root.clientWidth;
 
-  // 0 means "no layout to measure" (jsdom, and any non-visual environment),
-  // not "the scrollbar is as wide as the window".
-  if (viewportWidth === 0) {
-    return NOOP;
-  }
+  if (holdCount === 0) {
+    const viewportWidth = root.clientWidth;
 
-  const previousGutter = root.style.scrollbarGutter;
-  const previousPadding = element.style.paddingRight;
-  const widthBefore = element.getBoundingClientRect().width;
+    // 0 means "no layout to measure" (jsdom, and any non-visual environment),
+    // not "the scrollbar is as wide as the window".
+    if (viewportWidth === 0 || window.innerWidth <= viewportWidth) {
+      return NOOP;
+    }
 
-  let heldGutter = false;
-  let padded = false;
-  let settled = false;
-
-  // Only when a space-taking scrollbar is actually there. Holding the gutter
-  // open on a page that never had one would carve out 15px that was never
-  // reserved — the same shift, in the other direction.
-  if (window.innerWidth > viewportWidth) {
+    restoreTo = root.style.scrollbarGutter;
     root.style.scrollbarGutter = 'stable';
-    heldGutter = true;
   }
 
-  return {
-    settle() {
-      if (settled) {
-        return;
-      }
-      settled = true;
+  holdCount += 1;
 
-      // What the lock actually did to this element, rather than what we
-      // assumed it would do. 0 on any engine where the gutter held — and on a
-      // page that already sets `scrollbar-gutter: stable` itself, where the
-      // scrollbar was never taking the space back.
-      const grew = element.getBoundingClientRect().width - widthBefore;
-      if (grew <= 0) {
-        return;
-      }
+  let released = false;
 
-      const existing =
-        Number.parseFloat(window.getComputedStyle(element).paddingRight) || 0;
-      element.style.paddingRight = `${existing + grew}px`;
-      padded = true;
-    },
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
 
-    release() {
-      if (padded) {
-        element.style.paddingRight = previousPadding;
-        padded = false;
-      }
-      if (heldGutter) {
-        root.style.scrollbarGutter = previousGutter;
-        heldGutter = false;
-      }
-    },
+    holdCount -= 1;
+
+    if (holdCount === 0 && restoreTo !== null) {
+      root.style.scrollbarGutter = restoreTo;
+      restoreTo = null;
+    }
   };
 }

--- a/packages/core/src/hooks/useScrollLock.doc.mjs
+++ b/packages/core/src/hooks/useScrollLock.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
   returns: [],
   usage: {
     description:
-      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked. Pinning hides the document scrollbar, so where that scrollbar takes layout space (desktop) the hook holds its gutter open with scrollbar-gutter: stable for the duration of the lock — the page, including any position: fixed chrome, does not shift sideways.',
+      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked. Pinning hides the document scrollbar, so where that scrollbar takes layout space (desktop) the hook holds its gutter open with scrollbar-gutter: stable for the duration of the lock — the page, including any position: fixed chrome, does not shift sideways. Nothing is applied where there is no gutter to hold — overlay scrollbars (mobile, and macOS by default) and pages too short to scroll are untouched.',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals or dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass the same boolean that controls dialog visibility (e.g., isOpen) as the isLocked parameter.' },
@@ -32,13 +32,13 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').HookTranslationDoc} */
 export const docsDense = {
   description:
-    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways.',
+    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways. No-op where the scrollbar takes no space (mobile, short pages).',
   paramDescriptions: {
     isLocked: 'whether body scroll should be locked.',
   },
   usage: {
     description:
-      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways.',
+      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways. No-op where the scrollbar takes no space (mobile, short pages).',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals / dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass same boolean that controls dialog visibility (e.g. isOpen) as isLocked parameter.' },

--- a/packages/core/src/hooks/useScrollLock.test.ts
+++ b/packages/core/src/hooks/useScrollLock.test.ts
@@ -142,4 +142,71 @@ describe('useScrollLock', () => {
 
     expect(document.documentElement.style.scrollbarGutter).toBe('');
   });
+
+  it('holds the scrollbar gutter while the body is pinned', () => {
+    // A 1024px window over a 1009px layout viewport = a 15px classic
+    // scrollbar. Pinning the body hides it, which would widen the page by
+    // those 15px and reflow everything sideways.
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1009,
+      configurable: true,
+    });
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const lock = renderHook(() => useScrollLock(true));
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+
+    lock.unmount();
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('');
+  });
+
+  it('leaves the page alone when the scrollbar takes no space', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1024,
+      configurable: true,
+    });
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const lock = renderHook(() => useScrollLock(true));
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('');
+
+    lock.unmount();
+  });
+
+  it('holds the gutter until the last overlay closes', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1009,
+      configurable: true,
+    });
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const first = renderHook(() => useScrollLock(true));
+    const second = renderHook(() => useScrollLock(true));
+
+    first.unmount();
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('stable');
+
+    second.unmount();
+
+    expect(document.documentElement.style.scrollbarGutter).toBe('');
+  });
 });

--- a/packages/core/src/hooks/useScrollLock.ts
+++ b/packages/core/src/hooks/useScrollLock.ts
@@ -17,7 +17,7 @@
  */
 
 import {useEffect} from 'react';
-import {holdScrollbarGutter, type ScrollbarGutterHold} from './scrollbarGutter';
+import {holdScrollbarGutter} from './scrollbarGutter';
 
 interface ScrollLockSnapshot {
   scrollX: number;
@@ -27,7 +27,7 @@ interface ScrollLockSnapshot {
   top: string;
   left: string;
   right: string;
-  gutter: ScrollbarGutterHold;
+  releaseGutter: () => void;
 }
 
 let lockCount = 0;
@@ -41,9 +41,9 @@ let originalBodyState: ScrollLockSnapshot | null = null;
  * does not prevent body scroll behind modals. Restores scroll position
  * on unlock.
  *
- * Pinning also hides the document's scrollbar, so the gutter that scrollbar
- * occupied is held open for the duration of the lock — without it the page
- * reflows sideways by ~15px the moment an overlay opens.
+ * Pinning also hides the document's scrollbar, so the gutter it occupied is
+ * held open for the duration of the lock — without that the page reflows
+ * sideways by ~15px the moment an overlay opens.
  *
  * @example
  * ```
@@ -63,7 +63,7 @@ export function useScrollLock(isLocked: boolean): void {
       const scrollY = window.scrollY;
 
       // Taken before the pinning styles below hide the scrollbar.
-      const gutter = holdScrollbarGutter(body);
+      const releaseGutter = holdScrollbarGutter();
 
       originalBodyState = {
         scrollX,
@@ -73,7 +73,7 @@ export function useScrollLock(isLocked: boolean): void {
         top: body.style.top,
         left: body.style.left,
         right: body.style.right,
-        gutter,
+        releaseGutter,
       };
 
       body.style.overflow = 'hidden';
@@ -81,8 +81,6 @@ export function useScrollLock(isLocked: boolean): void {
       body.style.top = `-${scrollY}px`;
       body.style.left = '0';
       body.style.right = '0';
-
-      gutter.settle();
     }
 
     lockCount += 1;
@@ -102,7 +100,7 @@ export function useScrollLock(isLocked: boolean): void {
       body.style.top = state.top;
       body.style.left = state.left;
       body.style.right = state.right;
-      state.gutter.release();
+      state.releaseGutter();
       window.scrollTo(state.scrollX, state.scrollY);
     };
   }, [isLocked]);


### PR DESCRIPTION
Refines #5219. Same trigger — the gutter is taken only while an overlay is open — but two things change.

## 1. `scrollbar-gutter: stable` instead of padding

Padding an element only holds content in the document flow. `position: fixed` chrome — a toast viewport, a sticky dock — resolves against the viewport and kept jumping the full 15px. Holding the gutter is a real layout change, so everything stays put.

It also can't double-compensate: #5219 measured the scrollbar's width and padded by it, which on a page that already sets `scrollbar-gutter: stable` shifted content 15px the *wrong* way. The gutter is idempotent.

## 2. Applied dynamically, never statically

An earlier revision of this PR put `html { scrollbar-gutter: stable }` in `reset.css`. That fixes more — navigation jank, content-growth jank, the `100vw` overflow bug — but it reserves the gutter for the **whole life of every document**, including pages too short to scroll, which never had the shift in the first place.

On a one-screen full-bleed marketing page that is a visible regression, measured at 900×600 with classic scrollbars:

| | without | with static rule |
|---|---|---|
| hero width | 900 | **885** |
| fixed nav right edge | 900 | **885** |
| headline center | 450 | **443** |
| `100vw` band | 900 | **885** |

The full-bleed gradient stops 15px short and the page background shows through as a strip down the right edge. So the rule is out of `reset.css`; the gutter is taken at lock time and given back on close.

## The whole decision is one boolean

```js
if (window.innerWidth > root.clientWidth) {
  root.style.scrollbarGutter = 'stable';   // CSS does the rest
}
```

No widths, no arithmetic, no padding to restore. Nothing is applied where there is no gutter to hold: overlay scrollbars (mobile, macOS by default) and pages too short to scroll.

## Test plan

**49/49** on the real components, with no static rule loaded so this path is the only mechanism — Dialog × BottomSheet × MobileNav, across four page shapes and four environments, plus nested overlays closed out of order:

| | tall | short | RTL | page reserves its own gutter |
|---|---|---|---|---|
| classic scrollbars | ✅ | ✅ | ✅ | ✅ |
| overlay scrollbars | ✅ | ✅ | ✅ | ✅ |
| iPhone 15 | ✅ | ✅ | ✅ | ✅ |
| Pixel 7 | ✅ | ✅ | ✅ | ✅ |

Every cell: 0px for in-flow content, 0px for `position: fixed` content, background scroll still locked, layout and the page's own `scrollbar-gutter` value restored on close.

And the case that drove the design — the short full-bleed marketing page, with this fix installed: hero 900, nav 900, headline centered 450, band 900, computed gutter `auto`. Byte-identical to a build with no fix at all.

Unit coverage: the helper (hold, release, overlay scrollbars, short pages, no-layout environments, nesting, out-of-order release, double-release, restoring the page's own value), the hook, and the drawer.

Gates: `pnpm lint:strict` (0 errors, 56 pre-existing warnings), `pnpm test` (7,384 core+lab; 3,407 cli+apps), `pnpm build`.

## Known limitation

Engines without `scrollbar-gutter` (Safari <18.2) get no compensation — #5219's padding fallback is gone with the padding. Safari defaults to overlay scrollbars, where there is no shift to fix; only Safari <18.2 with "always show scroll bars" turned on is affected, and it degrades to today's behavior rather than anything worse.

## Not doing (for now)

The static rule fixes two janks this doesn't: navigating short page → scrolling page, and content growing past the viewport (a list loads, an accordion opens). Both shift by the same 15px. If we want those, the static rule is the answer — but it's a layout change for every consumer on upgrade and belongs in its own PR, marked `[breaking]` for the minor bump, not smuggled in with a modal fix.