### PR TITLE
ci: unbreak the two red scheduled maintenance jobs

### DIFF
--- a/.github/scripts/compact-gh-pages-history.sh
+++ b/.github/scripts/compact-gh-pages-history.sh
@@ -7,6 +7,7 @@ PAGES_BRANCH="${PAGES_BRANCH:-gh-pages}"
 REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
 REMOTE_URL="https://x-access-token:${TOKEN}@github.com/${REPO}.git"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
 WORK_DIR="$(mktemp -d)"
 
 cleanup() {
@@ -17,17 +18,51 @@ trap cleanup EXIT
 CURRENT_DIR="${WORK_DIR}/current"
 COMPACT_DIR="${WORK_DIR}/compact"
 
-git clone --depth=1 --single-branch --branch "${PAGES_BRANCH}" "${REMOTE_URL}" "${CURRENT_DIR}"
-OLD_HEAD="$(git -C "${CURRENT_DIR}" rev-parse HEAD)"
+# gh-pages has concurrent writers this workflow is not serialized against —
+# preview deploys and cleanup runs sit in their own concurrency groups — and
+# compaction takes ~10 minutes, so the lease taken at clone time regularly goes
+# stale before the push ("[rejected] (stale info)"). The snapshot is of the tip
+# it cloned, so a retry has to re-clone: pushing the old snapshot would silently
+# revert whatever landed meanwhile. Same shape as the retry in
+# cleanup-previews.yml.
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+  if [ "${attempt}" -gt 1 ]; then
+    echo "Retrying compaction in $((attempt * 2))s (attempt ${attempt}/${MAX_ATTEMPTS})"
+    sleep $((attempt * 2))
+  fi
 
-mkdir -p "${COMPACT_DIR}"
-rsync -a --delete --exclude='.git' "${CURRENT_DIR}/" "${COMPACT_DIR}/"
+  rm -rf "${CURRENT_DIR}" "${COMPACT_DIR}"
 
-cd "${COMPACT_DIR}"
-git init -b "${PAGES_BRANCH}"
-git config user.name "github-actions[bot]"
-git config user.email "github-actions[bot]@users.noreply.github.com"
-git add -A
-git commit --allow-empty -m "chore: compact ${PAGES_BRANCH} history"
-git remote add origin "${REMOTE_URL}"
-git push origin "HEAD:refs/heads/${PAGES_BRANCH}" "--force-with-lease=refs/heads/${PAGES_BRANCH}:${OLD_HEAD}"
+  git clone --depth=1 --single-branch --branch "${PAGES_BRANCH}" "${REMOTE_URL}" "${CURRENT_DIR}"
+  OLD_HEAD="$(git -C "${CURRENT_DIR}" rev-parse HEAD)"
+
+  mkdir -p "${COMPACT_DIR}"
+  rsync -a --delete --exclude='.git' "${CURRENT_DIR}/" "${COMPACT_DIR}/"
+
+  (
+    cd "${COMPACT_DIR}"
+    git init -b "${PAGES_BRANCH}"
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git add -A
+    git commit --allow-empty -m "chore: compact ${PAGES_BRANCH} history"
+    git remote add origin "${REMOTE_URL}"
+  )
+
+  if PUSH_OUT=$(git -C "${COMPACT_DIR}" push origin \
+    "HEAD:refs/heads/${PAGES_BRANCH}" \
+    "--force-with-lease=refs/heads/${PAGES_BRANCH}:${OLD_HEAD}" 2>&1); then
+    echo "Compacted ${PAGES_BRANCH} to a single commit (previous tip ${OLD_HEAD})"
+    exit 0
+  fi
+  echo "${PUSH_OUT}"
+
+  # A permission denial is not a race; retrying can never clear it.
+  if echo "${PUSH_OUT}" | grep -qiE 'denied|403|permission|not authorized'; then
+    echo "::error::Push to ${PAGES_BRANCH} denied (403/permissions) — not a race, aborting."
+    exit 1
+  fi
+done
+
+echo "::error::Failed to compact ${PAGES_BRANCH} after ${MAX_ATTEMPTS} attempts"
+exit 1

--- a/scripts/prune-branches.sh
+++ b/scripts/prune-branches.sh
@@ -84,7 +84,7 @@ else
 fi
 
 # Progress (count files in all dirs)
-done_count=$(ls "$tmp_dir/delete" "$tmp_dir/keep" "$tmp_dir/stale" 2>/dev/null | wc -l | tr -d ' ')
+done_count=$(find "$tmp_dir/delete" "$tmp_dir/keep" "$tmp_dir/stale" -type f 2>/dev/null | wc -l | tr -d ' ')
 printf "\r  %s/%s checked" "$done_count" "$5" >&2
 CHECKER
 chmod +x "$tmp_dir/checker.sh"
@@ -152,13 +152,19 @@ DELETER
 
   echo "" # newline after progress
 
-  deleted=$(grep -rl "ok" "$tmp_dir/results" 2>/dev/null | wc -l | tr -d ' ')
-  failed=$(grep -rl "fail" "$tmp_dir/results" 2>/dev/null | wc -l | tr -d ' ')
+  # grep exits 1 when a class is empty, and under `set -e` + `pipefail` that
+  # aborts the script — on the all-succeeded path, which is the normal one.
+  deleted=$(grep -rl "ok" "$tmp_dir/results" 2>/dev/null | wc -l | tr -d ' ' || true)
+  failed=$(grep -rl "fail" "$tmp_dir/results" 2>/dev/null | wc -l | tr -d ' ' || true)
 
   echo ""
   echo -e "${BOLD}Results:${NC}"
   echo -e "  ${GREEN}Deleted:${NC}   $deleted"
-  [ "$failed" -gt 0 ] && echo -e "  ${RED}Failed:${NC}    $failed"
+  # `[ … ] && echo` would return 1 here when nothing failed, which `set -e`
+  # reads as the script failing.
+  if [ "$failed" -gt 0 ]; then
+    echo -e "  ${RED}Failed:${NC}    $failed"
+  fi
   echo -e "  ${YELLOW}Remaining:${NC} $keep_count + protected"
 else
   echo ""


### PR DESCRIPTION
Two scheduled jobs on `main` are red. Both are script bugs.

**Prune merged branches** — failing every night since 2026-08-16 ([latest run](https://github.com/facebook/astryx/actions/runs/32622210065)). It deletes the branches fine, then exits 1 before printing its summary: `grep -rl "fail"` exits 1 when *no* deletion failed, and under `set -euo pipefail` that aborts the script. The job is red exactly when everything worked. `[ "$failed" -gt 0 ] && echo …` is the same bug one line later — it returns 1 when there is nothing to report. Progress counting also moves from `ls` to `find`; `ls` with three directory arguments prints headers, which is where "177/172 checked" came from.

**Compact GitHub Pages History** — failed its last weekly run ([run](https://github.com/facebook/astryx/actions/runs/32015347336)) with `! [rejected] HEAD -> gh-pages (stale info)`. gh-pages has writers this workflow is not serialized against (`deploy-preview.yml`, `cleanup-previews.yml`, `redeploy-preview.yml` all sit in their own concurrency groups) and compaction takes ~10 minutes, so the lease taken at clone time goes stale. Now retries up to 5 times, re-cloning each attempt so the snapshot is of the *current* tip — pushing the stale snapshot would silently revert whatever landed meanwhile — and fails fast on a permission denial instead of burning attempts. Same shape as the retry already in `cleanup-previews.yml`.

## Test plan

Neither script is reachable from CI on a PR, so both were exercised locally against stubs.

`prune-branches.sh`, with `git`/`gh` stubbed to report 3 merged branches and 1 open:

| case | before | after |
|---|---|---|
| all deletions succeed | **exit 1**, no `Results:` block — reproduces the CI failure exactly | exit 0, `Deleted: 3` |
| one deletion fails | exit 1 | exit 0, `Deleted: 2` / `Failed: 1` |
| nothing to prune | exit 0 | exit 0 |
| dry run | exit 0 | exit 0 |
| progress counter | `4/4 checked` (`5/4` with the header rows) | `4/4 checked` |

`compact-gh-pages-history.sh`, against a local bare repo standing in for the remote:

- 3-commit gh-pages → 1 commit, tree and file contents identical.
- Concurrent writer pushed between clone and push: first push rejected with the same `(stale info)` error seen in CI, attempt 2 re-clones and succeeds — **and the racing writer's file survives** in the compacted tree.
- Push denied with a 403-style message: exits 1 immediately, zero retries.
- Push always rejected: retries to `MAX_ATTEMPTS`, then exits 1 with an `::error::`.

## Not fixed here

The **Weekly A11y Scan** is also red, and it is red for a real reason — 8 new axe violations against the checked-in baseline, in `Schedule`, `TableRowExpansion`, `TableTree` and `useContainerReveal`. Separate change.