### PR TITLE
fix(useLayer): stabilize context trigger ref and return objects

### DIFF
--- a/.changeset/uselayer-stable-ref-and-api.md
+++ b/.changeset/uselayer-stable-ref-and-api.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `useLayer({mode: 'context'})` now returns a stable trigger ref callback and a stable API object when nothing exposed by it has changed. Previously the trigger ref was recreated on every render, so React detached and reattached an unchanged trigger element (removing and reapplying its CSS anchor name for no reason), and the returned object (both `context` and `fixed` modes) was rebuilt every render, defeating memoization in consumers like Carousel, ContextMenu, Popover, Tooltip, HoverCard, and BaseTypeahead.
+
+@nynexman4464
+
+@HelloOjasMutreja

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -70,6 +70,40 @@ function ContextLayerHarness({
   );
 }
 
+/**
+ * Reports the full context-mode API object on every render, so tests can
+ * compare identity across rerenders (issue #5271).
+ */
+function ContextStabilityHarness({
+  onLayer,
+  onShow,
+}: {
+  onLayer: (layer: ContextLayerReturn) => void;
+  onShow?: () => void;
+}) {
+  const layer = useLayer({mode: 'context', onShow});
+  onLayer(layer);
+  return (
+    <>
+      <button type="button" ref={layer.ref}>
+        Trigger
+      </button>
+      {layer.render(<span>Layer content</span>)}
+    </>
+  );
+}
+
+/** Same as ContextStabilityHarness but for fixed mode. */
+function FixedStabilityHarness({
+  onLayer,
+}: {
+  onLayer: (layer: FixedLayerReturn) => void;
+}) {
+  const layer = useLayer({mode: 'fixed'});
+  onLayer(layer);
+  return <>{layer.render(<span>Layer content</span>, {x: 0, y: 0})}</>;
+}
+
 function ContextHostingHarness({
   unsafe,
   themeColor,
@@ -929,6 +963,7 @@ describe('useLayer context positioning', () => {
   });
 });
 
+
 describe('useLayer public return types', () => {
   it('keeps dismissal helpers internal', () => {
     const contextHasKeepOpenProps: 'keepOpenProps' extends keyof ContextLayerReturn
@@ -1180,5 +1215,63 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
     fireEvent.click(trigger);
 
     expect(getByTestId('state')).toHaveTextContent('closed');
+  });
+});
+
+describe('useLayer stability (issue #5271)', () => {
+  it('keeps the context trigger ref stable across unrelated rerenders', () => {
+    // Mounting a context layer settles its own internal contextMount state
+    // (set from the sentinel ref callback) before any explicit rerender, so
+    // more than one render can already have happened by the time render()
+    // returns. Compare the last settled render against one triggered after
+    // it, not a fixed array length.
+    const layers: ContextLayerReturn[] = [];
+    const onLayer = (layer: ContextLayerReturn) => layers.push(layer);
+
+    const {rerender} = render(<ContextStabilityHarness onLayer={onLayer} />);
+    const beforeRerender = layers.at(-1)!;
+    rerender(<ContextStabilityHarness onLayer={onLayer} />);
+    const afterRerender = layers.at(-1)!;
+
+    expect(afterRerender.ref).toBe(beforeRerender.ref);
+  });
+
+  it('keeps the context return object stable while its members are unchanged', () => {
+    const layers: ContextLayerReturn[] = [];
+    const onLayer = (layer: ContextLayerReturn) => layers.push(layer);
+
+    const {rerender} = render(<ContextStabilityHarness onLayer={onLayer} />);
+    const beforeRerender = layers.at(-1)!;
+    rerender(<ContextStabilityHarness onLayer={onLayer} />);
+    const afterRerender = layers.at(-1)!;
+
+    expect(afterRerender).toBe(beforeRerender);
+  });
+
+  it('keeps the fixed return object stable while its members are unchanged', () => {
+    const layers: FixedLayerReturn[] = [];
+    const onLayer = (layer: FixedLayerReturn) => layers.push(layer);
+
+    const {rerender} = render(<FixedStabilityHarness onLayer={onLayer} />);
+    rerender(<FixedStabilityHarness onLayer={onLayer} />);
+
+    expect(layers[1]).toBe(layers[0]);
+  });
+
+  it('refreshes the context API object when onShow changes, without replacing the trigger ref', () => {
+    const layers: ContextLayerReturn[] = [];
+    const onLayer = (layer: ContextLayerReturn) => layers.push(layer);
+    const onShowA = () => {};
+    const onShowB = () => {};
+
+    const {rerender} = render(
+      <ContextStabilityHarness onLayer={onLayer} onShow={onShowA} />,
+    );
+    const beforeRerender = layers.at(-1)!;
+    rerender(<ContextStabilityHarness onLayer={onLayer} onShow={onShowB} />);
+    const afterRerender = layers.at(-1)!;
+
+    expect(afterRerender).not.toBe(beforeRerender);
+    expect(afterRerender.ref).toBe(beforeRerender.ref);
   });
 });

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -1045,8 +1045,14 @@ export function useLayer(options: FixedLayerOptions): FixedLayerReturn;
 export function useLayer(
   options: ContextLayerOptions | FixedLayerOptions,
 ): ContextLayerReturn | FixedLayerReturn {
-  const {wasJustDismissed: _, ...layer} = useLayerImplementation(options);
-  return layer;
+  const layer = useLayerImplementation(options);
+  // Stripping wasJustDismissed via spread would build a fresh object on every
+  // call even when `layer` itself is unchanged, defeating the memoization
+  // useLayerImplementation does for exactly this purpose.
+  return useMemo(() => {
+    const {wasJustDismissed: _, ...rest} = layer;
+    return rest;
+  }, [layer]);
 }
 
 /** @internal Shared with usePopover; not exported from the package barrel. */

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -676,23 +676,27 @@ function useLayerImplementation(
     clearContextMount();
   }, [onHide, clearContextMount]);
 
-  // Ref for trigger element (context mode only)
+  // Ref for trigger element (context mode only). Stable across renders so
+  // React does not detach and reattach an unchanged trigger element, which
+  // would otherwise remove and reapply the CSS anchor name for no reason.
+  const contextTriggerRef: RefCallback<HTMLElement> = useCallback(
+    (el: HTMLElement | null) => {
+      // Remove only THIS layer's anchor name from the previous element so
+      // other layers sharing the same trigger keep their anchors.
+      if (triggerRef.current && triggerRef.current !== el) {
+        removeAnchorName(triggerRef.current, anchorId);
+      }
+
+      if (el) {
+        addAnchorName(el, anchorId);
+      }
+
+      triggerRef.current = el;
+    },
+    [anchorId],
+  );
   const ref: RefCallback<HTMLElement> | undefined =
-    mode === 'context'
-      ? (el: HTMLElement | null) => {
-          // Remove only THIS layer's anchor name from the previous element so
-          // other layers sharing the same trigger keep their anchors.
-          if (triggerRef.current && triggerRef.current !== el) {
-            removeAnchorName(triggerRef.current, anchorId);
-          }
-
-          if (el) {
-            addAnchorName(el, anchorId);
-          }
-
-          triggerRef.current = el;
-        }
-      : undefined;
+    mode === 'context' ? contextTriggerRef : undefined;
 
   // Arm only when the dismissing gesture's click is still ahead of us. Some
   // engines deliver click first; in that order there is nothing left to absorb.
@@ -997,8 +1001,13 @@ function useLayerImplementation(
     [popoverRefCallback, id, lightDismiss],
   );
 
-  if (mode === 'context') {
-    return {
+  // Memoized on the same members consumers actually see, so a rerender that
+  // doesn't change any of them (isOpen, the callbacks, the render function)
+  // returns the exact same object. Without this, every rerender produces a
+  // new API object, which reruns effects/listeners in consumers that
+  // correctly depend on it even though nothing about the layer changed.
+  const contextReturn = useMemo(
+    () => ({
       ref: ref as RefCallback<HTMLElement>,
       anchorId,
       show,
@@ -1007,18 +1016,28 @@ function useLayerImplementation(
       wasJustDismissed,
       id,
       render: renderContext,
-    };
+    }),
+    [ref, anchorId, show, hide, isOpen, wasJustDismissed, id, renderContext],
+  );
+
+  const fixedReturn = useMemo(
+    () => ({
+      ref: undefined,
+      show,
+      hide,
+      isOpen,
+      wasJustDismissed,
+      id,
+      render: renderFixed,
+    }),
+    [show, hide, isOpen, wasJustDismissed, id, renderFixed],
+  );
+
+  if (mode === 'context') {
+    return contextReturn;
   }
 
-  return {
-    ref: undefined,
-    show,
-    hide,
-    isOpen,
-    wasJustDismissed,
-    id,
-    render: renderFixed,
-  };
+  return fixedReturn;
 }
 
 export function useLayer(options: ContextLayerOptions): ContextLayerReturn;


### PR DESCRIPTION
Fixes #5271.

## Problem

`useLayer({mode: 'context'})` created a new trigger callback ref on every render:

```tsx
const ref: RefCallback<HTMLElement> | undefined =
  mode === 'context'
    ? (el: HTMLElement | null) => { ... }
    : undefined;
```

React detaches and reattaches a ref whose identity changes between renders, even when the underlying trigger element hasn't. That means every unrelated rerender removed and reapplied the trigger's CSS anchor name for no reason.

`useLayer` also returned a new plain object on every render, in both context and fixed modes:

```tsx
return {ref, anchorId, show, hide, isOpen, id, render: renderContext};
```

Consumers that correctly memoize off the returned layer object (or depend on it in an effect) rerun that work on every unrelated rerender, since the object's identity always changes. Affects Carousel, ContextMenu, Popover, Tooltip, HoverCard, and BaseTypeahead, all of which use `useLayer` under the hood.

## Fix

- The context trigger ref is now wrapped in `useCallback`, keyed on `anchorId` (which itself only changes if the `useId()`-derived id changes, i.e. never across the hook's lifetime).
- Both the context and fixed return objects are memoized via `useMemo` from their exposed members (`show`, `hide`, `isOpen`, `id`, `render`, plus `ref`/`anchorId` for context), so identity only changes when one of those actually changes.

No public types or behavior change.

## Verification

Added a regression suite (`useLayer stability (issue #5271)`) covering exactly what the issue asked for:
- the context trigger ref stays stable across an unrelated rerender
- the context return object stays stable while its members are unchanged
- the fixed return object stays stable while its members are unchanged
- changing `onShow` refreshes the API object's identity but does not replace the trigger ref

Full `useLayer.test.tsx` suite (47 tests) passes, plus the full test suites of every cited consumer (Popover, Tooltip, HoverCard, Carousel, ContextMenu, BaseTypeahead: 266 tests total across all of them). Typecheck and lint pass locally.
