### PR TITLE
fix(storybook): use a size token Avatar still has in the Chat align story

### DIFF
--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -629,7 +629,7 @@ export const Alignment: StoryObj = {
             </ChatMessage>
             <ChatMessage
               sender="assistant"
-              avatar={<Avatar name="Navi" size="small" />}>
+              avatar={<Avatar name="Navi" size="sm" />}>
               <ChatMessageBubble>
                 {align === 'top'
                   ? 'Top alignment keeps messages at the top — good for logs and document-style lists.'


### PR DESCRIPTION
## Problem

`main` is red, and it blocks the `build` job on every open PR:

```
stories/Chat.stories.tsx(632,43): error TS2322:
  Type '"small"' is not assignable to type 'AvatarSize | undefined'.
```

Avatar's named size scale became `xsm | sm | md | lg | xl` in [#4140](https://github.com/facebook/astryx/pull/4140). The `ChatMessageList align` story landed after that in [#3933](https://github.com/facebook/astryx/pull/3933) still using the old `"small"`, so the two are individually fine and broken together.

`build-storybook` fails at its typecheck step, `build` is the aggregator that asserts it passed, and auto-merge stays blocked. Found it on [#5379](https://github.com/facebook/astryx/pull/5379), which touches one test file and nothing else.

## Change

One token: `size="small"` → `size="sm"`. It is the only `size="small"` left in the repo, and every other Avatar in `Chat.stories.tsx` already uses `"md"`.

## Test plan

`pnpm -F @astryxdesign/storybook typecheck` — the `TS2322` is gone. The `TS2307`s that remain locally are unbuilt workspace packages (`@astryxdesign/vega`, `@astryxdesign/theme-neutral`); CI builds those first, and this is the error it reported.

No changeset — Storybook is not published.