### PR TITLE
feat(core): let Selector, MultiSelector, and ComplexSelector drop the trigger chevron

### DIFF
--- a/.changeset/selector-chevron-opt-out.md
+++ b/.changeset/selector-chevron-opt-out.md
@@ -2,7 +2,8 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Selector, MultiSelector, ComplexSelector: let the trigger opt out of the chevron
+[feat] Selector, MultiSelector, ComplexSelector: let the trigger opt out of the chevron (#5318)
+@ernestt
 
 The chevron is a sibling of the trigger button, after the optional clear
 button, so a selector with `hasClear` and a value showed both a `×` and a
@@ -23,5 +24,3 @@ selected mark inside an option row.
 ```tsx
 <Selector hasClear hasChevron={false} value={value} onChange={setValue} />
 ```
-
-@ernestt

--- a/.changeset/selector-chevron-opt-out.md
+++ b/.changeset/selector-chevron-opt-out.md
@@ -1,0 +1,27 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector, MultiSelector, ComplexSelector: let the trigger opt out of the chevron
+
+The chevron is a sibling of the trigger button, after the optional clear
+button, so a selector with `hasClear` and a value showed both a `×` and a
+chevron in the same slot. StyleX has no descendant selectors and
+`stylex.when.*` only reads upward, so an `xstyle` on the field could not reach
+the icon — there was no supported way to drop it.
+
+`hasChevron` turns it off. It defaults to `true`, so existing selectors render
+identically. Only the chevron goes: a status glyph shares that slot and still
+appears, and because the chevron is decorative (`aria-hidden`) and sits outside
+the button, the accessible name, focus order, and keyboard behaviour are
+untouched.
+
+The name matches `DropdownMenu`'s existing `hasChevron`, and avoids colliding
+with `indicatorPosition`, which on Selector and MultiSelector already means the
+selected mark inside an option row.
+
+```tsx
+<Selector hasClear hasChevron={false} value={value} onChange={setValue} />
+```
+
+@ernestt

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -121,6 +121,13 @@ export const docs = {
           description: 'Icon displayed at the start of the trigger.',
         },
         {
+          name: 'hasChevron',
+          type: 'boolean',
+          description:
+            'Shows the chevron at the end of the trigger. Set false when the trigger content already reads as "this opens something", or when the composed content supplies its own end affordance. The chevron is decorative (aria-hidden) and sits outside the trigger button, so the accessible name, focus order, and keyboard behaviour are unchanged.',
+          default: 'true',
+        },
+        {
           name: 'width',
           type: 'SizeValue',
           description: 'Width of the field.',
@@ -202,6 +209,28 @@ export const docs = {
       },
     ],
   },
+  examples: [
+    {
+      label: 'Trigger without the chevron',
+      code: `
+// ComplexSelector has no built-in clear button, so the end slot holds only
+// the chevron. Drop it when the composed content puts its own affordance
+// there, or when the trigger already reads as openable on its own.
+<ComplexSelector
+  label="Date range"
+  value={range}
+  onChange={setRange}
+  triggerLabel={formatRange(range)}
+  variant="ghost"
+  startIcon="calendar"
+  hasChevron={false}>
+  {(value, onChange, close) => (
+    <RangeCalendar value={value} onChange={onChange} onDone={close} />
+  )}
+</ComplexSelector>
+`,
+    },
+  ],
 };
 
 export const docsDense = {
@@ -271,6 +300,8 @@ export const docsDense = {
     triggerLabel: 'Closed trigger label/content.',
     variant: 'input for forms; ghost for toolbar triggers.',
     startIcon: 'Leading trigger icon.',
+    hasChevron:
+      'false => drop the trigger chevron when the trigger supplies its own end affordance. Chevron is aria-hidden and outside the button, so name/focus/keyboard are unchanged. Defaults to true.',
     placement: 'Popup placement.',
     alignment: 'Popup alignment.',
     handleRef: 'Imperative open/close/toggle handle.',

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -418,3 +418,97 @@ describe('ComplexSelector popup theme target', () => {
     ).not.toBeNull();
   });
 });
+
+describe('ComplexSelector hasChevron', () => {
+  const chevron = (container: HTMLElement) =>
+    container.querySelector('.astryx-complex-selector-indicator-icon');
+
+  it('renders the chevron by default', () => {
+    const {container} = render(
+      <ComplexSelector label="Fruit blend" value="Apple" triggerLabel="Apple">
+        {() => <div>Options</div>}
+      </ComplexSelector>,
+    );
+    expect(chevron(container)).not.toBeNull();
+  });
+
+  it('drops the chevron when hasChevron is false', () => {
+    const {container} = render(
+      <ComplexSelector
+        label="Fruit blend"
+        value="Apple"
+        triggerLabel="Apple"
+        hasChevron={false}>
+        {() => <div>Options</div>}
+      </ComplexSelector>,
+    );
+    expect(chevron(container)).toBeNull();
+  });
+
+  it('keeps the trigger accessible name and the tab stop unchanged', async () => {
+    const user = userEvent.setup();
+
+    const {unmount} = render(
+      <ComplexSelector label="Fruit blend" value="Apple" triggerLabel="Apple">
+        {() => <div>Options</div>}
+      </ComplexSelector>,
+    );
+    const before = screen.getByRole('button', {name: 'Fruit blend'});
+    expect(before).toHaveAccessibleName('Fruit blend');
+    const beforeText = before.textContent;
+    unmount();
+
+    const {container} = render(
+      <ComplexSelector
+        label="Fruit blend"
+        value="Apple"
+        triggerLabel="Apple"
+        hasChevron={false}>
+        {() => <div>Options</div>}
+      </ComplexSelector>,
+    );
+    expect(chevron(container)).toBeNull();
+    const trigger = screen.getByRole('button', {name: 'Fruit blend'});
+    expect(trigger).toHaveAccessibleName('Fruit blend');
+    expect(trigger.textContent).toBe(beforeText);
+
+    // The chevron was never a tab stop — it is a decorative sibling of the
+    // button, not a control — so the trigger is still the single stop.
+    await user.tab();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('is decorative — the chevron is aria-hidden and outside the trigger button', () => {
+    const {container} = render(
+      <ComplexSelector label="Fruit blend" value="Apple" triggerLabel="Apple">
+        {() => <div>Options</div>}
+      </ComplexSelector>,
+    );
+    const icon = chevron(container);
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(
+      screen.getByRole('button', {name: 'Fruit blend'}).contains(icon),
+    ).toBe(false);
+  });
+
+  it('still opens the popup with the chevron off', async () => {
+    const user = userEvent.setup();
+    const {container} = render(
+      <ComplexSelector
+        label="Fruit blend"
+        value="Apple"
+        triggerLabel="Apple"
+        hasChevron={false}>
+        {() => <button type="button">Done</button>}
+      </ComplexSelector>,
+    );
+    expect(chevron(container)).toBeNull();
+    const trigger = screen.getByRole('button', {name: 'Fruit blend'});
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(
+      screen.getByRole('button', {name: 'Done', ...h}),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -268,6 +268,18 @@ export interface ComplexSelectorProps<Value> extends Omit<
   variant?: ComplexSelectorVariant;
   /** Icon displayed at the start of the trigger. */
   startIcon?: ReactNode | IconType;
+  /**
+   * Whether to show the chevron at the end of the trigger. Set false when the
+   * trigger's own content already reads as "this opens something" — an
+   * affordance the product supplies itself, for instance.
+   *
+   * The chevron is decorative (`aria-hidden`) and sits outside the trigger
+   * button, so dropping it leaves the accessible name, the focus order, and
+   * the keyboard behaviour untouched.
+   *
+   * @default true
+   */
+  hasChevron?: boolean;
   /** Width of the field. */
   width?: SizeValue;
   /** Popup placement. */
@@ -333,6 +345,7 @@ export function ComplexSelector<Value>({
   size = 'md',
   variant = 'input',
   startIcon,
+  hasChevron = true,
   width,
   placement = 'below',
   alignment = 'start',
@@ -514,23 +527,25 @@ export function ComplexSelector<Value>({
           <span {...stylex.props(styles.triggerText)}>{triggerContent}</span>
         </button>
         {isBusy && <Spinner size="sm" />}
-        <Icon
-          icon="chevronDown"
-          size="sm"
-          color="secondary"
-          // No wrapper: Icon's own span already provides the 16px box (`sm`)
-          // and the secondary icon color the wrapper used to set, so the glyph
-          // IS the trigger's icon element — one node carrying the box, the
-          // color, the rotation, and the theme target.
-          xstyle={[
-            styles.triggerIcon,
-            styles.triggerIconRotation,
-            isOpen && styles.triggerIconOpen,
-          ]}
-          {...themeProps('complex-selector-indicator-icon', {
-            state: isOpen ? 'expanded' : 'collapsed',
-          })}
-        />
+        {hasChevron && (
+          <Icon
+            icon="chevronDown"
+            size="sm"
+            color="secondary"
+            // No wrapper: Icon's own span already provides the 16px box (`sm`)
+            // and the secondary icon color the wrapper used to set, so the glyph
+            // IS the trigger's icon element — one node carrying the box, the
+            // color, the rotation, and the theme target.
+            xstyle={[
+              styles.triggerIcon,
+              styles.triggerIconRotation,
+              isOpen && styles.triggerIconOpen,
+            ]}
+            {...themeProps('complex-selector-indicator-icon', {
+              state: isOpen ? 'expanded' : 'collapsed',
+            })}
+          />
+        )}
       </div>
 
       {popover.render(content, {

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -25,7 +25,10 @@ export const docs = {
         visualProps: ['variant', 'size', 'status'],
         states: ['disabled'],
       },
-      {className: 'astryx-multi-selector-clear-icon', deprecatedFor: 'input-clear-icon'},
+      {
+        className: 'astryx-multi-selector-clear-icon',
+        deprecatedFor: 'input-clear-icon',
+      },
       {className: 'astryx-multi-selector-empty-state'},
       {className: 'astryx-multi-selector-search'},
       {className: 'astryx-multi-selector-section-heading'},
@@ -126,6 +129,13 @@ export const docs = {
           type: 'boolean',
           description:
             'Whether to show a search input for filtering options. As the user types, the match count (or "No results found") is announced to screen readers via a polite live region. The search field has built-in affordances: a leading magnifier icon and, once a query is typed, a trailing clear (✕) button that resets the query and returns focus to the input.',
+        },
+        {
+          name: 'hasChevron',
+          type: 'boolean',
+          description:
+            'Shows the chevron at the end of the trigger. Set false to let the clear button stand alone in that slot — with hasClear, a selector that has values otherwise shows both a × and a chevron. Only the chevron is dropped: a status glyph shares the slot and still appears, and since the chevron is decorative (aria-hidden) and sits outside the trigger button, the accessible name, focus order, and keyboard behaviour are unchanged.',
+          default: 'true',
         },
         {
           name: 'searchPlaceholder',
@@ -265,6 +275,24 @@ export const docs = {
       },
     ],
   },
+  examples: [
+    {
+      label: 'Let the clear button replace the chevron',
+      code: `
+// With hasClear alone, a selector that has values shows both a × and a
+// chevron in the end slot. hasChevron={false} leaves the × on its own, so
+// the one affordance in that slot is the one the user can act on.
+<MultiSelector
+  label="Tags"
+  options={tags}
+  value={selectedTags}
+  onChange={setSelectedTags}
+  hasClear
+  hasChevron={false}
+/>
+`,
+    },
+  ],
 };
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
@@ -289,6 +317,8 @@ export const docsZh = {
         hasSelectAll: '是否显示全选复选框。',
         selectAllLabel: '全选复选框的标签。',
         hasSearch: '是否显示用于过滤选项的搜索输入。',
+        hasChevron:
+          '是否在触发器末尾显示折叠箭头。设为 false 可让清除按钮独占该位置——配合 hasClear 时，已有选中值的选择器否则会同时显示 × 和箭头。仅去掉箭头：状态图标共用该位置且不受影响；箭头是装饰性的（aria-hidden）且位于触发按钮之外，因此无障碍名称、焦点顺序与键盘行为均不变。',
         searchPlaceholder: '搜索输入的占位文本。',
         isDisabled: '禁用选择器。',
         htmlName:
@@ -424,6 +454,8 @@ export const docsDense = {
         hasSelectAll: 'show select-all checkbox',
         selectAllLabel: 'select-all label',
         hasSearch: 'show search input',
+        hasChevron:
+          "false => drop the trigger chevron so hasClear's × owns the end slot alone. Status glyph unaffected; chevron is aria-hidden and outside the button, so name/focus/keyboard are unchanged. Defaults to true.",
         searchPlaceholder: 'search placeholder',
         isDisabled: 'disables selector',
         htmlName: 'HTML name attr; one hidden input per selected value.',

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1918,6 +1918,163 @@ describe('MultiSelector indicator (chevron) icon theme target', () => {
   });
 });
 
+describe('MultiSelector hasChevron', () => {
+  const CHEVRON_OPTIONS = ['Apple', 'Banana', 'Orange'];
+  const SELECTED = ['Apple'];
+
+  const chevron = (container: HTMLElement) =>
+    container.querySelector('.astryx-multi-selector-indicator-icon');
+
+  it('renders the chevron by default', () => {
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={CHEVRON_OPTIONS}
+        value={EMPTY_VALUE}
+        onChange={() => {}}
+      />,
+    );
+    expect(chevron(container)).not.toBeNull();
+  });
+
+  it('drops the chevron when hasChevron is false', () => {
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={CHEVRON_OPTIONS}
+        value={EMPTY_VALUE}
+        onChange={() => {}}
+        hasChevron={false}
+      />,
+    );
+    expect(chevron(container)).toBeNull();
+  });
+
+  it('leaves the clear button alone in the end slot', () => {
+    // The motivating case: with hasClear a MultiSelector that has values
+    // shows both a × and a chevron. Turning the chevron off leaves the × as
+    // the only glyph there, and it still works.
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={CHEVRON_OPTIONS}
+        value={SELECTED}
+        onChange={() => {}}
+        hasClear
+        hasChevron={false}
+      />,
+    );
+    expect(chevron(container)).toBeNull();
+    expect(
+      screen.getByRole('button', {name: 'Clear all Fruit'}),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the trigger accessible name and the tab stops unchanged', async () => {
+    const user = userEvent.setup();
+
+    const {unmount} = render(
+      <MultiSelector
+        label="Fruit"
+        options={CHEVRON_OPTIONS}
+        value={SELECTED}
+        onChange={() => {}}
+        hasClear
+      />,
+    );
+    const before = screen.getByRole('combobox');
+    expect(before).toHaveAccessibleName('Fruit');
+    const beforeText = before.textContent;
+    unmount();
+
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={CHEVRON_OPTIONS}
+        value={SELECTED}
+        onChange={() => {}}
+        hasClear
+        hasChevron={false}
+      />,
+    );
+    expect(chevron(container)).toBeNull();
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAccessibleName('Fruit');
+    expect(trigger.textContent).toBe(beforeText);
+
+    // Focus order is unchanged: the trigger is still first and the clear
+    // button still follows it. The chevron was never a tab stop — it is a
+    // decorative sibling of the button, not a control.
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('button', {name: 'Clear all Fruit'})).toHaveFocus();
+  });
+
+  it('is decorative — the chevron is aria-hidden and outside the trigger button', () => {
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={CHEVRON_OPTIONS}
+        value={EMPTY_VALUE}
+        onChange={() => {}}
+      />,
+    );
+    const icon = chevron(container);
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByRole('combobox').contains(icon)).toBe(false);
+  });
+
+  it('keeps the status glyph, which shares the slot but is not the chevron', () => {
+    // hasChevron gates the chevron arm only. With an attached status the
+    // chevron arm never runs, so the flag is a no-op there — the same single
+    // glyph either way.
+    const iconCount = (hasChevron: boolean) => {
+      const {container, unmount} = render(
+        <MultiSelector
+          label="Fruit"
+          options={CHEVRON_OPTIONS}
+          value={EMPTY_VALUE}
+          onChange={() => {}}
+          status={{type: 'error', message: 'Required'}}
+          hasChevron={hasChevron}
+          data-testid="field"
+        />,
+      );
+      const field = container.querySelector(
+        '[data-testid="field"]',
+      ) as HTMLElement;
+      const count = field.querySelectorAll('.astryx-icon').length;
+      expect(chevron(container)).toBeNull();
+      unmount();
+      return count;
+    };
+
+    expect(iconCount(false)).toBe(1);
+    expect(iconCount(false)).toBe(iconCount(true));
+  });
+
+  it('still opens the popup with the chevron off', async () => {
+    const user = userEvent.setup();
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={CHEVRON_OPTIONS}
+        value={EMPTY_VALUE}
+        onChange={() => {}}
+        hasChevron={false}
+      />,
+    );
+    expect(chevron(container)).toBeNull();
+    await user.click(screen.getByRole('combobox'));
+    expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+});
+
 describe('MultiSelector list structure', () => {
   it('does not draw a divider under select-all', async () => {
     const user = userEvent.setup();

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -579,6 +579,27 @@ export interface MultiSelectorProps<
   hasSearch?: boolean;
 
   /**
+   * Whether to show the chevron at the end of the trigger. Set false to let
+   * the clear button stand alone in that slot instead of sitting beside a
+   * second glyph — with `hasClear`, a selector that has values otherwise
+   * shows both.
+   *
+   * This is about the chevron only. A status glyph takes the same slot and is
+   * unaffected: an errored selector still shows its status icon.
+   *
+   * The chevron is decorative (`aria-hidden`) and sits outside the trigger
+   * button, so dropping it leaves the accessible name, the focus order, and
+   * the keyboard behaviour untouched.
+   *
+   * @default true
+   * @example
+   * ```
+   * <MultiSelector hasClear hasChevron={false} value={value} onChange={setValue} />
+   * ```
+   */
+  hasChevron?: boolean;
+
+  /**
    * Placeholder text for the search input.
    * @default 'Search...'
    */
@@ -694,6 +715,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   hasSelectAll = false,
   selectAllLabel: selectAllLabelFromProps,
   hasSearch = false,
+  hasChevron = true,
   searchPlaceholder: searchPlaceholderFromProps,
   triggerDisplay = 'count',
   maxBadges = 3,
@@ -1569,6 +1591,10 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           and the icon color, so the status glyph and the chevron are each
           directly targetable instead of sharing one untargetable parent — and
           the two affordances stop sharing a node.
+
+          `hasChevron` gates only the chevron arm. A status glyph is a report
+          about the value, not an expand affordance, so it keeps the slot even
+          when the chevron is off.
         */}
         {showStatusIcon ? (
           showStatusTooltip ? (
@@ -1597,7 +1623,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               xstyle={styles.triggerIcon}
             />
           )
-        ) : (
+        ) : hasChevron ? (
           <Icon
             icon="chevronDown"
             size="sm"
@@ -1619,7 +1645,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               state: popover.isOpen ? 'expanded' : 'collapsed',
             })}
           />
-        )}
+        ) : null}
       </div>
 
       {popover.render(

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -84,6 +84,13 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'hasChevron',
+      type: 'boolean',
+      description:
+        'Shows the chevron at the end of the trigger. Set false to let the clear button stand alone in that slot — with hasClear, a selector that has a value otherwise shows both a × and a chevron. Only the chevron is dropped: a status glyph shares the slot and still appears, and since the chevron is decorative (aria-hidden) and sits outside the trigger button, the accessible name, focus order, and keyboard behaviour are unchanged.',
+      default: 'true',
+    },
+    {
       name: 'searchPlaceholder',
       type: 'string',
       description: 'Placeholder text for the search input.',
@@ -292,6 +299,24 @@ export const docs = {
       },
     ],
   },
+  examples: [
+    {
+      label: 'Let the clear button replace the chevron',
+      code: `
+// With hasClear alone, a selector that has a value shows both a × and a
+// chevron in the end slot. hasChevron={false} leaves the × on its own, so
+// the one affordance in that slot is the one the user can act on.
+<Selector
+  label="Country"
+  options={countries}
+  value={country}
+  onChange={setCountry}
+  hasClear
+  hasChevron={false}
+/>
+`,
+    },
+  ],
 };
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -2449,6 +2449,143 @@ describe('Selector indicator (chevron) icon theme target', () => {
   });
 });
 
+describe('Selector hasChevron', () => {
+  const chevron = (container: HTMLElement) =>
+    container.querySelector('.astryx-selector-indicator-icon');
+
+  it('renders the chevron by default', () => {
+    const {container} = render(
+      <Selector label="Fruit" options={OPTIONS} onChange={() => {}} />,
+    );
+    expect(chevron(container)).not.toBeNull();
+  });
+
+  it('drops the chevron when hasChevron is false', () => {
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={() => {}}
+        hasChevron={false}
+      />,
+    );
+    expect(chevron(container)).toBeNull();
+  });
+
+  it('leaves the clear button alone in the end slot', () => {
+    // The motivating case: with hasClear a selected Selector shows both a ×
+    // and a chevron. Turning the chevron off leaves the × as the only glyph
+    // there, and it still works.
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        hasClear
+        hasChevron={false}
+      />,
+    );
+    expect(chevron(container)).toBeNull();
+    expect(
+      screen.getByRole('button', {name: 'Clear Fruit'}),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the trigger accessible name and the tab stops unchanged', async () => {
+    const user = userEvent.setup();
+    const props = {
+      label: 'Fruit',
+      options: OPTIONS,
+      value: 'Banana',
+      onChange: () => {},
+      hasClear: true,
+    } as const;
+
+    const {unmount} = render(<Selector {...props} />);
+    const before = screen.getByRole('combobox');
+    expect(before).toHaveAccessibleName('Fruit');
+    const beforeText = before.textContent;
+    unmount();
+
+    const {container} = render(<Selector {...props} hasChevron={false} />);
+    expect(chevron(container)).toBeNull();
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAccessibleName('Fruit');
+    expect(trigger.textContent).toBe(beforeText);
+
+    // Focus order is unchanged: the trigger is still first and the clear
+    // button still follows it. The chevron was never a tab stop — it is a
+    // decorative sibling of the button, not a control.
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('button', {name: 'Clear Fruit'})).toHaveFocus();
+  });
+
+  it('is decorative — the chevron is aria-hidden and outside the trigger button', () => {
+    // Why dropping it cannot touch the accessible name, asserted rather than
+    // assumed: it is hidden from the a11y tree AND it is not a descendant of
+    // the button whose name would be computed from its contents.
+    const {container} = render(
+      <Selector label="Fruit" options={OPTIONS} onChange={() => {}} />,
+    );
+    const icon = chevron(container);
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByRole('combobox').contains(icon)).toBe(false);
+  });
+
+  it('keeps the status glyph, which shares the slot but is not the chevron', () => {
+    // hasChevron gates the chevron arm only. A status glyph reports on the
+    // value; suppressing it would hide information, not an affordance. With
+    // an attached status the chevron arm never runs, so the flag is a no-op
+    // there — the same single glyph either way.
+    const iconCount = (hasChevron: boolean) => {
+      const {container, unmount} = render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          onChange={() => {}}
+          status={{type: 'error', message: 'Required'}}
+          hasChevron={hasChevron}
+          data-testid="field"
+        />,
+      );
+      const field = container.querySelector(
+        '[data-testid="field"]',
+      ) as HTMLElement;
+      const count = field.querySelectorAll('.astryx-icon').length;
+      expect(chevron(container)).toBeNull();
+      unmount();
+      return count;
+    };
+
+    expect(iconCount(false)).toBe(1);
+    expect(iconCount(false)).toBe(iconCount(true));
+  });
+
+  it('still opens the popup with the chevron off', async () => {
+    const user = userEvent.setup();
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={() => {}}
+        hasChevron={false}
+      />,
+    );
+    expect(chevron(container)).toBeNull();
+    await user.click(screen.getByRole('combobox'));
+    // `hidden: true` matches the house convention here: the panel is a native
+    // popover, which jsdom reports as hidden.
+    expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+});
+
 describe('Selector section headings', () => {
   it('renders a section title as a plain heading inside the group, not a divider', async () => {
     const user = userEvent.setup();

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -631,6 +631,27 @@ interface SelectorPropsBase<
   hasSearch?: boolean;
 
   /**
+   * Whether to show the chevron at the end of the trigger. Set false to let
+   * the clear button stand alone in that slot instead of sitting beside a
+   * second glyph — with `hasClear`, a selector that has a value otherwise
+   * shows both.
+   *
+   * This is about the chevron only. A status glyph takes the same slot and is
+   * unaffected: an errored selector still shows its status icon.
+   *
+   * The chevron is decorative (`aria-hidden`) and sits outside the trigger
+   * button, so dropping it leaves the accessible name, the focus order, and
+   * the keyboard behaviour untouched.
+   *
+   * @default true
+   * @example
+   * ```
+   * <Selector hasClear hasChevron={false} value={value} onChange={setValue} />
+   * ```
+   */
+  hasChevron?: boolean;
+
+  /**
    * Placeholder text for the search input.
    * @default 'Search...'
    */
@@ -781,6 +802,7 @@ export function Selector<T extends SelectorOptionType>(
     renderValue,
     indicatorPosition = 'end',
     hasSearch = false,
+    hasChevron = true,
     searchPlaceholder: searchPlaceholderFromProps,
     placement,
     isDefaultOpen = false,
@@ -1528,6 +1550,10 @@ export function Selector<T extends SelectorOptionType>(
           and the icon color, so the status glyph and the chevron are each
           directly targetable instead of sharing one untargetable parent — and
           the two affordances stop sharing a node.
+
+          `hasChevron` gates only the chevron arm. A status glyph is a report
+          about the value, not an expand affordance, so it keeps the slot even
+          when the chevron is off.
         */}
         {showStatusIcon ? (
           showStatusTooltip ? (
@@ -1556,7 +1582,7 @@ export function Selector<T extends SelectorOptionType>(
               xstyle={styles.triggerIcon}
             />
           )
-        ) : (
+        ) : hasChevron ? (
           <Icon
             icon="chevronDown"
             size="sm"
@@ -1578,7 +1604,7 @@ export function Selector<T extends SelectorOptionType>(
               state: popover.isOpen ? 'expanded' : 'collapsed',
             })}
           />
-        )}
+        ) : null}
       </div>
 
       {popover.render(


### PR DESCRIPTION
## Problem

The chevron renders as a **sibling** of the trigger button, after the optional `InputClearButton`. So with `hasClear` and a value selected, the trigger shows both a `×` and a chevron in the same end slot, and consumers who wanted the clear affordance to *replace* the chevron had no way to say so:

- The chevron's theme target (`astryx-selector-indicator-icon`) only carries `data-state="expanded|collapsed"`.
- The selector root publishes `data-variant`, `data-size`, `data-status`, `data-disabled` — nothing for "has a value".
- StyleX has no descendant selectors and `stylex.when.*` only reads *upward*, so an `xstyle` on the field cannot reach the icon.

No sanctioned escape hatch existed.

## API added

One optional boolean on all three components:

```ts
/** Whether to show the chevron at the end of the trigger. ... @default true */
hasChevron?: boolean;
```

```tsx
<Selector hasClear hasChevron={false} value={value} onChange={setValue} />
```

- **Default unchanged.** `hasChevron = true` in the destructure (the component idiom here — `DropdownMenu` uses `hasChevron = true`, `Selector` uses `indicatorPosition = 'end'`; the `?? true` form in #5310 was for a hook *config object*, which has no destructure to default). A consumer that omits it renders identically.
- **Gates only the chevron.** On `Selector` and `MultiSelector` the end slot is a ternary: a status glyph renders *instead of* the chevron when a status is attached. `hasChevron` gates the chevron arm alone — a status glyph reports on the value, so suppressing it would hide information rather than an affordance. With an attached status the flag is a no-op, which is asserted.
- **a11y-neutral, verified in the markup rather than assumed.** `Icon` without a `label` emits `aria-hidden="true"`, and the chevron is a sibling of the `<button>`, not a descendant — so it is neither in the a11y tree nor part of the button's name computation. Both facts are asserted in tests, alongside accessible name, `textContent`, and tab order being identical across the two modes.

### Why `hasChevron`, not `hasIndicator`

`indicator` is **already taken on two of the three components, meaning something else**. `Selector` and `MultiSelector` both expose `indicatorPosition` — which edge of an *option row inside the popup* carries the selected mark (a check on Selector, a checkbox on MultiSelector). `Selector.tsx` imports `useIndicator` and `IndicatorPosition` from the `Indicator` module for exactly that. `hasIndicator={false}` next to `indicatorPosition="start"` would read as "turn off the option checkmarks."

`hasChevron` is the existing house name for this exact affordance: `DropdownMenu` already ships `hasChevron?: boolean` defaulting to `true` to suppress its trigger chevron — and its theme target is likewise named `astryx-dropdown-menu-indicator-icon`, so the theme-target/prop-name split is precedent, not a new inconsistency. It also matches the `has*` convention for presentational sub-affordances (`hasClear`, `hasSearch`, `hasHover`, `hasRowHighlight`).

## Per-component notes

They are consistent in name, default, and semantics, but the trigger markup differs in two ways worth flagging:

- **`ComplexSelector` has no `hasClear`.** Its end slot holds only the chevron, so the clear-replaces-chevron motivation does not apply. The flag is still useful (a trigger whose composed content supplies its own end affordance), and its doc example says so rather than reusing the clear-button framing.
- **`ComplexSelector` renders no on-field status glyph**, so its chevron was unconditional. It becomes `{hasChevron && <Icon …/>}`; the other two become a third ternary arm.

## Docs

Per-file, matching each doc's actual shape rather than assuming three surfaces everywhere:

- `Selector.doc.mjs` — `docs.props` + a new `examples` entry. Its `docsZh`/`docsDense` are usage-only overlays with no `propDescriptions` at all; adding a lone Chinese entry would have been the only one in the file, so it was left alone.
- `MultiSelector.doc.mjs` — all three: `docs…props`, `docsZh…propDescriptions` (translated), `docsDense…propDescriptions`, plus an `examples` entry.
- `ComplexSelector.doc.mjs` — `docs…props` + `docsDense.propDescriptions` (it has no `docsZh`), plus an `examples` entry.

`SYNC:` headers were checked on all three sources — each already lists its own `.doc.mjs`, so unlike #5310 there was no missing entry to add. The lists also name storybook stories and `packages/cli/assets/templates/blocks/**`; neither needs a change, since the prop is additive with an unchanged default (and templates were out of bounds for this PR).

Changeset: `[feat]` / `patch`, per the 0.x coupling `check:changesets` enforces (only `[breaking]` may bump the minor while 0.x).

## Test plan

19 tests added — 7 on `Selector`, 7 on `MultiSelector`, 5 on `ComplexSelector`:

- [x] The chevron renders by default (all three)
- [x] `hasChevron={false}` removes it (all three)
- [x] With `hasClear` + a value, the clear button is still present and the chevron is gone (Selector, MultiSelector)
- [x] Accessible name, trigger `textContent`, and tab order are identical across both modes (all three)
- [x] The chevron is `aria-hidden="true"` and is **not** contained by the trigger button (all three)
- [x] An attached status glyph still renders with the chevron off, and the icon count is the same either way (Selector, MultiSelector)
- [x] The popup still opens and `aria-expanded` still flips with the chevron off (all three)

**Non-vacuity was checked, not assumed.** I stashed only the three `.tsx` sources, kept the tests, and re-ran: **11 of the 19 fail without the change.** The 8 that pass either way do so by construction, and I want to be straight about which:

- 3 × "renders the chevron by default" — a default-preservation guard necessarily passes both ways; its value is catching a future change of default.
- 3 × "chevron is aria-hidden and outside the button" — deliberate characterization of *pre-existing* markup. This is the evidence for the a11y-neutrality claim, so it is meant to hold before and after.
- 2 × "keeps the status glyph" — with an attached status the chevron arm never runs either way, so this is a forward guard on the semantic split (it fails if someone later widens the flag to gate the status icon).

Every test that asserts the opt-out itself fails without the change; each `hasChevron={false}` render asserts the chevron is absent so none of them can drift vacuous.

Gates:

- [x] `pnpm -F @astryxdesign/core typecheck` and `typecheck:docs` — clean
- [x] `eslint` on all 10 changed files at `ASTRYX_STRICT_LINT=1` — 0 errors (the one warning, unused `borderVars` in `MultiSelector.tsx`, reproduces on `origin/main` and is untouched here)
- [x] `prettier --check` on all 10 changed files — clean
- [x] `vitest run` — Selector 150 passed, MultiSelector 112 passed, ComplexSelector 17 passed (279 total, 3 files)
- [x] `pnpm check:repo` — exit 0
- [x] `astryx component <Name> --dense` renders the new prop row and example for all three

Made with [Cursor](https://cursor.com)