### PR TITLE
fix(a11y-audit): scan a still page, so a fade cannot read as low contrast

### DIFF
--- a/.github/scripts/accessibility-audit.js
+++ b/.github/scripts/accessibility-audit.js
@@ -11,7 +11,8 @@
  * @output JSON report with accessibility violations; with --baseline, a gate
  *   summary (new / baselined / resolved) on stdout and a non-zero exit code
  *   when --fail-on-new finds regressions. Diff logic lives in
- *   lib/a11y-baseline.js.
+ *   lib/a11y-baseline.js. Pages are scanned with animations held at their end
+ *   state.
  */
 
 const { chromium } = require('playwright');
@@ -44,6 +45,21 @@ const emptyComponentSet = componentsArg !== null && components.length === 0;
 const baselineFile = getArg('baseline');
 const failOnNew = hasFlag('fail-on-new');
 const updateBaseline = hasFlag('update-baseline');
+
+// Held at the end state before every scan, the way the visual gate does it
+// (visual-gate/lib/capture.mjs). axe blends an element's opacity into the
+// foreground color, so a scan that lands mid-transition measures a frame no
+// user is expected to read: Markdown's streaming fade reported contrast of
+// 1.63 on text whose resting color is #171717, on ~1 run in 6.
+const FREEZE_CSS = `
+*, *::before, *::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0s !important;
+  transition-delay: 0s !important;
+}
+`;
 
 // Rules to disable — these are Storybook-context false positives, not component issues
 const DISABLED_RULES = [
@@ -188,6 +204,7 @@ async function runAccessibilityAudit() {
   try {
     const context = await browser.newContext({
       viewport: { width: 1280, height: 720 },
+      reducedMotion: 'reduce',
     });
 
     for (const [component, componentStories] of Object.entries(storyGroups)) {
@@ -200,6 +217,7 @@ async function runAccessibilityAudit() {
           const url = `http://localhost:${port}/iframe.html?id=${story.id}&viewMode=story`;
           // Higher timeout to accommodate axe-core's heavier DOM analysis
           await page.goto(url, { waitUntil: 'networkidle', timeout: 15000 });
+          await page.addStyleTag({ content: FREEZE_CSS }).catch(() => {});
           // Brief wait for any post-load rendering before axe-core scans the DOM
           await page.waitForTimeout(500);
 


### PR DESCRIPTION
The daily release gate published `a11y: crashed` twice. Two separate causes sat
behind that, and only one of them is still live.

**Not this PR:** the cancellations were an under-sized budget — both runs
([32683897819](https://github.com/facebook/astryx/actions/runs/32683897819),
[32681968228](https://github.com/facebook/astryx/actions/runs/32681968228)) ran
commits from before [#5388](https://github.com/facebook/astryx/pull/5388)
landed, so they still carried `timeout-minutes: 45` against a ~57-60 min audit,
and both died at exactly 45:16. Already fixed. The deliberate bad-contrast demo
in `MediaTheme Auto / Flat Surface Theme` is likewise already handled, by
[#5401](https://github.com/facebook/astryx/pull/5401).

**This PR** is the one that is left: the audit can fail on an animation frame.

axe blends an element's opacity into the foreground color, so a scan that lands
mid-transition measures a frame no reader is expected to see. `Markdown /
Streaming` fades each chunk in over `--duration-medium`, and the scan catches it
in flight:

```
Element has insufficient color contrast of 1.63 (foreground color: #cacaca, background: #ffffff)
live: {"opacity":"0.894158","color":"rgb(23, 23, 23)","transition":"0.3s"}
```

2 of 12 local runs. A gate that fails one run in six holds a release cut one day
in six, for nothing.

The visual gate already solved this for screenshots — `reducedMotion: 'reduce'`
on the context plus a stylesheet that holds animation at its end state
(`visual-gate/lib/capture.mjs`). The audit now does the same, so it measures the
state a reader actually gets. No component or story changes; no baseline
entries.

## Test plan

Built Storybook on the M5 and ran the audit before and after.

| | before | after |
|---|---|---|
| `Markdown / Streaming`, repeated scans | 2/12 flagged color-contrast | 0/20 |
| `Markdown` + `MediaTheme Auto`, full audits | — | 0 violations, 3/3 |

Positive control — the freeze does not neuter the scan. Known baseline entries
are still found:

```
✓ Audited: Badge / Variants - 1 issues
✓ Audited: Badge / Status Labels - 1 issues
```

## One thing worth flagging, not fixed here

[#5401](https://github.com/facebook/astryx/pull/5401) took a baseline entry for
`MediaTheme Auto::Flat Surface Theme::color-contrast`. Baseline keys are
`Component::Story::rule-id`, so that entry now covers the whole story — including
the `auto` panel, which is the half that is supposed to be readable and is the
point of the story. An element-scoped exemption would keep that panel audited.
Deliberately left alone: it landed reviewed, and this PR is a release blocker.