### PR TITLE
fix(Toast): drop the trailing gap below the last toast

### DIFF
--- a/.changeset/toast-viewport-trailing-gap.md
+++ b/.changeset/toast-viewport-trailing-gap.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ToastViewport: the space below the bottom-most toast is the viewport's own padding again, not the viewport's padding plus the toast's. Each toast carries a trailing `--spacing-3` as the inter-toast gap, and the one at the visual bottom of the stack added it on top of the viewport's `--spacing-4` — 28px there against 16px on every other edge. That toast now drops its trailing gap. The flex direction flips with `position`, so it is the last toast for `bottomEnd`/`bottomStart` and the first for `topEnd`/`topStart`; all four are corrected. The gap is still padding, so entry and exit animate as before.
+
+@cixzhang

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -58,7 +58,6 @@ const styles = stylex.create({
     pointerEvents: 'auto',
     display: 'grid',
     gridTemplateRows: '1fr',
-    paddingBlockEnd: spacingVars['--spacing-3'],
     transitionProperty: 'grid-template-rows, padding',
     transitionDuration: {
       default: durationVars['--duration-fast'],
@@ -69,6 +68,18 @@ const styles = stylex.create({
       gridTemplateRows: '0fr',
       paddingBlockEnd: 0,
     },
+  },
+  // The inter-toast gap is padding on each toast rather than `gap` on the
+  // viewport so it can animate alongside gridTemplateRows on entry and exit.
+  // That makes it the toast's own trailing space, so the toast at the visual
+  // bottom of the stack has to give it up — otherwise it stacks on top of the
+  // viewport's own padding. Which child that is flips with the flex direction
+  // the position sets.
+  toastWrapperGap: {
+    paddingBlockEnd: {default: spacingVars['--spacing-3'], ':last-child': 0},
+  },
+  toastWrapperGapReversed: {
+    paddingBlockEnd: {default: spacingVars['--spacing-3'], ':first-child': 0},
   },
   toastWrapperExiting: {
     gridTemplateRows: '0fr',
@@ -417,6 +428,10 @@ export function ToastViewport({
         : position === 'bottomStart'
           ? styles.bottomStart
           : styles.bottomEnd;
+  const isReversed = position === 'topEnd' || position === 'topStart';
+  const gapStyle = isReversed
+    ? styles.toastWrapperGapReversed
+    : styles.toastWrapperGap;
 
   return (
     <ToastContext value={contextValue}>
@@ -444,6 +459,7 @@ export function ToastViewport({
               data-toast-id={entry.id}
               {...stylex.props(
                 styles.toastWrapper,
+                gapStyle,
                 isExiting && styles.toastWrapperExiting,
               )}
               onTransitionEnd={


### PR DESCRIPTION
## The bug

`ToastViewport` pads itself with `--spacing-4` on all four sides, and every
toast carries a trailing `--spacing-3` that acts as the gap to the next one.
Nothing takes that trailing gap away from the toast at the visual bottom of the
stack, so its space lands on top of the viewport's own padding:

```
bottom edge:  --spacing-4 + --spacing-3  =  16 + 12  =  28px
every other:  --spacing-4               =            =  16px
```

The stack is 12px off-centre in its own container, in every position, at every
toast count.

## Why not `gap`

The obvious fix is `gap: --spacing-3` on the viewport and no padding on the
toasts. It is the wrong one here: the trailing padding is what animates
alongside `grid-template-rows` on entry (`@starting-style` zeroes both) and on
exit. `gap` does not participate in either transition, so it would trade a
spacing bug for a motion regression. The gap stays padding; the toast at the
bottom edge just gives it up.

## The complication

Which toast that is flips with the position, because the flex direction does:

- `bottomEnd` / `bottomStart` — `column`, so it is the **last** DOM child
- `topEnd` / `topStart` — `column-reverse`, so it is the **first** DOM child

A `:last-child` rule alone would fix two positions and leave the other two
wrong. Both are handled, and the measurements below drive all four.

## Measured

Real Chromium, Storybook `dev`, one viewport per position. Each number is a
`getBoundingClientRect` delta between the viewport's box and the nearest
toast's box, in CSS px; **between toasts** is the delta between adjacent
toasts. Intended values are `16` on every outer edge and `12` between toasts.

| position | toasts | top | **bottom** | start | end | between toasts |
|---|---|---|---|---|---|---|
| `bottomEnd` | 1 | 16 | **28 → 16** | 16 | 16 | — |
| `bottomEnd` | 2 | 16 | **28 → 16** | 16 | 16 | 12 |
| `bottomEnd` | 3 | 16 | **28 → 16** | 16 | 16 | 12, 12 |
| `bottomStart` | 1 | 16 | **28 → 16** | 16 | 16 | — |
| `bottomStart` | 2 | 16 | **28 → 16** | 16 | 16 | 12 |
| `bottomStart` | 3 | 16 | **28 → 16** | 16 | 16 | 12, 12 |
| `topEnd` | 1 | 16 | **28 → 16** | 16 | 16 | — |
| `topEnd` | 2 | 16 | **28 → 16** | 16 | 16 | 12 |
| `topEnd` | 3 | 16 | **28 → 16** | 16 | 16 | 12, 12 |
| `topStart` | 1 | 16 | **28 → 16** | 16 | 16 | — |
| `topStart` | 2 | 16 | **28 → 16** | 16 | 16 | 12 |
| `topStart` | 3 | 16 | **28 → 16** | 16 | 16 | 12, 12 |

Every outer edge and every inter-toast gap now equals its intended token; 12 of
12 cases matched, 0 of 12 before.

## Frames

Each frame is clipped exactly to the viewport's box and outlined 1px inside it,
so the white band between the outline and the nearest toast **is** the gap.
Look at the bottom band against the top one.

### `bottomEnd`, 3 toasts

| before | after |
|---|---|
| ![bottomEnd before](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5460/pr-assets/bottomEnd-before.png) | ![bottomEnd after](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5460/pr-assets/bottomEnd-after.png) |

### `topEnd`, 2 toasts

| before | after |
|---|---|
| ![topEnd before](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5460/pr-assets/topEnd-before.png) | ![topEnd after](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5460/pr-assets/topEnd-after.png) |

## Motion still works

Sampled `padding-block-end` and `grid-template-rows` on every animation frame
while raising a toast, raising a second, and dismissing one. Distinct values a
channel passed through — a snap would be two, an animation is a ramp:

**Raise the first toast** — the row opens, the toast holds no gap:

```
rows    0px -> 12.02 -> 29.73 -> 43.08 -> 48.41 -> 50.88 -> 51.78 -> 51.97 -> 52px
padding 0px
```

**Raise a second** — the previously-bottom-most toast *gains* its gap, and it
ramps rather than snapping:

```
toast 0 padding 0px -> 5.72 -> 8.94 -> 10.80 -> 11.55 -> 11.87 -> 11.98 -> 12px
toast 1 rows    0px -> 11.78 -> 28.84 -> 42.09 -> 48.17 -> 50.91 -> 51.81 -> 52px
```

**Dismiss one** — the row collapses while the survivor gives its gap back:

```
toast 1 rows    52px -> 16.09 -> 2.81 -> 0.45 -> 0.05 -> 0px
toast 0 padding 12px -> 6.23 -> 3.14 -> 1.17 -> 0.42 -> 0.12 -> 0.02 -> 0px
```

`column-reverse` behaves the same way with the roles swapped (the surviving
first child ramps 12 → 0 over 7 frames). Under
`prefers-reduced-motion: reduce` every channel is a single step, as designed,
and the resting geometry is 16/16 in both cases.

## Test plan

- `packages/core/src/Toast/ToastViewport.test.tsx` gains a **stack spacing**
  block: 8 cases covering all four positions at 1/2/3 toasts, asserting which
  toast carries the trailing gap token and which one drops it. All 8 fail on
  `main` and pass here.
- `vitest run --project ui packages/core/src` — green.
- `eslint packages/core/src/Toast` — clean.
- Chromium measurements and motion sampling above.

## Scope

Two style entries and one extra argument to an existing `stylex.props` call.
No renames, no restructuring of the styles object, nothing added to the render
tree — [#5428](https://github.com/facebook/astryx/pull/5428) is open against
this file and should rebase over this cleanly.
