### PR TITLE
fix: stabilize useLayer references

### DIFF
--- a/.changeset/stable-use-layer.md
+++ b/.changeset/stable-use-layer.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep useLayer trigger refs and return objects stable when their inputs are unchanged.
+
+@nynexman4464

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -10,7 +10,13 @@
  */
 
 import {describe, it, expect, vi, afterEach} from 'vitest';
-import {render, act, fireEvent, waitFor} from '@testing-library/react';
+import {
+  render,
+  renderHook,
+  act,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -145,6 +151,43 @@ function RelocatingOpenContextHostingHarness({
     </>
   );
 }
+
+describe('useLayer identity', () => {
+  it('keeps the context ref and API object stable across rerenders', () => {
+    const {result, rerender} = renderHook(() => useLayer({mode: 'context'}));
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current.ref).toBe(first.ref);
+    expect(result.current).toBe(first);
+  });
+
+  it('keeps the context ref stable when callbacks change', () => {
+    const firstOnShow = vi.fn();
+    const secondOnShow = vi.fn();
+    const {result, rerender} = renderHook(
+      ({onShow}: {onShow: () => void}) => useLayer({mode: 'context', onShow}),
+      {initialProps: {onShow: firstOnShow}},
+    );
+    const first = result.current;
+    const firstRef = result.current.ref;
+
+    rerender({onShow: secondOnShow});
+
+    expect(result.current).not.toBe(first);
+    expect(result.current.ref).toBe(firstRef);
+  });
+
+  it('keeps the fixed API object stable across rerenders', () => {
+    const {result, rerender} = renderHook(() => useLayer({mode: 'fixed'}));
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});
 
 describe('getPositionTryFallbacks (issue #3671)', () => {
   const FLIPS = 'flip-block, flip-inline, flip-block flip-inline';

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -676,23 +676,23 @@ function useLayerImplementation(
     clearContextMount();
   }, [onHide, clearContextMount]);
 
-  // Ref for trigger element (context mode only)
-  const ref: RefCallback<HTMLElement> | undefined =
-    mode === 'context'
-      ? (el: HTMLElement | null) => {
-          // Remove only THIS layer's anchor name from the previous element so
-          // other layers sharing the same trigger keep their anchors.
-          if (triggerRef.current && triggerRef.current !== el) {
-            removeAnchorName(triggerRef.current, anchorId);
-          }
+  // Stable ref for the trigger element (context mode only).
+  const contextRef = useCallback(
+    (el: HTMLElement | null) => {
+      // Remove only THIS layer's anchor name from the previous element so
+      // other layers sharing the same trigger keep their anchors.
+      if (triggerRef.current && triggerRef.current !== el) {
+        removeAnchorName(triggerRef.current, anchorId);
+      }
 
-          if (el) {
-            addAnchorName(el, anchorId);
-          }
+      if (el) {
+        addAnchorName(el, anchorId);
+      }
 
-          triggerRef.current = el;
-        }
-      : undefined;
+      triggerRef.current = el;
+    },
+    [anchorId],
+  );
 
   // Arm only when the dismissing gesture's click is still ahead of us. Some
   // engines deliver click first; in that order there is nothing left to absorb.
@@ -997,9 +997,9 @@ function useLayerImplementation(
     [popoverRefCallback, id, lightDismiss],
   );
 
-  if (mode === 'context') {
-    return {
-      ref: ref as RefCallback<HTMLElement>,
+  const contextResult = useMemo<InternalContextLayerReturn>(
+    () => ({
+      ref: contextRef,
       anchorId,
       show,
       hide,
@@ -1007,18 +1007,32 @@ function useLayerImplementation(
       wasJustDismissed,
       id,
       render: renderContext,
-    };
-  }
+    }),
+    [
+      contextRef,
+      anchorId,
+      show,
+      hide,
+      isOpen,
+      wasJustDismissed,
+      id,
+      renderContext,
+    ],
+  );
+  const fixedResult = useMemo<InternalFixedLayerReturn>(
+    () => ({
+      ref: undefined,
+      show,
+      hide,
+      isOpen,
+      wasJustDismissed,
+      id,
+      render: renderFixed,
+    }),
+    [show, hide, isOpen, wasJustDismissed, id, renderFixed],
+  );
 
-  return {
-    ref: undefined,
-    show,
-    hide,
-    isOpen,
-    wasJustDismissed,
-    id,
-    render: renderFixed,
-  };
+  return mode === 'context' ? contextResult : fixedResult;
 }
 
 export function useLayer(options: ContextLayerOptions): ContextLayerReturn;
@@ -1026,8 +1040,11 @@ export function useLayer(options: FixedLayerOptions): FixedLayerReturn;
 export function useLayer(
   options: ContextLayerOptions | FixedLayerOptions,
 ): ContextLayerReturn | FixedLayerReturn {
-  const {wasJustDismissed: _, ...layer} = useLayerImplementation(options);
-  return layer;
+  const internalLayer = useLayerImplementation(options);
+  return useMemo(() => {
+    const {wasJustDismissed: _, ...layer} = internalLayer;
+    return layer;
+  }, [internalLayer]);
 }
 
 /** @internal Shared with usePopover; not exported from the package barrel. */


### PR DESCRIPTION
## Summary

- keep the context trigger ref returned by `useLayer` stable across unrelated rerenders
- memoize the context and fixed API objects from their exposed members
- preserve updates when callbacks, open state, or render behavior actually change
- add regression coverage for stable refs and return objects

Fixes #5271.

## Test plan

- fail-first on current `main`: the three identity tests fail (3 failed, 43 passed)
- `pnpm vitest run packages/core/src/Layer/useLayer.test.tsx` — 46 passed
- `pnpm lint:strict`
- `pnpm build`
- `pnpm vitest run --maxWorkers=8` — 12,226 passed, 5 skipped
