### PR TITLE
fix(cli): an unknown manifest key no longer discards the whole integration

### DIFF
--- a/.changeset/cli-manifest-forward-compat.md
+++ b/.changeset/cli-manifest-forward-compat.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] A manifest key this CLI does not know no longer discards the whole integration. `astryx.integration.*` was parsed with a strict schema, so one unrecognized field failed the parse — and an integration whose manifest fails to parse contributes _nothing_, taking its components, templates and codemods down with it. Since an integration is published once and installed against many CLI versions, a field added by a newer CLI reached every older consumer as total, silent loss of that package (#5119). Unknown fields are now ignored with an `unknown_manifest_key` warning naming them, and the rest of the manifest still applies; a _known_ field of the wrong type is still an error. (#5311 follow-up)
+
+@josephfarina

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -597,9 +597,11 @@ from `@astryxdesign/cli/authoring` for editor autocomplete and type-checking.
 
 Every command loads the consumer's `astryx.config`, resolves each listed
 integration's manifest from `node_modules`, and discovers its contributions.
-Everything is validated against one strict schema at the load boundary, so the
-CLI presents core and integration contributions through a single, uniform
-surface.
+Everything is parsed at the load boundary, so the CLI presents core and
+integration contributions through a single, uniform surface. A field of the
+wrong type fails there; a field this CLI does not know is ignored with a
+warning naming it, so a manifest written against a newer CLI still contributes
+everything this one understands.
 
 Discovery is resilient: a broken or misconfigured integration is skipped with a
 one-line warning on stderr instead of crashing the CLI, and it never corrupts a

--- a/packages/cli/api/integration/validate-integration.mjs
+++ b/packages/cli/api/integration/validate-integration.mjs
@@ -35,7 +35,7 @@ import * as path from 'node:path';
 import {assertWithin} from '../../foundation/fs/path-safety.mjs';
 import {
   findManifestPaths,
-  loadManifestObject,
+  loadManifest,
   resolvePackageDir,
 } from '../../foundation/integrations/integrations.mjs';
 // The on-disk contribution validators live in foundation: Project and
@@ -121,16 +121,18 @@ async function validateAtPackageDir(packageDir, identity) {
   const manifestFile = manifests[0];
   result.manifestFile = manifestFile;
 
-  // loadManifestObject loads the default export and validates it against the
+  // loadManifest loads the default export and validates it against the
   // integration schema (the shared load boundary). A missing default export or
   // a schema failure throws; we convert either into a single invalid_manifest
   // error issue so validate-integration stays exit-1-but-not-crash.
   let manifest;
+  /** @type {string[]} */
+  let unknownKeys;
   try {
-    manifest = await loadManifestObject(
+    ({manifest, unknownKeys} = await loadManifest(
       manifestFile,
       `Integration manifest (${path.basename(manifestFile)})`,
-    );
+    ));
   } catch (err) {
     issues.push(error('invalid_manifest', /** @type {any} */ (err).message));
     return result;
@@ -160,6 +162,7 @@ async function validateAtPackageDir(packageDir, identity) {
     codemods: resolveRoot(manifest.codemods),
     docs: resolveRoot(manifest.docs),
     issuesUrl: manifest.issuesUrl,
+    __unknownKeys: unknownKeys,
     __spec: identity.name,
     __packageDir: packageDir,
     __manifestFile: manifestFile,

--- a/packages/cli/api/integration/validate-integration.test.mjs
+++ b/packages/cli/api/integration/validate-integration.test.mjs
@@ -68,10 +68,32 @@ describe('validate-integration API', () => {
     expect(errors).toBe(0);
   });
 
-  it('flags an unknown manifest key as invalid_manifest error', async () => {
+  it('reports an unknown manifest key as a warning, and still loads the rest', async () => {
+    // The manifest used to be parsed with a strict schema, so a single unknown
+    // key failed the parse — and an integration whose manifest fails to parse
+    // contributes NOTHING, taking its components, templates and codemods down
+    // with it on every consumer resolving an older CLI (#5119). A key this CLI
+    // does not know is almost always a key from a newer one.
     const pkgDir = path.join(tmpDir, 'pkg');
     writePackage(pkgDir, {
       manifest: `export default { components: './c', bogus: true };\n`,
+    });
+    const result = await validateLocalIntegration(pkgDir);
+    expect(byCode(result.issues, 'invalid_manifest')).toHaveLength(0);
+
+    const unknown = byCode(result.issues, 'unknown_manifest_key');
+    expect(unknown).toHaveLength(1);
+    expect(unknown[0].severity).toBe('warning');
+    expect(unknown[0].message).toContain('"bogus"');
+    // The declared root is still seen — it is missing on disk, which is the
+    // proof the rest of the manifest was read rather than discarded.
+    expect(byCode(result.issues, 'missing_root')).toHaveLength(1);
+  });
+
+  it('still flags a known manifest key of the wrong type as invalid_manifest', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default { components: 42 };\n`,
     });
     const result = await validateLocalIntegration(pkgDir);
     const manifestIssues = byCode(result.issues, 'invalid_manifest');

--- a/packages/cli/api/integration/validate-integration.type.mjs
+++ b/packages/cli/api/integration/validate-integration.type.mjs
@@ -19,6 +19,7 @@
  * @property {string} [codemods]
  * @property {string} [docs]
  * @property {string} [issuesUrl]
+ * @property {string[]} [__unknownKeys]
  * @property {string} __spec
  * @property {string} __packageDir
  * @property {string} __manifestFile

--- a/packages/cli/assets/docs/cli-integrations.doc.mjs
+++ b/packages/cli/assets/docs/cli-integrations.doc.mjs
@@ -172,7 +172,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Every CLI command loads the consumer\'s `astryx.config`, resolves each listed integration\'s manifest from `node_modules`, and discovers its contributions. Everything is validated against one strict schema at the load boundary: the CLI parses each file through `@astryxdesign/cli/authoring` when it loads it, not when you author it. There are no factories; you write a plain object and stamp its `type`.',
+          text: 'Every CLI command loads the consumer\'s `astryx.config`, resolves each listed integration\'s manifest from `node_modules`, and discovers its contributions. Each file is parsed at the load boundary through `@astryxdesign/cli/authoring` — when the CLI loads it, not when you author it. A field of the wrong type fails there. A field this CLI does not know is ignored with a warning naming it, so a manifest written against a newer CLI still contributes everything this one understands. There are no factories; you write a plain object and stamp its `type`.',
         },
         {
           type: 'prose',

--- a/packages/cli/authoring/integration/integration.doc.mjs
+++ b/packages/cli/authoring/integration/integration.doc.mjs
@@ -77,8 +77,11 @@ export const doc = {
       type: 'prose',
       text:
         'Validate a manifest with `astryx validate-integration`. It is checked ' +
-        'at the load boundary with a strict schema (parseIntegration): unknown ' +
-        'keys are errors, and issuesUrl must be a valid URL.',
+        'at the load boundary (parseIntegration): a known field of the wrong ' +
+        'type is an error, and issuesUrl must be a valid URL. A field this CLI ' +
+        'does not know is ignored with a warning rather than rejected, so a ' +
+        'manifest written against a newer CLI still contributes everything ' +
+        'this one understands.',
     },
   ],
 };

--- a/packages/cli/authoring/integration/parse.mjs
+++ b/packages/cli/authoring/integration/parse.mjs
@@ -2,76 +2,26 @@
 
 /**
  * @file Integration-manifest parser — the load-boundary validator for
- * `astryx.integration.*`. Zod is sealed here; consumers call `parseIntegration`
- * or import the {@link AstryxIntegration} type.
+ * `astryx.integration.*`.
+ *
+ * This module IS the published `./integration` subpath, so it exports the
+ * parser and nothing else. The schema it parses against, and the key census
+ * derived from that schema, are internal to `./schema.mjs`; zod is sealed
+ * there. Consumers call `parseIntegration` or import the
+ * {@link AstryxIntegration} type.
  */
 
-import {z} from 'zod';
 import {formatZodError} from '../_shared/errors.mjs';
+import {integrationSchema} from './schema.mjs';
 
 /** @typedef {import('./type').AstryxIntegration} AstryxIntegration */
 
 /**
- * The keys this CLI knows. A manifest may hold others: an integration is
- * published once and installed against many CLI versions, so a key introduced
- * later arrives here routinely and is not an authoring mistake.
- */
-export const KNOWN_INTEGRATION_KEYS = [
-  'components',
-  'templates',
-  'codemods',
-  'docs',
-  'issuesUrl',
-];
-
-// Unknown keys are stripped rather than rejected. `.strict()` made a key from a
-// newer CLI a hard parse failure, and a manifest that fails to parse
-// contributes NOTHING — an integration that added one field lost its
-// components, templates and codemods too, on every consumer resolving an older
-// CLI, silently (#5119). A key this CLI does not know is a key it cannot act
-// on; the rest of the manifest is still good, so the rest of the manifest is
-// still loaded and the unknown key is reported as a warning by
-// `unknownIntegrationKeys`. Known keys stay strictly typed: a `components: 42`
-// IS an authoring mistake and still fails here.
-const integrationSchema = z.object({
-  components: z.string().optional(),
-  templates: z.string().optional(),
-  codemods: z.string().optional(),
-  docs: z.string().optional(),
-  issuesUrl: z.string().url().optional(),
-});
-
-/**
- * Compile-time drift-lock: sealed schema must infer exactly {@link AstryxIntegration}.
- *
- * @typedef {import('../_shared/contract').Expect<
- *   import('../_shared/contract').Equal<z.infer<typeof integrationSchema>, AstryxIntegration>
- * >} _IntegrationDriftLock
- */
-
-/**
- * The manifest keys this CLI does not know, in the order they were authored.
- *
- * Separate from `parseIntegration` because the two answer different questions:
- * the parser says whether the manifest is usable, and this says how much of it
- * this CLI is able to use. Callers report the difference — as a warning, never
- * a failure. Almost always the author is on a newer CLI than the consumer.
- *
- * @param {unknown} input
- * @returns {string[]}
- */
-export function unknownIntegrationKeys(input) {
-  if (input == null || typeof input !== 'object' || Array.isArray(input)) {
-    return [];
-  }
-  return Object.keys(input).filter(
-    key => !KNOWN_INTEGRATION_KEYS.includes(key),
-  );
-}
-
-/**
  * Validate an unknown value as an Astryx integration manifest, or throw.
- * Keys this CLI does not know are ignored (see `unknownIntegrationKeys`).
+ *
+ * A key this CLI does not know is stripped rather than rejected — `schema.mjs`
+ * carries the reasoning, and `unknownIntegrationKeys` there names the stripped
+ * keys for callers that report them.
  *
  * @param {unknown} input
  * @param {string} [label]

--- a/packages/cli/authoring/integration/parse.mjs
+++ b/packages/cli/authoring/integration/parse.mjs
@@ -11,15 +11,35 @@ import {formatZodError} from '../_shared/errors.mjs';
 
 /** @typedef {import('./type').AstryxIntegration} AstryxIntegration */
 
-const integrationSchema = z
-  .object({
-    components: z.string().optional(),
-    templates: z.string().optional(),
-    codemods: z.string().optional(),
-    docs: z.string().optional(),
-    issuesUrl: z.string().url().optional(),
-  })
-  .strict();
+/**
+ * The keys this CLI knows. A manifest may hold others: an integration is
+ * published once and installed against many CLI versions, so a key introduced
+ * later arrives here routinely and is not an authoring mistake.
+ */
+export const KNOWN_INTEGRATION_KEYS = [
+  'components',
+  'templates',
+  'codemods',
+  'docs',
+  'issuesUrl',
+];
+
+// Unknown keys are stripped rather than rejected. `.strict()` made a key from a
+// newer CLI a hard parse failure, and a manifest that fails to parse
+// contributes NOTHING — an integration that added one field lost its
+// components, templates and codemods too, on every consumer resolving an older
+// CLI, silently (#5119). A key this CLI does not know is a key it cannot act
+// on; the rest of the manifest is still good, so the rest of the manifest is
+// still loaded and the unknown key is reported as a warning by
+// `unknownIntegrationKeys`. Known keys stay strictly typed: a `components: 42`
+// IS an authoring mistake and still fails here.
+const integrationSchema = z.object({
+  components: z.string().optional(),
+  templates: z.string().optional(),
+  codemods: z.string().optional(),
+  docs: z.string().optional(),
+  issuesUrl: z.string().url().optional(),
+});
 
 /**
  * Compile-time drift-lock: sealed schema must infer exactly {@link AstryxIntegration}.
@@ -30,7 +50,28 @@ const integrationSchema = z
  */
 
 /**
+ * The manifest keys this CLI does not know, in the order they were authored.
+ *
+ * Separate from `parseIntegration` because the two answer different questions:
+ * the parser says whether the manifest is usable, and this says how much of it
+ * this CLI is able to use. Callers report the difference — as a warning, never
+ * a failure. Almost always the author is on a newer CLI than the consumer.
+ *
+ * @param {unknown} input
+ * @returns {string[]}
+ */
+export function unknownIntegrationKeys(input) {
+  if (input == null || typeof input !== 'object' || Array.isArray(input)) {
+    return [];
+  }
+  return Object.keys(input).filter(
+    key => !KNOWN_INTEGRATION_KEYS.includes(key),
+  );
+}
+
+/**
  * Validate an unknown value as an Astryx integration manifest, or throw.
+ * Keys this CLI does not know are ignored (see `unknownIntegrationKeys`).
  *
  * @param {unknown} input
  * @param {string} [label]

--- a/packages/cli/authoring/integration/parse.test.mjs
+++ b/packages/cli/authoring/integration/parse.test.mjs
@@ -8,7 +8,8 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {parseIntegration, unknownIntegrationKeys} from './parse.mjs';
+import {parseIntegration} from './parse.mjs';
+import {integrationSchema, unknownIntegrationKeys} from './schema.mjs';
 
 /** Run parseIntegration and return the thrown message (asserting it throws). */
 function reason(value, label = 'integration') {
@@ -47,6 +48,16 @@ describe('parseIntegration (load boundary)', () => {
     // Not a manifest at all — nothing to report, and the parser owns the error.
     expect(unknownIntegrationKeys(null)).toEqual([]);
     expect(unknownIntegrationKeys([1, 2])).toEqual([]);
+  });
+
+  it('reports no known key as unknown, whatever the schema grows', () => {
+    // The census is read off the schema, so this holds for keys that do not
+    // exist yet. A hand-maintained list would pass today and start warning
+    // falsely about a supported field the day someone forgot to update it.
+    const everyKnownKey = Object.fromEntries(
+      Object.keys(integrationSchema.shape).map(key => [key, './x']),
+    );
+    expect(unknownIntegrationKeys(everyKnownKey)).toEqual([]);
   });
 
   it('still rejects a known key of the wrong type', () => {

--- a/packages/cli/authoring/integration/parse.test.mjs
+++ b/packages/cli/authoring/integration/parse.test.mjs
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {parseIntegration} from './parse.mjs';
+import {parseIntegration, unknownIntegrationKeys} from './parse.mjs';
 
 /** Run parseIntegration and return the thrown message (asserting it throws). */
 function reason(value, label = 'integration') {
@@ -32,8 +32,27 @@ describe('parseIntegration (load boundary)', () => {
     ).not.toThrow();
   });
 
-  it('rejects unknown keys (strict)', () => {
-    expect(reason({name: '@acme/widgets'})).toContain('Unrecognized key');
+  it('ignores a key it does not know, and keeps the rest of the manifest', () => {
+    // A key from a NEWER CLI is the common case, not an authoring mistake: the
+    // integration is published once and installed against many CLI versions.
+    // Rejecting the manifest took the whole package's contributions down with
+    // it, silently, on every older consumer (#5119).
+    expect(parseIntegration({components: './src', futureRoot: './future'})).toEqual({
+      components: './src',
+    });
+    expect(unknownIntegrationKeys({components: './src', futureRoot: './future'})).toEqual([
+      'futureRoot',
+    ]);
+    expect(unknownIntegrationKeys({components: './src'})).toEqual([]);
+    // Not a manifest at all — nothing to report, and the parser owns the error.
+    expect(unknownIntegrationKeys(null)).toEqual([]);
+    expect(unknownIntegrationKeys([1, 2])).toEqual([]);
+  });
+
+  it('still rejects a known key of the wrong type', () => {
+    // The relaxation is about keys this CLI has never heard of. A key it DOES
+    // know, holding the wrong type, is a real authoring mistake.
+    expect(reason({components: 42})).toContain('components');
   });
 
   it('rejects a non-URL issuesUrl', () => {

--- a/packages/cli/authoring/integration/schema.mjs
+++ b/packages/cli/authoring/integration/schema.mjs
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file The integration-manifest schema, and the key census derived from it.
+ *
+ * Internal. No `exports` entry in package.json resolves here, so nothing in
+ * this file is reachable from a published subpath — `parse.mjs` is the public
+ * face of `./integration` and exports `parseIntegration` alone. Zod stays
+ * sealed on this side of that line.
+ *
+ * The census is READ OFF the schema rather than written beside it. A key added
+ * to one is a key added to the other, so a field this CLI supports can never
+ * be reported as unsupported.
+ */
+
+import {z} from 'zod';
+
+/** @typedef {import('./type').AstryxIntegration} AstryxIntegration */
+
+// Unknown keys are stripped rather than rejected. `.strict()` made a key from a
+// newer CLI a hard parse failure, and a manifest that fails to parse
+// contributes NOTHING — an integration that added one field lost its
+// components, templates and codemods too, on every consumer resolving an older
+// CLI, silently (#5119). A key this CLI does not know is a key it cannot act
+// on; the rest of the manifest is still good, so the rest of the manifest is
+// still loaded and the unknown key is reported as a warning by
+// `unknownIntegrationKeys`. Known keys stay strictly typed: a `components: 42`
+// IS an authoring mistake and still fails here.
+export const integrationSchema = z.object({
+  components: z.string().optional(),
+  templates: z.string().optional(),
+  codemods: z.string().optional(),
+  docs: z.string().optional(),
+  issuesUrl: z.string().url().optional(),
+});
+
+/**
+ * Compile-time drift-lock: sealed schema must infer exactly {@link AstryxIntegration}.
+ *
+ * @typedef {import('../_shared/contract').Expect<
+ *   import('../_shared/contract').Equal<z.infer<typeof integrationSchema>, AstryxIntegration>
+ * >} _IntegrationDriftLock
+ */
+
+/**
+ * The keys this CLI knows, taken from the schema itself.
+ *
+ * A manifest may hold others: an integration is published once and installed
+ * against many CLI versions, so a key introduced later arrives here routinely
+ * and is not an authoring mistake.
+ *
+ * @type {string[]}
+ */
+export const KNOWN_INTEGRATION_KEYS = Object.keys(integrationSchema.shape);
+
+/**
+ * The manifest keys this CLI does not know, in the order they were authored.
+ *
+ * Separate from `parseIntegration` because the two answer different questions:
+ * the parser says whether the manifest is usable, and this says how much of it
+ * this CLI is able to use. Callers report the difference — as a warning, never
+ * a failure. Almost always the author is on a newer CLI than the consumer.
+ *
+ * @param {unknown} input
+ * @returns {string[]}
+ */
+export function unknownIntegrationKeys(input) {
+  if (input == null || typeof input !== 'object' || Array.isArray(input)) {
+    return [];
+  }
+  return Object.keys(input).filter(
+    key => !KNOWN_INTEGRATION_KEYS.includes(key),
+  );
+}

--- a/packages/cli/foundation/config/project.test.mjs
+++ b/packages/cli/foundation/config/project.test.mjs
@@ -25,6 +25,7 @@ function scaffold({
   brokenComponent = false,
   brokenCodemod = false,
   docs = null,
+  unknownKeys = null,
   integrationIssuesUrl = 'https://example.com/widgets/issues',
 } = {}) {
   fs.writeFileSync(
@@ -50,6 +51,7 @@ function scaffold({
   if (withTemplates) manifest.templates = './templates';
   if (withCodemods) manifest.codemods = './codemods';
   if (docs) manifest.docs = './docs';
+  if (unknownKeys) Object.assign(manifest, unknownKeys);
   if (integrationIssuesUrl) manifest.issuesUrl = integrationIssuesUrl;
   fs.writeFileSync(
     path.join(pkgDir, 'astryx.integration.mjs'),
@@ -274,6 +276,39 @@ describe('Project discovery', () => {
     // Same identity (cached value) and no additional discovery walk.
     expect(second).toBe(first);
     expect(spy.mock.calls.length).toBe(callsAfterFirst);
+  });
+});
+
+describe('Project forward compatibility', () => {
+  // An integration is published once and installed against many CLI versions,
+  // so a manifest key from a NEWER CLI reaches an older one routinely. It used
+  // to fail the strict parse, and a manifest that fails to parse contributes
+  // nothing — one added field cost the package its components, templates and
+  // codemods on every older consumer, silently (#5119).
+  it('keeps every contribution when the manifest holds a key this CLI does not know', async () => {
+    scaffold({unknownKeys: {futureRoot: './future', anotherOne: 42}});
+    const project = await Project.load(tmpDir);
+
+    const comps = await project.components();
+    expect(comps.some(c => c.name === 'Widget' && c.package === '@acme/widgets')).toBe(true);
+    expect((await project.templates()).some(t => t.package === '@acme/widgets')).toBe(true);
+    const {integration} = await project.codemods('0.1.0', '0.2.0');
+    expect(integration).toHaveLength(1);
+
+    const issues = await project.issues();
+    expect(issues.every(i => i.severity !== 'error')).toBe(true);
+    const unknown = issues.filter(i => i.code === 'unknown_manifest_key');
+    expect(unknown).toHaveLength(1);
+    expect(unknown[0].severity).toBe('warning');
+    expect(unknown[0].message).toContain('"futureRoot"');
+    expect(unknown[0].message).toContain('"anotherOne"');
+  });
+
+  it('still refuses a known key of the wrong type', async () => {
+    scaffold({unknownKeys: {components: 42}});
+    const project = await Project.load(tmpDir);
+    const issues = await project.issues();
+    expect(issues.some(i => i.severity === 'error')).toBe(true);
   });
 });
 

--- a/packages/cli/foundation/integrations/integrations.mjs
+++ b/packages/cli/foundation/integrations/integrations.mjs
@@ -13,10 +13,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {assertWithin} from '../fs/path-safety.mjs';
-import {
-  parseIntegration,
-  unknownIntegrationKeys,
-} from '../../authoring/integration/parse.mjs';
+import {parseIntegration} from '../../authoring/integration/parse.mjs';
+// The key census is internal to the schema module on purpose: it is derived
+// from the schema so it cannot drift, and it is not public API.
+import {unknownIntegrationKeys} from '../../authoring/integration/schema.mjs';
 import {importUserModule, findPresentFiles} from '../fs/module-loader.mjs';
 
 /**

--- a/packages/cli/foundation/integrations/integrations.mjs
+++ b/packages/cli/foundation/integrations/integrations.mjs
@@ -13,8 +13,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {assertWithin} from '../fs/path-safety.mjs';
-import {parseIntegration} from '../../authoring/integration/parse.mjs';
-import {loadModuleWithParser, findPresentFiles} from '../fs/module-loader.mjs';
+import {
+  parseIntegration,
+  unknownIntegrationKeys,
+} from '../../authoring/integration/parse.mjs';
+import {importUserModule, findPresentFiles} from '../fs/module-loader.mjs';
 
 /**
  * A fully-resolved, loaded integration. Identity (`name`, `version`) comes from
@@ -34,6 +37,8 @@ import {loadModuleWithParser, findPresentFiles} from '../fs/module-loader.mjs';
  * @property {string} __manifestFile
  * @property {string} [__loadError] set when the manifest failed to load/validate;
  *   such an integration contributes nothing and is surfaced via Project.issues()
+ * @property {string[]} [__unknownKeys] manifest keys this CLI does not know —
+ *   surfaced as a warning; the rest of the manifest still contributes
  */
 
 /** Conventional manifest basenames, in load-precedence order. */
@@ -56,15 +61,37 @@ export function findManifestPaths(dir) {
 
 /**
  * Load and validate a manifest module's default export against the integration
- * schema. Default export only — `.ts` is loaded via jiti; `.mjs`/`.js` via
- * dynamic import. Throws if the default export is missing or invalid. Exposed
- * for validate-integration.
+ * schema, and report the keys this CLI does not know. Default export only —
+ * `.ts` is loaded via jiti; `.mjs`/`.js` via dynamic import. Throws if the
+ * default export is missing or invalid.
+ *
+ * The raw default export is inspected before it is parsed, because parsing
+ * strips the unknown keys: after `parseIntegration` there is nothing left to
+ * report. Exposed for validate-integration.
+ *
+ * @param {string} file absolute manifest path
+ * @param {string} [label] used in error messages
+ * @returns {Promise<{manifest: import('../../authoring/integration/type').AstryxIntegration, unknownKeys: string[]}>}
+ */
+export async function loadManifest(file, label = 'integration manifest') {
+  const mod = await importUserModule(file);
+  const raw = mod?.default;
+  return {
+    manifest: parseIntegration(raw, label),
+    unknownKeys: unknownIntegrationKeys(raw),
+  };
+}
+
+/**
+ * Load and validate a manifest module's default export against the integration
+ * schema. Throws if the default export is missing or invalid. Exposed for
+ * validate-integration.
  * @param {string} file absolute manifest path
  * @param {string} [label] used in error messages
  * @returns {Promise<import('../../authoring/integration/type').AstryxIntegration>}
  */
 export async function loadManifestObject(file, label = 'integration manifest') {
-  return loadModuleWithParser(file, parseIntegration, {label});
+  return (await loadManifest(file, label)).manifest;
 }
 
 /**
@@ -149,12 +176,13 @@ export async function loadIntegrations(specs = [], {cwd = process.cwd()} = {}) {
 
     const manifestFile = resolveManifestPath(packageDir, spec);
     let manifest;
+    /** @type {string[]} */
+    let unknownKeys;
     try {
-      manifest = await loadModuleWithParser(
+      ({manifest, unknownKeys} = await loadManifest(
         manifestFile,
-        parseIntegration,
-        {label: `Integration ${spec}`},
-      );
+        `Integration ${spec}`,
+      ));
     } catch (err) {
       // A manifest that throws on import or fails schema validation must NOT take
       // down every command (component/docs/theme don't need this integration).
@@ -190,6 +218,7 @@ export async function loadIntegrations(specs = [], {cwd = process.cwd()} = {}) {
       codemods: resolveRoot(manifest.codemods),
       docs: resolveRoot(manifest.docs),
       issuesUrl: manifest.issuesUrl,
+      __unknownKeys: unknownKeys,
       __spec: spec,
       __packageDir: packageDir,
       __manifestFile: manifestFile,

--- a/packages/cli/foundation/integrations/validate-contributions.mjs
+++ b/packages/cli/foundation/integrations/validate-contributions.mjs
@@ -35,6 +35,40 @@ export function issueError(code, message) {
   return {code, severity: 'error', message};
 }
 
+/** @param {string} code @param {string} message @returns {Issue} */
+export function issueWarning(code, message) {
+  return {code, severity: 'warning', message};
+}
+
+/**
+ * Report the manifest keys this CLI does not know.
+ *
+ * A WARNING, deliberately: an integration is published once and installed
+ * against many CLI versions, so a key introduced by a later CLI arrives here
+ * routinely and means only that this CLI cannot act on it. It used to be fatal
+ * — `.strict()` rejected the manifest, and a manifest that fails to parse
+ * contributes nothing at all, so one added field took the package's
+ * components, templates and codemods down with it on every older consumer
+ * (#5119). The fix is upgrading the CLI, which is what the message says.
+ *
+ * @param {LoadedIntegration} integration
+ * @param {Issue[]} issues
+ */
+function checkUnknownKeys(integration, issues) {
+  const keys = integration.__unknownKeys ?? [];
+  if (keys.length === 0) return;
+  issues.push(
+    issueWarning(
+      'unknown_manifest_key',
+      `This CLI does not know the manifest ${keys.length === 1 ? 'key' : 'keys'} ` +
+        `${keys.map(key => `"${key}"`).join(', ')}, so ${keys.length === 1 ? 'it is' : 'they are'} ` +
+        `ignored — everything else in the manifest still applies. This usually ` +
+        `means the integration was published against a newer Astryx CLI than ` +
+        `this project resolves; upgrading @astryxdesign/cli picks it up.`,
+    ),
+  );
+}
+
 /**
  * Verify each declared contribution root exists on disk. A declared-but-missing
  * root is a `missing_root` error.
@@ -183,6 +217,7 @@ export async function validateLoadedIntegration(loaded) {
   if (loaded.__loadError) {
     return [issueError('integration_error', loaded.__loadError)];
   }
+  checkUnknownKeys(loaded, issues);
   checkRoots(
     {
       components: loaded.components,


### PR DESCRIPTION
## What

A key in `astryx.integration.*` that this CLI does not know is now **ignored with a warning** instead of failing the parse.

```js
// astryx.integration.mjs, authored against a newer CLI
export default {
  components: './src',
  templates: './blocks',
  someFutureRoot: './future', // ← this CLI has never heard of it
};
```

| | Before | After |
| --- | --- | --- |
| The manifest | rejected | loaded |
| `components`, `templates`, `codemods` | **all lost** | all contributed |
| Diagnostic | `invalid_manifest` error | `unknown_manifest_key` warning naming the keys |
| `components: 42` | error | error (unchanged) |

## Why

The manifest was parsed with `.strict()`, so one unrecognized field failed the parse — and an integration whose manifest fails to parse contributes *nothing*. Not just the unknown field: its components, templates and codemods went with it.

That is the wrong default for this particular file. An integration is **published once and installed against many CLI versions**, so a field added by a newer CLI reaches older consumers as a matter of course. It means only that this CLI cannot act on that field. Treating it as corruption costs the consumer the entire package.

This has already happened once, and the CHANGELOG for 0.4.x describes it:

> Meta's internal `@nest/xds-meta` sat invisible to CLI discovery for a week that way, and the app team's conclusion was that the components did not exist (#5119).

0.4.x fixed the *visibility* half — the load error is now reported rather than silent. This fixes the cause: the load should not have failed at all.

It is also, concretely, what stops the next occurrence. `docs` shipped in 0.4.6 (#5311). An integration that adopts it is unusable on every consumer resolving ≤ 0.4.5 — which is most of them, since consumers pin the CLI and upgrade on their own schedule. The same will be true of the field after that, and the one after that, unless the default changes.

## How

- **`.strict()` → default strip.** Unknown keys are dropped from the parsed value rather than rejected. A *known* key of the wrong type still fails: `components: 42` is an authoring mistake, not version skew.
- **`unknownIntegrationKeys(raw)`** reads the raw default export before parsing strips it. It is separate from `parseIntegration` because the two answer different questions — "is this manifest usable" versus "how much of it can this CLI use".
- **`loadManifest`** returns `{manifest, unknownKeys}`; `loadManifestObject` stays as the value-only form. The keys ride on the loaded integration as `__unknownKeys`, beside the existing `__loadError`.
- **One warning, both surfaces.** `checkUnknownKeys` lives in the shared `validate-contributions`, so `Project.issues()` and `astryx validate-integration` report it identically — and because it is `severity: 'warning'`, `Project`'s skip-on-error policy does not withhold the package's contributions, which is the entire point.

The message names the keys and says what to do:

```
This CLI does not know the manifest key "someFutureRoot", so it is ignored —
everything else in the manifest still applies. This usually means the
integration was published against a newer Astryx CLI than this project
resolves; upgrading @astryxdesign/cli picks it up.
```

## Compatibility

No API signature changes. `parseIntegration` keeps its shape, and a manifest with no unknown keys parses to exactly what it did before. The one behavior change is the intended one, and it is strictly more permissive — nothing that loaded before fails now.

`--json` gains no new field; the warning travels in the existing `issues` array that already carries `missing_root`, `invalid_template`, and the rest.

## Test plan

- `authoring/integration/parse.test.mjs` — an unknown key is stripped and reported; a known key of the wrong type still throws.
- `api/integration/validate-integration.test.mjs` — the unknown key is a `warning`, not `invalid_manifest`, **and the declared root is still validated**, which is the proof the rest of the manifest was read rather than discarded.
- `foundation/config/project.test.mjs` — the load-bearing one: with an unknown key present, `components()`, `templates()` and `codemods()` all still return the integration's contributions, and no issue has `severity: 'error'`.
- End-to-end through the binary, against a scaffolded consumer whose integration manifest carries a future key: `astryx --json component --list --package @acme/w` lists the integration's component with this branch, and omits the package entirely on `main`.
- `pnpm build`, `pnpm test` (569 files), `pnpm lint:strict`, `check:cli-structure`, `typecheck:authoring`, `typecheck:strict`, `readme:check` — all clean.

No visual change — this PR touches only `packages/cli`.
