### PR TITLE
test(cli): count Switch's fourth theme target

### DIFF
--- a/packages/cli/api/theme/targets/targets.test.mjs
+++ b/packages/cli/api/theme/targets/targets.test.mjs
@@ -34,6 +34,7 @@ describe('themeTargets (api/theme/targets)', () => {
     expect(data.targets.map(t => t.key)).toEqual([
       'switch',
       'switch-field',
+      'switch-label',
       'switch-thumb',
     ]);
   }, 60_000);

--- a/packages/cli/clients/cli/commands/theme-targets.behavior.test.mjs
+++ b/packages/cli/clients/cli/commands/theme-targets.behavior.test.mjs
@@ -19,7 +19,7 @@ describe('astryx theme targets', () => {
     expect(status).toBe(0);
     expect(stdout).toMatch(/^switch\s+Switch\s+size\s+checked, disabled$/m);
     expect(stdout).toMatch(/^switch-thumb\s+Switch\s+size\s+checked$/m);
-    expect(stdout).toMatch(/3 across 1 component/);
+    expect(stdout).toMatch(/4 across 1 component/);
   });
 
   it('lists the whole surface when unfiltered', async () => {


### PR DESCRIPTION
`main` is red and has been since [#5183](https://github.com/facebook/astryx/pull/5183) landed.

That PR gave `Switch` a `switch-label` theme target — correctly, and it ships — but two CLI tests count theme targets and still assert three:

- `packages/cli/api/theme/targets/targets.test.mjs:34` — the key list
- `packages/cli/clients/cli/commands/theme-targets.behavior.test.mjs:22` — `/3 across 1 component/`

Both fail on `origin/main` at `cd1a2daa59a` with no other change, so every open PR inherits them: `test` is red on the merge and auto-merge cannot fire anywhere.

Expectations only. Nothing about the target, the component or the CLI changes.

`vitest run packages/cli/api/theme/targets packages/cli/clients/cli/commands/theme-targets.behavior.test.mjs` — 10 pass.