### PR TITLE
fix(a11y): no hover state on disabled elements

### DIFF
--- a/.changeset/disabled-no-hover-state.md
+++ b/.changeset/disabled-no-hover-state.md
@@ -1,0 +1,26 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Disabled elements no longer light up under the pointer
+
+`:hover` keeps matching a disabled control — browsers suppress its events, not
+its styling — so a hover treatment written for the enabled element was still
+painted under the pointer. StyleX does not take it away by accident either: a
+`disabled` style setting `backgroundImage: 'none'` overrides the DEFAULT
+condition only, leaving the variant's `:hover` class to win the moment the
+pointer arrives. Button shipped exactly that, in every variant, and it reached
+eleven components that render a Button.
+
+Every self-`:hover` selector in core and lab now carries a zero-specificity
+guard (`:hover:where(:not(:disabled,[aria-disabled="true"]))`), and so does
+every `:hover` a theme authors through `components`, so a theme override cannot
+reintroduce it library-wide. `:where()` adds no specificity, so existing hover
+overrides still weigh exactly what they weighed.
+
+Two new gates keep it that way: `@astryx/no-hover-on-disabled` (autofixable)
+rejects an unguarded hover at author time, and a Chromium sweep forces `:hover`
+on every disabled element in every story and fails on any painted difference —
+the invariant is invisible to jsdom, which has neither a pointer nor a cascade.
+
+@cixzhang

--- a/.changeset/disabled-no-hover-state.md
+++ b/.changeset/disabled-no-hover-state.md
@@ -2,25 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Disabled elements no longer light up under the pointer
-
-`:hover` keeps matching a disabled control — browsers suppress its events, not
-its styling — so a hover treatment written for the enabled element was still
-painted under the pointer. StyleX does not take it away by accident either: a
-`disabled` style setting `backgroundImage: 'none'` overrides the DEFAULT
-condition only, leaving the variant's `:hover` class to win the moment the
-pointer arrives. Button shipped exactly that, in every variant, and it reached
-eleven components that render a Button.
-
-Every self-`:hover` selector in core and lab now carries a zero-specificity
-guard (`:hover:where(:not(:disabled,[aria-disabled="true"]))`), and so does
-every `:hover` a theme authors through `components`, so a theme override cannot
-reintroduce it library-wide. `:where()` adds no specificity, so existing hover
-overrides still weigh exactly what they weighed.
-
-Two new gates keep it that way: `@astryx/no-hover-on-disabled` (autofixable)
-rejects an unguarded hover at author time, and a Chromium sweep forces `:hover`
-on every disabled element in every story and fails on any painted difference —
-the invariant is invisible to jsdom, which has neither a pointer nor a cascade.
+[fix] Disabled elements no longer paint a hover state: every self-`:hover` in core and lab, and every `:hover` a theme authors, now carries the zero-specificity guard `:hover:where(:not(:disabled,[aria-disabled="true"]))`, so existing overrides weigh exactly what they weighed before. A lint rule and a Chromium sweep over every story keep it that way.
 
 @cixzhang

--- a/.github/scripts/disabled-hover-audit.js
+++ b/.github/scripts/disabled-hover-audit.js
@@ -91,11 +91,10 @@ const DISABLED_SELECTOR = ':disabled, [aria-disabled="true"]';
 /**
  * Which stories belong to the requested components.
  *
- * `--components` absent means every story (the weekly contract). Present but
- * empty means the caller derived an empty set — audit nothing and pass,
- * rather than fanning out to a full sweep the PR never asked for. Same
- * contract as accessibility-audit.js, so the two CI steps can share one
- * component list.
+ * `--components` absent means every story (the full-sweep contract). Present
+ * but empty means the caller derived an empty set — audit nothing and pass,
+ * rather than fanning out to a full sweep the caller never asked for. Same
+ * contract as accessibility-audit.js, so both can share one component list.
  */
 function selectStories(entries, components) {
   const wanted = (components || []).map(c => c.toLowerCase());

--- a/.github/scripts/disabled-hover-audit.js
+++ b/.github/scripts/disabled-hover-audit.js
@@ -28,7 +28,10 @@
  * the result.
  *
  * The gate is zero-tolerance and has no baseline: a hover state on a disabled
- * element is never correct, so there is nothing to grandfather.
+ * element is never correct, so there is nothing to grandfather. What it does
+ * skip is an element nothing can point at — no box, or `pointer-events: none`
+ * over its whole subtree — because a hover rule that can never be reached is
+ * not a defect a user can see.
  */
 
 const {chromium} = require('playwright');
@@ -209,7 +212,7 @@ const PAGE_HARNESS = `
 window.__astryxHoverAudit = {
   collect(selector) {
     this.nodes = [...document.querySelectorAll(selector)].filter(
-      el => el.getClientRects().length > 0
+      el => el.getClientRects().length > 0 && this.isHoverable(el)
     );
     return this.nodes.map(el => {
       const id = el.id ? '#' + el.id : '';
@@ -219,6 +222,16 @@ window.__astryxHoverAudit = {
       const role = el.getAttribute('role');
       return '<' + el.tagName.toLowerCase() + id + cls + (role ? ' role=' + role : '') + '>';
     });
+  },
+  // An element no pointer can hit never gets :hover in the first place, so a
+  // hover rule matching it is unreachable rather than wrong (Link's disabled
+  // style sets pointer-events: none, for one). A descendant that IS hittable
+  // brings the whole ancestor chain back into :hover, so the subtree decides.
+  isHoverable(el) {
+    if (getComputedStyle(el).pointerEvents !== 'none') return true;
+    return [...el.querySelectorAll('*')].some(
+      child => getComputedStyle(child).pointerEvents !== 'none'
+    );
   },
   snapshot(index, properties) {
     const out = [];
@@ -258,8 +271,20 @@ async function auditStory(context, port, entry, limits) {
       timeout: limits.timeout,
     });
     await page.evaluate(() => document.fonts?.ready).catch(() => {});
+    // Wait for the story to actually mount before counting disabled elements:
+    // a bare `load` can land before React has rendered, and the sweep would
+    // then report a story as having nothing to check.
+    await page
+      .waitForFunction(
+        () => {
+          const root = document.getElementById('storybook-root');
+          return Boolean(root && root.children.length > 0);
+        },
+        {timeout: 5000},
+      )
+      .catch(() => {});
     await page.addStyleTag({content: FREEZE_MOTION});
-    await page.waitForTimeout(150);
+    await page.waitForTimeout(200);
     await page.evaluate(PAGE_HARNESS);
 
     const labels = await page.evaluate(
@@ -282,7 +307,12 @@ async function auditStory(context, port, entry, limits) {
         selector: DISABLED_SELECTOR,
       });
       const boxed = await page.evaluate(
-        selector => [...document.querySelectorAll(selector)].map(el => el.getClientRects().length > 0),
+        selector =>
+          [...document.querySelectorAll(selector)].map(
+            el =>
+              el.getClientRects().length > 0 &&
+              window.__astryxHoverAudit.isHoverable(el),
+          ),
         DISABLED_SELECTOR,
       );
       const hoverable = nodeIds.filter((_, i) => boxed[i]);

--- a/.github/scripts/disabled-hover-audit.js
+++ b/.github/scripts/disabled-hover-audit.js
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+
+/**
+ * @description Asserts no disabled element paints a hover state
+ * @input --storybook-dir <path> [--components <csv>] [--output <file>]
+ *   [--concurrency <n>] [--port <n>]
+ * @output JSON report of violations; exit 1 if any disabled element changes
+ *   appearance under :hover
+ *
+ * A disabled control must look inert. `:hover` does not care: it keeps
+ * matching a `<button disabled>` in every engine, so a hover treatment
+ * declared on the enabled element is still painted under the pointer unless
+ * something takes it away. StyleX will not take it away by accident either —
+ * `disabled: {backgroundImage: 'none'}` overrides the DEFAULT condition only,
+ * leaving the variant's `:hover` class untouched and winning the moment the
+ * pointer arrives. Button shipped exactly that (see the fix in this change).
+ *
+ * jsdom has no pointer and no cascade, so the unit suite cannot see any of
+ * it. Chromium can: for every disabled element in every story we force
+ * `:hover` through CDP (the same switch DevTools' `:hov` panel throws) and
+ * compare the element's painted properties, and those of its subtree and its
+ * ::before/::after, against the unhovered render. Any difference is a
+ * violation. Forcing beats moving a real mouse here: it needs no geometry, it
+ * cannot miss a covered or scrolled-out element, and it puts the state on the
+ * disabled element ALONE, so an ancestor's legitimate hover never leaks into
+ * the result.
+ *
+ * The gate is zero-tolerance and has no baseline: a hover state on a disabled
+ * element is never correct, so there is nothing to grandfather.
+ */
+
+const {chromium} = require('playwright');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+
+// ---------------------------------------------------------------------------
+// pure logic (exported for the unit test)
+// ---------------------------------------------------------------------------
+
+/**
+ * Painted properties compared hovered vs unhovered.
+ *
+ * Every entry is something a user can SEE change. `cursor` is here because a
+ * pointer cursor is an affordance: a disabled control that answers the mouse
+ * with `pointer` promises a click it will not honour.
+ */
+const VISUAL_PROPERTIES = [
+  'background-color',
+  'background-image',
+  'border-block-end-color',
+  'border-block-start-color',
+  'border-inline-end-color',
+  'border-inline-start-color',
+  'box-shadow',
+  'color',
+  'cursor',
+  'fill',
+  'filter',
+  'font-weight',
+  'opacity',
+  'outline-color',
+  'outline-offset',
+  'outline-style',
+  'outline-width',
+  'scale',
+  'stroke',
+  'text-decoration-color',
+  'text-decoration-line',
+  'text-decoration-thickness',
+  'transform',
+  'translate',
+  'visibility',
+];
+
+/**
+ * What counts as disabled.
+ *
+ * `:disabled` covers the native form controls (including everything inside a
+ * disabled fieldset); `[aria-disabled="true"]` covers the pattern astryx uses
+ * wherever a disabled control must stay focusable so its reason is
+ * discoverable — Button with a tooltip, Selector's trigger, SideNavItem.
+ */
+const DISABLED_SELECTOR = ':disabled, [aria-disabled="true"]';
+
+/**
+ * Which stories belong to the requested components.
+ *
+ * `--components` absent means every story (the weekly contract). Present but
+ * empty means the caller derived an empty set — audit nothing and pass,
+ * rather than fanning out to a full sweep the PR never asked for. Same
+ * contract as accessibility-audit.js, so the two CI steps can share one
+ * component list.
+ */
+function selectStories(entries, components) {
+  const wanted = (components || []).map(c => c.toLowerCase());
+  return entries.filter(entry => {
+    if (entry.type === 'docs' || entry.id.endsWith('--docs')) return false;
+    if (!/^(core|lab)-/.test(entry.id)) return false;
+    if (wanted.length === 0) return true;
+    const title = entry.title || '';
+    const parts = title.split('/');
+    const componentPart = parts.length > 1 ? parts[1] : parts[0];
+    return wanted.includes(componentPart.replace(/^XDS/i, '').toLowerCase());
+  });
+}
+
+/**
+ * Compare two subtree snapshots and return the properties that moved.
+ *
+ * A snapshot is a flat list of nodes in document order, each node a
+ * `{label, styles}` record whose `styles` holds one entry per
+ * VISUAL_PROPERTIES for the element and for its ::before/::after. Both
+ * snapshots come from the same DOM microseconds apart, so a length mismatch
+ * means the story re-rendered underneath us; report it rather than guess.
+ */
+function diffSnapshots(before, after) {
+  if (before.length !== after.length) {
+    return [{label: '(subtree)', property: '(node count)', from: String(before.length), to: String(after.length)}];
+  }
+  const deltas = [];
+  for (let i = 0; i < before.length; i++) {
+    const b = before[i];
+    const a = after[i];
+    for (const property of Object.keys(b.styles)) {
+      if (b.styles[property] !== a.styles[property]) {
+        deltas.push({label: b.label, property, from: b.styles[property], to: a.styles[property]});
+      }
+    }
+  }
+  return deltas;
+}
+
+/** One line per violation, grouped by component, for the CI log. */
+function formatViolations(violations) {
+  if (violations.length === 0) return 'No disabled element paints a hover state.';
+  const byComponent = new Map();
+  for (const violation of violations) {
+    const list = byComponent.get(violation.component) || [];
+    list.push(violation);
+    byComponent.set(violation.component, list);
+  }
+  const lines = [`${violations.length} disabled element(s) paint a hover state:`, ''];
+  for (const [component, list] of [...byComponent.entries()].sort()) {
+    lines.push(`  ${component} (${list.length})`);
+    for (const violation of list) {
+      const deltas = violation.deltas
+        .slice(0, 4)
+        .map(d => `${d.label} ${d.property}: ${d.from} -> ${d.to}`)
+        .join('; ');
+      lines.push(`    ${violation.story}  ${violation.element}`);
+      lines.push(`      ${deltas}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// browser sweep
+// ---------------------------------------------------------------------------
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json',
+  '.ico': 'image/x-icon',
+};
+
+function serve(root, port) {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      let url = decodeURIComponent(req.url.split('?')[0]);
+      if (url === '/') url = '/index.html';
+      const filePath = path.resolve(path.join(root, url));
+      if (!filePath.startsWith(path.resolve(root))) {
+        res.writeHead(403);
+        return res.end('Forbidden');
+      }
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          res.writeHead(404);
+          return res.end('Not found');
+        }
+        res.writeHead(200, {'Content-Type': MIME[path.extname(filePath)] || 'application/octet-stream'});
+        res.end(data);
+      });
+    });
+    server.listen(port, '127.0.0.1', () => resolve({server, port: server.address().port}));
+  });
+}
+
+/**
+ * Installed in the page: index the disabled elements and snapshot one.
+ *
+ * Snapshots run inside the page so a single round trip covers the whole
+ * subtree. The label is only for the report — it never affects the verdict.
+ */
+const PAGE_HARNESS = `
+window.__astryxHoverAudit = {
+  collect(selector) {
+    this.nodes = [...document.querySelectorAll(selector)].filter(
+      el => el.getClientRects().length > 0
+    );
+    return this.nodes.map(el => {
+      const id = el.id ? '#' + el.id : '';
+      const cls = typeof el.className === 'string' && el.className
+        ? '.' + el.className.trim().split(/\\s+/).slice(0, 3).join('.')
+        : '';
+      const role = el.getAttribute('role');
+      return '<' + el.tagName.toLowerCase() + id + cls + (role ? ' role=' + role : '') + '>';
+    });
+  },
+  snapshot(index, properties) {
+    const out = [];
+    const visit = (node, label) => {
+      for (const pseudo of [null, '::before', '::after']) {
+        const computed = getComputedStyle(node, pseudo);
+        const styles = {};
+        for (const property of properties) styles[property] = computed.getPropertyValue(property);
+        out.push({label: label + (pseudo || ''), styles});
+      }
+      let child = 0;
+      for (const element of node.children) {
+        visit(element, label + ' > ' + element.tagName.toLowerCase() + ':nth-child(' + ++child + ')');
+      }
+    };
+    visit(this.nodes[index], '');
+    return out;
+  },
+};
+`;
+
+/** Freeze motion so a snapshot taken right after the state change is final. */
+const FREEZE_MOTION = `*, *::before, *::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}`;
+
+async function auditStory(context, port, entry, limits) {
+  const page = await context.newPage();
+  const violations = [];
+  let disabledElements = 0;
+  try {
+    await page.goto(`http://127.0.0.1:${port}/iframe.html?id=${entry.id}&viewMode=story`, {
+      waitUntil: 'load',
+      timeout: limits.timeout,
+    });
+    await page.evaluate(() => document.fonts?.ready).catch(() => {});
+    await page.addStyleTag({content: FREEZE_MOTION});
+    await page.waitForTimeout(150);
+    await page.evaluate(PAGE_HARNESS);
+
+    const labels = await page.evaluate(
+      selector => window.__astryxHoverAudit.collect(selector),
+      DISABLED_SELECTOR,
+    );
+    disabledElements = labels.length;
+    if (disabledElements === 0) return {violations, disabledElements};
+
+    const cdp = await context.newCDPSession(page);
+    try {
+      await cdp.send('DOM.enable');
+      await cdp.send('CSS.enable');
+      const {root} = await cdp.send('DOM.getDocument', {depth: -1, pierce: true});
+      // Re-query through CDP so the nodeIds line up with the same filter the
+      // page harness used: both walk the document in order, and the harness
+      // drops only elements with no box, so we skip those here too.
+      const {nodeIds} = await cdp.send('DOM.querySelectorAll', {
+        nodeId: root.nodeId,
+        selector: DISABLED_SELECTOR,
+      });
+      const boxed = await page.evaluate(
+        selector => [...document.querySelectorAll(selector)].map(el => el.getClientRects().length > 0),
+        DISABLED_SELECTOR,
+      );
+      const hoverable = nodeIds.filter((_, i) => boxed[i]);
+
+      for (let i = 0; i < hoverable.length && i < limits.elementsPerStory; i++) {
+        const nodeId = hoverable[i];
+        if (!nodeId) continue;
+        const before = await page.evaluate(
+          ([index, properties]) => window.__astryxHoverAudit.snapshot(index, properties),
+          [i, VISUAL_PROPERTIES],
+        );
+        await cdp.send('CSS.forcePseudoState', {nodeId, forcedPseudoClasses: ['hover']});
+        const after = await page.evaluate(
+          ([index, properties]) => window.__astryxHoverAudit.snapshot(index, properties),
+          [i, VISUAL_PROPERTIES],
+        );
+        await cdp.send('CSS.forcePseudoState', {nodeId, forcedPseudoClasses: []});
+
+        const deltas = diffSnapshots(before, after);
+        if (deltas.length > 0) {
+          violations.push({
+            component: entry.title || entry.id,
+            story: entry.id,
+            element: labels[i],
+            deltas,
+          });
+        }
+      }
+    } finally {
+      await cdp.detach().catch(() => {});
+    }
+  } finally {
+    await page.close().catch(() => {});
+  }
+  return {violations, disabledElements};
+}
+
+async function run() {
+  const args = process.argv.slice(2);
+  const getArg = name => {
+    const index = args.indexOf(`--${name}`);
+    return index !== -1 ? args[index + 1] : null;
+  };
+
+  const storybookDir = getArg('storybook-dir') || 'apps/storybook/dist';
+  const outputFile = getArg('output');
+  const componentsArg = getArg('components');
+  const concurrency = Math.max(1, Number(getArg('concurrency') || 4));
+  const port = Number(getArg('port') || 0);
+  const limits = {
+    timeout: Number(getArg('timeout') || 20000),
+    elementsPerStory: Number(getArg('max-elements') || 30),
+  };
+
+  if (componentsArg !== null && componentsArg.split(',').filter(Boolean).length === 0) {
+    console.log('No components to audit (--components is empty) — skipping.');
+    return 0;
+  }
+  const components = (componentsArg || '').split(',').filter(Boolean);
+
+  const dist = path.resolve(process.cwd(), storybookDir);
+  if (!fs.existsSync(path.join(dist, 'index.json'))) {
+    console.error(`Storybook build not found at ${dist}`);
+    return 1;
+  }
+  const index = JSON.parse(fs.readFileSync(path.join(dist, 'index.json'), 'utf8'));
+  const stories = selectStories(Object.values(index.entries || index.stories || {}), components);
+  console.log(`Auditing ${stories.length} stories for hover states on disabled elements`);
+
+  const {server, port: servedPort} = await serve(dist, port);
+  const browser = await chromium.launch();
+  const violations = [];
+  const failures = [];
+  let storiesWithDisabled = 0;
+  let disabledElements = 0;
+
+  try {
+    const context = await browser.newContext({viewport: {width: 1280, height: 900}});
+    const queue = [...stories];
+    const workers = Array.from({length: concurrency}, async () => {
+      for (;;) {
+        const entry = queue.shift();
+        if (!entry) return;
+        try {
+          const result = await auditStory(context, servedPort, entry, limits);
+          if (result.disabledElements > 0) {
+            storiesWithDisabled++;
+            disabledElements += result.disabledElements;
+          }
+          violations.push(...result.violations);
+        } catch (error) {
+          failures.push({story: entry.id, error: error.message});
+        }
+      }
+    });
+    await Promise.all(workers);
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  const report = {
+    summary: {
+      storiesAudited: stories.length,
+      storiesWithDisabledElements: storiesWithDisabled,
+      disabledElementsChecked: disabledElements,
+      violations: violations.length,
+      auditedAt: new Date().toISOString(),
+    },
+    violations,
+    failures,
+  };
+  if (outputFile) fs.writeFileSync(outputFile, JSON.stringify(report, null, 2) + '\n');
+
+  console.log(
+    `\nChecked ${disabledElements} disabled element(s) across ${storiesWithDisabled} of ${stories.length} stories`,
+  );
+  if (failures.length > 0) {
+    console.warn(`${failures.length} story/stories failed to load:`);
+    for (const failure of failures.slice(0, 10)) console.warn(`  ${failure.story}: ${failure.error}`);
+  }
+  console.log(formatViolations(violations));
+
+  return violations.length > 0 ? 1 : 0;
+}
+
+if (require.main === module) {
+  run()
+    .then(code => {
+      process.exitCode = code;
+    })
+    .catch(error => {
+      console.error('Disabled-hover audit failed:', error);
+      process.exit(1);
+    });
+}
+
+module.exports = {VISUAL_PROPERTIES, DISABLED_SELECTOR, selectStories, diffSnapshots, formatViolations};

--- a/.github/scripts/disabled-hover-audit.test.mjs
+++ b/.github/scripts/disabled-hover-audit.test.mjs
@@ -1,0 +1,154 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file disabled-hover-audit.test.mjs
+ * Covers the parts of the disabled-hover gate that do not need a browser:
+ * the story-scoping contract it shares with the a11y audit, the snapshot
+ * diff that decides a verdict, and the report it prints. The Chromium sweep
+ * itself is exercised by the CI job that runs it against the real Storybook
+ * build.
+ */
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {createRequire} from 'node:module';
+import {describe, it, expect} from 'vitest';
+
+const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(SCRIPTS_DIR, 'disabled-hover-audit.js');
+const {selectStories, diffSnapshots, formatViolations, VISUAL_PROPERTIES} =
+  createRequire(import.meta.url)(SCRIPT);
+
+const story = (id, title) => ({id, title, type: 'story'});
+
+describe('selectStories', () => {
+  const entries = [
+    story('core-button--default', 'Core/Button'),
+    story('core-button--disabled', 'Core/Button'),
+    story('core-button--docs', 'Core/Button'),
+    story('lab-stepper--default', 'Lab/Stepper'),
+    story('example-introduction--page', 'Example/Introduction'),
+  ];
+
+  it('audits every core and lab story when no components are named', () => {
+    expect(selectStories(entries, []).map(e => e.id)).toEqual([
+      'core-button--default',
+      'core-button--disabled',
+      'lab-stepper--default',
+    ]);
+  });
+
+  it('scopes to the named components, case-insensitively', () => {
+    expect(selectStories(entries, ['button']).map(e => e.id)).toEqual([
+      'core-button--default',
+      'core-button--disabled',
+    ]);
+  });
+
+  it('covers lab as well as core', () => {
+    expect(selectStories(entries, ['Stepper']).map(e => e.id)).toEqual([
+      'lab-stepper--default',
+    ]);
+  });
+
+  it('skips docs entries', () => {
+    expect(selectStories(entries, ['button']).some(e => e.id.endsWith('--docs'))).toBe(false);
+  });
+});
+
+describe('diffSnapshots', () => {
+  const node = (label, styles) => ({label, styles});
+
+  it('passes an element that renders identically hovered', () => {
+    const snapshot = [node('', {'background-color': 'red', cursor: 'not-allowed'})];
+    expect(diffSnapshots(snapshot, structuredClone(snapshot))).toEqual([]);
+  });
+
+  it('reports the property that moved', () => {
+    const before = [node('', {'background-image': 'none'})];
+    const after = [node('', {'background-image': 'linear-gradient(grey, grey)'})];
+    expect(diffSnapshots(before, after)).toEqual([
+      {
+        label: '',
+        property: 'background-image',
+        from: 'none',
+        to: 'linear-gradient(grey, grey)',
+      },
+    ]);
+  });
+
+  it('sees a change on a descendant, not just the disabled element itself', () => {
+    const before = [node('', {color: 'grey'}), node(' > svg:nth-child(1)', {fill: 'grey'})];
+    const after = [node('', {color: 'grey'}), node(' > svg:nth-child(1)', {fill: 'blue'})];
+    expect(diffSnapshots(before, after)).toEqual([
+      {label: ' > svg:nth-child(1)', property: 'fill', from: 'grey', to: 'blue'},
+    ]);
+  });
+
+  it('reports a re-render rather than guessing which nodes line up', () => {
+    const deltas = diffSnapshots([node('', {color: 'red'})], []);
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0].property).toBe('(node count)');
+  });
+
+  it('compares the cursor: a pointer on a disabled control is an affordance', () => {
+    expect(VISUAL_PROPERTIES).toContain('cursor');
+  });
+});
+
+describe('formatViolations', () => {
+  it('says so plainly when there is nothing to report', () => {
+    expect(formatViolations([])).toContain('No disabled element paints a hover state');
+  });
+
+  it('groups by component and names the story and the delta', () => {
+    const output = formatViolations([
+      {
+        component: 'Core/Button',
+        story: 'core-button--disabled',
+        element: '<button.astryx-button>',
+        deltas: [{label: '', property: 'background-image', from: 'none', to: 'linear-gradient(grey, grey)'}],
+      },
+    ]);
+    expect(output).toContain('Core/Button (1)');
+    expect(output).toContain('core-button--disabled');
+    expect(output).toContain('background-image: none -> linear-gradient(grey, grey)');
+  });
+});
+
+describe('CLI contract', () => {
+  /** Run the audit in an empty temp cwd; returns {status, stdout}. */
+  function runAudit(args) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'disabled-hover-'));
+    try {
+      const result = execFileSync(process.execPath, [SCRIPT, ...args], {
+        cwd: dir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return {status: 0, stdout: result};
+    } catch (error) {
+      return {status: error.status, stdout: (error.stdout || '') + (error.stderr || '')};
+    } finally {
+      fs.rmSync(dir, {recursive: true, force: true});
+    }
+  }
+
+  // Same contract as accessibility-audit.js so the two CI steps can share one
+  // component list: an EMPTY --components means the PR touched no component,
+  // and must pass without fanning out into a full sweep.
+  it('passes and audits nothing when --components is empty', () => {
+    const {status, stdout} = runAudit(['--components', '']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('skipping');
+  });
+
+  it('fails loudly when the storybook build is missing', () => {
+    const {status, stdout} = runAudit(['--storybook-dir', 'nope', '--components', 'Button']);
+    expect(status).toBe(1);
+    expect(stdout).toContain('Storybook build not found');
+  });
+});

--- a/.github/workflows/a11y-weekly.yml
+++ b/.github/workflows/a11y-weekly.yml
@@ -79,8 +79,7 @@ jobs:
             $BASELINE_FLAGS
 
       - name: Summarize report
-        id: summarize
-        env:
+        id: summarize        env:
           AUDIT_OUTCOME: ${{ steps.audit.outcome }}
         run: |
           node .github/scripts/weekly-a11y-summary.js \
@@ -100,6 +99,34 @@ jobs:
             a11y-weekly-summary.md
           retention-days: 30
           if-no-files-found: warn
+
+      # Full sweep of the invariant the PR job checks on changed components
+      # only: no disabled element may paint a hover state. A token or
+      # shared-style change can regress a component no PR touched, which is
+      # what this weekly exists for. continue-on-error so its report still
+      # uploads; the run is failed at the end.
+      - name: Run full-suite disabled-hover audit
+        id: disabled_hover
+        continue-on-error: true
+        run: |
+          node .github/scripts/disabled-hover-audit.js \
+            --storybook-dir apps/storybook/dist \
+            --output disabled-hover-weekly-report.json
+
+      - name: Upload disabled-hover report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: disabled-hover-weekly-report
+          path: disabled-hover-weekly-report.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Fail on hover states shown for disabled elements
+        if: steps.disabled_hover.outcome == 'failure'
+        run: |
+          echo "::error::A disabled element paints a hover state — see the disabled-hover-weekly-report artifact"
+          exit 1
 
       # Surface infra breakage (crashed) and gate failures (failed) as a red
       # run. Plain violations without baseline gating stay green here — the

--- a/.github/workflows/a11y-weekly.yml
+++ b/.github/workflows/a11y-weekly.yml
@@ -79,7 +79,8 @@ jobs:
             $BASELINE_FLAGS
 
       - name: Summarize report
-        id: summarize        env:
+        id: summarize
+        env:
           AUDIT_OUTCOME: ${{ steps.audit.outcome }}
         run: |
           node .github/scripts/weekly-a11y-summary.js \
@@ -99,34 +100,6 @@ jobs:
             a11y-weekly-summary.md
           retention-days: 30
           if-no-files-found: warn
-
-      # Full sweep of the invariant the PR job checks on changed components
-      # only: no disabled element may paint a hover state. A token or
-      # shared-style change can regress a component no PR touched, which is
-      # what this weekly exists for. continue-on-error so its report still
-      # uploads; the run is failed at the end.
-      - name: Run full-suite disabled-hover audit
-        id: disabled_hover
-        continue-on-error: true
-        run: |
-          node .github/scripts/disabled-hover-audit.js \
-            --storybook-dir apps/storybook/dist \
-            --output disabled-hover-weekly-report.json
-
-      - name: Upload disabled-hover report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: disabled-hover-weekly-report
-          path: disabled-hover-weekly-report.json
-          retention-days: 30
-          if-no-files-found: warn
-
-      - name: Fail on hover states shown for disabled elements
-        if: steps.disabled_hover.outcome == 'failure'
-        run: |
-          echo "::error::A disabled element paints a hover state — see the disabled-hover-weekly-report artifact"
-          exit 1
 
       # Surface infra breakage (crashed) and gate failures (failed) as a red
       # run. Plain violations without baseline gating stay green here — the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,29 +463,6 @@ jobs:
       - name: Run modal close visibility guard
         run: node .github/scripts/modal-close-visibility.js --storybook-dir apps/storybook/dist
 
-      # A disabled control that lights up under the pointer promises a click
-      # it will not honour. `:hover` keeps matching a disabled element in
-      # every engine, and jsdom has neither a pointer nor a cascade, so this
-      # Chromium sweep is the only place the invariant can be observed.
-      # Zero-tolerance and no baseline: a hover state on a disabled element is
-      # never correct, so there is nothing to grandfather.
-      - name: Run disabled-hover audit
-        run: |
-          COMPONENTS=$(cat analysis.json | jq -r '(.newComponents + .modifiedComponents) | join(",")')
-          node .github/scripts/disabled-hover-audit.js \
-            --storybook-dir apps/storybook/dist \
-            --components "$COMPONENTS" \
-            --output disabled-hover-report.json
-
-      - name: Upload disabled-hover artifact
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: disabled-hover-report
-          path: disabled-hover-report.json
-          retention-days: 1
-          if-no-files-found: ignore
-
   # RTL semantic audit. Sibling to pr-a11y: same build-storybook artifact, same
   # analysis.json scoping, so a PR only pays for the components it touched.
   # Unscoped this swept ~1400 stories and took ~26 min. The full sweep that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,29 @@ jobs:
       - name: Run modal close visibility guard
         run: node .github/scripts/modal-close-visibility.js --storybook-dir apps/storybook/dist
 
+      # A disabled control that lights up under the pointer promises a click
+      # it will not honour. `:hover` keeps matching a disabled element in
+      # every engine, and jsdom has neither a pointer nor a cascade, so this
+      # Chromium sweep is the only place the invariant can be observed.
+      # Zero-tolerance and no baseline: a hover state on a disabled element is
+      # never correct, so there is nothing to grandfather.
+      - name: Run disabled-hover audit
+        run: |
+          COMPONENTS=$(cat analysis.json | jq -r '(.newComponents + .modifiedComponents) | join(",")')
+          node .github/scripts/disabled-hover-audit.js \
+            --storybook-dir apps/storybook/dist \
+            --components "$COMPONENTS" \
+            --output disabled-hover-report.json
+
+      - name: Upload disabled-hover artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: disabled-hover-report
+          path: disabled-hover-report.json
+          retention-days: 1
+          if-no-files-found: ignore
+
   # RTL semantic audit. Sibling to pr-a11y: same build-storybook artifact, same
   # analysis.json scoping, so a PR only pays for the components it touched.
   # Unscoped this swept ~1400 stories and took ~26 min. The full sweep that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -491,6 +491,17 @@ browser is not obliged to release that when `close()` finally runs — Safari
 cannot see it and the unit suites pass either way. Add a target here when a
 component closes a `<dialog>` on a delay.
 
+### Disabled hover guard
+
+A disabled element must never paint a hover state: `:hover` keeps matching a
+disabled control in every engine, so a hover treatment written for the enabled
+element is still painted under the pointer. Guard every self-`:hover` with
+`:hover:where(:not(:disabled,[aria-disabled="true"]))` — `:where()` adds no
+specificity, so the rule weighs the same as before. The `@astryx/no-hover-on-disabled`
+lint rule (autofixable) enforces it at author time; `pnpm guard:disabled-hover
+--storybook-dir apps/storybook/dist` sweeps a built Storybook in Chromium and
+fails on any disabled element whose paint changes under a forced `:hover`.
+
 ## Versioning & Releases
 
 We use [Changesets](https://github.com/changesets/changesets) for versioning, with a thin Astryx layer on top so changelogs stay categorized, contributor-attributed, and aligned with our pre-1.0 conventions.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -223,6 +223,18 @@ export default defineConfig(
       '@astryx/no-hardcoded-i18n-string': isStrictMode ? 'error' : 'warn',
     },
   },
+  // A hover state on a disabled control is a defect wherever it ships, so
+  // this one rule reaches past core: lab components are consumed the same
+  // way, and lab is where the next core component comes from.
+  {
+    files: ["packages/lab/src/**/*.{ts,tsx}"],
+    plugins: {
+      '@astryx': astryxEslintPlugin,
+    },
+    rules: {
+      '@astryx/no-hover-on-disabled': 'error',
+    },
+  },
   // The i18n runtime itself defines the message strings the rest of the
   // package resolves against; a "hardcoded string" check against it would be
   // circular. Turn off @astryx/no-hardcoded-i18n-string just for this dir.

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -270,7 +270,7 @@ Use `:focus-visible`, or `:has(:focus-visible)` when the ring is drawn on a wrap
 
 **Bad:**
 
-```ts
+````ts
 const styles = stylex.create({
   base: {
     outline: {
@@ -291,7 +291,7 @@ import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 // Preferred — the shared ring: .focusVisible on the focusable element,
 // .focusWithin (`:has(:focus-visible)`) on a wrapper around it.
 stylex.props(focusOutlineStyles.focusVisible);
-```
+````
 
 **Scope:** `outline` and its longhands only, and only where the ring is drawn — suppressing one on a broader selector (`outline: {':focus': 'none'}`) is legitimate and is not flagged. A field's `:focus-within` border and inset box-shadow (`Field/inputStyles.stylex.ts`) are a different treatment — "you are typing here" — and are deliberately not policed by this rule.
 
@@ -323,6 +323,41 @@ stylex.props(focusOutlineStyles.focusVisible, styles.base);
 ```
 
 **Scope:** only what the ring LOOKS like — the `outline` shorthand, `outlineWidth`, `outlineStyle` — under a literal `:focus-visible` condition. Not flagged: `outlineOffset` (where the ring sits is a local constraint — inset into a tight grid, or held clear of a field border — and such a component still follows the theme's width, style and color), `outlineColor` (re-coloring per variant is the documented override), and a computed condition key such as `stylex.when.ancestor(':has(:focus-visible)', scope)`, which a shared style cannot express because a scope marker cannot be shared between components.
+
+Ships as an **error in both tiers**: core and lab are clean, and this keeps them that way.
+
+### `@astryx/no-hover-on-disabled`
+
+Flags a `:hover` condition inside `stylex.create()` that can still match a disabled element. Browsers suppress a disabled control's **events**, not its **hover styling**, so a hover treatment written for the enabled element is painted under the pointer anyway — the control says "press me" while refusing to be pressed.
+
+StyleX will not take it away for you. A `disabled` style setting `backgroundImage: 'none'` overrides the **default** condition only; the variant's `:hover` class survives the merge and wins the moment the pointer arrives. Button shipped that in every variant, and both halves read as correct in review.
+
+**Bad:**
+
+```ts
+const styles = stylex.create({
+  item: {backgroundColor: {default: 'transparent', ':hover': OVERLAY}},
+});
+```
+
+**Good:**
+
+```ts
+const styles = stylex.create({
+  item: {
+    backgroundColor: {
+      default: 'transparent',
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': OVERLAY,
+    },
+  },
+});
+```
+
+`:where()` contributes no specificity, so the guarded selector weighs exactly what `:hover` weighed and every existing override still wins the way it used to.
+
+**Scope:** `:hover` on the styled element itself. A key that hovers something else — `:is(th:hover *)`, `stylex.when.ancestor(':hover')` — styles a descendant when an **ancestor** is hovered, which is a different question (a row may legitimately highlight around a disabled control) and is left alone. The rule is deliberately unconditional rather than scoped to components that have a disabled state: on an element that can never be disabled the guard is a no-op, and asking the question per component is what leaves the gaps.
+
+Autofixable, and mirrored at runtime by `.github/scripts/disabled-hover-audit.js`, which forces `:hover` on every disabled element in every story in Chromium and fails on any painted difference.
 
 Ships as an **error in both tiers**: core and lab are clean, and this keeps them that way.
 

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -34,6 +34,7 @@ import noBorderShorthandRule from './no-border-shorthand.js';
 import noPhysicalPropertiesRule from './no-physical-properties.js';
 import focusOutlineKeyboardOnlyRule from './focus-outline-keyboard-only.js';
 import focusOutlineSharedRule from './focus-outline-shared.js';
+import noHoverOnDisabledRule from './no-hover-on-disabled.js';
 import noReactNamespaceHooksRule from './no-react-namespace-hooks.js';
 import copyrightHeaderRule from './copyright-header.js';
 import noRawConsoleCliRule from './no-raw-console-cli.js';
@@ -257,6 +258,7 @@ const plugin = {
     'no-physical-properties': noPhysicalPropertiesRule,
     'focus-outline-keyboard-only': focusOutlineKeyboardOnlyRule,
     'focus-outline-shared': focusOutlineSharedRule,
+    'no-hover-on-disabled': noHoverOnDisabledRule,
     'no-react-namespace-hooks': noReactNamespaceHooksRule,
     'require-base-props': requireBasePropsRule,
     'require-ref-prop': requireRefPropRule,
@@ -309,6 +311,11 @@ plugin.configs.strict = {
     // Core and lab draw every ring from the shared utility; error so the one
     // themeable definition stays the only one.
     '@astryx/focus-outline-shared': 'error',
+    // A disabled control that lights up under the pointer promises a click it
+    // will not honour, and `:hover` matches a disabled element in every
+    // engine. Error in both tiers: core and lab are clean, and the fix is
+    // autofixable.
+    '@astryx/no-hover-on-disabled': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'error',
     '@astryx/require-ref-prop': 'error',
@@ -348,6 +355,11 @@ plugin.configs.recommended = {
     // Core and lab draw every ring from the shared utility; error so the one
     // themeable definition stays the only one.
     '@astryx/focus-outline-shared': 'error',
+    // A disabled control that lights up under the pointer promises a click it
+    // will not honour, and `:hover` matches a disabled element in every
+    // engine. Error in both tiers: core and lab are clean, and the fix is
+    // autofixable.
+    '@astryx/no-hover-on-disabled': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'warn',
     '@astryx/require-ref-prop': 'warn',

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -12,6 +12,7 @@
  * - no-style-only-wrapper: Disallows div/span wrappers that only style a single Astryx component (use xstyle)
  * - no-nullish-jsx-guard: Flags `!= null` JSX render guards for rendered values (use isRenderable so false/''/true slots don't leak an empty element)
  * - no-unguarded-ime-keydown: Flags an onKeyDown on an editable surface that branches on command keys without an IME composition guard (isImeKeyEvent/isComposing)
+ * - no-hover-on-disabled: Flags a :hover condition that can still match a disabled element (browsers suppress a disabled control's events, not its hover styling)
  *
  * Philosophy: Strict for agents (CI), lenient for humans (local dev)
  * - "strict" config: All rules as errors - use in CI/agent environments

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.js
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.js
@@ -1,0 +1,146 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file no-hover-on-disabled.js
+ * @description A `:hover` condition must be written so it cannot match a
+ * disabled element.
+ *
+ * `:hover` keeps matching a disabled control. Browsers suppress its EVENTS,
+ * not its styling, so a hover treatment declared on the enabled element is
+ * still painted under the pointer — the control says "press me" while
+ * refusing to be pressed.
+ *
+ * Nothing in StyleX takes it away for you. A `disabled` style that sets
+ * `backgroundImage: 'none'` overrides the DEFAULT condition only: the
+ * variant's `:hover` class survives the merge and wins the moment the pointer
+ * arrives. Button shipped that bug in every variant, and it survived because
+ * both halves read as correct in review.
+ *
+ * So the guard goes on the selector, where it cannot be missed:
+ *
+ *   BAD   backgroundColor: {default: 'transparent', ':hover': OVERLAY}
+ *   GOOD  backgroundColor: {
+ *           default: 'transparent',
+ *           ':hover:where(:not(:disabled,[aria-disabled="true"]))': OVERLAY,
+ *         }
+ *
+ * `:where()` contributes no specificity, so the guarded selector weighs
+ * exactly what `:hover` weighed and every existing override still wins the
+ * way it used to.
+ *
+ * The rule is unconditional — it does not try to guess which components have
+ * a disabled state. On an element that can never be disabled the guard is a
+ * no-op, and asking the question per component is what leaves the gaps. It is
+ * autofixable: `eslint --fix` rewrites the key.
+ *
+ * SCOPE: `:hover` on the styled element ITSELF. A key that hovers something
+ * else — `:is(th:hover *)`, `stylex.when.ancestor(':hover')` — styles a
+ * descendant when an ANCESTOR is hovered, which is a different question (a
+ * row may legitimately highlight around a disabled control) and is left
+ * alone.
+ */
+
+/** Zero-specificity guard appended to a self-hover selector. */
+const GUARD = ':where(:not(:disabled,[aria-disabled="true"]))';
+
+/**
+ * Is this key a `:hover` on the styled element itself?
+ *
+ * Anything that hovers another element — a descendant combinator, or `:hover`
+ * buried inside `:is()`/`:where()`/`:has()` — is out of scope, so the test is
+ * deliberately narrow: the key must OPEN with `:hover`.
+ */
+function isSelfHoverKey(key) {
+  return typeof key === 'string' && /^:hover(?![-\w])/.test(key);
+}
+
+/** Already guarded, in any spelling a hand might use. */
+function hasDisabledGuard(key) {
+  return /:not\([^)]*(?::disabled|\[aria-disabled)/.test(key);
+}
+
+/**
+ * Insert the guard, keeping any pseudo-ELEMENT last.
+ *
+ * `:hover::after` becomes `:hover<guard>::after` — a pseudo-element has to
+ * end the selector, so the guard cannot simply be appended.
+ */
+function guardKey(key) {
+  const pseudoElement = key.indexOf('::');
+  if (pseudoElement === -1) return key + GUARD;
+  return key.slice(0, pseudoElement) + GUARD + key.slice(pseudoElement);
+}
+
+function keyOf(property) {
+  if (!property || property.type !== 'Property') return null;
+  if (property.key?.type === 'Literal') return String(property.key.value);
+  if (property.key?.type === 'Identifier' && !property.computed) {
+    return property.key.name;
+  }
+  return null;
+}
+
+function isInsideStylexCreate(node) {
+  let current = node;
+  while (current) {
+    if (
+      current.type === 'CallExpression' &&
+      current.callee?.type === 'MemberExpression' &&
+      current.callee.object?.name === 'stylex' &&
+      current.callee.property?.name === 'create'
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description:
+        'A :hover condition must be written so it cannot match a disabled element',
+      category: 'Accessibility',
+      recommended: true,
+    },
+    messages: {
+      unguardedHover:
+        "'{{key}}' still matches a disabled element — browsers suppress a disabled control's events, not its hover styling. " +
+        "Write '{{fixed}}' instead (`:where()` adds no specificity, so overrides are unaffected).",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Property(node) {
+        if (!isInsideStylexCreate(node)) return;
+        const key = keyOf(node);
+        if (!isSelfHoverKey(key) || hasDisabledGuard(key)) return;
+
+        const fixed = guardKey(key);
+        context.report({
+          node: node.key,
+          messageId: 'unguardedHover',
+          data: {key, fixed},
+          fix(fixer) {
+            // Only a string-literal key can be rewritten safely; an identifier
+            // key cannot spell this selector in the first place.
+            if (node.key.type !== 'Literal') return null;
+            // The guard carries double quotes, so the result is single-quoted
+            // unless its own content rules that out.
+            const quoted = fixed.includes("'")
+              ? JSON.stringify(fixed)
+              : `'${fixed}'`;
+            return fixer.replaceText(node.key, quoted);
+          },
+        });
+      },
+    };
+  },
+};
+
+export default rule;
+export {GUARD, guardKey, isSelfHoverKey, hasDisabledGuard};

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
@@ -1,0 +1,155 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file no-hover-on-disabled.test.mjs
+ */
+
+import {RuleTester} from 'eslint';
+import rule from './no-hover-on-disabled.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+const GUARD = ':where(:not(:disabled,[aria-disabled="true"]))';
+
+ruleTester.run('no-hover-on-disabled', rule, {
+  valid: [
+    // The guarded form, property-first.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {
+            backgroundColor: {
+              default: 'transparent',
+              ':hover${GUARD}': 'rgba(0,0,0,0.05)',
+            },
+          },
+        });
+      `,
+    },
+    // The guarded form, condition-first with a nested media query.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {
+            ':hover${GUARD}': {
+              '@media (hover: hover)': {backgroundColor: 'red'},
+            },
+          },
+        });
+      `,
+    },
+    // Not a hover condition at all.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {color: {default: 'red', ':active': 'blue', ':focus-visible': 'green'}},
+        });
+      `,
+    },
+    // An ANCESTOR's hover styling a descendant — a row may legitimately
+    // highlight around a disabled control, so this is out of scope.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          cell: {opacity: {default: 0, ':is(th:hover *)': 1}},
+        });
+      `,
+    },
+    // Plain object literals outside stylex.create are not styles.
+    {
+      code: `const handlers = {':hover': () => {}};`,
+    },
+  ],
+  invalid: [
+    // The bare key, property-first.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {backgroundColor: {default: 'transparent', ':hover': 'red'}},
+        });
+      `,
+      errors: [{messageId: 'unguardedHover'}],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {backgroundColor: {default: 'transparent', ':hover${GUARD}': 'red'}},
+        });
+      `,
+    },
+    // Condition-first, nested media block preserved by the fix.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {':hover': {'@media (hover: hover)': {backgroundColor: 'red'}}},
+        });
+      `,
+      errors: [{messageId: 'unguardedHover'}],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {':hover${GUARD}': {'@media (hover: hover)': {backgroundColor: 'red'}}},
+        });
+      `,
+    },
+    // An existing qualifier is kept and the guard appended after it.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          field: {borderColor: {default: 'grey', ':hover:not(:focus-within)': 'black'}},
+        });
+      `,
+      errors: [{messageId: 'unguardedHover'}],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          field: {borderColor: {default: 'grey', ':hover:not(:focus-within)${GUARD}': 'black'}},
+        });
+      `,
+    },
+    // A pseudo-ELEMENT has to stay last, so the guard goes before it.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          tab: {opacity: {default: 0, ':hover::after': 1}},
+        });
+      `,
+      errors: [{messageId: 'unguardedHover'}],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          tab: {opacity: {default: 0, ':hover${GUARD}::after': 1}},
+        });
+      `,
+    },
+    // A double-quoted key is rewritten single-quoted: the guard carries its
+    // own double quotes.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {color: {default: 'red', ":hover": 'blue'}},
+        });
+      `,
+      errors: [{messageId: 'unguardedHover'}],
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {color: {default: 'red', ':hover${GUARD}': 'blue'}},
+        });
+      `,
+    },
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lab:readiness": "node internal/lab-readiness/audit.mjs",
     "lab:readiness:check": "node internal/lab-readiness/audit.mjs --check",
     "guard:modal-close": "node .github/scripts/modal-close-visibility.js",
+    "guard:disabled-hover": "node .github/scripts/disabled-hover-audit.js",
     "storybook": "pnpm -F @astryxdesign/storybook dev",
     "storybook:build": "pnpm -F @astryxdesign/storybook build",
     "docsite": "pnpm -F @astryxdesign/docsite dev",

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -88,7 +88,7 @@ const styles = stylex.create({
     // Interactive overlay states layered on top via backgroundImage
     backgroundImage: {
       default: `linear-gradient(${colorVars['--color-neutral']}, ${colorVars['--color-neutral']})`,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']}), linear-gradient(${colorVars['--color-neutral']}, ${colorVars['--color-neutral']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']}), linear-gradient(${colorVars['--color-neutral']}, ${colorVars['--color-neutral']})`,

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -158,7 +158,7 @@ const itemStyles = stylex.create({
     paddingBlock: spacingVars['--spacing-1'],
     textDecoration: {
       default: 'none',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': 'underline',
       },
     },

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -107,11 +107,11 @@ const styles = stylex.create({
     },
   },
   ariaDisabled: {
+    // The variants' hover treatment already steps aside for
+    // `[aria-disabled]`; `:active` still matches a press on an aria-disabled
+    // button, so that one is suppressed here.
     backgroundImage: {
       default: 'none',
-      ':hover': {
-        '@media (hover: hover)': 'none',
-      },
       ':active': 'none',
     },
   },
@@ -198,7 +198,7 @@ const variants = stylex.create({
     color: colorVars['--color-on-accent'],
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
@@ -209,7 +209,7 @@ const variants = stylex.create({
     color: colorVars['--color-text-primary'],
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
@@ -220,7 +220,7 @@ const variants = stylex.create({
     color: colorVars['--color-text-primary'],
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
@@ -235,7 +235,7 @@ const variants = stylex.create({
     outlineColor: {default: null, ':focus-visible': colorVars['--color-error']},
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -254,7 +254,7 @@ export const dayCellTheme = stylex.create({
     backgroundColor: 'transparent',
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
     },
@@ -281,7 +281,7 @@ export const dayCellTheme = stylex.create({
     color: colorVars['--color-on-accent'],
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
     },
@@ -292,7 +292,7 @@ export const dayCellTheme = stylex.create({
     opacity: 0.3,
     backgroundImage: {
       default: 'none',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': 'none',
       },
     },

--- a/packages/core/src/Chat/ChatComposer.tsx
+++ b/packages/core/src/Chat/ChatComposer.tsx
@@ -273,7 +273,9 @@ const elevationStyles = stylex.create({
   low: {
     boxShadow: {
       default: shadowVars['--shadow-low'],
-      ':hover': {'@media (hover: hover)': shadowVars['--shadow-med']},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': shadowVars['--shadow-med'],
+      },
     },
     ':focus-within': {
       boxShadow: shadowVars['--shadow-med'],
@@ -292,9 +294,10 @@ const elevationStyles = stylex.create({
     padding: `calc(var(--_chat-composer-padding) - ${borderVars['--border-width']})`,
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': `inset 0px 0px 0px 2px color-mix(in srgb, ${colorVars['--color-border-emphasized']} 30%, transparent)`,
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': `inset 0px 0px 0px 2px color-mix(in srgb, ${colorVars['--color-border-emphasized']} 30%, transparent)`,
+        },
       ':focus-within': `inset 0px 0px 0px 2px ${colorVars['--color-accent-muted']}`,
     },
   },

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -197,7 +197,7 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-1'],
     marginInline: `calc(-1 * ${spacingVars['--spacing-1']})`,
     '@media (hover: hover)': {
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -103,7 +103,7 @@ const styles = stylex.create({
   },
   labelHover: {
     backgroundColor: {
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
@@ -112,7 +112,7 @@ const styles = stylex.create({
       // the base secondary color from `label` (last-wins property merge),
       // leaving linked citations to inherit the surrounding text color.
       default: colorVars['--color-text-secondary'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-text-primary'],
       },
     },
@@ -145,7 +145,7 @@ const styles = stylex.create({
       // hover-only conditional replaces the base accent-muted pill from
       // `number` on merge, leaving linked badges transparent.
       default: colorVars['--color-accent-muted'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -78,7 +78,7 @@ const styles = stylex.create({
   },
   hoverOnPointer: {
     '@media (hover: hover)': {
-      ':hover::after': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))::after': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
     },
@@ -110,7 +110,7 @@ const styles = stylex.create({
   // @media (hover: hover) so touch devices don't get a stuck hover state.
   borderedHoverOnPointer: {
     '@media (hover: hover)': {
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         borderColor: colorVars['--color-border-emphasized'],
       },
     },

--- a/packages/core/src/CommandPalette/CommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteItem.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     userSelect: 'none',
   },
   itemHover: {
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       [HOVER_HOVER]: {
         backgroundColor: colorVars['--color-overlay-hover'],
       },

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -111,16 +111,17 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': 'none',
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': 'none',
+        },
       ':focus-within': 'none',
     },
     fontWeight: fontWeightVars['--font-weight-medium'],

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -1186,7 +1186,7 @@ describe('DateInput clear icon theme target', () => {
     expect(css).toContain('.astryx-date-input-clear-icon {');
     expect(css).toContain('width: 12px');
     expect(css).toContain('height: 12px');
-    expect(css).toContain('.astryx-date-input-clear-icon:hover {');
+    expect(css).toContain('.astryx-date-input-clear-icon:hover');
     expect(css).toContain('color: var(--color-icon-primary)');
   });
 });

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -148,7 +148,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/Field/InputClearButton.test.tsx
+++ b/packages/core/src/Field/InputClearButton.test.tsx
@@ -111,7 +111,7 @@ describe('InputClearButton', () => {
     const css = generateThemeTestCSS(theme);
     expect(css).toContain('.astryx-input-clear-icon {');
     expect(css).toContain('width: 12px');
-    expect(css).toContain('.astryx-input-clear-icon:hover {');
+    expect(css).toContain('.astryx-input-clear-icon:hover');
     expect(css).toContain('color: var(--color-icon-primary)');
   });
 
@@ -136,7 +136,7 @@ describe('InputClearButton', () => {
     const css = generateThemeTestCSS(theme);
     expect(css).toContain('.astryx-input-clear-button {');
     expect(css).toContain('height: 28px');
-    expect(css).toContain('.astryx-input-clear-button:hover {');
+    expect(css).toContain('.astryx-input-clear-button:hover');
     expect(css).toContain('background-image: none');
   });
 });

--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -56,9 +56,10 @@ export const inputWrapperStyles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': `inset 0px 0px 0px 2px color-mix(in srgb, ${colorVars['--color-border-emphasized']} 30%, transparent)`,
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': `inset 0px 0px 0px 2px color-mix(in srgb, ${colorVars['--color-border-emphasized']} 30%, transparent)`,
+        },
       ':focus-within': `inset 0px 0px 0px 2px ${colorVars['--color-accent-muted']}`,
     },
     outline: 'none',
@@ -96,25 +97,28 @@ export const inputStatusHoverShadowStyles = stylex.create({
   warning: {
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': shadowVars['--shadow-inset-warning'],
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': shadowVars['--shadow-inset-warning'],
+        },
     },
   },
   error: {
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': shadowVars['--shadow-inset-error'],
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': shadowVars['--shadow-inset-error'],
+        },
     },
   },
   success: {
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': shadowVars['--shadow-inset-success'],
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': shadowVars['--shadow-inset-success'],
+        },
     },
   },
 });

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -158,7 +158,7 @@ const styles = stylex.create({
   dropzoneHover: {
     boxShadow: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `inset 0 0 0 2px color-mix(in srgb, ${colorVars['--color-accent']} 20%, transparent)`,
       },
     },
@@ -197,9 +197,10 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': `inset 0 0 0 2px color-mix(in srgb, ${colorVars['--color-accent']} 20%, transparent)`,
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': `inset 0 0 0 2px color-mix(in srgb, ${colorVars['--color-accent']} 20%, transparent)`,
+        },
     },
     cursor: 'pointer',
     height: sizeVars['--size-element-md'],

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -222,7 +222,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
       ':active': colorVars['--color-overlay-pressed'],

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -61,7 +61,7 @@ const styles = stylex.create({
     fontWeight: 'inherit',
     textDecoration: {
       default: 'none',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': 'underline',
       },
     },
@@ -103,7 +103,7 @@ const linkColorStyles = stylex.create({
   primary: {
     color: {
       default: colorVars['--color-text-primary'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-text-primary']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },
@@ -111,7 +111,7 @@ const linkColorStyles = stylex.create({
   secondary: {
     color: {
       default: colorVars['--color-text-secondary'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-text-secondary']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },
@@ -125,7 +125,7 @@ const linkColorStyles = stylex.create({
   accent: {
     color: {
       default: colorVars['--color-text-accent'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-text-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1790,7 +1790,7 @@ describe('MultiSelector clear icon theme target', () => {
     expect(css).toContain('.astryx-multi-selector-clear-icon {');
     expect(css).toContain('width: 12px');
     expect(css).toContain('height: 12px');
-    expect(css).toContain('.astryx-multi-selector-clear-icon:hover {');
+    expect(css).toContain('.astryx-multi-selector-clear-icon:hover');
     expect(css).toContain('color: var(--color-icon-primary)');
   });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -190,16 +190,17 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': 'none',
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': 'none',
+        },
       ':focus-within': 'none',
     },
     fontWeight: fontWeightVars['--font-weight-medium'],

--- a/packages/core/src/NavItem/navItemStyles.stylex.ts
+++ b/packages/core/src/NavItem/navItemStyles.stylex.ts
@@ -72,7 +72,7 @@ export const navItemStyles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     textAlign: 'start',
     boxSizing: 'border-box',
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
@@ -98,7 +98,7 @@ export const navItemStyles = stylex.create({
       '@media (forced-colors: active)': 'HighlightText',
     },
     fontWeight: fontWeightVars['--font-weight-medium'],
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       '@media (hover: hover)': {
         backgroundColor: {
           default: colorVars['--color-neutral'],

--- a/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
@@ -43,7 +43,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -161,7 +161,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-background-surface'],
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,

--- a/packages/core/src/Outline/Outline.tsx
+++ b/packages/core/src/Outline/Outline.tsx
@@ -203,7 +203,7 @@ const styles = stylex.create({
     width: '100%',
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-overlay-hover'],
         color: colorVars['--color-text-primary'],

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -90,7 +90,7 @@ const styles = stylex.create({
   hover: {
     backgroundColor: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -80,7 +80,7 @@ const styles = stylex.create({
   },
   hoverOnPointer: {
     '@media (hover: hover)': {
-      ':hover::after': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))::after': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -2340,7 +2340,7 @@ describe('Selector clear icon theme target', () => {
     expect(css).toContain('.astryx-selector-clear-icon {');
     expect(css).toContain('width: 12px');
     expect(css).toContain('height: 12px');
-    expect(css).toContain('.astryx-selector-clear-icon:hover {');
+    expect(css).toContain('.astryx-selector-clear-icon:hover');
     expect(css).toContain('color: var(--color-icon-primary)');
   });
 });

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -213,16 +213,17 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
     boxShadow: {
       default: 'none',
-      ':hover:not(:focus-within)': {
-        '@media (hover: hover)': 'none',
-      },
+      ':hover:not(:focus-within):where(:not(:disabled,[aria-disabled="true"]))':
+        {
+          '@media (hover: hover)': 'none',
+        },
       ':focus-within': 'none',
     },
     fontWeight: fontWeightVars['--font-weight-medium'],

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -82,7 +82,7 @@ const styles = stylex.create({
     fontSize: 'inherit',
     fontWeight: fontWeightVars['--font-weight-normal'],
     textAlign: 'start',
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
@@ -104,7 +104,7 @@ const styles = stylex.create({
   interactiveCollapsed: {
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': 'transparent',
       },
     },

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -147,7 +147,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: 'pointer',
     borderRadius: radiusVars['--radius-element'],
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -268,7 +268,7 @@ const styles = stylex.create({
   thumbHover: {
     backgroundColor: {
       default: colorVars['--color-accent'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },

--- a/packages/core/src/TabList/TabMenu.tsx
+++ b/packages/core/src/TabList/TabMenu.tsx
@@ -191,7 +191,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/Table/TableRow.tsx
+++ b/packages/core/src/Table/TableRow.tsx
@@ -61,13 +61,13 @@ const hoverRowStyles = stylex.create({
   row: {
     backgroundColor: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
     '--table-row-overlay': {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
@@ -82,14 +82,14 @@ const stripedHoverRowStyles = stylex.create({
     backgroundColor: {
       default: null,
       ':nth-child(even)': colorVars['--color-background-muted'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
     '--table-row-overlay': {
       default: null,
       ':nth-child(even)': colorVars['--color-background-muted'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
@@ -216,7 +216,8 @@ const handleStyles = stylex.create({
     // can't receive :hover directly.
     '--indicator-color': {
       default: 'transparent',
-      ':hover': colorVars['--color-accent'],
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))':
+        colorVars['--color-accent'],
       ':focus-visible': colorVars['--color-accent'],
     },
     '@media (pointer: coarse)': {

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -148,7 +148,8 @@ const styles = stylex.create({
     cursor: 'pointer',
     color: {
       default: colorVars['--color-icon-secondary'],
-      ':hover': colorVars['--color-icon-primary'],
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))':
+        colorVars['--color-icon-primary'],
     },
   },
   chevronIcon: {

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -85,11 +85,11 @@ const expansionStyles = stylex.create({
     // Match IconButton ghost hover: subtle overlay background.
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
     },
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       color: colorVars['--color-icon-primary'],
     },
   },

--- a/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
@@ -251,11 +251,11 @@ const treeStyles = stylex.create({
     // Match IconButton ghost hover: subtle overlay background
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
     },
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       color: colorVars['--color-icon-primary'],
     },
   },

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -183,7 +183,7 @@ const styles = stylex.create({
   },
   hoverOnPointer: {
     '@media (hover: hover)': {
-      ':hover::after': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))::after': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -142,7 +142,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -72,7 +72,7 @@ const styles = stylex.create({
     fontSize: 'inherit',
     fontWeight: fontWeightVars['--font-weight-normal'],
     textAlign: 'start',
-    ':hover': {
+    ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },

--- a/packages/core/src/TopNav/TopNavItem.tsx
+++ b/packages/core/src/TopNav/TopNavItem.tsx
@@ -59,7 +59,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
       ':active': colorVars['--color-overlay-pressed'],
@@ -70,7 +70,7 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-semibold'],
     backgroundColor: {
       default: colorVars['--color-neutral'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-neutral'],
       },
       ':active': colorVars['--color-neutral'],

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -84,7 +84,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
@@ -56,7 +56,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
       ':active': colorVars['--color-overlay-pressed'],

--- a/packages/core/src/TopNav/TopNavMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMenu.tsx
@@ -71,7 +71,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
@@ -121,7 +121,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -101,7 +101,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundImage: {
       default: null,
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,

--- a/packages/core/src/hooks/containerReveal.stylex.ts
+++ b/packages/core/src/hooks/containerReveal.stylex.ts
@@ -32,13 +32,17 @@ export const styles = stylex.create({
     '--_hover-delay': '0s',
     '--_reveal-opacity': {
       default: 0,
-      ':hover': {'@media (hover: hover)': 1},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 1,
+      },
       ':focus-within': 1,
       '@media (any-pointer: coarse)': 1,
     },
     '--_reveal-position': {
       default: 'absolute',
-      ':hover': {'@media (hover: hover)': 'static'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 'static',
+      },
       ':focus-within': 'static',
       '@media (any-pointer: coarse)': 'static',
     },
@@ -49,7 +53,9 @@ export const styles = stylex.create({
     // content would snap out of flow at full opacity and flicker.
     '--_reveal-delay': {
       default: REST_DELAY,
-      ':hover': {'@media (hover: hover)': HOVER_DELAY + ', ' + HOVER_DELAY},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': HOVER_DELAY + ', ' + HOVER_DELAY,
+      },
       ':focus-within': '0s, 0s',
       '@media (any-pointer: coarse)': '0s, 0s',
     },
@@ -57,7 +63,9 @@ export const styles = stylex.create({
     // for) but keeps the dwell: an intent gate is timing, not motion.
     '--_reveal-delay-reduced': {
       default: '0s, 0s',
-      ':hover': {'@media (hover: hover)': HOVER_DELAY + ', ' + HOVER_DELAY},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': HOVER_DELAY + ', ' + HOVER_DELAY,
+      },
       ':focus-within': '0s, 0s',
       '@media (any-pointer: coarse)': '0s, 0s',
     },
@@ -66,13 +74,17 @@ export const styles = stylex.create({
     // coarse-pointer branch (it stays visible on touch).
     '--_conceal-opacity': {
       default: 1,
-      ':hover': {'@media (hover: hover)': 0},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 0,
+      },
     },
     // Single-value dwell for the opacity-only blocks, which have no discrete
     // position to sequence.
     '--_fade-delay': {
       default: '0s',
-      ':hover': {'@media (hover: hover)': HOVER_DELAY},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': HOVER_DELAY,
+      },
       ':focus-within': '0s',
       '@media (any-pointer: coarse)': '0s',
     },
@@ -87,35 +99,47 @@ export const styles = stylex.create({
   stateInactive: {
     '--_reveal-opacity': {
       default: 0,
-      ':hover': {'@media (hover: hover)': 0},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 0,
+      },
       ':focus-within': 1,
       '@media (any-pointer: coarse)': 1,
     },
     '--_reveal-position': {
       default: 'absolute',
-      ':hover': {'@media (hover: hover)': 'absolute'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 'absolute',
+      },
       ':focus-within': 'static',
       '@media (any-pointer: coarse)': 'static',
     },
     '--_reveal-delay': {
       default: REST_DELAY,
-      ':hover': {'@media (hover: hover)': REST_DELAY},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': REST_DELAY,
+      },
       ':focus-within': '0s, 0s',
       '@media (any-pointer: coarse)': '0s, 0s',
     },
     '--_reveal-delay-reduced': {
       default: '0s, 0s',
-      ':hover': {'@media (hover: hover)': '0s, 0s'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': '0s, 0s',
+      },
       ':focus-within': '0s, 0s',
       '@media (any-pointer: coarse)': '0s, 0s',
     },
     '--_conceal-opacity': {
       default: 1,
-      ':hover': {'@media (hover: hover)': 1},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 1,
+      },
     },
     '--_fade-delay': {
       default: '0s',
-      ':hover': {'@media (hover: hover)': '0s'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': '0s',
+      },
       ':focus-within': '0s',
       '@media (any-pointer: coarse)': '0s',
     },
@@ -126,35 +150,47 @@ export const styles = stylex.create({
   stateActive: {
     '--_reveal-opacity': {
       default: 1,
-      ':hover': {'@media (hover: hover)': 1},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 1,
+      },
       ':focus-within': 1,
       '@media (any-pointer: coarse)': 1,
     },
     '--_reveal-position': {
       default: 'static',
-      ':hover': {'@media (hover: hover)': 'static'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 'static',
+      },
       ':focus-within': 'static',
       '@media (any-pointer: coarse)': 'static',
     },
     '--_reveal-delay': {
       default: '0s, 0s',
-      ':hover': {'@media (hover: hover)': '0s, 0s'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': '0s, 0s',
+      },
       ':focus-within': '0s, 0s',
       '@media (any-pointer: coarse)': '0s, 0s',
     },
     '--_reveal-delay-reduced': {
       default: '0s, 0s',
-      ':hover': {'@media (hover: hover)': '0s, 0s'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': '0s, 0s',
+      },
       ':focus-within': '0s, 0s',
       '@media (any-pointer: coarse)': '0s, 0s',
     },
     '--_conceal-opacity': {
       default: 0,
-      ':hover': {'@media (hover: hover)': 0},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': 0,
+      },
     },
     '--_fade-delay': {
       default: '0s',
-      ':hover': {'@media (hover: hover)': '0s'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        '@media (hover: hover)': '0s',
+      },
       ':focus-within': '0s',
       '@media (any-pointer: coarse)': '0s',
     },

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -738,7 +738,9 @@ describe('pseudo-class overrides in components', () => {
     expect(css).toContain('.astryx-radio {');
     expect(css).toContain('border-color: #8F9296');
     // Pseudo rule — separate selector
-    expect(css).toContain('.astryx-radio:hover {');
+    expect(css).toContain(
+      '.astryx-radio:hover:where(:not(:disabled,[aria-disabled="true"])) {',
+    );
     expect(css).toContain(
       'border-color: color-mix(in srgb, #8F9296, black 20%)',
     );
@@ -764,7 +766,9 @@ describe('pseudo-class overrides in components', () => {
     const css = generateThemeTestCSS(theme);
     expect(css).toContain('.astryx-button.primary-muted {');
     expect(css).toContain('background-color: #ECF5FF');
-    expect(css).toContain('.astryx-button.primary-muted:hover {');
+    expect(css).toContain(
+      '.astryx-button.primary-muted:hover:where(:not(:disabled,[aria-disabled="true"])) {',
+    );
     expect(css).toContain('background-color: #D6EBFF');
     expect(css).toContain('.astryx-button.primary-muted:focus-visible {');
     expect(css).toContain('outline: 2px solid var(--color-accent)');
@@ -787,7 +791,9 @@ describe('pseudo-class overrides in components', () => {
     // Should NOT emit an empty base rule
     expect(css).not.toMatch(/\.astryx-switch\s*\{\s*\}/);
     // Should emit the pseudo rule
-    expect(css).toContain('.astryx-switch:hover {');
+    expect(css).toContain(
+      '.astryx-switch:hover:where(:not(:disabled,[aria-disabled="true"])) {',
+    );
   });
 
   it('keeps non-pseudo string values as regular properties', () => {

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -113,6 +113,11 @@ export type TokenValue = string | [light: string, dark: string];
  * to the component selector. Supported pseudo-classes include `:hover`,
  * `:focus-visible`, `:active`, `:checked`, `:disabled`, etc.
  *
+ * A `:hover` override describes the ENABLED control: it is emitted with a
+ * guard that keeps it off disabled and `aria-disabled` elements, which
+ * `:hover` would otherwise still match. Style the disabled state through
+ * `:disabled` instead.
+ *
  * @example
  * ```ts
  * {

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -179,13 +179,14 @@ describe('generateThemeRules', () => {
     });
     const hoverRules = generateThemeRules(hoverTheme);
     const hoverRule = hoverRules.find(rule => rule.includes(':hover'));
+    expect(hoverRule).toBeDefined();
     expect(hoverRule).toContain(
       '.astryx-button:hover:where(:not(:disabled,[aria-disabled="true"]))',
     );
     // Every selector in a comma-separated list carries its own guard —
     // a trailing pseudo does not distribute over a selector list. (Counted,
     // not split: the guard contains a comma of its own.)
-    const selectorText = hoverRule.split('{')[0];
+    const selectorText = String(hoverRule).split('{')[0];
     const hovers = selectorText.match(/:hover/g) || [];
     const guards = selectorText.match(/:where\(:not\(:disabled/g) || [];
     expect(hovers.length).toBeGreaterThan(0);

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -160,6 +160,44 @@ describe('generateThemeRules', () => {
     ).toBe(true);
   });
 
+  // A theme authoring `:hover` is describing the ENABLED control. Without a
+  // guard the rule paints a disabled one too, because browsers suppress a
+  // disabled control's events, not its hover styling — and a theme override
+  // would then reintroduce, on every component at once, the defect the
+  // components' own styles were fixed for.
+  it('keeps a themed :hover off disabled elements', () => {
+    const hoverTheme = defineTheme({
+      name: 'hover-guard',
+      components: {
+        button: {
+          base: {
+            ':hover': {color: 'red'},
+            ':focus-visible': {outline: '2px solid blue'},
+          },
+        },
+      },
+    });
+    const hoverRules = generateThemeRules(hoverTheme);
+    const hoverRule = hoverRules.find(rule => rule.includes(':hover'));
+    expect(hoverRule).toContain(
+      '.astryx-button:hover:where(:not(:disabled,[aria-disabled="true"]))',
+    );
+    // Every selector in a comma-separated list carries its own guard —
+    // a trailing pseudo does not distribute over a selector list. (Counted,
+    // not split: the guard contains a comma of its own.)
+    const selectorText = hoverRule.split('{')[0];
+    const hovers = selectorText.match(/:hover/g) || [];
+    const guards = selectorText.match(/:where\(:not\(:disabled/g) || [];
+    expect(hovers.length).toBeGreaterThan(0);
+    expect(guards.length).toBe(hovers.length);
+    // Other pseudo-classes are untouched: a disabled control can still be
+    // focused (that is the point of aria-disabled), and :focus-visible on it
+    // is correct.
+    const focusRule = hoverRules.find(rule => rule.includes(':focus-visible'));
+    expect(focusRule).toContain('.astryx-button:focus-visible {');
+    expect(focusRule).not.toContain('aria-disabled');
+  });
+
   // --- Prose rules ---
 
   it('includes prose heading rules with computed values', () => {

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -47,11 +47,29 @@ function componentClassSelector(component: string, suffix: string): string {
 }
 
 /**
+ * Guard appended to a themed `:hover` rule so it cannot match a disabled
+ * element.
+ *
+ * A theme authoring `':hover': {backgroundColor: …}` is describing the
+ * enabled control; `:hover` on its own would paint that background on a
+ * disabled one too, because browsers suppress a disabled control's events,
+ * not its hover styling. `:where()` contributes no specificity, so a themed
+ * hover rule still weighs exactly what it weighed before.
+ *
+ * Mirrors the `@astryx/no-hover-on-disabled` lint rule, which enforces the
+ * same guard on the components' own StyleX styles.
+ */
+const HOVER_DISABLED_GUARD = ':where(:not(:disabled,[aria-disabled="true"]))';
+
+/**
  * Append a pseudo-class to every selector in a comma-separated selector list.
  *
  * Selector helpers may emit comma-separated lists. CSS does not distribute a
  * trailing pseudo over selector lists, so `${list}:hover` would only target the
  * final selector. Rewrite each item so the pseudo applies to all of them.
+ *
+ * A `:hover` pseudo also picks up the disabled guard. A pseudo-ELEMENT has to
+ * end the selector, so the guard is spliced in before it.
  */
 function appendPseudoToSelectorList(selector: string, pseudo: string): string {
   const parts: string[] = [];
@@ -71,7 +89,22 @@ function appendPseudoToSelectorList(selector: string, pseudo: string): string {
   }
   parts.push(selector.slice(start).trim());
 
-  return parts.map(part => `${part}${pseudo}`).join(', ');
+  const guarded = guardHoverPseudo(pseudo);
+
+  return parts.map(part => `${part}${guarded}`).join(', ');
+}
+
+/** Insert the disabled guard into a `:hover` pseudo, keeping any pseudo-element last. */
+function guardHoverPseudo(pseudo: string): string {
+  if (!/^:hover(?![-\w])/.test(pseudo) || pseudo.includes('[aria-disabled')) {
+    return pseudo;
+  }
+  const pseudoElement = pseudo.indexOf('::');
+  return pseudoElement === -1
+    ? pseudo + HOVER_DISABLED_GUARD
+    : pseudo.slice(0, pseudoElement) +
+        HOVER_DISABLED_GUARD +
+        pseudo.slice(pseudoElement);
 }
 
 // =============================================================================

--- a/packages/lab/src/Chat/ChatEmojiPicker.tsx
+++ b/packages/lab/src/Chat/ChatEmojiPicker.tsx
@@ -140,7 +140,7 @@ const styles = stylex.create({
     padding: 0,
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         default: 'transparent',
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },

--- a/packages/lab/src/Chat/ChatReactionBar.tsx
+++ b/packages/lab/src/Chat/ChatReactionBar.tsx
@@ -118,7 +118,7 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         default: 'transparent',
         '@media (hover: hover)': colorVars['--color-border-emphasized'],
       },
@@ -138,7 +138,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-accent-muted'],
     borderColor: {
       default: colorVars['--color-accent'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         default: colorVars['--color-accent'],
         '@media (hover: hover)': colorVars['--color-accent'],
       },
@@ -170,7 +170,7 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         default: 'transparent',
         '@media (hover: hover)': colorVars['--color-border-emphasized'],
       },

--- a/packages/lab/src/InfoTip/InfoTip.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.tsx
@@ -66,7 +66,7 @@ const styles = stylex.create({
     cursor: 'pointer',
     color: {
       default: colorVars['--color-icon-secondary'],
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         default: null,
         '@media (hover: hover)': colorVars['--color-icon-primary'],
       },

--- a/packages/lab/src/LogStream/LogStream.tsx
+++ b/packages/lab/src/LogStream/LogStream.tsx
@@ -193,13 +193,17 @@ const styles = stylex.create({
     cursor: 'pointer',
     backgroundColor: {
       default: 'transparent',
-      ':hover': {[HOVER]: colorVars['--color-overlay-hover']},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        [HOVER]: colorVars['--color-overlay-hover'],
+      },
     },
   },
   rowButtonTerminal: {
     backgroundColor: {
       default: 'transparent',
-      ':hover': {[HOVER]: TERM.surfaceRaised},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        [HOVER]: TERM.surfaceRaised,
+      },
     },
   },
   // Level tints: faint full-row wash for error/warn (color-mix keeps the
@@ -284,7 +288,9 @@ const styles = stylex.create({
     borderColor: colorVars['--color-border-emphasized'],
     backgroundColor: {
       default: colorVars['--color-background-surface'],
-      ':hover': {[HOVER]: colorVars['--color-background-muted']},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        [HOVER]: colorVars['--color-background-muted'],
+      },
     },
     color: colorVars['--color-text-primary'],
     fontFamily: typographyVars['--font-family-code'],
@@ -297,7 +303,9 @@ const styles = stylex.create({
     borderColor: TERM.border,
     backgroundColor: {
       default: TERM.surfaceRaised,
-      ':hover': {[HOVER]: '#1d1d21'},
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
+        [HOVER]: '#1d1d21',
+      },
     },
     color: TERM.textBright,
   },

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -433,7 +433,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
       ':active': colorVars['--color-overlay-pressed'],
@@ -477,7 +477,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     backgroundColor: {
       default: 'transparent',
-      ':hover': {
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
       ':active': colorVars['--color-overlay-pressed'],

--- a/packages/lab/src/TransferList/TransferList.tsx
+++ b/packages/lab/src/TransferList/TransferList.tsx
@@ -282,12 +282,12 @@ const styles = stylex.create({
     color: colorVars['--color-text-accent'],
     backgroundImage: {
       default: 'none',
-      ':hover': 'none',
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': 'none',
       ':active': 'none',
     },
     textDecoration: {
       default: 'none',
-      ':hover': 'underline',
+      ':hover:where(:not(:disabled,[aria-disabled="true"]))': 'underline',
     },
     fontSize: typeScaleVars['--text-body-size'],
     fontWeight: typeScaleVars['--text-body-weight'],


### PR DESCRIPTION
## Why

`:hover` keeps matching a disabled control. Browsers suppress a disabled
element's **events**, not its **styling**, so a hover treatment written for the
enabled element is still painted under the pointer — the control says "press
me" while refusing to be pressed.

Nothing in StyleX takes it away for you, and that is what hid this for so long.
Button's `disabled` style sets `backgroundImage: 'none'`, which overrides the
**default** condition only: the variant's `:hover` class survives the merge and
wins the moment the pointer arrives. Both halves read as correct in review, and
jsdom has neither a pointer nor a cascade, so no unit test could see it either.

## What

Every self-`:hover` selector in core and lab now carries a zero-specificity
guard — `:hover:where(:not(:disabled,[aria-disabled="true"]))` — so the
selector itself cannot match a disabled element. `:where()` contributes no
specificity, so each guarded rule weighs exactly what it weighed before and
existing overrides still win the way they used to.

The same guard is applied to every `:hover` a **theme** authors through
`components`, in the one place theme CSS is generated. Without it a theme
override would reintroduce the defect library-wide, on every component at once.

Two gates keep it that way:

- `@astryx/no-hover-on-disabled` — autofixable lint rule, error in both tiers,
  core and lab. Deliberately unconditional rather than scoped to components
  that have a disabled state: on an element that can never be disabled the
  guard is a no-op, and asking the question per component is what leaves the
  gaps.
- `.github/scripts/disabled-hover-audit.js` — a Chromium sweep that forces
  `:hover` on every disabled element in every story (the same switch DevTools'
  `:hov` panel throws) and compares the element, its subtree and their
  `::before`/`::after` against the unhovered render. Any painted difference
  fails. Zero-tolerance, no baseline — a hover state on a disabled element is
  never correct, so there is nothing to grandfather. Exposed as `pnpm
  guard:disabled-hover` against a built Storybook, alongside the modal-close
  guard it mirrors — no workflow changes here; the lint rule and both unit
  suites ride the `pnpm lint` and `pnpm test` runs CI already does.

## Evidence

Full sweep, 1,682 stories, real Chromium, run on this branch and on `main`:

| | disabled elements checked | painting a hover state |
|---|---|---|
| `main` | 570 | **151** |
| this branch | 570 | **0** |

Two owners produced all 151: `astryx-button` (reaching 17 story groups —
Pagination, TablePagination, Carousel, Calendar, MoreMenu, IconButton, the Chat
surfaces, TransferList…) and `astryx-nav-heading-menu-item`.

Looked at in Chrome, not inferred: hovering the disabled "Analytics" item in
`core-navmenu--disabled-items` on `main` raises the full rounded hover
highlight; on this branch nothing changes. The disabled Button case is the same
defect with a subtler paint (a 5% overlay under 50% opacity), which is exactly
why it survived so long.

Link, Item, SideNavItem and TopNavItem also declared unguarded hover styles,
but set `pointer-events: none` when disabled, so no pointer can reach them.
The audit skips elements nothing can point at, and those components are now
correct in the selector rather than by a second mechanism that a theme could
undo.

## Risk

- **Theme behavior change:** a theme's `:hover` override no longer applies to
  disabled elements. That is the intent — `:disabled` is how the disabled state
  is styled — and it is documented on `StyleOverrides`.
- Five theme-CSS assertions asserted the emitted `:hover` selector verbatim and
  now assert the selector without pinning the guard.
- Button's `aria-disabled` hover suppression became dead code and is removed;
  its `:active` suppression stays, since `:active` still matches a press on an
  aria-disabled button.

## Not covered

- An **ancestor's** hover styling a disabled descendant (`:is(th:hover *)`,
  `stylex.when.ancestor(':hover')`) is a different question — a row may
  legitimately highlight around a disabled control — and is deliberately out of
  scope for both gates.
- The sweep only sees disabled states that a story renders. The lint rule is
  what covers the rest, which is why it is unconditional.

## Testing

- `no-hover-on-disabled`: 10 RuleTester cases, including the fixer keeping a
  pseudo-element last and an existing qualifier intact.
- `generateThemeRules`: a themed `:hover` carries the guard on every selector
  in a list; `:focus-visible` is untouched (a disabled control can still be
  focused).
- `disabled-hover-audit`: 13 cases over story scoping, the snapshot diff and
  the report, plus the CLI's empty-`--components` and missing-build contracts.
- Full unit suite green (the two `packages/cli` case-sensitivity failures on
  this macOS checkout fail identically on `main`).
- Strict lint clean: `CI=true eslint .` — 0 errors.

Rubric: this ships as **A20** in the [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) (§1, FIX), rubric **1.6**.

