### PR TITLE
fix(docsite): pin the hero with sticky rails, drop the overscroll suppression

### DIFF
--- a/apps/docsite/src/__tests__/home-hero-overscroll.test.ts
+++ b/apps/docsite/src/__tests__/home-hero-overscroll.test.ts
@@ -115,24 +115,202 @@ function allValues(block: string, property: string): string[] {
   });
 }
 
-describe('docsite globals.css never suppresses overscroll (#5392, #5470)', () => {
-  it('has no overscroll-behavior declaration other than auto, at any width', () => {
-    const css = stripComments(read(path.join(APP, 'globals.css')));
-    const offenders: string[] = [];
-    for (const match of css.matchAll(
-      /overscroll-behavior(?:-x|-y|-block|-inline)?\s*:\s*([^;}]+)/gi,
-    )) {
-      const value = match[1].trim();
-      if (value !== 'auto') {
-        // Name the enclosing at-rule so a re-scoped rule is still reported.
-        const before = css.slice(0, match.index);
-        const atRule = /@media[^{]*\{(?:[^{}]|\{[^{}]*\})*$/.exec(before)?.[0];
-        offenders.push(
-          `${atRule ? atRule.split('{')[0].trim() + ' > ' : ''}overscroll-behavior: ${value}`,
-        );
-      }
+/**
+ * The open `{` preludes (at-rules and selectors, outermost first) enclosing
+ * `index`. Enough of a CSS parser for a source invariant: the input is
+ * comment-stripped and holds no braces inside strings.
+ */
+function enclosingPreludes(css: string, index: number): string[] {
+  const stack: string[] = [];
+  let prelude = '';
+  for (let i = 0; i < index; i++) {
+    const char = css[i];
+    if (char === '{') {
+      stack.push(prelude.trim());
+      prelude = '';
+    } else if (char === '}') {
+      stack.pop();
+      prelude = '';
+    } else if (char === ';') {
+      prelude = '';
+    } else {
+      prelude += char;
     }
-    expect(offenders).toEqual([]);
+  }
+  return stack;
+}
+
+/** Split `text` on `separator` characters that sit outside parentheses. */
+function splitTopLevel(text: string, separator: RegExp): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of text) {
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+    }
+    if (depth === 0 && separator.test(char)) {
+      if (current) {
+        parts.push(current);
+      }
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  if (current) {
+    parts.push(current);
+  }
+  return parts;
+}
+
+/**
+ * Whether a selector list targets the page itself. `overscroll-behavior`
+ * reaches the viewport (pull-to-refresh, the trackpad rubber-band) only from
+ * the root element: `html` / `:root`, or `body`, whose value browsers
+ * propagate when the root's is `auto`; `*` covers both. `:is()` and
+ * `:where()` are looked through.
+ */
+function isPageWide(selectorList: string): boolean {
+  return splitTopLevel(selectorList, /,/).some(selector => {
+    const compounds = splitTopLevel(selector.trim(), /[\s>+~]/);
+    const subject = compounds[compounds.length - 1] ?? '';
+    const wrapped = /^:(?:is|where)\((.*)\)$/i.exec(subject);
+    if (wrapped) {
+      return isPageWide(wrapped[1]);
+    }
+    return /^(?:html|body|:root|\*)(?![\w-])/i.test(subject);
+  });
+}
+
+/**
+ * Every non-`auto` `overscroll-behavior` declaration in `css` whose selector
+ * is page-wide, labelled with its enclosing at-rules and selector so a
+ * re-scoped rule is still reported. Only declarations count (the property
+ * inside an `@supports` prelude is not one). `contain` on a nested scroller
+ * only stops that box's scroll from chaining outward, so it is legitimate and
+ * not reported.
+ */
+function pageWideOverscrollSuppressions(css: string): string[] {
+  const offenders: string[] = [];
+  for (const match of css.matchAll(
+    /(?<=[{;]\s*)(overscroll-behavior(?:-x|-y|-block|-inline)?)\s*:\s*([^;{}]+)/gi,
+  )) {
+    const property = match[1].toLowerCase();
+    const value = match[2].trim();
+    if (value === 'auto') {
+      continue;
+    }
+    const preludes = enclosingPreludes(css, match.index);
+    const atRules = preludes.filter(p => p.startsWith('@'));
+    const selectors = preludes.filter(p => !p.startsWith('@'));
+    const selector = selectors[selectors.length - 1] ?? '';
+    if (!isPageWide(selector)) {
+      continue;
+    }
+    offenders.push(
+      `${[...atRules, selector].join(' > ')} { ${property}: ${value} }`,
+    );
+  }
+  return offenders;
+}
+
+describe('docsite globals.css never suppresses overscroll (#5392, #5470)', () => {
+  it('never sets overscroll-behavior on html, :root, body or * away from auto, at any width', () => {
+    const css = stripComments(read(path.join(APP, 'globals.css')));
+    expect(pageWideOverscrollSuppressions(css)).toEqual([]);
+  });
+});
+
+/**
+ * The guard's own contract, on fixtures: it must keep catching the root-level
+ * rule this change deletes, inside any at-rule, and it must not reject
+ * scroll-chaining control on a nested scroller.
+ */
+describe('the globals.css overscroll guard', () => {
+  it('reports a suppression on html inside a media query, naming the at-rule', () => {
+    const css = `
+@media (min-width: 1024px) {
+  html {
+    overscroll-behavior-y: none;
+  }
+}
+`;
+    expect(pageWideOverscrollSuppressions(css)).toEqual([
+      '@media (min-width: 1024px) > html { overscroll-behavior-y: none }',
+    ]);
+  });
+
+  it('reports contain on :root and a longhand on body', () => {
+    const css = `
+:root {
+  overscroll-behavior: contain;
+}
+body {
+  overscroll-behavior-x: none;
+}
+`;
+    expect(pageWideOverscrollSuppressions(css)).toEqual([
+      ':root { overscroll-behavior: contain }',
+      'body { overscroll-behavior-x: none }',
+    ]);
+  });
+
+  it('looks through :is() and :where() to the page-wide selector inside', () => {
+    const css = `
+:is(html, body) {
+  overscroll-behavior: none;
+}
+`;
+    expect(pageWideOverscrollSuppressions(css)).toEqual([
+      ':is(html, body) { overscroll-behavior: none }',
+    ]);
+  });
+
+  it('matches selectors case-insensitively, as CSS does', () => {
+    const css = `
+HTML {
+  OVERSCROLL-BEHAVIOR-Y: NONE;
+}
+:ROOT {
+  overscroll-behavior: contain;
+}
+`;
+    expect(pageWideOverscrollSuppressions(css)).toEqual([
+      'HTML { overscroll-behavior-y: NONE }',
+      ':ROOT { overscroll-behavior: contain }',
+    ]);
+  });
+
+  it('is not fooled by the property inside an @supports prelude', () => {
+    const css = `
+@supports (overscroll-behavior: none) {
+  html {
+    overscroll-behavior: none;
+  }
+}
+`;
+    expect(pageWideOverscrollSuppressions(css)).toEqual([
+      '@supports (overscroll-behavior: none) > html { overscroll-behavior: none }',
+    ]);
+  });
+
+  it('allows contain on nested scrollers, under html and inside :where() too', () => {
+    const css = `
+.dialog-body {
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+html .sheet {
+  overscroll-behavior: contain;
+}
+:where(.sheet) {
+  overscroll-behavior-y: none;
+}
+`;
+    expect(pageWideOverscrollSuppressions(css)).toEqual([]);
   });
 });
 

--- a/apps/docsite/src/__tests__/home-hero-overscroll.test.ts
+++ b/apps/docsite/src/__tests__/home-hero-overscroll.test.ts
@@ -1,0 +1,274 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file home-hero-overscroll.test.ts
+ * @input globals.css, the home hero sources and core's AppShell/LayoutContent,
+ *   read as text
+ * @output Invariants that keep native overscroll alive on every docsite route
+ * @position Regression guard for #5392 / #5470 (the hero's pin containment)
+ *
+ * `overscroll-behavior-y: none` on the root element is how you turn off
+ * pull-to-refresh (mobile) and the trackpad rubber-band (macOS). The docsite
+ * carried it app-wide (#3032), then desktop-only (#5415), to hide the home
+ * hero's `position: fixed` layers from the strip an overscroll opens past the
+ * end of the page. The layers are bounded now, so the rule is gone (#5470).
+ *
+ * The docsite suite is node-only with StyleX untransformed, so these are
+ * source invariants (the idiom of component-preview-theme.test.ts): read the
+ * files as text and assert on the declarations that would let the bleed —
+ * and therefore the rule — come back.
+ *
+ * Run: pnpm -F @astryxdesign/docsite test src/__tests__/home-hero-overscroll.test.ts
+ */
+
+import {describe, it, expect} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.join(HERE, '..', 'app');
+const SITE = path.join(APP, '(site)');
+const HERO = path.join(SITE, '_landing', 'hero');
+const CORE = path.join(HERE, '..', '..', '..', '..', 'packages', 'core', 'src');
+
+function read(file: string): string {
+  const source = fs.readFileSync(file, 'utf8');
+  // Anti-vacuity: a moved or emptied file must fail loudly, not pass silently.
+  expect(source.length, `${file} is empty`).toBeGreaterThan(200);
+  return source;
+}
+
+/** Drop comments so prose about `fixed` or `none` can't match. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[^]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '')
+    .replace(/([,;{}])\s*\/\/.*$/gm, '$1');
+}
+
+/** The brace-balanced `{...}` starting at `open` (which must be a `{`). */
+function balanced(source: string, open: number): string {
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') {
+      depth++;
+    } else if (source[i] === '}' && --depth === 0) {
+      return source.slice(open, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces at ${open}`);
+}
+
+/** The `{...}` body of one top-level `stylex.create` entry, e.g. `backdropGlow`. */
+function styleBlock(source: string, name: string): string {
+  const match = new RegExp(`^  ${name}: \\{`, 'm').exec(source);
+  expect(match, `no \`${name}\` style entry in the source`).not.toBeNull();
+  return balanced(source, match!.index + match![0].length - 1);
+}
+
+/**
+ * The raw text of one property's value inside a style block: the scalar up to
+ * its trailing comma, or the whole brace-balanced conditional object. Asserting
+ * on this text is independent of key syntax (`default`, a quoted media query,
+ * or a computed `[BREAKPOINT]` key) and of line layout.
+ */
+function valueText(block: string, property: string): string {
+  const match = new RegExp(`\\n\\s*${property}: `).exec(block);
+  expect(match, `no \`${property}\` declaration in the block`).not.toBeNull();
+  const start = match!.index + match![0].length;
+  if (block[start] === '{') {
+    return balanced(block, start);
+  }
+  const end = block.indexOf('\n', start);
+  return block.slice(start, end).replace(/,\s*$/, '').trim();
+}
+
+/**
+ * Every value a property takes — the scalar, or each arm of its conditional
+ * object — unquoted. Parsing is strict: an arm this helper cannot read fails
+ * the test rather than vanishing from the result.
+ */
+function allValues(block: string, property: string): string[] {
+  const text = valueText(block, property);
+  const unquote = (v: string) => v.trim().replace(/^(['"])(.*)\1$/, '$2');
+  if (!text.startsWith('{')) {
+    return [unquote(text)];
+  }
+  const inner = text.slice(1, -1);
+  // One arm per line as prettier writes them, or top-level commas when the
+  // whole object fits on one line.
+  const arms = (
+    inner.includes('\n')
+      ? inner.split('\n')
+      : inner.split(/,\s*(?=default\b|['"[])/)
+  )
+    .map(l => l.trim().replace(/,$/, ''))
+    .filter(l => l.length > 0);
+  expect(arms.length, `no arms in \`${property}\``).toBeGreaterThan(0);
+  return arms.map(arm => {
+    const parsed = /^(?:default|'[^']*'|"[^"]*"|\[[^\]]+\])\s*:\s*(.+)$/.exec(
+      arm,
+    );
+    expect(parsed, `unreadable arm in \`${property}\`: ${arm}`).not.toBeNull();
+    return unquote(parsed![1]);
+  });
+}
+
+describe('docsite globals.css never suppresses overscroll (#5392, #5470)', () => {
+  it('has no overscroll-behavior declaration other than auto, at any width', () => {
+    const css = stripComments(read(path.join(APP, 'globals.css')));
+    const offenders: string[] = [];
+    for (const match of css.matchAll(
+      /overscroll-behavior(?:-x|-y|-block|-inline)?\s*:\s*([^;}]+)/gi,
+    )) {
+      const value = match[1].trim();
+      if (value !== 'auto') {
+        // Name the enclosing at-rule so a re-scoped rule is still reported.
+        const before = css.slice(0, match.index);
+        const atRule = /@media[^{]*\{(?:[^{}]|\{[^{}]*\})*$/.exec(before)?.[0];
+        offenders.push(
+          `${atRule ? atRule.split('{')[0].trim() + ' > ' : ''}overscroll-behavior: ${value}`,
+        );
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+/**
+ * A `fixed` layer is glued to the viewport and is not part of the document,
+ * so when the document rubber-bands past its own edge the layer sits in the
+ * exposed gap. A `sticky` layer lifts with the document and cannot paint past
+ * its containing block — that is structural, which is what let the root rule
+ * be deleted rather than narrowed. None of the hero's pinned layers may go
+ * back to `fixed` in any media arm.
+ *
+ * `navBackdrop` is deliberately not listed: it is a header-height strip at
+ * the very top of the viewport and never reaches the bottom gap.
+ */
+describe('home hero pinned layers are never position: fixed (#5470)', () => {
+  const layers: ReadonlyArray<[string, string, string]> = [
+    ['hero text block', path.join(SITE, 'page.tsx'), 'heroContent'],
+    ['aurora glow', path.join(HERO, 'HeroThemeReel.tsx'), 'backdropGlow'],
+    ['floating cards stage', path.join(HERO, 'HeroFloatingCards.tsx'), 'stage'],
+  ];
+
+  for (const [label, file, style] of layers) {
+    it(`${label} (${style})`, () => {
+      const block = styleBlock(stripComments(read(file)), style);
+      // Raw text first: catches `fixed` under any key syntax or line layout.
+      expect(valueText(block, 'position')).not.toMatch(/['"]fixed['"]/);
+      // Then the parsed arms, which must all be readable.
+      const positions = allValues(block, 'position');
+      expect(positions.length).toBeGreaterThan(0);
+      expect(positions).not.toContain('fixed');
+    });
+  }
+});
+
+/**
+ * Sticky is bounded by its containing block, so each pinned layer rides in a
+ * full-height rail that spans the hero band AND the showcase (a rail inside
+ * the 760px band alone releases the hero after 48px of scroll). The rails are
+ * absolute against heroScope, and every hero layer ties at z-index 0/auto, so
+ * tree order is paint order: the rails must come before the showcase overlay
+ * or the showcase stops covering them.
+ */
+describe('home hero rails are bounded by heroScope and precede the showcase (#5470)', () => {
+  const page = () => stripComments(read(path.join(SITE, 'page.tsx')));
+  const reel = () => stripComments(read(path.join(HERO, 'HeroThemeReel.tsx')));
+
+  it('heroScope is the positioned ancestor and the rails fill it', () => {
+    expect(allValues(styleBlock(page(), 'heroScope'), 'position')).toEqual([
+      'relative',
+    ]);
+    const rail = styleBlock(reel(), 'rail');
+    expect(allValues(rail, 'position')).toEqual(['absolute']);
+    expect(allValues(rail, 'inset')).toEqual(['0']);
+    const contentRail = styleBlock(page(), 'heroContentRail');
+    expect(allValues(contentRail, 'position')).toContain('absolute');
+    expect(allValues(contentRail, 'inset')).toContain('0');
+  });
+
+  it('sizes the pinned boxes against the rail, never the viewport', () => {
+    // 100vw includes a classic scrollbar, so it can exceed the rail's width;
+    // an over-wide block zeroes its auto margins and shoves the box left.
+    expect(
+      valueText(styleBlock(reel(), 'backdropGlow'), 'width'),
+    ).not.toContain('100vw');
+    const cards = stripComments(read(path.join(HERO, 'HeroFloatingCards.tsx')));
+    expect(valueText(styleBlock(cards, 'stage'), 'width')).not.toContain(
+      '100vw',
+    );
+  });
+
+  it('renders the backdrop, cards and hero-text rails inside heroScope, before showcaseOverlay', () => {
+    const source = page();
+    const jsx = source.slice(
+      source.indexOf('export default function HomePage'),
+    );
+    expect(jsx.length).toBeGreaterThan(200);
+    const at = (needle: string) => {
+      const index = jsx.indexOf(needle);
+      expect(index, `\`${needle}\` not rendered by HomePage`).toBeGreaterThan(
+        -1,
+      );
+      return index;
+    };
+    const scope = at('styles.heroScope');
+    const showcase = at('styles.showcaseOverlay');
+    const backdrop = at('<HeroReelBackdrop');
+    const cards = at('<HeroReelCards');
+    const text = at('<HeroContent');
+    // Inside heroScope: after its opening tag, before the showcase it also holds.
+    expect(scope).toBeLessThan(backdrop);
+    expect(backdrop).toBeLessThan(cards);
+    expect(cards).toBeLessThan(text);
+    expect(text).toBeLessThan(showcase);
+    // The showcase is heroScope's last child: no hero piece may render after it.
+    expect(jsx.slice(showcase)).not.toMatch(/<Hero/);
+  });
+});
+
+/**
+ * `sticky` also breaks — silently, with no error — if any ancestor becomes a
+ * scroll container. AppShell's main area (`#astryx-app-shell-main`, rendered
+ * by LayoutContent) is `overflow: clip` in auto-height layouts: clip creates
+ * no scroll container, so the hero keeps pinning. LayoutContent switches to
+ * `overflow: auto` only through `isScrollable`, which AppShell wires to fill
+ * mode, and the landing layout asks for `height="auto"`. Any of those three
+ * links flipping would un-pin the entire landing page.
+ */
+describe('AppShell content area stays a non-scroll container for sticky', () => {
+  it('LayoutContent.styles.content uses overflow: clip and no per-axis longhand', () => {
+    const source = stripComments(
+      read(path.join(CORE, 'Layout', 'LayoutContent.tsx')),
+    );
+    const content = styleBlock(source, 'content');
+    expect(allValues(content, 'overflow')).toEqual(['clip']);
+    expect(content).not.toMatch(/\n\s*overflow(?:X|Y|Block|Inline)\s*:/);
+    // The scroll container is opt-in, via a separate style.
+    expect(allValues(styleBlock(source, 'scrollable'), 'overflow')).toEqual([
+      'auto',
+    ]);
+  });
+
+  it('AppShell only makes the main area scrollable in fill mode', () => {
+    const source = stripComments(
+      read(path.join(CORE, 'AppShell', 'AppShell.tsx')),
+    );
+    expect(source).toMatch(/const isFill = height === 'fill'/);
+    const main = source.indexOf('id={MAIN_CONTENT_ID}');
+    expect(main, 'main LayoutContent not found').toBeGreaterThan(-1);
+    const openingTag = source.slice(source.lastIndexOf('<LayoutContent', main));
+    expect(openingTag.slice(0, openingTag.indexOf('>'))).toMatch(
+      /isScrollable=\{isFill\}/,
+    );
+  });
+
+  it('the landing layout renders AppShell in auto height', () => {
+    const source = stripComments(read(path.join(SITE, 'layout.tsx')));
+    expect(source).toMatch(/<AppShell[^>]*\sheight="auto"/);
+  });
+});

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
@@ -34,15 +34,22 @@ const REWARD_MEMBER_NAME = 'Ami Pena';
 const REWARD_MEMBER_AVATAR = '/images/avatars/DATA-Ami-Pena.png';
 
 const styles = stylex.create({
-  // Desktop overlap stage: fixed, viewport-centered 1200px box (shared with the
-  // aurora blobs) so cards track the blobs on resize. Capped to 100vw to avoid
-  // horizontal scroll. Hidden <1024px, where the collage takes over.
+  // Desktop overlap stage: a centered 1200px box (shared with the aurora blobs)
+  // so cards track the blobs on resize. Capped to the rail's width, never
+  // 100vw: with a classic scrollbar 100vw is wider than the rail, which zeroes
+  // the auto margins and shoves the box left. Hidden <1024px, where the
+  // collage takes over.
+  //
+  // Sticky inside HeroThemeReel's cards rail, not fixed: it pins under the
+  // header for the whole pin-and-cover but lifts with the document, so it can
+  // never paint into an overscroll gap (#5470). Centered by auto margins in
+  // the full-width rail — on a sticky box `left` is an inset, so the old
+  // `left: 50%; translateX(-50%)` trick would shift it instead.
   stage: {
-    position: 'fixed',
+    position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
-    left: '50%',
-    transform: 'translateX(-50%)',
-    width: 'min(1200px, 100vw)',
+    marginInline: 'auto',
+    width: 'min(1200px, 100%)',
     height: 1050,
     pointerEvents: 'none',
     display: {

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -138,7 +138,11 @@ const styles = stylex.create({
   // lifts with the document and can never paint past its own edge — which is
   // what lets the site keep native overscroll instead of suppressing it
   // (#5470). A rail inside the 760px band alone releases its layer after ~48px
-  // of scroll. Decorative: never intercepts pointer events.
+  // of scroll. Sticky also needs no scroll container between the rail and the
+  // viewport: AppShell's main area (core LayoutContent) is `overflow: clip` in
+  // auto-height shells, and `hidden` or `auto` there would silently un-pin
+  // every layer; home-hero-overscroll.test.ts guards that link. Decorative:
+  // never intercepts pointer events.
   rail: {
     position: 'absolute',
     inset: 0,

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -5,16 +5,24 @@
 /**
  * @file HeroThemeReel.tsx
  * @input none (reads the generated theme registry via heroThemeContent)
- * @output Provider + placed pieces (wordmark, cards, dots) consumed by page.tsx
+ * @output Provider, the swipe/hover surface, the pinned backdrop + cards rails,
+ *   and placed pieces (wordmark, collage, dots) consumed by page.tsx
  * @position Home hero — orchestrates the per-theme reel behind the headline.
  *
  * The cycling state (active index + auto-advance clock) lives in HeroReelProvider
  * so the wordmark, cards, and dots — placed in different parts of the DOM by
- * page.tsx — re-skin together. Auto-advance pauses on hover/focus and when the
- * tab is hidden, and respects prefers-reduced-motion.
+ * page.tsx — re-skin together. Auto-advance pauses on hover/focus (inside
+ * HeroReelSwipeArea) and when the tab is hidden, and respects
+ * prefers-reduced-motion.
  *
  * Manual control: touch swipe (mobile) and the Pagination dots, which own
  * keyboard navigation (arrow keys, Home/End) via the useListFocus primitive.
+ *
+ * Desktop pin-and-cover: the backdrop (fills + aurora glow) and the overlap
+ * cards each ride their own full-height rail (`styles.rail`, absolute against
+ * page.tsx's heroScope) as a `position: sticky` layer. Sticky, not fixed, is
+ * what bounds them to the document so the site never has to suppress native
+ * overscroll to hide them (#3032 → #5392 → #5470).
  */
 
 import {
@@ -29,6 +37,7 @@ import {
   type TouchEvent as ReactTouchEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {Theme} from '@astryxdesign/core/theme';
 import {Text} from '@astryxdesign/core/Text';
 import {Pagination} from '@astryxdesign/core/Pagination';
@@ -123,15 +132,17 @@ const styles = stylex.create({
     },
     height: 'auto',
   },
-  // Sticky, zero-height layer hosting the overlap cards so they pin with the
-  // hero and don't intercept clicks.
-  cardsLayer: {
-    position: 'sticky',
-    top: 'var(--appshell-header-height, 0px)',
-    height: 0,
-    width: '100%',
+  // Full-height rail for one pinned layer. Absolute against heroScope
+  // (page.tsx, position: relative), so it spans the hero band AND the
+  // showcase: a `position: sticky` child pins for the whole pin-and-cover, yet
+  // lifts with the document and can never paint past its own edge — which is
+  // what lets the site keep native overscroll instead of suppressing it
+  // (#5470). A rail inside the 760px band alone releases its layer after ~48px
+  // of scroll. Decorative: never intercepts pointer events.
+  rail: {
+    position: 'absolute',
+    inset: 0,
     pointerEvents: 'none',
-    zIndex: 0,
   },
   // Per-slide body fill behind the hero (resolves to the active theme's body
   // color). Covers the band + an extra strip so the color sits behind the
@@ -170,32 +181,41 @@ const styles = stylex.create({
   },
   // Blurred aurora glow — in the same 1200px box as the cards so blobs and
   // cards stay aligned; pinned at >=1024px and scrolling away with the hero
-  // below that (see `position`). Capped to 100vw to avoid horizontal scroll.
+  // below that (see `position`). Capped to the rail's width (see the stage).
   // Blob centers sit under the card clusters; colors come from --aurora-* per
   // slide.
   backdropGlow: {
-    // Desktop: fixed, part of the pin-and-cover effect alongside heroContent
-    // and the cards stage. Narrow: absolute within heroScope (position:
-    // relative), so it scrolls away with the hero instead of staying pinned
-    // for the whole page — a fixed glow below 1024px reached past the footer
-    // into the bottom-overscroll gap. That exposure is what the app-global
-    // `overscroll-behavior-y: none` in globals.css was suppressing, at the
-    // cost of pull-to-refresh on every route on mobile; bounding the glow
-    // here is what lets that rule scope to desktop widths (#5392).
+    // Desktop: sticky inside its rail, part of the pin-and-cover effect
+    // alongside heroContent and the cards stage; sticky rather than fixed so
+    // it lifts with the document and cannot bleed into an overscroll gap
+    // (#5470). Narrow: absolute within the rail, so it scrolls away with the
+    // hero instead of staying pinned for the whole page. A fixed glow below
+    // 1024px reached past the footer into the bottom-overscroll gap; that
+    // exposure is what the app-global `overscroll-behavior-y: none` in
+    // globals.css was suppressing, at the cost of pull-to-refresh on every
+    // route on mobile. Bounding the glow is what let that rule scope to
+    // desktop widths (#5392); the sticky rails are what let it go entirely
+    // (#5470).
     position: {
       default: 'absolute',
-      '@media (min-width: 1024px)': 'fixed',
+      '@media (min-width: 1024px)': 'sticky',
     },
-    // heroScope already starts below the header (it's the sibling after
-    // navBackdrop in document flow), so the absolute case needs no offset;
-    // only the fixed case has to clear the header itself.
+    // The rail starts where heroScope does, below the header, so the absolute
+    // case needs no offset; the sticky case pins under the header.
     top: {
       default: 0,
       '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
     },
-    left: '50%',
-    transform: 'translateX(-50%)',
-    width: 'min(1200px, 100vw)',
+    // Centered by auto margins in the full-width rail. The old
+    // `left: 50%; translateX(-50%)` can't survive the move: on a sticky box
+    // `left` is an inset, not an offset. The absolute case needs both inline
+    // insets set for the auto margins to resolve.
+    insetInline: {
+      default: 0,
+      '@media (min-width: 1024px)': 'auto',
+    },
+    marginInline: 'auto',
+    width: 'min(1200px, 100%)',
     height: 1050,
     pointerEvents: 'none',
     opacity: 0.7,
@@ -243,8 +263,9 @@ const dynamic = stylex.create({
 
 /**
  * Owns the cycling state + auto-advance clock and exposes them via context.
- * Renders no DOM of its own beyond the provider + a hover/focus wrapper so the
- * hero can pause cycling while the user interacts with it.
+ * Renders no DOM of its own — HeroReelSwipeArea is the hover/focus/touch
+ * surface — so the pinned rails and the hero text can all be direct children
+ * of page.tsx's heroScope while sharing one reel.
  */
 export function HeroReelProvider({children}: {children: ReactNode}) {
   const slides = HERO_THEME_SLIDES;
@@ -263,45 +284,6 @@ export function HeroReelProvider({children}: {children: ReactNode}) {
         return;
       }
       setIndex(((next % count) + count) % count);
-    },
-    [slides.length],
-  );
-
-  // Touch swipe (mobile): swipe left → next theme, right → previous.
-  const touchStart = useRef<{x: number; y: number} | null>(null);
-  const SWIPE_THRESHOLD_PX = 45;
-  const onTouchStart = useCallback((e: ReactTouchEvent) => {
-    const t = e.touches[0];
-    if (!t) {
-      return;
-    }
-    touchStart.current = {x: t.clientX, y: t.clientY};
-    // Touch devices have no hover, so pause auto-advance while the finger is down.
-    setPaused(true);
-  }, []);
-  const onTouchEnd = useCallback(
-    (e: ReactTouchEvent) => {
-      setPaused(false);
-      const start = touchStart.current;
-      touchStart.current = null;
-      if (!start || slides.length <= 1) {
-        return;
-      }
-      const t = e.changedTouches[0];
-      if (!t) {
-        return;
-      }
-      const dx = t.clientX - start.x;
-      const dy = t.clientY - start.y;
-      // Only a mostly-horizontal gesture counts, so vertical scroll isn't a swipe.
-      if (Math.abs(dx) < SWIPE_THRESHOLD_PX || Math.abs(dx) <= Math.abs(dy)) {
-        return;
-      }
-      setIndex(i => {
-        const count = slides.length;
-        const next = dx < 0 ? i + 1 : i - 1;
-        return ((next % count) + count) % count;
-      });
     },
     [slides.length],
   );
@@ -374,19 +356,76 @@ export function HeroReelProvider({children}: {children: ReactNode}) {
     [slides, index, goTo, reduceMotion, userMode],
   );
 
+  return <HeroReelContext value={value}>{children}</HeroReelContext>;
+}
+
+// A horizontal touch travel shorter than this is a tap or a scroll, not a swipe.
+const SWIPE_THRESHOLD_PX = 45;
+
+/**
+ * The reel's interaction surface: hover or focus inside pauses auto-advance,
+ * and a horizontal touch swipe steps the reel (left → next, right → previous).
+ * Wraps the hero text block — CTAs, dots and the narrow-screen collage — and
+ * page.tsx also makes it the hero text's full-height rail, so on desktop the
+ * band and its gutters pause the reel exactly as the old provider wrapper did.
+ */
+export function HeroReelSwipeArea({
+  children,
+  xstyle,
+}: {
+  children: ReactNode;
+  xstyle?: StyleXStyles;
+}) {
+  const reel = useHeroReel();
+  const setPaused = reel?.setPaused;
+
+  const touchStart = useRef<{x: number; y: number} | null>(null);
+  const onTouchStart = useCallback(
+    (e: ReactTouchEvent) => {
+      const t = e.touches[0];
+      if (!t) {
+        return;
+      }
+      touchStart.current = {x: t.clientX, y: t.clientY};
+      // Touch devices have no hover, so pause auto-advance while the finger is down.
+      setPaused?.(true);
+    },
+    [setPaused],
+  );
+  const onTouchEnd = useCallback(
+    (e: ReactTouchEvent) => {
+      setPaused?.(false);
+      const start = touchStart.current;
+      touchStart.current = null;
+      if (!start || !reel || reel.slides.length <= 1) {
+        return;
+      }
+      const t = e.changedTouches[0];
+      if (!t) {
+        return;
+      }
+      const dx = t.clientX - start.x;
+      const dy = t.clientY - start.y;
+      // Only a mostly-horizontal gesture counts, so vertical scroll isn't a swipe.
+      if (Math.abs(dx) < SWIPE_THRESHOLD_PX || Math.abs(dx) <= Math.abs(dy)) {
+        return;
+      }
+      reel.goTo(reel.index + (dx < 0 ? 1 : -1));
+    },
+    [reel, setPaused],
+  );
+
   return (
-    <HeroReelContext value={value}>
-      <div
-        {...stylex.props(styles.swipeArea)}
-        onMouseEnter={() => setPaused(true)}
-        onMouseLeave={() => setPaused(false)}
-        onFocusCapture={() => setPaused(true)}
-        onBlurCapture={() => setPaused(false)}
-        onTouchStart={onTouchStart}
-        onTouchEnd={onTouchEnd}>
-        {children}
-      </div>
-    </HeroReelContext>
+    <div
+      {...stylex.props(styles.swipeArea, xstyle)}
+      onMouseEnter={() => setPaused?.(true)}
+      onMouseLeave={() => setPaused?.(false)}
+      onFocusCapture={() => setPaused?.(true)}
+      onBlurCapture={() => setPaused?.(false)}
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}>
+      {children}
+    </div>
   );
 }
 
@@ -430,7 +469,40 @@ export function HeroReelWordmark() {
   );
 }
 
-/** Full-bleed floating cards layer for the hero gutters. */
+/**
+ * The backdrop rail: the per-slide body fill, the nav retint strip and the
+ * aurora glow. First of the pinned rails in page.tsx, so it paints under the
+ * cards and the hero text.
+ */
+export function HeroReelBackdrop() {
+  const reel = useHeroReel();
+  if (!reel || reel.slides.length === 0) {
+    return null;
+  }
+
+  const active = reel.slides[reel.index];
+  return (
+    <div {...stylex.props(styles.rail)}>
+      <Theme theme={active.theme} mode={effectiveMode(active, reel.userMode)}>
+        <div {...stylex.props(styles.themeFill)} aria-hidden="true" />
+        <div {...stylex.props(styles.navBackdrop)} aria-hidden="true" />
+        <div
+          aria-hidden="true"
+          {...stylex.props(
+            styles.backdropGlow,
+            dynamic.aurora(
+              active.aurora.left,
+              active.aurora.center,
+              active.aurora.right,
+            ),
+          )}
+        />
+      </Theme>
+    </div>
+  );
+}
+
+/** The cards rail: full-bleed floating cards for the hero gutters. */
 export function HeroReelCards() {
   const reel = useHeroReel();
   const [mounted, setMounted] = useState(false);
@@ -448,25 +520,11 @@ export function HeroReelCards() {
   const shown = reel.animate ? mounted : true;
 
   return (
-    <Theme theme={active.theme} mode={effectiveMode(active, reel.userMode)}>
-      <div {...stylex.props(styles.themeFill)} aria-hidden="true" />
-      <div {...stylex.props(styles.navBackdrop)} aria-hidden="true" />
-      <div
-        aria-hidden="true"
-        {...stylex.props(
-          styles.backdropGlow,
-          dynamic.aurora(
-            active.aurora.left,
-            active.aurora.center,
-            active.aurora.right,
-          ),
-        )}
-      />
-      {/* Floating cards layer */}
-      <div {...stylex.props(styles.cardsLayer)}>
+    <div {...stylex.props(styles.rail)}>
+      <Theme theme={active.theme} mode={effectiveMode(active, reel.userMode)}>
         <HeroFloatingCards content={active.content} mounted={shown} />
-      </div>
-    </Theme>
+      </Theme>
+    </div>
   );
 }
 

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -17,6 +17,8 @@ import {astryxTheme} from '@/themes/astryx';
 import {layout} from '../../layout.stylex';
 import {
   HeroReelProvider,
+  HeroReelSwipeArea,
+  HeroReelBackdrop,
   HeroReelCards,
   HeroReelStack,
   HeroReelWordmark,
@@ -39,22 +41,39 @@ const styles = stylex.create({
     // Shared by the nav→wordmark gap and the text→cards gap so they match.
     '--hero-gap': 'calc(var(--spacing-12) * 2)',
   },
-  // Desktop: fixed for pin-and-cover (heroSpacer reserves its height). Narrow:
-  // in flow — the mobile hero is taller than the viewport, so pinning stranded
-  // the lower collage below the fold.
+  // Desktop: the hero text's rail — absolute over the whole of heroScope (hero
+  // band + showcase) so the sticky heroContent inside pins for the entire
+  // pin-and-cover; inside the 760px band alone it would release after ~48px.
+  // It doubles as the reel's swipe/hover surface (HeroReelSwipeArea), so it
+  // keeps pointer events: over the band it is the top-most hit target, and the
+  // showcase, later in tree order, covers it as it scrolls up. Narrow: in flow,
+  // wrapping the hero text like the old provider wrapper did.
+  heroContentRail: {
+    position: {
+      default: 'static',
+      '@media (min-width: 1024px)': 'absolute',
+    },
+    inset: {
+      default: 'auto',
+      '@media (min-width: 1024px)': 0,
+    },
+  },
+  // Desktop: sticky for pin-and-cover (heroSpacer reserves its height) —
+  // sticky rather than fixed so the band lifts with the document and can't
+  // bleed into an overscroll gap (#5470). Narrow: in flow — the mobile hero is
+  // taller than the viewport, so pinning stranded the lower collage below the
+  // fold.
   heroContent: {
     position: {
       default: 'relative',
-      '@media (min-width: 1024px)': 'fixed',
+      '@media (min-width: 1024px)': 'sticky',
     },
-    // top offset only matters when fixed; in flow it would leave a gap.
+    // top offset only matters when sticky; in flow it would leave a gap.
     top: {
       default: 0,
       '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
     },
-    left: 0,
-    right: 0,
-    // Desktop: fixed band, centered (cards are a separate overlap layer).
+    // Desktop: pinned band, centered (cards are a separate overlap layer).
     // Narrow: auto height (sizes to text + collage); a ResizeObserver applies it
     // to heroSpacer so the showcase starts right after the cards.
     height: {
@@ -85,7 +104,7 @@ const styles = stylex.create({
     // content (the buttons/links re-enable pointer events on themselves).
     zIndex: 0,
   },
-  // Reserves the fixed hero's height (desktop); 0 on narrow (hero is in flow).
+  // Reserves the pinned hero's height (desktop); 0 on narrow (hero is in flow).
   heroSpacer: {
     height: {
       default: 0,
@@ -146,7 +165,7 @@ const styles = stylex.create({
     },
     insetBlockEnd: {
       default: 'auto',
-      // The fixed band's bottom sits a nav-height above the real seam, so
+      // The pinned band's bottom sits a nav-height above the real seam, so
       // subtract it to land 32px above the features surface.
       '@media (min-width: 1024px)':
         'calc(var(--spacing-8) - var(--appshell-header-height, 0px))',
@@ -342,11 +361,18 @@ export default function HomePage() {
       {/* HeroReelProvider holds the shared cycling state for the cards, wordmark,
           and dots. The headline/CTAs stay in stable Astryx brand style. */}
       <HeroReelProvider>
-        {/* Desktop overlap cards layer (the gutters). */}
-        <HeroReelCards />
-        {/* Reserves the fixed hero's height so the showcase starts below it. */}
+        {/* Reserves the pinned hero's height so the showcase starts below it. */}
         <div {...stylex.props(styles.heroSpacer)} aria-hidden="true" />
-        <HeroContent contentRef={heroContentRef} />
+        {/* The pinned layers, one full-height rail each, all direct children of
+            heroScope (HeroReelProvider renders no DOM). Every hero layer ties
+            at z-index 0/auto, so this tree order IS the paint order: backdrop,
+            then the overlap cards, then the hero text — and all of them before
+            the showcase, which covers them as it scrolls up. */}
+        <HeroReelBackdrop />
+        <HeroReelCards />
+        <HeroReelSwipeArea xstyle={styles.heroContentRail}>
+          <HeroContent contentRef={heroContentRef} />
+        </HeroReelSwipeArea>
       </HeroReelProvider>
       <VStack ref={showcaseRef} xstyle={styles.showcaseOverlay}>
         <FeaturesShowcase />

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -12,18 +12,6 @@
    reset, astryx-base, astryx-theme so product styles always win. */
 @stylex;
 
-/* Disable overscroll bounce so the home hero's still-fixed (>=1024px) layers
-   can't show through past the top/bottom of the page. Below 1024px the hero
-   no longer pins anything past the fold (see HeroThemeReel's backdropGlow),
-   so this rule only needs to apply at desktop widths — leaving it unscoped
-   also silently disabled pull-to-refresh on every route, everywhere on
-   mobile, which is not what it was written for (#5392). */
-@media (min-width: 1024px) {
-  html {
-    overscroll-behavior-y: none;
-  }
-}
-
 /* Marketing-only custom properties for the docsite home page. These are
    NOT Astryx theming tokens — they're docsite-specific values that back the
    landing page's bento feature cards + section rhythm — so they live here

--- a/packages/core/src/Layout/LayoutContent.tsx
+++ b/packages/core/src/Layout/LayoutContent.tsx
@@ -37,6 +37,10 @@ const styles = stylex.create({
     height: '100%',
     flex: 1,
     minHeight: 0,
+    // `clip`, never `hidden`/`auto`: clip creates no scroll container, so
+    // `position: sticky` descendants keep tracking the viewport in auto-height
+    // shells. The docsite home hero pins its whole pin-and-cover this way —
+    // `hidden` here would silently un-pin it (see #5470).
     overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
     paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,

--- a/packages/core/src/Layout/LayoutContent.tsx
+++ b/packages/core/src/Layout/LayoutContent.tsx
@@ -37,10 +37,6 @@ const styles = stylex.create({
     height: '100%',
     flex: 1,
     minHeight: 0,
-    // `clip`, never `hidden`/`auto`: clip creates no scroll container, so
-    // `position: sticky` descendants keep tracking the viewport in auto-height
-    // shells. The docsite home hero pins its whole pin-and-cover this way —
-    // `hidden` here would silently un-pin it (see #5470).
     overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
     paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,


### PR DESCRIPTION
Step 2 of #5392. Fixes #5470.

## What this does

Keeps the home page hero pinned exactly as it is today, but without the CSS rule that switched off the browser's native overscroll. On a Mac trackpad the page rubber-bands again at the top and bottom, like every other page on the web. Nothing changes visually.

## Why

The hero's three pinned layers (the aurora glow, the floating cards and the headline block) were `position: fixed`. A fixed layer is glued to the screen rather than to the page, so when the page rubber-bands past its own end the layer sits in the gap that opens up. #3032 hid that by turning overscroll off for the whole site, and #5415 narrowed the rule to desktop widths to give mobile its pull-to-refresh back. This finishes the job: the layers are now `position: sticky` inside full-height rails, so they lift with the page and physically cannot paint past its end. That is structural, which is why the rule can be deleted instead of narrowed further.

## What changed

- Each pinned layer rides its own rail: a `position: absolute; inset: 0` box that is a direct child of `heroScope`, spans the hero band and the showcase, and sits ahead of the showcase overlay so tree order still equals paint order (backdrop, cards, hero text, then the showcase covering them). A rail inside the 760px band alone releases its layer after about 48px, which is the trap the issue calls out.
- `backdropGlow`, the cards `stage` and `heroContent` go `fixed` -> `sticky; top: var(--appshell-header-height)` at 1024px and up. Narrow widths are untouched: the glow stays absolute and the hero text stays in flow.
- Centering moves from `left: 50%` + `translateX(-50%)` to auto margins in the full-width rail (on a sticky box `left` is an inset, not an offset). The 1200px box is capped to the rail's width rather than `100vw`: with a classic scrollbar `100vw` is wider than the rail, which zeroes the auto margins and shoves the box left.
- `HeroReelProvider` renders no DOM any more. Its hover / focus / touch surface is the new `HeroReelSwipeArea`, which `page.tsx` uses as the hero text's rail, so the band and its gutters still pause the reel and the phone collage still swipes. `HeroReelCards` is split into `HeroReelBackdrop` (fills + glow) and `HeroReelCards` (stage).
- The `@media (min-width: 1024px) { html { overscroll-behavior-y: none } }` block is deleted from `globals.css`.
- Sticky also needs AppShell's main area to stay a non-scroll container (`overflow: clip` in `LayoutContent`; `hidden` or `auto` there would silently un-pin the landing page). That is recorded on the hero's rail style and enforced by the test below; core is untouched.
- New `home-hero-overscroll.test.ts`. The docsite suite is node-only with StyleX untransformed, so these are source invariants in the shape of `component-preview-theme.test.ts`: `globals.css` never sets `overscroll-behavior` on `html`, `:root`, `body` or `*` away from `auto`, at any width (a `contain` on a nested scroller is fine; the guard has its own fixtures for `@media` and `@supports` wrappers, `:is()` / `:where()` and upper-case selectors); none of the three layers is ever `fixed` in any media arm; the rails are bounded by `heroScope` and precede the showcase; the boxes are sized against the rail, not `100vw`; and the AppShell / LayoutContent links that keep the main area a non-scroll container (`overflow: clip`, `isScrollable={isFill}`, the landing layout's `height="auto"`) hold. It is red on `main` today, and single-line mutations (a `fixed` behind a trailing comment, double quotes, a computed `[BREAKPOINT]` key, an `overflowY` longhand, `isScrollable` unconditional, `height="fill"`, the width back to `100vw`, `heroScope` static, a rail moved after the showcase, the old `@media` root rule, `:root { overscroll-behavior: contain }`, an upper-case `HTML` rule, a minified root rule, a root rule inside `@supports`) each turn it red again.

## How to see it

Nothing should look different; that is the point. Run the docsite with the canary banner off so the header is the production 48px (`NEXT_PUBLIC_DOCS_TARGET=latest pnpm -F @astryxdesign/docsite dev`), open the home page on a Mac and rubber-band at the bottom: the page bounces and the footer stays clean. The Vercel preview on this PR shows the same page.

Measured against an untouched `main` checkout with Playwright + pixelmatch, both served with the banner hidden, `prefers-reduced-motion: reduce` so the reel holds its first slide, and transitions frozen, at ten scroll offsets per viewport (0, 100, 200, 400, 712, 760, 800, 1400, 2200, max):

| viewport | pixels differing from `main` | `overscroll-behavior-y` | fixed layers reaching the viewport bottom at page end |
| --- | --- | --- | --- |
| 1280 x 900 | 0 | `none` -> `auto` | 2 -> 0 |
| 1280 x 600 | 0 | `none` -> `auto` | 3 -> 0 |
| 1440 x 1400 | 0 | `none` -> `auto` | 0 -> 0 |
| 1024 x 768 | 0 | `none` -> `auto` | 2 -> 0 |
| 900 x 1200 | 0 | `auto` -> `auto` | 0 -> 0 |
| 390 x 844 | 0 | `auto` -> `auto` | 0 -> 0 |

Layer geometry matches `fixed` at every offset (hero text at y=48 and 712px tall, glow and stage at x=40 and 1200px wide at 1280) until max scroll, where sticky releases behind the opaque showcase. Document height is unchanged (3540px). `elementFromPoint` on the "Get started" button still returns the button.

Also checked on both trees: hover in the gutter, on the CTA and over the pinned hero while scrolled pauses the reel, hover on the showcase does not, keyboard focus on a dot pauses and blur resumes, a phone swipe steps the reel left and right and a vertical drag does not (11 checks, identical results before and after); resize while scrolled (1280 -> 1440 -> 1100 at scroll 400) and a theme swap mid-scroll with transitions running, 0 pixels differing; and a forced 15px classic scrollbar, where the old `fixed` box sat at x=-7.5 overflowing both sides and the new one sits centered inside the rail.

`pnpm -F @astryxdesign/docsite test` (29 files, 434 tests), `tsc --noEmit`, strict eslint and prettier are green.

## Not verified here

Safari and WebKit, and a real rubber-band gesture, which cannot be driven headlessly. That is the careful visual pass the issue budgets for.

## Related

- #5431 takes the other route the issue mentions (a zero-height sticky pin with absolute children) and has been conflicting since #5415 landed; this follows the rails design written up in #5470 instead.
- #5467 (merged) corrected the `backdropGlow` comment's causal chain; this branch carries that wording and updates its tail for the deleted rule.
