### PR TITLE
fix(storybook): use a reserved example address in Stepper demo data

### DIFF
--- a/apps/storybook/stories/Stepper.stories.tsx
+++ b/apps/storybook/stories/Stepper.stories.tsx
@@ -183,7 +183,7 @@ export const StatusVertical: Story = {
           <Step
             step={0}
             label="Email verified"
-            description="ernesttien@meta.com"
+            description="alice@example.com"
             status="success"
           />
           <Step
@@ -905,7 +905,7 @@ export const OnTrackStatus: Story = {
           <Step
             step={0}
             label="Email verified"
-            description="ernesttien@meta.com"
+            description="alice@example.com"
             status="success"
           />
           <Step


### PR DESCRIPTION
Closes [#5436](https://github.com/facebook/astryx/issues/5436).

The Stepper stories rendered **`ernesttien@meta.com`** — a real colleague's work address — as the description of an "Email verified" step, in two places. Replaced with `alice@example.com`.

## How it surfaced

A session capturing screenshots for the 0.5.0 blog post shot the Stepper story, and the address was legible in the image. It was one review pass away from being published on the docsite. It has been in the repo since [#4214](https://github.com/facebook/astryx/pull/4214) landed on 2026-07-23.

## Why `example.com`

RFC 2606 reserves it for exactly this, and it is already the house convention — the story fixtures use `alice@`, `bob@`, `charlie@`, `diana@` and `eve@example.com` well over fifty times between them. `alice@` is the most common of those, so this is the existing cast rather than a new name.

These two lines were the only real address in `apps/storybook/stories` or `packages/*/src`; a scan for any non-`example.com` address in fixture data comes back empty after this change.

## Scope

`apps/storybook` is `private: true`, so nothing here ships in an npm tarball. But Storybook **is** deployed publicly to `facebook.github.io/astryx/storybook/`, and the story source is visible in the docs viewer, so this was public.

## Test plan

- `grep -rn 'ernesttien@meta.com'` across the repo → no matches
- The only addresses remaining in story and doc fixtures are `@example.com` (plus one `a@b.com` placeholder in a validation example)
- Story renders unchanged apart from the string