### PR TITLE
fix(cli): rank exact keyword phrase matches above token-sum scores

### DIFF
--- a/.changeset/cli-search-exact-keyword-phrase-ranking.md
+++ b/.changeset/cli-search-exact-keyword-phrase-ranking.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `astryx search` (and `astryx build`, which shares its ranking) never surfaced a component whose exact multi-word keyword phrase was searched, if enough other unrelated candidates happened to each contain one of the query's individual words. Searching `"table of contents"` returned no results for `Outline`, even though `Outline.doc.mjs` declares `'table of contents'` verbatim as a keyword, because `Table`-related templates each matched `table` and `contents` separately and their combined per-word score outranked Outline's single exact match.
+
+A query that exactly matches a candidate's declared keyword (or name) verbatim is now promoted to a top-tier score, so it always outranks a candidate that only coincidentally contains several of the query's individual words. Single-word queries and queries that don't exactly match a keyword are unaffected.
+
+@nynexman4464

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -221,6 +221,21 @@ export function scoreQuery(term, tokens, candidate) {
     return single;
   }
 
+  // The full (untokenized) query matching a candidate's name or a declared
+  // keyword VERBATIM — full.score 90 or 100, the only two scoreCandidate
+  // outcomes at or above that mark — is a deliberate, explicit label the
+  // author chose for exactly this multi-word concept. Promote it to a
+  // reserved top tier, safely above the token-sum path's ceiling below
+  // (~151: 100 avg + 36 bonus + 15 coverage), so it always outranks a
+  // candidate that merely happens to contain several of the query's
+  // individual words. Without this, "table of contents" never surfaces
+  // Outline (which declares that exact phrase as a keyword) because dozens
+  // of Table-related templates each match "table" and "contents" separately
+  // and accumulate a higher raw score (#5239).
+  if (full && full.score >= 90) {
+    return {score: full.score + 100, reason: full.reason};
+  }
+
   // Multi-word natural language: score each content token, counting only
   // strong hits, then reward coverage so candidates matching more terms win.
   let sum = 0;

--- a/packages/cli/api/search/search.test.mjs
+++ b/packages/cli/api/search/search.test.mjs
@@ -58,6 +58,27 @@ describe('search leaf — --type filter', () => {
   });
 });
 
+describe('search leaf — exact keyword phrase outranks incidental token matches (issue #5239)', () => {
+  it('surfaces Outline for its own declared keyword "table of contents", ranked first', async () => {
+    // Before the fix, "table" and "contents" each separately matched dozens
+    // of unrelated Table-related templates by coincidence, and their
+    // combined token-sum score outranked Outline's single exact match —
+    // pushing it out of the results entirely at the default limit.
+    const r = await search('table of contents', {cwd});
+    expect(r.data.results[0]?.name).toBe('Outline');
+  }, SLOW);
+
+  it('surfaces Outline for its own declared keyword "heading navigation", ranked first', async () => {
+    const r = await search('heading navigation', {cwd});
+    expect(r.data.results[0]?.name).toBe('Outline');
+  }, SLOW);
+
+  it('still returns no results for a nonsense query (the fix does not loosen matching)', async () => {
+    const r = await search('zzzzqqqx', {cwd});
+    expect(r.data.results).toEqual([]);
+  }, SLOW);
+});
+
 describe('search leaf — error paths (pinned)', () => {
   it('throws ERR_INVALID_ARGUMENT when the query is empty/whitespace', async () => {
     await expect(search('   ', {cwd})).rejects.toMatchObject({

--- a/packages/cli/api/search/search.test.mjs
+++ b/packages/cli/api/search/search.test.mjs
@@ -62,7 +62,7 @@ describe('search leaf — exact keyword phrase outranks incidental token matches
   it('surfaces Outline for its own declared keyword "table of contents", ranked first', async () => {
     // Before the fix, "table" and "contents" each separately matched dozens
     // of unrelated Table-related templates by coincidence, and their
-    // combined token-sum score outranked Outline's single exact match —
+    // combined token-sum score outranked Outline's single exact match,
     // pushing it out of the results entirely at the default limit.
     const r = await search('table of contents', {cwd});
     expect(r.data.results[0]?.name).toBe('Outline');


### PR DESCRIPTION
Fixes #5239 (the first, cheapest of the issue's suggested fixes: "rank exact whole-phrase keyword matches above partial name-token matches").

## Problem

`astryx search "table of contents"` never surfaced `Outline`, even though `Outline.doc.mjs` declares `'table of contents'` verbatim as a keyword. Traced precisely: `scoreCandidate` correctly computes an exact-keyword score of 90 for Outline against that query. The bug is that `scoreQuery`'s multi-word token-sum path (which scores `"table"` and `"contents"` as separate tokens against every OTHER candidate) regularly produces scores above 90, since dozens of Table-related templates and components each match one of those two common words independently. With the default `--limit 20`, roughly 53 other candidates outscored Outline's exact match, pushing it out of the results entirely.

Same root cause for `"heading navigation"` against Outline's `'heading navigation'` keyword.

## Fix

When the full, untokenized query exactly matches a candidate's name or a declared keyword verbatim (`scoreCandidate` score 90 or 100, the only two outcomes at or above that mark), promote it to a reserved top tier (`score + 100`) that's safely above the token-sum path's mathematical ceiling (~151: 100 avg + 36 matched-count bonus + 15 coverage bonus). This is a targeted priority rule, not a rebalancing of the existing 0-100 scale, so it can't regress any query that doesn't have a genuine exact whole-phrase match.

## Scope (intentionally narrow)

This addresses exactly suggestion #1 from the issue, "no metadata changes anywhere." The issue's second, narrower bug ("on this page" returning zero results because a query consisting entirely of stopwords has no fallback) is a separate, vaguer problem the issue itself frames as needing more judgment ("relax to a ranked OR... though it is a band-aid"), so I left it out of this PR rather than bundle a riskier, less-verified change into the same fix. Happy to take that on separately if useful.

## Verification

Ran every query from the issue's own reproduction table against the real component registry, before and after:

| query | before | after |
|---|---|---|
| `table of contents` | absent | **Outline, rank 1** |
| `heading navigation` | absent | **Outline, rank 1** |
| `copy button` (already worked) | useClipboard, rank 1 | useClipboard, rank 1 (unaffected) |
| `markdown renderer` (already worked) | Markdown, rank 1 | Markdown, rank 1 (unaffected) |
| `mobile drawer` (already worked) | useAppShellMobile, rank 1 | useAppShellMobile, rank 1 (unaffected) |
| `data visualization` (already worked) | useTheme, rank 1 | useTheme, rank 1 (unaffected) |
| `zzzzqqqx` (nonsense) | 0 results | 0 results (unaffected, confirms no over-triggering) |

Added two regression tests (a new "exact keyword phrase outranks incidental token matches" describe block, matching the file's existing em-dash naming convention for its own describe blocks) asserting Outline ranks first for both previously-failing queries, plus a nonsense-query sanity check. Both fail against the pre-fix implementation (verified by temporarily reverting just the implementation file) and pass with the fix.

Full `search` and `build` API test suites pass (19 tests; `build`'s own ranking floors in `kit.mjs` are all `>=` threshold checks, so this monotonic score increase for exact matches can only make `build` more confident about a genuine keyword match, never less). Lint and typecheck (`tsconfig.strict.json`) show no new issues; a pre-existing, unrelated failure in `component.test.mjs` (a case-sensitivity assertion, confirmed failing identically on a clean baseline with my changes fully reverted) is untouched by this diff.
