### PR TITLE
docs: replace em dashes in useScrollLock, Tooltip, and service-monitoring prose

### DIFF
--- a/packages/cli/assets/templates/pages/dashboard-service-monitoring/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-service-monitoring/template.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   name: 'Service Monitoring Dashboard',
   displayName: 'Service Monitoring Dashboard',
   description:
-    'Live-ops service-health dashboard: traffic-light KPI tiles with sparklines, and multi-line latency and request-volume charts with a 1h/1d/7d window, beside a triage rail split into two independently scrolling sections — active alerts over a worst-first per-service breakdown with inline status coloring. Global environment, region, and auto-refresh controls; the rail folds into the content column as two cards below 1024px.',
+    'Live-ops service-health dashboard: traffic-light KPI tiles with sparklines, and multi-line latency and request-volume charts with a 1h/1d/7d window, beside a triage rail split into two independently scrolling sections: active alerts over a worst-first per-service breakdown with inline status coloring. Global environment, region, and auto-refresh controls; the rail folds into the content column as two cards below 1024px.',
   isReady: false,
   category: 'Dashboard - Monitoring',
 };

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -70,7 +70,7 @@ export const docs = {
           name: 'touchTrigger',
           type: "'auto' | 'tap' | 'none'",
           description:
-            'What a tap does where there is no hover. auto opens on tap unless the trigger performs an action of its own (a button, link, or form control), whose tap belongs to the control. tap always opens — use it for an info icon rendered as a button, whose only job is to reveal the tooltip. none never opens on touch.',
+            'What a tap does where there is no hover. auto opens on tap unless the trigger performs an action of its own (a button, link, or form control), whose tap belongs to the control. tap always opens; use it for an info icon rendered as a button, whose only job is to reveal the tooltip. none never opens on touch.',
           default: "'auto'",
         },
         {

--- a/packages/core/src/hooks/useScrollLock.doc.mjs
+++ b/packages/core/src/hooks/useScrollLock.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
   returns: [],
   usage: {
     description:
-      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked. Pinning hides the document scrollbar, so where that scrollbar takes layout space (desktop) the hook holds its gutter open with scrollbar-gutter: stable for the duration of the lock — the page, including any position: fixed chrome, does not shift sideways.',
+      'Locks body scroll when active by pinning the body with position: fixed. This prevents background scrolling behind modals and dialogs, which is necessary for iOS Safari where overscroll-behavior: contain does not work. Restores the original scroll position when unlocked. Pinning hides the document scrollbar, so where that scrollbar takes layout space (desktop) the hook holds its gutter open with scrollbar-gutter: stable for the duration of the lock. The page, including any position: fixed chrome, does not shift sideways.',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals or dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass the same boolean that controls dialog visibility (e.g., isOpen) as the isLocked parameter.' },
@@ -32,13 +32,13 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').HookTranslationDoc} */
 export const docsDense = {
   description:
-    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways.',
+    'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page (incl. position: fixed chrome) does not shift sideways.',
   paramDescriptions: {
     isLocked: 'whether body scroll should be locked.',
   },
   usage: {
     description:
-      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page — incl. position: fixed chrome — does not shift sideways.',
+      'Locks body scroll when active by pinning body w/ position: fixed. Prevents background scrolling behind modals + dialogs, necessary for iOS Safari where overscroll-behavior: contain does not work. Restores original scroll position when unlocked. Holds the hidden scrollbar\'s gutter open (scrollbar-gutter: stable) so the page (incl. position: fixed chrome) does not shift sideways.',
     bestPractices: [
       { guidance: true, description: 'Use when opening full-screen modals / dialogs to prevent background content from scrolling.' },
       { guidance: true, description: 'Pass same boolean that controls dialog visibility (e.g. isOpen) as isLocked parameter.' },


### PR DESCRIPTION
## What

Three doc prose strings used an em dash where a plainer break reads better. All are natural-language description fields; no code, labels, or identifiers changed, and no meaning was altered.

- `useScrollLock.doc.mjs`: recast the em-dash asides in the English and dense usage descriptions with a period and parentheses.
- `Tooltip.doc.mjs`: recast the em-dash break in the `touchTrigger` description with a semicolon.
- `dashboard-service-monitoring/template.doc.mjs`: recast the em-dash appositive in the page description with a colon.

Detected by the check 17 (AI-Slop Prose Tells) classified scan. These files are not touched by any other open PR.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes (after core build)
- [x] CLI render verified (`component Tooltip --props`, `hook useScrollLock --lang dense`)
- [x] Prose strings only; meaning preserved

Night Watch — Doc Reviewer