### PR TITLE
ci(a11y): baseline MediaTheme Auto's deliberate bad-contrast demo

### DIFF
--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -654,6 +654,11 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
+      "key": "MediaTheme Auto::Flat Surface Theme::color-contrast",
+      "impact": "serious",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
+    },
+    {
       "key": "OverflowList::With Badges::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"


### PR DESCRIPTION
With the 8 violations from [#5383](https://github.com/facebook/astryx/pull/5383) cleared, the [Weekly A11y Scan](https://github.com/facebook/astryx/actions/workflows/a11y-weekly.yml) is down to **one** — and it is deliberate.

`MediaThemeAuto`'s **Flat Surface Theme** story sits under a literal `// The bug` heading. It renders `HardcodedToast` — the hardcoded inversion rule failing — directly beside `AutoToast`, which `mode="auto"` gets right. The story's own description states the number axe reports:

> Light mode: the hardcoded rule paints white on pale grey at **1.25:1**; auto measures the theme's own text at 14.36:1 …

axe measures **1.24:1** (`#ffffff` on `#e4e6eb`) on the two nodes in the hardcoded panel — the toast message and its `Undo` action. That is the "before" half of the comparison the story exists to make; fixing the contrast would delete the demonstration.

So this is the *known, intentional exception* case the audit script itself points at the baseline for:

> If it is a known, intentional exception, add it to the baseline … or hand-add the key to `.github/a11y-baseline.json` with a reviewer's blessing.

It surfaces only now because the story landed with [#5299](https://github.com/facebook/astryx/pull/5299) on 2026-08-21 — after the 2026-08-17 scan, and the scans since have been failing on the other 8.

## Test plan

Evidence is the [weekly run itself](https://github.com/facebook/astryx/actions/runs/32689479440) on current main — `1 new, 119 baselined, 77 resolved`, the single NEW entry being this one:

```
✗ [serious] color-contrast — MediaTheme Auto / Flat Surface Theme (2 nodes)
```

Read from that run's `a11y-weekly-report` artifact, both failing nodes are inside the hardcoded panel:

| node | contrast |
|---|---|
| `<span …>Your changes were saved</span>` | 1.24:1 (`#ffffff` on `#e4e6eb`) |
| `<span …>Undo</span>` | 1.24:1 (same pair) |

One added entry, `MediaTheme Auto::Flat Surface Theme::color-contrast` (196 → 197). No source change, so nothing else can regress from it — and with it in, the weekly scan goes green.