### PR TITLE
refactor(MultiSelector): rename formatTriggerCount to formatValue and widen it to the trigger line

### DIFF
--- a/.changeset/multiselector-format-value.md
+++ b/.changeset/multiselector-format-value.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[component] MultiSelector: rename the unreleased `formatTriggerCount` prop to `formatValue` and widen it to the whole trigger line. It now receives the selected items (`{value, label}[]`, count available as `.length`) and formats the trigger for `triggerDisplay="count"` and `"labels"`; `"badges"` renders elements, so it is not used there. `formatValue` matches NumberInput and Slider, so the same idea has one name across the system. Defaults are unchanged when the prop is absent.
+
+@Kevinjohn

--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -629,7 +629,7 @@ export const Alignment: StoryObj = {
             </ChatMessage>
             <ChatMessage
               sender="assistant"
-              avatar={<Avatar name="Navi" size="small" />}>
+              avatar={<Avatar name="Navi" size="sm" />}>
               <ChatMessageBubble>
                 {align === 'top'
                   ? 'Top alignment keeps messages at the top — good for logs and document-style lists.'

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -104,10 +104,10 @@ export const docs = {
           default: "'count'",
         },
         {
-          name: 'formatTriggerCount',
-          type: '(count: number) => string',
+          name: 'formatValue',
+          type: '(items: {value: string; label: string}[]) => string',
           description:
-            'Formats the trigger text when triggerDisplay="count". Receives the selected count and returns the full trigger text.',
+            'Formats the trigger text when triggerDisplay="count" or "labels". Receives the selected items (value plus resolved label); the count is items.length. Not used by triggerDisplay="badges".',
         },
         {
           name: 'maxBadges',
@@ -290,6 +290,8 @@ export const docsZh = {
         placeholder: '未选择值时显示的占位文本。',
         size: '选择器的尺寸变体。',
         triggerDisplay: '在触发器中显示选中项的方式。',
+        formatValue:
+          '格式化 triggerDisplay="count" 或 "labels" 时的触发器文本。接收选中项（value 及解析后的 label），数量为 items.length。triggerDisplay="badges" 不使用此属性。',
         maxBadges:
           '显示"+N"之前的最大徽章数。仅适用于 triggerDisplay="badges"。',
         hasSelectAll: '是否显示全选复选框。',
@@ -426,8 +428,8 @@ export const docsDense = {
         variant:
           'visual trigger style: input bordered control or ghost toolbar control',
         triggerDisplay: 'how to show selected in trigger',
-        formatTriggerCount:
-          'formats count-mode trigger text; receives selected count',
+        formatValue:
+          'formats count/labels trigger text; receives selected items',
         maxBadges: 'max badges before "+N"; badges mode only',
         hasSelectAll: 'show select-all checkbox',
         selectAllLabel: 'select-all label',

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -128,17 +128,88 @@ describe('MultiSelector', () => {
     expect(screen.getByText('2 selected')).toBeInTheDocument();
   });
 
-  it('formats the count display with formatTriggerCount', () => {
+  it('formats the count display with formatValue', () => {
     render(
       <MultiSelector
         label="Spaces"
         options={defaultOptions}
         value={['Apple', 'Banana']}
         onChange={() => {}}
-        formatTriggerCount={count => `${count} spaces selected`}
+        formatValue={items => `${items.length} spaces selected`}
       />,
     );
     expect(screen.getByText('2 spaces selected')).toBeInTheDocument();
+  });
+
+  it('passes selected values and resolved labels to formatValue', () => {
+    const formatValue = vi.fn(
+      (items: {value: string; label: string}[]) =>
+        `${items[0].label} and ${items.length - 1} more`,
+    );
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={[
+          {value: 'a', label: 'Apple'},
+          {value: 'b', label: 'Banana'},
+        ]}
+        value={['a', 'b']}
+        onChange={() => {}}
+        formatValue={formatValue}
+      />,
+    );
+    expect(formatValue).toHaveBeenCalledWith([
+      {value: 'a', label: 'Apple'},
+      {value: 'b', label: 'Banana'},
+    ]);
+    expect(screen.getByText('Apple and 1 more')).toBeInTheDocument();
+  });
+
+  it('formats the labels display with formatValue', () => {
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={defaultOptions}
+        value={['Apple', 'Banana', 'Orange']}
+        onChange={() => {}}
+        triggerDisplay="labels"
+        formatValue={items => items.map(item => item.label).join(' & ')}
+      />,
+    );
+    expect(screen.getByText('Apple & Banana & Orange')).toBeInTheDocument();
+  });
+
+  it('ignores formatValue in badges display', () => {
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={defaultOptions}
+        value={['Apple', 'Banana']}
+        onChange={() => {}}
+        triggerDisplay="badges"
+        formatValue={() => 'formatted'}
+      />,
+    );
+    expect(screen.queryByText('formatted')).not.toBeInTheDocument();
+    const trigger = within(screen.getByRole('combobox'));
+    expect(trigger.getByText('Apple')).toBeInTheDocument();
+    expect(trigger.getByText('Banana')).toBeInTheDocument();
+  });
+
+  it('shows the placeholder rather than calling formatValue when empty', () => {
+    const formatValue = vi.fn(() => 'formatted');
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={defaultOptions}
+        value={[]}
+        onChange={() => {}}
+        placeholder="Pick fruits..."
+        formatValue={formatValue}
+      />,
+    );
+    expect(screen.getByText('Pick fruits...')).toBeInTheDocument();
+    expect(formatValue).not.toHaveBeenCalled();
   });
 
   it('shows labels display', () => {

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -424,6 +424,11 @@ export type MultiSelectorStatusType = 'warning' | 'error' | 'success';
 
 export type {MultiSelectorStatus};
 
+export interface MultiSelectorSelectedItem {
+  value: string;
+  label: string;
+}
+
 export interface MultiSelectorProps<
   T extends MultiSelectorOptionType = MultiSelectorOptionType,
 > extends Omit<BaseProps, 'onChange' | 'defaultValue'> {
@@ -609,11 +614,15 @@ export interface MultiSelectorProps<
   triggerDisplay?: 'count' | 'labels' | 'badges';
 
   /**
-   * Formats the trigger text when triggerDisplay is 'count'.
-   * Receives the number of selected values and returns the full trigger text.
-   * @default count => `${count} selected`
+   * Formats the trigger text when triggerDisplay is 'count' or 'labels'.
+   * Receives the selected items (value plus resolved label, in selection
+   * order) and returns the full trigger text; the count is `items.length`.
+   * Not called when nothing is selected — the placeholder shows instead — and
+   * not called for triggerDisplay 'badges', which renders Badge elements
+   * rather than text.
+   * @default items => `${items.length} selected` for 'count', "A, B, C, +N" for 'labels'
    */
-  formatTriggerCount?: (count: number) => string;
+  formatValue?: (items: MultiSelectorSelectedItem[]) => string;
 
   /**
    * Maximum number of badges to show before showing "+N".
@@ -718,7 +727,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   hasSearch = false,
   searchPlaceholder: searchPlaceholderFromProps,
   triggerDisplay = 'count',
-  formatTriggerCount,
+  formatValue,
   maxBadges = 3,
   renderOption,
   indicatorPosition = 'start',
@@ -1115,12 +1124,17 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   }, [popover.isOpen, highlightedIndex, getItemId]);
 
   // Build trigger display content
-  const selectedLabels = useMemo(() => {
+  const selectedItems = useMemo(() => {
     return optimisticValue.map(v => {
       const item = selectableItems.find(i => i.value === v);
-      return item?.label ?? v;
+      return {value: v, label: item?.label ?? v};
     });
   }, [optimisticValue, selectableItems]);
+
+  const selectedLabels = useMemo(
+    () => selectedItems.map(item => item.label),
+    [selectedItems],
+  );
 
   const renderTriggerContent = useCallback(() => {
     if (optimisticValue.length === 0) {
@@ -1131,7 +1145,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       case 'count':
         return (
           <span {...stylex.props(styles.triggerText)}>
-            {formatTriggerCount?.(optimisticValue.length) ??
+            {formatValue?.(selectedItems) ??
               `${optimisticValue.length} selected`}
           </span>
         );
@@ -1143,7 +1157,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           remaining > 0
             ? `${displayed.join(', ')}, +${remaining}`
             : displayed.join(', ');
-        return <span {...stylex.props(styles.triggerText)}>{text}</span>;
+        return (
+          <span {...stylex.props(styles.triggerText)}>
+            {formatValue?.(selectedItems) ?? text}
+          </span>
+        );
       }
 
       case 'badges': {
@@ -1166,9 +1184,10 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   }, [
     optimisticValue,
     triggerDisplay,
+    selectedItems,
     selectedLabels,
     placeholder,
-    formatTriggerCount,
+    formatValue,
     maxBadges,
   ]);
 

--- a/packages/core/src/MultiSelector/index.ts
+++ b/packages/core/src/MultiSelector/index.ts
@@ -13,6 +13,7 @@ export {
   type MultiSelectorProps,
   type MultiSelectorSize,
   type MultiSelectorStatusType,
+  type MultiSelectorSelectedItem,
 } from './MultiSelector';
 export type {
   MultiSelectorOptionType,


### PR DESCRIPTION
## Problem

A builder who wants to control the text a component renders for its value finds a different prop name on every component they reach for:

| component | prop | signature |
|---|---|---|
| [NumberInput](https://github.com/facebook/astryx/blob/main/packages/core/src/NumberInput) | `formatValue` | `(value: number) => string` |
| [Slider](https://github.com/facebook/astryx/blob/main/packages/core/src/Slider) | `formatValue` | `(value: number) => string` |
| ProgressBar | `formatValueLabel` | `(value: number, max: number) => string` |
| MultiSelector | `formatTriggerCount` | `(count: number) => string` |

[#4032](https://github.com/facebook/astryx/pull/4032) added the fourth spelling this morning. It has **not shipped**: `git tag --contains b31b8a0b5d7` is empty and the published `@astryxdesign/core` is 0.4.7, which predates the merge. So fixing the name today costs nothing — no codemod, no deprecation window, no breaking changeset, just a `patch`. The moment it ships once, it is permanent public surface and this becomes a migration.

## Change

`formatTriggerCount` → **`formatValue`**, and the callback now formats the whole trigger line rather than only the count.

```ts
formatValue?: (items: MultiSelectorSelectedItem[]) => string;  // {value: string; label: string}[]
```

**Why items rather than a count.** A prop named `formatValue` that only sees `count` cannot express what people actually want in the trigger — "Alice, Bob and 2 others", or a language whose plural rule depends on the items. The count survives as `items.length`, so nothing is lost against `(count: number) => string`. Handing over both the value and the resolved label is what makes it usable: values are opaque ids in real configs (`{value: 'a', label: 'Apple'}`), and labels are what the trigger renders — a caller who got only the values would have to re-resolve them against `options`, which the component already did just above. `MultiSelectorSelectedItem` is exported.

**Which display modes it reaches.** `triggerDisplay="count"` and `"labels"`, both of which render a single text string. It is deliberately **not** used by `"badges"`, which renders `Badge` elements rather than text; a string formatter there would have to either throw the badges away or be silently ignored, and neither is a good default for a mode whose whole point is the elements. That exclusion is stated in the JSDoc and in the docs, and there is a test that pins it. If someone wants a string trigger, `"count"`/`"labels"` is the mode for it.

A generic name that silently did nothing on two of three modes would be worse than the specific name was — this is what earns it.

**Defaults are byte-identical when the prop is absent**, which is the safety of the change: `count` still renders `` `${n} selected` ``, `labels` still renders `A, B, C, +N`, `badges` is untouched, and an empty selection still shows the placeholder without calling the formatter. All 111 existing MultiSelector tests pass unchanged, including the ones that assert those exact strings.

**Not done, deliberately:**

- **`ProgressBar.formatValueLabel` stays as it is.** It is released, so renaming it costs a codemod and a deprecation cycle — a separate decision nobody has made. It remains the odd one out until someone makes it.
- **The `?? '${n} selected'` fallback stays at the call site** rather than becoming a real default parameter. With the prop now covering two modes the default output is mode-dependent (`count` → `"3 selected"`, `labels` → `"A, B, C, +N"`), so a single default value cannot express it.

## Test plan

- `vitest run packages/core/src/MultiSelector/MultiSelector.test.tsx` — **111 passed**. New: `formatValue` in count mode; the items argument carries values *and* resolved labels (`{value: 'a', label: 'Apple'}`); `formatValue` in labels mode; badges mode ignores it and still renders badges; an empty selection shows the placeholder and never calls the formatter.
- `pnpm -F @astryxdesign/core typecheck` and `typecheck:docs` — both clean.
- `git grep -rn formatTriggerCount` — no matches anywhere in the repo, including `packages/cli/assets/templates/`.
- Docs updated in all three blocks of `MultiSelector.doc.mjs` (full, `docsZh`, `docsDense`); the zh block never had an entry for this prop, so one was added.

Changeset: `patch`, credited to @Kevinjohn, whose PR this refines.

---

**One unrelated commit, because main is red.** `build-storybook` fails on current main, not on this change: [#3933](https://github.com/facebook/astryx/pull/3933) landed `<Avatar size="small">` in `Chat.stories.tsx:632` after [#4140](https://github.com/facebook/astryx/pull/4140) replaced Avatar's named sizes with the abbreviated scale (`xsm | sm | md | lg | xl`), so `pnpm -F @astryxdesign/storybook typecheck` errors and blocks every PR branched off it. Fixed here as a separate commit (`"small"` → `"sm"`) rather than left for someone else to hit. Happy to split it out if you would rather it landed on its own.
