### PR TITLE
fix(core): Calendar nightly audit — provider locale in an announcement, 320px reflow, forced-colors selection

### DIFF
--- a/.changeset/calendar-nightly-audit-20260824.md
+++ b/.changeset/calendar-nightly-audit-20260824.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: announce a cleared range in the provider locale, wrap the two-month layout instead of overflowing a narrow viewport, keep the selected date visible under forced colors
+
+@cixzhang

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -133,6 +133,28 @@ export const TwoMonthsRangeSelection: Story = {
   },
 };
 
+/**
+ * The two-month layout inside a container narrower than the two months need.
+ * The second month wraps below the first instead of overflowing, so a 320px
+ * viewport does not scroll sideways and the next-month button stays on screen.
+ */
+export const TwoMonthsNarrowContainer: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(undefined);
+    return (
+      <div style={{width: 320}}>
+        <Calendar
+          mode="single"
+          numberOfMonths={2}
+          value={value}
+          onChange={val => setValue(val)}
+          focusDate="2026-01-01"
+        />
+      </div>
+    );
+  },
+};
+
 export const MinMaxBoundary: Story = {
   render: () => {
     const [value, setValue] = useState<ISODateString | undefined>(undefined);

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -13,6 +13,10 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {act, render, screen, within, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {getButton} from '../__tests__/fastRoleQueries';
+import {
+  getForcedColorsRules,
+  getAllInjectedCss,
+} from '../__tests__/forcedColors';
 import * as stylex from '@stylexjs/stylex';
 import {Calendar} from './Calendar';
 import type {CalendarHandle} from './Calendar';
@@ -387,6 +391,33 @@ describe('Calendar', () => {
     // the old anchor are selectable again, so a new start can be placed there.
     expect(getDayButton(11)).not.toBeDisabled();
     expect(getDayButton(9)).not.toBeDisabled();
+  });
+
+  it('announces the cleared range in the provider locale', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <InternationalizationProvider locale="ja-JP">
+        <Calendar mode="range" focusDate="2026-01-01" />
+      </InternationalizationProvider>,
+    );
+
+    // The day button's own accessible name is already localized through the
+    // provider. The announcement has to use the same date string: formatting
+    // it without the locale silently falls back to the host locale, so a
+    // Japanese user hears an English date.
+    const anchor = document.querySelector<HTMLButtonElement>(
+      'button[data-date="2026-01-10"]',
+    );
+    const localizedDate = anchor?.getAttribute('aria-label');
+    expect(localizedDate).toBeTruthy();
+
+    await user.click(anchor as HTMLButtonElement);
+    await user.click(anchor as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(politeRegion()?.textContent).toContain(localizedDate);
+    });
   });
 
   it('does not apply range-span constraints in single mode', async () => {
@@ -1428,5 +1459,25 @@ describe('Calendar', () => {
       expect(css).toContain('.astryx-calendar-nav.next');
       expect(css).toContain('background-color: var(--color-accent-muted)');
     });
+  });
+});
+
+// jsdom cannot emulate forced-colors rendering, so this asserts that the
+// compiled output includes the forced-colors rules; visual behavior needs
+// manual verification under Windows High Contrast.
+describe('forced colors (WCAG 1.4.11)', () => {
+  it('compiles a forced-colors fill so the selected date survives Windows High Contrast', () => {
+    render(
+      <Calendar mode="single" value="2026-01-15" focusDate="2026-01-01" />,
+    );
+
+    const css = getForcedColorsRules();
+    // Without these the accent fill is stripped and the selected date renders
+    // identically to every other day in the month.
+    expect(css).toContain('background-color: highlight;');
+    expect(css).toContain('color: highlighttext;');
+    // A <button> keeps the native ButtonFace surface and ignores the authored
+    // Highlight fill unless it opts out of UA remapping.
+    expect(getAllInjectedCss()).toContain('forced-color-adjust: none;');
   });
 });

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -462,7 +462,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
             setRangeSelectionStart(null);
             announce(
               t('@astryx.calendar.rangeClearedAnnounce', {
-                date: plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY),
+                date: plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY, locale),
               }),
             );
             return;

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -51,18 +51,11 @@ export const calendarStyles = stylex.create({
   },
   monthsContainer: {
     display: 'flex',
+    // Wraps rather than overflowing: two months side by side need ~488px, so
+    // an unwrapped row scrolls the document sideways below that and puts the
+    // next-month button off-viewport (WCAG 1.4.10). Above 488px nothing moves.
+    flexWrap: 'wrap',
     gap: spacingVars['--spacing-4'],
-  },
-  srOnly: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
   },
   /**
    * Wrapper for the month nav chevrons. RTL mirroring is applied by
@@ -123,6 +116,13 @@ export const monthGridStyles = stylex.create({
 // Day Cell Styles - Structural (layout, sizing, positioning)
 // =============================================================================
 
+// The range/preview band is inset one half-step from the cell box so its
+// rounded caps line up with the 28px day button inside the 32px cell; the day's
+// own ::before bleeds out by the same step so adjacent hit targets meet with no
+// dead gap between them.
+const BAND_INSET = spacingVars['--spacing-0-5'];
+const HIT_BLEED = `calc(${spacingVars['--spacing-0-5']} * -1)`;
+
 export const dayCellStyles = stylex.create({
   // Cell container
   cell: {
@@ -137,53 +137,53 @@ export const dayCellStyles = stylex.create({
   // Range background - structural positioning
   rangeBg: {
     position: 'absolute',
-    top: '2px',
-    bottom: '2px',
+    top: BAND_INSET,
+    bottom: BAND_INSET,
     insetInlineStart: 0,
     insetInlineEnd: 0,
   },
   rangeBgRadiusStart: {
-    insetInlineStart: '2px',
+    insetInlineStart: BAND_INSET,
     borderStartStartRadius: radiusVars['--radius-full'],
     borderEndStartRadius: radiusVars['--radius-full'],
   },
   rangeBgRadiusEnd: {
-    insetInlineEnd: '2px',
+    insetInlineEnd: BAND_INSET,
     borderStartEndRadius: radiusVars['--radius-full'],
     borderEndEndRadius: radiusVars['--radius-full'],
   },
   rangeInsetStart: {
-    insetInlineStart: '2px',
+    insetInlineStart: BAND_INSET,
   },
   rangeInsetEnd: {
-    insetInlineEnd: '2px',
+    insetInlineEnd: BAND_INSET,
   },
 
   // Preview background - structural positioning
   previewBg: {
     position: 'absolute',
-    top: '2px',
-    bottom: '2px',
+    top: BAND_INSET,
+    bottom: BAND_INSET,
     insetInlineStart: 0,
     insetInlineEnd: 0,
   },
   previewBgRadiusStart: {
-    insetInlineStart: '2px',
+    insetInlineStart: BAND_INSET,
     borderStartStartRadius: radiusVars['--radius-full'],
     borderEndStartRadius: radiusVars['--radius-full'],
   },
   previewBgRadiusEnd: {
-    insetInlineEnd: '2px',
+    insetInlineEnd: BAND_INSET,
     borderStartEndRadius: radiusVars['--radius-full'],
     borderEndEndRadius: radiusVars['--radius-full'],
   },
   previewStart: {
-    insetInlineStart: '2px',
+    insetInlineStart: BAND_INSET,
     borderStartStartRadius: radiusVars['--radius-full'],
     borderEndStartRadius: radiusVars['--radius-full'],
   },
   previewEnd: {
-    insetInlineEnd: '2px',
+    insetInlineEnd: BAND_INSET,
     borderStartEndRadius: radiusVars['--radius-full'],
     borderEndEndRadius: radiusVars['--radius-full'],
   },
@@ -195,7 +195,7 @@ export const dayCellStyles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: '50%',
+    borderRadius: radiusVars['--radius-full'],
     borderWidth: 0,
     borderStyle: 'none',
     cursor: {
@@ -213,14 +213,14 @@ export const dayCellStyles = stylex.create({
     },
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    // Expand hit target by 2px on each side to prevent gaps
+    // Expand hit target so adjacent days meet with no gap
     '::before': {
       content: '""',
       position: 'absolute',
-      top: '-2px',
-      insetInlineEnd: '-2px',
-      bottom: '-2px',
-      insetInlineStart: '-2px',
+      top: HIT_BLEED,
+      insetInlineEnd: HIT_BLEED,
+      bottom: HIT_BLEED,
+      insetInlineStart: HIT_BLEED,
     },
   },
 
@@ -280,8 +280,22 @@ export const dayCellTheme = stylex.create({
 
   // Selected state (single selection or range endpoints)
   daySelected: {
-    backgroundColor: colorVars['--color-accent'],
-    color: colorVars['--color-on-accent'],
+    // Forced colors (Windows High Contrast) strips the accent fill, which
+    // leaves the selected date looking exactly like every other day.
+    // Highlight/HighlightText is the platform convention for a selected
+    // control (WCAG 1.4.11), and `forced-color-adjust: none` is required
+    // because this is a <button>: the UA otherwise keeps the native
+    // ButtonFace surface and ignores the authored fill, the same trap
+    // ToggleButton documents.
+    forcedColorAdjust: 'none',
+    backgroundColor: {
+      default: colorVars['--color-accent'],
+      '@media (forced-colors: active)': 'Highlight',
+    },
+    color: {
+      default: colorVars['--color-on-accent'],
+      '@media (forced-colors: active)': 'HighlightText',
+    },
     backgroundImage: {
       default: null,
       ':hover:where(:not(:disabled,[aria-disabled="true"]))': {

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -116,12 +116,16 @@ export const monthGridStyles = stylex.create({
 // Day Cell Styles - Structural (layout, sizing, positioning)
 // =============================================================================
 
-// The range/preview band is inset one half-step from the cell box so its
-// rounded caps line up with the 28px day button inside the 32px cell; the day's
-// own ::before bleeds out by the same step so adjacent hit targets meet with no
-// dead gap between them.
-const BAND_INSET = spacingVars['--spacing-0-5'];
-const HIT_BLEED = `calc(${spacingVars['--spacing-0-5']} * -1)`;
+// Half the gap between the day button and its cell — (--size-element-md minus
+// --size-element-sm) / 2 — so the band's rounded caps line up with the button
+// and the button's ::before bleeds out to meet its neighbour's. Deliberately a
+// literal and NOT a spacing token: this is a layout value derived from the two
+// size tokens, and pinning it to --spacing-0-5 desynchronises it from them
+// (matcha sets that step to 3px, which overlaps adjacent days' hit targets by
+// 2px). Deriving it with calc() from the size tokens would be better still and
+// would close butter's 4px dead gap; that needs its own measured change.
+const BAND_INSET = '2px';
+const HIT_BLEED = '-2px';
 
 export const dayCellStyles = stylex.create({
   // Cell container


### PR DESCRIPTION
Nightly component audit of **Calendar** (`core`), rubric **v1.8**, against `cd1a2daa59a`.

| | Score | Grade | Open BLOCKs |
|---|---|---|---|
| Before | 78.6 | C | 2 |
| After | 85.9 | B | 0 |

Every finding below was measured in real Chromium before and after — not read off the source.

---

## What this fixes

### 🔴 I21 — the cleared-range announcement was spoken in the host locale

> **Overlaps open work.** [#5296](https://github.com/facebook/astryx/pull/5296) fixes this at the root (`plainDateFormat`'s locale default) and has been approved since 24 Aug; [#5303](https://github.com/facebook/astryx/pull/5303) threads the provider locale through all twelve call sites, rewrites this same function, and adds a lint that makes the class of bug unrepresentable. **Land #5296 first.** This one-line change and its test are kept because they close the bug tonight and the test is worth keeping under either of those; expect a trivial conflict when #5303 rebases. The two of them also collide with each other — same changeset filename.

`Calendar.tsx:465` formatted its date with `plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY)` and omitted the `locale` argument that the other **nine** call sites in the file pass. `Intl.DateTimeFormat(undefined, …)` falls back to the browser's locale, so this one announcement ignored `InternationalizationProvider`.

The new test makes it concrete — with the provider on `ja-JP`:

```
Expected: "2026年1月10日土曜日"
Received: "Cleared start date Saturday, January 10, 2026. Select a start date."
```

The expected string is the day button's *own* accessible name, which was already localized correctly. Red before, green after.

### 🔴 R1 — `numberOfMonths={2}` overflowed a 320px viewport

Measured at 320px CSS width:

| | before | after |
|---|---|---|
| `scrollWidth` / `clientWidth` | **504** / 320 | **320** / 320 |
| calendar width | 488px | 288px |
| next-month button right edge | 492px — **off screen** | 292px — on screen |

The document scrolled sideways (WCAG 1.4.10) and the next-month button sat outside the viewport. The docs actively recommend this configuration — *"Show two months side by side when the user frequently selects dates that span a month boundary"* — so the layout that failed is the one the component tells people to use.

`monthsContainer` now wraps. Above 488px nothing moves; below it the second month stacks.

**Before / after at 320px:**

| before | after |
|---|---|
| <img src="https://github.com/facebook/astryx/blob/assets/pr-5453/before/Calendar__twoMonths__narrow320__light.png?raw=1" width="260"> | <img src="https://github.com/facebook/astryx/blob/assets/pr-5453/after/Calendar__twoMonths__narrow320__light.png?raw=1" width="260"> |

### 🟠 A14 — the selected date vanished under forced colors

Under `forced-colors: active` the selected day read `backgroundColor rgb(255,255,255)` / `color rgb(0,0,0)` / `forced-color-adjust auto` — identical to every unselected day, so a Windows High Contrast user could not see which date was selected.

Fixed with the pattern `ToggleButton.tsx:56` already uses: `Highlight` / `HighlightText` plus `forced-color-adjust: none`, which a `<button>` needs because the UA otherwise keeps the native ButtonFace surface and ignores the authored fill. After: `bg rgba(5,0,73,0.8)`, `color rgb(255,255,255)`, `forced-color-adjust none`. A compiled-rule test guards it, in the same shape as the CheckboxInput / Skeleton / ToggleButton ones.

| before | after |
|---|---|
| <img src="https://github.com/facebook/astryx/blob/assets/pr-5453/before/Calendar__selected__forcedColors__light.png?raw=1" width="300"> | <img src="https://github.com/facebook/astryx/blob/assets/pr-5453/after/Calendar__selected__forcedColors__light.png?raw=1" width="300"> |

### 🟡 D4 — a literal radius where a role token exists

`borderRadius: '50%'` on the day button → `radiusVars['--radius-full']`. Equivalent only while the box stays square, which is exactly the caveat the radius convention names — and the review found it does more than I claimed: **in y2k the range endpoints stop poking out of a square band.**

### ↩︎ Withdrawn: the ten `2px` insets

I originally swapped these for `--spacing-0-5` and the review loop blocked it, correctly. That `2px` is `(--size-element-md − --size-element-sm) / 2` — the gap between the day button and its cell — not a step on the spacing scale, and the two only coincide on the neutral theme:

```
neutral   (32 − 28)/2 = 2    --spacing-0-5 = 2px    hit target 32 in a 32px cell
matcha    (40 − 36)/2 = 2    --spacing-0-5 = 3px    hit target 42 in a 40px cell
```

On matcha the tokenised version grew the hit target past its cell and overlapped adjacent days by 2px. Reverted to the literal, with the geometry recorded in a comment so the next reader does not make the same swap. An absolute inset is a layout value and is sanctioned as-is.

Deriving it with `calc()` from the two size tokens would be better than either, and would also close butter's pre-existing 4px dead gap between adjacent day hit targets. That is its own measured change, not this one.

### 🧹 Dead code

An unused `srOnly` style that hand-rolled `VisuallyHidden` (§1 A17) with a deprecated `clip: rect(…)`. Nothing referenced it.

---

## Needs review — carried, not fixed

**System-level, filed as #5451: the pressed overlay never paints, library-wide.** Calendar's day button has no pressed state, and it turns out it cannot get one at the component level. I added the house `:active` overlay, measured it, and found it dead: StyleX gives a `@media`-nested `:hover` a higher priority bucket than a bare `:active`, so the compiled hover selector out-specifies the pressed one *(3,4,0)* vs *(3,3,0)* and wins while the pointer is down — which is the only time `:active` matches. The same masking applies to `Button`'s four variants and `AvatarGroupOverflow`; `Button` only *looks* fine because its `transform: scale(0.98)` still fires. I backed my change out rather than ship dead CSS that reads like a fix, and filed one issue with the compiled-CSS evidence. Cousin of #5442.

Everything else here needs a decision rather than a correction, so none of it is touched:

- **A8/A9 — the range preview is hover-only.** `onDayHover` is wired to `onMouseEnter`/`onMouseLeave` and nothing else, so a keyboard user arrowing toward the second endpoint sees no preview of the range they are about to commit. Wiring it to focus is a behaviour change, not a correction.
- **P30 — no `label` prop.** A consumer cannot name the widget for its purpose ("Departure date"); the grid's only accessible name is the month it happens to be showing. Adding one is new public API.
- **P25 — no `changeAction`**, where the convention says async-capable core components ship one. Also new API.
- **A10 — no coarse-pointer hit expansion.** The day button is 28×28 in a 32×32 cell, over the 24px floor. Expanding to ~44px on coarse pointers would overlap the neighbouring days at a 32px pitch, which is worse; recorded with that reason rather than "fixed".
- **A7 / C3 — two Effects, one announcing and one moving focus.** Both are on C3's bright line, but the harm the rule guards (a double fire) is provably absent and under test, and neither has an obvious handler to move to: a month change can originate in a controlled `focusDate` prop, which has no callback, and the focus target does not exist until the new grid has rendered.
- **A14, part two — the *today* ring also disappears under forced colors** (box-shadow is stripped). The fix wants an outline, which would collide with the focus ring; left for a decision rather than guessed at.
- **Both themed stories pin `mode="light"`** on their `<Theme>`, so under the dark toolbar global they render light-mode tokens against a dark page and are close to illegible. Visible in the contact sheet. A story fix, and `<Theme>`'s nested-mode semantics are subtle enough that I did not want to guess in this PR.

---

## Verification

- `pnpm test` — Calendar 148 pass (146 + 2 new). Full suite was 7 red on the first push — all in `packages/cli`, none Calendar's. [#5452](https://github.com/facebook/astryx/pull/5452) fixed those fixtures on main; **main is merged in** and the two that CI blocks on now pass locally.
- `pnpm build`, `pnpm lint:strict` (scoped), `check:sync`, `check:changesets`, `typecheck:docs`, `check-use-client` — clean.
- `pnpm a11y:audit --components Calendar` — 0 violations over 20 stories, **0 new baseline entries, baseline file untouched**.
- `pnpm rtl:audit --filter Calendar` — measured, not N-A'd: D1 auto-pass on 2 icons, curated D2 pass, 0 fail, 0 surprise.
- **92 Chromium captures** over 16 stories × light / dark / matcha, including driven hover, focus-visible, active, mid-flight range preview, forced colors and 320px — [contact sheet on `assets/pr-5453`](https://github.com/facebook/astryx/tree/assets/pr-5453).

Changeset is `patch`. No API added, no behaviour broken.
