### PR TITLE
docs(ComplexSelector): backfill two missing dense best-practice bullets

### DIFF
--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -218,6 +218,16 @@ export const docsDense = {
       {
         guidance: true,
         description:
+          'Use variant="ghost" with a startIcon for a toolbar trigger. Use alignment="end" when a wide surface should align its end edge to the trigger.',
+      },
+      {
+        guidance: true,
+        description:
+          'For staged editors, keep draft state in the composed content and call the provided onChange helper only from Apply. Cancel or dismiss without committing.',
+      },
+      {
+        guidance: true,
+        description:
           'Compose content from the right accessible structure: RadioList for a simple choice, Calendar/date inputs for dates, TreeList or a searchable list for hierarchy, a custom grid for 2D arrow navigation.',
       },
       {


### PR DESCRIPTION
## What

The dense best-practices overlay for ComplexSelector carried 7 bullets against 9 in the English docs, so `astryx component ComplexSelector --lang dense` silently dropped two pieces of guidance:

- the ghost-trigger + `alignment="end"` guidance
- the staged-editor draft-state guidance

This adds compressed versions of both, restoring one-to-one parity in count, order, and `guidance` flag with the English `usage.bestPractices`.

Detected by the check 13 translation-coverage audit (bullet-count drift). No other open PR fixes this gap; #5123 and #5211 touch this file only on disjoint lines (a new prop and a nested-flyout bullet) and both merge cleanly with this change.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] Dense render verified (`component ComplexSelector --lang dense` shows both bullets)
- [x] Count, order, and guidance flags match English one for one

Night Watch — Doc Reviewer