### PR TITLE
fix(Dialog): improve responsive presentation behavior

### DIFF
--- a/.changeset/dialog-responsive-interaction.md
+++ b/.changeset/dialog-responsive-interaction.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Clamp standard Dialog width to dynamic viewport space with token gutters, add safe-area/fullscreen sizing updates, and add an opt-in adaptive Dialog/BottomSheet recipe.
+[fix] Clamp standard Dialog width to dynamic viewport space with token gutters, add safe-area/fullscreen sizing and fade-only fullscreen motion updates, add opt-in adaptive Dialog/BottomSheet recipes, and add explicit presentation comparison stories.
 
 @rubycheung

--- a/.changeset/dialog-responsive-interaction.md
+++ b/.changeset/dialog-responsive-interaction.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Clamp standard Dialog width to dynamic viewport space with token gutters, add safe-area/fullscreen sizing updates, and add an opt-in adaptive Dialog/BottomSheet recipe.
+
+@rubycheung

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -2,15 +2,19 @@
 
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
+import {BottomSheet} from '@astryxdesign/core/BottomSheet';
 import {Dialog, DialogHeader} from '@astryxdesign/core/Dialog';
 import {
   Layout,
   LayoutContent,
   LayoutFooter,
   HStack,
+  VStack,
 } from '@astryxdesign/core/Layout';
 import {Button} from '@astryxdesign/core/Button';
+import {Heading} from '@astryxdesign/core/Heading';
 import {Text} from '@astryxdesign/core/Text';
+import {TextArea} from '@astryxdesign/core/TextArea';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import * as stylex from '@stylexjs/stylex';
 
@@ -945,6 +949,153 @@ export const ReadinessNarrowViewport: Story = {
       description: {
         story:
           'Visual evidence for the narrow viewport layout scenario using a constrained review frame. Storybook does not emulate coarse pointer or no-hover capability here.',
+      },
+    },
+  },
+};
+
+type PresentationChoiceProps = {
+  presentation: 'dialog' | 'fullscreen' | 'bottom-sheet';
+};
+
+function PresentationChoice({presentation}: PresentationChoiceProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [filter, setFilter] = useState('Active');
+  const [notes, setNotes] = useState('');
+  const title =
+    presentation === 'fullscreen'
+      ? 'Edit workflow details'
+      : presentation === 'bottom-sheet'
+        ? 'Filter results'
+        : 'Confirm status change';
+
+  const openButtonLabel =
+    presentation === 'fullscreen'
+      ? 'Open fullscreen Dialog'
+      : presentation === 'bottom-sheet'
+        ? 'Open Bottom Sheet'
+        : 'Open Dialog';
+
+  const footer = (
+    <HStack gap={2} hAlign="end" wrap="wrap">
+      <Button
+        label="Cancel"
+        variant="secondary"
+        onClick={() => setIsOpen(false)}
+      />
+      <Button
+        label="Apply"
+        variant="primary"
+        onClick={() => setIsOpen(false)}
+      />
+    </HStack>
+  );
+
+  const formContent = (
+    <VStack gap={4}>
+      <Text type="supporting" color="secondary">
+        These deterministic examples compare presentation choices. The adaptive
+        recipe uses BottomSheet only after explicit touchPresentation opt-in and
+        matching touch-oriented conditions.
+      </Text>
+      <TextInput label="Status" value={filter} onChange={setFilter} />
+      <TextArea label="Notes" rows={6} value={notes} onChange={setNotes} />
+    </VStack>
+  );
+
+  if (presentation === 'bottom-sheet') {
+    return (
+      <>
+        <Button label={openButtonLabel} onClick={() => setIsOpen(true)} />
+        <BottomSheet
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          label={title}
+          purpose="info"
+          height="hug">
+          <VStack gap={4} style={{padding: 'var(--spacing-4)'}}>
+            <Heading level={3}>{title}</Heading>
+            <Text type="supporting" color="secondary">
+              Use Bottom Sheet for lightweight contextual actions, pickers, or
+              filters. Its purpose contract controls Escape, scrim click, and
+              swipe dismissal.
+            </Text>
+            <Button label="Active" variant="secondary" />
+            <Button label="Archived" variant="secondary" />
+            <Button label="Owned by me" variant="secondary" />
+            {footer}
+          </VStack>
+        </BottomSheet>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Button label={openButtonLabel} onClick={() => setIsOpen(true)} />
+      <Dialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        purpose="form"
+        variant={presentation === 'fullscreen' ? 'fullscreen' : 'standard'}>
+        <Layout
+          header={<DialogHeader title={title} onOpenChange={setIsOpen} />}
+          content={
+            <LayoutContent>
+              {presentation === 'fullscreen' ? (
+                formContent
+              ) : (
+                <Text type="body">
+                  Keep Dialog for centered, focused tasks and confirmations. It
+                  stays the default presentation on every device.
+                </Text>
+              )}
+            </LayoutContent>
+          }
+          footer={<LayoutFooter>{footer}</LayoutFooter>}
+        />
+      </Dialog>
+    </>
+  );
+}
+
+/** Mobile presentation alternative: keep centered Dialog for focused tasks. */
+export const MobilePresentationKeepDialog: Story = {
+  name: 'Mobile presentation alternatives / keep Dialog',
+  render: () => <PresentationChoice presentation="dialog" />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Deterministic presentation example: keep the centered responsive Dialog for confirmations and focused tasks. This is the default choice, not device emulation.',
+      },
+    },
+  },
+};
+
+/** Mobile presentation alternative: fullscreen Dialog for complex workflows. */
+export const MobilePresentationFullscreenDialog: Story = {
+  name: 'Mobile presentation alternatives / fullscreen Dialog',
+  render: () => <PresentationChoice presentation="fullscreen" />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Deterministic presentation example: use fullscreen Dialog for complex, long, or keyboard-heavy workflows when the user should stay in a Dialog contract.',
+      },
+    },
+  },
+};
+
+/** Mobile presentation alternative: BottomSheet for lightweight contextual UI. */
+export const MobilePresentationBottomSheet: Story = {
+  name: 'Mobile presentation alternatives / BottomSheet',
+  render: () => <PresentationChoice presentation="bottom-sheet" />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Deterministic presentation example: use BottomSheet for lightweight contextual actions, pickers, or filters. Its purpose prop controls Escape, scrim click, and swipe dismissal.',
       },
     },
   },

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof Dialog> = {
     },
     maxHeight: {
       control: 'text',
-      description: 'Maximum height of the dialog (default: 75vh)',
+      description: 'Maximum height of the dialog (default: 75dvh)',
     },
     variant: {
       control: 'select',
@@ -866,4 +866,86 @@ function NestedDialogsExample() {
 
 export const NestedDialogs: Story = {
   render: () => <NestedDialogsExample />,
+};
+
+type ReadinessReferenceProps = {
+  frameWidth: number;
+  summary: string;
+  title: string;
+};
+
+function ReadinessReference({
+  frameWidth,
+  summary,
+  title,
+}: ReadinessReferenceProps) {
+  return (
+    <div style={{width: frameWidth, maxWidth: '100%'}}>
+      <Text type="supporting" color="secondary">
+        {summary}
+      </Text>
+      <Dialog isOpen isInline onOpenChange={() => {}} width={400}>
+        <Layout
+          header={<DialogHeader title={title} onOpenChange={() => {}} />}
+          content={
+            <LayoutContent>
+              <Text type="body">
+                This dialog keeps long content inside the surface. Resize or
+                compare the frame to confirm text wraps instead of forcing
+                horizontal overflow.
+              </Text>
+            </LayoutContent>
+          }
+          footer={
+            <LayoutFooter>
+              <HStack gap={2} hAlign="end" wrap="wrap">
+                <Button label="Cancel" variant="secondary" />
+                <Button label="Save changes" variant="primary" />
+              </HStack>
+            </LayoutFooter>
+          }
+        />
+      </Dialog>
+    </div>
+  );
+}
+
+/** Responsive and Interaction Readiness visual reference for wide viewport layout. */
+export const ReadinessWideViewport: Story = {
+  name: 'Readiness / wide viewport',
+  render: () => (
+    <ReadinessReference
+      frameWidth={720}
+      title="Wide viewport dialog"
+      summary="Wide viewport reference: the requested 400px surface is preserved."
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Visual evidence for the wide viewport layout scenario. Storybook does not emulate pointer or hover capability here; pointer/hover independence is covered by implementation tests and audit notes.',
+      },
+    },
+  },
+};
+
+/** Responsive and Interaction Readiness visual reference for narrow viewport layout. */
+export const ReadinessNarrowViewport: Story = {
+  name: 'Readiness / narrow viewport',
+  render: () => (
+    <ReadinessReference
+      frameWidth={320}
+      title="Narrow viewport dialog"
+      summary="Narrow viewport reference: the surface clamps to the frame and wraps labels/content."
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Visual evidence for the narrow viewport layout scenario using a constrained review frame. Storybook does not emulate coarse pointer or no-hover capability here.',
+      },
+    },
+  },
 };

--- a/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.doc.mjs
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Dialog',
+  alsoExampleFor: ['BottomSheet', 'useMediaQuery'],
+  name: 'Dialog — Adaptive presentation',
+  displayName: 'Dialog — Adaptive presentation',
+  description:
+    'Opt-in recipe for an AdaptiveDialog wrapper: Dialog remains the default everywhere, while touchPresentation="bottom-sheet" switches only at lg and below when pointer is coarse and hover is unavailable. Includes a deterministic presentation override for tests/unusual environments and notes that BottomSheet purpose controls swipe and scrim dismissal. Do not use this by default for AlertDialog or destructive confirmations.',
+  isReady: true,
+  aspectRatio: 3 / 4,
+  componentsUsed: [
+    'Dialog',
+    'DialogHeader',
+    'BottomSheet',
+    'Layout',
+    'Button',
+    'Text',
+    'TextInput',
+    'TextArea',
+    'useMediaQuery',
+  ],
+};

--- a/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.doc.mjs
@@ -8,7 +8,7 @@ export const doc = {
   name: 'Dialog — Adaptive presentation',
   displayName: 'Dialog — Adaptive presentation',
   description:
-    'Opt-in recipe for an AdaptiveDialog wrapper: Dialog remains the default everywhere, while touchPresentation="bottom-sheet" switches only at lg and below when pointer is coarse and hover is unavailable. Includes a deterministic presentation override for tests/unusual environments and notes that BottomSheet purpose controls swipe and scrim dismissal. Do not use this by default for AlertDialog or destructive confirmations.',
+    'Opt-in recipe for an AdaptiveDialog wrapper: Dialog remains the default everywhere, while touchPresentation="bottom-sheet" switches only at lg and below when pointer is coarse and hover is unavailable. Includes a deterministic presentation override for tests/unusual environments and notes that BottomSheet purpose controls swipe and scrim dismissal. Usage examples: touchPresentation="dialog" keeps Dialog, "fullscreen" chooses fullscreen Dialog, and "bottom-sheet" chooses BottomSheet only for the touch-oriented range. Keep presentation as the deterministic override. Do not use this by default for AlertDialog or destructive confirmations.',
   isReady: true,
   aspectRatio: 3 / 4,
   componentsUsed: [

--- a/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.tsx
+++ b/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.tsx
@@ -1,0 +1,159 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState, type ReactNode} from 'react';
+import {BottomSheet} from '@astryxdesign/core/BottomSheet';
+import {Button} from '@astryxdesign/core/Button';
+import {
+  Dialog,
+  DialogHeader,
+  type DialogPurpose,
+} from '@astryxdesign/core/Dialog';
+import {Heading} from '@astryxdesign/core/Heading';
+import {
+  HStack,
+  Layout,
+  LayoutContent,
+  LayoutFooter,
+  VStack,
+} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+import {TextArea} from '@astryxdesign/core/TextArea';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {useMediaQuery} from '@astryxdesign/core/hooks';
+
+const TOUCH_ORIENTED_LG_QUERY =
+  '(max-width: 1024px) and (pointer: coarse) and (hover: none)';
+
+type AdaptivePresentation = 'dialog' | 'fullscreen' | 'bottom-sheet';
+
+type AdaptiveDialogProps = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  purpose?: DialogPurpose;
+  width?: number | string;
+  maxHeight?: number | string;
+  touchPresentation?: AdaptivePresentation;
+  presentation?: AdaptivePresentation;
+  bottomSheetHeight?: 'hug' | 'capped' | 'tall' | number | string;
+};
+
+function AdaptiveDialog({
+  isOpen,
+  onOpenChange,
+  title,
+  children,
+  footer,
+  purpose = 'info',
+  width = 480,
+  maxHeight = '75dvh',
+  touchPresentation = 'dialog',
+  presentation,
+  bottomSheetHeight = 'capped',
+}: AdaptiveDialogProps) {
+  const isTouchOrientedLargeOrBelow = useMediaQuery(TOUCH_ORIENTED_LG_QUERY);
+  const resolvedPresentation =
+    presentation ??
+    (isTouchOrientedLargeOrBelow ? touchPresentation : 'dialog');
+
+  if (resolvedPresentation === 'bottom-sheet') {
+    return (
+      <BottomSheet
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        label={title}
+        purpose={purpose}
+        height={bottomSheetHeight}>
+        <VStack gap={4} style={{padding: 'var(--spacing-4)'}}>
+          <Heading level={3}>{title}</Heading>
+          {children}
+          {footer}
+        </VStack>
+      </BottomSheet>
+    );
+  }
+
+  const dialogContent = (
+    <Layout
+      header={<DialogHeader title={title} onOpenChange={onOpenChange} />}
+      content={<LayoutContent>{children}</LayoutContent>}
+      footer={footer ? <LayoutFooter>{footer}</LayoutFooter> : undefined}
+    />
+  );
+
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      purpose={purpose}
+      width={width}
+      maxHeight={maxHeight}
+      variant={
+        resolvedPresentation === 'fullscreen' ? 'fullscreen' : 'standard'
+      }>
+      {dialogContent}
+    </Dialog>
+  );
+}
+
+export default function DialogAdaptivePresentation() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState('Ruby Cheung');
+  const [email, setEmail] = useState('ruby@example.com');
+  const [notes, setNotes] = useState('');
+
+  return (
+    <>
+      <Button label="Edit profile" onClick={() => setIsOpen(true)} />
+      <AdaptiveDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        title="Edit profile"
+        purpose="form"
+        touchPresentation="bottom-sheet"
+        bottomSheetHeight="tall"
+        footer={
+          <HStack gap={2} hAlign="end" wrap="wrap">
+            <Button
+              label="Cancel"
+              variant="secondary"
+              onClick={() => setIsOpen(false)}
+            />
+            <Button
+              label="Save profile"
+              variant="primary"
+              onClick={() => setIsOpen(false)}
+            />
+          </HStack>
+        }>
+        <VStack gap={4}>
+          <Text type="supporting" color="secondary">
+            Dialog remains the default presentation. This example explicitly
+            opts into a Bottom Sheet only at lg and below when the device has a
+            coarse pointer and no hover. Pass the presentation prop to make
+            tests or unusual environments deterministic.
+          </Text>
+          <Text type="supporting" color="secondary">
+            In Bottom Sheet presentation, purpose="form" blocks scrim clicks and
+            swipe dismissal while preserving Escape. Use this opt-in only when
+            that contract is acceptable; keep AlertDialog/destructive
+            confirmations on Dialog unless a product deliberately chooses
+            otherwise.
+          </Text>
+          <TextInput label="Name" value={name} onChange={setName} />
+          <TextInput
+            label="Email"
+            type="email"
+            value={email}
+            onChange={setEmail}
+          />
+          <TextArea label="Notes" rows={6} value={notes} onChange={setNotes} />
+        </VStack>
+      </AdaptiveDialog>
+    </>
+  );
+}

--- a/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.tsx
+++ b/packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.tsx
@@ -109,6 +109,14 @@ export default function DialogAdaptivePresentation() {
   return (
     <>
       <Button label="Edit profile" onClick={() => setIsOpen(true)} />
+      {/*
+        touchPresentation examples:
+        - "dialog" keeps Dialog even in touch-oriented <=lg contexts.
+        - "fullscreen" uses fullscreen Dialog there.
+        - "bottom-sheet" uses BottomSheet there.
+        presentation="dialog" | "fullscreen" | "bottom-sheet" overrides
+        the media query for tests and unusual environments.
+      */}
       <AdaptiveDialog
         isOpen={isOpen}
         onOpenChange={setIsOpen}

--- a/packages/cli/assets/templates/blocks/components/Dialog/DialogScrollingContent.tsx
+++ b/packages/cli/assets/templates/blocks/components/Dialog/DialogScrollingContent.tsx
@@ -69,7 +69,7 @@ function Content({onClose}: {onClose: () => void}) {
 
 // Remove isInline for production — dialogs should be modal.
 export default function DialogScrollingContent() {
-  const dialog = useImperativeDialog({maxHeight: '50vh'});
+  const dialog = useImperativeDialog({maxHeight: '50dvh'});
 
   return (
     <>

--- a/packages/cli/clients/cli/commands/dialog-adaptive-template.test.mjs
+++ b/packages/cli/clients/cli/commands/dialog-adaptive-template.test.mjs
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {component} from '../../../api/component/component.mjs';
+
+const CWD = {cwd: '.'};
+
+// Resolves built-in block templates by walking the source tree.
+const SCAN_TIMEOUT = 30_000;
+
+describe(
+  'Dialog adaptive presentation template',
+  () => {
+    it('is listed as a Dialog example block', async () => {
+      const result = await component('Dialog', {
+        ...CWD,
+        blocks: true,
+      });
+      const exampleNames = result.data.examples.map(b => b.name);
+      expect(exampleNames).toContain('DialogAdaptivePresentation');
+    });
+  },
+  SCAN_TIMEOUT,
+);

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -62,14 +62,14 @@ export const docs = {
     {
       name: 'width',
       type: 'number | string',
-      description: 'Width of the dialog in pixels or any CSS value.',
+      description: 'Preferred width of the dialog in pixels or any CSS value. Standard dialogs clamp to their container and the dynamic viewport with spacing-token gutters so narrow viewports keep content on screen.',
       default: '400',
     },
     {
       name: 'maxHeight',
       type: 'number | string',
-      description: 'Maximum height of the dialog.',
-      default: "'75vh'",
+      description: 'Maximum height of the dialog. Defaults to a dynamic viewport value so browser UI changes are reflected where supported.',
+      default: "'75dvh'",
     },
     {
       name: 'position',

--- a/packages/core/src/Dialog/Dialog.test.tsx
+++ b/packages/core/src/Dialog/Dialog.test.tsx
@@ -184,6 +184,47 @@ describe('Dialog', () => {
     });
   });
 
+  describe('responsive sizing', () => {
+    it('keeps the requested width but clamps standard dialogs to container and dynamic viewport gutters', () => {
+      render(
+        <Dialog
+          isOpen={true}
+          onOpenChange={() => {}}
+          width={600}
+          maxHeight="70dvh"
+          aria-label="Sized dialog">
+          Content
+        </Dialog>,
+      );
+
+      const dialog = screen.getByRole('dialog');
+      const inlineStyle = dialog.getAttribute('style') ?? '';
+      expect(inlineStyle).toContain('--x-width: 600px');
+      expect(inlineStyle).toContain(
+        '--x-maxWidth: min(100%, calc(100dvw - var(--spacing-4) - var(--spacing-4)))',
+      );
+      expect(inlineStyle).toContain('--x-maxHeight: 70dvh');
+    });
+
+    it('protects fullscreen content with safe-area padding', () => {
+      render(
+        <Dialog
+          isOpen={true}
+          onOpenChange={() => {}}
+          variant="fullscreen"
+          aria-label="Fullscreen dialog">
+          <div data-testid="child">Content</div>
+        </Dialog>,
+      );
+
+      const wrapper = screen.getByTestId('child').parentElement!;
+      const computed = window.getComputedStyle(wrapper);
+      expect(computed.paddingInlineStart).toContain('safe-area-inset-left');
+      expect(computed.paddingInlineEnd).toContain('safe-area-inset-right');
+      expect(wrapper.parentElement!.tagName).toBe('DIALOG');
+    });
+  });
+
   describe('position prop', () => {
     it('accepts position configuration', () => {
       render(

--- a/packages/core/src/Dialog/Dialog.test.tsx
+++ b/packages/core/src/Dialog/Dialog.test.tsx
@@ -9,6 +9,7 @@
  * SYNC: When Dialog.tsx changes, update tests to match new behavior
  */
 
+import {readFileSync} from 'node:fs';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Dialog, resolveDialogPositionOffsets} from './Dialog';
@@ -204,6 +205,35 @@ describe('Dialog', () => {
         '--x-maxWidth: min(100%, calc(100dvw - var(--spacing-4) - var(--spacing-4)))',
       );
       expect(inlineStyle).toContain('--x-maxHeight: 70dvh');
+    });
+
+    it('uses a fullscreen-specific fade animation instead of centered dialog movement', () => {
+      const source = readFileSync(
+        'packages/core/src/Dialog/Dialog.tsx',
+        'utf8',
+      );
+      const standardOpen = source.slice(
+        source.indexOf('  open: {'),
+        source.indexOf('  // Backdrop using ::backdrop'),
+      );
+      const fullscreenOpen = source.slice(
+        source.indexOf('  fullscreenOpen: {'),
+        source.indexOf('  fullscreenSafeArea: {'),
+      );
+      const modalStyleOrder = source.slice(
+        source.indexOf('focusOutlineProps.focusVisible('),
+        source.indexOf(
+          '          xstyle,',
+          source.indexOf('focusOutlineProps.focusVisible('),
+        ),
+      );
+
+      expect(standardOpen).toContain('enterDirectional');
+      expect(fullscreenOpen).toContain('enterFullscreen');
+      expect(fullscreenOpen).not.toContain('enterDirectional');
+      expect(modalStyleOrder.indexOf('styles.open')).toBeLessThan(
+        modalStyleOrder.indexOf('styles.fullscreenOpen'),
+      );
     });
 
     it('protects fullscreen content with safe-area padding', () => {

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -8,6 +8,12 @@
  * @output Exports Dialog component, DialogProps, DialogVariant, DialogPurpose types
  * @position Core implementation; consumed by index.ts, tested by Dialog.test.tsx
  *
+ * The standard variant treats `width` as the preferred surface width, then
+ * clamps it to the dynamic viewport with spacing-token gutters so narrow
+ * viewports keep content and controls on screen without changing the public API.
+ * Fullscreen dialogs preserve the same padding floor while honoring safe-area
+ * insets around notches, rounded corners, and home indicators.
+ *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Dialog/Dialog.doc.mjs (props table, features, implementation notes)
  * - /packages/core/src/Dialog/Dialog.test.tsx (tests for new/changed behavior)
@@ -35,6 +41,7 @@ import {
   durationVars,
   easeVars,
   shadowVars,
+  spacingVars,
 } from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
 import type {SpacingToken} from '../Layout/container.stylex';
@@ -171,6 +178,16 @@ const styles = stylex.create({
     margin: 0,
     inset: 0,
   },
+  fullscreenSafeArea: {
+    paddingBlockStart:
+      'max(var(--container-padding-block-start), env(safe-area-inset-top, 0px))',
+    paddingBlockEnd:
+      'max(var(--container-padding-block-end), env(safe-area-inset-bottom, 0px))',
+    paddingInlineStart:
+      'max(var(--container-padding-inline-start), env(safe-area-inset-left, 0px))',
+    paddingInlineEnd:
+      'max(var(--container-padding-inline-end), env(safe-area-inset-right, 0px))',
+  },
   inner: {
     display: 'flex',
     flexDirection: 'column',
@@ -194,12 +211,30 @@ const styles = stylex.create({
   },
 });
 
-// Dynamic styles for width, maxHeight, and position
+const STANDARD_DIALOG_VIEWPORT_GUTTER = spacingVars['--spacing-4'];
+const STANDARD_DIALOG_VIEWPORT_MAX_WIDTH = `calc(100dvw - ${STANDARD_DIALOG_VIEWPORT_GUTTER} - ${STANDARD_DIALOG_VIEWPORT_GUTTER})`;
+const STANDARD_DIALOG_MAX_WIDTH = `min(100%, ${STANDARD_DIALOG_VIEWPORT_MAX_WIDTH})`;
+
+function formatSizeValue(value: number | string): string {
+  return typeof value === 'number' ? `${value}px` : value;
+}
+
+function resolveDialogSizing(
+  width: number | string,
+  maxHeight: number | string,
+) {
+  return {
+    width: formatSizeValue(width),
+    maxWidth: STANDARD_DIALOG_MAX_WIDTH,
+    maxHeight: formatSizeValue(maxHeight),
+  };
+}
+
 const dynamicStyles = stylex.create({
-  sizing: (width: number | string, maxHeight: number | string) => ({
-    width: typeof width === 'number' ? `${width}px` : width,
-    maxWidth: '90vw',
-    maxHeight: typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight,
+  sizing: (width: string, maxWidth: string, maxHeight: string) => ({
+    width,
+    maxWidth,
+    maxHeight,
   }),
   position: (
     top: string,
@@ -288,7 +323,7 @@ export interface DialogProps extends BaseProps<HTMLDialogElement> {
    * The actual height will be the height of its content.
    * Numbers are treated as pixels, strings are used as-is.
    * Ignored when variant is 'fullscreen'.
-   * @default '75vh'
+   * @default '75dvh'
    */
   maxHeight?: number | string;
 
@@ -356,7 +391,7 @@ export function Dialog({
   isInline = false,
   onOpenChange,
   width = 400,
-  maxHeight = '75vh',
+  maxHeight = '75dvh',
   position,
   variant = 'standard',
   purpose = 'info',
@@ -374,6 +409,9 @@ export function Dialog({
   const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
 
   const isFullscreen = variant === 'fullscreen';
+  const standardSizing = isFullscreen
+    ? null
+    : resolveDialogSizing(width, maxHeight);
 
   // Default accessible name: publish a title id through DialogContext so a
   // DialogHeader applies it to its heading (mirrors AlertDialog's explicit
@@ -550,7 +588,6 @@ export function Dialog({
     }
   };
 
-  // Shared inner content wrapper
   const innerContent = (
     <div
       {...stylex.props(
@@ -559,22 +596,14 @@ export function Dialog({
           useThemeDefault
             ? {
                 useThemeDefault: 'dialog',
-                maxHeight: isFullscreen
-                  ? undefined
-                  : typeof maxHeight === 'number'
-                    ? `${maxHeight}px`
-                    : maxHeight,
+                maxHeight: standardSizing?.maxHeight,
               }
             : {
                 paddingInnerX: paddingToken,
                 paddingInnerY: paddingToken,
                 paddingOuterX: paddingToken,
                 paddingOuterY: paddingToken,
-                maxHeight: isFullscreen
-                  ? undefined
-                  : typeof maxHeight === 'number'
-                    ? `${maxHeight}px`
-                    : maxHeight,
+                maxHeight: standardSizing?.maxHeight,
               },
         ),
         !useThemeDefault &&
@@ -589,6 +618,7 @@ export function Dialog({
         !useThemeDefault &&
           effectivePadding !== 4 &&
           containerPaddingBlockEndVarStyles[effectivePadding],
+        isFullscreen && styles.fullscreenSafeArea,
       )}>
       <DialogContext value={dialogContextValue}>{children}</DialogContext>
     </div>
@@ -612,7 +642,12 @@ export function Dialog({
           stylex.props(
             styles.inlineWrapper,
             overlayPaddingReset.reset,
-            !isFullscreen && dynamicStyles.sizing(width, maxHeight),
+            standardSizing &&
+              dynamicStyles.sizing(
+                standardSizing.width,
+                standardSizing.maxWidth,
+                standardSizing.maxHeight,
+              ),
             isFullscreen && styles.fullscreen,
             xstyle,
           ),
@@ -641,7 +676,12 @@ export function Dialog({
           overlayPaddingReset.reset,
           isOpen && styles.open,
           styles.backdrop,
-          !isFullscreen && dynamicStyles.sizing(width, maxHeight),
+          standardSizing &&
+            dynamicStyles.sizing(
+              standardSizing.width,
+              standardSizing.maxWidth,
+              standardSizing.maxHeight,
+            ),
           hasPosition &&
             (() => {
               const o = resolveDialogPositionOffsets(position);

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -12,7 +12,7 @@
  * clamps it to the dynamic viewport with spacing-token gutters so narrow
  * viewports keep content and controls on screen without changing the public API.
  * Fullscreen dialogs preserve the same padding floor while honoring safe-area
- * insets around notches, rounded corners, and home indicators.
+ * insets, and fade in without the centered-dialog translate/scale motion.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Dialog/Dialog.doc.mjs (props table, features, implementation notes)
@@ -125,6 +125,11 @@ const enterDirectional = stylex.keyframes({
   to: {opacity: 1, transform: 'translate(0, 0) scale(1)'},
 });
 
+const enterFullscreen = stylex.keyframes({
+  from: {opacity: 0},
+  to: {opacity: 1},
+});
+
 /**
  * Dialog styles using native <dialog> element
  * Uses ::backdrop pseudo-element for overlay
@@ -177,6 +182,12 @@ const styles = stylex.create({
     borderRadius: 0,
     margin: 0,
     inset: 0,
+  },
+  fullscreenOpen: {
+    animationName: {
+      default: enterFullscreen,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
   },
   fullscreenSafeArea: {
     paddingBlockStart:
@@ -693,6 +704,7 @@ export function Dialog({
               );
             })(),
           isFullscreen && styles.fullscreen,
+          isFullscreen && isOpen && styles.fullscreenOpen,
           xstyle,
         ),
         className,


### PR DESCRIPTION
## Summary

- clamp standard Dialog width to the container and dynamic viewport with spacing-token gutters, preserving consumer `width` as the preferred surface width
- switch Dialog's default max height from `75vh` to `75dvh`, add safe-area-aware padding for fullscreen Dialog content, and make fullscreen open with fade-only motion instead of the centered Dialog translate/scale
- add honest wide/narrow Dialog Storybook layout references plus explicit mobile presentation alternatives: keep Dialog, fullscreen Dialog, or BottomSheet
- add an opt-in `DialogAdaptivePresentation` block recipe showing an `AdaptiveDialog` wrapper: Dialog remains the default everywhere, and callers may explicitly opt into BottomSheet only for touch-oriented <=lg contexts

## Responsive and Interaction Readiness outcomes

### Responsive layout

| Check | Result | Evidence |
| --- | --- | --- |
| Wide viewport layout | Pass | Existing Dialog stories plus `Core/Dialog -- Readiness / wide viewport`; requested 400px/default width remains the preferred surface width. |
| Narrow viewport layout | Pass | `Core/Dialog -- Readiness / narrow viewport`; standard Dialog now emits `max-width: min(100%, calc(100dvw - var(--spacing-4) - var(--spacing-4)))`. |
| Content fit / wrapping / overflow | Pass | Dialog body remains in the existing flex/scroll wrapper; tests assert the emitted width clamp and max-height variables; narrow story uses wrapping footer buttons. |

### Touch, pointer, and hover

| Check | Result | Evidence |
| --- | --- | --- |
| Narrow viewport + coarse pointer + no hover | Pass | Core Dialog has no pointer/hover media branch; geometry remains width-driven. Storybook references are visual viewport/layout references only, not pointer emulation. |
| Wide viewport + coarse pointer + no hover | Pass | Core Dialog does not force narrow/mobile geometry from coarse pointer state. |
| Hover independence | Pass | Required actions are visible buttons; no required action or information depends on hover. |
| Gestures and alternatives | N/A for Core Dialog | Core Dialog adds no custom gesture behavior. Gesture adaptation exists only in the explicit BottomSheet recipe, where callers knowingly opt into BottomSheet dismissal semantics. |

### Accessibility and interaction contracts

| Check | Result | Evidence |
| --- | --- | --- |
| WCAG 2.2 AA target size | Pass | Dialog actions use Button sizing; default md Button is 32px, above SC 2.5.8's 24x24 CSS px minimum. No 44/48 guidance is introduced. |
| Semantics | Pass | Native `<dialog>`, `aria-modal`, `DialogHeader` labeling, and `alertdialog` only for `purpose="required"` remain unchanged and covered by existing tests. |
| Keyboard/focus/dismissal | Pass | Existing Dialog/DialogHeader tests cover Escape behavior, purpose mapping, accessible name precedence, title focus, and focus restoration paths; AlertDialog tests pass against the shared Dialog changes. |
| Reduced motion | Pass | Standard Dialog keeps the existing directional translate/scale entrance and reduced-motion disable. Fullscreen Dialog now uses a separate opacity-only entrance, also disabled under `prefers-reduced-motion: reduce`. |

### Mobile viewport constraints

| Check | Result | Evidence |
| --- | --- | --- |
| Dynamic viewport sizing | Pass | Default `maxHeight` is now `75dvh`; standard Dialog width clamp uses `100dvw`. |
| Safe-area insets | Pass | Fullscreen Dialog inner padding uses `max(existing token padding, env(safe-area-inset-* , 0px))`, preserving the spacing-token floor while honoring larger safe-area insets. |
| Software keyboard | Partial / improved | `dvh` improves dynamic viewport sizing where supported, and the adaptive recipe uses `BottomSheet height="tall"` for keyboard-heavy forms. This does not prove keyboard occlusion handling for every Dialog/browser/content combination. |
| Scroll behavior | Pass | Existing flex wrapper and scroll support remain in place; tests keep the wrapper path attached. |

## Presentation choice

Dialog remains the default component and default presentation. This PR does not add automatic BottomSheet behavior to Core Dialog and does not introduce a universal adaptive component.

The new recipe demonstrates component substitution only when a caller explicitly opts in:

- `touchPresentation="dialog"` keeps Dialog even in touch-oriented <=lg contexts.
- `touchPresentation="fullscreen"` chooses fullscreen Dialog for touch-oriented <=lg contexts.
- `touchPresentation="bottom-sheet"` chooses BottomSheet only when `(max-width: 1024px) and (pointer: coarse) and (hover: none)` matches.
- Narrow fine-pointer environments remain Dialog unless the deterministic `presentation` override says otherwise.
- `presentation="dialog" | "fullscreen" | "bottom-sheet"` provides a deterministic override for tests and unusual environments.
- `isOpen`, `onOpenChange`, `purpose`, and accessible label/title contracts are aligned across presentations.
- BottomSheet's `purpose` mapping controls swipe and scrim dismissal (`form` blocks swipe/scrim, `info` allows them, `required` blocks implicit dismissal), so callers choose the adaptive presentation knowingly.
- The recipe is for touch-oriented form/detail contexts; AlertDialog/destructive confirmations should stay on Dialog by default.

## Local Storybook review

Storybook is running locally on port 6007. Useful story IDs:

- `core-dialog--readiness-wide-viewport`
- `core-dialog--readiness-narrow-viewport`
- `core-dialog--mobile-presentation-keep-dialog`
- `core-dialog--mobile-presentation-fullscreen-dialog`
- `core-dialog--mobile-presentation-bottom-sheet`

## Validation

All of these passed locally:

- `pnpm exec prettier --check packages/core/src/Dialog/Dialog.tsx packages/core/src/Dialog/Dialog.test.tsx apps/storybook/stories/Dialog.stories.tsx packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.tsx packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.doc.mjs .changeset/dialog-responsive-interaction.md`
- `pnpm exec vitest run packages/core/src/Dialog/Dialog.test.tsx packages/core/src/Dialog/DialogHeader.test.tsx packages/core/src/AlertDialog/AlertDialog.test.tsx`
- `pnpm exec vitest run packages/cli/clients/cli/commands/dialog-adaptive-template.test.mjs`
- `pnpm -F @astryxdesign/cli astryx template DialogAdaptivePresentation` plus checks for `touchPresentation="bottom-sheet"`, `TOUCH_ORIENTED_LG_QUERY`, and `presentation prop`
- `pnpm -F @astryxdesign/cli astryx component Dialog --dense`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm -F @astryxdesign/cli typecheck:template-docs`
- `pnpm exec eslint packages/core/src/Dialog/Dialog.tsx packages/core/src/Dialog/Dialog.test.tsx apps/storybook/stories/Dialog.stories.tsx packages/cli/assets/templates/blocks/components/Dialog/DialogAdaptivePresentation.tsx packages/cli/clients/cli/commands/dialog-adaptive-template.test.mjs`
- `pnpm check:changesets`
- `pnpm check:repo`
- `pnpm lab:readiness:check`
- `git diff --check`

## Relationship

Independent of AlertDialog #5343 and the Responsive and Interaction Readiness rubric #5351. Neither unmerged PR is a dependency.
