### PR TITLE
fix(cli): handle multi-dot filenames, m4v/mkv video formats, and avoid silent image fall-through in template asset stripping

### DIFF
--- a/.changeset/cli-asset-strip-fix.md
+++ b/.changeset/cli-asset-strip-fix.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] handle multi-dot filenames, m4v/mkv video formats, and avoid silent image fall-through when stripping template demo assets
+@Geervan

--- a/packages/cli/api/template/template.test.mjs
+++ b/packages/cli/api/template/template.test.mjs
@@ -61,12 +61,26 @@ describe('stripTemplateAssetRefs', () => {
     expect(out).not.toContain('/template-assets/');
   });
 
-  it('strips other video extensions (.webm, .mov, .ogv) the same way', () => {
-    for (const ext of ['webm', 'mov', 'ogv']) {
+  it('strips other video extensions (.webm, .mov, .ogv, .m4v, .mkv) the same way', () => {
+    for (const ext of ['webm', 'mov', 'ogv', 'm4v', 'mkv']) {
       const src = `src: '/template-assets/clip.${ext}',`;
       const out = stripTemplateAssetRefs(src);
       expect(out).toBe("src: '',");
     }
+  });
+
+  it('correctly matches multi-dot filenames up to the final extension', () => {
+    const src = "src: '/template-assets/clip.min.mp4',";
+    const out = stripTemplateAssetRefs(src);
+    expect(out).toBe("src: '',");
+    expect(out).not.toContain('data:image/svg+xml,');
+  });
+
+  it('strips unrecognized non-image extensions to empty string instead of image data URI', () => {
+    const src = "src: '/template-assets/model.bin',";
+    const out = stripTemplateAssetRefs(src);
+    expect(out).toBe("src: '',");
+    expect(out).not.toContain('data:image/svg+xml,');
   });
 
   it('still replaces an adjacent image reference with the placeholder when a video reference is also present', () => {

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -154,19 +154,27 @@ const PLACEHOLDER_IMAGE =
 
 /**
  * Extensions that need a video-safe placeholder rather than the image data
- * URI (see stripTemplateAssetRefs). There's no equivalent self-contained
- * inline placeholder for video: unlike an SVG data URI, a `<video src>`
- * needs actual encoded media, and hand-authoring a valid tiny MP4/WebM
- * blob isn't something we can do reliably here — an unverifiable, possibly
- * still-broken binary would just trade one silent failure for another.
- * Rather than mis-render image data as video (the original bug) or guess at
- * binary bytes, video sources are stripped to an empty string so the
- * scaffolded example is honest about needing the builder to supply their
- * own file, instead of silently pointing at something that can't play.
+ * URI (see stripTemplateAssetRefs).
  *
  * @type {Set<string>}
  */
-const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv']);
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv', 'm4v', 'mkv']);
+
+/**
+ * Image extensions that safely map to the SVG data URI placeholder.
+ *
+ * @type {Set<string>}
+ */
+const IMAGE_EXTENSIONS = new Set([
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'svg',
+  'webp',
+  'avif',
+  'ico',
+]);
 
 /**
  * Demo-asset sources to strip from scaffolded projects. Template demo imagery
@@ -177,9 +185,12 @@ const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv']);
  * otherwise 404. Genuine third-party URLs (e.g. brand logos from
  * paypalobjects.com) are intentionally left untouched.
  *
+ * Captures the file extension after the final dot to handle multi-dot filenames
+ * (e.g. `/template-assets/clip.min.mp4`).
+ *
  * @type {RegExp}
  */
-const DEMO_ASSET_PATTERN = /\/template-assets\/[\w-]+\.(\w+)/g;
+const DEMO_ASSET_PATTERN = /\/template-assets\/[\w.-]+\.([a-zA-Z0-9]+)/g;
 
 /**
  * Normalize path into Unix path (using forward slashes) for consistent comparison
@@ -194,18 +205,24 @@ function toPosixPath(p) {
 
 /**
  * Replace demo asset references with a placeholder so scaffolded pages
- * render with zero setup. Images get a self-contained data URI; videos
- * (which have no equivalent inline placeholder — see VIDEO_EXTENSIONS) are
- * stripped to an empty src instead of being mis-replaced with image data.
- * Builders drop in their own media either way.
+ * render with zero setup. Recognized images get a self-contained SVG data URI;
+ * videos and unrecognized non-image formats are stripped to an empty string instead of
+ * being mis-replaced with image SVG data.
  *
  * @param {string} source - Template source code.
  * @returns {string} Source with demo asset references replaced.
  */
 export function stripTemplateAssetRefs(source) {
-  return source.replace(DEMO_ASSET_PATTERN, (match, extension) =>
-    VIDEO_EXTENSIONS.has(extension.toLowerCase()) ? '' : PLACEHOLDER_IMAGE,
-  );
+  return source.replace(DEMO_ASSET_PATTERN, (match, extension) => {
+    const ext = extension.toLowerCase();
+    if (VIDEO_EXTENSIONS.has(ext)) {
+      return '';
+    }
+    if (IMAGE_EXTENSIONS.has(ext)) {
+      return PLACEHOLDER_IMAGE;
+    }
+    return '';
+  });
 }
 /**
  * Load a template-spec module and return its metadata object. Supports both


### PR DESCRIPTION
Fixes #5423

Fixes template demo asset reference stripping in `packages/cli/foundation/discovery/template-adapter.mjs`. 

Previously, `stripTemplateAssetRefs()` made two key assumptions:
1. `DEMO_ASSET_PATTERN` (`/\/template-assets\/[\w-]+\.(\w+)/g`) captured the extension from the **first** dot. For filenames with multiple dots (e.g. `/template-assets/clip.min.mp4`), it captured `min`, corrupting the asset URL to `data:image/svg+xml,...%3E.mp4`.
2. `VIDEO_EXTENSIONS` lacked Apple `.m4v` (and `.mkv`) video extensions.
3. Any extension not in `VIDEO_EXTENSIONS` silently fell through to `PLACEHOLDER_IMAGE` (an SVG image data URI), causing video/non-image assets to silently mis-render as broken images.

## The Fix

- **Multi-Dot Match**: Updated `DEMO_ASSET_PATTERN` to `/\/template-assets\/[\w.-]+\.([a-zA-Z0-9]+)/g` to capture the extension after the final dot.
- **Explicit Classification**: Defined `IMAGE_EXTENSIONS` (`png`, `jpg`, `jpeg`, `gif`, `svg`, `webp`, `avif`, `ico`) alongside `VIDEO_EXTENSIONS` (`mp4`, `webm`, `mov`, `ogv`, `m4v`, `mkv`).
- **Safe Fall-Through**: Non-image assets and unrecognized extensions now fall back to `''` instead of mis-rendering image SVG data URIs into media tags.

## Test Plan

- **Vitest Unit Tests**: Added unit tests to `packages/cli/api/template/template.test.mjs` (`12/12` passed).
- **Reproduction**: Verified via Node.js execution across all 3 reproduction scenarios (multi-dot filenames, `.m4v`, and non-image fall-through).
- **Changeset**: Added `.changeset/cli-asset-strip-fix.md` (`node scripts/check-changesets.mjs` passed).
