### PR TITLE
test(markdown): assert the streaming cache holds at every document length

### DIFF
--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -8,7 +8,10 @@ import {
 } from './parser';
 import type {BlockNode, ParseOptions} from './parser';
 
-function generateAIResponse(paragraphs: number): string {
+function generateAIResponse(
+  paragraphs: number,
+  {codeBlocks = true}: {codeBlocks?: boolean} = {},
+): string {
   const sections: string[] = [];
   for (let i = 0; i < paragraphs; i++) {
     const mod = i % 6;
@@ -20,7 +23,9 @@ function generateAIResponse(paragraphs: number): string {
         break;
       case 1:
         sections.push(
-          '```typescript\nfunction process(data: Record<string, unknown>[]) {\n  return data.filter(item => item.valid)\n    .map(item => transform(item))\n    .reduce((acc, val) => merge(acc, val), {});\n}\n```',
+          codeBlocks
+            ? '```typescript\nfunction process(data: Record<string, unknown>[]) {\n  return data.filter(item => item.valid)\n    .map(item => transform(item))\n    .reduce((acc, val) => merge(acc, val), {});\n}\n```'
+            : `Paragraph ${i} continues the explanation with a second block of prose, keeping the block mix realistic without opening a fence.`,
         );
         break;
       case 2:
@@ -100,8 +105,10 @@ function blocksBuiltPerChunk(
   return built;
 }
 
-const median = (values: number[]): number =>
-  [...values].sort((a, b) => a - b)[Math.floor((values.length - 1) / 2)];
+const percentile = (values: number[], p: number): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))];
+};
 
 const sum = (values: number[]): number => values.reduce((a, b) => a + b, 0);
 
@@ -248,7 +255,10 @@ describe('parseMarkdownIncremental cache', () => {
   it('builds a bounded number of blocks per chunk however long the document is', () => {
     const chunkSize = 50;
     const medians = [50, 200, 500].map(paragraphs =>
-      median(blocksBuiltPerChunk(generateAIResponse(paragraphs), chunkSize)),
+      percentile(
+        blocksBuiltPerChunk(generateAIResponse(paragraphs), chunkSize),
+        0.5,
+      ),
     );
     console.log(
       `  median blocks built per chunk (50/200/500 paragraphs): ${medians.join('/')}`,
@@ -256,6 +266,28 @@ describe('parseMarkdownIncremental cache', () => {
     // A chunk re-parses its unsettled tail, not the document — so the typical
     // chunk's cost is a constant, and a 10x longer document does not move it.
     expect(medians).toEqual([2, 2, 2]);
+  });
+
+  it('bounds the p95 chunk, not just the median one, at every document length', () => {
+    const chunkSize = 50;
+    const p95s = [50, 200, 500].map(paragraphs =>
+      percentile(
+        blocksBuiltPerChunk(
+          generateAIResponse(paragraphs, {codeBlocks: false}),
+          chunkSize,
+        ),
+        0.95,
+      ),
+    );
+    console.log(
+      `  p95 blocks built per chunk (50/200/500 paragraphs): ${p95s.join('/')}`,
+    );
+    // The median above cannot see a cache that holds for the typical chunk and
+    // collapses on a minority of them — p50-flat, still O(N). Fence-free takes
+    // out the worse of the two paths that still dump the whole cache on main
+    // (#5378); the other is live at ~2% of chunks, which puts the cliff just
+    // under p98 — so p95 is the bound with margin rather than the highest one.
+    expect(p95s).toEqual([3, 3, 3]);
   });
 
   it('keeps the cache when source ranges are asked for', () => {


### PR DESCRIPTION
## Problem

A chat view streaming a Markdown-heavy AI response re-parses on every token. The
incremental parser exists so that each token re-parses the *unsettled tail*, not
the document; when that cache is lost the cost per token becomes O(N) and the
user watches the message stutter as it grows.

**The wall-clock budgets could not have told us.** `parser.perf.test.ts` asserts
them with 10x headroom. Destroying the cache locally — dropping
`settledText`/`settledBlocks` on every call — left all five budget tests passing,
the XL streaming case at 2741ms against its 30000ms budget.

The `blocksBuiltPerChunk` median added in
[#5366](https://github.com/facebook/astryx/pull/5366) closes part of that, but
only part: **a cache that holds for the typical chunk and collapses on a minority
of them is p50-flat and still O(N) overall.** The median cannot see that shape,
and that shape is what
[#5378](https://github.com/facebook/astryx/issues/5378) documents on `main`.

## Change

Test-only, no production code touched. Adds one assertion to the
`parseMarkdownIncremental cache` block: **p95 blocks rebuilt per chunk, and that
it does not move across a 10x document** — 3 at 50, 200 and 500 paragraphs.

The signal is object identity. A block the parser kept in its settled cache is
handed back as the very same object, so a returned block that is not one of the
previous chunk's is one this chunk built. That reads the cache without a counter,
a mock, or a test-only export. Fixture and chunking are deterministic, so every
asserted number is an integer with no timing input — it reads the same on a
loaded CI box as on an idle laptop.

`generateAIResponse` grows one optional `{codeBlocks: false}` flag; the default is
unchanged and every existing test keeps its old fixture. The one-off `median`
helper is gone and the [#5366](https://github.com/facebook/astryx/pull/5366)
assertion now calls `percentile(v, 0.5)` — one convention for one statistic;
verified value-identical at all three asserted lengths.

## Deliberate break — the assertion has been watched fail

Two breaks to `parseMarkdownIncremental`, each run and then reverted.

**A — the settled cache dropped on every chunk**, the shape of the design that
measured 71.8ms against 34.9ms on a 14k document:

| test | broken | restored |
| --- | --- | --- |
| 5x `full re-parse … under Nms` | **pass** | pass |
| `streaming full re-parse Medium/XL` | **pass** | pass |
| `streaming incremental Medium/XL` | **pass** (2741ms / 30000ms) | pass |
| `incremental parse is faster than full re-parse` | fail — 0.79x against a 1.1x tolerance | pass |
| `median blocks built per chunk` | fail — `[31, 118, 293]` vs `[2, 2, 2]` | pass |
| **`p95 blocks built per chunk`** | **fail — `[58, 223, 556]` vs `[3, 3, 3]`** | pass |

Every wall-clock *budget* passed with the cache completely destroyed. The one
wall-clock test that did catch it is a ratio, and it caught it by 21%.

**B — the cache dropped on one chunk in eight**, a minority collapse, which is
the case this PR exists for:

| test | broken |
| --- | --- |
| `incremental parse is faster than full re-parse` | **pass** — 1.60x |
| `median blocks built per chunk` | **pass** — `2/2/2` |
| **`p95 blocks built per chunk`** | **fail — `[42, 161, 387]` vs `[3, 3, 3]`** |

Nothing that was already there sees it. In both breaks the new assertion's
failure values grow with document length — the O(N) signature the budgets cannot
see.

## Why p95, and why no code fences

Two paths still drop the whole settled cache on `main` — an open code fence, and
a chunk boundary landing one line past a blank line — both filed as
[#5378](https://github.com/facebook/astryx/issues/5378), both parser bugs, both
out of scope for a test-only PR.

Removing fences from the fixture takes the first out. The second is still live at
~2% of chunks, so **this assertion does not catch the O(N) that is on `main`
today** — measured fence-free, total blocks rebuilt is 214 / 2156 / 9359 at
50 / 200 / 500 paragraphs while p95 stays flat at 3. It is the strongest bound
that is green, not a clean bill of health.

What it does bound: any collapse hitting more than ~5% of chunks, at any document
length. p90 (2/2/2) would only reach 10%; the cliff is just under p98, which is
already red on `main` (`3/44/3`). p95 is chosen for margin, not for being the
highest green value — p96, p97 and p97.5 are all 3/3/3 too.

The five wall-clock tests are left alone. Deleting them is a separate argument.

## Test plan

`pnpm exec vitest run packages/core/src/Markdown/parser.perf.test.ts` — 14
passed.

```
  median blocks built per chunk (50/200/500 paragraphs): 2/2/2
  p95 blocks built per chunk (50/200/500 paragraphs): 3/3/3
```

Rebased onto `main` — the earlier red was
`apps/storybook/stories/Chat.stories.tsx` failing typecheck on `size="small"`,
which was on the branch's merge-base and fixed on `main` by
[#5377](https://github.com/facebook/astryx/pull/5377).

No changeset — test-only, matching recent `test(...)` commits.
