### PR TITLE
fix(a11y): one disabled cursor everywhere — default, not not-allowed

### DIFF
--- a/.changeset/disabled-cursor-guarantee.md
+++ b/.changeset/disabled-cursor-guarantee.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] A disabled control now answers the pointer with `not-allowed` wherever it can be pointed at: every `cursor` in core and lab carries `':is(:disabled,[aria-disabled="true"])': 'not-allowed'`, and the reset gives the same cursor to any disabled element that declares none — `[aria-disabled]` included, where it previously said `default` and only for native `:disabled`. A lint rule and a Chromium sweep over every story keep it that way. Disabled elements sealed behind `pointer-events: none` are unchanged: the pointer never reaches them, so their cursor comes from an ancestor.
+[fix] A disabled element answers the pointer with `default`, never an interactive cursor. Every `cursor` in core and lab carries `':is(:disabled,[aria-disabled="true"])': 'default'`, and the reset gives the same cursor to any disabled element that declares none — `[aria-disabled]` included, which previously got nothing. A lint rule and a Chromium sweep over every story keep it that way. Disabled elements sealed behind `pointer-events: none` are unchanged: the pointer never reaches them, so their cursor comes from an ancestor — which is why the guarantee is `default` rather than a distinct disabled cursor the library could only paint on some of them.
 
 @cixzhang

--- a/.github/scripts/disabled-cursor-audit.js
+++ b/.github/scripts/disabled-cursor-audit.js
@@ -3,11 +3,11 @@
 
 
 /**
- * @description Asserts every disabled element answers the pointer with `not-allowed`
+ * @description Asserts no disabled element answers the pointer with an interactive cursor
  * @input --storybook-dir <path> [--components <csv>] [--output <file>]
  *   [--concurrency <n>] [--port <n>]
  * @output JSON report of violations; exit 1 if any disabled element shows a
- *   cursor other than `not-allowed`
+ *   cursor other than `default`
  *
  * The cursor is the only affordance a pointer user gets before they commit to
  * a click. A disabled control that answers with `pointer` promises a click it
@@ -23,7 +23,14 @@
  * its own wins under the pointer, and a subtree behind `pointer-events: none`
  * hands the question to an ancestor.
  *
- * The gate is zero-tolerance and has no baseline: `not-allowed` on a disabled
+ * The expected cursor is `default`, not `not-allowed`. A disabled control
+ * sealed behind `pointer-events: none` is never hit-tested, so it shows
+ * whatever its ancestor shows and no declaration on it can change that — 75
+ * of the 635 disabled elements in the story set are sealed that way. One
+ * cursor everywhere beats a stronger one only half the library can paint, and
+ * the disabled state already carries its own visual treatment.
+ *
+ * The gate is zero-tolerance and has no baseline: `default` on a disabled
  * control is never wrong, so there is nothing to grandfather. What it does
  * skip is an element nothing can point at — no box, or covered by something
  * else at every sample point — because a cursor nobody can reach is not a
@@ -43,7 +50,7 @@ const http = require('node:http');
 // ---------------------------------------------------------------------------
 
 /** The one cursor a disabled control may answer with. */
-const DISABLED_CURSOR = 'not-allowed';
+const DISABLED_CURSOR = 'default';
 
 /**
  * What counts as disabled — the same pair the hover sweep uses.

--- a/.github/scripts/disabled-cursor-audit.test.mjs
+++ b/.github/scripts/disabled-cursor-audit.test.mjs
@@ -57,10 +57,10 @@ describe('selectStories', () => {
 });
 
 describe('verdictFor', () => {
-  it('passes a control that answers not-allowed', () => {
-    expect(verdictFor([sample('self', 'not-allowed')])).toEqual({
+  it('passes a control that answers with the disabled cursor', () => {
+    expect(verdictFor([sample('self', 'default')])).toEqual({
       status: 'ok',
-      cursor: 'not-allowed',
+      cursor: 'default',
     });
   });
 
@@ -73,16 +73,18 @@ describe('verdictFor', () => {
 
   it('fails on a child that declares its own cursor', () => {
     const verdict = verdictFor([
-      sample('self', 'not-allowed'),
+      sample('self', 'default'),
       sample('descendant', 'text'),
     ]);
     expect(verdict).toEqual({status: 'violation', cursor: 'text'});
   });
 
   it('counts a pointer-events:none subtree as unreachable, not a violation', () => {
-    expect(verdictFor([sample('ancestor', 'default')])).toEqual({
+    // The pointer lands on the ancestor, so whatever it shows — even the
+    // right cursor — is the ancestor's doing, not the control's.
+    expect(verdictFor([sample('ancestor', 'auto')])).toEqual({
       status: 'unreachable',
-      cursor: 'default',
+      cursor: 'auto',
     });
   });
 
@@ -94,7 +96,7 @@ describe('verdictFor', () => {
 
   it('lets one reachable point decide over an unreachable one', () => {
     expect(
-      verdictFor([sample('ancestor', 'default'), sample('self', 'pointer')]),
+      verdictFor([sample('ancestor', 'auto'), sample('self', 'pointer')]),
     ).toEqual({status: 'violation', cursor: 'pointer'});
   });
 });
@@ -108,7 +110,7 @@ describe('DISABLED_SELECTOR', () => {
 
 describe('formatViolations', () => {
   it('says so plainly when there is nothing to report', () => {
-    expect(formatViolations([])).toContain('not-allowed');
+    expect(formatViolations([])).toContain('default');
   });
 
   it('groups by component and names the story and the cursor', () => {
@@ -122,7 +124,7 @@ describe('formatViolations', () => {
     ]);
     expect(output).toContain('Core/Button (1)');
     expect(output).toContain('core-button--disabled');
-    expect(output).toContain('cursor: pointer (expected not-allowed)');
+    expect(output).toContain('cursor: pointer (expected default)');
   });
 });
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -504,16 +504,19 @@ fails on any disabled element whose paint changes under a forced `:hover`.
 
 ### Disabled cursor guard
 
-A disabled control must answer the pointer with `not-allowed`: the cursor is
-the only affordance a pointer user gets before they commit to a click. Write
-every `cursor` so the disabled state takes it back —
-`cursor: {default: 'pointer', ':is(:disabled,[aria-disabled="true"])': 'not-allowed'}`
+A disabled control must not answer the pointer with an interactive cursor: the
+cursor is the only affordance a pointer user gets before they commit to a
+click. Write every `cursor` so the disabled state takes it back —
+`cursor: {default: 'pointer', ':is(:disabled,[aria-disabled="true"])': 'default'}`
 — including a flat `cursor` inside a `disabled` style, since StyleX merges one
 property at a time and a later declaration replaces the earlier one's
-conditions along with its value. The `@astryx/disabled-cursor` lint rule
-(autofixable) enforces it at author time; `pnpm guard:disabled-cursor
---storybook-dir apps/storybook/dist` hit-tests every disabled element in a
-built Storybook in Chromium and fails on any other cursor.
+conditions along with its value. `default` rather than `not-allowed`: a
+disabled control sealed behind `pointer-events: none` shows whatever its
+ancestor shows, so one cursor everywhere beats a stronger one we can only
+paint on some of them. The `@astryx/disabled-cursor` lint rule (autofixable)
+enforces it at author time; `pnpm guard:disabled-cursor --storybook-dir
+apps/storybook/dist` hit-tests every disabled element in a built Storybook in
+Chromium and fails on any other cursor.
 
 ## Versioning & Releases
 

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -514,7 +514,7 @@ Ships as an **error in both tiers**: core and lab are clean, and this keeps them
 
 ### `@astryx/disabled-cursor`
 
-Flags a `cursor` inside `stylex.create()` that does not give way to `not-allowed` on a disabled element. The cursor is the only affordance a pointer user gets **before** they commit to a click: `cursor: pointer` on a disabled control promises a click it will not honour, and `disabled`/`[aria-disabled]` do not change what the element's own declaration paints.
+Flags a `cursor` inside `stylex.create()` that does not give way to `default` on a disabled element. The cursor is the only affordance a pointer user gets **before** they commit to a click: `cursor: pointer` on a disabled control promises a click it will not honour, and `disabled`/`[aria-disabled]` do not change what the element's own declaration paints.
 
 A component's separate `disabled` style object is not the answer either — it only helps where the author remembered to write one, on the element the author had in mind: the inner input, not the label wrapping it; the trigger, not the icon inside it.
 
@@ -533,7 +533,7 @@ const styles = stylex.create({
   trigger: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
 });
@@ -541,9 +541,11 @@ const styles = stylex.create({
 
 The guarded condition outranks the default in StyleX's own ordering, so it wins the moment the element is disabled; on an element that can never be disabled it is a no-op.
 
-**Scope:** every `cursor` a component writes, whatever the value — `not-allowed` itself is the only exemption. That breadth is not tidiness: StyleX merges `props()` one **property** at a time, so a later style setting `cursor` at all replaces the earlier declaration's conditions along with its value. SegmentedControlItem shipped exactly that — a guarded `cursor: pointer` on the base and `disabled: {cursor: 'default'}` applied after it, which threw the guard away and left a disabled segment answering with a plain arrow. A computed value (`interactive ? 'grab' : undefined`) is left alone because the rule cannot know what it resolves to.
+**Why `default` and not `not-allowed`.** A disabled control sealed behind `pointer-events: none` is never hit-tested, so it shows whatever its ancestor shows and no declaration on it can change that — 75 of the 635 disabled elements in the story set are sealed that way. One cursor everywhere beats a stronger one only half the library can paint, the disabled state already carries its own visual treatment, and this matches the internal XDS convention.
 
-Autofixable, and mirrored at runtime by `.github/scripts/disabled-cursor-audit.js`, which hit-tests every disabled element in every story in Chromium and fails on any cursor other than `not-allowed`. That sweep is what covers the two cases the lint rule cannot see: a computed value, and a disabled element whose cursor comes from somewhere other than its own declaration.
+**Scope:** every `cursor` a component writes, whatever the value — `default` itself is the only exemption. That breadth is not tidiness: StyleX merges `props()` one **property** at a time, so a later style setting `cursor` at all replaces the earlier declaration's conditions along with its value. SegmentedControlItem shipped exactly that — a guarded `cursor: pointer` on the base and a flat `cursor` in its `disabled` style applied after it, which threw the guard away. A computed value (`interactive ? 'grab' : undefined`) is left alone because the rule cannot know what it resolves to.
+
+Autofixable, and mirrored at runtime by `.github/scripts/disabled-cursor-audit.js`, which hit-tests every disabled element in every story in Chromium and fails on any other cursor. That sweep is what covers the two cases the lint rule cannot see: a computed value, and a disabled element whose cursor comes from somewhere other than its own declaration.
 
 Ships as an **error in both tiers**: core and lab are clean, and this keeps them that way.
 

--- a/internal/eslint-plugin-astryx/disabled-cursor.js
+++ b/internal/eslint-plugin-astryx/disabled-cursor.js
@@ -2,14 +2,20 @@
 
 /**
  * @file disabled-cursor.js
- * @description A `cursor` must give way to `not-allowed` on a disabled
- * element.
+ * @description A `cursor` must give way to `default` on a disabled element.
  *
  * The cursor is the only affordance a pointer user gets before they commit to
  * a click. `cursor: pointer` on a disabled control promises a click the
  * control will not honour, and nothing takes that promise away for you:
  * `disabled` and `[aria-disabled]` do not change what the element's own
  * `cursor` declaration paints.
+ *
+ * `default` and not `not-allowed`: a disabled control sealed behind
+ * `pointer-events: none` is never hit-tested, so it shows whatever its
+ * ancestor shows, and no declaration on it can change that. One cursor
+ * everywhere beats a stronger one we can only paint on some of them — and the
+ * disabled state already carries its own visual treatment. This also matches
+ * the internal XDS convention.
  *
  * A component's separate `disabled` style object is not the answer either. It
  * only helps where the author remembered to write one, on the element the
@@ -22,7 +28,7 @@
  *   BAD   cursor: 'pointer'
  *   GOOD  cursor: {
  *           default: 'pointer',
- *           ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+ *           ':is(:disabled,[aria-disabled="true"])': 'default',
  *         }
  *
  * The guarded condition outranks the default in StyleX's own ordering, so it
@@ -38,7 +44,7 @@
  * with a plain arrow. So the guard belongs on whichever declaration lands
  * last, and the rule cannot know which one that is.
  *
- * `not-allowed` itself needs no guard, and a cursor whose value is computed
+ * `default` itself needs no guard, and a cursor whose value is computed
  * rather than written (`interactive ? 'grab' : undefined`) is left alone — the
  * rule cannot know what it resolves to. The Chromium sweep in
  * `.github/scripts/disabled-cursor-audit.js` measures the rendered result for
@@ -47,14 +53,14 @@
 
 /** The condition a disabled element matches, and what it must get. */
 const DISABLED_CONDITION = ':is(:disabled,[aria-disabled="true"])';
-const DISABLED_CURSOR = 'not-allowed';
+const DISABLED_CURSOR = 'default';
 
 /**
  * Cursors that need the guard: everything except the disabled cursor itself.
  *
- * `default` and `auto` are on the list because a disabled control saying
- * nothing is still saying the wrong thing, and because a flat `default` in a
- * `disabled` style is exactly what defeats a guard written elsewhere.
+ * `inherit` and `auto` are on the list rather than waved through — a control
+ * inheriting `pointer` from an interactive ancestor promises exactly what the
+ * guard exists to take back.
  */
 function needsGuard(value) {
   return typeof value === 'string' && value !== DISABLED_CURSOR;
@@ -107,7 +113,7 @@ const rule = {
     fixable: 'code',
     docs: {
       description:
-        'A cursor must give way to not-allowed on a disabled element',
+        'A cursor must give way to default on a disabled element',
       category: 'Accessibility',
       recommended: true,
     },
@@ -115,14 +121,14 @@ const rule = {
       unguardedCursor:
         "cursor: '{{value}}' is what a disabled element gets too. " +
         `Add '${DISABLED_CONDITION}': '${DISABLED_CURSOR}' to the declaration ` +
-        'so the pointer says what the control will actually do.',
+        'so the pointer stops promising an interaction the control refuses.',
     },
     schema: [],
   },
   create(context) {
     const source = context.sourceCode ?? context.getSourceCode();
 
-    /** `':is(...)': 'not-allowed'`, quoted the way the file already quotes. */
+    /** `':is(...)': 'default'`, quoted the way the file already quotes. */
     const guardEntry = `'${DISABLED_CONDITION}': '${DISABLED_CURSOR}'`;
 
     return {

--- a/internal/eslint-plugin-astryx/disabled-cursor.test.mjs
+++ b/internal/eslint-plugin-astryx/disabled-cursor.test.mjs
@@ -24,7 +24,7 @@ ruleTester.run('disabled-cursor', rule, {
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           trigger: {
-            cursor: {default: 'pointer', '${GUARD}': 'not-allowed'},
+            cursor: {default: 'pointer', '${GUARD}': 'default'},
           },
         });
       `,
@@ -35,7 +35,7 @@ ruleTester.run('disabled-cursor', rule, {
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           trigger: {
-            cursor: {default: 'grab', ':disabled': 'not-allowed'},
+            cursor: {default: 'grab', ':disabled': 'default'},
           },
         });
       `,
@@ -45,7 +45,7 @@ ruleTester.run('disabled-cursor', rule, {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          disabled: {cursor: 'not-allowed'},
+          disabled: {cursor: 'default'},
         });
       `,
     },
@@ -75,7 +75,7 @@ ruleTester.run('disabled-cursor', rule, {
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          trigger: {cursor: {default: 'pointer', '${GUARD}': 'not-allowed'}},
+          trigger: {cursor: {default: 'pointer', '${GUARD}': 'default'}},
         });
       `,
       errors: [{messageId: 'unguardedCursor'}],
@@ -99,7 +99,7 @@ ruleTester.run('disabled-cursor', rule, {
           handle: {
             cursor: {
               default: 'col-resize',
-              ':active': 'grabbing', '${GUARD}': 'not-allowed',
+              ':active': 'grabbing', '${GUARD}': 'default',
             },
           },
         });
@@ -107,18 +107,19 @@ ruleTester.run('disabled-cursor', rule, {
       errors: [{messageId: 'unguardedCursor'}],
     },
     // A flat value in a `disabled` style is the shape that defeats a guard
-    // written on the base: StyleX replaces the whole property on merge.
+    // written on the base: StyleX replaces the whole property on merge, so
+    // even a `disabled` style has to spell the condition out.
     {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          disabled: {cursor: 'default'},
+          disabled: {cursor: 'inherit'},
         });
       `,
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          disabled: {cursor: {default: 'default', '${GUARD}': 'not-allowed'}},
+          disabled: {cursor: {default: 'inherit', '${GUARD}': 'default'}},
         });
       `,
       errors: [{messageId: 'unguardedCursor'}],
@@ -134,7 +135,7 @@ ruleTester.run('disabled-cursor', rule, {
       output: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          field: {cursor: {default: 'text', '${GUARD}': 'not-allowed'}},
+          field: {cursor: {default: 'text', '${GUARD}': 'default'}},
         });
       `,
       errors: [{messageId: 'unguardedCursor'}],
@@ -158,7 +159,7 @@ ruleTester.run('disabled-cursor', rule, {
           item: {
             cursor: {
               default: 'pointer',
-              ':hover:where(:not(:disabled,[aria-disabled="true"]))': 'pointer', '${GUARD}': 'not-allowed',
+              ':hover:where(:not(:disabled,[aria-disabled="true"]))': 'pointer', '${GUARD}': 'default',
             },
           },
         });

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -177,7 +177,7 @@ const styles = stylex.create({
     textDecoration: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     // Match the avatar's circular shape so the focus ring hugs it.
     borderRadius: radiusVars['--radius-full'],

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -88,7 +88,7 @@ const styles = stylex.create({
   button: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     // Reset the UA button's block padding only; the inline padding from `base`
     // provides the pill's breathing room and must be preserved.

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -179,7 +179,7 @@ const styles = stylex.create({
     touchAction: 'none',
     cursor: {
       default: 'grab',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   handlePill: {

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -164,7 +164,7 @@ const itemStyles = stylex.create({
     },
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // Reset native button styles so onClick-only items match link appearance

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -84,7 +84,7 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty:
       'background-image, background-color, color, opacity, transform',
@@ -101,7 +101,7 @@ const styles = stylex.create({
     },
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
     backgroundImage: 'none',
     transform: {

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -200,7 +200,7 @@ export const dayCellStyles = stylex.create({
     borderStyle: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     fontFamily: 'inherit',
     fontSize: typeScaleVars['--text-body-size'],
@@ -232,7 +232,7 @@ export const dayCellStyles = stylex.create({
   dayTodayInRange: {},
   daySelected: {},
   dayDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 });
 

--- a/packages/core/src/Chat/ChatComposer.tsx
+++ b/packages/core/src/Chat/ChatComposer.tsx
@@ -154,7 +154,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-background-popover'],
     cursor: {
       default: 'text',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transition: `box-shadow ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}, border-color ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
   },

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -119,7 +119,7 @@ const styles = stylex.create({
     marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     userSelect: 'none',
   },

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -107,7 +107,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1-5'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     userSelect: 'none',
     minHeight: '24px',
@@ -197,7 +197,7 @@ const styles = stylex.create({
   callRowClickable: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     paddingInline: spacingVars['--spacing-1'],
@@ -211,7 +211,7 @@ const styles = stylex.create({
   callRowToggle: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   statusIcon: {

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -119,7 +119,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     outline: 'none',
     backgroundColor: 'transparent',

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -82,7 +82,7 @@ const styles = stylex.create({
     opacity: 0,
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     zIndex: 1,
     minInlineSize: {
@@ -107,7 +107,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   labelWrapper: {
     display: 'flex',

--- a/packages/core/src/Citation/Citation.test.tsx
+++ b/packages/core/src/Citation/Citation.test.tsx
@@ -23,7 +23,7 @@ const probe = stylex.create({
   pointerCursor: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
 });

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -101,7 +101,7 @@ const styles = stylex.create({
   labelInteractive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   labelHover: {
@@ -142,7 +142,7 @@ const styles = stylex.create({
   numberInteractive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   numberHover: {

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -57,7 +57,7 @@ const styles = stylex.create({
     position: 'relative',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textDecoration: 'none',
     color: 'inherit',
@@ -119,7 +119,7 @@ const styles = stylex.create({
     },
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
   },
   srOnly: {

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -217,7 +217,7 @@ const styles = stylex.create({
   headerCollapsible: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     userSelect: 'none',
     // Restore a keyboard-only focus ring with the standard token/offset so this

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -67,7 +67,7 @@ const styles = stylex.create({
     width: '100%',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-large-size'],
@@ -87,7 +87,7 @@ const styles = stylex.create({
   // button blocks click + keyboard activation; these styles restore the
   // visual affordance that `all: unset` wipes.
   triggerDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
   },
   // Chevron indicator

--- a/packages/core/src/CommandPalette/CommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteItem.tsx
@@ -45,7 +45,7 @@ const styles = stylex.create({
     border: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textAlign: 'start' as const,
     outline: 'none',
@@ -66,7 +66,7 @@ const styles = stylex.create({
   },
   itemDisabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   itemSelected: {
     backgroundColor: colorVars['--color-accent-muted'],

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -72,7 +72,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   trigger: {
@@ -95,7 +95,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     outline: 'none',
     borderRadius: radiusVars['--radius-element'],
@@ -184,7 +184,7 @@ const styles = stylex.create({
     height: sizeVars['--size-element-lg'],
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 });
 

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -84,12 +84,12 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   input: {
     display: 'block',
@@ -112,7 +112,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/DateInput/MonthScroller.tsx
+++ b/packages/core/src/DateInput/MonthScroller.tsx
@@ -151,7 +151,7 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-normal'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     // A tap on a 44px target should not also select the number inside it.
     userSelect: 'none',
@@ -249,7 +249,7 @@ const styles = stylex.create({
     // five levels apart, which is no difference at all. That is the whole
     // reason the two were hard to tell apart.
     opacity: 0.3,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 });
 

--- a/packages/core/src/DateInput/TouchDateField.tsx
+++ b/packages/core/src/DateInput/TouchDateField.tsx
@@ -178,12 +178,12 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   input: {
     display: 'block',
@@ -207,7 +207,7 @@ const styles = stylex.create({
     caretColor: 'transparent',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     userSelect: 'none',
     '::placeholder': {
@@ -215,7 +215,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 
   // ---- the picker surface ----
@@ -328,7 +328,7 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-semibold'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     whiteSpace: 'nowrap',
   },

--- a/packages/core/src/DateInput/Wheel.tsx
+++ b/packages/core/src/DateInput/Wheel.tsx
@@ -130,7 +130,7 @@ const styles = stylex.create({
     // frozen at 50% forever. Clipping belongs on the inner element.
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     userSelect: 'none',
     transitionProperty: 'color, font-weight',
@@ -177,7 +177,7 @@ const styles = stylex.create({
   },
   itemDisabled: {
     color: colorVars['--color-text-disabled'],
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   /**
    * The selection band: a single centred row-height plate behind the options.

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -108,7 +108,7 @@ const styles = stylex.create({
     outline: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textAlign: 'start',
     whiteSpace: 'nowrap',
@@ -119,7 +119,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
   },
   triggerDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   iconButton: {
     display: 'flex',
@@ -132,12 +132,12 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   popoverLayout: {
     display: 'flex',
@@ -172,7 +172,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textAlign: 'start',
   },
@@ -182,7 +182,7 @@ const styles = stylex.create({
   },
   presetButtonDisabled: {
     color: colorVars['--color-text-disabled'],
-    cursor: 'not-allowed',
+    cursor: 'default',
     backgroundColor: 'transparent',
   },
 });

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -123,12 +123,12 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
   },
   iconButtonDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   icon: {
     display: 'flex',
@@ -157,7 +157,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
@@ -48,13 +48,13 @@ const styles = stylex.create({
     },
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     outline: 'none',
   },
   disabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   // Rendered in Item's `marker` slot as a raw flex child, so `order` moves it
   // relative to the label within the row. On touch it moves to the inline-end.

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -56,14 +56,14 @@ const menuItemStyles = stylex.create({
     border: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textAlign: 'start',
     outline: 'none',
   },
   disabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   destructive: {
     // Only recolor the text/icon; the hover / focus background stays the shared

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
@@ -44,13 +44,13 @@ const styles = stylex.create({
     },
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     outline: 'none',
   },
   disabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   // Rendered in Item's `marker` slot as a raw flex child. On touch it moves to
   // the inline-end of the row via `order`.

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -98,7 +98,7 @@ const triggerStyles = stylex.create({
     border: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textAlign: 'start',
     outline: 'none',
@@ -110,7 +110,7 @@ const triggerStyles = stylex.create({
   },
   disabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   caret: {
     display: 'flex',

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -47,12 +47,12 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   labelDisabled: {
     color: colorVars['--color-text-disabled'],
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   srOnly: {
     borderStyle: 'none',
@@ -87,7 +87,7 @@ const styles = stylex.create({
   descriptionClickable: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
 });

--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -65,7 +65,7 @@ export const inputWrapperStyles = stylex.create({
     outline: 'none',
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
     borderColor: colorVars['--color-border-emphasized'],
     // Suppress the base hover ring — a disabled control must not react to hover.

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -154,7 +154,7 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     outline: 'none',
   },
@@ -171,7 +171,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-accent-muted'],
   },
   dropzoneDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
     borderColor: colorVars['--color-border-emphasized'],
   },
@@ -207,13 +207,13 @@ const styles = stylex.create({
     },
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     height: sizeVars['--size-element-md'],
     outline: 'none',
   },
   compactDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
     borderColor: colorVars['--color-border-emphasized'],
   },

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -40,7 +40,7 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
   },
 });

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -218,7 +218,7 @@ const styles = stylex.create({
   interactive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast-min'],
@@ -238,7 +238,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-accent-muted'],
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     pointerEvents: 'none' as const,
   },
   disabledContent: {
@@ -248,7 +248,7 @@ const styles = stylex.create({
     all: 'unset',
     cursor: {
       default: 'inherit',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     font: 'inherit',
     color: 'inherit',
@@ -263,7 +263,7 @@ const styles = stylex.create({
     all: 'unset',
     cursor: {
       default: 'inherit',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     font: 'inherit',
     color: 'inherit',

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -150,10 +150,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     overflow: 'hidden',
-    cursor: {
-      default: 'default',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
-    },
+    cursor: 'default',
     userSelect: 'none',
     minHeight: 0,
   },
@@ -161,19 +158,19 @@ const styles = stylex.create({
     cursor: {
       default: 'zoom-in',
       '@media (hover: hover)': 'zoom-in',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   imageWrapperZoomed: {
     cursor: {
       default: 'grab',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   imageWrapperDragging: {
     cursor: {
       default: 'grabbing',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   image: {

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -67,7 +67,7 @@ const styles = stylex.create({
     },
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'color, text-decoration',
     transitionDuration: durationVars['--duration-fast'],
@@ -88,7 +88,7 @@ const styles = stylex.create({
     textDecoration: 'underline',
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
     pointerEvents: 'none',
   },

--- a/packages/core/src/MetadataList/MetadataList.tsx
+++ b/packages/core/src/MetadataList/MetadataList.tsx
@@ -148,7 +148,7 @@ const styles = stylex.create({
     padding: `${spacingVars['--spacing-2']} 0`,
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     color: colorVars['--color-accent'],
     fontSize: typeScaleVars['--text-body-size'],

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -105,7 +105,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // Trigger button — the actual combobox button, visually integrated with the container
@@ -129,7 +129,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     // The wrapper (inputWrapperStyles.base) renders the focus ring via
     // :focus-within when this button is focused, matching
@@ -238,7 +238,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
   },
@@ -263,7 +263,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
 
@@ -297,7 +297,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     // Row typography lives here, not on the label span, so a theme override on
     // the row target reaches both the fallback label and renderOption output
@@ -317,7 +317,7 @@ const styles = stylex.create({
   itemDisabled: {
     opacity: 0.5,
     color: colorVars['--color-text-disabled'],
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 
   // Decorative checkbox (non-interactive, purely visual)

--- a/packages/core/src/NavItem/navItemStyles.stylex.ts
+++ b/packages/core/src/NavItem/navItemStyles.stylex.ts
@@ -67,7 +67,7 @@ export const navItemStyles = stylex.create({
     textDecoration: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     fontFamily: 'inherit',
     fontSize: typeScaleVars['--text-label-size'],
@@ -123,7 +123,7 @@ export const navItemStyles = stylex.create({
   /** Disabled state — muted color, no interaction */
   disabled: {
     color: colorVars['--color-text-disabled'],
-    cursor: 'not-allowed',
+    cursor: 'default',
     pointerEvents: 'none' as const,
   },
 

--- a/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenuItem.tsx
@@ -50,7 +50,7 @@ const styles = stylex.create({
     border: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textAlign: 'start',
     outline: 'none',
@@ -64,7 +64,7 @@ const styles = stylex.create({
   },
   disabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 });
 

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -115,7 +115,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
@@ -168,13 +168,13 @@ const styles = stylex.create({
     },
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     outline: 'none',
   },
   numberStepperButtonDisabled: {
     color: colorVars['--color-icon-disabled'],
-    cursor: 'not-allowed',
+    cursor: 'default',
     backgroundImage: 'none',
   },
   decrementButton: {

--- a/packages/core/src/Outline/Outline.tsx
+++ b/packages/core/src/Outline/Outline.tsx
@@ -192,7 +192,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     display: 'flex',
     fontWeight: fontWeightVars['--font-weight-normal'],

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -216,7 +216,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-neutral'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
@@ -230,7 +230,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-accent'],
   },
   dotDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
   },
   activePage: {

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -46,7 +46,7 @@ const styles = stylex.create({
     opacity: 0,
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     zIndex: 1,
     minInlineSize: {
@@ -71,7 +71,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   // Holds only the indicator, so the focus ring has one unambiguous target.
   indicatorSlot: {

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -121,7 +121,7 @@ const styles = stylex.create({
     height: '100%',
     cursor: {
       default: 'col-resize',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   vertical: {
@@ -129,7 +129,7 @@ const styles = stylex.create({
     width: '100%',
     cursor: {
       default: 'row-resize',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   noDividerHorizontal: {
@@ -147,7 +147,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-border-emphasized'],
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     pointerEvents: 'none',
   },
 
@@ -163,7 +163,7 @@ const styles = stylex.create({
     bottom: 0,
     cursor: {
       default: 'col-resize',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   hitAreaVertical: {
@@ -172,7 +172,7 @@ const styles = stylex.create({
     insetInlineEnd: 0,
     cursor: {
       default: 'row-resize',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // Centered grab zone (pillPlacement 'center' / no bias): sit the hit area on

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -84,7 +84,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     whiteSpace: 'nowrap',
     transitionProperty: 'color, background-color, box-shadow',
@@ -124,7 +124,7 @@ const styles = stylex.create({
     boxShadow: shadowVars['--shadow-low'],
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     color: colorVars['--color-text-disabled'],
   },
   fill: {

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -57,7 +57,7 @@ const styles = stylex.create({
     position: 'relative',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'box-shadow, border-color',
     transitionDuration: durationVars['--duration-fast'],
@@ -89,7 +89,7 @@ const styles = stylex.create({
     },
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
   },
   srOnly: {

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -112,7 +112,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // Trigger button — the actual combobox button, visually integrated with the container
@@ -136,7 +136,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     // The wrapper (inputWrapperStyles.base) renders the focus ring via
     // :focus-within when this button is focused, matching TextInput/NumberInput.
@@ -261,7 +261,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
   },
@@ -342,7 +342,7 @@ const styles = stylex.create({
     border: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textAlign: 'start',
     outline: 'none',
@@ -381,7 +381,7 @@ const styles = stylex.create({
   },
   itemDisabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 });
 

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -66,10 +66,7 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     textDecoration: 'none',
     color: 'inherit',
-    cursor: {
-      default: 'default',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
-    },
+    cursor: 'default',
   },
   rootCollapsed: {
     justifyContent: 'center',
@@ -78,7 +75,7 @@ const styles = stylex.create({
   interactive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
@@ -99,7 +96,7 @@ const styles = stylex.create({
   menuTrigger: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
@@ -223,7 +220,7 @@ const styles = stylex.create({
     marginInline: spacingVars['--spacing-1'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // Chevron inside the popover heading — same as chevron but rotated up

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -147,7 +147,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
@@ -186,7 +186,7 @@ const styles = stylex.create({
     textAlign: 'start',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // No border and no background: `usePopover` paints the panel this renders

--- a/packages/core/src/SideNav/SideNavSection.tsx
+++ b/packages/core/src/SideNav/SideNavSection.tsx
@@ -47,10 +47,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
-    cursor: {
-      default: 'default',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
-    },
+    cursor: 'default',
     userSelect: 'none',
   },
 

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -186,7 +186,7 @@ const styles = stylex.create({
     width: '100%',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   trackContainerVertical: {
@@ -206,12 +206,12 @@ const styles = stylex.create({
     justifyContent: 'center',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   trackContainerDisabled: {
     opacity: 0.5,
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   track: {
     position: 'absolute',
@@ -259,7 +259,7 @@ const styles = stylex.create({
     outline: 'none',
     cursor: {
       default: 'grab',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     zIndex: 1,
   },
@@ -284,7 +284,7 @@ const styles = stylex.create({
   },
   thumbDisabled: {
     backgroundColor: colorVars['--color-background-muted'],
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   textValue: {
     fontFamily: typographyVars['--font-family-body'],

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -163,7 +163,7 @@ const styles = stylex.create({
     opacity: 0,
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     zIndex: 1,
     minInlineSize: {
@@ -188,7 +188,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   inputBusy: {
     pointerEvents: 'none',

--- a/packages/core/src/TabList/Tab.tsx
+++ b/packages/core/src/TabList/Tab.tsx
@@ -103,7 +103,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textDecoration: 'none',
     whiteSpace: 'nowrap',

--- a/packages/core/src/TabList/TabMenu.tsx
+++ b/packages/core/src/TabList/TabMenu.tsx
@@ -89,7 +89,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     textDecoration: 'none',
     transitionProperty: 'color',
@@ -190,7 +190,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
@@ -209,7 +209,7 @@ const handleStyles = stylex.create({
     width: '8px',
     cursor: {
       default: 'ew-resize',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     zIndex: 1,
     touchAction: 'none',

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
@@ -364,7 +364,7 @@ const filterStyles = stylex.create({
     border: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     display: 'inline-flex',
     alignItems: 'center',

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -115,7 +115,7 @@ const styles = stylex.create({
   headerRow: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     userSelect: 'none',
     backgroundColor: colorVars['--color-background-muted'],
@@ -150,7 +150,7 @@ const styles = stylex.create({
     border: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     color: {
       default: colorVars['--color-icon-secondary'],

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -79,7 +79,7 @@ const expansionStyles = stylex.create({
     borderRadius: radiusVars['--radius-inner'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     color: colorVars['--color-icon-secondary'],
     transitionProperty: 'transform, color',

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -127,7 +127,7 @@ const sortStyles = stylex.create({
     margin: 0,
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     font: 'inherit',
     color: 'inherit',

--- a/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
@@ -244,7 +244,7 @@ const treeStyles = stylex.create({
     borderRadius: radiusVars['--radius-inner'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     color: colorVars['--color-icon-secondary'],
     transitionProperty: 'color, background-color',
@@ -301,7 +301,7 @@ const treeStyles = stylex.create({
   clickableRow: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
 });

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -108,7 +108,7 @@ const styles = stylex.create({
     resize: 'vertical',
   },
   textareaDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   // Reserve start padding so text clears the start icon.
   // inline inset + 16px icon (sm) + 8px gap

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -71,7 +71,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
 });
 

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -161,7 +161,7 @@ const styles = stylex.create({
   interactive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // Hover/pressed overlay — the exact same treatment as ClickableCard and
@@ -195,7 +195,7 @@ const styles = stylex.create({
     all: 'unset',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     display: 'block',
     width: '100%',

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -102,7 +102,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -138,7 +138,7 @@ const styles = stylex.create({
   interactive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-image',
     transitionDuration: durationVars['--duration-fast'],
@@ -152,7 +152,7 @@ const styles = stylex.create({
     },
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
     pointerEvents: 'none' as const,
   },
@@ -171,7 +171,7 @@ const styles = stylex.create({
     all: 'unset',
     cursor: {
       default: 'inherit',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     font: 'inherit',
     color: 'inherit',
@@ -189,7 +189,7 @@ const styles = stylex.create({
     marginInlineEnd: `calc(-1 * ${spacingVars['--spacing-1']})`,
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-full'],
     width: '16px',

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -226,7 +226,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
     cursor: {
       default: 'text',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     height: 'auto',
   },

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -60,15 +60,12 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     textDecoration: 'none',
     color: colorVars['--color-text-primary'],
-    cursor: {
-      default: 'default',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
-    },
+    cursor: 'default',
   },
   interactive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
@@ -87,7 +84,7 @@ const styles = stylex.create({
   menuTrigger: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,
@@ -201,7 +198,7 @@ const styles = stylex.create({
     marginInline: spacingVars['--spacing-1'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   // Composes over `chevron` — the flipped popover copy differs only by the

--- a/packages/core/src/TopNav/TopNavItem.tsx
+++ b/packages/core/src/TopNav/TopNavItem.tsx
@@ -55,7 +55,7 @@ const styles = stylex.create({
     textDecoration: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color, color',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -80,7 +80,7 @@ const styles = stylex.create({
     textDecoration: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color, color',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
@@ -52,7 +52,7 @@ const styles = stylex.create({
     textDecoration: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/TopNav/TopNavMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMenu.tsx
@@ -67,7 +67,7 @@ const styles = stylex.create({
     textDecoration: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color, color',
     transitionDuration: durationVars['--duration-fast'],
@@ -120,7 +120,7 @@ const styles = stylex.create({
     textDecoration: 'none',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -97,7 +97,7 @@ const styles = stylex.create({
   interactive: {
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     transitionProperty: 'background-image',
     transitionDuration: durationVars['--duration-fast'],
@@ -111,7 +111,7 @@ const styles = stylex.create({
     },
   },
   disabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
     opacity: 0.5,
     pointerEvents: 'none' as const,
   },
@@ -122,7 +122,7 @@ const styles = stylex.create({
     all: 'unset',
     cursor: {
       default: 'inherit',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     font: 'inherit',
     color: 'inherit',
@@ -138,7 +138,7 @@ const styles = stylex.create({
     all: 'unset',
     cursor: {
       default: 'inherit',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     font: 'inherit',
     color: 'inherit',
@@ -185,7 +185,7 @@ const styles = stylex.create({
     fontSize: spacingVars['--spacing-4'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     border: 'none',
     background: 'none',
@@ -205,7 +205,7 @@ const styles = stylex.create({
     fontSize: spacingVars['--spacing-4'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     color: colorVars['--color-icon-secondary'],
     borderRadius: radiusVars['--radius-inner'],

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -215,7 +215,7 @@ const styles = stylex.create({
     },
   },
   inputDisabled: {
-    cursor: 'not-allowed',
+    cursor: 'default',
   },
   dropdown: {
     boxSizing: 'border-box',
@@ -235,7 +235,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     outline: 'none',
     backgroundColor: 'transparent',

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -169,7 +169,7 @@ const styles = stylex.create({
     paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
     cursor: {
       default: 'text',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
   },
   token: {

--- a/packages/core/src/hooks/useInputStatusIcon.tsx
+++ b/packages/core/src/hooks/useInputStatusIcon.tsx
@@ -83,7 +83,7 @@ const styles = stylex.create({
     color: 'inherit',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     // Own the interactivity so the tooltip opens on hover even when the field
     // renders this affordance inside a non-interactive trailing slot. TextArea

--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -262,14 +262,17 @@
   }
 
   /*
-   * Disabled elements answer the pointer with the disabled cursor, so a
-   * control that will not respond says so before it is clicked. Covers
-   * [aria-disabled] too: astryx keeps a disabled control focusable that way
-   * wherever its reason must stay discoverable (Button with a tooltip,
-   * Selector's trigger, SideNavItem).
+   * Disabled elements take back any interactive cursor: a control that will
+   * not respond must not answer the pointer as though it will. `default`
+   * rather than `not-allowed` — a disabled control sealed behind
+   * `pointer-events: none` shows whatever its ancestor shows, and one cursor
+   * everywhere beats a stronger one we can only paint on half of them.
+   * Covers [aria-disabled] too: astryx keeps a disabled control focusable
+   * that way wherever its reason must stay discoverable (Button with a
+   * tooltip, Selector's trigger, SideNavItem).
    */
   :where(:disabled, [aria-disabled='true']) {
-    cursor: not-allowed;
+    cursor: default;
   }
 
   /*

--- a/packages/core/src/reset.test.ts
+++ b/packages/core/src/reset.test.ts
@@ -59,9 +59,8 @@ describe('reset.css accessibility invariants', () => {
   });
 
   /**
-   * A disabled control must answer the pointer with the disabled cursor: the
-   * cursor is the only affordance a pointer user gets before they commit to a
-   * click. The reset is the floor for any element that declares no cursor of
+   * A disabled control must not answer the pointer with an interactive
+   * cursor. The reset is the floor for any element that declares no cursor of
    * its own — components declare theirs under the `disabled-cursor` lint
    * rule, and the Chromium sweep measures the rendered result.
    */
@@ -72,9 +71,7 @@ describe('reset.css accessibility invariants', () => {
     );
     expect(disabledBlocks.length).toBeGreaterThan(0);
     for (const {selector, body} of disabledBlocks) {
-      expect(body, `disabled rule "${selector}"`).toMatch(
-        /cursor:\s*not-allowed/,
-      );
+      expect(body, `disabled rule "${selector}"`).toMatch(/cursor:\s*default/);
     }
     // aria-disabled is how astryx keeps a disabled control focusable, so the
     // reset has to cover it alongside the native state.

--- a/packages/lab/src/Chat/ChatEmojiPicker.tsx
+++ b/packages/lab/src/Chat/ChatEmojiPicker.tsx
@@ -147,7 +147,7 @@ const styles = stylex.create({
     },
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     fontSize: 18,
     lineHeight: typeScaleVars['--text-body-leading'],

--- a/packages/lab/src/Chat/ChatReactionBar.tsx
+++ b/packages/lab/src/Chat/ChatReactionBar.tsx
@@ -126,7 +126,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-background-muted'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     fontFamily: typographyVars['--font-family-body'],
     boxSizing: 'border-box',
@@ -182,7 +182,7 @@ const styles = stylex.create({
     color: colorVars['--color-icon-secondary'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     boxSizing: 'border-box',
     fontSize: 15,

--- a/packages/lab/src/ChatReasoning/ChatReasoning.tsx
+++ b/packages/lab/src/ChatReasoning/ChatReasoning.tsx
@@ -76,7 +76,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1-5'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     userSelect: 'none',
     minHeight: '24px',

--- a/packages/lab/src/InfoTip/InfoTip.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.tsx
@@ -65,7 +65,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-full'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     color: {
       default: colorVars['--color-icon-secondary'],

--- a/packages/lab/src/LogStream/LogStream.tsx
+++ b/packages/lab/src/LogStream/LogStream.tsx
@@ -192,7 +192,7 @@ const styles = stylex.create({
     fontSize: textSizeVars['--font-size-sm'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     backgroundColor: {
       default: 'transparent',
@@ -301,7 +301,7 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     boxShadow: shadowVars['--shadow-med'],
   },

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -425,7 +425,7 @@ const styles = stylex.create({
     width: '100%',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     transitionProperty: 'background-color',
@@ -472,7 +472,7 @@ const styles = stylex.create({
     textAlign: 'start',
     cursor: {
       default: 'pointer',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     borderRadius: radiusVars['--radius-element'],
     transitionProperty: 'background-color',

--- a/packages/lab/src/reorderStyles.ts
+++ b/packages/lab/src/reorderStyles.ts
@@ -68,14 +68,14 @@ export const reorderStyles = stylex.create({
   handle: {
     cursor: {
       default: 'grab',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     touchAction: 'none',
   },
   handleActive: {
     cursor: {
       default: 'grabbing',
-      ':is(:disabled,[aria-disabled="true"])': 'not-allowed',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     touchAction: 'none',
   },


### PR DESCRIPTION
## Why

Follow-up to [#5323](https://github.com/facebook/astryx/pull/5323), which guaranteed `not-allowed` on a disabled element. It cannot actually be a guarantee.

**75 of the 635 disabled elements in the story set are sealed behind `pointer-events: none`.** Those are never hit-tested, so they show whatever their ancestor shows — no declaration on the control can change that. So the library was painting the stronger cursor on the reachable ones and a plain arrow on the rest: exactly the inconsistency the work was meant to remove, just relocated.

`default` is paintable everywhere, matches the internal XDS convention, and costs nothing we were relying on — a disabled control already reads as disabled from its own visual treatment; the cursor's job here is to stop *promising* an interaction, not to explain one.

The mechanism from #5323 is unchanged and still doing the real work: the guard on every declaration, the merge-order trap, the lint rule, the sweep. Only the value moves.

## What

- Every guarded `cursor` in core and lab resolves to `default` when disabled — 126 sites.
- The 49 pre-existing flat `cursor: 'not-allowed'` declarations inside `disabled` styles become `default` too. Leaving those would have kept two conventions in the library, which is the thing being fixed.
- A declaration whose base was already `default` collapses back to a flat `cursor: 'default'` — the guard is redundant there (Lightbox, SideNavHeading, SideNavSection, TopNavHeading).
- `reset.css`, the lint rule, the sweep, `reset.test.ts` and the docs all expect `default`. The rule now exempts `default` instead of `not-allowed`.
- #5323's changeset is amended rather than answered with a second one — it has not shipped, so the changelog tells one story instead of contradicting itself.

## Risk

Same blast radius as #5323 and no larger: only what a disabled element shows under the pointer. Nothing about markup, props, events or the sealed elements changes.

## Testing

- `pnpm guard:disabled-cursor` over all 1704 stories: **0 violations**, 635 disabled elements checked, 75 sealed (reported, not passed).
- `@astryx/disabled-cursor` over core and lab: **0 findings**.
- Unit: rule `RuleTester` suite, sweep verdict/CLI suite, `reset.test.ts` — 27 passing.
- Rubric [A21](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) updated to expect `default` (v1.7.1, patch — nothing was audited under 1.7, so no score is invalidated).
