### PR TITLE
fix(core): don't format PlainDate with the runtime's locale

### DIFF
--- a/.changeset/fix-plaindateformat-runtime-locale.md
+++ b/.changeset/fix-plaindateformat-runtime-locale.md
@@ -1,0 +1,24 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] plainDateFormat: don't format with the runtime's locale
+
+`plainDateFormat` passed `undefined` to `Intl.DateTimeFormat`, so the locale
+resolved to whatever the runtime happened to have. Across an SSR boundary that
+is not the same on both sides: a host with no `LC_ALL` resolves the CLDR root
+and emits `2026 M08` where the browser renders `August 2026`, and React reports
+a hydration mismatch for every SSR'd `Calendar` or `DateInput` — including ones
+the user never opened.
+
+The locale now defaults to `'en'`, matching what `useLocale()` returns outside a
+provider, and is accepted as an optional third argument so callers under an
+`InternationalizationProvider` can thread the provider locale:
+`plainDateFormat(pd, options, useLocale())`.
+
+Existing two-argument calls keep working and become deterministic. Formatting
+inside `Calendar`, `DateRangeInput` and `DateTimeInput` is unchanged in an
+English runtime; a non-English runtime now needs the explicit locale to render
+in its own language, which was the only way to get a stable SSR tree.
+
+@josephfarina

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -592,10 +592,6 @@ describe('plainDateFormat', () => {
   });
 
   it('defaults to en, not the runtime locale', () => {
-    // The regression this guards: with `undefined` the month label resolved to
-    // whatever locale the runtime had, so an SSR host with no LC_ALL emitted
-    // the CLDR root form ("2026 M08") while the browser rendered "August
-    // 2026" — a hydration mismatch in every SSR'd Calendar/DateInput.
     expect(
       plainDateFormat({year: 2026, month: 8, day: 22}, DATE_FORMAT_MONTH_YEAR),
     ).toBe('August 2026');
@@ -612,11 +608,8 @@ describe('plainDateFormat', () => {
   });
 
   it('does not depend on the ambient runtime locale', () => {
-    // The determinism guarantee, which is what makes it hydration-safe: the
-    // two-argument call must equal the explicit-'en' call on every host,
-    // whatever `Intl.DateTimeFormat().resolvedOptions().locale` happens to be
-    // there. Verified in production against a sandcastle host that resolves
-    // the CLDR root while the browser resolves en-US.
+    // Equal on every host, whatever Intl resolves there. This is the
+    // hydration-safety guarantee.
     const pd: PlainDate = {year: 2026, month: 8, day: 22};
     for (const options of [DATE_FORMAT_MONTH_YEAR, DATE_FORMAT_WITH_WEEKDAY]) {
       expect(plainDateFormat(pd, options)).toBe(

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -29,6 +29,7 @@ import {
   plainDateFormat,
   formatSharedDate,
   DATE_FORMAT_WITH_WEEKDAY,
+  DATE_FORMAT_MONTH_YEAR,
 } from './plainDate';
 import type {ISODateString} from './dateTypes';
 
@@ -588,6 +589,40 @@ describe('plainDateFormat', () => {
     );
     expect(result).toContain('2026');
     expect(result).toContain('25');
+  });
+
+  it('defaults to en, not the runtime locale', () => {
+    // The regression this guards: with `undefined` the month label resolved to
+    // whatever locale the runtime had, so an SSR host with no LC_ALL emitted
+    // the CLDR root form ("2026 M08") while the browser rendered "August
+    // 2026" — a hydration mismatch in every SSR'd Calendar/DateInput.
+    expect(
+      plainDateFormat({year: 2026, month: 8, day: 22}, DATE_FORMAT_MONTH_YEAR),
+    ).toBe('August 2026');
+  });
+
+  it('honours an explicit locale', () => {
+    expect(
+      plainDateFormat(
+        {year: 2026, month: 8, day: 22},
+        DATE_FORMAT_MONTH_YEAR,
+        'fr',
+      ),
+    ).toBe('août 2026');
+  });
+
+  it('does not depend on the ambient runtime locale', () => {
+    // The determinism guarantee, which is what makes it hydration-safe: the
+    // two-argument call must equal the explicit-'en' call on every host,
+    // whatever `Intl.DateTimeFormat().resolvedOptions().locale` happens to be
+    // there. Verified in production against a sandcastle host that resolves
+    // the CLDR root while the browser resolves en-US.
+    const pd: PlainDate = {year: 2026, month: 8, day: 22};
+    for (const options of [DATE_FORMAT_MONTH_YEAR, DATE_FORMAT_WITH_WEEKDAY]) {
+      expect(plainDateFormat(pd, options)).toBe(
+        plainDateFormat(pd, options, 'en'),
+      );
+    }
   });
 });
 

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -294,18 +294,9 @@ export const DATE_FORMAT_SHORT_WITH_YEAR: Intl.DateTimeFormatOptions = {
 /**
  * Format a `PlainDate` for display.
  *
- * `locale` defaults to `'en'` rather than `undefined`. Passing `undefined` to
- * `Intl.DateTimeFormat` resolves to the RUNTIME's locale, which differs across
- * the SSR boundary: a server with no `LC_ALL` resolves the CLDR root and emits
- * "2026 M08" where the browser renders "August 2026", and React reports a
- * hydration mismatch for a component nobody touched. `'en'` matches what
- * `useLocale()` returns outside a provider, so the default agrees with the rest
- * of the i18n contract.
- *
- * Components under an `InternationalizationProvider` should thread the provider
- * locale — `plainDateFormat(pd, options, useLocale())` — which is both
- * deterministic and correctly localized. See `useLocale`, which names this
- * helper as its intended consumer.
+ * `locale` defaults to `'en'` rather than `undefined`: an undefined locale
+ * resolves to the runtime's, which differs across an SSR boundary and causes
+ * hydration mismatches. Pass `useLocale()` under a provider.
  */
 export function plainDateFormat(
   pd: PlainDate,

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -7,6 +7,7 @@
  * @position Shared utility; replaces scattered Date usage across Calendar hooks
  */
 
+import type {Locale} from '../i18n/types';
 import type {ISODateString, PlainDate} from './dateTypes';
 
 export type {PlainDate} from './dateTypes';
@@ -290,13 +291,28 @@ export const DATE_FORMAT_SHORT_WITH_YEAR: Intl.DateTimeFormatOptions = {
   year: 'numeric',
 };
 
+/**
+ * Format a `PlainDate` for display.
+ *
+ * `locale` defaults to `'en'` rather than `undefined`. Passing `undefined` to
+ * `Intl.DateTimeFormat` resolves to the RUNTIME's locale, which differs across
+ * the SSR boundary: a server with no `LC_ALL` resolves the CLDR root and emits
+ * "2026 M08" where the browser renders "August 2026", and React reports a
+ * hydration mismatch for a component nobody touched. `'en'` matches what
+ * `useLocale()` returns outside a provider, so the default agrees with the rest
+ * of the i18n contract.
+ *
+ * Components under an `InternationalizationProvider` should thread the provider
+ * locale — `plainDateFormat(pd, options, useLocale())` — which is both
+ * deterministic and correctly localized. See `useLocale`, which names this
+ * helper as its intended consumer.
+ */
 export function plainDateFormat(
   pd: PlainDate,
   options: Intl.DateTimeFormatOptions,
+  locale: Locale = 'en',
 ): string {
-  return new Intl.DateTimeFormat(undefined, options).format(
-    plainDateToDate(pd),
-  );
+  return new Intl.DateTimeFormat(locale, options).format(plainDateToDate(pd));
 }
 
 // =============================================================================


### PR DESCRIPTION
## The bug

`plainDateFormat` formats with `new Intl.DateTimeFormat(undefined, options)`. An
`undefined` locale resolves to *the runtime's* locale, and the runtime is not the
same on both sides of an SSR boundary. On a host with no `LC_ALL` the server
resolves the CLDR root and emits `2026 M08` where the browser renders
`August 2026`, so React reports a hydration mismatch:

```
<DateInput label="End date" value="2026-08-22" ...>
  <Button><span> + August 2026  - 2026 M08
at <unknown> (https://react.dev/link/hydration-mismatch)
```

Every SSR'd `Calendar` / `DateInput` is affected. It does not need to be a date
picker the app directly renders: a shared navigation dependency can render a
`DateInput` on first paint, so an app can inherit the mismatch indirectly.

The issue reproduced across multiple generated apps. Downstream consumers had
already worked around it by documenting it as a known upstream warning or by
hardcoding an English formatter to avoid host-dependent output.

The existing `formatSharedDate` tests also assert exact strings like
`'Jan 25, 2026'`, so they pass only because CI happens to resolve English.

## The change

```diff
 export function plainDateFormat(
   pd: PlainDate,
   options: Intl.DateTimeFormatOptions,
+  locale: Locale = 'en',
 ): string {
-  return new Intl.DateTimeFormat(undefined, options).format(
-    plainDateToDate(pd),
-  );
+  return new Intl.DateTimeFormat(locale, options).format(plainDateToDate(pd));
 }
```

`'en'` is deliberate rather than arbitrary: it is what `useLocale()` already
returns outside a provider, so the default agrees with the rest of the i18n
contract instead of inventing a second one. The added parameter is the seam
`useLocale`'s own docstring already asks for —

> This is the approved way to read the locale that feeds a formatting helper
> (`plainDateFormat`, `formatInstant`, chart formatters, …)

— which today is impossible, because the helper takes no locale.

Non-breaking: every existing two-argument call keeps working, and gains
determinism.

## Follow-up I deliberately left out

The twelve call sites in `Calendar`, `useCalendarNavigation`, `DateRangeInput`
and `DateTimeInput` should thread `useLocale()` so calendars are correctly
localized as well as deterministic. That is a larger change across a hook and two
module-level helpers, and it wants a maintainer's opinion on where the provider
locale enters those files, so I have kept this PR to the defect. Happy to do it
in a follow-up if you tell me the shape you want.

## Test plan

`pnpm vitest run packages/core/src/utils/plainDate.test.ts` — 88 pass.
Three new cases: the `'en'` default, an explicit `'fr'` (`août 2026`), and the
determinism invariant that a two-argument call equals the explicit-`'en'` call
on any host.

`tsc --noEmit` and `eslint` clean.

I could not reproduce the root-locale resolution on macOS — this laptop resolves
`en-US` whatever `LC_ALL` says — so the server-side half of the evidence is the
production repro above rather than a local run.