### PR TITLE
fix(TransferList): localize all strings and stop disabling on busy

### DIFF
--- a/.changeset/transfer-list-promotion-prep.md
+++ b/.changeset/transfer-list-promotion-prep.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `TransferList` and `TransferListSelector` now route every user- and screen-reader-facing string through the i18n catalog, and no longer disable themselves while an async change is pending. Previously all 28 strings were hardcoded English literals — panel headings, row action labels, locked-item tooltips, the keyboard reorder instructions, and every live-region announcement — and item counts were pluralized by a `count === 1` ternary rather than an ICU plural, so no locale with different plural rules could ever read correctly. Separately, `TransferListSelector` wrapped its list in `<fieldset disabled={isDisabled || state.isBusy}>`, and because the user is holding focus on the Add or Remove button that started the change, disabling on busy dropped their focus to `<body>`. Busy is now carried by `aria-busy` and the trigger's existing spinner, with transfers ignored until the change settles.
+
+@ernestt

--- a/internal/lab-readiness/manifest.mjs
+++ b/internal/lab-readiness/manifest.mjs
@@ -29,6 +29,10 @@ const pr = n => ({
   label: `PR #${n}`,
   url: `https://github.com/facebook/astryx/pull/${n}`,
 });
+const issueComment = (n, id, label) => ({
+  label,
+  url: `https://github.com/facebook/astryx/issues/${n}#issuecomment-${id}`,
+});
 
 /**
  * The lab components currently queued for promotion into core.
@@ -49,8 +53,7 @@ export const CANDIDATES = [
     storybookStoryId: 'lab-listinput--tag-options',
     publicExports: ['ListInput'],
     stateProps: ['isDisabled', 'isLoading', 'status'],
-    summary:
-      'Compact editor for short collections of simple records.',
+    summary: 'Compact editor for short collections of simple records.',
     declared: {
       triage: {
         state: 'passed',
@@ -125,8 +128,7 @@ export const CANDIDATES = [
     storybookStoryId: 'lab-transferlist--basic',
     publicExports: ['TransferList', 'TransferListSelector', 'transferListVars'],
     stateProps: ['isReorderable', 'hasSearch', 'hasSelectAll', 'hasClear'],
-    summary:
-      'Controlled dual-panel input for moving options between lists.',
+    summary: 'Controlled dual-panel input for moving options between lists.',
     declared: {
       triage: {
         state: 'passed',
@@ -155,13 +157,27 @@ export const CANDIDATES = [
       },
       surfaceAudit: {
         state: 'in_progress',
-        note: 'The RFC labels its surface audit preliminary and leaves naming and composition questions open. TransferListSelector shipped after it was written and is not covered.',
-        evidence: [issue(3281), pr(4773)],
+        note: 'Design review closed the naming and composition questions: the listbox semantics are withdrawn and the unbuilt Listbox primitive is split into its own RFC. TransferListSelector shipped after the audit was written and its prop surface is still not covered.',
+        evidence: [
+          issue(3281),
+          pr(4773),
+          issueComment(
+            3281,
+            5403206870,
+            'Design review: ARIA semantics resolved',
+          ),
+        ],
       },
       specReview: {
-        state: 'not_started',
-        note: 'No design or engineering review resolving blocking RFC feedback has been recorded.',
-        evidence: [issue(3281)],
+        state: 'passed',
+        note: 'Design review resolved the blocking RFC feedback, ruling that role=group plus semantic lists is correct because role=option forbids the interactive row descendants this component ships.',
+        evidence: [
+          issueComment(
+            3281,
+            5403206870,
+            'Design review: ARIA semantics resolved',
+          ),
+        ],
       },
       apiArbitration: {
         state: 'passed',
@@ -169,9 +185,15 @@ export const CANDIDATES = [
         evidence: [issue(3281)],
       },
       finalizedSpec: {
-        state: 'not_started',
-        note: 'RFC #3281 is still open, and its proposed listbox semantics contradict the shipped tests, which require semantic lists without listbox roles.',
-        evidence: [issue(3281)],
+        state: 'passed',
+        note: 'The listbox-versus-lists contradiction is settled: the RFC accessibility section is amended to the shipped semantics. RFC #3281 stays open only for the Listbox primitive, which is out of scope for this component.',
+        evidence: [
+          issueComment(
+            3281,
+            5403206870,
+            'Design review: ARIA semantics resolved',
+          ),
+        ],
       },
       reviewAndCI: {
         state: 'in_progress',

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1238,5 +1238,117 @@
   "@astryx.lightbox.mediaPosition": {
     "defaultMessage": "{alt}, {index, number} of {total, number}",
     "description": "Polite screen-reader announcement when a Lightbox moves to a media item that has alt text, composing that alt with the item's position. Live-region text, never shown on screen; example: `Sunset over the bay, 3 of 12`."
+  },
+  "@astryx.transferList.selectedLabel": {
+    "defaultMessage": "Selected",
+    "description": "Default heading above the right-hand panel of a lab TransferList, which holds the options the user has chosen. Consumers usually override this with a domain noun (e.g. \"Shown columns\")."
+  },
+  "@astryx.transferList.availableLabel": {
+    "defaultMessage": "Available",
+    "description": "Default heading above the left-hand panel of a lab TransferList, which holds the options not yet chosen. Consumers usually override this with a domain noun (e.g. \"Hidden columns\")."
+  },
+  "@astryx.transferList.searchPlaceholder": {
+    "defaultMessage": "Search…",
+    "description": "Placeholder in the single search field that filters both panels of a lab TransferList. Same English as `selector.searchPlaceholder` but a separate key so it can be phrased for two lists."
+  },
+  "@astryx.transferList.searchLabel": {
+    "defaultMessage": "Search {label}",
+    "description": "Screen-reader-only label on the search field of a lab TransferList, naming what is being searched. `{label}` is the component's own label (e.g. \"Search Table columns\")."
+  },
+  "@astryx.transferList.selectedEmpty": {
+    "defaultMessage": "No selected options",
+    "description": "Message shown inside the selected panel of a lab TransferList when the user has chosen nothing yet."
+  },
+  "@astryx.transferList.availableEmpty": {
+    "defaultMessage": "No available options",
+    "description": "Message shown inside the available panel of a lab TransferList when every option has already been moved to the selected panel."
+  },
+  "@astryx.transferList.noResults": {
+    "defaultMessage": "No results",
+    "description": "Message shown inside either panel of a lab TransferList when the search query matches nothing in that panel."
+  },
+  "@astryx.transferList.clear": {
+    "defaultMessage": "Clear",
+    "description": "Label on the bulk action in a lab TransferList's selected-panel header that removes every option that is allowed to be removed. Locked options stay."
+  },
+  "@astryx.transferList.addAll": {
+    "defaultMessage": "Add all",
+    "description": "Label on the bulk action in a lab TransferList's available-panel header that moves every remaining option into the selected panel."
+  },
+  "@astryx.transferList.addOption": {
+    "defaultMessage": "Add {label}",
+    "description": "Accessible label on the per-row + button that moves one option into the selected panel of a lab TransferList. `{label}` is that option's visible text (e.g. \"Add Owner\")."
+  },
+  "@astryx.transferList.removeOption": {
+    "defaultMessage": "Remove {label}",
+    "description": "Accessible label on the per-row × button that moves one option out of the selected panel of a lab TransferList. `{label}` is that option's visible text (e.g. \"Remove Name\")."
+  },
+  "@astryx.transferList.reorderOption": {
+    "defaultMessage": "Reorder {label}",
+    "description": "Accessible label on the per-row drag handle that reorders one option within the selected panel of a lab TransferList. `{label}` is that option's visible text (e.g. \"Reorder Name\")."
+  },
+  "@astryx.transferList.transferDisabled": {
+    "defaultMessage": "{label} cannot be moved",
+    "description": "Default tooltip explaining why a locked option in a lab TransferList cannot be transferred between panels. `{label}` is the option's visible text. Consumers may override per option."
+  },
+  "@astryx.transferList.reorderDisabled": {
+    "defaultMessage": "{label} cannot be reordered",
+    "description": "Default tooltip explaining why a locked option in a lab TransferList cannot be moved within the selected panel. `{label}` is the option's visible text. Consumers may override per option."
+  },
+  "@astryx.transferList.reorderInstructions": {
+    "defaultMessage": "Press Space or Enter to pick up an item. Use Arrow Up, Arrow Down, Home, or End to move it. Press Space or Enter to drop, or Escape to cancel.",
+    "description": "Screen-reader-only instructions describing the keyboard reorder contract, referenced by every drag handle in a lab TransferList. Never shown on screen. Name the actual keys your locale's users press."
+  },
+  "@astryx.transferList.announceAdded": {
+    "defaultMessage": "{label} added. {count, number} {count, plural, one {item} other {items}} selected.",
+    "description": "Polite screen-reader announcement after one option moves into the selected panel of a lab TransferList. Live-region text, never shown on screen; `{label}` is the option's visible text and `{count}` is the new selected total."
+  },
+  "@astryx.transferList.announceRemoved": {
+    "defaultMessage": "{label} removed. {count, number} {count, plural, one {item} other {items}} selected.",
+    "description": "Polite screen-reader announcement after one option moves out of the selected panel of a lab TransferList. Live-region text, never shown on screen; `{label}` is the option's visible text and `{count}` is the new selected total."
+  },
+  "@astryx.transferList.announceBulkAdded": {
+    "defaultMessage": "{count, number} {count, plural, one {item} other {items}} added.",
+    "description": "Polite screen-reader announcement after the Add all bulk action in a lab TransferList. Live-region text, never shown on screen; `{count}` is how many options moved."
+  },
+  "@astryx.transferList.announceBulkRemoved": {
+    "defaultMessage": "{count, number} {count, plural, one {item} other {items}} removed.",
+    "description": "Polite screen-reader announcement after the Clear bulk action in a lab TransferList. Live-region text, never shown on screen; `{count}` is how many options moved."
+  },
+  "@astryx.transferList.announceGrabbed": {
+    "defaultMessage": "{label} picked up, position {position, number} of {total, number}. Use arrow keys to move, Space or Enter to drop, or Escape to cancel.",
+    "description": "Polite screen-reader announcement when a lab TransferList row enters keyboard reorder mode. Live-region text, never shown on screen; `{position}` is 1-based within the selected panel."
+  },
+  "@astryx.transferList.announceMoveCancelled": {
+    "defaultMessage": "{label} move cancelled.",
+    "description": "Polite screen-reader announcement when a lab TransferList reorder is abandoned with Escape or a cancelled pointer drag, restoring the original order. Live-region text, never shown on screen."
+  },
+  "@astryx.transferList.announceDropped": {
+    "defaultMessage": "{label} dropped at position {position, number} of {total, number}.",
+    "description": "Polite screen-reader announcement when a lab TransferList reorder commits at a new position. Live-region text, never shown on screen; `{position}` is 1-based within the selected panel."
+  },
+  "@astryx.transferList.announceReturned": {
+    "defaultMessage": "{label} returned to position {position, number}.",
+    "description": "Polite screen-reader announcement when a lab TransferList pointer drag ends where it began, so the order did not change. Live-region text, never shown on screen; `{position}` is 1-based."
+  },
+  "@astryx.transferList.announceMovedToPosition": {
+    "defaultMessage": "{label}, position {position, number} of {total, number}.",
+    "description": "Polite screen-reader announcement after each arrow-key step of an in-progress lab TransferList reorder. Live-region text, never shown on screen; `{position}` is 1-based within the selected panel."
+  },
+  "@astryx.transferList.announceSearchResults": {
+    "defaultMessage": "{count, number} {count, plural, one {item} other {items}} found.",
+    "description": "Polite screen-reader announcement of how many options a lab TransferList search matched across both panels. Live-region text, never shown on screen."
+  },
+  "@astryx.transferListSelector.apply": {
+    "defaultMessage": "Apply",
+    "description": "Label on the button that commits the staged draft of a lab TransferListSelector and closes it. Only rendered in staged commit mode."
+  },
+  "@astryx.transferListSelector.cancel": {
+    "defaultMessage": "Cancel",
+    "description": "Label on the button that discards the staged draft of a lab TransferListSelector and closes it. Only rendered in staged commit mode."
+  },
+  "@astryx.transferListSelector.triggerLabel": {
+    "defaultMessage": "{count, number} selected",
+    "description": "Default summary on the closed trigger of a lab TransferListSelector, stating how many options are currently chosen. Consumers usually override this with a domain phrase (e.g. \"7 columns\")."
   }
 }

--- a/packages/lab/src/TransferList/TransferList.tsx
+++ b/packages/lab/src/TransferList/TransferList.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file TransferList.tsx
- * @input Controlled option data, React DOM portals, local action glyphs, and shared Lab reorder styles
+ * @input Controlled option data, React DOM portals, local action glyphs, shared Lab reorder styles, and the core i18n catalog
  * @output Exports TransferList with immediate transfers, vertical reordering, and responsive scroll ownership
  * @position Lab collection input; consumed by index.ts, TransferListSelector, docs, and tests
  *
@@ -40,6 +40,7 @@ import {Text} from '@astryxdesign/core/Text';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {VisuallyHidden} from '@astryxdesign/core/VisuallyHidden';
 import {useAnnounce} from '@astryxdesign/core/hooks';
+import {useTranslator} from '@astryxdesign/core/i18n';
 import {
   borderVars,
   colorVars,
@@ -364,6 +365,9 @@ function moveItem<T>(
   return nextValue;
 }
 
+// Case folding is locale-independent here, matching Selector, MultiSelector,
+// and CommandPalette. Locale-sensitive folding would mean raw Intl access,
+// which the shipped packages route through the provider instead.
 function matchesQuery<T extends string>(
   option: TransferListOption<T>,
   query: string,
@@ -374,12 +378,8 @@ function matchesQuery<T extends string>(
   const description =
     typeof option.description === 'string' ? option.description : '';
   return [option.label, description, option.group ?? ''].some(part =>
-    part.toLocaleLowerCase().includes(query),
+    part.toLowerCase().includes(query),
   );
-}
-
-function itemCount(count: number): string {
-  return `${count} ${count === 1 ? 'item' : 'items'}`;
 }
 
 /**
@@ -405,18 +405,18 @@ export function TransferList<T extends string = string>({
   options,
   value,
   onChange,
-  selectedLabel = 'Selected',
-  availableLabel = 'Available',
+  selectedLabel: selectedLabelFromProps,
+  availableLabel: availableLabelFromProps,
   hasSearch = false,
   searchLabel,
-  searchPlaceholder = 'Search…',
+  searchPlaceholder: searchPlaceholderFromProps,
   isReorderable = true,
   hasSelectAll = false,
   hasClear = false,
   renderOption,
-  selectedEmptyText = 'No selected options',
-  availableEmptyText = 'No available options',
-  noResultsText = 'No results',
+  selectedEmptyText: selectedEmptyTextFromProps,
+  availableEmptyText: availableEmptyTextFromProps,
+  noResultsText: noResultsTextFromProps,
   xstyle,
   className,
   style,
@@ -426,6 +426,19 @@ export function TransferList<T extends string = string>({
   'aria-describedby': ariaDescribedBy,
   ...restProps
 }: TransferListProps<T>): ReactNode {
+  const t = useTranslator();
+  const selectedLabel =
+    selectedLabelFromProps ?? t('@astryx.transferList.selectedLabel');
+  const availableLabel =
+    availableLabelFromProps ?? t('@astryx.transferList.availableLabel');
+  const searchPlaceholder =
+    searchPlaceholderFromProps ?? t('@astryx.transferList.searchPlaceholder');
+  const selectedEmptyText =
+    selectedEmptyTextFromProps ?? t('@astryx.transferList.selectedEmpty');
+  const availableEmptyText =
+    availableEmptyTextFromProps ?? t('@astryx.transferList.availableEmpty');
+  const noResultsText =
+    noResultsTextFromProps ?? t('@astryx.transferList.noResults');
   const labelId = useId();
   const descriptionId = useId();
   const selectedHeadingId = useId();
@@ -466,7 +479,7 @@ export function TransferList<T extends string = string>({
     return map;
   }, [options]);
   const selectedValues = useMemo(() => new Set(value), [value]);
-  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const normalizedQuery = query.trim().toLowerCase();
   const selectedOptions = useMemo(
     () =>
       value
@@ -603,11 +616,14 @@ export function TransferList<T extends string = string>({
       const nextValue = [...currentValueRef.current, option.value];
       commit(nextValue);
       announce(
-        `${option.label} added. ${itemCount(nextValue.length)} selected.`,
+        t('@astryx.transferList.announceAdded', {
+          label: option.label,
+          count: nextValue.length,
+        }),
       );
       focusAfterTransfer('available', index);
     },
-    [announce, commit, focusAfterTransfer],
+    [announce, commit, focusAfterTransfer, t],
   );
 
   const removeOption = useCallback(
@@ -620,11 +636,14 @@ export function TransferList<T extends string = string>({
       );
       commit(nextValue);
       announce(
-        `${option.label} removed. ${itemCount(nextValue.length)} selected.`,
+        t('@astryx.transferList.announceRemoved', {
+          label: option.label,
+          count: nextValue.length,
+        }),
       );
       focusAfterTransfer('selected', index);
     },
-    [announce, commit, focusAfterTransfer],
+    [announce, commit, focusAfterTransfer, t],
   );
 
   const addAll = useCallback(() => {
@@ -637,9 +656,13 @@ export function TransferList<T extends string = string>({
       .map(option => option.value);
     if (additions.length > 0) {
       commit([...currentValueRef.current, ...additions]);
-      announce(`${itemCount(additions.length)} added.`);
+      announce(
+        t('@astryx.transferList.announceBulkAdded', {
+          count: additions.length,
+        }),
+      );
     }
-  }, [announce, commit, options]);
+  }, [announce, commit, options, t]);
 
   const clearSelected = useCallback(() => {
     const nextValue = currentValueRef.current.filter(optionValue => {
@@ -649,9 +672,9 @@ export function TransferList<T extends string = string>({
     const removed = currentValueRef.current.length - nextValue.length;
     if (removed > 0) {
       commit(nextValue);
-      announce(`${itemCount(removed)} removed.`);
+      announce(t('@astryx.transferList.announceBulkRemoved', {count: removed}));
     }
-  }, [announce, commit, optionByValue]);
+  }, [announce, commit, optionByValue, t]);
 
   const movableRange = useCallback(
     (optionValue: T, orderedValue: readonly T[]) => {
@@ -721,11 +744,15 @@ export function TransferList<T extends string = string>({
       });
       if (mode === 'keyboard') {
         announce(
-          `${option.label} picked up, position ${index + 1} of ${currentValueRef.current.length}. Use arrow keys to move, Space or Enter to drop, or Escape to cancel.`,
+          t('@astryx.transferList.announceGrabbed', {
+            label: option.label,
+            position: index + 1,
+            total: currentValueRef.current.length,
+          }),
         );
       }
     },
-    [announce, isReorderable, setReorderSession],
+    [announce, isReorderable, setReorderSession, t],
   );
 
   const finishReorder = useCallback(
@@ -738,7 +765,11 @@ export function TransferList<T extends string = string>({
         if (cancelled || !session.hasPointerMoved) {
           setReorderSession(null);
           if (cancelled) {
-            announce(`${session.label} move cancelled.`);
+            announce(
+              t('@astryx.transferList.announceMoveCancelled', {
+                label: session.label,
+              }),
+            );
           }
           return;
         }
@@ -752,27 +783,42 @@ export function TransferList<T extends string = string>({
         if (hasChanged) {
           commit(nextValue);
           announce(
-            `${session.label} dropped at position ${session.toIndex + 1} of ${session.originalValue.length}.`,
+            t('@astryx.transferList.announceDropped', {
+              label: session.label,
+              position: session.toIndex + 1,
+              total: session.originalValue.length,
+            }),
           );
         } else {
           announce(
-            `${session.label} returned to position ${session.fromIndex + 1}.`,
+            t('@astryx.transferList.announceReturned', {
+              label: session.label,
+              position: session.fromIndex + 1,
+            }),
           );
         }
         return;
       }
       if (cancelled) {
         commit(session.originalValue);
-        announce(`${session.label} move cancelled.`);
+        announce(
+          t('@astryx.transferList.announceMoveCancelled', {
+            label: session.label,
+          }),
+        );
       } else {
         const index = currentValueRef.current.indexOf(session.value);
         announce(
-          `${session.label} dropped at position ${index + 1} of ${currentValueRef.current.length}.`,
+          t('@astryx.transferList.announceDropped', {
+            label: session.label,
+            position: index + 1,
+            total: currentValueRef.current.length,
+          }),
         );
       }
       setReorderSession(null);
     },
-    [announce, commit, setReorderSession],
+    [announce, commit, setReorderSession, t],
   );
 
   const handleReorderClick = useCallback(
@@ -827,11 +873,15 @@ export function TransferList<T extends string = string>({
       if (moveOption(option.value, target)) {
         const nextIndex = currentValueRef.current.indexOf(option.value);
         announce(
-          `${option.label}, position ${nextIndex + 1} of ${currentValueRef.current.length}.`,
+          t('@astryx.transferList.announceMovedToPosition', {
+            label: option.label,
+            position: nextIndex + 1,
+            total: currentValueRef.current.length,
+          }),
         );
       }
     },
-    [announce, finishReorder, movableRange, moveOption],
+    [announce, finishReorder, movableRange, moveOption, t],
   );
 
   const handlePointerDown = useCallback(
@@ -922,11 +972,15 @@ export function TransferList<T extends string = string>({
       setReorderSession(nextSession);
       if (hasCrossedThreshold && session.toIndex !== targetIndex) {
         announce(
-          `${option.label}, position ${targetIndex + 1} of ${session.originalValue.length}.`,
+          t('@astryx.transferList.announceMovedToPosition', {
+            label: option.label,
+            position: targetIndex + 1,
+            total: session.originalValue.length,
+          }),
         );
       }
     },
-    [announce, movableRange, setReorderSession],
+    [announce, movableRange, setReorderSession, t],
   );
 
   const handlePointerEnd = useCallback(
@@ -956,17 +1010,17 @@ export function TransferList<T extends string = string>({
   const handleSearch = useCallback(
     (nextQuery: string) => {
       setQuery(nextQuery);
-      const normalized = nextQuery.trim().toLocaleLowerCase();
+      const normalized = nextQuery.trim().toLowerCase();
       if (normalized === '') {
         announce('');
       } else {
         const count = options.filter(option =>
           matchesQuery(option, normalized),
         ).length;
-        announce(`${itemCount(count)} found.`);
+        announce(t('@astryx.transferList.announceSearchResults', {count}));
       }
     },
-    [announce, options],
+    [announce, options, t],
   );
 
   const optionActions = (
@@ -976,11 +1030,12 @@ export function TransferList<T extends string = string>({
   ) => {
     const isTransferDisabled = option.isTransferDisabled === true;
     const disabledReason =
-      option.disabledMessage ?? `${option.label} cannot be moved`;
+      option.disabledMessage ??
+      t('@astryx.transferList.transferDisabled', {label: option.label});
     if (side === 'available') {
       return (
         <IconButton
-          label={`Add ${option.label}`}
+          label={t('@astryx.transferList.addOption', {label: option.label})}
           icon={<PlusIcon />}
           size="sm"
           variant="ghost"
@@ -993,7 +1048,7 @@ export function TransferList<T extends string = string>({
     }
     return (
       <IconButton
-        label={`Remove ${option.label}`}
+        label={t('@astryx.transferList.removeOption', {label: option.label})}
         icon={<RemoveIcon />}
         size="sm"
         variant="ghost"
@@ -1034,10 +1089,11 @@ export function TransferList<T extends string = string>({
     const active = reorderSession?.value === option.value;
     const isReorderDisabled = option.isReorderDisabled === true;
     const disabledReason =
-      option.disabledMessage ?? `${option.label} cannot be reordered`;
+      option.disabledMessage ??
+      t('@astryx.transferList.reorderDisabled', {label: option.label});
     return (
       <IconButton
-        label={`Reorder ${option.label}`}
+        label={t('@astryx.transferList.reorderOption', {label: option.label})}
         aria-describedby={reorderInstructionsId}
         aria-pressed={active}
         icon={<GripVerticalIcon />}
@@ -1164,7 +1220,9 @@ export function TransferList<T extends string = string>({
           <TextInput
             ref={searchRef}
             role="searchbox"
-            label={searchLabel ?? `Search ${label}`}
+            label={
+              searchLabel ?? t('@astryx.transferList.searchLabel', {label})
+            }
             isLabelHidden
             value={query}
             placeholder={searchPlaceholder}
@@ -1178,8 +1236,7 @@ export function TransferList<T extends string = string>({
       )}
 
       <VisuallyHidden id={reorderInstructionsId}>
-        Press Space or Enter to pick up an item. Use Arrow Up, Arrow Down, Home,
-        or End to move it. Press Space or Enter to drop, or Escape to cancel.
+        {t('@astryx.transferList.reorderInstructions')}
       </VisuallyHidden>
 
       <div
@@ -1202,7 +1259,7 @@ export function TransferList<T extends string = string>({
             </Text>
             {hasClear && (
               <Button
-                label="Clear"
+                label={t('@astryx.transferList.clear')}
                 size="sm"
                 variant="ghost"
                 xstyle={styles.headerAction}
@@ -1259,7 +1316,7 @@ export function TransferList<T extends string = string>({
             </Text>
             {hasSelectAll && (
               <Button
-                label="Add all"
+                label={t('@astryx.transferList.addAll')}
                 size="sm"
                 variant="ghost"
                 xstyle={styles.headerAction}

--- a/packages/lab/src/TransferList/TransferListSelector.test.tsx
+++ b/packages/lab/src/TransferList/TransferListSelector.test.tsx
@@ -420,7 +420,7 @@ describe('TransferListSelector', () => {
     ).toHaveTextContent('3 selected');
   });
 
-  it('disables list controls and Apply while keeping Cancel operable', async () => {
+  it('disables list controls when disabled, but never when merely busy', async () => {
     const view = render(
       <TransferListSelector
         label="Visible fields"
@@ -477,13 +477,56 @@ describe('TransferListSelector', () => {
     await waitFor(() => {
       expect(dialog.querySelector('[aria-busy="true"]')).not.toBeNull();
     });
-    expect(dialog.querySelector('fieldset')).toBeDisabled();
+    // A pending change is announced with aria-busy, never by disabling the
+    // fieldset: `disabled` here would blur the row button the user just
+    // activated and drop focus to <body>.
+    expect(dialog.querySelector('fieldset')).toBeEnabled();
     expect(
       within(dialog).getByRole('button', {name: 'Cancel', hidden: true}),
     ).toBeEnabled();
     expect(
       within(dialog).getByRole('button', {name: 'Apply', hidden: true}),
     ).toBeDisabled();
+  });
+
+  it('keeps focus on the activated row control while a change is pending', async () => {
+    const user = userEvent.setup();
+    const view = render(
+      <TransferListSelector
+        label="Visible fields"
+        options={OPTIONS}
+        value={['name']}
+        onChange={() => {}}
+      />,
+    );
+    await openSelector();
+    const dialog = screen.getByRole('dialog', {
+      name: 'Visible fields',
+      ...hidden,
+    });
+
+    const addStatus = within(dialog).getByRole('button', {
+      name: 'Add Status',
+      hidden: true,
+    });
+    await user.click(addStatus);
+    expect(addStatus).toHaveFocus();
+
+    view.rerender(
+      <TransferListSelector
+        label="Visible fields"
+        options={OPTIONS}
+        value={['name']}
+        onChange={() => {}}
+        isLoading
+      />,
+    );
+
+    await waitFor(() => {
+      expect(dialog.querySelector('[aria-busy="true"]')).not.toBeNull();
+    });
+    expect(addStatus).toHaveFocus();
+    expect(document.body).not.toHaveFocus();
   });
 
   it('forwards intentional selector shell and transfer-list content props', async () => {

--- a/packages/lab/src/TransferList/TransferListSelector.tsx
+++ b/packages/lab/src/TransferList/TransferListSelector.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file TransferListSelector.tsx
- * @input Controlled option data, uncontrolled ComplexSelector state, TransferList, and action controls
+ * @input Controlled option data, uncontrolled ComplexSelector state, TransferList, action controls, and the core i18n catalog
  * @output Exports the immediate-or-staged TransferListSelector composition with draft cleanup after dismissal
  * @position Lab collection input shell; consumed by the TransferList entry point, docs, and tests
  *
@@ -21,6 +21,7 @@ import {
   ComplexSelector,
   type ComplexSelectorProps,
 } from '@astryxdesign/core/ComplexSelector';
+import {useTranslator} from '@astryxdesign/core/i18n';
 import {HStack} from '@astryxdesign/core/Stack';
 import {borderVars, colorVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {TransferList, type TransferListProps} from './TransferList';
@@ -57,6 +58,16 @@ const styles = stylex.create({
     borderStyle: 'none',
     overflowY: 'auto',
     overscrollBehavior: 'contain',
+  },
+  // Busy is not disabled: `disabled` on this fieldset would blur the Add or
+  // Remove button the user just activated, dropping focus to <body>. The
+  // pending state is carried by aria-busy plus the trigger's spinner, so this
+  // only has to read as unavailable to the pointer.
+  fieldsetBusy: {
+    cursor: {
+      default: 'progress',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
+    },
   },
   footer: {
     flexShrink: 0,
@@ -184,8 +195,8 @@ export function TransferListSelector<T extends string = string>({
   isDisabled,
   isLoading,
   width,
-  applyLabel = 'Apply',
-  cancelLabel = 'Cancel',
+  applyLabel: applyLabelFromProps,
+  cancelLabel: cancelLabelFromProps,
   selectedLabel,
   availableLabel,
   hasSearch,
@@ -200,6 +211,11 @@ export function TransferListSelector<T extends string = string>({
   noResultsText,
   ...selectorProps
 }: TransferListSelectorProps<T>): ReactNode {
+  const t = useTranslator();
+  const applyLabel =
+    applyLabelFromProps ?? t('@astryx.transferListSelector.apply');
+  const cancelLabel =
+    cancelLabelFromProps ?? t('@astryx.transferListSelector.cancel');
   const [draftValue, setDraftValue] = useState<readonly T[]>(value);
   const previousAppliedValueRef = useRef<readonly T[]>([...value]);
   const previousCommitBehaviorRef = useRef(commitBehavior);
@@ -236,7 +252,10 @@ export function TransferListSelector<T extends string = string>({
       value={value}
       onChange={onChange}
       changeAction={changeAction}
-      triggerLabel={triggerLabel ?? `${value.length} selected`}
+      triggerLabel={
+        triggerLabel ??
+        t('@astryx.transferListSelector.triggerLabel', {count: value.length})
+      }
       isDisabled={isDisabled}
       isLoading={isLoading}
       width={resolvedWidth}
@@ -256,14 +275,23 @@ export function TransferListSelector<T extends string = string>({
               />
             )}
             <fieldset
-              disabled={isDisabled || state.isBusy}
-              {...stylex.props(styles.fieldset)}>
+              disabled={isDisabled}
+              {...stylex.props(
+                styles.fieldset,
+                state.isBusy && styles.fieldsetBusy,
+              )}>
               <TransferList
                 label={label}
                 isLabelHidden
                 options={options}
                 value={transferListValue}
                 onChange={nextValue => {
+                  // Now that busy no longer disables the fieldset, the controls
+                  // stay live while a change is in flight; ignore transfers
+                  // until it settles so one pending action cannot be stacked.
+                  if (state.isBusy) {
+                    return;
+                  }
                   if (isStaged) {
                     setDraftValue(nextValue);
                   } else {


### PR DESCRIPTION
Prepares `lab/TransferList` for promotion to core by clearing the two open BLOCKs against it, so the promotion PR can be a near-pure rename rather than a rename plus a rewrite. This mirrors the split that worked for Bottom Sheet, where #5078 cleaned up in place and #5080 did the move two days later.

**This PR does not promote anything.** `TransferList` stays in lab.

## Why this is needed: the filter table template

`packages/cli/assets/templates/pages/table-filter/page.tsx` needs a transfer list for the columns section of its view-options popover, and today it hand-rolls one — roughly 120 lines of StyleX plus 250 lines of JSX, including its own pointer-and-keyboard reorder implementation. The template says why in a comment at line 1411:

> Copies the lab TransferList's panel chrome rather than importing it: that package is unpublished and does not resolve from the template viewer, so the visual contract is restated here against the same tokens.

That is accurate. The docsite doesn't list `@astryxdesign/lab` as a dependency, and unlike blocks, page templates have no skip-the-preview escape hatch — they're wired into a hand-maintained lazy-import map, so a lab import would fail `next build` outright. Promoting `TransferList` to core is what lets that template delete its copy and import the real component. It's the clearest demand signal the component has.

## Audit status: honest numbers

`TransferList` is **not** currently promotion-ready, and this PR does not claim otherwise.

**Lab readiness gate** (`pnpm lab:readiness`) — **22/30 → 24/30** with this change:

| Stage | Before | After |
|---|---|---|
| Research | 4/4 passed | 4/4 passed |
| Spec | 2/5 | **4/5** |
| Build | 6/7 | 6/7 |
| Harden checks | 10/10 passed | 10/10 passed |
| Harden review | 0/4 not started | 0/4 not started |

**Component Audit Rubric ledger** — **75.9, grade C**, capped at C by 3 open BLOCKs. All three are now closed:

- **T4** (no theming block) — already fixed on main before this PR; `TransferList.doc.mjs` declares all four targets.
- **I1** (no i18n) — fixed here.
- **A11** (busy disables focus) — fixed here.

The ledger's own sensitivity analysis states: *"fix the 3 open BLOCKs ... and change nothing else → §1 ~4.5, §2 ~4.5, §9 ~4.5 → projected ~87 (B)"*. So this should re-audit to a **B**, though that projection is the ledger's, not a re-run — the ledger has not been re-scored against this commit.

The mechanical bar was already strong before this PR and is worth stating plainly: Harden checks pass 10/10, axe is clean across six states in both themes with zero violations, and the suite carries roughly 59 role and ARIA assertions.

## What changed

### I1 — i18n

All 28 user- and screen-reader-facing strings now resolve through the core catalog: panel headings, the search label and placeholder, row action labels, locked-item tooltips, keyboard reorder instructions, empty and no-results copy, both bulk actions, all 11 live-region announcements, and the selector's Apply/Cancel/trigger summary.

Two things beyond a find-and-replace:

- **Counts use ICU plurals.** `itemCount()` previously did `` `${count} ${count === 1 ? 'item' : 'items'}` ``, which no locale with different plural rules could render correctly. The helper is deleted.
- **Announcements interpolate whole sentences.** They previously concatenated a fragment onto a count (`` `${label} added. ${itemCount(n)} selected.` ``). Word order is not portable, so each announcement is now a single message with named placeholders.

This was invisible to lint: `@astryx/no-hardcoded-i18n-string` is scoped to `packages/core/src/**` and set to `error` only under CI. The config comment at `eslint.config.js:208` says so outright — *"Lab adopts this gate when a component graduates."* A plain `git mv` into core would therefore have turned this rule on against ~28 sites and failed the build.

Case folding in search stays on plain `toLowerCase()`, matching `Selector`, `MultiSelector`, and `CommandPalette`. Locale-sensitive folding would trip `@astryx/no-raw-intl-locale`, which is also core-scoped.

### A11 — busy must not disable

`TransferListSelector` wrapped its list in `<fieldset disabled={isDisabled || state.isBusy}>`. Since the user is necessarily holding focus on the Add or Remove button that started the async change, disabling on busy blurred it and dropped focus to `<body>`.

Busy is now carried by `aria-busy` (already on the wrapper) plus the trigger's existing spinner, with `cursor: progress` as the pointer affordance. Because the controls stay live, `onChange` ignores transfers until the change settles, so a pending action cannot be stacked. Genuine `isDisabled` still disables.

The existing test asserted the buggy behavior (`expect(fieldset).toBeDisabled()` under `isLoading`), so it's been rewritten, and a regression test now asserts focus survives.

### Spec — RFC #3281 resolved

The audit's `finalizedSpec` was blocked on a real contradiction: the RFC specifies `role="listbox"` with `role="option"` and `aria-selected`, while the shipped component uses `role="group"` with semantic lists, and a test explicitly asserts `listbox` and `option` are absent.

[Resolved by design review](https://github.com/facebook/astryx/issues/3281#issuecomment-5403206870) in favour of the shipped semantics. The short version: the RFC's ARIA section assumes select-then-transfer, but what shipped is direct-action with per-row buttons — and `role="option"` does not permit interactive descendants, `aria-selected` would conflate panel membership with selection, and keyboard reorder needs a focusable grip that cannot live inside an option. The RFC contradicts itself here: its own motivating reference describes per-row add/remove/drag controls, which listbox semantics cannot carry. The `Listbox` primitive it also specifies was never built, so the "TransferList composes Listbox" premise is moot and should be split into its own RFC.

That closes `specReview` and `finalizedSpec` in the manifest, both citing the comment.

## What still blocks promotion

Six checks remain open. Five of them are exactly what review of a promotion PR produces:

- `reviewAndCI` — needs an approving review
- `visualQuality`, `compositionQuality`, `scopeBoundary`, `archivedReview` — human sign-off; `audit.mjs` refuses to let automation propose these

The sixth needs real work: `surfaceAudit` is still `in_progress` because `TransferListSelector` shipped after the RFC's audit was written and its prop surface has never been reviewed. The design review closed the naming and composition questions but did not audit that surface, so I left the check open rather than inflate it.

Two more things the promotion PR will have to handle, found by re-running the core-scoped lint rules against this directory:

- **~24 core-only lint findings** that activate on the move, none i18n or a11y: 16 `@typescript-eslint/array-type` (`readonly T[]` → `ReadonlyArray<T>`), 2 `set-state-in-effect` (the ledger's C1/C16 finding about the selector mirroring props into draft state), plus single hits on `dom-no-flush-sync`, `no-unstable-merged-refs`, `naming-convention-ref-name`, and `no-nullish-jsx-guard`. Both i18n rules are confirmed clean after this PR.
- **`packages/lab/src/reorderStyles.ts`** is shared with `ListInput`, so it can't simply move with the component.

## Test plan

- [x] `pnpm vitest run packages/lab/src/TransferList/` — 38 pass (37 existing + 1 new focus regression test)
- [x] `pnpm vitest run internal/lab-readiness/audit.test.mjs` — 22 pass
- [x] `CI=true eslint packages/lab/src/TransferList/` — clean
- [x] Core-scoped lint simulation — `no-hardcoded-i18n-string` and `no-raw-intl-locale` both clean
- [x] `pnpm check:i18n-catalog` — 336 keys over 436 references resolve, 338 en entries described, 29 locales consistent
- [x] `pnpm check:sync`, `pnpm check:changesets`, `pnpm lab:readiness:check` — all pass
- [x] `tsc --noEmit` on lab — no new errors (one pre-existing `Drawer.test.tsx` failure, untouched)
- [ ] Reviewer: confirm the busy state still reads correctly in Storybook (`Lab/TransferListSelector`), since the fieldset no longer greys out
- [ ] Reviewer: the four Harden review sign-offs, if you're satisfied
