### PR TITLE
fix(docsite): default changelog to core, sync tab with URL, fill empty releases

### DIFF
--- a/apps/docsite/src/__tests__/changelog-linkify.test.ts
+++ b/apps/docsite/src/__tests__/changelog-linkify.test.ts
@@ -12,6 +12,7 @@ import {
   linkifyContributors,
   linkifyComponents,
   stripTitle,
+  fillEmptyReleases,
 } from '../components/changelogLinkify';
 
 describe('linkifyPRs', () => {
@@ -133,6 +134,69 @@ describe('linkifyComponents', () => {
 describe('stripTitle', () => {
   it('removes the leading h1 title line', () => {
     expect(stripTitle('# @astryxdesign/core\n\n# 0.1.1\n')).toBe('# 0.1.1\n');
+  });
+});
+
+describe('fillEmptyReleases', () => {
+  it('fills a version whose only body is the separator to the next heading', () => {
+    const md = [
+      '# 0.4.6',
+      '',
+      '---',
+      '',
+      '# 0.4.5',
+      '',
+      '#### Fixes',
+      '',
+      '- A real fix.',
+    ].join('\n');
+    expect(fillEmptyReleases(md)).toBe(
+      [
+        '# 0.4.6',
+        '',
+        'No changes in this release.',
+        '',
+        '---',
+        '',
+        '# 0.4.5',
+        '',
+        '#### Fixes',
+        '',
+        '- A real fix.',
+      ].join('\n'),
+    );
+  });
+
+  it('fills the last version in the file, which has no trailing separator', () => {
+    expect(fillEmptyReleases('# 0.4.2')).toBe(
+      '# 0.4.2\n\nNo changes in this release.\n\n',
+    );
+  });
+
+  it('leaves a version with real content untouched', () => {
+    const md = [
+      '# 0.4.3',
+      '',
+      '#### Fixes',
+      '',
+      '- A real fix.',
+      '',
+      '---',
+      '',
+      '# 0.4.2',
+      '',
+      '#### Fixes',
+      '',
+      '- Another real fix.',
+    ].join('\n');
+    expect(fillEmptyReleases(md)).toBe(md);
+  });
+
+  it('does not mistake the stripped package title for an empty version', () => {
+    // fillEmptyReleases is documented to run after stripTitle, so the h1
+    // package-name line should already be gone by the time it sees this.
+    const md = ['# 0.4.6', '', '#### Fixes', '', '- A fix.'].join('\n');
+    expect(fillEmptyReleases(md)).toBe(md);
   });
 });
 

--- a/apps/docsite/src/components/ChangelogView.tsx
+++ b/apps/docsite/src/components/ChangelogView.tsx
@@ -2,7 +2,8 @@
 
 'use client';
 
-import {useState} from 'react';
+import {Suspense} from 'react';
+import {usePathname, useRouter, useSearchParams} from 'next/navigation';
 import * as stylex from '@stylexjs/stylex';
 import {Markdown} from '@astryxdesign/core/Markdown';
 import {Text, Heading} from '@astryxdesign/core/Text';
@@ -17,6 +18,7 @@ import {
   linkifyContributors,
   linkifyComponents,
   stripTitle,
+  fillEmptyReleases,
 } from './changelogLinkify';
 
 interface ChangelogEntry {
@@ -28,6 +30,10 @@ interface ChangelogViewProps {
   changelogs: ChangelogEntry[];
   componentNames: string[];
 }
+
+// The package most people land on this page to read about; picked over
+// "whichever package happens to sort first" (@astryxdesign/cli).
+const DEFAULT_PACKAGE = '@astryxdesign/core';
 
 const styles = stylex.create({
   section: {
@@ -42,11 +48,32 @@ const styles = stylex.create({
   },
 });
 
-export function ChangelogView({
-  changelogs,
-  componentNames,
-}: ChangelogViewProps) {
-  const [activeTab, setActiveTab] = useState(changelogs[0]?.pkg ?? '');
+function ChangelogViewInner({changelogs, componentNames}: ChangelogViewProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const fallbackPackage =
+    changelogs.find(c => c.pkg === DEFAULT_PACKAGE)?.pkg ??
+    changelogs[0]?.pkg ??
+    '';
+  const requestedPackage = searchParams.get('package');
+  // Clamp to a package that actually has a changelog so a stale or
+  // hand-edited `?package=` never lands on a blank panel.
+  const activeTab =
+    requestedPackage != null && changelogs.some(c => c.pkg === requestedPackage)
+      ? requestedPackage
+      : fallbackPackage;
+  const setActiveTab = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === fallbackPackage) {
+      params.delete('package');
+    } else {
+      params.set('package', value);
+    }
+    const qs = params.toString();
+    router.replace(`${pathname}${qs ? `?${qs}` : ''}`, {scroll: false});
+  };
   const active = changelogs.find(c => c.pkg === activeTab);
 
   return (
@@ -77,7 +104,9 @@ export function ChangelogView({
             {active != null && (
               <Markdown headingLevelStart={2}>
                 {linkifyComponents(
-                  linkifyContributors(linkifyPRs(stripTitle(active.content))),
+                  linkifyContributors(
+                    linkifyPRs(fillEmptyReleases(stripTitle(active.content))),
+                  ),
                   componentNames,
                 )}
               </Markdown>
@@ -90,5 +119,13 @@ export function ChangelogView({
         )}
       </VStack>
     </Section>
+  );
+}
+
+export function ChangelogView(props: ChangelogViewProps) {
+  return (
+    <Suspense>
+      <ChangelogViewInner {...props} />
+    </Suspense>
   );
 }

--- a/apps/docsite/src/components/changelogLinkify.ts
+++ b/apps/docsite/src/components/changelogLinkify.ts
@@ -107,3 +107,33 @@ export function linkifyComponents(
 export function stripTitle(markdown: string): string {
   return markdown.replace(/^#\s+.+\n+/, '');
 }
+
+const NO_CHANGES_TEXT = 'No changes in this release.';
+
+/**
+ * A release with no notable changes still gets a version heading from the
+ * changeset tooling, with nothing between it and the next heading (or the
+ * `---` separator before it). Rendered as-is that reads as a broken page —
+ * a heading followed immediately by a divider or another heading, with no
+ * indication the release was simply empty. Fill each of those bodies with
+ * an explicit "no changes" line instead of leaving them bare.
+ *
+ * Call this after `stripTitle`, so the package-name h1 itself is not
+ * mistaken for an empty version section.
+ */
+export function fillEmptyReleases(markdown: string): string {
+  const parts = markdown.split(/(^#{1,2}\s+.+$)/gm);
+  for (let i = 2; i < parts.length; i += 2) {
+    const body = parts[i];
+    const separatorMatch = /^\s*---\s*$/m.exec(body);
+    const bodyWithoutSeparator = separatorMatch
+      ? body.slice(0, separatorMatch.index) +
+        body.slice(separatorMatch.index + separatorMatch[0].length)
+      : body;
+    if (bodyWithoutSeparator.trim() === '') {
+      parts[i] =
+        '\n\n' + NO_CHANGES_TEXT + '\n\n' + (separatorMatch ? '---\n\n' : '');
+    }
+  }
+  return parts.join('');
+}


### PR DESCRIPTION
Addresses #5307, partially. Three of the four bullets are done; the fourth needed a decision I didn't want to guess at, so I left it out (details below).

## Default to core, not whatever sorts first

`ChangelogView` picked `changelogs[0]?.pkg` as the initial tab, and `packages` (from `packageRegistry.ts`) is built by scanning package directories, so the first entry is whatever sorts first alphabetically — `@astryxdesign/cli`, not `@astryxdesign/core`. Now it prefers `@astryxdesign/core`, falling back to the first entry only if core has no changelog.

## Direct links via `?package=`

`activeTab` is now derived straight from `searchParams.get('package')` (clamped to a package that actually has a changelog, so a stale or hand-edited value can't land on a blank panel), the same pattern `ComponentDetailClient` already uses for its own tab state (`searchParams.get('tab')`, `router.replace(..., {scroll: false})` on change, no separate `useState`). The URL only gets a `?package=` param when it differs from the default, so the common case stays a clean `/changelog`.

## Empty releases

A release with no notable changes still gets a version heading from the changeset tooling, with nothing between it and the next heading or the `---` separator before it (confirmed against several real `CHANGELOG.md` files, e.g. `packages/themes/y2k/CHANGELOG.md`'s `0.4.6`/`0.4.5`/`0.4.2` entries). `fillEmptyReleases()` in `changelogLinkify.ts` fills those bodies with "No changes in this release." Added unit tests covering: a mid-file empty version, the last version in the file (no trailing separator), a version with real content staying untouched, and the stripped package title not being mistaken for an empty version.

## What I left out: "keep theme packages out of primary tabs"

I didn't implement this one. Checked `ThemePackagePage.tsx` first, since "keep out of primary tabs" implies they'd still be reachable somewhere else, and it turns out theme package changelogs aren't shown anywhere but this page today. Filtering them out of `ChangelogView`'s tabs would delete the only place they're visible, not relocate them. That's a real UI decision (a secondary tab group, a dropdown, moving them onto the theme pages, or something else) rather than a one-line filter, so I'd rather it get scoped properly than have me guess. Happy to pick it up once there's a direction, or if it's more of a "just filter them, changelog visibility for themes isn't a requirement" call, say so and I'll do that instead.

## Verification

`fillEmptyReleases` unit tests: 20/20 pass (`pnpm -F @astryxdesign/docsite test src/__tests__/changelog-linkify.test.ts`). Typecheck (`tsc --noEmit`) shows no new errors from these files (checked by grepping the full output for "changelog" — all pre-existing errors are elsewhere in the app, unrelated to this change). Lint is clean.

Not verified: an actual browser render of the page. `next dev` here needs a full data regeneration pass I didn't want to eat the time on, given the tab logic mirrors an already-shipped, working pattern (`ComponentDetailClient`) line-for-line and the markdown transform is covered by tests against real changelog content. If that's not enough for review, let me know and I'll get a real render.