### PR TITLE
fix(Chat): align message-bubble tokens the way the composer does

### DIFF
--- a/.changeset/fix-chat-bubble-token-alignment.md
+++ b/.changeset/fix-chat-bubble-token-alignment.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat: a token in a message bubble now sits on the line the way it does in the composer. `ChatTokenizedText` wraps each token in the same `inline-flex` / `vertical-align: middle` box `ChatComposerInput` uses, so a chip stops lifting off the text the moment the message is sent. Follows #5324, which fixed the composer half.
+
+@cixzhang

--- a/apps/storybook/stories/ChatTokenizedText.stories.tsx
+++ b/apps/storybook/stories/ChatTokenizedText.stories.tsx
@@ -3,6 +3,8 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {ChatTokenizedText} from '@astryxdesign/core/Chat';
 import {ChatMessage, ChatMessageBubble} from '@astryxdesign/core/Chat';
+import {Icon} from '@astryxdesign/core/Icon';
+import {UserCircleIcon} from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof ChatTokenizedText> = {
   title: 'Core/ChatTokenizedText',
@@ -91,6 +93,46 @@ export const TokensAtEdges: Story = {
       <ChatMessageBubble>
         <ChatTokenizedText tokens={mentionTokens}>
           @cindy this is for @navi
+        </ChatTokenizedText>
+      </ChatMessageBubble>
+    </ChatMessage>
+  ),
+};
+
+/** Tokens carrying an icon, and a fully custom token — both sit on the line */
+export const IconAndCustomTokens: Story = {
+  render: () => (
+    <ChatMessage sender="user">
+      <ChatMessageBubble>
+        <ChatTokenizedText
+          tokens={[
+            {
+              value: '@cindy',
+              label: '@Cindy Zhang',
+              variant: 'blue',
+              icon: <Icon icon={UserCircleIcon} size="sm" />,
+            },
+            {
+              value: '@navi',
+              render: () => (
+                <span
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 4,
+                    height: 20,
+                    padding: '0 8px',
+                    borderRadius: 999,
+                    background: '#e8def8',
+                    fontSize: 12,
+                  }}>
+                  <span aria-hidden>★</span>
+                  @Navi
+                </span>
+              ),
+            },
+          ]}>
+          Hey @cindy and @navi can you take a look?
         </ChatTokenizedText>
       </ChatMessageBubble>
     </ChatMessage>

--- a/packages/core/src/Chat/ChatTokenizedText.tsx
+++ b/packages/core/src/Chat/ChatTokenizedText.tsx
@@ -14,6 +14,8 @@
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/index.ts
+ * - /packages/core/src/Chat/ChatComposerInput.tsx (token alignment must match,
+ *   or a token moves when the message is sent)
  * - /packages/cli/assets/templates/blocks/components/ChatTokenizedText/ (block examples)
  */
 
@@ -32,6 +34,10 @@ import {themeProps} from '../utils/themeProps';
 const styles = stylex.create({
   root: {
     display: 'inline',
+  },
+  token: {
+    display: 'inline-flex',
+    verticalAlign: 'middle',
   },
 });
 
@@ -156,16 +162,17 @@ function renderTokens(text: string, tokens: ChatComposerToken[]): ReactNode[] {
     const token = tokenMap.get(matched);
     if (token) {
       parts.push(
-        isCustomToken(token) ? (
-          <span key={`${matched}-${match.index}`}>{token.render()}</span>
-        ) : (
-          <Badge
-            key={`${matched}-${match.index}`}
-            label={token.label}
-            variant={token.variant}
-            icon={token.icon}
-          />
-        ),
+        <span key={`${matched}-${match.index}`} {...stylex.props(styles.token)}>
+          {isCustomToken(token) ? (
+            token.render()
+          ) : (
+            <Badge
+              label={token.label}
+              variant={token.variant}
+              icon={token.icon}
+            />
+          )}
+        </span>,
       );
     }
 


### PR DESCRIPTION
### Why

[#5324](https://github.com/facebook/astryx/pull/5324) aligned tokens in the chat **composer** and left `ChatTokenizedText` — the same token, in the **message bubble** — alone. Both halves were misaligned before, so nothing looked wrong. Now they disagree: you pick a name, it sits on the line you are typing, you send it, and the chip lifts off the line in the bubble.

Measured in Chromium on the real round trip (type `@`, pick a name, send):

| token | composer | bubble before | bubble after |
|---|---|---|---|
| with an icon (`<Icon>`) | 3.69px above baseline | **8.00px** | 3.69px |
| label only | 3.69px | 4.50px | 3.69px |
| custom `render()` | 3.69px | 4.43px | 3.69px |

### What

`ChatTokenizedText` wraps each token in the same `inline-flex` / `vertical-align: middle` box `ChatComposerInput` already uses, for both badge tokens and custom `render()` tokens. Nothing else moves.

The alignment stays at the site that puts a chip into a text flow, rather than going onto `Badge`: `Badge` is mostly a flex child, where `vertical-align` is inert, and it is not the only chip of this shape — `Citation`'s label variant has the same one and is not a `Badge`. A change on `Badge` would reach every consumer's badge in a table cell or a paragraph without fixing the class.

### Risk

Visual, in message bubbles only. A bubble whose token carries an icon gets **shorter** (67.57 → 65.31px in the story below); a bubble with a label-only token grows 0.81px. No API change, no new theme targets, no new dependency, no runtime work added.

### Testing

- 183 Chat tests pass unchanged.
- Round trip driven in real Chromium on `Core/ChatLayout` → *Full AI Chat*: composer and bubble now measure identically (jump 0.00px, was 3.31px with an icon).
- New story `Core/ChatTokenizedText` → *Icon and custom tokens* — the case was not reproducible from any shipped story before, which is why the bubble half was easy to miss.

Before / after, icon token in a bubble:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5402/story-before__icon-custom.png) | ![after](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5402/story-after__icon-custom.png) |
