### PR TITLE
fix(docsite): bound the hero's pin so overscroll works everywhere

### DIFF
--- a/apps/docsite/src/__tests__/mobile-overscroll.test.ts
+++ b/apps/docsite/src/__tests__/mobile-overscroll.test.ts
@@ -2,8 +2,8 @@
 
 /**
  * @file mobile-overscroll.test.ts
- * @input apps/docsite/src/app/globals.css and the home hero's HeroThemeReel
- * @output Guards that the docsite never suppresses pull-to-refresh on touch
+ * @input apps/docsite/src/app/globals.css and the home hero's pinned layers
+ * @output Guards that the docsite never suppresses the platform's overscroll
  * @position Regression test for #5392
  *
  * `overscroll-behavior-y: none` on the root element is how you turn
@@ -12,10 +12,11 @@
  * (#3032), and silently cost pull-to-refresh on every route of the site on
  * every touch browser.
  *
- * These two checks are the halves of the fix, stated as invariants rather than
- * as a mirror of the code: the root may not refuse overscroll at a width a
- * phone can actually have, and the one hero layer that reached the gap there
- * has to stay bounded to the hero instead of pinned to the viewport.
+ * These checks are the halves of the fix, stated as invariants rather than as
+ * a mirror of the code: the root may not refuse overscroll at any width, and
+ * no hero layer may be pinned to the viewport — a viewport-pinned layer is
+ * exactly what paints into the strip an overscroll opens past the end of the
+ * page, and is the only reason the root rule was ever wanted.
  */
 
 import {describe, it, expect} from 'vitest';
@@ -25,9 +26,6 @@ import {fileURLToPath} from 'node:url';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP = path.join(HERE, '..', 'app');
-
-/** A phone-class viewport, comfortably under every breakpoint the site uses. */
-const PHONE_WIDTH_PX = 430;
 
 function read(...parts: string[]): string {
   return fs.readFileSync(path.join(APP, ...parts), 'utf8');
@@ -62,24 +60,8 @@ function openBlocksAt(css: string, offset: number): string[] {
   return stack;
 }
 
-/**
- * Whether a media prelude matches a viewport `width` px wide. Only the width
- * features are modelled; anything else is treated as matching, so an unhandled
- * query fails the test loudly rather than passing it by omission.
- */
-function mediaMatchesWidth(prelude: string, width: number): boolean {
-  for (const [, feature, value] of prelude.matchAll(
-    /\((min|max)-width:\s*([\d.]+)px\)/g,
-  )) {
-    const px = Number(value);
-    if (feature === 'min' && width < px) {return false;}
-    if (feature === 'max' && width > px) {return false;}
-  }
-  return true;
-}
-
 describe('docsite globals.css', () => {
-  it('never disables overscroll at a phone width (pull-to-refresh, #5392)', () => {
+  it('never disables overscroll — that is pull-to-refresh (#5392)', () => {
     const css = stripComments(read('globals.css'));
     const offenders: string[] = [];
 
@@ -91,13 +73,9 @@ describe('docsite globals.css', () => {
         continue;
       }
       const blocks = openBlocksAt(css, match.index);
-      const selector = blocks.at(-1) ?? '(top level)';
-      const reachesPhone = blocks
-        .filter(b => b.startsWith('@media'))
-        .every(b => mediaMatchesWidth(b, PHONE_WIDTH_PX));
-      if (reachesPhone) {
-        offenders.push(`${selector} { overscroll-behavior: ${value} }`);
-      }
+      offenders.push(
+        `${blocks.join(' > ') || '(top level)'} { overscroll-behavior: ${value} }`,
+      );
     }
 
     expect(offenders).toEqual([]);
@@ -112,41 +90,58 @@ function styleBlock(source: string, name: string): string {
   let depth = 0;
   for (let i = open; i < source.length; i++) {
     if (source[i] === '{') {depth++;}
-    else if (source[i] === '}' && --depth === 0)
-      {return source.slice(open, i + 1);}
+    else if (source[i] === '}' && --depth === 0) {
+      return source.slice(open, i + 1);
+    }
   }
   throw new Error(`unbalanced braces in \`${name}\``);
 }
 
-/**
- * The value a StyleX property resolves to with no media query in play — the
- * literal itself, or the `default:` arm of a conditional value object.
- */
-function mobileValue(block: string, property: string): string {
+/** Every value a StyleX property can take — the literal, or each media arm. */
+function allValues(block: string, property: string): string[] {
   const at = block.indexOf(`${property}: `);
   expect(at, `no \`${property}\` declaration`).toBeGreaterThan(-1);
   const rest = block.slice(at + property.length + 2);
   if (!rest.startsWith('{')) {
-    return rest.slice(0, rest.search(/[,\n]/)).trim();
+    return [rest.slice(0, rest.search(/[,\n]/)).trim()];
   }
-  const fallback = /default:\s*([^,\n]+)/.exec(rest);
-  expect(fallback, `\`${property}\` has no default arm`).not.toBeNull();
-  return fallback![1].trim();
+  // One arm per line. The key is matched explicitly (`default`, or a quoted
+  // condition) because a condition contains a colon of its own —
+  // `'@media (min-width: 1024px)'` — which a bare `:` split would trip on.
+  return rest
+    .slice(0, rest.indexOf('}'))
+    .split('\n')
+    .map(line => /^\s*(?:default|'[^']*')\s*:\s*(.+?),?\s*$/.exec(line)?.[1])
+    .filter((v): v is string => v != null);
 }
 
-describe('home hero — HeroThemeReel', () => {
-  const source = read('(site)', '_landing', 'hero', 'HeroThemeReel.tsx');
+/**
+ * The hero's decorative layers, and the hero text itself, all used to be
+ * `position: fixed`. Fixed is unbounded: the layer stays glued to the viewport
+ * for the entire document scroll, so at the end of the page it is still
+ * painting in the strip a bottom overscroll opens — the aurora glow bleeding
+ * under the footer is exactly that. They are pinned with a bounded sticky
+ * layer now, which looks identical while the hero is on screen.
+ *
+ * `navBackdrop` is deliberately not listed: it is a header-height strip at the
+ * very top of the viewport and never reaches the bottom gap.
+ */
+describe('home hero — no layer is pinned to the viewport (#5392)', () => {
+  const cases: ReadonlyArray<[string, string, string]> = [
+    ['aurora glow', 'hero/HeroThemeReel.tsx', 'backdropGlow'],
+    ['floating cards stage', 'hero/HeroFloatingCards.tsx', 'stage'],
+    ['hero text block', 'page.tsx', 'heroContent'],
+  ];
 
-  /**
-   * Below 1024px the hero barely pins: heroContent is relative, the floating
-   * cards are display:none, and the nav backdrop is a short strip at the very
-   * top. A viewport-fixed glow, on the other hand, spans the whole page scroll
-   * and paints into the gap under the footer — which is the only reason
-   * globals.css was suppressing overscroll on phones.
-   */
-  it('does not pin the aurora glow to the viewport on mobile (#5392)', () => {
-    expect(
-      mobileValue(styleBlock(source, 'backdropGlow'), 'position'),
-    ).not.toBe("'fixed'");
-  });
+  for (const [label, file, style] of cases) {
+    it(`${label} (${style})`, () => {
+      const source =
+        file === 'page.tsx'
+          ? read('(site)', 'page.tsx')
+          : read('(site)', '_landing', ...file.split('/'));
+      expect(allValues(styleBlock(source, style), 'position')).not.toContain(
+        "'fixed'",
+      );
+    });
+  }
 });

--- a/apps/docsite/src/__tests__/mobile-overscroll.test.ts
+++ b/apps/docsite/src/__tests__/mobile-overscroll.test.ts
@@ -1,0 +1,152 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file mobile-overscroll.test.ts
+ * @input apps/docsite/src/app/globals.css and the home hero's HeroThemeReel
+ * @output Guards that the docsite never suppresses pull-to-refresh on touch
+ * @position Regression test for #5392
+ *
+ * `overscroll-behavior-y: none` on the root element is how you turn
+ * pull-to-refresh off. It was added app-wide to keep the home hero's
+ * `position: fixed` layers from showing through the top/bottom overscroll gap
+ * (#3032), and silently cost pull-to-refresh on every route of the site on
+ * every touch browser.
+ *
+ * These two checks are the halves of the fix, stated as invariants rather than
+ * as a mirror of the code: the root may not refuse overscroll at a width a
+ * phone can actually have, and the one hero layer that reached the gap there
+ * has to stay bounded to the hero instead of pinned to the viewport.
+ */
+
+import {describe, it, expect} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.join(HERE, '..', 'app');
+
+/** A phone-class viewport, comfortably under every breakpoint the site uses. */
+const PHONE_WIDTH_PX = 430;
+
+function read(...parts: string[]): string {
+  return fs.readFileSync(path.join(APP, ...parts), 'utf8');
+}
+
+/** Drop comments so their contents can't be mistaken for CSS or braces. */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[^]*?\*\//g, '');
+}
+
+/**
+ * The `{...}` preludes open at `offset`, outermost first — e.g.
+ * `['@media (min-width: 1024px)', 'html']` for a declaration inside a media
+ * block. Good enough for this file's hand-written CSS (no strings, no nesting
+ * beyond at-rules).
+ */
+function openBlocksAt(css: string, offset: number): string[] {
+  const stack: string[] = [];
+  let preludeStart = 0;
+  for (let i = 0; i < offset; i++) {
+    const ch = css[i];
+    if (ch === '{') {
+      stack.push(css.slice(preludeStart, i).trim());
+      preludeStart = i + 1;
+    } else if (ch === '}') {
+      stack.pop();
+      preludeStart = i + 1;
+    } else if (ch === ';') {
+      preludeStart = i + 1;
+    }
+  }
+  return stack;
+}
+
+/**
+ * Whether a media prelude matches a viewport `width` px wide. Only the width
+ * features are modelled; anything else is treated as matching, so an unhandled
+ * query fails the test loudly rather than passing it by omission.
+ */
+function mediaMatchesWidth(prelude: string, width: number): boolean {
+  for (const [, feature, value] of prelude.matchAll(
+    /\((min|max)-width:\s*([\d.]+)px\)/g,
+  )) {
+    const px = Number(value);
+    if (feature === 'min' && width < px) {return false;}
+    if (feature === 'max' && width > px) {return false;}
+  }
+  return true;
+}
+
+describe('docsite globals.css', () => {
+  it('never disables overscroll at a phone width (pull-to-refresh, #5392)', () => {
+    const css = stripComments(read('globals.css'));
+    const offenders: string[] = [];
+
+    for (const match of css.matchAll(
+      /overscroll-behavior(?:-block|-y)?\s*:\s*([^;}]+)/g,
+    )) {
+      const value = match[1].trim();
+      if (value === 'auto') {
+        continue;
+      }
+      const blocks = openBlocksAt(css, match.index);
+      const selector = blocks.at(-1) ?? '(top level)';
+      const reachesPhone = blocks
+        .filter(b => b.startsWith('@media'))
+        .every(b => mediaMatchesWidth(b, PHONE_WIDTH_PX));
+      if (reachesPhone) {
+        offenders.push(`${selector} { overscroll-behavior: ${value} }`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+/** The `{...}` body of one `stylex.create` entry, e.g. `backdropGlow`. */
+function styleBlock(source: string, name: string): string {
+  const start = source.indexOf(`${name}: {`);
+  expect(start, `no \`${name}\` style in the source`).toBeGreaterThan(-1);
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') {depth++;}
+    else if (source[i] === '}' && --depth === 0)
+      {return source.slice(open, i + 1);}
+  }
+  throw new Error(`unbalanced braces in \`${name}\``);
+}
+
+/**
+ * The value a StyleX property resolves to with no media query in play — the
+ * literal itself, or the `default:` arm of a conditional value object.
+ */
+function mobileValue(block: string, property: string): string {
+  const at = block.indexOf(`${property}: `);
+  expect(at, `no \`${property}\` declaration`).toBeGreaterThan(-1);
+  const rest = block.slice(at + property.length + 2);
+  if (!rest.startsWith('{')) {
+    return rest.slice(0, rest.search(/[,\n]/)).trim();
+  }
+  const fallback = /default:\s*([^,\n]+)/.exec(rest);
+  expect(fallback, `\`${property}\` has no default arm`).not.toBeNull();
+  return fallback![1].trim();
+}
+
+describe('home hero — HeroThemeReel', () => {
+  const source = read('(site)', '_landing', 'hero', 'HeroThemeReel.tsx');
+
+  /**
+   * Below 1024px the hero barely pins: heroContent is relative, the floating
+   * cards are display:none, and the nav backdrop is a short strip at the very
+   * top. A viewport-fixed glow, on the other hand, spans the whole page scroll
+   * and paints into the gap under the footer — which is the only reason
+   * globals.css was suppressing overscroll on phones.
+   */
+  it('does not pin the aurora glow to the viewport on mobile (#5392)', () => {
+    expect(
+      mobileValue(styleBlock(source, 'backdropGlow'), 'position'),
+    ).not.toBe("'fixed'");
+  });
+});

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
@@ -34,12 +34,15 @@ const REWARD_MEMBER_NAME = 'Ami Pena';
 const REWARD_MEMBER_AVATAR = '/images/avatars/DATA-Ami-Pena.png';
 
 const styles = stylex.create({
-  // Desktop overlap stage: fixed, viewport-centered 1200px box (shared with the
+  // Desktop overlap stage: a viewport-centered 1200px box (shared with the
   // aurora blobs) so cards track the blobs on resize. Capped to 100vw to avoid
   // horizontal scroll. Hidden <1024px, where the collage takes over.
+  // Absolute against HeroThemeReel's pinLayer, which supplies the pin and the
+  // header offset — this was `fixed`, which bypassed that layer entirely and
+  // left the cards painting past the end of the page (#5392).
   stage: {
-    position: 'fixed',
-    top: 'var(--appshell-header-height, 0px)',
+    position: 'absolute',
+    top: 0,
     left: '50%',
     transform: 'translateX(-50%)',
     width: 'min(1200px, 100vw)',

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -123,9 +123,17 @@ const styles = stylex.create({
     },
     height: 'auto',
   },
-  // Sticky, zero-height layer hosting the overlap cards so they pin with the
-  // hero and don't intercept clicks.
-  cardsLayer: {
+  // The hero's pinned layer: the aurora glow and the overlap cards ride here
+  // so they pin with the hero and don't intercept clicks.
+  //
+  // Sticky, not fixed — sticky pins to the viewport exactly like fixed but is
+  // bounded by its container, so the layer stops existing on screen once the
+  // hero band has scrolled by and can never paint into the strip an overscroll
+  // opens past the end of the page (#5392). Zero height is what makes that
+  // work: a sticky box only stays pinned for the slack between its own height
+  // and its container's, so a zero-height layer gets the whole band to travel,
+  // and the visuals inside it are positioned absolutely against it.
+  pinLayer: {
     position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
     height: 0,
@@ -171,28 +179,10 @@ const styles = stylex.create({
   // Blurred aurora glow — in the same 1200px box as the cards so blobs and
   // cards stay aligned. Capped to 100vw to avoid horizontal scroll. Blob
   // centers sit under the card clusters; colors come from --aurora-* per slide.
-  //
-  // Desktop: fixed, part of the hero's pin-and-cover. Narrow: absolute inside
-  // heroScope — the same switch heroContent makes in page.tsx. Below 1024px
-  // this is the only fixed layer that survives (heroContent goes relative, the
-  // floating-cards stage is display:none, the nav backdrop is a 48px strip at
-  // the very top), and being fixed it spanned the viewport for the whole page
-  // scroll and bled into the bottom overscroll gap under the footer. Bounding
-  // it to the hero is what lets globals.css stop suppressing overscroll below
-  // 1024px, which restores pull-to-refresh (#5392).
-  //
-  // `top` drops to 0 in the absolute case: heroScope already starts below the
-  // header, so keeping the header offset would push the glow down by that
-  // height a second time.
+  // Absolute against pinLayer, which supplies the pin and the header offset.
   backdropGlow: {
-    position: {
-      default: 'absolute',
-      '@media (min-width: 1024px)': 'fixed',
-    },
-    top: {
-      default: 0,
-      '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
-    },
+    position: 'absolute',
+    top: 0,
     left: '50%',
     transform: 'translateX(-50%)',
     width: 'min(1200px, 100vw)',
@@ -451,19 +441,19 @@ export function HeroReelCards() {
     <Theme theme={active.theme} mode={effectiveMode(active, reel.userMode)}>
       <div {...stylex.props(styles.themeFill)} aria-hidden="true" />
       <div {...stylex.props(styles.navBackdrop)} aria-hidden="true" />
-      <div
-        aria-hidden="true"
-        {...stylex.props(
-          styles.backdropGlow,
-          dynamic.aurora(
-            active.aurora.left,
-            active.aurora.center,
-            active.aurora.right,
-          ),
-        )}
-      />
-      {/* Floating cards layer */}
-      <div {...stylex.props(styles.cardsLayer)}>
+      {/* Pinned layer: aurora glow underneath, floating cards over it. */}
+      <div {...stylex.props(styles.pinLayer)}>
+        <div
+          aria-hidden="true"
+          {...stylex.props(
+            styles.backdropGlow,
+            dynamic.aurora(
+              active.aurora.left,
+              active.aurora.center,
+              active.aurora.right,
+            ),
+          )}
+        />
         <HeroFloatingCards content={active.content} mounted={shown} />
       </div>
     </Theme>

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -168,12 +168,31 @@ const styles = stylex.create({
     transition: 'background-color 600ms ease',
     zIndex: 0,
   },
-  // Blurred aurora glow — fixed, in the same 1200px box as the cards so blobs
-  // and cards stay aligned. Capped to 100vw to avoid horizontal scroll. Blob
+  // Blurred aurora glow — in the same 1200px box as the cards so blobs and
+  // cards stay aligned. Capped to 100vw to avoid horizontal scroll. Blob
   // centers sit under the card clusters; colors come from --aurora-* per slide.
+  //
+  // Desktop: fixed, part of the hero's pin-and-cover. Narrow: absolute inside
+  // heroScope — the same switch heroContent makes in page.tsx. Below 1024px
+  // this is the only fixed layer that survives (heroContent goes relative, the
+  // floating-cards stage is display:none, the nav backdrop is a 48px strip at
+  // the very top), and being fixed it spanned the viewport for the whole page
+  // scroll and bled into the bottom overscroll gap under the footer. Bounding
+  // it to the hero is what lets globals.css stop suppressing overscroll below
+  // 1024px, which restores pull-to-refresh (#5392).
+  //
+  // `top` drops to 0 in the absolute case: heroScope already starts below the
+  // header, so keeping the header offset would push the glow down by that
+  // height a second time.
   backdropGlow: {
-    position: 'fixed',
-    top: 'var(--appshell-header-height, 0px)',
+    position: {
+      default: 'absolute',
+      '@media (min-width: 1024px)': 'fixed',
+    },
+    top: {
+      default: 0,
+      '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
+    },
     left: '50%',
     transform: 'translateX(-50%)',
     width: 'min(1200px, 100vw)',

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -39,19 +39,40 @@ const styles = stylex.create({
     // Shared by the nav→wordmark gap and the text→cards gap so they match.
     '--hero-gap': 'calc(var(--spacing-12) * 2)',
   },
-  // Desktop: fixed for pin-and-cover (heroSpacer reserves its height). Narrow:
-  // in flow — the mobile hero is taller than the viewport, so pinning stranded
-  // the lower collage below the fold.
+  // Desktop: the layer that pins the hero text over the band. Sticky rather
+  // than fixed so the pin is bounded by the band and can't paint past the end
+  // of the page (#5392); zero height so it gets the whole band to travel,
+  // with heroContent placed absolutely against it. Narrow: an inert wrapper —
+  // the mobile hero is taller than the viewport, so pinning it stranded the
+  // lower collage below the fold.
+  //
+  // It has to sit BEFORE heroSpacer in the DOM: a sticky layer pins from its
+  // natural flow position, so after the spacer it would only start pinning
+  // once the whole band had already scrolled by.
+  heroPin: {
+    position: {
+      default: 'static',
+      '@media (min-width: 1024px)': 'sticky',
+    },
+    top: {
+      default: 'auto',
+      '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
+    },
+    height: {
+      default: 'auto',
+      '@media (min-width: 1024px)': 0,
+    },
+    width: '100%',
+    zIndex: 0,
+  },
+  // Desktop: absolute inside heroPin, which supplies the pin and the header
+  // offset (heroSpacer reserves the band's height). Narrow: in flow.
   heroContent: {
     position: {
       default: 'relative',
-      '@media (min-width: 1024px)': 'fixed',
+      '@media (min-width: 1024px)': 'absolute',
     },
-    // top offset only matters when fixed; in flow it would leave a gap.
-    top: {
-      default: 0,
-      '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
-    },
+    top: 0,
     left: 0,
     right: 0,
     // Desktop: fixed band, centered (cards are a separate overlap layer).
@@ -85,7 +106,7 @@ const styles = stylex.create({
     // content (the buttons/links re-enable pointer events on themselves).
     zIndex: 0,
   },
-  // Reserves the fixed hero's height (desktop); 0 on narrow (hero is in flow).
+  // Reserves the pinned hero's height (desktop); 0 on narrow (hero is in flow).
   heroSpacer: {
     height: {
       default: 0,
@@ -344,9 +365,14 @@ export default function HomePage() {
       <HeroReelProvider>
         {/* Desktop overlap cards layer (the gutters). */}
         <HeroReelCards />
-        {/* Reserves the fixed hero's height so the showcase starts below it. */}
+        {/* Desktop: pins the hero text over the band. Narrow: inert wrapper.
+            Must precede heroSpacer — a sticky layer pins from its natural
+            flow position. */}
+        <div {...stylex.props(styles.heroPin)}>
+          <HeroContent contentRef={heroContentRef} />
+        </div>
+        {/* Reserves the pinned hero's height so the showcase starts below it. */}
         <div {...stylex.props(styles.heroSpacer)} aria-hidden="true" />
-        <HeroContent contentRef={heroContentRef} />
       </HeroReelProvider>
       <VStack ref={showcaseRef} xstyle={styles.showcaseOverlay}>
         <FeaturesShowcase />

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -13,9 +13,22 @@
 @stylex;
 
 /* Disable overscroll bounce so the home hero's position:fixed layers can't
-   show through past the top/bottom of the page. */
-html {
-  overscroll-behavior-y: none;
+   show through past the top/bottom of the page (#3032).
+
+   Desktop only. This is an app-global rule, so below 1024px it was costing
+   pull-to-refresh on every route of the site — nothing to do with the home
+   hero (#5392). Below 1024px the hero's only fixed layer that can reach the
+   overscroll gap is the aurora glow, and that is now bounded to the hero
+   scope instead (HeroThemeReel's backdropGlow), so there is nothing left for
+   this rule to protect there.
+
+   ≥1024px the hero really is pinned — heroContent, the floating-cards stage
+   and the glow are all fixed — so the rule stays until those layers are
+   contained too (#5392 step 2). */
+@media (min-width: 1024px) {
+  html {
+    overscroll-behavior-y: none;
+  }
 }
 
 /* Marketing-only custom properties for the docsite home page. These are

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -12,25 +12,6 @@
    reset, astryx-base, astryx-theme so product styles always win. */
 @stylex;
 
-/* Disable overscroll bounce so the home hero's position:fixed layers can't
-   show through past the top/bottom of the page (#3032).
-
-   Desktop only. This is an app-global rule, so below 1024px it was costing
-   pull-to-refresh on every route of the site — nothing to do with the home
-   hero (#5392). Below 1024px the hero's only fixed layer that can reach the
-   overscroll gap is the aurora glow, and that is now bounded to the hero
-   scope instead (HeroThemeReel's backdropGlow), so there is nothing left for
-   this rule to protect there.
-
-   ≥1024px the hero really is pinned — heroContent, the floating-cards stage
-   and the glow are all fixed — so the rule stays until those layers are
-   contained too (#5392 step 2). */
-@media (min-width: 1024px) {
-  html {
-    overscroll-behavior-y: none;
-  }
-}
-
 /* Marketing-only custom properties for the docsite home page. These are
    NOT Astryx theming tokens — they're docsite-specific values that back the
    landing page's bento feature cards + section rhythm — so they live here


### PR DESCRIPTION
Fixes #5392.

`apps/docsite/src/app/globals.css` turned overscroll off on the root element for the whole app:

```css
html {
  overscroll-behavior-y: none;
}
```

That is also the standard way to turn **pull-to-refresh** off, and the rule is unscoped — so pull-to-refresh was dead on every route of the docsite, on every touch browser. It was added in #3032 to stop the home hero's `position: fixed` layers showing through the top/bottom overscroll gap, a bug reported on desktop; the mobile cost looks unintentional (it appears in that PR's title, summary, test plan or review nowhere).

The issue split this into a small mobile step and a hard desktop step, on the reading that the desktop hero's layers must stay `fixed` because their fixedness *is* the pin-and-cover. **They don't have to.** One mechanism covers both widths, so this removes the rule outright instead of scoping it.

## The insight

`fixed` is an *unbounded* pin: the layer stays glued to the viewport for the entire document scroll, so at the end of the page it is still painting into the strip a bottom overscroll opens. `sticky` pins to the same place but is bounded by its container — it stops existing on screen once its container has gone by, and the container here is the hero band, which the showcase has covered by then. So it looks the same and cannot bleed.

The hero already had exactly this: `cardsLayer` is a zero-height `position: sticky` layer. The glow and the cards stage just bypassed it by being `fixed`.

**Zero height is the load-bearing part.** A sticky box only stays pinned for the slack between its own height and its container's, so a zero-height layer gets the whole band to travel while the visual inside it is placed absolutely. An in-flow 712px hero inside a 760px band un-pins after 48px — I tried it, and it doesn't work.

## What changed

| layer | was | now |
|---|---|---|
| `backdropGlow` (`HeroThemeReel`) | `fixed`, all widths | `absolute` inside the pin layer |
| `stage` (`HeroFloatingCards`) | `fixed` | `absolute` inside the pin layer |
| `heroContent` (`(site)/page.tsx`) | `relative` / `fixed` ≥1024 | `relative` / `absolute` ≥1024, inside a new zero-height sticky `heroPin` |
| `navBackdrop` | `fixed` | unchanged — a header-height strip at the very top, never in the bottom gap |
| `globals.css` | `overscroll-behavior-y: none` | **deleted** |

`cardsLayer` is renamed `pinLayer` since it now carries the glow as well as the cards. `heroPin` must precede `heroSpacer` in the DOM: a sticky layer pins from its natural flow position, so after the spacer it would only start pinning once the whole band had already scrolled past.

## Test plan

`pnpm lint:strict` (0 errors), `pnpm build`, `apps/docsite` `vitest run` (406 passed) and `tsc --noEmit` all green, rebased on current `main`. The two `packages/cli` failures in the root `node` project (`component.test.mjs`, `hook-discovery.test.mjs`, both about component-name case sensitivity) reproduce identically on a clean `8a055dfb` worktree — pre-existing, unrelated.

**New test** — `apps/docsite/src/__tests__/mobile-overscroll.test.ts`, written as invariants rather than as a mirror of the code:

- `globals.css` may not disable overscroll, at any width. It parses the file and reports any `overscroll-behavior*` declaration that isn't `auto`, naming its enclosing blocks.
- none of the three hero layers may be `position: fixed`, in any media arm.

All four fail on the pre-fix sources and pass after.

**Measured** by running this branch and a pristine `main` worktree side by side (`next dev`, headless Chromium, `reducedMotion: 'reduce'` so the 4.5s theme reel is frozen and the arms show the same slide), pixel-diffing the home page with `pixelmatch` at ten scroll offsets each — 0, 200, 400, 600, 712, 760, 800, 1000, 1600, 2400.

| viewport | pixels differing from `main` | `overscroll-behavior-y` | fixed layers reaching the viewport bottom at page end |
|---|---|---|---|
| desktop 1280×900 | **0** at all ten offsets | `none` → `auto` | glow + stage → **none** |
| short desktop 1280×700 | **0** | `none` → `auto` | glow + stage + hero text → **none** |
| tablet 900×1200 | **0** | `none` → `auto` | none → none |
| phone 390×844 | **0** | `none` → `auto` | glow → **none** |

So the pin-and-cover is byte-identical to what ships today, at every width, and nothing is left that can paint into the overscroll gap. The short-desktop row is why `heroContent` is in scope: below ~760px of viewport height it reaches the bottom edge too, so a mobile-only fix would have left a hole on any non-maximized laptop window.

Two notes for anyone reproducing locally:

- The dev build shows a **"You're viewing unreleased docs (Canary)" banner** that is not on the deployed site and inflates the mobile header from 48px to 232px. It is removed before measuring; otherwise the hero geometry looks 184px off.
- The top overscroll gap paints the white canvas (`html`/`body` are both transparent), which is the same "clean" state the issue already measured under the footer — no new exposure there.
