### PR TITLE
fix(theme): give syntax punctuation its own AA-passing colour

### DIFF
--- a/.changeset/syntax-punctuation-contrast.md
+++ b/.changeset/syntax-punctuation-contrast.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Syntax-highlighted punctuation (brackets, commas, semicolons, operators) now meets WCAG 2.1 AA contrast (4.5:1) against the code surface in every bundled theme.
+
+`--color-syntax-punctuation` borrowed `--color-text-disabled`, a token WCAG deliberately exempts from the normal-text contrast requirement because it marks an inactive control. Punctuation in a code sample is always-active, normal text, and measured well under 4.5:1 in three themes: neutral (2.42:1 light, 2.53:1 dark), chocolate (3.06:1 light, 2.56:1 dark), and matcha (3.83:1 light, 2.73:1 dark). The other four themes (butter, gothic, stone, y2k) already defined their own passing punctuation colour and are untouched.
+
+The shared default now points at `--color-text-secondary` instead (used for `--color-syntax-comment` too, and already verified to clear AA). Neutral, chocolate and matcha each get a dedicated punctuation colour in their own syntax palette, since they define one rather than inheriting the shared default: neutral `#6e6e6e`/`#a0a0a0` (4.89:1/7.57:1), chocolate `#9e622e`/`#cb884d` (4.84:1/6.12:1), matcha `#566a39`/`#92af6a` (5.19:1/7.02:1).
+
+Adds `scripts/check-syntax-punctuation-contrast.test.mjs`, resolving each theme's `--color-syntax-punctuation`/`--color-syntax-background` pair through `light-dark()`/`var()` indirection (the pattern from #4446's badge contrast guard) and holding every theme, both colour schemes, to AA — so a regression here fails the build instead of shipping.
+
+@HelloOjasMutreja

--- a/packages/cli/assets/templates/themes/chocolate/chocolateTheme.ts
+++ b/packages/cli/assets/templates/themes/chocolate/chocolateTheme.ts
@@ -27,7 +27,9 @@ const chocolateSyntax = defineSyntaxTheme({
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#8C5927', '#d4a06a'],
     property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#B88859', '#6b5540'],
+    // #B88859/#6b5540 failed WCAG AA against the syntax background: 3.06:1
+    // light, 2.56:1 dark. #5386.
+    punctuation: ['#9e622e', '#cb884d'], // 4.84:1 / 6.12:1
     background: ['#FFFCF7', '#1c1610'],
   },
 });

--- a/packages/cli/assets/templates/themes/matcha/matchaTheme.ts
+++ b/packages/cli/assets/templates/themes/matcha/matchaTheme.ts
@@ -27,7 +27,9 @@ const matchaSyntax = defineSyntaxTheme({
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#7c5e3a', '#c4a882'],
     property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#707E46', '#5a6440'],
+    // #707E46/#5a6440 failed WCAG AA against the syntax background: 3.83:1
+    // light, 2.73:1 dark. #5386.
+    punctuation: ['#566a39', '#92af6a'], // 5.19:1 / 7.02:1
     background: ['#F0F0E0', '#1a1c14'],
   },
 });

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -52,7 +52,9 @@ const neutralSyntax = defineSyntaxTheme({
     tag: ['#89001a', '#ffaeaa'], // red
     attribute: ['#584400', '#eec12f'], // yellow
     property: ['#005348', '#83dac9'], // teal
-    punctuation: ['#a3a3a3', '#525252'], // neutral
+    // #a3a3a3/#525252 (this pair's own disabled-text tone) failed WCAG AA
+    // against the syntax background: 2.42:1 light, 2.53:1 dark. #5386.
+    punctuation: ['#6e6e6e', '#a0a0a0'], // neutral, 4.89:1 / 7.57:1
     background: ['#fafafa', '#0a0a0a'],
   },
 });

--- a/packages/core/src/theme/syntax/tokens.ts
+++ b/packages/core/src/theme/syntax/tokens.ts
@@ -44,8 +44,11 @@ export const syntaxTokenDefaults = {
   '--color-syntax-attribute': 'var(--color-text-teal)',
   // property -> cyan text (object properties)
   '--color-syntax-property': 'var(--color-text-cyan)',
-  // punctuation -> disabled text (brackets, semicolons)
-  '--color-syntax-punctuation': 'var(--color-text-disabled)',
+  // punctuation -> secondary text (brackets, semicolons). Not disabled text:
+  // disabled grey is calibrated to fail AA on purpose (WCAG exempts inactive
+  // controls), and punctuation in a code sample is normal, always-active
+  // text — see #5386.
+  '--color-syntax-punctuation': 'var(--color-text-secondary)',
   // background -> muted surface
   '--color-syntax-background': 'var(--color-background-muted)',
 } as const;

--- a/packages/themes/chocolate/src/chocolateTheme.ts
+++ b/packages/themes/chocolate/src/chocolateTheme.ts
@@ -27,7 +27,9 @@ const chocolateSyntax = defineSyntaxTheme({
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#8C5927', '#d4a06a'],
     property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#B88859', '#6b5540'],
+    // #B88859/#6b5540 failed WCAG AA against the syntax background: 3.06:1
+    // light, 2.56:1 dark. #5386.
+    punctuation: ['#9e622e', '#cb884d'], // 4.84:1 / 6.12:1
     background: ['#FFFCF7', '#1c1610'],
   },
 });

--- a/packages/themes/matcha/src/matchaTheme.ts
+++ b/packages/themes/matcha/src/matchaTheme.ts
@@ -27,7 +27,9 @@ const matchaSyntax = defineSyntaxTheme({
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#7c5e3a', '#c4a882'],
     property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#707E46', '#5a6440'],
+    // #707E46/#5a6440 failed WCAG AA against the syntax background: 3.83:1
+    // light, 2.73:1 dark. #5386.
+    punctuation: ['#566a39', '#92af6a'], // 5.19:1 / 7.02:1
     background: ['#F0F0E0', '#1a1c14'],
   },
 });

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -52,7 +52,9 @@ const neutralSyntax = defineSyntaxTheme({
     tag: ['#89001a', '#ffaeaa'], // red
     attribute: ['#584400', '#eec12f'], // yellow
     property: ['#005348', '#83dac9'], // teal
-    punctuation: ['#a3a3a3', '#525252'], // neutral
+    // #a3a3a3/#525252 (this pair's own disabled-text tone) failed WCAG AA
+    // against the syntax background: 2.42:1 light, 2.53:1 dark. #5386.
+    punctuation: ['#6e6e6e', '#a0a0a0'], // neutral, 4.89:1 / 7.57:1
     background: ['#fafafa', '#0a0a0a'],
   },
 });

--- a/scripts/check-syntax-punctuation-contrast.test.mjs
+++ b/scripts/check-syntax-punctuation-contrast.test.mjs
@@ -84,7 +84,20 @@ function resolve(value, theme, modeIndex, seen = new Set()) {
     return resolve(next, theme, modeIndex, new Set([...seen, name]));
   }
 
-  return /^#[0-9a-f]{3,8}$/i.test(v) ? v : null;
+  if (/^#[0-9a-f]{3,8}$/i.test(v)) return v;
+
+  // Every value this file resolves today is hex, at every step: authored
+  // literals, and var() indirection through other --color-* tokens (which
+  // are hex too). A colour in oklch()/hsl()/rgb() would silently fall
+  // through to null here otherwise, and the only visible symptom would be
+  // `rows` coming up short with no clue why. Fail loud with the actual
+  // unresolvable value instead.
+  throw new Error(
+    `check-syntax-punctuation-contrast: cannot resolve "${v}" to a hex ` +
+      `colour. Only hex literals, light-dark(), and var() indirection are ` +
+      `supported — add a case here if a theme starts using a different ` +
+      `colour syntax.`,
+  );
 }
 
 /** `#rgb` / `#rrggbb` / `#rrggbbaa` -> `{r, g, b, a}` in 0-255 / 0-1. */

--- a/scripts/check-syntax-punctuation-contrast.test.mjs
+++ b/scripts/check-syntax-punctuation-contrast.test.mjs
@@ -1,0 +1,162 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Syntax punctuation contrast guard.
+ *
+ * `--color-syntax-punctuation` renders brackets, commas, semicolons and
+ * operators in every code sample — normal text, held to WCAG 2.1 AA's 4.5:1,
+ * not the lower bar a genuinely disabled control is exempt from. Each theme
+ * defines its own syntax palette via `defineSyntaxTheme`, so the pair that
+ * actually ships (punctuation foreground against the syntax background) has
+ * to be resolved through the theme's `light-dark()`/`var()` tokens, the same
+ * as check-badge-contrast.test.mjs resolves the badge label/fill pair.
+ *
+ * @input The seven first-party theme objects.
+ * @output Fails when a theme's punctuation/background pair drops below 4.5:1
+ *   in either colour scheme.
+ * @position Repo-level guard, sibling of the other scripts/check-*.
+ * @see https://github.com/facebook/astryx/issues/5386
+ */
+
+import {describe, it, expect} from 'vitest';
+import {butterTheme} from '../packages/themes/butter/src/butterTheme.ts';
+import {chocolateTheme} from '../packages/themes/chocolate/src/chocolateTheme.ts';
+import {gothicTheme} from '../packages/themes/gothic/src/gothicTheme.ts';
+import {matchaTheme} from '../packages/themes/matcha/src/matchaTheme.ts';
+import {neutralTheme} from '../packages/themes/neutral/src/neutralTheme.ts';
+import {stoneTheme} from '../packages/themes/stone/src/stoneTheme.ts';
+import {y2kTheme} from '../packages/themes/y2k/src/y2kTheme.ts';
+
+const THEMES = {
+  butter: butterTheme,
+  chocolate: chocolateTheme,
+  gothic: gothicTheme,
+  matcha: matchaTheme,
+  neutral: neutralTheme,
+  stone: stoneTheme,
+  y2k: y2kTheme,
+};
+
+const MODES = ['light', 'dark'];
+/** WCAG 2.1 AA, normal-size text. */
+const AA_NORMAL = 4.5;
+
+/** Split `a, b` at the top level, ignoring commas nested in parens. */
+function splitArgs(input) {
+  const out = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of input) {
+    if (ch === '(') depth++;
+    if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  out.push(current.trim());
+  return out;
+}
+
+/**
+ * Resolve a theme colour expression down to a hex string for one colour
+ * scheme, following `light-dark()` and `var()` indirection.
+ */
+function resolve(value, theme, modeIndex, seen = new Set()) {
+  if (typeof value !== 'string') return null;
+  const v = value.trim();
+
+  if (v.startsWith('light-dark(')) {
+    const args = splitArgs(v.slice('light-dark('.length, -1));
+    return resolve(args[modeIndex], theme, modeIndex, seen);
+  }
+
+  if (v.startsWith('var(')) {
+    const args = splitArgs(v.slice('var('.length, -1));
+    const [name, fallback] = args;
+    if (seen.has(name)) return null; // cycle guard
+    const next = theme.tokens?.[name];
+    if (next == null) {
+      return fallback ? resolve(fallback, theme, modeIndex, seen) : null;
+    }
+    return resolve(next, theme, modeIndex, new Set([...seen, name]));
+  }
+
+  return /^#[0-9a-f]{3,8}$/i.test(v) ? v : null;
+}
+
+/** `#rgb` / `#rrggbb` / `#rrggbbaa` -> `{r, g, b, a}` in 0-255 / 0-1. */
+function parseHex(hex) {
+  let h = hex.slice(1);
+  if (h.length === 3 || h.length === 4) h = [...h].map(c => c + c).join('');
+  const n = i => parseInt(h.slice(i, i + 2), 16);
+  return {r: n(0), g: n(2), b: n(4), a: h.length === 8 ? n(6) / 255 : 1};
+}
+
+function luminance({r, g, b}) {
+  const lin = c => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(fg, bg) {
+  const [hi, lo] = [luminance(fg), luminance(bg)].sort((a, b) => b - a);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Every resolvable punctuation/background pair, as
+ * `{theme, mode, fg, bg, ratio}`.
+ */
+function punctuationPairs() {
+  const rows = [];
+  for (const [themeName, theme] of Object.entries(THEMES)) {
+    for (let modeIndex = 0; modeIndex < MODES.length; modeIndex++) {
+      const fgHex = resolve(
+        theme.tokens?.['--color-syntax-punctuation'],
+        theme,
+        modeIndex,
+      );
+      const bgHex = resolve(
+        theme.tokens?.['--color-syntax-background'],
+        theme,
+        modeIndex,
+      );
+      if (!fgHex || !bgHex) continue; // not expressible as a flat pair
+      rows.push({
+        theme: themeName,
+        mode: MODES[modeIndex],
+        fg: fgHex,
+        bg: bgHex,
+        ratio: contrast(parseHex(fgHex), parseHex(bgHex)),
+      });
+    }
+  }
+  return rows;
+}
+
+const ALL_THEMES = Object.keys(THEMES);
+
+describe('Syntax punctuation contrast', () => {
+  const rows = punctuationPairs();
+  const label = r => `${r.theme}/${r.mode}`;
+
+  it('resolves a punctuation/background pair for every theme, both schemes', () => {
+    // Guards the resolver itself: a refactor that silently stops resolving
+    // would otherwise turn this whole file into a no-op.
+    const covered = [...new Set(rows.map(r => r.theme))].sort();
+    expect(covered).toEqual([...ALL_THEMES].sort());
+    expect(rows).toHaveLength(ALL_THEMES.length * MODES.length);
+  });
+
+  it('meets WCAG AA (4.5:1) for every theme in both colour schemes', () => {
+    const failures = rows
+      .filter(r => r.ratio < AA_NORMAL)
+      .map(r => `${label(r)} — ${r.fg} on ${r.bg} = ${r.ratio.toFixed(2)}:1`);
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #5386.

## Problem

`--color-syntax-punctuation` borrowed `--color-text-disabled`, a token WCAG deliberately exempts from the normal-text contrast requirement because it marks an inactive control. Punctuation in a code sample is always-active, normal text.

Measured every theme's punctuation/background pair (resolving `light-dark()`/`var()` indirection, same approach as #4446's badge contrast guard). Three fail AA (4.5:1):

| theme | light | dark |
|---|---|---|
| neutral | 2.42:1 | 2.53:1 |
| chocolate | 3.06:1 | 2.56:1 |
| matcha | 3.83:1 | 2.73:1 |

butter, gothic, stone, and y2k already had their own passing punctuation colour and are untouched.

## Fix

The shared default (used by any theme that doesn't define its own syntax palette) now points at `--color-text-secondary` instead — already used for `--color-syntax-comment`, already verified to clear AA.

The three failing themes each define their own syntax palette rather than inheriting the default, so each needed a dedicated fix:

| theme | new light | new dark | new ratios |
|---|---|---|---|
| neutral | `#6e6e6e` | `#a0a0a0` | 4.89:1 / 7.57:1 |
| chocolate | `#9e622e` | `#cb884d` | 4.84:1 / 6.12:1 |
| matcha | `#566a39` | `#92af6a` | 5.19:1 / 7.02:1 |

Regenerated the CLI theme template bundle (`pnpm bundle:cli-themes`) so `astryx theme add` scaffolds the fixed values too.

## Verification

Added `scripts/check-syntax-punctuation-contrast.test.mjs`: resolves every theme's punctuation/background pair the same way the badge guard does, and holds all seven to AA in both colour schemes. Confirmed it catches a real regression — reverted neutral's fix locally, ran the suite, watched it fail with the exact numbers from the issue (`neutral/light — #a3a3a3 on #fafafa = 2.42:1`), then restored it.

**Before** (neutral theme, dark mode) — punctuation dims into the background:
![before](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/syntax-punctuation-contrast/before.png)

**After** — clearly legible:
![after](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/syntax-punctuation-contrast/after.png)

Typecheck and lint clean. Full `packages/themes` + `packages/core/src/theme` suite passes (749/751 — the 2 failures are `theme/extensibleAxes.test.ts`, a pre-existing, unrelated AST-scan failure I confirmed present on a clean `upstream/main` checkout before touching anything here).