### PR TITLE
feat(Table): let useTableSelection opt out of the checked-row highlight

### DIFF
--- a/.changeset/table-selection-row-highlight-opt-out.md
+++ b/.changeset/table-selection-row-highlight-opt-out.md
@@ -1,0 +1,21 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Table: let `useTableSelection` opt out of the checked-row accent wash
+
+The selection plugin paints checked rows by writing `backgroundColor` straight
+onto each `<tr>` from its row ref callback. An inline style outranks anything
+StyleX can layer on, so a product that wanted the row background for its own
+meaning had no way to reclaim it short of forking the plugin.
+
+`hasRowHighlight` turns the wash off. It defaults to `true`, so existing tables
+are untouched. Only the background is dropped — `aria-selected` is still set and
+removed exactly as before, since that is the half of the state screen readers
+read.
+
+```tsx
+useTableSelection({...config, hasRowHighlight: false});
+```
+
+@ernestt

--- a/packages/core/src/Table/plugins/selection/useTableSelection.test.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelection.test.tsx
@@ -13,6 +13,7 @@ import {act, render, renderHook, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Table} from '../../Table';
 import {useTableSelection} from './useTableSelection';
+import {colorVars} from '../../../theme/tokens.stylex';
 import type {BodyRowRenderProps, TableColumn} from '../../types';
 
 // =============================================================================
@@ -41,10 +42,12 @@ function SelectionTable({
   getIsItemSelectable,
   getIsItemEnabled,
   getRowLabel,
+  hasRowHighlight,
 }: {
   getIsItemSelectable?: (item: SelectableUser) => boolean;
   getIsItemEnabled?: (item: SelectableUser) => boolean;
   getRowLabel?: (item: SelectableUser) => string;
+  hasRowHighlight?: boolean;
 }) {
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
 
@@ -78,6 +81,7 @@ function SelectionTable({
     getIsItemSelectable,
     getIsItemEnabled,
     getRowLabel,
+    hasRowHighlight,
   });
 
   return (
@@ -209,6 +213,78 @@ describe('useTableSelection', () => {
     const headerRow = screen.getAllByRole('row')[0];
     const headers = within(headerRow).getAllByRole('columnheader');
     expect(headers).toHaveLength(3);
+  });
+
+  describe('hasRowHighlight', () => {
+    const selectedBgColor = colorVars['--color-accent-muted'];
+
+    it('paints a checked row with the accent wash by default', async () => {
+      const user = userEvent.setup();
+      render(<SelectionTable />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+
+      const row = screen.getAllByRole('row')[1];
+      expect(row.style.backgroundColor).toBe(selectedBgColor);
+      expect(row).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('leaves the row background alone when hasRowHighlight is false', async () => {
+      const user = userEvent.setup();
+      render(<SelectionTable hasRowHighlight={false} />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+
+      const row = screen.getAllByRole('row')[1];
+      expect(row.style.backgroundColor).toBe('');
+      // The wash is opt-out; the semantics are not.
+      expect(row).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('clears an already-painted row when the flag flips to false', async () => {
+      const user = userEvent.setup();
+      const {rerender} = render(<SelectionTable />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+      expect(screen.getAllByRole('row')[1].style.backgroundColor).toBe(
+        selectedBgColor,
+      );
+
+      rerender(<SelectionTable hasRowHighlight={false} />);
+
+      const row = screen.getAllByRole('row')[1];
+      expect(row.style.backgroundColor).toBe('');
+      expect(row).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('repaints an already-checked row when the flag flips back to true', async () => {
+      const user = userEvent.setup();
+      const {rerender} = render(<SelectionTable hasRowHighlight={false} />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+      rerender(<SelectionTable hasRowHighlight />);
+
+      expect(screen.getAllByRole('row')[1].style.backgroundColor).toBe(
+        selectedBgColor,
+      );
+    });
+
+    it('never paints unchecked rows in either mode', async () => {
+      const user = userEvent.setup();
+      const {rerender} = render(<SelectionTable />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+      expect(screen.getAllByRole('row')[2].style.backgroundColor).toBe('');
+      expect(screen.getAllByRole('row')[2]).not.toHaveAttribute(
+        'aria-selected',
+      );
+
+      rerender(<SelectionTable hasRowHighlight={false} />);
+      expect(screen.getAllByRole('row')[2].style.backgroundColor).toBe('');
+      expect(screen.getAllByRole('row')[2]).not.toHaveAttribute(
+        'aria-selected',
+      );
+    });
   });
 
   it('unsubscribes detached row refs instead of accumulating listeners', () => {

--- a/packages/core/src/Table/plugins/selection/useTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelection.tsx
@@ -26,7 +26,13 @@
  * DOM elements and no central element tracking. Each subscription
  * self-cleans when the row disconnects.
  *
+ * Because the background is an inline style, it outranks anything
+ * userland can layer on with StyleX. `hasRowHighlight: false` is the
+ * supported way to reclaim the row background; `aria-selected` is
+ * unaffected by it.
+ *
  * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Table/useTableSelection.doc.mjs (config prop table)
  * - /packages/core/src/Table/Table.doc.mjs (selection documentation)
  * - /packages/core/src/Table/index.ts (exports)
  */
@@ -81,6 +87,22 @@ export interface UseTableSelectionConfig<T extends Record<string, unknown>> {
    * ```
    */
   getRowLabel?: (item: T) => string;
+  /**
+   * Paint checked rows with the accent wash. Set false when the surrounding
+   * UI already uses row background to mean something else — a row that is
+   * open in a detail panel, for instance. The wash is an inline style, so
+   * it cannot be overridden from userland; this flag is the way off it.
+   *
+   * Only the background is dropped. `aria-selected` is still set on checked
+   * rows either way, so the selection stays legible to screen readers.
+   *
+   * @default true
+   * @example
+   * ```
+   * useTableSelection({...config, hasRowHighlight: false})
+   * ```
+   */
+  hasRowHighlight?: boolean;
 }
 
 // =============================================================================
@@ -121,18 +143,24 @@ function createSelectionStore<T extends Record<string, unknown>>(
 
 /**
  * Apply or remove selection styling on a <tr> element.
+ *
+ * `aria-selected` tracks selection on its own: it is the semantic half of
+ * the state and stays correct whether or not the row is painted.
  */
 function applyRowSelectionStyle(
   el: HTMLTableRowElement,
   isSelected: boolean,
+  hasRowHighlight: boolean,
 ): void {
   if (isSelected) {
     el.setAttribute('aria-selected', 'true');
-    el.style.backgroundColor = selectedBgColor;
   } else {
     el.removeAttribute('aria-selected');
-    el.style.backgroundColor = '';
   }
+  // Written on every pass, not just when painting: the flag can flip while a
+  // row is already selected, and the wash has to come back off.
+  el.style.backgroundColor =
+    isSelected && hasRowHighlight ? selectedBgColor : '';
 }
 
 // =============================================================================
@@ -358,18 +386,23 @@ export function useTableSelection<T extends Record<string, unknown>>(
           if (!el) {
             return;
           }
+          const applyStyle = () => {
+            const config = store.getConfig();
+            applyRowSelectionStyle(
+              el,
+              config.getIsItemSelected(item),
+              config.hasRowHighlight ?? true,
+            );
+          };
           // Apply initial style
-          applyRowSelectionStyle(el, store.getConfig().getIsItemSelected(item));
+          applyStyle();
           // Subscribe for future changes
           const unsub = store.subscribe(() => {
             if (!el.isConnected) {
               unsub();
               return;
             }
-            applyRowSelectionStyle(
-              el,
-              store.getConfig().getIsItemSelected(item),
-            );
+            applyStyle();
           });
           return () => {
             unsub();

--- a/packages/core/src/Table/useTableSelection.doc.mjs
+++ b/packages/core/src/Table/useTableSelection.doc.mjs
@@ -61,6 +61,13 @@ export const docs = {
       description:
         'Derives a human-readable identity for a row; the row checkbox\'s hidden label becomes `Select ${getRowLabel(item)}` so screen readers announce which row each checkbox selects. Falls back to "Select row" when omitted.',
     },
+    {
+      name: 'hasRowHighlight',
+      type: 'boolean',
+      description:
+        'Paints checked rows with the accent wash. Set false when the surrounding UI already uses row background to mean something else (a row open in a detail panel, say) — the wash is an inline style, so it cannot be overridden from userland. Only the background is dropped: aria-selected is still set on checked rows either way.',
+      default: 'true',
+    },
   ],
   examples: [
     {
@@ -82,6 +89,21 @@ const selectionPlugin = useTableSelection({
   idKey="id"
   plugins={{selection: selectionPlugin}}
 />;
+`,
+    },
+    {
+      label: 'Opt out of the checked-row wash',
+      code: `
+// This table already uses row background to mean "open in the detail
+// panel". Turning the selection wash off keeps that meaning unambiguous;
+// the checkbox and aria-selected still carry the selection.
+const selectionPlugin = useTableSelection({
+  getIsItemSelected: item => selectedIds.has(item.id),
+  onSelectItem: ({item, isSelected}) => toggle(item.id, isSelected),
+  onSelectAll: ({isAllSelected}) => selectAll(isAllSelected),
+  getIsAllSelected: () => selectedIds.size === users.length,
+  hasRowHighlight: false,
+});
 `,
     },
   ],
@@ -142,6 +164,13 @@ export const docsZh = {
       description:
         '为行派生人类可读的标识；行复选框的隐藏标签变为 `Select ${getRowLabel(item)}`，让屏幕阅读器播报每个复选框选择的是哪一行。省略时回退为 "Select row"。',
     },
+    {
+      name: 'hasRowHighlight',
+      type: 'boolean',
+      description:
+        '为选中的行绘制强调色背景。当周围的界面已用行背景表达其他含义（例如该行已在详情面板中打开）时设为 false —— 该背景是内联样式，无法从业务代码覆盖。仅去掉背景：无论如何选中的行仍会设置 aria-selected。',
+      default: 'true',
+    },
   ],
 };
 
@@ -164,5 +193,7 @@ export const docsDense = {
       'Returns whether row checkbox is interactive; disabled rows show disabled checkbox.',
     getRowLabel:
       'Derives row identity for the checkbox\'s hidden label: `Select ${getRowLabel(item)}`. Falls back to "Select row" when omitted.',
+    hasRowHighlight:
+      'false => skip the accent wash on checked rows (inline style, not overridable from userland). aria-selected is unaffected. Defaults to true.',
   },
 };


### PR DESCRIPTION
## Problem

The selection plugin paints checked rows by writing `backgroundColor` straight onto each `<tr>`, imperatively, from the per-row ref callback:

```ts
el.style.backgroundColor = selectedBgColor; // colorVars['--color-accent-muted']
```

An inline style outranks anything StyleX can layer on, and `UseTableSelectionConfig` exposed no flag to turn it off. So the accent wash was unconditional and unreachable from userland — the only way out was to fork the plugin.

## Motivating use case

A table template uses row background to mean "this row is open in the detail panel." The selection wash on checked rows collides with that meaning, and there was no supported way to opt out.

## API added

One optional field on `UseTableSelectionConfig`:

```ts
/** Paint checked rows with the accent wash. ... @default true */
hasRowHighlight?: boolean;
```

```tsx
useTableSelection({...config, hasRowHighlight: false});
```

- **Default is unchanged.** It defaults to `true` and is read as `config.hasRowHighlight ?? true`, so every existing table paints exactly as before. Additive and non-breaking.
- **`aria-selected` is intentionally preserved.** The flag drops *only* the background. Checked rows still get `aria-selected="true"` and unchecked rows still have it removed, in both modes — that is the semantic half of the state and screen readers depend on it. This is deliberate, not an oversight.
- **Runtime flips settle.** The background is now written on every pass instead of only when painting, so flipping the flag while a row is already checked clears the inline value rather than stranding it. The existing `useEffect(() => store.notify())` already re-runs each row's ref subscription on every render, so no new plumbing was needed.

The name follows the `has*` convention already used for presentational booleans in this area — `hasHover` and `isStriped` on `Table`, `hasExpandAllControl` and `hasRowClickExpansion` on the tree plugin.

`useTableSelectionState` is not touched: it builds only the *state* half of the config, and the other presentational option (`getRowLabel`) is not threaded through it either. Consumers spread it — `useTableSelection({...selectionConfig, hasRowHighlight: false})`.

## Docs

- `useTableSelection.doc.mjs`: prop added to `docs.props`, `docsZh.props`, and `docsDense.propDescriptions`, plus an example showing the opt-out.
- File header updated, and its `SYNC:` list now names `useTableSelection.doc.mjs` — the config prop table lives there and the list had never mentioned it.
- Changeset: `[feat]` / `patch`, per the 0.x coupling `check:changesets` enforces (only `[breaking]` bumps the minor while 0.x).

## Test plan

Five cases added to `useTableSelection.test.tsx`:

- [x] Checked row is painted with `--color-accent-muted` by default, and carries `aria-selected`
- [x] Checked row is **not** painted with `hasRowHighlight: false`, and still carries `aria-selected`
- [x] Flipping the flag to `false` while a row is checked clears the stranded background
- [x] Flipping it back to `true` repaints the still-checked row
- [x] Unchecked rows are never painted and never carry `aria-selected`, in either mode

Verified the default-case assertion is non-vacuous: the token resolves to a non-empty `var(...)` string that jsdom retains verbatim on `style.backgroundColor`, so the two modes assert genuinely different values.

Gates:

- [x] `pnpm -F @astryxdesign/core typecheck` and `typecheck:docs`
- [x] `eslint` on the changed files at `ASTRYX_STRICT_LINT=1` — clean
- [x] `prettier --check` on all four changed files — clean
- [x] `vitest run packages/core/src/Table/` — 481 passed across 22 files (selection alone: 37)
- [x] `pnpm check:repo` — clean (also re-run by the pre-commit hook)

Made with [Cursor](https://cursor.com)