### PR TITLE
fix: stabilize default resize snaps

### DIFF
--- a/.changeset/stable-resizable-snaps.md
+++ b/.changeset/stable-resizable-snaps.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep useResizable callbacks stable when snap points are omitted.
+
+@nynexman4464

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -400,3 +400,22 @@ describe('useResizable live collapse state', () => {
     expect(onCollapseChange).toHaveBeenCalledExactlyOnceWith(true);
   });
 });
+
+describe('useResizable identity', () => {
+  it('keeps callbacks stable when optional snaps are omitted', () => {
+    const {result, rerender} = renderHook(() =>
+      useResizable({defaultSize: 200, minSizePx: 100, maxSizePx: 400}),
+    );
+    const first = {
+      expand: result.current.expand,
+      resize: result.current.resize,
+      snaps: result.current.props._snaps,
+    };
+
+    rerender();
+
+    expect(result.current.expand).toBe(first.expand);
+    expect(result.current.resize).toBe(first.resize);
+    expect(result.current.props._snaps).toBe(first.snaps);
+  });
+});

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -253,13 +253,15 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
     maxSizePx = Infinity,
     collapsible = false,
     collapsedSize = DEFAULT_COLLAPSED_SIZE,
-    snaps = [],
+    snaps: configuredSnaps,
     autoSaveId,
     defaultIsCollapsed,
     isCollapsed: controlledIsCollapsed,
     onSizeChange,
     onCollapseChange,
   } = config;
+  const emptySnapsRef = useRef<number[]>([]);
+  const snaps = configuredSnaps ?? emptySnapsRef.current;
 
   const resolvedDefault = resolveDefaultSize(defaultSize);
   const persisted = autoSaveId ? loadPersistedState(autoSaveId) : null;


### PR DESCRIPTION
## Summary

- replace the render-time `snaps = []` default with one stable empty array per hook instance
- keep `expand`, `resize`, and `_snaps` stable when callers omit snap points
- add focused identity regression coverage

Fixes #5275.

## Test plan

- fail-first on current `main` (`5c396656f`): `pnpm exec vitest run packages/core/src/Resizable/useResizable.test.tsx` fails the callback identity assertion as expected
- `pnpm exec vitest run packages/core/src/Resizable/useResizable.test.tsx packages/core/src/Resizable/ResizeHandle.test.tsx` — 21 passed
- `pnpm lint:strict` — passed with 0 errors; 80 existing warnings outside the changed files
- `pnpm build` — passed
- `pnpm test` — 12,214 passed, 5 skipped (581 test files passed, 1 skipped)
