### PR TITLE
test(cli): lint assets/docs for our-process words shipped to callers

### DIFF
--- a/packages/cli/foundation/discovery/docs-discovery.test.mjs
+++ b/packages/cli/foundation/discovery/docs-discovery.test.mjs
@@ -13,6 +13,7 @@
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {CLI_ROOT} from '../fs/paths.mjs';
 import {
   BUILTIN_DOCS_PACKAGE,
   DocsCatalog,
@@ -57,6 +58,41 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('assets/docs audience', () => {
+  // packages/cli/assets/docs ships to people BUILDING WITH Astryx, not people
+  // building Astryx itself — see the README's own audience rule and routing
+  // table. These five words are a clean, measured signal for material that
+  // belongs on the wiki instead: 0 hits across the directory as authored
+  // today, 56 in the draft (#5351) that prompted this check. Deliberately
+  // narrower than the README's own longer "tells" list — audit/checklist/gate
+  // also match plenty of innocent prose ("Verification Checklist", "Audit
+  // every reset stylesheet"), which would make the check noisy enough to get
+  // suppressed rather than acted on.
+  const OUR_PROCESS_WORDS =
+    /\b(rubric|readiness|promotion|sign-off|evidence)\b/i;
+  const DOCS_DIR = path.join(CLI_ROOT, 'assets', 'docs');
+
+  it('has no our-process words in a caller-facing doc topic', () => {
+    const hits = [];
+    for (const file of fs.readdirSync(DOCS_DIR)) {
+      if (!file.endsWith('.mjs')) {
+        continue; // README.md documents the rule; it isn't shipped as a topic.
+      }
+      const content = fs.readFileSync(path.join(DOCS_DIR, file), 'utf8');
+      const match = content.match(OUR_PROCESS_WORDS);
+      if (match) {
+        hits.push(`${file}: "${match[0]}"`);
+      }
+    }
+    expect(
+      hits,
+      'This word describes building Astryx, not building with it. Move ' +
+        'the material to the matching wiki page in assets/docs/README.md\'s ' +
+        'routing table instead of shipping it here.',
+    ).toEqual([]);
+  });
 });
 
 describe('discoverBuiltinTopics', () => {

--- a/packages/cli/foundation/discovery/docs-discovery.test.mjs
+++ b/packages/cli/foundation/discovery/docs-discovery.test.mjs
@@ -70,9 +70,40 @@ describe('assets/docs audience', () => {
   // also match plenty of innocent prose ("Verification Checklist", "Audit
   // every reset stylesheet"), which would make the check noisy enough to get
   // suppressed rather than acted on.
+  //
+  // The README's own rule (line 24) is that these words are a tell "as
+  // things the reader must produce" — not as vocabulary. "A component's
+  // theme targets are stable once published" is caller-facing even where it
+  // sounds like process; only a statement asking the reader to produce or
+  // hand over one of these things is ours. "GPU compositor promotion" is a
+  // real caller-facing rendering term with no reader-facing directive
+  // anywhere near it, and matched before this fixed it (#5370). So a process
+  // word only counts when the SAME sentence also carries a directive or
+  // audience marker — "must", "before merging/promoting", "attach",
+  // "complete", "reviewer(s)", "checklist", "gate", "sign off" — which is
+  // exactly the shape of language the draft (#5351) that prompted this check
+  // actually used.
   const OUR_PROCESS_WORDS =
     /\b(rubric|readiness|promotion|sign-off|evidence)\b/i;
+  const PROCESS_DIRECTIVE_CONTEXT =
+    /\b(you|reviewer|reviewers|must|should|before (merging|promoting)|attach|produce|complete|pass(?:es|ing)?|need to|checklist|gate|sign[- ]?off)\b/i;
   const DOCS_DIR = path.join(CLI_ROOT, 'assets', 'docs');
+
+  /**
+   * Sentence-level, not file-level: a process word appearing anywhere in a
+   * long topic file, however many caller-facing paragraphs away from any
+   * directive language, is not the pattern this check exists to catch.
+   */
+  function findOurProcessWordHits(content) {
+    const hits = [];
+    for (const sentence of content.split(/(?<=[.!?])\s+|\n{2,}/)) {
+      const wordMatch = sentence.match(OUR_PROCESS_WORDS);
+      if (wordMatch && PROCESS_DIRECTIVE_CONTEXT.test(sentence)) {
+        hits.push(wordMatch[0]);
+      }
+    }
+    return hits;
+  }
 
   it('has no our-process words in a caller-facing doc topic', () => {
     const hits = [];
@@ -81,9 +112,8 @@ describe('assets/docs audience', () => {
         continue; // README.md documents the rule; it isn't shipped as a topic.
       }
       const content = fs.readFileSync(path.join(DOCS_DIR, file), 'utf8');
-      const match = content.match(OUR_PROCESS_WORDS);
-      if (match) {
-        hits.push(`${file}: "${match[0]}"`);
+      for (const word of findOurProcessWordHits(content)) {
+        hits.push(`${file}: "${word}"`);
       }
     }
     expect(
@@ -91,6 +121,26 @@ describe('assets/docs audience', () => {
       'This word describes building Astryx, not building with it. Move ' +
         'the material to the matching wiki page in assets/docs/README.md\'s ' +
         'routing table instead of shipping it here.',
+    ).toEqual([]);
+  });
+
+  it('flags process language asking the reader to produce one of these things', () => {
+    expect(
+      findOurProcessWordHits(
+        'Reviewers must attach evidence to the readiness checklist before sign-off.',
+      ),
+    ).toEqual(['evidence']);
+  });
+
+  it('allows a caller-facing rendering term that happens to share a word', () => {
+    // The exact false positive from #5370: "promotion" describing GPU
+    // compositor behavior, a fact about the system a caller can rely on, not
+    // a reader-facing directive.
+    expect(
+      findOurProcessWordHits(
+        'A layer with a running transform animation gets its own compositor ' +
+          'promotion, which keeps the animation off the main thread.',
+      ),
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #5369.

## Problem

`packages/cli/assets/docs/` ships to people building **with** Astryx. Material about building Astryx itself (grading rubrics, promotion gates, review evidence) keeps landing there instead of the wiki, and it was only ever caught if a human happened to read the diff. #5368 added a README to that directory with the audience rule and a routing table; this is the automated half the issue asked for.

## What it checks

Added a case to `packages/cli/foundation/discovery/docs-discovery.test.mjs`, which already walks `assets/docs`, per the issue's suggestion. Fails on `rubric`, `readiness`, `promotion`, `sign-off`, `evidence` (case-insensitive, word-boundary) appearing in any `.mjs` file there.

Deliberately narrower than the README's own longer "tells" list. `audit`, `checklist`, and `gate` were the obvious additions, but checked first: all their current hits in the directory are innocent prose ("Verification Checklist", "Audit every reset stylesheet"), and `lab` collides with `label`/`available` 148 times. A noisy check gets suppressed rather than acted on, so I left those out.

Verified the five-word list is clean today (0 hits) and matches what the issue measured against the draft that prompted it (#5351, 56 hits) — didn't re-run that PR's diff since it's someone else's draft, took the issue's numbers as the baseline signal instead.

`.mjs`-only is deliberate too: it naturally excludes `README.md`, which legitimately contains all five words since it's the document *describing* the rule — filtering by extension is simpler than an explicit exclude-list and won't need updating if another non-`.mjs` file shows up in the directory later.

The failure message points at the README's routing table so the author knows which wiki page the material actually wants, per the issue's ask.

## Verification

Confirmed the test fails against a real violation: temporarily appended a comment with `rubric`, `readiness`, `evidence` to `getting-started.doc.mjs`, ran the suite, watched it fail with the expected message naming the word and file, then reverted. Full `docs-discovery.test.mjs` suite: 23/23 passing. Typecheck and lint clean.

Not a visual change (a test file, no rendered output), so no screenshot.