### PR TITLE
RadioListItem and CheckboxListItem accept rich label and description content

### DIFF
--- a/.changeset/radio-checkbox-list-item-rich-content.md
+++ b/.changeset/radio-checkbox-list-item-rich-content.md
@@ -1,0 +1,21 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] RadioListItem and CheckboxListItem accept rich `label` and `description`
+
+`RadioListItem` typed `label` and `description` as `string` while its sibling
+`CheckboxListItem` already typed `label` as `ReactNode` — so the same slot had
+two contracts, and an app whose option descriptions carry links could not type
+them on either component. Both now take `ReactNode`; the runtime already
+rendered it.
+
+`RadioListItem` gains the `aria-label` escape hatch `CheckboxListItem`
+established, with the same meaning: a plain-text accessible name for the
+control. The radio differs in one way worth knowing — it points at its visible
+label for its accessible name, so a rich label still names it from its own
+text, and `aria-label` is there to narrow a name that reads badly rather than
+to supply a missing one. `aria-label` now lands on the radio instead of the row `<div>`,
+where ARIA ignored it.
+
+@cixzhang

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -11,6 +11,28 @@
     }
   },
   {
+    "component": "CheckboxList",
+    "storyId": "core-checkboxlist--rich-descriptions",
+    "dims": [
+      "D2"
+    ],
+    "selectors": {
+      "prev": ".astryx-checkbox-input",
+      "next": "[data-testid=\"checkbox-end-content\"]"
+    }
+  },
+  {
+    "component": "RadioList",
+    "storyId": "core-radiolist--rich-content",
+    "dims": [
+      "D2"
+    ],
+    "selectors": {
+      "prev": "input[aria-label=\"Pro\"]",
+      "next": "[data-testid=\"radio-end-content\"]"
+    }
+  },
+  {
     "component": "Calendar",
     "storyId": "core-calendar--default",
     "dims": [

--- a/apps/storybook/stories/CheckboxList.stories.tsx
+++ b/apps/storybook/stories/CheckboxList.stories.tsx
@@ -5,6 +5,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {CheckboxList, CheckboxListItem} from '@astryxdesign/core/CheckboxList';
 import {List} from '@astryxdesign/core/List';
 import {Card} from '@astryxdesign/core/Card';
+import {Link} from '@astryxdesign/core/Link';
 
 const meta: Meta<typeof CheckboxList> = {
   title: 'Core/CheckboxList',
@@ -93,6 +94,46 @@ export const WithDescriptions: Story = {
     label: 'Notification preferences',
     description: 'Choose how you would like to be notified',
     hasDividers: true,
+  },
+};
+
+export const RichDescriptions: Story = {
+  render: args => {
+    const [value, setValue] = useState<string[]>(args.value ?? ['analytics']);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <CheckboxList {...restArgs} value={value} onChange={setValue}>
+        <CheckboxListItem
+          label={
+            <>
+              Analytics <Link href="#analytics-details">details</Link>
+            </>
+          }
+          aria-label="Analytics"
+          value="analytics"
+          description={
+            <>
+              Usage data only. <Link href="#privacy">Read the policy</Link>
+            </>
+          }
+          endContent={<span data-testid="checkbox-end-content">$0/mo</span>}
+        />
+        <CheckboxListItem
+          label="Personalization"
+          value="personalization"
+          description={
+            <>
+              Tailors what you see. <Link href="#privacy">Learn more</Link>
+            </>
+          }
+        />
+      </CheckboxList>
+    );
+  },
+  args: {
+    label: 'Data sharing',
+    description:
+      'Labels and descriptions can carry links and other rich content without toggling the item.',
   },
 };
 

--- a/apps/storybook/stories/RadioList.stories.tsx
+++ b/apps/storybook/stories/RadioList.stories.tsx
@@ -3,6 +3,8 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Link} from '@astryxdesign/core/Link';
 
 const meta: Meta<typeof RadioList> = {
   title: 'Core/RadioList',
@@ -98,6 +100,47 @@ export const WithDescription: Story = {
   args: {
     label: 'Notification preference',
     description: 'Choose how you would like to be notified',
+  },
+};
+
+export const RichContent: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 'pro');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <RadioList {...restArgs} value={value} onChange={setValue}>
+        <RadioListItem
+          label="Starter"
+          value="starter"
+          description={
+            <>
+              Free forever. <Link href="#pricing">Compare plans</Link>
+            </>
+          }
+        />
+        <RadioListItem
+          label={
+            <>
+              Pro <Link href="#pro-details">details</Link>{' '}
+              <Badge label="Popular" />
+            </>
+          }
+          aria-label="Pro"
+          value="pro"
+          description={
+            <>
+              $12 per seat. <Link href="#pricing">See what is included</Link>
+            </>
+          }
+          endContent={<span data-testid="radio-end-content">$12/mo</span>}
+        />
+      </RadioList>
+    );
+  },
+  args: {
+    label: 'Plan',
+    description:
+      'A ReactNode label or description can carry links and other rich content. Nested controls keep their own behavior without selecting the option.',
   },
 };
 

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -339,6 +339,51 @@ describe('CheckboxList', () => {
     expect(screen.getByText('This is option A')).toBeInTheDocument();
   });
 
+  it('renders a ReactNode description on items', () => {
+    render(
+      <CheckboxList label="Plans" value={[]} onChange={() => {}}>
+        <CheckboxListItem
+          label="Pro plan"
+          value="pro"
+          description={
+            <span>
+              See the <a href="#pricing">pricing page</a>
+            </span>
+          }
+        />
+      </CheckboxList>,
+    );
+    expect(
+      screen.getByRole('link', {name: 'pricing page'}),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps a link in a ReactNode label independent from selection', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <CheckboxList label="Plans" value={[]} onChange={onChange}>
+        <CheckboxListItem
+          label={
+            <>
+              Pro plan <a href="#pricing">pricing details</a>
+            </>
+          }
+          aria-label="Pro plan"
+          value="pro"
+        />
+      </CheckboxList>,
+    );
+    const checkbox = screen.getByRole('checkbox', {name: 'Pro plan'});
+    const link = screen.getByRole('link', {name: 'pricing details'});
+    await user.tab();
+    expect(checkbox).toHaveFocus();
+    await user.tab();
+    expect(link).toHaveFocus();
+    await user.click(link);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('renders description on the checkbox list group', () => {
     render(
       <CheckboxList

--- a/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
@@ -14,7 +14,7 @@ export const docs = {
       name: 'label',
       type: 'ReactNode',
       description:
-        'Primary text label for the item. A plain string names the checkbox automatically; a rich (ReactNode) label should be paired with aria-label so screen readers get a concise name.',
+        'Primary text label for the item. Rich labels may contain links or buttons, which keep their own behavior without toggling the item. Pair a ReactNode label with aria-label so screen readers get a concise checkbox name.',
       required: true,
     },
     {
@@ -30,8 +30,8 @@ export const docs = {
     },
     {
       name: 'description',
-      type: 'string',
-      description: 'Secondary text below the label.',
+      type: 'ReactNode',
+      description: 'Secondary content below the label. String or ReactNode.',
     },
     {
       name: 'endContent',
@@ -98,8 +98,9 @@ export const docsZh = {
   props: [
     {
       name: 'label',
-      type: 'string',
-      description: '选项的主要文本标签。',
+      type: 'ReactNode',
+      description:
+        '选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会切换该选项。ReactNode 标签应同时传入 aria-label，为屏幕阅读器提供简洁的复选框名称。',
       required: true,
     },
     {
@@ -115,8 +116,8 @@ export const docsZh = {
     },
     {
       name: 'description',
-      type: 'string',
-      description: '标签下方的辅助文本。',
+      type: 'ReactNode',
+      description: '标签下方的辅助内容。可为字符串或 ReactNode。',
     },
     {
       name: 'endContent',
@@ -156,11 +157,12 @@ export const docsDense = {
   description:
     'Individual checkbox item w/ label, description, end content slot.',
   propDescriptions: {
-    label: 'Primary text label for item.',
+    label:
+      'Primary label. String or ReactNode; nested controls keep their behavior.',
     'aria-label':
       'Plain-text checkbox name when label is a ReactNode. Without it, rich-label items all announce as "Checkbox".',
     value: 'Identity key (required inside CheckboxList).',
-    description: 'Secondary text below label.',
+    description: 'Secondary content below label. String or ReactNode.',
     endContent: 'Content rendered after label area.',
     isDisabled: 'Whether this individual item disabled.',
     isLoading:

--- a/packages/core/src/CheckboxList/CheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/CheckboxListItem.tsx
@@ -48,7 +48,9 @@ export interface CheckboxListItemProps extends BaseProps<HTMLLIElement> {
    *
    * Accepts a plain string (single-line truncation applied automatically)
    * or a ReactNode for rich content (no truncation constraints —
-   * child components control their own text behavior).
+   * child components control their own text behavior). Links and buttons in
+   * the label keep their own behavior; only non-interactive row clicks
+   * delegate to the checkbox.
    */
   label: ReactNode;
   /**
@@ -76,9 +78,9 @@ export interface CheckboxListItemProps extends BaseProps<HTMLLIElement> {
    */
   value?: string;
   /**
-   * Secondary text below the label.
+   * Secondary content below the label. Accepts a plain string or a ReactNode.
    */
-  description?: string;
+  description?: ReactNode;
   /**
    * Content rendered after the label area.
    */

--- a/packages/core/src/RadioList/RadioList.test.tsx
+++ b/packages/core/src/RadioList/RadioList.test.tsx
@@ -666,13 +666,147 @@ describe('RadioList', () => {
             value="a"
             data-testid="item-a"
             id="item-a-id"
-            aria-label="First option"
+            aria-describedby="help-text"
           />
         </RadioList>,
       );
       const item = screen.getByTestId('item-a');
       expect(item).toHaveAttribute('id', 'item-a-id');
-      expect(item).toHaveAttribute('aria-label', 'First option');
+      expect(item).toHaveAttribute('aria-describedby', 'help-text');
+    });
+
+    it('routes aria-label to the radio control, not the row', () => {
+      render(
+        <RadioList label="Preference" value="" onChange={() => {}}>
+          <RadioListItem
+            label="Option A"
+            value="a"
+            data-testid="item-a"
+            aria-label="First option"
+          />
+        </RadioList>,
+      );
+      expect(screen.getByTestId('item-a')).not.toHaveAttribute('aria-label');
+      expect(
+        screen.getByRole('radio', {name: 'First option'}),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('RadioListItem rich content', () => {
+    it('names the radio from the text of a ReactNode label', () => {
+      render(
+        <RadioList label="Plans" value="" onChange={() => {}}>
+          <RadioListItem
+            label={
+              <span>
+                Pro plan <em>(recommended)</em>
+              </span>
+            }
+            value="pro"
+          />
+        </RadioList>,
+      );
+      // The radio points at its visible label, so the name is computed from
+      // the rich node's own text — unlike CheckboxListItem, whose control has
+      // a separate hidden label and needs aria-label to say anything useful.
+      expect(
+        screen.getByRole('radio', {name: 'Pro plan (recommended)'}),
+      ).toBeInTheDocument();
+    });
+
+    it('lets aria-label override the name a ReactNode label would compute', () => {
+      render(
+        <RadioList label="Plans" value="" onChange={() => {}}>
+          <RadioListItem
+            label={
+              <span>
+                Pro plan <em>(recommended)</em>
+              </span>
+            }
+            aria-label="Pro plan"
+            value="pro"
+          />
+        </RadioList>,
+      );
+      expect(screen.getByRole('radio', {name: 'Pro plan'})).toBeInTheDocument();
+    });
+
+    it('selects the option when a ReactNode label is clicked', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <RadioList label="Plans" value="" onChange={onChange}>
+          <RadioListItem label={<span>Pro plan</span>} value="pro" />
+        </RadioList>,
+      );
+      await user.click(screen.getByText('Pro plan'));
+      expect(onChange).toHaveBeenCalledWith('pro');
+    });
+
+    it('keeps a link in a ReactNode label independent from selection', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <RadioList label="Plans" value="" onChange={onChange}>
+          <RadioListItem
+            label={
+              <>
+                Pro plan <a href="#pricing">pricing details</a>
+              </>
+            }
+            aria-label="Pro plan"
+            value="pro"
+          />
+        </RadioList>,
+      );
+      const radio = screen.getByRole('radio', {name: 'Pro plan'});
+      const link = screen.getByRole('link', {name: 'pricing details'});
+      await user.tab();
+      expect(radio).toHaveFocus();
+      await user.tab();
+      expect(link).toHaveFocus();
+      await user.click(link);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('renders a ReactNode description and keeps it linked to the radio', async () => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <RadioList label="Plans" value="" onChange={onChange}>
+          <RadioListItem
+            label="Pro plan"
+            description={
+              <span>
+                See the <a href="#pricing">pricing page</a>
+              </span>
+            }
+            value="pro"
+          />
+        </RadioList>,
+      );
+      const radio = screen.getByRole('radio', {name: 'Pro plan'});
+      expect(radio).toHaveAccessibleDescription('See the pricing page');
+      // The row delegates surface clicks to the radio, but a nested link is
+      // its own click target — following it must not also select the option.
+      await user.click(screen.getByRole('link', {name: 'pricing page'}));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('leaves aria-describedby off when a conditional description renders nothing', () => {
+      const showDetails = false;
+      render(
+        <RadioList label="Plans" value="" onChange={() => {}}>
+          <RadioListItem
+            label="Pro plan"
+            // The common conditional-slot idiom yields `false`, not undefined.
+            description={showDetails && <span>Billing details</span>}
+            value="pro"
+          />
+        </RadioList>,
+      );
+      expect(screen.getByRole('radio')).not.toHaveAttribute('aria-describedby');
     });
   });
 

--- a/packages/core/src/RadioList/RadioListItem.doc.mjs
+++ b/packages/core/src/RadioList/RadioListItem.doc.mjs
@@ -7,7 +7,8 @@ export const docs = {
   subComponentOf: 'RadioList',
   displayName: 'Radio List Item',
   isHiddenFromOverview: true,
-  description: 'Individual radio item with label, description, and content slots.',
+  description:
+    'Individual radio item with label, description, and content slots.',
   // RadioListItem requires RadioList context; wrap it so the preview doesn't throw.
   playground: {
     defaults: {value: 'option-1', label: 'Option'},
@@ -19,9 +20,16 @@ export const docs = {
   props: [
     {
       name: 'label',
-      type: 'string',
-      description: 'Label text for the radio item.',
+      type: 'ReactNode',
+      description:
+        'Primary label for the radio item. Rich labels may contain links or buttons, which keep their own behavior without selecting the item. The label text names the radio; pair it with aria-label when that text does not read well on its own.',
       required: true,
+    },
+    {
+      name: 'aria-label',
+      type: 'string',
+      description:
+        'Plain-text accessible name for the radio, applied to the control rather than the row. It overrides whatever the label element computes — a plain string label included — so reach for it when a rich label\u2019s own text is absent or reads badly.',
     },
     {
       name: 'value',
@@ -31,8 +39,9 @@ export const docs = {
     },
     {
       name: 'description',
-      type: 'string',
-      description: 'Description text displayed below the label.',
+      type: 'ReactNode',
+      description:
+        'Secondary content displayed below the label. Links and buttons keep their own click behaviour — the row only delegates clicks from its non-interactive surface to the radio.',
     },
     {
       name: 'isDisabled',
@@ -85,9 +94,16 @@ export const docsZh = {
   props: [
     {
       name: 'label',
-      type: 'string',
-      description: '单选选项的标签文本。',
+      type: 'ReactNode',
+      description:
+        '单选选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会选中该选项。标签文本用于命名单选框；若朗读效果不佳，请同时传入 aria-label。',
       required: true,
+    },
+    {
+      name: 'aria-label',
+      type: 'string',
+      description:
+        '单选框的纯文本无障碍名称，应用于控件本身而非整行。它会覆盖标签元素计算出的名称（包括纯字符串标签），因此仅在富文本标签自身缺少文本或朗读效果不佳时使用。',
     },
     {
       name: 'value',
@@ -97,8 +113,9 @@ export const docsZh = {
     },
     {
       name: 'description',
-      type: 'string',
-      description: '显示在标签下方的描述文本。',
+      type: 'ReactNode',
+      description:
+        '显示在标签下方的次要内容。链接和按钮保留自身的点击行为——整行仅将非交互区域的点击委派给单选框。',
     },
     {
       name: 'isDisabled',
@@ -125,9 +142,11 @@ export const docsDense = {
   displayName: 'Radio List Item',
   description: 'Individual radio item w/ label, description, content slots.',
   propDescriptions: {
-    label: 'Label text for radio item.',
+    label:
+      'Primary label. String or ReactNode; nested controls keep their behavior.',
+    'aria-label': 'Plain-text radio name; overrides any label.',
     value: 'Value of this radio item.',
-    description: 'Description text below label.',
+    description: 'Secondary content below label. String or ReactNode.',
     isDisabled: 'Whether this individual radio item disabled.',
     startContent: 'Content rendered before radio circle.',
     endContent: 'Content rendered after label.',

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -113,17 +113,42 @@ const rowStyles = stylex.create({
 export interface RadioListItemProps extends BaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
   /**
-   * Label text for the radio item.
+   * Primary label for the radio item.
+   *
+   * Accepts a plain string or a ReactNode for rich content. Links and buttons
+   * in the label keep their own behavior; only non-interactive row clicks
+   * delegate to the radio. The radio points at the rendered label for its
+   * accessible name, so a rich label still names it from its own text — pass
+   * `aria-label` when that text is absent or too noisy to announce.
    */
-  label: string;
+  label: ReactNode;
+  /**
+   * Plain-text accessible name for the radio, applied to the control rather
+   * than the row. It replaces the name the label would otherwise supply — a
+   * plain string label included — so reach for it when a rich label's own
+   * text is absent or reads badly, not as a routine addition.
+   *
+   * @example
+   * ```
+   * <RadioListItem
+   *   label={<span>Pro plan <Badge label="Recommended" /></span>}
+   *   aria-label="Pro plan"
+   *   value="pro"
+   * />
+   * ```
+   */
+  'aria-label'?: string;
   /**
    * Value of this radio item.
    */
   value: string;
   /**
-   * Description text displayed below the label.
+   * Secondary content displayed below the label. Accepts a plain string or a
+   * ReactNode. Links and buttons anywhere in the row keep their own click
+   * behaviour — the row only delegates clicks from its non-interactive
+   * surface to the radio.
    */
-  description?: string;
+  description?: ReactNode;
   /**
    * Whether this individual radio item is disabled.
    * @default false
@@ -155,6 +180,7 @@ export interface RadioListItemProps extends BaseProps<HTMLDivElement> {
 export function RadioListItem({
   ref,
   label,
+  'aria-label': ariaLabel,
   value,
   description,
   isDisabled: isItemDisabled = false,
@@ -172,6 +198,7 @@ export function RadioListItem({
   }
 
   const id = useId();
+  const labelID = useId();
   const descriptionID = useId();
   const isDisabled = context.isDisabled || isItemDisabled;
   // When the whole group is disabled with a disabledMessage, radios stay
@@ -181,6 +208,10 @@ export function RadioListItem({
   const keepsFocusableForMessage =
     context.hasDisabledMessage && !isItemDisabled;
   const isChecked = context.value === value;
+  // One predicate for both the rendered element and the aria-describedby that
+  // points at it. A ReactNode description can be `false` or `''`, which render
+  // nothing — a `!= null` check would leave the link dangling.
+  const hasDescription = isRenderable(description);
   const size = context.size;
   // The radio visual is an indicator: a theme can restyle it through the
   // `radio` / `radio-dot` targets or replace the component outright.
@@ -211,7 +242,6 @@ export function RadioListItem({
         name={context.name}
         value={value}
         checked={isChecked}
-        aria-label={label}
         disabled={isDisabled && !keepsFocusableForMessage}
         aria-disabled={keepsFocusableForMessage ? 'true' : undefined}
         // A focusable-disabled radio is not natively disabled, so detach it
@@ -229,7 +259,13 @@ export function RadioListItem({
         // both direct control clicks and row-surface clicks the row delegates
         // to the input — the same routing CheckboxListItem uses.
         onClick={onClick}
-        aria-describedby={description ? descriptionID : undefined}
+        // The radio names itself from the visible label element, which works
+        // for a rich label as well as a plain string. `aria-label` replaces
+        // that name rather than adding to it, so the two are mutually
+        // exclusive — aria-labelledby would otherwise win over it.
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabel == null ? labelID : undefined}
+        aria-describedby={hasDescription ? descriptionID : undefined}
         {...stylex.props(
           styles.input,
           wrapperSizeStyles[size],
@@ -264,9 +300,9 @@ export function RadioListItem({
       // focusable control, so the row adds no second tab stop.
       interactiveRef={radioRef}
       isDisabled={isDisabled}
-      label={<span>{label}</span>}
+      label={<span id={labelID}>{label}</span>}
       description={
-        isRenderable(description) ? (
+        hasDescription ? (
           <span id={descriptionID}>{description}</span>
         ) : undefined
       }


### PR DESCRIPTION
## Why

`RadioListItem` types `label` and `description` as `string`. Its sibling `CheckboxListItem` already types `label` as `ReactNode`, so radio and checkbox disagree about the same slot — and an app whose option descriptions carry a link can type one on neither.

The runtime was never the obstacle. `Item` and `ListItem` have taken `ReactNode` for both slots all along, so a rich node already rendered and the label element already named the radio from its own text. Only the types refused.

## What

`label` on `RadioListItem`, and `description` on both items, are now `ReactNode`. `RadioListItem` picks up the `aria-label` escape hatch `CheckboxListItem` established, with the same meaning: a plain-text accessible name applied to the control, not the row.

The two controls reach that name by different routes, and the prop docs say so rather than pretending they match:

- `CheckboxListItem`'s checkbox carries its own visually hidden label, so a rich `label` leaves it named "Checkbox" — it warns in dev until you pass `aria-label`.
- `RadioListItem`'s `<label htmlFor>` wraps the visible content and is tied to the input, so a rich label still computes a name from its text. `aria-label` narrows a name that reads badly, rather than rescuing a missing one, so there is no dev warning here — it would fire on labels that are already named correctly.

Rich labels may include links or other interactive content. The visual label renders in a plain `<span>`, while the row delegates only non-interactive surface clicks to the control. Nested links and buttons therefore keep their own behavior without selecting or toggling the item. The radio still derives its accessible name from the rich label text; pass `aria-label` when that flattened text is absent or reads poorly.

**Left alone deliberately.** `RadioList` and `CheckboxList` keep `label: string` and `description?: string`. Those are the group's field-level label and helper text, owned by `Field` and shared with every input that composes it; widening them is a change to `Field`'s contract alongside `isLabelHidden` and `labelTooltip`, with its own accessible-name story. Different change.

## Risk

One behavior change: `aria-label` on `RadioListItem` used to land on the row `<div>`, where ARIA ignores it on a role-less element. It now names the radio. Every other `aria-*` still forwards to the row, matching `CheckboxListItem`.

Widening `description` also made a latent guard mismatch reachable, so it is fixed here: the description element was guarded by `!= null` while its `aria-describedby` used truthiness, and the ordinary `flag && <span>…</span>` idiom yields `false` — enough to render an empty described-by target. Both now go through `isRenderable`.

## Testing

Core suite (7057 tests), `typecheck`, `typecheck:docs` and lint all green. New unit tests cover the name computed from a rich label, `aria-label` overriding it, non-interactive rich-label content still selecting on click, links inside labels and descriptions remaining separate keyboard targets without selecting or toggling the item, and an empty description leaving `aria-describedby` off.

jsdom cannot settle accessible names, so the a11y half was read out of Chromium's own accessibility tree against the new stories:

| Control | Accessible name | Accessible description |
|---|---|---|
| radio, label `Pro <Badge label="Popular" />`, no `aria-label` | `Pro Popular` | — |
| same, with `aria-label="Pro"` | `Pro` | `$12 per seat. See what is included` |
| radio, string label, rich description | `Starter` | `Free forever. Compare plans` |
| checkbox, rich description | `Personalization` | — |

Interaction in the same browser: clicking a rich label selects its radio; clicking a link inside a description selects nothing, on radio and checkbox alike, while a click on the rest of the checkbox row still toggles it.
