### PR TITLE
fix(selector): block popup activation while isLoading is true

### DIFF
--- a/.changeset/selector-isloading-blocks-open.md
+++ b/.changeset/selector-isloading-blocks-open.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector, MultiSelector, and ComplexSelector now block popup activation while `isLoading` is true. Previously the trigger opened a blank panel because nothing gated activation during a loading state. The trigger remains focusable and visible (no disabled treatment); only activation is suppressed via the existing combobox guards.
+
+@athz

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -389,7 +389,7 @@ export function ComplexSelector<Value>({
   const isOpen = popover.isOpen;
 
   const handleTriggerClick = useCallback(() => {
-    if (isDisabled || Date.now() - lastHideTimeRef.current < 50) {
+    if (isDisabled || isLoading || Date.now() - lastHideTimeRef.current < 50) {
       return;
     }
     if (popover.isOpen) {
@@ -397,7 +397,7 @@ export function ComplexSelector<Value>({
     } else {
       popover.show();
     }
-  }, [isDisabled, popover]);
+  }, [isDisabled, isLoading, popover]);
 
   const close = useCallback(() => {
     popover.hide();
@@ -407,13 +407,13 @@ export function ComplexSelector<Value>({
     handleRef,
     () => ({
       open: () => {
-        if (!isDisabled) {
+        if (!isDisabled && !isLoading) {
           popover.show();
         }
       },
       close: () => popover.hide(),
       toggle: () => {
-        if (isDisabled) {
+        if (isDisabled || isLoading) {
           return;
         }
         if (popover.isOpen) {
@@ -424,7 +424,7 @@ export function ComplexSelector<Value>({
       },
       isOpen: () => popover.isOpen,
     }),
-    [isDisabled, popover],
+    [isDisabled, isLoading, popover],
   );
 
   const commitValue = useCallback(
@@ -505,7 +505,12 @@ export function ComplexSelector<Value>({
           aria-busy={isBusy || undefined}
           disabled={isDisabled}
           onKeyDown={event => {
-            if (event.key === 'ArrowDown' && !isOpen && !isDisabled) {
+            if (
+              event.key === 'ArrowDown' &&
+              !isOpen &&
+              !isDisabled &&
+              !isLoading
+            ) {
               event.preventDefault();
               popover.show();
             }

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1123,6 +1123,54 @@ describe('MultiSelector', () => {
       expect(screen.getByRole('combobox')).toHaveAttribute('tabIndex', '-1');
     });
 
+    it('does not open the popup when isLoading is true (click)', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={[]}
+          value={[]}
+          onChange={() => {}}
+          isLoading
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('does not open the popup when isLoading is true (ArrowDown)', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={[]}
+          value={[]}
+          onChange={() => {}}
+          isLoading
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('keeps the trigger focusable while isLoading (not disabled)', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={[]}
+          value={[]}
+          onChange={() => {}}
+          isLoading
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).not.toHaveAttribute('disabled');
+      expect(trigger).toHaveAttribute('tabIndex', '0');
+    });
+
     it('opens the listbox with ArrowDown from a focused trigger', async () => {
       const user = userEvent.setup();
       render(

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1057,6 +1057,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   } = useMultiCombobox({
     selectableItems: sortedItems,
     isDisabled,
+    isLoading,
     isOpen: popover.isOpen,
     hasSearch,
     onOpen: useCallback(() => {

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -18,6 +18,7 @@ import type {MultiSelectorOptionData} from './types';
 interface UseMultiComboboxOptions {
   selectableItems: MultiSelectorOptionData[];
   isDisabled?: boolean;
+  isLoading?: boolean;
   isOpen: boolean;
   hasSearch?: boolean;
   onOpen: () => void;
@@ -55,6 +56,7 @@ interface UseMultiComboboxResult {
 export function useMultiCombobox({
   selectableItems,
   isDisabled = false,
+  isLoading = false,
   isOpen,
   hasSearch = false,
   onOpen,
@@ -64,6 +66,7 @@ export function useMultiCombobox({
   hasValue = false,
   listboxId,
 }: UseMultiComboboxOptions): UseMultiComboboxResult {
+  const isInactive = isDisabled || isLoading;
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   const [typeahead, setTypeahead] = useState('');
   const typeaheadTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -87,7 +90,7 @@ export function useMultiCombobox({
   }, [onClose]);
 
   const onTriggerClick = useCallback(() => {
-    if (isDisabled) {
+    if (isInactive) {
       return;
     }
     if (isOpen) {
@@ -98,7 +101,7 @@ export function useMultiCombobox({
         setHighlightedIndex(0);
       }
     }
-  }, [isDisabled, isOpen, onOpen, closeAndReset, hasSearch]);
+  }, [isInactive, isOpen, onOpen, closeAndReset, hasSearch]);
 
   const onItemMouseEnter = useCallback(
     (item: MultiSelectorOptionData, index: number) => {
@@ -111,7 +114,7 @@ export function useMultiCombobox({
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (isDisabled) {
+      if (isInactive) {
         return;
       }
 
@@ -250,7 +253,7 @@ export function useMultiCombobox({
       }
     },
     [
-      isDisabled,
+      isInactive,
       isOpen,
       onOpen,
       closeAndReset,

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1266,6 +1266,32 @@ describe('Selector', () => {
       expect(screen.getByRole('combobox')).toHaveAttribute('tabIndex', '-1');
     });
 
+    it('does not open the popup when isLoading is true (click)', async () => {
+      const user = userEvent.setup();
+      render(<Selector label="Fruit" options={[]} isLoading />);
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('does not open the popup when isLoading is true (ArrowDown)', async () => {
+      const user = userEvent.setup();
+      render(<Selector label="Fruit" options={[]} isLoading />);
+
+      const trigger = screen.getByRole('combobox');
+      await user.tab();
+      await user.keyboard('{ArrowDown}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('keeps the trigger focusable while isLoading (not disabled)', () => {
+      render(<Selector label="Fruit" options={[]} isLoading />);
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).not.toHaveAttribute('disabled');
+      expect(trigger).toHaveAttribute('tabIndex', '0');
+    });
+
     it('opens the listbox with ArrowDown from a focused trigger', async () => {
       const user = userEvent.setup();
       render(<Selector label="Fruit" options={OPTIONS} />);

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1015,6 +1015,7 @@ export function Selector<T extends SelectorOptionType>(
     // already replaced.
     value: optimisticValue,
     isDisabled,
+    isLoading,
     isOpen: popover.isOpen,
     hasSearch,
     onOpen: useCallback(() => {
@@ -1067,13 +1068,13 @@ export function Selector<T extends SelectorOptionType>(
   const handleTriggerKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       // With hasSearch the query input owns typing, so type-to-select is off.
-      if (!isDisabled && !hasSearch && typeahead.onKeyDown(e)) {
+      if (!isDisabled && !isLoading && !hasSearch && typeahead.onKeyDown(e)) {
         e.preventDefault();
         return;
       }
       onKeyDown(e);
     },
-    [isDisabled, hasSearch, typeahead, onKeyDown],
+    [isDisabled, isLoading, hasSearch, typeahead, onKeyDown],
   );
 
   // Keep the highlighted option visible during keyboard navigation. The

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -157,6 +157,7 @@ interface UseComboboxOptions {
   selectableItems: SelectorOptionData[];
   value?: string;
   isDisabled?: boolean;
+  isLoading?: boolean;
   isOpen: boolean;
   hasSearch?: boolean;
   onOpen: () => void;
@@ -201,6 +202,7 @@ export function useCombobox({
   selectableItems,
   value,
   isDisabled = false,
+  isLoading = false,
   isOpen,
   hasSearch = false,
   onOpen,
@@ -210,6 +212,7 @@ export function useCombobox({
   onSearchSeed,
   listboxId,
 }: UseComboboxOptions): UseComboboxResult {
+  const isInactive = isDisabled || isLoading;
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
 
   const getItemId = useCallback(
@@ -244,7 +247,7 @@ export function useCombobox({
   );
 
   const onTriggerClick = useCallback(() => {
-    if (isDisabled) {
+    if (isInactive) {
       return;
     }
     if (isOpen) {
@@ -256,7 +259,7 @@ export function useCombobox({
         setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
       }
     }
-  }, [isDisabled, isOpen, onOpen, closeAndReset, findSelectedIndex, hasSearch]);
+  }, [isInactive, isOpen, onOpen, closeAndReset, findSelectedIndex, hasSearch]);
 
   const onItemMouseEnter = useCallback(
     (item: SelectorOptionData, index: number) => {
@@ -269,7 +272,7 @@ export function useCombobox({
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (isDisabled) {
+      if (isInactive) {
         return;
       }
 
@@ -403,7 +406,7 @@ export function useCombobox({
       }
     },
     [
-      isDisabled,
+      isInactive,
       isOpen,
       onOpen,
       closeAndReset,


### PR DESCRIPTION
## Summary

`Selector`, `MultiSelector`, and `ComplexSelector` allow opening the popup while `isLoading` is true. Because the empty state is gated on an active search query, this presents a completely blank panel — no options, no message, no spinner inside the panel.

This PR makes `isLoading` block popup activation the same way `isDisabled` does, but without the disabled visual treatment:

- Trigger stays focusable (not removed from tab order)
- No greyed-out appearance
- `aria-busy` + field-level spinner still signal the pending state
- Only activation (click, ArrowDown, Space/Enter) is suppressed

## Changes

- **`packages/core/src/Selector/hooks.ts`** — `useCombobox` accepts `isLoading`; combines with `isDisabled` into an `isInactive` guard on `onTriggerClick` and `onKeyDown`.
- **`packages/core/src/Selector/Selector.tsx`** — passes `isLoading` to `useCombobox`; adds `isLoading` to the typeahead key-down guard.
- **`packages/core/src/MultiSelector/hooks.ts`** — same pattern for `useMultiCombobox`.
- **`packages/core/src/MultiSelector/MultiSelector.tsx`** — passes `isLoading` to `useMultiCombobox`.
- **`packages/core/src/ComplexSelector/ComplexSelector.tsx`** — adds `isLoading` to inline activation guards (`handleTriggerClick`, `useImperativeHandle`, `onKeyDown`).
- **Tests** — 6 new tests across Selector and MultiSelector confirming:
  - Click does not open when loading
  - ArrowDown does not open when loading
  - Trigger remains focusable (not disabled)

## Reproduction

```tsx
<Selector label="Owner" options={[]} isLoading hasSearch placeholder="Loading owners…" />
```

Before: opens a completely blank popup.
After: trigger stays inert until loading completes.
