### PR TITLE
fix(markdown): keep the streaming cache across open fences and chunk boundaries

### DIFF
--- a/.changeset/markdown-incremental-cache-holds.md
+++ b/.changeset/markdown-incremental-cache-holds.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Markdown streaming: `parseMarkdownIncremental` no longer throws away its settled blocks while a code fence is open, or when a chunk happens to end on a newline — both re-parsed the whole document, so a long streamed response got slower the longer it grew. Blocks rebuilt across a streamed 500-paragraph document: 126,756 → 1,869.
+@cixzhang

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -131,12 +131,26 @@ describe('parseMarkdownIncremental', () => {
     expect(state.settledText).toBe('');
   });
 
-  it('unclosed fence keeps everything unsettled', () => {
+  it('settles what precedes an unclosed fence, and nothing inside it', () => {
     const state = createIncrementalState();
     const input =
       '# Title\n\n```python\ndef foo():\n    pass\n\n# still inside fence';
     parseMarkdownIncremental(input, state);
-    expect(state.settledBlocks).toHaveLength(0);
+    expect(state.settledText).toBe('# Title');
+    expect(state.settledBlocks).toHaveLength(1);
+  });
+
+  it('does not hold back lines inside an unclosed fence', () => {
+    const state = createIncrementalState();
+    const blocks = parseMarkdownIncremental(
+      'Intro\n\n```ts\ntype Id = string | number;\n- still code',
+      state,
+    );
+    const code = blocks.find(block => block.type === 'codeblock');
+    expect(code).toMatchObject({
+      type: 'codeblock',
+      content: 'type Id = string | number;\n- still code',
+    });
   });
 
   it('handles task list streaming', () => {

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -143,13 +143,13 @@ describe('parseMarkdownIncremental', () => {
   it('does not hold back lines inside an unclosed fence', () => {
     const state = createIncrementalState();
     const blocks = parseMarkdownIncremental(
-      'Intro\n\n```ts\ntype Id = string | number;\n- still code',
+      'Intro\n\n```ts\ntype Id = string | number;',
       state,
     );
     const code = blocks.find(block => block.type === 'codeblock');
     expect(code).toMatchObject({
       type: 'codeblock',
-      content: 'type Id = string | number;\n- still code',
+      content: 'type Id = string | number;',
     });
   });
 

--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -273,13 +273,13 @@ describe('parseMarkdownIncremental cache', () => {
     console.log(
       `  worst chunk's blocks built (50/200/500 paragraphs): ${worst.join('/')}`,
     );
-    // A cache that holds for the typical chunk and dumps on a minority of them
-    // is flat at the median and at p95 while the total work is still O(N²):
-    // that is what #5378 was, on 2% of chunks by one path and 31% by the other.
-    // Only the worst chunk sees a rare collapse, and every collapse costs more
-    // as the document grows — so this asserts the worst one and that a 10x
-    // document does not move it. Deterministic: same fixture, same chunking,
-    // integers with no timing input.
+    // A cache that dumps on a minority of chunks is flat at the median and at
+    // p95 while the total work is still quadratic: the blank-line path of
+    // #5378 hit ~1.4% of chunks on this fixture, and no percentile bound saw
+    // it. The worst chunk does, and each collapse costs more as the document
+    // grows — so this asserts the worst one, and that a 10x document does not
+    // move it. Deterministic: same fixture, same chunking, integers with no
+    // timing input.
     expect(worst).toEqual([3, 3, 3]);
   });
 

--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -8,10 +8,7 @@ import {
 } from './parser';
 import type {BlockNode, ParseOptions} from './parser';
 
-function generateAIResponse(
-  paragraphs: number,
-  {codeBlocks = true}: {codeBlocks?: boolean} = {},
-): string {
+function generateAIResponse(paragraphs: number): string {
   const sections: string[] = [];
   for (let i = 0; i < paragraphs; i++) {
     const mod = i % 6;
@@ -23,9 +20,7 @@ function generateAIResponse(
         break;
       case 1:
         sections.push(
-          codeBlocks
-            ? '```typescript\nfunction process(data: Record<string, unknown>[]) {\n  return data.filter(item => item.valid)\n    .map(item => transform(item))\n    .reduce((acc, val) => merge(acc, val), {});\n}\n```'
-            : `Paragraph ${i} continues the explanation with a second block of prose, keeping the block mix realistic without opening a fence.`,
+          '```typescript\nfunction process(data: Record<string, unknown>[]) {\n  return data.filter(item => item.valid)\n    .map(item => transform(item))\n    .reduce((acc, val) => merge(acc, val), {});\n}\n```',
         );
         break;
       case 2:
@@ -265,29 +260,27 @@ describe('parseMarkdownIncremental cache', () => {
     );
     // A chunk re-parses its unsettled tail, not the document — so the typical
     // chunk's cost is a constant, and a 10x longer document does not move it.
-    expect(medians).toEqual([2, 2, 2]);
+    expect(medians).toEqual([1, 1, 1]);
   });
 
-  it('bounds the p95 chunk, not just the median one, at every document length', () => {
+  it('bounds the worst chunk, not just the typical one, at every document length', () => {
     const chunkSize = 50;
-    const p95s = [50, 200, 500].map(paragraphs =>
-      percentile(
-        blocksBuiltPerChunk(
-          generateAIResponse(paragraphs, {codeBlocks: false}),
-          chunkSize,
-        ),
-        0.95,
+    const worst = [50, 200, 500].map(paragraphs =>
+      Math.max(
+        ...blocksBuiltPerChunk(generateAIResponse(paragraphs), chunkSize),
       ),
     );
     console.log(
-      `  p95 blocks built per chunk (50/200/500 paragraphs): ${p95s.join('/')}`,
+      `  worst chunk's blocks built (50/200/500 paragraphs): ${worst.join('/')}`,
     );
-    // The median above cannot see a cache that holds for the typical chunk and
-    // collapses on a minority of them — p50-flat, still O(N). Fence-free takes
-    // out the worse of the two paths that still dump the whole cache on main
-    // (#5378); the other is live at ~2% of chunks, which puts the cliff just
-    // under p98 — so p95 is the bound with margin rather than the highest one.
-    expect(p95s).toEqual([3, 3, 3]);
+    // A cache that holds for the typical chunk and dumps on a minority of them
+    // is flat at the median and at p95 while the total work is still O(N²):
+    // that is what #5378 was, on 2% of chunks by one path and 31% by the other.
+    // Only the worst chunk sees a rare collapse, and every collapse costs more
+    // as the document grows — so this asserts the worst one and that a 10x
+    // document does not move it. Deterministic: same fixture, same chunking,
+    // integers with no timing input.
+    expect(worst).toEqual([3, 3, 3]);
   });
 
   it('keeps the cache when source ranges are asked for', () => {

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -1586,12 +1586,26 @@ export function createIncrementalState(): IncrementalState {
 
 /**
  * Find the line-index of the last blank line that is NOT inside a fenced code
- * block.  Returns -1 when nothing is settled (unclosed fence or no blank line).
+ * block, and report whether a fence is still open at the end of the input.
+ * Returns -1 when nothing is settled.
+ *
+ * This index must never move backwards as more of the document arrives. The
+ * caller's cache is keyed on the settled text staying a prefix of what it was,
+ * so a boundary that retracts by one line costs a re-parse of every block in
+ * the document. Two things used to retract it: a blank last line, which is
+ * just the newline the stream has written so far and stops being blank as soon
+ * as the next chunk appends to it; and an open fence, which used to collapse
+ * the boundary to -1 even though the content before the fence opened cannot be
+ * changed by anything typed inside it.
  */
-function findSettledBoundary(lines: string[]): number {
+function findSettledBoundary(lines: string[]): {
+  boundary: number;
+  openFence: boolean;
+} {
   let inFence = false;
   let fenceMarker = '';
   let lastBoundary = -1;
+  let boundaryBeforeFence = -1;
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
     const line = lines[lineIndex];
@@ -1602,6 +1616,7 @@ function findSettledBoundary(lines: string[]): number {
       if (!inFence) {
         inFence = true;
         fenceMarker = fenceMatch[1];
+        boundaryBeforeFence = lastBoundary;
       } else if (
         fenceMatch[1].startsWith(fenceMarker[0]) &&
         fenceMatch[1].length >= fenceMarker.length
@@ -1611,12 +1626,20 @@ function findSettledBoundary(lines: string[]): number {
       }
     }
 
-    if (!inFence && line.trim() === '' && lineIndex > 0) {
+    if (
+      !inFence &&
+      line.trim() === '' &&
+      lineIndex > 0 &&
+      lineIndex < lines.length - 1
+    ) {
       lastBoundary = lineIndex;
     }
   }
 
-  return inFence ? -1 : lastBoundary;
+  return {
+    boundary: inFence ? boundaryBeforeFence : lastBoundary,
+    openFence: inFence,
+  };
 }
 
 /**
@@ -1945,17 +1968,23 @@ export function parseMarkdownIncremental(
     linkDefs.size > 0 ? {...opts, linkDefs} : opts;
 
   const lines = input.split('\n');
-  const boundary = findSettledBoundary(lines);
+  const {boundary, openFence} = findSettledBoundary(lines);
 
   if (boundary < 0) {
-    // Inside an unclosed fence or no blank-line boundary — full re-parse
+    // Nothing settled yet — no blank line, or a fence opened before the first
+    // one — so there is no prefix to keep and the whole input is re-parsed.
     state.prevInput = input;
     return parseMarkdownImpl(input, parseOpts);
   }
 
   const settledText = lines.slice(0, boundary).join('\n');
   const unsettledRaw = lines.slice(boundary).join('\n').trim();
-  const unsettledText = trimUnsettledStructural(unsettledRaw);
+  // Structural trimming holds back lines that look like an incomplete list or
+  // table, which inside a fence is ordinary code: a TypeScript union or a `- `
+  // would disappear from the code block as it streams.
+  const unsettledText = openFence
+    ? unsettledRaw
+    : trimUnsettledStructural(unsettledRaw);
 
   let settledBlocks: BlockNode[];
 


### PR DESCRIPTION
## Problem

A chat or docs surface streaming a Markdown answer pays parse work that grows
with how much of the answer has already arrived. `parseMarkdownIncremental`
exists so each arriving token re-parses only the unsettled tail; on two paths it
throws the settled cache away and re-parses the whole document instead —
[#5378](https://github.com/facebook/astryx/issues/5378).

Streaming the perf suite's own fixture at 50-char chunks, counting blocks
rebuilt by object identity — a block handed back from the cache is the same
object; one that is not is one this chunk built:

| paragraphs | chunks | worst chunk | total rebuilt |
| --- | --- | --- | --- |
| 50 (6.6k) | 133 | 59 | 1,513 |
| 200 (26k) | 528 | 234 | 20,975 |
| 500 (66k) | 1,320 | 584 | 126,756 |
| 1000 (132k) | 2,639 | 1,166 | 497,878 |

Twenty times the document, 329 times the work. **It is not a dropped frame** —
no single chunk is slow enough to be seen as a hitch. It is main-thread CPU that
keeps growing while the answer streams, on a device that is also rendering it.

## Cause — one invariant, broken two ways

The settled prefix is recomputed from the current input on every chunk, and the
cache is keyed on that prefix still starting with the previous one. **So the
boundary may never move backwards.** Both paths move it backwards, and each
retraction costs a re-parse of every block in the document:

1. **A blank last line.** `settledText` is `lines.slice(0, boundary)`, and the
   last "line" of a chunk that ends on a newline is `''`, which reads as a blank
   line and settles everything before it. The next chunk appends to that line,
   it stops being blank, and the boundary drops back to the previous one — one
   line, the whole cache. It fires on a small minority of chunks, which is why
   nothing saw it.
2. **An open code fence.** `findSettledBoundary` ended `return inFence ? -1 :
   lastBoundary`, and the caller reads `-1` as "nothing is settled". Nothing
   typed inside a fence can change the content before the fence opened, so that
   prefix is still settled. AI answers are full of fences.

Two defects, one invariant. Neither half alone reaches it — measured, worst
chunk at 50/200/500 paragraphs: fence half only `3/215/565`, blank-line half
only `59/234/584`, both `3/3/3`. So they ship together.

## Change

`findSettledBoundary` returns the boundary and whether a fence is still open. A
blank line settles nothing until the stream has moved past it, and an open fence
holds the boundary it had when the fence opened.

The second half needs one thing at the call site: the tail now contains the open
fence, and `trimUnsettledStructural` holds back trailing lines that look like an
incomplete list or table — inside a fence that is ordinary code. Skipping it
while a fence is open is not tidiness: with the skip removed, streaming
` ```ts` + `type Id = string | number;` leaves `codeblock.content === ''`, so
the code block blanks out until the next line arrives. `incremental.test.ts`
pins that, and the test has been watched fail with the skip deleted.

After, same fixture, same chunking:

| paragraphs | chunks | worst chunk | total rebuilt |
| --- | --- | --- | --- |
| 50 | 133 | 3 | 190 |
| 200 | 528 | 3 | 749 |
| 500 | 1,320 | 3 | 1,869 |
| 1000 | 2,639 | 3 | 3,734 |

1.4 blocks per chunk at every length — flat, which is what the cache was for. On
the fence-free document [#5379](https://github.com/facebook/astryx/pull/5379)
measured, total rebuilt goes 214 / 2,156 / 9,359 → 172 / 693 / 1,735.

**In wall clock**, streaming the same document takes roughly 1.5–3x less time
— and the ratio moves that much between identical runs on this one laptop,
which is the argument for asserting the count and not the clock.

**Two behaviour changes ride with the fix, both toward the one-shot parse.**
Streamed final output now equals `parseMarkdown` of the same text across 168
combinations — 14 documents (`~~~` fences, CRLF, nested fences, fence-inside-
list, link-ref footers, lists and tables across the boundary) × 6 chunk sizes ×
with and without `sourceRanges`. `main` differs from a one-shot parse on 8 of
them: a streamed list comes out `loose` where a one-shot parse says tight. And
while a fence is open the tail is now whitespace-trimmed like every other tail
(`main` took the full-reparse branch and skipped that), so a half-typed indent
no longer sits at the bottom of the code block for one chunk.

**What this does not fix.** Streaming is still superlinear: every chunk re-scans
the whole input four separate ways, none of them the cache. Measured and filed
as [#5406](https://github.com/facebook/astryx/issues/5406), with the shape a fix
would take — it wants `IncrementalState` to carry more than a cache, which is
not a repair.

## The assertion that would have caught this

[#5379](https://github.com/facebook/astryx/pull/5379) landed p95 blocks-built
per chunk and said plainly what it could not see: a collapse on a small
minority of chunks leaves p95 flat at 3. With the parser holding, the bound the
fixed parser actually supports is the **worst** chunk — no chunk rebuilds more
than its tail, at any document length — so that is what this asserts, on the
default fixture with its code fences rather than the fence-free one #5379 had to
use.

**Watched fail, three ways.** Each row is the new test against a parser missing
part of the fix, at 50/200/500 paragraphs.

| the parser | median (#5366) | p95, fence-free (#5379) | p95, fenced | **worst chunk** | the 5 wall-clock budgets |
| --- | --- | --- | --- | --- | --- |
| `main` | fail 2/2/2 | **pass** 3/3/3 | fail 52/200/500 | **fail 59/234/584** | all pass |
| fence half reverted | fail 2/2/2 | **pass** 3/3/3 | fail 52/199/493 | **fail 59/234/584** | all pass |
| blank-line half reverted | **pass** 1/1/1 | **pass** 3/3/3 | **pass** 3/3/3 | **fail 3/215/565** | all pass |

The bound that landed tonight passes on all three broken parsers, and so does it
with fences put back in its fixture on the last row. Only the worst chunk sees
the minority collapse — and its failure values grow with document length, the
O(N) signature a budget with 10x headroom cannot see.

**Why 3.** It is a property of the chunk size, not of the parser or the
document: 2 at 10-char chunks, 3 at 25/50/100, 4 at 200, 7 at 500 — and flat
across 50/200/500 paragraphs at every one of them. What the test asserts is the
flatness; `chunkSize` sits three lines above it.

`generateAIResponse`'s `{codeBlocks: false}` flag came in with the p95 bound
because the fenced path was broken; with it fixed the flag has no caller and is
removed. The median assertion moves 2 → 1: the typical chunk now rebuilds one
block, not two.

## Test plan

`pnpm exec vitest run packages/core/src/Markdown/` — 274 passed.

```
  median blocks built per chunk (50/200/500 paragraphs): 1/1/1
  worst chunk's blocks built (50/200/500 paragraphs): 3/3/3
  blocks built streaming 26351 chars: 749 without ranges, 749 with
```

Both new fence tests were run against a parser with the corresponding half of
the fix removed and watched fail. `tsc --noEmit` and `eslint` clean on
`packages/core`. Every count above is deterministic — same fixture, same
chunking, integers with no timing input.

Closes [#5378](https://github.com/facebook/astryx/issues/5378).
