### PR TITLE
ci: ship the built themes to the PR visual gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,18 @@ jobs:
           path: apps/storybook/dist/
           retention-days: 30
 
+      # pr-visual reads each theme's built source to learn which targets that
+      # theme styles — a theme's component map is what defineTheme returns, not
+      # a literal in its source. This job has already built them; shipping the
+      # artifact keeps that job on a download instead of a second full build.
+      - name: Upload built themes
+        if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: themes-${{ steps.urls.outputs.short_hash }}
+          path: packages/themes/*/dist/
+          retention-days: 1
+
       - name: Analyze components
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
         run: |
@@ -560,6 +572,12 @@ jobs:
         with:
           name: storybook-${{ needs.build-storybook.outputs.short_hash }}
           path: apps/storybook/dist
+
+      - name: Download built themes
+        uses: actions/download-artifact@v8
+        with:
+          name: themes-${{ needs.build-storybook.outputs.short_hash }}
+          path: packages/themes
 
       - name: Install Playwright
         run: pnpm install --frozen-lockfile && npx playwright install chromium


### PR DESCRIPTION
`pr-visual` has failed on every PR since it landed in [#5396](https://github.com/facebook/astryx/pull/5396) — [#5468](https://github.com/facebook/astryx/pull/5468) and [#5466](https://github.com/facebook/astryx/pull/5466) both fail at the identical step with:

```
Theme butter is not built (packages/themes/butter/dist/source.mjs missing) — run pnpm build before the visual gate.
```

`loadThemeOverrides` reads each theme's built `dist/source.mjs`, because a theme's component map is the product of `defineTheme` rather than a literal in its source. The job downloads the Storybook artifact, which does not carry it, and never builds anything.

The job is `continue-on-error`, so nothing was blocked — the signal was just dead.

## Why not `pnpm build` in the job

That is what `release-gate.yml` does, and it works, but it costs a full build (~1 min locally, longer on a 2-core runner) on every component PR — which destroys the thing that makes a per-PR gate defensible: a median PR is ~16 shots, about 10 seconds. `build-storybook` already runs `pnpm build`, so the artifact is free. Filtering (`pnpm -F "@astryxdesign/theme-*..." build`) does not work: themes take `@astryxdesign/core` as a **peer** dependency, so the filter cannot reach it and the build fails on a missing `core/dist/theme/index.js`.

## Verified

The upload glob's common ancestor is `packages/themes`, so entries are `<theme>/dist/…` and the download restores them in place. Simulated the round trip locally: with the dists removed `loadThemeOverrides` throws exactly the CI error, and after restoring the artifact it returns all seven themes.

Suggested by the session that owns `.github/scripts/visual-gate/**`.