### PR TITLE
fix(cli): resolve component and hook names case-exactly on case-insensitive filesystems

### DIFF
--- a/.changeset/cli-case-exact-name-resolution.md
+++ b/.changeset/cli-case-exact-name-resolution.md
@@ -11,7 +11,8 @@ folding. On a case-insensitive filesystem `astryx component button` resolved to
 `findHookDoc(core, 'mediaquery')` returned `.../hooks/useMediaquery.doc.mjs` — a
 spelling that exists nowhere, and that breaks any consumer reading it on Linux.
 The probes now verify each path segment against its parent's real directory
-listing, so every host resolves the same names to the same real paths. The
+listing, so these component and hook lookups resolve the same names to the
+same real paths on every host. The
 deliberate case-insensitive hook lookup is unchanged; it now returns the file's
 true casing.
 

--- a/.changeset/cli-case-exact-name-resolution.md
+++ b/.changeset/cli-case-exact-name-resolution.md
@@ -1,0 +1,18 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Component and hook names resolve case-exactly on macOS and Windows, matching Linux
+
+`findComponentReadme`, `findComponentSource` and `findHookDoc` probed candidate
+paths with `fs.existsSync`, which answers through the filesystem's own case
+folding. On a case-insensitive filesystem `astryx component button` resolved to
+`Button` instead of reporting an unknown component with suggestions, and
+`findHookDoc(core, 'mediaquery')` returned `.../hooks/useMediaquery.doc.mjs` — a
+spelling that exists nowhere, and that breaks any consumer reading it on Linux.
+The probes now verify each path segment against its parent's real directory
+listing, so every host resolves the same names to the same real paths. The
+deliberate case-insensitive hook lookup is unchanged; it now returns the file's
+true casing.
+
+@cixzhang

--- a/packages/cli/foundation/discovery/component-discovery.mjs
+++ b/packages/cli/foundation/discovery/component-discovery.mjs
@@ -6,6 +6,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {existsCaseExact} from '../fs/paths.mjs';
 
 const SKIP_DIRS = new Set(['hooks', 'utils', '__tests__', 'node_modules']);
 
@@ -243,27 +244,27 @@ export function findComponentReadme(coreDir, name) {
 
   // Direct match: src/{name}/{Name}.doc.mjs or src/{name}/Astryx{Name}.doc.mjs
   const direct = path.join(srcDir, name, exactDoc);
-  if (fs.existsSync(direct)) return direct;
+  if (existsCaseExact(direct, srcDir)) return direct;
   const directXds = path.join(srcDir, name, xdsDoc);
-  if (fs.existsSync(directXds)) return directXds;
+  if (existsCaseExact(directXds, srcDir)) return directXds;
 
   // Nested match: src/*/{name}/{Name}.doc.mjs or src/*/{name}/Astryx{Name}.doc.mjs
   const entries = fs.readdirSync(srcDir, {withFileTypes: true});
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const nested = path.join(srcDir, entry.name, name, exactDoc);
-    if (fs.existsSync(nested)) return nested;
+    if (existsCaseExact(nested, srcDir)) return nested;
     const nestedXds = path.join(srcDir, entry.name, name, xdsDoc);
-    if (fs.existsSync(nestedXds)) return nestedXds;
+    if (existsCaseExact(nestedXds, srcDir)) return nestedXds;
   }
 
   // Per-component doc in a parent directory: src/*/{Name}.doc.mjs or src/*/Astryx{Name}.doc.mjs
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const perComp = path.join(srcDir, entry.name, exactDoc);
-    if (fs.existsSync(perComp)) return perComp;
+    if (existsCaseExact(perComp, srcDir)) return perComp;
     const perCompXds = path.join(srcDir, entry.name, xdsDoc);
-    if (fs.existsSync(perCompXds)) return perCompXds;
+    if (existsCaseExact(perCompXds, srcDir)) return perCompXds;
   }
 
   // Sub-component fallback: find the source file, then walk up
@@ -321,7 +322,7 @@ export function findComponentSource(coreDir, name) {
     // Check for an exact match (prefixed or bare) first
     for (const candidate of candidateFiles) {
       const exact = path.join(dirPath, candidate);
-      if (fs.existsSync(exact)) return exact;
+      if (existsCaseExact(exact, dirPath)) return exact;
     }
 
     // Recurse into subdirectories
@@ -336,7 +337,7 @@ export function findComponentSource(coreDir, name) {
 
   // Search in the component's directory
   const directDir = path.join(srcDir, name);
-  if (fs.existsSync(directDir)) {
+  if (existsCaseExact(directDir, srcDir)) {
     const found = searchDir(directDir);
     if (found) return found;
   }
@@ -346,7 +347,7 @@ export function findComponentSource(coreDir, name) {
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     const nestedDir = path.join(srcDir, entry.name, name);
-    if (fs.existsSync(nestedDir)) {
+    if (existsCaseExact(nestedDir, srcDir)) {
       const found = searchDir(nestedDir);
       if (found) return found;
     }

--- a/packages/cli/foundation/discovery/hook-discovery.mjs
+++ b/packages/cli/foundation/discovery/hook-discovery.mjs
@@ -6,6 +6,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {existsCaseExact} from '../fs/paths.mjs';
 import {levenshteinDistance} from '../text/string-utils.mjs';
 
 const SKIP_DIRS = new Set(['utils', '__tests__', 'node_modules']);
@@ -157,7 +158,7 @@ export function findHookDoc(coreDir, name) {
   // 1. Check src/hooks/{name}.doc.mjs first
   for (const candidate of uniqueCandidates) {
     const direct = path.join(hooksDir, `${candidate}.doc.mjs`);
-    if (fs.existsSync(direct)) return direct;
+    if (existsCaseExact(direct, hooksDir)) return direct;
   }
 
   // 2. Case-insensitive search in hooks directory

--- a/packages/cli/foundation/fs/paths.mjs
+++ b/packages/cli/foundation/fs/paths.mjs
@@ -160,3 +160,39 @@ export function listComponents(coreDir) {
     .map(e => e.name)
     .sort();
 }
+
+/**
+ * Does `targetPath` exist with EXACTLY this spelling?
+ *
+ * `fs.existsSync` answers through the filesystem's own case folding, so on
+ * macOS and Windows a probe for `src/button/Button.doc.mjs` succeeds against
+ * the real `src/Button/Button.doc.mjs`. Name resolvers built on that probe
+ * then resolve a component or hook the caller never named, and hand back a
+ * path spelled the way the caller typed it — a path that does not exist on
+ * Linux, where the same lookup correctly misses. Every segment below
+ * `rootDir` is checked against its parent's real directory listing.
+ *
+ * @param {string} targetPath - Path to probe; must be inside `rootDir`.
+ * @param {string} rootDir - Already-real path; it and its parents are not checked.
+ * @returns {boolean}
+ */
+export function existsCaseExact(targetPath, rootDir) {
+  if (!fs.existsSync(targetPath)) return false;
+
+  const rel = path.relative(rootDir, targetPath);
+  if (rel === '') return true;
+  if (path.isAbsolute(rel) || rel === '..' || rel.startsWith(`..${path.sep}`)) return false;
+
+  let dir = rootDir;
+  for (const segment of rel.split(path.sep)) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return false;
+    }
+    if (!entries.includes(segment)) return false;
+    dir = path.join(dir, segment);
+  }
+  return true;
+}

--- a/packages/cli/foundation/fs/paths.test.mjs
+++ b/packages/cli/foundation/fs/paths.test.mjs
@@ -4,7 +4,7 @@ import {describe, it, expect, beforeEach, afterEach} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import {findCoreDir, findProjectRoot, listComponents, discoverExternalPackages} from './paths.mjs';
+import {findCoreDir, findProjectRoot, listComponents, discoverExternalPackages, existsCaseExact} from './paths.mjs';
 
 let tmpDir;
 
@@ -207,5 +207,33 @@ describe('listComponents', () => {
 
   it('returns empty array when src dir is missing', () => {
     expect(listComponents(tmpDir)).toEqual([]);
+  });
+});
+
+describe('existsCaseExact', () => {
+  it('accepts the real spelling and rejects a case variant of the file', () => {
+    fs.writeFileSync(path.join(tmpDir, 'Button.doc.mjs'), '');
+
+    expect(existsCaseExact(path.join(tmpDir, 'Button.doc.mjs'), tmpDir)).toBe(true);
+    expect(existsCaseExact(path.join(tmpDir, 'button.doc.mjs'), tmpDir)).toBe(false);
+    expect(existsCaseExact(path.join(tmpDir, 'BUTTON.DOC.MJS'), tmpDir)).toBe(false);
+  });
+
+  it('checks every segment below the root, not just the basename', () => {
+    const dir = path.join(tmpDir, 'src', 'Button');
+    fs.mkdirSync(dir, {recursive: true});
+    fs.writeFileSync(path.join(dir, 'Button.doc.mjs'), '');
+
+    expect(existsCaseExact(path.join(tmpDir, 'src', 'Button', 'Button.doc.mjs'), tmpDir)).toBe(true);
+    expect(existsCaseExact(path.join(tmpDir, 'src', 'button', 'Button.doc.mjs'), tmpDir)).toBe(false);
+  });
+
+  it('returns false for a missing path, and true for the root itself', () => {
+    expect(existsCaseExact(path.join(tmpDir, 'nope.mjs'), tmpDir)).toBe(false);
+    expect(existsCaseExact(tmpDir, tmpDir)).toBe(true);
+  });
+
+  it('refuses a target outside the root', () => {
+    expect(existsCaseExact(os.tmpdir(), tmpDir)).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

Two CLI tests fail on macOS on a clean `origin/main`, and pass in CI:

- `hook-discovery.test.mjs` → `resolves a bare (use-prefix-stripped, case-insensitive) name`
- `component.test.mjs` → `is case-SENSITIVE: a lowercased name is unknown`

They are not a matched pair pulling in opposite directions, and no rule changed.
Both are the same defect, and the tests encode the correct behaviour.

`findComponentReadme`, `findComponentSource` and `findHookDoc` probe candidate
paths with `fs.existsSync`, which answers through the **filesystem's own case
folding**. On case-insensitive APFS/NTFS, `existsSync('src/button/button.doc.mjs')`
is `true` against the real `src/Button/Button.doc.mjs`. So on a Mac:

- `astryx component button` silently answers for `Button` instead of reporting an
  unknown component with suggestions.
- `findHookDoc(core, 'mediaquery')` returns `.../hooks/useMediaquery.doc.mjs` — a
  spelling that exists nowhere. It is read back fine on the Mac that produced it
  and breaks anywhere case-sensitive.

Confirmed by running the unmodified resolvers against the same `packages/core`
tree on a case-sensitive APFS volume and on the Mac's normal one:

| call | case-sensitive volume | Mac (before) |
| --- | --- | --- |
| `findHookDoc(core, 'mediaquery')` | `src/hooks/useMediaQuery.doc.mjs` | `src/hooks/useMediaquery.doc.mjs` |
| `findComponentReadme(core, 'button')` | `null` | `src/button/button.doc.mjs` |

## What

Adds `existsCaseExact(targetPath, rootDir)` to `foundation/fs/paths.mjs`: it
keeps the cheap `existsSync` short-circuit, then verifies every path segment
below `rootDir` against its parent's real directory listing. The three resolvers
use it for their name-derived probes.

The deliberate case-insensitive hook lookup is unchanged — `mediaquery` still
resolves, it now just returns the file's true casing (step 2 of `findHookDoc`,
which reads real names off `readdirSync`, does the work the folded `existsSync`
was shadowing).

## Risk

Low, and confined to the CLI's name resolution.

Behaviour on Linux is unchanged by construction — `existsSync` already answered
case-exactly there, so the added check can only agree. On macOS/Windows, a
lowercase name that used to resolve by accident now takes the normal
unknown-name path (fuzzy suggestions, or `ERR_UNKNOWN_COMPONENT`) — the same
answer Linux and CI have always given.

One cost: on macOS a miss like `component button` now pays the full-tree
fallback scan (~0.5ms → ~50ms), because it stops short-circuiting on a wrong-case
hit. That is the cost every unknown name already pays, and the cost Linux
already paid.

## Testing

- Both named tests pass; the full `packages/cli` node suite is green
  (2837/2837). At the default 30s per-test timeout this laptop flakes several
  unrelated tests under load — `--testTimeout=180000` clears them, on this branch
  and on `origin/main` alike.
- New colocated tests for `existsCaseExact` in `paths.test.mjs` cover basename
  case, a wrong-case *directory* segment, missing paths, and a target outside the
  root. They pass on both filesystem kinds (trivially on Linux, meaningfully on a
  Mac).
- Re-ran the case-sensitive-volume comparison with the fix: all four probes now
  return byte-identical paths on both filesystems.
- `astryx component button` on macOS now prints `No component named "button"`
  with `Button (exact name)` / `IconButton (keyword "button")` suggestions.
- `eslint` clean; all four `packages/cli` typecheck projects clean.
