### PR TITLE
ci: ship core's dist to the PR visual gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,12 +259,21 @@ jobs:
       # theme styles — a theme's component map is what defineTheme returns, not
       # a literal in its source. This job has already built them; shipping the
       # artifact keeps that job on a download instead of a second full build.
-      - name: Upload built themes
+      #
+      # core's dist ships with them because importing a built theme executes
+      # `import {defineTheme} from '@astryxdesign/core/theme'`, which pnpm
+      # resolves through the workspace link into packages/core/dist.
+      #
+      # Two paths, so the artifact is rooted at their common ancestor
+      # (packages/) — the download below unpacks it there.
+      - name: Upload built themes and core
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: themes-${{ steps.urls.outputs.short_hash }}
-          path: packages/themes/*/dist/
+          name: dists-${{ steps.urls.outputs.short_hash }}
+          path: |
+            packages/themes/*/dist/
+            packages/core/dist/
           retention-days: 1
 
       - name: Analyze components
@@ -573,11 +582,11 @@ jobs:
           name: storybook-${{ needs.build-storybook.outputs.short_hash }}
           path: apps/storybook/dist
 
-      - name: Download built themes
+      - name: Download built themes and core
         uses: actions/download-artifact@v8
         with:
-          name: themes-${{ needs.build-storybook.outputs.short_hash }}
-          path: packages/themes
+          name: dists-${{ needs.build-storybook.outputs.short_hash }}
+          path: packages
 
       - name: Install Playwright
         run: pnpm install --frozen-lockfile && npx playwright install chromium


### PR DESCRIPTION
## Problem

Every PR that touches a component gets a red `pr-visual`, outside contributors'
included — [#5466](https://github.com/facebook/astryx/pull/5466),
[#5462](https://github.com/facebook/astryx/pull/5462),
[#5468](https://github.com/facebook/astryx/pull/5468),
[#5018](https://github.com/facebook/astryx/pull/5018). The job crashes before it
shoots anything:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '…/packages/themes/butter/node_modules/@astryxdesign/core/dist/theme/index.js'
  imported from …/packages/themes/butter/dist/source.mjs
```

Root cause: **`@astryxdesign/core` is not built when the gate runs.** A built
theme is not self-contained — `dist/source.mjs` keeps
`import {defineTheme} from '@astryxdesign/core/theme'` as an external, so
`loadThemeOverrides` importing it executes that import, pnpm resolves it through
the workspace link, and core's `exports` map sends it to
`packages/core/dist/theme/index.js`.
[#5477](https://github.com/facebook/astryx/pull/5477) ships
`packages/themes/*/dist/` and nothing else, and `pr-visual` never builds, so
that file is absent.

The other two candidates are both ruled out, not assumed:

- **The symlink farm is fine.** `pnpm install --frozen-lockfile` in the job
  restores `packages/themes/butter/node_modules/@astryxdesign/core` → `../../../../core`;
  Node resolved *through* it, which is why the error names a file inside the
  package rather than "Cannot find package".
- **The exports map is fine.** `"./theme"` maps to `./dist/theme/index.js`. A
  blocked subpath would be `ERR_PACKAGE_PATH_NOT_EXPORTED`, not a missing file.

## Solution

- Ship core's `dist` from `build-storybook`, which has already built it, rather
  than adding a build step to `pr-visual` — [#5477](https://github.com/facebook/astryx/pull/5477)'s
  reasoning, unchanged.
- Carry it in the existing artifact instead of a second one: two search paths, so
  the artifact roots at their common ancestor `packages/` and the download
  unpacks there. Renamed `themes-<hash>` → `dists-<hash>` because it is no longer
  only themes.

## Impact

Every component PR in the repo, including outside contributors'. `pr-visual` is
`continue-on-error`, so this was never blocking a merge — it was showing every
contributor a red check they could do nothing about.

## API

None. Workflow-only.

## Theme targets

None.

## Breaking

None. The artifact is internal to one workflow run and consumed only by
`pr-visual`.

## Performance & resources

One artifact, ~14 MB / ~1600 files larger; no extra job, no extra build.
Building core inside `pr-visual` instead would cost minutes of every component
PR's CI.

## Visual evidence

None — this is CI plumbing, no pixels change.

## Testing

- **Local reproduction of the exact CI failure**: fresh worktree,
  `pnpm install --frozen-lockfile`, themes' `dist/` copied in and nothing else
  (the state [#5477](https://github.com/facebook/astryx/pull/5477) leaves) →
  same `ERR_MODULE_NOT_FOUND` on the same path. Dropping `packages/core/dist/`
  in and changing nothing else → all eight themes import and yield their
  component maps (`butter` 21 targets, `probe` 268, …), and
  `gate.mjs plan` gets past theme loading to the Storybook index it downloads
  in CI.
- **The real job on this PR.** A workflow-only PR skips `pr-visual` by design
  (`check-components` finds no component change), so this branch carried a
  throwaway commit touching `Spinner.tsx` to arm it. That commit is dropped
  before merge; the run it produced is linked in the comments.
