### PR TITLE
fix(useTheme): stabilize token resolver and return object

### DIFF
--- a/.changeset/usetheme-stable-token-resolver.md
+++ b/.changeset/usetheme-stable-token-resolver.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `useTheme` now returns a stable `token` resolver and a stable return object when the resolved theme and effective mode haven't changed. Previously both were recreated on every render, which defeated memoization in consumers like `useChartColors` (it memoizes its palette from `token`, so the changing resolver rebuilt the full color API after every unrelated rerender, and any effect depending on it reran unnecessarily).
+
+@nynexman4464
+
+@HelloOjasMutreja

--- a/packages/core/src/theme/useTheme.test.tsx
+++ b/packages/core/src/theme/useTheme.test.tsx
@@ -309,4 +309,15 @@ describe('useTheme root-attribute observer lifecycle', () => {
     second.unmount();
     expect(disconnect).toHaveBeenCalledTimes(2);
   });
+
+  it('keeps the returned token function and object stable across rerenders when theme and mode are unchanged', () => {
+    const {result, rerender} = renderHook(() => useTheme());
+
+    const first = result.current;
+    rerender();
+    const second = result.current;
+
+    expect(second.token).toBe(first.token);
+    expect(second).toBe(first);
+  });
 });

--- a/packages/core/src/theme/useTheme.ts
+++ b/packages/core/src/theme/useTheme.ts
@@ -21,7 +21,13 @@
  * - /packages/core/src/theme/index.ts
  */
 
-import {createContext, use, useMemo, useSyncExternalStore} from 'react';
+import {
+  createContext,
+  use,
+  useCallback,
+  useMemo,
+  useSyncExternalStore,
+} from 'react';
 import type {ThemeMode} from './types';
 import type {DefinedTheme} from './defineTheme';
 import {resolveThemeTokens} from './tokens';
@@ -281,14 +287,25 @@ export function useTheme(): UseThemeReturn {
     [theme, effectiveMode],
   );
 
-  const token = (name: string): string => {
-    return tokens[name] ?? '';
-  };
+  const token = useCallback(
+    (name: string): string => tokens[name] ?? '',
+    [tokens],
+  );
 
-  return {
-    name: theme?.name ?? 'default',
-    mode: effectiveMode,
-    token,
-    tokens,
-  };
+  const themeName = theme?.name ?? 'default';
+
+  // Memoized on the same values consumers actually care about, so a
+  // rerender that doesn't change the resolved theme/mode returns the exact
+  // same object and token function. Without this, useChartColors (and any
+  // other consumer memoizing off `token`) rebuilds on every unrelated
+  // rerender instead of only when the theme or effective mode changes.
+  return useMemo(
+    () => ({
+      name: themeName,
+      mode: effectiveMode,
+      token,
+      tokens,
+    }),
+    [themeName, effectiveMode, token, tokens],
+  );
 }


### PR DESCRIPTION
Fixes #5273.

## Problem

`useTheme` memoizes its resolved `tokens` map, but rebuilds the `token` resolver function and the returned object on every render:

```tsx
const token = (name: string) => tokens[name] ?? '';
return {name, mode, token, tokens};
```

This defeats memoization for any consumer that depends on `token` or the returned object's identity. `useChartColors` memoizes its color palette from `token`, so the changing resolver rebuilds the full color API after every unrelated rerender, and any effect depending on that API reruns even though the theme and effective mode never changed.

## Fix

`token` is memoized via `useCallback` from the resolved `tokens` map. The returned `UseThemeReturn` object is memoized via `useMemo` from its exposed members (`name`, `mode`, `token`, `tokens`), so identity only changes when the theme or effective mode actually changes.

No public types or resolved token values change.

## Verification

Added a regression test that rerenders `useTheme` with no theme change and asserts both the token resolver and the returned object keep referential identity. It fails on current main and passes with this fix. Full `useTheme.test.tsx` suite (21 tests) still passes. Typecheck and lint pass locally.
