### PR TITLE
fix(field): pass shade="inherit" to Spinner in input components and Switch

### DIFF
--- a/.changeset/spinner-inherit-shade.md
+++ b/.changeset/spinner-inherit-shade.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Pass `shade="inherit"` to Spinner in input components and Switch so the loading indicator respects the parent color context and is themeable via CSS.
+@athz

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -770,7 +770,7 @@ export function DateInput({
           iconClassName={stableClassName('date-input-clear-icon')}
         />
       )}
-      {isBusy && <Spinner size="sm" />}
+      {isBusy && <Spinner size="sm" shade="inherit" />}
       {statusIcon}
       {popover.render(
         <Calendar

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -679,7 +679,7 @@ export function FileInput({
 
   const renderDropzoneContent = () => {
     if (isLoading) {
-      return <Spinner size="md" />;
+      return <Spinner size="md" shade="inherit" />;
     }
     if (hasFiles) {
       return (
@@ -705,7 +705,7 @@ export function FileInput({
           <span {...stylex.props(styles.fileNameText)}>
             {fileNames ?? displayPlaceholder}
           </span>
-          <Spinner size="sm" />
+          <Spinner size="sm" shade="inherit" />
         </>
       );
     }

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1514,7 +1514,7 @@ export function Selector<T extends SelectorOptionType>(
             disabled={isDisabled}
           />
         )}
-        {isBusy && <Spinner size="sm" />}
+        {isBusy && <Spinner size="sm" shade="inherit" />}
         {hasClear && value != null && !isDisabled && (
           <InputClearButton
             label={t('@astryx.selector.clearLabel', {label})}

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -619,7 +619,7 @@ export function Switch({
               isOn ? styles.thumbOn : styles.thumbOff,
             ),
           )}>
-          {isBusy && <Spinner size="sm" />}
+          {isBusy && <Spinner size="sm" shade="inherit" />}
         </div>
       </div>
       {isBusy && <VisuallyHidden role="status">Loading</VisuallyHidden>}

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -625,7 +625,7 @@ export function TextArea({
         />
         {(isBusy || statusIcon) && (
           <span {...stylex.props(styles.endSlot)}>
-            {isBusy && <Spinner size="sm" />}
+            {isBusy && <Spinner size="sm" shade="inherit" />}
             {statusIcon}
           </span>
         )}

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -459,7 +459,7 @@ export function TextInput({
           onClick={handleClear}
         />
       )}
-      {isBusy && <Spinner size="sm" />}
+      {isBusy && <Spinner size="sm" shade="inherit" />}
       {statusIcon}
     </div>
   );


### PR DESCRIPTION
## Summary

Pass `shade="inherit"` to `<Spinner>` in all input-family components and `Switch`.

## Problem

Spinner's default shade reads `themeTokens["--color-accent"]` from `useTheme()` — a global JS object — then paints the ring imperatively onto a `<canvas>` via `context.strokeStyle`. Nothing in CSS can reach that: not a token remap, not a `components` entry, not `!important`. The result is a hardcoded accent-blue spinner that ignores theme overrides entirely.

## Solution

`shade="inherit"` is the only code path that reads the CSS cascade (`getComputedStyle(canvas).color`), making the spinner respect its parent's `color` context. This is already the pattern used by `Button` (line 703).

## Affected components

| Component | Lines |
|-----------|-------|
| TextInput | 462 |
| TextArea | 628 |
| DateInput | 773 |
| Selector | 1517 |
| FileInput | 682, 708 |
| Switch | 622 |

## Why this matters for theming

With `shade="inherit"`, downstream consumers can control spinner color through normal CSS inheritance — set `color` on a parent and the spinner follows. Without it, the only lever is the global `--color-accent` JS token, which is not per-component configurable.
