### PR TITLE
fix(core): avoid dangling selector controls

### DIFF
--- a/.changeset/quiet-selectors-control-mounted-listboxes.md
+++ b/.changeset/quiet-selectors-control-mounted-listboxes.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Omit `aria-controls` from a closed Selector until its lazy listbox is mounted,
+preventing an invalid ARIA reference on initial render while preserving the
+combobox relationship whenever the popup is expanded.
+
+@light-merlin-dark

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1253,6 +1253,21 @@ describe('Selector', () => {
   });
 
   describe('keyboard accessibility', () => {
+    it('does not reference the listbox before the popup is mounted', async () => {
+      const user = userEvent.setup();
+      render(<Selector label="Fruit" options={OPTIONS} />);
+
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).not.toHaveAttribute('aria-controls');
+
+      await user.click(trigger);
+      const listbox = screen.getByRole('listbox', h);
+      expect(trigger).toHaveAttribute('aria-controls', listbox.id);
+
+      await user.keyboard('{Escape}');
+      expect(trigger).not.toHaveAttribute('aria-controls');
+    });
+
     it('trigger is focusable via Tab when enabled', async () => {
       const user = userEvent.setup();
       render(<Selector label="Fruit" options={OPTIONS} />);

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1493,7 +1493,10 @@ export function Selector<T extends SelectorOptionType>(
           {...rest}
           aria-haspopup="listbox"
           aria-expanded={popover.isOpen}
-          aria-controls={listboxId}
+          // The listbox is lazy-mounted on first open. Do not reference an
+          // absent element from the initial closed trigger; axe treats that as
+          // an invalid critical ARIA relationship.
+          aria-controls={popover.isOpen ? listboxId : undefined}
           aria-activedescendant={
             !hasSearch && popover.isOpen && highlightedIndex >= 0
               ? getItemId(highlightedIndex)


### PR DESCRIPTION
## Context

Related to #3343, the shared accessibility and keyboard-management program.

A serious-impact axe scan exposed an invalid initial ARIA relationship: the closed Selector trigger referenced a listbox that is lazy-mounted only after the popup opens. This patch keeps the relationship truthful across the closed → open → closed lifecycle without changing the public API.

## Summary

- omit `aria-controls` from the initial closed Selector trigger before its lazy listbox exists
- restore the relationship whenever the popup is expanded
- add focused open/close regression coverage and a patch changeset

## Verification

- `pnpm vitest run packages/core/src/Selector/Selector.test.tsx` (144/144)
- focused ESLint
- `pnpm check:changesets`
- repository pre-commit checks

By Merlin ([rbeckner.com](https://rbeckner.com)) and his AI agent (Codex, GPT-5, thinking on: high).