### PR TITLE
fix(core): only cancel Tab when focus is inside the focus trap

### DIFF
--- a/.changeset/focus-trap-tab-outside.md
+++ b/.changeset/focus-trap-tab-outside.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useFocusTrap: Tab is only cancelled when focus is actually inside the trapped container. An open layer whose focus legitimately sits outside it — a listbox popup anchored to its own input, as in DateTimeInput, Typeahead, Selector and MultiSelector — no longer swallows Tab for the whole page, so keyboard users move to the next control on the first press. A trapped surface with no tabbable controls and focus on a `tabIndex={-1}` panel still keeps Tab inside it.
+@cixzhang

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -437,6 +437,7 @@ describe('MultiSelector', () => {
 
     await user.keyboard('{Tab}');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('button', {name: 'Next'})).toHaveFocus();
   });
 
   it('supports keyboard navigation with ArrowDown/ArrowUp', async () => {

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -961,7 +961,7 @@ describe('Selector', () => {
       expect(onChange).toHaveBeenCalledWith('Banana');
     });
 
-    it('closes dropdown on Tab without preventing default focus movement', async () => {
+    it('closes the search dropdown on Tab without preventing default focus movement', async () => {
       const user = userEvent.setup();
       render(
         <>
@@ -1253,6 +1253,29 @@ describe('Selector', () => {
   });
 
   describe('keyboard accessibility', () => {
+    it('Tab from the open listbox moves focus to the next control', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <Selector
+            label="Fruit"
+            options={OPTIONS}
+            value="Apple"
+            onChange={() => {}}
+          />
+          <button type="button">Next</button>
+        </>,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{Tab}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.getByRole('button', {name: 'Next'})).toHaveFocus();
+    });
+
     it('trigger is focusable via Tab when enabled', async () => {
       const user = userEvent.setup();
       render(<Selector label="Fruit" options={OPTIONS} />);

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -420,6 +420,30 @@ describe('BaseTypeahead focus-out', () => {
     });
   });
 
+  it('Tab from the input with the list open moves focus to the next control', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />
+        <button type="button">Next</button>
+      </>,
+    );
+    const input = screen.getByRole('combobox');
+    input.focus();
+    fireEvent.change(input, {target: {value: 'App'}});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    await user.keyboard('{Tab}');
+    expect(screen.getByRole('button', {name: 'Next'})).toHaveFocus();
+  });
+
   it('keeps the dropdown open when focus moves into the anchor wrapper', async () => {
     const anchor = document.createElement('div');
     document.body.appendChild(anchor);

--- a/packages/core/src/hooks/useFocusTrap.test.tsx
+++ b/packages/core/src/hooks/useFocusTrap.test.tsx
@@ -208,6 +208,20 @@ describe('useFocusTrap tabbable model (infra-8)', () => {
     expect(target).toHaveFocus();
     expect(screen.getByTestId('outside')).not.toHaveFocus();
   });
+
+  it('leaves Tab alone when focus is outside a trap with no tabbable controls', () => {
+    render(
+      <Trap>
+        <div role="option" tabIndex={-1} data-testid="option">
+          Option
+        </div>
+      </Trap>,
+    );
+    const outside = screen.getByTestId('outside');
+    outside.focus();
+
+    expect(fireEvent.keyDown(outside, {key: 'Tab'})).toBe(true);
+  });
 });
 
 describe('FOCUSABLE_SELECTOR href matching', () => {

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -356,14 +356,18 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
 
         const focusable = getFocusableElements(container);
         if (focusable.length === 0) {
+          const active = document.activeElement;
+          if (!(active instanceof HTMLElement) || !container.contains(active)) {
+            // A layer can be open while focus legitimately sits outside it —
+            // a listbox popup anchored to its own input. Cancelling there
+            // would take Tab away from the whole page.
+            return;
+          }
           // There is nowhere to advance to. Keep focus on the current
           // programmatic target (for example a dialog panel with tabIndex=-1)
           // rather than allowing the browser to move into background content.
           event.preventDefault();
-          const active = document.activeElement;
-          if (active instanceof HTMLElement && container.contains(active)) {
-            lastFocusRef.current = active;
-          }
+          lastFocusRef.current = active;
           isKeyboardNavigationRef.current = false;
           return;
         }


### PR DESCRIPTION
## Problem

A keyboard user opens a `Typeahead`, presses Tab to move to the next control, and focus does not move.

Measured in Chromium against `main`, `core-typeahead--default`:

```
tabPrevented=true   focusBefore=#_r_1_   focusAfter=#_r_1_   moved=false
```

`useFocusTrap` cancels Tab whenever the trapped container has no focusable children, and it does **not** check that focus is inside the container. The listener is on `document`, so the cancel applies to the press wherever it came from. Every listbox popup in the system keeps DOM focus on its own input or trigger and fills the popup with `role="option" tabIndex={-1}` divs, so every one of them puts the trap in that state.

The branch landed in [#5023](https://github.com/facebook/astryx/pull/5023) for a modal surface that intentionally has no tabbable controls and places initial focus on a `tabIndex={-1}` panel (`BottomSheetSwitcher`). **That case has focus inside the container.** Everything else is over-catch.

## Solution

One condition — cancel only when `document.activeElement` is inside the trapped container.

```ts
const focusable = getFocusableElements(container);
if (focusable.length === 0) {
  const active = document.activeElement;
  if (!(active instanceof HTMLElement) || !container.contains(active)) {
    return;
  }
  event.preventDefault();
  …
}
```

The `tabIndex={-1}` panel case is preserved exactly, and its existing test (`keeps a programmatic focus target when the trap has no tabbable controls`) passes unmodified. The guard is narrowed, not removed.

## This is necessary, not sufficient

Worth stating plainly, because the measurement says so. With **only** this diff, Typeahead's own Tab still does not advance focus:

```
tabPrevented=false   focusAfter=#_r_1_   moved=false
```

The cancel is gone, but `BaseTypeahead.handleBlur` closes the popup *during* the focusout, Chrome abandons the in-flight focus move, focus lands on `<body>`, and the trap's restore-on-deactivate correctly repairs `<body>` by returning focus to the input. `Selector` and `MultiSelector` avoid this by dismissing on the Tab **keydown** instead, before the browser moves anything. Making `BaseTypeahead` do the same turns the measurement into `moved=true`.

That is a second, independent decision in a different file, so it goes in its own PR on top of this one. This PR is the invariant: a focus trap acts on focus that is inside it.

## Tests

| test | fails on `main` in | file |
|---|---|---|
| `leaves Tab alone when focus is outside a trap with no tabbable controls` | jsdom **and** Chromium | `useFocusTrap.test.tsx` |
| `Tab from the input with the list open moves focus to the next control` | jsdom **and** Chromium | `Typeahead.test.tsx` |
| `Tab from the open listbox moves focus to the next control` | jsdom only — guard | `Selector.test.tsx` |
| `closes combobox on Tab and moves focus to next element` (focus assertion added) | jsdom only — guard | `MultiSelector.test.tsx` |

The last two are honest guards rather than reproductions: in Chromium `main` already passes Tab through for `Selector` and `MultiSelector`, because each closes its popup inside the keydown and so wins a race against the trap's `document` listener. They are not broken today; they would be the moment either moved its dismissal to blur, which is exactly how `Typeahead` got here.

The `MultiSelector` and `Selector` tests already carried names promising Tab was not blocked. Neither asserted it. That is how this survived.

`Selector` with `hasSearch` was never affected — its popup contains a focusable search input, so the empty-container branch never runs.

## Breaking

- **API** — none.
- **Visual** — none; nothing rendered changes.
- **Theme** — none; no target added, removed or repointed.
