### PR TITLE
fix(markdown): a table column that declares :--- says so

### DIFF
--- a/.changeset/markdown-table-explicit-left-align.md
+++ b/.changeset/markdown-table-explicit-left-align.md
@@ -1,0 +1,19 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Markdown: a table column that declares `:---` says so
+
+`cellAlignStyles` had entries for `center` and `end` only, so a column written
+`| :--- |` got no style at all and rendered exactly like an undeclared one. It
+looks right in isolation, because a cell already starts at the inline start —
+but `text-align` inherits, so the column follows whatever the table is nested
+in. Rendered inside a centered block, a table whose first column explicitly
+declares `:---` centers it, and there is nothing in the markdown that says it
+should.
+
+A declared alignment is now always written out, `start` included. Only the
+`:---` case changes, and only where something around the table had already
+moved the default.
+
+@lexs

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -124,6 +124,34 @@ describe('Markdown', () => {
     expect(second.className).toContain('astryx-markdown-paragraph');
   });
 
+  describe('table column alignment', () => {
+    // A declared alignment has to be written out even when it names the side a
+    // cell would otherwise take: `text-align` inherits, so a `:---` column left
+    // unstyled follows whatever the table is nested in instead of the source.
+    it('applies every declared alignment, and leaves an undeclared column alone', () => {
+      const {container} = render(
+        <Markdown>
+          {[
+            '| a | b | c | d |',
+            '| :-- | :-: | --: | --- |',
+            '| 1 | 2 | 3 | 4 |',
+          ].join('\n')}
+        </Markdown>,
+      );
+      const headers = Array.from(container.querySelectorAll('th'));
+      const cells = Array.from(container.querySelectorAll('td'));
+      for (const row of [headers, cells]) {
+        expect(row[0]).toHaveStyle({textAlign: 'start'});
+        expect(row[1]).toHaveStyle({textAlign: 'center'});
+        expect(row[2]).toHaveStyle({textAlign: 'end'});
+      }
+      // An undeclared column keeps taking the table's own default — the header
+      // cell's `start`, and nothing of its own on the body cell.
+      expect(headers[3]).toHaveStyle({textAlign: 'start'});
+      expect(getComputedStyle(cells[3] as Element).textAlign).toBe('');
+    });
+  });
+
   describe('block spacing theme targets', () => {
     // Every block type renders a stable astryx-markdown-<block> class so a
     // theme can tune the gap around it (marginBlockStart/marginBlockEnd) via

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -235,7 +235,11 @@ const dynamicStyles = stylex.create({
   }),
 });
 
+// A column that declares its alignment states it, including the one that lands
+// where an undeclared column happens to sit: `textAlign` inherits, so leaving
+// `:---` unstyled hands it to whatever the table is nested in.
 const cellAlignStyles = stylex.create({
+  start: {textAlign: 'start'},
   center: {textAlign: 'center'},
   end: {textAlign: 'end'},
 });
@@ -1472,6 +1476,7 @@ function renderBlock(
                     key={i}
                     xstyle={[
                       dynamicStyles.cellMinWidth(`${colMinWidths[i]}px`),
+                      node.alignments[i] === 'left' && cellAlignStyles.start,
                       node.alignments[i] === 'center' && cellAlignStyles.center,
                       node.alignments[i] === 'right' && cellAlignStyles.end,
                     ]}>
@@ -1498,6 +1503,7 @@ function renderBlock(
                     // eslint-disable-next-line @eslint-react/no-array-index-key -- markdown table cells are positional by row and column
                     key={j}
                     xstyle={[
+                      node.alignments[j] === 'left' && cellAlignStyles.start,
                       node.alignments[j] === 'center' && cellAlignStyles.center,
                       node.alignments[j] === 'right' && cellAlignStyles.end,
                     ]}>


### PR DESCRIPTION
Split out of #5288, where @cixzhang pointed at the bug underneath it.

`cellAlignStyles` (`Markdown.tsx`) had entries for `center` and `end` only, so a column written `| :--- |` got no style at all and rendered exactly like an undeclared one. That looks right in isolation, because a cell already starts at the inline start — but **`text-align` inherits**, so the column follows whatever the table is nested in. Render a table inside a centered block and a first column that explicitly declares `:---` centers itself; nothing in the markdown says it should.

A declared alignment is now always written out, `start` included. Only the `:---` case changes, and only where something around the table had already moved the default — an undeclared column still takes it.

**One thing worth your ruling.** The GFM semantics behind these markers are physical: the spec's HTML output is `align="left"`, and GitHub renders a `:---` column on the left in an RTL document. `no-physical-properties` says the migration to logical is complete and gates at `error`, so this follows the house rule and keeps `:---` → `start` / `---: ` → `end`, which mirror-flips under RTL. That is a deliberate deviation from the source language, and it is also, I suspect, how the missing `start` came about in the first place — `end` is what the lint rule leaves you with, and `start` then looks redundant. If you would rather match GFM exactly, it is the same three lines with a scoped suppression.

Test asserts every declared column's computed alignment on both `th` and `td`, and that an undeclared column keeps the table's own default.
