### PR TITLE
fix(a11y): a disabled control answers the pointer with not-allowed

### DIFF
--- a/.changeset/disabled-cursor-guarantee.md
+++ b/.changeset/disabled-cursor-guarantee.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] A disabled control now answers the pointer with `not-allowed` wherever it can be pointed at: every `cursor` in core and lab carries `':is(:disabled,[aria-disabled="true"])': 'not-allowed'`, and the reset gives the same cursor to any disabled element that declares none — `[aria-disabled]` included, where it previously said `default` and only for native `:disabled`. A lint rule and a Chromium sweep over every story keep it that way. Disabled elements sealed behind `pointer-events: none` are unchanged: the pointer never reaches them, so their cursor comes from an ancestor.
+
+@cixzhang

--- a/.github/scripts/disabled-cursor-audit.js
+++ b/.github/scripts/disabled-cursor-audit.js
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+
+/**
+ * @description Asserts every disabled element answers the pointer with `not-allowed`
+ * @input --storybook-dir <path> [--components <csv>] [--output <file>]
+ *   [--concurrency <n>] [--port <n>]
+ * @output JSON report of violations; exit 1 if any disabled element shows a
+ *   cursor other than `not-allowed`
+ *
+ * The cursor is the only affordance a pointer user gets before they commit to
+ * a click. A disabled control that answers with `pointer` promises a click it
+ * will not honour, and one that answers with `default` says nothing at all —
+ * the user learns the control is dead only by clicking it and watching
+ * nothing happen.
+ *
+ * jsdom has no cursor and no hit testing, so the unit suite cannot see any of
+ * this. Chromium can. For every disabled element in every story we hit-test
+ * the points a pointer would actually land on and read the computed `cursor`
+ * of the element that answers — which is the element the pointer hits, not
+ * necessarily the disabled one: `cursor` inherits, so a child that declares
+ * its own wins under the pointer, and a subtree behind `pointer-events: none`
+ * hands the question to an ancestor.
+ *
+ * The gate is zero-tolerance and has no baseline: `not-allowed` on a disabled
+ * control is never wrong, so there is nothing to grandfather. What it does
+ * skip is an element nothing can point at — no box, or covered by something
+ * else at every sample point — because a cursor nobody can reach is not a
+ * defect a user can see. Elements sealed behind `pointer-events: none` are
+ * counted and reported separately: the pointer lands on an ancestor there, so
+ * the value is a property of the surrounding layout rather than the control,
+ * and holding a component to it would be holding it to its consumer's markup.
+ */
+
+const {chromium} = require('playwright');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+
+// ---------------------------------------------------------------------------
+// pure logic (exported for the unit test)
+// ---------------------------------------------------------------------------
+
+/** The one cursor a disabled control may answer with. */
+const DISABLED_CURSOR = 'not-allowed';
+
+/**
+ * What counts as disabled — the same pair the hover sweep uses.
+ *
+ * `:disabled` covers the native form controls (including everything inside a
+ * disabled fieldset); `[aria-disabled="true"]` covers the pattern astryx uses
+ * wherever a disabled control must stay focusable so its reason is
+ * discoverable — Button with a tooltip, Selector's trigger, SideNavItem.
+ */
+const DISABLED_SELECTOR = ':disabled, [aria-disabled="true"]';
+
+/**
+ * Which stories belong to the requested components.
+ *
+ * `--components` absent means every story (the full-sweep contract). Present
+ * but empty means the caller derived an empty set — audit nothing and pass,
+ * rather than fanning out to a full sweep the caller never asked for. Same
+ * contract as accessibility-audit.js, so both can share one component list.
+ */
+function selectStories(entries, components) {
+  const wanted = (components || []).map(c => c.toLowerCase());
+  return entries.filter(entry => {
+    if (entry.type === 'docs' || entry.id.endsWith('--docs')) return false;
+    if (!/^(core|lab)-/.test(entry.id)) return false;
+    if (wanted.length === 0) return true;
+    const title = entry.title || '';
+    const parts = title.split('/');
+    const componentPart = parts.length > 1 ? parts[1] : parts[0];
+    return wanted.includes(componentPart.replace(/^XDS/i, '').toLowerCase());
+  });
+}
+
+/**
+ * Turn one element's sampled points into a verdict.
+ *
+ * A sample is `{cursor, relation}`, where `relation` says what the pointer
+ * found at that point: `self` or `descendant` (the control answered),
+ * `ancestor` (the control is sealed behind `pointer-events: none`), `covered`
+ * (something else is on top), or `none` (outside the viewport).
+ *
+ * The worst answer decides — one reachable point promising `pointer` is a
+ * defect however many other points behave.
+ */
+function verdictFor(samples) {
+  const answered = samples.filter(
+    s => s.relation === 'self' || s.relation === 'descendant',
+  );
+  if (answered.length > 0) {
+    const wrong = answered.find(s => s.cursor !== DISABLED_CURSOR);
+    return wrong
+      ? {status: 'violation', cursor: wrong.cursor}
+      : {status: 'ok', cursor: DISABLED_CURSOR};
+  }
+  const ancestor = samples.find(s => s.relation === 'ancestor');
+  if (ancestor) return {status: 'unreachable', cursor: ancestor.cursor};
+  return {status: 'skipped', cursor: null};
+}
+
+/** One line per violation, grouped by component, for the CI log. */
+function formatViolations(violations) {
+  if (violations.length === 0) {
+    return `Every disabled element answers the pointer with ${DISABLED_CURSOR}.`;
+  }
+  const byComponent = new Map();
+  for (const violation of violations) {
+    const list = byComponent.get(violation.component) || [];
+    list.push(violation);
+    byComponent.set(violation.component, list);
+  }
+  const lines = [
+    `${violations.length} disabled element(s) answer the pointer with the wrong cursor:`,
+    '',
+  ];
+  for (const [component, list] of [...byComponent.entries()].sort()) {
+    lines.push(`  ${component} (${list.length})`);
+    for (const violation of list) {
+      lines.push(`    ${violation.story}  ${violation.element}`);
+      lines.push(
+        `      cursor: ${violation.cursor} (expected ${DISABLED_CURSOR})`,
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// browser sweep
+// ---------------------------------------------------------------------------
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json',
+  '.ico': 'image/x-icon',
+};
+
+function serve(root, port) {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      let url = decodeURIComponent(req.url.split('?')[0]);
+      if (url === '/') url = '/index.html';
+      const filePath = path.resolve(path.join(root, url));
+      if (!filePath.startsWith(path.resolve(root))) {
+        res.writeHead(403);
+        return res.end('Forbidden');
+      }
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          res.writeHead(404);
+          return res.end('Not found');
+        }
+        res.writeHead(200, {
+          'Content-Type':
+            MIME[path.extname(filePath)] || 'application/octet-stream',
+        });
+        res.end(data);
+      });
+    });
+    server.listen(port, '127.0.0.1', () =>
+      resolve({server, port: server.address().port}),
+    );
+  });
+}
+
+/**
+ * Installed in the page: hit-test every disabled element and report what the
+ * pointer would find.
+ *
+ * Sampling runs inside the page so one round trip covers every element in the
+ * story. Five points per element — the centre and the four quadrant
+ * midpoints — because a child that declares its own cursor often covers only
+ * part of the control (an icon, a label, an inner input), and the centre
+ * alone would miss it.
+ */
+const PAGE_HARNESS = `
+window.__astryxCursorAudit = {
+  label(el) {
+    const id = el.id ? '#' + el.id : '';
+    const cls = typeof el.className === 'string' && el.className
+      ? '.' + el.className.trim().split(/\\s+/).slice(0, 3).join('.')
+      : '';
+    const role = el.getAttribute('role');
+    return '<' + el.tagName.toLowerCase() + id + cls + (role ? ' role=' + role : '') + '>';
+  },
+  points(rect) {
+    const inset = (a, b, t) => a + (b - a) * t;
+    return [
+      [inset(rect.left, rect.right, 0.5), inset(rect.top, rect.bottom, 0.5)],
+      [inset(rect.left, rect.right, 0.25), inset(rect.top, rect.bottom, 0.25)],
+      [inset(rect.left, rect.right, 0.75), inset(rect.top, rect.bottom, 0.25)],
+      [inset(rect.left, rect.right, 0.25), inset(rect.top, rect.bottom, 0.75)],
+      [inset(rect.left, rect.right, 0.75), inset(rect.top, rect.bottom, 0.75)],
+    ];
+  },
+  relation(el, hit) {
+    if (!hit) return 'none';
+    if (hit === el) return 'self';
+    if (el.contains(hit)) return 'descendant';
+    if (hit.contains(el)) return 'ancestor';
+    return 'covered';
+  },
+  sample(selector) {
+    return [...document.querySelectorAll(selector)]
+      .filter(el => el.getClientRects().length > 0)
+      .map(el => {
+        const rect = el.getBoundingClientRect();
+        const samples = this.points(rect)
+          .filter(
+            ([x, y]) =>
+              x >= 0 && y >= 0 && x < innerWidth && y < innerHeight,
+          )
+          .map(([x, y]) => {
+            const hit = document.elementFromPoint(x, y);
+            return {
+              relation: this.relation(el, hit),
+              cursor: hit ? getComputedStyle(hit).cursor : null,
+            };
+          });
+        return {label: this.label(el), samples};
+      });
+  },
+};
+`;
+
+async function auditStory(context, port, entry, limits) {
+  const page = await context.newPage();
+  const violations = [];
+  const unreachable = [];
+  let disabledElements = 0;
+  try {
+    await page.goto(
+      `http://127.0.0.1:${port}/iframe.html?id=${entry.id}&viewMode=story`,
+      {waitUntil: 'load', timeout: limits.timeout},
+    );
+    await page.evaluate(() => document.fonts?.ready).catch(() => {});
+    // Wait for the story to actually mount before counting disabled elements:
+    // a bare `load` can land before React has rendered, and the sweep would
+    // then report a story as having nothing to check.
+    await page
+      .waitForFunction(
+        () => {
+          const root = document.getElementById('storybook-root');
+          return Boolean(root && root.children.length > 0);
+        },
+        {timeout: 5000},
+      )
+      .catch(() => {});
+    await page.waitForTimeout(200);
+    await page.evaluate(PAGE_HARNESS);
+
+    const elements = await page.evaluate(
+      selector => window.__astryxCursorAudit.sample(selector),
+      DISABLED_SELECTOR,
+    );
+    disabledElements = elements.length;
+
+    for (const element of elements.slice(0, limits.elementsPerStory)) {
+      const verdict = verdictFor(element.samples);
+      const record = {
+        component: entry.title || entry.id,
+        story: entry.id,
+        element: element.label,
+        cursor: verdict.cursor,
+      };
+      if (verdict.status === 'violation') violations.push(record);
+      if (verdict.status === 'unreachable') unreachable.push(record);
+    }
+  } finally {
+    await page.close().catch(() => {});
+  }
+  return {violations, unreachable, disabledElements};
+}
+
+async function run() {
+  const args = process.argv.slice(2);
+  const getArg = name => {
+    const index = args.indexOf(`--${name}`);
+    return index !== -1 ? args[index + 1] : null;
+  };
+
+  const storybookDir = getArg('storybook-dir') || 'apps/storybook/dist';
+  const outputFile = getArg('output');
+  const componentsArg = getArg('components');
+  const concurrency = Math.max(1, Number(getArg('concurrency') || 4));
+  const port = Number(getArg('port') || 0);
+  const limits = {
+    timeout: Number(getArg('timeout') || 20000),
+    elementsPerStory: Number(getArg('max-elements') || 30),
+  };
+
+  if (
+    componentsArg !== null &&
+    componentsArg.split(',').filter(Boolean).length === 0
+  ) {
+    console.log('No components to audit (--components is empty) — skipping.');
+    return 0;
+  }
+  const components = (componentsArg || '').split(',').filter(Boolean);
+
+  const dist = path.resolve(process.cwd(), storybookDir);
+  if (!fs.existsSync(path.join(dist, 'index.json'))) {
+    console.error(`Storybook build not found at ${dist}`);
+    return 1;
+  }
+  const index = JSON.parse(
+    fs.readFileSync(path.join(dist, 'index.json'), 'utf8'),
+  );
+  const stories = selectStories(
+    Object.values(index.entries || index.stories || {}),
+    components,
+  );
+  console.log(`Auditing ${stories.length} stories for the disabled cursor`);
+
+  const {server, port: servedPort} = await serve(dist, port);
+  const browser = await chromium.launch();
+  const violations = [];
+  const unreachable = [];
+  const failures = [];
+  let storiesWithDisabled = 0;
+  let disabledElements = 0;
+
+  try {
+    const context = await browser.newContext({
+      viewport: {width: 1280, height: 900},
+    });
+    const queue = [...stories];
+    const workers = Array.from({length: concurrency}, async () => {
+      for (;;) {
+        const entry = queue.shift();
+        if (!entry) return;
+        try {
+          const result = await auditStory(context, servedPort, entry, limits);
+          if (result.disabledElements > 0) {
+            storiesWithDisabled++;
+            disabledElements += result.disabledElements;
+          }
+          violations.push(...result.violations);
+          unreachable.push(...result.unreachable);
+        } catch (error) {
+          failures.push({story: entry.id, error: error.message});
+        }
+      }
+    });
+    await Promise.all(workers);
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  const report = {
+    summary: {
+      storiesAudited: stories.length,
+      storiesWithDisabledElements: storiesWithDisabled,
+      disabledElementsChecked: disabledElements,
+      violations: violations.length,
+      unreachable: unreachable.length,
+      auditedAt: new Date().toISOString(),
+    },
+    violations,
+    unreachable,
+    failures,
+  };
+  if (outputFile) {
+    fs.writeFileSync(outputFile, JSON.stringify(report, null, 2) + '\n');
+  }
+
+  console.log(
+    `\nChecked ${disabledElements} disabled element(s) across ${storiesWithDisabled} of ${stories.length} stories`,
+  );
+  if (unreachable.length > 0) {
+    console.log(
+      `${unreachable.length} sealed behind pointer-events: none (cursor comes from an ancestor)`,
+    );
+  }
+  if (failures.length > 0) {
+    console.warn(`${failures.length} story/stories failed to load:`);
+    for (const failure of failures.slice(0, 10)) {
+      console.warn(`  ${failure.story}: ${failure.error}`);
+    }
+  }
+  console.log(formatViolations(violations));
+
+  return violations.length > 0 ? 1 : 0;
+}
+
+if (require.main === module) {
+  run()
+    .then(code => {
+      process.exitCode = code;
+    })
+    .catch(error => {
+      console.error('Disabled-cursor audit failed:', error);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  DISABLED_CURSOR,
+  DISABLED_SELECTOR,
+  selectStories,
+  verdictFor,
+  formatViolations,
+};

--- a/.github/scripts/disabled-cursor-audit.test.mjs
+++ b/.github/scripts/disabled-cursor-audit.test.mjs
@@ -1,0 +1,169 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file disabled-cursor-audit.test.mjs
+ * Covers the parts of the disabled-cursor gate that do not need a browser:
+ * the story-scoping contract it shares with the a11y audit, the verdict it
+ * draws from a set of sampled points, and the report it prints. The Chromium
+ * sweep itself is exercised by the CI job that runs it against the real
+ * Storybook build.
+ */
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {createRequire} from 'node:module';
+import {describe, it, expect} from 'vitest';
+
+const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(SCRIPTS_DIR, 'disabled-cursor-audit.js');
+const {selectStories, verdictFor, formatViolations, DISABLED_SELECTOR} =
+  createRequire(import.meta.url)(SCRIPT);
+
+const story = (id, title) => ({id, title, type: 'story'});
+const sample = (relation, cursor) => ({relation, cursor});
+
+describe('selectStories', () => {
+  const entries = [
+    story('core-button--default', 'Core/Button'),
+    story('core-button--disabled', 'Core/Button'),
+    story('core-button--docs', 'Core/Button'),
+    story('lab-stepper--default', 'Lab/Stepper'),
+    story('example-introduction--page', 'Example/Introduction'),
+  ];
+
+  it('audits every core and lab story when no components are named', () => {
+    expect(selectStories(entries, []).map(e => e.id)).toEqual([
+      'core-button--default',
+      'core-button--disabled',
+      'lab-stepper--default',
+    ]);
+  });
+
+  it('scopes to the named components, case-insensitively', () => {
+    expect(selectStories(entries, ['button']).map(e => e.id)).toEqual([
+      'core-button--default',
+      'core-button--disabled',
+    ]);
+  });
+
+  it('skips docs entries', () => {
+    expect(
+      selectStories(entries, ['button']).some(e => e.id.endsWith('--docs')),
+    ).toBe(false);
+  });
+});
+
+describe('verdictFor', () => {
+  it('passes a control that answers not-allowed', () => {
+    expect(verdictFor([sample('self', 'not-allowed')])).toEqual({
+      status: 'ok',
+      cursor: 'not-allowed',
+    });
+  });
+
+  it('fails a disabled control that still promises a click', () => {
+    expect(verdictFor([sample('self', 'pointer')])).toEqual({
+      status: 'violation',
+      cursor: 'pointer',
+    });
+  });
+
+  it('fails on a child that declares its own cursor', () => {
+    const verdict = verdictFor([
+      sample('self', 'not-allowed'),
+      sample('descendant', 'text'),
+    ]);
+    expect(verdict).toEqual({status: 'violation', cursor: 'text'});
+  });
+
+  it('counts a pointer-events:none subtree as unreachable, not a violation', () => {
+    expect(verdictFor([sample('ancestor', 'default')])).toEqual({
+      status: 'unreachable',
+      cursor: 'default',
+    });
+  });
+
+  it('skips an element nothing can point at', () => {
+    expect(
+      verdictFor([sample('covered', 'pointer'), sample('none', null)]),
+    ).toEqual({status: 'skipped', cursor: null});
+  });
+
+  it('lets one reachable point decide over an unreachable one', () => {
+    expect(
+      verdictFor([sample('ancestor', 'default'), sample('self', 'pointer')]),
+    ).toEqual({status: 'violation', cursor: 'pointer'});
+  });
+});
+
+describe('DISABLED_SELECTOR', () => {
+  it('covers the aria-disabled pattern as well as the native state', () => {
+    expect(DISABLED_SELECTOR).toContain(':disabled');
+    expect(DISABLED_SELECTOR).toContain('[aria-disabled="true"]');
+  });
+});
+
+describe('formatViolations', () => {
+  it('says so plainly when there is nothing to report', () => {
+    expect(formatViolations([])).toContain('not-allowed');
+  });
+
+  it('groups by component and names the story and the cursor', () => {
+    const output = formatViolations([
+      {
+        component: 'Core/Button',
+        story: 'core-button--disabled',
+        element: '<button.astryx-button>',
+        cursor: 'pointer',
+      },
+    ]);
+    expect(output).toContain('Core/Button (1)');
+    expect(output).toContain('core-button--disabled');
+    expect(output).toContain('cursor: pointer (expected not-allowed)');
+  });
+});
+
+describe('CLI contract', () => {
+  /** Run the audit in an empty temp cwd; returns {status, stdout}. */
+  function runAudit(args) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'disabled-cursor-'));
+    try {
+      const result = execFileSync(process.execPath, [SCRIPT, ...args], {
+        cwd: dir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return {status: 0, stdout: result};
+    } catch (error) {
+      return {
+        status: error.status,
+        stdout: (error.stdout || '') + (error.stderr || ''),
+      };
+    } finally {
+      fs.rmSync(dir, {recursive: true, force: true});
+    }
+  }
+
+  // Same contract as accessibility-audit.js so the two CI steps can share one
+  // component list: an EMPTY --components means the PR touched no component,
+  // and must pass without fanning out into a full sweep.
+  it('passes and audits nothing when --components is empty', () => {
+    const {status, stdout} = runAudit(['--components', '']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('skipping');
+  });
+
+  it('fails loudly when the storybook build is missing', () => {
+    const {status, stdout} = runAudit([
+      '--storybook-dir',
+      'nope',
+      '--components',
+      'Button',
+    ]);
+    expect(status).toBe(1);
+    expect(stdout).toContain('Storybook build not found');
+  });
+});

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -502,6 +502,19 @@ lint rule (autofixable) enforces it at author time; `pnpm guard:disabled-hover
 --storybook-dir apps/storybook/dist` sweeps a built Storybook in Chromium and
 fails on any disabled element whose paint changes under a forced `:hover`.
 
+### Disabled cursor guard
+
+A disabled control must answer the pointer with `not-allowed`: the cursor is
+the only affordance a pointer user gets before they commit to a click. Write
+every `cursor` so the disabled state takes it back —
+`cursor: {default: 'pointer', ':is(:disabled,[aria-disabled="true"])': 'not-allowed'}`
+— including a flat `cursor` inside a `disabled` style, since StyleX merges one
+property at a time and a later declaration replaces the earlier one's
+conditions along with its value. The `@astryx/disabled-cursor` lint rule
+(autofixable) enforces it at author time; `pnpm guard:disabled-cursor
+--storybook-dir apps/storybook/dist` hit-tests every disabled element in a
+built Storybook in Chromium and fails on any other cursor.
+
 ## Versioning & Releases
 
 We use [Changesets](https://github.com/changesets/changesets) for versioning, with a thin Astryx layer on top so changelogs stay categorized, contributor-attributed, and aligned with our pre-1.0 conventions.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -241,9 +241,9 @@ export default defineConfig(
       '@astryx/no-hardcoded-i18n-string': isStrictMode ? 'error' : 'warn',
     },
   },
-  // A hover state on a disabled control is a defect wherever it ships, so
-  // this one rule reaches past core: lab components are consumed the same
-  // way, and lab is where the next core component comes from.
+  // What a disabled control says to the pointer is a defect wherever it
+  // ships, so these two rules reach past core: lab components are consumed
+  // the same way, and lab is where the next core component comes from.
   {
     files: ["packages/lab/src/**/*.{ts,tsx}"],
     plugins: {
@@ -251,6 +251,7 @@ export default defineConfig(
     },
     rules: {
       '@astryx/no-hover-on-disabled': 'error',
+      '@astryx/disabled-cursor': 'error',
     },
   },
   // The i18n runtime itself defines the message strings the rest of the

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -512,6 +512,41 @@ Autofixable, and mirrored at runtime by `.github/scripts/disabled-hover-audit.js
 
 Ships as an **error in both tiers**: core and lab are clean, and this keeps them that way.
 
+### `@astryx/disabled-cursor`
+
+Flags a `cursor` inside `stylex.create()` that does not give way to `not-allowed` on a disabled element. The cursor is the only affordance a pointer user gets **before** they commit to a click: `cursor: pointer` on a disabled control promises a click it will not honour, and `disabled`/`[aria-disabled]` do not change what the element's own declaration paints.
+
+A component's separate `disabled` style object is not the answer either — it only helps where the author remembered to write one, on the element the author had in mind: the inner input, not the label wrapping it; the trigger, not the icon inside it.
+
+**Bad:**
+
+```ts
+const styles = stylex.create({
+  trigger: {cursor: 'pointer'},
+});
+```
+
+**Good:**
+
+```ts
+const styles = stylex.create({
+  trigger: {
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
+  },
+});
+```
+
+The guarded condition outranks the default in StyleX's own ordering, so it wins the moment the element is disabled; on an element that can never be disabled it is a no-op.
+
+**Scope:** every `cursor` a component writes, whatever the value — `not-allowed` itself is the only exemption. That breadth is not tidiness: StyleX merges `props()` one **property** at a time, so a later style setting `cursor` at all replaces the earlier declaration's conditions along with its value. SegmentedControlItem shipped exactly that — a guarded `cursor: pointer` on the base and `disabled: {cursor: 'default'}` applied after it, which threw the guard away and left a disabled segment answering with a plain arrow. A computed value (`interactive ? 'grab' : undefined`) is left alone because the rule cannot know what it resolves to.
+
+Autofixable, and mirrored at runtime by `.github/scripts/disabled-cursor-audit.js`, which hit-tests every disabled element in every story in Chromium and fails on any cursor other than `not-allowed`. That sweep is what covers the two cases the lint rule cannot see: a computed value, and a disabled element whose cursor comes from somewhere other than its own declaration.
+
+Ships as an **error in both tiers**: core and lab are clean, and this keeps them that way.
+
 ### `@astryx/no-unguarded-ime-keydown`
 
 Flags an `onKeyDown` handler on an **editable surface** that branches on a

--- a/internal/eslint-plugin-astryx/disabled-cursor.js
+++ b/internal/eslint-plugin-astryx/disabled-cursor.js
@@ -1,0 +1,189 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file disabled-cursor.js
+ * @description A `cursor` must give way to `not-allowed` on a disabled
+ * element.
+ *
+ * The cursor is the only affordance a pointer user gets before they commit to
+ * a click. `cursor: pointer` on a disabled control promises a click the
+ * control will not honour, and nothing takes that promise away for you:
+ * `disabled` and `[aria-disabled]` do not change what the element's own
+ * `cursor` declaration paints.
+ *
+ * A component's separate `disabled` style object is not the answer either. It
+ * only helps where the author remembered to write one, on the element the
+ * author had in mind — the inner input, not the label that wraps it; the
+ * trigger, not the icon inside it. Asking the question per component is what
+ * leaves the gaps.
+ *
+ * So the answer goes on the declaration itself, where it cannot be missed:
+ *
+ *   BAD   cursor: 'pointer'
+ *   GOOD  cursor: {
+ *           default: 'pointer',
+ *           ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+ *         }
+ *
+ * The guarded condition outranks the default in StyleX's own ordering, so it
+ * wins the moment the element is disabled, and on an element that can never
+ * be disabled it is a no-op.
+ *
+ * SCOPE: every `cursor` a component writes, whatever the value. That breadth
+ * is not tidiness — StyleX merges `props()` one PROPERTY at a time, so a later
+ * style setting `cursor` at all replaces the earlier declaration's conditions
+ * along with its value. SegmentedControlItem shipped exactly that: a guarded
+ * `cursor: pointer` on the base, and `disabled: {cursor: 'default'}` applied
+ * after it, which threw the guard away and left a disabled segment answering
+ * with a plain arrow. So the guard belongs on whichever declaration lands
+ * last, and the rule cannot know which one that is.
+ *
+ * `not-allowed` itself needs no guard, and a cursor whose value is computed
+ * rather than written (`interactive ? 'grab' : undefined`) is left alone — the
+ * rule cannot know what it resolves to. The Chromium sweep in
+ * `.github/scripts/disabled-cursor-audit.js` measures the rendered result for
+ * both.
+ */
+
+/** The condition a disabled element matches, and what it must get. */
+const DISABLED_CONDITION = ':is(:disabled,[aria-disabled="true"])';
+const DISABLED_CURSOR = 'not-allowed';
+
+/**
+ * Cursors that need the guard: everything except the disabled cursor itself.
+ *
+ * `default` and `auto` are on the list because a disabled control saying
+ * nothing is still saying the wrong thing, and because a flat `default` in a
+ * `disabled` style is exactly what defeats a guard written elsewhere.
+ */
+function needsGuard(value) {
+  return typeof value === 'string' && value !== DISABLED_CURSOR;
+}
+
+/**
+ * Already handled, in any spelling a hand might use.
+ *
+ * A `:not()` group is dropped before the test: the hover guard this codebase
+ * writes everywhere — `:hover:where(:not(:disabled,[aria-disabled="true"]))` —
+ * names the disabled state in order to EXCLUDE it, and reading that as
+ * "handled" would wave through the very declaration the rule exists for.
+ */
+function hasDisabledCondition(keys) {
+  return keys.some(key => {
+    if (typeof key !== 'string') return false;
+    const positive = key.replace(/:not\([^)]*\)/g, '');
+    return /:disabled|\[aria-disabled/.test(positive);
+  });
+}
+
+function keyOf(property) {
+  if (!property || property.type !== 'Property') return null;
+  if (property.key?.type === 'Literal') return String(property.key.value);
+  if (property.key?.type === 'Identifier' && !property.computed) {
+    return property.key.name;
+  }
+  return null;
+}
+
+function isInsideStylexCreate(node) {
+  let current = node;
+  while (current) {
+    if (
+      current.type === 'CallExpression' &&
+      current.callee?.type === 'MemberExpression' &&
+      current.callee.object?.name === 'stylex' &&
+      current.callee.property?.name === 'create'
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description:
+        'A cursor must give way to not-allowed on a disabled element',
+      category: 'Accessibility',
+      recommended: true,
+    },
+    messages: {
+      unguardedCursor:
+        "cursor: '{{value}}' is what a disabled element gets too. " +
+        `Add '${DISABLED_CONDITION}': '${DISABLED_CURSOR}' to the declaration ` +
+        'so the pointer says what the control will actually do.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const source = context.sourceCode ?? context.getSourceCode();
+
+    /** `':is(...)': 'not-allowed'`, quoted the way the file already quotes. */
+    const guardEntry = `'${DISABLED_CONDITION}': '${DISABLED_CURSOR}'`;
+
+    return {
+      Property(node) {
+        if (!isInsideStylexCreate(node)) return;
+        if (keyOf(node) !== 'cursor') return;
+
+        // A written-out value: rewrite it into the conditional form.
+        if (node.value.type === 'Literal' && needsGuard(node.value.value)) {
+          const value = node.value.value;
+          context.report({
+            node: node.value,
+            messageId: 'unguardedCursor',
+            data: {value},
+            fix(fixer) {
+              return fixer.replaceText(
+                node.value,
+                `{default: '${value}', ${guardEntry}}`,
+              );
+            },
+          });
+          return;
+        }
+
+        // Already conditional: the default branch is the one a disabled
+        // element falls through to, so that is the branch that needs the
+        // guard beside it.
+        if (node.value.type !== 'ObjectExpression') return;
+        const branches = node.value.properties.filter(
+          property => property.type === 'Property',
+        );
+        const keys = branches.map(keyOf);
+        if (hasDisabledCondition(keys)) return;
+
+        const defaultBranch = branches.find(
+          (property, index) => keys[index] === 'default',
+        );
+        if (
+          !defaultBranch ||
+          defaultBranch.value.type !== 'Literal' ||
+          !needsGuard(defaultBranch.value.value)
+        ) {
+          return;
+        }
+
+        context.report({
+          node: defaultBranch.value,
+          messageId: 'unguardedCursor',
+          data: {value: defaultBranch.value.value},
+          fix(fixer) {
+            const last = branches[branches.length - 1];
+            const after = source.getTokenAfter(last);
+            return after?.value === ','
+              ? fixer.insertTextAfter(after, ` ${guardEntry},`)
+              : fixer.insertTextAfter(last, `, ${guardEntry}`);
+          },
+        });
+      },
+    };
+  },
+};
+
+export default rule;
+export {DISABLED_CONDITION, DISABLED_CURSOR, hasDisabledCondition, needsGuard};

--- a/internal/eslint-plugin-astryx/disabled-cursor.test.mjs
+++ b/internal/eslint-plugin-astryx/disabled-cursor.test.mjs
@@ -1,0 +1,171 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file disabled-cursor.test.mjs
+ */
+
+import {RuleTester} from 'eslint';
+import rule from './disabled-cursor.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+const GUARD = ':is(:disabled,[aria-disabled="true"])';
+
+ruleTester.run('disabled-cursor', rule, {
+  valid: [
+    // The guarded form.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          trigger: {
+            cursor: {default: 'pointer', '${GUARD}': 'not-allowed'},
+          },
+        });
+      `,
+    },
+    // A hand-written condition that names the disabled state its own way.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          trigger: {
+            cursor: {default: 'grab', ':disabled': 'not-allowed'},
+          },
+        });
+      `,
+    },
+    // The disabled cursor itself is the one value that needs no guard.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          disabled: {cursor: 'not-allowed'},
+        });
+      `,
+    },
+    // A computed value is out of scope — the sweep measures it instead.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          handle: (interactive) => ({cursor: interactive ? 'grab' : undefined}),
+        });
+      `,
+    },
+    // Outside stylex.create this is not a style declaration at all.
+    {
+      code: `const options = {cursor: 'pointer'};`,
+    },
+  ],
+  invalid: [
+    // The plain declaration becomes the conditional form.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          trigger: {cursor: 'pointer'},
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          trigger: {cursor: {default: 'pointer', '${GUARD}': 'not-allowed'}},
+        });
+      `,
+      errors: [{messageId: 'unguardedCursor'}],
+    },
+    // An existing condition keeps its branches; the guard joins them.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          handle: {
+            cursor: {
+              default: 'col-resize',
+              ':active': 'grabbing',
+            },
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          handle: {
+            cursor: {
+              default: 'col-resize',
+              ':active': 'grabbing', '${GUARD}': 'not-allowed',
+            },
+          },
+        });
+      `,
+      errors: [{messageId: 'unguardedCursor'}],
+    },
+    // A flat value in a `disabled` style is the shape that defeats a guard
+    // written on the base: StyleX replaces the whole property on merge.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          disabled: {cursor: 'default'},
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          disabled: {cursor: {default: 'default', '${GUARD}': 'not-allowed'}},
+        });
+      `,
+      errors: [{messageId: 'unguardedCursor'}],
+    },
+    // No trailing comma: the fix has to supply the separator itself.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          field: {cursor: {default: 'text'}},
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          field: {cursor: {default: 'text', '${GUARD}': 'not-allowed'}},
+        });
+      `,
+      errors: [{messageId: 'unguardedCursor'}],
+    },
+    // The hover guard names :disabled to EXCLUDE it, so it does not count.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {
+            cursor: {
+              default: 'pointer',
+              ':hover:where(:not(:disabled,[aria-disabled="true"]))': 'pointer',
+            },
+          },
+        });
+      `,
+      output: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          item: {
+            cursor: {
+              default: 'pointer',
+              ':hover:where(:not(:disabled,[aria-disabled="true"]))': 'pointer', '${GUARD}': 'not-allowed',
+            },
+          },
+        });
+      `,
+      errors: [{messageId: 'unguardedCursor'}],
+    },
+  ],
+});
+
+console.log('disabled-cursor: all tests passed');

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -14,6 +14,7 @@
  * - no-raw-intl-locale: Forbids raw Intl formatting/comparison outside the approved i18n infrastructure boundary, and navigator.language(s) as a locale source
  * - no-unguarded-ime-keydown: Flags an onKeyDown on an editable surface that branches on command keys without an IME composition guard (isImeKeyEvent/isComposing)
  * - no-hover-on-disabled: Flags a :hover condition that can still match a disabled element (browsers suppress a disabled control's events, not its hover styling)
+ * - disabled-cursor: Flags a cursor that promises an interaction without giving way to not-allowed on a disabled element
  *
  * Philosophy: Strict for agents (CI), lenient for humans (local dev)
  * - "strict" config: All rules as errors - use in CI/agent environments
@@ -38,6 +39,7 @@ import noPhysicalPropertiesRule from './no-physical-properties.js';
 import focusOutlineKeyboardOnlyRule from './focus-outline-keyboard-only.js';
 import focusOutlineSharedRule from './focus-outline-shared.js';
 import noHoverOnDisabledRule from './no-hover-on-disabled.js';
+import disabledCursorRule from './disabled-cursor.js';
 import noReactNamespaceHooksRule from './no-react-namespace-hooks.js';
 import copyrightHeaderRule from './copyright-header.js';
 import noRawConsoleCliRule from './no-raw-console-cli.js';
@@ -263,6 +265,7 @@ const plugin = {
     'focus-outline-keyboard-only': focusOutlineKeyboardOnlyRule,
     'focus-outline-shared': focusOutlineSharedRule,
     'no-hover-on-disabled': noHoverOnDisabledRule,
+    'disabled-cursor': disabledCursorRule,
     'no-react-namespace-hooks': noReactNamespaceHooksRule,
     'require-base-props': requireBasePropsRule,
     'require-ref-prop': requireRefPropRule,
@@ -321,6 +324,10 @@ plugin.configs.strict = {
     // engine. Error in both tiers: core and lab are clean, and the fix is
     // autofixable.
     '@astryx/no-hover-on-disabled': 'error',
+    // The cursor is the affordance a pointer user reads before they click; a
+    // disabled control answering with `pointer` promises a click it will not
+    // honour. Error in both tiers, and autofixable.
+    '@astryx/disabled-cursor': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'error',
     '@astryx/require-ref-prop': 'error',
@@ -366,6 +373,10 @@ plugin.configs.recommended = {
     // engine. Error in both tiers: core and lab are clean, and the fix is
     // autofixable.
     '@astryx/no-hover-on-disabled': 'error',
+    // The cursor is the affordance a pointer user reads before they click; a
+    // disabled control answering with `pointer` promises a click it will not
+    // honour. Error in both tiers, and autofixable.
+    '@astryx/disabled-cursor': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'warn',
     '@astryx/require-ref-prop': 'warn',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lab:readiness:check": "node internal/lab-readiness/audit.mjs --check",
     "guard:modal-close": "node .github/scripts/modal-close-visibility.js",
     "guard:disabled-hover": "node .github/scripts/disabled-hover-audit.js",
+    "guard:disabled-cursor": "node .github/scripts/disabled-cursor-audit.js",
     "storybook": "pnpm -F @astryxdesign/storybook dev",
     "storybook:build": "pnpm -F @astryxdesign/storybook build",
     "docsite": "pnpm -F @astryxdesign/docsite dev",

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -170,7 +170,10 @@ const styles = stylex.create({
     color: 'inherit',
     font: 'inherit',
     textDecoration: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     // Match the avatar's circular shape so the focus ring hugs it.
     borderRadius: radiusVars['--radius-full'],
   },

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -86,7 +86,10 @@ const styles = stylex.create({
     backgroundImage: `linear-gradient(${colorVars['--color-neutral']}, ${colorVars['--color-neutral']})`,
   },
   button: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     // Reset the UA button's block padding only; the inline padding from `base`
     // provides the pill's breathing room and must be preserved.
     paddingBlock: 0,

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -177,7 +177,10 @@ const styles = stylex.create({
     // content emerging below has no visible cut line.
     backgroundImage: `linear-gradient(to bottom, ${colorVars['--color-background-surface']} 60%, transparent)`,
     touchAction: 'none',
-    cursor: 'grab',
+    cursor: {
+      default: 'grab',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   handlePill: {
     width: sizeVars['--size-element-lg'],

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -162,7 +162,10 @@ const itemStyles = stylex.create({
         '@media (hover: hover)': 'underline',
       },
     },
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // Reset native button styles so onClick-only items match link appearance
   buttonReset: {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -82,7 +82,10 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     whiteSpace: 'nowrap',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty:
       'background-image, background-color, color, opacity, transform',
     transitionDuration: {

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -198,7 +198,10 @@ export const dayCellStyles = stylex.create({
     borderRadius: '50%',
     borderWidth: 0,
     borderStyle: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     fontFamily: 'inherit',
     fontSize: typeScaleVars['--text-body-size'],
     padding: 0,

--- a/packages/core/src/Chat/ChatComposer.tsx
+++ b/packages/core/src/Chat/ChatComposer.tsx
@@ -152,7 +152,10 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     borderRadius: 'var(--_chat-composer-radius)',
     backgroundColor: colorVars['--color-background-popover'],
-    cursor: 'text',
+    cursor: {
+      default: 'text',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transition: `box-shadow ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}, border-color ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
   },
   header: {

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -117,7 +117,10 @@ const styles = stylex.create({
     height: spacingVars['--spacing-5'],
     paddingInline: spacingVars['--spacing-4'],
     marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
   },
   toggleCollapsed: {},

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -105,7 +105,10 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1-5'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
     minHeight: '24px',
     paddingBlock: spacingVars['--spacing-0-5'],
@@ -192,7 +195,10 @@ const styles = stylex.create({
     paddingBlock: spacingVars['--spacing-0-5'],
   },
   callRowClickable: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     paddingInline: spacingVars['--spacing-1'],
     marginInline: `calc(-1 * ${spacingVars['--spacing-1']})`,
@@ -203,7 +209,10 @@ const styles = stylex.create({
     },
   },
   callRowToggle: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   statusIcon: {
     position: 'relative',

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -117,7 +117,10 @@ const styles = stylex.create({
     width: '100%',
     padding: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-element'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -80,7 +80,10 @@ const styles = stylex.create({
     margin: 0,
     padding: 0,
     opacity: 0,
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     zIndex: 1,
     minInlineSize: {
       default: null,

--- a/packages/core/src/Citation/Citation.test.tsx
+++ b/packages/core/src/Citation/Citation.test.tsx
@@ -20,7 +20,12 @@ const probe = stylex.create({
   secondaryText: {color: colorVars['--color-text-secondary']},
   accentText: {color: colorVars['--color-text-accent']},
   badgeBackground: {backgroundColor: colorVars['--color-accent-muted']},
-  pointerCursor: {cursor: 'pointer'},
+  pointerCursor: {
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
+  },
 });
 
 function atomicClasses(style: (typeof probe)[keyof typeof probe]): string[] {

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -99,7 +99,10 @@ const styles = stylex.create({
     minWidth: 0,
   },
   labelInteractive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   labelHover: {
     backgroundColor: {
@@ -137,7 +140,10 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   numberInteractive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   numberHover: {
     backgroundColor: {

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -55,7 +55,10 @@ import {focusOutlineProps} from '../utils/focusOutline.stylex';
 const styles = stylex.create({
   interactive: {
     position: 'relative',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textDecoration: 'none',
     color: 'inherit',
   },

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -215,7 +215,10 @@ const styles = stylex.create({
     transform: 'rotate(90deg)',
   },
   headerCollapsible: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
     // Restore a keyboard-only focus ring with the standard token/offset so this
     // disclosure control matches the rest of the system (Collapsible, TabMenu);

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -65,7 +65,10 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     width: '100%',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-large-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],

--- a/packages/core/src/CommandPalette/CommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteItem.tsx
@@ -43,7 +43,10 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     border: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textAlign: 'start' as const,
     outline: 'none',
     userSelect: 'none',

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -70,7 +70,10 @@ const styles = stylex.create({
     },
     lineHeight: typeScaleVars['--text-label-leading'],
     color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   trigger: {
     display: 'flex',
@@ -90,7 +93,10 @@ const styles = stylex.create({
     fontSize: 'inherit',
     lineHeight: 'inherit',
     color: 'inherit',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     outline: 'none',
     borderRadius: radiusVars['--radius-element'],
   },

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -82,7 +82,10 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     backgroundColor: 'transparent',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {

--- a/packages/core/src/DateInput/MonthScroller.tsx
+++ b/packages/core/src/DateInput/MonthScroller.tsx
@@ -149,7 +149,10 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     fontSize: typeScaleVars['--text-body-size'],
     fontWeight: fontWeightVars['--font-weight-normal'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     // A tap on a 44px target should not also select the number inside it.
     userSelect: 'none',
     WebkitTapHighlightColor: 'transparent',

--- a/packages/core/src/DateInput/TouchDateField.tsx
+++ b/packages/core/src/DateInput/TouchDateField.tsx
@@ -176,7 +176,10 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     backgroundColor: 'transparent',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {
@@ -202,7 +205,10 @@ const styles = stylex.create({
     outline: 'none',
     // It opens a picker; it does not take text. The caret would say otherwise.
     caretColor: 'transparent',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
     '::placeholder': {
       color: colorVars['--color-text-secondary'],
@@ -320,7 +326,10 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     fontSize: typeScaleVars['--text-large-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     whiteSpace: 'nowrap',
   },
   titleChevron: {

--- a/packages/core/src/DateInput/Wheel.tsx
+++ b/packages/core/src/DateInput/Wheel.tsx
@@ -128,7 +128,10 @@ const styles = stylex.create({
     // container, and `view()` binds to the subject's nearest ancestor scroll
     // container — the falloff would measure the row against itself and sit
     // frozen at 50% forever. Clipping belongs on the inner element.
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
     transitionProperty: 'color, font-weight',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -106,7 +106,10 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     outline: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textAlign: 'start',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -127,7 +130,10 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     backgroundColor: 'transparent',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {
@@ -164,7 +170,10 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-label-size'],
     lineHeight: typeScaleVars['--text-label-leading'],
     color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textAlign: 'start',
   },
   presetButtonActive: {

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -121,7 +121,10 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     backgroundColor: 'transparent',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {

--- a/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
@@ -46,7 +46,10 @@ const styles = stylex.create({
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
     },
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     outline: 'none',
   },
   disabled: {

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -54,7 +54,10 @@ const menuItemStyles = stylex.create({
       ':focus': colorVars['--color-overlay-hover'],
     },
     border: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textAlign: 'start',
     outline: 'none',
   },

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
@@ -42,7 +42,10 @@ const styles = stylex.create({
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
     },
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     outline: 'none',
   },
   disabled: {

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -96,7 +96,10 @@ const triggerStyles = stylex.create({
       ':focus': colorVars['--color-overlay-hover'],
     },
     border: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textAlign: 'start',
     outline: 'none',
   },

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -45,7 +45,10 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   labelDisabled: {
     color: colorVars['--color-text-disabled'],
@@ -82,7 +85,10 @@ const styles = stylex.create({
   // When the description forwards clicks to a click-activatable control
   // (checkbox/switch), it reads as part of the same hit target as the label.
   descriptionClickable: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
 });
 

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -152,7 +152,10 @@ const styles = stylex.create({
       '@media (prefers-reduced-motion: reduce)': '0s',
     },
     transitionTimingFunction: easeVars['--ease-standard'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     outline: 'none',
   },
   dropzoneHover: {
@@ -202,7 +205,10 @@ const styles = stylex.create({
           '@media (hover: hover)': `inset 0 0 0 2px color-mix(in srgb, ${colorVars['--color-accent']} 20%, transparent)`,
         },
     },
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     height: sizeVars['--size-element-md'],
     outline: 'none',
   },

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -216,7 +216,10 @@ const styles = stylex.create({
     alignItems: 'flex-start',
   },
   interactive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast-min'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -243,7 +246,10 @@ const styles = stylex.create({
   },
   invisibleButton: {
     all: 'unset',
-    cursor: 'inherit',
+    cursor: {
+      default: 'inherit',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     font: 'inherit',
     color: 'inherit',
     display: 'flex',
@@ -255,7 +261,10 @@ const styles = stylex.create({
   },
   invisibleAnchor: {
     all: 'unset',
-    cursor: 'inherit',
+    cursor: {
+      default: 'inherit',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     font: 'inherit',
     color: 'inherit',
     display: 'flex',

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -150,7 +150,10 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'hidden',
-    cursor: 'default',
+    cursor: {
+      default: 'default',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
     minHeight: 0,
   },
@@ -158,13 +161,20 @@ const styles = stylex.create({
     cursor: {
       default: 'zoom-in',
       '@media (hover: hover)': 'zoom-in',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
     },
   },
   imageWrapperZoomed: {
-    cursor: 'grab',
+    cursor: {
+      default: 'grab',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   imageWrapperDragging: {
-    cursor: 'grabbing',
+    cursor: {
+      default: 'grabbing',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   image: {
     maxWidth: '100%',

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -65,7 +65,10 @@ const styles = stylex.create({
         '@media (hover: hover)': 'underline',
       },
     },
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'color, text-decoration',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/MetadataList/MetadataList.tsx
+++ b/packages/core/src/MetadataList/MetadataList.tsx
@@ -146,7 +146,10 @@ const styles = stylex.create({
     background: 'none',
     border: 'none',
     padding: `${spacingVars['--spacing-2']} 0`,
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     color: colorVars['--color-accent'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -103,7 +103,10 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-label-size'],
     lineHeight: typeScaleVars['--text-label-leading'],
     color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // Trigger button — the actual combobox button, visually integrated with the container
   trigger: {
@@ -124,7 +127,10 @@ const styles = stylex.create({
     fontSize: 'inherit',
     lineHeight: 'inherit',
     color: 'inherit',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     // The wrapper (inputWrapperStyles.base) renders the focus ring via
     // :focus-within when this button is focused, matching
     // TextInput/NumberInput/Selector. The button must not draw its own
@@ -230,7 +236,10 @@ const styles = stylex.create({
     borderStyle: 'none',
     backgroundColor: 'transparent',
     color: 'inherit',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
   },
 
@@ -252,7 +261,10 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
 
   // Section heading. Plain secondary text, no rules — the same treatment
@@ -283,7 +295,10 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     width: '100%',
     borderRadius: radiusVars['--radius-element'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     // Row typography lives here, not on the label span, so a theme override on
     // the row target reaches both the fallback label and renderOption output
     // (a declaration on the span would win over the inherited row value).

--- a/packages/core/src/NavItem/navItemStyles.stylex.ts
+++ b/packages/core/src/NavItem/navItemStyles.stylex.ts
@@ -65,7 +65,10 @@ export const navItemStyles = stylex.create({
     backgroundColor: 'transparent',
     color: colorVars['--color-text-primary'],
     textDecoration: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     fontFamily: 'inherit',
     fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-normal'],

--- a/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
@@ -48,7 +48,10 @@ const styles = stylex.create({
       },
     },
     border: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textAlign: 'start',
     outline: 'none',
     textDecoration: 'none',

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -166,7 +166,10 @@ const styles = stylex.create({
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     outline: 'none',
   },
   numberStepperButtonDisabled: {

--- a/packages/core/src/Outline/Outline.tsx
+++ b/packages/core/src/Outline/Outline.tsx
@@ -190,7 +190,10 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     boxSizing: 'border-box',
     color: colorVars['--color-text-secondary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     display: 'flex',
     fontWeight: fontWeightVars['--font-weight-normal'],
     outline: 'none',

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -214,7 +214,10 @@ const styles = stylex.create({
     padding: 0,
     borderRadius: '50%',
     backgroundColor: colorVars['--color-neutral'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -44,7 +44,10 @@ const styles = stylex.create({
     margin: 0,
     padding: 0,
     opacity: 0,
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     zIndex: 1,
     minInlineSize: {
       default: null,

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -119,12 +119,18 @@ const styles = stylex.create({
   horizontal: {
     width: 1,
     height: '100%',
-    cursor: 'col-resize',
+    cursor: {
+      default: 'col-resize',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   vertical: {
     height: 1,
     width: '100%',
-    cursor: 'row-resize',
+    cursor: {
+      default: 'row-resize',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   noDividerHorizontal: {
     backgroundColor: 'transparent',
@@ -141,7 +147,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-border-emphasized'],
   },
   disabled: {
-    cursor: 'default',
+    cursor: 'not-allowed',
     pointerEvents: 'none',
   },
 
@@ -155,13 +161,19 @@ const styles = stylex.create({
     width: spacingVars['--spacing-4'],
     top: 0,
     bottom: 0,
-    cursor: 'col-resize',
+    cursor: {
+      default: 'col-resize',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   hitAreaVertical: {
     height: spacingVars['--spacing-4'],
     insetInlineStart: 0,
     insetInlineEnd: 0,
-    cursor: 'row-resize',
+    cursor: {
+      default: 'row-resize',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // Centered grab zone (pillPlacement 'center' / no bias): sit the hit area on
   // the divider itself. Inline centering comes from rtlStyles.centerInline at

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -82,7 +82,10 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     whiteSpace: 'nowrap',
     transitionProperty: 'color, background-color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
@@ -121,7 +124,7 @@ const styles = stylex.create({
     boxShadow: shadowVars['--shadow-low'],
   },
   disabled: {
-    cursor: 'default',
+    cursor: 'not-allowed',
     color: colorVars['--color-text-disabled'],
   },
   fill: {

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -55,7 +55,10 @@ import {focusOutlineProps} from '../utils/focusOutline.stylex';
 const styles = stylex.create({
   interactive: {
     position: 'relative',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'box-shadow, border-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -110,7 +110,10 @@ const styles = stylex.create({
     // pinned. Item's own rows set their line heights and are unaffected.
     lineHeight: spacingVars['--spacing-5'],
     color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // Trigger button — the actual combobox button, visually integrated with the container
   trigger: {
@@ -131,7 +134,10 @@ const styles = stylex.create({
     fontSize: 'inherit',
     lineHeight: 'inherit',
     color: 'inherit',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     // The wrapper (inputWrapperStyles.base) renders the focus ring via
     // :focus-within when this button is focused, matching TextInput/NumberInput.
     // The button must not draw its own :focus-visible outline or the two stack
@@ -253,7 +259,10 @@ const styles = stylex.create({
     borderStyle: 'none',
     backgroundColor: 'transparent',
     color: 'inherit',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
   },
 
@@ -331,7 +340,10 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     border: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textAlign: 'start',
     outline: 'none',
   },

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -66,14 +66,20 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     textDecoration: 'none',
     color: 'inherit',
-    cursor: 'default',
+    cursor: {
+      default: 'default',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   rootCollapsed: {
     justifyContent: 'center',
     paddingInline: 0,
   },
   interactive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
     borderStyle: 'none',
@@ -91,7 +97,10 @@ const styles = stylex.create({
   // Menu trigger: like interactive but no hover background.
   // Only cursor:pointer signals interactivity; the popover provides context.
   menuTrigger: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
     borderStyle: 'none',
@@ -212,7 +221,10 @@ const styles = stylex.create({
     marginBlockStart: spacingVars['--spacing-1'],
     marginBlockEnd: spacingVars['--spacing-2'],
     marginInline: spacingVars['--spacing-1'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // Chevron inside the popover heading — same as chevron but rotated up
   popoverChevron: {

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -145,7 +145,10 @@ const styles = stylex.create({
     borderStyle: 'none',
     backgroundColor: 'transparent',
     color: 'inherit',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       '@media (hover: hover)': {
@@ -181,7 +184,10 @@ const styles = stylex.create({
     fontWeight: 'inherit',
     lineHeight: 'inherit',
     textAlign: 'start',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // No border and no background: `usePopover` paints the panel this renders
   // into. Drawing a second surface here put square corners inside its rounded

--- a/packages/core/src/SideNav/SideNavSection.tsx
+++ b/packages/core/src/SideNav/SideNavSection.tsx
@@ -47,7 +47,10 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
-    cursor: 'default',
+    cursor: {
+      default: 'default',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
   },
 

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -184,7 +184,10 @@ const styles = stylex.create({
       '@media (pointer: coarse)': '24px',
     },
     width: '100%',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   trackContainerVertical: {
     width: THUMB_SIZE,
@@ -201,7 +204,10 @@ const styles = stylex.create({
     },
     flexDirection: 'column',
     justifyContent: 'center',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   trackContainerDisabled: {
     opacity: 0.5,
@@ -251,7 +257,10 @@ const styles = stylex.create({
     },
     transitionTimingFunction: easeVars['--ease-standard'],
     outline: 'none',
-    cursor: 'grab',
+    cursor: {
+      default: 'grab',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     zIndex: 1,
   },
   thumbHorizontal: {

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -161,7 +161,10 @@ const styles = stylex.create({
     margin: 0,
     padding: 0,
     opacity: 0,
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     zIndex: 1,
     minInlineSize: {
       default: null,

--- a/packages/core/src/TabList/Tab.tsx
+++ b/packages/core/src/TabList/Tab.tsx
@@ -101,7 +101,10 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textDecoration: 'none',
     whiteSpace: 'nowrap',
     transitionProperty: 'color',

--- a/packages/core/src/TabList/TabMenu.tsx
+++ b/packages/core/src/TabList/TabMenu.tsx
@@ -87,7 +87,10 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     textDecoration: 'none',
     transitionProperty: 'color',
     transitionDuration: durationVars['--duration-fast'],
@@ -185,7 +188,10 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
@@ -207,7 +207,10 @@ const handleStyles = stylex.create({
     // Wide transparent hit area; the visible indicator uses ::after to span
     // the full handle height independently of the border box.
     width: '8px',
-    cursor: 'ew-resize',
+    cursor: {
+      default: 'ew-resize',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     zIndex: 1,
     touchAction: 'none',
     userSelect: 'none',

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
@@ -362,7 +362,10 @@ const filterStyles = stylex.create({
   triggerButton: {
     background: 'none',
     border: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -113,7 +113,10 @@ export interface UseTableGroupedRowsResult<T extends Record<string, unknown>> {
 
 const styles = stylex.create({
   headerRow: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
     backgroundColor: colorVars['--color-background-muted'],
     // Divider beneath each group header row (Ernest review #2).
@@ -145,7 +148,10 @@ const styles = stylex.create({
     margin: 0,
     background: 'transparent',
     border: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     color: {
       default: colorVars['--color-icon-secondary'],
       ':hover:where(:not(:disabled,[aria-disabled="true"]))':

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -77,7 +77,10 @@ const expansionStyles = stylex.create({
     background: 'transparent',
     border: 'none',
     borderRadius: radiusVars['--radius-inner'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     color: colorVars['--color-icon-secondary'],
     transitionProperty: 'transform, color',
     transitionDuration: '150ms',

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -125,7 +125,10 @@ const sortStyles = stylex.create({
     border: 'none',
     padding: 0,
     margin: 0,
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     font: 'inherit',
     color: 'inherit',
     width: '100%',

--- a/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
@@ -242,7 +242,10 @@ const treeStyles = stylex.create({
     background: 'transparent',
     border: 'none',
     borderRadius: radiusVars['--radius-inner'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     color: colorVars['--color-icon-secondary'],
     transitionProperty: 'color, background-color',
     transitionDuration: '150ms',
@@ -296,7 +299,10 @@ const treeStyles = stylex.create({
   },
   /** Whole-row-click expansion: signal the row is interactive. */
   clickableRow: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
 });
 

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -159,7 +159,10 @@ const styles = stylex.create({
     color: colorVars['--color-icon-secondary'],
   },
   interactive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // Hover/pressed overlay — the exact same treatment as ClickableCard and
   // SelectableCard. A transparent `::after` tints on hover/press instead of
@@ -190,7 +193,10 @@ const styles = stylex.create({
   },
   interactiveButton: {
     all: 'unset',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     display: 'block',
     width: '100%',
     height: '100%',

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -136,7 +136,10 @@ const styles = stylex.create({
     minWidth: 0,
   },
   interactive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-image',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -166,7 +169,10 @@ const styles = stylex.create({
   },
   invisibleButton: {
     all: 'unset',
-    cursor: 'inherit',
+    cursor: {
+      default: 'inherit',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     font: 'inherit',
     color: 'inherit',
     outline: 'none',
@@ -181,7 +187,10 @@ const styles = stylex.create({
     position: 'relative',
     padding: 0,
     marginInlineEnd: `calc(-1 * ${spacingVars['--spacing-1']})`,
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-full'],
     width: '16px',
     height: '16px',

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -224,7 +224,10 @@ const styles = stylex.create({
     position: 'relative',
     flexWrap: 'wrap',
     gap: spacingVars['--spacing-1'],
-    cursor: 'text',
+    cursor: {
+      default: 'text',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     height: 'auto',
   },
   wrapperWithTokens: {

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -60,10 +60,16 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     textDecoration: 'none',
     color: colorVars['--color-text-primary'],
-    cursor: 'default',
+    cursor: {
+      default: 'default',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   interactive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
     borderStyle: 'none',
@@ -79,7 +85,10 @@ const styles = stylex.create({
     },
   },
   menuTrigger: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
     borderStyle: 'none',
@@ -190,7 +199,10 @@ const styles = stylex.create({
     marginBlockStart: spacingVars['--spacing-1'],
     marginBlockEnd: spacingVars['--spacing-2'],
     marginInline: spacingVars['--spacing-1'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   // Composes over `chevron` — the flipped popover copy differs only by the
   // rotation, so it carries just that.

--- a/packages/core/src/TopNav/TopNavItem.tsx
+++ b/packages/core/src/TopNav/TopNavItem.tsx
@@ -53,7 +53,10 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
     textDecoration: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color, color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -78,7 +78,10 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
     textDecoration: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color, color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
@@ -50,7 +50,10 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-3'],
     borderRadius: radiusVars['--radius-element'],
     textDecoration: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/TopNav/TopNavMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMenu.tsx
@@ -65,7 +65,10 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
     textDecoration: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color, color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -115,7 +118,10 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-3'],
     borderRadius: radiusVars['--radius-element'],
     textDecoration: 'none',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -95,7 +95,10 @@ const styles = stylex.create({
     marginInlineStart: 'var(--_tree-indent, 0px)',
   },
   interactive: {
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     transitionProperty: 'background-image',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -117,7 +120,10 @@ const styles = stylex.create({
   },
   invisibleButton: {
     all: 'unset',
-    cursor: 'inherit',
+    cursor: {
+      default: 'inherit',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     font: 'inherit',
     color: 'inherit',
     display: 'flex',
@@ -130,7 +136,10 @@ const styles = stylex.create({
   },
   invisibleAnchor: {
     all: 'unset',
-    cursor: 'inherit',
+    cursor: {
+      default: 'inherit',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     font: 'inherit',
     color: 'inherit',
     display: 'flex',
@@ -174,7 +183,10 @@ const styles = stylex.create({
     width: spacingVars['--spacing-4'],
     height: spacingVars['--spacing-4'],
     fontSize: spacingVars['--spacing-4'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     border: 'none',
     background: 'none',
     padding: 0,
@@ -191,7 +203,10 @@ const styles = stylex.create({
     width: spacingVars['--spacing-4'],
     height: spacingVars['--spacing-4'],
     fontSize: spacingVars['--spacing-4'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     color: colorVars['--color-icon-secondary'],
     borderRadius: radiusVars['--radius-inner'],
     marginInlineStart: spacingVars['--spacing-1'],

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -233,7 +233,10 @@ const styles = stylex.create({
     width: '100%',
     padding: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-element'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     outline: 'none',
     backgroundColor: 'transparent',
     border: 'none',

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -167,7 +167,10 @@ const styles = stylex.create({
     // Standard padding minus border width to prevent height jump
     // when a token (28px) is added inside the input
     paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
-    cursor: 'text',
+    cursor: {
+      default: 'text',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
   },
   token: {
     // Offset token so it sits 3px from the inner edge (4px from outer edge

--- a/packages/core/src/hooks/useInputStatusIcon.tsx
+++ b/packages/core/src/hooks/useInputStatusIcon.tsx
@@ -81,7 +81,10 @@ const styles = stylex.create({
     border: 'none',
     background: 'none',
     color: 'inherit',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     // Own the interactivity so the tooltip opens on hover even when the field
     // renders this affordance inside a non-interactive trailing slot. TextArea
     // positions its end slot as an absolute overlay with `pointer-events: none`

--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -262,10 +262,14 @@
   }
 
   /*
-   * Default cursor for disabled elements.
+   * Disabled elements answer the pointer with the disabled cursor, so a
+   * control that will not respond says so before it is clicked. Covers
+   * [aria-disabled] too: astryx keeps a disabled control focusable that way
+   * wherever its reason must stay discoverable (Button with a tooltip,
+   * Selector's trigger, SideNavItem).
    */
-  :where(:disabled) {
-    cursor: default;
+  :where(:disabled, [aria-disabled='true']) {
+    cursor: not-allowed;
   }
 
   /*

--- a/packages/core/src/reset.test.ts
+++ b/packages/core/src/reset.test.ts
@@ -57,4 +57,29 @@ describe('reset.css accessibility invariants', () => {
         .not.toMatch(/outline(?:-style|-width)?\s*:\s*(?:none|0)/);
     }
   });
+
+  /**
+   * A disabled control must answer the pointer with the disabled cursor: the
+   * cursor is the only affordance a pointer user gets before they commit to a
+   * click. The reset is the floor for any element that declares no cursor of
+   * its own — components declare theirs under the `disabled-cursor` lint
+   * rule, and the Chromium sweep measures the rendered result.
+   */
+  it('gives disabled elements the disabled cursor', () => {
+    const disabledBlocks = ruleBlocks.filter(
+      ({selector}) =>
+        selector.includes(':disabled') && !selector.includes(':not('),
+    );
+    expect(disabledBlocks.length).toBeGreaterThan(0);
+    for (const {selector, body} of disabledBlocks) {
+      expect(body, `disabled rule "${selector}"`).toMatch(
+        /cursor:\s*not-allowed/,
+      );
+    }
+    // aria-disabled is how astryx keeps a disabled control focusable, so the
+    // reset has to cover it alongside the native state.
+    expect(
+      disabledBlocks.some(({selector}) => selector.includes('aria-disabled')),
+    ).toBe(true);
+  });
 });

--- a/packages/lab/src/Chat/ChatEmojiPicker.tsx
+++ b/packages/lab/src/Chat/ChatEmojiPicker.tsx
@@ -145,7 +145,10 @@ const styles = stylex.create({
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
     },
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     fontSize: 18,
     lineHeight: typeScaleVars['--text-body-leading'],
     // Inset, not the shared offset: the cells sit in a tight 8-across grid, so

--- a/packages/lab/src/Chat/ChatReactionBar.tsx
+++ b/packages/lab/src/Chat/ChatReactionBar.tsx
@@ -124,7 +124,10 @@ const styles = stylex.create({
       },
     },
     backgroundColor: colorVars['--color-background-muted'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     fontFamily: typographyVars['--font-family-body'],
     boxSizing: 'border-box',
     transitionProperty: 'border-color, background-color',
@@ -177,7 +180,10 @@ const styles = stylex.create({
     },
     backgroundColor: colorVars['--color-background-muted'],
     color: colorVars['--color-icon-secondary'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     boxSizing: 'border-box',
     fontSize: 15,
     lineHeight: typeScaleVars['--text-supporting-leading'],

--- a/packages/lab/src/ChatReasoning/ChatReasoning.tsx
+++ b/packages/lab/src/ChatReasoning/ChatReasoning.tsx
@@ -74,7 +74,10 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1-5'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     userSelect: 'none',
     minHeight: '24px',
     paddingBlock: spacingVars['--spacing-0-5'],

--- a/packages/lab/src/InfoTip/InfoTip.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.tsx
@@ -63,7 +63,10 @@ const styles = stylex.create({
     borderStyle: 'none',
     backgroundColor: 'transparent',
     borderRadius: radiusVars['--radius-full'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     color: {
       default: colorVars['--color-icon-secondary'],
       ':hover:where(:not(:disabled,[aria-disabled="true"]))': {

--- a/packages/lab/src/LogStream/LogStream.tsx
+++ b/packages/lab/src/LogStream/LogStream.tsx
@@ -190,7 +190,10 @@ const styles = stylex.create({
     borderInlineWidth: 0,
     fontFamily: typographyVars['--font-family-code'],
     fontSize: textSizeVars['--font-size-sm'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     backgroundColor: {
       default: 'transparent',
       ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
@@ -296,7 +299,10 @@ const styles = stylex.create({
     fontFamily: typographyVars['--font-family-code'],
     fontSize: textSizeVars['--font-size-sm'],
     fontWeight: fontWeightVars['--font-weight-medium'],
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     boxShadow: shadowVars['--shadow-med'],
   },
   jumpToLatestTerminal: {

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -423,7 +423,10 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     width: '100%',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     transitionProperty: 'background-color',
     transitionDuration: {
@@ -467,7 +470,10 @@ const styles = stylex.create({
     // start so vertical labels/descriptions read left-aligned. Horizontal
     // labels re-center via otLabelWrapH (a deeper element).
     textAlign: 'start',
-    cursor: 'pointer',
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     borderRadius: radiusVars['--radius-element'],
     transitionProperty: 'background-color',
     transitionDuration: {

--- a/packages/lab/src/reorderStyles.ts
+++ b/packages/lab/src/reorderStyles.ts
@@ -66,11 +66,17 @@ export const reorderStyles = stylex.create({
     },
   },
   handle: {
-    cursor: 'grab',
+    cursor: {
+      default: 'grab',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     touchAction: 'none',
   },
   handleActive: {
-    cursor: 'grabbing',
+    cursor: {
+      default: 'grabbing',
+      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+    },
     touchAction: 'none',
   },
 });


### PR DESCRIPTION
## Why

The cursor is the only affordance a pointer user gets **before** they commit to a click. A disabled control answering with `pointer` promises a click it will not honour; one answering with `default` says nothing at all, and the user learns the control is dead by clicking it and watching nothing happen.

Nothing took that promise away for us. `disabled` and `[aria-disabled]` do not change what an element's own `cursor` declaration paints, and the per-component `disabled` style only helps where the author remembered to write one, on the element the author had in mind. A Chromium sweep over every story found **26 disabled elements answering with the wrong cursor** — `pointer` on Selector's and MultiSelector's triggers, `grab` on the drag handles in ListInput and TransferList, `default` on SegmentedControl's segments, `auto` on TreeList's rows.

One of those deserves calling out, because it is the shape that will keep producing this bug: **StyleX merges `props()` one PROPERTY at a time**, so a later style setting `cursor` at all replaces the earlier declaration's *conditions* along with its value. SegmentedControlItem held a correctly guarded `cursor: pointer` on its base and a flat `disabled: {cursor: 'default'}` applied after it — and shipped a disabled segment answering with a plain arrow. Both halves read as correct in review. That is why the guard has to go on every declaration, not on the ones we judge interactive.

Sibling of [#5247](https://github.com/facebook/astryx/pull/5247): that one stopped a disabled control from *lighting up* under the pointer, this one makes it *say what it is*.

## What

- Every `cursor` in core and lab carries `':is(:disabled,[aria-disabled="true"])': 'not-allowed'` — 128 declarations across 76 files, all applied by the new rule's autofix. `:is()` outranks the default in StyleX's own ordering (priority 3040 vs 3000), and on an element that can never be disabled it is a no-op.
- `reset.css` gives the same cursor to any disabled element that declares none. It previously said `cursor: default`, and only for native `:disabled` — `[aria-disabled]`, which is how astryx keeps a disabled control focusable, got nothing.
- `@astryx/disabled-cursor` — a new autofixable lint rule, error in core and lab, so an unguarded cursor cannot land again.
- `.github/scripts/disabled-cursor-audit.js` (`pnpm guard:disabled-cursor`) — a Chromium sweep that hit-tests five points per disabled element in every story and fails on any cursor other than `not-allowed`. Five points, not one: a child that declares its own cursor often covers only part of a control.
- Two `disabled` styles that set `cursor: 'default'` (SegmentedControlItem, ResizeHandle) now say `not-allowed` outright.

## Risk

Behavioral change is confined to what a disabled element shows under the pointer. No selector that was not already scoped to a disabled element changes; no component's markup, props or events move.

**Known limit, unchanged by this PR:** 75 of the 635 disabled elements in the story set are sealed behind `pointer-events: none`, so the pointer lands on an ancestor and the control never gets to answer — the sweep counts these separately rather than passing them. Making those answer means removing `pointer-events: none`, which is a separate change with real behavior behind it: on Item, TreeListItem and SideNavItem the disabled row still renders a live `href`, and today only `pointer-events: none` stops that click. Worth doing, not here.

No screenshots: the cursor is the one visual property a screenshot cannot capture. The measurement below is the evidence.

## Testing

- `pnpm guard:disabled-cursor` over all 1700 stories: **26 violations → 0**, 635 disabled elements checked, 75 sealed (see above).
- `@astryx/disabled-cursor` over core and lab: **117 findings → 0**.
- Unit: the rule's `RuleTester` suite, the sweep's verdict/CLI suite, and a new `reset.test.ts` invariant that every disabled rule in the reset carries `not-allowed`. `Table.perf.test.tsx` failed once under parallel load and passes alone — unrelated timing test.
- Added as **A21** to the [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) (v1.7), scored `auto`; A20 hands it the cursor rider it was carrying.
