### PR TITLE
fix(AlertDialog): keep actions readable on narrow surfaces

### DIFF
--- a/.changeset/alert-dialog-responsive-actions.md
+++ b/.changeset/alert-dialog-responsive-actions.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AlertDialog action labels now wrap, and the action row stacks based on the dialog's own width so destructive decisions remain fully readable on narrow surfaces and at increased zoom.
+
+@rubycheung

--- a/.changeset/alert-dialog-responsive-actions.md
+++ b/.changeset/alert-dialog-responsive-actions.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] AlertDialog lets Dialog preserve and clamp its preferred width, stacks the destructive action above Cancel at 640px and below, and wraps complete decision labels in both horizontal and stacked action layouts regardless of pointer type.
+[fix] AlertDialog lets Dialog preserve and clamp its preferred width, lets whole actions move to another row when needed, and stacks full-width destructive and Cancel actions at 640px and below while preserving standard single-line Button sizing and labels regardless of pointer type.
 
 @rubyycheung

--- a/.changeset/alert-dialog-responsive-actions.md
+++ b/.changeset/alert-dialog-responsive-actions.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] AlertDialog preserves its >640px centered layout and, at 640px and below, fills available width with token gutters, stacks the destructive action above Cancel, and wraps complete decision labels regardless of pointer type.
+[fix] AlertDialog lets Dialog preserve and clamp its preferred width, stacks the destructive action above Cancel at 640px and below, and wraps complete decision labels in both horizontal and stacked action layouts regardless of pointer type.
 
-@rubycheung
+@rubyycheung

--- a/.changeset/alert-dialog-responsive-actions.md
+++ b/.changeset/alert-dialog-responsive-actions.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] AlertDialog action labels now wrap, and the action row stacks based on the dialog's own width so destructive decisions remain fully readable on narrow surfaces and at increased zoom.
+[fix] AlertDialog preserves its >640px centered layout and, at 640px and below, fills available width with token gutters, stacks the destructive action above Cancel, and wraps complete decision labels regardless of pointer type.
 
 @rubycheung

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -86,8 +86,8 @@ export const Async: Story = {
 };
 
 /**
- * Desktop fine-pointer reference. Above 640px the dialog keeps the pre-existing
- * 400px centered surface and horizontal Cancel/destructive action row.
+ * Wide reference state. In a wide viewport, Dialog preserves AlertDialog's
+ * preferred 400px surface and AlertDialog renders a horizontal action row.
  */
 export const DesktopFinePointer: Story = {
   args: {
@@ -102,9 +102,8 @@ export const DesktopFinePointer: Story = {
 };
 
 /**
- * Narrow fine-pointer reference. At 640px and below, available width determines
- * layout: the surface uses token gutters, destructive appears above Cancel, and
- * labels wrap even when the pointer can hover.
+ * Narrow reference state. Use a <=640px viewport to see Dialog's width clamp
+ * with AlertDialog's destructive-above-Cancel stacked action order.
  */
 export const NarrowFinePointer: Story = {
   args: {
@@ -120,9 +119,8 @@ export const NarrowFinePointer: Story = {
 };
 
 /**
- * Mobile touch reference. A <=640px coarse-pointer/no-hover viewport uses the
- * same narrow stacked layout as NarrowFinePointer; pointer type does not decide
- * geometry.
+ * Mobile reference state. Use a <=640px mobile viewport to verify the same
+ * stacked action order; this story does not emulate pointer or hover capability.
  */
 export const MobileTouch: Story = {
   args: NarrowFinePointer.args,

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -86,15 +86,29 @@ export const Async: Story = {
 };
 
 /**
- * Narrow surface with long decision labels. The dialog itself is the responsive
- * container: actions stack and labels wrap without treating narrow width as a
- * proxy for touch input.
+ * Desktop fine-pointer reference. Above 640px the dialog keeps the pre-existing
+ * 400px centered surface and horizontal Cancel/destructive action row.
  */
-export const NarrowLongActions: Story = {
+export const DesktopFinePointer: Story = {
   args: {
     isOpen: true,
-    isInline: true,
-    width: 280,
+    title: 'Delete item?',
+    description:
+      'This action cannot be undone. The item and all its data will be permanently removed.',
+    actionLabel: 'Delete',
+    onOpenChange: () => {},
+    onAction: () => {},
+  },
+};
+
+/**
+ * Narrow fine-pointer reference. At 640px and below, available width determines
+ * layout: the surface uses token gutters, destructive appears above Cancel, and
+ * labels wrap even when the pointer can hover.
+ */
+export const NarrowFinePointer: Story = {
+  args: {
+    isOpen: true,
     title: 'Permanently delete this workspace?',
     description:
       'Everyone will lose access to its dashboards, saved queries, and sharing links. This cannot be undone.',
@@ -103,6 +117,15 @@ export const NarrowLongActions: Story = {
     onOpenChange: () => {},
     onAction: () => {},
   },
+};
+
+/**
+ * Mobile touch reference. A <=640px coarse-pointer/no-hover viewport uses the
+ * same narrow stacked layout as NarrowFinePointer; pointer type does not decide
+ * geometry.
+ */
+export const MobileTouch: Story = {
+  args: NarrowFinePointer.args,
 };
 
 /**

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -86,29 +86,22 @@ export const Async: Story = {
 };
 
 /**
- * Non-destructive confirmation with a primary action button.
+ * Narrow surface with long decision labels. The dialog itself is the responsive
+ * container: actions stack and labels wrap without treating narrow width as a
+ * proxy for touch input.
  */
-export const Informational: Story = {
-  render: () => {
-    const [isOpen, setIsOpen] = useState(false);
-    return (
-      <>
-        <Button
-          label="Show notice"
-          variant="secondary"
-          onClick={() => setIsOpen(true)}
-        />
-        <AlertDialog
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          title="Session expired"
-          description="Your session has expired. You will be redirected to the login page."
-          actionLabel="Sign in"
-          actionVariant="primary"
-          onAction={() => setIsOpen(false)}
-        />
-      </>
-    );
+export const NarrowLongActions: Story = {
+  args: {
+    isOpen: true,
+    isInline: true,
+    width: 280,
+    title: 'Permanently delete this workspace?',
+    description:
+      'Everyone will lose access to its dashboards, saved queries, and sharing links. This cannot be undone.',
+    cancelLabel: 'Keep this workspace',
+    actionLabel: 'Permanently delete workspace',
+    onOpenChange: () => {},
+    onAction: () => {},
   },
 };
 

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nThe surface is capped to the viewport and its body scrolls when block space is constrained. Actions wrap as needed and stack when the dialog itself is narrow, so complete decision labels remain visible without coupling the layout to touch input or a device category.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
+      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nAt widths above 640px, AlertDialog keeps its requested width and horizontal Cancel/destructive actions. At 640px and below, the surface fills the viewport with token gutters, the destructive action appears above Cancel, and complete labels wrap. Geometry follows available width, not pointer or hover capability. The body scrolls when block space is constrained.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
     bestPractices: [
       {
         guidance: true,
@@ -41,7 +41,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use complete action labels. The footer wraps and stacks them when the dialog surface is narrow instead of truncating the decision.',
+          'Use complete action labels. At 640px and below, the destructive action appears above Cancel and both labels wrap instead of truncating, regardless of pointer type.',
       },
       {
         guidance: false,
@@ -168,7 +168,7 @@ export const docs = {
       type: 'number | string',
       default: '400',
       description:
-        'Requested dialog width. The rendered surface remains capped to 90% of the viewport width.',
+        'Requested dialog width above 640px. At 640px and below, the dialog fills available width with token gutters regardless of pointer type.',
     },
     {
       name: 'isInline',
@@ -190,7 +190,7 @@ export const docsDense = {
     'Confirms destructive/irreversible action before it happens (delete, revoke access, discard unsaved changes).',
   usage: {
     description:
-      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. Surface caps to viewport; body scrolls when height is constrained; action labels wrap and stack based on dialog width. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
+      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. >640px keeps requested width + horizontal actions. <=640px fills w/ token gutters, puts destructive action above Cancel, and wraps labels regardless of pointer/hover capability. Body scrolls when height constrained. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
     bestPractices: [
       {
         guidance: true,
@@ -210,7 +210,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use complete action labels; footer wraps and stacks them based on dialog width.',
+          'Use complete action labels; <=640px puts the destructive action above Cancel and allows wrapping regardless of pointer type.',
       },
       {
         guidance: false,

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nAt widths above 640px, AlertDialog keeps its requested width and horizontal Cancel/destructive actions. At 640px and below, the surface fills the viewport with token gutters, the destructive action appears above Cancel, and complete labels wrap. Geometry follows available width, not pointer or hover capability. The body scrolls when block space is constrained.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
+      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nAlertDialog passes its requested width through to Dialog, which clamps the surface to the container and dynamic viewport with token gutters. Generic Dialog footers should wrap, but Dialog does not own action semantics or order; consumer composition controls that. AlertDialog owns its confirmation semantics: above 640px, actions render horizontally and may wrap onto another row; at 640px and below, the destructive action appears above Cancel and both labels wrap. The breakpoint follows available width, not pointer or hover capability. The body scrolls when block space is constrained.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
     bestPractices: [
       {
         guidance: true,
@@ -36,12 +36,12 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Keep the cancel button first: it takes initial focus, so the least destructive choice is the one already selected when the dialog opens.',
+          'Keep the cancel button as the least-destructive focus target. On narrow screens the destructive action is visually and structurally above Cancel, but Cancel still receives initial focus.',
       },
       {
         guidance: true,
         description:
-          'Use complete action labels. At 640px and below, the destructive action appears above Cancel and both labels wrap instead of truncating, regardless of pointer type.',
+          'Use complete action labels. Horizontal actions wrap instead of overflowing; at 640px and below, the destructive action appears above Cancel and both labels wrap regardless of pointer type.',
       },
       {
         guidance: false,
@@ -168,7 +168,7 @@ export const docs = {
       type: 'number | string',
       default: '400',
       description:
-        'Requested dialog width above 640px. At 640px and below, the dialog fills available width with token gutters regardless of pointer type.',
+        'Requested dialog width. Dialog preserves this preferred width and clamps it to the container and dynamic viewport with token gutters.',
     },
     {
       name: 'isInline',
@@ -190,7 +190,7 @@ export const docsDense = {
     'Confirms destructive/irreversible action before it happens (delete, revoke access, discard unsaved changes).',
   usage: {
     description:
-      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. >640px keeps requested width + horizontal actions. <=640px fills w/ token gutters, puts destructive action above Cancel, and wraps labels regardless of pointer/hover capability. Body scrolls when height constrained. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
+      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. Dialog preserves requested width + clamps it to container/dynamic viewport gutters. Generic Dialog footers wrap while consumers own action order. AlertDialog owns confirmation action layout: >640px horizontal actions wrap; <=640px puts destructive action above Cancel and wraps labels regardless of pointer/hover capability. Body scrolls when height constrained. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
     bestPractices: [
       {
         guidance: true,
@@ -205,12 +205,12 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Keep cancel first: it takes initial focus, so least destructive choice is preselected.',
+          'Keep cancel as initial focus: least destructive choice is preselected even when narrow visual/DOM order places it after the destructive action.',
       },
       {
         guidance: true,
         description:
-          'Use complete action labels; <=640px puts the destructive action above Cancel and allows wrapping regardless of pointer type.',
+          'Use complete action labels; horizontal actions wrap, and <=640px puts the destructive action above Cancel with wrapping regardless of pointer type.',
       },
       {
         guidance: false,

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -21,21 +21,75 @@ export const docs = {
   ],
   usage: {
     description:
-      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
+      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nThe surface is capped to the viewport and its body scrolls when block space is constrained. Actions wrap as needed and stack when the dialog itself is narrow, so complete decision labels remain visible without coupling the layout to touch input or a device category.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
     bestPractices: [
-      {guidance: true, description: 'Make the action button label specific: "Delete project" is better than "OK" or "Confirm".'},
-      {guidance: true, description: 'Describe what will happen in the description so the user knows the consequences before confirming.'},
-      {guidance: true, description: 'Keep the cancel button first: it takes initial focus, so the least destructive choice is the one already selected when the dialog opens.'},
-      {guidance: false, description: 'Use AlertDialog for non-destructive actions; use a standard Dialog instead.'},
-      {guidance: false, description: 'Rely on color alone to signal danger; the action label itself should say what will happen.'},
-      {guidance: false, description: 'Close the dialog from onAction before the work finishes; hold it open with isActionLoading and call onOpenChange(false) when the action settles.'},
+      {
+        guidance: true,
+        description:
+          'Make the action button label specific: "Delete project" is better than "OK" or "Confirm".',
+      },
+      {
+        guidance: true,
+        description:
+          'Describe what will happen in the description so the user knows the consequences before confirming.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep the cancel button first: it takes initial focus, so the least destructive choice is the one already selected when the dialog opens.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use complete action labels. The footer wraps and stacks them when the dialog surface is narrow instead of truncating the decision.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use AlertDialog for non-destructive actions; use a standard Dialog instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on color alone to signal danger; the action label itself should say what will happen.',
+      },
+      {
+        guidance: false,
+        description:
+          'Close the dialog from onAction before the work finishes; hold it open with isActionLoading and call onOpenChange(false) when the action settles.',
+      },
     ],
     anatomy: [
-      {name: 'Title', required: true, description: 'The question being asked. Renders as a level-2 heading and labels the dialog via aria-labelledby.'},
-      {name: 'Description', required: true, description: 'What will happen if the user confirms. Linked to the dialog via aria-describedby.'},
-      {name: 'Cancel button', required: true, description: 'Ghost button that dismisses without acting. Takes initial focus, and Escape does the same thing.'},
-      {name: 'Action button', required: true, description: 'The confirming action. Destructive by default; shows a spinner while isActionLoading is set.'},
-      {name: 'Backdrop', required: true, description: 'Overlay behind the dialog that blocks page interaction. Clicking it does not dismiss.'},
+      {
+        name: 'Title',
+        required: true,
+        description:
+          'The question being asked. Renders as a level-2 heading and labels the dialog via aria-labelledby.',
+      },
+      {
+        name: 'Description',
+        required: true,
+        description:
+          'What will happen if the user confirms. Linked to the dialog via aria-describedby.',
+      },
+      {
+        name: 'Cancel button',
+        required: true,
+        description:
+          'Ghost button that dismisses without acting. Takes initial focus, and Escape does the same thing.',
+      },
+      {
+        name: 'Action button',
+        required: true,
+        description:
+          'The confirming action. Destructive by default; shows a spinner while isActionLoading is set.',
+      },
+      {
+        name: 'Backdrop',
+        required: true,
+        description:
+          'Overlay behind the dialog that blocks page interaction. Clicking it does not dismiss.',
+      },
     ],
   },
   // Intentionally a contained isInline preview, not playground.overlay: the
@@ -48,11 +102,13 @@ export const docs = {
       isInline: true,
       onOpenChange: undefined,
       title: 'Delete item?',
-      description: 'This action cannot be undone. The item and all its data will be permanently removed.',
+      description:
+        'This action cannot be undone. The item and all its data will be permanently removed.',
       actionLabel: 'Delete',
     },
   },
-  description: 'A modal dialog that asks the user to confirm a destructive action.',
+  description:
+    'A modal dialog that asks the user to confirm a destructive action.',
   props: [
     {
       name: 'isOpen',
@@ -111,38 +167,66 @@ export const docs = {
       name: 'width',
       type: 'number | string',
       default: '400',
-      description: 'Dialog width.',
+      description:
+        'Requested dialog width. The rendered surface remains capped to 90% of the viewport width.',
     },
     {
       name: 'isInline',
       type: 'boolean',
       default: 'false',
-      description: 'Renders alert dialog content inline without modal behavior. For documentation previews and showcases only. Not being a modal, the inline path renders role="group" instead of role="alertdialog".',
+      description:
+        'Renders alert dialog content inline without modal behavior. For documentation previews and showcases only. Not being a modal, the inline path renders role="group" instead of role="alertdialog".',
     },
   ],
-  components: [
-    {name: 'useImperativeAlertDialog'},
-  ],
+  components: [{name: 'useImperativeAlertDialog'}],
   theming: {
-    targets: [
-      {className: 'astryx-alert-dialog'},
-    ],
+    targets: [{className: 'astryx-alert-dialog'}],
   },
 };
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
-  description: 'Confirms destructive/irreversible action before it happens (delete, revoke access, discard unsaved changes).',
+  description:
+    'Confirms destructive/irreversible action before it happens (delete, revoke access, discard unsaved changes).',
   usage: {
     description:
-      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
+      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. Surface caps to viewport; body scrolls when height is constrained; action labels wrap and stack based on dialog width. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
     bestPractices: [
-      {guidance: true, description: 'Make action button label specific: "Delete project" > "OK"/"Confirm".'},
-      {guidance: true, description: 'Describe consequences in description so user knows outcome before confirming.'},
-      {guidance: true, description: 'Keep cancel first: it takes initial focus, so least destructive choice is preselected.'},
-      {guidance: false, description: 'Use AlertDialog for non-destructive actions; use standard Dialog instead.'},
-      {guidance: false, description: 'Rely on color alone for danger; the action label should say what happens.'},
-      {guidance: false, description: 'Close from onAction before work finishes; hold open w/ isActionLoading, call onOpenChange(false) when it settles.'},
+      {
+        guidance: true,
+        description:
+          'Make action button label specific: "Delete project" > "OK"/"Confirm".',
+      },
+      {
+        guidance: true,
+        description:
+          'Describe consequences in description so user knows outcome before confirming.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep cancel first: it takes initial focus, so least destructive choice is preselected.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use complete action labels; footer wraps and stacks them based on dialog width.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use AlertDialog for non-destructive actions; use standard Dialog instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on color alone for danger; the action label should say what happens.',
+      },
+      {
+        guidance: false,
+        description:
+          'Close from onAction before work finishes; hold open w/ isActionLoading, call onOpenChange(false) when it settles.',
+      },
     ],
   },
 };

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nAlertDialog passes its requested width through to Dialog, which clamps the surface to the container and dynamic viewport with token gutters. Generic Dialog footers should wrap, but Dialog does not own action semantics or order; consumer composition controls that. AlertDialog owns its confirmation semantics: above 640px, actions render horizontally and may wrap onto another row; at 640px and below, the destructive action appears above Cancel and both labels wrap. The breakpoint follows available width, not pointer or hover capability. The body scrolls when block space is constrained.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
+      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nAlertDialog passes its requested width through to Dialog, which clamps the surface to the container and dynamic viewport with token gutters. Generic Dialog footers should wrap, but Dialog does not own action semantics or order; consumer composition controls that. AlertDialog owns its confirmation semantics: above 640px, actions render horizontally and may move onto another row; at 640px and below, the destructive action appears above Cancel and both buttons fill the footer width. Button labels retain their standard single-line behavior. The breakpoint follows available width, not pointer or hover capability. The body scrolls when block space is constrained.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
     bestPractices: [
       {
         guidance: true,
@@ -41,7 +41,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use complete action labels. Horizontal actions wrap instead of overflowing; at 640px and below, the destructive action appears above Cancel and both labels wrap regardless of pointer type.',
+          'Use concise, specific action labels. Above 640px, complete buttons may move onto another row; at 640px and below, the destructive action appears above Cancel and both buttons fill the footer width.',
       },
       {
         guidance: false,
@@ -190,7 +190,7 @@ export const docsDense = {
     'Confirms destructive/irreversible action before it happens (delete, revoke access, discard unsaved changes).',
   usage: {
     description:
-      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. Dialog preserves requested width + clamps it to container/dynamic viewport gutters. Generic Dialog footers wrap while consumers own action order. AlertDialog owns confirmation action layout: >640px horizontal actions wrap; <=640px puts destructive action above Cancel and wraps labels regardless of pointer/hover capability. Body scrolls when height constrained. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
+      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. Dialog preserves requested width + clamps it to container/dynamic viewport gutters. Generic Dialog footers wrap while consumers own action order. AlertDialog owns confirmation action layout: >640px horizontal buttons may move to another row; <=640px puts the destructive action above Cancel and makes both buttons full width regardless of pointer/hover capability. Button labels remain single-line. Body scrolls when height constrained. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
     bestPractices: [
       {
         guidance: true,
@@ -210,7 +210,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use complete action labels; horizontal actions wrap, and <=640px puts the destructive action above Cancel with wrapping regardless of pointer type.',
+          'Use concise action labels; >640px complete buttons may move to another row, and <=640px puts the destructive action above Cancel with both buttons full width regardless of pointer type.',
       },
       {
         guidance: false,

--- a/packages/core/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.test.tsx
@@ -167,7 +167,11 @@ describe('AlertDialog', () => {
   });
 
   describe('responsive actions', () => {
-    it('preserves the desktop fine-pointer layout above the small breakpoint', () => {
+    const longCancelLabel = 'Keep this workspace and all of its dashboards';
+    const longActionLabel =
+      'Permanently delete this workspace and all dashboards';
+
+    it('preserves the preferred width and horizontal order above the small breakpoint', () => {
       stubAlertDialogMedia({
         smallScreen: false,
         coarsePointer: false,
@@ -180,15 +184,49 @@ describe('AlertDialog', () => {
       expect(window.matchMedia).not.toHaveBeenCalledWith('(hover: none)');
       const dialog = screen.getByRole('alertdialog');
       const buttons = within(dialog).getAllByRole('button');
+      const footerStack = buttons[0].parentElement!;
       expect(dialog.getAttribute('style')).toContain('--x-width: 400px');
+      expect(dialog.getAttribute('style')).toContain(
+        '--x-maxWidth: min(100%, calc(100dvw - var(--spacing-4) - var(--spacing-4)))',
+      );
       expect(buttons.map(button => button.textContent)).toEqual([
         'Cancel',
         'Delete',
       ]);
-      expect(getComputedStyle(buttons[0]).whiteSpace).toBe('nowrap');
+      expect(getComputedStyle(footerStack).flexWrap).toBe('wrap');
     });
 
-    it('stacks destructive above cancel on a narrow fine-pointer screen', () => {
+    it('wraps long action labels in the wide horizontal branch', () => {
+      stubAlertDialogMedia({
+        smallScreen: false,
+        coarsePointer: false,
+        noHover: false,
+      });
+      render(
+        <AlertDialog
+          {...defaultProps}
+          cancelLabel={longCancelLabel}
+          actionLabel={longActionLabel}
+        />,
+      );
+
+      const dialog = screen.getByRole('alertdialog');
+      const buttons = within(dialog).getAllByRole('button');
+      const footerStack = buttons[0].parentElement!;
+      expect(buttons.map(button => button.textContent)).toEqual([
+        longCancelLabel,
+        longActionLabel,
+      ]);
+      expect(getComputedStyle(footerStack).flexWrap).toBe('wrap');
+      for (const button of buttons) {
+        const computed = getComputedStyle(button);
+        expect(computed.whiteSpace).toBe('normal');
+        expect(computed.height).toBe('auto');
+        expect(computed.maxWidth).toBe('100%');
+      }
+    });
+
+    it('stacks long destructive action labels above cancel on a narrow fine-pointer screen', () => {
       stubAlertDialogMedia({
         smallScreen: true,
         coarsePointer: false,
@@ -197,8 +235,8 @@ describe('AlertDialog', () => {
       render(
         <AlertDialog
           {...defaultProps}
-          cancelLabel="Keep this workspace"
-          actionLabel="Permanently delete workspace"
+          cancelLabel={longCancelLabel}
+          actionLabel={longActionLabel}
         />,
       );
 
@@ -207,15 +245,19 @@ describe('AlertDialog', () => {
       expect(window.matchMedia).not.toHaveBeenCalledWith('(hover: none)');
       const dialog = screen.getByRole('alertdialog');
       const buttons = within(dialog).getAllByRole('button');
-      expect(dialog.getAttribute('style')).toContain('100dvw');
+      const footerStack = buttons[0].parentElement!;
+      expect(dialog.getAttribute('style')).toContain('--x-width: 400px');
       expect(buttons.map(button => button.textContent)).toEqual([
-        'Permanently delete workspace',
-        'Keep this workspace',
+        longActionLabel,
+        longCancelLabel,
       ]);
-      expect(getComputedStyle(buttons[0]).whiteSpace).toBe('normal');
-      expect(getComputedStyle(buttons[0]).width).toBe('100%');
-      expect(getComputedStyle(buttons[1]).whiteSpace).toBe('normal');
-      expect(getComputedStyle(buttons[1]).width).toBe('100%');
+      expect(getComputedStyle(footerStack).flexDirection).toBe('column');
+      for (const button of buttons) {
+        const computed = getComputedStyle(button);
+        expect(computed.whiteSpace).toBe('normal');
+        expect(computed.width).toBe('100%');
+        expect(computed.maxWidth).toBe('100%');
+      }
     });
 
     it('uses the same stacked layout on a mobile touch screen', () => {
@@ -237,7 +279,7 @@ describe('AlertDialog', () => {
       expect(window.matchMedia).not.toHaveBeenCalledWith('(hover: none)');
       const dialog = screen.getByRole('alertdialog');
       const buttons = within(dialog).getAllByRole('button');
-      expect(dialog.getAttribute('style')).toContain('100dvw');
+      expect(dialog.getAttribute('style')).toContain('--x-width: 400px');
       expect(buttons.map(button => button.textContent)).toEqual([
         'Permanently delete workspace',
         'Keep this workspace',
@@ -246,6 +288,33 @@ describe('AlertDialog', () => {
       expect(getComputedStyle(buttons[0]).width).toBe('100%');
       expect(getComputedStyle(buttons[1]).whiteSpace).toBe('normal');
       expect(getComputedStyle(buttons[1]).width).toBe('100%');
+    });
+
+    it('keeps narrow visual, DOM, and tab order aligned while autofocus stays on cancel', async () => {
+      const user = userEvent.setup();
+      stubAlertDialogMedia({
+        smallScreen: true,
+        coarsePointer: false,
+        noHover: false,
+      });
+      render(
+        <AlertDialog
+          {...defaultProps}
+          cancelLabel={longCancelLabel}
+          actionLabel={longActionLabel}
+        />,
+      );
+
+      const action = screen.getByRole('button', {name: longActionLabel});
+      const cancel = screen.getByRole('button', {name: longCancelLabel});
+      expect(
+        action.compareDocumentPosition(cancel) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+      expect(cancel).toHaveAttribute('data-autofocus');
+      action.focus();
+      await user.tab();
+      expect(cancel).toHaveFocus();
     });
   });
 

--- a/packages/core/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.test.tsx
@@ -9,14 +9,64 @@
  * SYNC: When AlertDialog.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {readFileSync} from 'node:fs';
-import {join} from 'node:path';
-import ts from 'typescript';
 import {AlertDialog} from './AlertDialog';
 import {useImperativeAlertDialog} from './useImperativeAlertDialog';
+
+function stubAlertDialogMedia({
+  smallScreen,
+  coarsePointer,
+  noHover,
+  reduceMotion = false,
+}: {
+  smallScreen: boolean;
+  coarsePointer: boolean;
+  noHover: boolean;
+  reduceMotion?: boolean;
+}): void {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query: string) => {
+      let matches = false;
+      if (query.includes('max-width: 640px')) {
+        matches = smallScreen;
+      } else if (query.includes('pointer: coarse')) {
+        matches = coarsePointer;
+      } else if (query.includes('pointer: fine')) {
+        matches = !coarsePointer;
+      } else if (query.includes('hover: none')) {
+        matches = noHover;
+      } else if (query.includes('hover: hover')) {
+        matches = !noHover;
+      } else if (query.includes('prefers-reduced-motion: reduce')) {
+        matches = reduceMotion;
+      } else if (query.includes('prefers-reduced-motion: no-preference')) {
+        matches = !reduceMotion;
+      } else if (query.includes('prefers-reduced-motion')) {
+        matches = reduceMotion;
+      }
+
+      return {
+        matches,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      };
+    }),
+  );
+}
 
 beforeEach(() => {
   HTMLDialogElement.prototype.showModal = vi.fn(function (
@@ -29,64 +79,9 @@ beforeEach(() => {
   });
 });
 
-const SOURCE = readFileSync(join(__dirname, 'AlertDialog.tsx'), 'utf8');
-const SOURCE_FILE = ts.createSourceFile(
-  'AlertDialog.tsx',
-  SOURCE,
-  ts.ScriptTarget.Latest,
-  true,
-  ts.ScriptKind.TSX,
-);
-
-function styleDefinition(name: string): ts.ObjectLiteralExpression {
-  let stylesObject: ts.ObjectLiteralExpression | undefined;
-
-  const visit = (node: ts.Node) => {
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.name.text === 'styles' &&
-      node.initializer != null &&
-      ts.isCallExpression(node.initializer) &&
-      node.initializer.arguments[0] != null &&
-      ts.isObjectLiteralExpression(node.initializer.arguments[0])
-    ) {
-      stylesObject = node.initializer.arguments[0];
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(SOURCE_FILE);
-
-  const style = stylesObject?.properties.find(
-    property =>
-      ts.isPropertyAssignment(property) &&
-      ts.isIdentifier(property.name) &&
-      property.name.text === name &&
-      ts.isObjectLiteralExpression(property.initializer),
-  );
-  if (style == null || !ts.isPropertyAssignment(style)) {
-    throw new Error(`No AlertDialog style named "${name}"`);
-  }
-  return style.initializer as ts.ObjectLiteralExpression;
-}
-
-function styleProperty(
-  style: ts.ObjectLiteralExpression,
-  name: string,
-): ts.PropertyAssignment {
-  const property = style.properties.find(
-    candidate =>
-      ts.isPropertyAssignment(candidate) &&
-      (ts.isIdentifier(candidate.name) ||
-        ts.isStringLiteral(candidate.name) ||
-        ts.isComputedPropertyName(candidate.name)) &&
-      candidate.name.getText(SOURCE_FILE).replace(/^\[|\]$/g, '') === name,
-  );
-  if (property == null || !ts.isPropertyAssignment(property)) {
-    throw new Error(`No AlertDialog style property named "${name}"`);
-  }
-  return property;
-}
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('AlertDialog', () => {
   const defaultProps = {
@@ -172,35 +167,85 @@ describe('AlertDialog', () => {
   });
 
   describe('responsive actions', () => {
-    it('queries the dialog layout rather than the viewport', () => {
-      const layout = styleDefinition('layout');
-      expect(styleProperty(layout, 'containerType').initializer.getText()).toBe(
-        "'inline-size'",
-      );
-      expect(styleProperty(layout, 'containerName').initializer.getText()).toBe(
-        'ALERT_DIALOG_CONTAINER',
-      );
-      expect(styleProperty(layout, 'width').initializer.getText()).toBe(
-        "'100%'",
-      );
+    it('preserves the desktop fine-pointer layout above the small breakpoint', () => {
+      stubAlertDialogMedia({
+        smallScreen: false,
+        coarsePointer: false,
+        noHover: false,
+      });
+      render(<AlertDialog {...defaultProps} />);
+
+      expect(window.matchMedia).toHaveBeenCalledWith('(max-width: 640px)');
+      expect(window.matchMedia).not.toHaveBeenCalledWith('(pointer: coarse)');
+      expect(window.matchMedia).not.toHaveBeenCalledWith('(hover: none)');
+      const dialog = screen.getByRole('alertdialog');
+      const buttons = within(dialog).getAllByRole('button');
+      expect(dialog.getAttribute('style')).toContain('--x-width: 400px');
+      expect(buttons.map(button => button.textContent)).toEqual([
+        'Cancel',
+        'Delete',
+      ]);
+      expect(getComputedStyle(buttons[0]).whiteSpace).toBe('nowrap');
     });
 
-    it('wraps actions and stacks them when the dialog surface is narrow', () => {
-      const actions = styleDefinition('actions').getText(SOURCE_FILE);
-      expect(actions).toContain("flexWrap: 'wrap'");
-      expect(actions).toContain('[STACKED_ACTIONS_QUERY]');
-      expect(actions).toContain("flexDirection: 'column'");
-      expect(actions).toContain("alignItems: 'stretch'");
+    it('stacks destructive above cancel on a narrow fine-pointer screen', () => {
+      stubAlertDialogMedia({
+        smallScreen: true,
+        coarsePointer: false,
+        noHover: false,
+      });
+      render(
+        <AlertDialog
+          {...defaultProps}
+          cancelLabel="Keep this workspace"
+          actionLabel="Permanently delete workspace"
+        />,
+      );
+
+      expect(window.matchMedia).toHaveBeenCalledWith('(max-width: 640px)');
+      expect(window.matchMedia).not.toHaveBeenCalledWith('(pointer: coarse)');
+      expect(window.matchMedia).not.toHaveBeenCalledWith('(hover: none)');
+      const dialog = screen.getByRole('alertdialog');
+      const buttons = within(dialog).getAllByRole('button');
+      expect(dialog.getAttribute('style')).toContain('100dvw');
+      expect(buttons.map(button => button.textContent)).toEqual([
+        'Permanently delete workspace',
+        'Keep this workspace',
+      ]);
+      expect(getComputedStyle(buttons[0]).whiteSpace).toBe('normal');
+      expect(getComputedStyle(buttons[0]).width).toBe('100%');
+      expect(getComputedStyle(buttons[1]).whiteSpace).toBe('normal');
+      expect(getComputedStyle(buttons[1]).width).toBe('100%');
     });
 
-    it('keeps complete action labels instead of truncating them', () => {
-      const action = styleDefinition('action').getText(SOURCE_FILE);
-      expect(action).toContain("maxWidth: '100%'");
-      expect(action).toContain("height: 'auto'");
-      expect(action).toContain("minHeight: sizeVars['--size-element-md']");
-      expect(action).toContain("whiteSpace: 'normal'");
-      expect(action).toContain('[STACKED_ACTIONS_QUERY]');
-      expect(action).toContain("width: '100%'");
+    it('uses the same stacked layout on a mobile touch screen', () => {
+      stubAlertDialogMedia({
+        smallScreen: true,
+        coarsePointer: true,
+        noHover: true,
+      });
+      render(
+        <AlertDialog
+          {...defaultProps}
+          cancelLabel="Keep this workspace"
+          actionLabel="Permanently delete workspace"
+        />,
+      );
+
+      expect(window.matchMedia).toHaveBeenCalledWith('(max-width: 640px)');
+      expect(window.matchMedia).not.toHaveBeenCalledWith('(pointer: coarse)');
+      expect(window.matchMedia).not.toHaveBeenCalledWith('(hover: none)');
+      const dialog = screen.getByRole('alertdialog');
+      const buttons = within(dialog).getAllByRole('button');
+      expect(dialog.getAttribute('style')).toContain('100dvw');
+      expect(buttons.map(button => button.textContent)).toEqual([
+        'Permanently delete workspace',
+        'Keep this workspace',
+      ]);
+      expect(getComputedStyle(buttons[0]).whiteSpace).toBe('normal');
+      expect(getComputedStyle(buttons[0]).width).toBe('100%');
+      expect(getComputedStyle(buttons[1]).whiteSpace).toBe('normal');
+      expect(getComputedStyle(buttons[1]).width).toBe('100%');
     });
   });
 

--- a/packages/core/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.test.tsx
@@ -196,7 +196,7 @@ describe('AlertDialog', () => {
       expect(getComputedStyle(footerStack).flexWrap).toBe('wrap');
     });
 
-    it('wraps long action labels in the wide horizontal branch', () => {
+    it('keeps long action buttons within the wide horizontal footer without changing Button sizing', () => {
       stubAlertDialogMedia({
         smallScreen: false,
         coarsePointer: false,
@@ -220,8 +220,8 @@ describe('AlertDialog', () => {
       expect(getComputedStyle(footerStack).flexWrap).toBe('wrap');
       for (const button of buttons) {
         const computed = getComputedStyle(button);
-        expect(computed.whiteSpace).toBe('normal');
-        expect(computed.height).toBe('auto');
+        expect(computed.whiteSpace).toBe('nowrap');
+        expect(computed.height).toBe('var(--size-element-md)');
         expect(computed.maxWidth).toBe('100%');
       }
     });
@@ -254,7 +254,7 @@ describe('AlertDialog', () => {
       expect(getComputedStyle(footerStack).flexDirection).toBe('column');
       for (const button of buttons) {
         const computed = getComputedStyle(button);
-        expect(computed.whiteSpace).toBe('normal');
+        expect(computed.whiteSpace).toBe('nowrap');
         expect(computed.width).toBe('100%');
         expect(computed.maxWidth).toBe('100%');
       }
@@ -284,9 +284,9 @@ describe('AlertDialog', () => {
         'Permanently delete workspace',
         'Keep this workspace',
       ]);
-      expect(getComputedStyle(buttons[0]).whiteSpace).toBe('normal');
+      expect(getComputedStyle(buttons[0]).whiteSpace).toBe('nowrap');
       expect(getComputedStyle(buttons[0]).width).toBe('100%');
-      expect(getComputedStyle(buttons[1]).whiteSpace).toBe('normal');
+      expect(getComputedStyle(buttons[1]).whiteSpace).toBe('nowrap');
       expect(getComputedStyle(buttons[1]).width).toBe('100%');
     });
 

--- a/packages/core/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.test.tsx
@@ -12,6 +12,9 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import ts from 'typescript';
 import {AlertDialog} from './AlertDialog';
 import {useImperativeAlertDialog} from './useImperativeAlertDialog';
 
@@ -25,6 +28,65 @@ beforeEach(() => {
     this.removeAttribute('open');
   });
 });
+
+const SOURCE = readFileSync(join(__dirname, 'AlertDialog.tsx'), 'utf8');
+const SOURCE_FILE = ts.createSourceFile(
+  'AlertDialog.tsx',
+  SOURCE,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TSX,
+);
+
+function styleDefinition(name: string): ts.ObjectLiteralExpression {
+  let stylesObject: ts.ObjectLiteralExpression | undefined;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'styles' &&
+      node.initializer != null &&
+      ts.isCallExpression(node.initializer) &&
+      node.initializer.arguments[0] != null &&
+      ts.isObjectLiteralExpression(node.initializer.arguments[0])
+    ) {
+      stylesObject = node.initializer.arguments[0];
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(SOURCE_FILE);
+
+  const style = stylesObject?.properties.find(
+    property =>
+      ts.isPropertyAssignment(property) &&
+      ts.isIdentifier(property.name) &&
+      property.name.text === name &&
+      ts.isObjectLiteralExpression(property.initializer),
+  );
+  if (style == null || !ts.isPropertyAssignment(style)) {
+    throw new Error(`No AlertDialog style named "${name}"`);
+  }
+  return style.initializer as ts.ObjectLiteralExpression;
+}
+
+function styleProperty(
+  style: ts.ObjectLiteralExpression,
+  name: string,
+): ts.PropertyAssignment {
+  const property = style.properties.find(
+    candidate =>
+      ts.isPropertyAssignment(candidate) &&
+      (ts.isIdentifier(candidate.name) ||
+        ts.isStringLiteral(candidate.name) ||
+        ts.isComputedPropertyName(candidate.name)) &&
+      candidate.name.getText(SOURCE_FILE).replace(/^\[|\]$/g, '') === name,
+  );
+  if (property == null || !ts.isPropertyAssignment(property)) {
+    throw new Error(`No AlertDialog style property named "${name}"`);
+  }
+  return property;
+}
 
 describe('AlertDialog', () => {
   const defaultProps = {
@@ -107,6 +169,39 @@ describe('AlertDialog', () => {
   it('accepts custom width', () => {
     render(<AlertDialog {...defaultProps} width={600} />);
     expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  describe('responsive actions', () => {
+    it('queries the dialog layout rather than the viewport', () => {
+      const layout = styleDefinition('layout');
+      expect(styleProperty(layout, 'containerType').initializer.getText()).toBe(
+        "'inline-size'",
+      );
+      expect(styleProperty(layout, 'containerName').initializer.getText()).toBe(
+        'ALERT_DIALOG_CONTAINER',
+      );
+      expect(styleProperty(layout, 'width').initializer.getText()).toBe(
+        "'100%'",
+      );
+    });
+
+    it('wraps actions and stacks them when the dialog surface is narrow', () => {
+      const actions = styleDefinition('actions').getText(SOURCE_FILE);
+      expect(actions).toContain("flexWrap: 'wrap'");
+      expect(actions).toContain('[STACKED_ACTIONS_QUERY]');
+      expect(actions).toContain("flexDirection: 'column'");
+      expect(actions).toContain("alignItems: 'stretch'");
+    });
+
+    it('keeps complete action labels instead of truncating them', () => {
+      const action = styleDefinition('action').getText(SOURCE_FILE);
+      expect(action).toContain("maxWidth: '100%'");
+      expect(action).toContain("height: 'auto'");
+      expect(action).toContain("minHeight: sizeVars['--size-element-md']");
+      expect(action).toContain("whiteSpace: 'normal'");
+      expect(action).toContain('[STACKED_ACTIONS_QUERY]');
+      expect(action).toContain("width: '100%'");
+    });
   });
 
   it('defaults cancel label to Cancel', () => {

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -22,7 +22,7 @@ import {Dialog} from '../Dialog';
 import {Layout} from '../Layout/Layout';
 import {LayoutContent} from '../Layout/LayoutContent';
 import {LayoutFooter} from '../Layout/LayoutFooter';
-import {HStack} from '../Stack';
+import {Stack} from '../Stack';
 import {Heading} from '../Heading/Heading';
 import {Text} from '../Text/Text';
 import {Button, type ButtonVariant} from '../Button';
@@ -30,36 +30,25 @@ import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
-import {sizeVars} from '../theme/tokens.stylex';
+import {useMediaQuery} from '../hooks';
+import {sizeVars, spacingVars} from '../theme/tokens.stylex';
 
-const ALERT_DIALOG_CONTAINER = 'astryx-alert-dialog';
-const STACKED_ACTIONS_QUERY = `@container ${ALERT_DIALOG_CONTAINER} (max-width: 20rem)`;
+const SMALL_SCREEN_QUERY = '(max-width: 640px)';
+const SMALL_SCREEN_DIALOG_WIDTH = `calc(100dvw - ${spacingVars['--spacing-4']} - ${spacingVars['--spacing-4']})`;
 
 const styles = stylex.create({
-  layout: {
-    containerType: 'inline-size',
-    containerName: ALERT_DIALOG_CONTAINER,
-    width: '100%',
+  smallScreenSurface: {
+    maxWidth: SMALL_SCREEN_DIALOG_WIDTH,
   },
-  actions: {
-    width: '100%',
-    flexWrap: 'wrap',
-    [STACKED_ACTIONS_QUERY]: {
-      flexDirection: 'column',
-      alignItems: 'stretch',
-    },
-  },
-  action: {
+  smallScreenAction: {
     // AlertDialog labels communicate the decision and must remain complete.
-    // The shared Button stays compact; only this decision surface opts into
-    // wrapping and lets its height grow when localization or zoom needs it.
+    // Only the small-screen state opts into wrapping and flexible height;
+    // the standard wider Button stays on its shared defaults.
+    width: '100%',
     maxWidth: '100%',
     height: 'auto',
     minHeight: sizeVars['--size-element-md'],
     whiteSpace: 'normal',
-    [STACKED_ACTIONS_QUERY]: {
-      width: '100%',
-    },
   },
 });
 
@@ -180,10 +169,39 @@ export function AlertDialog({
   const cancelLabel = cancelLabelFromProps ?? t('@astryx.alertDialog.cancel');
   const titleId = useId();
   const descriptionId = useId();
+  const isSmallScreen = useMediaQuery(SMALL_SCREEN_QUERY);
 
   const handleCancel = useCallback(() => {
     onOpenChange(false);
   }, [onOpenChange]);
+
+  const smallScreenActionStyle = isSmallScreen
+    ? styles.smallScreenAction
+    : undefined;
+  const cancelButton = (
+    <Button
+      key="cancel"
+      variant="ghost"
+      label={cancelLabel}
+      onClick={handleCancel}
+      xstyle={smallScreenActionStyle}
+      // Dialog focuses [data-autofocus] itself after showModal(), because
+      // React's autoFocus runs during commit while the dialog is invisible.
+      // Cancel is least destructive, so it remains the autofocus target even
+      // when small-screen visual order places the destructive action above it.
+      data-autofocus
+    />
+  );
+  const actionButton = (
+    <Button
+      key="action"
+      variant={actionVariant}
+      label={actionLabel}
+      onClick={onAction}
+      isLoading={isActionLoading}
+      xstyle={smallScreenActionStyle}
+    />
+  );
 
   return (
     <Dialog
@@ -192,7 +210,7 @@ export function AlertDialog({
       isOpen={isOpen}
       isInline={isInline}
       onOpenChange={onOpenChange}
-      width={width}
+      width={isSmallScreen ? SMALL_SCREEN_DIALOG_WIDTH : width}
       purpose="form"
       // `alertdialog` is a modal role: it promises an interruption the user
       // has to deal with, a focus trap, and an inert page behind it. The
@@ -203,10 +221,9 @@ export function AlertDialog({
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
       {...mergeProps(themeProps('alert-dialog'), {className, style})}
-      xstyle={xstyle}
+      xstyle={isSmallScreen ? [styles.smallScreenSurface, xstyle] : xstyle}
       data-testid={testId}>
       <Layout
-        xstyle={styles.layout}
         content={
           <LayoutContent>
             <Heading level={2} id={titleId}>
@@ -219,26 +236,14 @@ export function AlertDialog({
         }
         footer={
           <LayoutFooter>
-            <HStack gap={2} hAlign="end" wrap="wrap" xstyle={styles.actions}>
-              <Button
-                variant="ghost"
-                label={cancelLabel}
-                onClick={handleCancel}
-                xstyle={styles.action}
-                // Dialog focuses [data-autofocus] itself after showModal(),
-                // because React's autoFocus runs during commit while the
-                // dialog is still invisible. Cancel is the least destructive
-                // choice, so it is the one that should be preselected.
-                data-autofocus
-              />
-              <Button
-                variant={actionVariant}
-                label={actionLabel}
-                onClick={onAction}
-                isLoading={isActionLoading}
-                xstyle={styles.action}
-              />
-            </HStack>
+            <Stack
+              direction={isSmallScreen ? 'vertical' : 'horizontal'}
+              gap={2}
+              hAlign={isSmallScreen ? 'stretch' : 'end'}>
+              {isSmallScreen
+                ? [actionButton, cancelButton]
+                : [cancelButton, actionButton]}
+            </Stack>
           </LayoutFooter>
         }
       />

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file AlertDialog.tsx
- * @input Uses React, StyleX, theme size tokens, Dialog, Layout, Heading, Text, Button
+ * @input Uses React, StyleX, Dialog, Layout, Heading, Text, Button
  * @output Exports AlertDialog component, AlertDialogProps type
  * @position Core implementation; consumed by index.ts, tested by AlertDialog.test.tsx
  *
@@ -31,7 +31,6 @@ import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
 import {useMediaQuery} from '../hooks';
-import {sizeVars} from '../theme/tokens.stylex';
 
 const SMALL_SCREEN_QUERY = '(max-width: 640px)';
 
@@ -39,14 +38,9 @@ const styles = stylex.create({
   action: {
     maxWidth: '100%',
     minWidth: 0,
-    height: 'auto',
-    minHeight: sizeVars['--size-element-md'],
-    whiteSpace: 'normal',
-    overflowWrap: 'anywhere',
   },
   stackedAction: {
     width: '100%',
-    maxWidth: '100%',
   },
 });
 

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -31,21 +31,22 @@ import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
 import {useMediaQuery} from '../hooks';
-import {sizeVars, spacingVars} from '../theme/tokens.stylex';
+import {sizeVars} from '../theme/tokens.stylex';
 
 const SMALL_SCREEN_QUERY = '(max-width: 640px)';
-const SMALL_SCREEN_DIALOG_WIDTH = `calc(100dvw - ${spacingVars['--spacing-4']} - ${spacingVars['--spacing-4']})`;
 
 const styles = stylex.create({
-  smallScreenSurface: {
-    maxWidth: SMALL_SCREEN_DIALOG_WIDTH,
-  },
-  smallScreenAction: {
-    width: '100%',
+  action: {
     maxWidth: '100%',
+    minWidth: 0,
     height: 'auto',
     minHeight: sizeVars['--size-element-md'],
     whiteSpace: 'normal',
+    overflowWrap: 'anywhere',
+  },
+  stackedAction: {
+    width: '100%',
+    maxWidth: '100%',
   },
 });
 
@@ -166,22 +167,26 @@ export function AlertDialog({
   const cancelLabel = cancelLabelFromProps ?? t('@astryx.alertDialog.cancel');
   const titleId = useId();
   const descriptionId = useId();
+  // Width stays delegated to Dialog: this query exists only so AlertDialog can
+  // keep narrow visual, DOM, and tab order aligned for its destructive/cancel
+  // semantics without coupling action order to pointer or hover capability.
   const isSmallScreen = useMediaQuery(SMALL_SCREEN_QUERY);
 
   const handleCancel = useCallback(() => {
     onOpenChange(false);
   }, [onOpenChange]);
 
-  const smallScreenActionStyle = isSmallScreen
-    ? styles.smallScreenAction
-    : undefined;
+  const buttonActionStyle = [
+    styles.action,
+    isSmallScreen && styles.stackedAction,
+  ];
   const cancelButton = (
     <Button
       key="cancel"
       variant="ghost"
       label={cancelLabel}
       onClick={handleCancel}
-      xstyle={smallScreenActionStyle}
+      xstyle={buttonActionStyle}
       // Dialog focuses [data-autofocus] itself after showModal(), because
       // React's autoFocus runs during commit while the dialog is invisible.
       // Cancel is least destructive, so it remains the autofocus target even
@@ -196,7 +201,7 @@ export function AlertDialog({
       label={actionLabel}
       onClick={onAction}
       isLoading={isActionLoading}
-      xstyle={smallScreenActionStyle}
+      xstyle={buttonActionStyle}
     />
   );
 
@@ -207,7 +212,7 @@ export function AlertDialog({
       isOpen={isOpen}
       isInline={isInline}
       onOpenChange={onOpenChange}
-      width={isSmallScreen ? SMALL_SCREEN_DIALOG_WIDTH : width}
+      width={width}
       purpose="form"
       // `alertdialog` is a modal role: it promises an interruption the user
       // has to deal with, a focus trap, and an inert page behind it. The
@@ -218,7 +223,7 @@ export function AlertDialog({
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
       {...mergeProps(themeProps('alert-dialog'), {className, style})}
-      xstyle={isSmallScreen ? [styles.smallScreenSurface, xstyle] : xstyle}
+      xstyle={xstyle}
       data-testid={testId}>
       <Layout
         content={
@@ -233,10 +238,15 @@ export function AlertDialog({
         }
         footer={
           <LayoutFooter>
+            {/* Generic Dialog footers should wrap, but their consumers own
+                action semantics and order. AlertDialog keeps this
+                destructive-above-Cancel narrow order because confirmation
+                actions have component-specific meaning here. */}
             <Stack
               direction={isSmallScreen ? 'vertical' : 'horizontal'}
               gap={2}
-              hAlign={isSmallScreen ? 'stretch' : 'end'}>
+              hAlign={isSmallScreen ? 'stretch' : 'end'}
+              wrap={isSmallScreen ? 'nowrap' : 'wrap'}>
               {isSmallScreen
                 ? [actionButton, cancelButton]
                 : [cancelButton, actionButton]}

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -41,9 +41,6 @@ const styles = stylex.create({
     maxWidth: SMALL_SCREEN_DIALOG_WIDTH,
   },
   smallScreenAction: {
-    // AlertDialog labels communicate the decision and must remain complete.
-    // Only the small-screen state opts into wrapping and flexible height;
-    // the standard wider Button stays on its shared defaults.
     width: '100%',
     maxWidth: '100%',
     height: 'auto',

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file AlertDialog.tsx
- * @input Uses React, Dialog, Layout, Heading, Text, Button
+ * @input Uses React, StyleX, theme size tokens, Dialog, Layout, Heading, Text, Button
  * @output Exports AlertDialog component, AlertDialogProps type
  * @position Core implementation; consumed by index.ts, tested by AlertDialog.test.tsx
  *
@@ -17,6 +17,7 @@
  */
 
 import React, {useId, useCallback} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {Dialog} from '../Dialog';
 import {Layout} from '../Layout/Layout';
 import {LayoutContent} from '../Layout/LayoutContent';
@@ -29,6 +30,38 @@ import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import {sizeVars} from '../theme/tokens.stylex';
+
+const ALERT_DIALOG_CONTAINER = 'astryx-alert-dialog';
+const STACKED_ACTIONS_QUERY = `@container ${ALERT_DIALOG_CONTAINER} (max-width: 20rem)`;
+
+const styles = stylex.create({
+  layout: {
+    containerType: 'inline-size',
+    containerName: ALERT_DIALOG_CONTAINER,
+    width: '100%',
+  },
+  actions: {
+    width: '100%',
+    flexWrap: 'wrap',
+    [STACKED_ACTIONS_QUERY]: {
+      flexDirection: 'column',
+      alignItems: 'stretch',
+    },
+  },
+  action: {
+    // AlertDialog labels communicate the decision and must remain complete.
+    // The shared Button stays compact; only this decision surface opts into
+    // wrapping and lets its height grow when localization or zoom needs it.
+    maxWidth: '100%',
+    height: 'auto',
+    minHeight: sizeVars['--size-element-md'],
+    whiteSpace: 'normal',
+    [STACKED_ACTIONS_QUERY]: {
+      width: '100%',
+    },
+  },
+});
 
 export interface AlertDialogProps extends BaseProps<HTMLDialogElement> {
   ref?: React.Ref<HTMLDialogElement>;
@@ -173,6 +206,7 @@ export function AlertDialog({
       xstyle={xstyle}
       data-testid={testId}>
       <Layout
+        xstyle={styles.layout}
         content={
           <LayoutContent>
             <Heading level={2} id={titleId}>
@@ -185,11 +219,12 @@ export function AlertDialog({
         }
         footer={
           <LayoutFooter>
-            <HStack gap={2} hAlign="end">
+            <HStack gap={2} hAlign="end" wrap="wrap" xstyle={styles.actions}>
               <Button
                 variant="ghost"
                 label={cancelLabel}
                 onClick={handleCancel}
+                xstyle={styles.action}
                 // Dialog focuses [data-autofocus] itself after showModal(),
                 // because React's autoFocus runs during commit while the
                 // dialog is still invisible. Cancel is the least destructive
@@ -201,6 +236,7 @@ export function AlertDialog({
                 label={actionLabel}
                 onClick={onAction}
                 isLoading={isActionLoading}
+                xstyle={styles.action}
               />
             </HStack>
           </LayoutFooter>


### PR DESCRIPTION
## Summary

- rebase the AlertDialog branch onto latest `main` so it relies on the merged Dialog responsive width clamp from #5352
- remove AlertDialog's small-screen width replacement and pass the consumer's preferred `width` through unchanged (default 400)
- keep AlertDialog's width-only action-order breakpoint for its destructive/cancel semantics, with narrow DOM/visual/tab order aligned and Cancel still the autofocus target
- keep Button labels single-line at the normal size-token height; wide footers may move whole buttons onto another row, while narrow footers stack full-width actions
- update responsive stories, docs, tests, and changeset credit

## Responsive and Interaction Readiness

### Responsive layout

| Check | Result | Evidence |
| --- | --- | --- |
| Dialog-owned surface geometry | Pass | AlertDialog passes `width` through to Dialog. Dialog preserves the requested width and clamps it with `max-width: min(100%, calc(100dvw - var(--spacing-4) - var(--spacing-4)))` from #5352. |
| Wide viewport actions | Pass | Above 640px, AlertDialog keeps Cancel before the destructive action and lets whole buttons move onto another row when both do not fit. Labels retain standard single-line Button behavior. |
| Narrow viewport actions | Pass | At 640px and below, AlertDialog stacks the destructive action above Cancel and stretches both actions to the row while preserving standard single-line Button sizing and labels. |
| Reference states and responsive tests | Pass | The three stories are reference states only unless the reviewer configures viewport/input. Tests cover Dialog's clamp, wide whole-button row movement without changing Button sizing, narrow stacking, pointer/hover independence, and tab-order/autofocus behavior. |

### Touch, pointer, and hover

| Check | Result | Evidence |
| --- | --- | --- |
| Pointer/hover independence | Pass | AlertDialog still queries only `(max-width: 640px)` for semantic action order; it does not query pointer or hover capability and does not reintroduce pointer/touch coupling. |
| Wide touch/coarse/no-hover viewport | Pass | Because action order is width-only, a wide coarse/no-hover viewport stays on the wide horizontal branch. |
| Narrow fine-pointer viewport | Pass | A narrow fine-pointer viewport uses the same stacked destructive-above-Cancel order as mobile. |
| Gestures | N/A | AlertDialog has no swipe dismissal path, and this diff does not add one. |

### Accessibility and interaction contracts

| Check | Result | Evidence |
| --- | --- | --- |
| Keyboard/focus order | Pass | Narrow visual order, DOM order, and tab order are aligned as destructive then Cancel. Cancel remains the `data-autofocus` least-destructive target when the dialog opens. |
| Role/semantics | Pass | The diff does not change AlertDialog's `role="alertdialog"`, modal behavior, or title/description wiring. |
| Action semantics ownership | Pass | Destructive-above-Cancel remains AlertDialog-specific. Generic Dialog owns the surface clamp and footer multi-row affordance; Button retains its standard single-line label behavior; consumers own footer composition, semantics, and ordering. |
| Motion/reduced motion | N/A | This diff does not change Dialog animation or reduced-motion behavior. |

### Mobile viewport constraints

| Check | Result | Evidence |
| --- | --- | --- |
| Width and dynamic viewport clamp | Pass | Dialog #5352 owns `max-width: min(100%, calc(100dvw - var(--spacing-4) - var(--spacing-4)))`; AlertDialog no longer sets `100dvw` or replaces `width` at small viewports. |
| Software keyboard | N/A | This diff changes action-row layout only; it does not change software-keyboard handling. |
| Safe area/dynamic viewport ownership | Pass | AlertDialog delegates viewport geometry to Dialog and only owns the confirmation action layout. |

## Test plan

- `pnpm exec vitest run packages/core/src/AlertDialog/AlertDialog.test.tsx packages/core/src/Dialog/Dialog.test.tsx`
- `pnpm -F @astryxdesign/core build`
- `pnpm -F @astryxdesign/theme-butter build`
- `pnpm -F @astryxdesign/theme-gothic build`
- `pnpm -F @astryxdesign/theme-matcha build`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm -F @astryxdesign/docsite generate && pnpm -F @astryxdesign/docsite typecheck`
- `pnpm exec prettier --check packages/core/src/AlertDialog/AlertDialog.tsx packages/core/src/AlertDialog/AlertDialog.test.tsx packages/core/src/AlertDialog/AlertDialog.doc.mjs apps/storybook/stories/AlertDialog.stories.tsx .changeset/alert-dialog-responsive-actions.md`
- `pnpm check:repo`
- `pnpm exec eslint packages/core/src/AlertDialog/AlertDialog.tsx packages/core/src/AlertDialog/AlertDialog.test.tsx apps/storybook/stories/AlertDialog.stories.tsx`
