### PR TITLE
ci: build Core before inspecting downloaded themes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,12 @@ jobs:
       - name: Install Playwright
         run: pnpm install --frozen-lockfile && npx playwright install chromium
 
+      # The downloaded theme builds import Core's consumer-facing dist files.
+      # Rebuild only Core here so those imports resolve without repeating the
+      # full workspace build that produced the theme artifact.
+      - name: Build Core dependency for theme inspection
+        run: pnpm -F @astryxdesign/core build
+
       - name: Fetch visual baseline from gh-pages
         run: |
           set -eu


### PR DESCRIPTION
## Summary

- rebuild `@astryxdesign/core` in `pr-visual` after dependency installation
- let the downloaded theme artifacts resolve their `@astryxdesign/core/dist/*` imports
- preserve #5477's downloaded-theme optimization without repeating the full workspace build

## Why

#5477 began shipping built theme artifacts to `pr-visual`, but those artifacts import Core's consumer-facing `dist` files. The downstream job starts from a fresh checkout, installs dependencies without building packages, and therefore still fails before taking a screenshot:

```text
ERR_MODULE_NOT_FOUND: packages/core/dist/theme/index.js
imported from packages/themes/butter/dist/source.mjs
```

This currently affects #5466 and #5475.

## Test plan

- removed `packages/core/dist` and reproduced the exact import failure from `packages/themes/butter/dist/source.mjs`
- ran `pnpm -F @astryxdesign/core build`
- imported the same Butter theme build successfully afterward
- `pnpm exec prettier --check .github/workflows/ci.yml`
- parsed the workflow and verified the Core build step runs after install and before the visual gate
