### PR TITLE
[Exploration] feat(core,lab): drag up from the page to open a Bottom Sheet

### DIFF
--- a/.changeset/sheet-drag-to-open-exploration.md
+++ b/.changeset/sheet-drag-to-open-exploration.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] EXPLORATION: drag up from the page to open a BottomSheet. Core gains a `dragSource` prop and a `createSheetDragSource()` seam, so a gesture recognized anywhere on the page can present a closed sheet mid-touch and pull it up on the same finger; the release runs through the sheet's existing settle, so a pull that stops short falls back closed. Lab gains `useSheetOpenGesture()`, the recognizer that decides which touches qualify (the end of the page, or a region you mark). Touch only, opt-in, and always an accelerator — never the only way into a sheet.
+
+@imdreamrunner

--- a/apps/storybook/stories/SheetOpenGesture.stories.tsx
+++ b/apps/storybook/stories/SheetOpenGesture.stories.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {BottomSheet} from '@astryxdesign/core/BottomSheet';
+import {Button} from '@astryxdesign/core/Button';
+import {Heading} from '@astryxdesign/core/Heading';
+import {Item} from '@astryxdesign/core/Item';
+import {Section} from '@astryxdesign/core/Section';
+import {VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import {useSheetOpenGesture} from '@astryxdesign/lab';
+
+const meta: Meta = {
+  title: 'Lab/SheetOpenGesture',
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'EXPLORATION. Opening a BottomSheet by dragging up from the page, ' +
+          'rather than from the sheet (which is not on screen yet) or a button ' +
+          '(which is a tap, not a drag).\n\n' +
+          '**Touch only** — try it in a device viewport, or with touch ' +
+          'emulation on. There is nothing to see with a mouse, by design: a ' +
+          'sheet reachable only by dragging is unreachable by keyboard, by ' +
+          'screen reader, and under WCAG 2.5.7. The button in each story is ' +
+          'not a fallback, it is the primary way in; the gesture is the ' +
+          'accelerator.',
+      },
+      story: {inline: false, height: '620px'},
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const PLACES = [
+  'Blue Bottle Coffee',
+  'Dolores Park',
+  'Tartine Bakery',
+  'Bi-Rite Market',
+  'Zuni Café',
+  'The Castro Theatre',
+  'Alamo Square',
+  'Ferry Building',
+];
+
+function PlaceList() {
+  return (
+    <VStack padding={4} gap={2}>
+      <Heading level={2}>Nearby places</Heading>
+      {PLACES.map(place => (
+        <Item key={place} label={place} description="Open until 8pm" />
+      ))}
+    </VStack>
+  );
+}
+
+/**
+ * Scroll to the bottom of the page, then keep pulling up: the sheet comes with
+ * the finger. Release near the top and it opens; let go early and it falls
+ * back where it came from.
+ *
+ * The end of the page is the one place an upward pull cannot be mistaken for
+ * scrolling — there is no scroll left in that direction — so the gesture needs
+ * no threshold beyond a few pixels of intent.
+ */
+export const PullUpFromPageEnd: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+    // Disabled while the sheet is up: from then on, a drag belongs to the
+    // sheet's own gestures.
+    const {source} = useSheetOpenGesture({enabled: !isOpen});
+
+    return (
+      <Section padding={4}>
+        <VStack gap={3}>
+          <Heading level={1}>Mission District</Heading>
+          <Button label="Nearby places" onClick={() => setIsOpen(true)} />
+          <Text type="supporting">
+            Scroll to the bottom, then keep pulling up.
+          </Text>
+          {Array.from({length: 24}, (_, index) => (
+            <Text key={index}>
+              Paragraph {index + 1} — filler so the page has an end to pull
+              past.
+            </Text>
+          ))}
+        </VStack>
+        <BottomSheet
+          label="Nearby places"
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          dragSource={source}>
+          <PlaceList />
+        </BottomSheet>
+      </Section>
+    );
+  },
+};
+
+/**
+ * The same gesture, armed only inside a region the app marks — here a dock
+ * pinned to the bottom of the screen. Use this shape when the page has no
+ * natural end to pull past: a long feed, an infinite scroller, a map.
+ *
+ * The dock is a button as well as a drag target, which is what keeps the
+ * pattern reachable without the gesture.
+ */
+export const PullUpFromADock: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+    const {source, regionProps} = useSheetOpenGesture({
+      from: 'element',
+      enabled: !isOpen,
+    });
+
+    return (
+      <Section padding={4}>
+        <VStack gap={3}>
+          <Heading level={1}>Mission District</Heading>
+          <Text type="supporting">
+            Pull up from the bar at the bottom — anywhere else scrolls.
+          </Text>
+          {Array.from({length: 24}, (_, index) => (
+            <Text key={index}>Paragraph {index + 1} — an endless feed.</Text>
+          ))}
+        </VStack>
+
+        <div
+          {...regionProps}
+          style={{
+            position: 'fixed',
+            insetInline: 0,
+            insetBlockEnd: 0,
+            padding: 12,
+            background: 'var(--color-background-surface)',
+            borderBlockStart: '1px solid var(--color-border-subtle)',
+          }}>
+          <Button
+            label="Nearby places"
+            width="100%"
+            onClick={() => setIsOpen(true)}
+          />
+        </div>
+
+        <BottomSheet
+          label="Nearby places"
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          dragSource={source}>
+          <PlaceList />
+        </BottomSheet>
+      </Section>
+    );
+  },
+};

--- a/packages/core/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/core/src/BottomSheet/BottomSheet.doc.mjs
@@ -112,6 +112,12 @@ export const docs = {
         "Extra heights the sheet can rest at when dragged; its own height is always the tallest stop, and omitting this gives a sheet that only opens and closes. Each stop is the sheet's visible height: a number is a viewport fraction (0.5 is half the screen), '50%' the same in CSS, '320px' an absolute length. A stop of a quarter of the sheet or less is a peek: it slides away instead of reflowing, and thins the scrim.",
     },
     {
+      name: 'dragSource',
+      type: 'SheetDragSource',
+      description:
+        "EXPLORATION, not a settled API. A drag recognized somewhere else on the page, which presents this closed sheet mid-touch and pulls it up on the same finger; released short of open, it falls back closed and the sheet is never reported open at all. Build one with useSheetOpenGesture() from @astryxdesign/lab, or any recognizer publishing to createSheetDragSource(). The gesture is an accelerator, never the only way in: a drag-only reveal is invisible to a screen reader, undiscoverable by sight, and fails WCAG 2.5.7 Dragging Movements, so keep a button as well. Standalone sheets only; a BottomSheetSwitcher owns its items' presentation.",
+    },
+    {
       name: 'hasScrim',
       type: 'boolean',
       description:
@@ -269,7 +275,7 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   description:
-    'mobile touch sheet rising from the bottom edge (native <dialog>): grab handle, opt-in transform-based drag-to-resize snap points (snapPoints: viewport fraction, percent or px length), scrolling area resizes to the snapped visible height on release (a peek stop, a quarter of the sheet or less, keeps the full height and slides instead), Dialog-aligned dismissal purpose (info/form/required), purpose-gated swipe-to-dismiss, fully-expanded Tall visual-viewport mobile-keyboard handling, named height scale, modal (default) or non-modal (hasScrim={false}) presentation',
+    'mobile touch sheet rising from the bottom edge (native <dialog>): grab handle, opt-in transform-based drag-to-resize snap points (snapPoints: viewport fraction, percent or px length), scrolling area resizes to the snapped visible height on release (a peek stop, a quarter of the sheet or less, keeps the full height and slides instead), Dialog-aligned dismissal purpose (info/form/required), purpose-gated swipe-to-dismiss, fully-expanded Tall visual-viewport mobile-keyboard handling, named height scale, modal (default) or non-modal (hasScrim={false}) presentation, EXPLORATION drag-to-open from a page gesture (dragSource + lab useSheetOpenGesture)',
   usage: {
     description:
       'Mobile touch surface for filters, actions, forms, and detail views that should rise from the bottom of the viewport; use BottomSheetSwitcher for multi-step flows.',

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -94,21 +94,17 @@ const styles = stylex.create({
         '@starting-style': 0,
       },
       transitionProperty: 'opacity, display',
-      transitionDuration: durationVars['--duration-medium'],
+      // Overridable per sheet, because a scrim driven by a finger must not
+      // smooth: `--_sheet-scrim-duration` is set to 0s for the duration of a
+      // drag-to-open gesture, and unset the rest of the time. Written as a
+      // custom property rather than a second class because ::backdrop cannot
+      // take an inline style — the same reason the opacity above is one.
+      transitionDuration: `var(--_sheet-scrim-duration, ${durationVars['--duration-medium']})`,
       transitionTimingFunction: easeVars['--ease-standard'],
       transitionBehavior: 'allow-discrete',
       '@media (prefers-reduced-motion: reduce)': {
         transitionDuration: '0.01s',
       },
-    },
-  },
-  // EXPLORATION: while a finger is pulling the sheet on, the scrim tracks the
-  // pull frame by frame. The entry transition would smear every one of those
-  // updates over its own duration, so the scrim would trail the sheet by a
-  // couple hundred milliseconds and still be catching up after the release.
-  scrimGestureDriven: {
-    '::backdrop': {
-      transitionDuration: '0s',
     },
   },
   positioner: {
@@ -301,7 +297,9 @@ function StandaloneBottomSheet({
     if (gesturePhaseRef.current === 'opening') {
       // The pull was abandoned. The sheet was never open, so there is no
       // controlled state to correct — it just plays the ordinary exit back
-      // off the screen, and the host is none the wiser.
+      // off the screen, and the host is none the wiser. That exit is a real
+      // animation, so the scrim's transition has to come back for it.
+      dialogRef.current?.style.removeProperty('--_sheet-scrim-duration');
       setGesturePhase('retracting');
       return;
     }
@@ -312,6 +310,8 @@ function StandaloneBottomSheet({
     if (gesturePhaseRef.current !== 'opening') {
       return;
     }
+    // The finger is off; hand the scrim back to its normal timing.
+    dialogRef.current?.style.removeProperty('--_sheet-scrim-duration');
     needsGestureFocusRef.current = true;
     setGesturePhase('idle');
     onOpenChange(true);
@@ -341,8 +341,11 @@ function StandaloneBottomSheet({
     if (dialog == null || gesturePhase !== 'opening' || dialog.open) {
       return;
     }
-    // Seeded dark-free: the scrim is the pull's progress bar from here on.
+    // Seeded dark-free: the scrim is the pull's progress bar from here on, and
+    // it tracks the finger frame by frame — a transition would smear every one
+    // of those updates and leave the scrim still catching up after the release.
     dialog.style.setProperty('--_sheet-scrim-opacity', '0');
+    dialog.style.setProperty('--_sheet-scrim-duration', '0s');
     if (hasScrim) {
       triggerRef.current = document.activeElement as HTMLElement | null;
       dialog.showModal();
@@ -439,7 +442,6 @@ function StandaloneBottomSheet({
         styles.dialog,
         shouldPresent && styles.dialogOpen,
         hasScrim && styles.scrim,
-        hasScrim && gesturePhase === 'opening' && styles.scrimGestureDriven,
         !hasScrim && styles.dialogNonModal,
       )}
       ref={dialogRef}

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file BottomSheet.tsx
- * @input Uses React, StyleX, core hooks/utils, BottomSheetPanel, BottomSheetSwitcherContext
+ * @input Uses React, StyleX, core hooks/utils, BottomSheetPanel, BottomSheetSwitcherContext, sheetDragSource
  * @output Exports BottomSheet component and BottomSheetProps
  * @position Public BottomSheet router plus private standalone/switcher hosts
  *
@@ -14,7 +14,15 @@
  * which owns sheet presentation, gestures, mobile-keyboard accommodation, and
  * motion completion.
  *
+ * EXPLORATION (drag-to-open): a standalone sheet can also be presented by a
+ * gesture recognized outside it — see `dragSource` and sheetDragSource.ts.
+ * Such a sheet is on screen before it is open: the host is only told it opened
+ * if the pull actually lands it on a detent, and an abandoned pull retracts
+ * without ever touching the controlled state.
+ *
  * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/BottomSheet/sheetDragSource.ts
+ * - /packages/core/src/BottomSheet/sheetDragSource.test.tsx
  * - /packages/core/src/BottomSheet/BottomSheetPanel.tsx
  * - /packages/core/src/BottomSheet/BottomSheet.doc.mjs
  * - /packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -43,6 +51,7 @@ import {
   type BottomSheetPanelMotion,
   type BottomSheetPanelState,
 } from './BottomSheetPanel';
+import type {SheetDragSource} from './sheetDragSource';
 import {
   BottomSheetSwitcherContext,
   type BottomSheetSwitcherContextValue,
@@ -91,6 +100,15 @@ const styles = stylex.create({
       '@media (prefers-reduced-motion: reduce)': {
         transitionDuration: '0.01s',
       },
+    },
+  },
+  // EXPLORATION: while a finger is pulling the sheet on, the scrim tracks the
+  // pull frame by frame. The entry transition would smear every one of those
+  // updates over its own duration, so the scrim would trail the sheet by a
+  // couple hundred milliseconds and still be catching up after the release.
+  scrimGestureDriven: {
+    '::backdrop': {
+      transitionDuration: '0s',
     },
   },
   positioner: {
@@ -146,6 +164,18 @@ interface StandaloneBottomSheetProps extends BottomSheetSharedProps {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   hasScrim?: boolean;
+  /**
+   * EXPLORATION — not a settled API.
+   *
+   * A drag recognized somewhere else on the page, which presents this sheet
+   * and pulls it up on the same finger. Build one with `useSheetOpenGesture`
+   * (or any recognizer that publishes to a `createSheetDragSource`).
+   *
+   * The gesture is an ACCELERATOR, never the only way in: a drag-only reveal
+   * is invisible to a screen reader, undiscoverable by sight, and fails WCAG
+   * 2.5.7 Dragging Movements. Keep a button, or leave the sheet peeking.
+   */
+  dragSource?: SheetDragSource;
   sheetId?: never;
 }
 
@@ -154,6 +184,8 @@ interface SwitcherBottomSheetProps extends BottomSheetSharedProps {
   isOpen?: never;
   onOpenChange?: never;
   hasScrim?: never;
+  /** A switcher owns its items' presentation; a gesture cannot present one. */
+  dragSource?: never;
 }
 
 export type BottomSheetProps =
@@ -206,6 +238,7 @@ function StandaloneBottomSheet({
   snapPoints,
   hasScrim = true,
   purpose = 'info',
+  dragSource,
   xstyle,
   ...props
 }: StandaloneBottomSheetProps) {
@@ -213,12 +246,23 @@ function StandaloneBottomSheet({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
   const [isPresented, setIsPresented] = useState(isOpen);
-  const shouldPresent = isOpen || isPresented;
+  // EXPLORATION: where a drag-to-open gesture has got to. `opening` is a sheet
+  // on screen because a finger is pulling it, before it has been opened in the
+  // controlled sense; `retracting` is that pull abandoned, playing the ordinary
+  // exit on its way back off. Neither is `isOpen` — the host is never told the
+  // sheet opened unless the gesture actually lands it on a detent.
+  const [gesturePhase, setGesturePhase] = useState<
+    'idle' | 'opening' | 'retracting'
+  >('idle');
+  const isGestureDriven = gesturePhase !== 'idle';
+  const shouldPresent = isOpen || isPresented || isGestureDriven;
   const panelState: BottomSheetPanelState = isOpen
     ? {kind: 'open', entering: false}
-    : isPresented
-      ? {kind: 'exiting'}
-      : {kind: 'hidden'};
+    : gesturePhase === 'opening'
+      ? {kind: 'opening'}
+      : isPresented || gesturePhase === 'retracting'
+        ? {kind: 'exiting'}
+        : {kind: 'hidden'};
 
   const dismissOnEscape = useCallback(() => {
     if (purpose !== 'required') {
@@ -243,6 +287,70 @@ function StandaloneBottomSheet({
     );
   }, []);
 
+  // EXPLORATION: drag-to-open.
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
+  const gesturePhaseRef = useRef(gesturePhase);
+  gesturePhaseRef.current = gesturePhase;
+  // A sheet the user arrived at by gesture still owes them focus, but the
+  // controlled-open effect below only moves it when it is the thing that
+  // opened the dialog — and by then the gesture already did.
+  const needsGestureFocusRef = useRef(false);
+
+  const handleDismiss = useCallback(() => {
+    if (gesturePhaseRef.current === 'opening') {
+      // The pull was abandoned. The sheet was never open, so there is no
+      // controlled state to correct — it just plays the ordinary exit back
+      // off the screen, and the host is none the wiser.
+      setGesturePhase('retracting');
+      return;
+    }
+    dismissOnLightInteraction();
+  }, [dismissOnLightInteraction]);
+
+  const handleGestureOpened = useCallback(() => {
+    if (gesturePhaseRef.current !== 'opening') {
+      return;
+    }
+    needsGestureFocusRef.current = true;
+    setGesturePhase('idle');
+    onOpenChange(true);
+  }, [onOpenChange]);
+
+  // Present on the FIRST published move, not on a later state change: the
+  // recognizer has already claimed the gesture from the browser by the time it
+  // publishes, and it only gets to claim it once (a touchmove that is allowed
+  // through stops being cancelable for the rest of the gesture).
+  useEffect(() => {
+    if (dragSource == null) {
+      return;
+    }
+    return dragSource.subscribe(event => {
+      if (event.type !== 'start' || isOpenRef.current) {
+        return;
+      }
+      setGesturePhase('opening');
+    });
+  }, [dragSource]);
+
+  // Before paint, in step with the panel's own gesture layout effect: the
+  // finger is mid-pull, so the sheet's first frame has to be the one the
+  // gesture asks for rather than an entrance animating past it.
+  useLayoutEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog == null || gesturePhase !== 'opening' || dialog.open) {
+      return;
+    }
+    // Seeded dark-free: the scrim is the pull's progress bar from here on.
+    dialog.style.setProperty('--_sheet-scrim-opacity', '0');
+    if (hasScrim) {
+      triggerRef.current = document.activeElement as HTMLElement | null;
+      dialog.showModal();
+    } else {
+      dialog.show();
+    }
+  }, [gesturePhase, hasScrim]);
+
   useEffect(() => {
     const dialog = dialogRef.current;
     if (dialog == null || !isOpen) {
@@ -263,14 +371,17 @@ function StandaloneBottomSheet({
         dialog.show();
       }
       focusPanel(panelRef.current, hasScrim);
+    } else if (needsGestureFocusRef.current) {
+      needsGestureFocusRef.current = false;
+      focusPanel(panelRef.current, hasScrim);
     }
   }, [hasScrim, isOpen]);
 
   useEffect(() => {
-    if (!isOpen && isPresented && hasScrim) {
+    if (!isOpen && hasScrim && (isPresented || gesturePhase === 'retracting')) {
       handleScrimOpacity(0);
     }
-  }, [handleScrimOpacity, hasScrim, isOpen, isPresented]);
+  }, [gesturePhase, handleScrimOpacity, hasScrim, isOpen, isPresented]);
 
   const handleMotionComplete = useCallback(
     (motion: BottomSheetPanelMotion) => {
@@ -282,6 +393,7 @@ function StandaloneBottomSheet({
         dialog.close();
       }
       setIsPresented(false);
+      setGesturePhase('idle');
       triggerRef.current?.focus();
       triggerRef.current = null;
     },
@@ -327,6 +439,7 @@ function StandaloneBottomSheet({
         styles.dialog,
         shouldPresent && styles.dialogOpen,
         hasScrim && styles.scrim,
+        hasScrim && gesturePhase === 'opening' && styles.scrimGestureDriven,
         !hasScrim && styles.dialogNonModal,
       )}
       ref={dialogRef}
@@ -347,8 +460,10 @@ function StandaloneBottomSheet({
           snapPoints={snapPoints}
           isSwipeDismissAllowed={purpose === 'info'}
           isPageScrollLocked={shouldPresent && hasScrim}
+          dragSource={isOpen ? undefined : dragSource}
           xstyle={xstyle}
-          onDismiss={dismissOnLightInteraction}
+          onDismiss={handleDismiss}
+          onGestureOpened={handleGestureOpened}
           onScrimOpacity={handleScrimOpacity}
           onElementChange={handlePanelElementChange}
           onMotionComplete={handleMotionComplete}>

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -15,6 +15,7 @@
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/BottomSheet/BottomSheet.tsx
+ * - /packages/core/src/BottomSheet/sheetDragSource.ts
  * - /packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
  * - /packages/core/src/BottomSheet/snapOffsets.ts
  * - /packages/core/src/BottomSheet/useMobileKeyboard.ts
@@ -50,6 +51,7 @@ import {
   resolveSnapPoints,
   type BottomSheetSnapPoint,
 } from './snapOffsets';
+import type {SheetDragSource} from './sheetDragSource';
 import {useMobileKeyboard} from './useMobileKeyboard';
 import {useSheetGestures} from './useSheetGestures';
 
@@ -230,6 +232,11 @@ export type BottomSheetPanelMotion =
 
 export type BottomSheetPanelState =
   | {kind: 'hidden'}
+  // EXPLORATION: on screen, but placed by a finger rather than by an entry
+  // animation — the sheet a drag-to-open gesture is currently pulling up. It
+  // is presented and interactive, and its position belongs to the gesture, so
+  // the CSS entrance must stay out of the way.
+  | {kind: 'opening'}
   | {kind: 'open'; entering: boolean}
   | {
       kind: 'retained';
@@ -248,7 +255,11 @@ interface BottomSheetPanelProps extends BaseProps<HTMLDivElement> {
   isSwipeDismissAllowed?: boolean;
   /** Whether the host has locked page scrolling (a modal, scrim-backed sheet). */
   isPageScrollLocked?: boolean;
+  /** EXPLORATION: an outside recognizer driving this sheet open. */
+  dragSource?: SheetDragSource;
   onDismiss: () => void;
+  /** EXPLORATION: a drag-to-open gesture settled on a detent instead of falling back closed. */
+  onGestureOpened?: () => void;
   onScrimOpacity: (opacity: number) => void;
   onElementChange?: (element: HTMLDivElement | null) => void;
   onMotionStart?: (motion: BottomSheetPanelMotion) => void;
@@ -377,7 +388,9 @@ export function BottomSheetPanel({
   xstyle,
   isSwipeDismissAllowed = true,
   isPageScrollLocked = false,
+  dragSource,
   onDismiss,
+  onGestureOpened,
   onScrimOpacity,
   onElementChange,
   onMotionStart,
@@ -407,7 +420,8 @@ export function BottomSheetPanel({
     onMotionCompleteRef.current = onMotionComplete;
   }, [onMotionComplete, onMotionStart, state]);
 
-  const isInteractive = state.kind === 'open';
+  const isOpening = state.kind === 'opening';
+  const isInteractive = state.kind === 'open' || isOpening;
   const isPresented = state.kind !== 'hidden';
   const isRetained = state.kind === 'retained';
   const isInactive = isRetained || state.kind === 'exiting';
@@ -461,10 +475,16 @@ export function BottomSheetPanel({
     completeScrollAreaSettle,
   } = useSheetGestures({
     isOpen: isInteractive,
-    canDismiss: isSwipeDismissAllowed,
+    // A gesture that is still pulling the sheet ONTO the screen must always be
+    // able to put it back, whatever the sheet's dismissal purpose says about
+    // swiping an open one away. `purpose` governs abandoning a sheet the user
+    // has arrived at; it cannot strand them inside one they never opened.
+    canDismiss: isSwipeDismissAllowed || isOpening,
     offscreenBlockEndInset: OVERSCROLL_PADDING,
+    dragSource,
     onDismiss,
     snapHeights,
+    onSnap: isOpening ? onGestureOpened : undefined,
     onScrimOpacity,
   });
 
@@ -483,7 +503,9 @@ export function BottomSheetPanel({
     isFullyExpanded: settledOffset === 0,
     isPageScrollLocked,
     isSheetTraveling: isDragging && dragOffset !== settledOffset,
-    isOpen: isInteractive,
+    // Not `isInteractive`: a sheet still being pulled open has no settled
+    // height for the keyboard to accommodate, and nothing in it is focused yet.
+    isOpen: state.kind === 'open',
     isPresented,
     sheetRef: elementRef,
   });

--- a/packages/core/src/BottomSheet/index.ts
+++ b/packages/core/src/BottomSheet/index.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file index.ts
- * @input BottomSheet.tsx, BottomSheetSwitcher.tsx
+ * @input BottomSheet.tsx, BottomSheetSwitcher.tsx, sheetDragSource.ts
  * @output Re-exports the BottomSheet public API
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  */
@@ -17,3 +17,13 @@ export type {
 } from './BottomSheet';
 export {BottomSheetSwitcher} from './BottomSheetSwitcher';
 export type {BottomSheetSwitcherProps} from './BottomSheetSwitcher';
+
+// EXPLORATION: the seam a drag-to-open recognizer publishes through.
+export {createSheetDragSource} from './sheetDragSource';
+export type {
+  SheetDragController,
+  SheetDragEvent,
+  SheetDragPoint,
+  SheetDragSnapshot,
+  SheetDragSource,
+} from './sheetDragSource';

--- a/packages/core/src/BottomSheet/sheetDragSource.test.tsx
+++ b/packages/core/src/BottomSheet/sheetDragSource.test.tsx
@@ -1,0 +1,343 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file sheetDragSource.test.tsx
+ * @input Uses vitest, @testing-library/react, createSheetDragSource, BottomSheet
+ * @output Unit tests for the drag-source contract and gesture-driven opening
+ * @position Core testing; validates sheetDragSource.ts and the BottomSheet
+ *   drag-to-open path added alongside it
+ *
+ * EXPLORATION — see the notes in sheetDragSource.ts.
+ *
+ * SYNC: When sheetDragSource.ts or the BottomSheet gesture path changes,
+ * update these tests to match.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {act, render, screen} from '@testing-library/react';
+import {useState} from 'react';
+import {BottomSheet} from './BottomSheet';
+import {createSheetDragSource} from './sheetDragSource';
+
+// The sheet the integration tests drive: tall enough that a partial pull is
+// unambiguously short of open, and a round number to assert against.
+const SHEET_HEIGHT = 400;
+
+let boundingRectSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+
+  // jsdom lays nothing out, so the sheet would measure 0 tall and the gesture
+  // would have no travel to work with.
+  boundingRectSpy = vi
+    .spyOn(HTMLDivElement.prototype, 'getBoundingClientRect')
+    .mockReturnValue({
+      height: SHEET_HEIGHT,
+      width: 320,
+      top: 0,
+      left: 0,
+      right: 320,
+      bottom: SHEET_HEIGHT,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  boundingRectSpy?.mockRestore();
+  boundingRectSpy = null;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('createSheetDragSource', () => {
+  it('reports no drag until one starts, and clears it on release', () => {
+    const source = createSheetDragSource();
+    expect(source.getSnapshot()).toBeNull();
+
+    source.start({y: 500, timeStamp: 0});
+    expect(source.getSnapshot()).toEqual({startY: 500, y: 500, timeStamp: 0});
+
+    source.move({y: 420, timeStamp: 16});
+    expect(source.getSnapshot()).toEqual({startY: 500, y: 420, timeStamp: 16});
+
+    source.end({y: 300, timeStamp: 32});
+    expect(source.getSnapshot()).toBeNull();
+  });
+
+  it('keeps the gesture start point across every move', () => {
+    const source = createSheetDragSource();
+    source.start({y: 600, timeStamp: 0});
+    source.move({y: 500, timeStamp: 16});
+    source.move({y: 400, timeStamp: 32});
+    // The whole point: a subscriber that arrives late still learns how far the
+    // finger has travelled, not just where it is now.
+    expect(source.getSnapshot()?.startY).toBe(600);
+  });
+
+  it('lets a subscriber that arrives mid-drag pick the drag up', () => {
+    const source = createSheetDragSource();
+    source.start({y: 500, timeStamp: 0});
+    source.move({y: 450, timeStamp: 16});
+
+    const late = vi.fn();
+    source.subscribe(late);
+    // Nothing is replayed — the snapshot is how a late subscriber catches up.
+    expect(late).not.toHaveBeenCalled();
+    expect(source.getSnapshot()).toEqual({startY: 500, y: 450, timeStamp: 16});
+
+    source.move({y: 400, timeStamp: 32});
+    expect(late).toHaveBeenCalledWith({type: 'move', y: 400, timeStamp: 32});
+  });
+
+  it('ignores moves and releases with no drag in flight', () => {
+    const source = createSheetDragSource();
+    const listener = vi.fn();
+    source.subscribe(listener);
+
+    source.move({y: 100, timeStamp: 0});
+    source.end({y: 100, timeStamp: 0});
+    source.cancel();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('stops notifying an unsubscribed listener', () => {
+    const source = createSheetDragSource();
+    const listener = vi.fn();
+    const unsubscribe = source.subscribe(listener);
+    unsubscribe();
+
+    source.start({y: 10, timeStamp: 0});
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('survives a listener that unsubscribes while being notified', () => {
+    const source = createSheetDragSource();
+    const second = vi.fn();
+    const unsubscribeFirst = source.subscribe(() => unsubscribeFirst());
+    source.subscribe(second);
+
+    source.start({y: 10, timeStamp: 0});
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});
+
+function GestureSheet({
+  source,
+  onOpenChange,
+}: {
+  source: ReturnType<typeof createSheetDragSource>;
+  onOpenChange?: (isOpen: boolean) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <BottomSheet
+      label="Nearby places"
+      isOpen={isOpen}
+      onOpenChange={next => {
+        setIsOpen(next);
+        onOpenChange?.(next);
+      }}
+      dragSource={source}>
+      <p>Sheet content</p>
+    </BottomSheet>
+  );
+}
+
+// Each touch event is its own tick in a browser, and the sheet needs the ticks:
+// the first published move is what mounts it, and it can only pick the drag up
+// once it exists. Batching a whole gesture into one `act` renders none of that.
+function publishDrag(
+  source: ReturnType<typeof createSheetDragSource>,
+  points: ReadonlyArray<{y: number; timeStamp: number}>,
+) {
+  const [first, ...rest] = points;
+  act(() => source.start(first));
+  for (const point of rest.slice(0, -1)) {
+    act(() => source.move(point));
+  }
+  const last = rest[rest.length - 1];
+  act(() => source.move(last));
+  act(() => source.end(last));
+}
+
+describe('BottomSheet drag-to-open', () => {
+  it('stays closed until a drag is published', () => {
+    const source = createSheetDragSource();
+    render(<GestureSheet source={source} />);
+
+    expect(document.querySelector('dialog')?.hasAttribute('open')).toBe(false);
+  });
+
+  it('presents the sheet on the first published move, before it is open', () => {
+    const source = createSheetDragSource();
+    const onOpenChange = vi.fn();
+    render(<GestureSheet source={source} onOpenChange={onOpenChange} />);
+
+    act(() => {
+      source.start({y: 600, timeStamp: 0});
+    });
+
+    // On screen, but the host has NOT been told it opened: the finger is still
+    // deciding, and it may yet put the sheet back.
+    expect(document.querySelector('dialog')?.hasAttribute('open')).toBe(true);
+    expect(screen.getByText('Sheet content')).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('opens when the pull is released past the fall-back threshold', () => {
+    const source = createSheetDragSource();
+    const onOpenChange = vi.fn();
+    render(<GestureSheet source={source} onOpenChange={onOpenChange} />);
+
+    publishDrag(source, [
+      {y: 600, timeStamp: 0},
+      {y: 300, timeStamp: 16},
+      {y: 220, timeStamp: 32},
+    ]);
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('falls back closed when the pull is released too early', () => {
+    const source = createSheetDragSource();
+    const onOpenChange = vi.fn();
+    render(<GestureSheet source={source} onOpenChange={onOpenChange} />);
+
+    publishDrag(source, [
+      {y: 600, timeStamp: 0},
+      {y: 590, timeStamp: 100},
+      {y: 580, timeStamp: 200},
+    ]);
+
+    // Never opened, so the host is never told it closed either — a gesture the
+    // user abandoned should leave no trace in their state.
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('opens on a fast upward flick that never reaches the top', () => {
+    const source = createSheetDragSource();
+    const onOpenChange = vi.fn();
+    render(<GestureSheet source={source} onOpenChange={onOpenChange} />);
+
+    // ~6 px/ms upward, far past the flick floor, over enough distance — but
+    // released while the sheet is still well short of open.
+    publishDrag(source, [
+      {y: 600, timeStamp: 0},
+      {y: 540, timeStamp: 8},
+      {y: 480, timeStamp: 16},
+    ]);
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('leaves the sheet closed when a drag is cancelled', () => {
+    const source = createSheetDragSource();
+    const onOpenChange = vi.fn();
+    render(<GestureSheet source={source} onOpenChange={onOpenChange} />);
+
+    act(() => source.start({y: 600, timeStamp: 0}));
+    act(() => source.move({y: 300, timeStamp: 16}));
+    act(() => source.cancel());
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('does not present a sheet that is already open', () => {
+    const source = createSheetDragSource();
+    render(
+      <BottomSheet
+        label="Nearby places"
+        isOpen
+        onOpenChange={() => {}}
+        dragSource={source}>
+        <p>Sheet content</p>
+      </BottomSheet>,
+    );
+    const showModal = HTMLDialogElement.prototype.showModal as ReturnType<
+      typeof vi.fn
+    >;
+    showModal.mockClear();
+
+    act(() => {
+      source.start({y: 600, timeStamp: 0});
+    });
+
+    expect(showModal).not.toHaveBeenCalled();
+  });
+
+  it('can pull open a sheet whose purpose forbids swipe-dismiss', () => {
+    const source = createSheetDragSource();
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet
+        label="Required sheet"
+        isOpen={false}
+        purpose="required"
+        onOpenChange={onOpenChange}
+        dragSource={source}>
+        <p>Sheet content</p>
+      </BottomSheet>,
+    );
+
+    publishDrag(source, [
+      {y: 600, timeStamp: 0},
+      {y: 300, timeStamp: 16},
+      {y: 220, timeStamp: 32},
+    ]);
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it('abandons the pull on a purpose that forbids swipe-dismiss', () => {
+    const source = createSheetDragSource();
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet
+        label="Required sheet"
+        isOpen={false}
+        purpose="required"
+        onOpenChange={onOpenChange}
+        dragSource={source}>
+        <p>Sheet content</p>
+      </BottomSheet>,
+    );
+
+    publishDrag(source, [
+      {y: 600, timeStamp: 0},
+      {y: 595, timeStamp: 100},
+      {y: 590, timeStamp: 200},
+    ]);
+
+    // `purpose` governs abandoning a sheet the user arrived at. It must not
+    // strand them inside one they never opened.
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/BottomSheet/sheetDragSource.ts
+++ b/packages/core/src/BottomSheet/sheetDragSource.ts
@@ -1,0 +1,132 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file sheetDragSource.ts
+ * @input Nothing; a standalone contract module
+ * @output Exports SheetDragSource, SheetDragEvent, SheetDragSnapshot types and
+ *   createSheetDragSource
+ * @position BottomSheet contract; re-exported from the BottomSheet barrel
+ *
+ * EXPLORATION — not a settled API. See the exploration notes in
+ * BottomSheet.tsx.
+ *
+ * A sheet's own gestures all begin inside the sheet, which means the sheet has
+ * to already be on screen. The one gesture that cannot work that way is the
+ * one that OPENS it: the finger lands on the page, and the sheet does not
+ * exist yet.
+ *
+ * This is the seam. A recognizer somewhere else on the page decides a gesture
+ * is a sheet-open pull, and publishes the pull's coordinates here; a closed
+ * sheet subscribed to the source presents itself and rides the same finger up.
+ * The sheet never learns where the gesture came from, and the recognizer never
+ * learns anything about detents, scrims, or dialogs.
+ *
+ * Deliberately NOT React state. A drag publishes a coordinate per touchmove
+ * (~120/s on a modern phone) and every one of them has to be on screen in the
+ * same frame it arrived; routing that through a state update per event would
+ * put a render between the finger and the pixels. Subscribers read the live
+ * value from `getSnapshot()` and write the DOM directly, the way the sheet's
+ * own pointer path already does.
+ *
+ * `getSnapshot()` is also what makes a mid-gesture subscribe work at all: the
+ * sheet's gesture hook does not exist when the drag starts — the drag start is
+ * what mounts it — so it cannot have heard the event. It reads the in-flight
+ * drag out of the snapshot instead, and picks the gesture up from there.
+ */
+
+/** A drag coordinate on the block axis, in client pixels. */
+export interface SheetDragPoint {
+  /** Client Y of the pointer. */
+  y: number;
+  /** Event timestamp (ms), used for flick velocity. */
+  timeStamp: number;
+}
+
+/**
+ * What a source publishes. `start` means a recognizer has committed: it has
+ * claimed the gesture from the browser and a closed sheet should present
+ * itself. `cancel` means the drag went away without a release (the recognizer
+ * handed the gesture back, the page was hidden, a second finger landed).
+ */
+export type SheetDragEvent =
+  | ({type: 'start'} & SheetDragPoint)
+  | ({type: 'move'} & SheetDragPoint)
+  | ({type: 'end'} & SheetDragPoint)
+  | {type: 'cancel'};
+
+/** The live drag, or null when no drag is in flight. */
+export interface SheetDragSnapshot extends SheetDragPoint {
+  /** Where the finger was when the recognizer committed. */
+  startY: number;
+}
+
+export interface SheetDragSource {
+  /** Notified on every published event until the returned function is called. */
+  subscribe: (listener: (event: SheetDragEvent) => void) => () => void;
+  /** The in-flight drag, for a subscriber that arrived after it started. */
+  getSnapshot: () => SheetDragSnapshot | null;
+}
+
+/** A source plus the publishing side a recognizer drives. */
+export interface SheetDragController extends SheetDragSource {
+  start: (point: SheetDragPoint) => void;
+  move: (point: SheetDragPoint) => void;
+  end: (point: SheetDragPoint) => void;
+  cancel: () => void;
+}
+
+/**
+ * A drag source with nothing attached to it. The caller owns the recognizer —
+ * deciding what counts as a sheet-open pull is a policy question this module
+ * takes no position on — and calls `start`/`move`/`end`/`cancel` as its
+ * gesture proceeds.
+ */
+export function createSheetDragSource(): SheetDragController {
+  const listeners = new Set<(event: SheetDragEvent) => void>();
+  let snapshot: SheetDragSnapshot | null = null;
+
+  const emit = (event: SheetDragEvent) => {
+    // Copied first: a listener may unsubscribe (or subscribe) in response,
+    // and a Set mutated mid-iteration silently skips entries.
+    for (const listener of [...listeners]) {
+      listener(event);
+    }
+  };
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot() {
+      return snapshot;
+    },
+    start(point) {
+      snapshot = {startY: point.y, y: point.y, timeStamp: point.timeStamp};
+      emit({type: 'start', ...point});
+    },
+    move(point) {
+      if (snapshot == null) {
+        return;
+      }
+      snapshot = {...snapshot, y: point.y, timeStamp: point.timeStamp};
+      emit({type: 'move', ...point});
+    },
+    end(point) {
+      if (snapshot == null) {
+        return;
+      }
+      snapshot = null;
+      emit({type: 'end', ...point});
+    },
+    cancel() {
+      if (snapshot == null) {
+        return;
+      }
+      snapshot = null;
+      emit({type: 'cancel'});
+    },
+  };
+}

--- a/packages/core/src/BottomSheet/useSheetGestures.ts
+++ b/packages/core/src/BottomSheet/useSheetGestures.ts
@@ -48,8 +48,15 @@
  * happens inside handlers. Respects prefers-reduced-motion by skipping the
  * settle transition.
  *
+ * EXPLORATION: a drag can also arrive from OUTSIDE the sheet, through the
+ * `dragSource` option — the one gesture the sheet cannot host itself, because
+ * it is the gesture that puts the sheet on screen. It is fed through the same
+ * synthetic-pointer path as the touch handoff, anchored a full sheet-height
+ * below open, so it settles through this same machinery.
+ *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/BottomSheet/useSheetGestures.test.ts
+ * - /packages/core/src/BottomSheet/sheetDragSource.ts
  */
 
 import {
@@ -66,6 +73,11 @@ import {
   type UIEvent as ReactUIEvent,
 } from 'react';
 import {useMediaQuery} from '../hooks';
+import type {
+  SheetDragEvent,
+  SheetDragPoint,
+  SheetDragSource,
+} from './sheetDragSource';
 import {
   computeDetentOffsets,
   peekOffsetFor,
@@ -113,6 +125,9 @@ const OVERSCROLL_RESISTANCE = 0.35;
 // bottom padding the lift reveals). Kept as a local const rather than a shared
 // import so it can be used inside stylex.create there.
 const OVERSCROLL_MAX = 48;
+// Pointer id for a drag published by an external recognizer. Negative so it
+// can never collide with a `Touch.identifier`, which is always >= 0.
+const EXTERNAL_DRAG_POINTER_ID = -1;
 // Travel past the point where a scrolling gesture ran out of content before it
 // hands the sheet the rest of the pull. Small enough to feel continuous with
 // the scroll, large enough that a swipe merely coming to rest on the last pixel
@@ -223,6 +238,17 @@ export interface UseSheetGesturesOptions {
   snapHeights?: () => number[];
   /** Notified when the settled visible detent height (px) changes. */
   onSnap?: (heightPx: number) => void;
+  /**
+   * EXPLORATION. A gesture recognized OUTSIDE the sheet, driving it from
+   * closed. Every other drag begins on the sheet's own handle or body, which
+   * needs the sheet to already be on screen; this is the one that opens it.
+   *
+   * Only pass a source while the sheet is closed. The drag it publishes is
+   * anchored a full sheet-height below open, so the release runs through the
+   * same settle the sheet's own drags use: pulled far enough and it lands on
+   * a detent, short of that and it falls back closed.
+   */
+  dragSource?: SheetDragSource;
   /**
    * Called with the scrim opacity the sheet should show (1 = fully visible,
    * 0 = hidden) as the drag moves and on settle. Full while the sheet is at
@@ -345,6 +371,7 @@ export function useSheetGestures({
   snapHeights,
   onSnap,
   onScrimOpacity,
+  dragSource,
 }: UseSheetGesturesOptions): UseSheetGesturesResult {
   const [dragOffset, setDragOffset] = useState(0);
   const [settledOffset, setSettledOffset] = useState(0);
@@ -914,7 +941,15 @@ export function useSheetGestures({
   );
 
   const beginDrag = useCallback(
-    (event: ReactPointerEvent, sheetHeight: number, startCoord?: number) => {
+    (
+      event: ReactPointerEvent,
+      sheetHeight: number,
+      startCoord?: number,
+      // Where the sheet is when the finger lands, overriding the resting
+      // detent. A drag from OUTSIDE a closed sheet starts a full height below
+      // open — the sheet is not resting anywhere, it is off screen.
+      baseOffsetOverride?: number,
+    ) => {
       const target = event.currentTarget as HTMLElement;
       const syntheticTouch = isSyntheticTouch(event);
       // Never capture for a touch drag. The id came from `Touch.identifier`,
@@ -932,6 +967,7 @@ export function useSheetGestures({
       const start = startCoord ?? event.clientY;
       const naturalEndGap = naturalEndGapFor(bodyNodeRef.current);
       const baseLayoutOffset = settledLayoutOffsetRef.current;
+      const baseOffset = baseOffsetOverride ?? settledOffset;
       dragStateRef.current = {
         syntheticTouch,
         pointerId: event.pointerId,
@@ -940,9 +976,9 @@ export function useSheetGestures({
         lastTime: event.timeStamp,
         velocity: 0,
         height: sheetHeight,
-        baseOffset: settledOffset,
+        baseOffset,
         baseLayoutOffset,
-        renderedOffset: settledOffset,
+        renderedOffset: baseOffset,
         layoutOffset: baseLayoutOffset,
         naturalEndGap,
       };
@@ -953,9 +989,9 @@ export function useSheetGestures({
           naturalEndGap,
         ),
       );
-      // Seed dragOffset at the resting detent so flipping isDragging doesn't
-      // jump the sheet to fully-open for one frame.
-      setDragOffset(settledOffset);
+      // Seed dragOffset where the sheet actually is so flipping isDragging
+      // doesn't jump it to fully-open for one frame.
+      setDragOffset(baseOffset);
       setIsDragging(true);
     },
     [settledOffset, updateScrollPreservationInset],
@@ -1388,6 +1424,100 @@ export function useSheetGestures({
       previousTouchHandlersRef.current = null;
     }
   }, []);
+
+  // EXPLORATION: a drag recognized outside the sheet, driving it from closed.
+  //
+  // A LAYOUT effect, unusually for a subscription, because the very first
+  // gesture-driven frame is the one that matters: this hook is mounting
+  // BECAUSE a finger is already pulling, and a passive effect would run after
+  // the browser had painted one frame of a sheet sitting at its open position.
+  // Beginning the drag before that paint puts the sheet where the finger is.
+  //
+  // The published coordinates are fed through the SAME synthetic-pointer path
+  // the touch handoff uses, so a gesture that started on the page lands in the
+  // one settle implementation: flick, magnet, detents, scrim, haptics. The only
+  // difference is where the drag is anchored — a full sheet-height below open,
+  // because the sheet is off screen rather than resting on a detent.
+  useLayoutEffect(() => {
+    if (dragSource == null) {
+      return;
+    }
+
+    const asPointer = (point: SheetDragPoint) =>
+      ({
+        // The sheet's own guards read this to tell a finger-driven drag from a
+        // real PointerEvent; an external drag is finger-driven by definition.
+        syntheticTouch: true,
+        pointerId: EXTERNAL_DRAG_POINTER_ID,
+        clientY: point.y,
+        timeStamp: point.timeStamp,
+        currentTarget: sheetElRef.current,
+        setPointerCapture: () => {},
+        releasePointerCapture: () => {},
+      }) as unknown as ReactPointerEvent;
+
+    const begin = (startY: number, point: SheetDragPoint) => {
+      if (dragStateRef.current != null) {
+        return;
+      }
+      // Measured fully-open, not remembered: this is usually the sheet's first
+      // frame, so the ResizeObserver has not reported and there is no stored
+      // height to read — and any inline height already on the element belongs
+      // to a previous life of the sheet, not to the one being pulled open now.
+      // The stored height is the fallback for the reverse case, an environment
+      // where the live measure reads 0 (an unlaid-out element, jsdom).
+      const height = measureFullyOpenHeight() || measureHeightRef.current();
+      if (height <= 0) {
+        return;
+      }
+      beginDragRef.current(asPointer(point), height, startY, height);
+      pointerMoveRef.current(asPointer(point));
+    };
+
+    const listener = (event: SheetDragEvent) => {
+      switch (event.type) {
+        case 'start':
+          begin(event.y, event);
+          return;
+        case 'move':
+          if (dragStateRef.current == null) {
+            // The drag has not started yet — presenting the sheet took a
+            // render, and this is a move that landed in the gap. Anchor it at
+            // the gesture's own start, never at where the finger happens to be
+            // now, or the sheet permanently trails the pull by however long
+            // the mount took.
+            begin(dragSource.getSnapshot()?.startY ?? event.y, event);
+            return;
+          }
+          pointerMoveRef.current(asPointer(event));
+          return;
+        case 'end':
+          if (dragStateRef.current == null) {
+            return;
+          }
+          endDragRef.current(asPointer(event));
+          return;
+        case 'cancel':
+          cancelDragRef.current(sheetElRef.current ?? undefined);
+      }
+    };
+
+    const unsubscribe = dragSource.subscribe(listener);
+    // The drag that mounted this hook already happened: presenting the sheet is
+    // what put the hook on the page, so its `start` event was published before
+    // there was anything here to hear it. Read it back out instead.
+    const inFlight = dragSource.getSnapshot();
+    if (inFlight != null) {
+      begin(inFlight.startY, inFlight);
+    }
+    return () => {
+      unsubscribe();
+      cancelDragRef.current(sheetElRef.current ?? undefined);
+    };
+    // Every handler above is reached through a ref on purpose: resubscribing
+    // on each render would tear down the subscription mid-gesture, and the
+    // cleanup would cancel the drag it is in the middle of.
+  }, [dragSource, measureFullyOpenHeight]);
 
   // Subscribed, not memoized: the preference can change while a sheet is open,
   // and this branch decides whether the settle runs as a transition at all.

--- a/packages/lab/src/SheetOpenGesture/index.ts
+++ b/packages/lab/src/SheetOpenGesture/index.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file index.ts
+ * @input useSheetOpenGesture.ts
+ * @output Re-exports the SheetOpenGesture exploration API
+ * @position Component entry point; re-exported by /packages/lab/src/index.ts
+ */
+
+export {useSheetOpenGesture} from './useSheetOpenGesture';
+export type {
+  SheetOpenGestureOrigin,
+  UseSheetOpenGestureOptions,
+  UseSheetOpenGestureResult,
+} from './useSheetOpenGesture';

--- a/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.test.tsx
+++ b/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.test.tsx
@@ -19,7 +19,7 @@
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {act, render} from '@testing-library/react';
-import type {SheetDragEvent} from '@astryxdesign/core';
+import type {SheetDragEvent} from '@astryxdesign/core/BottomSheet';
 import {useSheetOpenGesture} from './useSheetOpenGesture';
 
 // jsdom has no constructible TouchEvent, and a bare Event carries no

--- a/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.test.tsx
+++ b/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.test.tsx
@@ -1,0 +1,424 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useSheetOpenGesture.test.tsx
+ * @input Uses vitest, @testing-library/react, useSheetOpenGesture
+ * @output Unit tests for the drag-to-open recognizer
+ * @position Lab testing; validates useSheetOpenGesture.ts
+ *
+ * EXPLORATION — see the notes in useSheetOpenGesture.ts.
+ *
+ * The claim rules these tests pin down were measured in a real engine, not
+ * inferred: see the table in that file's header. jsdom cannot reproduce them
+ * (nothing scrolls, nothing is cancelable on its own), so what is asserted
+ * here is that the recognizer FOLLOWS them — which move it cancels, which it
+ * lets through, and what it publishes.
+ *
+ * SYNC: When useSheetOpenGesture.ts changes, update these tests to match.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {act, render} from '@testing-library/react';
+import type {SheetDragEvent} from '@astryxdesign/core';
+import {useSheetOpenGesture} from './useSheetOpenGesture';
+
+// jsdom has no constructible TouchEvent, and a bare Event carries no
+// changedTouches for the recognizer to read.
+function touchEvent(
+  type: 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel',
+  touches: ReadonlyArray<{id: number; x: number; y: number}>,
+  {
+    cancelable = true,
+    active = touches,
+  }: {
+    cancelable?: boolean;
+    active?: ReadonlyArray<{id: number; x: number; y: number}>;
+  } = {},
+): Event {
+  const event = new Event(type, {bubbles: true, cancelable});
+  const list = touches.map(touch => ({
+    identifier: touch.id,
+    clientX: touch.x,
+    clientY: touch.y,
+  }));
+  const activeList = active.map(touch => ({
+    identifier: touch.id,
+    clientX: touch.x,
+    clientY: touch.y,
+  }));
+  Object.defineProperties(event, {
+    changedTouches: {value: list},
+    touches: {value: type === 'touchend' ? [] : activeList},
+    targetTouches: {value: activeList},
+  });
+  return event;
+}
+
+function setDocumentScroll({
+  scrollTop,
+  clientHeight,
+  scrollHeight,
+}: {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+}) {
+  const scroller = (document.scrollingElement ??
+    document.documentElement) as HTMLElement;
+  Object.defineProperty(scroller, 'scrollTop', {
+    value: scrollTop,
+    configurable: true,
+  });
+  Object.defineProperty(scroller, 'clientHeight', {
+    value: clientHeight,
+    configurable: true,
+  });
+  Object.defineProperty(scroller, 'scrollHeight', {
+    value: scrollHeight,
+    configurable: true,
+  });
+}
+
+function Harness({
+  events,
+  enabled = true,
+  from = 'page-end' as const,
+}: {
+  events: SheetDragEvent[];
+  enabled?: boolean;
+  from?: 'page-end' | 'element';
+}) {
+  const {source, regionProps} = useSheetOpenGesture({enabled, from});
+  // Subscribing during render is fine here: the source is a plain emitter with
+  // no React state, and the test needs every event including the first.
+  const subscribed = (source as unknown as {__subscribed?: boolean})
+    .__subscribed;
+  if (!subscribed) {
+    (source as unknown as {__subscribed?: boolean}).__subscribed = true;
+    source.subscribe(event => events.push(event));
+  }
+  return <div data-testid="region" {...regionProps} />;
+}
+
+beforeEach(() => {
+  // At the end of the page: an upward pull has no scrolling left to be.
+  setDocumentScroll({scrollTop: 400, clientHeight: 600, scrollHeight: 1000});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useSheetOpenGesture', () => {
+  it('claims the first upward move past the threshold and publishes the pull', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+    });
+    const move = touchEvent('touchmove', [{id: 1, x: 100, y: 480}]);
+    act(() => {
+      document.dispatchEvent(move);
+    });
+
+    expect(move.defaultPrevented).toBe(true);
+    expect(events).toEqual([
+      {type: 'start', y: 500, timeStamp: move.timeStamp},
+      {type: 'move', y: 480, timeStamp: move.timeStamp},
+    ]);
+  });
+
+  it('anchors the pull at the touch, not at the threshold crossing', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 470}]),
+      );
+    });
+
+    // Starting at 500, not 470: the sheet should rise by the whole 30 px the
+    // finger has already travelled, not just by what is left after the
+    // threshold.
+    expect(events[0]).toMatchObject({type: 'start', y: 500});
+  });
+
+  it('keeps cancelling every move once the gesture is claimed', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 480}]),
+      );
+    });
+    const later = touchEvent('touchmove', [{id: 1, x: 100, y: 300}]);
+    act(() => {
+      document.dispatchEvent(later);
+    });
+
+    // Letting one move through ends the claim for the rest of the gesture and
+    // hands the page back to native scrolling mid-drag.
+    expect(later.defaultPrevented).toBe(true);
+    expect(events.at(-1)).toMatchObject({type: 'move', y: 300});
+  });
+
+  it('ignores a pull that is under the threshold', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    const move = touchEvent('touchmove', [{id: 1, x: 100, y: 497}]);
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(move);
+    });
+
+    expect(move.defaultPrevented).toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  it('leaves a downward drag to the page', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 540}]),
+      );
+      // Reversing upward afterwards must not resurrect the gesture: by now the
+      // browser owns the scroll.
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 400}]),
+      );
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('leaves a mostly-sideways drag to the page', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 220, y: 480}]),
+      );
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('does not arm away from the end of the page', () => {
+    setDocumentScroll({scrollTop: 0, clientHeight: 600, scrollHeight: 2000});
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 400}]),
+      );
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('arms on a page that does not scroll at all', () => {
+    setDocumentScroll({scrollTop: 0, clientHeight: 600, scrollHeight: 600});
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 400}]),
+      );
+    });
+
+    expect(events[0]).toMatchObject({type: 'start'});
+  });
+
+  it('does nothing while disabled', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} enabled={false} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 400}]),
+      );
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('refuses a second finger', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 2, x: 150, y: 500}], {
+          active: [
+            {id: 1, x: 100, y: 500},
+            {id: 2, x: 150, y: 500},
+          ],
+        }),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 2, x: 150, y: 400}]),
+      );
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('will not claim a move the browser has already committed to scrolling', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 400}], {cancelable: false}),
+      );
+      // And it stays disarmed: a drag that shares the gesture with the page
+      // scrolling behind it is worse than no drag at all.
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 300}]),
+      );
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it('publishes the release', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 300}]),
+      );
+      document.dispatchEvent(touchEvent('touchend', [{id: 1, x: 100, y: 300}]));
+    });
+
+    expect(events.at(-1)).toMatchObject({type: 'end', y: 300});
+  });
+
+  it('cancels an interrupted gesture', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchmove', [{id: 1, x: 100, y: 300}]),
+      );
+      document.dispatchEvent(
+        touchEvent('touchcancel', [{id: 1, x: 100, y: 300}]),
+      );
+    });
+
+    expect(events.at(-1)).toEqual({type: 'cancel'});
+  });
+
+  it('publishes nothing for a touch that ended without being claimed', () => {
+    const events: SheetDragEvent[] = [];
+    render(<Harness events={events} />);
+
+    act(() => {
+      document.dispatchEvent(
+        touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+      );
+      document.dispatchEvent(touchEvent('touchend', [{id: 1, x: 100, y: 500}]));
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  describe("from: 'element'", () => {
+    it('claims a pull that began inside the region', () => {
+      const events: SheetDragEvent[] = [];
+      const {getByTestId} = render(<Harness events={events} from="element" />);
+
+      act(() => {
+        const start = touchEvent('touchstart', [{id: 1, x: 100, y: 500}]);
+        getByTestId('region').dispatchEvent(start);
+        document.dispatchEvent(
+          touchEvent('touchmove', [{id: 1, x: 100, y: 400}]),
+        );
+      });
+
+      expect(events[0]).toMatchObject({type: 'start', y: 500});
+    });
+
+    it('ignores a pull that began outside it', () => {
+      const events: SheetDragEvent[] = [];
+      render(<Harness events={events} from="element" />);
+
+      act(() => {
+        document.dispatchEvent(
+          touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+        );
+        document.dispatchEvent(
+          touchEvent('touchmove', [{id: 1, x: 100, y: 400}]),
+        );
+      });
+
+      expect(events).toEqual([]);
+    });
+
+    it('keeps a claimed gesture that has since left the region', () => {
+      const events: SheetDragEvent[] = [];
+      const {getByTestId} = render(<Harness events={events} from="element" />);
+
+      act(() => {
+        getByTestId('region').dispatchEvent(
+          touchEvent('touchstart', [{id: 1, x: 100, y: 500}]),
+        );
+        document.dispatchEvent(
+          touchEvent('touchmove', [{id: 1, x: 100, y: 400}]),
+        );
+        // A full-height pull ends nowhere near where it started, so the moves
+        // stop being targeted at the region long before the finger lifts.
+        document.dispatchEvent(
+          touchEvent('touchmove', [{id: 1, x: 100, y: 80}]),
+        );
+      });
+
+      expect(events.at(-1)).toMatchObject({type: 'move', y: 80});
+    });
+  });
+});

--- a/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.ts
+++ b/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.ts
@@ -1,0 +1,293 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useSheetOpenGesture.ts
+ * @input Uses React, and the SheetDragSource contract from @astryxdesign/core
+ * @output Exports useSheetOpenGesture and its option/result types
+ * @position Lab hook; feeds core's BottomSheet `dragSource` prop
+ *
+ * EXPLORATION — not a settled API.
+ *
+ * Opening a bottom sheet by dragging up from the page, rather than from the
+ * sheet (which is not there yet) or a button (which is a tap, not a drag).
+ *
+ * This hook is only the RECOGNIZER: it decides which touches are a sheet-open
+ * pull and publishes their coordinates. What the sheet does with them —
+ * presenting, tracking the finger, settling or falling back — is the sheet's
+ * business, and lives in core.
+ *
+ * ## Why the recognizer must commit on the first move
+ *
+ * A browser hands out one chance to claim a touch. Measured on a 7-move sweep
+ * (Chromium, iPhone 15 profile, CDP-dispatched touches):
+ *
+ * | preventDefault policy | moves still cancelable | page scrolled |
+ * |---|---|---|
+ * | every move            | all 7 | 0 px   |
+ * | first move only       | 1-2   | 162 px |
+ * | all but the third     | 1-3   | 137 px |
+ * | never                 | 1     | 162 px |
+ *
+ * Let one move through and cancelability is gone for the rest of the gesture,
+ * whatever you do afterwards — and the page has already scrolled out from
+ * under the user. So there is no "watch a few frames, then decide": the
+ * decision is made from what is knowable at `touchstart` (where the scroller
+ * is, where the finger landed), taken on move 1, and then held for every move
+ * until the finger lifts.
+ *
+ * This is the same shape BottomSheet's own scroll-edge handoff uses, for the
+ * same reason.
+ *
+ * ## Where the gesture may come from
+ *
+ * `page-end` arms when the document is scrolled to its end. That is the one
+ * place an upward pull cannot be mistaken for scrolling — there is no scroll
+ * left in that direction — which is why it needs no threshold beyond a couple
+ * of pixels of intent.
+ *
+ * `element` arms anywhere inside a region the app marks with `regionProps`: a
+ * bottom dock, a summary bar, the lower third of a map. Use it when the page
+ * has no natural end to pull past.
+ *
+ * There is deliberately no "screen bottom edge" mode. iOS Safari's address bar
+ * and Android's gesture navigation both live in that strip, and a web page
+ * that competes with them loses.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/SheetOpenGesture/useSheetOpenGesture.test.tsx
+ * - /packages/lab/src/SheetOpenGesture/SheetOpenGesture.doc.mjs
+ */
+
+import {useEffect, useMemo, useRef} from 'react';
+import {createSheetDragSource, type SheetDragSource} from '@astryxdesign/core';
+
+/** Where an upward pull is allowed to become a sheet-open gesture. */
+export type SheetOpenGestureOrigin = 'page-end' | 'element';
+
+export interface UseSheetOpenGestureOptions {
+  /**
+   * Which touches are candidates.
+   * - `page-end`: the document is scrolled to the bottom (default)
+   * - `element`: the touch began inside the element given `regionProps`
+   * @default 'page-end'
+   */
+  from?: SheetOpenGestureOrigin;
+  /**
+   * Turns the recognizer off without unmounting it. Set this to `false` while
+   * the sheet is open, so a drag inside the open sheet is the sheet's own.
+   * @default true
+   */
+  enabled?: boolean;
+  /**
+   * Upward travel, in px, before the pull is claimed. Small on purpose: the
+   * claim has to happen on the first move that clears it, and every px spent
+   * waiting is a px the sheet did not follow the finger for.
+   * @default 6
+   */
+  thresholdPx?: number;
+}
+
+export interface UseSheetOpenGestureResult {
+  /** Hand to `<BottomSheet dragSource={...} />`. */
+  source: SheetDragSource;
+  /** Spread on the region that owns the gesture. Only used by `from: 'element'`. */
+  regionProps: {ref: (node: HTMLElement | null) => void};
+}
+
+/** Whether the document scroller has no downward scrolling left. */
+function isDocumentAtEnd(): boolean {
+  // `scrollingElement` is the right answer in both standards and quirks mode,
+  // but it is null in a document that has neither (and in some test DOMs).
+  const scroller = document.scrollingElement ?? document.documentElement;
+  if (scroller == null) {
+    return false;
+  }
+  // A page that does not scroll at all is trivially at its end, and is a
+  // perfectly good place to pull a sheet up from.
+  return (
+    scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 1
+  );
+}
+
+/**
+ * EXPLORATION. Recognizes an upward pull on the page as "open the sheet", and
+ * publishes it for a `BottomSheet` to ride.
+ *
+ * Touch only: a mouse has no equivalent gesture, and a sheet that can only be
+ * reached by dragging is unreachable by keyboard, by screen reader, and under
+ * WCAG 2.5.7. Always keep a button, or leave the sheet peeking.
+ *
+ * @example
+ * ```
+ * const [isOpen, setIsOpen] = useState(false);
+ * const {source} = useSheetOpenGesture({enabled: !isOpen});
+ *
+ * <>
+ *   <Button onClick={() => setIsOpen(true)}>Nearby places</Button>
+ *   <BottomSheet
+ *     label="Nearby places"
+ *     isOpen={isOpen}
+ *     onOpenChange={setIsOpen}
+ *     dragSource={source}>
+ *     <PlaceList />
+ *   </BottomSheet>
+ * </>
+ * ```
+ */
+export function useSheetOpenGesture({
+  from = 'page-end',
+  enabled = true,
+  thresholdPx = 6,
+}: UseSheetOpenGestureOptions = {}): UseSheetOpenGestureResult {
+  // One controller for the hook's life. A new identity mid-gesture would
+  // resubscribe the sheet and drop the drag it is riding.
+  const controller = useMemo(() => createSheetDragSource(), []);
+  const regionRef = useRef<HTMLElement | null>(null);
+  const optionsRef = useRef({from, enabled, thresholdPx});
+  optionsRef.current = {from, enabled, thresholdPx};
+
+  useEffect(() => {
+    // What the recognizer knows about the touch in flight. `eligible` and the
+    // start point are decided at `touchstart` and never revisited; `claimed`
+    // records that the gesture is ours and must stay cancelled.
+    interface ArmedTouch {
+      id: number;
+      startY: number;
+      startX: number;
+      eligible: boolean;
+      claimed: boolean;
+    }
+    let state: ArmedTouch | null = null;
+
+    const onTouchStart = (event: TouchEvent) => {
+      const {from: origin, enabled: isEnabled} = optionsRef.current;
+      const touch = event.changedTouches[0];
+      // Multi-touch is a pinch or a two-finger scroll, never a sheet pull.
+      if (!isEnabled || touch == null || event.touches.length > 1) {
+        state = null;
+        return;
+      }
+      // Everything the decision rests on is read HERE. By the time the first
+      // move arrives it is too late to go looking: claiming has to be the
+      // first thing that move does.
+      const target = event.target;
+      const eligible =
+        origin === 'element'
+          ? regionRef.current != null &&
+            target instanceof Node &&
+            regionRef.current.contains(target)
+          : isDocumentAtEnd();
+      state = {
+        id: touch.identifier,
+        startY: touch.clientY,
+        startX: touch.clientX,
+        eligible,
+        claimed: false,
+      };
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      if (state == null) {
+        return;
+      }
+      const touch = [...event.changedTouches].find(
+        candidate => candidate.identifier === state?.id,
+      );
+      if (touch == null) {
+        return;
+      }
+      const deltaY = touch.clientY - state.startY;
+      const deltaX = touch.clientX - state.startX;
+
+      if (state.claimed) {
+        // Holding the claim is not optional — see the table in the file header.
+        if (event.cancelable) {
+          event.preventDefault();
+        }
+        controller.move({y: touch.clientY, timeStamp: event.timeStamp});
+        return;
+      }
+      if (!state.eligible) {
+        return;
+      }
+      // Downward, or mostly sideways: not ours. Disarm rather than keep
+      // watching, so a scroll that later reverses upward is left alone.
+      if (deltaY > 0 || Math.abs(deltaX) > Math.abs(deltaY)) {
+        state = null;
+        return;
+      }
+      if (-deltaY < optionsRef.current.thresholdPx) {
+        return;
+      }
+      // A move the browser has already committed to scrolling cannot be
+      // claimed, and a sheet dragged by a finger that is also scrolling the
+      // page behind it is worse than no gesture at all.
+      if (!event.cancelable) {
+        state = null;
+        return;
+      }
+      event.preventDefault();
+      state.claimed = true;
+      // Anchored at the touch, not at the threshold crossing, so the sheet
+      // rises by the whole distance the finger has travelled.
+      controller.start({y: state.startY, timeStamp: event.timeStamp});
+      controller.move({y: touch.clientY, timeStamp: event.timeStamp});
+    };
+
+    const onTouchEnd = (event: TouchEvent) => {
+      if (state == null) {
+        return;
+      }
+      const wasClaimed = state.claimed;
+      const touch = [...event.changedTouches].find(
+        candidate => candidate.identifier === state?.id,
+      );
+      state = null;
+      if (!wasClaimed) {
+        return;
+      }
+      if (touch == null) {
+        controller.cancel();
+        return;
+      }
+      controller.end({y: touch.clientY, timeStamp: event.timeStamp});
+    };
+
+    const onTouchCancel = () => {
+      const wasClaimed = state?.claimed ?? false;
+      state = null;
+      if (wasClaimed) {
+        controller.cancel();
+      }
+    };
+
+    // Listeners on the document, not the region: `from: 'element'` still needs
+    // every move of a gesture that STARTED in the region, including the ones
+    // whose target has since left it, and by the end of a full-height pull the
+    // finger is nowhere near where it began.
+    document.addEventListener('touchstart', onTouchStart, {passive: true});
+    document.addEventListener('touchmove', onTouchMove, {passive: false});
+    document.addEventListener('touchend', onTouchEnd, {passive: true});
+    document.addEventListener('touchcancel', onTouchCancel, {passive: true});
+    return () => {
+      document.removeEventListener('touchstart', onTouchStart);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onTouchEnd);
+      document.removeEventListener('touchcancel', onTouchCancel);
+      controller.cancel();
+    };
+  }, [controller]);
+
+  const regionProps = useMemo(
+    () => ({
+      ref: (node: HTMLElement | null) => {
+        regionRef.current = node;
+      },
+    }),
+    [],
+  );
+
+  return {source: controller, regionProps};
+}

--- a/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.ts
+++ b/packages/lab/src/SheetOpenGesture/useSheetOpenGesture.ts
@@ -61,7 +61,15 @@
  */
 
 import {useEffect, useMemo, useRef} from 'react';
-import {createSheetDragSource, type SheetDragSource} from '@astryxdesign/core';
+// Subpath, not the '@astryxdesign/core' barrel: a bare root import from lab is
+// a runtime edge into core's ENTIRE public surface, and inside a consuming app
+// it can resolve to core's source rather than its build — dragging every core
+// component through that app's compiler. Every other value import in lab is a
+// subpath for this reason; only erased `import type`s use the root.
+import {
+  createSheetDragSource,
+  type SheetDragSource,
+} from '@astryxdesign/core/BottomSheet';
 
 /** Where an upward pull is allowed to become a sheet-open gesture. */
 export type SheetOpenGestureOrigin = 'page-end' | 'element';

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -258,3 +258,6 @@ export {
 // into its own canary-only package, @astryxdesign/richtext, so it can be canaried
 // independently (e.g. into EPS/Nest). Import it from there:
 //   import {RichTextEditor, RichTextView} from '@astryxdesign/richtext';
+
+// SheetOpenGesture — EXPLORATION: drag up from the page to open a BottomSheet
+export * from './SheetOpenGesture';


### PR DESCRIPTION
> **This is an exploration, not a proposal to merge.** It is a working
> implementation put up so the *shape of the seam* can be argued about against
> something real rather than a sketch. Nothing here is a settled API; every new
> export is marked `EXPLORATION` in its own source. Happy to throw all of it
> away.

Related: #5087 (Define BottomSheet vertical drag behavior), #4476 (Responsive
web tracker).

## The gap

Every gesture `BottomSheet` has begins **inside** the sheet — the handle, the
scrolling body, the scroll-edge handoff. All of them need the sheet to already
be on screen. The one gesture that cannot work that way is the one that *opens*
it: the finger lands on the page, and there is no sheet yet.

So today a sheet can only be opened by a tap. "Drag up to reveal" — the Maps /
Music / Wallet pattern — has nowhere to attach.

## What this does

Adds the seam, and one recognizer that uses it.

```tsx
const [isOpen, setIsOpen] = useState(false);
const {source} = useSheetOpenGesture({enabled: !isOpen});   // @astryxdesign/lab

<Button label="Nearby places" onClick={() => setIsOpen(true)} />
<BottomSheet
  label="Nearby places"
  isOpen={isOpen}
  onOpenChange={setIsOpen}
  dragSource={source}>
  <PlaceList />
</BottomSheet>
```

Scroll to the end of the page, keep pulling up, and the sheet comes with the
finger — from off-screen to open, 1:1, in one continuous gesture. Let go early
and it falls back where it came from, and `onOpenChange` is never called at
all: a gesture the user abandoned leaves no trace in their state.

**core** — `createSheetDragSource()` and a `dragSource` prop, plus an `opening`
panel state for a sheet placed by a finger rather than by an entry animation.

**lab** — `useSheetOpenGesture()`, the recognizer: which touches qualify (the
end of the page, or a region you mark with `regionProps`).

The split is deliberate. Deciding *what counts as a sheet-open pull* is policy
and belongs where it can change freely; *presenting a sheet and settling it* is
the sheet's own business and already exists.

## The one design decision worth arguing about

**The release goes through the sheet's existing settle, not a new one.**

The published drag is fed through the same synthetic-pointer path the touch
handoff already uses, anchored a full sheet-height below open. Everything then
falls out of machinery that is already there and already tested:

| behaviour | where it comes from |
|---|---|
| pulled far enough → opens | `resolveSettleOffset` |
| released short → falls back closed | the existing `DISMISS_OVERSHOOT_RATIO` check |
| fast flick opens from anywhere | `FLICK_VELOCITY` |
| lands on a snap point on the way in | `computeDetentOffsets` |
| scrim tracks the pull | `scrimOpacityForOffset` |
| detent haptics | `hapticTick` |

Not one of those is reimplemented here. If the seam is wrong, this is the part
to attack first.

## Measured

Chromium, iPhone 15 profile, real touches via CDP `Input.dispatchTouchEvent`,
against a build of core.

**`showModal()` mid-touch does not break the touch stream.** The whole feature
rests on this. After the sheet goes modal and the page goes inert, every
remaining `touchmove` is still delivered to the *original* page element and
still reaches the document listener, through to `touchend`. The touch target is
latched at `touchstart`; the page going inert underneath does not disturb it.

**A browser hands out one chance to claim a touch** — which is why the
recognizer commits on the first move and then holds the claim:

| `preventDefault` policy | moves still cancelable (of 7) | page scrolled |
|---|---|---|
| every move | 7 | 0 px |
| first move only | 2 | 162 px |
| all but the third | 3 | 137 px |
| never | 1 | 162 px |

Let one move through and cancelability is gone for the rest of the gesture,
whatever you do afterwards — and the page has already scrolled out from under
the user. Same on a non-scrollable page. So there is no "watch a few frames and
then decide": arm from what is knowable at `touchstart`, claim on move 1, hold
it. (This is the same shape the sheet's own scroll-edge handoff uses.)

**End to end**, four cases, each driven as a real touch sweep:

| | result |
|---|---|
| full pull at page end | opens; tracks the finger exactly (`top` 707 → 655 → 629 → … → 250, 26 px per move) |
| short pull, released early | falls back closed, page scroll restored, `onOpenChange` never called |
| pull up away from the page end | pure scroll — no dialog, nothing presented |
| swipe the sheet back down afterwards | dismisses normally; focus restored to the trigger |

Focus lands on the panel inside the dialog, `aria-modal="true"`, and Escape
still closes.

## Accessibility

The gesture is an **accelerator, never a way in**. A drag-only reveal is
invisible to a screen reader, undiscoverable by sight, and fails WCAG 2.5.7
Dragging Movements. Both stories keep a real button, and the docs say so in the
prop description, the hook's JSDoc, and the Storybook page.

The better long-term affordance is a **visible peek** — a sliver of sheet that
can be tapped as well as dragged. That is not expressible today: `snapPoints`
are only stops the user can drag *to*, so `snapPoints={[64, 0.5]}` still opens
at the tallest detent. An initial-detent prop (`restAt`) would fix it, is
useful on its own, and independently answers question 3 of #5087. **I'd rather
land that first than land this.**

## Known rough edges

- **One 22 px frame at the very start of the pull.** The sheet's first laid-out
  frame is ~22 px off before its height is pinned; from the next frame on it
  tracks exactly. It is a height settle at mount, not a position error — the
  fix is measuring the sheet before its first gesture frame.
- **iOS Safari is unverified, and it is the real risk.** WebKit reclaims
  pointer capture aggressively (it is why `beginDrag` never captures for a
  touch drag), and it is the one engine that could invalidate the finding this
  is built on. Needs the simulator before anyone believes it works.
- **No screen-edge mode, on purpose.** iOS Safari's address bar and Android's
  gesture navigation both live in that strip. A web page competing with them
  loses, so `from` deliberately offers no such option.
- A horizontal scroller at the page end will hit the `touch-action: pan-x`
  dead-zone; untested here.
- Android Chrome's overscroll glow will paint under the promoted drag unless
  `overscroll-behavior` is set for the gesture's duration.
- Gesture-opening onto an *intermediate* snap point works, but is barely
  exercised — the interesting case is opening to full height.

## Tests

32 new (15 core, 17 lab). The recognizer's tests pin down the claim rules
above — which move is cancelled, which is let through, what is published —
since jsdom cannot reproduce the browser behaviour that motivated them.

Gates: `lint:strict`, `build`, `pnpm vitest run packages/core packages/lab`
(7536 passing), `lab:readiness:check`, and the `build-storybook` typecheck stack
(core/lab/charts `typecheck:docs`, cli `typecheck:strict` +
`typecheck:template-docs`, storybook `typecheck` + `build`, core `typecheck`).

## Questions for review

1. Is a published drag-source the right seam, or should the sheet own the
   recognizer behind a `dragToOpen` prop? (I think not — that hides a
   document-level listener behind an innocuous prop and gives no way to scope
   the region — but it is the obvious alternative.)
2. Should `restAt` / a peek land first and this be rebased on top of it?
3. Does the recognizer belong in lab at all, given core has to define the
   contract and carry the prop either way?
