### PR TITLE
refactor(core): draw the Spinner ring in SVG instead of canvas

### DIFF
--- a/.changeset/spinner-svg-ring.md
+++ b/.changeset/spinner-svg-ring.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[refactor] Spinner: the ring is drawn in SVG instead of `<canvas>`. The arc and track take their colours from the cascade (`currentColor` for `shade="inherit"`), so nothing resolves a colour in JS: a colour change after mount now repaints the ring instead of leaving it stale until it remounts, and mounting spinners no longer costs a `getComputedStyle` each. Rings are pinned to the document timeline's origin, so spinners mounted at different times turn in phase. No API, geometry or theme-target change.
+
+@cixzhang

--- a/packages/core/src/Spinner/Spinner.test.tsx
+++ b/packages/core/src/Spinner/Spinner.test.tsx
@@ -9,9 +9,28 @@
  * SYNC: When Spinner.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Spinner} from './Spinner';
+
+/** sm/md/lg/xl, as Spinner.tsx defines them. */
+const SIZES = {
+  sm: {diameter: 10, border: 2},
+  md: {diameter: 14, border: 3},
+  lg: {diameter: 18, border: 3},
+  xl: {diameter: 28, border: 4},
+} as const;
+
+const ring = (testId = 'spinner') =>
+  screen.getByTestId(testId).querySelector('svg') as SVGSVGElement;
+
+const circles = (testId = 'spinner') => {
+  const [track, arc] = [...ring(testId).querySelectorAll('circle')];
+  return {track, arc};
+};
+
+const dashOf = (el: SVGCircleElement) =>
+  (el.getAttribute('stroke-dasharray') ?? '').split(/[\s,]+/).map(Number);
 
 describe('Spinner', () => {
   it('renders with default props', () => {
@@ -120,5 +139,132 @@ describe('Spinner', () => {
     render(<Spinner data-testid="spinner" />);
     const spinner = screen.getByTestId('spinner');
     expect(spinner.tagName.toLowerCase()).toBe('span');
+  });
+});
+
+describe('Spinner ring', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('draws the ring in SVG', () => {
+    render(<Spinner data-testid="spinner" />);
+    const svg = ring();
+    expect(svg).not.toBeNull();
+    expect(svg.querySelectorAll('circle')).toHaveLength(2);
+    expect(screen.getByTestId('spinner').querySelector('canvas')).toBeNull();
+  });
+
+  it.each(Object.entries(SIZES))(
+    'sizes the %s ring from its size token',
+    (size, {diameter, border}) => {
+      render(
+        <Spinner size={size as keyof typeof SIZES} data-testid="spinner" />,
+      );
+      const frame = diameter + border * 2;
+      const svg = ring();
+      expect(svg.getAttribute('viewBox')).toBe(`0 0 ${frame} ${frame}`);
+      for (const c of [circles().track, circles().arc]) {
+        expect(Number(c.getAttribute('cx'))).toBe(frame / 2);
+        expect(Number(c.getAttribute('cy'))).toBe(frame / 2);
+        expect(Number(c.getAttribute('r'))).toBe(diameter / 2);
+        expect(Number(c.getAttribute('stroke-width'))).toBe(border);
+      }
+    },
+  );
+
+  // The canvas ring swept 135deg, not the 270deg its SPREAD comment claimed.
+  it.each(Object.entries(SIZES))(
+    'sweeps 135 degrees at %s',
+    (size, {diameter}) => {
+      render(
+        <Spinner size={size as keyof typeof SIZES} data-testid="spinner" />,
+      );
+      const {track, arc} = circles();
+      const [on, off] = dashOf(arc);
+      expect(on + off).toBeCloseTo(Math.PI * diameter, 6);
+      expect((on / (on + off)) * 360).toBeCloseTo(135, 6);
+      expect(track.getAttribute('stroke-dasharray')).toBeNull();
+    },
+  );
+
+  it('starts the arc at twelve o’clock', () => {
+    render(<Spinner data-testid="spinner" />);
+    const frame = SIZES.md.diameter + SIZES.md.border * 2;
+    expect(circles().arc.getAttribute('transform')).toBe(
+      `rotate(-90 ${frame / 2} ${frame / 2})`,
+    );
+  });
+
+  // The whole point of the SVG ring: the colours come off the cascade, so
+  // nothing has to resolve them in JS. A read reaching the paint path again
+  // fails here.
+  it.each(['default', 'subtle', 'onMedia', 'inherit'] as const)(
+    'reads no computed style to paint the %s shade',
+    shade => {
+      const spy = vi.spyOn(window, 'getComputedStyle');
+      render(<Spinner shade={shade} data-testid="spinner" />);
+      const spinner = screen.getByTestId('spinner');
+      const onSpinner = spy.mock.calls.filter(
+        ([el]) => el instanceof Element && spinner.contains(el),
+      );
+      expect(onSpinner).toEqual([]);
+    },
+  );
+
+  it('schedules no frame where the Web Animations API is absent', () => {
+    expect(SVGElement.prototype).not.toHaveProperty('getAnimations');
+    const raf = vi.spyOn(window, 'requestAnimationFrame');
+    render(<Spinner data-testid="spinner" />);
+    expect(ring()).not.toBeNull();
+    expect(raf).not.toHaveBeenCalled();
+  });
+
+  it('pins every ring to the timeline origin in a single frame', () => {
+    const animations: {startTime: number | null}[] = [];
+    const getAnimations = vi.fn(function (this: SVGElement) {
+      const a = {startTime: null as number | null};
+      animations.push(a);
+      return [a];
+    });
+    Object.defineProperty(SVGElement.prototype, 'getAnimations', {
+      value: getAnimations,
+      configurable: true,
+      writable: true,
+    });
+    const frames: FrameRequestCallback[] = [];
+    const raf = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(cb => {
+        frames.push(cb);
+        return frames.length;
+      });
+    const computed = vi.spyOn(window, 'getComputedStyle');
+
+    try {
+      const {container} = render(
+        <>
+          {Array.from({length: 5}, (_, i) => (
+            <Spinner key={i} />
+          ))}
+        </>,
+      );
+      // One frame for five spinners: the reads are batched, so no mount
+      // re-forces what the previous mount invalidated.
+      expect(raf).toHaveBeenCalledTimes(1);
+      frames.forEach(cb => cb(0));
+      expect(animations).toHaveLength(5);
+      expect(animations.every(a => a.startTime === 0)).toBe(true);
+      // The pin runs on the branch the other shade cases cannot reach, so the
+      // no-read assertion is made here too.
+      expect(
+        computed.mock.calls.filter(
+          ([el]) => el instanceof Element && container.contains(el),
+        ),
+      ).toEqual([]);
+    } finally {
+      // @ts-expect-error — removing the stub restores jsdom's real surface
+      delete SVGElement.prototype.getAnimations;
+    }
   });
 });

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Spinner.tsx
- * @input Uses React, StyleX, canvas rendering
+ * @input Uses React, StyleX, SVG rendering
  * @output Exports Spinner component, SpinnerProps, SpinnerSize, SpinnerShade types
  * @position Core implementation of spinner loading indicator
  *
@@ -16,10 +16,9 @@
  * - /packages/cli/assets/templates/blocks/components/Spinner/ (showcase blocks)
  */
 
-import {useEffect, useId, useRef, type ReactNode} from 'react';
+import {useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {durationVars, spacingVars} from '../theme/tokens.stylex';
-import {useTheme} from '../theme/useTheme';
+import {colorVars, durationVars, spacingVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
 import {Text} from '../Text/Text';
 import {mergeProps} from '../utils';
@@ -29,10 +28,11 @@ import {themeProps} from '../utils/themeProps';
 // Constants
 // =============================================================================
 
-/** How much of the circle the active arc covers (as a fraction of 2π) */
-const SPREAD = 0.75;
-/** Where the active arc starts (as a fraction of 2π) */
-const START_POINT = 1.5;
+/**
+ * Fraction of the ring the moving arc covers. The canvas ring this replaces
+ * swept 135deg, not the 270deg its constant's comment claimed.
+ */
+const ARC_FRACTION = 0.375;
 
 const SIZES = {
   sm: {diameter: 10, border: 2},
@@ -40,6 +40,61 @@ const SIZES = {
   lg: {diameter: 18, border: 3},
   xl: {diameter: 28, border: 4},
 };
+
+/** `onMedia` keeps the 77/255 its token's `4D` hex suffix used to encode. */
+const TRACK_OPACITY = {
+  default: 1,
+  subtle: 1,
+  onMedia: 77 / 255,
+  inherit: 0.3,
+};
+
+/**
+ * Pin every ring's rotation to the document timeline's origin instead of its
+ * own start time, so spinners mounted seconds apart turn in phase.
+ *
+ * Setting `startTime` is exact where arithmetic on a clock read is not: a
+ * negative `animation-delay` computed at mount is only as good as the gap
+ * between reading the clock and the frame the animation starts in, which at
+ * 10x CPU throttling measured 116deg of drift.
+ *
+ * Rings are collected and pinned in one frame because `getAnimations()`
+ * resolves style and `startTime` dirties it again, so pinning them one at a
+ * time makes each mount re-force what the previous one invalidated — 53 style
+ * recalcs for 38 spinners against 19 batched.
+ */
+const pendingRings = new Set<SVGSVGElement>();
+let flushScheduled = false;
+
+function pinRingsToTimelineOrigin(): void {
+  flushScheduled = false;
+  const animations: Animation[] = [];
+  for (const svg of pendingRings) {
+    animations.push(...svg.getAnimations());
+  }
+  pendingRings.clear();
+  for (const animation of animations) {
+    animation.startTime = 0;
+  }
+}
+
+function syncRotationPhase(
+  svg: SVGSVGElement | null,
+): (() => void) | undefined {
+  // jsdom implements no Web Animations, and this runs in every consumer's
+  // component tests.
+  if (svg == null || typeof svg.getAnimations !== 'function') {
+    return undefined;
+  }
+  pendingRings.add(svg);
+  if (!flushScheduled) {
+    flushScheduled = true;
+    requestAnimationFrame(pinRingsToTimelineOrigin);
+  }
+  return () => {
+    pendingRings.delete(svg);
+  };
+}
 
 // =============================================================================
 // Animation
@@ -67,7 +122,7 @@ const styles = stylex.create({
     overflow: 'hidden',
     verticalAlign: 'middle',
   },
-  canvas: {
+  ring: {
     backfaceVisibility: 'hidden',
     display: 'block',
     willChange: 'transform',
@@ -82,6 +137,33 @@ const styles = stylex.create({
     animationName: rotation,
     animationTimingFunction: 'linear',
   },
+  circle: {
+    fill: 'none',
+    strokeLinecap: 'round',
+  },
+});
+
+const arcStyles = stylex.create({
+  default: {stroke: colorVars['--color-accent']},
+  subtle: {stroke: colorVars['--color-text-secondary']},
+  onMedia: {stroke: colorVars['--color-on-dark']},
+  inherit: {stroke: 'currentColor'},
+});
+
+const trackStyles = stylex.create({
+  default: {
+    stroke: colorVars['--color-track'],
+    strokeOpacity: TRACK_OPACITY.default,
+  },
+  subtle: {
+    stroke: colorVars['--color-track'],
+    strokeOpacity: TRACK_OPACITY.subtle,
+  },
+  onMedia: {
+    stroke: colorVars['--color-on-dark'],
+    strokeOpacity: TRACK_OPACITY.onMedia,
+  },
+  inherit: {stroke: 'currentColor', strokeOpacity: TRACK_OPACITY.inherit},
 });
 
 // =============================================================================
@@ -100,7 +182,7 @@ export interface SpinnerProps extends BaseProps<HTMLSpanElement> {
    * - 'sm': 10px diameter
    * - 'md': 14px diameter
    * - 'lg': 18px diameter
-   * - 'xl': 36px diameter
+   * - 'xl': 28px diameter
    * @default 'md'
    */
   size?: SpinnerSize;
@@ -141,7 +223,7 @@ export interface SpinnerProps extends BaseProps<HTMLSpanElement> {
 // =============================================================================
 
 /**
- * An animated loading indicator. Available in three sizes and two color shades.
+ * An animated loading indicator. Available in four sizes and four color shades.
  *
  * @example
  * ```
@@ -164,97 +246,11 @@ export function Spinner({
   ref,
   ...restProps
 }: SpinnerProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const {tokens: themeTokens} = useTheme();
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (canvas == null) {
-      return;
-    }
-
-    const context = canvas.getContext('2d');
-    if (!context) {
-      return;
-    }
-
-    const {border, diameter} = SIZES[size];
-    const pixelRatio = window.devicePixelRatio || 1;
-
-    // Resolve colors from theme tokens (useTheme handles light/dark resolution).
-    // - default → accent ring on a track tuned to body luminance
-    // - subtle  → secondary text color, less prominent
-    // - onMedia → on-dark color, with a translucent track for photos/video
-    // - inherit → the inherited currentColor, so the ring matches the parent's
-    //   resolved foreground (e.g. a button's variant text color)
-    const inheritedColor =
-      shade === 'inherit' ? getComputedStyle(canvas).color : null;
-    const activeColor =
-      shade === 'inherit'
-        ? (inheritedColor as string)
-        : shade === 'onMedia'
-          ? themeTokens['--color-on-dark']
-          : shade === 'subtle'
-            ? themeTokens['--color-text-secondary']
-            : themeTokens['--color-accent'];
-    // Track derives from --color-on-dark for onMedia (with a 30% alpha so the
-    // ring reads against arbitrary backgrounds) and from --color-track for the
-    // body-luminance shades. For inherit, the track is the same currentColor
-    // drawn at reduced alpha via globalAlpha (see below). All branches are
-    // fully theme-driven.
-    const backgroundColor =
-      shade === 'inherit'
-        ? (inheritedColor as string)
-        : shade === 'onMedia'
-          ? `${themeTokens['--color-on-dark']}4D`
-          : themeTokens['--color-track'];
-
-    const cssSize = diameter + border * 2;
-
-    // Round to an even number of device pixels so the center stays on a whole
-    // pixel (avoids rotation jitter); keep CSS size pinned to cssSize (#2732).
-    const rawFrameSize = Math.round(cssSize * pixelRatio);
-    const frameSize = rawFrameSize + (rawFrameSize % 2);
-
-    const scale = frameSize / cssSize;
-    const radius = (diameter / 2) * scale;
-    const lineWidth = border * scale;
-
-    canvas.height = canvas.width = frameSize;
-    canvas.style.width = canvas.style.height = cssSize + 'px';
-
-    context.lineCap = 'round';
-    context.lineWidth = lineWidth;
-
-    const center = frameSize / 2;
-
-    // Background circle (full ring, faded). For the inherit shade the track is
-    // the same currentColor as the arc, so fade it via globalAlpha (the
-    // computed color is an opaque rgb() string with no alpha channel to tweak).
-    context.beginPath();
-    context.arc(center, center, radius, 0, 2 * Math.PI);
-    context.strokeStyle = backgroundColor;
-    if (shade === 'inherit') {
-      context.globalAlpha = 0.3;
-    }
-    context.stroke();
-    context.globalAlpha = 1;
-
-    // Active arc (partial ring, colored)
-    context.beginPath();
-    context.arc(
-      center,
-      center,
-      radius,
-      START_POINT * Math.PI,
-      ((START_POINT + SPREAD) % 2) * Math.PI,
-    );
-    context.strokeStyle = activeColor;
-    context.stroke();
-  }, [shade, size, themeTokens]);
-
   const {border, diameter} = SIZES[size];
   const frameSize = diameter + border * 2;
+  const center = frameSize / 2;
+  const circumference = Math.PI * diameter;
+  const arcLength = circumference * ARC_FRACTION;
   const hasLabel = label != null;
   const labelId = useId();
 
@@ -283,7 +279,30 @@ export function Spinner({
         hasLabel ? undefined : className,
         {...(hasLabel ? {} : style), width: frameSize, height: frameSize},
       )}>
-      <canvas ref={canvasRef} {...stylex.props(styles.canvas)} />
+      <svg
+        ref={syncRotationPhase}
+        width={frameSize}
+        height={frameSize}
+        viewBox={`0 0 ${frameSize} ${frameSize}`}
+        aria-hidden="true"
+        {...stylex.props(styles.ring)}>
+        <circle
+          cx={center}
+          cy={center}
+          r={diameter / 2}
+          strokeWidth={border}
+          {...stylex.props(styles.circle, trackStyles[shade])}
+        />
+        <circle
+          cx={center}
+          cy={center}
+          r={diameter / 2}
+          strokeWidth={border}
+          strokeDasharray={`${arcLength} ${circumference - arcLength}`}
+          transform={`rotate(-90 ${center} ${center})`}
+          {...stylex.props(styles.circle, arcStyles[shade])}
+        />
+      </svg>
     </span>
   );
 


### PR DESCRIPTION
Someone watching a form submit sees the spinner go the wrong colour, or stop
matching the button it sits in, or sit at a different angle from the spinner
next to it. All three come from the ring being painted on a `<canvas>`, and
this replaces it with SVG. No API change, no geometry change, no theme-target
change — only the single child of the `<span role="status">`.

## Why

Canvas 2D `strokeStyle` cannot resolve `currentColor`, so `shade="inherit"`
read the resolved colour out of the cascade
(`getComputedStyle(canvas).color`) on mount and baked it into a bitmap. Three
things followed from that, and all three are gone:

**A colour that changes after mount.** A theme swap, a variant change, dark
mode: the ring kept the colour it was born with. Parent goes from
`rgb(0,100,224)` to `rgb(216,27,96)`, same component, same moment:

| | before the swap | after the swap |
|---|---|---|
| canvas | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/recolour-canvas-before.png) | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/recolour-canvas-after.png) |
| SVG | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/recolour-svg-before.png) | ![](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/recolour-svg-after.png) |

**A read on the paint path.** One `getComputedStyle` per spinner, and the
style recalcs it forces grow with how many mount together. Now the stroke *is*
`currentColor` and nothing resolves a colour in JS.

**`inherit` as a special case.** It had its own colour branch and used
`globalAlpha` for the track, because a computed `rgb()` string has no alpha to
tweak. It is now one `stroke: currentColor` rule with `stroke-opacity`, the
same shape as the other three shades.

Canvas was never a measured requirement: it arrived in
[#137](https://github.com/facebook/astryx/pull/137) as a copy of an internal
implementation ("crisp at any DPI"), and
[#2732](https://github.com/facebook/astryx/issues/2732) — cited in the
even-frame rounding this deletes — is a *centering* bug whose own fix
([#2905](https://github.com/facebook/astryx/pull/2905)) says so.

## What it draws

One `<svg>` and two `<circle>`s (`Spinner.tsx:282–305`). Two, because two
strokes of different colour and opacity are two paint operations. A two-node
variant that made the track a CSS `border` on the `<svg>` measured a 13.3°
mean / 28.4° max wobble under rotation at `md` (10.5° / 22.1° at `lg`) against
0.9° for canvas, so it is out on evidence rather than taste.

Everything is a presentation attribute computed from the existing `SIZES`
table: `viewBox`, `cx`/`cy`/`r`, `stroke-width`, a user-unit
`stroke-dasharray`, `transform="rotate(-90 …)"`.

## Spinners now turn in phase

Two spinners mounted a second apart used to sit at unrelated angles — measured
**177° apart** — which side by side reads as one of them being stuck. Canvas
top, SVG bottom, four spinners mounted 260 ms apart:

![phase](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/phase-dpr2.png)

Each ring is pinned to the document timeline's origin, so its angle depends on
the clock and not on when it mounted.

The obvious way to write that is a negative `animation-delay` computed from
`document.timeline.currentTime` at mount. **It is not exact, and the error is
not small**: the delay is arithmetic on a clock read while the animation starts
at the next style resolution, and the gap between the two is the drift. Max
separation across four spinners mounted 260 ms apart, three runs per row
([raw output](https://github.com/cixzhang/astryx/tree/assets/pr-5408/measurements)):

| | 1× CPU | 4× | 10× |
|---|---|---|---|
| canvas (today) | 177° | 177° | 178° |
| `animation-delay = -currentTime`, at mount | 0.8–12.7° | 23.0–69.2° | 102–116° |
| same, read inside a `requestAnimationFrame` | 0.06–0.11° | 22.9–34.2° | 44.5–68.9° |
| **`animation.startTime = 0`** | **0.00°** | **0.00°** | **0.00°** |

`startTime = 0` states the thing instead of computing it, so there is no gap to
be wrong about, and it is duration-agnostic — it survives the reduced-motion
swap and a theme changing `--duration-slow-min`.

**It also has a cost, and the cost is the bug this PR is removing.**
`getAnimations()` resolves style and setting `startTime` dirties it again, so
pinning rings one at a time makes each mount re-force what the last one
invalidated — the same cross-instance interleaving that made the canvas read
expensive. Rings are therefore collected and pinned in one frame
(`Spinner.tsx:66–92`). Style recalcs, N spinners mounted in one commit, both
arms from one run:

| | N=1 | 8 | 20 | 38 |
|---|---|---|---|---|
| pinned one at a time | 18 | 24 | 36 | **53** |
| **pinned in one frame** | 19 | 16 | 19 | **19** |

Where the Web Animations API is missing the pin is skipped and the ring still
spins, unsynchronised (`Spinner.tsx:86`).

## Performance

Chromium, the real component through Storybook, canvas and SVG in the same
page, `shade="inherit"`, driven with Playwright. **Every number below is
reproducible from the [raw output](https://github.com/cixzhang/astryx/tree/assets/pr-5408/measurements)**, which carries a README saying what
each file measures.

- **Render.** The `useEffect` and the `useTheme()` context subscription are
  gone. What replaces them is a ref callback that adds a node to a `Set`, plus
  one `requestAnimationFrame` per *batch* of mounts — not per spinner, not per
  frame.
- **Reads.** Canvas calls `getComputedStyle` once per spinner on the paint path
  — 20 calls at twenty spinners, all attributed by stack to
  `Spinner.tsx`'s own effect. SVG: **none from Astryx code**. That is an
  attribution, not a raw count: the page still shows 4–5 spinner-scoped calls
  per spinner on both arms, and every one of them resolves by stack to
  Storybook's preview runtime walking the DOM (`isInfiniteAnimation` and a
  filter over every element). SVG shows *more* of those than canvas, because
  the harness walks two more nodes per spinner. Every call is listed with its
  stack in the raw output.
- **Style recalcs at mount**, N spinners in one commit: canvas 19 / 22 / 30 /
  34 at N = 1 / 8 / 20 / 38; SVG **20 / 19 / 19 / 19**. Flat.
- **Layout.** No forced reflow. Over 3 s × 20 spinners: **0 layouts** on both,
  and the recalc count over that window is the same on both arms (18–23,
  three runs each) — that is Storybook's own ticking, not the animation, and
  it does not move when the mechanism changes. The ring keeps its own
  compositor layer (`ActiveTransformAnimation`, `WillChangeTransform`,
  `BackfaceVisibilityHidden`), read out of the layer tree.
- **Who pays.** The mount saving is a **user's**: 38 spinners appearing at once
  lose 38 forced style resolutions and ~15 style recalcs in the frame they
  appear in. The two extra DOM nodes per spinner are **ours** — 76 more
  elements on a 38-spinner page — bought in exchange for the cascade doing the
  colour work. Nobody perceives them; it is a cost we would be choosing to
  carry.
- **Bundle.** ~100 lines of draw machinery deleted, SVG markup added. CI's
  analysis report carries the byte delta; I did not measure it separately.

## Visual evidence

Canvas **left**, SVG **right** in every pair, frozen at the same angle. All
four sizes × all four shades, at DPR 1 and DPR 2 — 32 cells, on the real
component.

![all sizes and shades, DPR 2](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/matrix-dpr2.png)

Measured over those 32 cells: the outer box is identical
in every one; worst ink-pixel difference **4** (of 106–4747 painted), worst
arc-position difference **1.49°**, worst outer-radius difference 0.4 px.
Magnified 4×, `default` at DPR 2:

![default row, 4x](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/row4x-default-dpr2.png)

`sm` at DPR 2 magnified 8× — the case the canvas whole-pixel rounding existed
for, and a dead heat:

![sm inherit, 8x](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5408/cell8x-inherit-sm-dpr2.png)

Also on the assets branch: `matrix-dpr1.png`,
`row4x-{subtle,onMedia,inherit}-dpr2.png`, `cell8x-{default-sm,onMedia-xl}-dpr2.png`.

## Cross-browser

**Not verified in WebKit or Firefox — neither will run on the machine this was
measured on** (WebKit launches and the page closes immediately; Firefox fails
to launch). So the shape was chosen to need no engine check: the ring uses only
SVG 1.1 presentation attributes and CSS Animations Level 1, and deliberately
avoids `pathLength`, `vector-effect: non-scaling-stroke`, a `calc()` dash and
`transform-box`, each of which has engine-specific behaviour and none of which
is needed once the viewBox maps 1:1 to CSS pixels. (`pathLength` does work in
Chromium on a plain `<circle>` — measured, ink within 1% of the user-unit dash
— but "works in the one engine I can drive" is the argument this section is
trying not to make.)

The one modern API is `Element.getAnimations()` (Safari 13.1, Firefox 75), and
it is feature-detected. Worth a second pair of eyes in Safari before release
anyway, because [#3628](https://github.com/facebook/astryx/pull/3628) added
`will-change: transform` here for a Safari/Tauri wobble and that declaration is
carried over untested (`Spinner.tsx:128`).

## Tests

`Spinner.test.tsx` goes from 17 to 33 cases. jsdom does no layout, so nothing
here claims anything about rendering. What it pins:

- **the read is gone** — a `getComputedStyle` spy asserts no call lands on any
  node inside the spinner, for each of the four shades
- **the pin is batched** — five spinners schedule exactly one frame, and every
  ring ends at `startTime = 0`
- **no frame is scheduled where Web Animations is absent** — an unguarded
  `getAnimations()` threw an uncaught `TypeError` in every consumer's jsdom run,
  which is how that guard got written
- the 135° sweep, the twelve o'clock start, and per-size geometry

Every new assertion was confirmed to fail when the defect is put back. The
read-spy is deliberately stricter than the defect it replaces: the canvas read
was gated on `shade === 'inherit'`, so restoring exactly that fails one of the
four shade cases, while an ungated read fails all four — both were tried. The
unbatched pin fails with "expected 1 times, but got 5 times".

**What jsdom cannot reach on its own** is the pin's branch, since it implements
no Web Animations — so the batching test stubs `getAnimations` and carries the
read-spy assertion too, and the combined case was confirmed to fail on a read
placed inside that branch. What is left unpinned is rendering: jsdom does no
layout, so nothing in this file claims the ring looks right. That is what the
frames above are for.

## Breaking

- **API** — none. `SpinnerProps` is unchanged and all 25 call sites compile
  untouched. No test in the repo asserts the canvas; `Button.test.tsx:114`
  queries `.astryx-spinner` and its `data-shade`, both of which survive.
- **Visual** — none, to 4 ink pixels and 1.49° of arc position across the 32
  cells above.
- **Theme** — none. The target stays `{className: 'astryx-spinner',
  visualProps: ['size','shade']}` on the same `<span>`, with the same
  `data-size` and `data-shade`.

**Risk class: low** — no new API surface, no new theme target, no behaviour
regression, no performance regression, and no outer dimension grew.

## What this means for the two open spinner PRs

Neither is touched here, and nothing is being asked of either author — but both
are being judged against a mechanism that is about to change, so their
reviewers should re-read rather than discover:

- **[#5214](https://github.com/facebook/astryx/pull/5214)** — both of its known
  defects are canvas artifacts. `--spinner-rail-width: 0` drawing a hairline is
  `lineWidth = 0` being ignored; a `--spinner-color` changed after mount not
  repainting is the stale read above. Under SVG those are `stroke-width` and
  `stroke`, and neither needs code. It also moves the computed-style read from
  the `inherit` shade to *every* shade, which raises a question its review will
  want to settle: whether that read has to exist at all once the ring paints
  `currentColor`.
- **[#5250](https://github.com/facebook/astryx/pull/5250)** — **SVG does not fix
  it.** `stroke="currentColor"` resolves against the same cascade the canvas
  read did, so a host that paints a background and sets no `color` still gives
  white on white. Its defect is the missing colour owner, and it survives this
  change untouched.

## One thing found on the way

`SPREAD = 0.75` was documented as three quarters of the circle, but
`((START_POINT + SPREAD) % 2) * Math.PI` is in units of π, so the shipped arc
is **135°**, not 270°. The code was right and the comment was wrong; both
constants are gone and the SVG copies the 135° the spinner has always drawn.
The `xl` size was also documented as 36 px and has always been 28 px — corrected
in the prop doc, no behaviour change.
