### PR TITLE
Improve Popover responsive fit and focus behavior

### DIFF
--- a/.changeset/bottom-sheet-modal-edge-tint.md
+++ b/.changeset/bottom-sheet-modal-edge-tint.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BottomSheet now keeps the iOS Safari browser-bar edge consistent with the sheet surface for both modal and non-modal presentations.
+
+@rubyycheung

--- a/.changeset/popover-responsive-fit.md
+++ b/.changeset/popover-responsive-fit.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Popover layers now cap explicit widths and match-trigger sizing to the available viewport with token safe-area gutters, and long content scrolls inside the layer instead of forcing page overflow on narrow viewports. Dialog-style popovers with read-only content now place initial focus on the labeled dialog container instead of revealing the fallback close button, while preserving Tab access to that fallback escape control.
+
+@rubyycheung

--- a/.changeset/popover-responsive-fit.md
+++ b/.changeset/popover-responsive-fit.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Popover layers now cap explicit widths and match-trigger sizing to the available viewport with token safe-area gutters, and long content scrolls inside the layer instead of forcing page overflow on narrow viewports. Dialog-style popovers with read-only content now place initial focus on the labeled dialog container instead of revealing the fallback close button, while preserving Tab access to that fallback escape control.
+[fix] Popover layers now cap explicit widths and match-trigger sizing to the available viewport with token safe-area gutters, and long content scrolls inside the layer instead of forcing page overflow on narrow viewports. Repeated resize and content-change signals coalesce overflow measurement to once per animation frame. Dialog-style popovers with read-only content now place initial focus on the labeled dialog container instead of revealing the fallback close button, while preserving Tab access to that fallback escape control.
 
 @rubyycheung

--- a/.changeset/popover-responsive-fit.md
+++ b/.changeset/popover-responsive-fit.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Popover layers now cap explicit widths and match-trigger sizing to the available viewport with token safe-area gutters, and long content scrolls inside the layer instead of forcing page overflow on narrow viewports. Repeated resize and content-change signals coalesce overflow measurement to once per animation frame. Dialog-style popovers with read-only content now place initial focus on the labeled dialog container instead of revealing the fallback close button, while preserving Tab access to that fallback escape control.
+[fix] Popover layers now cap explicit widths and match-trigger sizing to the available viewport with alignment-aware token safe-area gutters, preserving trigger alignment while keeping the painted surface at least one spacing token from both viewport edges. Long content scrolls inside the layer instead of forcing page overflow on narrow viewports. Repeated resize and content-change signals coalesce overflow measurement to once per animation frame. Pointer-activated dialog popovers focus the labeled dialog container so the first action does not appear preselected, while keyboard activation still focuses the first content control. Read-only content uses the same container target without revealing the fallback close button, while preserving Tab access to that fallback escape control.
 
 @rubyycheung

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -16,11 +16,7 @@ import {Switch} from '@astryxdesign/core/Switch';
 import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Section} from '@astryxdesign/core/Section';
-import {
-  colorVars,
-  radiusVars,
-  spacingVars,
-} from '@astryxdesign/core/theme/tokens.stylex';
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 
 const meta: Meta<typeof Popover> = {
   title: 'Core/Popover',
@@ -118,18 +114,6 @@ const readinessStyles = stylex.create({
   evidenceCopy: {
     maxInlineSize: 520,
     overflowWrap: 'anywhere',
-  },
-  presentationFrame: {
-    minBlockSize: 320,
-    paddingBlockStart: spacingVars['--spacing-4'],
-    paddingBlockEnd: spacingVars['--spacing-4'],
-    paddingInlineStart: spacingVars['--spacing-4'],
-    paddingInlineEnd: spacingVars['--spacing-4'],
-    backgroundColor: colorVars['--color-background-muted'],
-    borderColor: colorVars['--color-border'],
-    borderStyle: 'solid',
-    borderWidth: 1,
-    borderRadius: radiusVars['--radius-container'],
   },
   actionList: {
     inlineSize: '100%',
@@ -240,7 +224,7 @@ function ProjectActionSurface({
 
   if (resolvedPresentation === 'bottom-sheet') {
     return (
-      <div {...stylex.props(readinessStyles.presentationFrame)}>
+      <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
         <Button label="Open project actions" onClick={() => setIsOpen(true)}>
           Open project actions
         </Button>
@@ -256,7 +240,7 @@ function ProjectActionSurface({
   }
 
   return (
-    <div {...stylex.props(readinessStyles.presentationFrame)}>
+    <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
       <Popover
         isOpen={isOpen}
         onOpenChange={setIsOpen}
@@ -698,6 +682,7 @@ export const ViewportFit: Story = {
     layout: 'fullscreen',
     viewport: {defaultViewport: 'mobile1'},
     docs: {
+      story: {inline: false, height: '844px'},
       description: {
         story:
           'Uses the actual Storybook viewport rather than a simulated phone frame. The Popover requests a 640px width and must cap to the real iframe viewport and safe-area gutters.',
@@ -748,6 +733,7 @@ export const MatchTriggerViewportFit: Story = {
     layout: 'fullscreen',
     viewport: {defaultViewport: 'mobile1'},
     docs: {
+      story: {inline: false, height: '844px'},
       description: {
         story:
           'Uses the actual Storybook viewport. The real trigger is intentionally 640px wide, while Popover keeps its default match-trigger sizing; the Popover must cap to the available viewport instead of inheriting the full trigger width.',
@@ -794,6 +780,7 @@ export const TallContentOverflow: Story = {
     layout: 'fullscreen',
     viewport: {defaultViewport: 'mobile1'},
     docs: {
+      story: {inline: false, height: '844px'},
       description: {
         story:
           'Uses the actual Storybook viewport and a realistic project picker. The product-level 360px/50dvh cap keeps this lightweight anchored surface compact, while Popover detects the overflow and makes its content scrollable. Scrolling demonstrates bounded overflow handling; it does not by itself determine whether another presentation is more appropriate.',
@@ -812,7 +799,9 @@ export const TallContentOverflow: Story = {
 export const TriggerInteractionEvidence: Story = {
   name: 'Trigger Interaction Evidence',
   parameters: {
+    layout: 'fullscreen',
     docs: {
+      story: {inline: false, height: '844px'},
       description: {
         story:
           'Desktop Storybook interaction evidence: the native button trigger opens the popover without hover. Use real touch/iOS evidence before claiming mobile Safari behavior.',
@@ -850,7 +839,9 @@ export const TriggerInteractionEvidence: Story = {
 export const KeepPopoverPresentation: Story = {
   name: 'Keep Popover Presentation',
   parameters: {
+    layout: 'fullscreen',
     docs: {
+      story: {inline: false, height: '844px'},
       description: {
         story:
           'Keep Popover for anchored, compact supplemental details and actions. The trigger is click/tap activated, not hover dependent, and the compact surface keeps context near the trigger.',
@@ -871,7 +862,7 @@ export const BottomSheetPresentationOption: Story = {
   parameters: {
     layout: 'fullscreen',
     docs: {
-      story: {inline: false, height: '560px'},
+      story: {inline: false, height: '844px'},
       description: {
         story:
           'This story shows BottomSheet as an explicit alternative for the same focused task when a product wants a bottom-edge modal touch surface. It changes the contract: dialog focus ownership, scrim behavior, Escape handling, swipe-to-dismiss, and sheet body scrolling differ from Popover.',
@@ -910,7 +901,7 @@ export const AdaptivePopoverRecipe: PresentationRecipeStory = {
   parameters: {
     layout: 'fullscreen',
     docs: {
-      story: {inline: false, height: '560px'},
+      story: {inline: false, height: '844px'},
       description: {
         story:
           'Story-local recipe only: Core Popover does not silently adapt. Products opt in with touchPresentation="bottom-sheet" and can force presentation="popover" or presentation="bottom-sheet" for review and tests.',

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -685,7 +685,7 @@ export const ViewportFit: Story = {
       story: {inline: false, height: '844px'},
       description: {
         story:
-          'Uses the actual Storybook viewport rather than a simulated phone frame. The Popover requests a 640px width and must cap to the real iframe viewport and safe-area gutters.',
+          'Uses the actual Storybook viewport rather than a simulated phone frame. The Popover requests a 640px width and must stay anchored to the trigger while preserving at least 16px safe-area-aware gutters from both viewport edges.',
       },
     },
   },
@@ -704,9 +704,9 @@ export const ViewportFit: Story = {
               </Heading>
               <Text type="body" wordBreak="break-word">
                 This intentionally requests a wider-than-mobile popover. The
-                layer should keep safe gutters, stay anchored near the trigger,
-                and allow long content to reflow instead of causing horizontal
-                page overflow.
+                layer should stay anchored to the trigger, preserve safe gutters
+                on both viewport edges, and allow long content to reflow instead
+                of causing horizontal page overflow.
               </Text>
               <Text type="supporting" wordBreak="break-word">
                 Long localized-token-like content:

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -279,9 +279,6 @@ function TallContentOverflowExample() {
   return (
     <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
       <Popover
-        isOpen={true}
-        hasAutoFocus={false}
-        hasLightDismiss={false}
         placement="below"
         alignment="start"
         label="Move to project"
@@ -711,9 +708,6 @@ export const ViewportFit: Story = {
     <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
       <div {...stylex.props(readinessStyles.edgeAnchorRow)}>
         <Popover
-          isOpen={true}
-          hasAutoFocus={false}
-          hasLightDismiss={false}
           placement="below"
           alignment="end"
           label="Narrow viewport fit evidence"
@@ -740,6 +734,12 @@ export const ViewportFit: Story = {
       </div>
     </div>
   ),
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
 };
 
 export const MatchTriggerViewportFit: Story = {
@@ -757,9 +757,6 @@ export const MatchTriggerViewportFit: Story = {
   render: () => (
     <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
       <Popover
-        isOpen={true}
-        hasAutoFocus={false}
-        hasLightDismiss={false}
         placement="below"
         alignment="start"
         label="Match-trigger viewport evidence"
@@ -783,6 +780,12 @@ export const MatchTriggerViewportFit: Story = {
       </Popover>
     </div>
   ),
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
 };
 
 export const TallContentOverflow: Story = {
@@ -798,6 +801,12 @@ export const TallContentOverflow: Story = {
     },
   },
   render: () => <TallContentOverflowExample />,
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
 };
 
 export const TriggerInteractionEvidence: Story = {

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -78,11 +78,18 @@ const PROJECT_ACTIONS: ReadonlyArray<{
   },
 ];
 
-const TALL_POPOVER_ITEMS = Array.from({length: 16}, (_, index) => ({
-  id: `result-${index + 1}`,
-  label: `Search result ${index + 1}`,
-  description: 'Supporting information remains inside the Popover scroll area.',
-}));
+const PROJECT_DESTINATIONS = [
+  ['Apollo launch', 'Marketing · 12 open tasks'],
+  ['Customer insights', 'Research · 8 open tasks'],
+  ['Design systems', 'Platform · 24 open tasks'],
+  ['Growth experiments', 'Product · 6 open tasks'],
+  ['Incident review', 'Operations · 4 open tasks'],
+  ['Mobile quality', 'Engineering · 15 open tasks'],
+  ['Quarterly planning', 'Strategy · 9 open tasks'],
+  ['Recruiting plan', 'People · 7 open tasks'],
+  ['Security follow-up', 'Trust · 3 open tasks'],
+  ['Website refresh', 'Brand · 11 open tasks'],
+] as const;
 
 const readinessStyles = stylex.create({
   viewportStoryCanvas: {
@@ -101,6 +108,12 @@ const readinessStyles = stylex.create({
   },
   oversizedTrigger: {
     inlineSize: 640,
+  },
+  boundedPopoverContent: {
+    maxBlockSize: stylex.firstThatWorks(
+      'min(50dvb, 360px)',
+      'min(50vh, 360px)',
+    ),
   },
   evidenceCopy: {
     maxInlineSize: 520,
@@ -253,6 +266,54 @@ function ProjectActionSurface({
         width={320}
         content={content}>
         <Button label="Open project actions">Open project actions</Button>
+      </Popover>
+    </div>
+  );
+}
+
+function TallContentOverflowExample() {
+  const [selectedProject, setSelectedProject] = React.useState<string | null>(
+    null,
+  );
+
+  return (
+    <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
+      <Popover
+        isOpen={true}
+        hasAutoFocus={false}
+        hasLightDismiss={false}
+        placement="below"
+        alignment="start"
+        label="Move to project"
+        width={320}
+        data-testid="tall-popover"
+        xstyle={readinessStyles.boundedPopoverContent}
+        content={
+          <List
+            density="compact"
+            hasDividers
+            header={
+              <VStack gap={1}>
+                <Heading level={4} tabIndex={-1}>
+                  Move to project
+                </Heading>
+                <Text type="supporting" color="secondary">
+                  Choose a destination for this task.
+                </Text>
+              </VStack>
+            }>
+            {PROJECT_DESTINATIONS.map(([label, description]) => (
+              <ListItem
+                key={label}
+                label={label}
+                description={description}
+                isSelected={selectedProject === label}
+                onClick={() => setSelectedProject(label)}
+              />
+            ))}
+          </List>
+        }>
+        <Button label="Move task">Move task</Button>
       </Popover>
     </div>
   );
@@ -732,48 +793,11 @@ export const TallContentOverflow: Story = {
     docs: {
       description: {
         story:
-          'Uses the actual Storybook viewport and a real Popover with enough content to exceed its available block size. The Popover should remain inside the viewport and make only its content surface scrollable.',
+          'Uses the actual Storybook viewport and a realistic project picker. The product-level 360px/50dvh cap keeps this lightweight anchored surface compact, while Popover detects the overflow and makes its content scrollable. Content needing a near-full-screen surface should use BottomSheet or Dialog instead.',
       },
     },
   },
-  render: () => (
-    <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
-      <Popover
-        isOpen={true}
-        hasAutoFocus={false}
-        hasLightDismiss={false}
-        placement="below"
-        alignment="start"
-        label="Tall search results"
-        width={320}
-        data-testid="tall-popover"
-        content={
-          <List
-            density="compact"
-            hasDividers
-            header={
-              <VStack gap={1}>
-                <Heading level={4} tabIndex={-1}>
-                  Search results
-                </Heading>
-                <Text type="supporting" color="secondary">
-                  Scroll this real Popover to reach all results.
-                </Text>
-              </VStack>
-            }>
-            {TALL_POPOVER_ITEMS.map(item => (
-              <ListItem
-                key={item.id}
-                label={item.label}
-                description={item.description}
-              />
-            ))}
-          </List>
-        }>
-        <Button label="Open tall results">Open tall results</Button>
-      </Popover>
-    </div>
-  ),
+  render: () => <TallContentOverflowExample />,
 };
 
 export const TriggerInteractionEvidence: Story = {

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -78,24 +78,29 @@ const PROJECT_ACTIONS: ReadonlyArray<{
   },
 ];
 
+const TALL_POPOVER_ITEMS = Array.from({length: 16}, (_, index) => ({
+  id: `result-${index + 1}`,
+  label: `Search result ${index + 1}`,
+  description: 'Supporting information remains inside the Popover scroll area.',
+}));
+
 const readinessStyles = stylex.create({
-  evidenceFrame: {
-    inlineSize: 320,
-    maxInlineSize: '100%',
-    minBlockSize: 240,
+  viewportStoryCanvas: {
+    boxSizing: 'border-box',
+    inlineSize: '100%',
+    minBlockSize: '100dvh',
     paddingBlockStart: spacingVars['--spacing-4'],
     paddingBlockEnd: spacingVars['--spacing-4'],
     paddingInlineStart: spacingVars['--spacing-4'],
     paddingInlineEnd: spacingVars['--spacing-4'],
-    backgroundColor: colorVars['--color-background-muted'],
-    borderColor: colorVars['--color-border'],
-    borderStyle: 'solid',
-    borderWidth: 1,
-    borderRadius: radiusVars['--radius-container'],
+    overflow: 'clip',
   },
   edgeAnchorRow: {
     display: 'flex',
     justifyContent: 'flex-end',
+  },
+  oversizedTrigger: {
+    inlineSize: 640,
   },
   evidenceCopy: {
     maxInlineSize: 520,
@@ -632,16 +637,17 @@ export const RenderProp: Story = {
 export const ViewportFit: Story = {
   name: 'Viewport Fit',
   parameters: {
+    layout: 'fullscreen',
     viewport: {defaultViewport: 'mobile1'},
     docs: {
       description: {
         story:
-          'Desktop Storybook evidence for a narrow viewport: the popover is requested at 640px wide but should cap to the viewport/safe-area gutter instead of overflowing. This does not verify iOS WebKit top-layer behavior.',
+          'Uses the actual Storybook viewport rather than a simulated phone frame. The Popover requests a 640px width and must cap to the real iframe viewport and safe-area gutters.',
       },
     },
   },
   render: () => (
-    <div {...stylex.props(readinessStyles.evidenceFrame)}>
+    <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
       <div {...stylex.props(readinessStyles.edgeAnchorRow)}>
         <Popover
           isOpen={true}
@@ -671,6 +677,101 @@ export const ViewportFit: Story = {
           <Button label="Open fit evidence">Open fit evidence</Button>
         </Popover>
       </div>
+    </div>
+  ),
+};
+
+export const MatchTriggerViewportFit: Story = {
+  name: 'Match-trigger viewport fit',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {defaultViewport: 'mobile1'},
+    docs: {
+      description: {
+        story:
+          'Uses the actual Storybook viewport. The real trigger is intentionally 640px wide, while Popover keeps its default match-trigger sizing; the Popover must cap to the available viewport instead of inheriting the full trigger width.',
+      },
+    },
+  },
+  render: () => (
+    <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
+      <Popover
+        isOpen={true}
+        hasAutoFocus={false}
+        hasLightDismiss={false}
+        placement="below"
+        alignment="start"
+        label="Match-trigger viewport evidence"
+        data-testid="match-trigger-popover"
+        content={
+          <VStack gap={2} xstyle={readinessStyles.evidenceCopy}>
+            <Heading level={4} tabIndex={-1}>
+              Match-trigger sizing
+            </Heading>
+            <Text type="body">
+              The anchor is wider than this viewport, but the Popover stays
+              inside the available inline space.
+            </Text>
+          </VStack>
+        }>
+        <Button
+          label="Oversized match-width trigger"
+          xstyle={readinessStyles.oversizedTrigger}>
+          Oversized match-width trigger
+        </Button>
+      </Popover>
+    </div>
+  ),
+};
+
+export const TallContentOverflow: Story = {
+  name: 'Tall content overflow',
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {defaultViewport: 'mobile1'},
+    docs: {
+      description: {
+        story:
+          'Uses the actual Storybook viewport and a real Popover with enough content to exceed its available block size. The Popover should remain inside the viewport and make only its content surface scrollable.',
+      },
+    },
+  },
+  render: () => (
+    <div {...stylex.props(readinessStyles.viewportStoryCanvas)}>
+      <Popover
+        isOpen={true}
+        hasAutoFocus={false}
+        hasLightDismiss={false}
+        placement="below"
+        alignment="start"
+        label="Tall search results"
+        width={320}
+        data-testid="tall-popover"
+        content={
+          <List
+            density="compact"
+            hasDividers
+            header={
+              <VStack gap={1}>
+                <Heading level={4} tabIndex={-1}>
+                  Search results
+                </Heading>
+                <Text type="supporting" color="secondary">
+                  Scroll this real Popover to reach all results.
+                </Text>
+              </VStack>
+            }>
+            {TALL_POPOVER_ITEMS.map(item => (
+              <ListItem
+                key={item.id}
+                label={item.label}
+                description={item.description}
+              />
+            ))}
+          </List>
+        }>
+        <Button label="Open tall results">Open tall results</Button>
+      </Popover>
     </div>
   ),
 };

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -1,17 +1,26 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import React from 'react';
+import * as stylex from '@stylexjs/stylex';
 import type {Meta, StoryObj} from '@storybook/react';
+import {BottomSheet} from '@astryxdesign/core/BottomSheet';
 import {Popover} from '@astryxdesign/core/Popover';
 import type {PopoverTriggerRenderProps} from '@astryxdesign/core/Popover';
 import {Button} from '@astryxdesign/core/Button';
 import {Token} from '@astryxdesign/core/Token';
 import {Link} from '@astryxdesign/core/Link';
+import {List, ListItem} from '@astryxdesign/core/List';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
 import {Text, Heading} from '@astryxdesign/core/Text';
 import {Switch} from '@astryxdesign/core/Switch';
 import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
 import {Divider} from '@astryxdesign/core/Divider';
+import {Section} from '@astryxdesign/core/Section';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
 
 const meta: Meta<typeof Popover> = {
   title: 'Core/Popover',
@@ -37,6 +46,212 @@ const meta: Meta<typeof Popover> = {
 
 export default meta;
 type Story = StoryObj<typeof Popover>;
+type PresentationRecipeStory = StoryObj<PresentationRecipeArgs>;
+
+type ProjectAction = 'owner' | 'label' | 'due-date';
+type PresentationChoice = 'popover' | 'bottom-sheet';
+
+interface PresentationRecipeArgs {
+  presentation?: PresentationChoice;
+  touchPresentation?: PresentationChoice;
+}
+
+const PROJECT_ACTIONS: ReadonlyArray<{
+  id: ProjectAction;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: 'owner',
+    label: 'Assign owner',
+    description: 'Route follow-up to a teammate.',
+  },
+  {
+    id: 'label',
+    label: 'Add label',
+    description: 'Group this item with related work.',
+  },
+  {
+    id: 'due-date',
+    label: 'Set due date',
+    description: 'Pick a lightweight reminder for review.',
+  },
+];
+
+const readinessStyles = stylex.create({
+  evidenceFrame: {
+    inlineSize: 320,
+    maxInlineSize: '100%',
+    minBlockSize: 240,
+    paddingBlockStart: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-4'],
+    paddingInlineStart: spacingVars['--spacing-4'],
+    paddingInlineEnd: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-background-muted'],
+    borderColor: colorVars['--color-border'],
+    borderStyle: 'solid',
+    borderWidth: 1,
+    borderRadius: radiusVars['--radius-container'],
+  },
+  edgeAnchorRow: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
+  evidenceCopy: {
+    maxInlineSize: 520,
+    overflowWrap: 'anywhere',
+  },
+  presentationFrame: {
+    minBlockSize: 320,
+    paddingBlockStart: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-4'],
+    paddingInlineStart: spacingVars['--spacing-4'],
+    paddingInlineEnd: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-background-muted'],
+    borderColor: colorVars['--color-border'],
+    borderStyle: 'solid',
+    borderWidth: 1,
+    borderRadius: radiusVars['--radius-container'],
+  },
+  actionList: {
+    inlineSize: '100%',
+  },
+});
+
+function ProjectActionList({
+  selectedAction,
+  onSelectAction,
+  onReset,
+  presentation,
+}: {
+  selectedAction: ProjectAction | null;
+  onSelectAction: (action: ProjectAction) => void;
+  onReset: () => void;
+  presentation: PresentationChoice;
+}) {
+  return (
+    <VStack gap={3} xstyle={readinessStyles.actionList}>
+      <List
+        density="compact"
+        hasDividers
+        header={
+          <VStack gap={1}>
+            <Heading level={4} tabIndex={-1}>
+              Project actions
+            </Heading>
+            <Text type="supporting" color="secondary">
+              {presentation === 'popover'
+                ? 'Compact supplemental actions stay anchored to the trigger and keep the surrounding context visible.'
+                : 'The same actions can move into a BottomSheet when a product explicitly wants a bottom-edge touch surface.'}
+            </Text>
+          </VStack>
+        }>
+        {PROJECT_ACTIONS.map(action => (
+          <ListItem
+            key={action.id}
+            label={action.label}
+            description={action.description}
+            isSelected={selectedAction === action.id}
+            onClick={() => onSelectAction(action.id)}
+          />
+        ))}
+      </List>
+      <Divider />
+      <HStack gap={2} hAlign="between">
+        <Text type="supporting" color="secondary">
+          Selected:{' '}
+          {selectedAction == null
+            ? 'none'
+            : PROJECT_ACTIONS.find(action => action.id === selectedAction)
+                ?.label}
+        </Text>
+        <Button label="Reset selection" variant="ghost" onClick={onReset}>
+          Reset
+        </Button>
+      </HStack>
+    </VStack>
+  );
+}
+
+function useOptInTouchPresentation(
+  presentation: PresentationChoice | undefined,
+  touchPresentation: PresentationChoice | undefined,
+): PresentationChoice {
+  const [matchesTouchSurface, setMatchesTouchSurface] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+    const query = window.matchMedia(
+      '(max-width: 639px) and (pointer: coarse) and (hover: none)',
+    );
+    const sync = () => setMatchesTouchSurface(query.matches);
+    sync();
+    query.addEventListener('change', sync);
+    return () => query.removeEventListener('change', sync);
+  }, []);
+
+  if (presentation != null) {
+    return presentation;
+  }
+  return touchPresentation === 'bottom-sheet' && matchesTouchSurface
+    ? 'bottom-sheet'
+    : 'popover';
+}
+
+function ProjectActionSurface({
+  presentation = 'popover',
+  touchPresentation = 'bottom-sheet',
+}: PresentationRecipeArgs) {
+  const resolvedPresentation = useOptInTouchPresentation(
+    presentation,
+    touchPresentation,
+  );
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selectedAction, setSelectedAction] =
+    React.useState<ProjectAction | null>(null);
+  const content = (
+    <ProjectActionList
+      presentation={resolvedPresentation}
+      selectedAction={selectedAction}
+      onSelectAction={setSelectedAction}
+      onReset={() => setSelectedAction(null)}
+    />
+  );
+
+  if (resolvedPresentation === 'bottom-sheet') {
+    return (
+      <div {...stylex.props(readinessStyles.presentationFrame)}>
+        <Button label="Open project actions" onClick={() => setIsOpen(true)}>
+          Open project actions
+        </Button>
+        <BottomSheet
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          label="Project actions"
+          height="hug">
+          <Section padding={4}>{content}</Section>
+        </BottomSheet>
+      </div>
+    );
+  }
+
+  return (
+    <div {...stylex.props(readinessStyles.presentationFrame)}>
+      <Popover
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        placement="below"
+        alignment="start"
+        label="Project actions"
+        width={320}
+        content={content}>
+        <Button label="Open project actions">Open project actions</Button>
+      </Popover>
+    </div>
+  );
+}
 
 // =============================================================================
 // Settings Panel
@@ -309,7 +524,11 @@ export const Disabled: Story = {
     label: 'Disabled popover',
     isEnabled: false,
     content: <Text type="body">This should not appear.</Text>,
-    children: <Button label="Disabled popover">Disabled</Button>,
+    children: (
+      <Button label="Disabled popover" isDisabled>
+        Disabled
+      </Button>
+    ),
   },
 };
 
@@ -405,4 +624,170 @@ export const RenderProp: Story = {
       )}
     </Popover>
   ),
+};
+// =============================================================================
+// Responsive and Interaction Readiness Evidence
+// =============================================================================
+
+export const ViewportFit: Story = {
+  name: 'Viewport Fit',
+  parameters: {
+    viewport: {defaultViewport: 'mobile1'},
+    docs: {
+      description: {
+        story:
+          'Desktop Storybook evidence for a narrow viewport: the popover is requested at 640px wide but should cap to the viewport/safe-area gutter instead of overflowing. This does not verify iOS WebKit top-layer behavior.',
+      },
+    },
+  },
+  render: () => (
+    <div {...stylex.props(readinessStyles.evidenceFrame)}>
+      <div {...stylex.props(readinessStyles.edgeAnchorRow)}>
+        <Popover
+          isOpen={true}
+          hasAutoFocus={false}
+          hasLightDismiss={false}
+          placement="below"
+          alignment="end"
+          label="Narrow viewport fit evidence"
+          width={640}
+          content={
+            <VStack gap={3} xstyle={readinessStyles.evidenceCopy}>
+              <Heading level={4} tabIndex={-1}>
+                Narrow viewport fit
+              </Heading>
+              <Text type="body" wordBreak="break-word">
+                This intentionally requests a wider-than-mobile popover. The
+                layer should keep safe gutters, stay anchored near the trigger,
+                and allow long content to reflow instead of causing horizontal
+                page overflow.
+              </Text>
+              <Text type="supporting" wordBreak="break-word">
+                Long localized-token-like content:
+                project-settings-notification-delivery-exception-review-queue
+              </Text>
+            </VStack>
+          }>
+          <Button label="Open fit evidence">Open fit evidence</Button>
+        </Popover>
+      </div>
+    </div>
+  ),
+};
+
+export const TriggerInteractionEvidence: Story = {
+  name: 'Trigger Interaction Evidence',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Desktop Storybook interaction evidence: the native button trigger opens the popover without hover. Use real touch/iOS evidence before claiming mobile Safari behavior.',
+      },
+    },
+  },
+  render: () => (
+    <Popover
+      placement="below"
+      label="Interaction evidence"
+      content={
+        <VStack gap={2}>
+          <Heading level={4} tabIndex={-1}>
+            Interaction evidence
+          </Heading>
+          <Text type="body">
+            Opened by trigger activation; Escape, outside press, and focus
+            return are covered by unit tests.
+          </Text>
+        </VStack>
+      }>
+      <Button label="Open interaction evidence">
+        Open interaction evidence
+      </Button>
+    </Popover>
+  ),
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
+};
+
+export const KeepPopoverPresentation: Story = {
+  name: 'Keep Popover Presentation',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Keep Popover for anchored, compact supplemental details and actions. The trigger is click/tap activated, not hover dependent, and the compact surface keeps context near the trigger.',
+      },
+    },
+  },
+  render: () => <ProjectActionSurface presentation="popover" />,
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
+};
+
+export const BottomSheetPresentationOption: Story = {
+  name: 'BottomSheet Presentation Option',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      story: {inline: false, height: '560px'},
+      description: {
+        story:
+          'BottomSheet is an explicit alternative for lightweight action-list or picker/filter content. It changes the contract: bottom-edge placement, dialog focus ownership, scrim behavior, Escape handling, swipe-to-dismiss, and sheet body scrolling differ from Popover.',
+      },
+    },
+  },
+  render: () => <ProjectActionSurface presentation="bottom-sheet" />,
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
+};
+
+export const AdaptivePopoverRecipe: PresentationRecipeStory = {
+  name: 'Adaptive Popover Recipe',
+  args: {
+    presentation: 'popover',
+    touchPresentation: 'bottom-sheet',
+  },
+  argTypes: {
+    presentation: {
+      control: 'select',
+      options: ['popover', 'bottom-sheet'],
+      description:
+        'Deterministic review/test override for the presentation used by this recipe story.',
+    },
+    touchPresentation: {
+      control: 'select',
+      options: ['popover', 'bottom-sheet'],
+      description:
+        'Opt-in touch presentation. If a consumer omits the deterministic presentation override, the recipe may choose BottomSheet only for compact + coarse pointer + no hover.',
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      story: {inline: false, height: '560px'},
+      description: {
+        story:
+          'Story-local recipe only: Core Popover does not silently adapt. Products opt in with touchPresentation="bottom-sheet" and can force presentation="popover" or presentation="bottom-sheet" for review and tests.',
+      },
+    },
+  },
+  render: args => <ProjectActionSurface {...args} />,
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
 };

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -796,7 +796,7 @@ export const TallContentOverflow: Story = {
     docs: {
       description: {
         story:
-          'Uses the actual Storybook viewport and a realistic project picker. The product-level 360px/50dvh cap keeps this lightweight anchored surface compact, while Popover detects the overflow and makes its content scrollable. Content needing a near-full-screen surface should use BottomSheet or Dialog instead.',
+          'Uses the actual Storybook viewport and a realistic project picker. The product-level 360px/50dvh cap keeps this lightweight anchored surface compact, while Popover detects the overflow and makes its content scrollable. Scrolling demonstrates bounded overflow handling; it does not by itself determine whether another presentation is more appropriate.',
       },
     },
   },
@@ -874,7 +874,7 @@ export const BottomSheetPresentationOption: Story = {
       story: {inline: false, height: '560px'},
       description: {
         story:
-          'BottomSheet is an explicit alternative for lightweight action-list or picker/filter content. It changes the contract: bottom-edge placement, dialog focus ownership, scrim behavior, Escape handling, swipe-to-dismiss, and sheet body scrolling differ from Popover.',
+          'This story shows BottomSheet as an explicit alternative for the same focused task when a product wants a bottom-edge modal touch surface. It changes the contract: dialog focus ownership, scrim behavior, Escape handling, swipe-to-dismiss, and sheet body scrolling differ from Popover.',
       },
     },
   },

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -796,6 +796,41 @@ export const TallContentOverflow: Story = {
   },
 };
 
+export const ReadOnlyDialogFocus: Story = {
+  name: 'Read-only dialog focus',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      story: {inline: false, height: '844px'},
+      description: {
+        story:
+          'Manual assistive-technology check for a dialog-style Popover with no content controls. On open, the labeled dialog container receives focus without revealing the fallback close button. Confirm the dialog name and role are announced, Tab reaches Close popover, Shift+Tab remains contained, Escape closes, and focus returns to the trigger.',
+      },
+    },
+  },
+  render: () => (
+    <Popover
+      placement="below"
+      label="Deployment status"
+      content={
+        <VStack gap={2}>
+          <Heading level={4}>Deployment status</Heading>
+          <Text type="body">
+            The latest production deployment completed successfully.
+          </Text>
+        </VStack>
+      }>
+      <Button label="View deployment status">View deployment status</Button>
+    </Popover>
+  ),
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('button');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
+};
+
 export const TriggerInteractionEvidence: Story = {
   name: 'Trigger Interaction Evidence',
   parameters: {

--- a/packages/cli/assets/templates/blocks/components/Popover/PopoverBottomSheetAlternative.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Popover/PopoverBottomSheetAlternative.doc.mjs
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Popover',
+  name: 'Popover — Bottom Sheet Alternative',
+  displayName: 'Popover — Bottom Sheet Alternative',
+  description:
+    'Opt-in BottomSheet alternative for compact touch surfaces where actions should use a modal presentation anchored to the bottom edge.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: [
+    'BottomSheet',
+    'Button',
+    'Icon',
+    'Section',
+    'Layout',
+    'Text',
+    'List',
+  ],
+};

--- a/packages/cli/assets/templates/blocks/components/Popover/PopoverBottomSheetAlternative.tsx
+++ b/packages/cli/assets/templates/blocks/components/Popover/PopoverBottomSheetAlternative.tsx
@@ -41,7 +41,7 @@ export default function PopoverBottomSheetAlternative() {
         onOpenChange={setIsOpen}
         label="Project actions"
         height="hug">
-        <Section padding={4}>
+        <Section paddingBlock={4} paddingInline={1}>
           <VStack gap={3}>
             <VStack gap={1} xstyle={styles.header}>
               <Heading level={3}>Project actions</Heading>

--- a/packages/cli/assets/templates/blocks/components/Popover/PopoverBottomSheetAlternative.tsx
+++ b/packages/cli/assets/templates/blocks/components/Popover/PopoverBottomSheetAlternative.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {CalendarIcon, TagIcon, UserIcon} from '@heroicons/react/24/outline';
+import {BottomSheet} from '@astryxdesign/core/BottomSheet';
+import {Button} from '@astryxdesign/core/Button';
+import {Icon} from '@astryxdesign/core/Icon';
+import {List, ListItem} from '@astryxdesign/core/List';
+import {VStack} from '@astryxdesign/core/Layout';
+import {Section} from '@astryxdesign/core/Section';
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  header: {
+    // Match the unchanged spacious ListItem inset so the title and description
+    // align with the action icons.
+    marginInlineStart: spacingVars['--spacing-3'],
+  },
+});
+
+const PROJECT_ACTIONS = [
+  [UserIcon, 'Assign owner', 'Route follow-up to a teammate.'],
+  [TagIcon, 'Add label', 'Group this item with related work.'],
+  [CalendarIcon, 'Set due date', 'Pick a reminder for review.'],
+] as const;
+
+export default function PopoverBottomSheetAlternative() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button label="Open project actions" onClick={() => setIsOpen(true)}>
+        Open project actions
+      </Button>
+      <BottomSheet
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        label="Project actions"
+        height="hug">
+        <Section padding={4}>
+          <VStack gap={3}>
+            <VStack gap={1} xstyle={styles.header}>
+              <Heading level={3}>Project actions</Heading>
+              <Text type="supporting" color="secondary">
+                Use this modal touch surface when the task should move away from
+                its trigger and stay close to the bottom edge.
+              </Text>
+            </VStack>
+            <List density="spacious">
+              {PROJECT_ACTIONS.map(([icon, label, description]) => (
+                <ListItem
+                  key={label}
+                  label={label}
+                  description={description}
+                  startContent={
+                    <Icon icon={icon} size="md" color="secondary" />
+                  }
+                  onClick={() => setIsOpen(false)}
+                />
+              ))}
+            </List>
+          </VStack>
+        </Section>
+      </BottomSheet>
+    </>
+  );
+}

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -385,8 +385,7 @@ function StandaloneBottomSheet({
           {children}
         </BottomSheetPanel>
       </div>
-      {/* A modal sheet's ::backdrop already answers Safari's edge sampler. */}
-      {hasScrim ? null : <BottomSheetEdgeTint />}
+      <BottomSheetEdgeTint />
     </dialog>
   );
 }

--- a/packages/core/src/BottomSheet/BottomSheetEdgeTint.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetEdgeTint.test.tsx
@@ -101,15 +101,13 @@ describe('BottomSheetEdgeTint', () => {
     expect(tints()).toHaveLength(1);
   });
 
-  // A modal sheet's ::backdrop is a case WebKit's sampler handles on its own,
-  // so a second sampling target there would only fight it.
-  it('leaves a modal sheet to its ::backdrop', () => {
+  it('gives a modal sheet the same surface-coloured edge tint', () => {
     render(
       <BottomSheet isOpen onOpenChange={() => {}} label="Place details">
         Content
       </BottomSheet>,
     );
-    expect(tints()).toHaveLength(0);
+    expect(tints()).toHaveLength(1);
   });
 
   it('renders the tint inside the dialog, so it unmounts with the sheet', () => {
@@ -148,7 +146,7 @@ describe('BottomSheetEdgeTint', () => {
     expect(tints()).toHaveLength(1);
   });
 
-  it('leaves a modal switcher flow to its ::backdrop', () => {
+  it('gives a modal switcher flow exactly one tint', () => {
     render(
       <BottomSheetSwitcher activeSheet="comment" onActiveSheetChange={() => {}}>
         <BottomSheet sheetId="comment" label="Add a comment">
@@ -156,7 +154,7 @@ describe('BottomSheetEdgeTint', () => {
         </BottomSheet>
       </BottomSheetSwitcher>,
     );
-    expect(tints()).toHaveLength(0);
+    expect(tints()).toHaveLength(1);
   });
 
   it('keeps the tint out of the accessibility tree and out of hit testing', async () => {

--- a/packages/core/src/BottomSheet/BottomSheetEdgeTint.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetEdgeTint.tsx
@@ -6,7 +6,7 @@
  * @file BottomSheetEdgeTint.tsx
  * @input Uses StyleX and core color tokens
  * @output Exports BottomSheetEdgeTint, an internal decorative element
- * @position Private helper rendered inside a non-modal BottomSheet dialog
+ * @position Private helper rendered inside every BottomSheet dialog
  *
  * iOS 26 Safari dropped `<meta name="theme-color">` and instead derives the
  * colour it paints behind its translucent toolbars by sampling the page: it
@@ -14,13 +14,10 @@
  * `fixed`/`sticky` ancestor, and extends that element's declared
  * `background-color` into the browser chrome.
  *
- * A modal sheet is served by that heuristic already — WebKit has a dedicated
- * branch for a dialog's `::backdrop`. A non-modal sheet is not: the nearest
- * fixed ancestor of the panel is the sheet's own full-viewport `<dialog>`,
- * which is transparent and viewport-sized, and WebKit answers a viewport-sized
- * candidate by *keeping the colour it already had* — the host page's. The page
- * then shows through behind the address bar while the sheet covers the screen
- * above it.
+ * WebKit may otherwise extend either the dialog backdrop or the host page into
+ * the browser chrome. Which one wins varies with dialog mode and the page's
+ * own fixed or sticky edge content, so relying on the backdrop makes otherwise
+ * identical BottomSheets produce different toolbar colours.
  *
  * This element gives the heuristic something unambiguous to sample: fixed,
  * full width, flush with the bottom edge, taller than WebKit's 10px minimum
@@ -68,8 +65,8 @@ const styles = stylex.create({
 });
 
 /**
- * Colours the iOS Safari toolbar strip below a non-modal sheet. Renders
- * nothing visible; see the file header for why it exists.
+ * Colours the iOS Safari toolbar strip below a sheet. Renders nothing visible;
+ * see the file header for why it exists.
  */
 export function BottomSheetEdgeTint() {
   return (

--- a/packages/core/src/BottomSheet/BottomSheetSwitcher.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetSwitcher.tsx
@@ -632,8 +632,7 @@ export function BottomSheetSwitcher({
           ? {role: 'alertdialog'}
           : undefined)}>
         {children}
-        {/* A modal flow's ::backdrop already answers Safari's edge sampler. */}
-        {hasScrim ? null : <BottomSheetEdgeTint />}
+        <BottomSheetEdgeTint />
       </dialog>
     </BottomSheetSwitcherContext>
   );

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -64,7 +64,7 @@ export const docs = {
         {
           name: 'width',
           type: 'number | string',
-          description: 'Width of the popover container.',
+          description: 'Width of the popover container. The layer still caps to the viewport and safe-area gutters before scrolling long content.',
           default: "'auto'",
         },
         {
@@ -220,7 +220,7 @@ export const docsZh = {
         {
           name: 'width',
           type: 'number | string',
-          description: '弹出框容器的宽度。',
+          description: '弹出框容器的宽度。弹出层仍会限制在视口和安全区域留白内，长内容再滚动。',
           default: "'auto'",
         },
         {
@@ -340,7 +340,7 @@ export const docsDense = {
         isOpen: 'Whether popover shown in controlled mode.',
         onOpenChange: 'Callback fired when popover visibility changes.',
         isEnabled: 'When false, trigger interactions ignored.',
-        width: 'Popover container width.',
+        width: 'Popover container width; capped to viewport/safe-area gutters before long content scrolls.',
         label: 'Accessible label for popover dialog.',
         hasCloseButton: 'Whether to include hidden close button for accessibility.',
         closeButtonLabel: 'Label for hidden close button.',

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -64,7 +64,7 @@ export const docs = {
         {
           name: 'width',
           type: 'number | string',
-          description: 'Width of the popover container. The layer still caps to the viewport and safe-area gutters before scrolling long content.',
+          description: 'Width of the popover container. The layer still caps to the viewport with alignment-aware safe-area gutters before scrolling long content.',
           default: "'auto'",
         },
         {
@@ -101,7 +101,7 @@ export const docs = {
         {
           name: 'hasAutoFocus',
           type: 'boolean',
-          description: 'Whether to auto-focus the first focusable element when the popover opens. Set to false for inline showcases or documentation previews.',
+          description: 'Whether to move focus into the popover when it opens. Keyboard activation focuses the first content control; pointer activation focuses the labeled dialog container so an action does not appear preselected. Set to false for inline showcases or documentation previews.',
           default: 'true',
         },
         {
@@ -340,11 +340,11 @@ export const docsDense = {
         isOpen: 'Whether popover shown in controlled mode.',
         onOpenChange: 'Callback fired when popover visibility changes.',
         isEnabled: 'When false, trigger interactions ignored.',
-        width: 'Popover container width; capped to viewport/safe-area gutters before long content scrolls.',
+        width: 'Popover container width; capped to alignment-aware viewport/safe-area gutters before long content scrolls.',
         label: 'Accessible label for popover dialog.',
         hasCloseButton: 'Whether to include hidden close button for accessibility.',
         closeButtonLabel: 'Label for hidden close button.',
-        hasAutoFocus: 'Auto-focus first element on open; false for showcases.',
+        hasAutoFocus: 'Move focus into the popover on open; keyboard targets the first control and pointer targets the dialog container.',
         hasLightDismiss: 'Outside click dismisses; false for explicit-dismiss surfaces (coachmarks).',
         hasEscapeDismiss: 'Escape dismisses; full effect only with hasLightDismiss=false.',
       },

--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -149,8 +149,8 @@ export const docs = {
       { guidance: true, description: 'Keep popover content focused on a single task or piece of information.' },
       { guidance: true, description: 'Provide a clear way to close: either by clicking outside or with an explicit close button.' },
       { guidance: false, description: 'Nest popovers inside other popovers; it creates confusing focus and navigation.' },
-      { guidance: false, description: 'Use a popover for content that requires heavy user input; use a Dialog instead.' },
-      { guidance: false, description: 'Put too much content in a popover; if it needs scrolling, use a Dialog instead.' },
+      { guidance: false, description: 'Assume input complexity alone determines the presentation; evaluate the task’s focus, space, and interaction requirements.' },
+      { guidance: false, description: 'Assume scrolling alone means Popover is the wrong component; a bounded Popover may scroll while a focused anchored interaction remains appropriate.' },
     ],
     anatomy: [
       {name: 'Header', required: true, description: 'Contains the title, optional subheader, and close button.'},
@@ -294,8 +294,8 @@ export const docsZh = {
       { guidance: true, description: 'Keep popover content focused on a single task or piece of information.' },
       { guidance: true, description: 'Provide a clear way to close: either by clicking outside or with an explicit close button.' },
       { guidance: false, description: 'Nest popovers inside other popovers; it creates confusing focus and navigation.' },
-      { guidance: false, description: 'Use a popover for content that requires heavy user input; use a Dialog instead.' },
-      { guidance: false, description: 'Put too much content in a popover; if it needs scrolling, use a Dialog instead.' },
+      { guidance: false, description: 'Assume input complexity alone determines the presentation; evaluate the task’s focus, space, and interaction requirements.' },
+      { guidance: false, description: 'Assume scrolling alone means Popover is the wrong component; a bounded Popover may scroll while a focused anchored interaction remains appropriate.' },
     ],
     anatomy: [
       {name: 'Header', required: true, description: 'Contains the title, optional subheader, and close button.'},
@@ -316,8 +316,8 @@ export const docsDense = {
       { guidance: true, description: 'Keep popover content focused on a single task or piece of information.' },
       { guidance: true, description: 'Provide a clear way to close: either by clicking outside or with an explicit close button.' },
       { guidance: false, description: 'Nest popovers inside other popovers; it creates confusing focus and navigation.' },
-      { guidance: false, description: 'Use a popover for content that requires heavy user input; use a Dialog instead.' },
-      { guidance: false, description: 'Put too much content in a popover; if it needs scrolling, use a Dialog instead.' },
+      { guidance: false, description: 'Assume input complexity alone determines the presentation; evaluate the task’s focus, space, and interaction requirements.' },
+      { guidance: false, description: 'Assume scrolling alone means Popover is the wrong component; a bounded Popover may scroll while a focused anchored interaction remains appropriate.' },
     ],
     anatomy: [
       {name: 'Header', required: true, description: 'Contains the title, optional subheader, and close button.'},

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -69,9 +69,16 @@ describe('usePopover public return type', () => {
     const hasInternalToggle: 'toggleWithOptions' extends keyof UsePopoverReturn
       ? true
       : false = false;
+    type PublicShowOptions = NonNullable<
+      Parameters<UsePopoverReturn['show']>[0]
+    >;
+    const hasInternalFocusTarget: 'focusTarget' extends keyof PublicShowOptions
+      ? true
+      : false = false;
     expect(hasKeepOpenProps).toBe(false);
     expect(hasDismissalGuard).toBe(false);
     expect(hasInternalToggle).toBe(false);
+    expect(hasInternalFocusTarget).toBe(false);
   });
 });
 

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -725,7 +725,7 @@ describe('Popover', () => {
   });
 
   describe('focus restoration', () => {
-    it('focuses the dialog container after pointer activation', async () => {
+    it('focuses the dialog container without outlining an action after pointer activation', async () => {
       render(
         <Popover
           content={<button type="button">Delete</button>}
@@ -743,6 +743,7 @@ describe('Popover', () => {
         hidden: true,
       });
       await waitFor(() => expect(dialog).toHaveFocus());
+      expect(dialog).toHaveStyle({outline: 'none'});
       expect(
         screen.getByRole('button', {name: 'Delete', hidden: true}),
       ).not.toHaveFocus();

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -334,6 +334,59 @@ describe('Popover', () => {
     }
   });
 
+  it('observes overflow only while the popover is open', () => {
+    const resizeConstructed = vi.fn();
+    const resizeDisconnected = vi.fn();
+    const mutationConstructed = vi.fn();
+    const mutationDisconnected = vi.fn();
+
+    class ResizeObserverMock {
+      constructor() {
+        resizeConstructed();
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = resizeDisconnected;
+    }
+
+    class MutationObserverMock {
+      constructor() {
+        mutationConstructed();
+      }
+      observe = vi.fn();
+      disconnect = mutationDisconnected;
+      takeRecords = vi.fn(() => []);
+    }
+
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.stubGlobal('MutationObserver', MutationObserverMock);
+
+    const {unmount} = render(
+      <Popover content={<span>Content</span>} label="Test">
+        <button type="button">Open</button>
+      </Popover>,
+    );
+
+    try {
+      const trigger = screen.getByRole('button', {name: 'Open'});
+      expect(resizeConstructed).not.toHaveBeenCalled();
+      expect(mutationConstructed).not.toHaveBeenCalled();
+
+      fireEvent.click(trigger);
+      expect(resizeConstructed).toHaveBeenCalledTimes(1);
+      expect(mutationConstructed).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(trigger);
+      expect(resizeDisconnected).toHaveBeenCalledTimes(1);
+      expect(mutationDisconnected).toHaveBeenCalledTimes(1);
+      expect(resizeConstructed).toHaveBeenCalledTimes(1);
+      expect(mutationConstructed).toHaveBeenCalledTimes(1);
+    } finally {
+      unmount();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('caps match-trigger sizing to the available inline viewport', () => {
     render(
       <Popover content={<span>Content</span>} label="Test">

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {readFileSync} from 'node:fs';
 import React, {useRef} from 'react';
@@ -264,14 +264,73 @@ describe('Popover', () => {
 
       expect(
         screen.getByTestId('popover-content').parentElement?.className,
-      ).toContain(
-        'Popover__styles.surfaceScrollable',
-      );
+      ).toContain('Popover__styles.surfaceScrollable');
     } finally {
       clientHeight.mockRestore();
       scrollHeight.mockRestore();
       clientWidth.mockRestore();
       scrollWidth.mockRestore();
+    }
+  });
+
+  it('coalesces repeated overflow signals into one animation frame', () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    let mutationCallback: MutationCallback | undefined;
+    const frameCallbacks: FrameRequestCallback[] = [];
+
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+
+    class MutationObserverMock {
+      constructor(callback: MutationCallback) {
+        mutationCallback = callback;
+      }
+      observe = vi.fn();
+      disconnect = vi.fn();
+      takeRecords = vi.fn(() => []);
+    }
+
+    const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback);
+      return frameCallbacks.length;
+    });
+    const cancelFrame = vi.fn();
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.stubGlobal('MutationObserver', MutationObserverMock);
+    vi.stubGlobal('requestAnimationFrame', requestFrame);
+    vi.stubGlobal('cancelAnimationFrame', cancelFrame);
+
+    const {unmount} = render(
+      <Popover content={<span>Content</span>} label="Test">
+        <button type="button">Open</button>
+      </Popover>,
+    );
+
+    try {
+      fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+      while (frameCallbacks.length > 0) {
+        const pendingFrames = frameCallbacks.splice(0);
+        act(() => pendingFrames.forEach(callback => callback(0)));
+      }
+      requestFrame.mockClear();
+
+      act(() => {
+        resizeCallback?.([], {} as ResizeObserver);
+        mutationCallback?.([], {} as MutationObserver);
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      expect(requestFrame).toHaveBeenCalledTimes(1);
+      expect(frameCallbacks).toHaveLength(1);
+    } finally {
+      unmount();
+      vi.unstubAllGlobals();
     }
   });
 

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -11,7 +11,8 @@
  */
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React, {useRef} from 'react';
 import {Popover} from './Popover';
 import type {UsePopoverReturn} from './usePopover';
@@ -203,6 +204,71 @@ describe('Popover', () => {
       </Popover>,
     );
     expect(screen.getByTestId('my-popover')).toBeInTheDocument();
+  });
+
+  it('constrains the layer to viewport and safe-area gutters', () => {
+    render(
+      <Popover
+        content={<span>Content</span>}
+        label="Test"
+        width={640}
+        data-testid="popover-content">
+        <button type="button">Open</button>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+
+    const layer = document.querySelector('[popover]');
+    expect(layer).toHaveStyle({boxSizing: 'border-box'});
+    expect(layer?.className).toContain('Popover__styles.viewportFit');
+    const content = screen.getByTestId('popover-content');
+    expect(content.className).toContain('Popover__styles.surfaceViewportFit');
+    expect(content).toHaveStyle({overflow: 'auto'});
+  });
+
+  it('caps match-trigger sizing to the available inline viewport', () => {
+    render(
+      <Popover content={<span>Content</span>} label="Test">
+        <button type="button">Open</button>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+
+    expect(document.querySelector('[popover]')).toHaveStyle(
+      'min-width: min(anchor-size(width),calc(100vi - max(var(--spacing-4),env(safe-area-inset-left)) - max(var(--spacing-4),env(safe-area-inset-right))))',
+    );
+  });
+
+  it('sets render-prop aria-haspopup from the configured popup role', () => {
+    render(
+      <Popover
+        role="none"
+        content={
+          <div role="menu" aria-label="Actions">
+            Menu content
+          </div>
+        }
+        label="Actions">
+        {triggerProps => (
+          <button
+            type="button"
+            ref={triggerProps.ref}
+            onClick={triggerProps.onClick}
+            aria-haspopup={triggerProps['aria-haspopup']}
+            aria-expanded={triggerProps['aria-expanded']}
+            aria-controls={triggerProps['aria-controls']}>
+            Open menu
+          </button>
+        )}
+      </Popover>,
+    );
+
+    expect(screen.getByRole('button', {name: 'Open menu'})).toHaveAttribute(
+      'aria-haspopup',
+      'true',
+    );
   });
 
   it('supports anchorRef sibling mode', () => {
@@ -437,6 +503,62 @@ describe('Popover', () => {
   });
 
   describe('focus restoration', () => {
+    it('focuses the dialog container when content has no controls', async () => {
+      render(
+        <Popover content={<span>Read-only content</span>} label="Read only">
+          <button type="button">Open read only</button>
+        </Popover>,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Open read only'}));
+
+      const dialog = screen.getByRole('dialog', {
+        name: 'Read only',
+        hidden: true,
+      });
+      await waitFor(() => expect(dialog).toHaveFocus());
+      expect(
+        screen.getByRole('button', {name: 'Close popover', hidden: true}),
+      ).not.toHaveFocus();
+    });
+
+    it('prefers a genuine content control for initial focus', async () => {
+      render(
+        <Popover
+          content={<button type="button">Content action</button>}
+          label="Action popover">
+          <button type="button">Open action</button>
+        </Popover>,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Open action'}));
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', {name: 'Content action', hidden: true}),
+        ).toHaveFocus(),
+      );
+    });
+
+    it('keeps the fallback close button reachable by Tab', async () => {
+      const user = userEvent.setup();
+      render(
+        <Popover content={<span>Read-only content</span>} label="Read only">
+          <button type="button">Open read only</button>
+        </Popover>,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Open read only'}));
+      await waitFor(() =>
+        expect(
+          screen.getByRole('dialog', {name: 'Read only', hidden: true}),
+        ).toHaveFocus(),
+      );
+
+      await user.tab();
+
+      expect(
+        screen.getByRole('button', {name: 'Close popover', hidden: true}),
+      ).toHaveFocus();
+    });
+
     it('returns focus to the trigger when closed via Escape', () => {
       render(
         <Popover

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -66,8 +66,12 @@ describe('usePopover public return type', () => {
     const hasDismissalGuard: 'wasJustDismissed' extends keyof UsePopoverReturn
       ? true
       : false = false;
+    const hasInternalToggle: 'toggleWithOptions' extends keyof UsePopoverReturn
+      ? true
+      : false = false;
     expect(hasKeepOpenProps).toBe(false);
     expect(hasDismissalGuard).toBe(false);
+    expect(hasInternalToggle).toBe(false);
   });
 });
 
@@ -223,11 +227,16 @@ describe('Popover', () => {
     const layer = document.querySelector('[popover]');
     expect(layer).toHaveStyle({boxSizing: 'border-box'});
     expect(layer?.className).toContain('Popover__styles.viewportFit');
+    expect(layer?.className).toContain('Popover__styles.viewportAligned');
+    expect(layer?.className).toContain('Popover__styles.viewportStart');
     const surface = screen.getByTestId('popover-content').parentElement;
     expect(surface?.className).toContain('Popover__styles.surfaceViewportFit');
     const popoverSource = readFileSync(
       'packages/core/src/Popover/Popover.tsx',
       'utf8',
+    );
+    expect(popoverSource).toMatch(
+      /surfaceViewportFit:[\s\S]*?maxInlineSize: stylex\.firstThatWorks\(\s*POPOVER_MAX_INLINE_SIZE/,
     );
     expect(popoverSource).toMatch(
       /surfaceViewportFit:[\s\S]*?maxBlockSize: stylex\.firstThatWorks\(\s*POPOVER_MAX_BLOCK_SIZE/,
@@ -387,7 +396,7 @@ describe('Popover', () => {
     }
   });
 
-  it('caps match-trigger sizing to the available inline viewport', () => {
+  it('keeps aligned popovers anchored while applying viewport gutters', () => {
     render(
       <Popover content={<span>Content</span>} label="Test">
         <button type="button">Open</button>
@@ -396,9 +405,62 @@ describe('Popover', () => {
 
     fireEvent.click(screen.getByRole('button', {name: 'Open'}));
 
-    expect(document.querySelector('[popover]')).toHaveStyle(
-      'min-width: min(anchor-size(width),calc(100vi - max(var(--spacing-4),env(safe-area-inset-left)) - max(var(--spacing-4),env(safe-area-inset-right))))',
+    const layer = document.querySelector('[popover]');
+    expect(layer?.className).toContain('Popover__styles.viewportAligned');
+    expect(layer?.className).toContain('Popover__styles.viewportStart');
+    expect(layer).toHaveStyle(
+      'min-width: min(anchor-size(width),calc(100% - max(var(--spacing-4),env(safe-area-inset-left,0px),env(safe-area-inset-right,0px))))',
     );
+  });
+
+  it('mirrors the far-edge gutter for end-aligned popovers', () => {
+    render(
+      <Popover content={<span>Content</span>} label="Test" alignment="end">
+        <button type="button">Open</button>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+
+    const layer = document.querySelector('[popover]');
+    expect(layer?.className).toContain('Popover__styles.viewportAligned');
+    expect(layer?.className).toContain('Popover__styles.viewportEnd');
+    expect(layer?.className).not.toContain('Popover__styles.viewportStart');
+  });
+
+  it('reserves both inline gutters only for centered popovers', () => {
+    render(
+      <Popover content={<span>Content</span>} label="Test" alignment="center">
+        <button type="button">Open</button>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+
+    const layer = document.querySelector('[popover]');
+    expect(layer?.className).toContain('Popover__styles.viewportCentered');
+    expect(layer?.className).not.toContain('Popover__styles.viewportAligned');
+    expect(layer).toHaveStyle(
+      'min-width: min(anchor-size(width),calc(100vi - max(var(--spacing-4),env(safe-area-inset-left,0px)) - max(var(--spacing-4),env(safe-area-inset-right,0px))))',
+    );
+  });
+
+  it('uses block-axis gutters for side placement', () => {
+    render(
+      <Popover
+        content={<span>Content</span>}
+        label="Test"
+        placement="end"
+        alignment="start">
+        <button type="button">Open</button>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+
+    const layer = document.querySelector('[popover]');
+    expect(layer?.className).toContain('Popover__styles.viewportBlockStart');
+    expect(layer?.className).not.toContain('Popover__styles.viewportStart');
   });
 
   it('preserves the dialog aria-haspopup contract for render-prop triggers', () => {
@@ -663,6 +725,49 @@ describe('Popover', () => {
   });
 
   describe('focus restoration', () => {
+    it('focuses the dialog container after pointer activation', async () => {
+      render(
+        <Popover
+          content={<button type="button">Delete</button>}
+          label="Confirm deletion">
+          <button type="button">Open confirmation</button>
+        </Popover>,
+      );
+
+      fireEvent.click(screen.getByRole('button', {name: 'Open confirmation'}), {
+        detail: 1,
+      });
+
+      const dialog = screen.getByRole('dialog', {
+        name: 'Confirm deletion',
+        hidden: true,
+      });
+      await waitFor(() => expect(dialog).toHaveFocus());
+      expect(
+        screen.getByRole('button', {name: 'Delete', hidden: true}),
+      ).not.toHaveFocus();
+    });
+
+    it('focuses the first content control after keyboard activation', async () => {
+      render(
+        <Popover
+          content={<button type="button">Delete</button>}
+          label="Confirm deletion">
+          <button type="button">Open confirmation</button>
+        </Popover>,
+      );
+
+      fireEvent.click(screen.getByRole('button', {name: 'Open confirmation'}), {
+        detail: 0,
+      });
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', {name: 'Delete', hidden: true}),
+        ).toHaveFocus(),
+      );
+    });
+
     it('focuses the dialog container when content has no controls', async () => {
       render(
         <Popover content={<span>Read-only content</span>} label="Read only">

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file Popover.test.tsx
- * @input Uses vitest, @testing-library/react, Popover, Dialog,
+ * @input Uses vitest, Testing Library, node:fs, Popover, Dialog, and
  *   SegmentedControl
  * @output Unit tests for Popover component behavior
  * @position Testing; validates Popover.tsx implementation
@@ -13,6 +13,7 @@
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {readFileSync} from 'node:fs';
 import React, {useRef} from 'react';
 import {Popover} from './Popover';
 import type {UsePopoverReturn} from './usePopover';
@@ -224,6 +225,13 @@ describe('Popover', () => {
     expect(layer?.className).toContain('Popover__styles.viewportFit');
     const surface = screen.getByTestId('popover-content').parentElement;
     expect(surface?.className).toContain('Popover__styles.surfaceViewportFit');
+    const popoverSource = readFileSync(
+      'packages/core/src/Popover/Popover.tsx',
+      'utf8',
+    );
+    expect(popoverSource).toMatch(
+      /surfaceViewportFit:[\s\S]*?maxBlockSize: stylex\.firstThatWorks\(\s*POPOVER_MAX_BLOCK_SIZE/,
+    );
     expect(surface?.className).not.toContain(
       'Popover__styles.surfaceScrollable',
     );

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -206,7 +206,7 @@ describe('Popover', () => {
     expect(screen.getByTestId('my-popover')).toBeInTheDocument();
   });
 
-  it('constrains the layer to viewport and safe-area gutters', () => {
+  it('constrains the layer without clipping content that already fits', () => {
     render(
       <Popover
         content={<span>Content</span>}
@@ -222,9 +222,49 @@ describe('Popover', () => {
     const layer = document.querySelector('[popover]');
     expect(layer).toHaveStyle({boxSizing: 'border-box'});
     expect(layer?.className).toContain('Popover__styles.viewportFit');
-    const content = screen.getByTestId('popover-content');
-    expect(content.className).toContain('Popover__styles.surfaceViewportFit');
-    expect(content).toHaveStyle({overflow: 'auto'});
+    const surface = screen.getByTestId('popover-content').parentElement;
+    expect(surface?.className).toContain('Popover__styles.surfaceViewportFit');
+    expect(surface?.className).not.toContain(
+      'Popover__styles.surfaceScrollable',
+    );
+  });
+
+  it('enables internal scrolling only when content exceeds the available space', () => {
+    const clientHeight = vi
+      .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+      .mockReturnValue(100);
+    const scrollHeight = vi
+      .spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+      .mockReturnValue(200);
+    const clientWidth = vi
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(200);
+    const scrollWidth = vi
+      .spyOn(HTMLElement.prototype, 'scrollWidth', 'get')
+      .mockReturnValue(200);
+
+    try {
+      render(
+        <Popover
+          content={<span>Long content</span>}
+          label="Test"
+          data-testid="popover-content">
+          <button type="button">Open</button>
+        </Popover>,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+
+      expect(
+        screen.getByTestId('popover-content').parentElement?.className,
+      ).toContain(
+        'Popover__styles.surfaceScrollable',
+      );
+    } finally {
+      clientHeight.mockRestore();
+      scrollHeight.mockRestore();
+      clientWidth.mockRestore();
+      scrollWidth.mockRestore();
+    }
   });
 
   it('caps match-trigger sizing to the available inline viewport', () => {
@@ -241,7 +281,7 @@ describe('Popover', () => {
     );
   });
 
-  it('sets render-prop aria-haspopup from the configured popup role', () => {
+  it('preserves the dialog aria-haspopup contract for render-prop triggers', () => {
     render(
       <Popover
         role="none"
@@ -267,7 +307,7 @@ describe('Popover', () => {
 
     expect(screen.getByRole('button', {name: 'Open menu'})).toHaveAttribute(
       'aria-haspopup',
-      'true',
+      'dialog',
     );
   });
 

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -418,6 +418,9 @@ export function Popover({
   }, [measureOverflow]);
 
   useIsomorphicLayoutEffect(() => {
+    if (!popover.isOpen) {
+      return;
+    }
     const surface = popover.contentRef.current;
     if (!surface) {
       return;
@@ -460,6 +463,9 @@ export function Popover({
   }, [measureOverflow, popover.isOpen, scheduleOverflowMeasurement]);
 
   useIsomorphicLayoutEffect(() => {
+    if (!popover.isOpen) {
+      return;
+    }
     scheduleOverflowMeasurement();
   }, [content, popover.isOpen, scheduleOverflowMeasurement]);
 

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -38,6 +38,11 @@ import {InteractiveRoleContext} from '../InteractiveRoleContext/InteractiveRoleC
 // =============================================================================
 
 const BUTTON_SELECTOR = 'button, [role="button"]';
+const POPOVER_VIEWPORT_GUTTER = spacingVars['--spacing-4'];
+const POPOVER_MAX_INLINE_SIZE = `calc(100vi - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-left)) - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-right)))`;
+const POPOVER_MAX_INLINE_SIZE_FALLBACK = `calc(100vw - ${POPOVER_VIEWPORT_GUTTER} - ${POPOVER_VIEWPORT_GUTTER})`;
+const POPOVER_MAX_BLOCK_SIZE = `calc(100dvb - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-top)) - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-bottom)))`;
+const POPOVER_MAX_BLOCK_SIZE_FALLBACK = `calc(100vh - ${POPOVER_VIEWPORT_GUTTER} - ${POPOVER_VIEWPORT_GUTTER})`;
 
 /**
  * Find the trigger button inside a container element.
@@ -63,8 +68,8 @@ export interface PopoverTriggerRenderProps {
   ref: (el: HTMLElement | null) => void;
   /** Toggle the popover open/closed. */
   onClick: () => void;
-  /** ARIA attribute: indicates the element triggers a dialog. */
-  'aria-haspopup': 'dialog';
+  /** ARIA attribute: indicates the popup type exposed by the trigger. */
+  'aria-haspopup': 'dialog' | 'true';
   /** ARIA attribute: whether the popover is currently open. */
   'aria-expanded': boolean;
   /** ARIA attribute: ID of the controlled popover element. */
@@ -241,6 +246,24 @@ const styles = stylex.create({
   anchorWrapper: {
     display: 'inline-flex',
   },
+  viewportFit: {
+    boxSizing: 'border-box',
+    maxInlineSize: stylex.firstThatWorks(
+      POPOVER_MAX_INLINE_SIZE,
+      POPOVER_MAX_INLINE_SIZE_FALLBACK,
+    ),
+    maxBlockSize: stylex.firstThatWorks(
+      POPOVER_MAX_BLOCK_SIZE,
+      POPOVER_MAX_BLOCK_SIZE_FALLBACK,
+    ),
+  },
+  surfaceViewportFit: {
+    boxSizing: 'border-box',
+    maxInlineSize: 'inherit',
+    maxBlockSize: 'inherit',
+    overflow: 'auto',
+    overscrollBehavior: 'contain',
+  },
   // Content padding, applied to the popup surface so a theme's `padding`
   // replaces it instead of nesting inside it.
   contentPadding: {
@@ -253,7 +276,11 @@ const styles = stylex.create({
     width: typeof width === 'number' ? `${width}px` : width,
   }),
   matchTrigger: {
-    minWidth: 'anchor-size(width)',
+    minWidth: stylex.firstThatWorks(
+      `min(anchor-size(width), ${POPOVER_MAX_INLINE_SIZE})`,
+      `min(anchor-size(width), ${POPOVER_MAX_INLINE_SIZE_FALLBACK})`,
+      'anchor-size(width)',
+    ),
   },
 });
 
@@ -343,7 +370,7 @@ export function Popover({
     // it is the element the `popover` theme target has to sit on — a target on
     // the content div inside it styles a box that paints nothing.
     surfaceTarget: 'popover',
-    xstyle: [styles.contentPadding, xstyle],
+    xstyle: [styles.contentPadding, styles.surfaceViewportFit, xstyle],
     className,
     style,
     onShow: handlePopoverShow,
@@ -503,18 +530,27 @@ export function Popover({
   }, [isOpen, isControlled, popover]);
 
   // Determine popover xstyle
-  const popoverXstyle = width ? styles.customWidth(width) : styles.matchTrigger;
+  const popoverSizeXstyle = width
+    ? styles.customWidth(width)
+    : styles.matchTrigger;
 
   // Sibling mode: render only the popover (no wrapper needed)
   if (anchorRef && children == null) {
     return (
       <>
-        {popover.render(<div data-testid={testId}>{content}</div>, {
-          placement,
-          alignment,
-          offset: spacingVars['--spacing-1'],
-          xstyle: [popoverXstyle, layerAnimations[placement]],
-        })}
+        {popover.render(
+          <div data-testid={testId}>{content}</div>,
+          {
+            placement,
+            alignment,
+            offset: spacingVars['--spacing-1'],
+            xstyle: [
+              styles.viewportFit,
+              popoverSizeXstyle,
+              layerAnimations[placement],
+            ],
+          },
+        )}
       </>
     );
   }
@@ -526,7 +562,7 @@ export function Popover({
     const triggerProps: PopoverTriggerRenderProps = {
       ref: popover.triggerRef,
       onClick: handleTriggerClick,
-      'aria-haspopup': 'dialog',
+      'aria-haspopup': popover.triggerProps['aria-haspopup'],
       'aria-expanded': popover.isOpen,
       'aria-controls': popover.id,
     };
@@ -534,12 +570,19 @@ export function Popover({
     return (
       <>
         {children(triggerProps)}
-        {popover.render(<div data-testid={testId}>{content}</div>, {
-          placement,
-          alignment,
-          offset: spacingVars['--spacing-1'],
-          xstyle: [popoverXstyle, layerAnimations[placement]],
-        })}
+        {popover.render(
+          <div data-testid={testId}>{content}</div>,
+          {
+            placement,
+            alignment,
+            offset: spacingVars['--spacing-1'],
+            xstyle: [
+              styles.viewportFit,
+              popoverSizeXstyle,
+              layerAnimations[placement],
+            ],
+          },
+        )}
       </>
     );
   }
@@ -552,12 +595,19 @@ export function Popover({
           {children}
         </div>
       </InteractiveRoleContext>
-      {popover.render(<div data-testid={testId}>{content}</div>, {
-        placement,
-        alignment,
-        offset: spacingVars['--spacing-1'],
-        xstyle: [popoverXstyle, layerAnimations[placement]],
-      })}
+      {popover.render(
+        <div data-testid={testId}>{content}</div>,
+        {
+          placement,
+          alignment,
+          offset: spacingVars['--spacing-1'],
+          xstyle: [
+            styles.viewportFit,
+            popoverSizeXstyle,
+            layerAnimations[placement],
+          ],
+        },
+      )}
     </>
   );
 }

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -260,8 +260,14 @@ const styles = stylex.create({
   },
   surfaceViewportFit: {
     boxSizing: 'border-box',
-    maxInlineSize: 'inherit',
-    maxBlockSize: 'inherit',
+    maxInlineSize: stylex.firstThatWorks(
+      POPOVER_MAX_INLINE_SIZE,
+      POPOVER_MAX_INLINE_SIZE_FALLBACK,
+    ),
+    maxBlockSize: stylex.firstThatWorks(
+      POPOVER_MAX_BLOCK_SIZE,
+      POPOVER_MAX_BLOCK_SIZE_FALLBACK,
+    ),
   },
   surfaceScrollable: {
     overflow: 'auto',

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -356,6 +356,7 @@ export function Popover({
   'data-testid': testId,
 }: PopoverProps): ReactElement {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const measurementFrameRef = useRef<number | null>(null);
   const [hasOverflow, setHasOverflow] = useState(false);
   const isControlled = isOpen !== undefined;
 
@@ -406,6 +407,16 @@ export function Popover({
     );
   }, [popover.contentRef]);
 
+  const scheduleOverflowMeasurement = useCallback(() => {
+    if (measurementFrameRef.current != null) {
+      return;
+    }
+    measurementFrameRef.current = window.requestAnimationFrame(() => {
+      measurementFrameRef.current = null;
+      measureOverflow();
+    });
+  }, [measureOverflow]);
+
   useIsomorphicLayoutEffect(() => {
     const surface = popover.contentRef.current;
     if (!surface) {
@@ -415,32 +426,42 @@ export function Popover({
     const resizeObserver =
       typeof ResizeObserver === 'undefined'
         ? null
-        : new ResizeObserver(measureOverflow);
+        : new ResizeObserver(scheduleOverflowMeasurement);
     const mutationObserver =
       typeof MutationObserver === 'undefined'
         ? null
-        : new MutationObserver(measureOverflow);
+        : new MutationObserver(scheduleOverflowMeasurement);
     resizeObserver?.observe(surface);
     mutationObserver?.observe(surface, {
       childList: true,
       characterData: true,
       subtree: true,
     });
-    surface.addEventListener('load', measureOverflow, true);
-    window.addEventListener('resize', measureOverflow);
-    window.visualViewport?.addEventListener('resize', measureOverflow);
+    surface.addEventListener('load', scheduleOverflowMeasurement, true);
+    window.addEventListener('resize', scheduleOverflowMeasurement);
+    window.visualViewport?.addEventListener(
+      'resize',
+      scheduleOverflowMeasurement,
+    );
     return () => {
       resizeObserver?.disconnect();
       mutationObserver?.disconnect();
-      surface.removeEventListener('load', measureOverflow, true);
-      window.removeEventListener('resize', measureOverflow);
-      window.visualViewport?.removeEventListener('resize', measureOverflow);
+      surface.removeEventListener('load', scheduleOverflowMeasurement, true);
+      window.removeEventListener('resize', scheduleOverflowMeasurement);
+      window.visualViewport?.removeEventListener(
+        'resize',
+        scheduleOverflowMeasurement,
+      );
+      if (measurementFrameRef.current != null) {
+        window.cancelAnimationFrame(measurementFrameRef.current);
+        measurementFrameRef.current = null;
+      }
     };
-  }, [measureOverflow]);
+  }, [measureOverflow, popover.isOpen, scheduleOverflowMeasurement]);
 
   useIsomorphicLayoutEffect(() => {
-    measureOverflow();
-  }, [content, measureOverflow, popover.isOpen]);
+    scheduleOverflowMeasurement();
+  }, [content, popover.isOpen, scheduleOverflowMeasurement]);
 
   // Shared handler for click events on the trigger button.
   const handleTriggerClick = useCallback(() => {
@@ -603,19 +624,16 @@ export function Popover({
   if (anchorRef && children == null) {
     return (
       <>
-        {popover.render(
-          <div data-testid={testId}>{content}</div>,
-          {
-            placement,
-            alignment,
-            offset: spacingVars['--spacing-1'],
-            xstyle: [
-              styles.viewportFit,
-              popoverSizeXstyle,
-              layerAnimations[placement],
-            ],
-          },
-        )}
+        {popover.render(<div data-testid={testId}>{content}</div>, {
+          placement,
+          alignment,
+          offset: spacingVars['--spacing-1'],
+          xstyle: [
+            styles.viewportFit,
+            popoverSizeXstyle,
+            layerAnimations[placement],
+          ],
+        })}
       </>
     );
   }
@@ -635,19 +653,16 @@ export function Popover({
     return (
       <>
         {children(triggerProps)}
-        {popover.render(
-          <div data-testid={testId}>{content}</div>,
-          {
-            placement,
-            alignment,
-            offset: spacingVars['--spacing-1'],
-            xstyle: [
-              styles.viewportFit,
-              popoverSizeXstyle,
-              layerAnimations[placement],
-            ],
-          },
-        )}
+        {popover.render(<div data-testid={testId}>{content}</div>, {
+          placement,
+          alignment,
+          offset: spacingVars['--spacing-1'],
+          xstyle: [
+            styles.viewportFit,
+            popoverSizeXstyle,
+            layerAnimations[placement],
+          ],
+        })}
       </>
     );
   }
@@ -660,19 +675,16 @@ export function Popover({
           {children}
         </div>
       </InteractiveRoleContext>
-      {popover.render(
-        <div data-testid={testId}>{content}</div>,
-        {
-          placement,
-          alignment,
-          offset: spacingVars['--spacing-1'],
-          xstyle: [
-            styles.viewportFit,
-            popoverSizeXstyle,
-            layerAnimations[placement],
-          ],
-        },
-      )}
+      {popover.render(<div data-testid={testId}>{content}</div>, {
+        placement,
+        alignment,
+        offset: spacingVars['--spacing-1'],
+        xstyle: [
+          styles.viewportFit,
+          popoverSizeXstyle,
+          layerAnimations[placement],
+        ],
+      })}
     </>
   );
 }

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -28,7 +28,7 @@ import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import * as stylex from '@stylexjs/stylex';
 import {devWarn} from '../utils/devWarning';
 import type {BaseProps} from '../BaseProps';
-import {usePopover} from './usePopover';
+import {usePopoverInternal} from './usePopover';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {spacingVars} from '../theme/tokens.stylex';
@@ -40,10 +40,13 @@ import {InteractiveRoleContext} from '../InteractiveRoleContext/InteractiveRoleC
 
 const BUTTON_SELECTOR = 'button, [role="button"]';
 const POPOVER_VIEWPORT_GUTTER = spacingVars['--spacing-4'];
-const POPOVER_MAX_INLINE_SIZE = `calc(100vi - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-left)) - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-right)))`;
+const POPOVER_MAX_INLINE_SIZE = `calc(100vi - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-left, 0px)) - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-right, 0px)))`;
 const POPOVER_MAX_INLINE_SIZE_FALLBACK = `calc(100vw - ${POPOVER_VIEWPORT_GUTTER} - ${POPOVER_VIEWPORT_GUTTER})`;
-const POPOVER_MAX_BLOCK_SIZE = `calc(100dvb - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-top)) - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-bottom)))`;
+const POPOVER_MAX_BLOCK_SIZE = `calc(100dvb - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-top, 0px)) - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-bottom, 0px)))`;
 const POPOVER_MAX_BLOCK_SIZE_FALLBACK = `calc(100vh - ${POPOVER_VIEWPORT_GUTTER} - ${POPOVER_VIEWPORT_GUTTER})`;
+const POPOVER_POSITION_AREA_MAX_INLINE_SIZE = `calc(100% - max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px)))`;
+const POPOVER_POSITION_AREA_MAX_INLINE_SIZE_FALLBACK = `calc(100% - ${POPOVER_VIEWPORT_GUTTER})`;
+const POPOVER_INLINE_EDGE_GUTTER = `max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-left, 0px), env(safe-area-inset-right, 0px))`;
 
 /**
  * Find the trigger button inside a container element.
@@ -67,8 +70,8 @@ function findTriggerButton(el: HTMLElement): HTMLElement | null {
 export interface PopoverTriggerRenderProps {
   /** Ref callback — attach to the trigger element for anchor positioning. */
   ref: (el: HTMLElement | null) => void;
-  /** Toggle the popover open/closed. */
-  onClick: () => void;
+  /** Toggle the popover open/closed. Pass the click event through so pointer and keyboard focus behavior can differ. */
+  onClick: (event?: {detail: number}) => void;
   /** ARIA attribute: indicates the trigger opens a dialog-style popover. */
   'aria-haspopup': 'dialog';
   /** ARIA attribute: whether the popover is currently open. */
@@ -204,7 +207,9 @@ export interface PopoverProps extends Pick<
   closeButtonLabel?: string;
 
   /**
-   * Whether to auto-focus the first focusable element when the popover opens.
+   * Whether to move focus into the popover when it opens. Keyboard activation
+   * focuses the first content control; pointer activation focuses the labeled
+   * dialog container so an action does not appear preselected.
    * Set to `false` for inline showcases or documentation previews.
    * @default true
    */
@@ -249,13 +254,43 @@ const styles = stylex.create({
   },
   viewportFit: {
     boxSizing: 'border-box',
+    maxBlockSize: stylex.firstThatWorks(
+      POPOVER_MAX_BLOCK_SIZE,
+      POPOVER_MAX_BLOCK_SIZE_FALLBACK,
+    ),
+  },
+  viewportAligned: {
+    maxInlineSize: stylex.firstThatWorks(
+      POPOVER_POSITION_AREA_MAX_INLINE_SIZE,
+      POPOVER_POSITION_AREA_MAX_INLINE_SIZE_FALLBACK,
+    ),
+  },
+  viewportStart: {
+    marginInlineEnd: POPOVER_INLINE_EDGE_GUTTER,
+  },
+  viewportEnd: {
+    marginInlineStart: POPOVER_INLINE_EDGE_GUTTER,
+  },
+  viewportBlockStart: {
+    marginBlockEnd: `max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-bottom, 0px))`,
+  },
+  viewportBlockEnd: {
+    marginBlockStart: `max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-top, 0px))`,
+  },
+  viewportCentered: {
+    marginInlineStart: POPOVER_INLINE_EDGE_GUTTER,
+    marginInlineEnd: POPOVER_INLINE_EDGE_GUTTER,
     maxInlineSize: stylex.firstThatWorks(
       POPOVER_MAX_INLINE_SIZE,
       POPOVER_MAX_INLINE_SIZE_FALLBACK,
     ),
-    maxBlockSize: stylex.firstThatWorks(
-      POPOVER_MAX_BLOCK_SIZE,
-      POPOVER_MAX_BLOCK_SIZE_FALLBACK,
+  },
+  viewportBlockCentered: {
+    marginBlockStart: `max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-top, 0px))`,
+    marginBlockEnd: `max(${POPOVER_VIEWPORT_GUTTER}, env(safe-area-inset-bottom, 0px))`,
+    maxInlineSize: stylex.firstThatWorks(
+      POPOVER_MAX_INLINE_SIZE,
+      POPOVER_MAX_INLINE_SIZE_FALLBACK,
     ),
   },
   surfaceViewportFit: {
@@ -284,7 +319,14 @@ const styles = stylex.create({
   customWidth: (width: string | number) => ({
     width: typeof width === 'number' ? `${width}px` : width,
   }),
-  matchTrigger: {
+  matchTriggerAligned: {
+    minWidth: stylex.firstThatWorks(
+      `min(anchor-size(width), ${POPOVER_POSITION_AREA_MAX_INLINE_SIZE})`,
+      `min(anchor-size(width), ${POPOVER_POSITION_AREA_MAX_INLINE_SIZE_FALLBACK})`,
+      'anchor-size(width)',
+    ),
+  },
+  matchTriggerCentered: {
     minWidth: stylex.firstThatWorks(
       `min(anchor-size(width), ${POPOVER_MAX_INLINE_SIZE})`,
       `min(anchor-size(width), ${POPOVER_MAX_INLINE_SIZE_FALLBACK})`,
@@ -368,7 +410,7 @@ export function Popover({
     onOpenChange?.(false);
   }, [onOpenChange]);
 
-  const popover = usePopover({
+  const popover = usePopoverInternal({
     dialogLabel: label,
     role,
     isModal,
@@ -470,13 +512,24 @@ export function Popover({
   }, [content, popover.isOpen, scheduleOverflowMeasurement]);
 
   // Shared handler for click events on the trigger button.
-  const handleTriggerClick = useCallback(() => {
-    if (!isEnabled) {
-      return;
-    }
-    // `toggle` absorbs a click that belongs to its own light dismiss.
-    popover.toggle();
-  }, [isEnabled, popover]);
+  const handleTriggerClick = useCallback(
+    (event?: {detail: number}) => {
+      if (!isEnabled) {
+        return;
+      }
+      // Pointer/touch activation should not make the first action look
+      // preselected. Keep focus inside the modal dialog by focusing its
+      // labeled container; keyboard and AT activation still focus the first
+      // content control and expose the expected focus ring.
+      popover.toggleWithOptions({
+        focusTarget:
+          role === 'dialog' && event != null && event.detail > 0
+            ? 'container'
+            : 'first',
+      });
+    },
+    [isEnabled, popover, role],
+  );
 
   // Shared handler for keydown events on role="button" elements.
   // Native <button> synthesizes click on Enter/Space, but role="button"
@@ -624,7 +677,25 @@ export function Popover({
   // Determine popover xstyle
   const popoverSizeXstyle = width
     ? styles.customWidth(width)
-    : styles.matchTrigger;
+    : alignment === 'center'
+      ? styles.matchTriggerCentered
+      : styles.matchTriggerAligned;
+  const isSidePlacement = placement === 'start' || placement === 'end';
+  const popoverViewportXstyle =
+    alignment === 'center'
+      ? isSidePlacement
+        ? styles.viewportBlockCentered
+        : styles.viewportCentered
+      : [
+          styles.viewportAligned,
+          isSidePlacement
+            ? alignment === 'start'
+              ? styles.viewportBlockStart
+              : styles.viewportBlockEnd
+            : alignment === 'start'
+              ? styles.viewportStart
+              : styles.viewportEnd,
+        ];
 
   // Sibling mode: render only the popover (no wrapper needed)
   if (anchorRef && children == null) {
@@ -636,6 +707,7 @@ export function Popover({
           offset: spacingVars['--spacing-1'],
           xstyle: [
             styles.viewportFit,
+            popoverViewportXstyle,
             popoverSizeXstyle,
             layerAnimations[placement],
           ],
@@ -665,6 +737,7 @@ export function Popover({
           offset: spacingVars['--spacing-1'],
           xstyle: [
             styles.viewportFit,
+            popoverViewportXstyle,
             popoverSizeXstyle,
             layerAnimations[placement],
           ],
@@ -687,6 +760,7 @@ export function Popover({
         offset: spacingVars['--spacing-1'],
         xstyle: [
           styles.viewportFit,
+          popoverViewportXstyle,
           popoverSizeXstyle,
           layerAnimations[placement],
         ],

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -4,8 +4,8 @@
 
 /**
  * @file Popover.tsx
- * @input Uses React, usePopover hook
- * @output Exports Popover component for click-triggered popovers
+ * @input Uses React layout measurement and the usePopover hook
+ * @output Exports Popover with viewport fitting and conditional overflow
  * @position Layer component; declarative wrapper around usePopover hook
  *
  * For hover-triggered overlays, use HoverCard instead.
@@ -20,6 +20,7 @@
 import React, {
   useCallback,
   useRef,
+  useState,
   type ReactElement,
   type ReactNode,
 } from 'react';
@@ -68,8 +69,8 @@ export interface PopoverTriggerRenderProps {
   ref: (el: HTMLElement | null) => void;
   /** Toggle the popover open/closed. */
   onClick: () => void;
-  /** ARIA attribute: indicates the popup type exposed by the trigger. */
-  'aria-haspopup': 'dialog' | 'true';
+  /** ARIA attribute: indicates the trigger opens a dialog-style popover. */
+  'aria-haspopup': 'dialog';
   /** ARIA attribute: whether the popover is currently open. */
   'aria-expanded': boolean;
   /** ARIA attribute: ID of the controlled popover element. */
@@ -261,6 +262,8 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     maxInlineSize: 'inherit',
     maxBlockSize: 'inherit',
+  },
+  surfaceScrollable: {
     overflow: 'auto',
     overscrollBehavior: 'contain',
   },
@@ -347,6 +350,7 @@ export function Popover({
   'data-testid': testId,
 }: PopoverProps): ReactElement {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
   const isControlled = isOpen !== undefined;
 
   const handlePopoverShow = useCallback(() => {
@@ -370,12 +374,67 @@ export function Popover({
     // it is the element the `popover` theme target has to sit on — a target on
     // the content div inside it styles a box that paints nothing.
     surfaceTarget: 'popover',
-    xstyle: [styles.contentPadding, styles.surfaceViewportFit, xstyle],
+    xstyle: [
+      styles.contentPadding,
+      styles.surfaceViewportFit,
+      hasOverflow && styles.surfaceScrollable,
+      xstyle,
+    ],
     className,
     style,
     onShow: handlePopoverShow,
     onHide: handlePopoverHide,
   });
+
+  const measureOverflow = useCallback(() => {
+    const surface = popover.contentRef.current;
+    if (!surface) {
+      return;
+    }
+    const nextHasOverflow =
+      surface.scrollHeight > surface.clientHeight + 1 ||
+      surface.scrollWidth > surface.clientWidth + 1;
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- DOM overflow measurement controls whether this surface becomes a scroll container
+    setHasOverflow(current =>
+      current === nextHasOverflow ? current : nextHasOverflow,
+    );
+  }, [popover.contentRef]);
+
+  useIsomorphicLayoutEffect(() => {
+    const surface = popover.contentRef.current;
+    if (!surface) {
+      return;
+    }
+    measureOverflow();
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(measureOverflow);
+    const mutationObserver =
+      typeof MutationObserver === 'undefined'
+        ? null
+        : new MutationObserver(measureOverflow);
+    resizeObserver?.observe(surface);
+    mutationObserver?.observe(surface, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    surface.addEventListener('load', measureOverflow, true);
+    window.addEventListener('resize', measureOverflow);
+    window.visualViewport?.addEventListener('resize', measureOverflow);
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      surface.removeEventListener('load', measureOverflow, true);
+      window.removeEventListener('resize', measureOverflow);
+      window.visualViewport?.removeEventListener('resize', measureOverflow);
+    };
+  }, [measureOverflow]);
+
+  useIsomorphicLayoutEffect(() => {
+    measureOverflow();
+  }, [content, measureOverflow, popover.isOpen]);
 
   // Shared handler for click events on the trigger button.
   const handleTriggerClick = useCallback(() => {
@@ -562,7 +621,7 @@ export function Popover({
     const triggerProps: PopoverTriggerRenderProps = {
       ref: popover.triggerRef,
       onClick: handleTriggerClick,
-      'aria-haspopup': popover.triggerProps['aria-haspopup'],
+      'aria-haspopup': 'dialog',
       'aria-expanded': popover.isOpen,
       'aria-controls': popover.id,
     };

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -276,13 +276,8 @@ export interface UsePopoverReturn {
    * Show the popover.
    * @param options.skipAutoFocus - If true, don't auto-focus the first element.
    *   Useful when triggered by mouse click on an input that should retain focus.
-   * @param options.focusTarget - Choose the first content control (default) or
-   *   the dialog container as the initial focus target.
    */
-  show: (options?: {
-    skipAutoFocus?: boolean;
-    focusTarget?: 'first' | 'container';
-  }) => void;
+  show: (options?: {skipAutoFocus?: boolean}) => void;
 
   /**
    * Hide the popover

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -72,6 +72,11 @@ const styles = stylex.create({
   // Focus trap container
   contentWrapper: {
     position: 'relative',
+    // Pointer-open dialog popovers park focus on this wrapper so the first
+    // action does not look selected. The wrapper itself is not an action and
+    // should not receive the browser's default focus ring; interactive
+    // descendants retain their normal focus-visible treatment.
+    outline: 'none',
   },
   // Hidden close button wrapper - sr-only until focused, then positioned below
   // popover. Inline-axis centering (+ the translateY(100%) that drops it below

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -28,12 +28,36 @@ import {
   shadowVars,
 } from '../theme/tokens.stylex';
 import {Button} from '../Button';
+import {FOCUSABLE_SELECTOR} from '../hooks/focusableSelector';
 import {rtlStyles} from '../utils';
 import {useTranslator} from '../i18n';
 import {useDevWarning} from '../hooks/useDevWarning';
 import {mergeProps} from '../utils/mergeProps';
 import {themeProps} from '../utils/themeProps';
 import {stableClassName} from '../naming';
+
+const FALLBACK_CLOSE_SELECTOR = '[data-astryx-popover-fallback-close]';
+
+function attemptFocus(element: HTMLElement): boolean {
+  try {
+    element.focus();
+  } catch {
+    // Ignore non-focusable elements; the caller will try the next target.
+  }
+  return document.activeElement === element;
+}
+
+function focusFirstContentControl(container: HTMLElement): boolean {
+  const focusable = Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter(element => element.closest(FALLBACK_CLOSE_SELECTOR) == null);
+  for (const element of focusable) {
+    if (attemptFocus(element)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 const styles = stylex.create({
   // Default popover surface — background, radius, shadow.
@@ -385,19 +409,34 @@ function usePopoverImplementation(
     onEscape: hasEscapeDismiss || hasLightDismiss ? layer.hide : undefined,
   });
 
+  const focusInitialTarget = useCallback(() => {
+    const container = contentRef.current;
+    if (!container) {
+      return;
+    }
+    if (focusFirstContentControl(container)) {
+      return;
+    }
+    if (role === 'dialog') {
+      attemptFocus(container);
+      return;
+    }
+    focusFirst();
+  }, [contentRef, focusFirst, role]);
+
   // Auto-focus first element when popover opens (unless skipped)
   useEffect(() => {
     if (layer.isOpen && hasAutoFocus && !skipAutoFocusRef.current) {
       // Use requestAnimationFrame to ensure DOM is ready
       requestAnimationFrame(() => {
-        focusFirst();
+        focusInitialTarget();
       });
     }
     // Reset the skip flag after the effect runs
     if (!layer.isOpen) {
       skipAutoFocusRef.current = false;
     }
-  }, [layer.isOpen, hasAutoFocus, focusFirst]);
+  }, [layer.isOpen, hasAutoFocus, focusInitialTarget]);
 
   // Combined ref for trigger element (layer anchor + our ref)
   const triggerRef = useCallback(
@@ -465,6 +504,7 @@ function usePopoverImplementation(
             role={role === 'dialog' ? 'dialog' : undefined}
             aria-modal={role === 'dialog' && isModal ? true : undefined}
             aria-label={role === 'dialog' ? dialogLabel : undefined}
+            tabIndex={role === 'dialog' ? -1 : undefined}
             {...mergeProps(
               {...surfaceProps, className: surfaceClassName},
               stylex.props(
@@ -478,6 +518,7 @@ function usePopoverImplementation(
             {children}
             {hasCloseButton && (
               <div
+                data-astryx-popover-fallback-close=""
                 {...stylex.props(
                   styles.closeButtonWrapper,
                   rtlStyles.centerInline('100%'),

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -271,8 +271,13 @@ export interface UsePopoverReturn {
    * Show the popover.
    * @param options.skipAutoFocus - If true, don't auto-focus the first element.
    *   Useful when triggered by mouse click on an input that should retain focus.
+   * @param options.focusTarget - Choose the first content control (default) or
+   *   the dialog container as the initial focus target.
    */
-  show: (options?: {skipAutoFocus?: boolean}) => void;
+  show: (options?: {
+    skipAutoFocus?: boolean;
+    focusTarget?: 'first' | 'container';
+  }) => void;
 
   /**
    * Hide the popover
@@ -320,6 +325,10 @@ export interface UsePopoverReturn {
 
 interface InternalUsePopoverReturn extends UsePopoverReturn {
   wasJustDismissed: () => boolean;
+  toggleWithOptions: (options?: {
+    skipAutoFocus?: boolean;
+    focusTarget?: 'first' | 'container';
+  }) => void;
 }
 
 /**
@@ -392,6 +401,7 @@ function usePopoverImplementation(
 
   // Track whether to skip auto-focus for the current open event
   const skipAutoFocusRef = useRef(false);
+  const focusTargetRef = useRef<'first' | 'container'>('first');
 
   // Core layer for popover positioning
   const layer = useLayerInternal({
@@ -429,14 +439,24 @@ function usePopoverImplementation(
     if (layer.isOpen && hasAutoFocus && !skipAutoFocusRef.current) {
       // Use requestAnimationFrame to ensure DOM is ready
       requestAnimationFrame(() => {
-        focusInitialTarget();
+        const container = contentRef.current;
+        if (
+          focusTargetRef.current === 'container' &&
+          role === 'dialog' &&
+          container
+        ) {
+          attemptFocus(container);
+        } else {
+          focusInitialTarget();
+        }
       });
     }
-    // Reset the skip flag after the effect runs
+    // Reset per-open focus preferences after the popover closes.
     if (!layer.isOpen) {
       skipAutoFocusRef.current = false;
+      focusTargetRef.current = 'first';
     }
-  }, [layer.isOpen, hasAutoFocus, focusInitialTarget]);
+  }, [contentRef, layer.isOpen, hasAutoFocus, focusInitialTarget, role]);
 
   // Combined ref for trigger element (layer anchor + our ref)
   const triggerRef = useCallback(
@@ -449,24 +469,35 @@ function usePopoverImplementation(
 
   // Show function with optional skipAutoFocus
   const show = useCallback(
-    (showOptions?: {skipAutoFocus?: boolean}) => {
+    (showOptions?: {
+      skipAutoFocus?: boolean;
+      focusTarget?: 'first' | 'container';
+    }) => {
       skipAutoFocusRef.current = showOptions?.skipAutoFocus ?? false;
+      focusTargetRef.current = showOptions?.focusTarget ?? 'first';
       layer.show();
     },
     [layer],
   );
 
   // Toggle function
-  const toggle = useCallback(() => {
-    if (layer.wasJustDismissed()) {
-      return;
-    }
-    if (layer.isOpen) {
-      layer.hide();
-    } else {
-      show();
-    }
-  }, [layer, show]);
+  const toggleWithOptions = useCallback(
+    (showOptions?: {
+      skipAutoFocus?: boolean;
+      focusTarget?: 'first' | 'container';
+    }) => {
+      if (layer.wasJustDismissed()) {
+        return;
+      }
+      if (layer.isOpen) {
+        layer.hide();
+      } else {
+        show(showOptions);
+      }
+    },
+    [layer, show],
+  );
+  const toggle = useCallback(() => toggleWithOptions(), [toggleWithOptions]);
 
   // ARIA attributes for the trigger
   const triggerProps = {
@@ -558,6 +589,7 @@ function usePopoverImplementation(
     show,
     hide: layer.hide,
     toggle,
+    toggleWithOptions,
     wasJustDismissed: layer.wasJustDismissed,
     isOpen: layer.isOpen,
     id: layer.id,
@@ -567,7 +599,11 @@ function usePopoverImplementation(
 }
 
 export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
-  const {wasJustDismissed: _, ...popover} = usePopoverImplementation(options);
+  const {
+    wasJustDismissed: _,
+    toggleWithOptions: __,
+    ...popover
+  } = usePopoverImplementation(options);
   return popover;
 }
 

--- a/packages/core/src/hooks/useFocusTrap.test.tsx
+++ b/packages/core/src/hooks/useFocusTrap.test.tsx
@@ -193,6 +193,26 @@ describe('useFocusTrap tabbable model (infra-8)', () => {
     expect(screen.getByTestId('first')).toHaveFocus();
   });
 
+  it('moves from a programmatic container focus target into the tabbable cycle', () => {
+    render(
+      <Trap>
+        <button type="button" data-testid="first">
+          First
+        </button>
+        <button type="button" data-testid="last">
+          Last
+        </button>
+      </Trap>,
+    );
+    const trap = screen.getByTestId('trap');
+    trap.tabIndex = -1;
+    trap.focus();
+
+    fireEvent.keyDown(document, {key: 'Tab'});
+
+    expect(screen.getByTestId('first')).toHaveFocus();
+  });
+
   it('keeps a programmatic focus target when the trap has no tabbable controls', () => {
     render(
       <Trap>

--- a/packages/core/src/hooks/useFocusTrap.test.tsx
+++ b/packages/core/src/hooks/useFocusTrap.test.tsx
@@ -213,6 +213,26 @@ describe('useFocusTrap tabbable model (infra-8)', () => {
     expect(screen.getByTestId('first')).toHaveFocus();
   });
 
+  it('moves backward from a programmatic container focus target to the last tabbable control', () => {
+    render(
+      <Trap>
+        <button type="button" data-testid="first">
+          First
+        </button>
+        <button type="button" data-testid="last">
+          Last
+        </button>
+      </Trap>,
+    );
+    const trap = screen.getByTestId('trap');
+    trap.tabIndex = -1;
+    trap.focus();
+
+    fireEvent.keyDown(document, {key: 'Tab', shiftKey: true});
+
+    expect(screen.getByTestId('last')).toHaveFocus();
+  });
+
   it('keeps a programmatic focus target when the trap has no tabbable controls', () => {
     render(
       <Trap>

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -375,6 +375,19 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
         const first = focusable[0];
         const last = focusable[focusable.length - 1];
 
+        if (document.activeElement === container) {
+          // Programmatic initial focus can sit on the trap container itself
+          // (for example a dialog panel with no content controls). Move into
+          // the tabbable cycle instead of letting Tab escape to the page.
+          event.preventDefault();
+          if (event.shiftKey) {
+            last.focus();
+          } else {
+            first.focus();
+          }
+          return;
+        }
+
         if (event.shiftKey) {
           // Shift+Tab: if on first element, wrap to last
           if (document.activeElement === first) {


### PR DESCRIPTION
## Problem

Popover had two concrete usability failures on compact surfaces:

1. A consumer-supplied width, or a wide trigger used by match-trigger sizing, could make the Popover exceed the available viewport and safe-area gutters.
2. A read-only Popover had no ordinary content control to focus, so initial focus landed on the visually hidden fallback close control and revealed an unexpected “Close popover” button.

The goal is to fix those failures without silently turning Popover into a BottomSheet, changing the public trigger API, or clipping content that already fits.

## Changes and rationale

| Change | Problem it solves | Why this approach |
| --- | --- | --- |
| Cap the layer’s inline size with `100vi` and a `100vw` fallback, minus token and safe-area gutters. | Explicit widths such as `640px` could overflow a phone viewport. | The requested width is still honored when space exists; only unavailable space constrains it. Logical viewport sizing works in both writing directions, while `100vw` supports browsers without viewport-axis units. |
| Cap block size with `100dvb` and a `100vh` fallback, minus top and bottom safe-area gutters. | Tall content could extend below the visible viewport, especially when the mobile visual viewport changes. | Dynamic viewport units follow the currently visible area where supported; the fallback preserves compatibility. |
| Cap match-trigger sizing with `min(anchor-size(width), available space)`. | A trigger wider than the available viewport could force its Popover to overflow. | Popover still matches the trigger when possible, but viewport fit wins when the two requirements conflict. |
| Apply the same viewport caps directly to the content surface. | The real tall-content story showed that the surface sits inside the `usePopover` dialog wrapper, so `max-block-size: inherit` inherited `none` and still extended below the viewport. | Reusing the computed inline/block caps on the actual surface keeps every wrapper in the sizing chain constrained; measured overflow then becomes internally scrollable. |
| Enable `overflow: auto` and overscroll containment only after measured content exceeds the available size. | Always making every Popover a scroll container could clip shadows or intentionally protruding content, even when nothing overflowed. | Resize, content-mutation, image-load, window-resize, and visual-viewport changes remeasure the surface; repeated signals are coalesced to one measurement per animation frame so live-updating content does not force repeated layout reads. |
| Prefer the first real focusable content control during autofocus. | The generated fallback close control could become the first focus target instead of the action the user opened the Popover to use. | The canonical focusable selector is reused, but elements inside the fallback-close wrapper are excluded from initial-focus selection. |
| Focus the labeled dialog container when a dialog-style Popover has no content controls. | Read-only content still needs a predictable initial focus target, but focusing the hidden close control made it visibly appear. | `tabIndex={-1}` makes the already labeled dialog container programmatically focusable without adding it to normal tab order. |
| Let Tab move from a programmatically focused trap container into its first control, and Shift+Tab into its last control. | Once the read-only dialog container owned focus, the existing focus trap could let the first Tab escape instead of entering the trap’s controls. | This extends the existing trap cycle only for the case where the trap container itself is focused; ordinary first/last-control wrapping is unchanged. |
| Mark the generated fallback close wrapper and retain the fallback control in the tab sequence. | Excluding the fallback from initial focus must not remove the keyboard escape mechanism. | The marker distinguishes generated fallback UI from product content; users can still Tab to the close control after reading the container content. |
| Preserve current trigger semantics and types. | Responsive work should not create source or ARIA regressions. | `PopoverTriggerRenderProps['aria-haspopup']` remains `'dialog'`; automatic triggers continue using the existing role-aware `usePopover` value. No public prop or dismissal contract changes. |
| Make the Disabled story’s Button actually disabled. | `isEnabled={false}` prevented Popover opening, but the trigger still looked and behaved like a clickable Button. | Setting `Button isDisabled` makes the example accurately demonstrate the whole disabled experience rather than only suppressing the Popover callback. |
| Add explicit-width, match-trigger, and tall-content stories using the actual Storybook viewport. | Unit styles alone did not prove the rendered wrapper chain; inline Docs previews can also make top-layer placement look like component overflow. | The stories use real Popover and List components, render in isolated Storybook iframes rather than the inline Docs canvas, and use no simulated phone or decorative frame. Reviewers or a device simulator can verify width caps, safe gutters, trigger-derived sizing, conditional scrolling, and page containment against the real story viewport. |
| Add trigger-interaction evidence that opens by activation rather than hover. | Popover must remain usable where hover is unavailable. | The story exercises click/tap-style activation and points to unit tests for Escape, outside press, and focus return. |
| Add a dedicated read-only dialog-focus story for manual assistive-technology checks. | Automated tests can verify ARIA and focus movement but cannot prove what a screen reader announces. | The story provides one stable scenario and explicit checks for the announced dialog name/role, forward and reverse Tab containment, Escape, and focus return. |
| Add separate “Keep Popover” and “BottomSheet option” stories using the same compact full-width action list. | Consumers needed a concrete way to compare the anchored and bottom-edge modal interaction contracts. | Holding task content constant makes those contract differences visible without claiming that content traits alone determine the component; compact `ListItem` rows are realistic actions rather than oversized custom Buttons. |
| Add an opt-in adaptive recipe. | Some products want a BottomSheet for compact coarse-pointer/no-hover environments, but automatic substitution would change focus, modality, scrim, scrolling, and dismissal semantics. | Core Popover remains unchanged. The story-local recipe adapts only when a product opts in and provides a deterministic override for review and tests. |
| Update Popover width documentation and the patch changeset. | Consumers otherwise would not know that requested widths are constrained or that long content may scroll. | The behavior is documented in full, translated, and dense component docs and is included in release notes. |
| Add regression tests for viewport caps, conditional overflow, trigger semantics, initial focus, fallback reachability, focus-trap entry, and measurement scheduling. | The fixes span CSS constraints, DOM measurement, ARIA, keyboard behavior, and live content updates. | Tests cover fitting versus overflowing content, one-measurement-per-frame coalescing, real controls winning focus, read-only content focusing the dialog, forward/reverse Tab entry, and the explicit empty-focusable guard. |

## Explicit non-goals

- Popover does **not** automatically become BottomSheet in Core.
- Width, pointer precision, and hover availability remain independent inputs.
- No public Popover prop, trigger type, or dismissal contract is changed.
- The comparison stories do not claim that scrolling, input complexity, search, content length, or hierarchy automatically determines another component.
- This PR does not define a universal component-selection rule; products must evaluate the task’s focus, space, modality, dismissal, and navigation requirements.
- Desktop Storybook and iOS Simulator do not establish VoiceOver or physical-device touch behavior.

## Responsive and Interaction Readiness

| Check | Result | Evidence |
| --- | --- | --- |
| Wide viewport + fine pointer + hover | Pass | Existing anchored presentation and non-overflowing content behavior are retained. |
| Narrow viewport + fine pointer + hover | Pass | Explicit and match-trigger widths cap to available space; scrolling activates only for measured overflow. |
| Narrow viewport + coarse pointer + no hover | Pass | Activation does not require hover; an opt-in BottomSheet recipe is available when product semantics justify it. |
| Wide viewport + coarse pointer + no hover | Pass | Popover remains anchored; touch availability alone does not substitute the component. |
| Keyboard initial focus | Pass | Real content controls receive initial focus; read-only dialog content focuses the labeled container. |
| Keyboard containment and escape | Pass | Tab enters the focusable cycle from the container, fallback close remains reachable, and Escape/focus return tests pass. |
| Adaptive presentation | Pass | Popover remains the default; BottomSheet is explicit and story-local. |
| Public API compatibility | Pass | Existing trigger props and `aria-haspopup` behavior are preserved. |
| iOS visual layout | Pass | The BottomSheet comparison was checked in Safari on an iPhone 17 Pro iOS 27 Simulator. |
| Screen-reader announcement | Follow-up | The `Read-only dialog focus` story now defines the manual test. NVDA + Chrome and VoiceOver + Safari announcement checks are not yet run, so this PR makes no screen-reader-announcement claim. |

## Validation

- `pnpm exec vitest run packages/core/src/Popover/Popover.test.tsx packages/core/src/hooks/useFocusTrap.test.tsx` — 52 tests pass
- `pnpm check:repo`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/storybook typecheck`
- targeted ESLint and Prettier checks
- `pnpm -F @astryxdesign/storybook build`
- Headless browser at 390×844: explicit-width and match-trigger Popovers remained within the viewport at 358px wide; the realistic project picker capped at 360px with `scrollHeight: 566px` and `overflow: auto`
- Real-viewport stories: `core-popover--viewport-fit`, `core-popover--match-trigger-viewport-fit`, and `core-popover--tall-content-overflow`
- Manual AT story: `core-popover--read-only-dialog-focus`; NVDA + Chrome and VoiceOver + Safari announcement checks remain follow-up work
- Headless Chromium at 390×844: the read-only story initially focuses the labeled `role="dialog"` container; Tab reaches the fallback Close button and Shift+Tab remains inside the dialog
- BottomSheet comparison checked in Safari on an iPhone 17 Pro iOS 27 Simulator





