### PR TITLE
fix(Resizable): stabilize useResizable callbacks when snaps omitted

### DIFF
--- a/.changeset/resizable-snaps-stability.md
+++ b/.changeset/resizable-snaps-stability.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `useResizable` no longer recreates its `expand`/`resize`/`onResizeMove` callbacks (and `props._snaps`) on every render when `snaps` is omitted. The hook previously defaulted `snaps` to a new `[]` array literal in its destructure, so every consumer that depends on those callbacks re-ran unnecessarily even when the configuration never changed. A caller-provided `snaps` array keeps its existing identity-preserving behavior.
+
+@HelloOjasMutreja

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -3,7 +3,8 @@
 /**
  * @file useResizable.test.ts
  * @input Uses vitest, @testing-library/react renderHook, useResizable
- * @output Unit tests for useResizable persistence and collapse state
+ * @output Unit tests for useResizable persistence, collapse state, and
+ *   callback/prop stability
  * @position Testing; validates useResizable implementation
  *
  * Persistence coverage originated in #4824 by @AKnassa.
@@ -15,6 +16,7 @@ import {useLayoutEffect} from 'react';
 import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import {useResizable} from './useResizable';
+import type {UseResizableSingleConfig} from './useResizable';
 
 const AUTO_SAVE_ID = 'test-panel';
 const KEY = `astryx-resizable:${AUTO_SAVE_ID}`;
@@ -398,5 +400,39 @@ describe('useResizable live collapse state', () => {
     });
 
     expect(onCollapseChange).toHaveBeenCalledExactlyOnceWith(true);
+  });
+});
+
+describe('useResizable callback stability', () => {
+  it('keeps expand, resize, and props._snaps stable across rerenders when snaps is omitted', () => {
+    const config: UseResizableSingleConfig = {
+      defaultSize: 200,
+      minSizePx: 100,
+      maxSizePx: 400,
+    };
+    const {result, rerender} = renderHook(() => useResizable(config));
+
+    const first = result.current;
+    rerender();
+    const second = result.current;
+
+    expect(second.expand).toBe(first.expand);
+    expect(second.resize).toBe(first.resize);
+    expect(second.props._snaps).toBe(first.props._snaps);
+  });
+
+  it('still returns a stable snaps identity for a caller-provided array across rerenders', () => {
+    const snaps = [100, 200, 300];
+    const config: UseResizableSingleConfig = {
+      defaultSize: 200,
+      minSizePx: 100,
+      maxSizePx: 400,
+      snaps,
+    };
+    const {result, rerender} = renderHook(() => useResizable(config));
+
+    expect(result.current.props._snaps).toBe(snaps);
+    rerender();
+    expect(result.current.props._snaps).toBe(snaps);
   });
 });

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -253,13 +253,21 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
     maxSizePx = Infinity,
     collapsible = false,
     collapsedSize = DEFAULT_COLLAPSED_SIZE,
-    snaps = [],
+    snaps: snapsProp,
     autoSaveId,
     defaultIsCollapsed,
     isCollapsed: controlledIsCollapsed,
     onSizeChange,
     onCollapseChange,
   } = config;
+
+  // A `snaps = []` default in the destructure above allocates a new array
+  // every render, which changes identity on every `expand`/`resize`/
+  // `onResizeMove` useCallback below (and on `props._snaps`) even when the
+  // caller's config never changes. Keep one stable empty array per hook
+  // instance instead, and only fall back to it when the caller omitted snaps.
+  const emptySnapsRef = useRef<number[]>([]);
+  const snaps = snapsProp ?? emptySnapsRef.current;
 
   const resolvedDefault = resolveDefaultSize(defaultSize);
   const persisted = autoSaveId ? loadPersistedState(autoSaveId) : null;


### PR DESCRIPTION
Fixes #5275.

## Problem

`useResizable`'s single-region path defaults `snaps` with an array literal during the destructure:

```ts
const {snaps = []} = config;
```

When a caller omits `snaps`, this allocates a new `[]` on every render. `expand`, `resize`, and `onResizeMove` all list `snaps` in their `useCallback` deps, so every one of them is recreated on every render even when the caller's configuration never changed. `props._snaps` (passed to `ResizeHandle`) changes identity for the same reason.

## Fix

Keep one stable empty array per hook instance via `useRef`, and only fall back to it when `config.snaps` is `undefined`. A caller-provided array is passed through unchanged and keeps its own identity, matching existing behavior.

## Verification

Added `useResizable.test.ts` with two tests:
- Rerenders a config that omits `snaps` and asserts `expand`, `resize`, and `props._snaps` are referentially stable across the rerender. Confirmed this fails on the pre-fix implementation (`expected [Function] to be [Function]`) and passes after.
- A caller-provided `snaps` array also keeps its identity across rerenders (unaffected by this change).

Full `Resizable` suite (22 tests across `useResizable.test.ts` and `ResizeHandle.test.tsx`) passes. Typecheck and lint clean.

This intentionally does not memoize the whole `useResizable` return object; that's a broader optimization not needed to fix the confirmed default-array defect, matching the issue's own scoping.
