### PR TITLE
fix(core): a blank client-hints platform is unknown, not non-Apple

### DIFF
--- a/.changeset/kbd-hotkeys-blank-client-hints-platform.md
+++ b/.changeset/kbd-hotkeys-blank-client-hints-platform.md
@@ -1,0 +1,16 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `mod` hotkeys and `Kbd` resolve to Cmd on macOS again when client hints report a blank platform
+
+`useHotkeys` and `Kbd` both prefer `navigator.userAgentData.platform` and fall
+back to `navigator.platform`, but guarded the preference with
+`'platform' in uaData`, which is true whenever the key exists at all. A build
+reporting `platform: ''` therefore committed to the client-hints branch and got
+`false` without ever reaching the fallback, so on macOS every `mod` combo
+listened for Ctrl and every `<Kbd>` drew Ctrl. Electron and other embedders
+that rewrite the app's user-agent identity ship exactly that. A blank platform
+is now treated as unknown and falls through.
+
+@Astro-Han

--- a/packages/core/src/Kbd/Kbd.test.tsx
+++ b/packages/core/src/Kbd/Kbd.test.tsx
@@ -23,6 +23,7 @@ describe('Kbd', () => {
       value: originalPlatform,
       configurable: true,
     });
+    delete (navigator as {userAgentData?: unknown}).userAgentData;
   });
 
   it('renders a single key', () => {
@@ -52,6 +53,22 @@ describe('Kbd', () => {
 
     render(<Kbd keys="mod" />);
     expect(screen.getByText('\u2318')).toBeInTheDocument(); // \u2318
+  });
+
+  it('reads a blank userAgentData.platform as unknown, not as non-Mac', () => {
+    // Builds that rewrite their client-hints identity expose the key with an
+    // empty value; navigator.platform is the only surface left that answers.
+    Object.defineProperty(navigator, 'userAgentData', {
+      value: {platform: ''},
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'platform', {
+      value: 'MacIntel',
+      configurable: true,
+    });
+
+    render(<Kbd keys="mod" />);
+    expect(screen.getByText('\u2318')).toBeInTheDocument();
   });
 
   it('maps modifier keys to symbols', () => {

--- a/packages/core/src/Kbd/Kbd.tsx
+++ b/packages/core/src/Kbd/Kbd.tsx
@@ -124,8 +124,9 @@ function getServerPlatformSnapshot(): boolean {
 
 /**
  * Detects whether the current platform is macOS/iOS.
- * Prefers the User-Agent Client Hints API when available (modern Chrome/Edge),
- * falls back to navigator.platform (deprecated but universally supported).
+ * Prefers the User-Agent Client Hints API when it names a platform (modern
+ * Chrome/Edge), falls back to navigator.platform (deprecated but universally
+ * supported) when it is absent or blank.
  */
 function detectMac(): boolean {
   if (typeof navigator === 'undefined') {
@@ -134,7 +135,13 @@ function detectMac(): boolean {
   // Prefer User-Agent Client Hints API (not deprecated)
   const uaData = 'userAgentData' in navigator ? navigator.userAgentData : null;
   if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
-    return /mac/i.test((uaData as {platform: string}).platform ?? '');
+    const uaPlatform = (uaData as {platform?: unknown}).platform;
+    // A blank platform is no answer, not a negative one. Builds that rewrite
+    // their client-hints identity ship '', so fall through rather than
+    // reading it as "not Apple".
+    if (typeof uaPlatform === 'string' && uaPlatform.trim() !== '') {
+      return /mac/i.test(uaPlatform);
+    }
   }
   // Fallback: navigator.platform (deprecated but still shipped everywhere)
   return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');

--- a/packages/core/src/hooks/useHotkeys.test.ts
+++ b/packages/core/src/hooks/useHotkeys.test.ts
@@ -67,6 +67,24 @@ describe('useHotkeys', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
+  it('reads a blank userAgentData.platform as unknown, not as non-Apple', () => {
+    // Builds that rewrite their client-hints identity expose the key with an
+    // empty value; navigator.platform is the only surface left that answers.
+    vi.stubGlobal('navigator', {
+      userAgentData: {platform: ''},
+      platform: 'MacIntel',
+    });
+    const onPress = vi.fn();
+    renderHook(() => useHotkeys([{keys: 'mod+k', onPress}]));
+
+    press('k', {ctrlKey: true});
+    expect(onPress).not.toHaveBeenCalled();
+
+    const event = press('k', {metaKey: true});
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledWith(event);
+  });
+
   it('does not fire a bare key when modifiers are held', () => {
     stubApplePlatform();
     const onPress = vi.fn();

--- a/packages/core/src/hooks/useHotkeys.ts
+++ b/packages/core/src/hooks/useHotkeys.ts
@@ -73,8 +73,9 @@ const KEY_ALIASES: Record<string, string> = {
 
 /**
  * Detects whether the current platform is macOS/iOS.
- * Prefers the User-Agent Client Hints API when available (modern Chrome/Edge),
- * falls back to navigator.platform (deprecated but universally supported).
+ * Prefers the User-Agent Client Hints API when it names a platform (modern
+ * Chrome/Edge), falls back to navigator.platform (deprecated but universally
+ * supported) when it is absent or blank.
  * Mirrors the detection used by Kbd so displayed and handled shortcuts agree.
  */
 function isApplePlatform(): boolean {
@@ -83,7 +84,13 @@ function isApplePlatform(): boolean {
   }
   const uaData = 'userAgentData' in navigator ? navigator.userAgentData : null;
   if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
-    return /mac/i.test((uaData as {platform: string}).platform ?? '');
+    const uaPlatform = (uaData as {platform?: unknown}).platform;
+    // A blank platform is no answer, not a negative one. Builds that rewrite
+    // their client-hints identity ship '', so fall through rather than
+    // reading it as "not Apple".
+    if (typeof uaPlatform === 'string' && uaPlatform.trim() !== '') {
+      return /mac/i.test(uaPlatform);
+    }
   }
   return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
 }


### PR DESCRIPTION
Fixes #5253.

## The defect

`isApplePlatform()` in `packages/core/src/hooks/useHotkeys.ts` and `detectMac()` in `packages/core/src/Kbd/Kbd.tsx` are independent copies of the same detection: prefer `navigator.userAgentData.platform`, fall back to `navigator.platform`. The guard on that preference was

```ts
if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
  return /mac/i.test((uaData as {platform: string}).platform ?? '');
}
return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
```

`'platform' in uaData` is true whenever the key exists **at all, blank or not**, and `??` only defends against `null`/`undefined`. So a blank platform takes the client-hints branch, evaluates `/mac/i.test('')`, returns `false`, and the fallback that would have answered correctly is never reached. An empty string was read as a negative answer rather than as no answer.

Electron and other embedders that rewrite the app's user-agent or client-hints identity ship exactly that. On macOS every `mod` combo registered through `useHotkeys` listened for Ctrl instead of Cmd, and every `<Kbd>` drew Ctrl. Both surfaces agreed with each other, so nothing looked broken: the shortcut simply never fired, and the hint named the key that also did not work. The same code in Safari or Chrome on the same machine behaved correctly.

## The fix

A blank (or non-string) platform is treated as *unknown* and falls through. A client-hints platform that actually names something is still preferred, so nothing changes for browsers that report one.

```ts
const uaPlatform = (uaData as {platform?: unknown}).platform;
if (typeof uaPlatform === 'string' && uaPlatform.trim() !== '') {
  return /mac/i.test(uaPlatform);
}
```

Both call sites change in one commit: the `useHotkeys` docstring states the hook "Mirrors the detection used by Kbd so displayed and handled shortcuts agree", so fixing one alone would produce the failure this bug is least likely to be noticed in — a shortcut that fires on a key the hint does not name. The shared docstring line is updated in both, kept identical.

## Tests

One regression test per call site, written in the platform-spoofing style each file already uses (`vi.stubGlobal` in `useHotkeys.test.ts`, `Object.defineProperty` in `Kbd.test.tsx`): with `userAgentData.platform: ''` and `navigator.platform: 'MacIntel'`, `mod+k` fires on `metaKey` and not on `ctrlKey`, and `<Kbd keys="mod" />` renders ⌘. Both fail on `main` and pass with the fix.

`Kbd.test.tsx`'s `afterEach` also deletes the spoofed `userAgentData` so nothing leaks into the tests that follow.

## Validation

- `vitest run` on both test files — 31 passed; verified the two new Mac tests fail with the source change reverted
- `pnpm -F @astryxdesign/core typecheck`, `eslint` on the touched files, `pnpm check:repo` — all clean

A `[fix]` changeset is included (`@astryxdesign/core: patch`).

---

*Diagnosis, patch, and this description were prepared with Claude Code; every line was read and verified by me before opening, and the validation above was run locally.*
