### PR TITLE
fix(docsite): verify the sender on the playground preview channel

### DIFF
--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -11,6 +11,36 @@ const nextConfig = {
   async rewrites() {
     return [{source: '/blog/:slug.txt', destination: '/blog/txt/:slug'}];
   },
+  // The playground preview evaluates user-authored code, so it is the one
+  // route that must never be embeddable by another site and never a loader of
+  // third-party script. The origin check on its postMessage channel is the
+  // actual guard (playground/previewChannel.ts); these headers are the layer
+  // underneath it. 'unsafe-eval' is inherent — the route's whole job is
+  // compiling and running TSX in the browser. img/connect stay open so demo
+  // code can still fetch and show remote data; the allowed hosts are the ones
+  // the site itself loads (Google Fonts, Vercel analytics).
+  async headers() {
+    return [
+      {
+        source: '/playground/preview',
+        headers: [
+          {key: 'X-Frame-Options', value: 'SAMEORIGIN'},
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "frame-ancestors 'self'",
+              "base-uri 'none'",
+              "object-src 'none'",
+              "form-action 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com",
+              "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+              "font-src 'self' https://fonts.gstatic.com data:",
+            ].join('; '),
+          },
+        ],
+      },
+    ];
+  },
   webpack: config => {
     // Webpack's CSS @import resolver doesn't follow package.json "exports".
     // Map each theme's /theme.css subpath to the actual dist file.

--- a/apps/docsite/src/__tests__/playground-preview-channel.test.ts
+++ b/apps/docsite/src/__tests__/playground-preview-channel.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {isTrustedPreviewMessage} from '../app/playground/previewChannel';
+
+const ORIGIN = 'https://astryx.atmeta.com';
+
+const parent = {} as MessageEventSource;
+const other = {} as MessageEventSource;
+
+function event(origin: string, source: MessageEventSource | null) {
+  return {origin, source};
+}
+
+describe('isTrustedPreviewMessage', () => {
+  it('accepts a message from the expected window on our own origin', () => {
+    expect(isTrustedPreviewMessage(event(ORIGIN, parent), ORIGIN, parent)).toBe(
+      true,
+    );
+  });
+
+  it('rejects another origin, even from the expected window', () => {
+    expect(
+      isTrustedPreviewMessage(
+        event('https://evil.example', parent),
+        ORIGIN,
+        parent,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects an opaque (sandboxed) origin', () => {
+    expect(isTrustedPreviewMessage(event('null', parent), ORIGIN, parent)).toBe(
+      false,
+    );
+  });
+
+  it('rejects our own origin sent from a window that is not the counterpart', () => {
+    expect(isTrustedPreviewMessage(event(ORIGIN, other), ORIGIN, parent)).toBe(
+      false,
+    );
+  });
+
+  it('rejects everything while the counterpart window does not exist', () => {
+    expect(isTrustedPreviewMessage(event(ORIGIN, parent), ORIGIN, null)).toBe(
+      false,
+    );
+    expect(
+      isTrustedPreviewMessage(event(ORIGIN, parent), ORIGIN, undefined),
+    ).toBe(false);
+  });
+
+  it('rejects a message with no source', () => {
+    expect(isTrustedPreviewMessage(event(ORIGIN, null), ORIGIN, parent)).toBe(
+      false,
+    );
+  });
+});

--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -37,6 +37,7 @@ import dynamic from 'next/dynamic';
 import * as stylex from '@stylexjs/stylex';
 import {AppShell} from '@astryxdesign/core/AppShell';
 import {compressCode, decompressCode} from '../../lib/compress';
+import {isTrustedPreviewMessage, trustedPreviewOrigin} from './previewChannel';
 import {Button} from '@astryxdesign/core/Button';
 import {Link} from '@astryxdesign/core/Link';
 import {HStack, VStack} from '@astryxdesign/core/Layout';
@@ -357,7 +358,7 @@ export function PlaygroundClient() {
   const postToPreview = useCallback((message: unknown) => {
     iframeRef.current?.contentWindow?.postMessage(
       message,
-      window.location.origin,
+      trustedPreviewOrigin(),
     );
   }, []);
 
@@ -407,7 +408,13 @@ export function PlaygroundClient() {
 
   useEffect(() => {
     const handler = (e: MessageEvent) => {
-      if (e.source !== iframeRef.current?.contentWindow) {
+      if (
+        !isTrustedPreviewMessage(
+          e,
+          trustedPreviewOrigin(),
+          iframeRef.current?.contentWindow,
+        )
+      ) {
         return;
       }
       if (e.data?.type === 'preview-ready') {

--- a/apps/docsite/src/app/playground/preview/page.tsx
+++ b/apps/docsite/src/app/playground/preview/page.tsx
@@ -22,6 +22,7 @@ import {
   setCleanSource,
 } from '../propertyEditor/targetingOverlay';
 import {runCode, setTypeScript} from './runner';
+import {isTrustedPreviewMessage, trustedPreviewOrigin} from '../previewChannel';
 import type * as TS from 'typescript';
 
 const FALLBACK_THEME =
@@ -116,7 +117,7 @@ export default function PreviewPage() {
   const theme = customTheme ?? themeByValue[themeName] ?? FALLBACK_THEME;
 
   const postToParent = useCallback((msg: Record<string, unknown>) => {
-    window.parent.postMessage(msg, '*');
+    window.parent.postMessage(msg, trustedPreviewOrigin());
   }, []);
 
   const targetingRef = useRef<ReturnType<
@@ -197,6 +198,13 @@ export default function PreviewPage() {
     }
 
     function onMessage(event: MessageEvent) {
+      // The switch below evaluates attacker-controllable source, so nothing is
+      // read off `event` until the sender is known to be our own playground.
+      if (
+        !isTrustedPreviewMessage(event, trustedPreviewOrigin(), window.parent)
+      ) {
+        return;
+      }
       if (!isPreviewMessage(event.data)) {
         return;
       }

--- a/apps/docsite/src/app/playground/previewChannel.ts
+++ b/apps/docsite/src/app/playground/previewChannel.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file previewChannel.ts
+ * @input An incoming MessageEvent plus the window we expect to hear from
+ * @output Whether the message may be acted on
+ * @position Playground <-> preview iframe — the postMessage trust boundary.
+ *
+ * The preview iframe compiles and evaluates whatever source arrives on this
+ * channel, so an unchecked `message` listener lets any window that can reach
+ * the frame run code in this site's origin. `window.postMessage` is delivered
+ * to every listener regardless of sender, so both ends must gate on the
+ * sender's identity themselves: the origin the message came from AND the
+ * window object it came from.
+ *
+ * The preview is always served from this site (the iframe uses a relative
+ * src), so "trusted" is same-origin — no host allowlist to keep in sync with
+ * production, Vercel previews, and localhost.
+ */
+
+/** The origin both ends of the channel must be on. */
+export function trustedPreviewOrigin(): string {
+  return window.location.origin;
+}
+
+/**
+ * True when `event` came from the window we expect, on our own origin.
+ *
+ * `expectedSource` is the counterpart window: the frame's parent (in the
+ * preview) or the iframe's contentWindow (in the playground). A nullish
+ * expected source means the counterpart does not exist yet, so nothing can be
+ * trusted.
+ */
+export function isTrustedPreviewMessage(
+  event: Pick<MessageEvent, 'origin' | 'source'>,
+  expectedOrigin: string,
+  expectedSource: MessageEventSource | null | undefined,
+): boolean {
+  if (event.origin !== expectedOrigin) {
+    return false;
+  }
+  if (expectedSource == null || event.source == null) {
+    return false;
+  }
+  return event.source === expectedSource;
+}

--- a/apps/docsite/src/app/playground/propertyEditor/targetingOverlay.tsx
+++ b/apps/docsite/src/app/playground/propertyEditor/targetingOverlay.tsx
@@ -28,6 +28,7 @@ import {Theme, MediaTheme} from '@astryxdesign/core/theme';
 import type {ThemeMode} from '@astryxdesign/core/theme';
 import {astryxTheme} from '../../../themes/astryx';
 import {PropertyEditor} from './PropertyEditor';
+import {trustedPreviewOrigin} from '../previewChannel';
 
 const styles = stylex.create({
   badge: {minHeight: 32},
@@ -129,7 +130,10 @@ export function setCleanSource(source: string) {
 }
 
 function postEditToParent(code: string) {
-  window.parent.postMessage({type: 'preview-edit-code', code}, '*');
+  window.parent.postMessage(
+    {type: 'preview-edit-code', code},
+    trustedPreviewOrigin(),
+  );
 }
 
 function renderTargetLabel(label: HTMLDivElement) {


### PR DESCRIPTION
## Why

The playground preview iframe compiles and evaluates whatever TSX arrives on
its `postMessage` channel — that is the feature. But `window.postMessage`
delivers to every listener regardless of who sent it, and the preview's
`message` handler acted on each one without checking the sender. Any window
holding a reference to the frame could therefore drive the code runner, and
the code it supplied would run in this site's own origin.

The same channel was also sending outbound with `targetOrigin: '*'`, so the
user's editor source was readable by any embedder.

## What

- `playground/previewChannel.ts` — one shared predicate for the trust
  boundary: a message is acted on only when its `origin` is our own and its
  `source` is the counterpart window (the frame's parent, or the iframe's
  `contentWindow`). Same-origin rather than a hostname allowlist, since the
  iframe is loaded from a relative path — nothing to keep in sync between
  production, Vercel previews, and localhost.
- Both ends now gate on it, and both now post with an explicit `targetOrigin`.
- The preview route is served with `frame-ancestors 'self'` (plus
  `X-Frame-Options` for older browsers) and a CSP that pins script, style, and
  font sources. `'unsafe-eval'` stays — compiling TSX in the browser is the
  route's job. `img-src`/`connect-src` stay open so demo code can still load
  and fetch remote data.

## Risk

The playground itself is unaffected: it was always same-origin with the
preview, so it passes the check unchanged. What stops working is driving the
preview from another origin, which was never a supported use — nothing in the
repo does it, and the route is already `disallow`ed in `robots.ts`.

The CSP is the part most likely to bite later: a future addition that loads
script from a new third-party host would need the header updated alongside it.

## Testing

- New unit tests for the predicate (foreign origin, opaque `null` origin,
  right origin from the wrong window, missing counterpart).
- Full docsite suite (383 tests), `tsc --noEmit`, and eslint clean; production
  build clean.
- Drove a real Chromium against a production build: a page on another origin
  can no longer make the preview run its code, either framed or via
  `window.open()` — including with CSP disabled in the browser, so the JS check
  is carrying the fix on its own rather than the headers hiding a gap. The
  frame also no longer answers a foreign parent at all.
- Same build, same browser, exercising the playground normally: the preview
  renders the editor's code and a theme change repaints it, with no CSP
  violations and no page errors.

One known consequence, preview-deploys only: Vercel injects its feedback
toolbar (`vercel.live`) at runtime, and the CSP blocks it *inside the preview
iframe*. Production never loads it, the toolbar still works on the surrounding
page, and allowlisting a third-party script host in this route's CSP to keep it
seemed the wrong trade.
