### PR TITLE
release-gate: run at 06:00 PT, give a11y a real timeout

### DIFF
--- a/.github/scripts/visual-gate/README.md
+++ b/.github/scripts/visual-gate/README.md
@@ -5,8 +5,9 @@ them against an accepted baseline, and answers one question before a release
 goes out: **did anything change on screen, and did we mean it?**
 
 Not part of PR CI — it costs minutes, not seconds. It runs once a day
-(`.github/workflows/release-gate.yml`, 07:10 PT) ahead of the 08:00 PT release
-cut, and on demand.
+(`.github/workflows/release-gate.yml`, 06:00 PT) ahead of the 08:00 PT release
+cut, and on demand. The two-hour margin is for the a11y leg, which audits every
+story and has taken ~57 minutes; the visual leg is ~15.
 
 ## Why it exists
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -9,10 +9,14 @@
 #             (the same full-suite audit a11y-weekly runs, run daily here)
 #
 # Why this is not in ci.yml: capturing several hundred screenshots and running
-# axe over every story costs ~15 minutes, which is the wrong tax on every push
-# to every PR. It runs once a day instead, at 07:10 PT — fifty minutes before
-# the 08:00 PT release cut — so the release has a fresh verdict to read, and on
-# demand for anyone who wants one sooner.
+# axe over every story is the wrong tax on every push to every PR. It runs once
+# a day instead, and on demand for anyone who wants one sooner.
+#
+# TIMING. It fires at 06:00 PT, two hours before the 08:00 PT release cut, and
+# the margin is deliberate: the visual leg takes ~15 min but the a11y leg audits
+# every story in the index and has taken ~57 min (a11y-weekly run 31998548109).
+# At the original 07:10 the verdict would have landed AFTER the cut window
+# opened — a gate the release cannot read in time is not a gate.
 #
 # THE VERDICT IS ADVICE WITH TEETH, NOT A VETO. `changed` is not `failed`: a
 # visual change is only a regression if nobody meant it. The release cut reads
@@ -29,8 +33,8 @@ name: Release Gate
 
 on:
   schedule:
-    # 14:10 UTC = 07:10 PT — before the 08:00 PT release cut, off the hour.
-    - cron: '10 14 * * *'
+    # 13:00 UTC = 06:00 PT — two hours before the 08:00 PT cut (see TIMING above).
+    - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:
       tiers:
@@ -135,7 +139,11 @@ jobs:
   a11y:
     name: Accessibility
     runs-on: 2-core-ubuntu-arm
-    timeout-minutes: 45
+    # The full-suite audit walks every story in the index and has taken ~57 min.
+    # A 45-minute budget killed it mid-audit, which reads as `crashed` — and a
+    # crashed gate holds the release, so an under-sized timeout would block
+    # every cut.
+    timeout-minutes: 90
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
Two timing bugs in the gate that just landed ([#5372](https://github.com/facebook/astryx/pull/5372)), both found by watching the first real runs.

**a11y needs 90 minutes, not 45.** The full-suite audit walks every story in the index; [a11y-weekly run 31998548109](https://github.com/facebook/astryx/actions/runs/31998548109) took 57 minutes. A 45-minute budget kills it mid-audit, the gate reports `crashed`, and a crashed gate holds the release — so an under-sized timeout would have blocked **every** cut.

**06:00 PT, not 07:10.** At 07:10 the a11y leg would finish around 08:07, after the 08:00 cut window opens. A gate the release cannot read in time is not a gate. Two hours of margin.

## Testing

The visual leg is verified end to end on main: gate run [32683897819](https://github.com/facebook/astryx/actions/runs/32683897819) reported **514/514 unchanged** against the baseline bootstrapped from run 32681968228 — two separate CI runners producing byte-identical shots, so determinism holds machine to machine and not just run to run.

The a11y leg is what this PR fixes; it was still running past 35 minutes on that same run when I caught the budget.