### PR TITLE
fix(BottomSheet): give the sheet one uniform edge against the scrim

### DIFF
--- a/.changeset/bottom-sheet-scrim-edge-hairline.md
+++ b/.changeset/bottom-sheet-scrim-edge-hairline.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BottomSheet: draw a hairline on the sheet's top and side edges so it separates from the scrim in dark mode. The surface fill alone did that job, which works in light mode but not in dark, where surface and scrim sit a few RGB steps apart and the `--shadow-high` drop shadow is black on near-black, leaving the sheet's left and right edges invisible (measured 1.16:1 boundary contrast in dark against 2.89:1 in light). Uses `--border-width` / `--color-border`, the same treatment MobileNav gives its scrim-facing edge; the block-end edge is left bare because it sits below the viewport.
+
+@imdreamrunner

--- a/.changeset/bottom-sheet-scrim-edge-hairline.md
+++ b/.changeset/bottom-sheet-scrim-edge-hairline.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] BottomSheet: draw a hairline on the sheet's top and side edges so it separates from the scrim in dark mode. The surface fill alone did that job, which works in light mode but not in dark, where surface and scrim sit a few RGB steps apart and the `--shadow-high` drop shadow is black on near-black, leaving the sheet's left and right edges invisible (measured 1.16:1 boundary contrast in dark against 2.89:1 in light). Uses `--border-width` / `--color-border`, the same treatment MobileNav gives its scrim-facing edge; the block-end edge is left bare because it sits below the viewport.
+[fix] BottomSheet: give the sheet one uniform edge against the scrim. Two things were wrong in dark mode. The sheet drew no edge of its own — surface and scrim sit a few RGB steps apart and the `--shadow-high` drop shadow is black on near-black, so the left and right edges were invisible (measured 1.16:1 boundary contrast in dark against 2.89:1 in light); it now carries a `--border-width` / `--color-border` hairline on its three scrim-facing edges, the same treatment MobileNav gives its scrim-facing edge. And under a theme that packs an inset ring into `--shadow-high` (every bundled theme adds one in dark mode) that ring was painted over by an opaque content wrapper such as `Section`, so it showed only in the gap below where the content ended and the side edges appeared to change width partway down; the scrolling body now paints the surface across the sheet's whole inner box, hiding the ring evenly.
 
 @imdreamrunner

--- a/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
@@ -307,4 +307,25 @@ describe('BottomSheetPanel', () => {
     // padding, so it carries no hairline to draw.
     expect(sheet![1]).not.toContain('borderBlockEndWidth');
   });
+
+  // A theme that packs an inset ring into --shadow-high (the bundled themes all
+  // add one in dark mode) draws it just inside the sheet, where an opaque
+  // content wrapper such as Section paints over it -- so it showed only in the
+  // gap below the content and the side edges appeared to change width partway
+  // down. The scrolling body paints the surface across the whole inner box to
+  // hide the ring evenly.
+  it('paints the surface across the scrolling body so the edge stays uniform', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const source = fs.readFileSync(
+      path.resolve(__dirname, './BottomSheetPanel.tsx'),
+      'utf-8',
+    );
+
+    const body = source.match(/\n {2}body: \{([\s\S]*?)\n {2}\},/);
+    expect(body).not.toBeNull();
+    expect(body![1]).toContain(
+      "backgroundColor: colorVars['--color-background-surface']",
+    );
+  });
 });

--- a/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
@@ -278,4 +278,33 @@ describe('BottomSheetPanel', () => {
     expect(handleBar![1]).toContain('linear-gradient(to bottom');
     expect(handleBar![1]).toContain("colorVars['--color-background-surface']");
   });
+
+  // In dark mode the surface fill and the scrim sit a few RGB steps apart and
+  // the drop shadow is black on near-black, so the fill alone leaves the
+  // sheet's left and right edges invisible against the scrim. A hairline on
+  // the scrim-facing edges is what draws them. Asserted on the style
+  // definition for the same reason as the test above.
+  it('draws a hairline on the three edges that face the scrim', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const source = fs.readFileSync(
+      path.resolve(__dirname, './BottomSheetPanel.tsx'),
+      'utf-8',
+    );
+
+    const sheet = source.match(/\n {2}sheet: \{([\s\S]*?)\n {2}\},/);
+    expect(sheet).not.toBeNull();
+    for (const edge of [
+      'borderBlockStart',
+      'borderInlineStart',
+      'borderInlineEnd',
+    ]) {
+      expect(sheet![1]).toContain(`${edge}Width: borderVars['--border-width']`);
+      expect(sheet![1]).toContain(`${edge}Style: 'solid'`);
+      expect(sheet![1]).toContain(`${edge}Color: colorVars['--color-border']`);
+    }
+    // The block-end edge sits below the viewport, under the overscroll
+    // padding, so it carries no hairline to draw.
+    expect(sheet![1]).not.toContain('borderBlockEndWidth');
+  });
 });

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -34,6 +34,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {useDevWarning} from '../hooks';
 import {
+  borderVars,
   colorVars,
   durationVars,
   easeVars,
@@ -112,6 +113,22 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 640,
     backgroundColor: colorVars['--color-background-surface'],
+    // Hairline on the three edges that face the scrim. The surface fill alone
+    // separates sheet from scrim in light mode, but not in dark: there the two
+    // sit within a few RGB steps of each other and the drop shadow is black on
+    // near-black, so the sheet's left and right edges disappear. Same
+    // treatment MobileNav gives its scrim-facing edge. The block-end edge is
+    // deliberately left bare; it sits below the viewport, under the overscroll
+    // padding.
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
+    borderInlineStartWidth: borderVars['--border-width'],
+    borderInlineStartStyle: 'solid',
+    borderInlineStartColor: colorVars['--color-border'],
+    borderInlineEndWidth: borderVars['--border-width'],
+    borderInlineEndStyle: 'solid',
+    borderInlineEndColor: colorVars['--color-border'],
     borderStartStartRadius: radiusVars['--radius-container'],
     borderStartEndRadius: radiusVars['--radius-container'],
     boxShadow: shadowVars['--shadow-high'],

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -192,6 +192,15 @@ const styles = stylex.create({
     overflowY: 'auto',
     overscrollBehavior: 'none',
     touchAction: 'pan-y',
+    // The scrolling area paints the surface itself, covering the sheet's whole
+    // inner box. Without it the sheet's edge is not uniform: a theme that packs
+    // an inset ring into --shadow-high (the bundled themes all add one in dark
+    // mode) draws that ring just inside the sheet, where an opaque content
+    // wrapper such as Section paints over it -- so the ring shows only in the
+    // gap below where the content ends, and the sheet's side edges appear to
+    // change width partway down. Painting the surface here hides the ring
+    // evenly, leaving the border below as the sheet's one edge.
+    backgroundColor: colorVars['--color-background-surface'],
     // No reserve for the handle bar: it floats, so the content starts at the
     // sheet's top edge and rides up under the pill. The pill is 4px centered
     // in a 24px band, so it occupies only 10-14px from the edge -- inside the


### PR DESCRIPTION
The bottom sheet's edge against the scrim was wrong in dark mode in two ways.

## 1. Unthemed: no edge at all

The sheet separates itself from the scrim with its surface fill plus a `--shadow-high` drop shadow. In light mode that reads: white on a darkened page. In dark mode it does not — `--color-background-surface` is `#1F1F22`, the scrim resolves to about `#111112`, and the shadow is black on near-black.

Measured across the left edge in Chromium, sheet open:

| | scrim | sheet | boundary contrast |
|---|---|---|---|
| light | `144,153,164` | `255,255,255` | **2.89:1** |
| dark | `16,16,18` | `31,31,34` | **1.16:1** |

Past 640px the sheet is centred at its max width, so the left and right edges are the whole outline.

## 2. Themed: an edge that changed width partway down

Every bundled theme packs an inset ring into `--shadow-high` for dark mode — neutral's is `inset 0 0 0 1px oklch(1 0 0 / 15%)`, deliberately dark-only. An inset shadow paints above the element's own background but **below its children**, so an opaque content wrapper flush to the inner edge paints over it. `Section` — the wrapper the BottomSheet showcase and most real sheets use — has an opaque `--color-background-surface` background and does exactly that.

So the ring is hidden for as far as the content runs, then switches on in the empty area below it. Sampling the left edge on the docs site in dark mode:

| | outside | edge | just inside |
|---|---|---|---|
| above the content end | `2,2,2` | `60,60,60` | `38,38,38` |
| below the content end | `2,2,2` | `60,60,60` | **`71,71,71`** |

A second light line appearing partway down, which reads as the border changing width.


## Fix

- A `--border-width` / `--color-border` hairline on the three scrim-facing edges. `MobileNav`, the other scrim-backed surface drawer, already does this on its scrim-facing edge; BottomSheet never picked it up. A border paints outside the padding box, where no child can reach. The block-end edge is left bare — it sits below the viewport under the overscroll padding.
- The scrolling body paints the surface across the sheet's whole inner box, so a theme's inset ring is covered evenly instead of half-covered, leaving the border as the sheet's one edge. The body is the only in-flow child and fills the inner box; the floating handle bar is positioned, so it still paints above.

## Result

Left and right edges sample identically above and below the content end, in dark and light, themed and unthemed. Light mode is unchanged to the eye — the hairline is a 10%-alpha ink on white.

## Test plan

- Two new `BottomSheetPanel.test.tsx` cases: the hairline on the three scrim-facing edges (and its absence on the block-end edge), and the body's surface fill. Negative control: deleting one of the three border declarations fails the first.
- Verified by pixel sampling on the running docs site (neutral theme, dark and light, the real showcase content), and in a standalone harness with default tokens — WebKit and Chromium, DPR 1/1.25/1.5/2/2.625, zoom 90–150%, three viewport widths.
- `pnpm lint:strict` (0 errors), `vitest run packages/core packages/lab` (7504), `vitest run packages/cli apps` (2801), `pnpm build`, the full `build-storybook` typecheck stack, and `pnpm lab:readiness:check` all pass.



---

**Follow-up:** the body-background half of this fix is a workaround, not a proper fix — the root cause is that themes pack the dark-mode inner ring into the shadow tokens, where any opaque child erases it. A component can't fix that locally. Filed as #5308 for discussion; the durable answer is likely a `--surface-ring` token applied as a border.
