### PR TITLE
fix(lab): mirror Schedule's pagination chevrons under RTL

### DIFF
--- a/packages/lab/src/Schedule/plugins/PaginationPlugin.tsx
+++ b/packages/lab/src/Schedule/plugins/PaginationPlugin.tsx
@@ -14,6 +14,7 @@ import {Button} from '@astryxdesign/core/Button';
 import {ButtonGroup} from '@astryxdesign/core/ButtonGroup';
 import {Icon} from '@astryxdesign/core/Icon';
 import {IconButton} from '@astryxdesign/core/IconButton';
+import {rtlStyles} from '@astryxdesign/core/utils';
 import {useScheduleContext} from '../context';
 import type {
   ScheduleHeaderContent,
@@ -37,13 +38,27 @@ function SchedulePaginationControls() {
     <ButtonGroup label="Schedule pagination" size="sm">
       <IconButton
         label={previousDateLabel}
-        icon={<Icon icon="chevronLeft" size="sm" color="inherit" />}
+        icon={
+          <Icon
+            icon="chevronLeft"
+            size="sm"
+            color="inherit"
+            xstyle={rtlStyles.mirror}
+          />
+        }
         onClick={onPreviousDate}
       />
       <Button label="Today" size="sm" onClick={onToday} />
       <IconButton
         label={nextDateLabel}
-        icon={<Icon icon="chevronRight" size="sm" color="inherit" />}
+        icon={
+          <Icon
+            icon="chevronRight"
+            size="sm"
+            color="inherit"
+            xstyle={rtlStyles.mirror}
+          />
+        }
         onClick={onNextDate}
       />
     </ButtonGroup>
@@ -85,14 +100,10 @@ function createSchedulePaginationPlugin({
   };
 }
 
-export const defaultSchedulePaginationPlugin =
-  createSchedulePaginationPlugin();
+export const defaultSchedulePaginationPlugin = createSchedulePaginationPlugin();
 
 export function useSchedulePaginationPlugin({
   position = 'start',
 }: SchedulePaginationPluginOptions = {}): SchedulePlugin {
-  return useMemo(
-    () => createSchedulePaginationPlugin({position}),
-    [position],
-  );
+  return useMemo(() => createSchedulePaginationPlugin({position}), [position]);
 }


### PR DESCRIPTION
Schedule's prev/next month buttons render a hardcoded `chevronLeft` / `chevronRight` with no mirror, so under RTL they keep pointing the LTR way while the rest of the calendar flips — "previous month" points backwards.

The RTL auditor has been calling this a hard fail on `main`:

```
AUTO FAIL schedule                 icons=2
  directional glyph never mirrors: aria:Previous month, aria:Next month
```

So `pr-rtl` goes red for **any** PR that touches Schedule — it is currently blocking [#5383](https://github.com/facebook/astryx/pull/5383).

Fix is `rtlStyles.mirror`, the same treatment `Pagination`, `Calendar` and `Stepper` already apply to their directional chevrons.

## Test plan

RTL audit, `--filter Schedule`, against a fresh Storybook build:

| | result |
|---|---|
| `main` | `AUTO FAIL schedule icons=2` — 1 fail, 1 surprise |
| this branch | `AUTO PASS schedule icons=2` — 1 pass, 0 fail, **exit 0** |

Computed transform on the glyph, measured in Chromium — the mirror is RTL-only and LTR is untouched:

| | LTR | RTL |
|---|---|---|
| `main` | none | none |
| this branch | none | `matrix(-1, 0, 0, 1, 0, 0)` |

Screenshotted the RTL monthly view: with the group's order flipped, "previous" now sits on the right and points right, "next" on the left pointing left. `packages/lab/src/Schedule` — 20/20 pass.