### PR TITLE
fix(chat): replace Badge with plain text in ChatComposerDrawer collapsed state

### DIFF
--- a/.changeset/chat-composer-drawer-badge-placement-8cq6.md
+++ b/.changeset/chat-composer-drawer-badge-placement-8cq6.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatComposerDrawer: replace the Badge in the collapsed toggle with plain text. The collapsed state now renders "{count} {label}" (e.g. "3 Attachments") as a single text span instead of a Badge component followed by a label.
+@aldentan

--- a/packages/core/src/Chat/ChatComposerDrawer.test.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.test.tsx
@@ -58,4 +58,14 @@ describe('ChatComposerDrawer', () => {
       'true',
     );
   });
+
+  it('renders count and label as plain text in collapsed state', () => {
+    render(
+      <ChatComposerDrawer count={3} label="Attachments" defaultIsCollapsed>
+        <span>Drawer content</span>
+      </ChatComposerDrawer>,
+    );
+
+    expect(screen.getByText('3 Attachments')).toBeInTheDocument();
+  });
 });

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -28,7 +28,6 @@ import {
   easeVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
-import {Badge} from '../Badge';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -300,8 +299,9 @@ export function ChatComposerDrawer({
               styles.toggleContent,
               !isCollapsed && styles.toggleContentHidden,
             )}>
-            <Badge variant="neutral" label={count} />
-            <span {...stylex.props(styles.collapseLabel)}>{label}</span>
+            <span {...stylex.props(styles.collapseLabel)}>
+              {count} {label}
+            </span>
           </div>
           <div
             {...stylex.props(


### PR DESCRIPTION
## Summary

Replace the `Badge` component in ChatComposerDrawer's collapsed state with plain text. The collapsed toggle now renders "{count} {label}" (e.g. "3 Attachments") as a single text span.

## Before / After

| Before | After |
|--------|-------|
| `[Badge: 3]` `Attachments` (two elements: Badge + span) | `3 Attachments` (single text span) |

## Motivation

The Badge added visual weight that isn't needed for a simple count indicator in a collapsed row. Plain text is simpler, lighter, and gives consumers a predictable "{count} {label}" pattern without needing to reason about Badge styling or placement.

Also removes the `Badge` import dependency from this component.

## Changes

- `ChatComposerDrawer.tsx` — remove Badge import, render count + label as a single text span
- `ChatComposerDrawer.test.tsx` — add test for the plain text rendering
- Changeset added
