### PR TITLE
fix(docsite): anatomy guard misses dark renderers; part names break mid-word

### DIFF
--- a/apps/docsite/src/__tests__/anatomy-helpers.test.ts
+++ b/apps/docsite/src/__tests__/anatomy-helpers.test.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, expect, it} from 'vitest';
-import {anatomyDescription} from '../components/component-detail/anatomyHelpers';
+import {
+  anatomyDescription,
+  anatomyNameSegments,
+} from '../components/component-detail/anatomyHelpers';
 
 describe('anatomy description', () => {
   it('marks a required element with a bold lead-in on its description', () => {
@@ -40,5 +43,28 @@ describe('anatomy description', () => {
         description: '\n  A small indicator in the bottom-right corner.\n',
       }),
     ).toBe('**Required:** A small indicator in the bottom-right corner.');
+  });
+});
+
+describe('anatomy name segments', () => {
+  it('offers a break after a solidus, which CSS does not', () => {
+    // Field: "Optional/Required" is 132px in a 108px content box and has no
+    // break opportunity, so it came out as "Optional/Requ" / "ired indicator".
+    expect(anatomyNameSegments('Optional/Required indicator')).toEqual([
+      'Optional/',
+      'Required indicator',
+    ]);
+  });
+
+  it('leaves a name the browser can already wrap as one piece', () => {
+    // A hyphen is a break opportunity, so "Scroll-to-bottom" wraps correctly.
+    expect(anatomyNameSegments('Scroll-to-bottom button')).toEqual([
+      'Scroll-to-bottom button',
+    ]);
+    expect(anatomyNameSegments('Status dot')).toEqual(['Status dot']);
+  });
+
+  it('splits every solidus in a name', () => {
+    expect(anatomyNameSegments('a/b/c')).toEqual(['a/', 'b/', 'c']);
   });
 });

--- a/apps/docsite/src/__tests__/component-detail-wiring.test.ts
+++ b/apps/docsite/src/__tests__/component-detail-wiring.test.ts
@@ -5,9 +5,9 @@
  *
  * The `component-detail/` directory holds the internal building blocks of a
  * single page. Unlike `app/`, it contains no Next.js route entry points and no
- * script-consumed modules, so every module in it must be reachable from an
- * import — a renderer that nothing imports is dead code, and the data it was
- * written to display silently never reaches the page.
+ * script-consumed modules, so every module in it must be reachable from the
+ * router — a renderer nothing on the page reaches is dead code, and the data it
+ * was written to display silently never reaches the page.
  *
  * Run: pnpm -F @astryxdesign/docsite test
  */
@@ -23,6 +23,7 @@ const SRC_DIR = path.resolve(
   '..',
 );
 const DETAIL_DIR = path.join(SRC_DIR, 'components/component-detail');
+const APP_DIR = path.join(SRC_DIR, 'app');
 const EXTENSIONS = ['.ts', '.tsx'];
 
 function walk(dir: string, out: string[] = []): string[] {
@@ -63,31 +64,47 @@ function resolveRelative(fromFile: string, specifier: string): string | null {
 
 const SPECIFIER_RE = /(?:from\s*|import\(\s*|require\(\s*)['"]([^'"]+)['"]/g;
 
-function collectImportedFiles(files: string[]): Set<string> {
-  const imported = new Set<string>();
-  for (const file of files) {
+/**
+ * Walk the relative-import graph out from `entries`, returning every file
+ * reachable from one of them.
+ *
+ * Reachability, not "somebody imports it": a renderer imported only by its own
+ * unit test — or only by another module the page never reaches — is still dark
+ * on the page, and a guard that counted those importers would pass on it.
+ */
+function collectReachable(entries: string[]): Set<string> {
+  const reachable = new Set<string>(entries);
+  const queue = [...entries];
+  while (queue.length > 0) {
+    const file = queue.pop()!;
     const source = fs.readFileSync(file, 'utf8');
     for (const match of source.matchAll(SPECIFIER_RE)) {
       const resolved = resolveRelative(file, match[1]);
-      if (resolved !== null) {
-        imported.add(resolved);
+      if (resolved !== null && !reachable.has(resolved)) {
+        reachable.add(resolved);
+        queue.push(resolved);
       }
     }
   }
-  return imported;
+  return reachable;
 }
 
 describe('component detail wiring', () => {
-  it('imports every module in component-detail/ from somewhere', () => {
+  it('reaches every module in component-detail/ from a page', () => {
     const detailModules = walk(DETAIL_DIR).filter(
       file => !file.includes('.test.'),
     );
     // Guard against a vacuous pass if the directory is ever moved or renamed.
     expect(detailModules.length).toBeGreaterThan(5);
 
-    const imported = collectImportedFiles(walk(SRC_DIR));
+    // The Next.js router loads `app/`; everything else in `src/` is only code
+    // that something under `app/` pulls in.
+    const entries = walk(APP_DIR);
+    expect(entries.length).toBeGreaterThan(5);
+
+    const reachable = collectReachable(entries);
     const orphans = detailModules
-      .filter(file => !imported.has(file))
+      .filter(file => !reachable.has(file))
       .map(file => path.relative(SRC_DIR, file))
       .sort();
 

--- a/apps/docsite/src/components/component-detail/Anatomy.tsx
+++ b/apps/docsite/src/components/component-detail/Anatomy.tsx
@@ -2,6 +2,7 @@
 
 'use client';
 
+import {Fragment} from 'react';
 import {Heading} from '@astryxdesign/core/Text';
 import {VStack} from '@astryxdesign/core/Layout';
 import {Section} from '@astryxdesign/core/Section';
@@ -9,7 +10,7 @@ import {Table, pixel} from '@astryxdesign/core/Table';
 import {Card} from '@astryxdesign/core/Card';
 import type {AnatomyElement} from '../../generated/componentRegistry';
 import {MarkdownText} from '../MarkdownText';
-import {anatomyDescription} from './anatomyHelpers';
+import {anatomyDescription, anatomyNameSegments} from './anatomyHelpers';
 
 interface AnatomyProps {
   elements: AnatomyElement[];
@@ -41,6 +42,15 @@ export function Anatomy({elements}: AnatomyProps) {
                 key: 'name',
                 header: 'Element',
                 width: pixel(140),
+                renderCell: (item: Record<string, unknown>) =>
+                  anatomyNameSegments(item.name as string).map(
+                    (segment, index) => (
+                      <Fragment key={index}>
+                        {index > 0 ? <wbr /> : null}
+                        {segment}
+                      </Fragment>
+                    ),
+                  ),
               },
               {
                 key: 'description',

--- a/apps/docsite/src/components/component-detail/anatomyHelpers.ts
+++ b/apps/docsite/src/components/component-detail/anatomyHelpers.ts
@@ -19,6 +19,24 @@ import type {AnatomyElement} from '../../generated/componentRegistry';
 const REQUIRED_LEAD_IN = '**Required:**';
 
 /**
+ * Split a part name where the browser is allowed to wrap it but will not on
+ * its own.
+ *
+ * The Anatomy table lays out `fixed`, so its Element column never grows to fit
+ * its content: a name with no break opportunity inside the column's ~108px of
+ * content box is broken inside a word instead — `Optional/Requ` / `ired
+ * indicator` on Field, `Collapse/expa` / `nd toggle` on SideNav. A solidus is
+ * not a break opportunity in CSS the way a hyphen is, so the renderer has to
+ * offer one.
+ *
+ * Returns the pieces to join with `<wbr />`; a name with no solidus comes back
+ * as a single piece and renders exactly as before.
+ */
+export function anatomyNameSegments(name: string): string[] {
+  return name.split(/(?<=\/)/);
+}
+
+/**
  * The description to render for one anatomy element. Required elements get a
  * bold `Required:` lead-in rather than a separate badge column, keeping the flag
  * inline with the prose it qualifies.


### PR DESCRIPTION
Two defects, both surfaced by the review of #4847, both ours.

## 1. The wiring guard passes on a renderer that ships dark

**Problem.** `component-detail-wiring.test.ts` exists so a section renderer cannot be written and then never wired into the page — which is how the Anatomy section sat unrendered for months. But it collected importers by walking all of `src/`, so a unit test counts as an importer. Unwire `Anatomy` and add a test that imports it: the guard goes green while 55 component pages quietly lose the section. The next renderer can ship invisible behind a green check.

**Change.** Walk the import graph out from `app/` — reachability from the router, not "somebody imports it". Tests are not entry points so they stop counting, and it also closes the case the obvious `.test.` filter would have left open: a module reached only by other modules the page never reaches.

Measured by mutating a checkout; "old" is the guard on `main` today.

| scenario | old guard | new guard |
|---|---|---|
| `main` as it stands | pass | pass |
| `Anatomy` unwired from the page | fail | fail |
| unwired, and a unit test imports it | **pass** | fail |
| unwired, and an unreachable module imports it | **pass** | fail |

## 2. A part name is broken mid-word on the Field and SideNav pages

**Problem.** A builder reading `/components/Field` sees `Optional/Requ` / `ired indicator`, and on `/components/SideNav`, `Collapse/expa` / `nd toggle`. The table lays out `fixed` at `pixel(140)`, so the Element column has ~108px of content box; `Optional/Required` is 132px and `Collapse/expand` 120px, and a solidus is not a break opportunity in CSS the way a hyphen is — so Chromium takes its last resort and breaks inside the word. `Scroll-to-bottom button` on ChatLayout is the same length and wraps correctly, because a hyphen gives it somewhere to go.

**Change.** Offer the break the text implies: a `<wbr />` after each solidus. The column keeps its 140px on every page and nothing else moves — widening the column instead would have taken the space out of the descriptions, which at 375px made the Field table 280px taller.

|  | before | after |
|---|---|---|
| Field, 1280px | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5391/field-before-1280.png) | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5391/field-after-1280.png) |
| SideNav, 1280px | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5391/sidenav-before-1280.png) | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5391/sidenav-after-1280.png) |
| Field, 375px | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5391/field-before-375.png) | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5391/field-after-375.png) |

## Test plan

- `pnpm -F @astryxdesign/docsite test` — 402 pass. `tsc --noEmit` clean.
- Guard: the four rows above, each run by mutating a checkout and running both the old guard and the new one.
- Chromium against the docsite dev server, on Field, SideNav, ChatLayout and Avatar at 1280px and 375px, before and after. Every word measured per line box: no name breaks mid-word afterwards. The Element column is 140px on every page before and after; ChatLayout and Avatar are unchanged in geometry; the Field anatomy table is 24px taller at 1280px (its long name takes a third line) and identical at 375px.
