### PR TITLE
fix(theme): route physical block padding through the container expansion

### DIFF
--- a/.changeset/physical-block-padding-container-expansion.md
+++ b/.changeset/physical-block-padding-container-expansion.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Theming: a physical `paddingTop`/`paddingBottom` now reaches the container padding expansion, so `card`, `dialog`, `section` and `number-input` track it the way they already track the logical spellings. A physical block longhand matched none of the padding property names the expansion recognizes, so it landed raw on the element while the component's internals kept reading the default — the NumberInput stepper column came up ~10px short of the field edges, and container bleed compensated by the wrong amount. Mixing spellings was worse than either alone: `padding: '10px'` plus `paddingTop: '14px'` published 10px in the tokens while the element painted 14px on top. `padding-top` and `padding-bottom` ARE the block edges in every horizontal writing mode, so this normalization assumes no direction. `paddingLeft`/`paddingRight` are deliberately unchanged: they are direction-relative — left is inline-start in LTR and inline-end in RTL — and the tokens are consumed by logical properties, so routing them would silently move the padding to the opposite edge under RTL. They keep their physical meaning, exactly as before.
+
+@cixzhang

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -1842,6 +1842,17 @@ describe('NumberInput stepper padding coupling', () => {
           '--astryx-number-input-padding-block-end: 12px',
         ],
       ],
+      [
+        // `paddingTop` is `paddingBlockStart` in every horizontal writing
+        // mode, so it normalizes onto the same tokens. The physical inline
+        // pair is deliberately not mapped — see generateThemeRules.
+        'the physical block longhands',
+        {paddingTop: '14px', paddingBottom: '6px'},
+        [
+          '--astryx-number-input-padding-block-start: 14px',
+          '--astryx-number-input-padding-block-end: 6px',
+        ],
+      ],
     ])('%s', (_label, base, expected) => {
       const theme = defineTheme({
         name: 'number-input-padding-spelling-test',
@@ -1853,7 +1864,9 @@ describe('NumberInput stepper padding coupling', () => {
       }
       // The expansion consumes the padding: a raw declaration left on the
       // wrapper is padding the column cannot see, which is the gap itself.
-      expect(css).not.toMatch(/^\s*padding(-block|-inline)?(-start|-end)?:/m);
+      expect(css).not.toMatch(
+        /^\s*padding(-block|-inline|-top|-bottom)?(-start|-end)?:/m,
+      );
     });
   });
 

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -584,3 +584,82 @@ describe('brutalist-style derived expansion', () => {
     expect(rule).toContain('--_dropdown-menu-padding: 4px');
   });
 });
+
+describe('physical padding longhands', () => {
+  const ruleFor = (
+    component: string,
+    base: Record<string, string>,
+    name = 'test-physical-padding',
+  ) =>
+    generateThemeRules(
+      defineTheme({name, components: {[component]: {base}}}),
+    ).find(r => r.includes(`.astryx-${component}`));
+
+  // `padding-top`/`padding-bottom` ARE the block edges in every horizontal
+  // writing mode, so the expansion can normalize them with no direction
+  // assumption. Without that, the padding lands raw on the element and the
+  // component's internals — the NumberInput stepper column, container bleed —
+  // read the default instead of what the theme set.
+  it.each([
+    ['paddingTop', {paddingTop: '14px'}, 'block-start'],
+    ['paddingBottom', {paddingBottom: '14px'}, 'block-end'],
+  ])('routes %s through the container expansion', (_label, base, edge) => {
+    const rule = ruleFor('card', base);
+    expect(rule).toContain(`--astryx-card-padding-${edge}: 14px`);
+    expect(rule).not.toMatch(/[{;]\s*padding-(top|bottom):/);
+  });
+
+  it('normalizes both block edges together, asymmetrically', () => {
+    const rule = ruleFor('number-input', {
+      paddingTop: '14px',
+      paddingBottom: '6px',
+    });
+    expect(rule).toContain('--astryx-number-input-padding-block-start: 14px');
+    expect(rule).toContain('--astryx-number-input-padding-block-end: 6px');
+  });
+
+  it.each(['card', 'dialog', 'section', 'number-input'])(
+    'reaches %s, which expands its padding',
+    component => {
+      expect(ruleFor(component, {paddingTop: '14px'})).toContain(
+        `--astryx-${component}-padding-block-start: 14px`,
+      );
+    },
+  );
+
+  // THE RTL GUARD. `paddingLeft` is inline-start in LTR and inline-end in RTL,
+  // and the tokens are consumed by logical properties, so mapping it would
+  // silently move the padding to the other edge in RTL. It stays physical —
+  // which is what the author wrote — and does not reach the tokens.
+  it('leaves the direction-relative inline pair physical', () => {
+    const rule = ruleFor('card', {paddingLeft: '20px', paddingRight: '8px'});
+    expect(rule).toContain('padding-left: 20px');
+    expect(rule).toContain('padding-right: 8px');
+    expect(rule).not.toContain('--astryx-card-padding-inline');
+  });
+
+  it('expands the block edges while leaving left physical', () => {
+    const rule = ruleFor('card', {paddingTop: '14px', paddingLeft: '20px'});
+    expect(rule).toContain('--astryx-card-padding-block-start: 14px');
+    expect(rule).toContain('padding-left: 20px');
+  });
+
+  // The shorthand-plus-override case was the worst one: the tokens carried
+  // 10px while the element painted 14px on top, so every internal compensated
+  // by the wrong amount.
+  it('lets a physical longhand override the shorthand per edge', () => {
+    const rule = ruleFor('card', {padding: '10px', paddingTop: '14px'});
+    expect(rule).toContain('--astryx-card-padding-block-start: 14px');
+    expect(rule).toContain('--astryx-card-padding-block-end: 10px');
+    expect(rule).toContain('--astryx-card-padding-inline: 10px');
+    expect(rule).not.toMatch(/[{;]\s*padding(-top)?:/);
+  });
+
+  // A `vars` entry carries one value for the whole box, so a single physical
+  // edge must not feed it — only the container expansion takes these.
+  it('does not feed a single edge to a whole-box derived var', () => {
+    const rule = ruleFor('dropdown-menu', {paddingTop: '14px'});
+    expect(rule).toContain('padding-top: 14px');
+    expect(rule).not.toContain('--_dropdown-menu-padding');
+  });
+});

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -128,6 +128,34 @@ const PADDING_PROPS = new Set([
   'paddingInlineEnd',
 ]);
 
+/**
+ * Physical block-axis longhands, and the logical longhand each one *is* in
+ * every horizontal writing mode. Normalizing them costs no direction
+ * assumption, which is why they can join the container expansion.
+ *
+ * `paddingLeft`/`paddingRight` are deliberately absent. They are
+ * direction-relative — left is inline-start in LTR and inline-end in RTL — and
+ * the expansion's tokens are consumed by logical properties, so mapping them
+ * would put the padding on the opposite edge in RTL. They keep their physical
+ * meaning and land on the element as `padding-left`/`padding-right`; the cost
+ * is that a component's internals cannot see them.
+ */
+const PHYSICAL_BLOCK_PADDING_PROPS: Record<string, string> = {
+  paddingTop: 'paddingBlockStart',
+  paddingBottom: 'paddingBlockEnd',
+};
+
+/**
+ * Every padding spelling the container expansion consumes. Kept separate from
+ * PADDING_PROPS, which also routes longhands to `vars`-style derived entries —
+ * those carry one value for the whole box, so a single physical edge must not
+ * reach them.
+ */
+const CONTAINER_PADDING_PROPS = new Set([
+  ...PADDING_PROPS,
+  ...Object.keys(PHYSICAL_BLOCK_PADDING_PROPS),
+]);
+
 interface ParsedPadding {
   blockStart?: string;
   blockEnd?: string;
@@ -138,12 +166,14 @@ interface ParsedPadding {
 
 /**
  * Parse CSS padding shorthand/longhand into block/inline values.
- * Supports 1-3 value shorthands and logical properties.
+ * Supports 1-3 value shorthands, logical properties, and the physical block
+ * longhands normalized by PHYSICAL_BLOCK_PADDING_PROPS.
  */
 function parsePadding(props: [string, string][]): ParsedPadding {
   const result: ParsedPadding = {};
 
-  for (const [prop, value] of props) {
+  for (const [rawProp, value] of props) {
+    const prop = PHYSICAL_BLOCK_PADDING_PROPS[rawProp] ?? rawProp;
     switch (prop) {
       case 'padding': {
         const parts = value.trim().split(/\s+/);
@@ -377,13 +407,28 @@ function generateComponentRules(
             }
           }
         }
+        // A physical block longhand reaches the container expansion only. It
+        // names one edge, so it must not feed a `vars` entry above, which
+        // carries the padding for the whole box.
+        if (
+          prop in PHYSICAL_BLOCK_PADDING_PROPS &&
+          getDerivedVars(component, 'padding').some(
+            e => e.expand === 'container',
+          )
+        ) {
+          containerExpanded = true;
+        }
       }
 
       // Container padding expansion: replace padding props with
       // component-scoped container tokens for layout integration.
       if (containerExpanded) {
-        const paddingProps = props.filter(([p]) => PADDING_PROPS.has(p));
-        const nonPaddingProps = props.filter(([p]) => !PADDING_PROPS.has(p));
+        const paddingProps = props.filter(([p]) =>
+          CONTAINER_PADDING_PROPS.has(p),
+        );
+        const nonPaddingProps = props.filter(
+          ([p]) => !CONTAINER_PADDING_PROPS.has(p),
+        );
         const parsed = parsePadding(paddingProps);
         const containerTokens = expandContainerPadding(component, parsed);
         finalProps = [...nonPaddingProps, ...containerTokens];


### PR DESCRIPTION
## What was broken

`PADDING_PROPS` in `generateThemeRules.ts` listed only the *logical* padding spellings, so a theme that wrote a **physical** longhand — `paddingTop`, `paddingBottom`, `paddingLeft`, `paddingRight` — matched no entry, `expand: 'container'` never fired, and the declaration landed raw on the element while the component's internals kept reading the default. It hits every `expand: 'container'` component: `card`, `dialog`, `number-input`, `section`.

- **NumberInput**: the stepper column cancels the wrapper's block padding by reading the padding tokens. With `paddingTop/Bottom: 14px` themed, the tokens were never set, so the column cancelled the 4px default and came up **11px short at each end** — a squashed 10px column inside a 32px field.
- **Card / Dialog / Section**: bleed children (Table, Divider, nested Section, Layout) compensate against `--container-padding-*`. With `paddingTop: 40px` themed, they pulled back only the default, leaving the table **25px** inside the card edge instead of flush.
- **Mixing spellings was worse than either alone**: `padding: '10px'` plus `paddingTop: '14px'` published 10px in the tokens while the element painted 14px on top — every internal silently compensated by the wrong amount, with nothing in the output to explain it.

Follow-up to [#5181](https://github.com/facebook/astryx/pull/5181), which fixed the logical spellings and routed NumberInput through the shared expansion. This extends that mechanism; it changes nothing that PR did.

## The RTL reasoning — read this part

**`paddingTop`/`paddingBottom` are mapped. `paddingLeft`/`paddingRight` are deliberately not.**

`padding-top` **is** `padding-block-start` in every horizontal writing mode. Normalizing it costs no direction assumption — it is an identity the codebase already relies on in both directions (StyleX compiles the block logical properties to `padding-top`/`padding-bottom`, and #5181's own test asserts exactly that).

`padding-left` is `padding-inline-start` **only in LTR**. Mapping it is not a small LTR lean: the expansion's tokens are consumed by *logical* properties (`margin-inline-start`, `--container-padding-inline-start`), so under RTL the padding would land on the **opposite edge** from the one the author named — a physical CSS property that stops being physical, invisibly to whoever wrote it. That is a worse bug than the one being fixed.

So the physical inline pair keeps its meaning and keeps landing as `padding-left` / `padding-right`, byte-identical to today. **RTL behavior: `paddingTop`/`paddingBottom` behave exactly like `paddingBlockStart`/`paddingBlockEnd` in both directions; `paddingLeft`/`paddingRight` stay on the physical left and right in both directions, and — unchanged from today — do not reach a component's internals.** Verified in Chromium below.

A direction-conditional emission (`:dir(rtl)` overrides, with the mirror token reset to `initial` for a partial declaration) *could* route left/right correctly, and browser support is a non-issue here — the generator already emits `@scope`, which is narrower than `:dir()`. I rejected it as disproportionate for a bug fix: it introduces direction-awareness into a generator that has none, doubles the emitted rules for every themed container, and needs a defined conflict rule against an explicit logical spelling in the same block. Worth a proposal of its own if a real theme needs physical inline padding on a container.

One more containment detail: `PADDING_PROPS` also routes longhands to `vars`-style derived entries (`chat`, `dropdown-menu`, `context-menu`, `segmented-control`), which carry one value for the **whole box**. A single physical edge must not feed those, so the physical pair is admitted to the container expansion path only — those four components are untouched.

## Before / after

Real Chromium, Storybook, `deviceScaleFactor: 2`. Four panels: untouched · `paddingTop/Bottom: 14px` (NumberInput) + `40px` (Card) · the same declaration in logical spelling · `paddingLeft: 40px, paddingRight: 4px`.

**LTR — before** (physical panel: squashed stepper column, table inset inside the card)
![LTR before](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5244/pr-assets/before-ltr.png)

**LTR — after** (physical panel is now pixel-identical to the logical one)
![LTR after](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5244/pr-assets/after-ltr.png)

**RTL — before**
![RTL before](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5244/pr-assets/before-rtl.png)

**RTL — after**
![RTL after](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5244/pr-assets/after-rtl.png)

Measured geometry, as supporting evidence (identical in LTR and RTL):

| panel | stepper column gap top / bottom | table inset from card top |
|---|---|---|
| before — physical | 11px / 11px | 25px |
| after — physical | 1px / 1px (the border) | 0px |
| after — logical (reference) | 1px / 1px | 0px |

The fourth panel is the RTL claim: `paddingLeft: 40px` computes to `padding-left: 40px` in **both** directions, before and after — physical stays physical.

## Testing

`generateThemeRules.test.ts` gains a `physical padding longhands` block: the two block edges route through the expansion, asymmetric block edges, all four container components, the mixed shorthand-plus-longhand case, and two guards — that the direction-relative inline pair stays physical and out of the tokens, and that a single physical edge never feeds a whole-box derived var. `NumberInput.test.tsx` gains a physical row in the existing spelling table (and its "the expansion consumed the raw declaration" assertion now also covers `padding-top`/`padding-bottom`).

Proven to fail against pre-fix code: with only `generateThemeRules.ts` reverted, **10 of the new tests fail**; restored, all 169 in those files pass. The two guard tests pass either way by design — they pin behavior this PR must not change. Full `packages/core` suite, `eslint`, and `tsc --noEmit` are clean apart from the repo's known load-sensitive perf tests (`Table.perf`, `Markdown/parser.perf`), which fail only under CPU contention and are unrelated.

## Adjacent, flagged not fixed

`parsePadding`'s 4-value `padding` shorthand (`top right bottom left`) collapses the inline axis to a single value: `padding: '1px 2px 3px 4px'` emits `inline: 2px`, so the left edge renders 2px and the authored `4px` is mirrored away rather than honored. Same family — the 4-value shorthand is inherently physical — so fixing it means answering the same left/right question this PR declines to answer.

