### PR TITLE
fix(Typeahead): dismiss the result list on the Tab keydown, not on the blur

### DIFF
--- a/.changeset/typeahead-tab-dismiss-on-keydown.md
+++ b/.changeset/typeahead-tab-dismiss-on-keydown.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Typeahead: Tab out of the field now moves focus to the next control. The result list is dismissed on the Tab keydown rather than from the blur that press produces — hiding a top-layer popover during the focusout makes Chrome abandon the in-flight focus move and drop focus to `<body>`, so the press appeared to do nothing. Selector and MultiSelector already dismissed on the keydown.
+@cixzhang

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -692,6 +692,14 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
           e.preventDefault();
           popover.hide();
           break;
+        case 'Tab':
+          // Dismiss here rather than from the blur this press produces:
+          // hiding a top-layer popover during the focusout makes Chrome
+          // abandon the in-flight focus move and drop focus to <body>, so the
+          // user's Tab appears to do nothing. Selector and MultiSelector
+          // already dismiss on this keydown.
+          popover.hide();
+          break;
         case 'Home':
           if (popover.isOpen) {
             e.preventDefault();

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -420,6 +420,31 @@ describe('BaseTypeahead focus-out', () => {
     });
   });
 
+  it('closes the list on the Tab keydown, before the blur it produces', async () => {
+    render(
+      <BaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    input.focus();
+    fireEvent.change(input, {target: {value: 'App'}});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    // No blur is fired here on purpose: dismissing from the blur instead lets
+    // the popover close mid-focus-move, which Chrome answers by dropping
+    // focus to <body>.
+    fireEvent.keyDown(input, {key: 'Tab'});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
   it('Tab from the input with the list open moves focus to the next control', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Problem

A keyboard user types in a `Typeahead`, presses Tab to move to the next control, and nothing happens. The caret stays in the field.

Measured in Chromium, `core-typeahead--default`, against `main` **after** [#5397](https://github.com/facebook/astryx/pull/5397):

```
tabPrevented=false   focusBefore=#_r_1_   focusAfter=#_r_1_   moved=false
```

Tab is not being cancelled any more — [#5397](https://github.com/facebook/astryx/pull/5397) fixed that. Focus genuinely leaves, and then comes straight back. Traced:

1. Tab moves focus out; `focusout` fires on the input with `relatedTarget` = the next control.
2. `BaseTypeahead.handleBlur` calls `popover.hide()` **inside that focusout**.
3. Hiding a top-layer popover mid-navigation makes Chrome abandon the in-flight focus move, so focus lands on `<body>` and never reaches the next control.
4. `useFocusTrap`'s restore-on-deactivate sees `<body>`, correctly concludes focus was lost, and returns it to the input.

Every step is doing its job. The timing is the defect.

## Solution

Dismiss on the Tab **keydown**, before the browser moves anything — which is what `Selector.tsx:1191` and `MultiSelector.tsx:1270` already do, and what `DateTimeInput.tsx:1316` does for its time list.

```ts
case 'Tab':
  popover.hide();
  break;
```

The blur handler stays untouched as the safety net for programmatic focus moves, which is what its docblock says it is for.

## Verification

Real Chromium, same probe, same story, single variable — only this hunk reverted for the BEFORE row:

| | tabPrevented | focus after | moved |
|---|---|---|---|
| before | false | the input | **no** |
| after | false | the next control | **yes** |

`SB_PORT=6522 node ~/astryx/probe-kit/focus-trap-tab-passthrough.cjs`

`Selector` and `MultiSelector` measured alongside as controls: `moved=true` on both rows, unchanged.

## Tests

`closes the list on the Tab keydown, before the blur it produces` — fires the keydown with no blur, so it fails if the dismissal moves back into `handleBlur`. Verified 1 failed / 55 passed without the fix, 56 passed with it.

jsdom cannot reproduce the Chrome focus-abandon itself, so the browser evidence above is the claim and the test is the guard.

## Breaking

- **API** — none.
- **Visual** — none; nothing rendered changes.
- **Theme** — none.
