### PR TITLE
fix(ButtonGroup): one roving tab stop across the group's members

### DIFF
--- a/.changeset/button-group-roving-tabindex.md
+++ b/.changeset/button-group-roving-tabindex.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ButtonGroup is a single tab stop. Its members now share one roving tab stop instead of taking one each, so a three-button group costs one Tab press rather than three. Arrow keys move between members along the orientation (flipped in RTL), Home/End jump to the ends, focus wraps, and disabled members are skipped. Two consequences worth knowing: a keyboard script or test that tabbed through a group member by member must use arrow keys now, and a member rendered as a link (`href`) joins the arrow order for the first time.
+
+@cixzhang

--- a/.changeset/button-group-roving-tabindex.md
+++ b/.changeset/button-group-roving-tabindex.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] ButtonGroup is a single tab stop. Its members now share one roving tab stop instead of taking one each, so a three-button group costs one Tab press rather than three. Arrow keys move between members along the orientation (flipped in RTL), Home/End jump to the ends, focus wraps, and disabled members are skipped. Two consequences worth knowing: a keyboard script or test that tabbed through a group member by member must use arrow keys now, and a member rendered as a link (`href`) joins the arrow order for the first time.
+[fix] ButtonGroup is a single tab stop. Its members now share one roving tab stop instead of taking one each, so a three-button group costs one Tab press rather than three. Arrow keys move between members along the orientation (flipped in RTL), Home/End jump to the ends, focus wraps, and disabled members are skipped. Two consequences worth knowing: a keyboard script or test that tabbed through a group member by member must use arrow keys now, and a member rendered as a link (`href`) joins the arrow order for the first time. (#5389)
 
 @cixzhang

--- a/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
+++ b/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
@@ -47,6 +47,7 @@ export const docs = {
       {guidance: false, description: "Don't use ButtonGroup for navigation. Use SegmentedControl or TabList for switching between views."},
       {guidance: false, description: "Don't nest ButtonGroups. If you need multiple groups, place them side by side with a gap."},
       {guidance: true, description: 'Name the group for what its buttons act on. The label is the group\u2019s accessible name and a screen reader reads it before each member.'},
+      {guidance: true, description: 'Keep the group a single Tab stop. Arrow keys move between members along the orientation, Home/End jump to the ends, and disabled members are skipped — the WAI-ARIA APG roving tabindex technique: https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex'},
       {guidance: false, description: "Don't disable the group to show that an action is in flight. A disabled member drops focus, so a keyboard user loses their place; leave the group enabled and show progress on the button that started the work."},
     ],
     anatomy: [
@@ -87,6 +88,7 @@ export const docsZh = {
       {guidance: false, description: '不要使用 ButtonGroup 进行导航，使用 SegmentedControl 或 TabList 切换视图。'},
       {guidance: false, description: '不要嵌套 ButtonGroup。如需多个组，请并排放置并留有间隔。'},
       {guidance: true, description: '按钮组的标签应说明这些按钮作用于什么。该标签是按钮组的无障碍名称，屏幕阅读器会在每个成员之前朗读它。'},
+      {guidance: true, description: '按钮组是单个 Tab 停靠点。方向键沿排列方向在成员间移动焦点，Home/End 跳到首尾，禁用成员会被跳过——即 WAI-ARIA APG 的 roving tabindex 技术。'},
       {guidance: false, description: '不要用禁用整个按钮组来表示操作进行中。禁用的成员会失去焦点，键盘用户会丢失位置；请保持按钮组可用，并在发起操作的按钮上显示进度。'},
     ],
     anatomy: [
@@ -110,6 +112,7 @@ export const docsDense = {
       {guidance: false, description: "Don't use for navigation. Use SegmentedControl or TabList."},
       {guidance: false, description: "Don't nest ButtonGroups."},
       {guidance: true, description: 'Label the group for what its buttons act on; it is the accessible name.'},
+      {guidance: true, description: 'Single Tab stop; arrows move between members, Home/End to ends, disabled skipped (APG roving tabindex).'},
       {guidance: false, description: "Don't disable the group for an in-flight action; a disabled member drops focus."},
     ],
   },

--- a/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
@@ -12,6 +12,7 @@
  */
 
 import {describe, it, expect} from 'vitest';
+import type {ReactNode} from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {transformSync} from '@babel/core';
@@ -764,6 +765,25 @@ describe('ButtonGroup', () => {
       ).toHaveFocus();
     });
 
+    it('leaves a link member in the arrow order', async () => {
+      const user = userEvent.setup();
+      render(
+        <ButtonGroup label="Docs actions">
+          <Button label="Save" />
+          <Button label="Docs" href="https://example.com" />
+          <Button label="Print" />
+        </ButtonGroup>,
+      );
+
+      screen.getByRole('button', {name: 'Save'}).focus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('link', {name: 'Docs'})).toHaveFocus();
+
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('button', {name: 'Print'})).toHaveFocus();
+    });
+
     it('still moves between its own members when the group sits inside a popover', async () => {
       const user = userEvent.setup();
       // A group rendered inside a Popover, ContextMenu, HoverCard or Toast has
@@ -794,6 +814,192 @@ describe('ButtonGroup', () => {
 
       await user.keyboard('{Home}');
       expect(button('Copy')).toHaveFocus();
+    });
+  });
+
+  // ===========================================================================
+  // Roving tabindex
+  //
+  // The group is a single tab stop: exactly one enabled member carries
+  // tabindex="0", the rest carry -1, and the stop moves with arrow navigation.
+  // Entering and leaving is asserted through the real tab order as well as the
+  // attribute, because the attribute alone says nothing about a member the
+  // itemSelector missed — such a member stays natively tabbable and quietly
+  // adds a second stop.
+  // ===========================================================================
+  describe('roving tabindex', () => {
+    const tabIndexOf = (name: string) =>
+      screen.getByRole('button', {name}).getAttribute('tabindex');
+
+    const bracketed = (group: ReactNode) => (
+      <>
+        <button type="button">before</button>
+        {group}
+        <button type="button">after</button>
+      </>
+    );
+
+    const clipboard = (
+      <ButtonGroup label="Actions">
+        <Button label="Copy" />
+        <Button label="Cut" />
+        <Button label="Paste" />
+      </ButtonGroup>
+    );
+
+    it('gives the group one tab stop, on the first member', () => {
+      render(clipboard);
+
+      expect(tabIndexOf('Copy')).toBe('0');
+      expect(tabIndexOf('Cut')).toBe('-1');
+      expect(tabIndexOf('Paste')).toBe('-1');
+    });
+
+    it('takes one Tab to enter and one to leave', async () => {
+      const user = userEvent.setup();
+      render(bracketed(clipboard));
+
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'before'})).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'Copy'})).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'after'})).toHaveFocus();
+    });
+
+    it('moves the tab stop with arrow navigation', async () => {
+      const user = userEvent.setup();
+      render(clipboard);
+
+      screen.getByRole('button', {name: 'Copy'}).focus();
+      await user.keyboard('{ArrowRight}');
+
+      expect(tabIndexOf('Copy')).toBe('-1');
+      expect(tabIndexOf('Cut')).toBe('0');
+    });
+
+    it('never parks the tab stop on a disabled member', () => {
+      render(
+        <ButtonGroup label="Actions">
+          <Button label="Copy" isDisabled />
+          <Button label="Cut" />
+          <Button label="Paste" />
+        </ButtonGroup>,
+      );
+
+      expect(tabIndexOf('Copy')).toBe('-1');
+      expect(tabIndexOf('Cut')).toBe('0');
+    });
+
+    it('repairs the tab stop when the member holding it unmounts', () => {
+      const {rerender} = render(
+        <ButtonGroup label="Actions">
+          <Button label="Copy" />
+          <Button label="Cut" />
+        </ButtonGroup>,
+      );
+      expect(tabIndexOf('Copy')).toBe('0');
+
+      rerender(
+        <ButtonGroup label="Actions">
+          <Button label="Cut" />
+        </ButtonGroup>,
+      );
+
+      expect(tabIndexOf('Cut')).toBe('0');
+    });
+
+    it('repairs the tab stop when the member holding it becomes disabled', () => {
+      const {rerender} = render(
+        <ButtonGroup label="Actions">
+          <Button label="Copy" />
+          <Button label="Cut" />
+        </ButtonGroup>,
+      );
+      expect(tabIndexOf('Copy')).toBe('0');
+
+      rerender(
+        <ButtonGroup label="Actions">
+          <Button label="Copy" isDisabled />
+          <Button label="Cut" />
+        </ButtonGroup>,
+      );
+
+      expect(tabIndexOf('Copy')).toBe('-1');
+      expect(tabIndexOf('Cut')).toBe('0');
+    });
+
+    it('counts a link member as the tab stop', async () => {
+      const user = userEvent.setup();
+      render(
+        bracketed(
+          <ButtonGroup label="Docs actions">
+            <Button label="Docs" href="https://example.com" />
+            <Button label="Print" />
+          </ButtonGroup>,
+        ),
+      );
+
+      expect(
+        screen.getByRole('link', {name: 'Docs'}).getAttribute('tabindex'),
+      ).toBe('0');
+      expect(tabIndexOf('Print')).toBe('-1');
+
+      await user.tab();
+      await user.tab();
+      expect(screen.getByRole('link', {name: 'Docs'})).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'after'})).toHaveFocus();
+    });
+
+    it('contributes no tab stop when the whole group is disabled', async () => {
+      const user = userEvent.setup();
+      render(
+        bracketed(
+          <ButtonGroup label="Actions" isDisabled>
+            <Button label="Copy" />
+            <Button label="Cut" />
+          </ButtonGroup>,
+        ),
+      );
+
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'before'})).toHaveFocus();
+
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'after'})).toHaveFocus();
+    });
+
+    it('leaves the tab stop on its own members when a member owns an open menu', async () => {
+      const user = userEvent.setup();
+      render(
+        <ButtonGroup label="Approve action">
+          <Button label="Allow once" />
+          <DropdownMenu
+            hasChevron={false}
+            button={{label: 'Allow options', isIconOnly: true}}
+            items={[{label: 'Allow for 30 minutes'}, {label: 'Always allow'}]}
+          />
+        </ButtonGroup>,
+      );
+
+      const trigger = screen.getByRole('button', {name: /Allow options/});
+      expect(tabIndexOf('Allow once')).toBe('0');
+      expect(trigger.getAttribute('tabindex')).toBe('-1');
+
+      await user.click(trigger);
+
+      // The menu's own items are a different list level (the boundary), so the
+      // group must not stamp them or hand them its tab stop.
+      const item = screen.getByRole('menuitem', {
+        name: 'Allow for 30 minutes',
+        hidden: true,
+      });
+      expect(item.getAttribute('tabindex')).not.toBe('0');
+      expect(tabIndexOf('Allow once')).toBe('0');
     });
   });
 });

--- a/packages/core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.tsx
@@ -130,6 +130,10 @@ const elevationStyles = stylex.create({
  * Children automatically detect the group via context and apply position-aware
  * styles in pure CSS.
  *
+ * The group is a single tab stop: arrow keys move between members along the
+ * orientation, Home/End jump to the ends, focus wraps, and disabled members are
+ * skipped (the APG roving tabindex technique, via `useListFocus`).
+ *
  * Members that render their own layer — a Button with a `tooltip`, or a
  * DropdownMenu — compose correctly, including as the trailing member.
  *
@@ -166,12 +170,16 @@ export function ButtonGroup({
   ref,
   'data-testid': testId,
   onKeyDown,
+  onFocus,
   ...props
 }: ButtonGroupProps): ReactNode {
   const size = useSize(sizeProp, 'md');
 
-  const {listRef, handleKeyDown} = useListFocus<HTMLDivElement>({
-    itemSelector: 'button, [tabindex="0"]',
+  const {listRef, handleKeyDown, handleFocus} = useListFocus<HTMLDivElement>({
+    // Roving rewrites `tabindex` on every item, so the selector cannot key off
+    // a value: `[tabindex="0"]` would drop each member the moment it is
+    // stamped -1. `a[href]` catches a Button rendered with `href`.
+    itemSelector: 'button, a[href], [tabindex]',
     // A member's layer renders inline inside the group (useLayer does not
     // portal it), so a key pressed in an open DropdownMenu bubbles here. The
     // boundary is the group's own root or any layer, whichever is nearer to
@@ -180,6 +188,7 @@ export function ButtonGroup({
     // instead would swallow every arrow key it owns.
     boundarySelector: '[role="group"], [popover]',
     orientation,
+    hasRovingTabIndex: true,
   });
 
   const contextValue = useMemo(
@@ -207,6 +216,7 @@ export function ButtonGroup({
           role="group"
           aria-label={label}
           onKeyDown={composeEventHandlers(onKeyDown, handleKeyDown)}
+          onFocus={composeEventHandlers(onFocus, handleFocus)}
           aria-disabled={isDisabled || undefined}
           data-testid={testId}>
           {children}


### PR DESCRIPTION
## What changed

`ButtonGroup` now asks `useListFocus` for `hasRovingTabIndex`, so the group is a
single tab stop with arrow-key navigation rather than one tab stop per member.
Three lines, all in `packages/core/src/ButtonGroup/ButtonGroup.tsx`, and each is
load-bearing.

| Line | Change |
|---|---|
| `ButtonGroup.tsx:191` | `hasRovingTabIndex: true` |
| `ButtonGroup.tsx:182` | `itemSelector: 'button, a[href], [tabindex]'` |
| `ButtonGroup.tsx:219` | `onFocus={composeEventHandlers(onFocus, handleFocus)}` |

**The selector had to change with it.** `'button, [tabindex="0"]'` cannot survive
roving: the hook stamps `tabindex="-1"` on every member but one, so anything the
`[tabindex="0"]` half was carrying drops out of its own list the moment the stop
moves. `Toolbar` matches on `[tabindex]` for exactly this reason
(`Toolbar.tsx:247`). The `a[href]` half is a defect the roving work surfaced: a
`Button` with `href` renders an `<a>` (`Button.tsx:609`), which `button` never
matched, so a link member was a stray tab stop that the arrow keys skipped over.
Both measured below.

**`onFocus` keeps the stop honest** after a click or a programmatic focus, which
is what `useListFocus` asks its roving consumers to attach. Same wiring as
`AvatarGroup.tsx:151`.

## The container role stays `group`

I kept `role="group"` deliberately, rather than moving to `role="toolbar"`.

- **This repo already has the toolbar.** `Toolbar` is `role="toolbar"` with
  `hasRovingTabIndex` (`Toolbar.tsx:246-251`), and a ButtonGroup is a normal
  thing to put *inside* one. APG's toolbar pattern uses `role="group"` for the
  subdivisions of a toolbar, so `group` is the right role for a component whose
  own docs say "for more actions, use a Toolbar". Making this a toolbar would
  produce nested toolbars in a composition the docs recommend.
- **Roving is not the toolbar role's property.** `AvatarGroup` is `role="group"`
  with `hasRovingTabIndex: true` today (`AvatarGroup.tsx:123-147`), so the
  precedent for this exact pairing is already in core.
- **`aria-disabled` on the container** is meaningful on `group` and is what the
  `isDisabled` prop renders.
- **The boundary selector added in [#5355](https://github.com/facebook/astryx/pull/5355) is keyed on `[role="group"]`**
  (`ButtonGroup.tsx:189`). Changing the role silently unmatches the group's own
  root and reintroduces that regression, so a role change is not a one-line
  change; it is a role change plus a selector change plus re-verification of
  both layer behaviours. That is a reason to do it deliberately, not a reason to
  avoid it, but combined with the three points above it is not what I would
  spend the blast radius on. Left in Needs review, tied to
  [#4238](https://github.com/facebook/astryx/issues/4238).

## Measured in Chromium

Static `storybook:build` output over plain HTTP, driven with Playwright. Two
builds from the same tree with only `ButtonGroup.tsx` differing: `78e8e1c`
(parent) and this branch. Every row below is a real key press against real
Chromium, not jsdom.

### Tab stops, before and after

A group of three buttons bracketed by a plain button on each side. Values are
the focused element after each Tab.

| | parent `78e8e1c` | this PR |
|---|---|---|
| Tab walk | before, **Copy, Cut, Paste**, after | before, **Copy**, after |
| `tabindex` on the members | none, none, none | **0, -1, -1** |
| link member (Save, Docs-as-`<a>`, Print) | before, **Save, Docs, Print**, after | before, **Save**, after |
| whole group `isDisabled` | before, after | before, after |

Three tab stops become one. A four-member group with a link member went from
three stops plus a stray anchor to one.

### Arrow keys, both axes and both directions

| Story | Keys | Result |
|---|---|---|
| horizontal | Right, Right, Right | Cut, Paste, Copy (wraps) |
| horizontal | Left | Paste |
| horizontal | End, Home | Paste, Copy |
| horizontal | Down | no move (axis respected) |
| vertical | Down, Down, Down | Cut, Paste, Copy (wraps) |
| vertical | Up | Paste |
| vertical | Right | no move |
| horizontal, `dir="rtl"` | Left, Left, Right | Cut, Paste, Cut |
| vertical, `dir="rtl"` | Down, Up | Cut, Copy (unflipped, correct) |

RTL flips the horizontal axis and leaves the vertical axis alone. Home and End
stay first/last in DOM order in both directions. Identical to the parent build,
which is the point: this PR moves the tab stop, it does not touch the arrow
semantics.

### Disabled members

| Group | Tab stop lands on | Arrows |
|---|---|---|
| Copy, ~~Cut~~, Paste | Copy (`0, -1, -1`) | Copy, Right, Paste |
| ~~Undo~~, Redo, Repeat | **Redo** (`-1, 0, -1`) | Redo, Left, Repeat (wraps past Undo); Home, Redo |
| Bold, Italic, ~~Underline~~ | Bold (`0, -1, -1`) | Italic, Right, Bold (wraps past Underline); End, Italic |

The stop is never parked on a disabled member, at either end or in the middle,
and arrows skip them.

### A member that owns a layer

`ButtonGroup` with a `Button` and a `DropdownMenu`
([#2508](https://github.com/facebook/astryx/issues/2508) composition):

| Key | Focus |
|---|---|
| Tab | `Allow once` (`tabindex=0`; the trigger is `-1`) |
| ArrowRight | `Allow options` trigger |
| Enter | `menuitem "Allow for 30 minutes"` |
| ArrowDown | `menuitem "Always allow"` |
| ArrowRight | `menuitem "Always allow"` (menu keeps the key) |
| Escape | `Allow options` trigger |
| ArrowLeft | `Allow once` |

The trigger participates in roving, the open menu owns the arrows, and Escape
comes back to the trigger. The group never stamps `tabindex` on the menu's own
items, which the boundary is what guarantees.

### A group inside a Popover

The case [#5355](https://github.com/facebook/astryx/pull/5355) fixed, re-verified: focus Copy, then ArrowRight, End,
Home gives Cut, Paste, Copy, and the members carry `0, -1, -1`. The boundary
still matches the group's own root because the role did not change.

### Where the stop starts, and what moves it

- It starts on the first enabled member and follows arrow navigation.
- Entering backwards (Shift+Tab from after the group) lands on the stop, not on
  the last member. Standard roving.
- A member unmounting while focused: focus goes to `<body>` (unchanged from the
  parent build; the hook does not move focus) and the stop is repaired onto the
  first enabled member on the same commit, so the next Tab re-enters correctly.
- A member becoming disabled while holding the stop: repaired the same way.

### The focus ring

Captured at `deviceScaleFactor: 3`, clipped to the group, with focus arrived at
by key press rather than by script, so the ring is the one a user sees. Every
capture is pixel-identical to the parent build: only `tabindex` moved.

| ArrowRight (LTR) | ArrowLeft (RTL) |
|---|---|
| ![ltr](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5389/horizontal-arrow-to-cut__after.png) | ![rtl](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5389/rtl-arrowleft__after.png) |

| ArrowDown (vertical) | ArrowRight past a disabled member |
|---|---|
| ![vertical](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5389/vertical-arrowdown__after.png) | ![disabled](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5389/disabled-skip__after.png) |

| A member's open menu | The group inside a Popover |
|---|---|
| ![menu](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5389/dropdown-open__after.png) | ![popover](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5389/in-popover__after.png) |

## Tests

`ButtonGroup.test.tsx` gains a `roving tabindex` describe (9 tests) plus one
arrow-order test for the link member. **Nine of the ten are red against the
parent commit** and green here, verified by swapping `ButtonGroup.tsx` in place:
one tab stop on the first member, one Tab in and one Tab out, the stop moving
with the arrows, never parking on a disabled member, repair on unmount, repair
on disable, a link member counted as the tab stop, and a member's open menu not
being handed the group's stop. The tenth (a fully disabled group contributes no
tab stop) passes both ways and is a guard.

**No existing test had to change.** The three-tab-stop assumption was not baked
into this suite or any other: all 36 pre-existing ButtonGroup tests pass
untouched, including the two boundary tests from
[#5355](https://github.com/facebook/astryx/pull/5355).

## [#4238](https://github.com/facebook/astryx/issues/4238)

That issue is about `ToggleButtonGroup`, and its account of `ButtonGroup` is
wrong: it says ButtonGroup "already does BOTH the connected visual AND roving
via `useListFocus`". It did not. It called the hook without
`hasRovingTabIndex`, wrote no `tabindex` at all, and measured three tab stops
for three buttons (the parent column above). **This PR makes that claim true**,
and I am leaving the issue open for @cixzhang rather than rewriting a design
issue's framing from a code PR.

There is a real concern underneath the wrong premise, and it is worth stating
precisely because it changes as of this PR. The issue's Option A worries that
composing `ToggleButtonGroup` on top of `ButtonGroup` would give "two roving
layers fighting". That was hypothetical before and is now literal: `ButtonGroup`
owns a tab stop, so anything that wraps it and also owns one has to decide who
wins. I measured the one composition of that shape that exists today, a
ButtonGroup inside a `Toolbar`, and it is benign in both builds: one tab stop
for the whole toolbar, and one focus move per arrow press, because the group
`preventDefault`s and `Toolbar` bails on `defaultPrevented`
(`Toolbar.tsx:261-268`). `ToggleButtonGroup` does not compose `ButtonGroup`
today, so nothing regresses; whoever picks up #4238 now has to design against a
ButtonGroup that really does own a tab stop.

## Release rules

`patch`, category `[fix]`, per [Release-Process](https://github.com/facebook/astryx/wiki/Release-Process).

`@astryxdesign/core` is published, so I checked whether this warrants
`[breaking]` (which is the minor bump while 0.x). The wiki's breaking tier is
API migration: prop or component renamed or removed, callback signature changed,
import path changed, and every row of the "what needs a codemod" table is a
codemod row. This changes no API and there is nothing to codemod. The repo's own
precedent for this exact change is consistent: TabList becoming a single tab
stop shipped under New Features, Outline's roving conversion under Other
Changes, and AvatarGroup's roving ([#4170](https://github.com/facebook/astryx/pull/4170)) under New Features. None were
`[breaking]`.

It is still a behaviour change on published surface, so the changeset says so in
the consumer's terms: a keyboard script or test that tabbed through a group
member by member has to use arrow keys now, and a link member joins the arrow
order.

## Needs review

**A disabled member with a `tooltip` is no longer reachable by keyboard.**
`Button` deliberately uses `aria-disabled` instead of `disabled` when a disabled
button carries a tooltip, precisely so a keyboard user can still reach it and
read why it is disabled (`Button.tsx:610-611`). Measured on the parent build,
that member is a tab stop; measured here, it is `tabindex="-1"` and the arrows
skip it (`useListFocus` treats `aria-disabled="true"` as disabled), so it cannot
be reached at all. This is the repo's settled position rather than a slip:
`SegmentedControl` removed the tab stop from disabled segments on purpose, and
every roving consumer shares the same `isItemDisabled`. But APG's toolbar
guidance is the other way, and the fix would be a new option on the shared hook
affecting 14 consumers, which is not this PR. Flagging it as the one real cost
of this change.

**Clicking a member does not move the tab stop.** After clicking the third
member, the stop stays on the first, so Shift+Tab from there re-enters the group
at the first member instead of leaving. That is `useListFocus`'s shared
`syncTabStops`, which keeps the current tabbable item when it is still enabled;
`Toolbar`, `TabList` and `AvatarGroup` all behave the same way. APG would have
the stop follow the click. A hook-level question, not a ButtonGroup one.

**No keyboard hint.** `AvatarGroup` pairs roving with a screen-reader hint via
`aria-describedby`, and `Toolbar` uses the visible `useKeyboardHint` badge.
ButtonGroup has neither. The visible badge would render a `[popover]` inside the
group and is a visual change; the screen-reader hint needs a new i18n key. Both
are follow-ups rather than parts of this diff.

**The role question** is above, and belongs to #4238.

## Checks

`pnpm build` and `pnpm lint:strict` clean. `pnpm vitest run` over ButtonGroup,
the whole `hooks` directory, and every other `useListFocus` consumer
(`AvatarGroup`, `Breadcrumbs`, `ContextMenu`, `DropdownMenu`, `NavMenu`,
`Outline`, `Pagination`, `SegmentedControl`, `SideNav`, `TabList`, `TabMenu`,
`TopNav`, `Toolbar`), plus `Button`, `ToggleButton`, `Popover`, `Toast` and
`HoverCard` for the layer and member sides: **1277 tests over 48 files, all
green**. `check:sync`, `check:changesets` and `check:use-client` pass in the
pre-commit gate.

Night Watch — Component Auditor
