### PR TITLE
fix(core): keep DateInput's pointer query internal, not a public export

### DIFF
--- a/.changeset/date-input-touch-surface.md
+++ b/.changeset/date-input-touch-surface.md
@@ -38,20 +38,21 @@ typable field (its keyboard is right there), while a narrowed desktop window is
 still a mouse. Adding a width test would only re-exclude tablets, which are the
 clearest case for a thumb picker.
 
-The public surface barely moves. One new export — `TOUCH_POINTER_QUERY`, the
-media query the switch uses, so an app can ask the same question the component
-does and lay out to match — plus six `@astryx.dateInput.*` catalog keys for
-the picker's header and footer.
+The public surface barely moves: six `@astryx.dateInput.*` catalog keys for the
+picker's header and footer, and nothing else. No new props, no new exports —
+`DateInputProps` is byte-identical at 25.
 
 Nothing else is published, on purpose. There is no export that forces a
 surface: the touch picker is reachable by being on a touch device, which is
-the only place it is worth looking at. The picker's two sizes (the 44px day
-cell, the 28px wheel row) are compile-time constants rather than theme
-variables — the day size is an accessibility floor, and a variable a theme can
-quietly lower is not a floor. And the sheet's header button is addressed by a
-`data-` attribute rather than a theme target, because nothing has asked to
-restyle it. Each of those is additive later and awkward to withdraw once
-shipped.
+the only place it is worth looking at. The media query the switch runs on is
+an internal constant, not an export — six other core components write
+`@media (pointer: coarse)` inline rather than sharing one, and nothing has
+asked to ask the same question. The picker's two sizes (the 44px day cell, the
+28px wheel row) are compile-time constants rather than theme variables — the
+day size is an accessibility floor, and a variable a theme can quietly lower
+is not a floor. And the sheet's header button is addressed by a `data-`
+attribute rather than a theme target, because nothing has asked to restyle it.
+Each of those is additive later and awkward to withdraw once shipped.
 
 The wheels also answer a mouse now. A wheel is a scroll container, so a finger
 pans it for free; a mouse got nothing, because browsers do not drag-scroll an

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -368,8 +368,15 @@ export interface DateInputProps extends Omit<
  * because its keyboard is there. A tablet reports `coarse` and gets the
  * picker, at any width. There is deliberately no width bound: it would only
  * re-exclude the tablets, since a narrowed desktop window is still a mouse.
+ *
+ * Deliberately NOT exported. It was, briefly, on the theory that an app might
+ * want to ask the same question and lay out to match — but nothing asked, and
+ * six other core components (CheckboxInput, ChatComposerInput, ...) just
+ * write `@media (pointer: coarse)` inline rather than sharing a constant. An
+ * export is additive later and awkward to withdraw, so it waits for a real
+ * caller.
  */
-export const TOUCH_POINTER_QUERY = '(pointer: coarse)';
+const TOUCH_POINTER_QUERY = '(pointer: coarse)';
 
 /**
  * The pointer-driven field: a text input you can type into, with a calendar

--- a/packages/core/src/DateInput/DateInputTouch.test.tsx
+++ b/packages/core/src/DateInput/DateInputTouch.test.tsx
@@ -2390,41 +2390,4 @@ describe('DateInput — scroll CSS (definition-level)', () => {
     expect(source).toContain('readOnly');
     expect(source).toContain('inputMode="none"');
   });
-
-  /**
-   * The touch surface publishes NOTHING beyond the component itself.
-   *
-   * `packages/core/src/index.ts` does `export * from './DateInput'`, so
-   * anything this barrel names is on the package root and is a public API
-   * whether or not it was meant to be. `TOUCH_POINTER_QUERY` reached it that
-   * way: it was exported on the theory that an app might want to ask the same
-   * question the switch does, nothing ever asked, and six other core
-   * components (CheckboxInput, ChatComposerInput, ...) just write
-   * `@media (pointer: coarse)` inline.
-   *
-   * An equality assertion, not a `not.toContain` on one name — a list says
-   * what the surface IS, so the next internal that leaks fails here too
-   * rather than only the one that already did.
-   */
-  it('publishes only DateInput and its prop types', () => {
-    const barrel = read('index.ts');
-    const exported = [...barrel.matchAll(/^\s{2}?([A-Za-z][\w]*),$/gm)]
-      .map(m => m[1])
-      .concat(
-        [...barrel.matchAll(/export \{([^}]+)\} from/g)].flatMap(m =>
-          m[1].split(',').map(s => s.trim()),
-        ),
-      )
-      .filter(Boolean)
-      .sort();
-
-    expect(exported).toEqual([
-      'DateInput',
-      'DateInputFormat',
-      'DateInputProps',
-      'DateInputSize',
-      'DateInputStatus',
-      'DateInputStatusType',
-    ]);
-  });
 });

--- a/packages/core/src/DateInput/DateInputTouch.test.tsx
+++ b/packages/core/src/DateInput/DateInputTouch.test.tsx
@@ -42,7 +42,7 @@ import {useState} from 'react';
 import type {ISODateString} from '../utils';
 import {InputGroup} from '../InputGroup';
 import {stableClassName} from '../naming';
-import {DateInput, TOUCH_POINTER_QUERY} from './DateInput';
+import {DateInput} from './DateInput';
 import {
   toMonthIndex,
   monthIndexOf,
@@ -79,11 +79,6 @@ const SCROLLPORT_WIDTH = 360;
 /** Matches the repo-wide setup polyfill, so hover-gated behavior still works. */
 const HOVER_CAPABLE = /\(\s*hover\s*:\s*hover\s*\)/;
 
-/**
- * Point the surface switch at a phone or at a desktop. Only
- * {@link TOUCH_POINTER_QUERY} is forced; every other query keeps the answer
- * the shared test setup gives it.
- */
 /**
  * Answer media queries the way a given device would.
  *
@@ -286,8 +281,7 @@ describe('DateInput — surface selection', () => {
     // typable field, and a narrowed desktop window is still a mouse. A width
     // bound would only re-exclude tablets — the clearest case for a thumb
     // picker there is — so there deliberately is not one.
-    expect(TOUCH_POINTER_QUERY).toBe('(pointer: coarse)');
-
+    //
     // An 1194px tablet in landscape: coarse pointer, far wider than any
     // handset breakpoint. It answers width queries honestly, so a width bound
     // creeping back in would fail here rather than pass silently.
@@ -2395,5 +2389,42 @@ describe('DateInput — scroll CSS (definition-level)', () => {
     // readOnly alone still opens the keyboard on some Android browsers.
     expect(source).toContain('readOnly');
     expect(source).toContain('inputMode="none"');
+  });
+
+  /**
+   * The touch surface publishes NOTHING beyond the component itself.
+   *
+   * `packages/core/src/index.ts` does `export * from './DateInput'`, so
+   * anything this barrel names is on the package root and is a public API
+   * whether or not it was meant to be. `TOUCH_POINTER_QUERY` reached it that
+   * way: it was exported on the theory that an app might want to ask the same
+   * question the switch does, nothing ever asked, and six other core
+   * components (CheckboxInput, ChatComposerInput, ...) just write
+   * `@media (pointer: coarse)` inline.
+   *
+   * An equality assertion, not a `not.toContain` on one name — a list says
+   * what the surface IS, so the next internal that leaks fails here too
+   * rather than only the one that already did.
+   */
+  it('publishes only DateInput and its prop types', () => {
+    const barrel = read('index.ts');
+    const exported = [...barrel.matchAll(/^\s{2}?([A-Za-z][\w]*),$/gm)]
+      .map(m => m[1])
+      .concat(
+        [...barrel.matchAll(/export \{([^}]+)\} from/g)].flatMap(m =>
+          m[1].split(',').map(s => s.trim()),
+        ),
+      )
+      .filter(Boolean)
+      .sort();
+
+    expect(exported).toEqual([
+      'DateInput',
+      'DateInputFormat',
+      'DateInputProps',
+      'DateInputSize',
+      'DateInputStatus',
+      'DateInputStatusType',
+    ]);
   });
 });

--- a/packages/core/src/DateInput/index.ts
+++ b/packages/core/src/DateInput/index.ts
@@ -9,7 +9,7 @@
  * @position Package entry point for DateInput
  */
 
-export {DateInput, TOUCH_POINTER_QUERY} from './DateInput';
+export {DateInput} from './DateInput';
 export type {
   DateInputProps,
   DateInputSize,


### PR DESCRIPTION
Follow-up to #5243, caught right after it merged. No release has consumed that
changeset yet (core is still 0.4.5), so `TOUCH_POINTER_QUERY` never reached
npm — this keeps it that way.

## What happened

`packages/core/src/index.ts` does `export * from './DateInput'`, so anything
DateInput's own barrel names lands on the package root and is public API
whether or not it was meant to be. Confirmed rather than assumed, by importing
the built dist:

```
root barrel  : (pointer: coarse)
```

## Why it should not be there

- **Nothing consumes it.** The only references were the component itself and a
  test asserting the constant equals its own value — which proves nothing.
- **No precedent.** Six other core components (`CheckboxInput`,
  `ChatComposerInput`, `CommandPaletteInput`, …) write
  `@media (pointer: coarse)` inline. Nobody exports a query constant.
- **It contradicts the cull already done on this component.** Two theme vars, a
  theme target and a forced-surface export were all pulled back before #5243
  went up for review, on the grounds that each was additive later and awkward
  to withdraw. This one is the same category and survived only because nobody
  looked at the barrel. The justification I wrote for it — "an app can ask the
  same question and lay out to match" — was speculative, not a real request.

## The changeset is amended, not answered

#5243's changeset is edited in place rather than met with a second one. It has
not been released, so the CHANGELOG should simply never claim the export; a new
entry saying "removed" would land in the **same release** as the one saying
"added", which reads as churn that never happened.

With this, the touch surface publishes exactly six `@astryx.dateInput.*`
catalog keys and nothing else. No new props, no new exports.

## Test

The test asserting the barrel's export list was dropped at review request. The
removal is still covered end to end: `pnpm -F @astryxdesign/core build` then
importing the built `dist/index.js` shows `TOUCH_POINTER_QUERY` gone from both
the root barrel and `dist/DateInput/`, with `DateInput` still exported, and it
appears in no `.d.ts`.

222 DateInput tests pass; full local gate set green.
