### PR TITLE
fix(visual-gate): freeze the clock at capture time, so date-driven stories stop reporting changed every day

### DIFF
--- a/.github/scripts/visual-gate/README.md
+++ b/.github/scripts/visual-gate/README.md
@@ -114,9 +114,17 @@ tells you to refresh rather than reporting hundreds of regressions.
 ## Determinism
 
 Every shot is taken with animations and transitions forced to their end state,
-carets hidden, a fixed viewport at device scale 1, fonts awaited, and **all
-off-origin requests blocked** — nothing that renders may depend on a CDN being
-up. Theme and colour mode are switched over Storybook's own channel rather than
+carets hidden, a fixed viewport at device scale 1, fonts awaited, **the clock
+frozen at a fixed instant in a fixed timezone**, and **all off-origin requests
+blocked** — nothing that renders may depend on a CDN being up.
+
+The frozen clock is why a story built from `new Date()` — Schedule, Calendar,
+DateRangeInput — does not report `changed` every day. Shots of those stories
+show 13 May 2026, not today; that is the capture's clock, not stale data. The
+instant lives in `lib/capture.mjs` and is recorded in every manifest. Changing
+it changes those shots, so it is a deliberate rebaseline, not a tweak.
+
+Theme and colour mode are switched over Storybook's own channel rather than
 by reloading, which is what keeps 514 shots inside a few minutes;
 `--no-fast-globals` forces a reload per shot if a story's state ever turns out
 to survive the re-render.

--- a/.github/scripts/visual-gate/lib/capture.mjs
+++ b/.github/scripts/visual-gate/lib/capture.mjs
@@ -14,10 +14,11 @@
  * false diff costs a human judgement and teaches everyone to ignore it. So
  * the page is pinned: no external network (nothing that renders may depend on
  * a CDN being up), animations and transitions forced to their end state,
- * carets hidden, a fixed viewport and device scale factor, and a wait on
- * `document.fonts.ready` before the shutter. Even so, a baseline is only
- * comparable against a capture from the same OS and browser build, which is
- * why the manifest records the platform and the comparison refuses to cross it.
+ * carets hidden, a fixed viewport and device scale factor, a frozen clock in
+ * a fixed timezone, and a wait on `document.fonts.ready` before the shutter.
+ * Even so, a baseline is only comparable against a capture from the same OS
+ * and browser build, which is why the manifest records the platform and the
+ * comparison refuses to cross it.
  *
  * Speed. Storybook applies the theme through a global, so a theme change is a
  * re-render, not a reload: the plan is walked grouped by story, and the theme
@@ -79,6 +80,24 @@ const SEEDED_RANDOM = `(() => {
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };
 })();`;
+
+/** The instant every capture happens at, and the zone it happens in.
+ *
+ * Stories that build their data from `new Date()` photograph a different day
+ * on every run, so the gate reports them changed every single day — and a
+ * gate that always says changed teaches everyone to skim the changed list.
+ *
+ * Wednesday 13 May 2026, 10:15 UTC, chosen so that a date-driven story still
+ * has something to show: mid-month and mid-week, so a "today" marker has
+ * ordinary days around it and does not sit on the edge of a month grid; and
+ * mid-morning, so the day's earlier events are already past while its later
+ * ones are still ahead. A clock that put everything in the past would hide a
+ * regression in how future events are drawn. The zone is pinned with it —
+ * an instant alone is a different wall-clock hour on every machine, and the
+ * hour is the half of this choice that does the work.
+ */
+const FROZEN_NOW = new Date('2026-05-13T10:15:00Z');
+const TIMEZONE_ID = 'UTC';
 
 /**
  * Serve a directory over loopback. The gate never talks to the network, so
@@ -255,7 +274,12 @@ export async function scout({storyIds, storybookDir, theme, viewport, onProgress
   const server = await serveDirectory(storybookDir);
   const origin = `http://127.0.0.1:${server.port}`;
   const browser = await chromium.launch();
-  const context = await browser.newContext({viewport, deviceScaleFactor: 1});
+  const context = await browser.newContext({
+    viewport,
+    deviceScaleFactor: 1,
+    timezoneId: TIMEZONE_ID,
+  });
+  await context.clock.setFixedTime(FROZEN_NOW);
   await context.addInitScript(SEEDED_RANDOM);
   await context.route('**', route =>
     route.request().url().startsWith(origin) ? route.continue() : route.abort(),
@@ -319,7 +343,9 @@ export async function capture({
     deviceScaleFactor: 1,
     reducedMotion: 'reduce',
     colorScheme: 'light',
+    timezoneId: TIMEZONE_ID,
   });
+  await context.clock.setFixedTime(FROZEN_NOW);
   await context.addInitScript(SEEDED_RANDOM);
   // Anything off-origin is a determinism hazard, and nothing in a component
   // story legitimately needs it.
@@ -401,6 +427,8 @@ export async function capture({
       browser: `chromium-${browserVersion}`,
       viewport,
       settleMs,
+      frozenClock: FROZEN_NOW.toISOString(),
+      timezoneId: TIMEZONE_ID,
       capturedAt: new Date().toISOString(),
       shots,
       observedTargets: Object.fromEntries(


### PR DESCRIPTION
The visual gate reports `lab-schedule--monthly` changed every single day, and
always will: the story builds its data from `new Date()`, so the captured day
is never the baselined day. Today the day rolled 23 → 24 and the changed pixels
sat in exactly two boxes — the "today" pill, and the 24th's timed events
flipping to past styling. Nothing repainted; only _which_ events were past.

Promotion cannot settle it, because tomorrow's capture differs again — it would
be a standing daily ritual. And a gate that always says `changed` teaches every
cut to skim the changed list, which is exactly how a real regression eventually
gets promoted alongside a clock tick.

## What

The capture context now runs at a fixed instant in a fixed timezone, alongside
the seeded PRNG and the animation freeze already there —
[#5427](https://github.com/facebook/astryx/pull/5427) took the same page for the
a11y audit. Playwright installs the clock before any page script runs, which is
what this needs: the Schedule story's `new Date()` is at module scope, so
anything applied after load is already too late.

The instant is **Wednesday 13 May 2026, 10:15 UTC**, and it is chosen rather
than arbitrary. Mid-month and mid-week, so a "today" marker has ordinary days
around it instead of sitting on the edge of a month grid. Mid-morning, so the
day's earlier events are already past while its later ones are still ahead — a
clock that put everything in the past would hide a regression in how future
events are drawn. The zone is pinned with it because a bare instant is a
different wall-clock hour on every machine, and the hour is the half of that
choice that does the work; the runner is already UTC, so the pin is a no-op
there and only makes a local capture mean the same thing.

## The shots change once, deliberately

Every date-driven shot moves on the first gate run after this merges — Schedule
photographs May 2026 instead of today. **That is the new baseline, not a
regression.** Promote those shots once and the daily churn is over.

## Test plan

Storybook built on the M5, shots taken with the gate itself. To get "a
different day" without waiting a day, each pair was captured under two
timezones that straddle a date boundary right now (`TZ=UTC` → 24 Aug,
`TZ=Pacific/Kiritimati` → 25 Aug):

| `lab-schedule--monthly`, captured on two different days | light                        | dark                         |
| ------------------------------------------------------- | ---------------------------- | ---------------------------- |
| before                                                   | **differs** `c16698cd2284` vs `ba0c4b751934` | **differs** `44551189c00b` vs `c35e3a61bc6f` |
| after                                                    | identical `bf242b0ab4f5`     | identical `baf48cbaae6b`     |

Four independent captures after the change produce those same two hashes.

The instant earns its choice — same story, same build, clock moved inside the
one day:

| frozen at | shot               |                                     |
| --------- | ------------------ | ----------------------------------- |
| 08:00Z    | `bae27abbd7331346` | nothing on today is past yet        |
| 10:15Z    | `bf242b0ab4f57382` | the chosen state                    |
| 23:00Z    | `8b57641f401b6e48` | everything on today is past         |

Between 08:00 and 10:15 exactly one pill flips to past styling (`Company all
hands`); between 10:15 and 23:00 the next one does (`Design review`). So the
frozen state has past events, a future event on the same day, and the "today"
pill — all three visible in one shot.

Gate unit tests: 41 passed.

## Other date-dependent stories

Swept the whole index — 3,572 shots, captured twice with the clock a day apart
— then re-captured every mover three times with the clock _frozen_, to tell
date dependence apart from ordinary flakiness.

| story                                                                                                                          | in the daily plan | verdict                                            |
| ------------------------------------------------------------------------------------------------------------------------------ | ----------------- | -------------------------------------------------- |
| `lab-schedule--*` (all seven)                                                                                                  | `--monthly` only  | date-driven, fixed here                            |
| `core-calendar--default`                                                                                                       | yes               | date-driven, fixed here                            |
| `core-calendar--themed-selected-and-today-ring`, `core-daterangeinput--themed-icons`, `core-daterangeinput--with-presets-and-value`, `core-powersearchwithtable--with-mixed-filters` | no (`--tiers full` only) | date-driven, fixed here                  |
| `core-markdown--streaming`, `core-markdowncitations--streaming-with-citations`, `core-breadcrumbs--menu-crumb-disabled-item`   | no                | not the clock — they move with the clock frozen too |

**Calendar is the one worth knowing about.** `core-calendar--default` renders
the current month with today ringed, and it _is_ in the daily plan — it has not
churned yet only because the baseline was bootstrapped at 02:40 UTC this
morning, so baseline and capture still share a UTC date. It joins Schedule
tomorrow. Schedule got there first because its story renders in
`America/Los_Angeles`, where the day had already rolled.

## Flagged, not fixed

`lab-schedule--day` and the two Markdown streaming stories fail to reproduce
themselves with the clock frozen (2 of 3 passes differ), so something other
than the date moves in them. None is in the daily plan, and each is a
per-story question rather than a gate one — out of scope here.
