### PR TITLE
fix(core): Slider draws the focus ring for keyboard focus only

### DIFF
--- a/.changeset/slider-keyboard-only-focus-ring.md
+++ b/.changeset/slider-keyboard-only-focus-ring.md
@@ -1,0 +1,22 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Slider: dragging the thumb with a mouse no longer draws the keyboard focus ring
+
+The thumb is a `div[role="slider"]`, and the track's `pointerdown` handler
+calls `preventDefault()` and then focuses the thumb from script. Chromium
+treats that script focus as focus-visible, so `:focus-visible` matched on
+mouse-down and every drag came with a 2px accent ring — measured in Chromium,
+not inferred.
+
+`:focus-visible` stays the CSS condition; it is now narrowed by the existing
+`interactionModality` utility, the same way PanelSearchInput and Selector
+narrow theirs. Keyboard focus rings exactly as before, and a mouse grab of a
+thumb that already had the ring drops it.
+
+One deliberate difference from the text-input cases: a keypress after a mouse
+drag brings the ring back. A text field has a caret to show where input is
+going, and a slider thumb has nothing else.
+
+@cixzhang

--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -13,7 +13,9 @@ import {useState} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, act, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as stylex from '@stylexjs/stylex';
 import {Slider} from './Slider';
+import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 import {__resetInteractionModalityForTest} from '../utils/interactionModality';
 
 // Mock showPopover/hidePopover (not implemented in jsdom) so the tooltip layer
@@ -909,6 +911,14 @@ describe('Slider', () => {
       __resetInteractionModalityForTest();
     });
 
+    // The ring is a stylex class, so derive it from the same source the
+    // component applies rather than hardcoding a hash.
+    const RING = stylex
+      .props(focusOutlineStyles.focusVisible)
+      .className!.split(' ');
+    const isRinged = (el: HTMLElement) =>
+      RING.every(c => el.classList.contains(c));
+
     // The track has no layout in jsdom; pointer maths needs a real rect.
     const grabTrack = (thumb: HTMLElement) => {
       const track = thumb.parentElement!;
@@ -930,10 +940,7 @@ describe('Slider', () => {
       const user = userEvent.setup();
       render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
       await user.tab();
-      expect(screen.getByRole('slider')).toHaveAttribute(
-        'data-keyboard-focus',
-        'true',
-      );
+      expect(isRinged(screen.getByRole('slider'))).toBe(true);
     });
 
     it('does not ring when the thumb is grabbed with the mouse', () => {
@@ -941,7 +948,7 @@ describe('Slider', () => {
       const thumb = screen.getByRole('slider');
       grabTrack(thumb);
       expect(thumb).toHaveFocus();
-      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+      expect(isRinged(thumb)).toBe(false);
     });
 
     it('drops the ring when the mouse grabs a thumb that already had it', async () => {
@@ -949,19 +956,28 @@ describe('Slider', () => {
       render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
       await user.tab();
       const thumb = screen.getByRole('slider');
-      expect(thumb).toHaveAttribute('data-keyboard-focus', 'true');
+      expect(isRinged(thumb)).toBe(true);
       // Already focused, so focus() fires no focus event.
       grabTrack(thumb);
-      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+      expect(isRinged(thumb)).toBe(false);
     });
 
     it('brings the ring back when an arrow key follows a mouse drag', () => {
       render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
       const thumb = screen.getByRole('slider');
       grabTrack(thumb);
-      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+      expect(isRinged(thumb)).toBe(false);
       fireEvent.keyDown(thumb, {key: 'ArrowRight'});
-      expect(thumb).toHaveAttribute('data-keyboard-focus', 'true');
+      expect(isRinged(thumb)).toBe(true);
+    });
+
+    it('leaves the ring off for a modifier chord after a mouse drag', () => {
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      const thumb = screen.getByRole('slider');
+      grabTrack(thumb);
+      // Copying or reloading is not navigation, and the mouse is still on it.
+      fireEvent.keyDown(thumb, {key: 'c', metaKey: true});
+      expect(isRinged(thumb)).toBe(false);
     });
 
     it('drops the ring on blur', async () => {
@@ -969,9 +985,9 @@ describe('Slider', () => {
       render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
       await user.tab();
       const thumb = screen.getByRole('slider');
-      expect(thumb).toHaveAttribute('data-keyboard-focus', 'true');
+      expect(isRinged(thumb)).toBe(true);
       act(() => thumb.blur());
-      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+      expect(isRinged(thumb)).toBe(false);
     });
 
     it('rings the range thumb the keyboard reached, not its sibling', async () => {
@@ -987,8 +1003,8 @@ describe('Slider', () => {
       await user.tab();
       const thumbs = screen.getAllByRole('slider');
       expect(thumbs[1]).toHaveFocus();
-      expect(thumbs[1]).toHaveAttribute('data-keyboard-focus', 'true');
-      expect(thumbs[0]).not.toHaveAttribute('data-keyboard-focus');
+      expect(isRinged(thumbs[1])).toBe(true);
+      expect(isRinged(thumbs[0])).toBe(false);
     });
   });
 });

--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -14,6 +14,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, act, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Slider} from './Slider';
+import {__resetInteractionModalityForTest} from '../utils/interactionModality';
 
 // Mock showPopover/hidePopover (not implemented in jsdom) so the tooltip layer
 // reflects its open state via a `popover-open` attribute the tests can assert.
@@ -854,7 +855,7 @@ describe('Slider', () => {
         />,
       );
       const thumb = screen.getByRole('slider');
-      thumb.focus();
+      act(() => thumb.focus());
       await user.keyboard('{ArrowRight}');
       expect(onChange).not.toHaveBeenCalled();
     });
@@ -900,6 +901,94 @@ describe('Slider', () => {
       expect([
         ...new FormData(container.querySelector('form')!).keys(),
       ]).toEqual([]);
+    });
+  });
+
+  describe('focus ring modality', () => {
+    beforeEach(() => {
+      __resetInteractionModalityForTest();
+    });
+
+    // The track has no layout in jsdom; pointer maths needs a real rect.
+    const grabTrack = (thumb: HTMLElement) => {
+      const track = thumb.parentElement!;
+      track.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        right: 200,
+        bottom: 20,
+        width: 200,
+        height: 20,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      });
+      fireEvent.pointerDown(track, {clientX: 100, clientY: 10, pointerId: 1});
+    };
+
+    it('rings when the thumb is reached with the keyboard', async () => {
+      const user = userEvent.setup();
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      await user.tab();
+      expect(screen.getByRole('slider')).toHaveAttribute(
+        'data-keyboard-focus',
+        'true',
+      );
+    });
+
+    it('does not ring when the thumb is grabbed with the mouse', () => {
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      const thumb = screen.getByRole('slider');
+      grabTrack(thumb);
+      expect(thumb).toHaveFocus();
+      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+    });
+
+    it('drops the ring when the mouse grabs a thumb that already had it', async () => {
+      const user = userEvent.setup();
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      await user.tab();
+      const thumb = screen.getByRole('slider');
+      expect(thumb).toHaveAttribute('data-keyboard-focus', 'true');
+      // Already focused, so focus() fires no focus event.
+      grabTrack(thumb);
+      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+    });
+
+    it('brings the ring back when an arrow key follows a mouse drag', () => {
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      const thumb = screen.getByRole('slider');
+      grabTrack(thumb);
+      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+      fireEvent.keyDown(thumb, {key: 'ArrowRight'});
+      expect(thumb).toHaveAttribute('data-keyboard-focus', 'true');
+    });
+
+    it('drops the ring on blur', async () => {
+      const user = userEvent.setup();
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      await user.tab();
+      const thumb = screen.getByRole('slider');
+      expect(thumb).toHaveAttribute('data-keyboard-focus', 'true');
+      act(() => thumb.blur());
+      expect(thumb).not.toHaveAttribute('data-keyboard-focus');
+    });
+
+    it('rings the range thumb the keyboard reached, not its sibling', async () => {
+      const user = userEvent.setup();
+      render(
+        <Slider
+          label="Price"
+          value={[20, 80] as [number, number]}
+          onChange={vi.fn()}
+        />,
+      );
+      await user.tab();
+      await user.tab();
+      const thumbs = screen.getAllByRole('slider');
+      expect(thumbs[1]).toHaveFocus();
+      expect(thumbs[1]).toHaveAttribute('data-keyboard-focus', 'true');
+      expect(thumbs[0]).not.toHaveAttribute('data-keyboard-focus');
     });
   });
 });

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -759,7 +759,11 @@ export function Slider({ref, ...props}: SliderProps) {
       }
       // Unlike a text field, a thumb has no caret to show where input is
       // going, so a keypress after a mouse drag must bring the ring back.
-      setKeyboardFocusThumb(thumbIndex);
+      // Ask the utility rather than assuming: a modifier chord (⌘R, ⌃C) is
+      // not navigation and must not re-ring a thumb the mouse is holding.
+      if (getInteractionModality() === 'keyboard') {
+        setKeyboardFocusThumb(thumbIndex);
+      }
       const currentVal = values[thumbIndex];
       let newVal: number;
 
@@ -885,9 +889,6 @@ export function Slider({ref, ...props}: SliderProps) {
         aria-label={thumbLabel}
         aria-labelledby={!isRange ? labelID : undefined}
         aria-describedby={ariaDescribedBy}
-        data-keyboard-focus={
-          keyboardFocusThumb === thumbIndex ? 'true' : undefined
-        }
         onKeyDown={e => handleKeyDown(thumbIndex, e)}
         onFocus={e => handleThumbFocus(thumbIndex, e)}
         onBlur={handleThumbBlur}

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -17,11 +17,13 @@
  */
 
 import {
+  useEffect,
   useId,
   useMemo,
   useRef,
   useState,
   useCallback,
+  type FocusEvent,
   type KeyboardEvent,
   type PointerEvent,
 } from 'react';
@@ -42,6 +44,10 @@ import {VisuallyHidden} from '../VisuallyHidden';
 import type {InputStatus} from '../Field/types';
 import {mergeProps, rtlStyles} from '../utils';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
+import {
+  getInteractionModality,
+  trackInteractionModality,
+} from '../utils/interactionModality';
 import {isRtlElement} from '../hooks/isRtlElement';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
@@ -493,6 +499,36 @@ export function Slider({ref, ...props}: SliderProps) {
   const draggingThumbRef = useRef<number | null>(null);
   const [draggingThumb, setDraggingThumb] = useState<number | null>(null);
 
+  // A thumb is a div[role="slider"], and `handlePointerDown` focuses it from
+  // script after preventDefault — which Chromium treats as focus-visible, so
+  // dragging with a mouse drew the keyboard ring (measured: `:focus-visible`
+  // true on pointerdown). Gate the ring on how the user last interacted; the
+  // CSS condition stays `:focus-visible`, this only narrows it.
+  const [keyboardFocusThumb, setKeyboardFocusThumb] = useState<number | null>(
+    null,
+  );
+
+  useEffect(() => {
+    trackInteractionModality();
+  }, []);
+
+  const handleThumbFocus = useCallback(
+    (thumbIndex: number, _e: FocusEvent<HTMLDivElement>) => {
+      // A disabled thumb draws no ring even when it stays focusable for its
+      // reason tooltip, so there is nothing to track for one.
+      setKeyboardFocusThumb(
+        !isDisabled && getInteractionModality() === 'keyboard'
+          ? thumbIndex
+          : null,
+      );
+    },
+    [isDisabled],
+  );
+
+  const handleThumbBlur = useCallback((_e: FocusEvent<HTMLDivElement>) => {
+    setKeyboardFocusThumb(null);
+  }, []);
+
   // Disabled-reason tooltip. This is a *separate* useTooltip instance from the
   // per-thumb value bubble (the `<Tooltip>` component below): it anchors to the
   // track container and fires on hover/focus of the whole control. Disabled
@@ -679,6 +715,10 @@ export function Slider({ref, ...props}: SliderProps) {
         const thumbs = track.querySelectorAll<HTMLElement>('[role="slider"]');
         thumbs[thumbIndex]?.focus();
       }
+      // Also clear it explicitly: focusing an already-focused thumb fires no
+      // focus event, so a thumb the user had tabbed to would keep its ring
+      // through the drag.
+      setKeyboardFocusThumb(null);
 
       if (
         typeof (e.currentTarget as HTMLElement).setPointerCapture === 'function'
@@ -717,6 +757,9 @@ export function Slider({ref, ...props}: SliderProps) {
       if (isDisabled) {
         return;
       }
+      // Unlike a text field, a thumb has no caret to show where input is
+      // going, so a keypress after a mouse drag must bring the ring back.
+      setKeyboardFocusThumb(thumbIndex);
       const currentVal = values[thumbIndex];
       let newVal: number;
 
@@ -842,7 +885,12 @@ export function Slider({ref, ...props}: SliderProps) {
         aria-label={thumbLabel}
         aria-labelledby={!isRange ? labelID : undefined}
         aria-describedby={ariaDescribedBy}
+        data-keyboard-focus={
+          keyboardFocusThumb === thumbIndex ? 'true' : undefined
+        }
         onKeyDown={e => handleKeyDown(thumbIndex, e)}
+        onFocus={e => handleThumbFocus(thumbIndex, e)}
+        onBlur={handleThumbBlur}
         {...mergeProps(
           themeProps('slider-thumb', {
             orientation,
@@ -854,7 +902,9 @@ export function Slider({ref, ...props}: SliderProps) {
               ? styles.thumbHorizontal
               : rtlStyles.centerInline('50%'),
             !isDisabled && styles.thumbHover,
-            !isDisabled && focusOutlineStyles.focusVisible,
+            !isDisabled &&
+              keyboardFocusThumb === thumbIndex &&
+              focusOutlineStyles.focusVisible,
             isDisabled && styles.thumbDisabled,
           ),
           undefined,


### PR DESCRIPTION
## Problem

Dragging a Slider thumb with the mouse drew the 2px keyboard focus ring.

The thumb is a `div[role="slider"]`, and the track's `pointerdown` handler calls
`preventDefault()` and then focuses the closest thumb from script. Chromium
treats that script focus as focus-visible, so `:focus-visible` matched from
mouse-down onward and stayed matched for the whole drag.

Measured in Chromium against `main`, not inferred — `:focus-visible` is `true`
and the computed outline is `2px solid` at mouse-down, during the drag, and
after mouse-up.

## Solution

`:focus-visible` stays the CSS condition. It is now narrowed by the existing
`interactionModality` utility, the same way `PanelSearchInput` and `Selector`
narrow theirs: the thumb records which device moved focus to it, and the ring
style is applied only for a keyboard focus.

Three details worth the review:

- The pointer path clears the state explicitly as well as through the focus
  event. Focusing an already-focused element fires no focus event, so a thumb
  the user had tabbed to would otherwise keep its ring through the drag.
- A keypress after a mouse drag brings the ring back. This is deliberately
  different from the text-input cases, where typing after a click does not —
  a text field has a caret to show where input is going, and a thumb has
  nothing else, so a keyboard user operating a mouse-focused thumb would have
  no visible focus indicator (WCAG 2.4.7). The keydown path asks the utility
  rather than assuming, so a modifier chord (⌘C, ⌃R) does not count.
- The state is per-thumb, so in range mode only the thumb that actually has
  keyboard focus rings.

No API change, no new DOM attribute, no visual change to keyboard focus, no
theme change. The ring's appearance still comes entirely from the
`--focus-outline-*` tokens.

## Evidence

Chromium, `core-slider--default`, 3x, cropped to the thumb.

| | mouse drag | keyboard Tab |
|---|---|---|
| before (`main`) | ![before drag](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5463/pr-assets/before-mouse-drag.png) | ![before tab](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5463/pr-assets/before-keyboard-tab.png) |
| after | ![after drag](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5463/pr-assets/after-mouse-drag.png) | ![after tab](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5463/pr-assets/after-keyboard-tab.png) |

The two keyboard frames are byte-identical (`64d8623…`) — the keyboard path is
untouched.

Full state matrix, driven in Chromium (`data-keyboard-focus` / computed
`outline-style`):

| interaction | before | after |
|---|---|---|
| mouse down on thumb | ring | no ring |
| dragging | ring | no ring |
| mouse up | ring | no ring |
| arrow key after a drag | ring | ring |
| Tab to the thumb | ring | ring |
| mouse grabs a thumb that already had the ring | ring | no ring |
| ⌘C / ⌃C / ⌥C after a drag | ring | no ring |
| range: Tab to the second thumb | ring on it, none on its sibling | same |

## Testing

`packages/core/src/Slider` — 58 tests pass. Seven are new, and six of them fail
against `main`; the seventh (keyboard rings) passes there because `main` rings
for everything. The modifier-chord test also fails against this PR's own first
commit, which is the defect it was written for.

Tests assert the ring by deriving its class from `focusOutlineStyles`, so they
check the ring itself rather than a marker standing in for it.

One unrelated `act()` warning in `blocks value changes while focusable-disabled`
is fixed on the way past — that test focused a thumb outside `act`, and the new
focus handler made it warn twice instead of once. The suite is now warning-free.

## Adjacent, not fixed

A thumb that is `isDisabled` with a `disabledMessage` stays focusable so its
reason tooltip is keyboard-discoverable, but has never drawn a focus ring at
all. That predates this change and is left as-is here.

`interactionModality`'s comment says holding Shift must not turn an interaction
into a keyboard one, but its guard covers only ⌘/⌃/⌥ — so a bare Shift press
does flip it, and re-rings a mouse-dragged thumb. Pre-existing, shared with
PanelSearchInput and Selector, and not obviously wrong (Shift+Tab *is*
keyboard navigation), so it is left for its own change.

@cixzhang
