### PR TITLE
fix(ButtonGroup): keep arrow keys inside a member's open menu, plus the ButtonGroup audit

### DIFF
--- a/.changeset/button-group-layer-arrow-keys.md
+++ b/.changeset/button-group-layer-arrow-keys.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ButtonGroup: arrow keys pressed inside a member's open menu stay with that menu. A DropdownMenu renders its menu inline inside the group, so ArrowLeft and ArrowRight used to bubble to the group and move focus onto a sibling button while the menu was still open. The group's `elevation` is also reflected as `data-elevation` now, so a theme can target it.
+
+@cixzhang

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -1,5 +1,16 @@
 [
   {
+    "component": "ButtonGroup",
+    "storyId": "core-buttongroup--horizontal",
+    "dims": [
+      "D2"
+    ],
+    "selectors": {
+      "prev": "[role=\"group\"] button:first-child",
+      "next": "[role=\"group\"] button:last-child"
+    }
+  },
+  {
     "component": "Calendar",
     "storyId": "core-calendar--default",
     "dims": [

--- a/apps/storybook/stories/ButtonGroup.stories.tsx
+++ b/apps/storybook/stories/ButtonGroup.stories.tsx
@@ -222,7 +222,10 @@ export const Elevation: Story = {
   ),
 };
 
-/** Long labels in a narrow container: text expansion and 320px reflow. */
+/**
+ * Long labels in a narrow container. Members neither wrap nor truncate, so a
+ * group whose labels are wider than its container overflows it.
+ */
 export const LongLabels: Story = {
   render: () => (
     <div style={{width: 280}}>

--- a/apps/storybook/stories/ButtonGroup.stories.tsx
+++ b/apps/storybook/stories/ButtonGroup.stories.tsx
@@ -184,3 +184,52 @@ export const WithDropdownMenu: Story = {
     </ButtonGroup>
   ),
 };
+
+/**
+ * Disabled members: the whole group via `isDisabled`, and a single member
+ * disabling itself inside an enabled group.
+ */
+export const Disabled: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: 16, alignItems: 'center'}}>
+      <ButtonGroup label="Clipboard actions" isDisabled>
+        <Button label="Copy" />
+        <Button label="Cut" />
+        <Button label="Paste" />
+      </ButtonGroup>
+      <ButtonGroup label="History">
+        <Button label="Undo" />
+        <Button label="Redo" isDisabled />
+      </ButtonGroup>
+    </div>
+  ),
+};
+
+/**
+ * The connected buttons share one surface, so the shadow sits on the group and
+ * lifts them together.
+ */
+export const Elevation: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: 24, alignItems: 'center'}}>
+      {(['none', 'low', 'med', 'high'] as const).map(elevation => (
+        <ButtonGroup key={elevation} label={elevation} elevation={elevation}>
+          <Button label="Copy" />
+          <Button label="Paste" />
+        </ButtonGroup>
+      ))}
+    </div>
+  ),
+};
+
+/** Long labels in a narrow container: text expansion and 320px reflow. */
+export const LongLabels: Story = {
+  render: () => (
+    <div style={{width: 280}}>
+      <ButtonGroup label="Review actions">
+        <Button label="Approve and merge immediately" />
+        <Button label="Request changes" />
+      </ButtonGroup>
+    </div>
+  ),
+};

--- a/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
+++ b/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
@@ -15,7 +15,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-button-group', visualProps: ['size', 'orientation']},
+      {className: 'astryx-button-group', visualProps: ['size', 'orientation', 'elevation']},
     ],
   },
   components: [
@@ -46,6 +46,8 @@ export const docs = {
       {guidance: false, description: "Don't mix wildly different actions. A Save button next to a Delete button in the same group is confusing."},
       {guidance: false, description: "Don't use ButtonGroup for navigation. Use SegmentedControl or TabList for switching between views."},
       {guidance: false, description: "Don't nest ButtonGroups. If you need multiple groups, place them side by side with a gap."},
+      {guidance: true, description: 'Name the group for what its buttons act on. The label is the group\u2019s accessible name and a screen reader reads it before each member.'},
+      {guidance: false, description: "Don't disable the group to show that an action is in flight. A disabled member drops focus, so a keyboard user loses their place; leave the group enabled and show progress on the button that started the work."},
     ],
     anatomy: [
       {name: 'Button', required: true, description: 'One or more Button or IconButton children that form the connected group.'},
@@ -84,6 +86,8 @@ export const docsZh = {
       {guidance: false, description: '不要混合差异很大的操作，将保存按钮和删除按钮放在同一组中会令人困惑。'},
       {guidance: false, description: '不要使用 ButtonGroup 进行导航，使用 SegmentedControl 或 TabList 切换视图。'},
       {guidance: false, description: '不要嵌套 ButtonGroup。如需多个组，请并排放置并留有间隔。'},
+      {guidance: true, description: '按钮组的标签应说明这些按钮作用于什么。该标签是按钮组的无障碍名称，屏幕阅读器会在每个成员之前朗读它。'},
+      {guidance: false, description: '不要用禁用整个按钮组来表示操作进行中。禁用的成员会失去焦点，键盘用户会丢失位置；请保持按钮组可用，并在发起操作的按钮上显示进度。'},
     ],
     anatomy: [
       {name: '按钮', required: true, description: '一个或多个 Button 或 IconButton 子元素，形成连接的组。'},
@@ -105,6 +109,8 @@ export const docsDense = {
       {guidance: false, description: "Don't mix unrelated actions in one group."},
       {guidance: false, description: "Don't use for navigation. Use SegmentedControl or TabList."},
       {guidance: false, description: "Don't nest ButtonGroups."},
+      {guidance: true, description: 'Label the group for what its buttons act on; it is the accessible name.'},
+      {guidance: false, description: "Don't disable the group for an in-flight action; a disabled member drops focus."},
     ],
   },
   components: [

--- a/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
@@ -12,7 +12,8 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {transformSync} from '@babel/core';
 import stylexBabelPlugin from '@stylexjs/babel-plugin';
 import {readFileSync} from 'node:fs';
@@ -610,6 +611,189 @@ describe('ButtonGroup', () => {
       expect(def.querySelector('[role="group"]')!.className).toBe(
         none.querySelector('[role="group"]')!.className,
       );
+    });
+
+    it('exposes the elevation to a theme as a data attribute', () => {
+      render(
+        <ButtonGroup label="Actions" elevation="high">
+          <Button label="One" />
+        </ButtonGroup>,
+      );
+
+      expect(screen.getByRole('group')).toHaveAttribute(
+        'data-elevation',
+        'high',
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Keyboard navigation
+  //
+  // The group wires useListFocus, so arrow keys move focus between members.
+  // The last two tests cover the boundary: a member can own a layer, whose
+  // keys belong to that layer, and the group itself can sit inside a layer,
+  // whose keys are still the group's own. Both must hold at once.
+  // ===========================================================================
+  describe('keyboard navigation', () => {
+    const clipboard = (
+      <ButtonGroup label="Actions">
+        <Button label="Copy" />
+        <Button label="Cut" />
+        <Button label="Paste" />
+      </ButtonGroup>
+    );
+
+    it('moves focus between members with the arrow keys, wrapping at the end', async () => {
+      const user = userEvent.setup();
+      render(clipboard);
+
+      screen.getByRole('button', {name: 'Copy'}).focus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'Cut'})).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'Copy'})).toHaveFocus();
+
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('button', {name: 'Paste'})).toHaveFocus();
+    });
+
+    it('jumps to the first and last member with Home and End', async () => {
+      const user = userEvent.setup();
+      render(clipboard);
+
+      screen.getByRole('button', {name: 'Cut'}).focus();
+
+      await user.keyboard('{End}');
+      expect(screen.getByRole('button', {name: 'Paste'})).toHaveFocus();
+
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('button', {name: 'Copy'})).toHaveFocus();
+    });
+
+    it('uses the vertical arrows when the group is vertical', async () => {
+      const user = userEvent.setup();
+      render(
+        <ButtonGroup label="Actions" orientation="vertical">
+          <Button label="Copy" />
+          <Button label="Cut" />
+        </ButtonGroup>,
+      );
+
+      screen.getByRole('button', {name: 'Copy'}).focus();
+
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('button', {name: 'Cut'})).toHaveFocus();
+
+      await user.keyboard('{ArrowUp}');
+      expect(screen.getByRole('button', {name: 'Copy'})).toHaveFocus();
+    });
+
+    it('follows visual direction in RTL', async () => {
+      const user = userEvent.setup();
+      // dir sits on the group because jsdom resolves computed direction from
+      // the element's own attribute, not from an ancestor.
+      render(
+        <ButtonGroup label="Actions" dir="rtl">
+          <Button label="Copy" />
+          <Button label="Cut" />
+          <Button label="Paste" />
+        </ButtonGroup>,
+      );
+      screen.getByRole('button', {name: 'Copy'}).focus();
+
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('button', {name: 'Cut'})).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'Copy'})).toHaveFocus();
+    });
+
+    it('skips a disabled member', async () => {
+      const user = userEvent.setup();
+      render(
+        <ButtonGroup label="Actions">
+          <Button label="Copy" />
+          <Button label="Cut" isDisabled />
+          <Button label="Paste" />
+        </ButtonGroup>,
+      );
+
+      screen.getByRole('button', {name: 'Copy'}).focus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'Paste'})).toHaveFocus();
+    });
+
+    it('leaves arrow keys to a member\u2019s open menu', async () => {
+      const user = userEvent.setup();
+      render(
+        <ButtonGroup label="Approve action">
+          <Button label="Allow once" />
+          <DropdownMenu
+            hasChevron={false}
+            button={{label: 'Allow options', isIconOnly: true}}
+            items={[{label: 'Allow for 30 minutes'}, {label: 'Always allow'}]}
+          />
+        </ButtonGroup>,
+      );
+
+      await user.click(screen.getByRole('button', {name: /Allow options/}));
+      const item = screen.getByRole('menuitem', {
+        name: 'Allow for 30 minutes',
+        hidden: true,
+      });
+      item.focus();
+
+      // Assert positively: the menu item keeps focus. `.not.toHaveFocus()` on
+      // the group's buttons would also pass if the group had thrown focus
+      // somewhere else entirely.
+      fireEvent.keyDown(item, {key: 'ArrowRight'});
+      expect(item).toHaveFocus();
+
+      fireEvent.keyDown(item, {key: 'ArrowLeft'});
+      expect(item).toHaveFocus();
+
+      // End belongs to the menu's own list focus, so it lands on the last menu
+      // item rather than the group's last button.
+      fireEvent.keyDown(item, {key: 'End'});
+      expect(
+        screen.getByRole('menuitem', {name: 'Always allow', hidden: true}),
+      ).toHaveFocus();
+    });
+
+    it('still moves between its own members when the group sits inside a popover', async () => {
+      const user = userEvent.setup();
+      // A group rendered inside a Popover, ContextMenu, HoverCard or Toast has
+      // a `[popover]` ancestor, because that is how useLayer mounts a layer.
+      // A bare `popover` div is the same DOM fact without the layer harness.
+      render(
+        <div popover="manual">
+          <ButtonGroup label="Actions">
+            <Button label="Copy" />
+            <Button label="Cut" />
+            <Button label="Paste" />
+          </ButtonGroup>
+        </div>,
+      );
+
+      // A closed popover is display:none in jsdom, so its contents read as
+      // inaccessible; focus and key handling still work on them.
+      const button = (name: string) =>
+        screen.getByRole('button', {name, hidden: true});
+
+      button('Copy').focus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(button('Cut')).toHaveFocus();
+
+      await user.keyboard('{End}');
+      expect(button('Paste')).toHaveFocus();
+
+      await user.keyboard('{Home}');
+      expect(button('Copy')).toHaveFocus();
     });
   });
 });

--- a/packages/core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.tsx
@@ -172,6 +172,13 @@ export function ButtonGroup({
 
   const {listRef, handleKeyDown} = useListFocus<HTMLDivElement>({
     itemSelector: 'button, [tabindex="0"]',
+    // A member's layer renders inline inside the group (useLayer does not
+    // portal it), so a key pressed in an open DropdownMenu bubbles here. The
+    // boundary is the group's own root or any layer, whichever is nearer to
+    // the target. Naming the group's own root is what keeps a group rendered
+    // inside a Popover or Toast working: bailing on any [popover] ancestor
+    // instead would swallow every arrow key it owns.
+    boundarySelector: '[role="group"], [popover]',
     orientation,
   });
 
@@ -187,7 +194,7 @@ export function ButtonGroup({
           ref={mergeRefs(ref, listRef)}
           {...props}
           {...mergeProps(
-            themeProps('button-group', {size, orientation}),
+            themeProps('button-group', {size, orientation, elevation}),
             stylex.props(
               styles.group,
               orientation === 'vertical' && styles.vertical,


### PR DESCRIPTION
## ButtonGroup, full audit

First audit of this component. Graded end to end against [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) v1.7.1, in Chromium against a static Storybook build.

## Corrections since the first push

A review of this PR found that its headline fix was a regression, plus three lesser defects. All four are corrected here.

1. **The A4 guard was a regression.** It bailed out whenever the key's target had *any* `[popover]` ancestor. Since `useLayer` wraps every layer's children in `[popover]`, a ButtonGroup rendered inside a Popover, ContextMenu, HoverCard or Toast matched an *ancestor* popover and swallowed all of its own arrow keys. The group stopped working entirely in those contexts. It is now scoped through `useListFocus`'s own `boundarySelector`, and both cases hold at once. Measured in Chromium, three ways, below.
2. **The regression test was too weak to catch it.** It asserted with two `.not.toHaveFocus()` calls, which pass when focus went nowhere at all, and in jsdom that is exactly what happened. It asserts positively now, and a second test covers the case the old guard broke.
3. **§2 was over-scored at 5, and is 4.** The 5/5 anchor asks for an extensible `*VariantMap` and MediaTheme verified. `ButtonGroup/index.ts` declares no variant map, `elevation` is a closed union over a closed style record, and MediaTheme was never rendered.
4. **The capture count was wrong.** 44 contact-sheet captures, not 34.

**Before: 72.0 / C, 4 open BLOCKs.** Ledger row recorded before any change: [f5fac81](https://github.com/facebook/astryx/wiki/_compare/f5fac813c2cbe3d14e22d6a05a116870ee99672f).
**After: 82.8 / B, 0 open BLOCKs.** Re-derived, not patched: `(4x16 + 4x14 + 4x14 + 4x12 + 5x6 + 4x4 + 4.5x8 + 4x8 + 4.5x8 + 4x5 + 4x5) / 5 = 82.8`. Held until this lands, so its `commit` can name a real `main` commit.

| Section | Before | After | What moved |
|---|---|---|---|
| §1 Accessibility | 3 | 4 | A4 closed, and closed both directions. A20 and A21 measured for the first time, both pass. |
| §2 Theming | 3 | 4 | T6 closed: a theme can reach `elevation`. Short of 5 on the variant map and MediaTheme. |
| §5b Design, rendered | 3 | 4 | The disabled state is captured now, so state coverage is complete. |
| §6 Testing | 2.5 | 4.5 | V6 and V10 closed, V11 closed. |
| §8 Docs | 4 | 4.5 | X10 at 100%, X12 and X16 closed. |

§3, §4, §5a, §7, §9 and §10 are unchanged.

## Fixed

### A4 (BLOCK): arrow keys crossed a layer boundary in both directions

`useLayer` renders a DropdownMenu's menu inline inside the group rather than portaling it, which is the same fact `IS_LAST_ITEM` relies on. So an arrow key pressed inside the open menu bubbles to the group's `useListFocus` handler, `getCurrentIndex()` returns -1 for the focused menu item, and the group focuses one of its own buttons. The menu stays open with focus behind it.

The first fix here was a hand-rolled `closest('[popover]')` bail-out in a wrapping keydown handler. `closest()` walks **up**, and every layer carries `[popover]`, so it also matched when the *group itself* was inside a layer. That killed arrow navigation for every ButtonGroup inside a Popover, ContextMenu, HoverCard or Toast.

The mechanism was already there, and `useListFocus` is where it belongs. `boundarySelector` scopes both halves of the problem in the hook that every other list consumer shares: an item counts as the group's own only when its nearest boundary ancestor is the group's container, and a key event is ignored when its nearest boundary ancestor is not. The boundary is `'[role="group"], [popover]'`: the group's own root, or any layer, whichever is **nearer** to the event target. Naming the group's own root is the whole difference, because a group inside a Popover reaches its own `role="group"` before it reaches the enclosing `[popover]`.

`packages/core/src/ButtonGroup/ButtonGroup.tsx:173-183`. The bespoke wrapper is gone; the group hands `handleKeyDown` straight to `onKeyDown` again.

**Measured in Chromium**, on one page carrying both scenarios, built three times from the same source tree with only `ButtonGroup.tsx` swapped:

| Build | A: group inside a Popover. Focus on Copy, then ArrowRight, End, Home | B: ArrowRight inside a member's open DropdownMenu |
|---|---|---|
| parent `b594d5c5fc4` | Cut, Paste, Copy | **`button "Allow once"`**, focus leaves the open menu |
| first fix (`closest('[popover]')`) | **Copy, Copy, Copy**, every key dead | `menuitem "Always allow"` |
| this PR (`boundarySelector`) | Cut, Paste, Copy | `menuitem "Always allow"` |

Only the boundary passes both. The menu is still open in every B measurement, so B is about where focus went, not whether the layer survived.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5355/ButtonGroup__with-dropdown-menu__arrow-in-open-menu__before.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5355/ButtonGroup__with-dropdown-menu__arrow-in-open-menu__after.png) |

**T6 (BLOCK): `elevation` selected between StyleX style objects but was missing from `themeProps`.**
The group rendered `data-size` and `data-orientation` only, so a theme had no hook for the elevation levels. Verified by injecting the rules a theme would emit: `.astryx-button-group[data-elevation="high"]` matched nothing before and matches now. `ButtonGroup.tsx:197`, `ButtonGroup.doc.mjs:18`.

**V6 (BLOCK): no keyboard test existed.**
28 tests, none of them keyboard, on a component that wires arrow navigation, wrapping, Home and End, and RTL flipping. Eight added: arrows and wrap, Home and End, vertical orientation, RTL, disabled-member skip, a member's open menu, and a group inside a popover. The last two are the boundary, and each is red against one of the two broken builds above: the open-menu test fails on the parent commit, the in-popover test fails on the first fix, both pass here. Verified by swapping the source in place.

**V10 (BLOCK): no story rendered a disabled member.**
So `disabled-cursor-audit` and `disabled-hover-audit` both reported a pass over zero elements for this component (`Checked 0 disabled element(s) across 0 of 12 stories`), and A20 and A21 were unmeasurable. With the `Disabled` story they check 5 elements: no disabled member paints a hover state, and every one answers the pointer with `default` at all five hit-test points, which is v1.7.1's expected value.

![disabled](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5355/contact-sheet-ButtonGroup__disabled__rest__light-ltr.png)

**X10, X12, X16, I15, I17 (FIX).** `isDisabled` was the one documented prop no story exercised. Added `Disabled`, `Elevation` and `LongLabels` stories; added a curated `targets.json` entry, so `rtl:audit --filter ButtonGroup` now reports `CUR RTL-ready ButtonGroup {"D2":"pass"}` instead of nothing; added labelling guidance to `usage.bestPractices`.

## Why §2 is 4 and not 5

T6 is genuinely closed, and everything else in the 5/5 anchor holds: every visual value is a token, `themeProps` sits on the painting element carrying every style-driving prop, `targets[]` moved in the same diff, both Vitest guards pass unmodified, and no new DOM node appeared. Two things in that anchor do not hold.

- **No extensible variant map.** The anchor wants `*VariantMap` in the component's public subpath barrel with the prop type derived from it. `ButtonGroup/index.ts` declares none, and `elevation` is `Elevation`, a closed union of four strings, indexed into a closed `elevationStyles` record. A theme cannot add a level.
- **MediaTheme was never rendered.** The anchor wants light, dark, a custom theme *and* `MediaTheme` verified with screenshots. The contact sheet has the first three.

Neither is a new BLOCK. T19 blocks a closed map on a *themeable* axis, and `elevation` resolves to whole `shadowVars` tiers, which makes it a closed system axis in the sense P18 carves out for `size`, not a theme-extensible one. So the honest read is 4: the 5 anchor minus two of its clauses.

## Needs review

**The roving-tabindex question, and which pattern this component claims (A2).**
The group renders `role="group"`, keeps every member in the tab order (three tab stops, measured), and also wires arrow-key navigation. That combination matches no APG pattern: `Toolbar` in this repo pairs arrow navigation with `role="toolbar"` and `hasRovingTabIndex: true`. Which model ButtonGroup should take is the open design question in [#4238](https://github.com/facebook/astryx/issues/4238), so it is not settled here.

**[#4238](https://github.com/facebook/astryx/issues/4238) rests on a false premise, and its text is not corrected from this PR.**
It states that ButtonGroup "already does BOTH the connected visual AND roving via `useListFocus`". It does not. `ButtonGroup.tsx:173` calls `useListFocus` **without** `hasRovingTabIndex`, so the hook only moves focus and never touches `tabindex`; there is no single tab stop, and therefore no two roving layers to fight. Anyone picking that issue up would be working from a premise that does not hold. Left for @cixzhang to decide, because rewriting a design issue's framing is not an audit PR's call, but it should not sit there unflagged.

**The same T6 shape sits in four sibling components, and stays there.**
`Card`, `Button`, `Banner` and `ChatComposer` all apply `elevationStyles[elevation]` with `elevation` absent from their `themeProps` call, all from [#4251](https://github.com/facebook/astryx/pull/4251). Not touched here on purpose. A four-component sweep is a different change with a different blast radius and a different reviewer, and folding it into an audit of one component would make both harder to review and harder to revert. Each will come up in its own audit, or in one sweep diff that owns the whole shape.

**A member inside a group has no pressed state (B4, §5b).**
Measured with the pointer down and `:active` matching: `transform` stays `none` because `Button` drops `styles.pressable` inside a group, and the background is identical to hover. A standalone Button gets `scale(0.98)`. Whether a connected member should depress, and how, is a design call rather than a correction.

**Long labels overflow their container (R1, I18).**
The group is `inline-flex` and members do not wrap or truncate, so a group whose labels are wider than its container overflows it: 376px of members in a 280px container, and at a 320px viewport the document scrolls sideways (`scrollWidth` 392 against `clientWidth` 320). The new `LongLabels` story shows it. Wrapping, truncating or allowing members to shrink are three different answers, so this needs a decision.

![long labels](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5355/ButtonGroup__long-labels__320px__light-ltr.png)

**`ref={mergeRefs(ref, listRef)}` is built during render (`ButtonGroup.tsx:194`).**
Left alone deliberately: [#5267](https://github.com/facebook/astryx/pull/5267) migrates this exact line to `useMergedRefs` and [#5269](https://github.com/facebook/astryx/pull/5269) lints the pattern.

**A coarse pointer gets no larger hit area.** Icon members stay 32x32 under emulated `any-pointer: coarse`. Over the 24px floor, so not a finding against the group, and the sizing belongs to Button and IconButton.

Full contact sheet, 44 captures across 12 stories in light and dark, RTL, the y2k theme and forced colors: [assets/pr-5355](https://github.com/facebook/astryx/tree/assets/pr-5355).

## Checks

`pnpm build` and `pnpm lint:strict` clean. The ButtonGroup suite (36 tests) plus every other `useListFocus` consumer, since the fix moved onto the shared hook: `AvatarGroup`, `Breadcrumbs`, `ContextMenu`, `DropdownMenu`, `NavMenu`, `Outline`, `Pagination`, `SegmentedControl`, `SideNav`, `TabList`, `TabMenu`, `Toolbar`, `TopNav`, the whole `hooks` directory, and `Popover`, `Toast` and `HoverCard` for the layer side. 1198 tests over 45 files, all green. `check:sync`, `check:changesets`, `check:use-client`, `a11y:audit --components ButtonGroup` (0 violations, baseline unchanged), `rtl:audit --filter ButtonGroup`, and both disabled sweeps also pass locally.

Night Watch — Component Auditor
