### PR TITLE
fix(Banner): center a title-only banner whose only control is the collapse toggle

### DIFF
--- a/.changeset/banner-single-line-toggle.md
+++ b/.changeset/banner-single-line-toggle.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Banner: a title-only collapsible banner now centers its header, as a title-only banner with any other control already does. `isSingleLine` counted `endContent` and the dismiss button but not the collapse toggle, so a banner whose only control was the toggle kept `align-items: flex-start` — leaving its icon and title 4px above the 28px toggle they sit beside, while the same banner with a dismiss button centered correctly.
+
+@freddymeta

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -650,4 +650,44 @@ describe('Banner', () => {
       expect(getComputedStyle(textColumn).flexBasis).not.toBe('8rem');
     });
   });
+  describe('single-line centering', () => {
+    const headerOf = (ui: React.ReactElement) => {
+      const {container} = render(ui);
+      return container.firstElementChild!.firstElementChild!;
+    };
+
+    it('centers a title-only banner that has a dismiss button', () => {
+      const header = headerOf(
+        <Banner status="info" title="Deploy finished" isDismissable />,
+      );
+      expect(getComputedStyle(header).alignItems).toBe('center');
+    });
+
+    it('centers a title-only banner whose only control is the collapse toggle', () => {
+      const header = headerOf(
+        <Banner status="info" title="Deploy finished">
+          <p>Details</p>
+        </Banner>,
+      );
+      expect(getComputedStyle(header).alignItems).toBe('center');
+    });
+
+    it('keeps a described banner top-aligned, toggle or not', () => {
+      const header = headerOf(
+        <Banner status="info" title="Deploy finished" description="Two lines">
+          <p>Details</p>
+        </Banner>,
+      );
+      expect(getComputedStyle(header).alignItems).toBe('flex-start');
+    });
+
+    it('keeps a banner with no controls at all top-aligned', () => {
+      const header = headerOf(
+        <Banner status="info" title="Deploy finished" collapsible={false}>
+          <p>Details</p>
+        </Banner>,
+      );
+      expect(getComputedStyle(header).alignItems).toBe('flex-start');
+    });
+  });
 });

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -534,8 +534,11 @@ export function Banner({
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = isRenderable(endContent) || isDismissable || hasToggle;
   // Center items vertically when there's only a title (no description)
-  // and the banner has action buttons
-  const hasActions = isRenderable(endContent) || isDismissable;
+  // and the banner has action buttons. The collapse toggle counts: it is the
+  // same 28px control as a dismiss button and shares the row with it, so a
+  // collapsible title-only banner is exactly the case this centers — leaving
+  // it out left the icon and title hanging above the toggle they sit beside.
+  const hasActions = isRenderable(endContent) || isDismissable || hasToggle;
   const isSingleLine = !isRenderable(description) && hasActions;
 
   // Non-collapsible children are always shown; collapsible ones follow the


### PR DESCRIPTION
## The bug

`Banner` centers its header vertically when the banner is one line of text with controls beside it — otherwise a 28px ghost button next to a 20px title reads as hanging. That is what `headerCentered` is for, and its comment says so: *"When there's only a title (no description) and actions, center everything vertically."*

But the test that drives it counts only two of the three things that can appear in the actions row:

```ts
const hasActions = isRenderable(endContent) || isDismissable;
const isSingleLine = !isRenderable(description) && hasActions;
```

The collapse toggle is missing. So two banners that render the same shape — a title, and one 28px icon-only ghost Button in the end area — align differently:

```tsx
<Banner status="info" title="Deploy finished" isDismissable />   // centered
<Banner status="info" title="Deploy finished"><p>Details</p></Banner>  // top-aligned
```

In the second, the icon and title sit 4px above the toggle they are level with. `showEndArea` on the line above already counts `hasToggle`; only `hasActions` does not.

## The fix

```ts
const hasActions = isRenderable(endContent) || isDismissable || hasToggle;
```

One term. `hasToggle` is already computed two lines up, and is itself `isCollapsible && hasChildren`, so a `collapsible={false}` banner and a banner with no children are untouched.

## Verification

`pnpm exec vitest run packages/core/src/Banner` — 56 passed (52 existing + 4 added under a new `single-line centering` describe, covering all four combinations: dismiss-only, toggle-only, described-with-toggle, and no controls).

**Negative control:** reverting the one-term change and re-running fails exactly one test — *"centers a title-only banner whose only control is the collapse toggle"* — and the other 55 stay green. So the new test really is watching this behaviour, and the change moves nothing else.

Found while bringing an internal EPS theme onto the real `Banner` (context in #5417 / #5483): the theme had to reproduce this centering with its own CSS rule to match, which is how the asymmetry surfaced.
