### PR TITLE
fix(Chat): align composer tokens to middle instead of synthesized baseline

### DIFF
--- a/.changeset/fix-chat-token-alignment.md
+++ b/.changeset/fix-chat-token-alignment.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat: composer tokens no longer sit above surrounding text — `vertical-align` changed from `baseline` to `middle`, and `ChatComposerTokenElement` now uses a StyleX class instead of an inline style so consumers can override alignment without `!important`.
+
+@athz

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -255,6 +255,10 @@ const styles = stylex.create({
     opacity: 0.5,
     pointerEvents: 'none' as const,
   },
+  tokenSpan: {
+    display: 'inline-flex',
+    verticalAlign: 'middle',
+  },
 });
 
 // =============================================================================
@@ -749,7 +753,7 @@ export function ChatComposerTokenElement({token}: {token: ChatComposerToken}) {
       data-astryx-token=""
       data-astryx-token-value={token.value}
       contentEditable={false}
-      style={{display: 'inline-flex', verticalAlign: 'baseline'}}>
+      {...stylex.props(styles.tokenSpan)}>
       {isCustomToken(token) ? (
         token.render()
       ) : (

--- a/packages/core/src/Chat/useChatComposerTokens.ts
+++ b/packages/core/src/Chat/useChatComposerTokens.ts
@@ -120,7 +120,7 @@ export function useChatComposerTokens({
       span.setAttribute('data-astryx-token-id', id);
       span.contentEditable = 'false';
       span.style.display = 'inline-flex';
-      span.style.verticalAlign = 'baseline';
+      span.style.verticalAlign = 'middle';
 
       range.deleteContents();
       range.insertNode(span);


### PR DESCRIPTION
## Problem

Tokens inserted into `ChatComposerInput` sit a few pixels high relative to typed text. The text appears to sag below the chip.

### Root cause

Three things compound:

1. Astryx wraps every inserted token in a `<span>` with `display: inline-flex` and `vertical-align: baseline`.
2. A flex container derives its baseline from its first flex item. For a token with an icon, that's an SVG — which has no text baseline — so CSS synthesizes one from the box's bottom margin edge.
3. `vertical-align: baseline` therefore aligns the chip's *bottom edge* to the text baseline, rather than the chip's label baseline. The visual gap equals roughly the label's descender depth.

## Fix

**Both sites changed together** (they must stay in sync):

- `useChatComposerTokens` (imperative span created on token insert): `vertical-align` → `middle`
- `ChatComposerTokenElement` (exported React component): moved from inline style to a StyleX class with `vertical-align: middle`

`middle` is the conventional alignment for an inline chip taller than its surrounding text — it centers the chip's midpoint on the parent's x-height midpoint, producing visually centered alignment regardless of icon presence.

### Bonus: StyleX over inline style

`ChatComposerTokenElement` previously used `style={{ display: 'inline-flex', verticalAlign: 'baseline' }}`. An inline style is unreachable from a stylesheet without `!important`, so consumers had no clean way to adjust alignment. It now uses a StyleX class, making it overridable through normal specificity.

## Risk

Low. No test pins the previous value (verified — the only `verticalAlign` assertions in the suite are in Table). All 51 Chat tests pass unchanged.
