### PR TITLE
fix(PowerSearch): make menuWidth size the field-search menu

### DIFF
--- a/.changeset/powersearch-menu-width.md
+++ b/.changeset/powersearch-menu-width.md
@@ -1,0 +1,25 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] PowerSearch `menuWidth` now sizes the field-search menu
+
+`PowerSearch` has accepted a public `menuWidth` prop that nothing read: the
+field-search menu always matched the input and grew with its content, and a
+consumer wanting a wider menu had no way to ask for one. The prop now reaches
+the menu. `Typeahead`, `Tokenizer` and `BaseTypeahead` gain the same prop, so
+the whole typeahead family sizes its menu the same way.
+
+Two details worth knowing:
+
+- The menu never renders narrower than the input. The `anchor-size(width)`
+  floor already in place stays, and a `menuWidth` below the input's width is
+  ignored by CSS rather than clamped in JS.
+- Only the field-search menu is affected. The operator and value popovers that
+  follow a field choice keep tracking the input.
+
+`menuWidth` also widens from `number` to `number | string`, matching
+`DropdownMenu`, `DropdownMenuSubMenu` and `ContextMenu`, so a CSS length like
+`'32rem'` works as well as pixels. Existing numeric values are unaffected.
+
+@cixzhang

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -319,6 +319,10 @@ const meta: Meta<typeof PowerSearch> = {
     isReadOnly: {control: 'boolean'},
     hasClear: {control: 'boolean'},
     maxTokenLength: {control: 'number'},
+    menuWidth: {
+      control: 'text',
+      description: 'Field-search menu width (number for px or CSS string)',
+    },
     popoverSaveButtonLabel: {control: 'text'},
     size: {
       control: 'radio',
@@ -1076,6 +1080,66 @@ export const WithStartIcon: Story = {
   name: 'With Start Icon',
 };
 
+export const MenuWidth: Story = {
+  decorators: [
+    Story => (
+      <div style={{width: 900}}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => {
+    const [a, setA] = useState<PowerSearchFilter[]>([]);
+    const [b, setB] = useState<PowerSearchFilter[]>([]);
+    const [c, setC] = useState<PowerSearchFilter[]>([]);
+    const [d, setD] = useState<PowerSearchFilter[]>([]);
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 24}}>
+        <div style={{width: 360}}>
+          <PowerSearch
+            label="Default width"
+            isLabelHidden={false}
+            config={basicConfig}
+            filters={a}
+            onChange={next => setA([...next])}
+          />
+        </div>
+        <div style={{width: 360}}>
+          <PowerSearch
+            label="Wider than the input"
+            isLabelHidden={false}
+            menuWidth={640}
+            config={basicConfig}
+            filters={b}
+            onChange={next => setB([...next])}
+          />
+        </div>
+        <div style={{width: 360}}>
+          <PowerSearch
+            label="Narrower than the input"
+            isLabelHidden={false}
+            menuWidth={200}
+            config={basicConfig}
+            filters={c}
+            onChange={next => setC([...next])}
+          />
+        </div>
+        <div style={{width: 360}}>
+          <PowerSearch
+            label="A CSS length"
+            isLabelHidden={false}
+            menuWidth="34rem"
+            config={basicConfig}
+            filters={d}
+            onChange={next => setD([...next])}
+          />
+        </div>
+      </div>
+    );
+  },
+  name: 'Menu Width',
+};
+
 export const WithResultCount: Story = {
   render: args => {
     const [filters, setFilters] = useState<PowerSearchFilter[]>([
@@ -1381,7 +1445,8 @@ export const StatusVariantComparison: Story = {
     const [a, setA] = useState<PowerSearchFilter[]>([]);
     const [b, setB] = useState<PowerSearchFilter[]>([]);
     return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 24, width: 400}}>
+      <div
+        style={{display: 'flex', flexDirection: 'column', gap: 24, width: 400}}>
         <PowerSearch
           config={basicConfig}
           filters={a}

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -98,6 +98,12 @@ export const docs = {
       default: "'attached'",
     },
     {
+      name: 'menuWidth',
+      type: 'number | string',
+      description:
+        "Width of the field-search menu. Numbers are pixels, strings are used as-is. Never renders narrower than the input. Omitted, the menu matches the input and grows with its content. Does not size the operator and value popovers.",
+    },
+    {
       name: 'maxTokenLength',
       type: 'number',
       description: 'Max character length for filter value display in tokens.',
@@ -263,6 +269,12 @@ export const docsZh = {
       default: "'attached'",
     },
     {
+      name: 'menuWidth',
+      type: 'number | string',
+      description:
+        '字段搜索菜单的宽度。数字为像素，字符串按原样使用。菜单不会窄于输入框。省略时，菜单与输入框等宽并随内容增长。不会影响运算符和值弹出层的宽度。',
+    },
+    {
       name: 'maxTokenLength',
       type: 'number',
       description: '令牌中过滤器值显示的最大字符长度。',
@@ -347,6 +359,7 @@ export const docsDense = {
     status: 'Validation status object w/ type + optional message.',
     startIcon: 'Icon at input start, before filter tokens. Forwarded to internal Tokenizer.',
     statusVariant: 'How status message is placed: attached overlaps below input; detached floats below w/ spacing.',
+    menuWidth: 'Field-search menu width; never narrower than input. Not the operator/value popovers.',
     maxTokenLength: 'Max char length for filter value display in tokens.',
     popoverSaveButtonLabel: 'Label for save button in edit popover.',
     timezoneID: 'Timezone ID for date formatting (e.g. "America/New_York").',

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -103,10 +103,14 @@ const config: PowerSearchConfig = {
   ],
 };
 
-function PowerSearchWrapper(props: {config: PowerSearchConfig}) {
+function PowerSearchWrapper(props: {
+  config: PowerSearchConfig;
+  menuWidth?: number | string;
+}) {
   const [filters, setFilters] = useState<PowerSearchFilter[]>([]);
   return (
     <PowerSearch
+      menuWidth={props.menuWidth}
       config={props.config}
       filters={filters}
       onChange={newFilters => {
@@ -490,5 +494,71 @@ describe('PowerSearch statusVariant forwarding', () => {
       'data-variant',
       'detached',
     );
+  });
+  describe('menuWidth', () => {
+    // The width lands as StyleX's dynamic-style custom property on the
+    // popover element; jsdom has no layout, so the clamp against the input
+    // (min-width: anchor-size(width), which CSS resolves in the browser) is
+    // covered by the browser measurements in the PR rather than here.
+    const widthVar = (el: Element | null | undefined) =>
+      (el as HTMLElement | undefined)?.style.getPropertyValue('--x-width') ??
+      null;
+
+    async function openFieldMenu(user: ReturnType<typeof userEvent.setup>) {
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('Ti');
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+      return document
+        .querySelector('[role="listbox"]')
+        ?.closest('[popover]') as HTMLElement | null;
+    }
+
+    it('sizes the field-search menu from a pixel number', async () => {
+      const user = userEvent.setup();
+      render(
+        <PowerSearch
+          config={config}
+          filters={[]}
+          onChange={() => {}}
+          menuWidth={520}
+        />,
+      );
+      expect(widthVar(await openFieldMenu(user))).toBe('520px');
+    });
+
+    it('passes a string width through untouched', async () => {
+      const user = userEvent.setup();
+      render(
+        <PowerSearch
+          config={config}
+          filters={[]}
+          onChange={() => {}}
+          menuWidth="32rem"
+        />,
+      );
+      expect(widthVar(await openFieldMenu(user))).toBe('32rem');
+    });
+
+    it('leaves the menu content-sized when omitted', async () => {
+      const user = userEvent.setup();
+      render(<PowerSearch config={config} filters={[]} onChange={() => {}} />);
+      expect(widthVar(await openFieldMenu(user))).toBe('');
+    });
+
+    it('does not size the value popover that follows a field choice', async () => {
+      const user = userEvent.setup();
+      render(<PowerSearchWrapper config={config} menuWidth={520} />);
+      await openFieldMenu(user);
+      await user.click(screen.getAllByRole('option', {hidden: true})[0]);
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+      const valuePopover = screen
+        .getByRole('button', {name: 'Apply', hidden: true})
+        .closest('[popover]');
+      expect(widthVar(valuePopover)).toBe('');
+    });
   });
 });

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -397,8 +397,17 @@ export interface PowerSearchProps extends Omit<
    * @default 'attached'
    */
   statusVariant?: FieldStatusVariant;
-  /** Max width for dropdown menu. */
-  menuWidth?: number;
+  /**
+   * Width of the field-search menu — the dropdown that offers fields and
+   * free-text search. Numbers are pixels, strings are used as-is (e.g.
+   * `'32rem'`). The menu never renders narrower than the input, so a value
+   * below the input's width has no effect. Omitted, the menu matches the
+   * input and grows with its content.
+   *
+   * Does not size the operator and value popovers that follow a field
+   * choice — those track the input on their own.
+   */
+  menuWidth?: number | string;
   /** Max display length for filter token values. @default 40 */
   maxTokenLength?: number;
   /** Max items in operator dropdown. */
@@ -542,6 +551,7 @@ export function PowerSearch({
   onBlur,
   status,
   statusVariant = 'attached',
+  menuWidth,
   maxTokenLength = 40,
   popoverSaveButtonLabel: popoverSaveButtonLabelFromProps,
   timezoneID,
@@ -1048,6 +1058,7 @@ export function PowerSearch({
           isDisabled={isDisabled}
           disabledMessage={disabledMessage}
           size={size}
+          menuWidth={menuWidth}
           tokenOverflowBehavior={tokenOverflowBehavior}
           hasEntriesOnFocus
           debounceMs={0}

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -136,6 +136,12 @@ export const docs = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number | string',
+      description:
+        'Width of the dropdown menu. Numbers are pixels, strings are used as-is. Never renders narrower than the field. Omitted, the menu matches the field and grows with its content.',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: 'Text shown when search returns no results.',
@@ -369,6 +375,12 @@ export const docsZh = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number | string',
+      description:
+        '\u4e0b\u62c9\u83dc\u5355\u7684\u5bbd\u5ea6\u3002\u6570\u5b57\u4e3a\u50cf\u7d20\uff0c\u5b57\u7b26\u4e32\u6309\u539f\u6837\u4f7f\u7528\u3002\u83dc\u5355\u4e0d\u4f1a\u7a84\u4e8e\u8f93\u5165\u6846\u3002\u7701\u7565\u65f6\uff0c\u83dc\u5355\u4e0e\u8f93\u5165\u6846\u7b49\u5bbd\u5e76\u968f\u5185\u5bb9\u589e\u957f\u3002',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: '\u641c\u7d22\u65e0\u7ed3\u679c\u65f6\u663e\u793a\u7684\u6587\u672c\u3002',
@@ -490,6 +502,7 @@ export const docsDense = {
     labelTooltip: 'Tooltip on label.',
     hasEntriesOnFocus: 'Show bootstrap results on focus before typing.',
     maxMenuItems: 'Max dropdown items to display.',
+    menuWidth: 'Dropdown menu width; never narrower than the field.',
     emptySearchResultsText: 'Text when search returns no results.',
     hasAutoFocus: 'Auto-focus input on mount.',
     size: 'Input+token size.',

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -156,6 +156,13 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
   hasEntriesOnFocus?: boolean;
   /** Max dropdown items. @default 10 */
   maxMenuItems?: number;
+  /**
+   * Width of the dropdown menu. Numbers are pixels, strings are used as-is
+   * (e.g. `'32rem'`). The menu never renders narrower than the field, so a
+   * value below the field's width has no effect. Omitted, the menu matches
+   * the field and grows with its content.
+   */
+  menuWidth?: number | string;
   /** Text shown when no results found. @default 'No results found' */
   emptySearchResultsText?: string;
   /** Whether the input is disabled. @default false */
@@ -390,6 +397,7 @@ export function Tokenizer<T extends SearchableItem>({
   placeholder,
   hasEntriesOnFocus,
   maxMenuItems,
+  menuWidth,
   emptySearchResultsText,
   isDisabled = false,
   htmlName,
@@ -775,6 +783,7 @@ export function Tokenizer<T extends SearchableItem>({
         placeholder={value.length === 0 ? placeholder : ''}
         hasEntriesOnFocus={isAtMax ? false : hasEntriesOnFocus}
         maxMenuItems={maxMenuItems}
+        menuWidth={menuWidth}
         emptySearchResultsText={emptySearchResultsText}
         isDisabled={isDisabled}
         isFocusableDisabled={showsDisabledMessage}

--- a/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
+++ b/packages/core/src/Typeahead/BaseTypeahead.doc.mjs
@@ -61,6 +61,12 @@ export const docs = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number | string',
+      description:
+        'Width of the dropdown menu. Numbers are pixels, strings are used as-is. Never renders narrower than the anchor. Omitted, the menu matches the anchor and grows with its content.',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: 'Text shown when search returns no results.',
@@ -170,6 +176,12 @@ export const docsZh = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number | string',
+      description:
+        '下拉菜单的宽度。数字为像素，字符串按原样使用。菜单不会窄于锚点元素。省略时，菜单与锚点等宽并随内容增长。',
+    },
+    {
       name: 'emptySearchResultsText',
       type: 'string',
       description: '搜索无结果时显示的文本。',
@@ -253,6 +265,7 @@ export const docsDense = {
     placeholder: 'Input placeholder.',
     hasEntriesOnFocus: 'Bootstrap results on focus.',
     maxMenuItems: 'Max dropdown items.',
+    menuWidth: 'Dropdown menu width; never narrower than the anchor.',
     emptySearchResultsText: 'Text when no results.',
     isDisabled: 'Whether input disabled.',
     hasAutoFocus: 'Auto-focus on mount.',

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -94,6 +94,14 @@ export interface BaseTypeaheadProps<T extends SearchableItem> extends Omit<
   maxMenuItems?: number;
 
   /**
+   * Width of the dropdown menu. Numbers are pixels, strings are used as-is
+   * (e.g. `'32rem'`). The menu never renders narrower than its anchor, so a
+   * value below the anchor's width has no effect. Omitted, the menu matches
+   * the anchor and grows with its content.
+   */
+  menuWidth?: number | string;
+
+  /**
    * Text shown when no results found.
    * @default 'No results found'
    */
@@ -226,6 +234,12 @@ const styles = stylex.create({
   popover: {
     minWidth: 'anchor-size(width)',
   },
+  // Pairs with `popover` rather than replacing it: min-width beats width in
+  // CSS, so the anchor-size floor keeps a small menuWidth from rendering the
+  // menu narrower than the field it hangs off.
+  popoverCustomWidth: (width: number | string) => ({
+    width: typeof width === 'number' ? `${width}px` : width,
+  }),
   item: {
     boxSizing: 'border-box',
     display: 'flex',
@@ -313,6 +327,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   placeholder: placeholderFromProps,
   hasEntriesOnFocus = false,
   maxMenuItems = 10,
+  menuWidth,
   emptySearchResultsText: emptySearchResultsTextFromProps,
   isDisabled = false,
   isFocusableDisabled = false,
@@ -869,7 +884,10 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
           placement: 'below',
           alignment: 'start',
           offset: spacingVars['--spacing-1'],
-          xstyle: styles.popover,
+          xstyle: [
+            styles.popover,
+            menuWidth != null && styles.popoverCustomWidth(menuWidth),
+          ] as StyleXStyles,
         },
       )}
     </>

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -84,6 +84,12 @@ export const docs = {
       default: '10',
     },
     {
+      name: 'menuWidth',
+      type: 'number | string',
+      description:
+        'Width of the dropdown menu. Numbers are pixels, strings are used as-is. Never renders narrower than the field. Omitted, the menu matches the field and grows with its content.',
+    },
+    {
       name: 'status',
       type: "{type: 'warning' | 'error' | 'success', message?: string}",
       description:

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -110,6 +110,13 @@ export interface TypeaheadProps<T extends SearchableItem> extends Omit<
   hasEntriesOnFocus?: boolean;
   /** Max dropdown items. @default 10 */
   maxMenuItems?: number;
+  /**
+   * Width of the dropdown menu. Numbers are pixels, strings are used as-is
+   * (e.g. `'32rem'`). The menu never renders narrower than the field, so a
+   * value below the field's width has no effect. Omitted, the menu matches
+   * the field and grows with its content.
+   */
+  menuWidth?: number | string;
   /** Text shown when no results found. @default 'No results found' */
   emptySearchResultsText?: string;
   /** Whether the input is disabled. @default false */
@@ -244,6 +251,7 @@ export function Typeahead<T extends SearchableItem>({
   placeholder,
   hasEntriesOnFocus,
   maxMenuItems,
+  menuWidth,
   emptySearchResultsText,
   isDisabled = false,
   disabledMessage,
@@ -463,6 +471,7 @@ export function Typeahead<T extends SearchableItem>({
           placeholder={showToken ? undefined : placeholder}
           hasEntriesOnFocus={hasEntriesOnFocus}
           maxMenuItems={maxMenuItems}
+          menuWidth={menuWidth}
           emptySearchResultsText={emptySearchResultsText}
           isDisabled={isDisabled}
           hasAutoFocus={hasAutoFocus}


### PR DESCRIPTION
## Why

`PowerSearch` declares a public `menuWidth?: number` prop that nothing in
`packages/core/src/PowerSearch/` ever reads. The field-search menu has always
matched the input and grown with its content, so a consumer who wants a wider
menu — long field labels, descriptions that wrap at the input's width — has no
way to ask for one, and the prop that looks like the way to ask does nothing.

## What

`menuWidth` now reaches the menu. `Typeahead`, `Tokenizer` and `BaseTypeahead`
all take the same prop, so the whole typeahead family sizes its menu one way
rather than only the component the bug was reported against.

Two constraints shaped the implementation:

- **The menu never renders narrower than the input.** `BaseTypeahead`'s popover
  already carries `min-width: anchor-size(width)`. The new width pairs with
  that floor instead of replacing it, so CSS resolves the clamp — min-width
  beats width — and no measurement is involved.
- **Only the field-search menu is sized.** The operator and value popovers that
  follow a field choice keep their own sizing and are untouched.

`menuWidth` also widens from `number` to `number | string`. `DropdownMenu`,
`DropdownMenuSubMenu` and `ContextMenu` already spell it that way, and a prop
of the same name that accepts less here would be its own small trap. Existing
numeric values are unaffected.

One deliberate difference from those three: they treat `menuWidth` as a
min-width that *replaces* the anchor floor, so a small value there can make the
menu narrower than its trigger. This keeps the floor, because a search menu
narrower than the field it hangs off reads as a rendering bug.

## Measured in Chromium

New `Core/PowerSearch → Menu Width` story, four 360px-wide fields; menu width
read off the rendered popover.

| `menuWidth` | menu | note |
|---|---|---|
| omitted | 360px | unchanged — matches the input |
| `640` | 640px | |
| `200` | 360px | floored at the input, not 200px |
| `'34rem'` | 544px | CSS length strings resolve |

RTL (`direction:rtl`): the menu stays start-aligned with the field's inline
start and grows toward the inline end — 640px menu, 360px field, same start
edge as the default menu. With `menuWidth={640}` set, the value popover opened
by choosing a field still measures 400px, its own width. Content longer than an
explicit width wraps inside the menu; an unbreakable token clips at the menu
edge, which is what a fixed width means.

## Testing

Unit tests cover the pixel form, the string form, the omitted default, and that
the value popover stays unsized. The clamp itself is a CSS resolution that jsdom
cannot compute, so it is covered by the browser measurements above.

`menuWidth` is documented now — it had no `doc.mjs` entry, so the docs promised
nothing, but the type did.
