### PR TITLE
fix(DateInput): clearing on touch no longer jumps the page to the top

### DIFF
--- a/.changeset/date-input-touch-clear-preventscroll.md
+++ b/.changeset/date-input-touch-clear-preventscroll.md
@@ -1,0 +1,19 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateInput: clearing on touch no longer jumps the page to the top
+
+On the touch surface, tapping the clear (✕) threw the user to the top of the
+page. Clearing unmounts the clear button, and `handleClear` focused the field
+in that same task — on iOS Safari, focusing an element as the focused button is
+removed scrolls the whole document to 0. The focus handoff is now deferred past
+the unmount, which keeps the page where it was and still returns focus to the
+field.
+
+Measured on the iOS 26 simulator against the live docsite (DateInput —
+Clearable, page at scrollY 2055): synchronous focus → 0, deferred focus → 2055.
+`preventScroll` alone does not fix it; it is kept for the ordinary
+scroll-into-view nudge, which is unwanted for the same reason.
+
+@imdreamrunner

--- a/packages/core/src/DateInput/DateInputTouch.test.tsx
+++ b/packages/core/src/DateInput/DateInputTouch.test.tsx
@@ -419,6 +419,42 @@ describe('DateInput — field parity', () => {
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
+  it('returns focus to the field without letting the page scroll', async () => {
+    // Clearing unmounts the clear button, and focusing another element in the
+    // same task as that unmount makes iOS Safari scroll the document to the
+    // top. Measured on the iOS 26 simulator against the live docsite, field at
+    // scrollY 2055: synchronous focus lands at 0, deferred focus stays at
+    // 2055. `preventScroll` alone does not fix it, so both halves are
+    // asserted: the focus is deferred past the unmount, and it is passed
+    // preventScroll. jsdom implements no scrolling, so the guard is asserted
+    // at the call.
+    vi.useFakeTimers();
+    try {
+      render(
+        <DateInput
+          label="Ship date"
+          value="2026-03-21"
+          hasClear
+          onChange={() => {}}
+        />,
+      );
+      const input = field();
+      const focus = vi.spyOn(input, 'focus');
+
+      fireEvent.click(screen.getByRole('button', {name: /Clear Ship date/}));
+
+      // Not synchronous — that is the whole point.
+      expect(focus).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+
+      expect(focus).toHaveBeenCalledWith({preventScroll: true});
+      focus.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not open the picker until the field is tapped', () => {
     withLayout(() => {
       render(<DateInput label="Ship date" onChange={() => {}} />);

--- a/packages/core/src/DateInput/TouchDateField.tsx
+++ b/packages/core/src/DateInput/TouchDateField.tsx
@@ -599,6 +599,16 @@ export function TouchDateField({
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [isWheelOpen, setIsWheelOpen] = useState(false);
   const scrollerHandleRef = useRef<MonthScrollerHandle | null>(null);
+  // Pending focus handoff from the clear button; see handleClear.
+  const clearFocusTimerRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (clearFocusTimerRef.current != null) {
+        clearTimeout(clearFocusTimerRef.current);
+      }
+    },
+    [],
+  );
 
   const today = useMemo(() => plainDateToday(), []);
   const selectedDate = useMemo(
@@ -708,7 +718,31 @@ export function TouchDateField({
 
   const handleClear = useCallback(() => {
     fireChange(undefined);
-    inputRef.current?.focus();
+    // Focus goes back to the field on the NEXT task, not synchronously.
+    //
+    // Clearing unmounts this button (it only renders while there is a value),
+    // and focusing another element in the same task as that unmount makes iOS
+    // Safari scroll the whole document to the top — the user is thrown from
+    // wherever the field sat to the start of the page. Measured on the iOS 26
+    // simulator against the live docsite, field at scrollY 2055: synchronous
+    // focus lands at 0, deferred focus stays at 2055.
+    //
+    // `preventScroll` alone does NOT fix it (verified: still 0) — this is not
+    // the browser's ordinary scroll-the-focused-element-into-view step, so the
+    // deferral is the load-bearing half. It is kept because the reveal scroll
+    // is real too, and unwanted for the same reason: the field the user just
+    // tapped is already on screen (+12px on a plain page without it).
+    //
+    // Skipping the focus entirely would also stop the scroll, but then focus
+    // dies with the unmounting button and lands on <body>.
+    const field = inputRef.current;
+    if (field == null) {
+      return;
+    }
+    clearFocusTimerRef.current = window.setTimeout(() => {
+      clearFocusTimerRef.current = null;
+      field.focus({preventScroll: true});
+    }, 0);
   }, [fireChange]);
 
   /**


### PR DESCRIPTION
## The bug

On touch, tapping DateInput's clear (✕) throws the user to the top of the page.

**Repro (real, on the live docsite):** open
https://astryx.atmeta.com/components/DateInput on a phone, scroll to the second
date input — the **DateInput — Clearable** example, "Event date / April 6,
2026" — and tap its ✕. The page jumps to the top. React state survives, so it
is an in-page scroll jump, not a reload.

## Cause

`TouchDateField.handleClear` clears the value and focuses the field in the same
task. Clearing unmounts the clear button — it only renders while there is a
value — and on iOS Safari, focusing an element in the same task as the focused
button's removal scrolls the whole document to 0.

Measured on the iOS 26 simulator driving real taps against the live docsite,
field at `scrollY 2055`, with every scroll API instrumented:

| variant | result |
|---|---|
| synchronous `focus()` (today) | 2055 → **0** |
| synchronous `focus({preventScroll: true})` | 2055 → **0** |
| focus suppressed entirely | 2055 (no move, but focus lost to `<body>`) |
| **deferred `focus({preventScroll: true})`** | **2055 (no move, focus kept)** |

What is *not* happening, all instrumented and silent through the jump: no
`scrollTo` / `scroll` / `scrollBy` / `scrollIntoView`, no `scrollTop` write, no
`history.pushState`/`replaceState`/hashchange, no scroll-lock `body` pinning,
and `document.scrollHeight` never changes (5156 throughout, so it is not a
height collapse clamping the scroll). Focus on the same field while the page is
quiet does not move it either — the unmount is required.

## The fix

Defer the focus handoff past the unmount. The page stays put and focus still
returns to the field, so it is not lost to `<body>`.

`preventScroll` is kept: the ordinary scroll-into-view nudge is real too (+12px
on a plain page) and unwanted for the same reason — the field the user just
tapped is already on screen. It is not sufficient on its own, per the table.

Only the touch surface is affected; the pointer surface is a different
component and does not do this.

## Test plan

- New test in `DateInputTouch.test.tsx`: focus is **not** called synchronously,
  and after timers run it is called with `{preventScroll: true}`. Negative
  control: restoring the synchronous call fails it.
- `packages/core/src/DateInput` — 229 tests pass.
- `pnpm lint:strict` — 0 errors (55 pre-existing warnings).
- `pnpm test` — 11376 pass; the 11 failures are all `packages/cli`, the known
  devvm full-run load flake, green under `vitest run --project node
  packages/cli` (200 files / 2780 tests).
- `pnpm build` plus the `build-storybook` typechecks
  (`core|lab|charts typecheck:docs`, `cli typecheck:{strict,template-docs}`,
  `storybook typecheck`, `core typecheck`, `lab:readiness:check`,
  `storybook build`) — all exit 0.

## Note on earlier revisions of this PR

The first version of this PR changed `DateRangeInput`, `Selector` and
`MultiSelector` — none of which are DateInput and none of which are the touch
surface. That was wrong and has been dropped. Those three do have a separate,
real defect (their clear leaves focus on `<body>`); worth its own PR, not this
one.
