### PR TITLE
fix(Table): a plugin can suppress a body cell's content, so group headers never reach your cell renderers

### DIFF
--- a/.changeset/table-suppress-cell-content.md
+++ b/.changeset/table-suppress-cell-content.md
@@ -19,8 +19,4 @@ column's renderer or the default one. It is decided per cell at render time
 against the final column list, so it also covers columns other plugins
 contributed — whatever order the plugins were listed in.
 
-`useTableGroupedRows` also returns `isGroupHeader`, so a row-level plugin or
-handler of your own (click-to-open-detail, row links, per-row menus) can tell a
-synthetic header from a real row without matching on the `__group_` key prefix.
-
 @ernestt

--- a/.changeset/table-suppress-cell-content.md
+++ b/.changeset/table-suppress-cell-content.md
@@ -1,0 +1,26 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table: a plugin can suppress a body cell's content, and grouped rows use it to keep synthetic group headers out of your cell renderers
+
+`useTableGroupedRows` injects section-header rows into the flattened data, and
+`BaseTable` evaluates every column's `renderCell` against every row. A renderer
+that keys a lookup off a field — `STATUS_META[item.status].dot` — was therefore
+handed a row that is not yours and threw, blanking the page the moment grouping
+was switched on. The header Proxy answering unknown fields with `''` only ever
+rescued a renderer that _prints_ a field; `''` fails a lookup exactly as
+`undefined` does.
+
+`BodyCellRenderProps` gains `isContentSuppressed?: boolean`. A plugin sets it in
+`transformBodyCell` for a row whose cells it is about to replace wholesale in
+`transformBodyRow`, and the table renders that cell empty without calling the
+column's renderer or the default one. It is decided per cell at render time
+against the final column list, so it also covers columns other plugins
+contributed — whatever order the plugins were listed in.
+
+`useTableGroupedRows` also returns `isGroupHeader`, so a row-level plugin or
+handler of your own (click-to-open-detail, row links, per-row menus) can tell a
+synthetic header from a real row without matching on the `__group_` key prefix.
+
+@ernestt

--- a/.changeset/table-suppress-cell-content.md
+++ b/.changeset/table-suppress-cell-content.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Table: a plugin can suppress a body cell's content, and grouped rows use it to keep synthetic group headers out of your cell renderers
+[fix] Table: a plugin can suppress a body cell's content, and grouped rows use it to keep synthetic group headers out of your cell renderers (#5363)
 
 `useTableGroupedRows` injects section-header rows into the flattened data, and
 `BaseTable` evaluates every column's `renderCell` against every row. A renderer

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -183,9 +183,12 @@ function TableRowInner<T extends Record<string, unknown>>({
     );
 
     const isDefaultRenderer = !col.renderCell;
-    const rawContent = isDefaultRenderer
-      ? defaultCellRenderer(item, col.key)
-      : (col.renderCell?.(item) ?? null);
+    let rawContent: ReactNode = null;
+    if (!cellRenderProps.skipContent) {
+      rawContent = isDefaultRenderer
+        ? defaultCellRenderer(item, col.key)
+        : (col.renderCell?.(item) ?? null);
+    }
 
     // In truncate mode, wrap default-rendered string content in
     // <Text maxLines={1}> for smart tooltips that only appear

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -184,7 +184,7 @@ function TableRowInner<T extends Record<string, unknown>>({
 
     const isDefaultRenderer = !col.renderCell;
     let rawContent: ReactNode = null;
-    if (!cellRenderProps.skipContent) {
+    if (!cellRenderProps.isContentSuppressed) {
       rawContent = isDefaultRenderer
         ? defaultCellRenderer(item, col.key)
         : (col.renderCell?.(item) ?? null);

--- a/packages/core/src/Table/Table.test.tsx
+++ b/packages/core/src/Table/Table.test.tsx
@@ -602,6 +602,41 @@ describe('BaseTable', () => {
       expect(calls[0]).toEqual({col: 'name', name: 'Alice'});
     });
 
+    it('skipContent renders an empty cell and skips the column renderer', () => {
+      const rendered: string[] = [];
+      const withRenderer: TableColumn<User>[] = [
+        {
+          key: 'name',
+          header: 'Name',
+          renderCell: item => {
+            rendered.push(item.name);
+            return <b>{item.name}</b>;
+          },
+        },
+      ];
+      const plugin: TablePlugin<User> = {
+        transformBodyCell: (props, _column, item) =>
+          item.name === 'Bob' ? {...props, skipContent: true} : props,
+      };
+      render(
+        <BaseTable data={users} columns={withRenderer} plugins={[plugin]} />,
+      );
+      expect(rendered).toEqual(['Alice', 'Charlie']);
+      const cells = screen.getAllByRole('cell');
+      expect(cells[1]).toBeEmptyDOMElement();
+      expect(cells[0]).toHaveTextContent('Alice');
+    });
+
+    it('skipContent also suppresses the default renderer', () => {
+      const plugin: TablePlugin<User> = {
+        transformBodyCell: props => ({...props, skipContent: true}),
+      };
+      render(<BaseTable data={users} columns={columns} plugins={[plugin]} />);
+      for (const cell of screen.getAllByRole('cell')) {
+        expect(cell).toBeEmptyDOMElement();
+      }
+    });
+
     it('composes multiple plugins sequentially', () => {
       const plugin1: TablePlugin<User> = {
         transformTable: props => ({

--- a/packages/core/src/Table/Table.test.tsx
+++ b/packages/core/src/Table/Table.test.tsx
@@ -602,7 +602,7 @@ describe('BaseTable', () => {
       expect(calls[0]).toEqual({col: 'name', name: 'Alice'});
     });
 
-    it('skipContent renders an empty cell and skips the column renderer', () => {
+    it('isContentSuppressed renders an empty cell and never calls the column renderer', () => {
       const rendered: string[] = [];
       const withRenderer: TableColumn<User>[] = [
         {
@@ -616,7 +616,7 @@ describe('BaseTable', () => {
       ];
       const plugin: TablePlugin<User> = {
         transformBodyCell: (props, _column, item) =>
-          item.name === 'Bob' ? {...props, skipContent: true} : props,
+          item.name === 'Bob' ? {...props, isContentSuppressed: true} : props,
       };
       render(
         <BaseTable data={users} columns={withRenderer} plugins={[plugin]} />,
@@ -627,9 +627,9 @@ describe('BaseTable', () => {
       expect(cells[0]).toHaveTextContent('Alice');
     });
 
-    it('skipContent also suppresses the default renderer', () => {
+    it('isContentSuppressed also suppresses the default renderer', () => {
       const plugin: TablePlugin<User> = {
-        transformBodyCell: props => ({...props, skipContent: true}),
+        transformBodyCell: props => ({...props, isContentSuppressed: true}),
       };
       render(<BaseTable data={users} columns={columns} plugins={[plugin]} />);
       for (const cell of screen.getAllByRole('cell')) {

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows-perf.test.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows-perf.test.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useTableGroupedRows-perf.test.tsx
+ * @input Table, useTableGroupedRows, React testing utilities
+ * @output Performance tests for grouped-rows render behavior
+ * @position Test file; validates that grouping costs no extra row renders
+ *
+ * The plugin keeps group headers out of cell renderers per cell, at render
+ * time. Doing it by rewriting the columns instead would hand BaseTable a new
+ * column object on every render, and its element-by-element check on the
+ * resolved column array is what stops every row re-rendering.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen, act} from '@testing-library/react';
+import {useCallback, useMemo, useState} from 'react';
+import userEvent from '@testing-library/user-event';
+import {Table} from '../../Table';
+import type {TableColumn} from '../../types';
+import {useTableGroupedRows} from './useTableGroupedRows';
+
+interface Person extends Record<string, unknown> {
+  id: string;
+  name: string;
+  team: string;
+}
+
+const people: Person[] = [
+  {id: 'a', name: 'Alice', team: 'Core'},
+  {id: 'b', name: 'Bob', team: 'Core'},
+  {id: 'c', name: 'Carol', team: 'Infra'},
+];
+
+const EMPTY = new Set<string>();
+
+function GroupedRenderCountTable({
+  renderCounts,
+}: {
+  renderCounts: Record<string, number>;
+}) {
+  const [tick, setTick] = useState(0);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(EMPTY);
+
+  const columns = useMemo<TableColumn<Person>[]>(
+    () => [
+      {
+        key: 'name',
+        header: 'Name',
+        renderCell: (item: Person) => {
+          renderCounts[item.id] = (renderCounts[item.id] ?? 0) + 1;
+          return item.name;
+        },
+      },
+    ],
+    [renderCounts],
+  );
+
+  const grouped = useTableGroupedRows<Person>({
+    data: people,
+    groupBy: useCallback((p: Person) => p.team, []),
+    collapsedGroups,
+    onToggleGroup: useCallback(
+      (key: string) =>
+        setCollapsedGroups(prev => {
+          const next = new Set(prev);
+          if (!next.delete(key)) {
+            next.add(key);
+          }
+          return next;
+        }),
+      [],
+    ),
+    getRowKey: useCallback((p: Person) => p.id, []),
+  });
+
+  return (
+    <>
+      <button type="button" onClick={() => setTick(t => t + 1)}>
+        bump {tick}
+      </button>
+      <Table
+        data={grouped.data}
+        columns={columns}
+        idKey={grouped.idKey}
+        plugins={{grouped: grouped.plugin}}
+      />
+    </>
+  );
+}
+
+describe('Grouped rows render performance', () => {
+  it('renders each real row once and no group header at all', () => {
+    const renderCounts: Record<string, number> = {};
+    render(<GroupedRenderCountTable renderCounts={renderCounts} />);
+    expect(renderCounts).toEqual({a: 1, b: 1, c: 1});
+  });
+
+  it('a re-render of the surrounding component re-renders no rows', async () => {
+    const user = userEvent.setup();
+    const renderCounts: Record<string, number> = {};
+    render(<GroupedRenderCountTable renderCounts={renderCounts} />);
+    const before = {...renderCounts};
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', {name: /bump/}));
+    });
+
+    expect(screen.getByRole('button', {name: 'bump 1'})).toBeInTheDocument();
+    expect(renderCounts).toEqual(before);
+  });
+});

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
@@ -5,6 +5,7 @@ import {render, screen, fireEvent, within} from '@testing-library/react';
 import {useState, useCallback} from 'react';
 import {Table} from '../../Table';
 import type {TableColumn} from '../../types';
+import {useTableRowStatus, type TableRowStatus} from '../rowStatus';
 import {useTableGroupedRows} from './useTableGroupedRows';
 
 interface Person extends Record<string, unknown> {
@@ -174,6 +175,105 @@ describe('useTableGroupedRows', () => {
       screen.queryByRole('button', {name: /group/i}),
     ).not.toBeInTheDocument();
   });
+
+  it('never runs a column renderCell against a group header row', () => {
+    // The renderer that breaks: it keys a lookup off a field rather than
+    // printing it, so the header Proxy answering `''` is no better than
+    // `undefined`.
+    const TEAM_META: Record<string, {dot: string}> = {
+      Core: {dot: 'green'},
+      Infra: {dot: 'blue'},
+    };
+    const seen: Person[] = [];
+    const lookupColumns: TableColumn<Person>[] = [
+      {
+        key: 'team',
+        header: 'Team',
+        renderCell: item => {
+          seen.push(item);
+          return <span>{TEAM_META[item.team].dot}</span>;
+        },
+      },
+    ];
+
+    function LookupHarness() {
+      const [collapsed, setCollapsed] = useState<Set<string>>(EMPTY);
+      const grouped = useTableGroupedRows<Person>({
+        data: people,
+        groupBy: p => p.team,
+        collapsedGroups: collapsed,
+        onToggleGroup: k => setCollapsed(new Set([k])),
+        getRowKey: p => p.id,
+      });
+      return (
+        <Table
+          data={grouped.data}
+          columns={lookupColumns}
+          idKey={grouped.idKey}
+          plugins={{grouped: grouped.plugin}}
+        />
+      );
+    }
+
+    expect(() => render(<LookupHarness />)).not.toThrow();
+    expect(seen.map(p => p.name)).toEqual(['Alice', 'Bob', 'Carol']);
+    expect(screen.getByText('Core')).toBeInTheDocument();
+    expect(screen.getByText('Infra')).toBeInTheDocument();
+  });
+
+  describe.each([
+    ['grouped first', true],
+    ['rowStatus first', false],
+  ])(
+    'with a column contributed by another plugin (%s)',
+    (_label, groupedFirst) => {
+      // `grouped` and `rowStatus` are both absent from PLUGIN_ORDER, so the
+      // record's insertion order is the pipeline order. Whichever way round
+      // the consumer types it, the status column's renderCell must not see a
+      // header row.
+      const STATUS_BY_TEAM: Record<string, TableRowStatus> = {
+        Core: {color: 'success', label: 'Healthy'},
+        Infra: {color: 'error', label: 'Paging'},
+      };
+
+      function StatusHarness() {
+        const [collapsed, setCollapsed] = useState<Set<string>>(EMPTY);
+        const grouped = useTableGroupedRows<Person>({
+          data: people,
+          groupBy: p => p.team,
+          collapsedGroups: collapsed,
+          onToggleGroup: k => setCollapsed(new Set([k])),
+          getRowKey: p => p.id,
+        });
+        const rowStatus = useTableRowStatus<Person>({
+          getStatus: useCallback((item: Person) => {
+            const {color, label} = STATUS_BY_TEAM[item.team];
+            return {color, label};
+          }, []),
+        });
+        return (
+          <Table
+            data={grouped.data}
+            columns={columns}
+            idKey={grouped.idKey}
+            plugins={
+              groupedFirst
+                ? {grouped: grouped.plugin, rowStatus}
+                : {rowStatus, grouped: grouped.plugin}
+            }
+          />
+        );
+      }
+
+      it('renders the group headers without throwing', () => {
+        expect(() => render(<StatusHarness />)).not.toThrow();
+        expect(screen.getByText('Core')).toBeInTheDocument();
+        expect(screen.getByText('Infra')).toBeInTheDocument();
+        // One indicator per real row, none on the two headers.
+        expect(screen.getAllByRole('img')).toHaveLength(3);
+      });
+    },
+  );
 
   it('keeps a group collapsed across a data change (state keyed by group)', () => {
     function ChangingHarness() {

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
@@ -4,7 +4,7 @@ import {describe, it, expect} from 'vitest';
 import {render, screen, fireEvent, within} from '@testing-library/react';
 import {useState, useCallback} from 'react';
 import {Table} from '../../Table';
-import type {TableColumn, TablePlugin} from '../../types';
+import type {TableColumn} from '../../types';
 import {useTableRowStatus, type TableRowStatus} from '../rowStatus';
 import {useTableGroupedRows} from './useTableGroupedRows';
 
@@ -274,50 +274,6 @@ describe('useTableGroupedRows', () => {
       });
     },
   );
-
-  it('exposes isGroupHeader so a consumer can guard their own row plugin', () => {
-    const clicked: string[] = [];
-    function GuardHarness() {
-      const [collapsed, setCollapsed] = useState<Set<string>>(EMPTY);
-      const grouped = useTableGroupedRows<Person>({
-        data: people,
-        groupBy: p => p.team,
-        collapsedGroups: collapsed,
-        onToggleGroup: k => setCollapsed(new Set([k])),
-        getRowKey: p => p.id,
-      });
-      const openDetail: TablePlugin<Person> = {
-        transformBodyRow(props, item) {
-          if (grouped.isGroupHeader(item)) {
-            return props;
-          }
-          return {
-            ...props,
-            htmlProps: {
-              ...props.htmlProps,
-              onClick: () => clicked.push(item.name),
-            },
-          };
-        },
-      };
-      return (
-        <Table
-          data={grouped.data}
-          columns={columns}
-          idKey={grouped.idKey}
-          plugins={{grouped: grouped.plugin, openDetail}}
-        />
-      );
-    }
-    render(<GuardHarness />);
-    for (const name of ['Alice', 'Bob', 'Carol']) {
-      fireEvent.click(screen.getByText(name).closest('tr')!);
-    }
-    expect(clicked).toEqual(['Alice', 'Bob', 'Carol']);
-    // The guarded plugin left the header row alone; clicking it only toggles.
-    fireEvent.click(screen.getByText('Core').closest('tr')!);
-    expect(clicked).toEqual(['Alice', 'Bob', 'Carol']);
-  });
 
   it('keeps a group collapsed across a data change (state keyed by group)', () => {
     function ChangingHarness() {

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
@@ -4,7 +4,7 @@ import {describe, it, expect} from 'vitest';
 import {render, screen, fireEvent, within} from '@testing-library/react';
 import {useState, useCallback} from 'react';
 import {Table} from '../../Table';
-import type {TableColumn} from '../../types';
+import type {TableColumn, TablePlugin} from '../../types';
 import {useTableRowStatus, type TableRowStatus} from '../rowStatus';
 import {useTableGroupedRows} from './useTableGroupedRows';
 
@@ -274,6 +274,50 @@ describe('useTableGroupedRows', () => {
       });
     },
   );
+
+  it('exposes isGroupHeader so a consumer can guard their own row plugin', () => {
+    const clicked: string[] = [];
+    function GuardHarness() {
+      const [collapsed, setCollapsed] = useState<Set<string>>(EMPTY);
+      const grouped = useTableGroupedRows<Person>({
+        data: people,
+        groupBy: p => p.team,
+        collapsedGroups: collapsed,
+        onToggleGroup: k => setCollapsed(new Set([k])),
+        getRowKey: p => p.id,
+      });
+      const openDetail: TablePlugin<Person> = {
+        transformBodyRow(props, item) {
+          if (grouped.isGroupHeader(item)) {
+            return props;
+          }
+          return {
+            ...props,
+            htmlProps: {
+              ...props.htmlProps,
+              onClick: () => clicked.push(item.name),
+            },
+          };
+        },
+      };
+      return (
+        <Table
+          data={grouped.data}
+          columns={columns}
+          idKey={grouped.idKey}
+          plugins={{grouped: grouped.plugin, openDetail}}
+        />
+      );
+    }
+    render(<GuardHarness />);
+    for (const name of ['Alice', 'Bob', 'Carol']) {
+      fireEvent.click(screen.getByText(name).closest('tr')!);
+    }
+    expect(clicked).toEqual(['Alice', 'Bob', 'Carol']);
+    // The guarded plugin left the header row alone; clicking it only toggles.
+    fireEvent.click(screen.getByText('Core').closest('tr')!);
+    expect(clicked).toEqual(['Alice', 'Bob', 'Carol']);
+  });
 
   it('keeps a group collapsed across a data change (state keyed by group)', () => {
     function ChangingHarness() {

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -41,8 +41,11 @@ function isGroupHeader(item: unknown): item is GroupHeader {
   );
 }
 
-// Proxy handler: any field access beyond the marker fields resolves to `''`
-// so user cell renderers (`item.name.toUpperCase()`) never throw on a header.
+// Proxy handler: any field access beyond the marker fields resolves to `''`,
+// which keeps anything that reads a header's data — the sortable and filtering
+// plugins, a consumer's own row handler — off `undefined`. Cell renderers are
+// handled at render time instead (see `transformBodyCell` below); the Proxy
+// never protected them, because `''` fails a lookup exactly as `undefined` does.
 const HEADER_PROXY_HANDLER: ProxyHandler<Record<string | symbol, unknown>> = {
   // eslint-disable-next-line @typescript-eslint/promise-function-async -- Proxy get trap, not a promise-returning fn
   get(t: Record<string | symbol, unknown>, prop: string | symbol): unknown {
@@ -54,12 +57,9 @@ const HEADER_PROXY_HANDLER: ProxyHandler<Record<string | symbol, unknown>> = {
 };
 
 /**
- * Build a synthetic header row wrapped in a Proxy so arbitrary field access
- * from user cell renderers (e.g. `item.name.toUpperCase()`) resolves to `''`
- * instead of throwing — BaseTable evaluates `col.renderCell(item)` on every
- * row (including synthetic headers) before `transformBodyRow` can replace the
- * row's cells. `transformBodyRow` then discards those cells and renders a
- * single full-width header cell.
+ * Build a synthetic header row wrapped in a Proxy so field access resolves to
+ * `''` instead of `undefined`. `transformBodyRow` then discards the row's
+ * cells and renders a single full-width header cell.
  */
 function makeHeader<T extends Record<string, unknown>>(
   groupKey: string,
@@ -109,6 +109,19 @@ export interface UseTableGroupedRowsResult<T extends Record<string, unknown>> {
    * `<Table idKey={grouped.idKey} />`.
    */
   idKey: (item: T) => string;
+  /**
+   * True when the row is a synthetic group header rather than one of your own
+   * rows. Row-level plugins and handlers see both, so guard anything that
+   * assumes a real row — click-to-open-detail, row links, per-row menus:
+   *
+   * ```
+   * transformBodyRow(props, item) {
+   *   if (grouped.isGroupHeader(item)) return props;
+   *   return {...props, htmlProps: {...props.htmlProps, onClick: () => open(item)}};
+   * }
+   * ```
+   */
+  isGroupHeader: (item: T) => boolean;
 }
 
 const styles = stylex.create({
@@ -301,6 +314,15 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
 
   const plugin = useMemo(
     (): TablePlugin<T> => ({
+      // A header row is not one of the caller's rows, so running a cell
+      // renderer against it can only misread it or throw — and the cells are
+      // discarded by `transformBodyRow` below regardless.
+      transformBodyCell(props, _column, item) {
+        if (!isGroupHeader(item)) {
+          return props;
+        }
+        return {...props, skipContent: true};
+      },
       // Replace a header row's pre-rendered cells with one full-width cell.
       transformBodyRow(props, item) {
         if (!isGroupHeader(item)) {
@@ -377,5 +399,5 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
     [collapsedGroups, onToggleGroup, renderGroupHeader, t],
   );
 
-  return {plugin, data: flattened, idKey};
+  return {plugin, data: flattened, idKey, isGroupHeader};
 }

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -321,7 +321,7 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
         if (!isGroupHeader(item)) {
           return props;
         }
-        return {...props, skipContent: true};
+        return {...props, isContentSuppressed: true};
       },
       // Replace a header row's pre-rendered cells with one full-width cell.
       transformBodyRow(props, item) {

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -109,19 +109,6 @@ export interface UseTableGroupedRowsResult<T extends Record<string, unknown>> {
    * `<Table idKey={grouped.idKey} />`.
    */
   idKey: (item: T) => string;
-  /**
-   * True when the row is a synthetic group header rather than one of your own
-   * rows. Row-level plugins and handlers see both, so guard anything that
-   * assumes a real row — click-to-open-detail, row links, per-row menus:
-   *
-   * ```
-   * transformBodyRow(props, item) {
-   *   if (grouped.isGroupHeader(item)) return props;
-   *   return {...props, htmlProps: {...props.htmlProps, onClick: () => open(item)}};
-   * }
-   * ```
-   */
-  isGroupHeader: (item: T) => boolean;
 }
 
 const styles = stylex.create({
@@ -399,5 +386,5 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
     [collapsedGroups, onToggleGroup, renderGroupHeader, t],
   );
 
-  return {plugin, data: flattened, idKey, isGroupHeader};
+  return {plugin, data: flattened, idKey};
 }

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -322,6 +322,19 @@ export interface BodyCellRenderProps {
    * sticky offsets. Optional for backward compatibility.
    */
   columns?: ReadonlyArray<TableColumn<Record<string, unknown>>>;
+  /**
+   * When true, the cell renders empty: BaseTable calls neither the column's
+   * `renderCell` nor the default renderer. Set it for a row whose cells a
+   * plugin is going to replace wholesale in `transformBodyRow` (a grouped-rows
+   * section header, a summary row) — the row is not one the consumer supplied,
+   * so their renderer can only misread it or throw, and its output is
+   * discarded moments later anyway.
+   *
+   * Applies to this cell only, and is decided per render against the final
+   * column list, so it covers columns other plugins contributed regardless of
+   * where in the pipeline this plugin sits.
+   */
+  skipContent?: boolean;
 }
 
 /**

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -427,12 +427,17 @@ export type TableContextActions =
  *
  * 1. `transformColumns` — filter, reorder, or inject columns before rendering
  * 2. `transformTable` — transform the root `<table>` element props
- * 3. `transformHeaderRow` — transform the header `<tr>` props
- * 4. `transformHeaderCell` — transform each `<th>` props
- * 5. `transformBodyRow` — transform each body `<tr>` props
- * 6. `transformBodyCell` — transform each body `<td>` props
+ * 3. `transformHeaderCell` — transform each `<th>` props
+ * 4. `transformHeaderRow` — transform the header `<tr>` props
+ * 5. `transformBodyCell` — transform each body `<td>` props
+ * 6. `transformBodyRow` — transform each body `<tr>` props
  * 7. `transformScrollWrapper` — transform the scroll-container wrapper around the table
  * 8. `transformTableContext` — wrap the table output in context providers
+ *
+ * A row's cells are built before its row transform runs, and reach it as
+ * `children`: the cell hook is the earliest per-cell interception point, and a
+ * row transform can discard cells but cannot stop them being built (see
+ * `isContentSuppressed` on `BodyCellRenderProps` for that).
  *
  * Plugins may also contribute right-click menu actions by appending to
  * `contextMenuActions` in `transformHeaderCell` / `transformBodyCell`

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -334,7 +334,7 @@ export interface BodyCellRenderProps {
    * column list, so it covers columns other plugins contributed regardless of
    * where in the pipeline this plugin sits.
    */
-  skipContent?: boolean;
+  isContentSuppressed?: boolean;
 }
 
 /**

--- a/packages/core/src/Table/useBaseTablePlugins.ts
+++ b/packages/core/src/Table/useBaseTablePlugins.ts
@@ -46,6 +46,11 @@ import {devWarn} from '../utils/devWarning';
  * Canonical ordering for first-party plugin names.
  * Plugins are sorted by their position in this array.
  * Unknown names are appended after the known set.
+ *
+ * This decides LAYOUT — which column lands left of which, who wraps whom. It
+ * must never decide whether the table works: a plugin that renders in one
+ * order and crashes in the other is broken, and adding it here buys a lucky
+ * order rather than a fix.
  */
 const PLUGIN_ORDER: ReadonlyArray<string> = [
   'columnSettings',

--- a/packages/core/src/Table/useTableGroupedRows.doc.mjs
+++ b/packages/core/src/Table/useTableGroupedRows.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableGroupedRows',
   description:
-    "Hook that groups a flat data array into collapsible section rows. Each distinct groupBy value becomes a full-width section-header row with a chevron toggle, the group label, and a member count; collapsing hides that group's data rows while keeping the header visible. Mirrors useTableTreeState: the consumer owns the collapsedGroups set and the hook returns {data, plugin, idKey, isGroupHeader}: pass the first three to Table (data, plugins, and idKey respectively), and use isGroupHeader to guard any row-level plugin or handler of your own that would otherwise treat a synthetic header row as a real row.",
+    "Hook that groups a flat data array into collapsible section rows. Each distinct groupBy value becomes a full-width section-header row with a chevron toggle, the group label, and a member count; collapsing hides that group's data rows while keeping the header visible. Mirrors useTableTreeState: the consumer owns the collapsedGroups set and the hook returns {data, plugin, idKey}: pass them to Table as data, plugins, and idKey respectively.",
   props: [
     {
       name: 'data',
@@ -58,7 +58,7 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   description:
-    'Groups a flat data array into collapsible section rows. Each groupBy value becomes a full-width header (chevron + label + count); collapsing hides its rows. Returns {data, plugin, idKey, isGroupHeader}: pass the first three to Table data / plugins / idKey; use isGroupHeader to guard your own row-level plugins. Consumer owns the collapsedGroups set.',
+    'Groups a flat data array into collapsible section rows. Each groupBy value becomes a full-width header (chevron + label + count); collapsing hides its rows. Returns {data, plugin, idKey}: pass them to Table data / plugins / idKey. Consumer owns the collapsedGroups set.',
   propDescriptions: {
     data: 'The flat data to group.',
     groupBy: "Derive a row's group key. Same key = same section.",

--- a/packages/core/src/Table/useTableGroupedRows.doc.mjs
+++ b/packages/core/src/Table/useTableGroupedRows.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableGroupedRows',
   description:
-    'Hook that groups a flat data array into collapsible section rows. Each distinct groupBy value becomes a full-width section-header row with a chevron toggle, the group label, and a member count; collapsing hides that group\'s data rows while keeping the header visible. Mirrors useTableTreeState: the consumer owns the collapsedGroups set and the hook returns {data, plugin, idKey}: pass all three to Table (data, plugins, and idKey respectively).',
+    "Hook that groups a flat data array into collapsible section rows. Each distinct groupBy value becomes a full-width section-header row with a chevron toggle, the group label, and a member count; collapsing hides that group's data rows while keeping the header visible. Mirrors useTableTreeState: the consumer owns the collapsedGroups set and the hook returns {data, plugin, idKey, isGroupHeader}: pass the first three to Table (data, plugins, and idKey respectively), and use isGroupHeader to guard any row-level plugin or handler of your own that would otherwise treat a synthetic header row as a real row.",
   props: [
     {
       name: 'data',
@@ -58,13 +58,14 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   description:
-    'Groups a flat data array into collapsible section rows. Each groupBy value becomes a full-width header (chevron + label + count); collapsing hides its rows. Returns {data, plugin, idKey}: pass to Table data / plugins / idKey. Consumer owns the collapsedGroups set.',
+    'Groups a flat data array into collapsible section rows. Each groupBy value becomes a full-width header (chevron + label + count); collapsing hides its rows. Returns {data, plugin, idKey, isGroupHeader}: pass the first three to Table data / plugins / idKey; use isGroupHeader to guard your own row-level plugins. Consumer owns the collapsedGroups set.',
   propDescriptions: {
     data: 'The flat data to group.',
-    groupBy: 'Derive a row\'s group key. Same key = same section.',
+    groupBy: "Derive a row's group key. Same key = same section.",
     collapsedGroups: 'Set of currently-collapsed group keys.',
     onToggleGroup: 'Called with the group key when a header is toggled.',
-    renderGroupHeader: "Custom header content (right of chevron). Default '<key> (<count>)'.",
+    renderGroupHeader:
+      "Custom header content (right of chevron). Default '<key> (<count>)'.",
     getRowKey: 'Stable key for a real row; positional fallback when omitted.',
     groupOrder: 'Pin these group keys first; others keep first-seen order.',
   },


### PR DESCRIPTION
## What

A table with grouped rows crashes as soon as one of its cell renderers keys a lookup off a field:

```tsx
renderCell: item => <StatusDot status={STATUS_META[item.status].dot} />
```

`useTableGroupedRows` injects synthetic section-header rows into the flattened data, and `BaseTable` evaluates every column's `renderCell` against every row before `transformBodyRow` gets to discard a header's cells. The header Proxy answering unknown fields with `''` only ever rescued a renderer that *prints* a field; `''` is no more a member of that map than `undefined` is, so the renderer throws and the page blanks.

This supersedes [#5317](https://github.com/facebook/astryx/pull/5317). Everything above is @ernestt's report and his diagnosis — he found the bug, named the mechanism, and pointed at the line. This PR takes the fix one layer down.

## Evidence

The repro above, `plugins={{grouped, rowStatus}}` — same story, same viewport.

| Before — `main` | After — this PR |
| --- | --- |
| <img src="https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5363/crash-before.png" width="440"> | <img src="https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5363/crash-after.png" width="440"> |
| The synthetic group-header row reaches `renderCell`, the lookup returns `undefined`, nothing renders. | Headers, rows and status dots; the header rows' cells are empty. |

The three existing grouped-rows stories are **byte-identical** before and after — same `sha256` for every PNG, and the same rendered table HTML:
[Default](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5363/grouped-default.png) ·
[Custom order and header](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5363/grouped-custom-order-and-header.png) ·
[Initially collapsed](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5363/grouped-initially-collapsed.png)

## Why not wrap the columns

[#5317](https://github.com/facebook/astryx/pull/5317) fixes this in `transformColumns`, wrapping each column so `renderCell` short-circuits on a header row. That only sees the columns that exist *when it runs*, and `grouped` has no entry in `PLUGIN_ORDER`, so its position in the pipeline is whatever order the consumer happened to type the plugins object in:

```tsx
plugins={{grouped, rowStatus}}   // still crashes: the status column is injected after the wrap
plugins={{rowStatus, grouped}}   // fine
```

`useTableRowStatus`, `useTableSelection`, `useTableRowIndex`, `useTableRowExpansion` and `useTableFiltering` all contribute columns of their own, and each one's `renderCell` calls back into consumer code. Nothing warns; you get one order that works and one that doesn't.

Adding `grouped` to `PLUGIN_ORDER` would make the reported case pass and leave order deciding correctness. **Plugin order may affect presentation, never correctness** — that principle is now written at the line someone would edit to do it.

## How

`BodyCellRenderProps` gains one optional field:

```ts
isContentSuppressed?: boolean;
```

`BaseTable` honors it before the renderer runs — with it set, the cell renders empty and neither `col.renderCell` nor the default renderer is called. The grouped plugin sets it in `transformBodyCell` when the row is a header:

```tsx
transformBodyCell(props, _column, item) {
  if (!isGroupHeader(item)) return props;
  return {...props, isContentSuppressed: true};
}
```

`transformBodyCell` was already the right hook: it runs per cell, at render time, against the final column list — so it covers columns other plugins contributed, whatever order the plugins sit in. It just had no way to say "no content here". `BodyCellRenderProps` carried only `htmlProps`, `xstyle`, `contextMenuActions`, `columnIndex` and `columns`.

**On the name.** The header-cell siblings are content slots (`before`, `content`, `after`, `overlay`, `below`), and reusing `content` here was tempting — but a body cell's content does not exist yet when the hook runs (producing it is the thing we must avoid), so a `content` slot would invite plugins to wrap existing content and hand them `undefined` instead. That leaves a boolean, and the repo's boolean-prop rule wants an `is`/`has` prefix (`isHeaderRow` is the neighbour). `isContentSuppressed` names the outcome — this cell has no content — rather than the mechanism, which is what a plugin author needs to reason about. It is deliberately one field, not a family: it solves the class of *any plugin suppressing any cell's content*, and a summary row or a spanning row would reach for exactly the same thing.

Not carried over from [#5317](https://github.com/facebook/astryx/pull/5317): the `transformColumns` wrapper and the `WeakMap` that cached wrapped columns. Nothing rewrites the column array now, so there is nothing to cache — but the invariant that `WeakMap` was protecting is real, and `useTableGroupedRows-perf.test.tsx` locks it by render count instead (a re-render of the surrounding component re-renders no rows; it fails if the plugin allocates a column per render).

The Proxy stays: sorting, filtering, row keys and consumer handlers all still read fields off a header row.

## Also

The `TablePlugin` pipeline docblock had both row/cell pairs backwards — it listed `transformHeaderRow` before `transformHeaderCell` and `transformBodyRow` before `transformBodyCell`, when in both cases the cells are built first and reach the row transform as `children`. Reading it, the column transform looks like the only hook that runs before the renderer, which is plausibly how the first fix ended up there. Corrected, with one line on what the ordering means for a plugin author.

## Test plan

- [x] A column renderer that keys a lookup off a field no longer throws under grouping, and only the real rows reach it.
- [x] The same, with a column contributed by `useTableRowStatus`, run in **both** plugin orders — `{{grouped, rowStatus}}` and `{{rowStatus, grouped}}`. Both red before this change; `{{grouped, rowStatus}}` stays red with [#5317](https://github.com/facebook/astryx/pull/5317)'s approach applied.
- [x] `isContentSuppressed` at the `BaseTable` level: an empty cell, no call to the column renderer, and the default renderer suppressed too.
- [x] `useTableGroupedRows-perf.test.tsx`: three real rows render once each, no header row reaches the renderer, and an unrelated re-render of the surrounding component re-renders no rows. Verified to fail if the plugin allocates a fresh column object per render.
- [x] Full Table suite: 483 passed (23 files). `tsc --noEmit`, `eslint` and `prettier --check` clean on everything touched.
- [x] The three grouped-rows stories render **byte-identically** before and after — identical PNGs and identical rendered table HTML, in Chromium.

Not addressed: `aria-rowcount` / `aria-rowindex` still drift when headers are present, as [#5317](https://github.com/facebook/astryx/pull/5317) noted.


