### PR TITLE
docs(docsite): correct two stale backdropGlow comments left by #5415

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -175,9 +175,11 @@ const styles = stylex.create({
     // Desktop: fixed, part of the pin-and-cover effect alongside heroContent
     // and the cards stage. Narrow: absolute within heroScope (position:
     // relative), so it scrolls away with the hero instead of staying pinned
-    // for the whole page — a fixed glow below 1024px reached past the
-    // footer into the bottom-overscroll gap, which blocked pull-to-refresh
-    // from ever registering a release (#5392).
+    // for the whole page — a fixed glow below 1024px reached past the footer
+    // into the bottom-overscroll gap. That exposure is what the app-global
+    // `overscroll-behavior-y: none` in globals.css was suppressing, at the
+    // cost of pull-to-refresh on every route on mobile; bounding the glow
+    // here is what lets that rule scope to desktop widths (#5392).
     position: {
       default: 'absolute',
       '@media (min-width: 1024px)': 'fixed',

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -168,9 +168,11 @@ const styles = stylex.create({
     transition: 'background-color 600ms ease',
     zIndex: 0,
   },
-  // Blurred aurora glow — fixed, in the same 1200px box as the cards so blobs
-  // and cards stay aligned. Capped to 100vw to avoid horizontal scroll. Blob
-  // centers sit under the card clusters; colors come from --aurora-* per slide.
+  // Blurred aurora glow — in the same 1200px box as the cards so blobs and
+  // cards stay aligned; pinned at >=1024px and scrolling away with the hero
+  // below that (see `position`). Capped to 100vw to avoid horizontal scroll.
+  // Blob centers sit under the card clusters; colors come from --aurora-* per
+  // slide.
   backdropGlow: {
     // Desktop: fixed, part of the pin-and-cover effect alongside heroContent
     // and the cards stage. Narrow: absolute within heroScope (position:


### PR DESCRIPTION
Follow-up to #5415 (issue #5392). Comments only — no behavior change, no CSS change.

#5415 made the hero's aurora glow responsive (`absolute` below 1024px, `fixed` at and above it). Two comments on that same style object were left describing the old unconditional behavior. Both are corrected here.

## 1. The causal chain was inverted

The comment added in #5415 says:

> a fixed glow below 1024px reached past the footer into the bottom-overscroll gap, **which blocked pull-to-refresh from ever registering a release**

The glow never blocked pull-to-refresh. `overscroll-behavior-y: none` in `globals.css` did — the glow is the *reason that rule was written*. The direction matters: the rule suppressed the whole page's overscroll to hide one bleeding layer, and bounding the layer is what let the rule retreat to desktop widths. As written, the comment sends the next person to the wrong file.

```
- for the whole page — a fixed glow below 1024px reached past the
- footer into the bottom-overscroll gap, which blocked pull-to-refresh
- from ever registering a release (#5392).
+ for the whole page — a fixed glow below 1024px reached past the footer
+ into the bottom-overscroll gap. That exposure is what the app-global
+ `overscroll-behavior-y: none` in globals.css was suppressing, at the
+ cost of pull-to-refresh on every route on mobile; bounding the glow
+ here is what lets that rule scope to desktop widths (#5392).
```

## 2. The header comment still claimed the glow is unconditionally fixed

Four lines above, the comment introducing `backdropGlow` opened with "Blurred aurora glow — **fixed**, …". Since #5415 that is only true at ≥1024px.

Both sibling layers state their split — `HeroFloatingCards`'s `stage` says "Hidden <1024px", `page.tsx`'s `heroContent` says "Desktop: fixed … Narrow: in flow" — so this was the one layer comment hiding its responsive behavior, and the first thing a reader hits.

```
- // Blurred aurora glow — fixed, in the same 1200px box as the cards so blobs
- // and cards stay aligned. Capped to 100vw to avoid horizontal scroll. Blob
- // centers sit under the card clusters; colors come from --aurora-* per slide.
+ // Blurred aurora glow — in the same 1200px box as the cards so blobs and
+ // cards stay aligned; pinned at >=1024px and scrolling away with the hero
+ // below that (see `position`). Capped to 100vw to avoid horizontal scroll.
+ // Blob centers sit under the card clusters; colors come from --aurora-* per
+ // slide.
```

## Risk

None. Ten comment lines in one file; no code, no styles.

## Testing

`prettier --check` and `eslint --no-cache` clean on the changed file. `check:changesets` passes — no changeset needed (docsite app code, not a published package, and nothing consumer-visible). CI was green on the first commit and covers the second.
