### PR TITLE
docs(storybook): show how to theme a toast's chrome and its content

### DIFF
--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -5,10 +5,12 @@ import {useState, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Toast, useToast, ToastViewport} from '@astryxdesign/core/Toast';
 import type {ToastOptions, ToastType} from '@astryxdesign/core/Toast';
+import {Theme, defineTheme, useTheme} from '@astryxdesign/core/theme';
 import {Button} from '@astryxdesign/core/Button';
 import {Link} from '@astryxdesign/core/Link';
 import {Card} from '@astryxdesign/core/Card';
 import {Stack} from '@astryxdesign/core/Stack';
+import {Heading} from '@astryxdesign/core/Text';
 import {Dialog} from '@astryxdesign/core/Dialog';
 import {Text} from '@astryxdesign/core/Text';
 
@@ -675,3 +677,158 @@ function DialogToastContent({onClose}: {onClose: () => void}) {
     </Stack>
   );
 }
+
+// =============================================================================
+// Theming
+// =============================================================================
+
+/**
+ * `toast` is the card — the surface the toast paints. `base` restyles every
+ * toast; `type:error` restyles just the error one, because `type` is the
+ * toast's visual prop and the card renders it as a `.error` class.
+ *
+ * That one target covers more of the toast than it looks like it should:
+ *
+ * - **Inherited properties reach the content.** Font, size and letter-spacing
+ *   set on `toast` cascade into the body and `endContent`. There is no
+ *   `toast-body` target and none is needed.
+ * - **Text colour looks after itself.** A toast measures the surface it just
+ *   painted and picks the side that reads on it, so restyling the background
+ *   is enough — the body, the dismiss glyph and `endContent` follow. Below,
+ *   the cream card gets dark text and the deep red one light text, from
+ *   nothing but the two `backgroundColor` rules.
+ *
+ * `onDark` / `onLight` are for overriding that choice, not for making it. They
+ * apply only when the surface actually resolves to that side, so a toast whose
+ * ambient text already reads gets neither.
+ *
+ * Wrap the viewport, not just the buttons: theme CSS is `@scope`d and the
+ * toast renders inside the viewport.
+ */
+const brandToastTheme = defineTheme({
+  name: 'toast-brand-demo',
+  components: {
+    toast: {
+      base: {
+        backgroundColor: '#FFF4D6',
+        borderRadius: 'var(--radius-full)',
+        paddingInline: 'var(--spacing-6)',
+        boxShadow: 'var(--shadow-high)',
+        fontFamily: 'var(--font-family-code)',
+      },
+      'type:error': {
+        backgroundColor: '#5C0A18',
+      },
+    },
+  },
+});
+
+/**
+ * Default and themed, side by side, in both types. These are inline `Toast`
+ * elements rather than fired ones so both states stay on screen together;
+ * `ThemedToastLive` shows the same theme driving real `useToast()` calls.
+ */
+export const ThemedToast: StoryObj = {
+  render: function ThemedToastStory() {
+    return (
+      <Stack direction="horizontal" gap={4} wrap="wrap">
+        <ToastSpecimens label="Default" />
+        <BrandToastScope>
+          <ToastSpecimens label="brandToastTheme" />
+        </BrandToastScope>
+      </Stack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pill radius, wider inline padding, the cream surface and the ' +
+          'monospace body all come from `components.toast.base`; the deep red ' +
+          'is `type:error`. Neither rule sets a text colour.',
+      },
+    },
+  },
+};
+
+/**
+ * The copyable shape: wrap the viewport in the theme and fire toasts normally.
+ */
+export const ThemedToastLive: StoryObj = {
+  render: function ThemedToastLiveStory() {
+    return (
+      <BrandToastScope>
+        <ToastViewport>
+          <ThemedToastTriggers />
+        </ToastViewport>
+      </BrandToastScope>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same theme, real toasts. The viewport is inside `Theme`, so the ' +
+          'scoped theme CSS reaches the toasts it renders.',
+      },
+    },
+  },
+};
+
+/**
+ * An app names its colour mode once, at its root `Theme`. A nested `Theme`
+ * defaults to `mode="system"`, which follows the OS rather than the mode the
+ * toolbar picked — and Toast reads that mode to choose its inverted-surface
+ * tokens, so an unthreaded nested theme renders dark text on a dark card.
+ */
+function BrandToastScope({children}: {children: ReactNode}) {
+  const {mode} = useTheme();
+  return (
+    <Theme theme={brandToastTheme} mode={mode}>
+      {children}
+    </Theme>
+  );
+}
+
+function ToastSpecimens({label}: {label: string}) {
+  return (
+    <Stack direction="vertical" gap={2}>
+      <Heading level={4}>{label}</Heading>
+      <Toast
+        type="info"
+        body="Your changes have been saved."
+        isAutoHide={false}
+        autoHideDuration={5000}
+        onDismiss={noop}
+      />
+      <Toast
+        type="error"
+        body="Could not reach the server."
+        isAutoHide={false}
+        autoHideDuration={5000}
+        onDismiss={noop}
+      />
+    </Stack>
+  );
+}
+
+function ThemedToastTriggers() {
+  const toast = useToast();
+  return (
+    <Stack direction="horizontal" gap={2}>
+      <Button
+        label="Themed info toast"
+        onClick={() => toast({body: 'Your changes have been saved.'})}
+      />
+      <Button
+        label="Themed error toast"
+        variant="destructive"
+        onClick={() =>
+          toast({body: 'Could not reach the server.', type: 'error'})
+        }
+      />
+    </Stack>
+  );
+}
+
+function noop() {}


### PR DESCRIPTION
Toast had no theming story. Two new stories in `Core/Toast` show a `defineTheme({components: {toast: …}})` override moving real pixels, in both types and both colour modes.

`ThemedToast` puts default and themed side by side (inline `Toast`, so both types stay on screen); `ThemedToastLive` is the copyable shape — the theme wraps the `ToastViewport` and toasts are fired normally.

### What the example teaches

One target, `toast`, reaches more of the toast than it looks like it should:

- **Chrome** — `base` (pill radius, wider inline padding, cream surface, shadow) and `type:error` (deep red), because `type` is the toast's visual prop.
- **Inherited properties reach the content** — the monospace body comes from `fontFamily` on `toast`. There is no `toast-body` target and none is needed.
- **Text colour looks after itself** — `Toast` renders `MediaTheme mode="auto"`, so it measures the surface it just painted. Neither rule sets a text colour, and the cream card still gets dark text while the deep red one gets light text, in both modes.

`onDark`/`onLight` are for overriding that choice, not making it — they apply only when the surface resolves to that side, which the story's doc block says so nobody writes a rule that silently matches nothing.

### Verified in Chromium

Receipt-backed Chromium captures against local Storybook at `0ca75baa1ef79ca9c966756eb789612bd72bab6f`, with both the static comparison and live `useToast()` story checked in light and dark.

| | light | dark |
|---|---:|---:|
| default info contrast | 18.8:1 | 17.9:1 |
| themed info contrast | 16.4:1 | 16.4:1 |
| themed error contrast | 13.9:1 | 13.3:1 |

| Light | Dark |
|---|---|
| ![Default and themed Toast examples in light mode](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5458/shots/Toast__themed-toast__light.png) | ![Default and themed Toast examples in dark mode](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5458/shots/Toast__themed-toast__dark.png) |

The themed surface resolves to 9999px radius, 24px inline padding, and `ui-monospace` in both modes. The cream info toast resolves dark text at 16.4:1; the deep-red error toast resolves light text at 13.9:1 in light mode and 13.3:1 in dark mode.

`pnpm vitest run apps/storybook/.storybook/main.test.ts packages/core/src/Toast` — 48 passed. Storybook's current `theme-layers` and full CI run on the pushed head.

### Note for #5428

[#5428](https://github.com/facebook/astryx/pull/5428) appends its `renderToast` story to the end of this same file, so expect a trivial tail conflict. Nothing in this story depends on that PR's targets — it uses only `astryx-toast`, which is on `main` today.

