### PR TITLE
fix(sandbox): prune unknown ledger keys one level down, not just the top

### DIFF
--- a/apps/sandbox/scripts/generate-score-ledger.mjs
+++ b/apps/sandbox/scripts/generate-score-ledger.mjs
@@ -102,9 +102,46 @@ const ENTRY_KEY_SHAPES = {
   },
 };
 
+/**
+ * The fields `LedgerSection` declares. `pruneEntry` guards the TOP level of an
+ * entry, but a section object is inlined whole, so an undeclared key one level
+ * down reds every build exactly as `regression` did at the top level — a
+ * `changedFrom` note recorded on 2026-08-23 did precisely that. Prune here too.
+ */
+const KNOWN_SECTION_KEYS = new Set([
+  'score',
+  'weight',
+  'state',
+  'note',
+  'blocks',
+  'changedFrom',
+]);
+
 /** Drop keys `LedgerEntry` doesn't declare, or whose shape it rejects. */
 const droppedKeys = new Set();
 const malformedKeys = new Set();
+
+/** Prune each section object to the keys `LedgerSection` declares. */
+function pruneSections(sections) {
+  if (sections == null || typeof sections !== 'object' || Array.isArray(sections)) {
+    return sections;
+  }
+  const kept = {};
+  for (const [id, section] of Object.entries(sections)) {
+    if (section == null || typeof section !== 'object' || Array.isArray(section)) {
+      kept[id] = section;
+      continue;
+    }
+    const kept_section = {};
+    for (const [k, v] of Object.entries(section)) {
+      if (KNOWN_SECTION_KEYS.has(k)) kept_section[k] = v;
+      else droppedKeys.add(`sections.*.${k}`);
+    }
+    kept[id] = kept_section;
+  }
+  return kept;
+}
+
 function pruneEntry(entry) {
   const kept = {};
   for (const [k, v] of Object.entries(entry)) {
@@ -118,7 +155,7 @@ function pruneEntry(entry) {
       if (shape.repair) kept[k] = shape.repair(v);
       continue;
     }
-    kept[k] = v;
+    kept[k] = k === 'sections' ? pruneSections(v) : v;
   }
   return kept;
 }
@@ -157,7 +194,7 @@ if (droppedKeys.size > 0) {
   console.warn(
     `componentScores: the wiki ledger carries ${droppedKeys.size} field(s) LedgerEntry does not declare ` +
       `(${[...droppedKeys].sort().join(', ')}) — dropped from the snapshot. ` +
-      `Add them to LedgerEntry and KNOWN_ENTRY_KEYS to surface them.`,
+      `Add them to LedgerEntry/LedgerSection and the matching KNOWN_*_KEYS set to surface them.`,
   );
 }
 
@@ -197,6 +234,8 @@ export interface LedgerSection {
   weight: number;
   state: 'scored' | 'limited' | 'not_measured' | 'na' | 'unpublished';
   note?: string | null;
+  /** Why this section's score changed from an earlier draft of the same audit. */
+  changedFrom?: string | null;
   blocks?: LedgerBlock[];
 }
 


### PR DESCRIPTION
**`build-sandbox` is red on every open PR right now**, with no commit responsible:

```
Type error: Object literal may only specify known properties,
and '"changedFrom"' does not exist in type 'LedgerSection'.
```

An auditor recorded a `changedFrom` note on three ButtonGroup sections in the wiki ledger. The generator snapshots that JSON into `componentScores.ts` as a typed literal, so the undeclared key emits a literal `tsc` rejects.

**Third time in two weeks** — [#4924](https://github.com/facebook/astryx/pull/4924) (`regression`), [#5033](https://github.com/facebook/astryx/pull/5033) (a bad `evidence` shape), now this.

[#4924](https://github.com/facebook/astryx/pull/4924) built exactly the right guard and it is still working — it just only covers **the top level of an entry**. `pruneEntry` sees `sections` in `KNOWN_ENTRY_KEYS` and copies its value through untouched, so a key the wiki adds *inside* a section walks straight past it. So: prune section objects too, against a `KNOWN_SECTION_KEYS` set, warning by name exactly as the entry-level pruner does.

Also **declares `changedFrom`** — it is a real auditor field ("why this section's score changed from an earlier draft of the same audit"), so the page should surface it rather than silently drop it. Pruning alone would have unbroken the build but thrown the data away.

The page's runtime fetch reads the raw ledger and is unaffected; the snapshot is only the until-it-resolves fallback.

## Test plan

**The actual break:** `pnpm -F @astryxdesign/sandbox build` — fails on `main` at the type error above, **completes on this branch** (all routes prerendered).

**Against the live wiki ledger** — the field is now declared, so it survives into the snapshot rather than being dropped: 3 `changedFrom` values present, 21 components snapshotted.

**Against a synthetic ledger** with two junk keys (`someBrandNewWikiField`, `anotherOne`) injected into a section:

| | leaked into the snapshot | warned |
|---|---|---|
| `main` | **2** — i.e. the next red build | no |
| this branch | **0** | yes, by name: `sections.*.anotherOne, sections.*.someBrandNewWikiField` |

Non-object sections and a non-object `sections` pass through untouched, so a malformed row still reaches the existing shape checks rather than crashing the generator.