### PR TITLE
docs: add PR references to the v0.4.7 changesets

### DIFF
--- a/.changeset/bottom-sheet-noscrim-edge-tint.md
+++ b/.changeset/bottom-sheet-noscrim-edge-tint.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] BottomSheet: a non-modal sheet now colours the iOS 26 Safari toolbar strip with its own surface instead of letting the page show through behind the address bar.
+[fix] BottomSheet: a non-modal sheet now colours the iOS 26 Safari toolbar strip with its own surface instead of letting the page show through behind the address bar (#5342).
 
 @imdreamrunner

--- a/.changeset/bottom-sheet-tap-and-exit.md
+++ b/.changeset/bottom-sheet-tap-and-exit.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] BottomSheet: a tap inside the sheet is a tap, and the sheet leaves on an exit curve.
+[fix] BottomSheet: a tap inside the sheet is a tap, and the sheet leaves on an exit curve (#5326).
 
 Two defects, both of which read as "the sheet closes with no animation" — reported against the touch DateInput picker, which is a Bottom Sheet.
 

--- a/.changeset/list-focus-escape-passthrough.md
+++ b/.changeset/list-focus-escape-passthrough.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] `useListFocus` no longer swallows Escape when no `onEscape` was supplied. The hook called `preventDefault()` on every Escape — a habit inherited from the arrow keys, which share the handler and need it to suppress page scroll — so a list with nothing to dismiss still marked the key handled, and a surrounding layer that defers to `defaultPrevented` (a focus trap, a native popover) never got its turn. Escape is now consumed only when an `onEscape` is passed. Arrow, Home and End handling is unchanged.
+[fix] `useListFocus` no longer swallows Escape when no `onEscape` was supplied. The hook called `preventDefault()` on every Escape — a habit inherited from the arrow keys, which share the handler and need it to suppress page scroll — so a list with nothing to dismiss still marked the key handled, and a surrounding layer that defers to `defaultPrevented` (a focus trap, a native popover) never got its turn. Escape is now consumed only when an `onEscape` is passed. Arrow, Home and End handling is unchanged (#5346).
 
 Behaviour change: `AvatarGroup`, `ButtonGroup`, `Outline`, `Pagination`, `SegmentedControl`, `TabList` and `Toolbar` pass no `onEscape`, so an Escape pressed inside one of them now reaches the surrounding layer and can dismiss it — the point of the fix, but a host that counted on the key stopping there will notice. `NavHeadingMenu` does the same when it renders without a menu close handler. Menus and flyouts that do pass `onEscape` are unaffected. `patch`, not `[breaking]`: the swallowing was never a contract — the hook documented Escape only as "custom callback", and no component advertised consuming the key.
 


### PR DESCRIPTION
Three of the four pending v0.4.7 changesets carry no `(#PR)` reference: [#5342](https://github.com/facebook/astryx/pull/5342), [#5326](https://github.com/facebook/astryx/pull/5326), [#5346](https://github.com/facebook/astryx/pull/5346). Reference appended to each headline; no other text changed.

## Test plan
`audit.py`: `NO PR REF: 3 of 4` → `0 of 4`. `node scripts/check-changesets.mjs`: 4 valid.