### PR TITLE
fix: verify canary packages and default-condition exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/lab build && pnpm -F @astryxdesign/charts build && pnpm -F @astryxdesign/vega build && pnpm -F @astryxdesign/theme-neutral build && pnpm -F @astryxdesign/theme-matcha build && pnpm -F @astryxdesign/theme-stone build && pnpm -F @astryxdesign/theme-gothic build && pnpm -F @astryxdesign/theme-chocolate build && pnpm -F @astryxdesign/theme-y2k build && pnpm -F @astryxdesign/theme-butter build && pnpm bundle:cli-themes && pnpm -F @astryxdesign/cli sync:api-types",
+    "build": "pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/lab build && pnpm -F @astryxdesign/charts build && pnpm -F @astryxdesign/richtext build && pnpm -F @astryxdesign/vega build && pnpm -F @astryxdesign/theme-neutral build && pnpm -F @astryxdesign/theme-matcha build && pnpm -F @astryxdesign/theme-stone build && pnpm -F @astryxdesign/theme-gothic build && pnpm -F @astryxdesign/theme-chocolate build && pnpm -F @astryxdesign/theme-y2k build && pnpm -F @astryxdesign/theme-butter build && pnpm bundle:cli-themes && pnpm -F @astryxdesign/cli sync:api-types",
     "bundle:cli-themes": "node scripts/generate-cli-themes.mjs",
     "dev": "pnpm -F @astryxdesign/storybook dev",
     "test": "vitest run",

--- a/scripts/verify-exports.mjs
+++ b/scripts/verify-exports.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-
 /**
  * verify-exports.mjs
  *
@@ -23,6 +22,11 @@
  * #4569 (`await import('@astryxdesign/core/Text')` succeeds on the unfixed bytes
  * even though the Tooltip specifier inside it is broken). Catching that needs a
  * static scan; see scripts/check-fully-specified.mjs.
+ *
+ * Coverage follows what actually ships, not what `private` says: `canaryOnly`
+ * packages are published to the `@canary` dist-tag, and their runtime entry is
+ * reached through `default`. Skipping both is why #5000 shipped an unimportable
+ * dist past this gate (#5132).
  *
  * Exit code 1 if any exports are broken.
  */
@@ -47,9 +51,9 @@ const SKIP_CONDITIONS = new Set(['source']);
 /**
  * Find all package.json files in packages/ (including nested workspaces like packages/themes/*)
  */
-function findPackageJsons() {
+function findPackageJsons(root) {
   const results = [];
-  const packagesDir = join(rootDir, 'packages');
+  const packagesDir = join(root, 'packages');
 
   function walk(dir, depth = 0) {
     if (depth > 2) return;
@@ -112,101 +116,154 @@ function checkWildcard(pkgDir, exportValue) {
  * ESM targets worth actually importing. `.cjs` and `require`-condition targets
  * are skipped (loading CJS here would fire side effects under a different
  * module system), as are type declarations and assets, which Node cannot import
- * as modules anyway. `default` targets are deliberately outside this probe:
- * many are browser-focused, and evaluating every default entry would broaden
- * this packaging check beyond the explicit ESM import surface it protects.
+ * as modules anyway.
+ *
+ * `default` is probed when it is the export's real ESM entry. It is not always:
+ * Node takes the first matching condition, so a `default` declared beside an
+ * `import` is the fallback for some other consumer, and a `default` nested
+ * under `require` is CJS. Everything else reaching `default` is what a
+ * consumer's `import` resolves to — for core, charts, lab and richtext it is
+ * the *only* runtime condition, so leaving it unprobed meant their entry points
+ * were never loaded (#5132). Non-module targets stay out either way: the
+ * extension filter, not the condition name, is what excludes a stylesheet or a
+ * JSON asset.
+ *
+ * The `import`-sibling check is sibling-scoped, so a `default` alongside a
+ * nested `node: {import: ...}` is still probed even though Node would resolve
+ * the `node` branch first. That is intentional: such a `default` is what
+ * non-Node consumers load, and only module-resolution failures are reported
+ * (see RESOLUTION_CODES), so an environment-specific runtime error in one
+ * cannot fail this gate. No workspace manifest uses that shape today.
  */
 const IMPORTABLE = /\.(js|mjs)$/;
-const NON_PROBED_CONDITIONS = new Set(['types', 'require', 'default']);
-
-/** Targets collected during the existence pass, imported afterwards. */
-const importTargets = [];
+const NON_PROBED_CONDITIONS = new Set(['types', 'require']);
 
 /**
- * Recursively check an exports map value.
- * Handles string paths, conditional objects, and nested structures.
+ * Whether a target that exists on disk is one this gate should import.
+ *
+ * `conditions` is the chain of export conditions above it, outermost first;
+ * `siblings` are the condition keys declared alongside it.
  */
-function checkExportsValue(pkgDir, pkgName, exportKey, value, parentCondition) {
-  const errors = [];
+function isProbeableTarget(value, conditions, siblings) {
+  if (!IMPORTABLE.test(value)) return false;
+  // A `require` or `types` anywhere above this target rules it out, not just
+  // immediately above it — a `default` nested inside `require` is still CJS.
+  if (conditions.some(condition => NON_PROBED_CONDITIONS.has(condition))) {
+    return false;
+  }
+  if (conditions.at(-1) === 'default' && siblings.has('import')) return false;
+  return true;
+}
 
-  if (typeof value === 'string') {
-    const isWildcard =
-      exportKey.split('*').length === 2 && value.split('*').length === 2;
-    const ok = isWildcard ? checkWildcard(pkgDir, value) : checkFile(pkgDir, value);
-    if (!ok) {
-      const label = parentCondition
-        ? `exports["${exportKey}"].${parentCondition}`
-        : `exports["${exportKey}"]`;
-      errors.push(`  ✗ ${label} → ${value} (${isWildcard ? 'no files match pattern' : 'file not found'})`);
-    } else if (
-      !isWildcard &&
-      IMPORTABLE.test(value) &&
-      !NON_PROBED_CONDITIONS.has(parentCondition)
-    ) {
-      importTargets.push({
+/**
+ * Whether a package's published artifacts are in scope for this gate.
+ *
+ * `private: true` normally means workspace-only — nothing is published, so
+ * there is no consumer for a broken export to reach. `astryx.canaryOnly`
+ * packages are the exception: they carry `private: true` purely as npm's hard
+ * guarantee against a stable publish, and the release workflow strips it in its
+ * ephemeral checkout to publish them on the `@canary` dist-tag. Those do ship,
+ * so they get the same checks.
+ *
+ * This is deliberately the same predicate the canary publish loop uses —
+ * `(!p.private || p.astryx?.canaryOnly)` in .github/workflows/release.yml — and
+ * it tests `canaryOnly` for truthiness for the same reason. A stricter test here
+ * (`=== true`) would let a package the publisher ships go unverified, which is
+ * the hole this gate exists to close. Whatever release.yml publishes, this
+ * checks.
+ */
+export function isPublishedPackage(pkg) {
+  return !pkg.private || Boolean(pkg.astryx?.canaryOnly);
+}
+
+/**
+ * Walk one package's exports map. Reports targets that do not exist, and
+ * collects the ESM targets worth importing.
+ */
+export function checkPackageExports(pkgDir, pkgName, exportsMap) {
+  const errors = [];
+  const targets = [];
+
+  const labelFor = (exportKey, conditions) =>
+    conditions.length > 0
+      ? `exports["${exportKey}"].${conditions.join('.')}`
+      : `exports["${exportKey}"]`;
+
+  function walk(exportKey, value, conditions, siblings) {
+    if (typeof value === 'string') {
+      const isWildcard =
+        exportKey.split('*').length === 2 && value.split('*').length === 2;
+      const ok = isWildcard
+        ? checkWildcard(pkgDir, value)
+        : checkFile(pkgDir, value);
+      if (!ok) {
+        errors.push(
+          `  ✗ ${labelFor(exportKey, conditions)} → ${value} (${isWildcard ? 'no files match pattern' : 'file not found'})`,
+        );
+        return;
+      }
+      if (isWildcard || !isProbeableTarget(value, conditions, siblings)) return;
+      targets.push({
         pkgName,
-        label: parentCondition
-          ? `exports["${exportKey}"].${parentCondition}`
-          : `exports["${exportKey}"]`,
+        label: labelFor(exportKey, conditions),
         value,
         abs: resolve(pkgDir, value),
       });
+      return;
     }
-  } else if (typeof value === 'object' && value !== null) {
-    for (const [condition, conditionValue] of Object.entries(value)) {
-      if (SKIP_CONDITIONS.has(condition)) continue;
-      errors.push(
-        ...checkExportsValue(pkgDir, pkgName, exportKey, conditionValue, condition),
-      );
+
+    if (typeof value === 'object' && value !== null) {
+      const keys = new Set(Object.keys(value));
+      for (const [condition, conditionValue] of Object.entries(value)) {
+        if (SKIP_CONDITIONS.has(condition)) continue;
+        walk(exportKey, conditionValue, [...conditions, condition], keys);
+      }
     }
   }
 
-  return errors;
+  for (const [exportKey, value] of Object.entries(exportsMap)) {
+    walk(exportKey, value, [], new Set());
+  }
+
+  return {errors, targets};
 }
 
-// --- Main ---
+/**
+ * Run the existence pass over every published package under `root`/packages.
+ * Returns one result per checked package and the import targets collected from
+ * all of them. Reports nothing — the caller prints.
+ */
+export function verifyExports(root) {
+  const results = [];
+  const targets = [];
 
-const packageJsons = findPackageJsons();
-let totalErrors = 0;
-let packagesChecked = 0;
+  for (const pkgJsonPath of findPackageJsons(root)) {
+    const pkgDir = dirname(pkgJsonPath);
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
 
-for (const pkgJsonPath of packageJsons) {
-  const pkgDir = dirname(pkgJsonPath);
-  const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+    if (!isPublishedPackage(pkg)) continue;
 
-  // Skip private packages
-  if (pkg.private) continue;
+    const errors = [];
 
-  const errors = [];
-
-  // Check top-level fields (main, module, types)
-  for (const field of TOP_LEVEL_FIELDS) {
-    if (pkg[field] && !checkFile(pkgDir, pkg[field])) {
-      errors.push(`  ✗ ${field} → ${pkg[field]} (file not found)`);
+    // Check top-level fields (main, module, types)
+    for (const field of TOP_LEVEL_FIELDS) {
+      if (pkg[field] && !checkFile(pkgDir, pkg[field])) {
+        errors.push(`  ✗ ${field} → ${pkg[field]} (file not found)`);
+      }
     }
+
+    // Check exports map
+    if (pkg.exports && typeof pkg.exports === 'object') {
+      const exports = checkPackageExports(pkgDir, pkg.name, pkg.exports);
+      errors.push(...exports.errors);
+      targets.push(...exports.targets);
+    }
+
+    results.push({name: pkg.name, path: pkgJsonPath, errors});
   }
 
-  // Check exports map
-  if (pkg.exports && typeof pkg.exports === 'object') {
-    for (const [exportKey, exportValue] of Object.entries(pkg.exports)) {
-      errors.push(...checkExportsValue(pkgDir, pkg.name, exportKey, exportValue));
-    }
-  }
-
-  packagesChecked++;
-
-  if (errors.length > 0) {
-    console.error(`\n❌ ${pkg.name} (${pkgJsonPath})`);
-    for (const error of errors) {
-      console.error(error);
-    }
-    totalErrors += errors.length;
-  } else {
-    console.log(`✓ ${pkg.name}`);
-  }
+  return {results, targets};
 }
-
-console.log(`\n${packagesChecked} packages checked.`);
 
 // Second pass: actually load each runtime ESM target. A target can exist and
 // still be unresolvable — see #4620, where every theme's `./built` entry was
@@ -227,53 +284,98 @@ const RESOLUTION_CODES = new Set([
 /** Sentinel exit code, distinct from anything an executable entry might use. */
 const IMPORT_FAILED = 9;
 
-let importFailures = 0;
+/**
+ * Import each target in a child process. Returns the ones that failed for a
+ * module-resolution reason, as `{...target, code}`.
+ */
+export function probeImportTargets(targets) {
+  const failures = [];
 
-for (const target of importTargets) {
-  const probe =
-    `import(${JSON.stringify(pathToFileURL(target.abs).href)})` +
-    `.then(() => process.exit(0))` +
-    `.catch(e => { process.stderr.write(String((e && e.code) || (e && e.name) || e)); process.exit(${IMPORT_FAILED}); })`;
+  for (const target of targets) {
+    const probe =
+      `import(${JSON.stringify(pathToFileURL(target.abs).href)})` +
+      `.then(() => process.exit(0))` +
+      `.catch(e => { process.stderr.write(String((e && e.code) || (e && e.name) || e)); process.exit(${IMPORT_FAILED}); })`;
 
-  const run = spawnSync(process.execPath, ['--input-type=module', '-e', probe], {
-    encoding: 'utf-8',
-    timeout: 20_000,
-    stdio: ['ignore', 'ignore', 'pipe'],
-  });
+    const run = spawnSync(
+      process.execPath,
+      ['--input-type=module', '-e', probe],
+      {
+        encoding: 'utf-8',
+        timeout: 20_000,
+        stdio: ['ignore', 'ignore', 'pipe'],
+      },
+    );
 
-  // Anything other than our sentinel is the module's own business: an
-  // executable entry that printed help and exited 0, or one that failed for a
-  // reason unrelated to packaging. Only resolution defects concern us here.
-  if (run.status !== IMPORT_FAILED) continue;
+    // Anything other than our sentinel is the module's own business: an
+    // executable entry that printed help and exited 0, or one that failed for a
+    // reason unrelated to packaging. Only resolution defects concern us here.
+    if (run.status !== IMPORT_FAILED) continue;
 
-  const code = (run.stderr || '').trim().split('\n')[0];
-  if (!RESOLUTION_CODES.has(code)) continue;
+    const code = (run.stderr || '').trim().split('\n')[0];
+    if (!RESOLUTION_CODES.has(code)) continue;
 
-  if (importFailures === 0) {
+    failures.push({...target, code});
+  }
+
+  return failures;
+}
+
+function main() {
+  const {results, targets} = verifyExports(rootDir);
+  let totalErrors = 0;
+
+  for (const {name, path: pkgJsonPath, errors} of results) {
+    if (errors.length > 0) {
+      console.error(`\n❌ ${name} (${pkgJsonPath})`);
+      for (const error of errors) {
+        console.error(error);
+      }
+      totalErrors += errors.length;
+    } else {
+      console.log(`✓ ${name}`);
+    }
+  }
+
+  console.log(`\n${results.length} packages checked.`);
+
+  const importFailures = probeImportTargets(targets);
+
+  if (importFailures.length > 0) {
     console.error('\n❌ Export targets that exist but cannot be imported:\n');
+    for (const failure of importFailures) {
+      console.error(
+        `  ✗ ${failure.pkgName} ${failure.label} → ${failure.value}`,
+      );
+      console.error(`      ${failure.code}`);
+    }
+  } else if (targets.length > 0) {
+    console.log(`${targets.length} ESM export target(s) imported cleanly.`);
   }
-  console.error(`  ✗ ${target.pkgName} ${target.label} → ${target.value}`);
-  console.error(`      ${code}`);
-  importFailures++;
-}
 
-if (importFailures === 0 && importTargets.length > 0) {
-  console.log(`${importTargets.length} ESM export target(s) imported cleanly.`);
-}
+  const failures = totalErrors + importFailures.length;
 
-const failures = totalErrors + importFailures;
-
-if (failures > 0) {
-  if (totalErrors > 0) {
-    console.error(`\n${totalErrors} broken export(s) found. Fix the paths above.`);
-  }
-  if (importFailures > 0) {
-    console.error(
-      `\n${importFailures} export target(s) exist but fail to load. A consumer importing ` +
-        `them from Node gets the same error.`,
+  if (failures > 0) {
+    if (totalErrors > 0) {
+      console.error(
+        `\n${totalErrors} broken export(s) found. Fix the paths above.`,
+      );
+    }
+    if (importFailures.length > 0) {
+      console.error(
+        `\n${importFailures.length} export target(s) exist but fail to load. A consumer importing ` +
+          `them from Node gets the same error.`,
+      );
+    }
+    process.exit(1);
+  } else {
+    console.log(
+      'All exports resolve to existing files; probed ESM targets load cleanly.',
     );
   }
-  process.exit(1);
-} else {
-  console.log('All exports resolve to existing files; probed ESM targets load cleanly.');
+}
+
+// Run as a script, but stay importable for unit tests.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
 }

--- a/scripts/verify-exports.test.mjs
+++ b/scripts/verify-exports.test.mjs
@@ -1,0 +1,437 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file verify-exports.test.mjs
+ * Unit tests for the packaging gate, plus the #5132 regression they were
+ * written for: a canary package could ship a dist that no consumer could
+ * import and this gate still passed, because `private: true` skipped the
+ * package outright and `default`-condition targets were never probed.
+ *
+ * The rules are exercised against fixture package trees, not just the repo: a
+ * gate that scans the wrong thing passes exactly like one that works. The last
+ * block then runs them over the real workspace manifests, so the rules and the
+ * data they are pointed at are both covered.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, it, expect, afterAll} from 'vitest';
+import {
+  isPublishedPackage,
+  checkPackageExports,
+  probeImportTargets,
+  verifyExports,
+} from './verify-exports.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Temp roots created by the fixture helper, removed after the run. */
+const tempRoots = [];
+
+afterAll(() => {
+  for (const dir of tempRoots) {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+/**
+ * Write a `packages/` tree the gate can walk.
+ *
+ * `packages` maps a directory name to `{manifest, files}` — `manifest` is
+ * written as its package.json, `files` as package-relative paths to contents.
+ * Returns the root to hand to verifyExports().
+ */
+function fixtureRoot(packages) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-exports-'));
+  tempRoots.push(root);
+  for (const [dir, {manifest, files = {}}] of Object.entries(packages)) {
+    const pkgDir = path.join(root, 'packages', dir);
+    fs.mkdirSync(pkgDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify(manifest, null, 2),
+    );
+    for (const [file, contents] of Object.entries(files)) {
+      const abs = path.join(pkgDir, file);
+      fs.mkdirSync(path.dirname(abs), {recursive: true});
+      fs.writeFileSync(abs, contents);
+    }
+  }
+  return root;
+}
+
+/**
+ * Write a single package directory and return its path, for the rules that take
+ * a `pkgDir` directly. `files` maps package-relative paths to contents.
+ */
+function fixturePkg(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-exports-'));
+  tempRoots.push(root);
+  for (const [file, contents] of Object.entries(files)) {
+    const abs = path.join(root, file);
+    fs.mkdirSync(path.dirname(abs), {recursive: true});
+    fs.writeFileSync(abs, contents);
+  }
+  return root;
+}
+
+/** A dist entry Node can load. */
+const LOADABLE = 'export const value = 1;\n';
+
+/**
+ * A dist entry that exists but cannot be imported — the #4620/#5000 shape: a
+ * relative specifier pointing at a file the build never emitted.
+ */
+const UNLOADABLE = "export * from './missing-chunk.js';\n";
+
+/** The publish posture of the repo's canary packages (charts, lab, …). */
+const canaryManifest = (name, extra = {}) => ({
+  name,
+  private: true,
+  astryx: {canaryOnly: true},
+  ...extra,
+});
+
+const labels = targets => targets.map(t => t.label);
+const names = results => results.map(r => r.name);
+
+describe('isPublishedPackage — which packages the gate covers', () => {
+  it('covers a plain public package', () => {
+    expect(isPublishedPackage({name: '@astryxdesign/core'})).toBe(true);
+  });
+
+  it('skips a genuinely private workspace-only package', () => {
+    // Nothing is published, so there is no consumer to break.
+    expect(
+      isPublishedPackage({name: '@astryxdesign/storybook', private: true}),
+    ).toBe(false);
+  });
+
+  it('covers a private package the release workflow publishes to @canary', () => {
+    // `private: true` here is only npm's guard against a stable publish; the
+    // canary job strips it and ships the package (#5132).
+    expect(isPublishedPackage(canaryManifest('@astryxdesign/charts'))).toBe(
+      true,
+    );
+  });
+
+  it('ignores the package name and reads only the marker', () => {
+    expect(
+      isPublishedPackage({name: '@astryxdesign/charts', private: true}),
+    ).toBe(false);
+    expect(
+      isPublishedPackage({
+        name: '@scope/anything',
+        private: true,
+        astryx: {canaryOnly: true},
+      }),
+    ).toBe(true);
+  });
+
+  it('covers everything the canary publish loop publishes', () => {
+    // release.yml decides publishability with `(!p.private ||
+    // p.astryx?.canaryOnly)` — truthy, not `=== true`. A stricter test here
+    // would skip a package the publisher ships, which is the hole this gate
+    // exists to close. Keep the two predicates in step.
+    const releaseYmlPublishes = pkg =>
+      Boolean(!pkg.private || pkg.astryx?.canaryOnly);
+    const manifests = [
+      {private: true, astryx: {canaryOnly: true}},
+      {private: true, astryx: {canaryOnly: 'soon'}},
+      {private: true, astryx: {canaryOnly: 1}},
+      {private: true, astryx: {canaryOnly: false}},
+      {private: true, astryx: {}},
+      {private: true},
+      {},
+    ];
+    for (const pkg of manifests) {
+      const shipped = releaseYmlPublishes(pkg);
+      expect(isPublishedPackage(pkg), JSON.stringify(pkg)).toBe(shipped);
+    }
+  });
+});
+
+describe('checkPackageExports — which targets get probed', () => {
+  /** A built package: ESM and CJS entries, declarations, a stylesheet, assets. */
+  const built = () =>
+    fixturePkg({
+      'dist/index.js': LOADABLE,
+      'dist/index.mjs': LOADABLE,
+      'dist/index.cjs': 'module.exports = {};\n',
+      'dist/index.d.ts': 'export declare const value: number;\n',
+      'dist/index.css': '.a{color:red}\n',
+      'dist/locales/en.json': '{}\n',
+      'src/index.ts': 'export const value = 1;\n',
+    });
+
+  it("probes a `default` target that is the export's only runtime condition", () => {
+    // The charts/lab/richtext/core shape: no `import` condition at all, so
+    // `default` is what a consumer's `import` actually resolves to.
+    const {errors, targets} = checkPackageExports(built(), '@fixture/pkg', {
+      '.': {
+        source: './src/index.ts',
+        types: './dist/index.d.ts',
+        default: './dist/index.js',
+      },
+    });
+    expect(errors).toEqual([]);
+    expect(labels(targets)).toEqual(['exports["."].default']);
+  });
+
+  it('does not probe a `default` that sits beside an `import` condition', () => {
+    // Node takes the first matching condition, so `import` wins and this
+    // `default` is the fallback for someone else — probing it would test a
+    // surface no ESM consumer reaches.
+    const {targets} = checkPackageExports(built(), '@fixture/pkg', {
+      '.': {import: './dist/index.mjs', default: './dist/index.js'},
+    });
+    expect(labels(targets)).toEqual(['exports["."].import']);
+  });
+
+  it('does not probe a `default` nested under `require` — that target is CJS', () => {
+    const {targets} = checkPackageExports(built(), '@fixture/pkg', {
+      '.': {
+        require: {types: './dist/index.d.ts', default: './dist/index.js'},
+        import: './dist/index.mjs',
+      },
+    });
+    expect(labels(targets)).toEqual(['exports["."].import']);
+  });
+
+  it('leaves non-runtime `default` targets alone — stylesheets and assets', () => {
+    // charts/lab expose their CSS through `default`; Node cannot import it, so
+    // the extension filter has to be what decides, not the condition name.
+    const {errors, targets} = checkPackageExports(built(), '@fixture/pkg', {
+      './styles.css': {default: './dist/index.css'},
+      './locales/*.json': './dist/locales/*.json',
+      './cjs': {default: './dist/index.cjs'},
+    });
+    expect(errors).toEqual([]);
+    expect(targets).toEqual([]);
+  });
+
+  it('still skips `types` and `require` targets', () => {
+    const {targets} = checkPackageExports(built(), '@fixture/pkg', {
+      '.': {
+        types: './dist/index.d.ts',
+        require: './dist/index.js',
+        import: './dist/index.mjs',
+      },
+    });
+    expect(labels(targets)).toEqual(['exports["."].import']);
+  });
+
+  it('reports a missing target instead of probing it', () => {
+    const {errors, targets} = checkPackageExports(built(), '@fixture/pkg', {
+      '.': {default: './dist/never-built.js'},
+    });
+    expect(errors).toEqual([
+      '  ✗ exports["."].default → ./dist/never-built.js (file not found)',
+    ]);
+    expect(targets).toEqual([]);
+  });
+});
+
+describe('verifyExports — package selection over a real tree', () => {
+  it('skips a genuinely private package, even with a broken entry', () => {
+    const root = fixtureRoot({
+      internal: {
+        manifest: {
+          name: '@fixture/internal',
+          private: true,
+          exports: {'.': {default: './dist/index.js'}},
+        },
+        files: {'dist/index.js': UNLOADABLE},
+      },
+    });
+    const {results, targets} = verifyExports(root);
+    expect(names(results)).toEqual([]);
+    expect(targets).toEqual([]);
+  });
+
+  it('checks a canaryOnly package and collects its `default` entry', () => {
+    const root = fixtureRoot({
+      charts: {
+        manifest: canaryManifest('@fixture/charts', {
+          main: './dist/index.js',
+          exports: {
+            '.': {
+              source: './src/index.ts',
+              types: './dist/index.d.ts',
+              default: './dist/index.js',
+            },
+            './charts.css': {default: './dist/charts.css'},
+          },
+        }),
+        files: {
+          'dist/index.js': LOADABLE,
+          'dist/index.d.ts': 'export declare const value: number;\n',
+          'dist/charts.css': '.a{color:red}\n',
+        },
+      },
+    });
+    const {results, targets} = verifyExports(root);
+    expect(names(results)).toEqual(['@fixture/charts']);
+    expect(results[0].errors).toEqual([]);
+    // The stylesheet is reached through `default` too, and stays unprobed.
+    expect(labels(targets)).toEqual(['exports["."].default']);
+  });
+
+  it('fails a canary package whose runtime entry cannot be imported', () => {
+    // The regression: on the unfixed gate this tree passed clean.
+    const root = fixtureRoot({
+      charts: {
+        manifest: canaryManifest('@fixture/charts', {
+          exports: {
+            '.': {types: './dist/index.d.ts', default: './dist/index.js'},
+          },
+        }),
+        files: {
+          'dist/index.js': UNLOADABLE,
+          'dist/index.d.ts': 'export declare const value: number;\n',
+        },
+      },
+    });
+    const {results, targets} = verifyExports(root);
+    // Every path exists, so the existence pass is clean — only loading it fails.
+    expect(results[0].errors).toEqual([]);
+    expect(targets).toHaveLength(1);
+
+    const failures = probeImportTargets(targets);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].code).toBe('ERR_MODULE_NOT_FOUND');
+  });
+
+  it('passes a canary package whose `default`-only entry loads', () => {
+    const root = fixtureRoot({
+      lab: {
+        manifest: canaryManifest('@fixture/lab', {
+          exports: {'.': {default: './dist/index.js'}},
+        }),
+        files: {'dist/index.js': LOADABLE},
+      },
+    });
+    const {results, targets} = verifyExports(root);
+    expect(results[0].errors).toEqual([]);
+    expect(probeImportTargets(targets)).toEqual([]);
+  });
+
+  it('keeps reporting a canary package that points at a file it never built', () => {
+    const root = fixtureRoot({
+      charts: {
+        manifest: canaryManifest('@fixture/charts', {
+          main: './dist/index.js',
+          exports: {'.': {default: './dist/index.js'}},
+        }),
+      },
+    });
+    const {results} = verifyExports(root);
+    expect(results[0].errors).toEqual([
+      '  ✗ main → ./dist/index.js (file not found)',
+      '  ✗ exports["."].default → ./dist/index.js (file not found)',
+    ]);
+  });
+
+  it('leaves import/require/source handling as it was', () => {
+    const root = fixtureRoot({
+      vega: {
+        manifest: {
+          name: '@fixture/vega',
+          exports: {
+            '.': {
+              source: './src/index.ts',
+              types: './dist/index.d.ts',
+              import: './dist/index.mjs',
+              require: './dist/index.js',
+            },
+          },
+        },
+        files: {
+          'dist/index.mjs': LOADABLE,
+          'dist/index.js': 'module.exports = {};\n',
+          'dist/index.d.ts': 'export declare const value: number;\n',
+        },
+      },
+    });
+    const {results, targets} = verifyExports(root);
+    // `source` points at a file that does not exist here and is still skipped;
+    // `require` is still not probed.
+    expect(results[0].errors).toEqual([]);
+    expect(labels(targets)).toEqual(['exports["."].import']);
+  });
+});
+
+describe('the real workspace manifests', () => {
+  /** Every package.json directly under packages/. */
+  const manifests = fs
+    .readdirSync(path.join(ROOT, 'packages'), {withFileTypes: true})
+    .filter(entry => entry.isDirectory())
+    .map(entry => path.join(ROOT, 'packages', entry.name, 'package.json'))
+    .filter(file => fs.existsSync(file))
+    .map(file => JSON.parse(fs.readFileSync(file, 'utf-8')));
+
+  /**
+   * Run a real export map through the rules without needing a built tree: every
+   * string target is stubbed on disk first, so what is asserted is the rules'
+   * verdict on shipped manifest data, not whether `pnpm build` has run. The
+   * `node` project's globalSetup builds core, but nothing builds charts, lab or
+   * richtext before `pnpm test`.
+   */
+  function targetsFor(pkg) {
+    const stubs = {};
+    const collect = value => {
+      if (typeof value === 'string') {
+        if (!value.includes('*')) stubs[value] = LOADABLE;
+      } else if (value && typeof value === 'object') {
+        Object.values(value).forEach(collect);
+      }
+    };
+    collect(pkg.exports);
+    return checkPackageExports(fixturePkg(stubs), pkg.name, pkg.exports)
+      .targets;
+  }
+
+  it('covers every canaryOnly package in packages/', () => {
+    const canaries = manifests.filter(pkg => pkg.astryx?.canaryOnly === true);
+
+    // The packages #5132 was filed about — they must not be skipped.
+    expect(canaries.length).toBeGreaterThan(0);
+    for (const pkg of canaries) {
+      expect(isPublishedPackage(pkg), pkg.name).toBe(true);
+    }
+  });
+
+  it("probes the `default` entries that are core's real import surface", () => {
+    const core = manifests.find(pkg => pkg.name === '@astryxdesign/core');
+    const targets = targetsFor(core);
+    // Core routes every subpath through `default`; before #5132 only the two
+    // unconditional `.mjs` docs entries were probed.
+    expect(targets.length).toBeGreaterThan(2);
+    expect(
+      targets.filter(t => t.label.endsWith('.default')).length,
+    ).toBeGreaterThan(2);
+    expect(targets.every(t => /\.(js|mjs)$/.test(t.value))).toBe(true);
+  });
+
+  it('probes a runtime entry for every canaryOnly package', () => {
+    // charts/lab/richtext each expose `.` only through `default`. If the rule
+    // stopped accepting it, their entry points would silently go unprobed
+    // again — which is what #5132 reported.
+    for (const pkg of manifests.filter(p => p.astryx?.canaryOnly === true)) {
+      expect(targetsFor(pkg).length, pkg.name).toBeGreaterThan(0);
+    }
+  });
+
+  it('never probes a stylesheet, declaration or asset', () => {
+    for (const pkg of manifests.filter(p => p.exports)) {
+      expect(
+        targetsFor(pkg).filter(
+          t => /\.(css|json)$/.test(t.value) || t.value.endsWith('.d.ts'),
+        ),
+        pkg.name,
+      ).toEqual([]);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`scripts/verify-exports.mjs` is the gate that catches packages whose published entry points don't resolve. Two blind spots let a canary dist ship that no consumer could import:

**1. Canary packages were skipped entirely.** The gate skipped every `private: true` package. `charts`, `lab`, `richtext` and `vega` carry `private: true` only as npm's guard against a stable publish — `release.yml` strips it in its ephemeral checkout and publishes them to the `@canary` dist-tag. They ship, but nothing checked them.

**2. `default`-condition targets were never probed.** `default` sat on the non-probed list beside `types` and `require`. For those canary packages `default` is the *only* runtime condition, so their entry points were never loaded. While validating the issue I found `core` is affected too, and most heavily: 119 of its 121 runtime targets resolve through `default`, so the gate was probing 2 of them.

## Fix

**Package selection** now follows what actually ships, keyed on the repo's existing `astryx.canaryOnly` marker rather than on any package name. `isPublishedPackage()` is deliberately the same predicate the canary publish loop already uses — `(!p.private || p.astryx?.canaryOnly)` — including testing `canaryOnly` for truthiness rather than `=== true`, so the gate cannot skip something the publisher ships.

**`default` is probed only when it is the export's real ESM entry**, not unconditionally. A `default` declared beside an `import` is a fallback that Node never reaches for an `import`, and a `default` nested under `require` is CJS; both stay unprobed. Condition tracking became the full ancestor chain, so a `require` or `types` *anywhere* above a target still rules it out. Non-module targets are excluded by the existing extension filter, so the stylesheets and JSON assets these packages expose through `default` are untouched.

**`pnpm build` now builds `richtext`.** It was promoted out of `lab` and the root build chain was missed, so its `dist` doesn't exist when CI runs this gate after `pnpm build` — the newly-covered package would otherwise fail on absent files rather than on a real defect. (`prepack` covers publishing but never fires in CI.)

Coverage goes from 10 packages / 31 probed targets to 14 / 154.

The script keeps its behavior, output format and exit codes; the printing and `process.exit` logic moved into a `main()` behind the usual `process.argv[1] === fileURLToPath(import.meta.url)` guard so the pure helpers are importable by tests.

## Tests

`scripts/verify-exports.test.mjs` (new, 21 tests).

The regression it was written for: a canary package whose entry exists but imports a file the build never emitted now fails with `ERR_MODULE_NOT_FOUND` — on the unfixed gate that same fixture passed clean. Alongside it, the `default` probing rules (only-condition, beside-`import`, nested-under-`require`, stylesheets/assets), proof that `import`/`require`/`source` handling is unchanged, and a check that `isPublishedPackage()` stays in step with `release.yml` across seven manifest shapes.

The rules are exercised against fixture package trees rather than only the repo, since a gate pointed at the wrong thing passes exactly like one that works. A final block then runs them over the real workspace manifests, so both the rules and the data they're aimed at are covered.

Fixes #5132
