### PR TITLE
spike(Indicator): make the loading visual replaceable — a stateless 'busy' family

### DIFF
--- a/apps/storybook/stories/SpinnerBranded.stories.tsx
+++ b/apps/storybook/stories/SpinnerBranded.stories.tsx
@@ -1,0 +1,288 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * The argument for making the busy visual replaceable, in one frame.
+ *
+ * Four replacements, each swapped in by `defineTheme({indicators: {spinner}})`
+ * and nothing else — no prop, no host change, no per-component styling. Each
+ * row renders the same three hosts as the default row above it, so what
+ * changes between rows is exactly one registry entry.
+ *
+ * They are deliberately not four recolours of our ring: a row of dots, a
+ * square, a reversed arc with a flat cap, and a rotating mark. Two of them are
+ * not circles and one of them is not square, which is the point — a
+ * replacement is not constrained to the shape we ship, and the demos are where
+ * that gets tested rather than asserted.
+ */
+
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {Button} from '@astryxdesign/core/Button';
+import type {IndicatorProps} from '@astryxdesign/core/Indicator';
+import {Spinner} from '@astryxdesign/core/Spinner';
+import {Switch} from '@astryxdesign/core/Switch';
+import {Text} from '@astryxdesign/core/Text';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
+import {HStack, VStack} from '@astryxdesign/core/Layout';
+
+const meta: Meta = {
+  title: 'Core/Spinner/Branded Replacements',
+};
+
+export default meta;
+type Story = StoryObj;
+
+// The busy family has no state to draw, so a replacement is a function of
+// `size` alone. `md` is the fallback every indicator defaults to.
+const PX: Record<string, number> = {sm: 10, md: 14, lg: 18, xl: 28};
+
+// -- 1. Bouncing dots — a ROW. Three times as wide as it is tall, which is the
+//       demo that probes whether a host's busy slot assumes a square.
+
+const bounce = stylex.keyframes({
+  '0%, 80%, 100%': {transform: 'translateY(0)', opacity: 0.4},
+  '40%': {transform: 'translateY(-40%)', opacity: 1},
+});
+
+const dotStyles = stylex.create({
+  row: {display: 'inline-flex', alignItems: 'center', gap: '2px'},
+  dot: {
+    backgroundColor: 'currentColor',
+    borderRadius: '50%',
+    animationName: bounce,
+    animationDuration: '1s',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'ease-in-out',
+  },
+  d2: {animationDelay: '0.15s'},
+  d3: {animationDelay: '0.3s'},
+});
+
+function BouncingDots({size = 'md'}: IndicatorProps<'busy'>) {
+  const d = Math.round(PX[size] / 2.2);
+  return (
+    <span aria-hidden="true" {...stylex.props(dotStyles.row)}>
+      <span {...stylex.props(dotStyles.dot)} style={{width: d, height: d}} />
+      <span
+        {...stylex.props(dotStyles.dot, dotStyles.d2)}
+        style={{width: d, height: d}}
+      />
+      <span
+        {...stylex.props(dotStyles.dot, dotStyles.d3)}
+        style={{width: d, height: d}}
+      />
+    </span>
+  );
+}
+
+// -- 2. Pulsing square — no rotation at all, and not round.
+
+const pulse = stylex.keyframes({
+  '0%, 100%': {transform: 'scale(0.6) rotate(0deg)', opacity: 0.45},
+  '50%': {transform: 'scale(1) rotate(45deg)', opacity: 1},
+});
+
+const squareStyles = stylex.create({
+  box: {
+    display: 'inline-block',
+    backgroundColor: 'currentColor',
+    borderRadius: '2px',
+    animationName: pulse,
+    animationDuration: '1.1s',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'ease-in-out',
+  },
+});
+
+function PulsingSquare({size = 'md'}: IndicatorProps<'busy'>) {
+  const d = PX[size];
+  return (
+    <span
+      aria-hidden="true"
+      {...stylex.props(squareStyles.box)}
+      style={{width: d, height: d}}
+    />
+  );
+}
+
+// -- 3. Counter-rotating arc — our geometry, run the other way, with a butt
+//       cap and a much longer sweep. The nearest thing to a "restyle", and the
+//       one that shows a product can keep the ring and still own it.
+
+const counterSpin = stylex.keyframes({
+  '0%': {transform: 'rotate(360deg)'},
+  '100%': {transform: 'rotate(0deg)'},
+});
+
+const arcStyles = stylex.create({
+  svg: {
+    display: 'block',
+    animationName: counterSpin,
+    animationDuration: '0.9s',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'linear',
+  },
+  arc: {fill: 'none', stroke: 'currentColor', strokeLinecap: 'butt'},
+});
+
+function ReverseArc({size = 'md'}: IndicatorProps<'busy'>) {
+  const frame = PX[size] + 6;
+  const r = frame / 2 - 2;
+  const c = 2 * Math.PI * r;
+  return (
+    <svg
+      aria-hidden="true"
+      width={frame}
+      height={frame}
+      viewBox={`0 0 ${frame} ${frame}`}
+      {...stylex.props(arcStyles.svg)}>
+      <circle
+        cx={frame / 2}
+        cy={frame / 2}
+        r={r}
+        strokeWidth={2}
+        strokeDasharray={`${c * 0.75} ${c * 0.25}`}
+        {...stylex.props(arcStyles.arc)}
+      />
+    </svg>
+  );
+}
+
+// -- 4. A rotating logo mark — an arbitrary glyph, which is the case Cindy
+//       described: a brand's own shape standing in for a loading ring.
+
+const markSpin = stylex.keyframes({
+  '0%': {transform: 'rotate(0deg) scale(1)'},
+  '50%': {transform: 'rotate(180deg) scale(0.75)'},
+  '100%': {transform: 'rotate(360deg) scale(1)'},
+});
+
+const markStyles = stylex.create({
+  svg: {
+    display: 'block',
+    animationName: markSpin,
+    animationDuration: '1.4s',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'ease-in-out',
+  },
+});
+
+function LogoMark({size = 'md'}: IndicatorProps<'busy'>) {
+  const d = PX[size] + 4;
+  return (
+    <svg
+      aria-hidden="true"
+      width={d}
+      height={d}
+      viewBox="0 0 24 24"
+      {...stylex.props(markStyles.svg)}>
+      <path
+        d="M12 1.5 22.5 20.5H1.5Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={3}
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+const brandThemes = [
+  {
+    label: "indicators: {spinner: BouncingDots}   ← wide, not square",
+    theme: defineTheme({
+      name: 'brand-dots',
+      indicators: {spinner: BouncingDots},
+    }),
+  },
+  {
+    label: 'indicators: {spinner: PulsingSquare}',
+    theme: defineTheme({
+      name: 'brand-square',
+      indicators: {spinner: PulsingSquare},
+    }),
+  },
+  {
+    label: 'indicators: {spinner: ReverseArc}',
+    theme: defineTheme({name: 'brand-arc', indicators: {spinner: ReverseArc}}),
+  },
+  {
+    label: 'indicators: {spinner: LogoMark}',
+    theme: defineTheme({name: 'brand-mark', indicators: {spinner: LogoMark}}),
+  },
+];
+
+const themes = [
+  {label: 'default — the ring we ship', theme: null},
+  ...brandThemes,
+];
+
+const layout = stylex.create({
+  page: {display: 'flex', flexDirection: 'column', gap: '20px', padding: 8},
+  row: {
+    display: 'grid',
+    gridTemplateColumns: '260px 120px 220px 90px 70px',
+    alignItems: 'center',
+    gap: '16px',
+  },
+  head: {opacity: 0.6},
+  mono: {fontFamily: 'ui-monospace, monospace', fontSize: '11px'},
+});
+
+/**
+ * One registry entry, four hosts, five rows. The hosts are unchanged between
+ * rows and none of them knows which visual it is rendering.
+ */
+export const BrandedSpinners: Story = {
+  render: () => (
+    <div {...stylex.props(layout.page)}>
+      <div {...stylex.props(layout.row, layout.head)}>
+        <Text type="supporting">theme</Text>
+        <Text type="supporting">Button (loading)</Text>
+        <Text type="supporting">TextInput (busy)</Text>
+        <Text type="supporting">Switch</Text>
+        <Text type="supporting">standalone</Text>
+      </div>
+      {themes.map(({label, theme}) => {
+        const row = (
+          <div {...stylex.props(layout.row)} key={label}>
+            <span {...stylex.props(layout.mono)}>{label}</span>
+            <Button label="Save" isLoading />
+            <TextInput label="Search" value="astryx" isLoading />
+            <Switch label="Sync" isLabelHidden value isLoading />
+            <Spinner size="md" />
+          </div>
+        );
+        return theme == null ? (
+          row
+        ) : (
+          <Theme theme={theme} mode="light" key={label}>
+            {row}
+          </Theme>
+        );
+      })}
+    </div>
+  ),
+};
+
+/**
+ * The same replacement at every size the busy family declares. `lg` and `xl`
+ * exist only for a standalone spinner; no control passes them.
+ */
+export const BrandedSizes: Story = {
+  render: () => (
+    <VStack gap={6}>
+      {brandThemes.map(({label, theme}) => (
+        <Theme theme={theme} mode="light" key={label}>
+          <HStack gap={6} vAlign="center">
+            <Spinner size="sm" />
+            <Spinner size="md" />
+            <Spinner size="lg" />
+            <Spinner size="xl" />
+          </HStack>
+        </Theme>
+      ))}
+    </VStack>
+  ),
+};

--- a/apps/storybook/stories/SpinnerBranded.stories.tsx
+++ b/apps/storybook/stories/SpinnerBranded.stories.tsx
@@ -46,7 +46,12 @@ const bounce = stylex.keyframes({
 });
 
 const dotStyles = stylex.create({
-  row: {display: 'inline-flex', alignItems: 'center', gap: '2px', color: '#7c3aed'},
+  row: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '2px',
+    color: '#7c3aed',
+  },
   dot: {
     backgroundColor: 'currentColor',
     borderRadius: '50%',
@@ -193,7 +198,7 @@ function LogoMark({size = 'md'}: IndicatorProps<'busy'>) {
 
 const brandThemes = [
   {
-    label: "indicators: {spinner: BouncingDots}   ← wide, not square",
+    label: 'indicators: {spinner: BouncingDots}   ← wide, not square',
     theme: defineTheme({
       name: 'brand-dots',
       indicators: {spinner: BouncingDots},
@@ -229,7 +234,6 @@ const layout = stylex.create({
     alignItems: 'center',
     gap: '16px',
   },
-  head: {opacity: 0.6},
   mono: {fontFamily: 'ui-monospace, monospace', fontSize: '11px'},
 });
 
@@ -240,7 +244,7 @@ const layout = stylex.create({
 export const BrandedSpinners: Story = {
   render: () => (
     <div {...stylex.props(layout.page)}>
-      <div {...stylex.props(layout.row, layout.head)}>
+      <div {...stylex.props(layout.row)}>
         <Text type="supporting">theme</Text>
         <Text type="supporting">Button (loading)</Text>
         <Text type="supporting">TextInput (busy)</Text>

--- a/apps/storybook/stories/SpinnerBranded.stories.tsx
+++ b/apps/storybook/stories/SpinnerBranded.stories.tsx
@@ -46,7 +46,7 @@ const bounce = stylex.keyframes({
 });
 
 const dotStyles = stylex.create({
-  row: {display: 'inline-flex', alignItems: 'center', gap: '2px'},
+  row: {display: 'inline-flex', alignItems: 'center', gap: '2px', color: '#7c3aed'},
   dot: {
     backgroundColor: 'currentColor',
     borderRadius: '50%',
@@ -86,6 +86,7 @@ const pulse = stylex.keyframes({
 const squareStyles = stylex.create({
   box: {
     display: 'inline-block',
+    color: '#ea580c',
     backgroundColor: 'currentColor',
     borderRadius: '2px',
     animationName: pulse,
@@ -118,6 +119,7 @@ const counterSpin = stylex.keyframes({
 const arcStyles = stylex.create({
   svg: {
     display: 'block',
+    color: '#0d9488',
     animationName: counterSpin,
     animationDuration: '0.9s',
     animationIterationCount: 'infinite',
@@ -161,6 +163,7 @@ const markSpin = stylex.keyframes({
 const markStyles = stylex.create({
   svg: {
     display: 'block',
+    color: '#db2777',
     animationName: markSpin,
     animationDuration: '1.4s',
     animationIterationCount: 'infinite',

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -121,9 +121,12 @@ describe('Button', () => {
       const {container, unmount} = render(
         <Button label="Submit" variant={variant} isLoading />,
       );
-      const spinner = container.querySelector('.astryx-spinner');
+      // The busy visual is the `spinner` indicator now, and it has no shade:
+      // it paints in `currentColor`, which the loading overlay sets to the
+      // button's own foreground. That is what shade="inherit" meant (#2717).
+      const spinner = container.querySelector('.astryx-spinner-indicator');
       expect(spinner).not.toBeNull();
-      expect(spinner).toHaveAttribute('data-shade', 'inherit');
+      expect(spinner?.closest('[aria-hidden="true"]')).not.toBeNull();
       unmount();
     }
   });

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -36,7 +36,7 @@ import {
   shadowVars,
   focusVars,
 } from '../theme/tokens.stylex';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {VisuallyHidden} from '../VisuallyHidden';
 
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
@@ -388,6 +388,11 @@ const loadingStyles = stylex.create({
     },
   },
   spinnerOverlay: {
+    // shade="inherit" used to say this; the vars say it to any busy visual,
+    // ours or a replacement's.
+    '--_spinner-color': 'currentColor',
+    '--_spinner-track-color': 'currentColor',
+    '--_spinner-track-opacity': '0.3',
     position: 'absolute',
     top: 0,
     insetInlineStart: 0,
@@ -692,7 +697,7 @@ export function Button({
             delaySpinner && loadingStyles.spinnerDelayed,
           )}
           aria-hidden="true">
-          <Spinner size="sm" shade="inherit" />
+          <BusyIndicator size="sm" />
         </span>
       )}
       <span

--- a/packages/core/src/Chat/ChatMessageList.test.tsx
+++ b/packages/core/src/Chat/ChatMessageList.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi} from 'vitest';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import {ChatMessageList} from './ChatMessageList';
 import {ChatMessage} from './ChatMessage';
 import {ChatMessageBubble} from './ChatMessageBubble';
@@ -44,6 +44,63 @@ describe('ChatMessageList', () => {
       </ChatMessageList>,
     );
     expect(screen.getByTestId('list')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('marks the log aria-busy while loading older messages', async () => {
+    let notify!: IntersectionObserverCallback;
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class implements IntersectionObserver {
+        readonly root = null;
+        readonly rootMargin = '0px';
+        readonly scrollMargin = '0px';
+        readonly thresholds = [0];
+
+        constructor(callback: IntersectionObserverCallback) {
+          notify = callback;
+        }
+
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords(): IntersectionObserverEntry[] {
+          return [];
+        }
+      },
+    );
+    let finish!: () => void;
+    const scrollToTopAction = vi.fn(
+      async () =>
+        new Promise<void>(resolve => {
+          finish = resolve;
+        }),
+    );
+
+    try {
+      render(
+        <ChatMessageList
+          data-testid="list"
+          scrollToTopAction={scrollToTopAction}>
+          <div>msg</div>
+        </ChatMessageList>,
+      );
+      act(() => {
+        notify(
+          [{isIntersecting: true} as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId('list')).toHaveAttribute('aria-busy', 'true'),
+      );
+
+      await act(async () => finish());
+      await waitFor(() =>
+        expect(screen.getByTestId('list')).not.toHaveAttribute('aria-busy'),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('renders empty state when no children', () => {

--- a/packages/core/src/Chat/ChatMessageList.tsx
+++ b/packages/core/src/Chat/ChatMessageList.tsx
@@ -32,7 +32,7 @@ import {
   useChatLayoutContext,
 } from './ChatContext';
 import {mergeProps} from '../utils';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import type {BaseProps} from '../BaseProps';
 import type {SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
@@ -308,7 +308,7 @@ export function ChatMessageList({
           {/* Loading spinner at top */}
           {isLoadingTop && (
             <div {...stylex.props(styles.loadingTop)}>
-              <Spinner size="md" />
+              <BusyIndicator size="md" />
             </div>
           )}
 

--- a/packages/core/src/Chat/ChatMessageList.tsx
+++ b/packages/core/src/Chat/ChatMessageList.tsx
@@ -290,7 +290,7 @@ export function ChatMessageList({
         ref={ref}
         role="log"
         aria-live="polite"
-        aria-busy={isStreaming || undefined}
+        aria-busy={isStreaming || isLoadingTop || undefined}
         tabIndex={0}
         data-testid={testId}
         {...mergeProps(

--- a/packages/core/src/Chat/ChatToolCalls.test.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.test.tsx
@@ -126,7 +126,10 @@ describe('ChatToolCalls', () => {
     const {container} = render(
       <ChatToolCalls calls={[{name: 'bash', status: 'running'}]} />,
     );
-    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+    expect(container.querySelector('[aria-busy="true"]')).toHaveAttribute(
+      'role',
+      'status',
+    );
   });
 
   it('defaults to collapsed', () => {

--- a/packages/core/src/Chat/ChatToolCalls.test.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.test.tsx
@@ -122,6 +122,13 @@ describe('ChatToolCalls', () => {
     ).toBeInTheDocument();
   });
 
+  it('exposes pending work on the call row', () => {
+    const {container} = render(
+      <ChatToolCalls calls={[{name: 'bash', status: 'running'}]} />,
+    );
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+
   it('defaults to collapsed', () => {
     render(
       <ChatToolCalls

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -34,7 +34,7 @@ import {
 import {getKey, mergeProps} from '../utils';
 import {Badge} from '../Badge';
 import {Icon, type IconName} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
@@ -215,6 +215,8 @@ const styles = stylex.create({
     },
   },
   statusIcon: {
+    // was shade="subtle"
+    '--_spinner-color': colorVars['--color-text-secondary'],
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',
@@ -431,9 +433,9 @@ function CallRow({call}: {call: ChatToolCallItem}) {
         title={status === 'error' ? call.errorMessage : undefined}
         {...stylex.props(styles.statusIcon, STATUS_STYLES[status])}>
         {status === 'running' ? (
-          <Spinner size="sm" shade="subtle" aria-hidden="true" />
+          <BusyIndicator size="sm" />
         ) : status === 'pending' ? (
-          <Spinner size="sm" shade="subtle" aria-hidden="true" />
+          <BusyIndicator size="sm" />
         ) : (
           <Icon
             icon={STATUS_ICON_NAMES[status] ?? 'success'}
@@ -624,9 +626,9 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
             <span
               {...stylex.props(styles.statusIcon, STATUS_STYLES[latestStatus])}>
               {latestStatus === 'running' ? (
-                <Spinner size="sm" shade="subtle" aria-hidden="true" />
+                <BusyIndicator size="sm" />
               ) : latestStatus === 'pending' ? (
-                <Spinner size="sm" shade="subtle" aria-hidden="true" />
+                <BusyIndicator size="sm" />
               ) : (
                 <Icon
                   icon={STATUS_ICON_NAMES[latestStatus] ?? 'success'}

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -398,6 +398,7 @@ function getToolCallKey(call: ChatToolCallItem): string {
 function CallRow({call}: {call: ChatToolCallItem}) {
   const t = useTranslator();
   const status = call.status ?? 'complete';
+  const isBusy = status === 'running' || status === 'pending';
   const hasDetail = call.resultDetail != null;
   const [isDetailOpen, setIsDetailOpen] = useState(false);
   const detailId = useId();
@@ -413,11 +414,11 @@ function CallRow({call}: {call: ChatToolCallItem}) {
 
   const row = (
     <div
-      role={hasDetail ? 'button' : undefined}
+      role={hasDetail ? 'button' : isBusy ? 'status' : undefined}
       tabIndex={hasDetail ? 0 : undefined}
       aria-expanded={hasDetail ? isDetailOpen : undefined}
       aria-controls={hasDetail && isDetailOpen ? detailId : undefined}
-      aria-busy={status === 'running' || status === 'pending' || undefined}
+      aria-busy={isBusy || undefined}
       onClick={toggleDetail}
       onKeyDown={
         hasDetail

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -417,6 +417,7 @@ function CallRow({call}: {call: ChatToolCallItem}) {
       tabIndex={hasDetail ? 0 : undefined}
       aria-expanded={hasDetail ? isDetailOpen : undefined}
       aria-controls={hasDetail && isDetailOpen ? detailId : undefined}
+      aria-busy={status === 'running' || status === 'pending' || undefined}
       onClick={toggleDetail}
       onKeyDown={
         hasDetail
@@ -604,6 +605,9 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
         tabIndex={0}
         aria-expanded={isExpanded}
         aria-controls={contentId}
+        aria-busy={
+          latestStatus === 'running' || latestStatus === 'pending' || undefined
+        }
         onClick={toggle}
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -42,7 +42,7 @@ import {FieldLabel} from '../Field/FieldLabel';
 import {FieldStatus} from '../FieldStatus/FieldStatus';
 import type {IconType} from '../Icon';
 import type {InputStatus} from '../Field/types';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {useTooltip} from '../Tooltip';
 import {mergeProps} from '../utils';
 import {indicatorScope} from '../Indicator/indicator.markers.stylex';
@@ -472,7 +472,7 @@ export function CheckboxInput({
               }
               size={size}
               isDisabled={isDisabled}>
-              {isBusy ? <Spinner size="sm" shade="inherit" /> : null}
+              {isBusy ? <BusyIndicator size="sm" /> : null}
             </CheckboxControl>
           </span>
         </div>

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -680,10 +680,12 @@ describe('CheckboxListItem ARIA props', () => {
         <CheckboxListItem label="Option A" value="a" isLoading />
       </CheckboxList>,
     );
-    // The spinner is decorative — it lives inside the checkbox's
-    // aria-hidden visual box, so query with hidden:true. The accessible
-    // loading signal is `aria-busy` on the item (asserted above).
-    expect(screen.getByRole('status', {hidden: true})).toBeInTheDocument();
+    // The busy visual is decorative — it lives inside the checkbox's
+    // aria-hidden box and carries no role at all. The accessible loading
+    // signal is `aria-busy` on the item (asserted above).
+    expect(
+      document.querySelector('.astryx-spinner-indicator'),
+    ).not.toBeNull();
   });
 
   it('does not toggle when item-level isLoading is set', () => {
@@ -718,16 +720,14 @@ describe('CheckboxListItem ARIA props', () => {
     // Toggle Option A.
     fireEvent.click(within(itemA).getByRole('checkbox'));
 
-    // The toggled item becomes busy and shows a spinner; the sibling stays idle.
-    // The spinner is decorative (inside the aria-hidden box), so query hidden.
-    expect(
-      await within(itemA).findByRole('status', {hidden: true}),
-    ).toBeInTheDocument();
+    // The toggled item becomes busy and shows the busy visual; the sibling
+    // stays idle. The visual is decorative and roleless, so match its class.
+    await waitFor(() =>
+      expect(itemA.querySelector('.astryx-spinner-indicator')).not.toBeNull(),
+    );
     expect(itemA).toHaveAttribute('aria-busy', 'true');
     expect(itemB).not.toHaveAttribute('aria-busy');
-    expect(
-      within(itemB).queryByRole('status', {hidden: true}),
-    ).not.toBeInTheDocument();
+    expect(itemB.querySelector('.astryx-spinner-indicator')).toBeNull();
     expect(changeAction).toHaveBeenCalledWith(['a']);
   });
 

--- a/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
@@ -131,6 +131,15 @@ describe('CommandPaletteInput dialog context', () => {
     };
   }
 
+  it('exposes the busy state on the combobox', () => {
+    render(
+      <CommandPaletteContext value={makeContext({isBusy: true})}>
+        <CommandPaletteInput />
+      </CommandPaletteContext>,
+    );
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-busy', 'true');
+  });
+
   it('does not auto-focus inside an inline dialog', () => {
     const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus');
     render(

--- a/packages/core/src/CommandPalette/CommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.tsx
@@ -15,7 +15,7 @@
 import {useCallback, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Icon} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {mergeProps} from '../utils';
 import {
   colorVars,
@@ -246,7 +246,7 @@ export function CommandPaletteInput({
         <span {...stylex.props(styles.end)}>
           {ctx?.isBusy && (
             <span {...stylex.props(styles.icon, styles.spinner)}>
-              <Spinner size="sm" />
+              <BusyIndicator size="sm" />
             </span>
           )}
           {endContent}

--- a/packages/core/src/CommandPalette/CommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.tsx
@@ -222,6 +222,7 @@ export function CommandPaletteInput({
         role="combobox"
         aria-expanded={ctx?.isOpen ?? true}
         aria-autocomplete="list"
+        aria-busy={ctx?.isBusy || undefined}
         aria-controls={ctx?.listId}
         aria-activedescendant={
           ctx && ctx.highlightedIndex >= 0

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -30,7 +30,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {Field, inputWrapperStyles, type FieldStatusVariant} from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {useTranslator} from '../i18n';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
@@ -529,7 +529,7 @@ export function ComplexSelector<Value>({
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerText)}>{triggerContent}</span>
         </button>
-        {isBusy && <Spinner size="sm" />}
+        {isBusy && <BusyIndicator size="sm" />}
         <Icon
           icon="chevronDown"
           size="sm"

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -48,7 +48,7 @@ import {VisuallyHidden} from '../VisuallyHidden';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 import {groupStyles} from '../InputGroup/groupStyles';
 import {useSize} from '../SizeContext/SizeContext';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {
   Calendar,
   type ISODateString,
@@ -835,7 +835,7 @@ function PointerDateField({
           iconClassName={stableClassName('date-input-clear-icon')}
         />
       )}
-      {isBusy && <Spinner size="sm" />}
+      {isBusy && <BusyIndicator size="sm" />}
       {statusIcon}
       {popover.render(
         <Calendar

--- a/packages/core/src/DateInput/NativeDateField.tsx
+++ b/packages/core/src/DateInput/NativeDateField.tsx
@@ -48,7 +48,7 @@ import {useInputGroup} from '../InputGroup';
 import {groupStyles} from '../InputGroup/groupStyles';
 import {stableClassName} from '../naming';
 import {useSize} from '../SizeContext';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {
   colorVars,
   radiusVars,
@@ -600,7 +600,7 @@ export function NativeDateField({
           iconClassName={stableClassName('date-input-clear-icon')}
         />
       )}
-      {isLoading && <Spinner size="sm" />}
+      {isLoading && <BusyIndicator size="sm" />}
       {statusIcon}
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}

--- a/packages/core/src/DateInput/TouchDateField.tsx
+++ b/packages/core/src/DateInput/TouchDateField.tsx
@@ -80,7 +80,7 @@ import {useInputGroup} from '../InputGroup';
 import {groupStyles} from '../InputGroup/groupStyles';
 import {stableClassName} from '../naming';
 import {useSize} from '../SizeContext';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {
   colorVars,
   spacingVars,
@@ -1257,7 +1257,7 @@ export function TouchDateField({
           iconClassName={stableClassName('date-input-clear-icon')}
         />
       )}
-      {isBusy && <Spinner size="sm" />}
+      {isBusy && <BusyIndicator size="sm" />}
       {statusIcon}
       <BottomSheet
         isOpen={isSheetOpen}

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -46,7 +46,7 @@ import {
   type FieldStatusVariant,
 } from '../Field';
 import {Icon} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {
   Calendar,
   type ISODateString,
@@ -704,7 +704,7 @@ export function DateRangeInput({
             iconClassName={stableClassName('date-range-input-clear-icon')}
           />
         )}
-        {isBusy && <Spinner size="sm" />}
+        {isBusy && <BusyIndicator size="sm" />}
         {statusIcon}
       </div>
       {popover.render(

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -53,7 +53,7 @@ import {
 } from '../Field';
 import {Icon} from '../Icon';
 import {VisuallyHidden} from '../VisuallyHidden';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {
   Calendar,
   type ISODateString,
@@ -1703,7 +1703,7 @@ function PointerDateTimeField({
               onClick={handleClear}
             />
           )}
-          {isBusy && <Spinner size="sm" />}
+          {isBusy && <BusyIndicator size="sm" />}
           {statusIcon}
         </div>
 

--- a/packages/core/src/DateTimeInput/TouchDateTimeField.tsx
+++ b/packages/core/src/DateTimeInput/TouchDateTimeField.tsx
@@ -52,7 +52,7 @@ import {IconButton} from '../IconButton';
 import {useTranslator, InternationalizationContext} from '../i18n';
 import {SegmentedControl, SegmentedControlItem} from '../SegmentedControl';
 import {useSize} from '../SizeContext/SizeContext';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {useTooltip} from '../Tooltip';
 import {
   colorVars,
@@ -1343,7 +1343,7 @@ export function TouchDateTimeField({
               onClick={handleClear}
             />
           )}
-          {isBusy && <Spinner size="sm" />}
+          {isBusy && <BusyIndicator size="sm" />}
           {isRenderable(statusIcon) && statusIcon}
         </div>
 

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
@@ -729,6 +729,7 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
       name: /Move to/,
       hidden: true,
     });
+    expect(trigger).toHaveAttribute('aria-busy', 'true');
     await waitFor(() => {
       expect(
         screen.getByRole('menu', {name: 'Actions', hidden: true}),

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -50,7 +50,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {Item} from '../Item';
 import {useLayer} from '../Layer/useLayer';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
@@ -520,7 +520,7 @@ export function DropdownMenuSubMenu(
 
   const endAffordance = hasSpinner ? (
     <span {...stylex.props(triggerStyles.caret)}>
-      <Spinner size="sm" />
+      <BusyIndicator size="sm" />
     </span>
   ) : (
     <span {...stylex.props(triggerStyles.caret)}>

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -554,6 +554,7 @@ export function DropdownMenuSubMenu(
         aria-expanded={isOpen}
         aria-controls={isOpen ? contentId : undefined}
         aria-disabled={isDisabled || undefined}
+        aria-busy={hasSpinner || undefined}
         data-testid={testId}
         onMouseEnter={triggerProps.onMouseEnter}
         onMouseLeave={triggerProps.onMouseLeave}

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -43,7 +43,7 @@ import {
   type FieldStatusVariant,
 } from '../Field';
 import {Icon} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {useInputStatusIcon} from '../hooks/useInputStatusIcon';
@@ -687,7 +687,7 @@ export function FileInput({
 
   const renderDropzoneContent = () => {
     if (isLoading) {
-      return <Spinner size="md" />;
+      return <BusyIndicator size="md" />;
     }
     if (hasFiles) {
       return (
@@ -713,7 +713,7 @@ export function FileInput({
           <span {...stylex.props(styles.fileNameText)}>
             {fileNames ?? displayPlaceholder}
           </span>
-          <Spinner size="sm" />
+          <BusyIndicator size="sm" />
         </>
       );
     }

--- a/packages/core/src/Indicator/BusyIndicator.tsx
+++ b/packages/core/src/Indicator/BusyIndicator.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file BusyIndicator.tsx
+ * @input Indicator props of the `busy` family
+ * @output Exports BusyIndicator — the resolved `spinner` indicator as a component
+ * @position What a control renders while work is in flight
+ *
+ * `useIndicator('spinner')` returns a component, so every host that wanted one
+ * would have to call the hook and bind a capitalised local before its JSX. This
+ * does that once. A host swaps `<Spinner size="sm" />` for
+ * `<BusyIndicator size="sm" />` and nothing else moves — no hook to place, no
+ * render-order constraint, and the theme's replacement reaches it.
+ *
+ * It is DECORATIVE. The control keeps `aria-busy` and the announcement; that is
+ * the whole difference from rendering `<Spinner>`, which brings a `role="status"`
+ * of its own into a control that already has an accessible name.
+ */
+
+import {useIndicator} from './useIndicator';
+import type {IndicatorProps} from './types';
+
+export function BusyIndicator(props: IndicatorProps<'busy'>) {
+  const Indicator = useIndicator('spinner');
+  return <Indicator {...props} />;
+}
+
+BusyIndicator.displayName = 'BusyIndicator';

--- a/packages/core/src/Indicator/CheckboxIndicator.tsx
+++ b/packages/core/src/Indicator/CheckboxIndicator.tsx
@@ -21,6 +21,15 @@ import {indicatorScope} from './indicator.markers.stylex';
 import type {IndicatorProps} from './types';
 
 const styles = stylex.create({
+  // A busy visual in the children slot paints in the box's own foreground, as
+  // the mark it stands in for would have — the same thing CheckIndicator's
+  // slot does by setting `color`. Set here rather than by the host so any
+  // checkbox that shows a pending state gets it.
+  busySlot: {
+    '--_spinner-color': 'currentColor',
+    '--_spinner-track-color': 'currentColor',
+    '--_spinner-track-opacity': '0.3',
+  },
   box: {
     boxSizing: 'border-box',
     display: 'flex',
@@ -212,6 +221,7 @@ export function CheckboxIndicator({
         ),
         stylex.props(
           styles.box,
+          styles.busySlot,
           boxSizeStyles[size],
           isCheckedOrIndeterminate ? styles.checked : styles.unchecked,
           isDisabled && styles.disabled,

--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -159,6 +159,22 @@ export const docs = {
         visualProps: ['size'],
         deprecatedFor: 'radio-indicator-dot',
       },
+      {className: 'astryx-spinner-indicator', visualProps: ['size']},
+    ],
+    vars: [
+      {
+        name: '--_spinner-color',
+        description:
+          'Colour the busy indicator paints in. Set by the host slot, not by a theme directly; the indicator turns it into `color`, so a replacement drawing in currentColor follows it too.',
+      },
+      {
+        name: '--_spinner-track-color',
+        description: 'Stroke of the track behind the moving arc.',
+      },
+      {
+        name: '--_spinner-track-opacity',
+        description: 'Opacity of that track.',
+      },
     ],
   },
   examples: [

--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -166,14 +166,20 @@ export const docs = {
         name: '--_spinner-color',
         description:
           'Colour the busy indicator paints in. Set by the host slot, not by a theme directly; the indicator turns it into `color`, so a replacement drawing in currentColor follows it too.',
+        default: 'var(--color-accent)',
+        private: true,
       },
       {
         name: '--_spinner-track-color',
         description: 'Stroke of the track behind the moving arc.',
+        default: 'var(--color-track)',
+        private: true,
       },
       {
         name: '--_spinner-track-opacity',
         description: 'Opacity of that track.',
+        default: '1',
+        private: true,
       },
     ],
   },

--- a/packages/core/src/Indicator/SpinnerIndicator.tsx
+++ b/packages/core/src/Indicator/SpinnerIndicator.tsx
@@ -137,7 +137,7 @@ const styles = stylex.create({
     overflow: 'hidden',
     verticalAlign: 'middle',
     flexShrink: 0,
-    color: `var(--spinner-color, var(--_spinner-color, ${colorVars['--color-accent']}))`,
+    color: `var(--_spinner-color, var(--spinner-color, ${colorVars['--color-accent']}))`,
     [BOX_SIZE]: `calc(var(${RESOLVED_DIAMETER}) + var(${RESOLVED_STROKE}) * 2)`,
   },
   ring: {
@@ -162,7 +162,7 @@ const styles = stylex.create({
     strokeWidth: `var(${RESOLVED_STROKE})`,
   },
   arc: {
-    stroke: 'currentColor',
+    stroke: 'var(--spinner-color, currentColor)',
     strokeDasharray: `calc(var(${RESOLVED_DIAMETER}) * ${ARC_DASH}) calc(var(${RESOLVED_DIAMETER}) * ${ARC_GAP})`,
   },
   track: {

--- a/packages/core/src/Indicator/SpinnerIndicator.tsx
+++ b/packages/core/src/Indicator/SpinnerIndicator.tsx
@@ -137,7 +137,7 @@ const styles = stylex.create({
     overflow: 'hidden',
     verticalAlign: 'middle',
     flexShrink: 0,
-    color: `var(--_spinner-color, var(--spinner-color, ${colorVars['--color-accent']}))`,
+    color: `var(--spinner-color, var(--_spinner-color, ${colorVars['--color-accent']}))`,
     [BOX_SIZE]: `calc(var(${RESOLVED_DIAMETER}) + var(${RESOLVED_STROKE}) * 2)`,
   },
   ring: {
@@ -166,7 +166,7 @@ const styles = stylex.create({
     strokeDasharray: `calc(var(${RESOLVED_DIAMETER}) * ${ARC_DASH}) calc(var(${RESOLVED_DIAMETER}) * ${ARC_GAP})`,
   },
   track: {
-    stroke: `var(--_spinner-track-color, var(--spinner-track-color, ${colorVars['--color-track']}))`,
+    stroke: `var(--spinner-track-color, var(--_spinner-track-color, ${colorVars['--color-track']}))`,
     strokeOpacity: 'var(--_spinner-track-opacity, 1)',
   },
   disabled: {opacity: 0.5},
@@ -235,7 +235,7 @@ export function SpinnerIndicator({
       ref={ref}
       aria-hidden="true"
       {...mergeProps(
-        themeProps('spinner-indicator', {size}),
+        themeProps('spinner-indicator', {size}, {legacyNames: ['spinner']}),
         stylex.props(
           styles.root,
           resolvedSizeStyles[size],

--- a/packages/core/src/Indicator/SpinnerIndicator.tsx
+++ b/packages/core/src/Indicator/SpinnerIndicator.tsx
@@ -1,0 +1,217 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file SpinnerIndicator.tsx
+ * @input Indicator props of the `busy` family
+ * @output Exports SpinnerIndicator — the default busy visual
+ * @position Decorative loading ring rendered by every control with a busy
+ *           state, and by the public Spinner
+ *
+ * This is the indicator a product replaces to ship its own loading visual.
+ * `defineTheme({indicators: {spinner: PulsingLogo}})` changes what "working"
+ * looks like in a Button, a TextInput, a Switch, a Thumbnail and every other
+ * host at once, without any of them knowing it happened.
+ *
+ * It is DECORATIVE, like every other indicator: `aria-hidden`, no role, no
+ * accessible name. The host owns `aria-busy` and the announcement — see
+ * Spinner.tsx for the standalone case, which is the one place the role stays.
+ *
+ * It paints with `currentColor` rather than taking a shade prop. That is what
+ * lets a host say what colour "busy" is by setting `color` on the slot it
+ * renders into — the mechanism `Spinner`'s `shade="inherit"` already used, and
+ * the one CheckIndicator already uses for a Spinner in its children slot.
+ * A replacement inherits it for free.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {durationVars} from '../theme/tokens.stylex';
+import {mergeProps} from '../utils';
+import {themeProps} from '../utils/themeProps';
+import type {IndicatorProps, IndicatorSizeOf} from './types';
+
+/**
+ * Fraction of the ring the moving arc covers. The canvas ring this replaces
+ * swept 135deg, not the 270deg its constant's comment claimed.
+ */
+const ARC_FRACTION = 0.375;
+
+const SIZES: Record<
+  IndicatorSizeOf<'busy'>,
+  {diameter: number; border: number}
+> = {
+  sm: {diameter: 10, border: 2},
+  md: {diameter: 14, border: 3},
+  lg: {diameter: 18, border: 3},
+  xl: {diameter: 28, border: 4},
+};
+
+/**
+ * Pin every ring's rotation to the document timeline's origin instead of its
+ * own start time, so spinners mounted seconds apart turn in phase.
+ *
+ * Setting `startTime` is exact where arithmetic on a clock read is not: a
+ * negative `animation-delay` computed at mount is only as good as the gap
+ * between reading the clock and the frame the animation starts in, which at
+ * 10x CPU throttling measured 116deg of drift.
+ *
+ * Rings are collected and pinned in one frame because `getAnimations()`
+ * resolves style and `startTime` dirties it again, so pinning them one at a
+ * time makes each mount re-force what the previous one invalidated — 53 style
+ * recalcs for 38 spinners against 19 batched.
+ */
+const pendingRings = new Set<SVGSVGElement>();
+let flushScheduled = false;
+
+function pinRingsToTimelineOrigin(): void {
+  flushScheduled = false;
+  const animations: Animation[] = [];
+  for (const svg of pendingRings) {
+    animations.push(...svg.getAnimations());
+  }
+  pendingRings.clear();
+  for (const animation of animations) {
+    animation.startTime = 0;
+  }
+}
+
+function syncRotationPhase(
+  svg: SVGSVGElement | null,
+): (() => void) | undefined {
+  // jsdom implements no Web Animations, and this runs in every consumer's
+  // component tests.
+  if (svg == null || typeof svg.getAnimations !== 'function') {
+    return undefined;
+  }
+  pendingRings.add(svg);
+  if (!flushScheduled) {
+    flushScheduled = true;
+    requestAnimationFrame(pinRingsToTimelineOrigin);
+  }
+  return () => {
+    pendingRings.delete(svg);
+  };
+}
+
+const rotation = stylex.keyframes({
+  '0%': {transform: 'rotate(0deg)'},
+  '100%': {transform: 'rotate(360deg)'},
+});
+
+const styles = stylex.create({
+  root: {
+    display: 'inline-grid',
+    placeItems: 'center',
+    overflow: 'hidden',
+    verticalAlign: 'middle',
+    flexShrink: 0,
+  },
+  ring: {
+    backfaceVisibility: 'hidden',
+    display: 'block',
+    willChange: 'transform',
+    // Slow the rotation dramatically under reduced-motion rather than freezing
+    // it (a frozen spinner reads as broken), matching ProgressBar's approach.
+    animationDuration: {
+      default: durationVars['--duration-slow-min'],
+      '@media (prefers-reduced-motion: reduce)': '3s',
+    },
+    animationIterationCount: 'infinite',
+    animationName: rotation,
+    animationTimingFunction: 'linear',
+  },
+  circle: {
+    fill: 'none',
+    strokeLinecap: 'round',
+  },
+  arc: {stroke: 'currentColor'},
+  // The host (or the Spinner wrapper) sets these to paint a track that is not
+  // simply a faded foreground; unset, the ring draws its own colour at 30%.
+  track: {
+    stroke: 'var(--_spinner-track-color, currentColor)',
+    strokeOpacity: 'var(--_spinner-track-opacity, 0.3)',
+  },
+  disabled: {opacity: 0.5},
+});
+
+/**
+ * The default busy visual: a rotating arc over a faint track.
+ *
+ * Decorative and non-interactive — `aria-hidden`, no role, no accessible name.
+ * The control that renders it owns `aria-busy` and whatever it announces.
+ *
+ * @example
+ * ```
+ * const Busy = useIndicator('spinner');
+ * <Busy size="sm" />
+ * ```
+ *
+ * Replace the loading visual everywhere at once:
+ *
+ * @example
+ * ```
+ * defineTheme({name: 'brand', indicators: {spinner: BouncingDots}});
+ * ```
+ */
+export function SpinnerIndicator({
+  size = 'md',
+  isDisabled = false,
+  children,
+  ref,
+  className,
+  style,
+  xstyle,
+  ...rest
+}: IndicatorProps<'busy'>) {
+  const {border, diameter} = SIZES[size];
+  const frameSize = diameter + border * 2;
+  const center = frameSize / 2;
+  const circumference = Math.PI * diameter;
+  const arcLength = circumference * ARC_FRACTION;
+
+  return (
+    <span
+      // `{...rest}` first, own contract after — TypeScript cannot reject a
+      // hyphenated JSX attribute (see IndicatorProps), so attribute order is
+      // what keeps a caller from un-hiding a decorative element.
+      {...rest}
+      ref={ref}
+      aria-hidden="true"
+      {...mergeProps(
+        themeProps('spinner-indicator', {size}),
+        stylex.props(styles.root, isDisabled && styles.disabled, xstyle),
+        className,
+        {...style, width: frameSize, height: frameSize},
+      )}>
+      {children ?? (
+        <svg
+          ref={syncRotationPhase}
+          width={frameSize}
+          height={frameSize}
+          viewBox={`0 0 ${frameSize} ${frameSize}`}
+          aria-hidden="true"
+          {...stylex.props(styles.ring)}>
+          <circle
+            cx={center}
+            cy={center}
+            r={diameter / 2}
+            strokeWidth={border}
+            {...stylex.props(styles.circle, styles.track)}
+          />
+          <circle
+            cx={center}
+            cy={center}
+            r={diameter / 2}
+            strokeWidth={border}
+            strokeDasharray={`${arcLength} ${circumference - arcLength}`}
+            transform={`rotate(-90 ${center} ${center})`}
+            {...stylex.props(styles.circle, styles.arc)}
+          />
+        </svg>
+      )}
+    </span>
+  );
+}
+
+SpinnerIndicator.displayName = 'SpinnerIndicator';

--- a/packages/core/src/Indicator/SpinnerIndicator.tsx
+++ b/packages/core/src/Indicator/SpinnerIndicator.tsx
@@ -18,15 +18,16 @@
  * accessible name. The host owns `aria-busy` and the announcement — see
  * Spinner.tsx for the standalone case, which is the one place the role stays.
  *
- * It paints with `currentColor` rather than taking a shade prop. That is what
- * lets a host say what colour "busy" is by setting `color` on the slot it
- * renders into — the mechanism `Spinner`'s `shade="inherit"` already used, and
- * the one CheckIndicator already uses for a Spinner in its children slot.
- * A replacement inherits it for free.
+ * It has no `shade` prop, and the omission is deliberate: the four shades were
+ * four ways of saying which colour the ring paints in, which is what `color`
+ * already says. A host sets `--_spinner-color` (and, if its track is not the
+ * default rail, the two track vars); the indicator turns that into its own
+ * `color`, so a REPLACEMENT written the obvious way — `stroke: currentColor` —
+ * honours the host's shade without knowing shades exist.
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {durationVars} from '../theme/tokens.stylex';
+import {colorVars, durationVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import type {IndicatorProps, IndicatorSizeOf} from './types';
@@ -106,6 +107,12 @@ const styles = stylex.create({
     overflow: 'hidden',
     verticalAlign: 'middle',
     flexShrink: 0,
+    // The one knob a host turns to say what colour "busy" is here. It sets
+    // `color`, not a stroke, so a REPLACEMENT painting in `currentColor` — the
+    // obvious way to write one — follows the same instruction without knowing
+    // the var exists. Unset, it resolves to the accent the ring has always
+    // drawn in.
+    color: `var(--_spinner-color, ${colorVars['--color-accent']})`,
   },
   ring: {
     backfaceVisibility: 'hidden',
@@ -126,11 +133,9 @@ const styles = stylex.create({
     strokeLinecap: 'round',
   },
   arc: {stroke: 'currentColor'},
-  // The host (or the Spinner wrapper) sets these to paint a track that is not
-  // simply a faded foreground; unset, the ring draws its own colour at 30%.
   track: {
-    stroke: 'var(--_spinner-track-color, currentColor)',
-    strokeOpacity: 'var(--_spinner-track-opacity, 0.3)',
+    stroke: `var(--_spinner-track-color, ${colorVars['--color-track']})`,
+    strokeOpacity: 'var(--_spinner-track-opacity, 1)',
   },
   disabled: {opacity: 0.5},
 });

--- a/packages/core/src/Indicator/SpinnerIndicator.tsx
+++ b/packages/core/src/Indicator/SpinnerIndicator.tsx
@@ -37,6 +37,9 @@ import type {IndicatorProps, IndicatorSizeOf} from './types';
  * swept 135deg, not the 270deg its constant's comment claimed.
  */
 const ARC_FRACTION = 0.375;
+const PI = 3.141592653589793;
+const ARC_DASH = PI * ARC_FRACTION;
+const ARC_GAP = PI * (1 - ARC_FRACTION);
 
 const SIZES: Record<
   IndicatorSizeOf<'busy'>,
@@ -47,6 +50,33 @@ const SIZES: Record<
   lg: {diameter: 18, border: 3},
   xl: {diameter: 28, border: 4},
 };
+
+const RESOLVED_DIAMETER = '--_spinner-ring-diameter';
+const RESOLVED_STROKE = '--_spinner-ring-stroke';
+const BOX_SIZE = '--_spinner-box-size';
+
+function registerSpinnerVars(): void {
+  if (
+    typeof CSS === 'undefined' ||
+    typeof CSS.registerProperty !== 'function'
+  ) {
+    return;
+  }
+  for (const name of [RESOLVED_DIAMETER, RESOLVED_STROKE]) {
+    try {
+      CSS.registerProperty({
+        name,
+        syntax: '<length>',
+        inherits: true,
+        initialValue: '0px',
+      });
+    } catch {
+      // A second package copy or fast refresh can register the same property.
+    }
+  }
+}
+
+registerSpinnerVars();
 
 /**
  * Pin every ring's rotation to the document timeline's origin instead of its
@@ -107,17 +137,14 @@ const styles = stylex.create({
     overflow: 'hidden',
     verticalAlign: 'middle',
     flexShrink: 0,
-    // The one knob a host turns to say what colour "busy" is here. It sets
-    // `color`, not a stroke, so a REPLACEMENT painting in `currentColor` — the
-    // obvious way to write one — follows the same instruction without knowing
-    // the var exists. Unset, it resolves to the accent the ring has always
-    // drawn in.
-    color: `var(--_spinner-color, ${colorVars['--color-accent']})`,
+    color: `var(--_spinner-color, var(--spinner-color, ${colorVars['--color-accent']}))`,
+    [BOX_SIZE]: `calc(var(${RESOLVED_DIAMETER}) + var(${RESOLVED_STROKE}) * 2)`,
   },
   ring: {
     backfaceVisibility: 'hidden',
     display: 'block',
     willChange: 'transform',
+    overflow: 'visible',
     // Slow the rotation dramatically under reduced-motion rather than freezing
     // it (a frozen spinner reads as broken), matching ProgressBar's approach.
     animationDuration: {
@@ -131,13 +158,37 @@ const styles = stylex.create({
   circle: {
     fill: 'none',
     strokeLinecap: 'round',
+    r: `calc(var(${RESOLVED_DIAMETER}) / 2)`,
+    strokeWidth: `var(${RESOLVED_STROKE})`,
   },
-  arc: {stroke: 'currentColor'},
+  arc: {
+    stroke: 'currentColor',
+    strokeDasharray: `calc(var(${RESOLVED_DIAMETER}) * ${ARC_DASH}) calc(var(${RESOLVED_DIAMETER}) * ${ARC_GAP})`,
+  },
   track: {
-    stroke: `var(--_spinner-track-color, ${colorVars['--color-track']})`,
+    stroke: `var(--_spinner-track-color, var(--spinner-track-color, ${colorVars['--color-track']}))`,
     strokeOpacity: 'var(--_spinner-track-opacity, 1)',
   },
   disabled: {opacity: 0.5},
+});
+
+const resolvedSizeStyles = stylex.create({
+  sm: {
+    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 10px)',
+    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 2px)',
+  },
+  md: {
+    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 14px)',
+    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 3px)',
+  },
+  lg: {
+    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 18px)',
+    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 3px)',
+  },
+  xl: {
+    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 28px)',
+    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 4px)',
+  },
 });
 
 /**
@@ -185,9 +236,18 @@ export function SpinnerIndicator({
       aria-hidden="true"
       {...mergeProps(
         themeProps('spinner-indicator', {size}),
-        stylex.props(styles.root, isDisabled && styles.disabled, xstyle),
+        stylex.props(
+          styles.root,
+          resolvedSizeStyles[size],
+          isDisabled && styles.disabled,
+          xstyle,
+        ),
         className,
-        {...style, width: frameSize, height: frameSize},
+        {
+          ...style,
+          width: `var(${BOX_SIZE}, ${frameSize}px)`,
+          height: `var(${BOX_SIZE}, ${frameSize}px)`,
+        },
       )}>
       {children ?? (
         <svg

--- a/packages/core/src/Indicator/SpinnerIndicator.tsx
+++ b/packages/core/src/Indicator/SpinnerIndicator.tsx
@@ -28,9 +28,13 @@
 
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, durationVars} from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {isRenderable, mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
-import type {IndicatorProps, IndicatorSizeOf} from './types';
+import {
+  SPINNER_SIZES,
+  resolvedSpinnerSizeStyles,
+} from '../Spinner/spinnerGeometry.stylex';
+import type {IndicatorProps} from './types';
 
 /**
  * Fraction of the ring the moving arc covers. The canvas ring this replaces
@@ -40,16 +44,6 @@ const ARC_FRACTION = 0.375;
 const PI = 3.141592653589793;
 const ARC_DASH = PI * ARC_FRACTION;
 const ARC_GAP = PI * (1 - ARC_FRACTION);
-
-const SIZES: Record<
-  IndicatorSizeOf<'busy'>,
-  {diameter: number; border: number}
-> = {
-  sm: {diameter: 10, border: 2},
-  md: {diameter: 14, border: 3},
-  lg: {diameter: 18, border: 3},
-  xl: {diameter: 28, border: 4},
-};
 
 const RESOLVED_DIAMETER = '--_spinner-ring-diameter';
 const RESOLVED_STROKE = '--_spinner-ring-stroke';
@@ -134,7 +128,6 @@ const styles = stylex.create({
   root: {
     display: 'inline-grid',
     placeItems: 'center',
-    overflow: 'hidden',
     verticalAlign: 'middle',
     flexShrink: 0,
     color: `var(--_spinner-color, var(--spinner-color, ${colorVars['--color-accent']}))`,
@@ -143,6 +136,8 @@ const styles = stylex.create({
   ring: {
     backfaceVisibility: 'hidden',
     display: 'block',
+    width: `var(${BOX_SIZE})`,
+    height: `var(${BOX_SIZE})`,
     willChange: 'transform',
     overflow: 'visible',
     // Slow the rotation dramatically under reduced-motion rather than freezing
@@ -157,12 +152,15 @@ const styles = stylex.create({
   },
   circle: {
     fill: 'none',
+    transformBox: 'fill-box',
+    transformOrigin: 'center',
     strokeLinecap: 'round',
     r: `calc(var(${RESOLVED_DIAMETER}) / 2)`,
     strokeWidth: `var(${RESOLVED_STROKE})`,
   },
   arc: {
     stroke: 'var(--spinner-color, currentColor)',
+    transform: 'rotate(-90deg)',
     strokeDasharray: `calc(var(${RESOLVED_DIAMETER}) * ${ARC_DASH}) calc(var(${RESOLVED_DIAMETER}) * ${ARC_GAP})`,
   },
   track: {
@@ -170,25 +168,6 @@ const styles = stylex.create({
     strokeOpacity: 'var(--_spinner-track-opacity, 1)',
   },
   disabled: {opacity: 0.5},
-});
-
-const resolvedSizeStyles = stylex.create({
-  sm: {
-    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 10px)',
-    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 2px)',
-  },
-  md: {
-    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 14px)',
-    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 3px)',
-  },
-  lg: {
-    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 18px)',
-    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 3px)',
-  },
-  xl: {
-    [RESOLVED_DIAMETER]: 'var(--spinner-diameter, 28px)',
-    [RESOLVED_STROKE]: 'var(--spinner-stroke-width, 4px)',
-  },
 });
 
 /**
@@ -210,7 +189,11 @@ const resolvedSizeStyles = stylex.create({
  * defineTheme({name: 'brand', indicators: {spinner: BouncingDots}});
  * ```
  */
-export function SpinnerIndicator({
+type SpinnerIndicatorVisualProps = IndicatorProps<'busy'> & {
+  hasLegacyTarget: boolean;
+};
+
+function SpinnerIndicatorVisual({
   size = 'md',
   isDisabled = false,
   children,
@@ -218,11 +201,11 @@ export function SpinnerIndicator({
   className,
   style,
   xstyle,
+  hasLegacyTarget,
   ...rest
-}: IndicatorProps<'busy'>) {
-  const {border, diameter} = SIZES[size];
+}: SpinnerIndicatorVisualProps) {
+  const {border, diameter} = SPINNER_SIZES[size];
   const frameSize = diameter + border * 2;
-  const center = frameSize / 2;
   const circumference = Math.PI * diameter;
   const arcLength = circumference * ARC_FRACTION;
 
@@ -235,10 +218,14 @@ export function SpinnerIndicator({
       ref={ref}
       aria-hidden="true"
       {...mergeProps(
-        themeProps('spinner-indicator', {size}, {legacyNames: ['spinner']}),
+        themeProps(
+          'spinner-indicator',
+          {size},
+          hasLegacyTarget ? {legacyNames: ['spinner']} : undefined,
+        ),
         stylex.props(
           styles.root,
-          resolvedSizeStyles[size],
+          resolvedSpinnerSizeStyles[size],
           isDisabled && styles.disabled,
           xstyle,
         ),
@@ -249,34 +236,45 @@ export function SpinnerIndicator({
           height: `var(${BOX_SIZE}, ${frameSize}px)`,
         },
       )}>
-      {children ?? (
+      {isRenderable(children) ? (
+        children
+      ) : (
         <svg
           ref={syncRotationPhase}
           width={frameSize}
           height={frameSize}
-          viewBox={`0 0 ${frameSize} ${frameSize}`}
           aria-hidden="true"
           {...stylex.props(styles.ring)}>
           <circle
-            cx={center}
-            cy={center}
+            cx="50%"
+            cy="50%"
             r={diameter / 2}
             strokeWidth={border}
             {...stylex.props(styles.circle, styles.track)}
           />
           <circle
-            cx={center}
-            cy={center}
+            cx="50%"
+            cy="50%"
             r={diameter / 2}
             strokeWidth={border}
             strokeDasharray={`${arcLength} ${circumference - arcLength}`}
-            transform={`rotate(-90 ${center} ${center})`}
             {...stylex.props(styles.circle, styles.arc)}
           />
         </svg>
       )}
     </span>
   );
+}
+
+export function SpinnerIndicator(props: IndicatorProps<'busy'>) {
+  return <SpinnerIndicatorVisual {...props} hasLegacyTarget />;
+}
+
+/** Internal standalone-Spinner path: the wrapper already owns the legacy target. */
+export function SpinnerIndicatorWithoutLegacyTarget(
+  props: IndicatorProps<'busy'>,
+) {
+  return <SpinnerIndicatorVisual {...props} hasLegacyTarget={false} />;
 }
 
 SpinnerIndicator.displayName = 'SpinnerIndicator';

--- a/packages/core/src/Indicator/index.ts
+++ b/packages/core/src/Indicator/index.ts
@@ -16,6 +16,7 @@
  * `check` and every single-selection mark in the app follows.
  */
 
+export {BusyIndicator} from './BusyIndicator';
 export {CheckboxIndicator} from './CheckboxIndicator';
 export {CheckIndicator} from './CheckIndicator';
 export {RadioIndicator} from './RadioIndicator';

--- a/packages/core/src/Indicator/index.ts
+++ b/packages/core/src/Indicator/index.ts
@@ -19,6 +19,7 @@
 export {CheckboxIndicator} from './CheckboxIndicator';
 export {CheckIndicator} from './CheckIndicator';
 export {RadioIndicator} from './RadioIndicator';
+export {SpinnerIndicator} from './SpinnerIndicator';
 
 // Registry (RSC-compatible, no 'use client')
 export {defaultIndicators, getIndicator} from './indicatorRegistry';
@@ -35,12 +36,15 @@ export type {
   IndicatorComponent,
   IndicatorFamily,
   IndicatorFamilyMap,
+  IndicatorFamilySizeMap,
   IndicatorMap,
   IndicatorName,
   IndicatorNameOfFamily,
   IndicatorPosition,
+  IndicatorCommonProps,
   IndicatorProps,
   IndicatorRegistry,
   IndicatorSize,
+  IndicatorSizeOf,
   IndicatorState,
 } from './types';

--- a/packages/core/src/Indicator/index.ts
+++ b/packages/core/src/Indicator/index.ts
@@ -37,7 +37,6 @@ export type {
   IndicatorComponent,
   IndicatorFamily,
   IndicatorFamilyMap,
-  IndicatorFamilySizeMap,
   IndicatorMap,
   IndicatorName,
   IndicatorNameOfFamily,

--- a/packages/core/src/Indicator/indicatorRegistry.test.tsx
+++ b/packages/core/src/Indicator/indicatorRegistry.test.tsx
@@ -57,6 +57,17 @@ describe('defaultIndicators', () => {
   });
 });
 
+describe('SpinnerIndicator', () => {
+  it('keeps the existing spinner target during the migration', () => {
+    const {container} = render(<SpinnerIndicator size="sm" />);
+    expect(container.firstChild).toHaveClass(
+      'astryx-spinner-indicator',
+      'astryx-spinner',
+      'sm',
+    );
+  });
+});
+
 describe('getIndicator', () => {
   it('resolves a core name to its built-in with no theme', () => {
     expect(getIndicator('check')).toBe(CheckIndicator);

--- a/packages/core/src/Indicator/indicatorRegistry.test.tsx
+++ b/packages/core/src/Indicator/indicatorRegistry.test.tsx
@@ -20,6 +20,7 @@ import {defineTheme} from '../theme/defineTheme';
 import {CheckboxIndicator} from './CheckboxIndicator';
 import {CheckIndicator} from './CheckIndicator';
 import {RadioIndicator} from './RadioIndicator';
+import {SpinnerIndicator} from './SpinnerIndicator';
 import {defaultIndicators, getIndicator} from './indicatorRegistry';
 import type {CoreIndicatorName} from './indicatorRegistry';
 import type {IndicatorName, IndicatorProps} from './types';
@@ -43,6 +44,7 @@ describe('defaultIndicators', () => {
       check: true,
       checkbox: true,
       radio: true,
+      spinner: true,
     };
 
     expect(Object.keys(defaultIndicators).sort()).toEqual(
@@ -51,6 +53,7 @@ describe('defaultIndicators', () => {
     expect(defaultIndicators.check).toBe(CheckIndicator);
     expect(defaultIndicators.checkbox).toBe(CheckboxIndicator);
     expect(defaultIndicators.radio).toBe(RadioIndicator);
+    expect(defaultIndicators.spinner).toBe(SpinnerIndicator);
   });
 });
 

--- a/packages/core/src/Indicator/indicatorRegistry.test.tsx
+++ b/packages/core/src/Indicator/indicatorRegistry.test.tsx
@@ -26,8 +26,12 @@ import type {CoreIndicatorName} from './indicatorRegistry';
 import type {IndicatorName, IndicatorProps} from './types';
 
 declare module './types' {
+  interface IndicatorFamilyMap {
+    brandState: 'off' | 'on';
+  }
   interface IndicatorMap {
     'brand-star': 'singleSelection';
+    'brand-state': 'brandState';
   }
 }
 
@@ -66,9 +70,25 @@ describe('SpinnerIndicator', () => {
       'sm',
     );
   });
+
+  it('keeps the default ring for false children', () => {
+    const {container} = render(
+      <SpinnerIndicator size="sm">{false}</SpinnerIndicator>,
+    );
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
 });
 
 describe('getIndicator', () => {
+  it('keeps augmented families on the existing size contract', () => {
+    const valid: IndicatorProps<'brandState'> = {state: 'on', size: 'md'};
+    // @ts-expect-error — only the core busy family adds standalone sizes.
+    const invalid: IndicatorProps<'brandState'> = {state: 'on', size: 'lg'};
+
+    expect(valid.size).toBe('md');
+    expect(invalid.size).toBe('lg');
+  });
+
   it('resolves a core name to its built-in with no theme', () => {
     expect(getIndicator('check')).toBe(CheckIndicator);
     expect(getIndicator('radio')).toBe(RadioIndicator);

--- a/packages/core/src/Indicator/indicatorRegistry.ts
+++ b/packages/core/src/Indicator/indicatorRegistry.ts
@@ -29,6 +29,7 @@ import {getRegisteredTheme} from '../theme/themeRegistry';
 import {CheckboxIndicator} from './CheckboxIndicator';
 import {CheckIndicator} from './CheckIndicator';
 import {RadioIndicator} from './RadioIndicator';
+import {SpinnerIndicator} from './SpinnerIndicator';
 import type {
   IndicatorComponent,
   IndicatorMap,
@@ -44,7 +45,7 @@ import type {
  * in {@link defaultIndicators} below. `indicatorRegistry.test.tsx` pins the two
  * together in both directions.
  */
-export type CoreIndicatorName = 'check' | 'checkbox' | 'radio';
+export type CoreIndicatorName = 'check' | 'checkbox' | 'radio' | 'spinner';
 
 /**
  * The indicators Astryx ships. A theme's `indicators` entries override these
@@ -60,6 +61,7 @@ export const defaultIndicators: {
   check: CheckIndicator,
   checkbox: CheckboxIndicator,
   radio: RadioIndicator,
+  spinner: SpinnerIndicator,
 };
 
 export type IndicatorRegistrySource = DefinedTheme | string | null | undefined;

--- a/packages/core/src/Indicator/types.ts
+++ b/packages/core/src/Indicator/types.ts
@@ -47,15 +47,36 @@ import type {BaseProps} from '../BaseProps';
  * two states are ever passed, and a radio cannot be asked to draw a partial
  * state it has no picture for.
  *
- * Adding a family is additive: declare it here, then declare indicators of
- * that family in {@link IndicatorMap}. Packages outside core can contribute
- * families through module augmentation.
+ * Adding a family is additive *when the family has states*: declare it here,
+ * then declare indicators of that family in {@link IndicatorMap}. Packages
+ * outside core can contribute families through module augmentation.
+ *
+ * A family with NO states is not additive, and `busy` is the case that found
+ * it. `state` was declared unconditionally required, so an empty state space
+ * (`never`) makes every call site unsatisfiable and a single-member filler
+ * state (`'busy'`) makes every call site write a word that carries nothing.
+ * Admitting one costs a change to {@link IndicatorProps}: `state` and `size`
+ * are now derived from the family rather than fixed, so a family declares the
+ * domain of each prop instead of only the state enum. Existing families
+ * resolve to exactly the props they had, which is why nothing downstream of
+ * them changed.
  */
 export interface IndicatorFamilyMap {
   /** Is this one thing chosen? Radios, and the mark on a selected option. */
   singleSelection: 'unchecked' | 'checked';
   /** Which of these are chosen? Checkboxes, including the partial state. */
   multiSelection: 'unchecked' | 'checked' | 'indeterminate';
+  /**
+   * Is work in flight? Spinners, and any branded loading visual standing in
+   * for one.
+   *
+   * The state space is EMPTY, and that is the point: a busy visual is either
+   * rendered or it is not, so there is no state for a host to pass and none
+   * for a replacement to draw. `never` says so in the type system — see
+   * {@link IndicatorProps}, where an empty state space removes the `state`
+   * prop instead of demanding an inhabitant of an uninhabitable type.
+   */
+  busy: never;
 }
 
 export type IndicatorFamily = keyof IndicatorFamilyMap & string;
@@ -66,6 +87,31 @@ export type IndicatorState<F extends IndicatorFamily = IndicatorFamily> =
 
 /** Indicator size scale — matches the control sizes of the owning inputs. */
 export type IndicatorSize = 'sm' | 'md';
+
+/**
+ * The size scale each family draws at.
+ *
+ * A family fixes the size space for the same reason it fixes the state space:
+ * the scale belongs to what the indicator IS, not to the mechanism. Selection
+ * marks sit inside a control and take the control's two sizes. A busy visual
+ * also stands alone — a page-level spinner is not sized by any control — so
+ * its family keeps the four sizes `Spinner` has always shipped.
+ *
+ * Every host that renders a busy indicator inside a control passes `sm` or
+ * `md`; `lg` and `xl` only ever appear on a standalone `<Spinner>`. So the two
+ * extra sizes cost the control hosts nothing, and a replacement that only
+ * draws `sm`/`md` is still a valid selection-mark replacement — the widening
+ * is confined to the family that asked for it.
+ */
+export interface IndicatorFamilySizeMap {
+  singleSelection: IndicatorSize;
+  multiSelection: IndicatorSize;
+  busy: IndicatorSize | 'lg' | 'xl';
+}
+
+/** The sizes an indicator of family `F` can be asked to draw at. */
+export type IndicatorSizeOf<F extends IndicatorFamily = IndicatorFamily> =
+  IndicatorFamilySizeMap[F];
 
 /**
  * Which edge of its row an indicator sits on.
@@ -79,12 +125,15 @@ export type IndicatorSize = 'sm' | 'md';
 export type IndicatorPosition = 'start' | 'end';
 
 /**
- * Props every indicator accepts.
+ * The props every indicator accepts, whatever its family. {@link IndicatorProps}
+ * adds the two the family parameterizes.
  *
  * Indicators are **decorative**: they render `aria-hidden` visuals and own no
  * role, focus, keyboard handling, or state. The component that renders one
- * (CheckboxInput, RadioListItem, a listbox option) keeps all of that. An
- * indicator's only job is to turn `state` into a picture.
+ * (CheckboxInput, RadioListItem, a listbox option, a loading Button) keeps all
+ * of that. An indicator's only job is to turn a piece of the host's state into
+ * a picture — for a busy indicator, the fact that it is rendered at all is
+ * that piece.
  *
  * The a11y props are omitted from this interface rather than left to
  * convention: un-hiding an indicator has it announced next to the control that
@@ -112,21 +161,12 @@ export type IndicatorPosition = 'start' | 'end';
  * boolean through React — and an owner that should not tint its indicator
  * simply does not apply the marker.
  */
-export interface IndicatorProps<
-  F extends IndicatorFamily = IndicatorFamily,
-> extends Omit<
+export interface IndicatorCommonProps extends Omit<
   BaseProps<HTMLSpanElement>,
   'aria-hidden' | 'role' | 'aria-label' | 'aria-labelledby' | 'tabIndex'
 > {
   /** Ref forwarded to the indicator's root element. */
   ref?: Ref<HTMLSpanElement>;
-  /** Which state to draw. The state space is fixed by the family. */
-  state: IndicatorState<F>;
-  /**
-   * Control size.
-   * @default 'md'
-   */
-  size?: IndicatorSize;
   /**
    * Whether the owning control is disabled. Purely visual — the owner still
    * owns the actual disabled semantics.
@@ -140,6 +180,39 @@ export interface IndicatorProps<
    */
   children?: ReactNode;
 }
+
+/**
+ * The `state` prop, present only for families that have states to draw.
+ *
+ * A family with an empty state space (`busy`) gets `state?: never`, which
+ * accepts a host that passes nothing and rejects a host that passes anything.
+ * Declaring `state: never` instead — the shape that falls out of the original
+ * definition — would make EVERY call site an error, because `never` has no
+ * inhabitant to pass.
+ *
+ * `[T] extends [never]` rather than `T extends never`: a bare conditional
+ * distributes over a naked type parameter, and distributing over `never`
+ * yields `never` for the whole conditional rather than taking the true branch.
+ */
+type IndicatorStateProp<F extends IndicatorFamily> = [
+  IndicatorState<F>,
+] extends [never]
+  ? {state?: never}
+  : {state: IndicatorState<F>};
+
+/**
+ * What an indicator of family `F` is rendered with: the common props, plus the
+ * two the family fixes the domain of — `state` and `size`.
+ */
+export type IndicatorProps<F extends IndicatorFamily = IndicatorFamily> =
+  IndicatorCommonProps &
+    IndicatorStateProp<F> & {
+      /**
+       * Control size. The scale is fixed by the family.
+       * @default 'md'
+       */
+      size?: IndicatorSizeOf<F>;
+    };
 
 /** An indicator is any component accepting {@link IndicatorProps} of its family. */
 export type IndicatorComponent<F extends IndicatorFamily = IndicatorFamily> =
@@ -174,6 +247,12 @@ export interface IndicatorMap {
   radio: 'singleSelection';
   /** The box of a checkbox control, including its partial state. */
   checkbox: 'multiSelection';
+  /**
+   * The visual for work in flight — a rotating ring by default, and the one
+   * name that reaches every loading affordance in the system at once: Button,
+   * the text and date inputs, Switch, Thumbnail, the selectors, the chat rows.
+   */
+  spinner: 'busy';
 }
 
 export type IndicatorName = keyof IndicatorMap & string;

--- a/packages/core/src/Indicator/types.ts
+++ b/packages/core/src/Indicator/types.ts
@@ -47,19 +47,19 @@ import type {BaseProps} from '../BaseProps';
  * two states are ever passed, and a radio cannot be asked to draw a partial
  * state it has no picture for.
  *
- * Adding a family is additive *when the family has states*: declare it here,
- * then declare indicators of that family in {@link IndicatorMap}. Packages
- * outside core can contribute families through module augmentation.
+ * Adding a family is additive: declare its state space here, then declare
+ * indicators of that family in {@link IndicatorMap}. Packages outside core can
+ * contribute families through module augmentation. Every added family keeps the
+ * established `sm | md` indicator size scale; the core `busy` family is the one
+ * exception because standalone Spinner already ships `lg` and `xl`.
  *
  * A family with NO states is not additive, and `busy` is the case that found
  * it. `state` was declared unconditionally required, so an empty state space
  * (`never`) makes every call site unsatisfiable and a single-member filler
  * state (`'busy'`) makes every call site write a word that carries nothing.
- * Admitting one costs a change to {@link IndicatorProps}: `state` and `size`
- * are now derived from the family rather than fixed, so a family declares the
- * domain of each prop instead of only the state enum. Existing families
- * resolve to exactly the props they had, which is why nothing downstream of
- * them changed.
+ * Admitting one costs a change to {@link IndicatorProps}: `state` is derived
+ * from the family rather than fixed. Existing and augmented families resolve
+ * to exactly the props they had, which is why nothing downstream changes.
  */
 export interface IndicatorFamilyMap {
   /** Is this one thing chosen? Radios, and the mark on a selected option. */
@@ -89,29 +89,13 @@ export type IndicatorState<F extends IndicatorFamily = IndicatorFamily> =
 export type IndicatorSize = 'sm' | 'md';
 
 /**
- * The size scale each family draws at.
+ * The sizes an indicator of family `F` can be asked to draw at.
  *
- * A family fixes the size space for the same reason it fixes the state space:
- * the scale belongs to what the indicator IS, not to the mechanism. Selection
- * marks sit inside a control and take the control's two sizes. A busy visual
- * also stands alone — a page-level spinner is not sized by any control — so
- * its family keeps the four sizes `Spinner` has always shipped.
- *
- * Every host that renders a busy indicator inside a control passes `sm` or
- * `md`; `lg` and `xl` only ever appear on a standalone `<Spinner>`. So the two
- * extra sizes cost the control hosts nothing, and a replacement that only
- * draws `sm`/`md` is still a valid selection-mark replacement — the widening
- * is confined to the family that asked for it.
+ * Existing and augmented families retain the established control scale. Busy
+ * alone widens it because the standalone Spinner already exposes `lg` and `xl`.
  */
-export interface IndicatorFamilySizeMap {
-  singleSelection: IndicatorSize;
-  multiSelection: IndicatorSize;
-  busy: IndicatorSize | 'lg' | 'xl';
-}
-
-/** The sizes an indicator of family `F` can be asked to draw at. */
 export type IndicatorSizeOf<F extends IndicatorFamily = IndicatorFamily> =
-  IndicatorFamilySizeMap[F];
+  F extends 'busy' ? IndicatorSize | 'lg' | 'xl' : IndicatorSize;
 
 /**
  * Which edge of its row an indicator sits on.

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1408,7 +1408,7 @@ describe('MultiSelector', () => {
       />,
     );
     expect(screen.getByRole('combobox')).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByRole('status', {name: 'Loading'})).toBeInTheDocument();
+    expect(document.querySelector('.astryx-spinner-indicator')).not.toBeNull();
   });
 
   it('renders with custom selectAllLabel', async () => {
@@ -2005,7 +2005,9 @@ describe('MultiSelector', () => {
 
       const trigger = screen.getByRole('combobox', {name: 'Fruit'});
       expect(trigger).toHaveAttribute('aria-busy', 'true');
-      expect(screen.getByRole('status', {name: 'Loading'})).toBeInTheDocument();
+      expect(
+        document.querySelector('.astryx-spinner-indicator'),
+      ).not.toBeNull();
 
       await user.click(trigger);
       expect(screen.queryByRole('listbox', h)).not.toBeInTheDocument();

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -41,7 +41,7 @@ import {
 import {useKeepLayerOpenProps} from '../Layer/useLayer';
 import {InternalInputClearButton} from '../Field/InputClearButton';
 import {Divider} from '../Divider';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {PanelSearchInput} from '../Field/PanelSearchInput';
 import {CheckboxInput} from '../CheckboxInput';
 import type {IndicatorPosition} from '../Indicator';
@@ -1855,7 +1855,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               disabled={isDisabled}
             />
           ))}
-        {isBusy && <Spinner size="sm" />}
+        {isBusy && <BusyIndicator size="sm" />}
         {hasClear &&
           value.length > 0 &&
           !isDisabled &&

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1169,7 +1169,9 @@ describe('Selector', () => {
       );
       const trigger = screen.getByRole('combobox', {name: 'Fruit'});
       expect(trigger).toHaveAttribute('aria-busy', 'true');
-      expect(screen.getByRole('status', {name: 'Loading'})).toBeInTheDocument();
+      expect(
+        document.querySelector('.astryx-spinner-indicator'),
+      ).not.toBeNull();
 
       await user.click(trigger);
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
@@ -2571,7 +2573,9 @@ describe('Selector', () => {
 
       const trigger = screen.getByRole('combobox', {name: 'Fruit'});
       expect(trigger).toHaveAttribute('aria-busy', 'true');
-      expect(screen.getByRole('status', {name: 'Loading'})).toBeInTheDocument();
+      expect(
+        document.querySelector('.astryx-spinner-indicator'),
+      ).not.toBeNull();
 
       await user.click(trigger);
       expect(screen.queryByRole('listbox', h)).not.toBeInTheDocument();

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -45,7 +45,7 @@ import {Divider} from '../Divider';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {useKeepLayerOpenProps, type LayerPlacement} from '../Layer/useLayer';
 import {InternalInputClearButton} from '../Field/InputClearButton';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {PanelSearchInput} from '../Field/PanelSearchInput';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {
@@ -1822,7 +1822,7 @@ export function Selector<T extends SelectorOptionType>(
             disabled={isDisabled}
           />
         )}
-        {isBusy && <Spinner size="sm" />}
+        {isBusy && <BusyIndicator size="sm" />}
         {hasClear && value != null && !isDisabled && !isEffectivelyReadOnly && (
           <InternalInputClearButton
             {...keepOpenProps}

--- a/packages/core/src/Spinner/Spinner.test.tsx
+++ b/packages/core/src/Spinner/Spinner.test.tsx
@@ -12,16 +12,12 @@
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Spinner} from './Spinner';
+import {SPINNER_SIZES} from './spinnerGeometry.stylex';
 import {defineTheme} from '../theme/defineTheme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
 
 /** sm/md/lg/xl, as Spinner.tsx defines them. */
-const SIZES = {
-  sm: {diameter: 10, border: 2},
-  md: {diameter: 14, border: 3},
-  lg: {diameter: 18, border: 3},
-  xl: {diameter: 28, border: 4},
-} as const;
+const SIZES = SPINNER_SIZES;
 
 const ring = (testId = 'spinner') =>
   screen.getByTestId(testId).querySelector('svg') as SVGSVGElement;
@@ -141,6 +137,11 @@ describe('Spinner', () => {
     render(<Spinner data-testid="spinner" />);
     const spinner = screen.getByTestId('spinner');
     expect(spinner.tagName.toLowerCase()).toBe('span');
+  });
+
+  it('applies the released spinner target once', () => {
+    const {container} = render(<Spinner data-testid="spinner" />);
+    expect(container.querySelectorAll('.astryx-spinner')).toHaveLength(1);
   });
 
   // The box has always been sized by an inline width/height written after the

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -40,6 +40,17 @@ import {Text} from '../Text/Text';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 
+const SIZES = {
+  sm: {diameter: 10, border: 2},
+  md: {diameter: 14, border: 3},
+  lg: {diameter: 18, border: 3},
+  xl: {diameter: 28, border: 4},
+};
+
+const RESOLVED_DIAMETER = '--_spinner-ring-diameter';
+const RESOLVED_STROKE = '--_spinner-ring-stroke';
+const BOX_SIZE = '--_spinner-box-size';
+
 const styles = stylex.create({
   wrapper: {
     display: 'inline-flex',
@@ -48,32 +59,66 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
   },
   status: {
-    display: 'inline-flex',
+    display: 'inline-grid',
+    placeItems: 'center',
+    overflow: 'hidden',
+    verticalAlign: 'middle',
+    [RESOLVED_DIAMETER]: 'var(--spinner-diameter)',
+    [RESOLVED_STROKE]: 'var(--spinner-stroke-width)',
+    [BOX_SIZE]: `calc(var(${RESOLVED_DIAMETER}) + var(${RESOLVED_STROKE}) * 2)`,
   },
 });
 
-/**
- * A shade sets the vars the indicator reads, rather than painting anything
- * itself: the indicator turns `--_spinner-color` into its own `color`, so a
- * branded replacement drawing in `currentColor` honours `shade` without
- * knowing the prop exists. `default` sets nothing — it IS the indicator's
- * unset appearance.
- *
- * `onMedia` keeps the 77/255 its token's `4D` hex suffix used to encode.
- */
+const sizeStyles = stylex.create({
+  sm: {
+    '--spinner-diameter': `${SIZES.sm.diameter}px`,
+    '--spinner-stroke-width': `${SIZES.sm.border}px`,
+  },
+  md: {
+    '--spinner-diameter': `${SIZES.md.diameter}px`,
+    '--spinner-stroke-width': `${SIZES.md.border}px`,
+  },
+  lg: {
+    '--spinner-diameter': `${SIZES.lg.diameter}px`,
+    '--spinner-stroke-width': `${SIZES.lg.border}px`,
+  },
+  xl: {
+    '--spinner-diameter': `${SIZES.xl.diameter}px`,
+    '--spinner-stroke-width': `${SIZES.xl.border}px`,
+  },
+});
+
 const shadeStyles = stylex.create({
-  default: {},
+  default: {
+    color: 'var(--spinner-color)',
+    '--spinner-color': colorVars['--color-accent'],
+    '--spinner-track-color': colorVars['--color-track'],
+    '--_spinner-color': 'var(--spinner-color)',
+    '--_spinner-track-color': 'var(--spinner-track-color)',
+    '--_spinner-track-opacity': '1',
+  },
   subtle: {
-    '--_spinner-color': colorVars['--color-text-secondary'],
+    color: 'var(--spinner-color)',
+    '--spinner-color': colorVars['--color-text-secondary'],
+    '--spinner-track-color': colorVars['--color-track'],
+    '--_spinner-color': 'var(--spinner-color)',
+    '--_spinner-track-color': 'var(--spinner-track-color)',
+    '--_spinner-track-opacity': '1',
   },
   onMedia: {
-    '--_spinner-color': colorVars['--color-on-dark'],
-    '--_spinner-track-color': 'currentColor',
+    color: 'var(--spinner-color)',
+    '--spinner-color': colorVars['--color-on-dark'],
+    '--spinner-track-color': colorVars['--color-on-dark'],
+    '--_spinner-color': 'var(--spinner-color)',
+    '--_spinner-track-color': 'var(--spinner-track-color)',
     '--_spinner-track-opacity': `${77 / 255}`,
   },
   inherit: {
-    '--_spinner-color': 'currentColor',
-    '--_spinner-track-color': 'currentColor',
+    color: 'var(--spinner-color)',
+    '--spinner-color': 'currentColor',
+    '--spinner-track-color': 'currentColor',
+    '--_spinner-color': 'var(--spinner-color)',
+    '--_spinner-track-color': 'var(--spinner-track-color)',
     '--_spinner-track-opacity': '0.3',
   },
 });
@@ -157,6 +202,8 @@ export function Spinner({
   ...restProps
 }: SpinnerProps) {
   const BusyIndicator = useIndicator('spinner');
+  const {border, diameter} = SIZES[size];
+  const frameSize = diameter + border * 2;
   const hasLabel = label != null;
   const labelId = useId();
 
@@ -181,9 +228,18 @@ export function Spinner({
       {...(hasLabel ? {} : restProps)}
       {...mergeProps(
         hasLabel ? '' : themeProps('spinner', {size, shade}),
-        stylex.props(styles.status, shadeStyles[shade], !hasLabel && xstyle),
+        stylex.props(
+          styles.status,
+          !hasLabel && sizeStyles[size],
+          !hasLabel && shadeStyles[shade],
+          !hasLabel && xstyle,
+        ),
         hasLabel ? undefined : className,
-        hasLabel ? undefined : style,
+        {
+          ...(hasLabel ? {} : style),
+          width: `var(${BOX_SIZE}, ${frameSize}px)`,
+          height: `var(${BOX_SIZE}, ${frameSize}px)`,
+        },
       )}>
       <BusyIndicator size={size} />
     </span>
@@ -200,7 +256,12 @@ export function Spinner({
       {...restProps}
       {...mergeProps(
         themeProps('spinner', {size, shade}),
-        stylex.props(styles.wrapper, xstyle),
+        stylex.props(
+          styles.wrapper,
+          sizeStyles[size],
+          shadeStyles[shade],
+          xstyle,
+        ),
         className,
         style,
       )}>

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -53,31 +53,26 @@ const styles = stylex.create({
 });
 
 /**
- * A shade resolves to the foreground the indicator paints with, plus the two
- * private vars its track reads. Colour reaches a replacement the same way it
- * reaches ours — through `currentColor` — so a branded visual honours `shade`
- * without knowing the prop exists.
+ * A shade sets the vars the indicator reads, rather than painting anything
+ * itself: the indicator turns `--_spinner-color` into its own `color`, so a
+ * branded replacement drawing in `currentColor` honours `shade` without
+ * knowing the prop exists. `default` sets nothing — it IS the indicator's
+ * unset appearance.
  *
  * `onMedia` keeps the 77/255 its token's `4D` hex suffix used to encode.
  */
 const shadeStyles = stylex.create({
-  default: {
-    color: colorVars['--color-accent'],
-    '--_spinner-track-color': colorVars['--color-track'],
-    '--_spinner-track-opacity': '1',
-  },
+  default: {},
   subtle: {
-    color: colorVars['--color-text-secondary'],
-    '--_spinner-track-color': colorVars['--color-track'],
-    '--_spinner-track-opacity': '1',
+    '--_spinner-color': colorVars['--color-text-secondary'],
   },
   onMedia: {
-    color: colorVars['--color-on-dark'],
+    '--_spinner-color': colorVars['--color-on-dark'],
     '--_spinner-track-color': 'currentColor',
     '--_spinner-track-opacity': `${77 / 255}`,
   },
   inherit: {
-    color: 'currentColor',
+    '--_spinner-color': 'currentColor',
     '--_spinner-track-color': 'currentColor',
     '--_spinner-track-opacity': '0.3',
   },

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -4,9 +4,10 @@
 
 /**
  * @file Spinner.tsx
- * @input Uses React, StyleX, SVG rendering
+ * @input Uses React, StyleX, the `spinner` indicator from the registry
  * @output Exports Spinner component, SpinnerProps, SpinnerSize, SpinnerShade types
- * @position Core implementation of spinner loading indicator
+ * @position The standalone, announced loading indicator; the busy visual
+ *           itself now lives in Indicator/SpinnerIndicator.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Spinner/Spinner.doc.mjs
@@ -14,207 +15,30 @@
  * - /packages/core/src/Spinner/index.ts
  * - /apps/storybook/stories/Spinner.stories.tsx
  * - /packages/cli/assets/templates/blocks/components/Spinner/ (showcase blocks)
+ *
+ * Spinner is now two things layered, and the split is the whole point:
+ *
+ *   - the PICTURE is `SpinnerIndicator`, resolved through the registry, so
+ *     `defineTheme({indicators: {spinner: X}})` replaces it here and in every
+ *     control that renders a busy visual, together;
+ *   - the ANNOUNCEMENT is this component's `role="status"`, which stays,
+ *     because a spinner a product renders by itself has no host to own it.
+ *
+ * A control that renders a busy visual inside itself uses the indicator
+ * directly and keeps the announcement on the control, where its accessible
+ * name already lives. Rendering `<Spinner>` inside one announced "Loading"
+ * next to a control that was already `aria-busy`.
  */
 
 import {useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, durationVars, spacingVars} from '../theme/tokens.stylex';
+import {useIndicator} from '../Indicator';
+import type {IndicatorSizeOf} from '../Indicator';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
 import {Text} from '../Text/Text';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
-
-// =============================================================================
-// Constants
-// =============================================================================
-
-/**
- * Fraction of the ring the moving arc covers. The canvas ring this replaces
- * swept 135deg, not the 270deg its constant's comment claimed.
- */
-const ARC_FRACTION = 0.375;
-
-/**
- * The dash pattern, per unit of diameter: one arc, then the gap that closes
- * the circle. The circumference is `pi x diameter`, so multiplying the
- * resolved diameter by these two constants gives exactly the lengths the
- * default render has always used, and scales them with a themed diameter.
- */
-const PI = 3.141592653589793;
-const ARC_DASH = PI * ARC_FRACTION;
-const ARC_GAP = PI * (1 - ARC_FRACTION);
-
-const SIZES = {
-  sm: {diameter: 10, border: 2},
-  md: {diameter: 14, border: 3},
-  lg: {diameter: 18, border: 3},
-  xl: {diameter: 28, border: 4},
-};
-
-/**
- * Opacity the track is drawn at, per shade. `77 / 255` is the `4D` the onMedia
- * track used to append to the token's hex — the same composite, but applied as
- * `stroke-opacity` to a color off the cascade, so it no longer depends on the
- * token being hex notation and it applies to a themed color too.
- */
-const TRACK_OPACITY: Record<SpinnerShade, number> = {
-  default: 1,
-  subtle: 1,
-  onMedia: 77 / 255,
-  inherit: 0.3,
-};
-
-/**
- * Where the resolved geometry lands: the public var, resolved into a registered
- * `<length>` the `calc()`s below can do arithmetic on. The box and the ring
- * read these; the public vars are declared once, on the element carrying the
- * theme target, by `sizeStyles`.
- */
-const RESOLVED_DIAMETER = '--_spinner-ring-diameter';
-const RESOLVED_STROKE = '--_spinner-ring-stroke';
-const RESOLVED_GEOMETRY_VARS = [RESOLVED_DIAMETER, RESOLVED_STROKE];
-
-/**
- * The composed box size: diameter plus a stroke width on each side.
- *
- * It is deliberately NOT registered, unlike the pair above. The element reads
- * it through an inline `width`/`height` with the size's own default as the
- * `var()` fallback, so a render with no stylesheet — where nothing declares
- * it — still sizes the box the way it always did. A registered property always
- * has a value (its `initial-value`), which would swallow that fallback and
- * collapse the box to zero.
- */
-const BOX_SIZE = '--_spinner-box-size';
-
-/**
- * Register the resolved geometry vars as `<length>`.
- *
- * Both are consumed inside `calc()` — the box adds two stroke widths to a diameter,
- * the circle halves one. Unregistered, a custom property substitutes as text,
- * so whatever a theme wrote lands in the expression verbatim and a bare `0`
- * (a valid length on its own, a `<number>` inside `calc()`) poisons the sum:
- * `calc(28px + 0 * 2)` is invalid at computed-value time and the box loses its
- * size. Registered, the value is already an absolute length by the time the
- * `calc()` sees it, so `0` means `0px` — a zero-width stroke that paints
- * nothing — rather than a bare `0` that invalidates the sum and leaves the box
- * with no size at all. One `stroke-width` drives both circles, so a themed
- * stroke width of `0` hides the arc along with the track; an arc with no track behind
- * it is `--spinner-track-color: transparent`.
- *
- * Only these private vars are registered. The four public ones deliberately
- * are not: a registered property has an `initial-value`, so every element in
- * the document would report a value for it — and
- * `.github/scripts/theme-var-reachability.js` finds a var's declaring element
- * by exactly that test, so registering them would point the guard at `<html>`
- * and report a var no theme can select.
- */
-function registerSpinnerVars(): void {
-  if (
-    typeof CSS === 'undefined' ||
-    typeof CSS.registerProperty !== 'function'
-  ) {
-    return;
-  }
-  for (const name of RESOLVED_GEOMETRY_VARS) {
-    try {
-      CSS.registerProperty({
-        name,
-        syntax: '<length>',
-        inherits: true,
-        initialValue: '0px',
-      });
-    } catch {
-      // Already registered — a second copy of the package on the page, or a
-      // fast-refresh re-evaluation. registerProperty throws rather than
-      // replacing, and the existing registration is this same one.
-    }
-  }
-}
-
-// Registering an inherited property with an `initial-value` invalidates style
-// for the whole document, so this runs when the module is evaluated rather
-// than when a spinner mounts. A spinner is the loading indicator: it mounts
-// onto a page that is already rendered, with someone already waiting, and the
-// recalc it triggers there is paid on the full tree. At import the tree is
-// whatever has rendered so far, which for a bundle loaded in the head is
-// nothing.
-//
-// It is safe at module scope in both directions. The `typeof CSS` guard above
-// keeps it out of the server render, and tree-shaking cannot strip it from a
-// build that renders a spinner: core's `sideEffects` allowlist does not name
-// this file, so a bundle that never imports `Spinner` drops the module whole —
-// registration and all, which is the outcome you want — while one that does
-// import it keeps the module, and a bare call is not something a bundler may
-// elide.
-registerSpinnerVars();
-
-/**
- * Pin every ring's rotation to the document timeline's origin instead of its
- * own start time, so spinners mounted seconds apart turn in phase.
- *
- * Setting `startTime` is exact where arithmetic on a clock read is not: a
- * negative `animation-delay` computed at mount is only as good as the gap
- * between reading the clock and the frame the animation starts in, which at
- * 10x CPU throttling measured 116deg of drift.
- *
- * Rings are collected and pinned in one frame because `getAnimations()`
- * resolves style and `startTime` dirties it again, so pinning them one at a
- * time makes each mount re-force what the previous one invalidated — 53 style
- * recalcs for 38 spinners against 19 batched.
- */
-const pendingRings = new Set<SVGSVGElement>();
-let flushScheduled = false;
-
-function pinRingsToTimelineOrigin(): void {
-  flushScheduled = false;
-  const animations: Animation[] = [];
-  for (const svg of pendingRings) {
-    animations.push(...svg.getAnimations());
-  }
-  pendingRings.clear();
-  for (const animation of animations) {
-    animation.startTime = 0;
-  }
-}
-
-/**
- * Ref callback for the ring: the one place a mounted ring touches the DOM.
- *
- * It reads nothing back — the geometry is resolved by the cascade, not in JS.
- */
-function syncRotationPhase(
-  svg: SVGSVGElement | null,
-): (() => void) | undefined {
-  if (svg == null) {
-    return undefined;
-  }
-  // jsdom implements no Web Animations, and this runs in every consumer's
-  // component tests.
-  if (typeof svg.getAnimations !== 'function') {
-    return undefined;
-  }
-  pendingRings.add(svg);
-  if (!flushScheduled) {
-    flushScheduled = true;
-    requestAnimationFrame(pinRingsToTimelineOrigin);
-  }
-  return () => {
-    pendingRings.delete(svg);
-  };
-}
-
-// =============================================================================
-// Animation
-// =============================================================================
-
-const rotation = stylex.keyframes({
-  '0%': {transform: 'rotate(0deg)'},
-  '100%': {transform: 'rotate(360deg)'},
-});
-
-// =============================================================================
-// Styles
-// =============================================================================
 
 const styles = stylex.create({
   wrapper: {
@@ -223,184 +47,43 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
   },
-  spinner: {
-    display: 'inline-grid',
-    placeItems: 'center',
-    verticalAlign: 'middle',
-    // The public geometry vars, resolved into the registered `<length>` pair
-    // the arithmetic below needs. Reading them here rather than in each
-    // `calc()` keeps one place where a themed value enters the component, and
-    // it is the span that reads them whether the theme target is the span or
-    // the wrapper — a custom property inherits either way.
-    [RESOLVED_DIAMETER]: 'var(--spinner-diameter)',
-    [RESOLVED_STROKE]: 'var(--spinner-stroke-width)',
-    // The size of the box, composed here and applied as an inline style at the
-    // element, so that the box and the drawn ring come from the same two vars
-    // and a themed size moves both together — without the sizing moving from
-    // an inline style to a rule, which would hand a caller's `style={{width}}`
-    // a precedence over the box that it has never had.
-    [BOX_SIZE]: `calc(var(${RESOLVED_DIAMETER}) + var(${RESOLVED_STROKE}) * 2)`,
-
-    // The box is the ring's size, and a host does not get to take that away.
-    //
-    // `overflow: hidden` used to sit here, carried over from the canvas ring
-    // this component no longer draws. It clipped nothing — the painted circle
-    // is inscribed in the box, so hiding and showing the overflow render
-    // byte-identical pixels at every size, every shade, the labelled case and
-    // every rotation angle. What it did do is remove the floor under this box:
-    // a flex item whose overflow is not `visible` has an automatic minimum
-    // size of zero, so a narrow flex host was free to compress the box while
-    // the ring kept drawing at the size its own attributes ask for, and then
-    // the clip cut the ring off at the box edge. Ordinary rows hit it — a
-    // spinner beside a label in a 140px row lost 4px of its ring, one beside a
-    // `flex: 1 0 100px` sibling lost half of it — with nothing reporting a
-    // problem, because a sliced ring still spins.
-    //
-    // `flex-shrink: 0` then states the invariant directly rather than leaving
-    // it to the automatic minimum size, which a host takes away again the
-    // moment it sets `min-width: 0` on its items. A spinner that does not fit
-    // overflows its host visibly instead of being silently sliced.
-    flexShrink: 0,
-  },
-  ring: {
-    backfaceVisibility: 'hidden',
-    display: 'block',
-    // The frame is the box, read from the same composed var the span is sized
-    // from — not from the size constant, which a theme cannot reach, and not
-    // from a percentage, which needs the grid area to be a definite size in
-    // both axes (an unresolved percentage height on an SVG falls back to the
-    // replaced-element default of 150px and drops the ring below the box).
-    // One expression, one source of truth, resolves in any layout.
-    width: `var(${BOX_SIZE})`,
-    height: `var(${BOX_SIZE})`,
-    willChange: 'transform',
-    // The svg is sized in CSS (100% of the span) rather than from the size
-    // constant, so one user unit is one CSS pixel AND the frame follows a
-    // themed diameter: the span's box is `diameter + 2 x stroke`, both public
-    // vars, so ring and frame move together. Sizing it from the constant
-    // instead left the svg larger than the box the moment a theme changed the
-    // diameter — an overflowing grid item aligns to start rather than centre,
-    // which put the ring 1.5-3.3px off across the four sizes.
-    overflow: 'visible',
-    // Slow the rotation dramatically under reduced-motion rather than freezing
-    // it (a frozen spinner reads as broken), matching ProgressBar's approach.
-    // The role="status" + "Loading" label still convey busy state (obs-6).
-    animationDuration: {
-      default: durationVars['--duration-slow-min'],
-      '@media (prefers-reduced-motion: reduce)': '3s',
-    },
-    animationIterationCount: 'infinite',
-    animationName: rotation,
-    animationTimingFunction: 'linear',
-  },
-  circle: {
-    fill: 'none',
-    // The ring is centred on the box (cx/cy 50%), so the arc's start offset
-    // pivots there too — as a CSS transform, since the SVG `transform`
-    // attribute would need that centre as a number in user units.
-    transformBox: 'fill-box',
-    transformOrigin: 'center',
-    strokeLinecap: 'round',
-    // The geometry the ring is actually drawn at. `r` and `stroke-width` are
-    // CSS properties on an SVG shape, and a CSS declaration outranks the
-    // presentation attribute of the same name — so the attributes below stay
-    // as the size's default (and as what a server render and a no-CSS render
-    // draw), and these take over the moment the cascade has a themed value.
-    r: `calc(var(${RESOLVED_DIAMETER}) / 2)`,
-    strokeWidth: `var(${RESOLVED_STROKE})`,
-  },
-  // The two ring colors ride `stroke` directly, read off the public vars the
-  // shade declares. The paint comes from the cascade, so every notation a
-  // theme can write — `var()`, `color-mix()`, and the `currentColor` the
-  // inherit shade is built on — resolves where it is used, and a color changed
-  // after mount repaints instead of going stale.
-  //
-  // The dash pattern is composed from the resolved diameter the same way, so a
-  // themed ring keeps the same fraction of arc rather than the same absolute
-  // dash. `pathLength` would be the shorter route to that, but it rescales the
-  // pattern against the path length the UA measures on its own approximation
-  // of the circle — 87.398 against the 87.965 of pi x 28 — which shortens the
-  // default arc by 0.64% and moves the cap by half a pixel. Composing the
-  // lengths keeps the default byte-identical to what it drew before.
-  arc: {
-    stroke: 'var(--spinner-color)',
-    transform: 'rotate(-90deg)',
-    strokeDasharray: `calc(var(${RESOLVED_DIAMETER}) * ${ARC_DASH}) calc(var(${RESOLVED_DIAMETER}) * ${ARC_GAP})`,
-  },
-  track: {stroke: 'var(--spinner-track-color)'},
-});
-
-// What each named `size` and `shade` resolve to. Both groups DECLARE the four
-// public vars, on the element that carries the `spinner` theme target, and
-// everything downstream reads them — so a theme's `@layer astryx-theme` rule
-// against `.astryx-spinner.xl` overrides the default the same way it does for
-// `--tree-list-indent` or `--button-focus-offset`, e.g.
-// spinner: { 'size:xl': { '--spinner-diameter': '40px' } }.
-//
-// Declaring is only safe because #5410 moved the compiled StyleX CSS inside
-// `@layer astryx-base`. Before it, StyleX emitted custom-property
-// declarations at priority 0 and therefore OUTSIDE its layers, and an
-// unlayered declaration beats every layer — so a StyleX-declared
-// `--spinner-diameter: 10px` shadowed the theme's own rule no matter how
-// specific the theme got. An earlier revision of this component worked around
-// that by never declaring the public var and reading it with the default as a
-// `var()` fallback; that is no longer necessary, and the fallback shape has a
-// cost of its own — with nothing declaring the var,
-// `theme-var-reachability.js` cannot find an element to check, so a documented
-// var reads as unreachable.
-const sizeStyles = stylex.create({
-  sm: {
-    '--spinner-diameter': `${SIZES.sm.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.sm.border}px`,
-  },
-  md: {
-    '--spinner-diameter': `${SIZES.md.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.md.border}px`,
-  },
-  lg: {
-    '--spinner-diameter': `${SIZES.lg.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.lg.border}px`,
-  },
-  xl: {
-    '--spinner-diameter': `${SIZES.xl.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.xl.border}px`,
+  status: {
+    display: 'inline-flex',
   },
 });
 
+/**
+ * A shade resolves to the foreground the indicator paints with, plus the two
+ * private vars its track reads. Colour reaches a replacement the same way it
+ * reaches ours — through `currentColor` — so a branded visual honours `shade`
+ * without knowing the prop exists.
+ *
+ * `onMedia` keeps the 77/255 its token's `4D` hex suffix used to encode.
+ */
 const shadeStyles = stylex.create({
   default: {
-    '--spinner-color': colorVars['--color-accent'],
-    '--spinner-track-color': colorVars['--color-track'],
+    color: colorVars['--color-accent'],
+    '--_spinner-track-color': colorVars['--color-track'],
+    '--_spinner-track-opacity': '1',
   },
   subtle: {
-    '--spinner-color': colorVars['--color-text-secondary'],
-    '--spinner-track-color': colorVars['--color-track'],
+    color: colorVars['--color-text-secondary'],
+    '--_spinner-track-color': colorVars['--color-track'],
+    '--_spinner-track-opacity': '1',
   },
   onMedia: {
-    '--spinner-color': colorVars['--color-on-dark'],
-    '--spinner-track-color': colorVars['--color-on-dark'],
+    color: colorVars['--color-on-dark'],
+    '--_spinner-track-color': 'currentColor',
+    '--_spinner-track-opacity': `${77 / 255}`,
   },
   inherit: {
-    '--spinner-color': 'currentColor',
-    '--spinner-track-color': 'currentColor',
+    color: 'currentColor',
+    '--_spinner-track-color': 'currentColor',
+    '--_spinner-track-opacity': '0.3',
   },
 });
 
-// The track's alpha is a property, not a color: it composites over whatever
-// color the shade or the theme supplies. `77 / 255` is the `4D` the onMedia
-// token's hex used to carry.
-const trackOpacityStyles = stylex.create({
-  default: {strokeOpacity: TRACK_OPACITY.default},
-  subtle: {strokeOpacity: TRACK_OPACITY.subtle},
-  onMedia: {strokeOpacity: TRACK_OPACITY.onMedia},
-  inherit: {strokeOpacity: TRACK_OPACITY.inherit},
-});
-
-// =============================================================================
-// Types
-// =============================================================================
-
-export type SpinnerSize = keyof typeof SIZES;
+export type SpinnerSize = IndicatorSizeOf<'busy'>;
 
 export type SpinnerShade = 'default' | 'onMedia' | 'subtle' | 'inherit';
 
@@ -408,9 +91,7 @@ export interface SpinnerProps extends BaseProps<HTMLSpanElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLSpanElement>;
   /**
-   * Spinner size. The diameter is the ring itself; the rendered box adds the
-   * stroke width on each side (xl draws a 28px ring in a 36px box). A theme can
-   * redefine what each named size resolves to — see `--spinner-diameter`.
+   * Spinner size.
    * - 'sm': 10px diameter
    * - 'md': 14px diameter
    * - 'lg': 18px diameter
@@ -450,12 +131,14 @@ export interface SpinnerProps extends BaseProps<HTMLSpanElement> {
   'data-testid'?: string;
 }
 
-// =============================================================================
-// Component
-// =============================================================================
-
 /**
- * An animated loading indicator. Available in four sizes and four color shades.
+ * An animated loading indicator that announces itself. Available in four sizes
+ * and four color shades.
+ *
+ * Use this where the loading state belongs to the page rather than to a
+ * control — a pending panel, a route transition, a standalone "working" state.
+ * A control with its own busy state renders the `spinner` indicator instead
+ * and keeps the announcement on itself.
  *
  * @example
  * ```
@@ -478,10 +161,7 @@ export function Spinner({
   ref,
   ...restProps
 }: SpinnerProps) {
-  const {border, diameter} = SIZES[size];
-  const frameSize = diameter + border * 2;
-  const circumference = Math.PI * diameter;
-  const arcLength = circumference * ARC_FRACTION;
+  const BusyIndicator = useIndicator('spinner');
   const hasLabel = label != null;
   const labelId = useId();
 
@@ -506,60 +186,11 @@ export function Spinner({
       {...(hasLabel ? {} : restProps)}
       {...mergeProps(
         hasLabel ? '' : themeProps('spinner', {size, shade}),
-        stylex.props(
-          styles.spinner,
-          // The defaults are declared on whichever element carries the theme
-          // target, and only there: when a label moves the target to the
-          // wrapper, this span must inherit the wrapper's value rather than
-          // declare its own, which would shadow a theme's override with the
-          // default it is trying to replace.
-          !hasLabel && sizeStyles[size],
-          !hasLabel && shadeStyles[shade],
-          !hasLabel && xstyle,
-        ),
+        stylex.props(styles.status, shadeStyles[shade], !hasLabel && xstyle),
         hasLabel ? undefined : className,
-        // The box is sized here, after the caller's `style`, exactly as it was
-        // before the geometry became themeable: the component's own size wins
-        // over a `style={{width}}` a caller passes, and the precedence between
-        // the two is unchanged by this PR. What the value is made of has
-        // changed — it is the composed var rather than a number — so a themed
-        // diameter moves the box with the ring. The fallback is the size's own
-        // frame, for the render where no stylesheet has declared the var.
-        {
-          ...(hasLabel ? {} : style),
-          width: `var(${BOX_SIZE}, ${frameSize}px)`,
-          height: `var(${BOX_SIZE}, ${frameSize}px)`,
-        },
+        hasLabel ? undefined : style,
       )}>
-      <svg
-        ref={syncRotationPhase}
-        width={frameSize}
-        height={frameSize}
-        aria-hidden="true"
-        {...stylex.props(styles.ring)}>
-        <circle
-          cx="50%"
-          cy="50%"
-          r={diameter / 2}
-          strokeWidth={border}
-          {...stylex.props(
-            styles.circle,
-            styles.track,
-            trackOpacityStyles[shade],
-          )}
-        />
-        <circle
-          cx="50%"
-          cy="50%"
-          r={diameter / 2}
-          strokeWidth={border}
-          // The size's own dash, for the render with no stylesheet. The rule
-          // above composes the same lengths from the resolved diameter, so a
-          // themed ring keeps this fraction of arc rather than this length.
-          strokeDasharray={`${arcLength} ${circumference - arcLength}`}
-          {...stylex.props(styles.circle, styles.arc)}
-        />
-      </svg>
+      <BusyIndicator size={size} />
     </span>
   );
 
@@ -574,12 +205,7 @@ export function Spinner({
       {...restProps}
       {...mergeProps(
         themeProps('spinner', {size, shade}),
-        stylex.props(
-          styles.wrapper,
-          sizeStyles[size],
-          shadeStyles[shade],
-          xstyle,
-        ),
+        stylex.props(styles.wrapper, xstyle),
         className,
         style,
       )}>

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -33,19 +33,17 @@
 import {useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useIndicator} from '../Indicator';
+import {SPINNER_SIZES, spinnerSizeStyles} from './spinnerGeometry.stylex';
+import {
+  SpinnerIndicator,
+  SpinnerIndicatorWithoutLegacyTarget,
+} from '../Indicator/SpinnerIndicator';
 import type {IndicatorSizeOf} from '../Indicator';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
 import {Text} from '../Text/Text';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
-
-const SIZES = {
-  sm: {diameter: 10, border: 2},
-  md: {diameter: 14, border: 3},
-  lg: {diameter: 18, border: 3},
-  xl: {diameter: 28, border: 4},
-};
 
 const RESOLVED_DIAMETER = '--_spinner-ring-diameter';
 const RESOLVED_STROKE = '--_spinner-ring-stroke';
@@ -61,30 +59,11 @@ const styles = stylex.create({
   status: {
     display: 'inline-grid',
     placeItems: 'center',
-    overflow: 'hidden',
     verticalAlign: 'middle',
+    flexShrink: 0,
     [RESOLVED_DIAMETER]: 'var(--spinner-diameter)',
     [RESOLVED_STROKE]: 'var(--spinner-stroke-width)',
     [BOX_SIZE]: `calc(var(${RESOLVED_DIAMETER}) + var(${RESOLVED_STROKE}) * 2)`,
-  },
-});
-
-const sizeStyles = stylex.create({
-  sm: {
-    '--spinner-diameter': `${SIZES.sm.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.sm.border}px`,
-  },
-  md: {
-    '--spinner-diameter': `${SIZES.md.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.md.border}px`,
-  },
-  lg: {
-    '--spinner-diameter': `${SIZES.lg.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.lg.border}px`,
-  },
-  xl: {
-    '--spinner-diameter': `${SIZES.xl.diameter}px`,
-    '--spinner-stroke-width': `${SIZES.xl.border}px`,
   },
 });
 
@@ -202,7 +181,13 @@ export function Spinner({
   ...restProps
 }: SpinnerProps) {
   const BusyIndicator = useIndicator('spinner');
-  const {border, diameter} = SIZES[size];
+  const busyVisual =
+    BusyIndicator === SpinnerIndicator ? (
+      <SpinnerIndicatorWithoutLegacyTarget size={size} />
+    ) : (
+      <BusyIndicator size={size} />
+    );
+  const {border, diameter} = SPINNER_SIZES[size];
   const frameSize = diameter + border * 2;
   const hasLabel = label != null;
   const labelId = useId();
@@ -230,7 +215,7 @@ export function Spinner({
         hasLabel ? '' : themeProps('spinner', {size, shade}),
         stylex.props(
           styles.status,
-          !hasLabel && sizeStyles[size],
+          !hasLabel && spinnerSizeStyles[size],
           !hasLabel && shadeStyles[shade],
           !hasLabel && xstyle,
         ),
@@ -241,7 +226,7 @@ export function Spinner({
           height: `var(${BOX_SIZE}, ${frameSize}px)`,
         },
       )}>
-      <BusyIndicator size={size} />
+      {busyVisual}
     </span>
   );
 
@@ -258,7 +243,7 @@ export function Spinner({
         themeProps('spinner', {size, shade}),
         stylex.props(
           styles.wrapper,
-          sizeStyles[size],
+          spinnerSizeStyles[size],
           shadeStyles[shade],
           xstyle,
         ),

--- a/packages/core/src/Spinner/spinnerGeometry.stylex.ts
+++ b/packages/core/src/Spinner/spinnerGeometry.stylex.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import * as stylex from '@stylexjs/stylex';
+import type {IndicatorSizeOf} from '../Indicator/types';
+
+export const SPINNER_SIZES = {
+  sm: {diameter: 10, border: 2},
+  md: {diameter: 14, border: 3},
+  lg: {diameter: 18, border: 3},
+  xl: {diameter: 28, border: 4},
+} as const satisfies Record<
+  IndicatorSizeOf<'busy'>,
+  {diameter: number; border: number}
+>;
+
+const RESOLVED_SPINNER_DIAMETER = '--_spinner-ring-diameter';
+const RESOLVED_SPINNER_STROKE = '--_spinner-ring-stroke';
+
+export const spinnerSizeStyles = stylex.create({
+  sm: {
+    '--spinner-diameter': `${SPINNER_SIZES.sm.diameter}px`,
+    '--spinner-stroke-width': `${SPINNER_SIZES.sm.border}px`,
+  },
+  md: {
+    '--spinner-diameter': `${SPINNER_SIZES.md.diameter}px`,
+    '--spinner-stroke-width': `${SPINNER_SIZES.md.border}px`,
+  },
+  lg: {
+    '--spinner-diameter': `${SPINNER_SIZES.lg.diameter}px`,
+    '--spinner-stroke-width': `${SPINNER_SIZES.lg.border}px`,
+  },
+  xl: {
+    '--spinner-diameter': `${SPINNER_SIZES.xl.diameter}px`,
+    '--spinner-stroke-width': `${SPINNER_SIZES.xl.border}px`,
+  },
+});
+
+export const resolvedSpinnerSizeStyles = stylex.create({
+  sm: {
+    [RESOLVED_SPINNER_DIAMETER]: `var(--spinner-diameter, ${SPINNER_SIZES.sm.diameter}px)`,
+    [RESOLVED_SPINNER_STROKE]: `var(--spinner-stroke-width, ${SPINNER_SIZES.sm.border}px)`,
+  },
+  md: {
+    [RESOLVED_SPINNER_DIAMETER]: `var(--spinner-diameter, ${SPINNER_SIZES.md.diameter}px)`,
+    [RESOLVED_SPINNER_STROKE]: `var(--spinner-stroke-width, ${SPINNER_SIZES.md.border}px)`,
+  },
+  lg: {
+    [RESOLVED_SPINNER_DIAMETER]: `var(--spinner-diameter, ${SPINNER_SIZES.lg.diameter}px)`,
+    [RESOLVED_SPINNER_STROKE]: `var(--spinner-stroke-width, ${SPINNER_SIZES.lg.border}px)`,
+  },
+  xl: {
+    [RESOLVED_SPINNER_DIAMETER]: `var(--spinner-diameter, ${SPINNER_SIZES.xl.diameter}px)`,
+    [RESOLVED_SPINNER_STROKE]: `var(--spinner-stroke-width, ${SPINNER_SIZES.xl.border}px)`,
+  },
+});

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -39,7 +39,7 @@ import {FieldLabel} from '../Field/FieldLabel';
 import {FieldStatus} from '../FieldStatus/FieldStatus';
 import type {IconType} from '../Icon';
 import type {InputStatus} from '../Field/types';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {useTooltip} from '../Tooltip';
 import {mergeProps} from '../utils';
 import {switchScope} from './switch.markers.stylex';
@@ -623,7 +623,7 @@ export function Switch({
               isOn ? styles.thumbOn : styles.thumbOff,
             ),
           )}>
-          {isBusy && <Spinner size="sm" />}
+          {isBusy && <BusyIndicator size="sm" />}
         </div>
       </div>
       {isBusy && <VisuallyHidden role="status">Loading</VisuallyHidden>}

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -346,9 +346,14 @@ describe('TextArea', () => {
           status={{type: 'error'}}
         />,
       );
-      // Matches the other inputs: spinner (role="status") and the status icon
-      // render side by side in the end slot, not mutually exclusively.
-      expect(screen.getByRole('status')).toBeInTheDocument();
+      // Matches the other inputs: the busy indicator and the status icon
+      // render side by side in the end slot, not mutually exclusively. The
+      // indicator is decorative; `aria-busy` on the textarea is the announced
+      // signal.
+      expect(
+        container.querySelector('.astryx-spinner-indicator'),
+      ).not.toBeNull();
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-busy', 'true');
       // Status icon svg is also present alongside the spinner.
       expect(container.querySelectorAll('svg').length).toBeGreaterThan(0);
     });

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -44,7 +44,7 @@ import {
   type FieldStatusVariant,
 } from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {useTooltip} from '../Tooltip';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
@@ -635,7 +635,7 @@ export function TextArea({
         />
         {(isBusy || statusIcon) && (
           <span {...stylex.props(styles.endSlot)}>
-            {isBusy && <Spinner size="sm" />}
+            {isBusy && <BusyIndicator size="sm" />}
             {statusIcon}
           </span>
         )}

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -44,7 +44,7 @@ import {
   type FieldStatusVariant,
 } from '../Field';
 import {renderIconSlot, type IconType} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {useTooltip} from '../Tooltip';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {getInputARIA} from '../utils';
@@ -460,7 +460,7 @@ export function TextInput({
           onClick={handleClear}
         />
       )}
-      {isBusy && <Spinner size="sm" />}
+      {isBusy && <BusyIndicator size="sm" />}
       {statusIcon}
     </div>
   );

--- a/packages/core/src/Thumbnail/Thumbnail.test.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.test.tsx
@@ -37,7 +37,9 @@ describe('Thumbnail', () => {
     );
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('src', '/local.jpg');
-    expect(screen.getByRole('status')).toBeInTheDocument();
+    // The overlay visual is decorative; the thumbnail itself carries the busy
+    // state, which is what a screen reader has to reach.
+    expect(screen.getByTestId('thumb')).toHaveAttribute('aria-busy', 'true');
   });
 
   it('exposes the label as an accessible name via a valid group role', () => {

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -406,6 +406,10 @@ export function Thumbnail({
       data-testid={testId}
       role="group"
       aria-label={accessibleName}
+      // The upload visual is decorative, so without this the thumbnail says
+      // nothing at all while it uploads. It had been leaning on the Spinner's
+      // own role="status" for that.
+      aria-busy={showUploadOverlay || undefined}
       {...mergeProps(
         themeProps('thumbnail'),
         stylex.props(styles.root, isDisabled && styles.disabled, xstyle),

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -37,7 +37,7 @@ import {
 import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {Skeleton} from '../Skeleton';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {Tooltip} from '../Tooltip/Tooltip';
 import {useDevWarning} from '../hooks/useDevWarning';
 import {useContainerReveal} from '../hooks/useContainerReveal';
@@ -236,6 +236,10 @@ const styles = stylex.create({
     pointerEvents: 'none' as const,
   },
   uploadOverlay: {
+    // was shade="onMedia"
+    '--_spinner-color': colorVars['--color-on-dark'],
+    '--_spinner-track-color': 'currentColor',
+    '--_spinner-track-opacity': '0.302',
     position: 'absolute',
     inset: 0,
     display: 'flex',
@@ -433,7 +437,7 @@ export function Thumbnail({
         {showImage && <div {...stylex.props(styles.insetBorder)} />}
         {showUploadOverlay && (
           <div {...stylex.props(styles.uploadOverlay)}>
-            <Spinner size="sm" shade="onMedia" />
+            <BusyIndicator size="sm" />
           </div>
         )}
         {removeButtonEl}

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -47,7 +47,7 @@ import {
   type FieldStatusVariant,
 } from '../Field';
 import {Icon} from '../Icon';
-import {Spinner} from '../Spinner';
+import {BusyIndicator} from '../Indicator';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {
   type ISOTimeString,
@@ -745,7 +745,7 @@ export function TimeInput({
           </VisuallyHidden>
         </>
       )}
-      {isBusy && <Spinner size="sm" />}
+      {isBusy && <BusyIndicator size="sm" />}
       {hasClear && optimisticValue && !isDisabled && (
         <InputClearButton
           label={t('@astryx.timeInput.clearLabel', {label})}

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -241,8 +241,8 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
  */
 const CROSS_COMPONENT_VARS: Record<string, string[]> = {
   Carousel: ['--_button-radius'],
-  Thumbnail: ['--_button-radius'],
-  Chat: ['--_button-radius'],
+  Thumbnail: ['--_button-radius', '--_spinner-color', '--_spinner-track-color', '--_spinner-track-opacity'],
+  Chat: ['--_button-radius', '--_spinner-color', '--_spinner-track-color', '--_spinner-track-opacity'],
   // AvatarGroupOverflow sets the overlap for the Avatars it lays out; Avatar
   // owns and documents it (and sets it itself when it is the group root).
   AvatarGroup: ['--_avatar-group-overlap'],
@@ -255,6 +255,10 @@ const CROSS_COMPONENT_VARS: Record<string, string[]> = {
   // The destructive item variant recolors the Item it renders; Item owns,
   // documents and reads both slots.
   DropdownMenu: ['--_item-label-color', '--_item-description-color'],
+  // A host says what colour "busy" is in its own slot; the spinner indicator
+  // owns, documents and reads all three.
+  Button: ['--_spinner-color', '--_spinner-track-color', '--_spinner-track-opacity'],
+  Spinner: ['--_spinner-color', '--_spinner-track-color', '--_spinner-track-opacity'],
 };
 
 /**
@@ -304,15 +308,17 @@ const VARS_WITHOUT_DERIVED_MAPPING = new Set([
   // It is one component of one shadow in the list, so no standard property
   // maps onto it either — a theme sets it beside the fill it has to contrast.
   '--selectable-card-ring-color',
-  // The spinner's ring is drawn as an SVG circle, so none of its four vars is
-  // a CSS property of the element carrying the theme target: `width` and
-  // `borderWidth` would name a box the ring is not, and a `color` mapping
-  // would take the label's text color with it. They are public vars a theme
-  // sets directly under a size- or shade-variant key.
+  // The spinner's ring is drawn as an SVG circle, so none of its public vars
+  // maps cleanly to a CSS property on the element carrying the theme target.
   '--spinner-diameter',
   '--spinner-stroke-width',
   '--spinner-color',
   '--spinner-track-color',
+  // Hosts pass color and track treatment to the replaceable busy indicator
+  // through private vars because the SVG shapes are implementation details.
+  '--_spinner-color',
+  '--_spinner-track-color',
+  '--_spinner-track-opacity',
 ]);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**Spike — not for merge.** Exploratory code answering a design question: should the loading visual become a replaceable indicator, so a product can ship its own branded one? Draft on purpose; no changeset, no docs, partial test coverage.

Run `Core/Spinner/Branded Replacements → BrandedSpinners` in Storybook. Four
structurally different loading visuals — a row of bouncing dots, a pulsing
square, a reversed arc, a rotating mark — each swapped in with nothing but

```ts
defineTheme({name: 'brand', indicators: {spinner: BouncingDots}})
```

and each rendering inside a real loading Button, a busy TextInput, a busy
Switch, and a standalone `<Spinner>`. The hosts are identical between rows and
none of them knows which visual it is drawing.

## What changed

**A `busy` family, and `spinner` in the indicator registry.** The mechanism was
already there (`packages/core/src/Indicator/`); this extends it rather than
inventing anything.

**One line per host.** `<Spinner size="sm" />` becomes
`<BusyIndicator size="sm" />` — 24 sites in 20 components. `BusyIndicator` is
the resolved registry entry, so a theme's replacement reaches every one of them
at once. `<Spinner>` itself now renders the same registry entry inside, so it
follows too.

**`role="status"` moved to the hosts.** The indicator is decorative and
`aria-hidden`, like every other indicator; the control keeps `aria-busy` and the
announcement. Standalone `<Spinner>` keeps its `role="status"`, because a
spinner a product renders by itself has no host to own it.

## The family system does not survive a stateless member unchanged

This is the interesting finding. `IndicatorProps.state` was declared required
and family-typed. A busy visual has no state — it is rendered or it is not — so:

- `busy: never` makes `state: never`, and **every call site becomes
  unsatisfiable**;
- `busy: 'busy'` type-checks and makes every call site write a word that carries
  no information.

The fix is one change in one place: **a family now fixes the *domain of the
props*, not just the state enum.** `state` is derived conditionally
(`[IndicatorState<F>] extends [never] ? {state?: never} : {state: …}`), and
`size` comes from a parallel `IndicatorFamilySizeMap`. Existing families resolve
to exactly the props they had, which is why nothing downstream of them changed —
but the docblock claiming "adding a family is additive" is now only true for
families that have states, and it says so.

Size falls out of the same change: selection marks keep `sm | md`, `busy` keeps
the four sizes `Spinner` ships. Worth knowing: **every one of the 24 host call
sites passes `sm` or `md`.** `lg` and `xl` only ever appear on a standalone
spinner, so widening one family costs the control hosts nothing.

## Colour, without a `shade` prop

`shade` was four ways of saying which colour the ring paints in, which is what
`color` already says. The indicator turns `--_spinner-color` into its own
`color` and strokes in `currentColor`, so a replacement written the obvious way
honours the host's shade without knowing shades exist. Three private vars
(`--_spinner-color`, `--_spinner-track-color`, `--_spinner-track-opacity`) are
the host→indicator contract. The default indicator also keeps the existing
`spinner` theme target and public vars, so current themes still override its arc,
track, and geometry inside controls as well as on standalone `<Spinner>`.

## Does a replacement break a host's layout?

Measured in Chromium rather than guessed, since the dots row is 19×5 and our
ring is 14.5×14.5:

| host | default | widest replacement | verdict |
|---|---|---|---|
| Button | 120×32 | 120×32 | unaffected — the spinner sits in an absolutely-positioned centred overlay |
| Switch track | 40×24 | 40×24 | not resized, but the visual **paints outside the thumb** |
| TextInput | 180 wide | 175–184 | the end slot is in flow, so the typing area moves by up to 9px |

Nothing clips and nothing breaks. But no host constrains the visual either, so a
replacement with a different aspect ratio changes the row it is in. If this
ships, the indicator contract should say what box a busy visual is given.

## Accessibility, measured before and after

Real accessibility trees (CDP `Accessibility.getFullAXTree`) in Chromium:

| host | before | after |
|---|---|---|
| Button | `button [busy]` + its own status region | identical |
| Switch | `switch [busy]` + its own status region | identical |
| TextInput | `textbox [busy]` + `status "Loading"` | `textbox [busy]` |
| TextArea | `textbox [busy]` + `status "Loading"` | `textbox [busy]` |
| Thumbnail | `group` + `status "Loading"` | `group [busy]` (added here) |

Button, Switch and CheckboxInput render the spinner inside an `aria-hidden`
subtree already, so its `role="status"` has been inert in them all along — three
of the loudest hosts lose nothing.

Hosts without an existing busy surface now expose one: `DropdownMenuSubMenu`
marks its menu item busy, `CommandPaletteInput` marks its combobox busy, and
`ChatToolCalls` marks each pending/running row busy (a non-interactive row becomes
a status region). Thumbnail likewise gains `aria-busy`. Fourteen more keep their
existing `aria-busy` but lose a second spoken "Loading" — a change in verbosity,
not in whether the state is reachable.

## Test cost

Whole suite: **5 tests** asserted the spinner's own `role="status"` inside a
host (Button, TextArea, Thumbnail, CheckboxList ×2). All five are updated here
to assert the host's `aria-busy` and the indicator's presence, which is the
migration in miniature. Six more were registry bookkeeping (documenting the new
theme target and the three vars). Everything else — 8129 tests — passed
untouched.


