### PR TITLE
fix(cli): give existing Tailwind apps safe Astryx guidance

### DIFF
--- a/.changeset/existing-tailwind-agent-guidance.md
+++ b/.changeset/existing-tailwind-agent-guidance.md
@@ -1,0 +1,26 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] init: tell an app that already had Tailwind not to adopt the bridge
+
+`detectStylingSystem` could not tell a project built around Astryx from one that
+had Tailwind and its own design tokens long before Astryx arrived — both are
+`tailwindcss` in `package.json`. Both were handed the same rule: reach for
+`bg-surface` and `text-primary` "via tailwind-theme.css".
+
+In the second kind of app that rule is wrong twice over. Those class names do
+not exist there, and the file it names declares ~25 of Tailwind's own theme
+variables plus the shadcn vocabulary, so adding it re-points utilities the app
+is already using, everywhere. Whether the project imports the bridge is the
+signal that separates the two, so `init` now reads the stylesheet as well as the
+dependency list, and an app that owns its utility layer is told to use its own
+token classes and to leave the bridge alone.
+
+The `never override --color-* in :root` rule also gains the one exception it
+needs there: a theme's tokens are set on the element carrying
+`data-astryx-theme`, so an app keeping a name it already owned has to re-assert
+it on that boundary — with the colour's partner, since `--color-accent` without
+`--color-on-accent` produces a button nobody can read.
+
+@nynexman4464

--- a/packages/cli/foundation/agent-docs/agent-docs.mjs
+++ b/packages/cli/foundation/agent-docs/agent-docs.mjs
@@ -33,7 +33,6 @@ const CURSOR_RULES = '.cursorrules';
 const HERMES_DOT_MD = '.hermes.md';
 const HERMES_MD = 'HERMES.md';
 
-
 const MARKER_START = '<!-- ASTRYX:START -->';
 const MARKER_END = '<!-- ASTRYX:END -->';
 // Legacy markers — read during migration so the script finds existing XDS blocks
@@ -131,7 +130,10 @@ export function isAstryxInitialized(targetDir = process.cwd()) {
   for (const rel of discoverAgentDocs(targetDir)) {
     try {
       const content = fs.readFileSync(path.join(targetDir, rel), 'utf-8');
-      if (content.includes(MARKER_START) || content.includes(LEGACY_MARKER_START)) {
+      if (
+        content.includes(MARKER_START) ||
+        content.includes(LEGACY_MARKER_START)
+      ) {
         return true;
       }
     } catch {
@@ -204,7 +206,11 @@ export function inspectAgentDocs(targetDir, installedVersion) {
   const staleEntries = files.filter(f => f.stale);
   const staleFiles = staleEntries.map(f => f.path);
   const blockVersions = [
-    ...new Set(staleEntries.map(f => f.blockVersion).filter(/** @returns {v is string} */ (v) => v != null)),
+    ...new Set(
+      staleEntries
+        .map(f => f.blockVersion)
+        .filter(/** @returns {v is string} */ v => v != null),
+    ),
   ];
 
   /** @type {'missing' | 'stale' | 'current'} */
@@ -235,7 +241,9 @@ export function resolveAgentPaths(targetDir, agent) {
     return {inject: [], create: [AGENTS_MD, CLAUDE_DIR_MD]};
   }
 
-  const searchPaths = /** @type {Record<string, string[]>} */ (AGENT_PRESETS)[agent];
+  const searchPaths = /** @type {Record<string, string[]>} */ (AGENT_PRESETS)[
+    agent
+  ];
   if (!searchPaths) {
     return {inject: [], create: [AGENTS_MD]};
   }
@@ -262,8 +270,60 @@ export function resolveAgentPaths(targetDir, agent) {
  * safe default. Precedence: stylex (compiler wired) → tailwind → css.
  *
  * @param {string} targetDir
- * @returns {'stylex' | 'tailwind' | 'css'}
+ * @returns {'stylex' | 'tailwind-bridge' | 'tailwind' | 'css'}
  */
+/**
+ * Conventional stylesheet entry points, in the order a project is likely to use
+ * one. Bounded on purpose: this runs on every `init` and `upgrade`, and a
+ * filesystem walk to answer a styling question is not a trade worth making.
+ */
+const CSS_ENTRY_POINTS = [
+  'app/globals.css',
+  'src/app/globals.css',
+  'src/globals.css',
+  'styles/globals.css',
+  'src/styles/globals.css',
+  'src/index.css',
+  'src/main.css',
+  'app/global.css',
+  'globals.css',
+];
+
+/**
+ * Does this project import the Tailwind bridge?
+ *
+ * `tailwind-theme.css` declares Astryx's tokens into Tailwind's own `@theme`
+ * namespaces, so `bg-surface` and `rounded-lg` resolve to system values. In a
+ * project built around Astryx that is the intended setup and an agent should be
+ * told to use those utilities.
+ *
+ * In a project that ALREADY had Tailwind it is a different thing entirely: the
+ * bridge declares ~25 names Tailwind ships by default and ~11 more that the
+ * common shadcn vocabulary uses, so importing it re-points utilities the app is
+ * already using, app-wide. Such a project usually — correctly — does not import
+ * it, and an agent told to reach for `bg-surface` there will either produce
+ * classes that resolve to nothing or add the import and restyle the app.
+ *
+ * Both are "a Tailwind project" to `package.json`, so the dependency list cannot
+ * separate them. What the app did with its own stylesheet can.
+ *
+ * @param {string} targetDir
+ * @returns {boolean}
+ */
+export function usesTailwindBridge(targetDir) {
+  for (const entry of CSS_ENTRY_POINTS) {
+    try {
+      const file = path.join(targetDir, entry);
+      if (!fs.existsSync(file)) continue;
+      if (/tailwind-theme\.css/.test(fs.readFileSync(file, 'utf-8')))
+        return true;
+    } catch {
+      // An unreadable entry point is not evidence either way; keep looking.
+    }
+  }
+  return false;
+}
+
 export function detectStylingSystem(targetDir) {
   try {
     const pkgPath = path.join(targetDir, 'package.json');
@@ -280,7 +340,9 @@ export function detectStylingSystem(targetDir) {
       'stylex-webpack',
     ];
     if (stylexCompilers.some(d => d in deps)) return 'stylex';
-    if ('tailwindcss' in deps) return 'tailwind';
+    if ('tailwindcss' in deps) {
+      return usesTailwindBridge(targetDir) ? 'tailwind-bridge' : 'tailwind';
+    }
     return 'css';
   } catch {
     // Best-effort: default to the universally-safe CSS-variable path.
@@ -300,10 +362,13 @@ export function detectStylingSystem(targetDir) {
  * styling path that isn't compiled here.
  *
  * @param {string} version
- * @param {{coreDir?: string|null, invocation?: string, stylingSystem?: 'stylex'|'tailwind'|'css', zh?: boolean, lang?: string}} [options]
+ * @param {{coreDir?: string|null, invocation?: string, stylingSystem?: 'stylex'|'tailwind-bridge'|'tailwind'|'css', zh?: boolean, lang?: string}} [options]
  * @returns {string}
  */
-export function generateCompressedIndex(version, {coreDir, invocation = getCliInvocation(), stylingSystem = 'css'} = {}) {
+export function generateCompressedIndex(
+  version,
+  {coreDir, invocation = getCliInvocation(), stylingSystem = 'css'} = {},
+) {
   const run = invocation;
   const lines = [MARKER_START];
 
@@ -322,39 +387,82 @@ export function generateCompressedIndex(version, {coreDir, invocation = getCliIn
 
   // Header — state the CLI prefix once; commands below are shown as `astryx <cmd>`.
   lines.push(`Astryx v${version} · ${componentCount} components`);
-  lines.push(`CLI: run every command as \`${run} <cmd>\` (shown below as \`astryx ...\`).`);
+  lines.push(
+    `CLI: run every command as \`${run} <cmd>\` (shown below as \`astryx ...\`).`,
+  );
   lines.push('');
 
   // Required setup — components ship precompiled CSS; without these imports
   // everything renders unstyled. Theme is optional (a default ships in astryx.css).
-  lines.push('SETUP (once, in your app entry e.g. main.tsx) — without these, components render unstyled:');
+  lines.push(
+    'SETUP (once, in your app entry e.g. main.tsx) — without these, components render unstyled:',
+  );
   lines.push('  import "@astryxdesign/core/reset.css";');
   lines.push('  import "@astryxdesign/core/astryx.css";');
   lines.push('');
 
   // Workflow — `build` is the front door; discover before writing UI.
   lines.push("WORKFLOW — discover, don't guess. Before writing UI:");
-  lines.push('1. `astryx build "<idea>"` — START HERE: returns a kit (closest [page] + [block]s + [component]s). No args = full playbook.');
-  lines.push('2. `astryx template <name> [--skeleton]` — scaffold the [page]/[block]s it named, or study their layout. Templates are reference code.');
-  lines.push('3. `astryx component <Name>` — props + examples for every component you use.');
+  lines.push(
+    '1. `astryx build "<idea>"` — START HERE: returns a kit (closest [page] + [block]s + [component]s). No args = full playbook.',
+  );
+  lines.push(
+    '2. `astryx template <name> [--skeleton]` — scaffold the [page]/[block]s it named, or study their layout. Templates are reference code.',
+  );
+  lines.push(
+    '3. `astryx component <Name>` — props + examples for every component you use.',
+  );
   lines.push('');
 
   // Rules — the top error-preventers.
   lines.push('RULES:');
-  lines.push('- No <div> — components do all layout/spacing, page frame included.');
-  lines.push('- Frame first: read `astryx docs layout` before writing any page or screen — page frame, region widths, breakpoint behavior.');
-  lines.push('- Dense data = rows (Table, List/Item), never Card-wrapped list items; Card is for standalone widgets. Status = StatusDot/Token; Badge = counts only.');
+  lines.push(
+    '- No <div> — components do all layout/spacing, page frame included.',
+  );
+  lines.push(
+    '- Frame first: read `astryx docs layout` before writing any page or screen — page frame, region widths, breakpoint behavior.',
+  );
+  lines.push(
+    '- Dense data = rows (Table, List/Item), never Card-wrapped list items; Card is for standalone widgets. Status = StatusDot/Token; Badge = counts only.',
+  );
   // Styling guidance tailored to the project's configured system — never
   // recommend a path that isn't compiled here (xstyle needs the StyleX compiler;
   // utilities need Tailwind). Tokens are always the source of truth.
   if (stylingSystem === 'stylex') {
-    lines.push('- Custom styling: component props first; else the xstyle prop / StyleX tokens (@astryxdesign/core/theme/tokens.stylex). No raw hex/px.');
+    lines.push(
+      '- Custom styling: component props first; else the xstyle prop / StyleX tokens (@astryxdesign/core/theme/tokens.stylex). No raw hex/px.',
+    );
+  } else if (stylingSystem === 'tailwind-bridge') {
+    lines.push(
+      '- Custom styling: component props first; else Tailwind utilities backed by tokens (bg-surface, text-primary, rounded-lg) via tailwind-theme.css. No raw hex/px.',
+    );
   } else if (stylingSystem === 'tailwind') {
-    lines.push('- Custom styling: component props first; else Tailwind utilities backed by tokens (bg-surface, text-primary, rounded-lg) via tailwind-theme.css. No raw hex/px.');
+    lines.push(
+      "- Custom styling: component props first; else this app's OWN Tailwind token classes — read its globals.css for the vocabulary and match the components next to yours. No raw hex/px.",
+    );
+    lines.push(
+      "- This app had Tailwind before Astryx and owns its utility layer. Do NOT add `@astryxdesign/core/tailwind-theme.css`: it declares --color-card/-muted/-border/-accent/-primary/-secondary, --radius-*, --shadow-*, --text-* and --spacing into Tailwind's theme, re-pointing utilities the app already uses everywhere.",
+    );
   } else {
-    lines.push("- Custom styling: component props first; else style/className with tokens — var(--color-*|--spacing-*|--radius-*). No raw hex/px. (No StyleX/Tailwind compiler here — don't use xstyle/utility classes.)");
+    lines.push(
+      "- Custom styling: component props first; else style/className with tokens — var(--color-*|--spacing-*|--radius-*). No raw hex/px. (No StyleX/Tailwind compiler here — don't use xstyle/utility classes.)",
+    );
   }
-  lines.push('- Tokens for every value (`astryx docs tokens`). Brand/accent belongs in the theme (`astryx theme list` / `theme add <slug>`, or `astryx theme template` for a custom one) — never override --color-* in :root.');
+  lines.push(
+    '- Tokens for every value (`astryx docs tokens`). Brand/accent belongs in the theme (`astryx theme list` / `theme add <slug>`, or `astryx theme template` for a custom one) — never override --color-* in :root.',
+  );
+  if (stylingSystem === 'tailwind') {
+    // The one place the rule above has to bend. A theme's tokens are set on the
+    // element carrying data-astryx-theme, which the provider also syncs onto
+    // <html>; a same-named app token declared in :root (or hoisted there by
+    // `@theme`) is a lower-priority layer and loses. Re-declaring on the
+    // boundary element is how the app keeps a name it already owned — and the
+    // pairing matters: --color-accent without --color-on-accent is how you get
+    // a button nobody can read.
+    lines.push(
+      "- Exception, for a name this app already defines (--color-accent and --color-border are the usual pair): re-assert it on [data-astryx-theme], not :root — :root loses to the theme layer. Override a colour's partner too (--color-on-accent with --color-accent), or the pairing breaks.",
+    );
+  }
   // Self-check — post-generation pass. Validated via vibe tests (internal/vibe-tests/
   // prompt-purity-test): on complex multi-step UIs the rules above alone still leave raw
   // CSS in ~11-13% of runs; a re-read-and-fix pass cuts that ~4x at negligible token cost.
@@ -362,8 +470,10 @@ export function generateCompressedIndex(version, {coreDir, invocation = getCliIn
   const selfCheckFix = {
     stylex:
       'replace any className=, style={{…}}, raw <div>/<span> layout, imported .css/@apply, or hardcoded #hex/px with the component or the xstyle prop + a token',
-    tailwind:
+    'tailwind-bridge':
       'replace any style={{…}}, raw <div>/<span> layout, imported .css/@apply, or hardcoded/arbitrary value (e.g. bg-[#fff], p-[13px]) with the component or a token-backed utility',
+    tailwind:
+      "replace any style={{…}}, raw <div>/<span> layout, imported .css/@apply, or hardcoded/arbitrary value (e.g. bg-[#fff], p-[13px]) with the component or one of this app's own token classes",
     css: 'replace any raw <div>/<span> layout, imported .css/@apply, or hardcoded value (#hex, 16px) with the component or a token (var(--color-*|--spacing-*|…))',
   };
   lines.push(
@@ -373,19 +483,25 @@ export function generateCompressedIndex(version, {coreDir, invocation = getCliIn
 
   // Command reference — build/template/component are covered in WORKFLOW above.
   lines.push('MORE CLI:');
-  lines.push('  search "<query>"   find any component / hook / doc / template / block');
+  lines.push(
+    '  search "<query>"   find any component / hook / doc / template / block',
+  );
   lines.push(`  component --list   ${componentCount} components by category`);
   lines.push('  template --list    page + block recipes');
   const docsDir = path.join(CLI_ROOT, 'assets', 'docs');
   if (fs.existsSync(docsDir)) {
-    const topics = fs.readdirSync(docsDir)
+    const topics = fs
+      .readdirSync(docsDir)
       .map(f => f.match(/^(\w+)\.doc\.mjs$/))
-      .filter(/** @returns {m is RegExpMatchArray} */ (m) => m != null)
+      .filter(/** @returns {m is RegExpMatchArray} */ m => m != null)
       .map(m => m[1])
       .sort();
-    if (topics.length > 0) lines.push(`  docs <topic>       ${topics.join(', ')}`);
+    if (topics.length > 0)
+      lines.push(`  docs <topic>       ${topics.join(', ')}`);
   }
-  lines.push('  swizzle <Name>     eject component source for deep customization');
+  lines.push(
+    '  swizzle <Name>     eject component source for deep customization',
+  );
   lines.push('  upgrade --apply    run after any @astryxdesign/core bump');
   lines.push(MARKER_END);
 
@@ -424,7 +540,11 @@ export function getXdsVersion(coreDir) {
  * @param {boolean} [options.onlyReplace] - Only write if Astryx markers already exist (skip files without markers)
  * @returns {boolean} Whether the file was written
  */
-export function injectXdsBlock(filePath, compressedIndex, {createIfMissing = false, header = '', onlyReplace = false} = {}) {
+export function injectXdsBlock(
+  filePath,
+  compressedIndex,
+  {createIfMissing = false, header = '', onlyReplace = false} = {},
+) {
   let content;
 
   if (fs.existsSync(filePath)) {
@@ -438,7 +558,10 @@ export function injectXdsBlock(filePath, compressedIndex, {createIfMissing = fal
         content.slice(0, block.start) +
         compressedIndex +
         content.slice(block.end);
-    } else if (content.includes(MARKER_START) || content.includes(LEGACY_MARKER_START)) {
+    } else if (
+      content.includes(MARKER_START) ||
+      content.includes(LEGACY_MARKER_START)
+    ) {
       // A START with no matching END (e.g. an interrupted previous write). Don't
       // append a second block below the broken one — that leaves two STARTs the
       // tool can never converge. Refuse and ask the user to clean it up.
@@ -453,7 +576,9 @@ export function injectXdsBlock(filePath, compressedIndex, {createIfMissing = fal
       content = content.trimEnd() + '\n\n' + compressedIndex + '\n';
     }
   } else if (createIfMissing) {
-    content = header ? header + '\n\n' + compressedIndex + '\n' : compressedIndex + '\n';
+    content = header
+      ? header + '\n\n' + compressedIndex + '\n'
+      : compressedIndex + '\n';
   } else {
     return false;
   }
@@ -568,12 +693,21 @@ export function removeAgentDocs(targetDir) {
  * @param {boolean} [options.onlyReplace] - Only update files that already have Astryx markers (for upgrades)
  * @returns {string[]} List of files written
  */
-export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onlyReplace = false} = {}) {
+export function installAgentDocs(
+  targetDir,
+  {zh = false, lang, agent, paths, onlyReplace = false} = {},
+) {
   const coreDir = findCoreDir(targetDir);
   const version = getXdsVersion(coreDir);
   const invocation = getCliInvocation(targetDir);
   const stylingSystem = detectStylingSystem(targetDir);
-  const compressedIndex = generateCompressedIndex(version, {coreDir, zh, lang, invocation, stylingSystem});
+  const compressedIndex = generateCompressedIndex(version, {
+    coreDir,
+    zh,
+    lang,
+    invocation,
+    stylingSystem,
+  });
   /** @type {string[]} */
   const written = [];
 
@@ -627,7 +761,11 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
 
   if (existing.length > 0) {
     for (const p of existing) {
-      const didWrite = injectXdsBlock(path.join(targetDir, p), compressedIndex, {onlyReplace});
+      const didWrite = injectXdsBlock(
+        path.join(targetDir, p),
+        compressedIndex,
+        {onlyReplace},
+      );
       if (didWrite) written.push(p);
     }
     return written;

--- a/packages/cli/foundation/agent-docs/agent-docs.test.mjs
+++ b/packages/cli/foundation/agent-docs/agent-docs.test.mjs
@@ -64,12 +64,18 @@ describe('generateCompressedIndex', () => {
   it('tailors the self-check to the styling system (xstyle for StyleX, not className for Tailwind)', () => {
     // StyleX path: className/inline style are veers; the fix is the xstyle prop + a token
     const stylex = generateCompressedIndex('1.0.0', {stylingSystem: 'stylex'});
-    const stylexSelfCheck = stylex.split('\n').find(l => l.includes('SELF-CHECK'));
+    const stylexSelfCheck = stylex
+      .split('\n')
+      .find(l => l.includes('SELF-CHECK'));
     expect(stylexSelfCheck).toMatch(/xstyle/);
     expect(stylexSelfCheck).toMatch(/className=/);
     // className IS the system in Tailwind — it must NOT be flagged
-    const tailwind = generateCompressedIndex('1.0.0', {stylingSystem: 'tailwind'});
-    const tailwindSelfCheck = tailwind.split('\n').find(l => l.includes('SELF-CHECK'));
+    const tailwind = generateCompressedIndex('1.0.0', {
+      stylingSystem: 'tailwind',
+    });
+    const tailwindSelfCheck = tailwind
+      .split('\n')
+      .find(l => l.includes('SELF-CHECK'));
     expect(tailwindSelfCheck).toBeDefined();
     expect(tailwindSelfCheck).not.toMatch(/className=/);
   });
@@ -87,10 +93,51 @@ describe('generateCompressedIndex', () => {
     expect(result).toMatch(/xstyle prop \/ StyleX tokens/);
   });
 
-  it('recommends Tailwind utilities when Tailwind is configured', () => {
-    const result = generateCompressedIndex('1.0.0', {stylingSystem: 'tailwind'});
+  it('recommends the bridge utilities when the project imports the bridge', () => {
+    const result = generateCompressedIndex('1.0.0', {
+      stylingSystem: 'tailwind-bridge',
+    });
     expect(result).toMatch(/Tailwind utilities backed by tokens/);
     expect(result).toMatch(/tailwind-theme\.css/);
+  });
+
+  it("points at the app's own classes when Tailwind is there without the bridge", () => {
+    const result = generateCompressedIndex('1.0.0', {
+      stylingSystem: 'tailwind',
+    });
+    // The app owns its utility layer: send the agent to read the vocabulary,
+    // not to reach for names the bridge would have had to introduce.
+    expect(result).toMatch(/OWN Tailwind token classes/);
+    expect(result).toMatch(/read its globals\.css/);
+    expect(result).not.toMatch(/Tailwind utilities backed by tokens/);
+  });
+
+  it('tells an existing Tailwind app not to add the bridge, and why', () => {
+    const result = generateCompressedIndex('1.0.0', {
+      stylingSystem: 'tailwind',
+    });
+    expect(result).toMatch(
+      /Do NOT add `@astryxdesign\/core\/tailwind-theme\.css`/,
+    );
+    // The reason has to travel with the rule, or it reads as arbitrary.
+    expect(result).toMatch(/re-pointing utilities the app already uses/);
+  });
+
+  it('gives the boundary-element exception only where it applies', () => {
+    const existing = generateCompressedIndex('1.0.0', {
+      stylingSystem: 'tailwind',
+    });
+    expect(existing).toMatch(
+      /re-assert it on \[data-astryx-theme\], not :root/,
+    );
+    // ...and names the pairing, because taking --color-accent alone is how you
+    // get a button whose label nobody can read.
+    expect(existing).toMatch(/--color-on-accent with --color-accent/);
+
+    for (const stylingSystem of ['tailwind-bridge', 'stylex', 'css']) {
+      const other = generateCompressedIndex('1.0.0', {stylingSystem});
+      expect(other).not.toMatch(/data-astryx-theme/);
+    }
   });
 
   it('includes upgrade command and migration rule', () => {
@@ -100,19 +147,25 @@ describe('generateCompressedIndex', () => {
   });
 
   it('states the invocation once in the CLI header (yarn)', () => {
-    const result = generateCompressedIndex('1.0.0', {invocation: 'yarn astryx'});
+    const result = generateCompressedIndex('1.0.0', {
+      invocation: 'yarn astryx',
+    });
     expect(result).toContain('yarn astryx <cmd>');
     expect(result).not.toContain('npx astryx');
   });
 
   it('uses the pnpm exec invocation', () => {
-    const result = generateCompressedIndex('1.0.0', {invocation: 'pnpm exec astryx'});
+    const result = generateCompressedIndex('1.0.0', {
+      invocation: 'pnpm exec astryx',
+    });
     expect(result).toContain('pnpm exec astryx <cmd>');
     expect(result).not.toContain('npx astryx');
   });
 
   it('uses the scoped package for one-off (uninstalled) runs so agents never hit the bare name', () => {
-    const result = generateCompressedIndex('1.0.0', {invocation: 'npx @astryxdesign/cli'});
+    const result = generateCompressedIndex('1.0.0', {
+      invocation: 'npx @astryxdesign/cli',
+    });
     expect(result).toContain('npx @astryxdesign/cli <cmd>');
     // The header defines the mapping; the bare "run every command as `npx astryx`" footgun must be absent.
     expect(result).not.toContain('npx astryx <cmd>');
@@ -146,6 +199,30 @@ describe('detectStylingSystem', () => {
     expect(detectStylingSystem(tmpDir)).toBe('tailwind');
   });
 
+  it('separates a bridge project from an app that already had Tailwind', () => {
+    // Same dependency list either way — what the app did with its own
+    // stylesheet is the only thing that can tell them apart.
+    writePkg({tailwindcss: '4.0.0'});
+    expect(detectStylingSystem(tmpDir)).toBe('tailwind');
+
+    fs.mkdirSync(path.join(tmpDir, 'app'), {recursive: true});
+    fs.writeFileSync(
+      path.join(tmpDir, 'app', 'globals.css'),
+      '@import "tailwindcss";\n@import "@astryxdesign/core/tailwind-theme.css";\n',
+    );
+    expect(detectStylingSystem(tmpDir)).toBe('tailwind-bridge');
+  });
+
+  it('does not call it a bridge project when the entry point omits it', () => {
+    writePkg({tailwindcss: '4.0.0'});
+    fs.mkdirSync(path.join(tmpDir, 'src'), {recursive: true});
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'index.css'),
+      '@import "tailwindcss";\n@import "@astryxdesign/core/astryx.css";\n',
+    );
+    expect(detectStylingSystem(tmpDir)).toBe('tailwind');
+  });
+
   it('does NOT treat the StyleX runtime alone as a compiler', () => {
     // Only the runtime, no compiler plugin → must stay on the safe css path.
     writePkg({'@stylexjs/stylex': '0.0.1'});
@@ -176,7 +253,10 @@ describe('injectXdsBlock', () => {
     const filePath = path.join(tmpDir, 'test.md');
     fs.writeFileSync(filePath, '# Existing content\n');
 
-    const result = injectXdsBlock(filePath, '<!-- ASTRYX:START -->\nnew\n<!-- ASTRYX:END -->');
+    const result = injectXdsBlock(
+      filePath,
+      '<!-- ASTRYX:START -->\nnew\n<!-- ASTRYX:END -->',
+    );
 
     expect(result).toBe(true);
     const content = fs.readFileSync(filePath, 'utf-8');
@@ -186,7 +266,10 @@ describe('injectXdsBlock', () => {
 
   it('replaces existing markers', () => {
     const filePath = path.join(tmpDir, 'test.md');
-    fs.writeFileSync(filePath, 'before\n<!-- XDS:START -->\nold\n<!-- XDS:END -->\nafter\n');
+    fs.writeFileSync(
+      filePath,
+      'before\n<!-- XDS:START -->\nold\n<!-- XDS:END -->\nafter\n',
+    );
 
     injectXdsBlock(filePath, '<!-- ASTRYX:START -->\nnew\n<!-- ASTRYX:END -->');
 
@@ -200,7 +283,10 @@ describe('injectXdsBlock', () => {
   it('returns false and does not create file when createIfMissing is false', () => {
     const filePath = path.join(tmpDir, 'nonexistent.md');
 
-    const result = injectXdsBlock(filePath, '<!-- ASTRYX:START -->\ncontent\n<!-- ASTRYX:END -->');
+    const result = injectXdsBlock(
+      filePath,
+      '<!-- ASTRYX:START -->\ncontent\n<!-- ASTRYX:END -->',
+    );
 
     expect(result).toBe(false);
     expect(fs.existsSync(filePath)).toBe(false);
@@ -210,7 +296,11 @@ describe('injectXdsBlock', () => {
     const filePath = path.join(tmpDir, 'test.md');
     fs.writeFileSync(filePath, '# Existing content\n\nNo XDS markers here.\n');
 
-    const result = injectXdsBlock(filePath, '<!-- ASTRYX:START -->\nnew\n<!-- ASTRYX:END -->', {onlyReplace: true});
+    const result = injectXdsBlock(
+      filePath,
+      '<!-- ASTRYX:START -->\nnew\n<!-- ASTRYX:END -->',
+      {onlyReplace: true},
+    );
 
     expect(result).toBe(false);
     const content = fs.readFileSync(filePath, 'utf-8');
@@ -220,9 +310,16 @@ describe('injectXdsBlock', () => {
 
   it('replaces existing markers even when onlyReplace is true', () => {
     const filePath = path.join(tmpDir, 'test.md');
-    fs.writeFileSync(filePath, 'before\n<!-- XDS:START -->\nold\n<!-- XDS:END -->\nafter\n');
+    fs.writeFileSync(
+      filePath,
+      'before\n<!-- XDS:START -->\nold\n<!-- XDS:END -->\nafter\n',
+    );
 
-    const result = injectXdsBlock(filePath, '<!-- ASTRYX:START -->\nnew\n<!-- ASTRYX:END -->', {onlyReplace: true});
+    const result = injectXdsBlock(
+      filePath,
+      '<!-- ASTRYX:START -->\nnew\n<!-- ASTRYX:END -->',
+      {onlyReplace: true},
+    );
 
     expect(result).toBe(true);
     const content = fs.readFileSync(filePath, 'utf-8');
@@ -233,10 +330,14 @@ describe('injectXdsBlock', () => {
   it('creates file when createIfMissing is true', () => {
     const filePath = path.join(tmpDir, 'new.md');
 
-    const result = injectXdsBlock(filePath, '<!-- ASTRYX:START -->\ncontent\n<!-- ASTRYX:END -->', {
-      createIfMissing: true,
-      header: '# Header',
-    });
+    const result = injectXdsBlock(
+      filePath,
+      '<!-- ASTRYX:START -->\ncontent\n<!-- ASTRYX:END -->',
+      {
+        createIfMissing: true,
+        header: '# Header',
+      },
+    );
 
     expect(result).toBe(true);
     const content = fs.readFileSync(filePath, 'utf-8');
@@ -296,7 +397,10 @@ Existing agent docs.
 
 describe('injectClaudeMd', () => {
   it('injects into existing CLAUDE.md', () => {
-    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Claude Config\n\nExisting rules.\n');
+    fs.writeFileSync(
+      path.join(tmpDir, 'CLAUDE.md'),
+      '# Claude Config\n\nExisting rules.\n',
+    );
 
     const result = injectClaudeMd(tmpDir, '1.0.0');
 
@@ -389,7 +493,10 @@ XDS index stuff
 
     removeAgentDocs(tmpDir);
 
-    const claudeContent = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    const claudeContent = fs.readFileSync(
+      path.join(tmpDir, 'CLAUDE.md'),
+      'utf-8',
+    );
     expect(claudeContent).toContain('Rules.');
     expect(claudeContent).toContain('More rules.');
     expect(claudeContent).not.toContain('<!-- XDS:START -->');
@@ -415,7 +522,9 @@ describe('installAgentDocs', () => {
     expect(written).toEqual(['AGENTS.md']);
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
     // Must NOT create the Claude-specific file by default.
-    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(
+      false,
+    );
     const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
     expect(content).toContain('# AGENTS.md');
     expect(content).toContain('<!-- ASTRYX:START -->');
@@ -425,13 +534,19 @@ describe('installAgentDocs', () => {
     // Default (no agent): tool-agnostic AGENTS.md, never the Claude file.
     setupCorePackage(tmpDir);
     expect(installAgentDocs(tmpDir)).toEqual(['AGENTS.md']);
-    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(
+      false,
+    );
 
     // Explicit Claude: the Claude-specific file, in a fresh project.
-    const claudeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-agent-docs-claude-'));
+    const claudeDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'astryx-agent-docs-claude-'),
+    );
     setupCorePackage(claudeDir);
     try {
-      expect(installAgentDocs(claudeDir, {agent: 'claude'})).toEqual(['.claude/CLAUDE.md']);
+      expect(installAgentDocs(claudeDir, {agent: 'claude'})).toEqual([
+        '.claude/CLAUDE.md',
+      ]);
       expect(fs.existsSync(path.join(claudeDir, 'AGENTS.md'))).toBe(false);
     } finally {
       fs.rmSync(claudeDir, {recursive: true, force: true});
@@ -440,28 +555,46 @@ describe('installAgentDocs', () => {
 
   it('injects into CLAUDE.md at root when it exists', () => {
     setupCorePackage(tmpDir);
-    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Claude\n\nProject rules.\n');
+    fs.writeFileSync(
+      path.join(tmpDir, 'CLAUDE.md'),
+      '# Claude\n\nProject rules.\n',
+    );
 
     const written = installAgentDocs(tmpDir);
 
     expect(written).toEqual(['CLAUDE.md']);
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
-    const claudeContent = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    const claudeContent = fs.readFileSync(
+      path.join(tmpDir, 'CLAUDE.md'),
+      'utf-8',
+    );
     expect(claudeContent).toContain('<!-- ASTRYX:START -->');
     expect(claudeContent).toContain('Project rules.');
   });
 
   it('injects into all existing agent doc files', () => {
     setupCorePackage(tmpDir);
-    fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '# Agents\n\nAgent rules.\n');
-    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Claude\n\nClaude rules.\n');
+    fs.writeFileSync(
+      path.join(tmpDir, 'AGENTS.md'),
+      '# Agents\n\nAgent rules.\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'CLAUDE.md'),
+      '# Claude\n\nClaude rules.\n',
+    );
 
     const written = installAgentDocs(tmpDir);
 
     expect(written).toContain('AGENTS.md');
     expect(written).toContain('CLAUDE.md');
-    const agentsContent = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
-    const claudeContent = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
+    const agentsContent = fs.readFileSync(
+      path.join(tmpDir, 'AGENTS.md'),
+      'utf-8',
+    );
+    const claudeContent = fs.readFileSync(
+      path.join(tmpDir, 'CLAUDE.md'),
+      'utf-8',
+    );
     expect(agentsContent).toContain('<!-- ASTRYX:START -->');
     expect(claudeContent).toContain('<!-- ASTRYX:START -->');
   });
@@ -469,12 +602,18 @@ describe('installAgentDocs', () => {
   it('updates existing .claude/CLAUDE.md', () => {
     setupCorePackage(tmpDir);
     fs.mkdirSync(path.join(tmpDir, '.claude'), {recursive: true});
-    fs.writeFileSync(path.join(tmpDir, '.claude', 'CLAUDE.md'), '# Project\n\nExisting content.\n');
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'CLAUDE.md'),
+      '# Project\n\nExisting content.\n',
+    );
 
     const written = installAgentDocs(tmpDir);
 
     expect(written).toEqual(['.claude/CLAUDE.md']);
-    const content = fs.readFileSync(path.join(tmpDir, '.claude', 'CLAUDE.md'), 'utf-8');
+    const content = fs.readFileSync(
+      path.join(tmpDir, '.claude', 'CLAUDE.md'),
+      'utf-8',
+    );
     expect(content).toContain('Existing content.');
     expect(content).toContain('<!-- ASTRYX:START -->');
   });
@@ -528,7 +667,10 @@ describe('installAgentDocs', () => {
 
   it('onlyReplace: skips files without XDS markers', () => {
     setupCorePackage(tmpDir);
-    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Claude\n\nProject rules only.\n');
+    fs.writeFileSync(
+      path.join(tmpDir, 'CLAUDE.md'),
+      '# Claude\n\nProject rules only.\n',
+    );
 
     const written = installAgentDocs(tmpDir, {onlyReplace: true});
 
@@ -561,7 +703,9 @@ describe('installAgentDocs', () => {
 
     expect(written).toEqual([]);
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
-    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(
+      false,
+    );
   });
 });
 
@@ -653,7 +797,9 @@ describe('parseBlockVersion', () => {
   });
 
   it('returns null when no versioned header is present', () => {
-    expect(parseBlockVersion('<!-- XDS:START -->\nold\n<!-- XDS:END -->')).toBeNull();
+    expect(
+      parseBlockVersion('<!-- XDS:START -->\nold\n<!-- XDS:END -->'),
+    ).toBeNull();
     expect(parseBlockVersion('')).toBeNull();
     expect(parseBlockVersion(undefined)).toBeNull();
   });
@@ -663,7 +809,10 @@ describe('inspectAgentDocs', () => {
   function writeBlock(rel, version) {
     const filePath = path.join(tmpDir, rel);
     fs.mkdirSync(path.dirname(filePath), {recursive: true});
-    fs.writeFileSync(filePath, `# Doc\n\n${generateCompressedIndex(version)}\n`);
+    fs.writeFileSync(
+      filePath,
+      `# Doc\n\n${generateCompressedIndex(version)}\n`,
+    );
   }
 
   it('reports missing when no agent docs exist at all', () => {
@@ -674,7 +823,10 @@ describe('inspectAgentDocs', () => {
   });
 
   it('reports missing when agent files exist but carry no Astryx marker', () => {
-    fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '# Agents\n\nHand-written notes.\n');
+    fs.writeFileSync(
+      path.join(tmpDir, 'AGENTS.md'),
+      '# Agents\n\nHand-written notes.\n',
+    );
     expect(inspectAgentDocs(tmpDir, '1.0.0').status).toBe('missing');
   });
 
@@ -717,7 +869,10 @@ describe('inspectAgentDocs', () => {
   it('defaults the installed version to the core package when omitted', () => {
     const coreDir = path.join(tmpDir, 'node_modules', '@astryxdesign', 'core');
     fs.mkdirSync(coreDir, {recursive: true});
-    fs.writeFileSync(path.join(coreDir, 'package.json'), JSON.stringify({version: '3.0.0'}));
+    fs.writeFileSync(
+      path.join(coreDir, 'package.json'),
+      JSON.stringify({version: '3.0.0'}),
+    );
     writeBlock('AGENTS.md', '3.0.0');
     const res = inspectAgentDocs(tmpDir);
     expect(res.installedVersion).toBe('3.0.0');
@@ -750,8 +905,12 @@ describe('injectXdsBlock / removeXdsBlock — malformed managed blocks (no user-
   it('refuses to append a second block when a START has no matching END', () => {
     const f = path.join(tmpDir, 'c.md');
     fs.writeFileSync(f, `# Doc\nUSER1\n${S}\nOLD (no end)\nUSER2\n`);
-    expect(() => injectXdsBlock(f, BLOCK)).toThrow(/end marker|malformed|no matching/i);
-    expect((fs.readFileSync(f, 'utf-8').match(/ASTRYX:START/g) || []).length).toBe(1);
+    expect(() => injectXdsBlock(f, BLOCK)).toThrow(
+      /end marker|malformed|no matching/i,
+    );
+    expect(
+      (fs.readFileSync(f, 'utf-8').match(/ASTRYX:START/g) || []).length,
+    ).toBe(1);
   });
 
   it('replaces a single well-formed block idempotently, preserving surrounding content', () => {
@@ -806,6 +965,8 @@ describe('isAstryxInitialized — resilient to malformed markers (postinstall ho
   });
 
   it('returns false for a nonexistent directory', () => {
-    expect(isAstryxInitialized(path.join(tmpDir, 'does-not-exist'))).toBe(false);
+    expect(isAstryxInitialized(path.join(tmpDir, 'does-not-exist'))).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
## The problem

`detectStylingSystem` reads `package.json`. So these two projects are indistinguishable to it:

- a project built around Astryx that also uses Tailwind, and imports the bridge;
- a console that has had Tailwind, its own token vocabulary and its own components for a year, into which someone just added `@astryxdesign/core`.

Both get the same line in their `AGENTS.md`:

> Custom styling: component props first; else Tailwind utilities backed by tokens (bg-surface, text-primary, rounded-lg) via tailwind-theme.css. No raw hex/px.

In the second app that is wrong twice over. `bg-surface` and `text-primary` don't exist there, so an agent following the rule either writes classes that resolve to nothing, or adds the import to make them work. And that import is not additive: measured against the shipped files, `tailwind-theme.css` declares **25 of Tailwind v4's own theme variables** (`--radius-*`, `--shadow-*`, `--text-*`, `--font-*`, `--font-weight-*`, `--ease-out`, `--spacing`) and **11 more** that the conventional shadcn vocabulary uses (`--color-card`, `--color-muted`, `--color-border`, `--color-accent`, `--color-primary`, `--color-secondary`, the radius ladder) — **32 names an existing Tailwind+shadcn app is already using**, re-pointed app-wide by one line, with a clean build and a silent console.

This block is the most-installed guidance surface we have. It is what `init` writes, what `upgrade` refreshes, and what the Nest `xds` feature installs into every internal app.

## The change

**Whether the project imports the bridge is the signal that separates the two cases**, and it is cheap to read. `usesTailwindBridge()` checks nine conventional stylesheet entry points for the import — best-effort, bounded, in the same spirit as the dependency probe it sits beside. No filesystem walk to answer a styling question.

- `'tailwind-bridge'` — the bridge is imported. Today's text, unchanged.
- `'tailwind'` — Tailwind is present and the app owns its utility layer. Now told to read the app's own vocabulary out of its `globals.css` and match its neighbours, plus an explicit "do not add `tailwind-theme.css`", with the reason attached so it doesn't read as arbitrary.

The unconditional `never override --color-* in :root` rule also gains the one exception it needs in that case:

> Exception, for a name this app already defines (`--color-accent` and `--color-border` are the usual pair): re-assert it on `[data-astryx-theme]`, not `:root` — `:root` loses to the theme layer. Override a colour's partner too (`--color-on-accent` with `--color-accent`), or the pairing breaks.

Both halves are measured, on a rendered page rather than inferred:

- **`:root` loses.** Three rules declare `--color-accent` on `<html>` in a normal setup: the app's (hoisted into `@layer theme` by `@theme inline`), `astryx.css`'s own default (`@layer astryx-base`), and the theme's (`@layer astryx-theme`). The recipe's layer order puts the app's first, so the app's loses. `@scope` doesn't contain it either — `@scope` bounds selector matching, not inheritance, and `<Theme>` syncs the attribute onto `<html>` for portals.
- **The pairing.** Overriding `--color-accent` alone on the boundary works, and takes the Astryx primary button from **15.04:1 to 1.28:1** — its label is still painted with `--color-on-accent`, computed for the accent it no longer has. `astryx docs theme` already warns about this for `defineTheme` ("`--color-on-accent` stays baked from `color.accent`"); nothing warned about it on this path.

## Verification

- 85 tests in this module, **2746 across `packages/cli`**, all green.
- **Each new check proven to fail without its change.** Made the bridge probe always return false, gave both Tailwind cases the bridge text, dropped the boundary exception, dropped the pairing warning — each turned the suite red, and green again on restore.
- Collision counts are computed by intersecting the shipped `tailwind-theme.css` against Tailwind v4's own `theme.css` and the shadcn vocabulary, not hand-listed. Contrast figures are from a rendered page in headless Chromium.

## Notes for review

- **Detection is heuristic and one-directional on purpose.** A project that imports the bridge from a path not in the list falls back to the existing-app text, which is the safer of the two mistakes: it declines to recommend utilities rather than recommending a repaint. Widening the list is cheap if a real project needs it.
- The exception is deliberately narrow — one line, only in the branch where it applies, and asserted absent from the other three.
- This is guidance, not a code change: no runtime behaviour moves.
- Companion evidence, and the harness these numbers come from, is #5268.

Marked draft — @cixzhang asked to talk recommendations through before anything lands, and this is the first of them.
