### PR TITLE
fix(HoverCard): expose rich cards as dialog popups, not descriptions

### DIFF
--- a/packages/cli/assets/templates/blocks/components/HoverCard/HoverCardHookUsage.tsx
+++ b/packages/cli/assets/templates/blocks/components/HoverCard/HoverCardHookUsage.tsx
@@ -22,7 +22,7 @@ export default function HoverCardHookUsage() {
         label="Hover profile"
         ref={hoverCard.ref}
         aria-haspopup="dialog"
-        aria-controls={hoverCard.id}
+        aria-controls={hoverCard.isOpen ? hoverCard.id : undefined}
         aria-expanded={hoverCard.isOpen}
       />
       {hoverCard.renderHoverCard(

--- a/packages/cli/assets/templates/blocks/components/HoverCard/HoverCardHookUsage.tsx
+++ b/packages/cli/assets/templates/blocks/components/HoverCard/HoverCardHookUsage.tsx
@@ -20,7 +20,9 @@ export default function HoverCardHookUsage() {
       <Button
         label="Hover profile"
         ref={hoverCard.ref}
-        aria-describedby={hoverCard.describedBy}
+        aria-haspopup="dialog"
+        aria-controls={hoverCard.id}
+        aria-expanded={hoverCard.isOpen}
       />
       {hoverCard.renderHoverCard(
         <VStack gap={1}>

--- a/packages/cli/assets/templates/blocks/components/HoverCard/HoverCardHookUsage.tsx
+++ b/packages/cli/assets/templates/blocks/components/HoverCard/HoverCardHookUsage.tsx
@@ -13,6 +13,7 @@ export default function HoverCardHookUsage() {
     placement: 'below',
     delay: 100,
     isDefaultOpen: true,
+    label: 'Alex Morgan',
   });
 
   return (

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -373,7 +373,9 @@ describe('HoverCard', () => {
     );
     const trigger = screen.getByRole('button', {name: 'Trigger'});
     expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
-    expect(trigger).toHaveAttribute('aria-controls');
+    // While closed, the layer is not in the DOM, so aria-controls must not
+    // point at a missing id (see DateInput). It is set once the card opens.
+    expect(trigger).not.toHaveAttribute('aria-controls');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(trigger).not.toHaveAttribute('aria-describedby');
   });
@@ -433,15 +435,20 @@ describe('HoverCard', () => {
     );
     const trigger = screen.getByRole('button', {name: 'Trigger'});
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveAttribute('aria-controls');
 
     fireEvent.mouseEnter(trigger);
     await waitFor(() => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      // The layer is in the DOM now, so aria-controls points at it.
+      expect(trigger).toHaveAttribute('aria-controls');
     });
 
     fireEvent.mouseLeave(trigger);
     await waitFor(() => {
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      // The layer is gone from the DOM, so aria-controls is cleared.
+      expect(trigger).not.toHaveAttribute('aria-controls');
     });
   });
 
@@ -497,7 +504,8 @@ describe('HoverCard', () => {
     expect(wrapper.tagName).toBe('SPAN');
     expect(wrapper).toHaveAttribute('aria-haspopup', 'dialog');
     expect(wrapper).toHaveAttribute('aria-expanded', 'false');
-    expect(wrapper).toHaveAttribute('aria-controls');
+    // While closed, the layer is not in the DOM, so aria-controls is unset.
+    expect(wrapper).not.toHaveAttribute('aria-controls');
     expect(wrapper).not.toHaveAttribute('aria-describedby');
   });
 

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -365,7 +365,20 @@ describe('HoverCard', () => {
     );
   });
 
-  it('injects aria-describedby on trigger', () => {
+  it('advertises a dialog popup on the trigger when labelled', () => {
+    render(
+      <HoverCard content={<span>Card content</span>} label="Profile actions">
+        <button type="button">Trigger</button>
+      </HoverCard>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-controls');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('keeps aria-describedby on the trigger when no label is provided', () => {
     render(
       <HoverCard content={<span>Card content</span>}>
         <button type="button">Trigger</button>
@@ -373,9 +386,10 @@ describe('HoverCard', () => {
     );
     const trigger = screen.getByRole('button', {name: 'Trigger'});
     expect(trigger).toHaveAttribute('aria-describedby');
+    expect(trigger).not.toHaveAttribute('aria-haspopup');
   });
 
-  it('merges existing aria-describedby', () => {
+  it('preserves existing aria-describedby when no label is provided', () => {
     render(
       <HoverCard content={<span>Card content</span>}>
         <button type="button" aria-describedby="existing-id">
@@ -386,6 +400,29 @@ describe('HoverCard', () => {
     const trigger = screen.getByRole('button', {name: 'Trigger'});
     const describedBy = trigger.getAttribute('aria-describedby');
     expect(describedBy).toContain('existing-id');
+  });
+
+  it('updates aria-expanded when the labelled hover card opens and closes', async () => {
+    render(
+      <HoverCard
+        content={<span>Card content</span>}
+        label="Profile actions"
+        delay={0}>
+        <button type="button">Trigger</button>
+      </HoverCard>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    fireEvent.mouseLeave(trigger);
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
   });
 
   it('calls onOpenChange(true) when shown', async () => {
@@ -429,16 +466,31 @@ describe('HoverCard', () => {
 
   it('supports text-only children with inline wrapper', () => {
     render(
-      <HoverCard content={<span>Card content</span>}>
+      <HoverCard content={<span>Card content</span>} label="Profile actions">
         Just text, no element
       </HoverCard>,
     );
     // Text should be rendered
     expect(screen.getByText('Just text, no element')).toBeInTheDocument();
-    // Should have aria-describedby on the wrapper span
+    // When labelled, the wrapper advertises a dialog popup.
+    const wrapper = screen.getByText('Just text, no element');
+    expect(wrapper.tagName).toBe('SPAN');
+    expect(wrapper).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(wrapper).toHaveAttribute('aria-expanded', 'false');
+    expect(wrapper).toHaveAttribute('aria-controls');
+    expect(wrapper).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('keeps aria-describedby on text-only children when no label is provided', () => {
+    render(
+      <HoverCard content={<span>Card content</span>}>
+        Just text, no element
+      </HoverCard>,
+    );
     const wrapper = screen.getByText('Just text, no element');
     expect(wrapper.tagName).toBe('SPAN');
     expect(wrapper).toHaveAttribute('aria-describedby');
+    expect(wrapper).not.toHaveAttribute('aria-haspopup');
   });
 
   describe('isDefaultOpen', () => {

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -378,6 +378,26 @@ describe('HoverCard', () => {
     expect(trigger).not.toHaveAttribute('aria-describedby');
   });
 
+  it('merges existing popup attributes on the trigger when labelled', () => {
+    render(
+      <HoverCard content={<span>Card content</span>} label="Profile actions">
+        <button
+          type="button"
+          aria-haspopup="menu"
+          aria-controls="menu-id"
+          aria-expanded="true">
+          Trigger
+        </button>
+      </HoverCard>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    // The hover card's dialog popup is advertised, but the trigger's own
+    // popup semantics are preserved rather than overwritten.
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger.getAttribute('aria-controls')).toContain('menu-id');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('keeps aria-describedby on the trigger when no label is provided', () => {
     render(
       <HoverCard content={<span>Card content</span>}>

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -273,10 +273,20 @@ export function HoverCard({
       const existingExpanded = firstChild.getAttribute('aria-expanded');
 
       firstChild.setAttribute('aria-haspopup', 'dialog');
-      firstChild.setAttribute(
-        'aria-controls',
-        mergeIds(existingControls, hoverCard.id) ?? '',
-      );
+      // Only point aria-controls at the layer while it is open and in the DOM.
+      // While closed, useLayer leaves only an inert <template> marker, so the
+      // id would reference nothing. DateInput gates it the same way. The
+      // trigger's own aria-controls (if any) is preserved either way.
+      if (hoverCard.isOpen) {
+        firstChild.setAttribute(
+          'aria-controls',
+          mergeIds(existingControls, hoverCard.id) ?? '',
+        );
+      } else if (existingControls) {
+        firstChild.setAttribute('aria-controls', existingControls);
+      } else {
+        firstChild.removeAttribute('aria-controls');
+      }
       firstChild.setAttribute('aria-expanded', String(hoverCard.isOpen));
 
       return () => {
@@ -343,7 +353,7 @@ export function HoverCard({
           ref={hoverCard.ref}
           tabIndex={0}
           aria-haspopup={label ? 'dialog' : undefined}
-          aria-controls={label ? hoverCard.id : undefined}
+          aria-controls={label && hoverCard.isOpen ? hoverCard.id : undefined}
           aria-expanded={label ? hoverCard.isOpen : undefined}
           aria-describedby={label ? undefined : hoverCard.describedBy}
           {...stylex.props(

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -264,15 +264,38 @@ export function HoverCard({
       // popup relationship with aria-haspopup/aria-expanded, not describe the
       // trigger with the dialog's content (aria-describedby is for plain-text
       // descriptions, not navigable regions). See #5049.
+      //
+      // Merge rather than overwrite: the trigger may already carry its own
+      // popup semantics (e.g. a menu button wrapped in a labelled HoverCard),
+      // so preserve the existing values and restore them on cleanup.
+      const existingHaspopup = firstChild.getAttribute('aria-haspopup');
+      const existingControls = firstChild.getAttribute('aria-controls');
+      const existingExpanded = firstChild.getAttribute('aria-expanded');
+
       firstChild.setAttribute('aria-haspopup', 'dialog');
-      firstChild.setAttribute('aria-controls', hoverCard.id);
+      firstChild.setAttribute(
+        'aria-controls',
+        mergeIds(existingControls, hoverCard.id) ?? '',
+      );
       firstChild.setAttribute('aria-expanded', String(hoverCard.isOpen));
 
       return () => {
         hoverCard.ref(null);
-        firstChild.removeAttribute('aria-haspopup');
-        firstChild.removeAttribute('aria-controls');
-        firstChild.removeAttribute('aria-expanded');
+        if (existingHaspopup) {
+          firstChild.setAttribute('aria-haspopup', existingHaspopup);
+        } else {
+          firstChild.removeAttribute('aria-haspopup');
+        }
+        if (existingControls) {
+          firstChild.setAttribute('aria-controls', existingControls);
+        } else {
+          firstChild.removeAttribute('aria-controls');
+        }
+        if (existingExpanded) {
+          firstChild.setAttribute('aria-expanded', existingExpanded);
+        } else {
+          firstChild.removeAttribute('aria-expanded');
+        }
       };
     }
 

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -259,7 +259,26 @@ export function HoverCard({
     // Use combined ref for position + interaction
     hoverCard.ref(firstChild);
 
-    // Set aria-describedby, merging with existing
+    if (label) {
+      // When named, the hover card is a dialog. The trigger should advertise the
+      // popup relationship with aria-haspopup/aria-expanded, not describe the
+      // trigger with the dialog's content (aria-describedby is for plain-text
+      // descriptions, not navigable regions). See #5049.
+      firstChild.setAttribute('aria-haspopup', 'dialog');
+      firstChild.setAttribute('aria-controls', hoverCard.id);
+      firstChild.setAttribute('aria-expanded', String(hoverCard.isOpen));
+
+      return () => {
+        hoverCard.ref(null);
+        firstChild.removeAttribute('aria-haspopup');
+        firstChild.removeAttribute('aria-controls');
+        firstChild.removeAttribute('aria-expanded');
+      };
+    }
+
+    // Unnamed fallback: the popup remains role="group", which is not a dialog,
+    // so keep the previous description relationship until a naming decision is
+    // made for the no-label case (tracked in #5049).
     const existingDescribedBy = firstChild.getAttribute('aria-describedby');
     firstChild.setAttribute(
       'aria-describedby',
@@ -274,7 +293,14 @@ export function HoverCard({
         firstChild.removeAttribute('aria-describedby');
       }
     };
-  }, [textOnly, hoverCard.ref, hoverCard.describedBy]);
+  }, [
+    textOnly,
+    label,
+    hoverCard.ref,
+    hoverCard.id,
+    hoverCard.isOpen,
+    hoverCard.describedBy,
+  ]);
 
   // While closed, useLayer leaves only an inert <template> marker at this JSX
   // position. When the card needs to open, it uses that marker to keep the
@@ -293,7 +319,10 @@ export function HoverCard({
         <span
           ref={hoverCard.ref}
           tabIndex={0}
-          aria-describedby={hoverCard.describedBy}
+          aria-haspopup={label ? 'dialog' : undefined}
+          aria-controls={label ? hoverCard.id : undefined}
+          aria-expanded={label ? hoverCard.isOpen : undefined}
+          aria-describedby={label ? undefined : hoverCard.describedBy}
           {...stylex.props(
             styles.wrapperInline,
             showHoverIndication && styles.hoverIndication,

--- a/packages/core/src/HoverCard/useHoverCard.tsx
+++ b/packages/core/src/HoverCard/useHoverCard.tsx
@@ -190,10 +190,21 @@ export interface HoverCardReturn {
   anchorId: string;
 
   /**
-   * ID for aria-describedby on the trigger element.
-   * Caller should compose with other IDs using mergeIds utility.
+   * Unique ID for the hover card container.
+   * Useful for `aria-controls` or `aria-owns` on the trigger.
+   */
+  id: string;
+
+  /**
+   * Deprecated alias of `id`. Kept for backwards compatibility; prefer `id`.
    */
   describedBy: string;
+
+  /**
+   * Whether the hover card is currently open.
+   * Useful for driving `aria-expanded` on the trigger.
+   */
+  isOpen: boolean;
 
   /**
    * Render function for hover card content.
@@ -681,7 +692,9 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     positionRef: layer.ref,
     interactionRef,
     anchorId: layer.anchorId,
+    id: layer.id,
     describedBy: layer.id,
+    isOpen: layer.isOpen,
     renderHoverCard,
     show: layer.show,
     hide: layer.hide,


### PR DESCRIPTION
Closes #5049

## Problem

When a HoverCard has a label, the floating layer renders role="dialog" with aria-label. The trigger previously used aria-describedby to point at that dialog, which flattens structured content into a plain-text description and announces the dialog's contents instead of the popup relationship. A screen-reader user on the trigger hears the dialog's content as a description rather than being told "this opens a dialog".

The issue also notes that the lazy context-layer work in #5039 leaves an inert <template> marker while the card is closed, and that marker should not double as the accessibility target. With the old model, the trigger's aria-describedby could point at an empty sentinel.

## Approach

Replace the description relationship with the correct popup contract when a label is provided:

- The trigger gets aria-haspopup="dialog", aria-controls pointing at the layer id, and aria-expanded synced to the open state.
- useHoverCard now exposes id (the layer id) and isOpen, so consumers can wire up aria-controls and aria-expanded themselves when using the hook directly.
- describedBy is kept as a deprecated alias of id for backwards compatibility.
- The no-label fallback still renders role="group"; for that case we keep the previous aria-describedby behavior because aria-haspopup="dialog" would be misleading for an unnamed group. The naming behavior for unlabelled rich HoverCards is left as a follow-up decision in #5049.

aria-details was considered but not used because support across screen readers is still inconsistent; aria-haspopup="dialog" + aria-expanded is the most broadly supported contract for a non-modal dialog opener.

## Test plan

- packages/core/src/HoverCard/HoverCard.test.tsx - 38 tests passing.
- pnpm --filter @astryxdesign/core typecheck - passing.
- pnpm --filter @astryxdesign/core build - passing.
- Updated the HoverCardHookUsage template to demonstrate the new hook contract.
