### PR TITLE
feat(PowerSearchMobile): the touch form of PowerSearch

### DIFF
--- a/.changeset/power-search-mobile.md
+++ b/.changeset/power-search-mobile.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] PowerSearchMobile — the touch form of PowerSearch
+
+Same props, same filter model, same tokens; the typeahead dropdown and the
+row-shaped edit popover are replaced by a pinned-tall bottom sheet that drills
+down field → operator → value. Choosing an enum value commits on one tap, a
+multi-select applies from a pinned footer, and tapping a token reopens that
+filter with Delete available. Pick between the two variants on viewport and the
+call site does not change.
+
+@imdreamrunner

--- a/apps/storybook/stories/PowerSearchMobile.stories.tsx
+++ b/apps/storybook/stories/PowerSearchMobile.stories.tsx
@@ -1,0 +1,318 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import React, {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {PowerSearch, PowerSearchMobile} from '@astryxdesign/core/PowerSearch';
+import type {
+  PowerSearchConfig,
+  PowerSearchFilter,
+} from '@astryxdesign/core/PowerSearch';
+import {useMediaQuery} from '@astryxdesign/core/hooks';
+import {Text} from '@astryxdesign/core/Text';
+import {VStack} from '@astryxdesign/core/Stack';
+
+// =============================================================================
+// Sample data
+// =============================================================================
+
+const statusValues = [
+  {value: 'open', label: 'Open'},
+  {value: 'in_progress', label: 'In Progress'},
+  {value: 'review', label: 'In Review'},
+  {value: 'closed', label: 'Closed'},
+];
+
+const tagValues = [
+  {value: 'bug', label: 'Bug'},
+  {value: 'feature', label: 'Feature'},
+  {value: 'docs', label: 'Documentation'},
+  {value: 'perf', label: 'Performance'},
+  {value: 'security', label: 'Security'},
+];
+
+const issueConfig: PowerSearchConfig = {
+  name: 'IssueSearch',
+  fields: [
+    {
+      key: 'status',
+      label: 'Status',
+      description: 'Where the issue sits in the workflow',
+      operators: [
+        {
+          key: 'is',
+          i18nKey: '@astryx.powersearch.operator.is',
+          value: {type: 'enum', values: statusValues},
+        },
+        {
+          key: 'isNot',
+          i18nKey: '@astryx.powersearch.operator.isNot',
+          value: {type: 'enum', values: statusValues},
+        },
+      ],
+    },
+    {
+      key: 'title',
+      label: 'Title',
+      description: 'Free text anywhere in the issue title',
+      operators: [
+        {
+          key: 'contains',
+          i18nKey: '@astryx.powersearch.operator.contains',
+          value: {type: 'string'},
+        },
+      ],
+    },
+    {
+      key: 'tags',
+      label: 'Tags',
+      group: 'Metadata',
+      operators: [
+        {
+          key: 'isAnyOf',
+          i18nKey: '@astryx.powersearch.operator.isAnyOf',
+          value: {type: 'enum_list', values: tagValues},
+        },
+      ],
+    },
+    {
+      key: 'points',
+      label: 'Story points',
+      group: 'Metadata',
+      operators: [
+        {
+          key: 'greaterThan',
+          i18nKey: '@astryx.powersearch.operator.greaterThan',
+          value: {type: 'integer', minValue: 0, maxValue: 21},
+        },
+      ],
+    },
+    {
+      key: 'created',
+      label: 'Created',
+      group: 'Dates',
+      operators: [
+        {
+          key: 'before',
+          i18nKey: '@astryx.powersearch.operator.before',
+          value: {type: 'date_absolute', isDateOnly: true},
+        },
+        {
+          key: 'after',
+          i18nKey: '@astryx.powersearch.operator.after',
+          value: {type: 'date_absolute', isDateOnly: true},
+        },
+      ],
+    },
+    {
+      key: 'unassigned',
+      label: 'Unassigned',
+      description: 'Nobody has picked it up yet',
+      group: 'Metadata',
+      operators: [
+        {
+          key: 'isTrue',
+          i18nKey: '@astryx.powersearch.operator.isTrue',
+          value: {type: 'empty'},
+        },
+      ],
+    },
+  ],
+};
+
+// A config long enough that the sheet offers a search box over the field list.
+const wideConfig: PowerSearchConfig = {
+  name: 'WideSearch',
+  fields: [
+    ...issueConfig.fields,
+    ...[
+      'Assignee',
+      'Reporter',
+      'Component',
+      'Milestone',
+      'Sprint',
+      'Resolution',
+    ].map(label => ({
+      key: label.toLowerCase(),
+      label,
+      group: 'People and planning',
+      operators: [
+        {
+          key: 'is',
+          i18nKey: '@astryx.powersearch.operator.is',
+          value: {type: 'string'} as const,
+        },
+      ],
+    })),
+  ],
+};
+
+// =============================================================================
+// Meta
+// =============================================================================
+
+const meta: Meta<typeof PowerSearchMobile> = {
+  title: 'Core/PowerSearchMobile',
+  component: PowerSearchMobile,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div style={{width: 390, maxWidth: '100%'}}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    placeholder: {control: 'text'},
+    isDisabled: {control: 'boolean'},
+    isReadOnly: {control: 'boolean'},
+    hasClear: {control: 'boolean'},
+    maxTokenLength: {control: 'number'},
+    popoverSaveButtonLabel: {control: 'text'},
+    size: {control: 'radio', options: ['sm', 'md', 'lg']},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PowerSearchMobile>;
+
+// =============================================================================
+// Stories
+// =============================================================================
+
+export const Default: Story = {
+  render: args => {
+    const [filters, setFilters] = useState<ReadonlyArray<PowerSearchFilter>>(
+      [],
+    );
+    return (
+      <PowerSearchMobile
+        {...args}
+        config={issueConfig}
+        filters={filters}
+        onChange={setFilters}
+      />
+    );
+  },
+};
+
+export const WithFilters: Story = {
+  render: args => {
+    const [filters, setFilters] = useState<ReadonlyArray<PowerSearchFilter>>([
+      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+      {
+        field: 'tags',
+        operator: 'isAnyOf',
+        value: {type: 'enum_list', value: ['bug', 'perf']},
+      },
+    ]);
+    return (
+      <PowerSearchMobile
+        {...args}
+        config={issueConfig}
+        filters={filters}
+        onChange={setFilters}
+        resultCount={filters.length === 0 ? 248 : 31}
+      />
+    );
+  },
+};
+
+/**
+ * Past seven or so fields the sheet adds a search box above the list, pinned
+ * under the title while the list scrolls.
+ */
+export const SearchableFieldList: Story = {
+  render: args => {
+    const [filters, setFilters] = useState<ReadonlyArray<PowerSearchFilter>>(
+      [],
+    );
+    return (
+      <PowerSearchMobile
+        {...args}
+        config={wideConfig}
+        filters={filters}
+        onChange={setFilters}
+      />
+    );
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {isReadOnly: true, isLabelHidden: false, label: 'Applied filters'},
+  render: args => (
+    <PowerSearchMobile
+      {...args}
+      config={issueConfig}
+      filters={[
+        {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+      ]}
+      onChange={() => {}}
+    />
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    isDisabled: true,
+    isLabelHidden: false,
+    label: 'Filters',
+    disabledMessage: 'Pick a project before filtering',
+  },
+  render: args => (
+    <PowerSearchMobile
+      {...args}
+      config={issueConfig}
+      filters={[]}
+      onChange={() => {}}
+    />
+  ),
+};
+
+export const WithStatus: Story = {
+  args: {
+    isLabelHidden: false,
+    label: 'Filters',
+    status: {type: 'error', message: 'Add at least one filter'},
+  },
+  render: args => {
+    const [filters, setFilters] = useState<ReadonlyArray<PowerSearchFilter>>(
+      [],
+    );
+    return (
+      <PowerSearchMobile
+        {...args}
+        config={issueConfig}
+        filters={filters}
+        onChange={setFilters}
+      />
+    );
+  },
+};
+
+/**
+ * The intended production shape: one call site, one viewport check, both
+ * variants fed the same props. Resize the preview across 768px to swap.
+ */
+export const Responsive: Story = {
+  parameters: {controls: {disable: true}},
+  render: () => {
+    const isTouch = useMediaQuery('(max-width: 768px)');
+    const Search = isTouch ? PowerSearchMobile : PowerSearch;
+    const [filters, setFilters] = useState<ReadonlyArray<PowerSearchFilter>>(
+      [],
+    );
+    return (
+      <VStack gap={2}>
+        <Text type="supporting" color="secondary">
+          Rendering {isTouch ? 'PowerSearchMobile' : 'PowerSearch'}
+        </Text>
+        <Search
+          config={issueConfig}
+          filters={filters}
+          onChange={setFilters}
+          resultCount={filters.length === 0 ? 248 : 31}
+        />
+      </VStack>
+    );
+  },
+};

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -767,6 +767,30 @@
     "defaultMessage": "Search…",
     "description": "Grey placeholder text inside the empty PowerSearch input. Imperative verb; trailing `…` is one character."
   },
+  "@astryx.powersearch.mobile.addFilter": {
+    "defaultMessage": "Add filter",
+    "description": "Label on the tap target that opens PowerSearchMobile's filter-builder sheet, and the title of that sheet. Imperative verb; \"filter\" is the noun (one search condition)."
+  },
+  "@astryx.powersearch.mobile.editFilter": {
+    "defaultMessage": "Edit filter",
+    "description": "Title of PowerSearchMobile's editor sheet when reopening a filter the user already added, as opposed to building a new one. Imperative verb."
+  },
+  "@astryx.powersearch.mobile.back": {
+    "defaultMessage": "Back",
+    "description": "Screen-reader-only label on the chevron button that returns to the previous step of PowerSearchMobile's filter-builder sheet. Navigation, not \"rear\"."
+  },
+  "@astryx.powersearch.mobile.searchFields": {
+    "defaultMessage": "Search filters",
+    "description": "Screen-reader-only label for the search box above the field list in PowerSearchMobile's sheet. It narrows the list of filters offered, not the underlying data."
+  },
+  "@astryx.powersearch.mobile.searchFieldsPlaceholder": {
+    "defaultMessage": "Search filters…",
+    "description": "Placeholder inside that same search box. Imperative verb; trailing `…` is one character."
+  },
+  "@astryx.powersearch.mobile.noFields": {
+    "defaultMessage": "No filters match your search",
+    "description": "Empty state shown in PowerSearchMobile's sheet when the typed query matches none of the available filters."
+  },
   "@astryx.resizable.collapsed": {
     "defaultMessage": "Collapsed",
     "description": "aria-valuetext for the Resizable drag handle (role=separator) while its panel is collapsed to zero size. Replaces the numeric value announcement, since the numeric value is clamped to the minimum while collapsed. Adjective describing the panel state, not a verb/command."

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -162,6 +162,13 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-power-search'},
+      // Same directory, same documented CSS surface: the touch variant's tap
+      // target is the class a theme reaches for on phone layouts.
+      {
+        className: 'astryx-power-search-mobile',
+        visualProps: ['size', 'status'],
+        states: ['disabled'],
+      },
     ],
   },
 };

--- a/packages/core/src/PowerSearch/PowerSearchMobile.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearchMobile.doc.mjs
@@ -1,0 +1,481 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
+
+export const docs = {
+  name: 'PowerSearchMobile',
+  displayName: 'Power Search Mobile',
+  category: 'Data Input',
+  keywords: [
+    'powersearch',
+    'mobile',
+    'touch',
+    'search',
+    'filter',
+    'filterbar',
+    'bottomsheet',
+    'faceted',
+    'querybuilder',
+    'responsive',
+  ],
+  props: [
+    {
+      name: 'config',
+      type: 'PowerSearchConfig',
+      description:
+        'Configuration defining available fields, operators, and their value types. Identical to PowerSearch.',
+      required: true,
+    },
+    {
+      name: 'filters',
+      type: 'ReadonlyArray<PowerSearchFilter>',
+      description: 'Currently active filters.',
+      required: true,
+    },
+    {
+      name: 'onChange',
+      type: "(filters: ReadonlyArray<PowerSearchFilter>, changeType: 'add' | 'edit' | 'remove', index: number) => void",
+      description:
+        "Called when filters change. changeType is 'add', 'edit', or 'remove'. index is the affected filter's position.",
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description:
+        'Accessible label for the tap target that opens the filter sheet.',
+      default: "'Search'",
+    },
+    {
+      name: 'isLabelHidden',
+      type: 'boolean',
+      description: 'Visually hides the label while keeping it accessible.',
+      default: 'true',
+    },
+    {
+      name: 'placeholder',
+      type: 'string',
+      description:
+        'Text shown on the tap target while no filters are selected. Once a filter exists the target reads "Add filter" instead.',
+      default: "'Search...'",
+    },
+    {
+      name: 'hasClear',
+      type: 'boolean',
+      description:
+        'Show a clear-all button on the tap target. Read-only filters are left in place.',
+      default: 'true',
+    },
+    {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description:
+        'Prevent adding, editing, or removing filters. The sheet no longer opens and tokens lose their remove buttons.',
+      default: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: 'Disables the entire component.',
+      default: 'false',
+    },
+    {
+      name: 'disabledMessage',
+      type: 'string',
+      description:
+        'Explains why the search is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the tap target focusable via aria-disabled (opening stays blocked). Use this instead of wrapping a disabled PowerSearchMobile in Tooltip. Disabled controls swallow the hover events an external Tooltip needs.',
+    },
+    {
+      name: 'status',
+      type: "{type: 'warning' | 'error' | 'success', message?: string}",
+      description: 'Validation status object with type and optional message.',
+    },
+    {
+      name: 'statusVariant',
+      type: "'attached' | 'detached'",
+      description:
+        'How the status message is placed relative to the tap target. attached overlaps directly below it (bordered treatment); detached floats below as a separate element with spacing.',
+      default: "'attached'",
+    },
+    {
+      name: 'startIcon',
+      type: 'ReactNode | IconType',
+      description:
+        'Icon displayed at the start of the tap target, before any filter tokens. Accepts a semantic icon name, an SVG icon component, or a ReactNode.',
+      slotElements: [{__element: 'Icon', props: {icon: 'search', size: 'sm'}}],
+    },
+    {
+      name: 'maxTokenLength',
+      type: 'number',
+      description: 'Max character length for filter value display in tokens.',
+      default: '40',
+    },
+    {
+      name: 'popoverSaveButtonLabel',
+      type: 'string',
+      description:
+        "Label for the sheet's confirm button. Named for the desktop popover so one call site can feed both variants.",
+      default: "'Apply'",
+    },
+    {
+      name: 'timezoneID',
+      type: 'string',
+      description: 'Timezone ID for date formatting (e.g. "America/New_York").',
+    },
+    {
+      name: 'endContent',
+      type: 'ReactNode',
+      description:
+        'Content displayed at the end of the tap target row, after the result count.',
+      slotElements: [{__element: 'Badge', props: {label: '3'}}],
+    },
+    {
+      name: 'resultCount',
+      type: 'number | string',
+      description:
+        'Number of results matching the current filters. When a number, formatted as "N results". When a string, displayed as-is. Changes are announced to screen readers via a polite live region.',
+    },
+    {
+      name: 'components',
+      type: 'PowerSearchComponents',
+      description:
+        'Per-operator-value-type overrides for token and editor rendering. A Token override replaces the pill on the tap target; an Editor override replaces the whole body of the editor sheet, including its own confirm and cancel controls.',
+    },
+    {
+      name: 'handleRef',
+      type: 'Ref<PowerSearchHandle>',
+      description:
+        'Imperative handle. This variant has no typeahead input, so focusTypeahead() and blurTypeahead() move focus to and from the tap target.',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: 'Size of the tap target and its tokens.',
+      default: "'md'",
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization. Must be a stylex.create() value.',
+    },
+  ],
+  usage: {
+    description:
+      'PowerSearchMobile is the touch-first form of PowerSearch: the same props, filter model, and tokens, with the typeahead dropdown and the row-shaped edit popover replaced by a pinned-tall bottom sheet that drills down field to operator to value. Reach for it on phone layouts, where a popover fights the on-screen keyboard and the editor row has nowhere to go. Choose between the two variants on viewport; do not render both.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Pick between PowerSearch and PowerSearchMobile with one viewport check (useMediaQuery or AppShell) and pass both the same props, so the two stay in step.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give each field a description; it is the second line of the field row, which is where users decide what a filter will do before opening it.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep operator lists short. The first operator is what a field row promises, and every extra one costs a drill-down.',
+      },
+      {
+        guidance: false,
+        description:
+          "Use it for fields whose only operators have a 'nested' value type; nested filter groups have no touch editor, so those fields are left out of the list and a dev warning fires.",
+      },
+      {
+        guidance: false,
+        description:
+          'Render it inside another dialog or bottom sheet. Its sheet is a top-layer dialog of its own and would stack a second modal surface on the first.',
+      },
+    ],
+  },
+  examples: [
+    {
+      label: 'Responsive: one call site, both variants',
+      code: `const isTouch = useMediaQuery('(max-width: 768px)');
+const Search = isTouch ? PowerSearchMobile : PowerSearch;
+
+<Search
+  config={config}
+  filters={filters}
+  onChange={setFilters}
+  resultCount={results.length}
+/>`,
+    },
+    {
+      label: 'Standalone',
+      code: `const [filters, setFilters] = useState([]);
+
+<PowerSearchMobile
+  config={config}
+  filters={filters}
+  onChange={setFilters}
+  placeholder="Filter issues…"
+/>`,
+    },
+  ],
+  theming: {
+    targets: [
+      {
+        className: 'astryx-power-search-mobile',
+        visualProps: ['size', 'status'],
+        states: ['disabled'],
+      },
+      // The desktop variant lives in the same directory and shares this
+      // documented surface.
+      {className: 'astryx-power-search'},
+    ],
+  },
+};
+
+// -------------------------------------------------------
+// Auto-generated translations below. Do not edit manually.
+// Regenerate with the dense compression protocol.
+// See .context/decisions/dense-compression-protocol.md
+// -------------------------------------------------------
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
+export const docsZh = {
+  name: 'PowerSearchMobile',
+  displayName: 'Power Search Mobile',
+  props: [
+    {
+      name: 'config',
+      type: 'PowerSearchConfig',
+      description: '定义可用字段、运算符及其值类型的配置。与 PowerSearch 相同。',
+      required: true,
+    },
+    {
+      name: 'filters',
+      type: 'ReadonlyArray<PowerSearchFilter>',
+      description: '当前活跃的过滤器。',
+      required: true,
+    },
+    {
+      name: 'onChange',
+      type: "(filters: ReadonlyArray<PowerSearchFilter>, changeType: 'add' | 'edit' | 'remove', index: number) => void",
+      description:
+        "当过滤器变更时调用。changeType 为 'add'、'edit' 或 'remove'。index 为受影响的过滤器位置。",
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description: '打开过滤器面板的点击目标的无障碍标签。',
+      default: "'Search'",
+    },
+    {
+      name: 'isLabelHidden',
+      type: 'boolean',
+      description: '视觉上隐藏标签，同时保持无障碍性。',
+      default: 'true',
+    },
+    {
+      name: 'placeholder',
+      type: 'string',
+      description:
+        '未选择过滤器时点击目标上显示的文本。存在过滤器后，目标改为显示"Add filter"。',
+      default: "'Search...'",
+    },
+    {
+      name: 'hasClear',
+      type: 'boolean',
+      description: '在点击目标上显示清除全部按钮。只读过滤器会被保留。',
+      default: 'true',
+    },
+    {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description:
+        '阻止添加、编辑或移除过滤器。面板不再打开，标记也不再显示移除按钮。',
+      default: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: '禁用整个组件。',
+      default: 'false',
+    },
+    {
+      name: 'disabledMessage',
+      type: 'string',
+      description:
+        'Explains why the search is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the tap target focusable via aria-disabled (opening stays blocked). Use this instead of wrapping a disabled PowerSearchMobile in Tooltip. Disabled controls swallow the hover events an external Tooltip needs.',
+    },
+    {
+      name: 'status',
+      type: "{type: 'warning' | 'error' | 'success', message?: string}",
+      description: '带有类型和可选消息的验证状态对象。',
+    },
+    {
+      name: 'statusVariant',
+      type: "'attached' | 'detached'",
+      description:
+        '状态消息相对于点击目标的放置方式。attached 直接叠加在其下方（带边框处理）；detached 作为独立元素浮于下方并留有间距。',
+      default: "'attached'",
+    },
+    {
+      name: 'startIcon',
+      type: 'ReactNode | IconType',
+      description:
+        '在点击目标开头（筛选 token 之前）显示的图标。接受语义图标名称、SVG 图标组件或 ReactNode。',
+    },
+    {
+      name: 'maxTokenLength',
+      type: 'number',
+      description: '令牌中过滤器值显示的最大字符长度。',
+      default: '40',
+    },
+    {
+      name: 'popoverSaveButtonLabel',
+      type: 'string',
+      description:
+        '面板确认按钮的标签。沿用桌面端弹出层的命名，便于同一处调用同时驱动两个变体。',
+      default: "'Apply'",
+    },
+    {
+      name: 'timezoneID',
+      type: 'string',
+      description: '用于日期格式化的时区 ID（例如 "America/New_York"）。',
+    },
+    {
+      name: 'endContent',
+      type: 'ReactNode',
+      description: '显示在点击目标行末尾、结果数量之后的内容。',
+    },
+    {
+      name: 'resultCount',
+      type: 'number | string',
+      description:
+        '匹配当前过滤器的结果数量。数字类型时格式化为"N results"。字符串类型时按原样显示。数量变化会通过 polite 实时区域向屏幕阅读器播报。',
+    },
+    {
+      name: 'components',
+      type: 'PowerSearchComponents',
+      description:
+        '按运算符值类型覆盖标记与编辑器的渲染。Token 覆盖替换点击目标上的标记；Editor 覆盖替换编辑器面板的整个主体，包括其自身的确认与取消控件。',
+    },
+    {
+      name: 'handleRef',
+      type: 'Ref<PowerSearchHandle>',
+      description:
+        '命令式句柄。此变体没有 typeahead 输入框，因此 focusTypeahead() 与 blurTypeahead() 将焦点移入或移出点击目标。',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: '点击目标及其标记的尺寸。',
+      default: "'md'",
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description: '用于布局自定义的 StyleX 样式。必须是 stylex.create() 值。',
+    },
+  ],
+  usage: {
+    description:
+      'PowerSearchMobile is the touch-first form of PowerSearch: the same props, filter model, and tokens, with the typeahead dropdown and the row-shaped edit popover replaced by a pinned-tall bottom sheet that drills down field to operator to value. Reach for it on phone layouts, where a popover fights the on-screen keyboard and the editor row has nowhere to go. Choose between the two variants on viewport; do not render both.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Pick between PowerSearch and PowerSearchMobile with one viewport check (useMediaQuery or AppShell) and pass both the same props, so the two stay in step.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give each field a description; it is the second line of the field row, which is where users decide what a filter will do before opening it.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep operator lists short. The first operator is what a field row promises, and every extra one costs a drill-down.',
+      },
+      {
+        guidance: false,
+        description:
+          "Use it for fields whose only operators have a 'nested' value type; nested filter groups have no touch editor, so those fields are left out of the list and a dev warning fires.",
+      },
+      {
+        guidance: false,
+        description:
+          'Render it inside another dialog or bottom sheet. Its sheet is a top-layer dialog of its own and would stack a second modal surface on the first.',
+      },
+    ],
+  },
+};
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
+export const docsDense = {
+  description:
+    'Touch-first PowerSearch. Same props/filter model/tokens; typeahead dropdown + row-shaped edit popover replaced by pinned-tall BottomSheet drilling field -> operator -> value. Tap target shows tokens; tap token to edit.',
+  usage: {
+    description:
+      'PowerSearchMobile is the touch-first form of PowerSearch: the same props, filter model, and tokens, with the typeahead dropdown and the row-shaped edit popover replaced by a pinned-tall bottom sheet that drills down field to operator to value. Reach for it on phone layouts, where a popover fights the on-screen keyboard and the editor row has nowhere to go. Choose between the two variants on viewport; do not render both.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Pick between PowerSearch and PowerSearchMobile with one viewport check (useMediaQuery or AppShell) and pass both the same props, so the two stay in step.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give each field a description; it is the second line of the field row, which is where users decide what a filter will do before opening it.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep operator lists short. The first operator is what a field row promises, and every extra one costs a drill-down.',
+      },
+      {
+        guidance: false,
+        description:
+          "Use it for fields whose only operators have a 'nested' value type; nested filter groups have no touch editor, so those fields are left out of the list and a dev warning fires.",
+      },
+      {
+        guidance: false,
+        description:
+          'Render it inside another dialog or bottom sheet. Its sheet is a top-layer dialog of its own and would stack a second modal surface on the first.',
+      },
+    ],
+  },
+  propDescriptions: {
+    config:
+      'Config defining available fields, operators, value types. Same as PowerSearch.',
+    filters: 'Currently active filters.',
+    onChange:
+      "Called on filter change. changeType is 'add', 'edit', or 'remove'. index is affected filter position.",
+    label: 'Accessible label for tap target that opens filter sheet.',
+    isLabelHidden: 'Visually hides label while keeping accessible.',
+    placeholder:
+      'Text on tap target while no filters selected. With filters, target reads "Add filter".',
+    hasClear: 'Show clear-all button on tap target. Read-only filters kept.',
+    isReadOnly:
+      'Prevent add/edit/remove. Sheet no longer opens; tokens lose remove buttons.',
+    isDisabled: 'Disables entire component.',
+    disabledMessage:
+      'Why search is disabled. Tooltip on hover/focus; tap target stays focusable via aria-disabled.',
+    status: 'Validation status object w/ type + optional message.',
+    statusVariant:
+      'How status message is placed: attached overlaps below tap target; detached floats below w/ spacing.',
+    startIcon: 'Icon at tap-target start, before filter tokens.',
+    maxTokenLength: 'Max char length for filter value display in tokens.',
+    popoverSaveButtonLabel:
+      "Label for sheet's confirm button. Named for desktop popover so one call site feeds both variants.",
+    timezoneID: 'Timezone ID for date formatting (e.g. "America/New_York").',
+    endContent: 'Content at end of tap-target row, after result count.',
+    resultCount:
+      'Result count matching current filters. Number formatted as "N results"; string displayed as-is.',
+    components:
+      'Per-type Token/Editor overrides. Token replaces the pill; Editor replaces the whole editor-sheet body incl. its own confirm/cancel.',
+    handleRef:
+      'Imperative handle. No typeahead input here, so focusTypeahead()/blurTypeahead() move focus to/from the tap target.',
+    size: 'Tap target + token size.',
+    xstyle:
+      'StyleX styles for layout customization. Must be stylex.create() value.',
+  },
+};

--- a/packages/core/src/PowerSearch/PowerSearchMobile.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchMobile.test.tsx
@@ -1,0 +1,445 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file PowerSearchMobile.test.tsx
+ * @input Uses vitest, @testing-library/react, PowerSearchMobile component
+ * @output Unit tests for the touch filter-builder flow
+ * @position Core testing; validates PowerSearchMobile.tsx implementation
+ *
+ * SYNC: When PowerSearchMobile.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, fireEvent, within} from '@testing-library/react';
+import {createRef} from 'react';
+import {PowerSearchMobile} from './PowerSearchMobile';
+import type {
+  PowerSearchConfig,
+  PowerSearchFilter,
+  PowerSearchHandle,
+} from './types';
+
+// jsdom implements neither <dialog> open/close nor pointer capture; the sheet
+// needs both. Same stubs BottomSheet's own tests install.
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  }
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }),
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  window.scrollTo = vi.fn();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const STATUS_VALUES = [
+  {value: 'open', label: 'Open'},
+  {value: 'closed', label: 'Closed'},
+];
+
+const config: PowerSearchConfig = {
+  name: 'Issues',
+  fields: [
+    {
+      key: 'status',
+      label: 'Status',
+      description: 'Workflow state',
+      operators: [
+        {key: 'is', label: 'is', value: {type: 'enum', values: STATUS_VALUES}},
+        {
+          key: 'isNot',
+          label: 'is not',
+          value: {type: 'enum', values: STATUS_VALUES},
+        },
+      ],
+    },
+    {
+      key: 'author',
+      label: 'Author',
+      operators: [{key: 'is', label: 'is', value: {type: 'string'}}],
+    },
+    {
+      key: 'labels',
+      label: 'Labels',
+      group: 'Metadata',
+      operators: [
+        {
+          key: 'isAnyOf',
+          label: 'is any of',
+          value: {
+            type: 'enum_list',
+            values: [
+              {value: 'bug', label: 'Bug'},
+              {value: 'urgent', label: 'Urgent'},
+            ],
+          },
+        },
+      ],
+    },
+    {
+      key: 'unassigned',
+      label: 'Unassigned',
+      operators: [{key: 'isTrue', label: 'is true', value: {type: 'empty'}}],
+    },
+  ],
+};
+
+const openFilter: PowerSearchFilter = {
+  field: 'status',
+  operator: 'is',
+  value: {type: 'enum', value: 'open'},
+};
+
+function setup(
+  props: Partial<React.ComponentProps<typeof PowerSearchMobile>> = {},
+) {
+  const onChange = vi.fn();
+  const result = render(
+    <PowerSearchMobile
+      config={config}
+      filters={[]}
+      onChange={onChange}
+      {...props}
+    />,
+  );
+  return {onChange, ...result};
+}
+
+function openSheet(): void {
+  fireEvent.click(
+    document.querySelector<HTMLElement>('[aria-haspopup="dialog"]')!,
+  );
+}
+
+/** The sheet the switcher is currently showing. */
+/**
+ * Whether the flow is open. The dialog element outlives a close by an exit
+ * transition that jsdom never fires, so the sheet's own state is read from the
+ * tap target's aria-expanded instead of the element's presence.
+ */
+function isSheetOpen(): boolean {
+  return (
+    document
+      .querySelector('[aria-haspopup="dialog"]')
+      ?.getAttribute('aria-expanded') === 'true'
+  );
+}
+
+function sheet(): HTMLElement {
+  const dialog = document.querySelector<HTMLElement>('dialog[open]');
+  if (!dialog) {
+    throw new Error('no open sheet');
+  }
+  return dialog;
+}
+
+function tapRow(name: RegExp | string): void {
+  const matches = within(sheet()).getAllByRole('button', {name});
+  // The switcher keeps the outgoing sheet mounted while the incoming one
+  // enters; the last match is always on the sheet that just arrived.
+  fireEvent.click(matches[matches.length - 1]);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('PowerSearchMobile', () => {
+  it('names the group with the label and the tap target with its own text', () => {
+    setup({label: 'Filter issues'});
+    expect(screen.getByRole('group', {name: 'Filter issues'})).toBeTruthy();
+    // The visible text is the accessible name — a <label> pointed at the
+    // button would silently replace it (WCAG 2.5.3).
+    expect(screen.getByRole('button', {name: 'Search…'})).toBeTruthy();
+  });
+
+  it('reads "Add filter" once a filter exists', () => {
+    setup({filters: [openFilter]});
+    expect(screen.getByRole('button', {name: 'Add filter'})).toBeTruthy();
+  });
+
+  it('lists the fields, grouped, when the tap target is pressed', () => {
+    setup();
+    openSheet();
+    const rows = within(sheet()).getAllByRole('button');
+    const labels = rows.map(r => r.textContent);
+    expect(labels.some(l => l?.includes('Status'))).toBe(true);
+    expect(labels.some(l => l?.includes('Author'))).toBe(true);
+    expect(within(sheet()).getByRole('list', {name: 'Metadata'})).toBeTruthy();
+  });
+
+  it('shows the default operator under each field name', () => {
+    setup();
+    openSheet();
+    expect(
+      within(sheet()).getByRole('button', {name: /Author\s*is/}),
+    ).toBeTruthy();
+  });
+
+  it('adds an enum filter on a single tap of the value', () => {
+    const {onChange} = setup();
+    openSheet();
+    tapRow(/^Status/);
+    tapRow('Closed');
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        {
+          field: 'status',
+          operator: 'is',
+          value: {type: 'enum', value: 'closed'},
+        },
+      ],
+      'add',
+      0,
+    );
+  });
+
+  it('closes the sheet once a filter is committed', () => {
+    setup();
+    openSheet();
+    tapRow(/^Status/);
+    tapRow('Closed');
+    expect(isSheetOpen()).toBe(false);
+  });
+
+  it('commits an empty-value operator without a value step', () => {
+    const {onChange} = setup();
+    openSheet();
+    tapRow(/^Unassigned/);
+    expect(onChange).toHaveBeenCalledWith(
+      [{field: 'unassigned', operator: 'isTrue', value: {type: 'empty'}}],
+      'add',
+      0,
+    );
+    expect(isSheetOpen()).toBe(false);
+  });
+
+  it('drills into a second operator and uses it for the filter', () => {
+    const {onChange} = setup();
+    openSheet();
+    tapRow(/^Status/);
+    tapRow(/^Operator/);
+    tapRow('is not');
+    tapRow('Open');
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        {
+          field: 'status',
+          operator: 'isNot',
+          value: {type: 'enum', value: 'open'},
+        },
+      ],
+      'add',
+      0,
+    );
+  });
+
+  it('offers no operator row when the field defines one operator', () => {
+    setup();
+    openSheet();
+    tapRow(/^Author/);
+    expect(
+      within(sheet()).queryByRole('button', {name: /^Operator/}),
+    ).toBeNull();
+  });
+
+  it('stages a multi-select and commits it from the footer', () => {
+    const {onChange} = setup();
+    openSheet();
+    tapRow(/^Labels/);
+    fireEvent.click(within(sheet()).getByRole('checkbox', {name: 'Bug'}));
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.click(within(sheet()).getByRole('checkbox', {name: 'Urgent'}));
+    fireEvent.click(within(sheet()).getByRole('button', {name: 'Apply'}));
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        {
+          field: 'labels',
+          operator: 'isAnyOf',
+          value: {type: 'enum_list', value: ['bug', 'urgent']},
+        },
+      ],
+      'add',
+      0,
+    );
+  });
+
+  it('keeps Apply disabled until a value is chosen', () => {
+    setup();
+    openSheet();
+    tapRow(/^Author/);
+    const apply = within(sheet()).getByRole('button', {name: 'Apply'});
+    expect(
+      apply.getAttribute('aria-disabled') ?? apply.hasAttribute('disabled'),
+    ).toBeTruthy();
+  });
+
+  it('opens a token in edit mode and replaces the filter in place', () => {
+    const {onChange} = setup({filters: [openFilter]});
+    fireEvent.click(screen.getByRole('button', {name: 'Status: is'}));
+    expect(within(sheet()).getByText('Edit filter')).toBeTruthy();
+    tapRow('Closed');
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        {
+          field: 'status',
+          operator: 'is',
+          value: {type: 'enum', value: 'closed'},
+        },
+      ],
+      'edit',
+      0,
+    );
+  });
+
+  it('deletes the edited filter from the sheet footer', () => {
+    const {onChange} = setup({filters: [openFilter]});
+    fireEvent.click(screen.getByRole('button', {name: 'Status: is'}));
+    fireEvent.click(within(sheet()).getByRole('button', {name: 'Delete'}));
+    expect(onChange).toHaveBeenCalledWith([], 'remove', 0);
+  });
+
+  it("removes a filter from its token's remove button", () => {
+    const {onChange} = setup({filters: [openFilter]});
+    fireEvent.click(screen.getByRole('button', {name: /^Remove/}));
+    expect(onChange).toHaveBeenCalledWith([], 'remove', 0);
+  });
+
+  it('clears every removable filter but keeps the read-only ones', () => {
+    const pinned: PowerSearchFilter = {...openFilter, isReadOnly: true};
+    const {onChange} = setup({
+      filters: [
+        pinned,
+        {
+          field: 'author',
+          operator: 'is',
+          value: {type: 'string', value: 'ada'},
+        },
+      ],
+    });
+    fireEvent.click(screen.getByRole('button', {name: 'Clear all'}));
+    expect(onChange).toHaveBeenCalledWith([pinned], 'remove', 1);
+  });
+
+  it('does not open, remove, or clear when read-only', () => {
+    const {onChange} = setup({filters: [openFilter], isReadOnly: true});
+    expect(screen.queryByRole('button', {name: /^Remove/})).toBeNull();
+    expect(screen.queryByRole('button', {name: 'Clear all'})).toBeNull();
+    openSheet();
+    expect(isSheetOpen()).toBe(false);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not open when disabled', () => {
+    setup({isDisabled: true});
+    openSheet();
+    expect(isSheetOpen()).toBe(false);
+  });
+
+  it('keeps the tap target focusable when a disabled reason is given', () => {
+    setup({isDisabled: true, disabledMessage: 'Pick a project first'});
+    const button = document.querySelector<HTMLElement>(
+      '[aria-haspopup="dialog"]',
+    )!;
+    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('searches the field list once there are enough fields to need it', () => {
+    const many: PowerSearchConfig = {
+      name: 'Many',
+      fields: Array.from({length: 10}, (_, i) => ({
+        key: `f${i}`,
+        label: `Field ${i}`,
+        operators: [{key: 'is', label: 'is', value: {type: 'string'} as const}],
+      })),
+    };
+    setup({config: many});
+    openSheet();
+    const search = within(sheet()).getByRole('textbox', {
+      name: 'Search filters',
+    });
+    fireEvent.change(search, {target: {value: 'Field 7'}});
+    expect(within(sheet()).getByRole('button', {name: /Field 7/})).toBeTruthy();
+    expect(within(sheet()).queryByRole('button', {name: /Field 3/})).toBeNull();
+    fireEvent.change(search, {target: {value: 'nope'}});
+    expect(
+      within(sheet()).getByText('No filters match your search'),
+    ).toBeTruthy();
+  });
+
+  it('offers no field search for a short list', () => {
+    setup();
+    openSheet();
+    expect(within(sheet()).queryByRole('textbox')).toBeNull();
+  });
+
+  it('leaves out fields it cannot edit and warns the developer', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const withNested: PowerSearchConfig = {
+      name: 'Nested',
+      fields: [
+        ...config.fields,
+        {
+          key: 'group',
+          label: 'Group',
+          operators: [{key: 'all', label: 'all of', value: {type: 'nested'}}],
+        },
+      ],
+    };
+    setup({config: withNested});
+    openSheet();
+    expect(within(sheet()).queryByRole('button', {name: /^Group/})).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('PowerSearchMobile: 1 field(s) were left out'),
+    );
+    warn.mockRestore();
+  });
+
+  it('moves focus to the tap target through the imperative handle', () => {
+    const handle = createRef<PowerSearchHandle>();
+    setup({handleRef: handle});
+    handle.current?.focusTypeahead();
+    expect(document.activeElement).toBe(
+      document.querySelector('[aria-haspopup="dialog"]'),
+    );
+  });
+
+  it('renders the result count and announces a change to it', () => {
+    const {rerender} = setup({resultCount: 12});
+    expect(screen.getByText('12 results')).toBeTruthy();
+    rerender(
+      <PowerSearchMobile
+        config={config}
+        filters={[]}
+        onChange={vi.fn()}
+        resultCount={3}
+      />,
+    );
+    expect(screen.getByText('3 results')).toBeTruthy();
+  });
+});

--- a/packages/core/src/PowerSearch/PowerSearchMobile.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchMobile.tsx
@@ -1,0 +1,1098 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file PowerSearchMobile.tsx
+ * @input PowerSearchConfig, filters, onChange — the PowerSearch props, unchanged
+ * @output Touch-first structured filter bar: a tap target plus a bottom-sheet
+ *   filter builder
+ * @position Sibling of PowerSearch; a drop-in replacement on touch layouts
+ *
+ * PowerSearch's desktop shape is a typeahead that drops a popover under the
+ * field, and an edit popover that lays field / operator / value out in a row.
+ * Neither survives a phone: the popover fights the on-screen keyboard, and the
+ * row has nowhere to go at 390px. This variant keeps the same props, the same
+ * filter model, and the same tokens, and moves the building into a bottom sheet
+ * that drills down field -> (operator) -> value.
+ *
+ * The sheets are pinned tall on purpose. The field list resizes as it is
+ * searched and the editor's content changes with the operator, so a sheet that
+ * sized itself to its content would jump on every keystroke and every step.
+ * A tall sheet is also the only height that gives mobile-keyboard
+ * accommodation, which the text and number value editors need.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/PowerSearch/index.ts
+ * - /packages/core/src/PowerSearch/PowerSearchMobile.doc.mjs
+ * - /apps/storybook/stories/PowerSearchMobile.stories.tsx
+ * - /packages/cli/assets/templates/blocks/components/PowerSearch/ (showcase blocks)
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {BottomSheet, BottomSheetSwitcher} from '../BottomSheet';
+import {Button} from '../Button';
+import {
+  Field,
+  InputClearButton,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
+import {Heading} from '../Heading';
+import {Icon, renderIconSlot} from '../Icon';
+import {List, ListItem} from '../List';
+import {Text} from '../Text';
+import {TextInput} from '../TextInput';
+import {useSize} from '../SizeContext/SizeContext';
+import {useAnnounce} from '../hooks/useAnnounce';
+import {useDevWarning} from '../hooks/useDevWarning';
+import {useTooltip} from '../Tooltip';
+import {useTranslator} from '../i18n';
+import {
+  borderVars,
+  colorVars,
+  sizeVars,
+  spacingVars,
+  typeScaleVars,
+  typographyVars,
+} from '../theme/tokens.stylex';
+import {isRenderable, mergeProps, mergeRefs} from '../utils';
+import {themeProps} from '../utils/themeProps';
+import {PowerSearchMobileValueEditor} from './PowerSearchMobileValueEditor';
+import {PowerSearchToken} from './PowerSearchToken';
+import {resolveOperatorLabel} from './resolveOperatorLabel';
+import {useInternalConfig} from './useInternalConfig';
+import type {PowerSearchProps} from './PowerSearch';
+import type {
+  FilterValue,
+  PowerSearchField,
+  PowerSearchFilter,
+  PowerSearchOperator,
+} from './types';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+/**
+ * PowerSearchMobile takes the same props as PowerSearch so the two can be
+ * swapped behind one responsive branch without rewriting the call site.
+ *
+ * Four props describe desktop-only affordances and are inert here, because the
+ * surfaces they configure do not exist on this variant: `hasAutoFocus` (the
+ * sheet is never auto-opened), `menuWidth` and `maxOperatorMenuItems` (the
+ * dropdown menus are lists in a sheet), and `tokenOverflowBehavior` (tokens
+ * wrap in the tap target rather than collapsing into a "+N more").
+ */
+export type PowerSearchMobileProps = PowerSearchProps;
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const sizeStyles = stylex.create({
+  sm: {minHeight: sizeVars['--size-element-sm']},
+  md: {minHeight: sizeVars['--size-element-md']},
+  lg: {minHeight: sizeVars['--size-element-lg']},
+});
+
+const styles = stylex.create({
+  // Mirrors Tokenizer's wrapper so the tap target is visually the same field
+  // the desktop variant renders, down to the concentric token inset.
+  wrapper: {
+    position: 'relative',
+    flexWrap: 'wrap',
+    gap: spacingVars['--spacing-1'],
+    cursor: 'pointer',
+    height: 'auto',
+  },
+  wrapperWithTokens: {
+    paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
+    paddingInline: `calc(${spacingVars['--spacing-1']} - 1px)`,
+    rowGap: `calc(${spacingVars['--spacing-1']} - 1px)`,
+  },
+  startIconWithTokens: {
+    marginInlineStart: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
+  },
+  // The trigger grows to fill the row so the field's empty space is the tap
+  // target, not dead pixels next to one.
+  trigger: {
+    appearance: 'none',
+    flexGrow: 1,
+    flexBasis: 0,
+    minWidth: sizeVars['--size-element-lg'],
+    display: 'flex',
+    alignItems: 'center',
+    minHeight: sizeVars['--size-element-sm'],
+    paddingBlock: 0,
+    paddingInline: spacingVars['--spacing-1'],
+    margin: 0,
+    borderWidth: 0,
+    borderRadius: 'var(--_field-radius)',
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-family-body'],
+    // Matches the text size the desktop field's input renders at, including
+    // its coarse-pointer floor, so swapping variants does not resize the
+    // placeholder.
+    fontSize: {
+      default: typeScaleVars['--text-body-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-body-size']})`,
+    },
+    lineHeight: typeScaleVars['--text-body-leading'],
+    textAlign: 'start',
+    cursor: {default: 'pointer', ':disabled': 'not-allowed'},
+    outline: 'none',
+  },
+  triggerReadOnly: {
+    cursor: 'default',
+  },
+  endSection: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    flexShrink: 0,
+    paddingInlineEnd: spacingVars['--spacing-1'],
+  },
+  resultCount: {
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    color: colorVars['--color-text-secondary'],
+    whiteSpace: 'nowrap',
+  },
+  // --- sheet shell ---------------------------------------------------------
+  sheet: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100%',
+  },
+  header: {
+    position: 'sticky',
+    insetBlockStart: 0,
+    // Deliberately 0, not a higher layer: the sheet's grab handle is an
+    // absolutely positioned sibling at z-index 1, and anything above that
+    // paints the pill out. 0 still lifts the header over the in-flow rows
+    // scrolling beneath it.
+    zIndex: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-3'],
+    // Clears the sheet's floating grab handle, which occupies the top 24px.
+    paddingBlockStart: spacingVars['--spacing-6'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-background-surface'],
+  },
+  headerRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+  },
+  headerText: {
+    minWidth: 0,
+    flexGrow: 1,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  body: {
+    flexGrow: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    // Separates the operator row from the value control below it, so the two
+    // read as different questions rather than one long list.
+    gap: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-4'],
+  },
+  footer: {
+    position: 'sticky',
+    insetBlockEnd: 0,
+    zIndex: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-4'],
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
+    backgroundColor: colorVars['--color-background-surface'],
+  },
+  footerActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    marginInlineStart: 'auto',
+  },
+  // Alone in the footer, the confirm button takes the whole row — the reach
+  // target a thumb expects at the bottom of a sheet.
+  footerSoleAction: {
+    flexGrow: 1,
+  },
+  // Rows run edge to edge inside the sheet's padded body.
+  flushList: {
+    marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
+  },
+  empty: {
+    paddingBlock: spacingVars['--spacing-6'],
+    textAlign: 'center',
+  },
+});
+
+// =============================================================================
+// Draft state
+// =============================================================================
+
+type SheetStep = 'fields' | 'operator' | 'value';
+
+interface FilterDraft {
+  readonly mode: 'create' | 'edit';
+  /** Index in `filters` — edit mode only. */
+  readonly filterIndex?: number;
+  readonly field: string;
+  readonly operator?: string;
+  readonly value?: FilterValue;
+}
+
+/** Operators the mobile editor can render. */
+function isSupportedOperator(operator: PowerSearchOperator): boolean {
+  // Nested filter groups are a desktop-density affordance: the desktop editor
+  // gives them a dedicated recursive row layout that has no touch equivalent
+  // yet, and the shared value editor renders nothing for them. Offering the
+  // field and then showing a blank sheet is worse than leaving it out.
+  return operator.value.type !== 'nested';
+}
+
+function matchesQuery(field: PowerSearchField, query: string): boolean {
+  if (query === '') {
+    return true;
+  }
+  if (field.label.toLowerCase().includes(query)) {
+    return true;
+  }
+  return (
+    field.typeaheadAliases?.some(alias =>
+      alias.toLowerCase().includes(query),
+    ) ?? false
+  );
+}
+
+// Below this many fields a search box is noise: the whole list is already on
+// screen. It is the same threshold CheckboxList uses to send a long list to
+// MultiSelector.
+const SEARCHABLE_FIELD_COUNT = 8;
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Touch-first PowerSearch: a tap target that shows the active filters as
+ * tokens, and a bottom sheet that builds one filter at a time.
+ *
+ * Same props, same `PowerSearchFilter` model and same tokens as
+ * {@link PowerSearch} — pick between them on viewport, and the call site does
+ * not change:
+ *
+ * @example
+ * ```
+ * const isTouch = useMediaQuery('(max-width: 768px)');
+ * const Search = isTouch ? PowerSearchMobile : PowerSearch;
+ * <Search config={config} filters={filters} onChange={setFilters} />
+ * ```
+ *
+ * Tapping the field opens a pinned-tall sheet listing the available fields.
+ * Choosing one opens its value editor; a field with more than one operator
+ * shows the operator as a row that drills into its own list. Tapping a token
+ * reopens that filter's editor, where Delete removes it.
+ */
+export function PowerSearchMobile({
+  config: configProp,
+  filters,
+  onChange,
+  label: labelFromProps,
+  isLabelHidden = true,
+  placeholder: placeholderFromProps,
+  hasClear = true,
+  isReadOnly = false,
+  isDisabled = false,
+  disabledMessage,
+  startIcon,
+  onFocus,
+  onBlur,
+  status,
+  statusVariant = 'attached',
+  maxTokenLength = 40,
+  popoverSaveButtonLabel: saveButtonLabelFromProps,
+  timezoneID,
+  endContent,
+  resultCount,
+  ref,
+  handleRef,
+  size: sizeProp,
+  'data-testid': testId,
+  xstyle,
+  className,
+  style,
+  components: componentOverrides,
+}: PowerSearchMobileProps) {
+  const size = useSize(sizeProp, 'md');
+  const config = useInternalConfig(configProp);
+  const t = useTranslator();
+
+  const label = labelFromProps ?? t('@astryx.powersearch.label');
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.powersearch.placeholder');
+  const saveButtonLabel =
+    saveButtonLabelFromProps ?? t('@astryx.powersearch.editor.apply');
+  const addFilterLabel = t('@astryx.powersearch.mobile.addFilter');
+
+  const triggerId = useId();
+  const labelId = useId();
+  const statusMessageId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const [step, setStep] = useState<SheetStep | null>(null);
+  // The draft outlives a step change on purpose: the switcher keeps the
+  // outgoing sheet mounted while the incoming one enters, and clearing the
+  // draft with the step would blank that sheet mid-transition.
+  const [draft, setDraft] = useState<FilterDraft | null>(null);
+  const [fieldQuery, setFieldQuery] = useState('');
+
+  const isInteractive = !isDisabled && !isReadOnly;
+
+  // ---------------------------------------------------------------- fields --
+
+  const fields = useMemo(
+    () =>
+      config
+        .getVisibleFields()
+        .filter(field => field.operators.some(isSupportedOperator)),
+    [config],
+  );
+
+  const droppedFieldCount = config.getVisibleFields().length - fields.length;
+  useDevWarning(
+    'PowerSearchMobile',
+    `${droppedFieldCount} field(s) were left out of the filter list because every operator they define has a 'nested' value type, which this variant cannot edit. Give those fields a non-nested operator, or render PowerSearch instead on touch layouts.`,
+    droppedFieldCount > 0,
+  );
+
+  const normalizedQuery = fieldQuery.trim().toLowerCase();
+  const matchingFields = useMemo(
+    () => fields.filter(field => matchesQuery(field, normalizedQuery)),
+    [fields, normalizedQuery],
+  );
+
+  const groupedFields = useMemo(() => {
+    const groups = new Map<string, PowerSearchField[]>();
+    for (const field of matchingFields) {
+      const key = field.group ?? '';
+      const existing = groups.get(key);
+      if (existing) {
+        existing.push(field);
+      } else {
+        groups.set(key, [field]);
+      }
+    }
+    return [...groups.entries()];
+  }, [matchingFields]);
+
+  const isFieldSearchShown = fields.length >= SEARCHABLE_FIELD_COUNT;
+
+  // ----------------------------------------------------------------- draft --
+
+  const draftField = draft ? config.getField(draft.field) : undefined;
+  const draftOperator =
+    draft?.operator != null
+      ? config.getOperator(draft.field, draft.operator)
+      : undefined;
+  const draftOperators = useMemo(
+    () =>
+      draft
+        ? config.getVisibleOperators(draft.field).filter(isSupportedOperator)
+        : [],
+    [config, draft],
+  );
+
+  const closeSheet = useCallback(() => {
+    setStep(null);
+  }, []);
+
+  const openFieldList = useCallback(() => {
+    if (!isInteractive) {
+      return;
+    }
+    setFieldQuery('');
+    setStep('fields');
+  }, [isInteractive]);
+
+  const commitFilter = useCallback(
+    (next: FilterDraft, value: FilterValue) => {
+      if (next.operator == null) {
+        return;
+      }
+      const filter: PowerSearchFilter = {
+        field: next.field,
+        operator: next.operator,
+        value,
+      };
+      if (next.mode === 'edit' && next.filterIndex != null) {
+        const updated = [...filters];
+        updated[next.filterIndex] = filter;
+        onChange(updated, 'edit', next.filterIndex);
+      } else {
+        onChange([...filters, filter], 'add', filters.length);
+      }
+      closeSheet();
+    },
+    [filters, onChange, closeSheet],
+  );
+
+  // Choosing a field opens its editor. An `empty` operator (`is unassigned`)
+  // has nothing to edit, so it lands as a filter straight away — the same
+  // shortcut the desktop tokenizer takes.
+  const handleFieldSelect = useCallback(
+    (field: PowerSearchField) => {
+      const operators = field.operators.filter(isSupportedOperator);
+      const preferred = config.getDefaultOperator(field.key);
+      const operator =
+        preferred && isSupportedOperator(preferred) ? preferred : operators[0];
+      if (operator == null) {
+        return;
+      }
+      const next: FilterDraft = {
+        mode: 'create',
+        field: field.key,
+        operator: operator.key,
+      };
+      if (operator.value.type === 'empty') {
+        setDraft(next);
+        commitFilter(next, {type: 'empty'});
+        return;
+      }
+      setDraft(next);
+      setStep('value');
+    },
+    [config, commitFilter],
+  );
+
+  const handleTokenClick = useCallback(
+    (index: number) => {
+      if (!isInteractive) {
+        return;
+      }
+      const filter = filters[index];
+      if (filter.isReadOnly) {
+        return;
+      }
+      setDraft({
+        mode: 'edit',
+        filterIndex: index,
+        field: filter.field,
+        operator: filter.operator,
+        value: filter.value,
+      });
+      setStep('value');
+    },
+    [filters, isInteractive],
+  );
+
+  const handleRemoveFilter = useCallback(
+    (index: number) => {
+      onChange(
+        filters.filter((_, i) => i !== index),
+        'remove',
+        index,
+      );
+    },
+    [filters, onChange],
+  );
+
+  const handleClearAll = useCallback(() => {
+    // Read-only filters are the consumer's, not the user's, so a clear-all
+    // leaves them in place — matching the desktop token, which has no remove.
+    const kept = filters.filter(filter => filter.isReadOnly);
+    if (kept.length === filters.length) {
+      return;
+    }
+    onChange(kept, 'remove', kept.length);
+  }, [filters, onChange]);
+
+  const handleOperatorSelect = useCallback((operator: PowerSearchOperator) => {
+    setDraft(current => {
+      if (current == null) {
+        return current;
+      }
+      // A value only survives an operator change when the new operator reads
+      // the same value type; otherwise the editor would be handed a value it
+      // cannot render.
+      const keepsValue =
+        current.value != null && current.value.type === operator.value.type;
+      return {
+        ...current,
+        operator: operator.key,
+        value: keepsValue ? current.value : undefined,
+      };
+    });
+    setStep('value');
+  }, []);
+
+  const handleDraftValueChange = useCallback((value: FilterValue) => {
+    setDraft(current => (current == null ? current : {...current, value}));
+  }, []);
+
+  const handleDraftValueCommit = useCallback(
+    (value: FilterValue) => {
+      if (draft == null) {
+        return;
+      }
+      setDraft({...draft, value});
+      commitFilter(draft, value);
+    },
+    [draft, commitFilter],
+  );
+
+  const handleApply = useCallback(() => {
+    if (draft?.value == null) {
+      return;
+    }
+    commitFilter(draft, draft.value);
+  }, [draft, commitFilter]);
+
+  const handleDelete = useCallback(() => {
+    if (draft?.mode !== 'edit' || draft.filterIndex == null) {
+      return;
+    }
+    handleRemoveFilter(draft.filterIndex);
+    closeSheet();
+  }, [draft, handleRemoveFilter, closeSheet]);
+
+  const handleActiveSheetChange = useCallback((active: string | null) => {
+    // The switcher only reports null, and only for a dismissal the active
+    // sheet allows. Every step change goes through the handlers above.
+    if (active == null) {
+      setStep(null);
+    }
+  }, []);
+
+  // ------------------------------------------------------------- imperative --
+
+  useImperativeHandle(handleRef, () => ({
+    // There is no typeahead input to focus on this variant; the tap target is
+    // the control the label names, so the handle moves focus there.
+    focusTypeahead() {
+      triggerRef.current?.focus();
+    },
+    blurTypeahead() {
+      triggerRef.current?.blur();
+    },
+  }));
+
+  // ----------------------------------------------------------- result count --
+
+  const resultCountText = useMemo((): string | null => {
+    if (resultCount == null) {
+      return null;
+    }
+    if (typeof resultCount === 'number') {
+      return t('@astryx.powersearch.resultCount', {count: resultCount});
+    }
+    return resultCount;
+  }, [resultCount, t]);
+
+  const announce = useAnnounce();
+  const hasMountedRef = useRef(false);
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+    if (resultCountText != null) {
+      announce(resultCountText);
+    }
+  }, [resultCountText, announce]);
+
+  // --------------------------------------------------------------- tooltip --
+
+  const showsDisabledMessage = isDisabled && !!disabledMessage;
+  const disabledMessageTooltip = useTooltip({
+    placement: 'above',
+    focusTrigger: 'always',
+    isEnabled: showsDisabledMessage,
+  });
+
+  const triggerDescribedBy =
+    [
+      status?.message ? statusMessageId : null,
+      showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  // ---------------------------------------------------------------- render --
+
+  const tokens = filters.map((filter, index) => {
+    const field = config.getField(filter.field);
+    const operator = config.getOperator(filter.field, filter.operator);
+    if (!field || !operator) {
+      return null;
+    }
+    const canInteract = isInteractive && !filter.isReadOnly;
+    const onClick = canInteract ? () => handleTokenClick(index) : undefined;
+    const onRemove = canInteract ? () => handleRemoveFilter(index) : undefined;
+    const TokenOverride = componentOverrides?.[operator.value.type]?.Token;
+    const key = `${index}-${filter.field}-${filter.operator}`;
+
+    if (TokenOverride) {
+      return (
+        <TokenOverride
+          key={key}
+          config={configProp}
+          filter={filter}
+          field={field}
+          operator={operator}
+          maxLength={maxTokenLength}
+          onClick={onClick}
+          onRemove={onRemove}
+          isDisabled={isDisabled}
+        />
+      );
+    }
+    return (
+      <PowerSearchToken
+        key={key}
+        config={configProp}
+        filter={filter}
+        field={field}
+        operator={operator}
+        maxLength={maxTokenLength}
+        onClick={onClick}
+        onRemove={onRemove}
+        isDisabled={isDisabled}
+      />
+    );
+  });
+
+  const hasRemovableFilter = filters.some(filter => !filter.isReadOnly);
+  const isClearShown = hasClear && hasRemovableFilter && isInteractive;
+
+  const EditorOverride =
+    draftOperator != null
+      ? componentOverrides?.[draftOperator.value.type]?.Editor
+      : undefined;
+
+  const editorTitle =
+    draft?.mode === 'edit'
+      ? t('@astryx.powersearch.mobile.editFilter')
+      : (draftField?.label ?? addFilterLabel);
+
+  // Only when the operator is not already spelled out by its own drill-down
+  // row, so the sheet never says the same thing twice.
+  const editorOperatorHint =
+    draftOperator != null && draftOperators.length <= 1
+      ? resolveOperatorLabel(draftOperator, t)
+      : '';
+
+  const isApplyDisabled = draft?.operator == null || draft.value == null;
+  const isValueCommittedOnTap = draftOperator?.value.type === 'enum';
+  const isEditorFooterShown =
+    !isReadOnly && (draft?.mode === 'edit' || !isValueCommittedOnTap);
+
+  return (
+    <>
+      <Field
+        ref={ref}
+        label={label}
+        isLabelHidden={isLabelHidden}
+        // The tap target is one control among the tokens rather than the only
+        // control in the field, so the label names the GROUP (a `<label>` can
+        // only name a single control, and pointing it at the button would
+        // override the button's own visible text as its accessible name).
+        inputID={triggerId}
+        labelID={labelId}
+        isGroupLabel
+        isDisabled={isDisabled}
+        status={
+          status
+            ? {
+                type: status.type,
+                message: status.message,
+                messageID: status.message ? statusMessageId : undefined,
+              }
+            : undefined
+        }
+        statusVariant={statusVariant}
+        xstyle={xstyle}
+        className={className}
+        style={style}>
+        <div
+          ref={disabledMessageTooltip.ref}
+          role="group"
+          aria-labelledby={labelId}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          data-testid={testId}
+          {...mergeProps(
+            themeProps('power-search-mobile', {
+              size,
+              status: status?.type,
+              disabled: isDisabled ? 'disabled' : null,
+            }),
+            stylex.props(
+              inputWrapperStyles.base,
+              styles.wrapper,
+              filters.length > 0 && styles.wrapperWithTokens,
+              sizeStyles[size],
+              isDisabled && inputWrapperStyles.disabled,
+              status && inputStatusBorderStyles[status.type],
+              status &&
+                !isDisabled &&
+                inputStatusHoverShadowStyles[status.type],
+              status && inputStatusFocusWithinStyles[status.type],
+            ),
+          )}>
+          {startIcon && (
+            <span
+              {...stylex.props(
+                filters.length > 0 && styles.startIconWithTokens,
+              )}>
+              {renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+            </span>
+          )}
+          {tokens}
+          <button
+            type="button"
+            id={triggerId}
+            ref={mergeRefs(triggerRef)}
+            onClick={openFieldList}
+            // A disabled button is unreachable, so the reason for it is too.
+            // Keep it focusable and block the action instead, the way the
+            // desktop field does.
+            disabled={isDisabled && !showsDisabledMessage}
+            aria-disabled={isDisabled || isReadOnly ? true : undefined}
+            aria-haspopup="dialog"
+            aria-expanded={step != null}
+            aria-describedby={triggerDescribedBy}
+            {...stylex.props(
+              styles.trigger,
+              isReadOnly && styles.triggerReadOnly,
+            )}>
+            {filters.length === 0 ? placeholder : addFilterLabel}
+          </button>
+          {(endContent || isRenderable(resultCountText) || isClearShown) && (
+            <div {...stylex.props(styles.endSection)}>
+              {isRenderable(resultCountText) && (
+                <span {...stylex.props(styles.resultCount)}>
+                  {resultCountText}
+                </span>
+              )}
+              {endContent}
+              {isClearShown && (
+                <InputClearButton
+                  label={t('@astryx.tokenizer.clearAll')}
+                  onClick={handleClearAll}
+                />
+              )}
+            </div>
+          )}
+        </div>
+        {showsDisabledMessage &&
+          disabledMessageTooltip.renderTooltip(disabledMessage)}
+      </Field>
+
+      <BottomSheetSwitcher
+        activeSheet={step}
+        onActiveSheetChange={handleActiveSheetChange}>
+        <BottomSheet sheetId="fields" label={addFilterLabel} height="tall">
+          <div {...stylex.props(styles.sheet)}>
+            <div {...stylex.props(styles.header)}>
+              <div {...stylex.props(styles.headerRow)}>
+                <div {...stylex.props(styles.headerText)}>
+                  <Heading level={3}>{addFilterLabel}</Heading>
+                </div>
+                <Button
+                  label={t('@astryx.powersearch.editor.cancel')}
+                  variant="ghost"
+                  size="sm"
+                  onClick={closeSheet}
+                />
+              </div>
+              {isFieldSearchShown && (
+                <TextInput
+                  label={t('@astryx.powersearch.mobile.searchFields')}
+                  isLabelHidden
+                  placeholder={t(
+                    '@astryx.powersearch.mobile.searchFieldsPlaceholder',
+                  )}
+                  value={fieldQuery}
+                  onChange={setFieldQuery}
+                  startIcon={<Icon icon="search" size="sm" color="secondary" />}
+                  width="100%"
+                />
+              )}
+            </div>
+            <div {...stylex.props(styles.body)}>
+              {groupedFields.length === 0 ? (
+                <div {...stylex.props(styles.empty)}>
+                  <Text type="supporting" color="secondary">
+                    {t('@astryx.powersearch.mobile.noFields')}
+                  </Text>
+                </div>
+              ) : (
+                groupedFields.map(([group, groupFields]) => (
+                  <List
+                    key={group}
+                    hasDividers
+                    density="spacious"
+                    header={group === '' ? undefined : group}
+                    xstyle={styles.flushList}>
+                    {groupFields.map(field => (
+                      <FieldRow
+                        key={field.key}
+                        field={field}
+                        operatorLabel={fieldOperatorHint(config, field, t)}
+                        onSelect={handleFieldSelect}
+                      />
+                    ))}
+                  </List>
+                ))
+              )}
+            </div>
+          </div>
+        </BottomSheet>
+
+        <BottomSheet
+          sheetId="operator"
+          label={t('@astryx.powersearch.editor.operator')}
+          height="tall"
+          purpose="form">
+          <div {...stylex.props(styles.sheet)}>
+            <div {...stylex.props(styles.header)}>
+              <div {...stylex.props(styles.headerRow)}>
+                <Button
+                  label={t('@astryx.powersearch.mobile.back')}
+                  icon={<Icon icon="chevronLeft" size="sm" />}
+                  isIconOnly
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setStep('value')}
+                />
+                <div {...stylex.props(styles.headerText)}>
+                  <Heading level={3}>
+                    {draftField?.label ??
+                      t('@astryx.powersearch.editor.operator')}
+                  </Heading>
+                  <Text type="supporting" color="secondary">
+                    {t('@astryx.powersearch.editor.operator')}
+                  </Text>
+                </div>
+              </div>
+            </div>
+            <div {...stylex.props(styles.body)}>
+              <List hasDividers density="spacious" xstyle={styles.flushList}>
+                {draftOperators.map(operator => {
+                  const isSelected = operator.key === draft?.operator;
+                  return (
+                    <ListItem
+                      key={operator.key}
+                      label={resolveOperatorLabel(operator, t)}
+                      isSelected={isSelected}
+                      endContent={
+                        isSelected ? (
+                          <Icon icon="check" size="sm" color="accent" />
+                        ) : undefined
+                      }
+                      onClick={() => handleOperatorSelect(operator)}
+                    />
+                  );
+                })}
+              </List>
+            </div>
+          </div>
+        </BottomSheet>
+
+        <BottomSheet
+          sheetId="value"
+          label={editorTitle}
+          height="tall"
+          purpose="form">
+          <div {...stylex.props(styles.sheet)}>
+            <div {...stylex.props(styles.header)}>
+              <div {...stylex.props(styles.headerRow)}>
+                {draft?.mode === 'create' && (
+                  <Button
+                    label={t('@astryx.powersearch.mobile.back')}
+                    icon={<Icon icon="chevronLeft" size="sm" />}
+                    isIconOnly
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setStep('fields')}
+                  />
+                )}
+                <div {...stylex.props(styles.headerText)}>
+                  <Heading level={3}>{editorTitle}</Heading>
+                  {/* With one operator there is no drill-down row to show it,
+                      so the header carries it: the sheet reads "Author / is"
+                      rather than naming a column and offering a bare input. */}
+                  {editorOperatorHint !== '' && (
+                    <Text type="supporting" color="secondary">
+                      {editorOperatorHint}
+                    </Text>
+                  )}
+                </div>
+              </div>
+            </div>
+            {draft != null && draftField != null && draftOperator != null ? (
+              EditorOverride != null ? (
+                <div {...stylex.props(styles.body)}>
+                  <EditorOverride
+                    key={`${draft.mode}-${draft.filterIndex ?? 'new'}-${draft.field}`}
+                    config={configProp}
+                    filter={{
+                      field: draft.field,
+                      operator: draft.operator,
+                      value: draft.value,
+                    }}
+                    mode={draft.mode}
+                    onSave={saved => {
+                      if (saved == null) {
+                        handleDelete();
+                      } else {
+                        commitFilter(draft, saved.value);
+                      }
+                    }}
+                    onCancel={closeSheet}
+                    saveButtonLabel={saveButtonLabel}
+                    isReadOnly={isReadOnly}
+                    timezoneID={timezoneID}
+                  />
+                </div>
+              ) : (
+                <>
+                  <div {...stylex.props(styles.body)}>
+                    {draftOperators.length > 1 && (
+                      <List
+                        hasDividers
+                        density="spacious"
+                        xstyle={styles.flushList}>
+                        <ListItem
+                          label={t('@astryx.powersearch.editor.operator')}
+                          description={resolveOperatorLabel(draftOperator, t)}
+                          endContent={
+                            <Icon
+                              icon="chevronRight"
+                              size="sm"
+                              color="secondary"
+                            />
+                          }
+                          isDisabled={isReadOnly}
+                          onClick={() => setStep('operator')}
+                        />
+                      </List>
+                    )}
+                    <PowerSearchMobileValueEditor
+                      key={`${draft.field}-${draft.operator}`}
+                      config={config}
+                      operatorValue={draftOperator.value}
+                      filterValue={draft.value}
+                      onChange={handleDraftValueChange}
+                      onCommit={handleDraftValueCommit}
+                      isDisabled={isReadOnly}
+                      timezoneID={timezoneID}
+                    />
+                  </div>
+                  {isEditorFooterShown && (
+                    <div {...stylex.props(styles.footer)}>
+                      {draft.mode === 'edit' && (
+                        <Button
+                          label={t('@astryx.powersearch.editor.delete')}
+                          variant="ghost"
+                          onClick={handleDelete}
+                        />
+                      )}
+                      {!isValueCommittedOnTap && (
+                        <div
+                          {...stylex.props(
+                            styles.footerActions,
+                            draft.mode !== 'edit' && styles.footerSoleAction,
+                          )}>
+                          <Button
+                            label={saveButtonLabel}
+                            variant="primary"
+                            isDisabled={isApplyDisabled}
+                            onClick={handleApply}
+                            width={draft.mode === 'edit' ? undefined : '100%'}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </>
+              )
+            ) : null}
+          </div>
+        </BottomSheet>
+      </BottomSheetSwitcher>
+    </>
+  );
+}
+
+PowerSearchMobile.displayName = 'PowerSearchMobile';
+
+// =============================================================================
+// Field row
+// =============================================================================
+
+function FieldRow({
+  field,
+  operatorLabel,
+  onSelect,
+}: {
+  field: PowerSearchField;
+  operatorLabel: string | undefined;
+  onSelect: (field: PowerSearchField) => void;
+}): ReactNode {
+  return (
+    <ListItem
+      label={field.label}
+      description={field.description ?? operatorLabel}
+      startContent={field.icon}
+      endContent={<Icon icon="chevronRight" size="sm" color="secondary" />}
+      onClick={() => onSelect(field)}
+    />
+  );
+}
+
+/**
+ * The default operator's label, shown under a field name so the row says what
+ * choosing it will produce ("Status" / "is") rather than just naming a column.
+ */
+function fieldOperatorHint(
+  config: ReturnType<typeof useInternalConfig>,
+  field: PowerSearchField,
+  t: ReturnType<typeof useTranslator>,
+): string | undefined {
+  const preferred = config.getDefaultOperator(field.key);
+  const operator =
+    preferred && isSupportedOperator(preferred)
+      ? preferred
+      : field.operators.find(isSupportedOperator);
+  if (operator == null) {
+    return undefined;
+  }
+  return resolveOperatorLabel(operator, t) || undefined;
+}

--- a/packages/core/src/PowerSearch/PowerSearchMobileValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchMobileValueEditor.tsx
@@ -1,0 +1,165 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file PowerSearchMobileValueEditor.tsx
+ * @input OperatorValue, FilterValue, onChange callback
+ * @output Touch-native value editor for one filter, rendered inside a BottomSheet
+ * @position Sub-component; consumed by PowerSearchMobile
+ *
+ * The desktop value editor renders `enum` and `enum_list` as Selectors, which
+ * open a dropdown layer. Inside a bottom sheet that stacks a second overlay on
+ * a surface the user is already inside, so those two types are re-rendered here
+ * as the sheet's own list: a single-select list that commits on tap (matching
+ * Selector's mobile pattern) and a CheckboxList applied from the footer
+ * (matching MultiSelector's). Every other type is a real input rather than a
+ * menu, so it falls through to the shared PowerSearchValueEditor unchanged.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/PowerSearch/index.ts
+ */
+
+import React, {useCallback, useMemo} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {CheckboxList, CheckboxListItem} from '../CheckboxList';
+import {Icon} from '../Icon';
+import {List, ListItem} from '../List';
+import {spacingVars} from '../theme/tokens.stylex';
+import {useTranslator} from '../i18n';
+import {PowerSearchValueEditor} from './PowerSearchValueEditor';
+import type {InternalConfig} from './useInternalConfig';
+import type {FilterValue, OperatorValue} from './types';
+
+const styles = stylex.create({
+  // The sheet's own padding surrounds the list; the rows themselves run edge
+  // to edge so a tap anywhere on the row width registers, the way a settings
+  // list behaves on a phone.
+  flush: {
+    marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
+  },
+  input: {
+    paddingBlockStart: spacingVars['--spacing-1'],
+  },
+});
+
+export interface PowerSearchMobileValueEditorProps {
+  config: InternalConfig;
+  operatorValue: OperatorValue;
+  filterValue: FilterValue | undefined;
+  /** Stage a value without leaving the sheet. */
+  onChange: (value: FilterValue) => void;
+  /** Stage a value and commit the filter immediately (single-tap choices). */
+  onCommit: (value: FilterValue) => void;
+  isDisabled?: boolean;
+  timezoneID?: string;
+}
+
+/**
+ * Renders the value control for one filter inside the mobile editor sheet.
+ */
+export function PowerSearchMobileValueEditor({
+  config,
+  operatorValue,
+  filterValue,
+  onChange,
+  onCommit,
+  isDisabled,
+  timezoneID,
+}: PowerSearchMobileValueEditorProps) {
+  const t = useTranslator();
+
+  const handleFallbackChange = useCallback(
+    (value: FilterValue, shouldSave?: boolean) => {
+      // The shared editor asks to close for choices that are complete the
+      // moment they are made (a relative-date preset, a typeahead pick).
+      // Honour that here exactly as the desktop popover does.
+      if (shouldSave) {
+        onCommit(value);
+      } else {
+        onChange(value);
+      }
+    },
+    [onChange, onCommit],
+  );
+
+  const enumSelection = useMemo(
+    () => (filterValue?.type === 'enum' ? filterValue.value : undefined),
+    [filterValue],
+  );
+
+  const enumListSelection = useMemo(
+    () => (filterValue?.type === 'enum_list' ? [...filterValue.value] : []),
+    [filterValue],
+  );
+
+  const handleEnumListChange = useCallback(
+    (values: string[]) => {
+      onChange({type: 'enum_list', value: values});
+    },
+    [onChange],
+  );
+
+  if (operatorValue.type === 'enum') {
+    return (
+      <List hasDividers density="spacious" xstyle={styles.flush}>
+        {operatorValue.values.map(item => {
+          const isSelected = item.value === enumSelection;
+          return (
+            <ListItem
+              key={item.value}
+              label={item.label}
+              startContent={item.icon}
+              isSelected={isSelected}
+              isDisabled={isDisabled}
+              endContent={
+                isSelected ? (
+                  <Icon icon="check" size="sm" color="accent" />
+                ) : undefined
+              }
+              onClick={() => onCommit({type: 'enum', value: item.value})}
+            />
+          );
+        })}
+      </List>
+    );
+  }
+
+  if (operatorValue.type === 'enum_list') {
+    return (
+      <CheckboxList
+        label={t('@astryx.powersearch.valueEditor.values')}
+        isLabelHidden
+        hasDividers
+        density="spacious"
+        value={enumListSelection}
+        onChange={handleEnumListChange}
+        isDisabled={isDisabled}
+        xstyle={styles.flush}>
+        {operatorValue.values.map(item => (
+          <CheckboxListItem
+            key={item.value}
+            label={item.label}
+            value={item.value}
+            endContent={item.icon}
+          />
+        ))}
+      </CheckboxList>
+    );
+  }
+
+  return (
+    <div {...stylex.props(styles.input)}>
+      <PowerSearchValueEditor
+        operatorValue={operatorValue}
+        filterValue={filterValue}
+        onChange={handleFallbackChange}
+        config={config}
+        isDisabled={isDisabled}
+        timezoneID={timezoneID}
+      />
+    </div>
+  );
+}
+
+PowerSearchMobileValueEditor.displayName = 'PowerSearchMobileValueEditor';

--- a/packages/core/src/PowerSearch/index.ts
+++ b/packages/core/src/PowerSearch/index.ts
@@ -14,6 +14,9 @@
 export {PowerSearch} from './PowerSearch';
 export type {PowerSearchProps, PowerSearchSize} from './PowerSearch';
 
+export {PowerSearchMobile} from './PowerSearchMobile';
+export type {PowerSearchMobileProps} from './PowerSearchMobile';
+
 export {PowerSearchToken} from './PowerSearchToken';
 export {PowerSearchFilterEditor} from './PowerSearchFilterEditor';
 


### PR DESCRIPTION
## What

`PowerSearchMobile` — the touch form of `PowerSearch`, in core.

Following the mobile exploration: [Mobile Prototypes → PowerSearch](https://facebook.github.io/astryx/sandbox/pages/mobile-prototypes/?p=powersearch) ("bottom sheet, pinned tall").

## Why

PowerSearch's desktop shape doesn't survive a phone. The typeahead drops a popover that fights the on-screen keyboard, and the edit popover lays field / operator / value out in a row that has nowhere to go at 390px.

## How

Same props, same `PowerSearchFilter` model, same tokens. The typeahead dropdown and the row-shaped popover are replaced by a pinned-tall bottom sheet that drills down **field → operator → value**. Pick between the two variants on viewport and the call site does not change:

```tsx
const isTouch = useMediaQuery('(max-width: 768px)');
const Search = isTouch ? PowerSearchMobile : PowerSearch;
<Search config={config} filters={filters} onChange={setFilters} />
```

| | |
|---|---|
| **Tap target** | The same input shell, showing the filters as tokens. Tapping a token reopens its editor, where **Delete** removes it; the token's own × removes it in place. |
| **Field list** | Grouped by `field.group`, each row captioned with the operator it will produce. Past seven fields it gains a search box pinned under the sheet title. |
| **Operator** | A drill-down row, shown only when the field defines more than one. With one, the sheet header carries it — so the happy path stays **two taps**, as in the prototype. |
| **Value** | `enum` commits on a single tap (Selector's mobile pattern); `enum_list` applies from a pinned footer (MultiSelector's); an `empty` operator lands with no value step at all; every other type falls through to the shared `PowerSearchValueEditor`. |

Both sheets are `height="tall"`: the field list resizes as it is searched and the editor's content changes with the operator, so a self-sizing sheet would jump on every keystroke and every step — and tall is the only height that gives mobile-keyboard accommodation, which the text and number editors need. The editor sheet is `purpose="form"`, so a stray scrim tap can't discard a half-built filter.

`nested` filter groups have no touch editor yet. Fields whose only operators are nested are left out of the list and a dev warning says so, rather than opening a blank sheet.

## Accessibility

- The field label names the **group**, not the tap target — a `<label>` pointed at the button would replace its visible text as the accessible name (WCAG 2.5.3). The button is named by its own text, and carries `aria-haspopup="dialog"` + `aria-expanded`.
- `disabledMessage` keeps the target focusable via `aria-disabled` and describes it, so the reason is reachable by keyboard; the action stays blocked.
- Result-count changes are announced through the same polite live region as the desktop variant.

## Screenshots

Light and dark, iPhone 15: **[assets/pr-5314](https://github.com/facebook/astryx/tree/assets/pr-5314)**

| Tap target | Field list | Value (enum) | Operators |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/1-tap-target-light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/2-field-list-light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/3-value-enum-light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/4-operators-light.png) |

| Value (multi) | Edit + delete | Value (text) | Field search |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/5-value-multi-light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/6-edit-light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/7-value-text-light.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/8-field-search-light.png) |

<details><summary>Dark</summary>

| Tap target | Field list | Value (enum) | Operators |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/1-tap-target-dark.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/2-field-list-dark.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/3-value-enum-dark.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/4-operators-dark.png) |

| Value (multi) | Edit + delete | Value (text) | Field search |
|---|---|---|---|
| ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/5-value-multi-dark.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/6-edit-dark.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/7-value-text-dark.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5314/8-field-search-dark.png) |

</details>

## Test plan

- 23 new tests in `PowerSearchMobile.test.tsx`, covering the whole flow: field → operator → value, the enum single-tap commit, the multi-select apply, the empty-operator shortcut, edit/delete, clear-all keeping read-only filters, read-only and disabled, the field search and its empty state, the nested-field warning, and the imperative handle.
- Driven in a real browser at iPhone 15 (light + dark) against built `dist`: the flow works end to end with no console errors, the tablet sheet caps at 640px, and the read-only / disabled / error states behave.
- Gates: `pnpm lint:strict`, `pnpm build`, `pnpm test` (7527 core+lab, 2804 cli+apps), `typecheck` + `typecheck:docs` across core/lab/charts/cli/storybook, `pnpm -F @astryxdesign/storybook build`, `pnpm lab:readiness:check` — all green.

## Notes for reviewers

- Four props describe desktop-only affordances and are inert here — `hasAutoFocus`, `menuWidth`, `maxOperatorMenuItems`, `tokenOverflowBehavior` — documented on the prop table rather than removed, so one call site can feed both variants.
- `handleRef`'s `focusTypeahead()` / `blurTypeahead()` move focus to and from the tap target; there is no typeahead input on this variant.
- The seven-field threshold for the search box is the number `CheckboxList` already uses to send a long list to `MultiSelector`.
