### PR TITLE
test: give the ui vitest project the same timeout budget as node

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -104,6 +104,13 @@ export default defineConfig({
         extends: true,
         test: {
           name: 'ui',
+          // A jsdom component suite can cost ~1.8s p95 per test where a
+          // comparable file costs ~80ms, so the 5s default leaves almost no
+          // headroom: on a busy machine slow-but-correct runs flake
+          // non-deterministically (every failure was "timed out in 5000ms",
+          // never a wrong value). Same budget as `node`, for the same reason.
+          testTimeout: 30_000,
+          hookTimeout: 30_000,
           include: [
             'packages/core/src/**/*.test.{ts,tsx,mjs}',
             'packages/lab/src/**/*.test.{ts,tsx,mjs}',


### PR DESCRIPTION
## Problem

The `ui` (jsdom) project runs on vitest's default 5s `testTimeout`. The `node`
project already carries `testTimeout: 30_000` / `hookTimeout: 30_000`, with a
comment describing exactly this failure mode — slow-but-correct runs tripping
the default on a busy machine. `ui` never got the same treatment and has the
same problem.

`packages/core/src/DateInput/DateInputTouch.test.tsx` is where it shows up
first. Run on its own on an unloaded 10-core laptop, the file's p95 test costs
~1.8s where comparable core suites cost tens of milliseconds:

| suite | tests | test time | median | p95 | slowest |
|---|---|---|---|---|---|
| `DateInputTouch.test.tsx` | 134 | 36.0s | 68ms | **1819ms** | 2023ms |
| `Selector.test.tsx` | 145 | 5.2s | 21ms | 82ms | 883ms |
| `MultiSelector.test.tsx` | 111 | 3.8s | 23ms | 92ms | 325ms |
| `Table.test.tsx` | 126 | 1.0s | 6ms | 24ms | 80ms |
| `BottomSheet.test.tsx` | 77 | 0.9s | 10ms | 27ms | 73ms |

2.0s against a 5s deadline is 2.5× of headroom, and that is not enough. Put
the machine under load and the same tests take ten times longer, so they cross
the line — a build, a dev server, or a second test run is all it takes.

Same file, same worktree, `--no-file-parallelism`, with ten busy cores
alongside it:

| budget | result | vitest duration | slowest test |
|---|---|---|---|
| 5s (today) | **14 failed** / 120 passed | 305.0s | 26.6s |
| 30s (this PR) | **134 passed** | 239.4s | 16.7s |

Every one of the 14 failures is `Test timed out in 5000ms`. No assertion
failures, no wrong values, no wrong ordering. Thirteen of the fourteen failing
bodies are synchronous `it()`s with no `await` in them at all — they have
nothing to race and can only fail by exceeding the deadline. Given time, every
assertion in the file passes.

This is mostly a local-development problem, and for four days it was only
that. It stopped being only that today:
[run 32690448839](https://github.com/facebook/astryx/actions/runs/32690448839)
failed the `test` job on a PR that touches DropdownMenu, on
`DateInputTouch.test.tsx:1504 — Test timed out in 5000ms`, in a job whose own
duration was 880s. It is the only occurrence in the last 40 failed CI runs, so
it is rare there — but it is not zero, and it costs an unrelated author a
re-run when it happens.

## Change

Give `ui` the same budget `node` already has, and nothing more. `node` is
untouched.

```ts
testTimeout: 30_000,
hookTimeout: 30_000,
```

At the project rather than at the file: the deadline is a property of the
machine the suite runs on, not of any one suite, and `DateInputTouch` is
simply the file with the least headroom today. Per-test timeouts are the right
tool when a test declares its own budget — [#4642](https://github.com/facebook/astryx/pull/4642)
gave the Markdown streaming perf tests explicit ones for exactly that reason —
but nothing here is asserting a budget. This follows `node`'s precedent, and it
is the same value, so the two projects do not drift apart again.

No changeset: this changes no published package. The comparable config-only
changes — the worker-heap bump, the `node` project's own timeout, the
ui/node split — all landed without one.

## What this does not fix

The timeout stops the flake; it does not make the file cheap. 36s of test time
for 134 tests, against ~1s for a file of similar size, is a real cost and it is
worth attacking separately — the suite's own comment above `withLayout` names
the cause (a `clientWidth`/`clientHeight` getter shadowed onto
`HTMLElement.prototype` puts every later DOM read on a slow path), and each
calendar pane renders 6 × 7 days across a 60-month range in jsdom. Cutting that
would be the better fix for the runtime. It is not this PR, and it would not
change the answer here: no test in the file legitimately needs more than ~2s,
so the 5s default is not guarding anything — it is just too tight.

## Test plan

- `vitest run --project ui packages/core/src/DateInput/DateInputTouch.test.tsx`
  — 134 passed, 44s, unloaded.
- The two contended runs in the table above, back to back in the same worktree:
  14 failed at 5s, 134 passed at 30s.
- Comparable-suite timings gathered the same way, in the first table.
