### PR TITLE
fix(cli): keep blog adapter timeout active through body reads

### DIFF
--- a/.changeset/cli-blog-adapter-timeout-and-size-cap.md
+++ b/.changeset/cli-blog-adapter-timeout-and-size-cap.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] The shared CLI blog adapter (`blog.list`, `blog.detail`) cleared its 15-second abort timer as soon as `fetch` returned response headers, leaving the later body read unbounded in time, and buffered the entire response before checking the 5 MB size limit, so the limit didn't actually cap how much was read into memory.
+
+The abort timer now stays active through body consumption. The body is read as a stream where available, checking decoded size after each chunk and aborting the read as soon as it exceeds the limit, instead of buffering the full response first.
+
+@harjothkhara

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -511,6 +511,8 @@ export default defineConfig(
         structuredClone: 'readonly',
         fetch: 'readonly',
         AbortController: 'readonly',
+        ReadableStream: 'readonly',
+        DOMException: 'readonly',
       },
     },
     rules: {

--- a/packages/cli/api/blog/_adapter.mjs
+++ b/packages/cli/api/blog/_adapter.mjs
@@ -27,6 +27,67 @@ const MAX_BYTES = 5 * 1024 * 1024; // 5 MB — a blog feed is never larger.
  */
 export const FEED_URL = new URL('/rss.xml', SITE_URL).toString();
 
+/** @param {string} url @param {unknown} e @returns {AstryxError} */
+function toFetchError(url, e) {
+  const reason =
+    e instanceof Error
+      ? e.name === 'AbortError'
+        ? 'timed out'
+        : e.message
+      : String(e);
+  return new AstryxError(
+    `Could not reach ${url}: ${reason}`,
+    [],
+    ERROR_CODES.ERR_FETCH_FAILED,
+  );
+}
+
+/**
+ * Reads a response body as text, stopping as soon as the decoded size
+ * exceeds MAX_BYTES instead of buffering the full response first. Falls
+ * back to `res.text()` when the runtime/stub doesn't expose a streamable
+ * body (buffers fully, but still enforces the cap after the fact).
+ * @param {Response} res
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+async function readLimitedText(res, url) {
+  if (!res.body) {
+    const body = await res.text();
+    if (Buffer.byteLength(body, 'utf8') > MAX_BYTES) {
+      throw new AstryxError(
+        `Response from ${url} exceeded ${MAX_BYTES} bytes`,
+        [],
+        ERROR_CODES.ERR_FETCH_FAILED,
+      );
+    }
+    return body;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let received = 0;
+  let text = '';
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) {
+      break;
+    }
+    received += value.byteLength;
+    if (received > MAX_BYTES) {
+      await reader.cancel();
+      throw new AstryxError(
+        `Response from ${url} exceeded ${MAX_BYTES} bytes`,
+        [],
+        ERROR_CODES.ERR_FETCH_FAILED,
+      );
+    }
+    text += decoder.decode(value, {stream: true});
+  }
+  text += decoder.decode();
+  return text;
+}
+
 /**
  * @param {string} url
  * @returns {Promise<string>}
@@ -34,43 +95,38 @@ export const FEED_URL = new URL('/rss.xml', SITE_URL).toString();
 async function fetchText(url) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  let res;
+  // The timer stays active through body consumption (cleared only in
+  // `finally`), so a response whose headers arrive promptly but whose body
+  // stream stalls is still bounded by FETCH_TIMEOUT_MS, not left pending
+  // indefinitely.
   try {
-    res = await fetch(url, {
-      signal: controller.signal,
-      redirect: 'follow',
-    });
-  } catch (e) {
+    let res;
+    try {
+      res = await fetch(url, {
+        signal: controller.signal,
+        redirect: 'follow',
+      });
+    } catch (e) {
+      throw toFetchError(url, e);
+    }
+    if (!res.ok) {
+      throw new AstryxError(
+        `Request to ${url} failed with ${res.status}`,
+        [],
+        ERROR_CODES.ERR_FETCH_FAILED,
+      );
+    }
+    try {
+      return await readLimitedText(res, url);
+    } catch (e) {
+      if (e instanceof AstryxError) {
+        throw e;
+      }
+      throw toFetchError(url, e);
+    }
+  } finally {
     clearTimeout(timer);
-    const reason =
-      e instanceof Error
-        ? e.name === 'AbortError'
-          ? 'timed out'
-          : e.message
-        : String(e);
-    throw new AstryxError(
-      `Could not reach ${url}: ${reason}`,
-      [],
-      ERROR_CODES.ERR_FETCH_FAILED,
-    );
   }
-  clearTimeout(timer);
-  if (!res.ok) {
-    throw new AstryxError(
-      `Request to ${url} failed with ${res.status}`,
-      [],
-      ERROR_CODES.ERR_FETCH_FAILED,
-    );
-  }
-  const body = await res.text();
-  if (body.length > MAX_BYTES) {
-    throw new AstryxError(
-      `Response from ${url} exceeded ${MAX_BYTES} bytes`,
-      [],
-      ERROR_CODES.ERR_FETCH_FAILED,
-    );
-  }
-  return body;
 }
 
 /**

--- a/packages/cli/api/blog/_adapter.test.mjs
+++ b/packages/cli/api/blog/_adapter.test.mjs
@@ -34,6 +34,54 @@ function stubFetch(routes) {
   });
 }
 
+/**
+ * Build a fetch stub whose response exposes a real streaming `body`
+ * (ReadableStream) instead of a `.text()` shortcut, so tests can exercise
+ * the adapter's chunked-read path. The stream reacts to the request's
+ * AbortSignal the way a real fetch response body does: aborting rejects any
+ * pending read with an AbortError, rather than hanging forever.
+ *
+ * @param {{chunks?: Uint8Array[], staysOpenUntilAbort?: boolean}} options
+ * @returns {{fetch: import('vitest').Mock, pulled: {count: number}}}
+ */
+function stubStreamingFetch({chunks = [], staysOpenUntilAbort = false} = {}) {
+  const pulled = {count: 0};
+  const fetch = vi.fn(async (_url, requestOptions) => {
+    const signal = requestOptions?.signal;
+    const stream = new ReadableStream({
+      start(controller) {
+        signal?.addEventListener('abort', () => {
+          controller.error(new DOMException('The operation was aborted', 'AbortError'));
+        });
+      },
+      pull(controller) {
+        if (staysOpenUntilAbort) {
+          // Never enqueue or close — only the abort listener above settles
+          // this stream, simulating a body that stalls after headers arrive.
+          return;
+        }
+        if (pulled.count >= chunks.length) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunks[pulled.count]);
+        pulled.count += 1;
+      },
+    });
+    return {
+      ok: true,
+      status: 200,
+      body: stream,
+      text: async () => {
+        throw new Error(
+          'text() should not be called when a streamable body is available',
+        );
+      },
+    };
+  });
+  return {fetch, pulled};
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -90,5 +138,46 @@ describe('blog adapter — fetchPostText SSRF/origin guard', () => {
     const url = `${SITE_URL}/blog/how-astryx-works.txt`;
     vi.stubGlobal('fetch', stubFetch({[url]: {status: 200, body: '# body'}}));
     await expect(fetchPostText(url)).resolves.toBe('# body');
+  });
+});
+
+describe('blog adapter — fetchPostText timeout and size cap (issue #5249)', () => {
+  it('keeps the abort timer active through body consumption, so a body that stalls after headers still times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const {fetch} = stubStreamingFetch({staysOpenUntilAbort: true});
+      vi.stubGlobal('fetch', fetch);
+      const url = `${SITE_URL}/blog/how-astryx-works.txt`;
+
+      const result = fetchPostText(url);
+      const assertion = expect(result).rejects.toMatchObject({
+        code: 'ERR_FETCH_FAILED',
+      });
+      // 15s is the adapter's own FETCH_TIMEOUT_MS. If the timer were cleared
+      // as soon as headers arrive (the bug), this stalled body would hang
+      // forever instead of rejecting once the timer fires.
+      await vi.advanceTimersByTimeAsync(15000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops reading once decoded size exceeds the cap, without pulling the rest of the stream', async () => {
+    const CHUNK_BYTES = 2 * 1024 * 1024; // 2 MB
+    const TOTAL_CHUNKS = 5; // 10 MB total; the adapter's cap is 5 MB.
+    const chunk = new Uint8Array(CHUNK_BYTES).fill(97); // 'a'
+    const chunks = Array.from({length: TOTAL_CHUNKS}, () => chunk);
+    const {fetch, pulled} = stubStreamingFetch({chunks});
+    vi.stubGlobal('fetch', fetch);
+    const url = `${SITE_URL}/blog/how-astryx-works.txt`;
+
+    await expect(fetchPostText(url)).rejects.toMatchObject({
+      code: 'ERR_FETCH_FAILED',
+    });
+    // 5 MB / 2 MB per chunk needs 3 chunks to cross the cap. Pulling fewer
+    // than all 5 proves the read stopped early instead of buffering the
+    // full 10 MB body before checking the limit.
+    expect(pulled.count).toBeLessThan(TOTAL_CHUNKS);
   });
 });


### PR DESCRIPTION
Fixes #5249.

## Problem

The shared CLI blog adapter (`packages/cli/api/blog/_adapter.mjs`, used by both `blog.list` and `blog.detail`) had two related issues in `fetchText`:

1. It cleared its 15-second abort timer as soon as `fetch()` returned response headers, before reading the body. A response whose headers arrive promptly but whose body stream stalls afterward has no timeout protecting it, and the call hangs indefinitely.
2. It read the body via `res.text()`, which buffers the entire response into memory before the code ever checks the 5 MB limit. The limit rejects an oversized response only after it has already been fully read, so it doesn't actually cap how much data gets buffered.

## Fix

- The abort timer is now cleared in a `finally` block after the read completes (success or failure), so it stays active through body consumption, not just through the initial `fetch()` call.
- The body is read via `res.body`'s stream where available (`getReader()`, decoding chunk by chunk), checking the running decoded size after each chunk and cancelling the read as soon as it exceeds 5 MB, instead of buffering the full response first. Falls back to `res.text()` when a runtime or test stub doesn't expose a streamable `body` (rare in practice; every real `fetch()` response has one), still enforcing the cap after the fact in that case.

## Verification

Added two regression tests matching the issue's own reproduction:

- **Timeout stays active through body consumption**: a stubbed `fetch` resolves immediately but its response body never closes. Using fake timers, advancing past the 15s timeout causes the call to reject with `ERR_FETCH_FAILED` rather than hang. The stub's stream reacts to the request's `AbortSignal` the way a real fetch response body does (rejects pending reads on abort), so this faithfully exercises the same mechanism a real network response uses.
- **Size cap stops the read early**: a stubbed response streams 5 chunks of 2 MB each (10 MB total) against the 5 MB cap. The call rejects with `ERR_FETCH_FAILED`, and the stub's pulled-chunk counter confirms fewer than all 5 chunks were consumed, proving the read stopped early rather than buffering the whole body before checking.

Both new tests fail against the pre-fix implementation (verified by temporarily reverting just the implementation file and re-running) and pass with the fix. Full blog test suite (22 tests across `_adapter`, `blog`, `blog.detail`, `blog.list`) passes. Lint required adding `ReadableStream`/`DOMException` to the CLI's ESLint global allowlist (needed by the new streaming-body test coverage; both are standard globals already implicitly relied on via `fetch`/`AbortController`). Typecheck (`tsconfig.strict.json`) shows no new errors; the pre-existing failures it reports are all in unrelated template/theme assets.
