### PR TITLE
fix(a11y,rtl): unbreak the weekly a11y scan and Schedule's RTL chevrons

### DIFF
--- a/.changeset/a11y-table-row-expansion-header.md
+++ b/.changeset/a11y-table-row-expansion-header.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table useTableRowExpansion: the chevron gutter's column header now carries a visually hidden localized name ("Row expansion", key `@astryx.tableRowExpansion.columnHeader`) instead of an empty `<th>` (axe empty-table-header, WCAG 1.3.1 best practice). The gutter stays visually blank.
+@cixzhang

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -919,6 +919,11 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-conditional-attr?application=playwright"
     },
     {
+      "key": "TableTree::Row Click Expansion::aria-conditional-attr",
+      "impact": "serious",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-conditional-attr?application=playwright"
+    },
+    {
       "key": "TableTree::With Selection::aria-conditional-attr",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-conditional-attr?application=playwright"
@@ -975,26 +980,6 @@
     },
     {
       "key": "Tokenizer::Disabled::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "useContainerReveal::Inverted Conceal::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "useContainerReveal::Nested Isolation::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "useContainerReveal::Preserve Layout::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "useContainerReveal::Reveal::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     }

--- a/apps/storybook/stories/UseContainerReveal.stories.tsx
+++ b/apps/storybook/stories/UseContainerReveal.stories.tsx
@@ -6,6 +6,7 @@ import {useState} from 'react';
 import {useContainerReveal} from '@astryxdesign/core/hooks';
 import {Button} from '@astryxdesign/core/Button';
 import {mergeProps} from '@astryxdesign/core/utils';
+import {colorVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {TrashIcon, PencilIcon} from '@heroicons/react/24/outline';
 
 const styles = stylex.create({
@@ -32,7 +33,11 @@ const styles = stylex.create({
   },
   label: {fontSize: 14},
   actions: {display: 'flex', gap: 4},
-  hint: {fontSize: 12, color: '#888', marginBottom: 8},
+  hint: {
+    fontSize: 12,
+    color: colorVars['--color-text-secondary'],
+    marginBottom: 8,
+  },
   toggle: {marginBottom: 8},
   nested: {
     marginTop: 8,

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1071,6 +1071,10 @@
     "defaultMessage": "Expand row",
     "description": "Screen-reader-only label on the row-expand chevron when the row is currently collapsed. Part of a four-way set with `collapseRow`, `expandAllRows`, `collapseAllRows`."
   },
+  "@astryx.tableRowExpansion.columnHeader": {
+    "defaultMessage": "Row expansion",
+    "description": "Screen-reader-only header for the leading column that holds the per-row expand/collapse chevrons. The column shows no visible label."
+  },
   "@astryx.tableRowExpansion.collapseAllRows": {
     "defaultMessage": "Collapse all rows",
     "description": "Screen-reader-only label on the same header button when every row is expanded. Part of the four-way set."

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -21,6 +21,7 @@ import {useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars, colorVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
+import {VisuallyHidden} from '../../../VisuallyHidden';
 import {resolveContextActions} from '../../tableContextMenu';
 import {useTranslator} from '../../../i18n';
 import {rtlStyles} from '../../../utils';
@@ -207,7 +208,13 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
   const expansionColumn = useMemo(
     (): TableColumn<T> => ({
       key: '__expansion',
-      header: '',
+      // A `<th>` with no discernible text is announced as an unlabelled
+      // column; the label is hidden because the column shows only chevrons.
+      header: (
+        <VisuallyHidden>
+          {t('@astryx.tableRowExpansion.columnHeader')}
+        </VisuallyHidden>
+      ),
       width: EXPANSION_COLUMN_WIDTH,
       resizable: false,
       renderCell: (item: T) => {
@@ -226,7 +233,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
         );
       },
     }),
-    [expandedKeys, onToggle, getRowKey, getIsItemExpandable],
+    [expandedKeys, onToggle, getRowKey, getIsItemExpandable, t],
   );
 
   return useMemo(

--- a/packages/lab/src/Schedule/plugins/PaginationPlugin.tsx
+++ b/packages/lab/src/Schedule/plugins/PaginationPlugin.tsx
@@ -14,6 +14,7 @@ import {Button} from '@astryxdesign/core/Button';
 import {ButtonGroup} from '@astryxdesign/core/ButtonGroup';
 import {Icon} from '@astryxdesign/core/Icon';
 import {IconButton} from '@astryxdesign/core/IconButton';
+import {rtlStyles} from '@astryxdesign/core/utils';
 import {useScheduleContext} from '../context';
 import type {
   ScheduleHeaderContent,
@@ -37,13 +38,27 @@ function SchedulePaginationControls() {
     <ButtonGroup label="Schedule pagination" size="sm">
       <IconButton
         label={previousDateLabel}
-        icon={<Icon icon="chevronLeft" size="sm" color="inherit" />}
+        icon={
+          <Icon
+            icon="chevronLeft"
+            size="sm"
+            color="inherit"
+            xstyle={rtlStyles.mirror}
+          />
+        }
         onClick={onPreviousDate}
       />
       <Button label="Today" size="sm" onClick={onToday} />
       <IconButton
         label={nextDateLabel}
-        icon={<Icon icon="chevronRight" size="sm" color="inherit" />}
+        icon={
+          <Icon
+            icon="chevronRight"
+            size="sm"
+            color="inherit"
+            xstyle={rtlStyles.mirror}
+          />
+        }
         onClick={onNextDate}
       />
     </ButtonGroup>
@@ -85,14 +100,10 @@ function createSchedulePaginationPlugin({
   };
 }
 
-export const defaultSchedulePaginationPlugin =
-  createSchedulePaginationPlugin();
+export const defaultSchedulePaginationPlugin = createSchedulePaginationPlugin();
 
 export function useSchedulePaginationPlugin({
   position = 'start',
 }: SchedulePaginationPluginOptions = {}): SchedulePlugin {
-  return useMemo(
-    () => createSchedulePaginationPlugin({position}),
-    [position],
-  );
+  return useMemo(() => createSchedulePaginationPlugin({position}), [position]);
 }

--- a/packages/lab/src/Schedule/shared.tsx
+++ b/packages/lab/src/Schedule/shared.tsx
@@ -244,12 +244,13 @@ export function ListEventRow({
   const {categories} = useScheduleContext();
   const category = getEventCategory(event, categories);
   return (
-    <div {...stylex.props(styles.listEventRow, isPast && styles.listEventPast)}>
+    <div {...stylex.props(styles.listEventRow)}>
       <span
         aria-hidden
         {...stylex.props(
           styles.listEventDot,
           eventDotColorStyle(category.color),
+          isPast && styles.listEventDotPast,
         )}
       />
       <span {...stylex.props(styles.listEventTime)}>
@@ -257,7 +258,13 @@ export function ListEventRow({
           ? 'All day'
           : formatEventTimeRange(event, timezoneID)}
       </span>
-      <span {...stylex.props(styles.listEventTitle)}>{event.title}</span>
+      <span
+        {...stylex.props(
+          styles.listEventTitle,
+          isPast && styles.listEventTitlePast,
+        )}>
+        {event.title}
+      </span>
     </div>
   );
 }
@@ -1072,7 +1079,13 @@ export const styles = stylex.create({
     lineHeight: typeScaleVars['--text-body-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
   },
-  listEventPast: {
+  // A past row is muted with the secondary text token, which the theme
+  // guarantees at AA. Fading the whole row with opacity instead pulled its
+  // text toward the surface behind it — 2.35:1 on the light theme.
+  listEventTitlePast: {
+    color: colorVars['--color-text-secondary'],
+  },
+  listEventDotPast: {
     opacity: 0.5,
   },
   eventBlue: {


### PR DESCRIPTION
Two independent `main` bugs, both in the same components, folded into one PR because **neither can go green alone**: `main` has a Schedule contrast violation *and* a Schedule RTL violation, so any PR touching Schedule reds both `pr-a11y` and `pr-rtl`. (This started as [#5383](https://github.com/facebook/astryx/pull/5383) + [#5387](https://github.com/facebook/astryx/pull/5387); #5387 is now folded in here and closed.)

Two commits, reviewable separately.

---

## 1 · `fix(a11y)` — clear the 8 violations failing the weekly scan

The [Weekly A11y Scan](https://github.com/facebook/astryx/actions/workflows/a11y-weekly.yml) has been red since 2026-08-03 ([latest run](https://github.com/facebook/astryx/actions/runs/31998548109)) — 8 axe violations not in `.github/a11y-baseline.json`. Seven fixed; one baselined alongside seven identical siblings that already were.

**`Table` / `useTableRowExpansion`** — the chevron gutter's `<th>` was `header: ''`, announced as an unlabelled column (`empty-table-header`). Now a `VisuallyHidden` localized name, the shape `useTableRowStatus` already uses for its status gutter ([#4693](https://github.com/facebook/astryx/pull/4693)). Adds `@astryx.tableRowExpansion.columnHeader`. The `<th>` box is unchanged at 40×38.

**`Schedule` list view** — a past row was faded with `opacity: 0.5`, pulling its text toward the surface behind it: **2.35:1** for the time, **3.4:1** for the title, both under AA. The title now uses `--color-text-secondary` (**7.81:1**, matching the time) and only the decorative category dot fades, so a past row still reads as past. The other Schedule views were already fixed this way — hence their five now-resolved baseline entries.

**`UseContainerReveal` stories** — the caption hardcoded `#888` (**3.54:1**) instead of a token; four newer stories inherited it. `--color-text-secondary` (**7.81:1**) clears all four *and* the four older captions in the baseline.

**Baselined, not fixed —** `TableTree::Row Click Expansion::aria-conditional-attr`: `aria-level` / `aria-expanded` on a `<tr>` inside `role="table"`. The plugin's **seven other stories carry the identical entry**, so this is that known issue on a story added later, not a new regression. Clearing it means promoting the tree table to `role="treegrid"` — a component change with keyboard implications, and its own diff.

Baseline delta `-4` / `+1` (207 → 204). The five resolved `Schedule` entries are deliberately **left in place**: those stories build data from `new Date()`, so which events are past depends on the weekday the audit runs.

## 2 · `fix(lab)` — mirror Schedule's pagination chevrons under RTL

Prev/next month render a hardcoded `chevronLeft`/`chevronRight` with no mirror, so under RTL they point the LTR way while the calendar flips — "previous month" points backwards. The auditor calls it a hard fail on `main` (`directional glyph never mirrors: aria:Previous month, aria:Next month`). Fix is `rtlStyles.mirror`, as `Pagination`, `Calendar` and `Stepper` already do.

---

## Test plan

**Both gates, run the way CI runs them**, against a fresh `pnpm build` + `storybook:build`:

| gate | `main` | this PR |
|---|---|---|
| a11y `--fail-on-new` | **8 new** | **0 new — gate passed** |
| RTL `--filter Schedule` | `AUTO FAIL schedule icons=2` | `AUTO PASS`, exit 0 |

**Measured in real Chromium**, not inferred from source:

| element | before | after |
|---|---|---|
| Schedule past event title | 2.35:1 / 3.4:1 | **7.81:1** |
| useContainerReveal caption | 3.54:1 | **7.81:1** |
| expansion `<th>` text | `null` | `"Row expansion"`, cell still 40×38 |
| chevron transform (LTR / RTL) | none / none | none / **`matrix(-1,0,0,1,0,0)`** |

The mirror is RTL-only — LTR is byte-identical.

**Screenshots** — Schedule List before/after differ only in the past rows reading darker; the RTL monthly view has "previous" on the right pointing right, "next" on the left pointing left.

**Suites:** `packages/core/src/Table` + `packages/lab/src/Schedule` — 508/508. `pnpm check:repo` clean (i18n: 307 en entries, 29 locales consistent). `eslint` clean.

`Table.perf.test.tsx` failed once at 209ms against a 200ms budget while a Storybook build shared the CPU; passes in isolation on this branch and on `main` — a known timing-sensitive test, unrelated.