### PR TITLE
docs(readme): link the Discord community

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An open source design system that's fully customizable and built for how we buil
 [![Storybook](https://img.shields.io/badge/Storybook-live-ff4785?logo=storybook&logoColor=white)](https://facebook.github.io/astryx/storybook/)
 [![Sandbox](https://img.shields.io/badge/Sandbox-playground-A9792B)](https://facebook.github.io/astryx/sandbox/)
 
-**[Docs](https://astryx.atmeta.com)** · **[Storybook](https://facebook.github.io/astryx/storybook/)** · **[Sandbox](https://facebook.github.io/astryx/sandbox/)** · **[Contributing](https://github.com/facebook/astryx/wiki/Contributing)**
+**[Docs](https://astryx.atmeta.com)** · **[Storybook](https://facebook.github.io/astryx/storybook/)** · **[Sandbox](https://facebook.github.io/astryx/sandbox/)** · **[Contributing](https://github.com/facebook/astryx/wiki/Contributing)** · **[Discord](https://discord.com/invite/XnsUcFykEP)**
 
 </div>
 
@@ -112,6 +112,9 @@ Battle-tested design solutions for common interactions and workflows: table page
 ## Contributing
 
 We welcome contributions! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide.
+
+Questions, or want a hand with a PR? Come find us in
+**[Discord](https://discord.com/invite/XnsUcFykEP)**.
 
 Our conventions and review rubrics live in the
 [Contributing wiki](https://github.com/facebook/astryx/wiki/Contributing) —


### PR DESCRIPTION
The docsite links Discord from its footer and its community page (`apps/docsite/src/constants.ts`), but the README never has — so it is invisible to anyone arriving from GitHub, which is where contributors actually start.

Two places, matching what is already there:

- the header link row, beside Docs / Storybook / Sandbox / Contributing
- one line under **Contributing**, so someone reading about opening a PR can find a human

Docs only. No changeset — nothing consumer-visible.