### PR TITLE
docs(cli): say who packages/cli/assets/docs is written for

### DIFF
--- a/.claude/skills/writing-component-docs.md
+++ b/.claude/skills/writing-component-docs.md
@@ -4,6 +4,8 @@
 
 Every component directory has a `{Name}.doc.mjs` file with structured documentation. The Astryx CLI reads these files to generate agent-friendly docs, skill files, and reference material.
 
+These docs are for people **building with** Astryx, not for people building Astryx. Before adding process material — a rubric, a readiness gate, an audit checklist, lab→core criteria — read [`packages/cli/assets/docs/README.md`](../../packages/cli/assets/docs/README.md), which carries the test and the wiki page each kind goes to.
+
 ## Exports
 
 | Export      | Type                      | Purpose                          | Required?                       |
@@ -122,7 +124,7 @@ astryx --detail compact --lang dense component Button  # Compact + compressed
 
 Reference docs (tokens, principles, theme) use a different type: `ReferenceDoc` from `@astryxdesign/cli/authoring`.
 
-They live in `packages/cli/docs/` as `.doc.mjs` files with translations in `*.doc.dense.mjs` and `*.doc.zh.mjs`.
+They live in `packages/cli/assets/docs/` as `.doc.mjs` files with translations in `*.doc.dense.mjs` and `*.doc.zh.mjs`.
 
 Content is structured as sections with ordered content blocks:
 
@@ -131,7 +133,7 @@ Content is structured as sections with ordered content blocks:
 - `table` — data tables (not translated)
 - `list` — rules, anti-patterns, tips (translatable)
 
-To add a new reference doc: create `packages/cli/docs/mytopic.doc.mjs` exporting a `docs` constant. It auto-discovers.
+To add a new reference doc: create `packages/cli/assets/docs/mytopic.doc.mjs` exporting a `docs` constant. It auto-discovers.
 
 ```bash
 astryx docs                          # list topics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,8 @@ Documentation lives in two places:
 
 **Update Protocol**: When modifying code, update the file's header comment. Look for `SYNC:` comments as reminders.
 
+**Audience**: every `.doc.mjs`, and everything under `packages/cli/assets/docs/`, is written for people **building with** Astryx — not for people building Astryx. Rubrics, readiness gates, audit checklists and lab→core criteria belong in the wiki. [`packages/cli/assets/docs/README.md`](packages/cli/assets/docs/README.md) has the test and the page each kind of material goes to.
+
 ## Quick Reference
 
 - **Package manager**: pnpm 11, pinned by the `packageManager` field (see

--- a/packages/cli/assets/docs/README.md
+++ b/packages/cli/assets/docs/README.md
@@ -2,7 +2,9 @@
 
 Reference topics for people **building with** Astryx. Not docs about building Astryx itself.
 
-One `{topic}.doc.mjs` per topic, plus optional `{topic}.doc.dense.mjs` / `{topic}.doc.zh.mjs` prose overlays. `foundation/discovery/docs-discovery.mjs` picks up any `{topic}.doc.mjs` in this directory with no registration, and `api/docs/_adapter.mjs` merges the overlays. What you add here reaches `astryx docs <topic>`, `astryx search`, the `--json` API, the agent-docs block, and the doc site — and ships on npm.
+One `{topic}.doc.mjs` per topic, plus optional `{topic}.doc.dense.mjs` / `{topic}.doc.zh.mjs` prose overlays. `foundation/discovery/docs-discovery.mjs` picks up any `{topic}.doc.mjs` here with no registration; `api/docs/_adapter.mjs` merges the overlays.
+
+What you add reaches `astryx docs <topic>`, `astryx search`, the `--json` API, the agent-docs block and the doc site — and ships on npm.
 
 ## Who you are writing for
 
@@ -21,14 +23,14 @@ Someone building a product with Astryx. Their questions:
 - second person aimed at the wrong reader — "reviewers should…", "before promoting a component…", "attach evidence for…"
 - **rubric, readiness, gate, audit, checklist, sign-off, promotion, evidence** as things the reader must produce
 - a table of things to verify rather than things to use
-- anything about lab → core, which is our lifecycle and not theirs
+- anything about lab → core, which is our lifecycle, not theirs
 - Storybook, Playwright, CI or the Simulator named as tools the reader runs
 
 One subtlety: a statement about the **system's behavior** is caller-facing even when it sounds like process. "A component's theme targets are stable once published" tells a caller what they can rely on; "reviewers must check that theme targets are stable" is ours. Same fact, different reader — **rewrite it rather than move it**.
 
 ## Where the rest goes
 
-The material is usually good; the finding is placement, not quality. It goes in the [wiki](https://github.com/facebook/astryx/wiki) — **as a section on the page that already covers it, not a new page.** The wiki is at 58 pages with several overlapping because every stray section got its own.
+The material is usually good; the finding is placement, not quality. It goes in the [wiki](https://github.com/facebook/astryx/wiki) — **as a section on the page that already covers it, not a new page.** The wiki is at nearly 60 pages, several of them overlapping, because every stray section got its own.
 
 | what you wrote                                      | where it goes                                                                                                                                                                                |
 | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -41,7 +43,7 @@ The material is usually good; the finding is placement, not quality. It goes in 
 | API naming and shape decisions                      | [API-Conventions](https://github.com/facebook/astryx/wiki/API-Conventions), [API-Arbitration](https://github.com/facebook/astryx/wiki/API-Arbitration)                                       |
 | contributor workflow, PR process                    | [Contributing](https://github.com/facebook/astryx/wiki/Contributing), [Contributing-with-AI-Assistants](https://github.com/facebook/astryx/wiki/Contributing-with-AI-Assistants)             |
 | release mechanics                                   | [Release-Process](https://github.com/facebook/astryx/wiki/Release-Process)                                                                                                                   |
-| what a nightly agent role does                      | the [Night-Watch-Overview](https://github.com/facebook/astryx/wiki/Night-Watch-Overview) pages                                                                                               |
+| what a nightly agent role does                      | the Night-Watch pages, from [Night-Watch-Overview](https://github.com/facebook/astryx/wiki/Night-Watch-Overview)                                                                             |
 
 **Fits no row?** It is still not caller-facing. Default it to [Contributing](https://github.com/facebook/astryx/wiki/Contributing), or `CONTRIBUTING.md` when it is a step someone follows with the repo cloned. Never default it back to this directory.
 

--- a/packages/cli/assets/docs/README.md
+++ b/packages/cli/assets/docs/README.md
@@ -1,0 +1,48 @@
+# /packages/cli/assets/docs
+
+Reference topics for people **building with** Astryx. Not docs about building Astryx itself.
+
+One `{topic}.doc.mjs` per topic, plus optional `{topic}.doc.dense.mjs` / `{topic}.doc.zh.mjs` prose overlays. `foundation/discovery/docs-discovery.mjs` picks up any `{topic}.doc.mjs` in this directory with no registration, and `api/docs/_adapter.mjs` merges the overlays. What you add here reaches `astryx docs <topic>`, `astryx search`, the `--json` API, the agent-docs block, and the doc site — and ships on npm.
+
+## Who you are writing for
+
+Someone building a product with Astryx. Their questions:
+
+- what a component is for, and when to reach for something else
+- the props, their defaults, and what each does to what they see
+- how to compose it, and the pattern to copy
+- what it costs — bundle size, the a11y obligations they inherit
+- how to theme it, and which targets are stable
+
+**The test for anything you add: does a caller act on it?** They are not reviewing a PR, promoting a component out of lab, or attaching evidence to a checklist.
+
+## Tells that you are writing for us instead
+
+- second person aimed at the wrong reader — "reviewers should…", "before promoting a component…", "attach evidence for…"
+- **rubric, readiness, gate, audit, checklist, sign-off, promotion, evidence** as things the reader must produce
+- a table of things to verify rather than things to use
+- anything about lab → core, which is our lifecycle and not theirs
+- Storybook, Playwright, CI or the Simulator named as tools the reader runs
+
+One subtlety: a statement about the **system's behavior** is caller-facing even when it sounds like process. "A component's theme targets are stable once published" tells a caller what they can rely on; "reviewers must check that theme targets are stable" is ours. Same fact, different reader — **rewrite it rather than move it**.
+
+## Where the rest goes
+
+The material is usually good; the finding is placement, not quality. It goes in the [wiki](https://github.com/facebook/astryx/wiki) — **as a section on the page that already covers it, not a new page.** The wiki is at 58 pages with several overlapping because every stray section got its own.
+
+| what you wrote                                      | where it goes                                                                                                                                                                                |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| how a component is graded — checks, scoring         | [Component-Audit-Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric)                                                                                                     |
+| lab → core promotion, what a component must satisfy | [Component-Lifecycle](https://github.com/facebook/astryx/wiki/Component-Lifecycle)                                                                                                           |
+| how to build a new component                        | [Component-Authoring-Guide](https://github.com/facebook/astryx/wiki/Component-Authoring-Guide), [Creating-New-Components](https://github.com/facebook/astryx/wiki/Creating-New-Components)   |
+| what a component must be hardened against           | [Component-Hardening-Protocol](https://github.com/facebook/astryx/wiki/Component-Hardening-Protocol), [Hardening-Audit-Guide](https://github.com/facebook/astryx/wiki/Hardening-Audit-Guide) |
+| a11y requirements as checks we run                  | [Accessibility-Checklist](https://github.com/facebook/astryx/wiki/Accessibility-Checklist)                                                                                                   |
+| how the system is put together                      | [System-Architecture](https://github.com/facebook/astryx/wiki/System-Architecture), [Theming-Infrastructure](https://github.com/facebook/astryx/wiki/Theming-Infrastructure)                 |
+| API naming and shape decisions                      | [API-Conventions](https://github.com/facebook/astryx/wiki/API-Conventions), [API-Arbitration](https://github.com/facebook/astryx/wiki/API-Arbitration)                                       |
+| contributor workflow, PR process                    | [Contributing](https://github.com/facebook/astryx/wiki/Contributing), [Contributing-with-AI-Assistants](https://github.com/facebook/astryx/wiki/Contributing-with-AI-Assistants)             |
+| release mechanics                                   | [Release-Process](https://github.com/facebook/astryx/wiki/Release-Process)                                                                                                                   |
+| what a nightly agent role does                      | the [Night-Watch-Overview](https://github.com/facebook/astryx/wiki/Night-Watch-Overview) pages                                                                                               |
+
+**Fits no row?** It is still not caller-facing. Default it to [Contributing](https://github.com/facebook/astryx/wiki/Contributing), or `CONTRIBUTING.md` when it is a step someone follows with the repo cloned. Never default it back to this directory.
+
+Worked example: a responsive-and-interaction readiness rubric is grading criteria → **Component-Audit-Rubric**, or **Component-Lifecycle** if it is a promotion gate.


### PR DESCRIPTION
## Summary

Nothing in `packages/cli/assets/docs/` says who its topics are written for, so material about *building Astryx* keeps landing in docs a *caller* reads. This adds the missing context where someone lands before adding a file.

- **`packages/cli/assets/docs/README.md`** (new) — what actually consumes this directory, then the audience: these topics are for people **building with** Astryx, not docs about building Astryx itself. The test (*does a caller act on this?*), the tells (*"reviewers should…"*, rubric/readiness/gate/audit/checklist/promotion as things the reader must produce, lab→core, CI tools named as tools the reader runs), and the subtlety that a statement about the *system's behavior* is caller-facing even when it sounds like process — rewrite, don't relocate.
- **A routing table to the wiki**, because "put it in the wiki" without a page gets ignored. Ten rows mapping the kind of material to the page that already covers it, with a default for material that fits none, an instruction to add a section rather than create a page, and one worked example (a responsive/interaction readiness rubric is grading criteria → Component-Audit-Rubric, or Component-Lifecycle if it is a promotion gate). All 15 linked pages return 200.
- **Two pointers, no copies** — `CLAUDE.md` and `.claude/skills/writing-component-docs.md` each get one sentence and a link. The README is the only place the rule is stated.
- **Drive-by**: that skill said reference docs live in `packages/cli/docs/`. They live in `packages/cli/assets/docs/`. Fixed both mentions — a wrong path there sends an agent to the wrong directory.

## The automated check: worth building, but narrower than the obvious version

Not in this PR. I measured it rather than guessing, because the obvious version is a word list and I assumed it would be noisy. Counting hits of each tell-word across the 27 existing `assets/docs/*.doc.mjs` files, against the file [#5351](https://github.com/facebook/astryx/pull/5351) adds:

| word | main (27 files) | [#5351](https://github.com/facebook/astryx/pull/5351) |
| --- | --- | --- |
| `evidence` | 0 | 47 |
| `readiness` | 0 | 7 |
| `rubric` | 0 | 2 |
| `promotion`, `sign-off` | 0 | 0 |
| `checklist` | 4 | 1 |
| `audit` | 2 | 0 |
| `gate` | 0 | 1 |
| `lab` | 148 | 5 |

**Drop `audit`, `checklist` and `gate`.** They produce all six of the current hits and every one is legitimate caller-facing prose — migration's "Verification Checklist", "Audit every pre-existing global or reset stylesheet", styling-libraries' "Interop Checklist". Those are checklists the *caller* runs on their own app, which is exactly the innocent use. **Drop `lab` too**: 148 hits, all `label`/`available`/`collaborate`.

**Keep `rubric`, `readiness`, `promotion`, `sign-off`, `evidence`.** That set scores **0 on main and 56 in [#5351](https://github.com/facebook/astryx/pull/5351)** — it would have caught it on the first commit, with no violations to migrate and no false positives to suppress. Cheapest home is a case in `docs-discovery.test.mjs`, which already walks the directory, with the failure message pointing at this README.

The residual risk is a legitimate future doc about, say, a component's readiness state; an inline suppression comment covers that, and one suppression a year is a fair price. Happy to build it as a follow-up if you want it.

## Validation

- `pnpm exec prettier --check` on all three files
- `pnpm exec vitest run packages/cli/foundation/discovery/docs-discovery.test.mjs packages/cli/api/docs` — 65 tests pass
- `pnpm check:cli-structure`, `pnpm check:sync`
- `astryx docs` still lists 20 topics; discovery's `^([\w-]+)\.doc\.mjs$` ignores `README.md`, so it is not a topic and does not appear in `astryx search`
- Rendered on GitHub in Chromium and read: h1, lead sentence, the 10-row table and all 16 wiki links resolve (`shots-5368/readme-rendered.png`)
- No changeset: nothing a consumer of `@astryxdesign/cli` can observe changes. The file does ride along in the published tarball (`files` includes `assets`), at ~4 KB.
