### PR TITLE
fix: stabilize useTheme return values

### DIFF
--- a/.changeset/stable-use-theme.md
+++ b/.changeset/stable-use-theme.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep useTheme token resolvers and return values stable when the resolved theme is unchanged.
+
+@nynexman4464

--- a/packages/core/src/theme/useTheme.test.tsx
+++ b/packages/core/src/theme/useTheme.test.tsx
@@ -108,6 +108,16 @@ describe('useTheme', () => {
     expect(result.current.token('--color-text-primary')).toBe('#DFE2E5');
   });
 
+  it('keeps the token resolver and return object stable across rerenders', () => {
+    const {result, rerender} = renderHook(() => useTheme());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current.token).toBe(first.token);
+    expect(result.current).toBe(first);
+  });
+
   it('returns empty string for unknown tokens', () => {
     const {result} = renderHook(() => useTheme(), {
       wrapper: ({children}) => wrapper({children, mode: 'light'}),

--- a/packages/core/src/theme/useTheme.ts
+++ b/packages/core/src/theme/useTheme.ts
@@ -21,7 +21,13 @@
  * - /packages/core/src/theme/index.ts
  */
 
-import {createContext, use, useMemo, useSyncExternalStore} from 'react';
+import {
+  createContext,
+  use,
+  useCallback,
+  useMemo,
+  useSyncExternalStore,
+} from 'react';
 import type {ThemeMode} from './types';
 import type {DefinedTheme} from './defineTheme';
 import {resolveThemeTokens} from './tokens';
@@ -281,14 +287,14 @@ export function useTheme(): UseThemeReturn {
     [theme, effectiveMode],
   );
 
-  const token = (name: string): string => {
-    return tokens[name] ?? '';
-  };
+  const token = useCallback(
+    (name: string): string => tokens[name] ?? '',
+    [tokens],
+  );
+  const name = theme?.name ?? 'default';
 
-  return {
-    name: theme?.name ?? 'default',
-    mode: effectiveMode,
-    token,
-    tokens,
-  };
+  return useMemo(
+    () => ({name, mode: effectiveMode, token, tokens}),
+    [name, effectiveMode, token, tokens],
+  );
 }


### PR DESCRIPTION
## Summary

- memoize the token resolver returned by `useTheme`
- keep the full theme API object stable while the resolved theme and mode are unchanged
- add regression coverage for referential stability across unrelated rerenders

Fixes #5273.

## Test plan

- fail-first on current `main` (`cb20a0185`): the focused file reports 1 failed / 20 passed; the new identity assertion fails because `token` changes across an unrelated rerender
- `pnpm vitest run packages/core/src/theme/useTheme.test.tsx` — 21 passed
- `pnpm lint:strict` — passed
- `pnpm build` — passed
- `pnpm vitest run --maxWorkers=8` — 580 files passed, 1 skipped; 12,214 tests passed, 5 skipped

The default-parallel `pnpm test` run is currently noisy on unchanged `main`: it reported 21 failed files / 24 failed tests, concentrated in CLI temporary-directory and timeout cases. The rebased branch showed the same failure class (18 failed files / 21 failed tests). Bounding Vitest to eight workers cleared the full suite.
