### PR TITLE
feat(core)!: Banner content is visible by default; collapse moves to a `collapsible` prop

### DIFF
--- a/.changeset/banner-collapsible-content.md
+++ b/.changeset/banner-collapsible-content.md
@@ -25,14 +25,20 @@ boolean-or-config convention `SideNav.collapsible` set, and backed by the shared
 **The default is unchanged** — a banner that never mentioned `defaultIsExpanded`
 behaves exactly as it did. The breaking part is the prop itself:
 `defaultIsExpanded` is removed in favour of the config, which is a type error at
-every call site rather than a silent change.
+every JSX call site that names it.
 
 **Codemod:** `npx astryx upgrade --codemod banner-collapsible-content`
 
 It rewrites `defaultIsExpanded` to `collapsible={{defaultIsOpen: true}}` and
 drops `defaultIsExpanded={false}`, which is now the default. Banners that never
-set the prop are left alone. `defaultIsExpanded` inside a props object (a
-Storybook `args`, for instance) is out of the transform's scope — the removed
-prop makes those a type error, so the compiler finds them.
+set the prop are left alone.
+
+**One case the codemod and the compiler both miss: a spread.**
+`defaultIsExpanded` inside a props object is out of the transform's scope. A
+props object in a typed position still fails to compile — but an inferred one
+that is spread, `<Banner {...args} />`, does not, because TypeScript does not
+excess-property-check a spread. The prop then falls through to the DOM and the
+banner quietly starts collapsed. **Grep for `defaultIsExpanded` after running
+the codemod** and migrate any spread sites by hand.
 
 @freddymeta

--- a/.changeset/banner-collapsible-content.md
+++ b/.changeset/banner-collapsible-content.md
@@ -26,8 +26,9 @@ boolean-or-config convention `SideNav.collapsible` set, and backed by the shared
 render instead of hiding. Run `astryx upgrade` — the
 `banner-collapsible-content` codemod rewrites `defaultIsExpanded` to the
 equivalent config and adds `collapsible={{defaultIsOpen: false}}` to banners
-that relied on the implicit collapse, so behaviour is preserved; those sites get
-a TODO comment, since always-visible content is usually what they want.
+that relied on the implicit collapse, so behaviour is preserved. Those marked
+collapsed are the ones worth a second look afterwards: content that is simply
+visible is usually what a banner wants, and is now one prop shorter to write.
 
 Note for a banner whose content is now always visible: `role="alert"` announces
 the whole region, so an error banner reads its detail out along with its title.

--- a/.changeset/banner-collapsible-content.md
+++ b/.changeset/banner-collapsible-content.md
@@ -1,0 +1,35 @@
+---
+'@astryxdesign/core': minor
+'@astryxdesign/cli': minor
+---
+
+[breaking] Banner: children are visible by default, and the collapse axis moves onto one `collapsible` prop
+
+Banner inferred its disclosure from its content: any `children` got a chevron in
+the header and were hidden until it was pressed. There was no way to show
+content without a toggle — the case a banner most often wants, a list of the
+three fields that failed validation — and `defaultIsExpanded` was the only knob,
+with no controlled mode.
+
+The whole axis is now one `boolean | CollapsibleConfig` prop, following the
+boolean-or-config convention `SideNav.collapsible` set, and backed by the shared
+`useCollapsible` hook rather than Banner's own state:
+
+```tsx
+<Banner status="error" title="3 fields need attention">…</Banner>  // always visible
+<Banner collapsible>…</Banner>                                     // collapsible, starts open
+<Banner collapsible={{defaultIsOpen: false}}>…</Banner>            // starts collapsed
+<Banner collapsible={{isOpen, onOpenChange}}>…</Banner>            // controlled (new)
+```
+
+`defaultIsExpanded` is removed, and children with no `collapsible` prop now
+render instead of hiding. Run `astryx upgrade` — the
+`banner-collapsible-content` codemod rewrites `defaultIsExpanded` to the
+equivalent config and adds `collapsible={{defaultIsOpen: false}}` to banners
+that relied on the implicit collapse, so behaviour is preserved; those sites get
+a TODO comment, since always-visible content is usually what they want.
+
+Note for a banner whose content is now always visible: `role="alert"` announces
+the whole region, so an error banner reads its detail out along with its title.
+
+@freddymeta

--- a/.changeset/banner-collapsible-content.md
+++ b/.changeset/banner-collapsible-content.md
@@ -3,7 +3,7 @@
 '@astryxdesign/cli': minor
 ---
 
-[breaking] Banner: children are visible by default, and the collapse axis moves onto one `collapsible` prop
+[breaking] Banner: the collapse axis moves onto one `collapsible` prop, and content can opt out of collapsing (#5255)
 
 Banner inferred its disclosure from its content: any `children` got a chevron in
 the header and were hidden until it was pressed. There was no way to show
@@ -16,21 +16,23 @@ boolean-or-config convention `SideNav.collapsible` set, and backed by the shared
 `useCollapsible` hook rather than Banner's own state:
 
 ```tsx
-<Banner status="error" title="3 fields need attention">…</Banner>  // always visible
-<Banner collapsible>…</Banner>                                     // collapsible, starts open
-<Banner collapsible={{defaultIsOpen: false}}>…</Banner>            // starts collapsed
-<Banner collapsible={{isOpen, onOpenChange}}>…</Banner>            // controlled (new)
+<Banner status="error" title="3 fields need attention">…</Banner>  // unchanged: collapsible, starts closed
+<Banner collapsible={false}>…</Banner>                             // new: always visible, no toggle
+<Banner collapsible={{defaultIsOpen: true}}>…</Banner>             // replaces defaultIsExpanded
+<Banner collapsible={{isOpen, onOpenChange}}>…</Banner>            // new: controlled
 ```
 
-`defaultIsExpanded` is removed, and children with no `collapsible` prop now
-render instead of hiding. Run `astryx upgrade` — the
-`banner-collapsible-content` codemod rewrites `defaultIsExpanded` to the
-equivalent config and adds `collapsible={{defaultIsOpen: false}}` to banners
-that relied on the implicit collapse, so behaviour is preserved. Those marked
-collapsed are the ones worth a second look afterwards: content that is simply
-visible is usually what a banner wants, and is now one prop shorter to write.
+**The default is unchanged** — a banner that never mentioned `defaultIsExpanded`
+behaves exactly as it did. The breaking part is the prop itself:
+`defaultIsExpanded` is removed in favour of the config, which is a type error at
+every call site rather than a silent change.
 
-Note for a banner whose content is now always visible: `role="alert"` announces
-the whole region, so an error banner reads its detail out along with its title.
+**Codemod:** `npx astryx upgrade --codemod banner-collapsible-content`
+
+It rewrites `defaultIsExpanded` to `collapsible={{defaultIsOpen: true}}` and
+drops `defaultIsExpanded={false}`, which is now the default. Banners that never
+set the prop are left alone. `defaultIsExpanded` inside a props object (a
+Storybook `args`, for instance) is out of the transform's scope — the removed
+prop makes those a type error, so the compiler finds them.
 
 @freddymeta

--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof Banner> = {
     collapsible: {
       control: 'boolean',
       description:
-        'Puts the content area behind an expand/collapse toggle. Omitted, children are always visible. Pass {defaultIsOpen: false} to start collapsed, or {isOpen, onOpenChange} for controlled.',
+        'Whether the content area sits behind an expand/collapse toggle. On by default, starting collapsed. false keeps children always visible with no toggle; pass {defaultIsOpen: true} to start open, or {isOpen, onOpenChange} for controlled.',
     },
   },
 };
@@ -125,34 +125,12 @@ export const SectionVariant: Story = {
   },
 };
 
-export const AlwaysVisibleContent: Story = {
-  name: 'Content (Always Visible)',
-  args: {
-    status: 'info',
-    title: 'Emphasized Text',
-    description: 'Description text',
-    endContent: <Button label="Button" variant="secondary" size="sm" />,
-    isDismissable: true,
-    children: (
-      <div
-        style={{
-          padding: '40px',
-          textAlign: 'center',
-          color: 'var(--color-text-secondary)',
-        }}>
-        Flex Slot
-      </div>
-    ),
-  },
-};
-
 export const CollapsibleContent: Story = {
   name: 'Collapsible Content (Collapsed)',
   args: {
     status: 'info',
     title: 'Emphasized Text',
     description: 'Description text',
-    collapsible: {defaultIsOpen: false},
     endContent: <Button label="Button" variant="secondary" size="sm" />,
     isDismissable: true,
     children: (
@@ -168,12 +146,35 @@ export const CollapsibleContent: Story = {
   },
 };
 
-export const WithContentArea: Story = {
-  name: 'With Content Area (Card Background)',
+export const CollapsibleContentExpanded: Story = {
+  name: 'Collapsible Content (Expanded)',
+  args: {
+    status: 'info',
+    title: 'Emphasized Text',
+    description: 'Description text',
+    collapsible: {defaultIsOpen: true},
+    endContent: <Button label="Button" variant="secondary" size="sm" />,
+    isDismissable: true,
+    children: (
+      <div
+        style={{
+          padding: '40px',
+          textAlign: 'center',
+          color: 'var(--color-text-secondary)',
+        }}>
+        Flex Slot
+      </div>
+    ),
+  },
+};
+
+export const AlwaysVisibleContent: Story = {
+  name: 'Content Always Visible (collapsible={false})',
   args: {
     status: 'error',
     title: 'Multiple errors found',
     description: 'The following issues need to be resolved:',
+    collapsible: false,
     children: (
       <ul style={{margin: 0, paddingInlineStart: '20px', fontSize: '13px'}}>
         <li>Email address is invalid</li>
@@ -192,7 +193,7 @@ export const ContentAreaWithAction: Story = {
     description: 'Review the changes before they take effect.',
     endContent: <Button label="Review" variant="secondary" size="sm" />,
     isDismissable: true,
-    collapsible: true,
+    collapsible: {defaultIsOpen: true},
     children: (
       <div style={{fontSize: '13px'}}>
         <p style={{margin: '0 0 8px'}}>Changed settings:</p>
@@ -244,22 +245,20 @@ export const AllFeatures: Story = {
       />
       <Banner
         status="error"
-        title="With content"
-        description="Children are visible by default — no toggle."
-        isDismissable>
+        title="With content, always visible"
+        description="collapsible={false} drops the toggle."
+        isDismissable
+        collapsible={false}>
         <div style={{fontSize: '13px'}}>
-          This content sits on a card-colored background, visually distinct from
+          The content sits on a card-colored background, visually distinct from
           the status header above.
         </div>
       </Banner>
       <Banner
         status="error"
         title="With collapsible content"
-        description="Click the chevron to expand."
-        isDismissable
-        collapsible={{
-          defaultIsOpen: false,
-        }}>
+        description="Click the chevron to expand. This is the default."
+        isDismissable>
         <div style={{fontSize: '13px'}}>
           This content sits on a card-colored background, visually distinct from
           the status header above.
@@ -269,10 +268,12 @@ export const AllFeatures: Story = {
         status="success"
         title="Expanded by default"
         description="This content area starts open."
-        collapsible
+        collapsible={{
+          defaultIsOpen: true,
+        }}
         isDismissable>
         <div style={{fontSize: '13px'}}>
-          Content is visible immediately because bare `collapsible` starts open.
+          Content is visible immediately because of defaultIsOpen.
         </div>
       </Banner>
       <Banner

--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -245,7 +245,7 @@ export const AllFeatures: Story = {
       <Banner
         status="error"
         title="With content"
-        description="Children are visible by default."
+        description="Children are visible by default — no toggle."
         isDismissable>
         <div style={{fontSize: '13px'}}>
           This content sits on a card-colored background, visually distinct from
@@ -253,14 +253,26 @@ export const AllFeatures: Story = {
         </div>
       </Banner>
       <Banner
-        status="success"
-        title="Collapsible, starting collapsed"
+        status="error"
+        title="With collapsible content"
         description="Click the chevron to expand."
-        collapsible={{defaultIsOpen: false}}
+        isDismissable
+        collapsible={{
+          defaultIsOpen: false,
+        }}>
+        <div style={{fontSize: '13px'}}>
+          This content sits on a card-colored background, visually distinct from
+          the status header above.
+        </div>
+      </Banner>
+      <Banner
+        status="success"
+        title="Expanded by default"
+        description="This content area starts open."
+        collapsible
         isDismissable>
         <div style={{fontSize: '13px'}}>
-          Content is hidden until the toggle is pressed, because collapsible was
-          given {'{defaultIsOpen: false}'}.
+          Content is visible immediately because bare `collapsible` starts open.
         </div>
       </Banner>
       <Banner

--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -31,10 +31,10 @@ const meta: Meta<typeof Banner> = {
       description:
         'Whether the banner can be dismissed (manages its own hidden state)',
     },
-    defaultIsExpanded: {
+    collapsible: {
       control: 'boolean',
       description:
-        'Whether the content area starts expanded (only relevant when children are provided)',
+        'Puts the content area behind an expand/collapse toggle. Omitted, children are always visible. Pass {defaultIsOpen: false} to start collapsed, or {isOpen, onOpenChange} for controlled.',
     },
   },
 };
@@ -125,8 +125,8 @@ export const SectionVariant: Story = {
   },
 };
 
-export const CollapsibleContent: Story = {
-  name: 'Collapsible Content (Collapsed)',
+export const AlwaysVisibleContent: Story = {
+  name: 'Content (Always Visible)',
   args: {
     status: 'info',
     title: 'Emphasized Text',
@@ -146,13 +146,13 @@ export const CollapsibleContent: Story = {
   },
 };
 
-export const CollapsibleContentExpanded: Story = {
-  name: 'Collapsible Content (Expanded)',
+export const CollapsibleContent: Story = {
+  name: 'Collapsible Content (Collapsed)',
   args: {
     status: 'info',
     title: 'Emphasized Text',
     description: 'Description text',
-    defaultIsExpanded: true,
+    collapsible: {defaultIsOpen: false},
     endContent: <Button label="Button" variant="secondary" size="sm" />,
     isDismissable: true,
     children: (
@@ -174,7 +174,6 @@ export const WithContentArea: Story = {
     status: 'error',
     title: 'Multiple errors found',
     description: 'The following issues need to be resolved:',
-    defaultIsExpanded: true,
     children: (
       <ul style={{margin: 0, paddingInlineStart: '20px', fontSize: '13px'}}>
         <li>Email address is invalid</li>
@@ -193,7 +192,7 @@ export const ContentAreaWithAction: Story = {
     description: 'Review the changes before they take effect.',
     endContent: <Button label="Review" variant="secondary" size="sm" />,
     isDismissable: true,
-    defaultIsExpanded: true,
+    collapsible: true,
     children: (
       <div style={{fontSize: '13px'}}>
         <p style={{margin: '0 0 8px'}}>Changed settings:</p>
@@ -245,8 +244,8 @@ export const AllFeatures: Story = {
       />
       <Banner
         status="error"
-        title="With collapsible content"
-        description="Click the chevron to expand."
+        title="With content"
+        description="Children are visible by default."
         isDismissable>
         <div style={{fontSize: '13px'}}>
           This content sits on a card-colored background, visually distinct from
@@ -255,12 +254,13 @@ export const AllFeatures: Story = {
       </Banner>
       <Banner
         status="success"
-        title="Expanded by default"
-        description="This content area starts open."
-        defaultIsExpanded
+        title="Collapsible, starting collapsed"
+        description="Click the chevron to expand."
+        collapsible={{defaultIsOpen: false}}
         isDismissable>
         <div style={{fontSize: '13px'}}>
-          Content is visible immediately because defaultIsExpanded is true.
+          Content is hidden until the toggle is pressed, because collapsible was
+          given {'{defaultIsOpen: false}'}.
         </div>
       </Banner>
       <Banner

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -24,35 +24,35 @@ const TRANSFORM = 'banner-collapsible-content';
 const IMPORT = "import {Banner} from '@astryxdesign/core/Banner';\n";
 
 describe('banner-collapsible-content', () => {
-  it('rewrites a bare defaultIsExpanded to collapsible', async () => {
+  it('rewrites a bare defaultIsExpanded to a starts-open config', async () => {
     const output = await apply(
       TRANSFORM,
       `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded><p>d</p></Banner>;`,
     );
-    expect(output).toContain('collapsible');
+    expect(output).toContain('defaultIsOpen: true');
     expect(output).not.toContain('defaultIsExpanded');
-    // Open by default is `collapsible` on its own — no config object needed.
-    expect(output).not.toContain('defaultIsOpen');
   });
 
-  it('rewrites defaultIsExpanded={true} to collapsible', async () => {
+  it('rewrites defaultIsExpanded={true} the same way', async () => {
     const output = await apply(
       TRANSFORM,
       `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded={true}><p>d</p></Banner>;`,
     );
-    expect(output).toContain('collapsible');
+    expect(output).toContain('defaultIsOpen: true');
     expect(output).not.toContain('defaultIsExpanded');
-    expect(output).not.toContain('defaultIsOpen');
   });
 
-  it('rewrites defaultIsExpanded={false} to a collapsed config', async () => {
+  it('drops defaultIsExpanded={false}, which is the default', async () => {
     const output = await apply(
       TRANSFORM,
       `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded={false}><p>d</p></Banner>;`,
     );
-    expect(output).toContain('collapsible={{');
-    expect(output).toContain('defaultIsOpen: false');
     expect(output).not.toContain('defaultIsExpanded');
+    // No config needed: starting collapsed is what a Banner does by default.
+    expect(output).not.toContain('collapsible');
+    // Untouched attributes keep their original text (recast only reprints
+    // what changed), so the element is exactly the base minus the prop.
+    expect(output).toContain('<Banner status="info" title="T">');
   });
 
   it('keeps a dynamic default dynamic', async () => {
@@ -64,25 +64,13 @@ describe('banner-collapsible-content', () => {
     expect(output).not.toContain('defaultIsExpanded');
   });
 
-  it('preserves the implicit collapse for children with no prop', async () => {
-    const output = await apply(
-      TRANSFORM,
-      `${IMPORT}const el = <Banner status="error" title="T"><ul><li>a</li></ul></Banner>;`,
-    );
-    // The old default hid these children, so the rewrite has to say so.
-    expect(output).toContain('defaultIsOpen: false');
+  it('leaves a banner that never set the prop alone', async () => {
+    // The default is unchanged, so this banner still behaves as it did. The
+    // migration must not touch it — that is the whole point of the shape.
+    const source = `${IMPORT}const el = <Banner status="error" title="T"><ul><li>a</li></ul></Banner>;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
   });
-
-  it.each([['{false}'], ['{null}'], ['{undefined}'], ["{''}"]])(
-    'leaves an empty slot (%s) alone',
-    async slot => {
-      // `isRenderable` rejects these, so the old Banner drew no chevron and
-      // hid nothing. Marking them collapsed would invent an affordance.
-      const source = `${IMPORT}const el = <Banner status="info" title="T">${slot}</Banner>;`;
-      const output = await apply(TRANSFORM, source);
-      expect(output).toBe(source);
-    },
-  );
 
   it('leaves a childless banner alone', async () => {
     const source = `${IMPORT}const el = <Banner status="info" title="T" />;`;
@@ -90,27 +78,21 @@ describe('banner-collapsible-content', () => {
     expect(output).toBe(source);
   });
 
-  it('treats whitespace-only children as no children', async () => {
-    const source = `${IMPORT}const el = <Banner status="info" title="T">\n  </Banner>;`;
-    const output = await apply(TRANSFORM, source);
-    expect(output).toBe(source);
-  });
-
   it('leaves a banner that already uses collapsible alone', async () => {
-    const source = `${IMPORT}const el = <Banner status="info" title="T" collapsible><p>d</p></Banner>;`;
+    const source = `${IMPORT}const el = <Banner status="info" title="T" collapsible={false} defaultIsExpanded><p>d</p></Banner>;`;
     const output = await apply(TRANSFORM, source);
     expect(output).toBe(source);
   });
 
   it('does not guess around a spread', async () => {
-    const source = `${IMPORT}const el = <Banner status="info" title="T" {...rest}><p>d</p></Banner>;`;
+    const source = `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded {...rest}><p>d</p></Banner>;`;
     const output = await apply(TRANSFORM, source);
     expect(output).toBe(source);
   });
 
   it("leaves another component's defaultIsExpanded alone", async () => {
     // ChatToolCalls has a prop of the same name that this migration must not
-    // touch, and a local component may be called Banner too.
+    // touch.
     const source = `import {ChatToolCalls} from '@astryxdesign/core/Chat';
 const el = <ChatToolCalls calls={calls} defaultIsExpanded />;`;
     const output = await apply(TRANSFORM, source);
@@ -124,13 +106,22 @@ const el = <Banner status="info" title="T" defaultIsExpanded><p>d</p></Banner>;`
     expect(output).toBe(source);
   });
 
+  it('leaves the prop inside a props object alone', async () => {
+    // Out of scope by design: which component the object feeds is a guess,
+    // and the removed prop makes those sites a type error anyway.
+    const source = `${IMPORT}const args = {status: 'info', title: 'T', defaultIsExpanded: true};
+const el = <Banner {...args} />;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
+  });
+
   it('migrates a Banner imported from the package root', async () => {
     const output = await apply(
       TRANSFORM,
       `import {Banner, Button} from '@astryxdesign/core';
-const el = <Banner status="info" title="T" defaultIsExpanded={false}><p>d</p></Banner>;`,
+const el = <Banner status="info" title="T" defaultIsExpanded><p>d</p></Banner>;`,
     );
-    expect(output).toContain('defaultIsOpen: false');
+    expect(output).toContain('defaultIsOpen: true');
     expect(output).not.toContain('defaultIsExpanded');
   });
 });

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -1,0 +1,127 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Unit tests for the staged (next-release) codemods.
+ *
+ * Mirrors v0.4.0/__tests__/next-codemods.test.mjs, which covers the codemods
+ * after promotion. Keeping a copy here means a staged transform is tested from
+ * the day it is written rather than the day it is released.
+ */
+
+import {describe, expect, it} from 'vitest';
+import jscodeshift from 'jscodeshift';
+
+const j = jscodeshift.withParser('tsx');
+const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+
+async function apply(name, source) {
+  const {default: transform} = await import(`../${name}.mjs`);
+  return transform({source, path: 'test.tsx'}, api) ?? source;
+}
+
+const TRANSFORM = 'banner-collapsible-content';
+
+const IMPORT = "import {Banner} from '@astryxdesign/core/Banner';\n";
+
+describe('banner-collapsible-content', () => {
+  it('rewrites a bare defaultIsExpanded to collapsible', async () => {
+    const output = await apply(
+      TRANSFORM,
+      `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded><p>d</p></Banner>;`,
+    );
+    expect(output).toContain('collapsible');
+    expect(output).not.toContain('defaultIsExpanded');
+    // Open by default is `collapsible` on its own — no config object needed.
+    expect(output).not.toContain('defaultIsOpen');
+  });
+
+  it('rewrites defaultIsExpanded={true} to collapsible', async () => {
+    const output = await apply(
+      TRANSFORM,
+      `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded={true}><p>d</p></Banner>;`,
+    );
+    expect(output).toContain('collapsible');
+    expect(output).not.toContain('defaultIsExpanded');
+    expect(output).not.toContain('defaultIsOpen');
+  });
+
+  it('rewrites defaultIsExpanded={false} to a collapsed config', async () => {
+    const output = await apply(
+      TRANSFORM,
+      `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded={false}><p>d</p></Banner>;`,
+    );
+    expect(output).toContain('collapsible={{');
+    expect(output).toContain('defaultIsOpen: false');
+    expect(output).not.toContain('defaultIsExpanded');
+  });
+
+  it('keeps a dynamic default dynamic', async () => {
+    const output = await apply(
+      TRANSFORM,
+      `${IMPORT}const el = <Banner status="info" title="T" defaultIsExpanded={isOpen}><p>d</p></Banner>;`,
+    );
+    expect(output).toContain('defaultIsOpen: isOpen');
+    expect(output).not.toContain('defaultIsExpanded');
+  });
+
+  it('preserves the implicit collapse for children with no prop', async () => {
+    const output = await apply(
+      TRANSFORM,
+      `${IMPORT}const el = <Banner status="error" title="T"><ul><li>a</li></ul></Banner>;`,
+    );
+    // The old default hid these children, so the rewrite has to say so.
+    expect(output).toContain('defaultIsOpen: false');
+    // And flag it, because always-visible is usually what this banner wants.
+    expect(output).toContain('TODO(astryx upgrade)');
+  });
+
+  it('leaves a childless banner alone', async () => {
+    const source = `${IMPORT}const el = <Banner status="info" title="T" />;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
+  });
+
+  it('treats whitespace-only children as no children', async () => {
+    const source = `${IMPORT}const el = <Banner status="info" title="T">\n  </Banner>;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
+  });
+
+  it('leaves a banner that already uses collapsible alone', async () => {
+    const source = `${IMPORT}const el = <Banner status="info" title="T" collapsible><p>d</p></Banner>;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
+  });
+
+  it('does not guess around a spread', async () => {
+    const source = `${IMPORT}const el = <Banner status="info" title="T" {...rest}><p>d</p></Banner>;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
+  });
+
+  it("leaves another component's defaultIsExpanded alone", async () => {
+    // ChatToolCalls has a prop of the same name that this migration must not
+    // touch, and a local component may be called Banner too.
+    const source = `import {ChatToolCalls} from '@astryxdesign/core/Chat';
+const el = <ChatToolCalls calls={calls} defaultIsExpanded />;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
+  });
+
+  it('leaves a Banner that is not the core Banner alone', async () => {
+    const source = `import {Banner} from './ui/Banner';
+const el = <Banner status="info" title="T" defaultIsExpanded><p>d</p></Banner>;`;
+    const output = await apply(TRANSFORM, source);
+    expect(output).toBe(source);
+  });
+
+  it('migrates a Banner imported from the package root', async () => {
+    const output = await apply(
+      TRANSFORM,
+      `import {Banner, Button} from '@astryxdesign/core';
+const el = <Banner status="info" title="T" defaultIsExpanded={false}><p>d</p></Banner>;`,
+    );
+    expect(output).toContain('defaultIsOpen: false');
+    expect(output).not.toContain('defaultIsExpanded');
+  });
+});

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -71,9 +71,18 @@ describe('banner-collapsible-content', () => {
     );
     // The old default hid these children, so the rewrite has to say so.
     expect(output).toContain('defaultIsOpen: false');
-    // And flag it, because always-visible is usually what this banner wants.
-    expect(output).toContain('TODO(astryx upgrade)');
   });
+
+  it.each([['{false}'], ['{null}'], ['{undefined}'], ["{''}"]])(
+    'leaves an empty slot (%s) alone',
+    async slot => {
+      // `isRenderable` rejects these, so the old Banner drew no chevron and
+      // hid nothing. Marking them collapsed would invent an affordance.
+      const source = `${IMPORT}const el = <Banner status="info" title="T">${slot}</Banner>;`;
+      const output = await apply(TRANSFORM, source);
+      expect(output).toBe(source);
+    },
+  );
 
   it('leaves a childless banner alone', async () => {
     const source = `${IMPORT}const el = <Banner status="info" title="T" />;`;

--- a/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
+++ b/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
@@ -1,0 +1,216 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: migrate Banner's collapse axis onto the `collapsible` prop
+ *
+ * Banner used to infer the disclosure from its content: any `children` got a
+ * chevron and were hidden until it was pressed, and `defaultIsExpanded` was
+ * the only knob. There was no way to show content without a toggle, and no
+ * controlled mode.
+ *
+ * The axis now lives on one `boolean | CollapsibleConfig` prop, per the
+ * boolean-or-config convention:
+ *
+ *   <Banner>{children}</Banner>                      → always visible, no toggle
+ *   <Banner collapsible>                             → collapsible, starts open
+ *   <Banner collapsible={{defaultIsOpen: false}}>    → collapsible, starts closed
+ *   <Banner collapsible={{isOpen, onOpenChange}}>    → controlled
+ *
+ * That inverts the default, so a banner with children that is left alone
+ * changes behaviour rather than breaking the build — which is exactly the
+ * silent kind of change a codemod has to cover. The rewrites are:
+ *
+ *   defaultIsExpanded            → collapsible
+ *   defaultIsExpanded={true}     → collapsible
+ *   defaultIsExpanded={false}    → collapsible={{defaultIsOpen: false}}
+ *   defaultIsExpanded={expr}     → collapsible={{defaultIsOpen: expr}}
+ *   (children, no prop)          → collapsible={{defaultIsOpen: false}}
+ *
+ * The last one is the behaviour-preserving rewrite for the implicit case. It
+ * is also the one worth a second look — most of those banners probably want
+ * their content simply visible now — so each site gets a TODO comment saying
+ * so. `api.report` is a stub in this runner, so comments are the only channel.
+ *
+ * Only elements named `Banner` are touched, and only when the file imports
+ * that name from `@astryxdesign/core`: `defaultIsExpanded` is also a
+ * ChatToolCalls prop, which this migration must leave alone.
+ */
+
+export const meta = {
+  title: "Migrate Banner's collapse axis onto the `collapsible` prop",
+  description:
+    'Banner children are now visible by default instead of hidden behind a ' +
+    'chevron, and `defaultIsExpanded` is replaced by ' +
+    '`collapsible?: boolean | CollapsibleConfig`. Rewrites ' +
+    '`defaultIsExpanded` to the equivalent `collapsible` config, and adds ' +
+    '`collapsible={{defaultIsOpen: false}}` to banners that relied on the ' +
+    'implicit collapse, so behaviour is preserved. Those sites also get a ' +
+    'TODO comment, because always-visible content is usually what they want.',
+  pr: '#5251',
+};
+
+const OLD_PROP = 'defaultIsExpanded';
+const NEW_PROP = 'collapsible';
+const COMPONENT = 'Banner';
+
+const TODO_COMMENT =
+  ' TODO(astryx upgrade): Banner content is visible by default now. This' +
+  ' banner used to hide its children behind a chevron, so it was given' +
+  ' `collapsible={{defaultIsOpen: false}}` to keep that. If the detail is' +
+  ' short enough to just show, drop the prop. ';
+
+/**
+ * Does this file use the core `Banner`?
+ *
+ * `defaultIsExpanded` is a ChatToolCalls prop too, and a local component may
+ * well be called Banner, so an unqualified element-name match is not enough.
+ *
+ * @param {any} j
+ * @param {any} root
+ * @returns {boolean}
+ */
+function importsCoreBanner(j, root) {
+  let found = false;
+  root.find(j.ImportDeclaration).forEach((/** @type {any} */ path) => {
+    const source = path.node.source?.value;
+    if (typeof source !== 'string' || !source.startsWith('@astryxdesign/core')) {
+      return;
+    }
+    for (const spec of path.node.specifiers ?? []) {
+      if (
+        (spec.type === 'ImportSpecifier' && spec.imported?.name === COMPONENT) ||
+        (spec.local?.name === COMPONENT &&
+          (spec.type === 'ImportDefaultSpecifier' ||
+            spec.type === 'ImportSpecifier'))
+      ) {
+        found = true;
+      }
+    }
+  });
+  return found;
+}
+
+/**
+ * Whether a JSX element renders anything as children.
+ *
+ * Mirrors the component's own `isRenderable` check closely enough for a
+ * migration: whitespace-only JSX text is not content, everything else is.
+ *
+ * @param {any} elementNode
+ * @returns {boolean}
+ */
+function hasJsxChildren(elementNode) {
+  if (elementNode?.type !== 'JSXElement') {
+    return false;
+  }
+  return (elementNode.children ?? []).some((/** @type {any} */ child) => {
+    if (child.type === 'JSXText') {
+      return child.value.trim() !== '';
+    }
+    if (child.type === 'JSXExpressionContainer') {
+      return child.expression?.type !== 'JSXEmptyExpression';
+    }
+    return true;
+  });
+}
+
+/**
+ * @param {import('../../../../authoring/codemod/type').AstryxCodemodFile} file
+ * @param {import('../../../../authoring/codemod/type').CodemodTransformApi} api
+ * @returns {string | null | undefined}
+ */
+export default function transformer(file, api) {
+  // Cheap bail-out: a file with no Banner in it cannot need this.
+  if (!file.source.includes(COMPONENT)) {
+    return undefined;
+  }
+
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  if (!importsCoreBanner(j, root)) {
+    return undefined;
+  }
+
+  let hasChanges = false;
+
+  /** `collapsible={{defaultIsOpen: <expr>}}` */
+  const collapsibleWithDefault = (/** @type {any} */ expression) =>
+    j.jsxAttribute(
+      j.jsxIdentifier(NEW_PROP),
+      j.jsxExpressionContainer(
+        j.objectExpression([
+          j.objectProperty(j.identifier('defaultIsOpen'), expression),
+        ]),
+      ),
+    );
+
+  root.find(j.JSXOpeningElement).forEach((/** @type {any} */ path) => {
+    const name = path.node.name;
+    if (name?.type !== 'JSXIdentifier' || name.name !== COMPONENT) {
+      return;
+    }
+
+    const attrs = path.node.attributes ?? [];
+
+    // A spread may carry either prop; rewriting around it would be guesswork.
+    const hasSpread = attrs.some(
+      (/** @type {any} */ a) => a.type === 'JSXSpreadAttribute',
+    );
+    // Already migrated by hand.
+    const hasNewProp = attrs.some(
+      (/** @type {any} */ a) =>
+        a.type === 'JSXAttribute' && a.name?.name === NEW_PROP,
+    );
+    if (hasSpread || hasNewProp) {
+      return;
+    }
+
+    const oldIndex = attrs.findIndex(
+      (/** @type {any} */ a) =>
+        a.type === 'JSXAttribute' && a.name?.name === OLD_PROP,
+    );
+
+    if (oldIndex !== -1) {
+      const value = attrs[oldIndex].value;
+
+      if (value == null) {
+        // Bare `defaultIsExpanded` — collapsible, open.
+        attrs[oldIndex] = j.jsxAttribute(j.jsxIdentifier(NEW_PROP));
+      } else if (value.type === 'JSXExpressionContainer') {
+        const expression = value.expression;
+        const isLiteral =
+          expression.type === 'BooleanLiteral' ||
+          (expression.type === 'Literal' && typeof expression.value === 'boolean');
+        if (isLiteral && expression.value === true) {
+          attrs[oldIndex] = j.jsxAttribute(j.jsxIdentifier(NEW_PROP));
+        } else if (isLiteral) {
+          attrs[oldIndex] = collapsibleWithDefault(j.booleanLiteral(false));
+        } else {
+          // A dynamic default stays dynamic.
+          attrs[oldIndex] = collapsibleWithDefault(expression);
+        }
+      } else {
+        // `defaultIsExpanded="something"` is not valid for a boolean prop;
+        // leave it for a human rather than inventing a meaning.
+        return;
+      }
+
+      hasChanges = true;
+      return;
+    }
+
+    // No `defaultIsExpanded`. Only a banner that actually had children was
+    // implicitly collapsible.
+    if (!hasJsxChildren(path.parent.node)) {
+      return;
+    }
+
+    const attribute = collapsibleWithDefault(j.booleanLiteral(false));
+    attribute.comments = [j.commentBlock(TODO_COMMENT, true, false)];
+    attrs.push(attribute);
+    hasChanges = true;
+  });
+
+  return hasChanges ? root.toSource({quote: 'single'}) : undefined;
+}

--- a/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
+++ b/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
@@ -27,9 +27,10 @@
  *   (children, no prop)          → collapsible={{defaultIsOpen: false}}
  *
  * The last one is the behaviour-preserving rewrite for the implicit case. It
- * is also the one worth a second look — most of those banners probably want
- * their content simply visible now — so each site gets a TODO comment saying
- * so. `api.report` is a stub in this runner, so comments are the only channel.
+ * is also the one worth a second look: most of those banners probably want
+ * their content simply visible now. The transform does not editorialize in the
+ * output — the nudge belongs in the changelog and the transform title, not as
+ * a TODO comment in every migrated file.
  *
  * Only elements named `Banner` are touched, and only when the file imports
  * that name from `@astryxdesign/core`: `defaultIsExpanded` is also a
@@ -37,27 +38,23 @@
  */
 
 export const meta = {
-  title: "Migrate Banner's collapse axis onto the `collapsible` prop",
+  title:
+    "Migrate Banner's collapse axis onto `collapsible` (content is visible " +
+    'by default now — review the banners this marks as collapsed)',
   description:
     'Banner children are now visible by default instead of hidden behind a ' +
     'chevron, and `defaultIsExpanded` is replaced by ' +
     '`collapsible?: boolean | CollapsibleConfig`. Rewrites ' +
     '`defaultIsExpanded` to the equivalent `collapsible` config, and adds ' +
     '`collapsible={{defaultIsOpen: false}}` to banners that relied on the ' +
-    'implicit collapse, so behaviour is preserved. Those sites also get a ' +
-    'TODO comment, because always-visible content is usually what they want.',
+    'implicit collapse, so behaviour is preserved. Those are the ones worth ' +
+    'a second look: always-visible content is usually what they want.',
   pr: '#5255',
 };
 
 const OLD_PROP = 'defaultIsExpanded';
 const NEW_PROP = 'collapsible';
 const COMPONENT = 'Banner';
-
-const TODO_COMMENT =
-  ' TODO(astryx upgrade): Banner content is visible by default now. This' +
-  ' banner used to hide its children behind a chevron, so it was given' +
-  ' `collapsible={{defaultIsOpen: false}}` to keep that. If the detail is' +
-  ' short enough to just show, drop the prop. ';
 
 /**
  * Does this file use the core `Banner`?
@@ -93,8 +90,11 @@ function importsCoreBanner(j, root) {
 /**
  * Whether a JSX element renders anything as children.
  *
- * Mirrors the component's own `isRenderable` check closely enough for a
- * migration: whitespace-only JSX text is not content, everything else is.
+ * Mirrors the component's own `isRenderable`, which is what decided whether
+ * the old Banner drew a chevron: whitespace-only text, `{false}`, `{null}`,
+ * `{undefined}` and `{''}` are all empty slots, and a banner holding one of
+ * those was never collapsible in the first place — adding `collapsible` to it
+ * would invent an affordance rather than preserve one.
  *
  * @param {any} elementNode
  * @returns {boolean}
@@ -107,9 +107,31 @@ function hasJsxChildren(elementNode) {
     if (child.type === 'JSXText') {
       return child.value.trim() !== '';
     }
-    if (child.type === 'JSXExpressionContainer') {
-      return child.expression?.type !== 'JSXEmptyExpression';
+    if (child.type !== 'JSXExpressionContainer') {
+      return true;
     }
+    const expression = child.expression;
+    if (expression == null || expression.type === 'JSXEmptyExpression') {
+      return false;
+    }
+    if (
+      expression.type === 'BooleanLiteral' ||
+      expression.type === 'NullLiteral'
+    ) {
+      return false;
+    }
+    if (expression.type === 'Identifier' && expression.name === 'undefined') {
+      return false;
+    }
+    if (expression.type === 'StringLiteral' && expression.value === '') {
+      return false;
+    }
+    // Older parsers surface all of those as `Literal`.
+    if (expression.type === 'Literal') {
+      return expression.value !== null && expression.value !== '' &&
+        typeof expression.value !== 'boolean';
+    }
+    // Anything dynamic may render — assume it does.
     return true;
   });
 }
@@ -206,9 +228,7 @@ export default function transformer(file, api) {
       return;
     }
 
-    const attribute = collapsibleWithDefault(j.booleanLiteral(false));
-    attribute.comments = [j.commentBlock(TODO_COMMENT, true, false)];
-    attrs.push(attribute);
+    attrs.push(collapsibleWithDefault(j.booleanLiteral(false)));
     hasChanges = true;
   });
 

--- a/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
+++ b/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
@@ -1,54 +1,47 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file Codemod: migrate Banner's collapse axis onto the `collapsible` prop
+ * @file Codemod: migrate Banner's `defaultIsExpanded` onto `collapsible`
  *
- * Banner used to infer the disclosure from its content: any `children` got a
- * chevron and were hidden until it was pressed, and `defaultIsExpanded` was
- * the only knob. There was no way to show content without a toggle, and no
- * controlled mode.
+ * Banner's collapse axis used to be a single knob, `defaultIsExpanded`, with
+ * the disclosure itself inferred from the presence of `children`. There was no
+ * way to have content without a toggle, and no controlled mode. The axis now
+ * lives on one `boolean | CollapsibleConfig` prop, per the boolean-or-config
+ * convention:
  *
- * The axis now lives on one `boolean | CollapsibleConfig` prop, per the
- * boolean-or-config convention:
+ *   <Banner>{children}</Banner>                     → collapsible, starts closed
+ *   <Banner collapsible={{defaultIsOpen: true}}>    → collapsible, starts open
+ *   <Banner collapsible={{isOpen, onOpenChange}}>   → controlled
+ *   <Banner collapsible={false}>                    → always visible, no toggle
  *
- *   <Banner>{children}</Banner>                      → always visible, no toggle
- *   <Banner collapsible>                             → collapsible, starts open
- *   <Banner collapsible={{defaultIsOpen: false}}>    → collapsible, starts closed
- *   <Banner collapsible={{isOpen, onOpenChange}}>    → controlled
+ * The default is unchanged, so a Banner that never mentioned the old prop needs
+ * no rewrite at all — this transform is a prop rename and nothing more:
  *
- * That inverts the default, so a banner with children that is left alone
- * changes behaviour rather than breaking the build — which is exactly the
- * silent kind of change a codemod has to cover. The rewrites are:
- *
- *   defaultIsExpanded            → collapsible
- *   defaultIsExpanded={true}     → collapsible
- *   defaultIsExpanded={false}    → collapsible={{defaultIsOpen: false}}
+ *   defaultIsExpanded            → collapsible={{defaultIsOpen: true}}
+ *   defaultIsExpanded={true}     → collapsible={{defaultIsOpen: true}}
+ *   defaultIsExpanded={false}    → (removed — it is the default)
  *   defaultIsExpanded={expr}     → collapsible={{defaultIsOpen: expr}}
- *   (children, no prop)          → collapsible={{defaultIsOpen: false}}
  *
- * The last one is the behaviour-preserving rewrite for the implicit case. It
- * is also the one worth a second look: most of those banners probably want
- * their content simply visible now. The transform does not editorialize in the
- * output — the nudge belongs in the changelog and the transform title, not as
- * a TODO comment in every migrated file.
+ * Only elements named `Banner` are touched, and only when the file imports that
+ * name from `@astryxdesign/core`: `defaultIsExpanded` is also a ChatToolCalls
+ * prop, which this migration must leave alone.
  *
- * Only elements named `Banner` are touched, and only when the file imports
- * that name from `@astryxdesign/core`: `defaultIsExpanded` is also a
- * ChatToolCalls prop, which this migration must leave alone.
+ * Scope: JSX attributes only. `defaultIsExpanded` inside a props object (a
+ * Storybook `args`, a spread built up in a variable) is left alone rather than
+ * rewritten on a guess about which component the object is for — removing the
+ * prop from the type makes those sites a type error, which is loud enough to
+ * find them.
  */
 
 export const meta = {
-  title:
-    "Migrate Banner's collapse axis onto `collapsible` (content is visible " +
-    'by default now — review the banners this marks as collapsed)',
+  title: "Rename Banner's `defaultIsExpanded` to the `collapsible` config",
   description:
-    'Banner children are now visible by default instead of hidden behind a ' +
-    'chevron, and `defaultIsExpanded` is replaced by ' +
-    '`collapsible?: boolean | CollapsibleConfig`. Rewrites ' +
-    '`defaultIsExpanded` to the equivalent `collapsible` config, and adds ' +
-    '`collapsible={{defaultIsOpen: false}}` to banners that relied on the ' +
-    'implicit collapse, so behaviour is preserved. Those are the ones worth ' +
-    'a second look: always-visible content is usually what they want.',
+    "Banner's collapse axis is now a single `collapsible?: boolean | " +
+    'CollapsibleConfig` prop. Rewrites `defaultIsExpanded` to the equivalent ' +
+    'config (`{defaultIsOpen: true}`), and drops ' +
+    '`defaultIsExpanded={false}`, which is the default. Banners that never ' +
+    'set the prop are untouched — the default is unchanged. Pass ' +
+    '`collapsible={false}` for content that is always visible.',
   pr: '#5255',
 };
 
@@ -88,62 +81,13 @@ function importsCoreBanner(j, root) {
 }
 
 /**
- * Whether a JSX element renders anything as children.
- *
- * Mirrors the component's own `isRenderable`, which is what decided whether
- * the old Banner drew a chevron: whitespace-only text, `{false}`, `{null}`,
- * `{undefined}` and `{''}` are all empty slots, and a banner holding one of
- * those was never collapsible in the first place — adding `collapsible` to it
- * would invent an affordance rather than preserve one.
- *
- * @param {any} elementNode
- * @returns {boolean}
- */
-function hasJsxChildren(elementNode) {
-  if (elementNode?.type !== 'JSXElement') {
-    return false;
-  }
-  return (elementNode.children ?? []).some((/** @type {any} */ child) => {
-    if (child.type === 'JSXText') {
-      return child.value.trim() !== '';
-    }
-    if (child.type !== 'JSXExpressionContainer') {
-      return true;
-    }
-    const expression = child.expression;
-    if (expression == null || expression.type === 'JSXEmptyExpression') {
-      return false;
-    }
-    if (
-      expression.type === 'BooleanLiteral' ||
-      expression.type === 'NullLiteral'
-    ) {
-      return false;
-    }
-    if (expression.type === 'Identifier' && expression.name === 'undefined') {
-      return false;
-    }
-    if (expression.type === 'StringLiteral' && expression.value === '') {
-      return false;
-    }
-    // Older parsers surface all of those as `Literal`.
-    if (expression.type === 'Literal') {
-      return expression.value !== null && expression.value !== '' &&
-        typeof expression.value !== 'boolean';
-    }
-    // Anything dynamic may render — assume it does.
-    return true;
-  });
-}
-
-/**
  * @param {import('../../../../authoring/codemod/type').AstryxCodemodFile} file
  * @param {import('../../../../authoring/codemod/type').CodemodTransformApi} api
  * @returns {string | null | undefined}
  */
 export default function transformer(file, api) {
-  // Cheap bail-out: a file with no Banner in it cannot need this.
-  if (!file.source.includes(COMPONENT)) {
+  // Cheap bail-out: nothing to rename without the old prop.
+  if (!file.source.includes(OLD_PROP)) {
     return undefined;
   }
 
@@ -174,61 +118,52 @@ export default function transformer(file, api) {
     }
 
     const attrs = path.node.attributes ?? [];
-
-    // A spread may carry either prop; rewriting around it would be guesswork.
-    const hasSpread = attrs.some(
-      (/** @type {any} */ a) => a.type === 'JSXSpreadAttribute',
-    );
-    // Already migrated by hand.
-    const hasNewProp = attrs.some(
-      (/** @type {any} */ a) =>
-        a.type === 'JSXAttribute' && a.name?.name === NEW_PROP,
-    );
-    if (hasSpread || hasNewProp) {
-      return;
-    }
-
     const oldIndex = attrs.findIndex(
       (/** @type {any} */ a) =>
         a.type === 'JSXAttribute' && a.name?.name === OLD_PROP,
     );
+    if (oldIndex === -1) {
+      return;
+    }
 
-    if (oldIndex !== -1) {
-      const value = attrs[oldIndex].value;
+    // Already migrated by hand, or a spread that may carry either prop:
+    // in both cases a rewrite would be guesswork.
+    const hasNewProp = attrs.some(
+      (/** @type {any} */ a) =>
+        a.type === 'JSXAttribute' && a.name?.name === NEW_PROP,
+    );
+    const hasSpread = attrs.some(
+      (/** @type {any} */ a) => a.type === 'JSXSpreadAttribute',
+    );
+    if (hasNewProp || hasSpread) {
+      return;
+    }
 
-      if (value == null) {
-        // Bare `defaultIsExpanded` — collapsible, open.
-        attrs[oldIndex] = j.jsxAttribute(j.jsxIdentifier(NEW_PROP));
-      } else if (value.type === 'JSXExpressionContainer') {
-        const expression = value.expression;
-        const isLiteral =
-          expression.type === 'BooleanLiteral' ||
-          (expression.type === 'Literal' && typeof expression.value === 'boolean');
-        if (isLiteral && expression.value === true) {
-          attrs[oldIndex] = j.jsxAttribute(j.jsxIdentifier(NEW_PROP));
-        } else if (isLiteral) {
-          attrs[oldIndex] = collapsibleWithDefault(j.booleanLiteral(false));
-        } else {
-          // A dynamic default stays dynamic.
-          attrs[oldIndex] = collapsibleWithDefault(expression);
-        }
+    const value = attrs[oldIndex].value;
+
+    if (value == null) {
+      // Bare `defaultIsExpanded` — starts open.
+      attrs[oldIndex] = collapsibleWithDefault(j.booleanLiteral(true));
+    } else if (value.type === 'JSXExpressionContainer') {
+      const expression = value.expression;
+      const isBooleanLiteral =
+        expression.type === 'BooleanLiteral' ||
+        (expression.type === 'Literal' && typeof expression.value === 'boolean');
+      if (isBooleanLiteral && expression.value === false) {
+        // Starting closed is the default now, so the prop simply goes.
+        attrs.splice(oldIndex, 1);
+      } else if (isBooleanLiteral) {
+        attrs[oldIndex] = collapsibleWithDefault(j.booleanLiteral(true));
       } else {
-        // `defaultIsExpanded="something"` is not valid for a boolean prop;
-        // leave it for a human rather than inventing a meaning.
-        return;
+        // A dynamic default stays dynamic.
+        attrs[oldIndex] = collapsibleWithDefault(expression);
       }
-
-      hasChanges = true;
+    } else {
+      // `defaultIsExpanded="something"` is not valid for a boolean prop;
+      // leave it for a human rather than inventing a meaning.
       return;
     }
 
-    // No `defaultIsExpanded`. Only a banner that actually had children was
-    // implicitly collapsible.
-    if (!hasJsxChildren(path.parent.node)) {
-      return;
-    }
-
-    attrs.push(collapsibleWithDefault(j.booleanLiteral(false)));
     hasChanges = true;
   });
 

--- a/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
+++ b/packages/cli/assets/codemods/transforms/next/banner-collapsible-content.mjs
@@ -46,7 +46,7 @@ export const meta = {
     '`collapsible={{defaultIsOpen: false}}` to banners that relied on the ' +
     'implicit collapse, so behaviour is preserved. Those sites also get a ' +
     'TODO comment, because always-visible content is usually what they want.',
-  pr: '#5251',
+  pr: '#5255',
 };
 
 const OLD_PROP = 'defaultIsExpanded';

--- a/packages/cli/assets/codemods/transforms/next/index.mjs
+++ b/packages/cli/assets/codemods/transforms/next/index.mjs
@@ -7,4 +7,14 @@
  * this file into the resolved version folder.
  */
 
-export default [];
+import bannerCollapsibleContent, {
+  meta as bannerCollapsibleContentMeta,
+} from './banner-collapsible-content.mjs';
+
+export default [
+  {
+    name: 'banner-collapsible-content',
+    transform: bannerCollapsibleContent,
+    meta: bannerCollapsibleContentMeta,
+  },
+];

--- a/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   exampleFor: 'Banner',
   name: 'Banner — Collapsible',
   displayName: 'Banner — Collapsible',
-  description: 'Combine an action button, dismiss control, and expandable detail area in one banner. Use for complex notifications like config changes or deployment summaries.',
+  description: 'Combine an action button, dismiss control, and a collapsible detail area in one banner. Children are visible by default; the `collapsible` prop is what adds the expand/collapse toggle. Use for complex notifications like config changes or deployment summaries.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Banner', 'Button', 'List', 'Layout', 'Text'],

--- a/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   exampleFor: 'Banner',
   name: 'Banner — Collapsible',
   displayName: 'Banner — Collapsible',
-  description: 'Combine an action button, dismiss control, and a collapsible detail area in one banner. Children are visible by default; the `collapsible` prop is what adds the expand/collapse toggle. Use for complex notifications like config changes or deployment summaries.',
+  description: 'Combine an action button, dismiss control, and a collapsible detail area in one banner. Children sit behind the toggle by default; `collapsible={{defaultIsOpen: true}}` starts it open, and `collapsible={false}` drops the toggle entirely. Use for complex notifications like config changes or deployment summaries.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Banner', 'Button', 'List', 'Layout', 'Text'],

--- a/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.tsx
+++ b/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.tsx
@@ -16,7 +16,7 @@ export default function BannerCollapsibleContent() {
       description="Review the changes before they take effect."
       endContent={<Button label="Review" variant="secondary" size="sm" />}
       isDismissable
-      collapsible>
+      collapsible={{defaultIsOpen: true}}>
       <Stack direction="vertical" gap={2}>
         <Text type="supporting" color="secondary">
           Changed settings:

--- a/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.tsx
+++ b/packages/cli/assets/templates/blocks/components/Banner/BannerCollapsibleContent.tsx
@@ -16,7 +16,7 @@ export default function BannerCollapsibleContent() {
       description="Review the changes before they take effect."
       endContent={<Button label="Review" variant="secondary" size="sm" />}
       isDismissable
-      defaultIsExpanded>
+      collapsible>
       <Stack direction="vertical" gap={2}>
         <Text type="supporting" color="secondary">
           Changed settings:

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -17,7 +17,7 @@ export const docs = {
       {guidance: true, description: 'Keep titles short and scannable: "Payment failed" not "There was a problem processing your most recent payment."'},
       {guidance: false, description: 'Use Banner for short-lived messages that disappear on their own; use Toast instead.'},
       {guidance: false, description: 'Stack multiple banners with the same status; combine related messages into one banner.'},
-      {guidance: true, description: 'Leave content visible when the user needs it to act on the message. Reach for collapsible only when the detail is long enough to bury the banner\u2019s own message.'},
+      {guidance: true, description: 'Set collapsible={false} when the user needs the content to act on the message, like the list of fields that failed validation. Keep the default toggle when the detail is long enough to bury the banner\u2019s own message.'},
       {guidance: true, description: 'Error and warning banners render as role="alert"; info and success render as role="status". Mount an alert banner in response to an event rather than on first paint, so assistive tech has a change to report.'},
       {guidance: false, description: 'Rely on the status color or icon alone to carry meaning; say which status it is in the title text, because the icon is decorative to a screen reader.'},
     ],
@@ -27,7 +27,7 @@ export const docs = {
       {name: 'Description', required: false, description: 'Additional detail below the title.'},
       {name: 'Action button', required: false, description: 'A button for the user to act on the message, like "Review" or "Retry".'},
       {name: 'Dismiss button', required: false, description: 'Lets the user close the banner. Enabled by setting isDismissable.'},
-      {name: 'Content', required: false, description: 'Extra detail below the banner header, like a list of errors. Visible by default; set collapsible to put it behind an expand/collapse toggle.'},
+      {name: 'Content', required: false, description: 'Extra detail below the banner header, like a list of errors. Sits behind an expand/collapse toggle by default; set collapsible={false} to keep it visible.'},
     ],
   },
 
@@ -95,14 +95,14 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'Content rendered in the card-background area below the colored header. Always visible unless `collapsible` is set.',
+        'Content rendered in the card-background area below the colored header. Sits behind an expand/collapse toggle unless `collapsible={false}`.',
     },
     {
       name: 'collapsible',
       type: 'boolean | {defaultIsOpen?: boolean; isOpen?: boolean; onOpenChange?: (isOpen: boolean) => void}',
       description:
-        'Puts the content area (children) behind an expand/collapse toggle in the header. Omit it and children are always visible, with no toggle. `true` enables it starting open; `{defaultIsOpen: false}` starts collapsed; `{isOpen, onOpenChange}` is controlled. Takes the same CollapsibleConfig as Collapsible.',
-      default: 'undefined',
+        'Whether the content area (children) sits behind an expand/collapse toggle in the header. On by default, starting collapsed. `false` opts out: children are always visible with no toggle. `{defaultIsOpen: true}` starts open; `{isOpen, onOpenChange}` is controlled. Takes the same CollapsibleConfig as Collapsible.',
+      default: 'true',
     },
     {
       name: 'xstyle',
@@ -155,7 +155,7 @@ export const docsZh = {
       {name: 'Description', required: false, description: 'Additional detail below the title.'},
       {name: 'Action button', required: false, description: 'A button for the user to act on the message, like "Review" or "Retry".'},
       {name: 'Dismiss button', required: false, description: 'Lets the user close the banner. Enabled by setting isDismissable.'},
-      {name: 'Content', required: false, description: 'Extra detail below the banner header, like a list of errors. Visible by default; set collapsible to put it behind an expand/collapse toggle.'},
+      {name: 'Content', required: false, description: 'Extra detail below the banner header, like a list of errors. Sits behind an expand/collapse toggle by default; set collapsible={false} to keep it visible.'},
     ],
   },
   props: [
@@ -168,8 +168,8 @@ export const docsZh = {
     {name: 'endContent', type: 'ReactNode', description: '渲染在头部区域末端对齐的操作内容，通常是按钮或链接。头部过窄时会整体换行到文本下方，自成一行。'},
     {name: 'container', type: "'card' | 'section'", description: '视觉变体：card 带圆角；section 无圆角全宽，适用于页面级场景。', default: "'card'"},
     {name: 'elevation', type: "'none' | 'low' | 'med' | 'high'", description: '静止阴影深度。用于悬浮于内容之上的浮动横幅；none 为默认内联横幅。', default: "'none'"},
-    {name: 'children', type: 'ReactNode', description: '渲染在彩色头部下方卡片背景区域的内容。默认始终可见，除非设置 collapsible。'},
-    {name: 'collapsible', type: 'boolean | {defaultIsOpen?: boolean; isOpen?: boolean; onOpenChange?: (isOpen: boolean) => void}', description: '将内容区域（children）置于头部的展开/折叠开关之后。省略时内容始终可见且没有开关。true 表示启用并默认展开；{defaultIsOpen: false} 表示默认折叠；{isOpen, onOpenChange} 为受控模式。与 Collapsible 使用同一套 CollapsibleConfig。', default: 'undefined'},
+    {name: 'children', type: 'ReactNode', description: '渲染在彩色头部下方卡片背景区域的内容。默认位于展开/折叠开关之后，除非设置 collapsible={false}。'},
+    {name: 'collapsible', type: 'boolean | {defaultIsOpen?: boolean; isOpen?: boolean; onOpenChange?: (isOpen: boolean) => void}', description: '内容区域（children）是否位于头部的展开/折叠开关之后。默认开启，且初始为折叠状态。false 表示关闭：内容始终可见且没有开关。{defaultIsOpen: true} 表示初始展开；{isOpen, onOpenChange} 为受控模式。与 Collapsible 使用同一套 CollapsibleConfig。', default: 'true'},
     {
       name: 'xstyle',
       type: 'StyleXStyles',
@@ -229,7 +229,7 @@ export const docsDense = {
       {name: 'Description', required: false, description: 'Detail below title.'},
       {name: 'Action button', required: false, description: 'CTA like Review or Retry.'},
       {name: 'Dismiss button', required: false, description: 'Close button via isDismissable.'},
-      {name: 'Content', required: false, description: 'Detail area; always visible unless collapsible is set.'},
+      {name: 'Content', required: false, description: 'Detail area; behind a toggle unless collapsible={false}.'},
     ],
   },
   propDescriptions: {
@@ -242,8 +242,8 @@ export const docsDense = {
     endContent: 'end-aligned action in header, typically button/link; wraps to its own row when the header is too narrow',
     container: 'card=border-radius; section=full-width no radius for page-level',
     elevation: 'resting shadow depth: none|low|med|high; raise for a floating banner',
-    children: 'content in card-bg area below colored header; always visible unless collapsible is set',
-    collapsible: 'put children behind a header toggle: true=open, {defaultIsOpen:false}=collapsed, {isOpen,onOpenChange}=controlled; omitted=always visible, no toggle',
+    children: 'content in card-bg area below colored header; behind a toggle unless collapsible={false}',
+    collapsible: 'children behind a header toggle; default true=collapsed. false=always visible, no toggle. {defaultIsOpen:true}=starts open, {isOpen,onOpenChange}=controlled',
     xstyle: 'StyleX layout customization via stylex.create()',
   },
 };

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -17,6 +17,7 @@ export const docs = {
       {guidance: true, description: 'Keep titles short and scannable: "Payment failed" not "There was a problem processing your most recent payment."'},
       {guidance: false, description: 'Use Banner for short-lived messages that disappear on their own; use Toast instead.'},
       {guidance: false, description: 'Stack multiple banners with the same status; combine related messages into one banner.'},
+      {guidance: true, description: 'Leave content visible when the user needs it to act on the message. Reach for collapsible only when the detail is long enough to bury the banner\u2019s own message.'},
       {guidance: true, description: 'Error and warning banners render as role="alert"; info and success render as role="status". Mount an alert banner in response to an event rather than on first paint, so assistive tech has a change to report.'},
       {guidance: false, description: 'Rely on the status color or icon alone to carry meaning; say which status it is in the title text, because the icon is decorative to a screen reader.'},
     ],
@@ -26,7 +27,7 @@ export const docs = {
       {name: 'Description', required: false, description: 'Additional detail below the title.'},
       {name: 'Action button', required: false, description: 'A button for the user to act on the message, like "Review" or "Retry".'},
       {name: 'Dismiss button', required: false, description: 'Lets the user close the banner. Enabled by setting isDismissable.'},
-      {name: 'Collapsible content', required: false, description: 'Extra detail that expands below the banner header, like a list of errors.'},
+      {name: 'Content', required: false, description: 'Extra detail below the banner header, like a list of errors. Visible by default; set collapsible to put it behind an expand/collapse toggle.'},
     ],
   },
 
@@ -94,14 +95,14 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'Content rendered in the card-background area below the colored header.',
+        'Content rendered in the card-background area below the colored header. Always visible unless `collapsible` is set.',
     },
     {
-      name: 'defaultIsExpanded',
-      type: 'boolean',
+      name: 'collapsible',
+      type: 'boolean | {defaultIsOpen?: boolean; isOpen?: boolean; onOpenChange?: (isOpen: boolean) => void}',
       description:
-        'Whether the content area (children) starts expanded. Only relevant when children are provided.',
-      default: 'false',
+        'Puts the content area (children) behind an expand/collapse toggle in the header. Omit it and children are always visible, with no toggle. `true` enables it starting open; `{defaultIsOpen: false}` starts collapsed; `{isOpen, onOpenChange}` is controlled. Takes the same CollapsibleConfig as Collapsible.',
+      default: 'undefined',
     },
     {
       name: 'xstyle',
@@ -154,7 +155,7 @@ export const docsZh = {
       {name: 'Description', required: false, description: 'Additional detail below the title.'},
       {name: 'Action button', required: false, description: 'A button for the user to act on the message, like "Review" or "Retry".'},
       {name: 'Dismiss button', required: false, description: 'Lets the user close the banner. Enabled by setting isDismissable.'},
-      {name: 'Collapsible content', required: false, description: 'Extra detail that expands below the banner header, like a list of errors.'},
+      {name: 'Content', required: false, description: 'Extra detail below the banner header, like a list of errors. Visible by default; set collapsible to put it behind an expand/collapse toggle.'},
     ],
   },
   props: [
@@ -167,8 +168,8 @@ export const docsZh = {
     {name: 'endContent', type: 'ReactNode', description: '渲染在头部区域末端对齐的操作内容，通常是按钮或链接。头部过窄时会整体换行到文本下方，自成一行。'},
     {name: 'container', type: "'card' | 'section'", description: '视觉变体：card 带圆角；section 无圆角全宽，适用于页面级场景。', default: "'card'"},
     {name: 'elevation', type: "'none' | 'low' | 'med' | 'high'", description: '静止阴影深度。用于悬浮于内容之上的浮动横幅；none 为默认内联横幅。', default: "'none'"},
-    {name: 'children', type: 'ReactNode', description: '渲染在彩色头部下方卡片背景区域的内容。'},
-    {name: 'defaultIsExpanded', type: 'boolean', description: '内容区域（children）是否初始展开。仅在提供 children 时相关。', default: 'false'},
+    {name: 'children', type: 'ReactNode', description: '渲染在彩色头部下方卡片背景区域的内容。默认始终可见，除非设置 collapsible。'},
+    {name: 'collapsible', type: 'boolean | {defaultIsOpen?: boolean; isOpen?: boolean; onOpenChange?: (isOpen: boolean) => void}', description: '将内容区域（children）置于头部的展开/折叠开关之后。省略时内容始终可见且没有开关。true 表示启用并默认展开；{defaultIsOpen: false} 表示默认折叠；{isOpen, onOpenChange} 为受控模式。与 Collapsible 使用同一套 CollapsibleConfig。', default: 'undefined'},
     {
       name: 'xstyle',
       type: 'StyleXStyles',
@@ -228,7 +229,7 @@ export const docsDense = {
       {name: 'Description', required: false, description: 'Detail below title.'},
       {name: 'Action button', required: false, description: 'CTA like Review or Retry.'},
       {name: 'Dismiss button', required: false, description: 'Close button via isDismissable.'},
-      {name: 'Collapsible content', required: false, description: 'Expandable detail area.'},
+      {name: 'Content', required: false, description: 'Detail area; always visible unless collapsible is set.'},
     ],
   },
   propDescriptions: {
@@ -241,7 +242,8 @@ export const docsDense = {
     endContent: 'end-aligned action in header, typically button/link; wraps to its own row when the header is too narrow',
     container: 'card=border-radius; section=full-width no radius for page-level',
     elevation: 'resting shadow depth: none|low|med|high; raise for a floating banner',
-    children: 'content in card-bg area below colored header',
+    children: 'content in card-bg area below colored header; always visible unless collapsible is set',
+    collapsible: 'put children behind a header toggle: true=open, {defaultIsOpen:false}=collapsed, {isOpen,onOpenChange}=controlled; omitted=always visible, no toggle',
     xstyle: 'StyleX layout customization via stylex.create()',
   },
 };

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -253,6 +253,18 @@ describe('Banner', () => {
     expect(screen.getByRole('button', {name: 'Collapse'})).toBeInTheDocument();
   });
 
+  it('treats a null collapsible as the default', () => {
+    render(
+      // @ts-expect-error null is outside the prop's type, but JS callers and a
+      // value widened to `| null` still reach this.
+      <Banner status="info" title="Nullish" collapsible={null}>
+        <div data-testid="child-content">Content</div>
+      </Banner>,
+    );
+    expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
+  });
+
   it('does not show expand/collapse button when no children', () => {
     render(<Banner status="info" title="No Children" />);
     expect(

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -184,12 +184,33 @@ describe('Banner', () => {
   });
 
   // =========================================================================
-  // Content area — always visible unless `collapsible` is set
+  // Content area — collapsible by default, `collapsible={false}` opts out
   // =========================================================================
 
-  it('shows children by default, with no toggle', () => {
+  it('hides children behind a toggle by default', () => {
     render(
-      <Banner status="info" title="Plain content">
+      <Banner status="info" title="Collapsible">
+        <div data-testid="child-content">Extra content</div>
+      </Banner>,
+    );
+    // The historical default, unchanged: chevron present, content collapsed.
+    expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
+  });
+
+  it('treats an explicit collapsible={true} as the default', () => {
+    render(
+      <Banner status="info" title="Explicit" collapsible>
+        <div data-testid="child-content">Extra content</div>
+      </Banner>,
+    );
+    expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
+  });
+
+  it('shows children with no toggle for collapsible={false}', () => {
+    render(
+      <Banner status="info" title="Opted out" collapsible={false}>
         <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
@@ -204,7 +225,11 @@ describe('Banner', () => {
 
   it('leaves non-collapsible content out of the disclosure wiring', () => {
     render(
-      <Banner status="info" title="Plain content" isDismissable>
+      <Banner
+        status="info"
+        title="Plain content"
+        isDismissable
+        collapsible={false}>
         <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
@@ -218,21 +243,9 @@ describe('Banner', () => {
     ).not.toHaveAttribute('id');
   });
 
-  it('treats collapsible={false} as not collapsible', () => {
+  it('starts open for collapsible={{defaultIsOpen: true}}', () => {
     render(
-      <Banner status="info" title="Opted out" collapsible={false}>
-        <div data-testid="child-content">Extra content</div>
-      </Banner>,
-    );
-    expect(screen.getByTestId('child-content')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {name: 'Expand'}),
-    ).not.toBeInTheDocument();
-  });
-
-  it('shows the toggle, open, for collapsible', () => {
-    render(
-      <Banner status="info" title="With Toggle" collapsible>
+      <Banner status="info" title="Open" collapsible={{defaultIsOpen: true}}>
         <div data-testid="child-content">Content</div>
       </Banner>,
     );
@@ -240,21 +253,8 @@ describe('Banner', () => {
     expect(screen.getByRole('button', {name: 'Collapse'})).toBeInTheDocument();
   });
 
-  it('starts collapsed for collapsible={{defaultIsOpen: false}}', () => {
-    render(
-      <Banner
-        status="info"
-        title="Collapsed"
-        collapsible={{defaultIsOpen: false}}>
-        <div data-testid="child-content">Content</div>
-      </Banner>,
-    );
-    expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
-  });
-
   it('does not show expand/collapse button when no children', () => {
-    render(<Banner status="info" title="No Children" collapsible />);
+    render(<Banner status="info" title="No Children" />);
     expect(
       screen.queryByRole('button', {name: 'Expand'}),
     ).not.toBeInTheDocument();
@@ -266,10 +266,7 @@ describe('Banner', () => {
   it('toggles children visibility on expand/collapse click', async () => {
     const user = userEvent.setup();
     render(
-      <Banner
-        status="info"
-        title="Toggle Test"
-        collapsible={{defaultIsOpen: false}}>
+      <Banner status="info" title="Toggle Test">
         <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
@@ -293,10 +290,7 @@ describe('Banner', () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
     render(
-      <Banner
-        status="info"
-        title="Notify"
-        collapsible={{defaultIsOpen: false, onOpenChange}}>
+      <Banner status="info" title="Notify" collapsible={{onOpenChange}}>
         <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
@@ -328,11 +322,7 @@ describe('Banner', () => {
 
   it('renders expand button to the left of dismiss button', () => {
     const {container} = render(
-      <Banner
-        status="info"
-        title="Order Test"
-        isDismissable
-        collapsible={{defaultIsOpen: false}}>
+      <Banner status="info" title="Order Test" isDismissable>
         <div>Content</div>
       </Banner>,
     );
@@ -347,7 +337,10 @@ describe('Banner', () => {
 
   it('links the expand toggle to its content region via aria-controls', () => {
     render(
-      <Banner status="info" title="Controls Test" collapsible>
+      <Banner
+        status="info"
+        title="Controls Test"
+        collapsible={{defaultIsOpen: true}}>
         <div data-testid="region-content">Region content</div>
       </Banner>,
     );
@@ -364,10 +357,7 @@ describe('Banner', () => {
   it('sets aria-controls only while the content region is mounted', async () => {
     const user = userEvent.setup();
     render(
-      <Banner
-        status="info"
-        title="Controls Toggle"
-        collapsible={{defaultIsOpen: false}}>
+      <Banner status="info" title="Controls Toggle">
         <div data-testid="region-content">Region content</div>
       </Banner>,
     );
@@ -496,7 +486,7 @@ describe('Banner', () => {
       ),
     });
     render(
-      <Banner status="info" title="Chevron Test" collapsible>
+      <Banner status="info" title="Chevron Test">
         <div>Content</div>
       </Banner>,
     );
@@ -571,10 +561,7 @@ describe('Banner', () => {
   describe('empty slots', () => {
     it('does not show the expand affordance for children that render nothing', () => {
       render(
-        <Banner
-          status="info"
-          title="Heads up"
-          collapsible={{defaultIsOpen: false}}>
+        <Banner status="info" title="Heads up">
           {false}
         </Banner>,
       );
@@ -585,10 +572,7 @@ describe('Banner', () => {
 
     it('still shows the expand affordance for real children', () => {
       render(
-        <Banner
-          status="info"
-          title="Heads up"
-          collapsible={{defaultIsOpen: false}}>
+        <Banner status="info" title="Heads up">
           <p>Detail</p>
         </Banner>,
       );
@@ -597,7 +581,7 @@ describe('Banner', () => {
 
     it('renders no content area for children that render nothing', () => {
       const {container} = render(
-        <Banner status="info" title="Heads up">
+        <Banner status="info" title="Heads up" collapsible={false}>
           {false}
         </Banner>,
       );

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -184,38 +184,77 @@ describe('Banner', () => {
   });
 
   // =========================================================================
-  // Collapsible content area
+  // Content area — always visible unless `collapsible` is set
   // =========================================================================
 
-  it('hides children by default (collapsed)', () => {
+  it('shows children by default, with no toggle', () => {
     render(
-      <Banner status="info" title="Collapsible">
-        <div data-testid="child-content">Extra content</div>
-      </Banner>,
-    );
-    expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
-  });
-
-  it('shows children when defaultIsExpanded is true', () => {
-    render(
-      <Banner status="info" title="Expanded" defaultIsExpanded>
+      <Banner status="info" title="Plain content">
         <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
     expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Expand'}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Collapse'}),
+    ).not.toBeInTheDocument();
   });
 
-  it('shows expand button when children are provided', () => {
+  it('leaves non-collapsible content out of the disclosure wiring', () => {
     render(
-      <Banner status="info" title="With Toggle">
-        <div>Content</div>
+      <Banner status="info" title="Plain content" isDismissable>
+        <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
+    // No toggle exists, so nothing should carry disclosure state, and the
+    // region needs no id for a button to point at.
+    const dismiss = screen.getByRole('button', {name: 'Dismiss'});
+    expect(dismiss).not.toHaveAttribute('aria-expanded');
+    expect(dismiss).not.toHaveAttribute('aria-controls');
+    expect(
+      screen.getByTestId('child-content').parentElement,
+    ).not.toHaveAttribute('id');
+  });
+
+  it('treats collapsible={false} as not collapsible', () => {
+    render(
+      <Banner status="info" title="Opted out" collapsible={false}>
+        <div data-testid="child-content">Extra content</div>
+      </Banner>,
+    );
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Expand'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the toggle, open, for collapsible', () => {
+    render(
+      <Banner status="info" title="With Toggle" collapsible>
+        <div data-testid="child-content">Content</div>
+      </Banner>,
+    );
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Collapse'})).toBeInTheDocument();
+  });
+
+  it('starts collapsed for collapsible={{defaultIsOpen: false}}', () => {
+    render(
+      <Banner
+        status="info"
+        title="Collapsed"
+        collapsible={{defaultIsOpen: false}}>
+        <div data-testid="child-content">Content</div>
+      </Banner>,
+    );
+    expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
   });
 
   it('does not show expand/collapse button when no children', () => {
-    render(<Banner status="info" title="No Children" />);
+    render(<Banner status="info" title="No Children" collapsible />);
     expect(
       screen.queryByRole('button', {name: 'Expand'}),
     ).not.toBeInTheDocument();
@@ -227,7 +266,10 @@ describe('Banner', () => {
   it('toggles children visibility on expand/collapse click', async () => {
     const user = userEvent.setup();
     render(
-      <Banner status="info" title="Toggle Test">
+      <Banner
+        status="info"
+        title="Toggle Test"
+        collapsible={{defaultIsOpen: false}}>
         <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
@@ -247,18 +289,50 @@ describe('Banner', () => {
     expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
   });
 
-  it('shows collapse button when defaultIsExpanded', () => {
+  it('reports open-state changes through onOpenChange', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
     render(
-      <Banner status="info" title="Expanded" defaultIsExpanded>
-        <div>Content</div>
+      <Banner
+        status="info"
+        title="Notify"
+        collapsible={{defaultIsOpen: false, onOpenChange}}>
+        <div data-testid="child-content">Extra content</div>
       </Banner>,
     );
-    expect(screen.getByRole('button', {name: 'Collapse'})).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Expand'}));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    await user.click(screen.getByRole('button', {name: 'Collapse'}));
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('defers to the consumer when collapsible is controlled', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Banner
+        status="info"
+        title="Controlled"
+        collapsible={{isOpen: false, onOpenChange}}>
+        <div data-testid="child-content">Extra content</div>
+      </Banner>,
+    );
+
+    // A controlled banner must not move on its own: the click reports, the
+    // content stays hidden until the consumer re-renders with isOpen.
+    await user.click(screen.getByRole('button', {name: 'Expand'}));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
   });
 
   it('renders expand button to the left of dismiss button', () => {
     const {container} = render(
-      <Banner status="info" title="Order Test" isDismissable>
+      <Banner
+        status="info"
+        title="Order Test"
+        isDismissable
+        collapsible={{defaultIsOpen: false}}>
         <div>Content</div>
       </Banner>,
     );
@@ -273,7 +347,7 @@ describe('Banner', () => {
 
   it('links the expand toggle to its content region via aria-controls', () => {
     render(
-      <Banner status="info" title="Controls Test" defaultIsExpanded>
+      <Banner status="info" title="Controls Test" collapsible>
         <div data-testid="region-content">Region content</div>
       </Banner>,
     );
@@ -290,7 +364,10 @@ describe('Banner', () => {
   it('sets aria-controls only while the content region is mounted', async () => {
     const user = userEvent.setup();
     render(
-      <Banner status="info" title="Controls Toggle">
+      <Banner
+        status="info"
+        title="Controls Toggle"
+        collapsible={{defaultIsOpen: false}}>
         <div data-testid="region-content">Region content</div>
       </Banner>,
     );
@@ -419,7 +496,7 @@ describe('Banner', () => {
       ),
     });
     render(
-      <Banner status="info" title="Chevron Test">
+      <Banner status="info" title="Chevron Test" collapsible>
         <div>Content</div>
       </Banner>,
     );
@@ -494,7 +571,10 @@ describe('Banner', () => {
   describe('empty slots', () => {
     it('does not show the expand affordance for children that render nothing', () => {
       render(
-        <Banner status="info" title="Heads up">
+        <Banner
+          status="info"
+          title="Heads up"
+          collapsible={{defaultIsOpen: false}}>
           {false}
         </Banner>,
       );
@@ -505,13 +585,24 @@ describe('Banner', () => {
 
     it('still shows the expand affordance for real children', () => {
       render(
-        <Banner status="info" title="Heads up">
+        <Banner
+          status="info"
+          title="Heads up"
+          collapsible={{defaultIsOpen: false}}>
           <p>Detail</p>
         </Banner>,
       );
-      expect(
-        screen.getByRole('button', {name: 'Expand'}),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
+    });
+
+    it('renders no content area for children that render nothing', () => {
+      const {container} = render(
+        <Banner status="info" title="Heads up">
+          {false}
+        </Banner>,
+      );
+      // Header only — an empty slot must not draw the card-background area.
+      expect(container.firstElementChild?.children).toHaveLength(1);
     });
 
     it('renders no description node for a description that renders nothing', () => {

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -463,7 +463,8 @@ export function Banner({
   // opens by default, a banner starts closed. Its header already carries the
   // message, so the content is supplementary — and this is the behaviour
   // Banner has always had.
-  const collapsibleConfig = typeof collapsible === 'object' ? collapsible : {};
+  const collapsibleConfig =
+    collapsible != null && typeof collapsible === 'object' ? collapsible : {};
   const {
     isEnabled: isCollapsible,
     isOpen: isExpanded,

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -17,10 +17,11 @@
  *   the glyph (#4166); for a custom `icon` node it stays on the layout wrapper
  * - No left border accent — color is expressed through the full header background
  * - Each visual area owns its own border-radius (no overflow:clip on the container)
- * - Children render in the content area by default. Passing `collapsible`
- *   puts them behind a disclosure toggle in the header end area; the whole
- *   collapse axis (enabled / default / controlled) lives on that one prop and
- *   is driven by the shared `useCollapsible` hook rather than local state.
+ * - Children are collapsible by default: a toggle appears in the header end
+ *   area and the content starts closed. `collapsible={false}` opts out and
+ *   pins the content open with no toggle. The whole collapse axis (enabled /
+ *   default / controlled) lives on that one prop and is driven by the shared
+ *   `useCollapsible` hook rather than local state.
  *
  * A status added through `BannerStatusMap` augmentation has no entry in the
  * status lookups, so it renders with no status fill, no default glyph and the
@@ -145,26 +146,29 @@ export interface BannerProps extends BaseProps<HTMLDivElement> {
    */
   elevation?: Elevation;
   /**
-   * Whether the content area (children) collapses behind a toggle in the
-   * header. Omit it and children are always visible — no toggle, no
-   * `aria-expanded`, and the content region stays mounted.
+   * Whether the content area (children) sits behind an expand/collapse toggle
+   * in the header. On by default, so a banner with children behaves as it
+   * always has.
    *
-   * - `true` — collapsible, starts open (the `useCollapsible` default)
-   * - `{defaultIsOpen: false}` — collapsible, starts collapsed
+   * - omitted / `true` — collapsible, starts collapsed
+   * - `{defaultIsOpen: true}` — collapsible, starts open
    * - `{isOpen, onOpenChange}` — controlled by the consumer
-   * - `false` or omitted — not collapsible
+   * - `false` — not collapsible: children are always visible, with no toggle,
+   *   no `aria-expanded`, and a content region that stays mounted
    *
    * Takes the shared `CollapsibleConfig` so a banner's disclosure is
    * configured exactly like `Collapsible`'s, rather than through a
-   * Banner-only vocabulary.
+   * Banner-only vocabulary. Banner's default differs from the hook's on one
+   * point — it starts closed, not open — because a banner's message lives in
+   * its header and the content is supplementary.
    *
-   * @default undefined
+   * @default true
    */
   collapsible?: boolean | CollapsibleConfig;
   /**
    * Extra content rendered below the header in a card-background area.
    * Use for rich content like lists, links, or detailed information.
-   * Visible by default; pass `collapsible` to put it behind a toggle.
+   * Collapsed behind a toggle unless `collapsible={false}`.
    */
   children?: ReactNode;
 }
@@ -385,9 +389,10 @@ const elevationStyles = stylex.create({
  * - Header: colored status background with icon, title, description, and actions
  * - Content (optional): card background area for additional rich content
  *
- * Children are visible by default. Pass `collapsible` and a chevron toggle
- * appears in the header end area (to the left of the dismiss button if
- * present), hiding and showing the content area.
+ * When children are provided, a chevron toggle appears in the header end area
+ * (to the left of the dismiss button if present) and the content starts
+ * collapsed. Pass `collapsible={false}` for content that is always visible,
+ * or a config object to change the initial state or control it.
  *
  * Manages its own dismissed state internally — the banner hides on dismiss
  * even if `onDismiss` is not provided, so product teams don't need to wire
@@ -418,8 +423,13 @@ const elevationStyles = stylex.create({
  * <Banner
  *   status="warning"
  *   title="Configuration changes"
- *   collapsible={{defaultIsOpen: false}}>
+ *   collapsible={{defaultIsOpen: true}}>
  *   <p>Details here...</p>
+ * </Banner>
+ * <Banner status="error" title="3 fields need attention" collapsible={false}>
+ *   <ul>
+ *     <li>Email address is invalid</li>
+ *   </ul>
  * </Banner>
  * ```
  */
@@ -433,7 +443,7 @@ export function Banner({
   endContent,
   container = 'card',
   elevation = 'none',
-  collapsible,
+  collapsible = true,
   children,
   xstyle,
   className,
@@ -446,13 +456,24 @@ export function Banner({
   const t = useTranslator();
   const [isDismissed, setIsDismissed] = useState(false);
   // The disclosure state machine is the shared one — Banner owns no collapse
-  // state of its own. `isEnabled` is false when `collapsible` is omitted, and
-  // that is what makes the content permanently visible.
+  // state of its own. `collapsible={false}` disables it, and that is what
+  // makes the content permanently visible.
+  //
+  // The one place Banner departs from the hook's defaults: `useCollapsible`
+  // opens by default, a banner starts closed. Its header already carries the
+  // message, so the content is supplementary — and this is the behaviour
+  // Banner has always had.
+  const collapsibleConfig = typeof collapsible === 'object' ? collapsible : {};
   const {
     isEnabled: isCollapsible,
     isOpen: isExpanded,
     toggle: handleToggleExpand,
-  } = useCollapsible({isCollapsible: collapsible});
+  } = useCollapsible({
+    isCollapsible: collapsible !== false && {
+      ...collapsibleConfig,
+      defaultIsOpen: collapsibleConfig.defaultIsOpen ?? false,
+    },
+  });
   // The element focus came from before it entered the banner. Dismissing
   // unmounts the whole banner, dismiss button included, so without a handoff
   // the browser drops focus to <body> and a keyboard user loses their place.

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -4,20 +4,23 @@
 
 /**
  * @file Banner.tsx
- * @input Uses React useState/useRef/useId, Button, Icon (with registry string names), StyleX
+ * @input Uses React useState/useRef/useId, useCollapsible, Button, Icon (with registry string names), StyleX
  * @output Exports Banner component, BannerProps, BannerStatus, BannerContainer types
  * @position Core implementation; consumed by index.ts, tested by Banner.test.tsx
  *
  * Visual structure:
  * - Root container: layout-only wrapper (flex column), no visual styling, no theme target
  * - Header area (themeProps 'banner'): colored status background with icon, title, description, actions, dismiss
- * - Content area (themeProps 'banner-content'): collapsible card background for additional content (children)
+ * - Content area (themeProps 'banner-content'): card background for additional content (children)
  * - Status icon (themeProps 'banner-icon'): the target rides on the default
  *   <Icon> itself — the element that paints — so 'status:X' overrides reach
  *   the glyph (#4166); for a custom `icon` node it stays on the layout wrapper
  * - No left border accent — color is expressed through the full header background
  * - Each visual area owns its own border-radius (no overflow:clip on the container)
- * - When children are provided, a collapse/expand toggle button appears in the end area
+ * - Children render in the content area by default. Passing `collapsible`
+ *   puts them behind a disclosure toggle in the header end area; the whole
+ *   collapse axis (enabled / default / controlled) lives on that one prop and
+ *   is driven by the shared `useCollapsible` hook rather than local state.
  *
  * A status added through `BannerStatusMap` augmentation has no entry in the
  * status lookups, so it renders with no status fill, no default glyph and the
@@ -55,6 +58,8 @@ import {
   easeVars,
   shadowVars,
 } from '../theme/tokens.stylex';
+import {useCollapsible} from '../Collapsible/useCollapsible';
+import type {CollapsibleConfig} from '../Collapsible/useCollapsible';
 import {composeEventHandlers, isRenderable, mergeProps} from '../utils';
 import type {Elevation} from '../utils/types';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
@@ -140,15 +145,26 @@ export interface BannerProps extends BaseProps<HTMLDivElement> {
    */
   elevation?: Elevation;
   /**
-   * Whether the content area (children) starts expanded.
-   * Only relevant when children are provided.
-   * @default false
+   * Whether the content area (children) collapses behind a toggle in the
+   * header. Omit it and children are always visible — no toggle, no
+   * `aria-expanded`, and the content region stays mounted.
+   *
+   * - `true` — collapsible, starts open (the `useCollapsible` default)
+   * - `{defaultIsOpen: false}` — collapsible, starts collapsed
+   * - `{isOpen, onOpenChange}` — controlled by the consumer
+   * - `false` or omitted — not collapsible
+   *
+   * Takes the shared `CollapsibleConfig` so a banner's disclosure is
+   * configured exactly like `Collapsible`'s, rather than through a
+   * Banner-only vocabulary.
+   *
+   * @default undefined
    */
-  defaultIsExpanded?: boolean;
+  collapsible?: boolean | CollapsibleConfig;
   /**
-   * Extra content rendered below the header in a collapsible card-background area.
+   * Extra content rendered below the header in a card-background area.
    * Use for rich content like lists, links, or detailed information.
-   * When provided, a collapse/expand toggle button appears in the header.
+   * Visible by default; pass `collapsible` to put it behind a toggle.
    */
   children?: ReactNode;
 }
@@ -367,11 +383,11 @@ const elevationStyles = stylex.create({
  *
  * Two-part visual structure:
  * - Header: colored status background with icon, title, description, and actions
- * - Content (optional): collapsible card background area for additional rich content
+ * - Content (optional): card background area for additional rich content
  *
- * When children are provided, a collapse/expand chevron button appears in the
- * header end area (to the left of the dismiss button if present). Clicking it
- * toggles the visibility of the content area.
+ * Children are visible by default. Pass `collapsible` and a chevron toggle
+ * appears in the header end area (to the left of the dismiss button if
+ * present), hiding and showing the content area.
  *
  * Manages its own dismissed state internally — the banner hides on dismiss
  * even if `onDismiss` is not provided, so product teams don't need to wire
@@ -402,7 +418,7 @@ const elevationStyles = stylex.create({
  * <Banner
  *   status="warning"
  *   title="Configuration changes"
- *   defaultIsExpanded>
+ *   collapsible={{defaultIsOpen: false}}>
  *   <p>Details here...</p>
  * </Banner>
  * ```
@@ -417,7 +433,7 @@ export function Banner({
   endContent,
   container = 'card',
   elevation = 'none',
-  defaultIsExpanded = false,
+  collapsible,
   children,
   xstyle,
   className,
@@ -429,7 +445,14 @@ export function Banner({
 }: BannerProps) {
   const t = useTranslator();
   const [isDismissed, setIsDismissed] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
+  // The disclosure state machine is the shared one — Banner owns no collapse
+  // state of its own. `isEnabled` is false when `collapsible` is omitted, and
+  // that is what makes the content permanently visible.
+  const {
+    isEnabled: isCollapsible,
+    isOpen: isExpanded,
+    toggle: handleToggleExpand,
+  } = useCollapsible({isCollapsible: collapsible});
   // The element focus came from before it entered the banner. Dismissing
   // unmounts the whole banner, dismiss button included, so without a handoff
   // the browser drops focus to <body> and a keyboard user loses their place.
@@ -438,7 +461,8 @@ export function Banner({
   // Links the expand/collapse toggle to the content region it shows/hides so
   // assistive tech can move from the button to its controlled content
   // (disclosure pattern). The region is conditionally rendered, so aria-controls
-  // below is set only while it's mounted to avoid a dangling reference.
+  // below is set only while it's mounted to avoid a dangling reference. A
+  // non-collapsible banner has no toggle, so neither end of the link is used.
   const contentId = useId();
   const defaultIconName = defaultIconNames[status];
   const role = statusRole[status] ?? FALLBACK_ROLE;
@@ -482,18 +506,19 @@ export function Banner({
     }
   };
 
-  const handleToggleExpand = () => {
-    setIsExpanded(prev => !prev);
-  };
-
+  // The toggle exists only for a collapsible banner that actually has content
+  // to disclose.
+  const hasToggle = isCollapsible && hasChildren;
   // Show the end area if there are actions, dismiss, or a collapsible toggle
-  const showEndArea = isRenderable(endContent) || isDismissable || hasChildren;
+  const showEndArea = isRenderable(endContent) || isDismissable || hasToggle;
   // Center items vertically when there's only a title (no description)
   // and the banner has action buttons
   const hasActions = isRenderable(endContent) || isDismissable;
   const isSingleLine = !isRenderable(description) && hasActions;
 
-  const showContent = hasChildren && isExpanded;
+  // Non-collapsible children are always shown; collapsible ones follow the
+  // hook's open state.
+  const showContent = hasChildren && (!isCollapsible || isExpanded);
   const isCard = container === 'card';
 
   return (
@@ -575,7 +600,7 @@ export function Banner({
               edgeCompSlot.inset(spacingVars['--spacing-2']),
             )}>
             {endContent}
-            {hasChildren && (
+            {hasToggle && (
               <Button
                 variant="ghost"
                 size="sm"
@@ -623,7 +648,7 @@ export function Banner({
       {/* Content area: collapsible card background — theme target ('banner-content') */}
       {showContent && (
         <div
-          id={contentId}
+          id={hasToggle ? contentId : undefined}
           {...mergeProps(
             themeProps('banner-content', {container, status}),
             stylex.props(styles.contentArea, isCard && styles.contentAreaCard),


### PR DESCRIPTION
## The gap

Banner infers its disclosure from its content: any `children` get a chevron in
the header and are hidden until it is pressed. There is no way to have content
and no toggle — which is the case a banner most often wants, the list of the
three fields that failed validation — and `defaultIsExpanded` is the only knob,
with no controlled mode.

## The shape

Adding an `isCollapsible` boolean beside `defaultIsExpanded` would put two props
on one axis, where one silently voids the other — the prop-independence
principle, and precisely the clutter [API Conventions § Boolean-or-Config
Props](https://github.com/facebook/astryx/wiki/API-Conventions#boolean-or-config-props)
names (`isCollapsible` + `defaultIsCollapsed` + `onCollapsedChange`). So the
whole axis becomes one prop, the shape `SideNav.collapsible` set:

```ts
/** @default true */
collapsible?: boolean | CollapsibleConfig;
```

```tsx
<Banner status="warning" title="Config changed">…</Banner>          // unchanged: collapsible, starts closed
<Banner collapsible={false}>…</Banner>                              // new: always visible, no toggle
<Banner collapsible={{defaultIsOpen: true}}>…</Banner>              // replaces defaultIsExpanded
<Banner collapsible={{isOpen, onOpenChange}}>…</Banner>             // new: controlled
```

**The default is unchanged.** `collapsible` defaults to `true`, and Banner hands
the hook `defaultIsOpen: false` — the one place it departs from `useCollapsible`,
which opens by default. A banner's message lives in its header and its content is
supplementary, and that is the behaviour Banner has always had.

Three deliberate choices:

- **`CollapsibleConfig`, not a Banner-only vocabulary.** The exported type from
  `useCollapsible` — so a banner's disclosure is configured exactly like
  `Collapsible`'s, and there is no third spelling of the same three fields.
- **The shared hook, not local `useState`.** Banner no longer owns collapse
  state at all (Use the System, rule 3). Controlled mode comes for free, which
  is why it is in this PR rather than a later one.
- **The default lives on the prop, not in a second prop.** `collapsible={false}`
  is the opt-out; there is nothing else on the axis to contradict it.

Lint-wise the `boolean | Config` union is exempt from
`@astryx/boolean-prop-naming`, so the unprefixed name is legal; a bare
`isCollapsible: boolean` would not have been.

With `collapsible={false}` there is no toggle, no `aria-expanded` /
`aria-controls`, and the content region stays mounted with no `id`.

## Evidence

Real builds, shot in Chromium — `before` from `main` at 5ab06259c, `after` from
this branch. Harness and DOM facts on the
[assets branch](https://github.com/facebook/astryx/tree/assets/banner-collapsible-content)
(delete it after merge).

**Nothing moves for existing code.** A banner with children and no collapse prop,
and one that starts open, are **byte-identical PNGs across the two builds**
(`dfbfe0a7…` and `147e808b…`):

| default (children, no prop) | starts open |
|---|---|
| ![default](https://raw.githubusercontent.com/facebook/astryx/assets/banner-collapsible-content/pr-assets/after-default.png) | ![open](https://raw.githubusercontent.com/facebook/astryx/assets/banner-collapsible-content/pr-assets/after-open.png) |

**`collapsible={false}` is the new capability.** Before, that content was
unreachable behind a chevron; after, it is simply there.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/banner-collapsible-content/pr-assets/before-optout.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/banner-collapsible-content/pr-assets/after-optout.png) |

Read off the DOM: before `{buttons: ["Expand"], listItems: 0, ariaExpanded:
["false"]}`, after `{buttons: [], listItems: 3, ariaExpanded: []}`.

## What breaks, and the codemod

Only the prop rename: `defaultIsExpanded` is gone in favour of the config. That
is a type error at every call site, not a silent behaviour change — nothing
changes under anyone without a compiler error first.

**Codemod:** `npx astryx upgrade --codemod banner-collapsible-content`
(staged in `transforms/next/` per [Release Process § Writing a
codemod](https://github.com/facebook/astryx/wiki/Release-Process#writing-a-codemod)).

| before | after |
|---|---|
| `defaultIsExpanded` / `={true}` | `collapsible={{defaultIsOpen: true}}` |
| `defaultIsExpanded={false}` | *(removed — it is the default)* |
| `defaultIsExpanded={expr}` | `collapsible={{defaultIsOpen: expr}}` |
| children, no prop | *(untouched)* |

It only fires on a `Banner` imported from `@astryxdesign/core` —
`defaultIsExpanded` is a `ChatToolCalls` prop too — and declines to guess around
a spread. One deliberate scope boundary: the prop inside a props object (a
Storybook `args`) is left alone rather than rewritten on a guess about which
component the object feeds; the removed prop makes those a type error, so the
compiler finds them. `verify-codemods` passes as a superset — Storybook's Banner
stories are this transform's own output plus the new opt-out demos, with the
`args` sites migrated by hand.

## Accessibility note

Content that is always visible inside `role="alert"` means an error banner
announces its detail along with its title. Usually what you want for a list of
validation errors; worth knowing when reaching for `collapsible={false}`. The
`Banner.doc.mjs` best practices now say to use it when the user needs the content
to act on the message, and to keep the toggle when the detail is long enough to
bury the banner's own message.

## Test plan

- `pnpm test` — 536 files / 10946 tests pass. Banner is 47 tests (8 new or
  rewritten: default-unchanged, explicit `true`, `collapsible={false}`, the
  disclosure wiring absent when opted out, `defaultIsOpen: true`,
  `onOpenChange`, controlled). Codemod is 12 tests.
- `pnpm lint:strict` — 0 errors (56 pre-existing warnings, none in touched files).
- `pnpm build` — clean. `pnpm -F @astryxdesign/core typecheck` — clean.
- `node .github/scripts/codemod-verify.mjs` — reproducible.
- Chromium before/after above.

Also updated: `Banner.doc.mjs` (en + zh + dense, props, anatomy, best practices),
stories, and the `BannerCollapsibleContent` showcase block.
