### PR TITLE
fix(BottomSheet): guard standalone Escape against IME composition

### DIFF
--- a/.changeset/bottom-sheet-ime-escape-guard.md
+++ b/.changeset/bottom-sheet-ime-escape-guard.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BottomSheet: a standalone sheet no longer dismisses when a CJK user presses Escape to cancel an in-progress IME composition. The browser fires that keydown before `compositionend`, so an Escape handler reading a bare `event.key` misread the composition cancel as a dismissal command and closed the sheet — losing whatever had been typed into a `purpose="form"` field inside it. The handler now early-returns on `isImeKeyEvent`, the same guard `Dialog` and `BottomSheetSwitcher` already carry, and claims the key first so the browser raises no close request of its own.
+
+@ernestt

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -334,6 +334,42 @@ describe('BottomSheet', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('ignores Escape while an IME composition is active', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
+        <input aria-label="Search" />
+      </BottomSheet>,
+    );
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.keyDown(dialog, {key: 'Escape', isComposing: true});
+    fireEvent.keyDown(dialog, {key: 'Escape', keyCode: 229});
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('claims the composing Escape so no native close request follows', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
+        <input aria-label="Search" />
+      </BottomSheet>,
+    );
+    const dialog = screen.getByRole('dialog');
+
+    // An unclaimed Escape lets the browser raise its own close request, which
+    // arrives as `cancel` and dismisses the sheet on the same keypress. The
+    // guard has to swallow the composing Escape, not merely skip dismissal.
+    const wasNotClaimed = fireEvent.keyDown(dialog, {
+      key: 'Escape',
+      isComposing: true,
+    });
+
+    expect(wasNotClaimed).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it('requests close when the scrim (dialog element itself) is clicked', () => {
     const onOpenChange = vi.fn();
     render(

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -370,6 +370,70 @@ describe('BottomSheet', () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
+  it('keeps a form sheet open when Escape cancels a field composition', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet
+        isOpen
+        purpose="form"
+        onOpenChange={onOpenChange}
+        label="Edit profile">
+        <input aria-label="Name" />
+      </BottomSheet>,
+    );
+
+    // The reported path: the keydown starts at the composing field and bubbles
+    // to the sheet's <dialog>, so the guard has to survive the trip.
+    fireEvent.keyDown(screen.getByRole('textbox', {name: 'Name'}), {
+      key: 'Escape',
+      isComposing: true,
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('still dismisses on the Escape after a composition is cancelled', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
+        <input aria-label="Search" />
+      </BottomSheet>,
+    );
+    const dialog = screen.getByRole('dialog');
+
+    fireEvent.keyDown(dialog, {key: 'Escape', isComposing: true});
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(dialog, {key: 'Escape'});
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('leaves the IME the composition keys that are not Escape', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
+        <input aria-label="Search" />
+      </BottomSheet>,
+    );
+    const dialog = screen.getByRole('dialog');
+
+    // Enter commits a candidate and the arrows walk the candidate window. The
+    // sheet must claim neither, or the IME loses keys it owns.
+    const enterUnclaimed = fireEvent.keyDown(dialog, {
+      key: 'Enter',
+      isComposing: true,
+    });
+    const arrowUnclaimed = fireEvent.keyDown(dialog, {
+      key: 'ArrowDown',
+      isComposing: true,
+    });
+
+    expect(enterUnclaimed).toBe(true);
+    expect(arrowUnclaimed).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it('requests close when the scrim (dialog element itself) is clicked', () => {
     const onOpenChange = vi.fn();
     render(
@@ -508,6 +572,29 @@ describe('BottomSheet', () => {
       );
       fireEvent.keyDown(screen.getByRole('dialog'), {key: 'Escape'});
       expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('ignores Escape while an IME composition is active', () => {
+      const onOpenChange = vi.fn();
+      render(
+        <BottomSheet
+          isOpen
+          hasScrim={false}
+          onOpenChange={onOpenChange}
+          label="Filters">
+          <input aria-label="Search" />
+        </BottomSheet>,
+      );
+
+      // Escape is this sheet's only keyboard route out — there is no native
+      // close request behind it — so the guard is all that stands between a
+      // composing CJK user and a dismissed sheet.
+      fireEvent.keyDown(screen.getByRole('dialog'), {
+        key: 'Escape',
+        isComposing: true,
+      });
+
+      expect(onOpenChange).not.toHaveBeenCalled();
     });
 
     it('still dismisses on a downward swipe past the threshold', () => {

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -37,7 +37,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import type {DialogPurpose} from '../Dialog';
 import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
-import {useDevWarning, useScrollLock} from '../hooks';
+import {isImeKeyEvent, useDevWarning, useScrollLock} from '../hooks';
 import {
   BottomSheetPanel,
   type BottomSheetPanelMotion,
@@ -298,6 +298,9 @@ function StandaloneBottomSheet({
 
   const handleCancel = useCallback(
     (event: React.SyntheticEvent<HTMLDialogElement>) => {
+      // No IME guard here: `cancel` is a plain Event carrying no composition
+      // state, and handleKeyDown claims a composing Escape before the browser
+      // can raise the close request that would arrive here.
       event.preventDefault();
       dismissOnEscape();
     },
@@ -305,10 +308,20 @@ function StandaloneBottomSheet({
   );
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDialogElement>) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        dismissOnEscape();
+      if (event.key !== 'Escape') {
+        return;
       }
+      // Claim the key before reading it: an unclaimed Escape lets the browser
+      // raise its own close request, which lands on handleCancel and dismisses
+      // on the same keypress.
+      event.preventDefault();
+      // An IME fires this keydown to cancel an in-progress composition, ahead
+      // of compositionend. It is a composition cancel, not a dismissal command
+      // — see utils/ime; Dialog and BottomSheetSwitcher guard the same way.
+      if (isImeKeyEvent(event.nativeEvent)) {
+        return;
+      }
+      dismissOnEscape();
     },
     [dismissOnEscape],
   );


### PR DESCRIPTION
## What this does

A bottom sheet no longer closes when someone typing Korean, Japanese or Chinese presses Escape to back out of a half-typed word.

## Why

While an IME is composing, the browser sends an Escape keydown to cancel the pending characters, and it sends it *before* `compositionend`. The standalone sheet read that as a plain "close me" command, so a CJK user correcting a word inside a sheet lost the whole sheet, along with anything already typed into it. The documented `purpose="form"` and `height="tall"` mobile-keyboard cases both put a text field in a standalone sheet, so this is an ordinary path rather than a corner.

The base `Dialog` already guards this, and so does the sibling `BottomSheetSwitcher`. Only the standalone sheet was missing it.

## What changed

- The sheet's Escape handler now ignores the keydown that belongs to an in-progress composition, via the shared `isImeKeyEvent` check the rest of the library uses.
- It claims the Escape *before* deciding what the key means. Left unclaimed, the browser raises its own close request, which arrives at the sheet's `onCancel` and closes it on the very same keypress. The guard on its own is not enough.
- `handleCancel` is unchanged, and gains a comment saying why: `cancel` is a plain `Event` carrying no composition state, so a guard there could never fire.
- Five tests, and a changeset.

## Evidence

This is a bug fix, so the bar is red before and green after.

The tests are red at `fba7b4009` (the branch base) and green after the fix. Reverting `handleKeyDown` to its previous shape turns four of the five red on their behaviour assertion (`onOpenChange` called once where it must not be called at all), and hoisting `preventDefault` above the key check turns the fifth red on its own. No test here passes vacuously, and the two halves of the fix are pinned separately.

Covered: both IME signals (`isComposing`, and the legacy keyCode 229); a composing Escape raised on a focused field and bubbling to the `<dialog>`; the release case, where the Escape *after* a cancelled composition still dismisses; the non-modal sheet, where Escape is the only route out; and Enter and ArrowDown mid-composition staying unclaimed, since the IME owns those keys.

Local: `pnpm lint:strict` clean, core typecheck clean, `pnpm build` green, BottomSheet suite 77/77, full suite 11289/11292. The three remaining failures are pre-existing and not from this branch: two cli tests that assume a case-sensitive filesystem, and one `DateInputTouch` test that times out at 5s only under load (127/127 in isolation, and `packages/core/src/DateInput/` is byte-identical to `main` on this branch).

No screenshots: nothing rendered changes, and a real IME composition cannot be driven from browser automation. A synthetic `KeyboardEvent` is untrusted, so it would not exercise the close-request path either.

## Rubric

`Triage: bug fix · non-breaking · low blast radius → fast path · checks: §1 A1-A7/A11-A12, §7 C1-C8/C11, Q1-Q12`

Component Audit Rubric v1.6, check §9 I19. §1: Escape stays operable; no ARIA, focus or live region touched. §7: no Effect, state, ref or observer added, and the shared `isImeKeyEvent` is composed rather than reimplemented. The component is not audited around the fix.

One note for the ledger row: the issue asks for the guard in both `handleKeyDown` and `handleCancel`. Only the first is implementable, for the reason above. The `preventDefault` hoist is what actually closes the cancel path.

Fixes #5302
