### PR TITLE
fix(DateInput): show the native control's own segments while it is typed into

### DIFF
--- a/.changeset/date-input-native-segments-visible.md
+++ b/.changeset/date-input-native-segments-visible.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateInput's native surface (`nativePicker`) now shows the engine's own date segments while the control has focus, instead of painting over them. On iOS and Android `<input type="date">` is a single untypable run, so DateInput's formatted text can cover it; on desktop engines — and in Chrome's touch simulator — it is a row of editable `mm`/`dd`/`yyyy` fields, and covering those hid the digits being typed. `format` reapplies on blur.
+
+@imdreamrunner

--- a/packages/core/src/DateInput/NativeDateField.test.tsx
+++ b/packages/core/src/DateInput/NativeDateField.test.tsx
@@ -22,7 +22,31 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {DateInput} from './DateInput';
+import type * as NativeDateSegments from './nativeDateSegments';
+import {
+  hasEditableDateSegments,
+  resetDateSegmentProbe,
+} from './nativeDateSegments';
 import {InternationalizationProvider} from '../i18n';
+
+/**
+ * Lets a test say which kind of `<input type="date">` the engine draws.
+ * `null` (the default) runs the real probe, so every other test in this file
+ * exercises the shipping path: jsdom lays nothing out, so the probe reports
+ * `'unknown'` and the coarse pointer resolves it to picker-only.
+ */
+const {segmentState} = vi.hoisted(() => ({
+  segmentState: {editable: null as boolean | null},
+}));
+
+vi.mock('./nativeDateSegments', async importOriginal => {
+  const actual = await importOriginal<typeof NativeDateSegments>();
+  return {
+    ...actual,
+    hasEditableDateSegments: (isTouchPointer: boolean) =>
+      segmentState.editable ?? actual.hasEditableDateSegments(isTouchPointer),
+  };
+});
 
 const HOVER_CAPABLE = /\(\s*hover\s*:\s*hover\s*\)/;
 
@@ -87,6 +111,8 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  segmentState.editable = null;
+  resetDateSegmentProbe();
 });
 
 describe('DateInput nativePicker', () => {
@@ -173,9 +199,7 @@ describe('DateInput nativePicker', () => {
   it('fires onChange with undefined when the control is emptied', () => {
     stubPointer(true);
     const onChange = vi.fn();
-    render(
-      <DateInput label="Date" value="2026-03-21" onChange={onChange} />,
-    );
+    render(<DateInput label="Date" value="2026-03-21" onChange={onChange} />);
 
     fireEvent.change(getInput(), {target: {value: ''}});
 
@@ -191,9 +215,7 @@ describe('DateInput nativePicker', () => {
     // sees the real one.
     stubPointer(true);
     const onChange = vi.fn();
-    render(
-      <DateInput label="Date" value="2026-03-21" onChange={onChange} />,
-    );
+    render(<DateInput label="Date" value="2026-03-21" onChange={onChange} />);
 
     const input = getInput();
     input.value = '2026-03-09';
@@ -205,9 +227,7 @@ describe('DateInput nativePicker', () => {
   it('fires one change when both commit paths see the same edit', () => {
     stubPointer(true);
     const onChange = vi.fn();
-    render(
-      <DateInput label="Date" value="2026-03-21" onChange={onChange} />,
-    );
+    render(<DateInput label="Date" value="2026-03-21" onChange={onChange} />);
 
     fireEvent.change(getInput(), {target: {value: '2026-03-09'}});
 
@@ -225,9 +245,7 @@ describe('DateInput nativePicker', () => {
     const input = getInput();
 
     fireEvent.focus(input);
-    rerender(
-      <DateInput label="Date" value="2026-12-25" onChange={() => {}} />,
-    );
+    rerender(<DateInput label="Date" value="2026-12-25" onChange={() => {}} />);
 
     expect(input).toHaveValue('2026-03-21');
   });
@@ -240,9 +258,7 @@ describe('DateInput nativePicker', () => {
     const input = getInput();
 
     fireEvent.focus(input);
-    rerender(
-      <DateInput label="Date" value="2026-12-25" onChange={() => {}} />,
-    );
+    rerender(<DateInput label="Date" value="2026-12-25" onChange={() => {}} />);
     fireEvent.blur(input);
 
     expect(input).toHaveValue('2026-12-25');
@@ -391,9 +407,7 @@ describe('DateInput nativePicker', () => {
   it('keeps painting the value while the picker is open', () => {
     // The OS picker has no segments to reveal, so `format` holds throughout.
     stubPointer(true);
-    render(
-      <DateInput label="Date" value="2026-01-25" onChange={() => {}} />,
-    );
+    render(<DateInput label="Date" value="2026-01-25" onChange={() => {}} />);
 
     fireEvent.focus(getInput());
 
@@ -402,14 +416,10 @@ describe('DateInput nativePicker', () => {
 
   it('shows the placeholder when empty, and drops it when filled', () => {
     stubPointer(true);
-    const {rerender} = render(
-      <DateInput label="Date" onChange={() => {}} />,
-    );
+    const {rerender} = render(<DateInput label="Date" onChange={() => {}} />);
     expect(screen.getByText('Select a date')).toBeInTheDocument();
 
-    rerender(
-      <DateInput label="Date" value="2026-01-25" onChange={() => {}} />,
-    );
+    rerender(<DateInput label="Date" value="2026-01-25" onChange={() => {}} />);
 
     expect(screen.queryByText('Select a date')).toBeNull();
   });
@@ -418,9 +428,7 @@ describe('DateInput nativePicker', () => {
     // The input still holds the value and carries the label, so announcing
     // the overlay too would double-speak.
     stubPointer(true);
-    render(
-      <DateInput label="Date" value="2026-01-25" onChange={() => {}} />,
-    );
+    render(<DateInput label="Date" value="2026-01-25" onChange={() => {}} />);
 
     expect(screen.getByText('January 25, 2026')).toHaveAttribute(
       'aria-hidden',
@@ -430,9 +438,7 @@ describe('DateInput nativePicker', () => {
 
   it('hides the engine\u2019s own text under the overlay', () => {
     stubPointer(true);
-    render(
-      <DateInput label="Date" value="2026-01-25" onChange={() => {}} />,
-    );
+    render(<DateInput label="Date" value="2026-01-25" onChange={() => {}} />);
 
     const rules = rulesFor(getInput());
     // One transparent colour covers Chromium's `::-webkit-datetime-edit` and
@@ -561,5 +567,69 @@ describe('DateInput nativePicker', () => {
     expect(input).toHaveAttribute('type', 'date');
     expect(input).toHaveAttribute('aria-required', 'true');
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
+  });
+
+  // ===========================================================================
+  // Engines that draw editable segments
+  //
+  // Chrome's touch simulator, a Windows tablet and a ChromeOS convertible all
+  // render `<input type="date">` as typable fields while reporting a coarse
+  // pointer. See ./nativeDateSegments.
+  // ===========================================================================
+
+  it('reveals the engine’s own segments while an editable control has focus', () => {
+    // Measured in Chrome: with the overlay up, typing paints nothing but a
+    // selection highlight drifting across the placeholder.
+    segmentState.editable = true;
+    stubPointer(true);
+    render(<DateInput label="Date" value="2026-01-25" onChange={() => {}} />);
+
+    expect(screen.getByText('January 25, 2026')).toBeInTheDocument();
+
+    fireEvent.focus(getInput());
+
+    expect(screen.queryByText('January 25, 2026')).toBeNull();
+    // `-webkit-text-fill-color` is what wins inside a date control, and
+    // unlike a bare `color:` cannot be confused with the wrapper's
+    // `background-color: transparent`.
+    expect(rulesFor(getInput())).not.toContain(
+      '-webkit-text-fill-color: transparent',
+    );
+  });
+
+  it('paints the formatted date again once the segments lose focus', () => {
+    segmentState.editable = true;
+    stubPointer(true);
+    render(<DateInput label="Date" value="2026-01-25" onChange={() => {}} />);
+
+    fireEvent.focus(getInput());
+    fireEvent.blur(getInput());
+
+    expect(screen.getByText('January 25, 2026')).toBeInTheDocument();
+    expect(rulesFor(getInput())).toContain(
+      '-webkit-text-fill-color: transparent',
+    );
+  });
+
+  it('stands aside for the engine’s placeholder while empty and focused', () => {
+    // `mm/dd/yyyy` says which order to type in, which ours cannot.
+    segmentState.editable = true;
+    stubPointer(true);
+    render(<DateInput label="Date" onChange={() => {}} />);
+
+    expect(screen.getByText('Select a date')).toBeInTheDocument();
+
+    fireEvent.focus(getInput());
+
+    expect(screen.queryByText('Select a date')).toBeNull();
+  });
+
+  it('resolves an unprobeable engine with the pointer', () => {
+    // jsdom lays nothing out, so neither pseudo can be measured — the same
+    // answer Firefox gives, which exposes neither.
+    resetDateSegmentProbe();
+
+    expect(hasEditableDateSegments(true)).toBe(false);
+    expect(hasEditableDateSegments(false)).toBe(true);
   });
 });

--- a/packages/core/src/DateInput/NativeDateField.tsx
+++ b/packages/core/src/DateInput/NativeDateField.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file NativeDateField.tsx
- * @input Uses React, Field, Icon, InputClearButton, Spinner, useCalendarConstraints
+ * @input Uses React, Field, Icon, InputClearButton, Spinner, useCalendarConstraints, hasEditableDateSegments
  * @output Exports NativeDateField — the OS-picker touch surface
  * @position One of DateInput's three surfaces. `DateInput` picks the pointer
  *   field on a mouse and, on touch, either `TouchDateField` (the default) or
@@ -22,13 +22,15 @@
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/DateInput/DateInput.tsx (the `nativePicker` prop)
  * - /packages/core/src/DateInput/DateInput.doc.mjs (prop table)
- * - /packages/core/src/DateInput/DateInputNative.test.tsx (tests)
+ * - /packages/core/src/DateInput/nativeDateSegments.ts (the engine probe)
+ * - /packages/core/src/DateInput/NativeDateField.test.tsx (tests)
  */
 
 import {useCallback, useEffect, useId, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useCalendarConstraints} from '../Calendar';
 import type {DateInputProps} from './DateInput';
+import {hasEditableDateSegments} from './nativeDateSegments';
 import {
   Field,
   InputClearButton,
@@ -38,6 +40,7 @@ import {
   inputWrapperStyles,
 } from '../Field';
 import {useInputStatusIcon, useMergedRefs} from '../hooks';
+import {useMediaQuery} from '../hooks/useMediaQuery';
 import {useResolvedRequired} from '../hooks/useResolvedRequired';
 import {Icon} from '../Icon';
 import {useLocale, useTranslator} from '../i18n';
@@ -254,6 +257,8 @@ export function NativeDateField({
   const placeholder =
     placeholderFromProps ?? t('@astryx.dateInput.placeholder');
   const size = useSize(sizeProp, 'md');
+  // Only breaks a tie the engine probe cannot: see ./nativeDateSegments.
+  const isTouchPointer = useMediaQuery('(pointer: coarse)');
 
   const id = useId();
   const inputLabelID = useId();
@@ -301,6 +306,10 @@ export function NativeDateField({
   // Whether the control has focus — which, on a touch device, means its
   // picker is open.
   const [isFocused, setIsFocused] = useState(false);
+  // Whether the engine draws this control as editable segments rather than a
+  // picker-only run. Latched on focus rather than read during render: the
+  // probe touches the DOM, and unfocused the answer changes nothing.
+  const [isSegmentEditable, setIsSegmentEditable] = useState(false);
   // The raw value the control last reported and we acted on, so the same edit
   // arriving through both commit paths only fires one change.
   const lastCommitRef = useRef<string | null>(null);
@@ -328,10 +337,14 @@ export function NativeDateField({
   );
 
   // This field paints the closed control's text itself, which is what keeps
-  // `format` and `placeholder` applying: the OS picker has no segments to
-  // edit, so our text holds even while the picker is open, and tracks it live.
+  // `format` and `placeholder` applying: a picker-only control has no
+  // segments to edit, so our text holds even while the picker is open, and
+  // tracks it live. An editable control is the opposite case — its text IS
+  // the edit surface, and it reports no `value` until every segment is
+  // filled, so the overlay has nothing to paint mid-edit — so step aside for
+  // as long as it has focus. See ./nativeDateSegments.
   const overlayText = nativeValue ? formatValue(nativeValue) : placeholder;
-  const showsOverlay = !!overlayText;
+  const showsOverlay = !!overlayText && !(isFocused && isSegmentEditable);
 
   const commitValue = useCallback(
     (newValue: string) => {
@@ -434,6 +447,11 @@ export function NativeDateField({
     }
   }, [isFocused, nativeValue]);
 
+  const handleFocus = useCallback(() => {
+    setIsSegmentEditable(hasEditableDateSegments(isTouchPointer));
+    setIsFocused(true);
+  }, [isTouchPointer]);
+
   const handleBlur = useCallback(() => {
     const domValue = inputRef.current?.value;
     setIsFocused(false);
@@ -533,7 +551,7 @@ export function NativeDateField({
           // mount — see `initialValueRef` and the sync effect above.
           defaultValue={initialValueRef.current ?? ''}
           onChange={handleChange}
-          onFocus={() => setIsFocused(true)}
+          onFocus={handleFocus}
           onBlur={handleBlur}
           min={min}
           max={max}

--- a/packages/core/src/DateInput/nativeDateSegments.ts
+++ b/packages/core/src/DateInput/nativeDateSegments.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file nativeDateSegments.ts
+ * @input Uses the DOM only
+ * @output Exports hasEditableDateSegments, resetDateSegmentProbe
+ * @position Internal helper for NativeDateField; answers "can the user type
+ *   into this engine's `<input type="date">`?"
+ *
+ * `<input type="date">` is two different controls wearing one tag name: a
+ * single untypable run the OS picker drives (iOS, Android), or a row of
+ * editable `mm`/`dd`/`yyyy` fields (desktop engines). Hiding the first costs
+ * nothing; hiding the second hides what the user is editing.
+ *
+ * Neither obvious test tells them apart. The pointer is wrong on Chrome's
+ * touch simulator, a Windows tablet and a ChromeOS convertible, which report
+ * a coarse pointer while Blink still renders segments. And measured, iOS and
+ * Chromium BOTH accept every `-webkit-datetime-*` selector, so
+ * `CSS.supports('selector(...)')` only proves the parser knows the name. What
+ * separates them is which pseudo is a real box, so this measures that.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/DateInput/NativeDateField.tsx (the caller)
+ * - /packages/core/src/DateInput/NativeDateField.test.tsx (tests)
+ */
+
+/** Marks the throwaway probe element for the probe stylesheet. */
+const PROBE_ATTR = 'data-astryx-date-probe';
+
+/** How much padding the probe adds, in px. Large enough to beat rounding. */
+const PROBE_PADDING = 100;
+
+type EngineKind = 'segmented' | 'picker-only' | 'unknown';
+
+let cachedEngine: EngineKind | null = null;
+
+/** Whether padding this pseudo-element moves the control's box. */
+function pseudoIsRealBox(
+  input: HTMLInputElement,
+  style: HTMLStyleElement,
+  pseudo: string,
+  baseWidth: number,
+): boolean {
+  style.textContent = `[${PROBE_ATTR}]${pseudo}{padding-inline-start:${PROBE_PADDING}px !important}`;
+  // Reading geometry flushes style and layout, so this already reflects it.
+  return input.getBoundingClientRect().width > baseWidth + PROBE_PADDING / 2;
+}
+
+/**
+ * Classifies the engine's date control. Cached: the answer is a build-time
+ * property of the browser, not of the field or the pointer in use.
+ */
+function probeEngine(): EngineKind {
+  if (cachedEngine !== null) {
+    return cachedEngine;
+  }
+  if (typeof document === 'undefined' || !document.body) {
+    return 'unknown';
+  }
+
+  const input = document.createElement('input');
+  input.setAttribute('type', 'date');
+  input.setAttribute(PROBE_ATTR, '');
+  // Off-screen, and immune to the page's own `input` rules: the probe reads a
+  // width DELTA, so anything pinning the width would swallow the signal.
+  input.style.cssText =
+    'position:fixed;top:-9999px;left:0;width:auto;min-width:0;max-width:none;' +
+    'padding:0;border:0;font-size:16px;box-sizing:content-box;';
+
+  const style = document.createElement('style');
+
+  let kind: EngineKind = 'unknown';
+  try {
+    document.body.appendChild(input);
+    document.head.appendChild(style);
+    const base = input.getBoundingClientRect().width;
+    if (pseudoIsRealBox(input, style, '::-webkit-datetime-edit', base)) {
+      // Chromium's editable field row, and WebKit's on macOS/GTK. Probe the
+      // container: the individual field pseudos overflow it rather than
+      // expand it, so they do not move the box even in Chromium.
+      kind = 'segmented';
+    } else if (
+      pseudoIsRealBox(input, style, '::-webkit-date-and-time-value', base)
+    ) {
+      // The single, untypable run iOS Safari and Chrome on Android paint.
+      kind = 'picker-only';
+    }
+  } catch {
+    // A hostile CSSOM leaves the answer unknown, resolved by the pointer.
+  } finally {
+    input.remove();
+    style.remove();
+  }
+
+  cachedEngine = kind;
+  return kind;
+}
+
+/**
+ * Whether the user can type into this engine's `<input type="date">`.
+ *
+ * Firefox exposes neither pseudo-element, so it — and any future engine —
+ * comes back `'unknown'` and the pointer breaks the tie. That is the right
+ * fallback precisely where the probe is blind: the pointer is wrong for
+ * Chromium because Blink's answer is fixed at build time and contradicts it,
+ * and an engine we cannot see is not in that position. It lands Firefox on
+ * the desktop (segmented) and on Android (picker-only) correctly.
+ *
+ * @param isTouchPointer Whether `(pointer: coarse)` matches.
+ * @internal Exported for tests.
+ */
+export function hasEditableDateSegments(isTouchPointer: boolean): boolean {
+  const engine = probeEngine();
+  return engine === 'unknown' ? !isTouchPointer : engine === 'segmented';
+}
+
+/**
+ * Drops the cached classification.
+ *
+ * @internal Exists for tests, which render against several engines in one
+ *   document.
+ */
+export function resetDateSegmentProbe(): void {
+  cachedEngine = null;
+}


### PR DESCRIPTION
## What

`<input type="date">` is two different controls sharing a tag name, and `NativeDateField` was built for only one of them.

| | picker-only | segmented |
| --- | --- | --- |
| where | iOS Safari, Chrome on Android | every desktop engine, **and Chrome's DevTools touch simulator** |
| what it is | one untypable run; tapping raises the OS picker | editable `mm`/`dd`/`yyyy` fields |
| empty state | **iOS paints nothing at all** | paints `mm/dd/yyyy` |
| `.value` while typing | n/a | **`''` until every segment is filled** |

The surface makes the control's text transparent and paints its own formatted date over the top. On a picker-only engine that costs nothing, and it is load-bearing: an empty native input on iOS is a blank box, so the overlay is what gives the field a placeholder at all. On a segmented engine it hides the thing the user is editing — and because the control reports no `value` until the date is complete, the overlay cannot track a partial edit either.

Measured in Chrome's touch simulator, typing into the field painted **no digits at all**, just the selection highlight drifting across the placeholder, until the last keystroke committed the whole date at once:

| after typing the month | after typing the day |
| --- | --- |
| `Sele`**`ct`**` a date` | `Select `**`a dat`**`e` |

The field was fully functional underneath — the overlay is `pointer-events: none`, so taps and keystrokes always reached the control. It was unreadable, not unusable.

## Fix

The overlay steps aside for as long as an **editable** control has focus, and `format` reapplies on blur. That is the shape `PointerDateField` already has with `pendingInput`.

No prop or docs change: `nativePicker` already scopes `format` to "the **closed** field's text", which stays true.

## Telling the two engines apart

Two obvious approaches both fail, measured:

- **`(pointer: coarse)`** — the touch simulator reports coarse while Blink still renders segments, because `InputMultipleFieldsUI` is fixed at build time and ignores emulation. Real hardware hits this too: a Windows tablet and a ChromeOS convertible both report a coarse pointer with segments.
- **`CSS.supports('selector(::-webkit-datetime-edit)')`** — returns `true` on iOS *and* Chromium. Both CSS parsers know every `-webkit-datetime-*` name; only one of them *matches an element* in each engine. (A bogus pseudo correctly returns `false`, so the API works — it just tests the parser, not the shadow tree.)

`nativeDateSegments.ts` pads a UA shadow pseudo-element and measures whether the control's box moves, which requires the pseudo to match a real box. The engines are exact mirror images:

| probe on an offscreen `<input type="date">` | iOS 26.5 | Chromium 149 |
| --- | --- | --- |
| base width | 0 | 150 |
| `::-webkit-datetime-edit` padded | 0 (no match) | **250** |
| `::-webkit-date-and-time-value` padded | **100** | 150 (no match) |

Probe the container, not the individual fields: `::-webkit-datetime-edit-year-field` does not move the box even in Chromium, since the inner fields overflow rather than expand it. The answer is a build-time property of the browser, so it is cached per document and latched on first focus rather than read during render.

Firefox exposes neither pseudo and comes back `unknown`, where the pointer breaks the tie — correct for Firefox desktop (segmented) and Firefox Android (picker-only) both. That fallback is right precisely where the probe is blind: the reason the pointer is wrong for Chromium is that Blink's answer contradicts it, and an engine we cannot see is not in that position.

## iOS is untouched by construction

The probe returns `picker-only` there, so `showsOverlay` evaluates to the identical expression it does today. Verified on the iOS 26.5 simulator rather than inferred.

## Verification

Driven against built `core` in Chromium 149 desktop + touch emulation:

| | before | after |
| --- | --- | --- |
| at rest | `March 14, 2026` | `March 14, 2026` |
| typing | placeholder + a drifting highlight | `03/14/`**`yyyy`** |
| after blur | `March 14, 2026` | `March 14, 2026`, `onChange` fired `2026-03-14` |

## Test plan

- `NativeDateField.test.tsx` +4 tests: the reveal on focus, the restore on blur, the engine's own placeholder while empty and focused, and the pointer fallback for an unprobeable engine. Every other test in the file runs the real probe, which reports `unknown` under jsdom and resolves to picker-only on a coarse pointer — the iOS/Android shape those tests are about. **264 pass** across the three DateInput suites.
- `pnpm lint:strict` 0 errors (58 pre-existing warnings, none in the touched files), `pnpm build`, `pnpm lab:readiness:check`, and the full `build-storybook` typecheck stack (`core`/`lab`/`charts typecheck:docs`, `cli typecheck:strict` + `typecheck:template-docs`, `storybook typecheck` + `build`, `core typecheck`) all pass. Rebased on `origin/main` and re-linted under the new raw-colour rule from #5446.
- Full `pnpm test`: 11927 pass. The 14 failures are all `packages/cli`; the 2 that survive running that package alone are `Switch` theme-target assertions from the `switch-label` change already on main.
