### PR TITLE
refactor(markdown): SourceRange as an object, not a tuple

### DIFF
--- a/.changeset/markdown-source-ranges.md
+++ b/.changeset/markdown-source-ranges.md
@@ -5,9 +5,10 @@
 [feat] Markdown: opt-in source ranges on parsed blocks
 
 `parseMarkdown(source, {sourceRanges: true})` now gives every top-level block a
-`range` — the `[start, end)` offsets it occupies in the source that was passed
-in — so a consumer holding that source can slice the original markdown for a
-block instead of reconstructing it from the node (or from the rendered DOM).
+`range` — `{start, end}`, the character offsets it occupies in the source that
+was passed in, with `end` exclusive — so a consumer holding that source can
+`source.slice(range.start, range.end)` for a block instead of reconstructing it
+from the node (or from the rendered DOM).
 Reconstruction is lossy in ways slicing is not: escapes, the exact emphasis and
 fence characters, heading depth beyond the clamp, and alignment all survive a
 slice unchanged.

--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -6,7 +6,7 @@ import {
   parseMarkdownIncremental,
   createIncrementalState,
 } from './parser';
-import type {BlockNode} from './parser';
+import type {BlockNode, ParseOptions} from './parser';
 
 function generateAIResponse(paragraphs: number): string {
   const sections: string[] = [];
@@ -68,6 +68,42 @@ function simulateStreamingIncremental(
   }
   return parseMarkdownIncremental(fullText, state);
 }
+
+/**
+ * How many blocks each chunk of a streamed document had to build.
+ *
+ * A block the parser kept in its settled cache is handed back as the very same
+ * object, so a returned block that is not one of the previous chunk's is one
+ * this chunk built. That makes the cache countable without reaching into the
+ * parser's internals.
+ */
+function blocksBuiltPerChunk(
+  fullText: string,
+  chunkSize: number,
+  options?: ParseOptions,
+): number[] {
+  const state = createIncrementalState();
+  let previous: ReadonlySet<BlockNode> = new Set();
+  const built: number[] = [];
+  const step = (text: string) => {
+    const blocks =
+      options == null
+        ? parseMarkdownIncremental(text, state)
+        : parseMarkdownIncremental(text, state, options);
+    built.push(blocks.reduce((n, b) => (previous.has(b) ? n : n + 1), 0));
+    previous = new Set(blocks);
+  };
+  for (let i = chunkSize; i <= fullText.length; i += chunkSize) {
+    step(fullText.slice(0, i));
+  }
+  step(fullText);
+  return built;
+}
+
+const median = (values: number[]): number =>
+  [...values].sort((a, b) => a - b)[Math.floor((values.length - 1) / 2)];
+
+const sum = (values: number[]): number => values.reduce((a, b) => a + b, 0);
 
 // A single wall-clock measurement is flaky when the whole suite runs in
 // parallel forks: scheduler contention can inflate a millisecond-scale
@@ -202,5 +238,39 @@ describe('parseMarkdown performance', () => {
 
     // Incremental should be at least as fast (allowing small margin for noise)
     expect(incrElapsed).toBeLessThanOrEqual(fullElapsed * 1.1);
+  });
+});
+
+// What the incremental parser exists for is a cache, so these assert the cache:
+// integers that come out the same on a loaded CI box as on an idle laptop,
+// unlike the wall-clock budgets above.
+describe('parseMarkdownIncremental cache', () => {
+  it('builds a bounded number of blocks per chunk however long the document is', () => {
+    const chunkSize = 50;
+    const medians = [50, 200, 500].map(paragraphs =>
+      median(blocksBuiltPerChunk(generateAIResponse(paragraphs), chunkSize)),
+    );
+    console.log(
+      `  median blocks built per chunk (50/200/500 paragraphs): ${medians.join('/')}`,
+    );
+    // A chunk re-parses its unsettled tail, not the document — so the typical
+    // chunk's cost is a constant, and a 10x longer document does not move it.
+    expect(medians).toEqual([2, 2, 2]);
+  });
+
+  it('keeps the cache when source ranges are asked for', () => {
+    const text = generateAIResponse(200);
+    const chunkSize = 50;
+    const without = sum(blocksBuiltPerChunk(text, chunkSize));
+    const withRanges = sum(
+      blocksBuiltPerChunk(text, chunkSize, {sourceRanges: true}),
+    );
+    console.log(
+      `  blocks built streaming ${text.length} chars: ${without} without ranges, ${withRanges} with`,
+    );
+    // Stamping offsets must not cost a cache entry. An implementation that
+    // tracked positions by invalidating the settled cache each chunk would
+    // still pass any time budget generous enough not to flake; it fails here.
+    expect(withRanges).toBe(without);
   });
 });

--- a/packages/core/src/Markdown/parser.test.ts
+++ b/packages/core/src/Markdown/parser.test.ts
@@ -1216,12 +1216,20 @@ describe('link reference definitions', () => {
 });
 
 describe('sourceRanges', () => {
-  const slice = (source: string, block: {range?: readonly [number, number]}) =>
-    block.range == null ? null : source.slice(block.range[0], block.range[1]);
+  const slice = (source: string, block: BlockNode) =>
+    block.range == null
+      ? null
+      : source.slice(block.range.start, block.range.end);
 
   it('is off by default', () => {
     const [block] = parseMarkdown('# Title');
     expect(block.range).toBeUndefined();
+  });
+
+  it('addresses a block with named start and end offsets', () => {
+    const source = 'One.\n\nTwo.';
+    const [, second] = parseMarkdown(source, {sourceRanges: true});
+    expect(second.range).toEqual({start: 6, end: 10});
   });
 
   it('gives every top-level block the source it came from', () => {
@@ -1324,7 +1332,11 @@ describe('sourceRanges', () => {
     const with_ = parseMarkdownIncremental(source, state, {
       sourceRanges: true,
     });
-    expect(with_.map(b => slice(source, b))).toEqual(['One.', 'Two.', 'Three.']);
+    expect(with_.map(b => slice(source, b))).toEqual([
+      'One.',
+      'Two.',
+      'Three.',
+    ]);
     const back = parseMarkdownIncremental(source, state);
     expect(back.every(b => b.range == null)).toBe(true);
   });

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -56,10 +56,15 @@ type BlockNodeKind =
   | {type: 'image'; src: string; alt: string};
 
 /**
- * Character offsets `[start, end)` of a block in the source string handed to
- * `parseMarkdown`. `end` excludes the block's trailing blank lines.
+ * Where a block sits in the source string handed to `parseMarkdown`:
+ * `source.slice(start, end)` is the block, and `end` excludes the block's
+ * trailing blank lines.
+ *
+ * An object rather than a `[start, end]` tuple so a second way of addressing
+ * the same block — line numbers, once a consumer needs them — can be added as
+ * optional fields without breaking anyone.
  */
-export type SourceRange = readonly [start: number, end: number];
+export type SourceRange = {readonly start: number; readonly end: number};
 
 export type ListItemNode = {checked?: boolean; children: BlockNode[]};
 export type TableCellNode = {children: InlineNode[]};
@@ -1540,7 +1545,7 @@ function stampSourceRanges(
     // range that dropped it would slice to something that re-parses
     // differently.
     const end = lineStart(endLine) + lines[endLine].length;
-    blocks[i] = {...blocks[i], range: [lineStart(startLine), end]};
+    blocks[i] = {...blocks[i], range: {start: lineStart(startLine), end}};
   }
 }
 
@@ -1876,7 +1881,7 @@ function mergeSettledBlocks(
       // One list now, so one range: from where the first half started to
       // where the second half ended.
       ...(prevLast.range != null && deltaFirst.range != null
-        ? {range: [prevLast.range[0], deltaFirst.range[1]] as SourceRange}
+        ? {range: {start: prevLast.range.start, end: deltaFirst.range.end}}
         : null),
     };
     return [...prev.slice(0, -1), merged, ...delta.slice(1)];


### PR DESCRIPTION
## Problem

[#5290](https://github.com/facebook/astryx/pull/5290) landed `parseMarkdown(source, {sourceRanges: true})` → `BlockNode.range` this morning, spelled as a tuple:

```ts
export type SourceRange = readonly [start: number, end: number];
```

Character offsets are the right primary unit — they are what a chat transcript needs to slice a selection back out as markdown, and the incremental parser stamps them without giving up its settled cache. But a tuple is a closed shape. The next consumer that needs a *line* (a diff or blame view is line-addressed, and a block nested in a blockquote has lines but no contiguous `[start, end)`) cannot be served by adding a field — it gets a second property with a second name, and `BlockNode` carries two spellings of one concept forever.

Core is published at 0.4.7 and `main` is unreleased, so today the shape is still free to change. After the release cut it is not.

## Solution

```ts
export type SourceRange = {readonly start: number; readonly end: number};
```

Same two numbers, same half-open meaning. Three call sites: `stampSourceRanges`, which builds the range for each block; `mergeSettledBlocks`, which joins the two halves of an incrementally-merged list into one; and the tests.

`mergeSettledBlocks` gets the clearest of it. `[prevLast.range[0], deltaFirst.range[1]] as SourceRange` needed the assertion because an array literal widens, and the reader has to know that index 0 is a start and index 1 is an end to see that it is right. `{start: prevLast.range.start, end: deltaFirst.range.end}` is structurally checked and says what it is.

Nothing here adds line numbers or nested-block coverage. Both are real and both want a consumer first; this is the shape only, so that when one arrives it is `{start, end, startLine?, endLine?}` and not a break.

## API

```
~ SourceRange: readonly [start, end]  →  {readonly start: number; readonly end: number}   (public, core barrel)
  BlockNode.range?: SourceRange — unchanged name, unchanged optionality
```

The `readonly` is carried over from the tuple, so the immutability guarantee is the same one #5290 shipped.

**What the change costs.** It costs the call site its nicest spelling: `source.slice(...block.range)` was a genuinely good line and `source.slice(block.range.start, block.range.end)` is not. That is the honest price and it is worth paying once. `SourceRange` is exported public surface, and an object is strictly more surface than a tuple: two named members that can never be renamed, plus the implicit promise that the type is open to more members. That is the point of paying it — the alternative is either freezing the tuple and adding `position` alongside it later, or a breaking change to a released type. The class this serves is not speculative: line-addressed consumers were the whole subject of [#5154](https://github.com/facebook/astryx/pull/5154), and nested blocks can only ever be addressed by line. What it costs to be wrong is small and bounded, because it is the same two numbers either way — the field names are the only thing being frozen that was not frozen before.

## Theme targets

No new theme targets.

## Breaking

- **API — yes, `SourceRange` changed shape**, and any `const [start, end] = block.range` stops compiling. But there is no consumer who can be broken: `@astryxdesign/core` is published at 0.4.7, `sourceRanges` merged into unreleased `main` a few hours ago, and nothing in the repo destructures a range outside the tests this PR updates. That is precisely why it is being done now rather than argued about later.
- **Visual** — no. Nothing renders; the parser's output is unchanged for every caller who does not pass `sourceRanges`.
- **Theme** — no. No targets, tokens or overrides involved.

Every difference between the two shapes surfaces at compile time — a destructure, a spread, an index — so there is no silent behavioral drift to hunt for. The two that would be silent if anything consumed them are `JSON.stringify` of a block (`[6,10]` becomes `{"start":6,"end":10}`) and a `toEqual` against a literal range; nothing outside the tests this PR updates does either.

The title says `refactor` and that is checked, not assumed: no runtime behavior changes, and no installed consumer can be broken, so it is not a `!`.

## Performance

No runtime cost. One object literal per block instead of one array literal per block, only when `sourceRanges: true`, and only for top-level blocks.

The real perf content here is a test that was owed. `parser.perf.test.ts` asserts wall-clock milliseconds; what the incremental parser actually exists to protect is its settled-block cache, and a cache is countable. A settled block is handed back as the same object, so a returned block that is not one of the previous chunk's is one this chunk built:

```
median blocks built per chunk (50/200/500 paragraphs): 2/2/2
blocks built streaming 26351 chars: 20975 without ranges, 20975 with
```

Two assertions, both integers, neither touching a clock:

1. The median chunk rebuilds 2 blocks at 50, 200 and 500 paragraphs — a chunk re-parses its unsettled tail, not the document, and a 10× longer document does not move that.
2. Asking for source ranges costs exactly zero extra rebuilds.

Both were checked against the failure they exist to catch. Making the parser drop its settled cache when `sourceRanges` is on takes (2) from `20975 === 20975` to `62524 vs 20975`; making it re-parse the whole input every chunk takes (1) from `2/2/2` to `31/118/293`. A wall-clock budget loose enough not to flake on a loaded runner passes both mutants.

## Testing

`vitest run packages/core/src/Markdown/` — 272 passing. Targeted only; CI is the full check.

## Two findings, deliberately not fixed here

Both are pre-existing and both want their own PR — one change at a time.

1. **`parser.perf.test.ts` has five `expect(elapsed).toBeLessThan(maxMs)` assertions.** They are the shape that gets deleted after it flakes on a shared runner, and they cannot see a 2× regression hiding under headroom. The new cache assertions are additive; replacing the wall-clock ones is a separate change with its own argument to make.
2. **`parseMarkdownIncremental` full-re-parses on every chunk that lands inside an unclosed code fence.** `findSettledBoundary` returns `-1` there and the whole input is re-parsed, so ~30% of chunks in the perf fixture rebuild every block — visible as the spread between the median (2) and the total (20975). Correct, but it is the streaming case an AI transcript hits most, and a fence that streams for 200 chars costs a full re-parse per chunk for its whole length.
