### PR TITLE
fix: standalone BottomSheet dismisses on Escape during IME composition-cancel

### DIFF
--- a/.changeset/bottomsheet-standalone-ime-escape.md
+++ b/.changeset/bottomsheet-standalone-ime-escape.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `BottomSheet`: the standalone sheet no longer dismisses on the Escape a CJK user presses to cancel an in-progress IME composition.
+
+`handleKeyDown` read a bare `event.key === 'Escape'`, so pressing Escape to cancel a pending IME candidate (Korean/Japanese/Chinese input) closed the sheet along with it. `Dialog` and `BottomSheetSwitcher` already guard their own Escape handling with `isImeKeyEvent()`; the standalone sheet's `handleKeyDown` was the one path that did not. The reachable case is the documented `purpose="form"` and mobile-keyboard (`height="tall"`) usages, where a text field sits inside the sheet.
+
+`handleCancel` is left as-is, matching both `Dialog` and `BottomSheetSwitcher`: it only fires from the browser's native close-watcher, which does not run when `handleKeyDown` skips `preventDefault()` for a composing keydown, so there is nothing for it to guard against.
+
+@HelloOjasMutreja

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -334,6 +334,19 @@ describe('BottomSheet', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('ignores Escape while an IME composition is active', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
+        Content
+      </BottomSheet>,
+    );
+    const dialog = screen.getByRole('dialog');
+    fireEvent.keyDown(dialog, {key: 'Escape', isComposing: true});
+    fireEvent.keyDown(dialog, {key: 'Escape', keyCode: 229});
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it('requests close when the scrim (dialog element itself) is clicked', () => {
     const onOpenChange = vi.fn();
     render(

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -39,6 +39,7 @@ import type {BaseProps} from '../BaseProps';
 import type {DialogPurpose} from '../Dialog';
 import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
 import {useDevWarning, useScrollLock} from '../hooks';
+import {isImeKeyEvent} from '../utils/ime';
 import {
   BottomSheetPanel,
   type BottomSheetPanelMotion,
@@ -321,7 +322,7 @@ function StandaloneBottomSheet({
   );
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDialogElement>) => {
-      if (event.key === 'Escape') {
+      if (event.key === 'Escape' && !isImeKeyEvent(event.nativeEvent)) {
         event.preventDefault();
         dismissOnEscape();
       }


### PR DESCRIPTION
Fixes #5302.

## Problem

The standalone `BottomSheet`'s `handleKeyDown` reads a bare `event.key === 'Escape'`, so a CJK (Korean/Japanese/Chinese) user pressing Escape to cancel an in-progress IME composition dismisses the sheet instead of just cancelling the candidate.

`Dialog` guards this in its native `keydown` listener via `isImeKeyEvent(event)`, and `BottomSheetSwitcher`'s own `handleKeyDown` guards it the same way (`!isImeKeyEvent(event.nativeEvent)`). The standalone sheet's `handleKeyDown` was the one path in this family that didn't.

Reachable via the documented `purpose="form"` and mobile-keyboard (`height="tall"`) use cases, which put a text field inside a standalone sheet.

## Fix

```ts
const handleKeyDown = useCallback(
  (event: React.KeyboardEvent<HTMLDialogElement>) => {
    if (event.key === 'Escape' && !isImeKeyEvent(event.nativeEvent)) {
      event.preventDefault();
      dismissOnEscape();
    }
  },
  [dismissOnEscape],
);
```

One deviation from the issue's suggested fix: I left `handleCancel` unguarded. Checked both existing precedents first — neither `Dialog.handleCancel` nor `BottomSheetSwitcher.handleCancel` check `isImeKeyEvent`, only `handleKeyDown` does in both. That's not an oversight: `handleCancel` only runs off the browser's native `<dialog>` close-watcher, which doesn't fire when `handleKeyDown` skips `preventDefault()` for a composing keydown — the browser's own IME handling takes it from there. Guarding `handleCancel` too would be dead code with no existing precedent for it anywhere in this component family.

## Verification

Added a regression test (`ignores Escape while an IME composition is active`) mirroring the existing one in `BottomSheetSwitcher.test.tsx`. Confirmed it fails against the pre-fix code (reverted the implementation locally, test failed with `onOpenChange` called twice) and passes with the fix. Full `BottomSheet` suite (186 tests) passes, typecheck and lint are clean.

Not a visual change, so no before/after screenshot.