### PR TITLE
docs: replace em dashes in theme and Selector block doc prose

### DIFF
--- a/packages/cli/assets/docs/theme.doc.mjs
+++ b/packages/cli/assets/docs/theme.doc.mjs
@@ -152,7 +152,7 @@ function App() {
         },
         {
           type: 'prose',
-          text: 'For an annotated map of the whole surface — every defineTheme field, the token families, and the component override syntax, each with the CLI command that prints its reference — run `astryx theme template`. It writes `theme.template.ts` into your project to read and copy from (`astryx init --features theme` writes it as part of project setup).',
+          text: 'For an annotated map of the whole surface (every defineTheme field, the token families, and the component override syntax, each with the CLI command that prints its reference), run `astryx theme template`. It writes `theme.template.ts` into your project to read and copy from (`astryx init --features theme` writes it as part of project setup).',
         },
       ],
     },
@@ -261,7 +261,7 @@ const brandTheme = defineTheme({
         },
         {
           type: 'prose',
-          text: 'Inheritance is resolved when the theme is defined, so an extended theme is flat: `astryx theme build` emits one self-contained stylesheet holding everything the child inherited, and the base theme\'s CSS does not need to be loaded next to it. A base that is not a theme — most often an import that missed — is a build error rather than a theme that silently inherits nothing.',
+          text: 'Inheritance is resolved when the theme is defined, so an extended theme is flat: `astryx theme build` emits one self-contained stylesheet holding everything the child inherited, and the base theme\'s CSS does not need to be loaded next to it. A base that is not a theme (most often an import that missed) is a build error rather than a theme that silently inherits nothing.',
         },
       ],
     },
@@ -425,7 +425,7 @@ import './themes/ocean.css';
         },
         {
           type: 'prose',
-          text: 'The build also warns when the theme names font families it does not load (webfonts like Fraunces) and prints the `<link>`/`@font-face` to add — the built CSS only sets font-family, so loading the font files stays the app\'s job. See `astryx docs typography` for the full recipe.',
+          text: 'The build also warns when the theme names font families it does not load (webfonts like Fraunces) and prints the `<link>`/`@font-face` to add. The built CSS only sets font-family, so loading the font files stays the app\'s job. See `astryx docs typography` for the full recipe.',
         },
       ],
     },

--- a/packages/cli/assets/templates/blocks/components/Selector/SelectorOptionDescriptions.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Selector/SelectorOptionDescriptions.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'Selector — Option descriptions',
   displayName: 'Selector — Option descriptions',
   description:
-    'Options carry a description, so the dropdown draws a two-line row. The closed trigger is sized by padding, so it is the size token for a one-line value and exactly one line taller for a two-line one — both on the 4px rhythm. An InputGroup pins the row, so the value folds back onto one line there.',
+    'Options carry a description, so the dropdown draws a two-line row. The closed trigger is sized by padding, so it is the size token for a one-line value and exactly one line taller for a two-line one; both on the 4px rhythm. An InputGroup pins the row, so the value folds back onto one line there.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Selector', 'SelectorOption', 'InputGroup', 'Button', 'Stack'],


### PR DESCRIPTION
## What

Four em-dash prose tells replaced with the right punctuation (AI-slop check 17, sub A1). Prose only; no meaning changed.

- `packages/cli/assets/docs/theme.doc.mjs` (three): the Quick Start map aside and the inheritance base-error aside become parentheses (appositives); the font-loading line's em-dash clause becomes a sentence break.
- `packages/cli/assets/templates/blocks/components/Selector/SelectorOptionDescriptions.doc.mjs` (one): the em dash before `both on the 4px rhythm` becomes a semicolon (two independent clauses).

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `tsc --project packages/cli/tsconfig.template-docs.json --noEmit`: only the pre-existing `theme.template.ts:83` TS2307 (untouched by this change)
- `astryx docs theme` renders the rewritten prose correctly
- Both files parse under `import()`

Merge-checked against the four other open PRs touching `theme.doc.mjs` (#5204, #5115, #5099, #4930): no conflict on either changed file.

Night Watch — Doc Reviewer