### PR TITLE
feat(Table): move the filters into a bottom sheet on a phone

### DIFF
--- a/.changeset/table-filter-sheet.md
+++ b/.changeset/table-filter-sheet.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] `useTableFiltering`: on a narrow viewport the filter controls leave the table header for a bottom sheet, opened from one Filter button that carries the active-filter count. A header cell is the wrong home for a filter on a phone — the column is too narrow to hold a control, and a popover anchored to it covers the rows the filter is meant to narrow. The sheet applies each change as it is made and has no scrim, so the rows behind stay visible and keep updating; short enum filters render as a list of checkboxes or radios rather than a Selector, so nothing opens a second layer on top of the sheet. `sheetBreakpoint` moves or disables the threshold (`'sm'` by default, `'none'` to keep the header controls at every width), `variant: 'sheet'` takes the presentation at any width, and `defaultIsMobile` seeds it for SSR.
+
+@imdreamrunner

--- a/apps/storybook/stories/TableFiltering.stories.tsx
+++ b/apps/storybook/stories/TableFiltering.stories.tsx
@@ -555,3 +555,47 @@ export const EmptyState: Story = {
     );
   },
 };
+
+export const SheetVariant: Story = {
+  name: 'Sheet variant (touch)',
+  parameters: {
+    viewport: {defaultViewport: 'mobile1'},
+  },
+  render: () => {
+    const {config, applyFilters} = usePowerSearchConfig(fieldDefs);
+    const {filters, onFilterChange} = useTableFilterState();
+    const columns: TableColumn<Employee>[] = [
+      {key: 'name', header: 'Name', filter: 'name'},
+      {key: 'role', header: 'Role', filter: 'role'},
+      {key: 'department', header: 'Department', filter: 'department'},
+    ];
+    // Pinned to 'sheet' so the variant is visible at any width. Left at the
+    // default, a table takes this presentation automatically below 640px.
+    const filterPlugin = useTableFiltering<Employee>({
+      filters,
+      onFilterChange,
+      variant: 'sheet',
+      searchConfig: config,
+    });
+    const data = applyFilters(
+      toSearchFilters(filters, columns, config) as PowerSearchFilter[],
+      employees,
+    );
+    return (
+      <div style={{maxWidth: 420}}>
+        <p style={{marginBottom: 8, fontSize: 14, color: '#666'}}>
+          Every filter lives behind the Filter button, which carries the active
+          count. Toggling one applies it straight away and the sheet has no
+          scrim, so the rows keep updating behind it. Showing {data.length}/
+          {employees.length} rows.
+        </p>
+        <Table
+          data={data}
+          columns={columns}
+          idKey="name"
+          plugins={{filter: filterPlugin}}
+        />
+      </div>
+    );
+  },
+};

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -563,6 +563,22 @@
     "defaultMessage": "Apply",
     "description": "Primary button label inside a table's filter panel/popover; commits pending filter values. Imperative verb; pairs with `Reset`."
   },
+  "@astryx.table.filter.button": {
+    "defaultMessage": "Filter",
+    "description": "Label on the button above a table that opens the filter sheet on small screens. Imperative verb (\"filter these rows\"), not the noun."
+  },
+  "@astryx.table.filter.buttonWithCount": {
+    "defaultMessage": "Filter, {count} active",
+    "description": "Accessible name for that same Filter button when filters are applied; the visible button shows the count as a badge. `count` is how many columns are currently filtered."
+  },
+  "@astryx.table.filter.title": {
+    "defaultMessage": "Filters",
+    "description": "Heading and accessible name of the bottom sheet holding a table's filter controls on small screens. Plural noun."
+  },
+  "@astryx.table.filter.done": {
+    "defaultMessage": "Done",
+    "description": "Primary button that closes a table's filter sheet. The filters are already applied, so this dismisses rather than commits — unlike `Apply` in the per-column popover."
+  },
   "@astryx.table.selection.selectAllRows": {
     "defaultMessage": "Select all rows",
     "description": "Aria label for the \"select all rows\" checkbox in a Table header."

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -122,6 +122,7 @@ export type {
   UseTableFilteringConfig,
   TableFilterState,
   TableFilterVariant,
+  TableFilterSheetBreakpoint,
   TableFilterValue,
   TableFilterFieldRef,
 } from './plugins/filtering';

--- a/packages/core/src/Table/plugins/filtering/index.ts
+++ b/packages/core/src/Table/plugins/filtering/index.ts
@@ -7,6 +7,7 @@ export type {
   UseTableFilteringConfig,
   TableFilterState,
   TableFilterVariant,
+  TableFilterSheetBreakpoint,
   TableFilterValue,
   TableFilterFieldRef,
 } from './useTableFiltering';

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.test.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.test.tsx
@@ -7,9 +7,9 @@
  * @position Test file; validates filter rendering, interaction, and accessibility
  */
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {useState} from 'react';
-import {render, screen} from '@testing-library/react';
+import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Table} from '../../Table';
 import {useTableFiltering, toSearchFilters} from './useTableFiltering';
@@ -17,6 +17,7 @@ import type {
   TableFilterState,
   TableFilterVariant,
   TableFilterValue,
+  TableFilterSheetBreakpoint,
 } from './useTableFiltering';
 import type {PowerSearchConfig} from '../../../PowerSearch/types';
 import type {TableColumn} from '../../types';
@@ -122,7 +123,14 @@ const allFilterColumns: TableColumn<TestRow>[] = [
 
 function FilterTable({
   columns = defaultColumns,
-  variant = 'popover' as TableFilterVariant,
+  variant = 'popover',
+  sheetBreakpoint,
+  defaultIsMobile,
+}: {
+  columns?: TableColumn<TestRow>[];
+  variant?: TableFilterVariant;
+  sheetBreakpoint?: TableFilterSheetBreakpoint;
+  defaultIsMobile?: boolean;
 }) {
   const [filters, setFilters] = useState<TableFilterState>({});
 
@@ -138,6 +146,8 @@ function FilterTable({
       });
     },
     variant,
+    sheetBreakpoint,
+    defaultIsMobile,
     searchConfig,
   });
 
@@ -314,6 +324,251 @@ describe('useTableFiltering', () => {
       expect(() =>
         render(<FilterTable columns={noFilterColumns} />),
       ).not.toThrow();
+    });
+  });
+  describe('sheet variant', () => {
+    // Every filtering test above runs at desktop width because the setup's
+    // matchMedia answers only `(hover: hover)`. These drive the width query
+    // directly so both sides of the breakpoint are reachable.
+    function stubViewportWidth(width: number) {
+      vi.stubGlobal('matchMedia', (query: string) => {
+        const maxWidth = /\(max-width:\s*(\d+)px\)/.exec(query);
+        return {
+          matches: maxWidth
+            ? width <= Number(maxWidth[1])
+            : /\(\s*hover\s*:\s*hover\s*\)/.test(query),
+          media: query,
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        };
+      });
+    }
+
+    const PHONE = 390;
+    const DESKTOP = 1280;
+
+    // jsdom implements neither <dialog> open/close nor pointer capture.
+    beforeEach(() => {
+      HTMLDialogElement.prototype.showModal = vi.fn(function (
+        this: HTMLDialogElement,
+      ) {
+        this.setAttribute('open', '');
+      });
+      HTMLDialogElement.prototype.show = vi.fn(function (
+        this: HTMLDialogElement,
+      ) {
+        this.setAttribute('open', '');
+      });
+      HTMLDialogElement.prototype.close = vi.fn(function (
+        this: HTMLDialogElement,
+      ) {
+        this.removeAttribute('open');
+      });
+      if (!Element.prototype.setPointerCapture) {
+        Element.prototype.setPointerCapture = vi.fn();
+        Element.prototype.releasePointerCapture = vi.fn();
+      }
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    async function openSheet(user: ReturnType<typeof userEvent.setup>) {
+      await user.click(screen.getByRole('button', {name: /^Filter/}));
+      return screen.getByRole('dialog', {name: 'Filters'});
+    }
+
+    it('takes the filters out of the header and puts them behind one Filter button', () => {
+      stubViewportWidth(PHONE);
+      render(<FilterTable />);
+
+      // The per-column funnel triggers are what a phone cannot use.
+      expect(screen.queryByRole('button', {name: 'Filter Name'})).toBeNull();
+      expect(screen.getByRole('button', {name: 'Filter'})).toBeInTheDocument();
+    });
+
+    it('keeps the header controls above the breakpoint', () => {
+      stubViewportWidth(DESKTOP);
+      render(<FilterTable />);
+
+      expect(
+        screen.getByRole('button', {name: 'Filter Name'}),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Filter'})).toBeNull();
+    });
+
+    it('honors sheetBreakpoint="none" on a narrow viewport', () => {
+      stubViewportWidth(PHONE);
+      // defaultIsMobile too: opting out has to survive the SSR hint.
+      render(<FilterTable sheetBreakpoint="none" defaultIsMobile />);
+
+      expect(
+        screen.getByRole('button', {name: 'Filter Name'}),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Filter'})).toBeNull();
+    });
+
+    it('honors variant="sheet" above the breakpoint', () => {
+      stubViewportWidth(DESKTOP);
+      render(<FilterTable variant="sheet" />);
+
+      expect(screen.getByRole('button', {name: 'Filter'})).toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Filter Name'})).toBeNull();
+    });
+
+    it('renders no Filter button when no column is filterable', () => {
+      stubViewportWidth(PHONE);
+      render(
+        <FilterTable
+          columns={[
+            {key: 'name', header: 'Name'},
+            {key: 'status', header: 'Status'},
+          ]}
+        />,
+      );
+
+      expect(screen.queryByRole('button', {name: /^Filter/})).toBeNull();
+    });
+
+    it('gives the sheet one labelled control per filterable column', async () => {
+      const user = userEvent.setup();
+      stubViewportWidth(PHONE);
+      render(<FilterTable columns={allFilterColumns} />);
+
+      const sheet = await openSheet(user);
+      // Labelled by the column header, not "Filter by Name": the header cell
+      // that carried that context is gone.
+      expect(within(sheet).getByLabelText('Name')).toBeInTheDocument();
+      expect(
+        within(sheet).getByRole('spinbutton', {name: 'Age'}),
+      ).toBeInTheDocument();
+      expect(
+        within(sheet).getByRole('radiogroup', {name: 'Status'}),
+      ).toBeInTheDocument();
+      expect(
+        within(sheet).getByRole('group', {name: 'Tags'}),
+      ).toBeInTheDocument();
+    });
+
+    it('applies a toggle immediately, with no Apply step', async () => {
+      const user = userEvent.setup();
+      stubViewportWidth(PHONE);
+      render(<FilterTable columns={allFilterColumns} />);
+
+      const sheet = await openSheet(user);
+      expect(within(sheet).queryByRole('button', {name: 'Apply'})).toBeNull();
+
+      await user.click(within(sheet).getByRole('checkbox', {name: 'Admin'}));
+
+      // The row count on the trigger is the only in-plugin evidence that the
+      // filter took effect (the consumer owns the data).
+      expect(
+        screen.getByRole('button', {name: 'Filter, 1 active'}),
+      ).toBeInTheDocument();
+    });
+
+    it('counts the active filters on the trigger', async () => {
+      const user = userEvent.setup();
+      stubViewportWidth(PHONE);
+      render(<FilterTable columns={allFilterColumns} />);
+
+      const sheet = await openSheet(user);
+      await user.click(within(sheet).getByRole('checkbox', {name: 'Admin'}));
+      await user.click(within(sheet).getByRole('radio', {name: 'Active'}));
+
+      const trigger = screen.getByRole('button', {name: 'Filter, 2 active'});
+      expect(within(trigger).getByText('2')).toBeInTheDocument();
+    });
+
+    it('clears every filter with Reset', async () => {
+      const user = userEvent.setup();
+      stubViewportWidth(PHONE);
+      render(<FilterTable columns={allFilterColumns} />);
+
+      const sheet = await openSheet(user);
+      const reset = within(sheet).getByRole('button', {name: 'Reset'});
+      expect(reset).toBeDisabled();
+
+      await user.click(within(sheet).getByRole('checkbox', {name: 'Admin'}));
+      await user.click(within(sheet).getByRole('radio', {name: 'Active'}));
+      await user.click(reset);
+
+      expect(screen.getByRole('button', {name: 'Filter'})).toBeInTheDocument();
+      expect(
+        within(sheet).getByRole('checkbox', {name: 'Admin'}),
+      ).not.toBeChecked();
+    });
+
+    it('closes on Done without dropping the filters', async () => {
+      const user = userEvent.setup();
+      stubViewportWidth(PHONE);
+      render(<FilterTable columns={allFilterColumns} />);
+
+      const sheet = await openSheet(user);
+      await user.click(within(sheet).getByRole('checkbox', {name: 'Admin'}));
+      await user.click(within(sheet).getByRole('button', {name: 'Done'}));
+
+      expect(
+        screen.getByRole('button', {name: 'Filter, 1 active'}),
+      ).toBeInTheDocument();
+    });
+
+    it('keeps a Selector for an enum longer than a list should be', async () => {
+      const user = userEvent.setup();
+      stubViewportWidth(PHONE);
+
+      const manyValues = Array.from({length: 12}, (_, i) => ({
+        value: `v${i}`,
+        label: `Value ${i}`,
+      }));
+      const wideConfig: PowerSearchConfig = {
+        name: 'test',
+        fields: [
+          {
+            key: 'status',
+            label: 'Status',
+            defaultOperator: 'is',
+            operators: [
+              {
+                key: 'is',
+                label: 'is',
+                value: {type: 'enum', values: manyValues},
+              },
+            ],
+          },
+        ],
+      };
+
+      function WideEnumTable() {
+        const [filters, setFilters] = useState<TableFilterState>({});
+        const plugin = useTableFiltering<TestRow>({
+          filters,
+          onFilterChange: (key, value) =>
+            setFilters(prev => ({...prev, [key]: value ?? undefined})),
+          searchConfig: wideConfig,
+        });
+        return (
+          <Table
+            data={testData}
+            columns={[{key: 'status', header: 'Status', filter: 'status'}]}
+            idKey="id"
+            plugins={{filter: plugin}}
+          />
+        );
+      }
+
+      render(<WideEnumTable />);
+      const sheet = await openSheet(user);
+
+      expect(within(sheet).queryByRole('radiogroup')).toBeNull();
+      expect(
+        within(sheet).getByRole('combobox', {name: 'Status'}),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
@@ -9,8 +9,10 @@
  * @position Filtering plugin; consumed by Table via plugins prop
  *
  * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Table/useTableFiltering.doc.mjs (props table)
  * - /packages/core/src/Table/Table.doc.mjs (filtering documentation)
  * - /packages/core/src/Table/index.ts (exports)
+ * - /apps/storybook/stories/TableFiltering.stories.tsx (variant coverage)
  */
 
 import {
@@ -25,7 +27,16 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
+import {Badge} from '../../../Badge';
 import {Button} from '../../../Button';
+import {BottomSheet} from '../../../BottomSheet';
+import {CheckboxList, CheckboxListItem} from '../../../CheckboxList';
+import {RadioList, RadioListItem} from '../../../RadioList';
+import {Heading} from '../../../Heading';
+import {HStack} from '../../../HStack';
+import {VStack} from '../../../VStack';
+import {Section} from '../../../Section';
+import {useMediaQuery} from '../../../hooks/useMediaQuery';
 import {Popover} from '../../../Popover';
 import {TextInput} from '../../../TextInput';
 import {NumberInput} from '../../../NumberInput';
@@ -272,8 +283,33 @@ export type TableFilterState = Record<string, TableFilterValue | undefined>;
  * - `'popover'` — filter icon in header; clicking opens a popover with the filter control
  * - `'inline'` — filter control rendered directly below header text inside the header cell
  * - `'inline-compact'` — same as inline but with compact-sized controls
+ * - `'sheet'` — every filter moves out of the header into a bottom sheet opened
+ *   from a single Filter button above the table. The touch presentation; the
+ *   other variants adopt it below {@link UseTableFilteringConfig.sheetBreakpoint}.
  */
-export type TableFilterVariant = 'popover' | 'inline' | 'inline-compact';
+export type TableFilterVariant =
+  'popover' | 'inline' | 'inline-compact' | 'sheet';
+
+/**
+ * Viewport width below which the filter controls collapse into a bottom sheet.
+ * Matches AppShell's breakpoint scale; `'none'` opts out of collapsing.
+ */
+export type TableFilterSheetBreakpoint = 'sm' | 'md' | 'lg' | 'none';
+
+const SHEET_BREAKPOINT_VALUES: Record<TableFilterSheetBreakpoint, number> = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  none: 0,
+};
+
+/**
+ * Option count up to which the sheet renders an enum filter as a list of
+ * checkboxes / radios instead of a Selector. Above it, the Selector's own
+ * search and scrolling are worth the nested layer — the same threshold
+ * CheckboxList and RadioList give for choosing themselves over a Selector.
+ */
+const SHEET_LIST_MAX_OPTIONS = 7;
 
 // =============================================================================
 // Hook Config
@@ -301,9 +337,36 @@ export interface UseTableFilteringConfig {
   /**
    * Display variant for filter controls.
    *
+   * Below `sheetBreakpoint` every variant renders as `'sheet'`; set
+   * `'sheet'` to use it at every width.
+   *
    * @default 'popover'
    */
   variant?: TableFilterVariant;
+  /**
+   * Viewport width below which the filter controls leave the header and
+   * collapse into a bottom sheet, opened from a single Filter button above
+   * the table.
+   *
+   * A header cell is the wrong place for a filter on a phone: the column is
+   * too narrow to hold a control, and a popover anchored to it covers the
+   * rows the filter is meant to narrow. Set `'none'` to keep the header
+   * controls at every width.
+   *
+   * @default 'sm'
+   */
+  sheetBreakpoint?: TableFilterSheetBreakpoint;
+  /**
+   * SSR hint: whether the initial render should assume a narrow viewport.
+   * Seeds the breakpoint state so server-rendered HTML matches the client on
+   * phones, avoiding a flash of the header controls.
+   *
+   * Derive it from the User-Agent header or a device-detection cookie in a
+   * server component, then pass it down.
+   *
+   * @default false
+   */
+  defaultIsMobile?: boolean;
   /**
    * PowerSearch configuration that defines the available filter fields.
    * Columns reference fields by key; the plugin resolves the operator's
@@ -322,6 +385,12 @@ export interface UseTableFilteringConfig {
 
 interface FilterStore {
   getConfig: () => UseTableFilteringConfig;
+  /**
+   * The table's final column list, as the plugin pipeline saw it in
+   * `transformColumns`. The sheet needs every filterable column at once,
+   * where the header slots only ever see one at a time.
+   */
+  getColumns: () => ReadonlyArray<TableColumn<Record<string, unknown>>>;
 }
 
 const FilterStoreContext = createContext<FilterStore | null>(null);
@@ -402,11 +471,47 @@ const filterStyles = stylex.create({
   placeholderCompact: {
     height: '28px',
   },
+  sheetToolbar: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginBottom: spacingVars['--spacing-2'],
+  },
+  sheetTrigger: {
+    // The one filter affordance on a touch screen; no size token reaches the
+    // 44px target on every theme, so the floor is set here. Matches the
+    // header trigger above.
+    minHeight: {
+      default: null,
+      '@media (pointer: coarse)': '44px',
+    },
+  },
 });
 
 // =============================================================================
 // Filter Control Components
 // =============================================================================
+
+/**
+ * Label props for one filter control.
+ *
+ * In a header cell the column name is already on screen, so the control's own
+ * label is hidden and spells the column out for assistive tech ("Filter by
+ * Status"). In the sheet there is no header cell, so the column name becomes
+ * the control's visible label.
+ */
+function useFilterLabel(header: string): {
+  label: string;
+  isLabelHidden: boolean;
+} {
+  const t = useTranslator();
+  const variant = use(FilterVariantContext);
+  return variant === 'sheet'
+    ? {label: header, isLabelHidden: false}
+    : {
+        label: t('@astryx.tableFiltering.filterByColumn', {header}),
+        isLabelHidden: true,
+      };
+}
 
 function TextFilterControl({
   columnKey,
@@ -420,6 +525,7 @@ function TextFilterControl({
   hasClear?: boolean;
 }) {
   const t = useTranslator();
+  const labelProps = useFilterLabel(header);
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -427,8 +533,7 @@ function TextFilterControl({
 
   return (
     <TextInput
-      label={t('@astryx.tableFiltering.filterByColumn', {header})}
-      isLabelHidden
+      {...labelProps}
       value={strValue}
       onChange={(newValue: string) => {
         store
@@ -456,6 +561,7 @@ function NumberFilterControl({
   hasClear?: boolean;
 }) {
   const t = useTranslator();
+  const labelProps = useFilterLabel(header);
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -473,8 +579,7 @@ function NumberFilterControl({
   if (hasClear) {
     return (
       <NumberInput
-        label={t('@astryx.tableFiltering.filterByColumn', {header})}
-        isLabelHidden
+        {...labelProps}
         value={numValue}
         onChange={handleChange}
         placeholder={t('@astryx.tableFiltering.filterByColumn', {header})}
@@ -489,8 +594,7 @@ function NumberFilterControl({
 
   return (
     <NumberInput
-      label={t('@astryx.tableFiltering.filterByColumn', {header})}
-      isLabelHidden
+      {...labelProps}
       value={numValue}
       onChange={handleChange}
       placeholder={t('@astryx.tableFiltering.filterByColumn', {header})}
@@ -516,6 +620,7 @@ function SelectorFilterControl({
   hasClear?: boolean;
 }) {
   const t = useTranslator();
+  const labelProps = useFilterLabel(header);
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -541,8 +646,7 @@ function SelectorFilterControl({
   if (hasClear) {
     return (
       <Selector
-        label={t('@astryx.tableFiltering.filterByColumn', {header})}
-        isLabelHidden
+        {...labelProps}
         options={options}
         value={strValue || null}
         onChange={handleChange}
@@ -555,8 +659,7 @@ function SelectorFilterControl({
 
   return (
     <Selector
-      label={t('@astryx.tableFiltering.filterByColumn', {header})}
-      isLabelHidden
+      {...labelProps}
       options={options}
       value={strValue}
       onChange={handleChange}
@@ -580,6 +683,7 @@ function MultiSelectorFilterControl({
   hasClear?: boolean;
 }) {
   const t = useTranslator();
+  const labelProps = useFilterLabel(header);
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -592,8 +696,7 @@ function MultiSelectorFilterControl({
 
   return (
     <MultiSelector
-      label={t('@astryx.tableFiltering.filterByColumn', {header})}
-      isLabelHidden
+      {...labelProps}
       options={options}
       value={arrValue}
       onChange={(newValue: string[]) => {
@@ -621,14 +724,13 @@ function DateFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const t = useTranslator();
+  const labelProps = useFilterLabel(header);
   const store = useFilterStore();
   const value = store.getConfig().filters[columnKey] as string | undefined;
 
   return (
     <DateInput
-      label={t('@astryx.tableFiltering.filterByColumn', {header})}
-      isLabelHidden
+      {...labelProps}
       value={(value as ISODateString | undefined) ?? undefined}
       onChange={newValue => {
         store.getConfig().onFilterChange(columnKey, newValue ?? null);
@@ -650,14 +752,13 @@ function TimeFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const t = useTranslator();
+  const labelProps = useFilterLabel(header);
   const store = useFilterStore();
   const value = store.getConfig().filters[columnKey] as string | undefined;
 
   return (
     <TimeInput
-      label={t('@astryx.tableFiltering.filterByColumn', {header})}
-      isLabelHidden
+      {...labelProps}
       value={(value as ISOTimeString | undefined) ?? undefined}
       onChange={newValue => {
         store.getConfig().onFilterChange(columnKey, newValue ?? null);
@@ -681,7 +782,7 @@ function StringListFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
-  const t = useTranslator();
+  const labelProps = useFilterLabel(header);
   const store = useFilterStore();
   const value =
     (store.getConfig().filters[columnKey] as string[] | undefined) ?? [];
@@ -701,8 +802,7 @@ function StringListFilterControl({
 
   return (
     <Tokenizer
-      label={t('@astryx.tableFiltering.filterByColumn', {header})}
-      isLabelHidden
+      {...labelProps}
       searchSource={searchSource}
       value={value.map(v => ({id: v, label: v}))}
       onChange={items => {
@@ -859,6 +959,7 @@ function PopoverFilterTrigger({
   // instead of the consumer's state.
   const draftStore = useMemo<FilterStore>(
     () => ({
+      ...store,
       getConfig() {
         return {
           ...store.getConfig(),
@@ -1010,6 +1111,280 @@ function InlineFilterSlot({
 }
 
 // =============================================================================
+// Sheet Variant
+//
+// A header cell is the wrong home for a filter on a phone: the column is too
+// narrow to hold a control, and a popover anchored to it covers the very rows
+// the filter is meant to narrow. The sheet variant takes every filter out of
+// the header and puts it behind one Filter button above the table, in a bottom
+// sheet with no scrim — so the rows stay visible and keep updating as filters
+// are toggled, which is the whole point of filtering on a small screen.
+// =============================================================================
+
+/** One filterable column, with its operator resolved to a control. */
+interface SheetFilterField {
+  columnKey: string;
+  header: string;
+  operatorValue: OperatorValue;
+}
+
+/** Whether a filter value narrows anything. */
+function isFilterActive(value: TableFilterValue | undefined): boolean {
+  if (value == null) {
+    return false;
+  }
+  if (typeof value === 'string') {
+    return value !== '';
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return true;
+}
+
+/**
+ * The columns the sheet renders a control for, in table order. Read from the
+ * store rather than props: the header slots each see one column, only
+ * `transformColumns` sees them all.
+ */
+function resolveSheetFields(store: FilterStore): SheetFilterField[] {
+  const {searchConfig} = store.getConfig();
+  const fields: SheetFilterField[] = [];
+  for (const column of store.getColumns()) {
+    if (column.filter == null) {
+      continue;
+    }
+    const operatorValue = resolveFilterConfig(column.filter, searchConfig);
+    if (!operatorValue) {
+      continue;
+    }
+    fields.push({
+      columnKey: column.key,
+      header: getHeaderString(column),
+      operatorValue,
+    });
+  }
+  return fields;
+}
+
+/**
+ * Multi-select filter as a list of checkboxes. Every option is on screen and
+ * one tap wide, and nothing opens a second layer on top of the sheet.
+ */
+function SheetCheckboxFilter({
+  columnKey,
+  header,
+  operatorValue,
+}: {
+  columnKey: string;
+  header: string;
+  operatorValue: EnumListOperatorValue;
+}) {
+  const store = useFilterStore();
+  const value = store.getConfig().filters[columnKey];
+  const selected = Array.isArray(value) ? value : [];
+
+  return (
+    <CheckboxList
+      label={header}
+      value={selected}
+      onChange={(next: string[]) => {
+        store
+          .getConfig()
+          .onFilterChange(columnKey, next.length === 0 ? null : next);
+      }}
+      hasDividers>
+      {operatorValue.values.map(option => (
+        <CheckboxListItem
+          key={option.value}
+          label={option.label}
+          value={option.value}
+        />
+      ))}
+    </CheckboxList>
+  );
+}
+
+/**
+ * Single-select filter as a list of radios. The leading option clears the
+ * filter, standing in for the Selector's "All" placeholder.
+ */
+function SheetRadioFilter({
+  columnKey,
+  header,
+  operatorValue,
+}: {
+  columnKey: string;
+  header: string;
+  operatorValue: EnumOperatorValue;
+}) {
+  const t = useTranslator();
+  const store = useFilterStore();
+  const value = store.getConfig().filters[columnKey];
+  const selected = typeof value === 'string' ? value : '';
+
+  return (
+    <RadioList
+      label={header}
+      value={selected}
+      onChange={(next: string) => {
+        store.getConfig().onFilterChange(columnKey, next === '' ? null : next);
+      }}>
+      <RadioListItem
+        label={t('@astryx.table.filter.allPlaceholder')}
+        value=""
+      />
+      {operatorValue.values.map(option => (
+        <RadioListItem
+          key={option.value}
+          label={option.label}
+          value={option.value}
+        />
+      ))}
+    </RadioList>
+  );
+}
+
+/**
+ * One field in the sheet. A short enum becomes a list of checkboxes or radios;
+ * everything else keeps the control the header variants use, at full width
+ * with its column name as a visible label.
+ */
+function SheetField({field}: {field: SheetFilterField}) {
+  const {columnKey, header, operatorValue} = field;
+
+  if (
+    operatorValue.type === 'enum_list' &&
+    operatorValue.values.length <= SHEET_LIST_MAX_OPTIONS
+  ) {
+    return (
+      <SheetCheckboxFilter
+        columnKey={columnKey}
+        header={header}
+        operatorValue={operatorValue}
+      />
+    );
+  }
+
+  if (
+    operatorValue.type === 'enum' &&
+    operatorValue.values.length <= SHEET_LIST_MAX_OPTIONS
+  ) {
+    return (
+      <SheetRadioFilter
+        columnKey={columnKey}
+        header={header}
+        operatorValue={operatorValue}
+      />
+    );
+  }
+
+  return (
+    <FilterControl
+      columnKey={columnKey}
+      header={header}
+      operatorValue={operatorValue}
+      size="md"
+      hasClear
+    />
+  );
+}
+
+/**
+ * Sheet variant chrome — the Filter button above the table and the sheet it
+ * opens. Rendered once per table by `transformTableContext`, so it reads every
+ * filterable column from the store rather than taking props.
+ */
+function TableFilterSheet() {
+  const t = useTranslator();
+  const store = useFilterStore();
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const fields = resolveSheetFields(store);
+  const {filters, onFilterChange} = store.getConfig();
+  const activeCount = fields.filter(field =>
+    isFilterActive(filters[field.columnKey]),
+  ).length;
+
+  // Nothing filterable — no button, no sheet.
+  if (fields.length === 0) {
+    return null;
+  }
+
+  const title = t('@astryx.table.filter.title');
+
+  return (
+    <>
+      <div {...stylex.props(filterStyles.sheetToolbar)}>
+        <Button
+          ref={triggerRef}
+          label={t('@astryx.table.filter.button')}
+          // The count reads as a bare number next to the label otherwise.
+          aria-label={
+            activeCount > 0
+              ? t('@astryx.table.filter.buttonWithCount', {count: activeCount})
+              : undefined
+          }
+          variant="secondary"
+          icon={<Icon icon="funnel" size="sm" />}
+          endContent={
+            activeCount > 0 ? (
+              <Badge label={activeCount} variant="info" />
+            ) : undefined
+          }
+          xstyle={filterStyles.sheetTrigger}
+          onClick={() => setIsOpen(true)}
+        />
+      </div>
+      <BottomSheet
+        isOpen={isOpen}
+        onOpenChange={open => {
+          setIsOpen(open);
+          // A scrim-less sheet never captured the trigger, so closing it would
+          // otherwise drop focus to the document.
+          if (!open) {
+            triggerRef.current?.focus();
+          }
+        }}
+        label={title}
+        height="hug"
+        // No scrim: the rows stay visible and keep updating underneath as
+        // filters are toggled, so the sheet shows its own effect.
+        hasScrim={false}>
+        <Section padding={4}>
+          <VStack gap={4}>
+            <HStack justify="between" align="center" gap={2}>
+              <Heading level={3}>{title}</Heading>
+              <Button
+                label={t('@astryx.table.filter.reset')}
+                variant="ghost"
+                size="sm"
+                isDisabled={activeCount === 0}
+                onClick={() => {
+                  for (const field of fields) {
+                    onFilterChange(field.columnKey, null);
+                  }
+                }}
+              />
+            </HStack>
+            {fields.map(field => (
+              <SheetField key={field.columnKey} field={field} />
+            ))}
+            <Button
+              label={t('@astryx.table.filter.done')}
+              variant="primary"
+              width="100%"
+              onClick={() => setIsOpen(false)}
+            />
+          </VStack>
+        </Section>
+      </BottomSheet>
+    </>
+  );
+}
+
+// =============================================================================
 // Hook
 // =============================================================================
 
@@ -1050,38 +1425,69 @@ export function useTableFiltering<T extends Record<string, unknown>>(
   const configRef = useRef(config);
   configRef.current = config;
 
+  // The columns the pipeline last rendered, captured in `transformColumns` so
+  // the sheet can render every filterable column at once. Read only by the
+  // sheet chrome, which renders after BaseTable's own render has filled it.
+  const columnsRef = useRef<
+    ReadonlyArray<TableColumn<Record<string, unknown>>>
+  >([]);
+
   const storeRef = useRef<FilterStore | null>(null);
   if (storeRef.current == null) {
     storeRef.current = {
       getConfig() {
         return configRef.current;
       },
+      getColumns() {
+        return columnsRef.current;
+      },
     };
   }
   const store = storeRef.current;
 
-  const variant = config.variant ?? 'popover';
+  const {
+    variant: variantProp = 'popover',
+    sheetBreakpoint = 'sm',
+    defaultIsMobile = false,
+  } = config;
+
+  const matchesNarrow = useMediaQuery(
+    `(max-width: ${SHEET_BREAKPOINT_VALUES[sheetBreakpoint]}px)`,
+    defaultIsMobile,
+  );
+  // A viewport narrower than the breakpoint gets the sheet whatever the
+  // configured variant is. `'none'` opts out entirely, including the SSR hint.
+  const isNarrow = sheetBreakpoint !== 'none' && matchesNarrow;
+  const variant: TableFilterVariant =
+    variantProp === 'sheet' || isNarrow ? 'sheet' : variantProp;
 
   return useMemo(
     (): TablePlugin<T> => ({
-      // For inline variants, upgrade columns with filters and no explicit width
-      // to proportional(1) so they get a default minWidth from the width resolver.
-      // Without this, inline filter inputs can collapse to unusable sizes.
-      transformColumns:
-        variant === 'inline' || variant === 'inline-compact'
-          ? (columns: TableColumn<T>[]) =>
-              columns.map(col => {
-                if (col.filter != null && col.width == null) {
-                  return {...col, width: proportional(1)};
-                }
-                return col;
-              })
-          : undefined,
+      transformColumns(columns: TableColumn<T>[]): TableColumn<T>[] {
+        columnsRef.current = columns as ReadonlyArray<
+          TableColumn<Record<string, unknown>>
+        >;
+
+        // For inline variants, upgrade columns with filters and no explicit
+        // width to proportional(1) so they get a default minWidth from the
+        // width resolver. Without this, inline filter inputs can collapse to
+        // unusable sizes.
+        if (variant !== 'inline' && variant !== 'inline-compact') {
+          return columns;
+        }
+        return columns.map(col => {
+          if (col.filter != null && col.width == null) {
+            return {...col, width: proportional(1)};
+          }
+          return col;
+        });
+      },
 
       transformTableContext(children: ReactNode) {
         return (
           <FilterStoreContext value={store}>
             <FilterVariantContext value={variant}>
+              {variant === 'sheet' && <TableFilterSheet />}
               {children}
             </FilterVariantContext>
           </FilterStoreContext>
@@ -1092,6 +1498,12 @@ export function useTableFiltering<T extends Record<string, unknown>>(
         props: HeaderCellRenderProps,
         column: TableColumn<T>,
       ): HeaderCellRenderProps {
+        // Sheet variant: every control lives in the sheet, so the header keeps
+        // nothing but its label.
+        if (variant === 'sheet') {
+          return props;
+        }
+
         const rawFilter = column.filter;
         const header = getHeaderString(
           column as TableColumn<Record<string, unknown>>,

--- a/packages/core/src/Table/useTableFiltering.doc.mjs
+++ b/packages/core/src/Table/useTableFiltering.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableFiltering',
   isHiddenFromOverview: true,
-  description: 'Table plugin that adds inline column filters with popover or inline controls. Pairs with useTableFilterState for managed state. Supports text, select, multi-select, date, and number filter types via PowerSearch field definitions.',
+  description: 'Table plugin that adds column filters as header popovers, inline header controls, or a bottom sheet. Pairs with useTableFilterState for managed state. Supports text, select, multi-select, date, and number filter types via PowerSearch field definitions. Below the sheet breakpoint the controls leave the header for a bottom sheet opened from one Filter button, because a phone column is too narrow to hold a control.',
   props: [
     {
       name: 'filters',
@@ -22,10 +22,28 @@ export const docs = {
       required: true,
     },
     {
+      name: 'searchConfig',
+      type: 'PowerSearchConfig',
+      description: 'PowerSearch config defining the filterable fields. Columns reference a field by key; the plugin resolves the operator value type and renders the matching control. Build it with createPowerSearchConfig or usePowerSearchConfig and share it with PowerSearch.',
+      required: true,
+    },
+    {
       name: 'variant',
-      type: "'popover' | 'inline' | 'inline-compact'",
-      description: 'Display variant for filter controls.',
+      type: "'popover' | 'inline' | 'inline-compact' | 'sheet'",
+      description: 'Display variant for filter controls. sheet moves every control out of the header into a bottom sheet opened from one Filter button above the table, with an active-filter count on the button, Reset, and Done; filters apply as they are toggled and the sheet has no scrim, so the rows behind stay visible and keep updating. Below sheetBreakpoint every variant renders as sheet.',
       default: "'popover'",
+    },
+    {
+      name: 'sheetBreakpoint',
+      type: "'sm' | 'md' | 'lg' | 'none'",
+      description: 'Viewport width below which the controls collapse into the sheet: sm 640px, md 768px, lg 1024px. none keeps the header controls at every width.',
+      default: "'sm'",
+    },
+    {
+      name: 'defaultIsMobile',
+      type: 'boolean',
+      description: 'SSR hint: whether the first render should assume a narrow viewport, so server HTML matches the client on phones. Derive it from the User-Agent header or a device cookie.',
+      default: 'false',
     },
   ],
 };
@@ -34,7 +52,7 @@ export const docsZh = {
   name: 'useTableFiltering',
   isHiddenFromOverview: true,
   displayName: 'useTableFiltering',
-  description: '表格筛选插件，添加内联列过滤器（弹出式或内联控件）。与 useTableFilterState 配合使用管理状态。',
+  description: '表格筛选插件，以表头弹出层、表头内联控件或底部弹层的形式添加列筛选。与 useTableFilterState 配合使用管理状态。窄屏下控件移出表头，改由一个"筛选"按钮打开底部弹层。',
   props: [
     {
       name: 'filters',
@@ -49,10 +67,28 @@ export const docsZh = {
       required: true,
     },
     {
+      name: 'searchConfig',
+      type: 'PowerSearchConfig',
+      description: '定义可筛选字段的 PowerSearch 配置。列通过 key 引用字段，插件据此渲染对应控件。',
+      required: true,
+    },
+    {
       name: 'variant',
-      type: "'popover' | 'inline' | 'inline-compact'",
-      description: '筛选控件的显示变体。',
+      type: "'popover' | 'inline' | 'inline-compact' | 'sheet'",
+      description: '筛选控件的显示变体。sheet 将所有控件移入底部弹层，由表格上方的"筛选"按钮打开，按钮显示生效筛选数量；切换即时生效，弹层无遮罩，后面的行保持可见并实时更新。低于 sheetBreakpoint 时所有变体都按 sheet 渲染。',
       default: "'popover'",
+    },
+    {
+      name: 'sheetBreakpoint',
+      type: "'sm' | 'md' | 'lg' | 'none'",
+      description: '控件收进底部弹层的视口宽度阈值：sm 640px、md 768px、lg 1024px。none 表示任何宽度都保留表头控件。',
+      default: "'sm'",
+    },
+    {
+      name: 'defaultIsMobile',
+      type: 'boolean',
+      description: 'SSR 提示：首次渲染是否按窄视口处理，使服务端 HTML 与手机端一致。',
+      default: 'false',
     },
   ],
 };
@@ -61,10 +97,13 @@ export const docsDense = {
   name: 'useTableFiltering',
   isHiddenFromOverview: true,
   displayName: 'useTableFiltering',
-  description: 'Table filtering plugin: inline column filters (popover/inline). Pairs w/ useTableFilterState.',
+  description: 'Table filtering plugin: column filters as header popover/inline, or a bottom sheet on narrow viewports. Pairs w/ useTableFilterState.',
   propDescriptions: {
     filters: 'Current filter state map (columnKey → value).',
     onFilterChange: 'Called on filter change. null clears.',
-    variant: 'Filter control display variant.',
+    searchConfig: 'PowerSearch config defining the filterable fields.',
+    variant: "Filter control display variant. 'sheet' = one Filter button + bottom sheet, live-applied, no scrim.",
+    sheetBreakpoint: "Width below which any variant becomes the sheet ('sm' 640 / 'md' 768 / 'lg' 1024 / 'none').",
+    defaultIsMobile: 'SSR hint for the first render below the breakpoint.',
   },
 };


### PR DESCRIPTION
## Why

The mobile prototype for the migration table specs the filtering plugin's
mobile form as a bottom sheet:
https://facebook.github.io/astryx/sandbox/pages/mobile-prototypes/?p=tablefilter

A header cell is the wrong home for a filter on a phone. The column is too
narrow to hold a control, so the `inline` variants squash to nothing, and the
`popover` variant anchors a 240px panel to a funnel icon inside a `<th>` —
covering the very rows the filter is meant to narrow. Every table using the
plugin has this today; nobody has to opt in to get it fixed.

## What

Below 640px the plugin takes every control out of the header and puts it behind
one **Filter** button above the table, carrying the count of active filters,
which opens a bottom sheet holding all of them at full width with their column
names as labels.

- **Applies live, no scrim.** Each change is applied as it is made and the
  sheet is non-modal, so the rows behind stay visible and keep updating — the
  point of filtering on a screen this small. `Done` dismisses; `Reset` clears
  every filter and is disabled when none are set.
- **Short enum filters become lists.** An `enum` renders as a `RadioList` (with
  a leading "All" that clears it) and an `enum_list` as a `CheckboxList`, up to
  the 7 options `CheckboxList`/`RadioList` themselves give as the point to
  switch to a `Selector`. Above that the `Selector` stays, for its search. This
  keeps a second layer from opening on top of the sheet, which also matters
  because `Selector` and `MultiSelector` are themselves specced to become
  sheets on mobile. Every other filter type keeps the control it already has.
- Three new config fields, all optional: `variant: 'sheet'` takes the
  presentation at any width, `sheetBreakpoint` (`'sm'` default, `'none'` to
  keep the header controls everywhere) moves the threshold on AppShell's scale,
  and `defaultIsMobile` seeds it for SSR.

Nothing above the breakpoint changes.

## Risk

The mobile presentation of an existing plugin changes without an opt-in — that
is the intent, but it is the thing to disagree with. `sheetBreakpoint: 'none'`
is the escape hatch. Everything else is additive: no prop, variant, or export
was removed or renamed, and the desktop DOM is untouched.

The trigger sets its own 44px floor under `(pointer: coarse)`: no `size` token
reaches 44px on every theme (base is 36px at `lg`), and this is the one filter
affordance on a touch screen. Same treatment the header funnel trigger already
gets in this file.

## Testing

`lint:strict`, `test`, `build`, and the storybook typecheck stack all pass.

12 new tests in `useTableFiltering.test.tsx` drive both sides of the breakpoint
through a query-aware `matchMedia` stub: the header controls disappear and the
Filter button appears below it, the header keeps its controls above it and
under `sheetBreakpoint: 'none'`, the sheet carries one labelled control per
filterable column, a toggle applies with no Apply step, the count reaches the
trigger's accessible name, Reset clears everything, Done keeps the filters, a
12-value enum keeps its Selector, and a table with no filterable column grows
no button.

Verified in Chromium on an iPhone 15 profile against built `core`, which is
where the two fixes above came from — measured 44px trigger, focus returning to
the trigger on close (a scrim-less sheet never captured it, so closing dropped
focus to the document), Escape closing the sheet, the page behind still
scrollable, the count badge updating while the sheet is open, RTL flipping the
trigger to the left edge, and dark mode. Storybook: **Core/TableFiltering →
Sheet variant (touch)**.
