### PR TITLE
docs(cli): document the integration manifest docs field in the README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -580,13 +580,13 @@ export default {
 };
 ```
 
-| Field        | Type     | Purpose                                                               |
-| ------------ | -------- | --------------------------------------------------------------------- |
-| `components` | `string` | Directory holding the package's components and their `.doc.*` files.  |
-| `templates`  | `string` | Directory holding the package's page/block templates.                 |
-| `codemods`   | `string` | Directory holding upgrade codemods run by `astryx upgrade`.           |
+| Field        | Type     | Purpose                                                                           |
+| ------------ | -------- | --------------------------------------------------------------------------------- |
+| `components` | `string` | Directory holding the package's components and their `.doc.*` files.              |
+| `templates`  | `string` | Directory holding the package's page/block templates.                             |
+| `codemods`   | `string` | Directory holding upgrade codemods run by `astryx upgrade`.                       |
 | `docs`       | `string` | Directory of reference docs; each `{topic}.doc.*` becomes a topic the CLI serves. |
-| `issuesUrl`  | `string` | Where "report an issue" links for this package's contributions point. |
+| `issuesUrl`  | `string` | Where "report an issue" links for this package's contributions point.             |
 
 Every field is optional; declare only the roots the package ships. There is no
 factory: write a plain object, and annotate it with the `AstryxIntegration` type

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -585,6 +585,7 @@ export default {
 | `components` | `string` | Directory holding the package's components and their `.doc.*` files.  |
 | `templates`  | `string` | Directory holding the package's page/block templates.                 |
 | `codemods`   | `string` | Directory holding upgrade codemods run by `astryx upgrade`.           |
+| `docs`       | `string` | Directory of reference docs; each `{topic}.doc.*` becomes a topic the CLI serves. |
 | `issuesUrl`  | `string` | Where "report an issue" links for this package's contributions point. |
 
 Every field is optional; declare only the roots the package ships. There is no


### PR DESCRIPTION
## What

The integration manifest schema (`configSchema`/`integrationSchema` in `packages/cli/authoring/integration/parse.mjs`) accepts an optional `docs` field, a directory of reference docs that the CLI serves as topics. The Integrations field table in the CLI README listed `components`, `templates`, `codemods`, and `issuesUrl` but not `docs`, so the documented manifest surface no longer matched what the CLI accepts.

Add the `docs` row, positioned to match the schema order (between `codemods` and `issuesUrl`). Names-in-sync only; no descriptions rewritten. After this, the config/README drift check reports OK for both the Configuration and Integrations tables.

## Checks
- Config/README drift audit reports OK for `astryx.config` and `astryx.integration`
- Merges cleanly with the other open README-touching PRs (#5260, #5226, #5138, #5115); disjoint sections

Night Watch — Doc Reviewer