### PR TITLE
fix(core): restore the SelectableCard/Thumbnail/ClickableCard hover overlay

### DIFF
--- a/.changeset/hover-overlay-specificity.md
+++ b/.changeset/hover-overlay-specificity.md
@@ -8,7 +8,7 @@
 
 The guard was redundant on these three anyway: each already applies the whole `hoverOnPointer` class conditionally (`!isDisabled && styles.hoverOnPointer`, or `isInteractive && ...` for Thumbnail, where `isInteractive` already excludes `isDisabled`), so a disabled/non-interactive card never carries the class that would need guarding. Reverted the three keys to bare `:hover::after`, restoring the pre-regression 7-boost CSS output exactly.
 
-`@astryx/no-hover-on-disabled` now knows to leave `:hover` + pseudo-element combinations alone — guarding them would just reintroduce this exact break until the StyleX tokenizer is fixed upstream. This is a real, documented coverage gap, not a free pass: a new `:hover::after`/`:hover::before` key that doesn't already exclude the disabled case some other way (as these three do, in JS) needs manual verification, since the lint rule can no longer catch it in this shape.
+`@astryx/no-hover-on-disabled` now knows not to autofix a `:hover` + pseudo-element key, anywhere — autofixing one would reintroduce this exact break until the StyleX tokenizer is fixed upstream. It still reports the key everywhere except these three files, so a new unguarded `:hover::after`/`:hover::before` still needs manual verification (does the component already exclude the disabled case in JS, the way these three do?) before it's added to the rule's narrow exemption list.
 
 Fixes #5442.
 

--- a/.changeset/hover-overlay-specificity.md
+++ b/.changeset/hover-overlay-specificity.md
@@ -1,0 +1,15 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `SelectableCard`, `Thumbnail`, and `ClickableCard`'s hover overlay paints again — it silently stopped rendering at 0.4.6.
+
+`#5247` added a zero-specificity `:where(:not(:disabled,[aria-disabled="true"]))` guard to every self-`:hover` selector for WCAG 1.4.1. On these three components the hover key also targets `::after`, and combining a hover pseudo-class with a pseudo-element hits a `@stylexjs/babel-plugin@0.19.0` tokenizer bug: `getCompoundPseudoPriority()` can't match the nested parens in `:where(:not(...))`, bails to a wrong priority default, and the rule's specificity boost silently dropped from 7 `:not(#\#)`s to 3. The resting `background-color: transparent` rule (still at 7) then out-specified the hover rule in the same layer, so the overlay never painted — verified by diffing the generated `astryx.css` byte-for-byte against 0.4.5.
+
+The guard was redundant on these three anyway: each already applies the whole `hoverOnPointer` class conditionally (`!isDisabled && styles.hoverOnPointer`, or `isInteractive && ...` for Thumbnail, where `isInteractive` already excludes `isDisabled`), so a disabled/non-interactive card never carries the class that would need guarding. Reverted the three keys to bare `:hover::after`, restoring the pre-regression 7-boost CSS output exactly.
+
+`@astryx/no-hover-on-disabled` now knows to leave `:hover` + pseudo-element combinations alone — guarding them would just reintroduce this exact break until the StyleX tokenizer is fixed upstream. This is a real, documented coverage gap, not a free pass: a new `:hover::after`/`:hover::before` key that doesn't already exclude the disabled case some other way (as these three do, in JS) needs manual verification, since the lint rule can no longer catch it in this shape.
+
+Fixes #5442.
+
+@HelloOjasMutreja

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.js
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.js
@@ -40,24 +40,35 @@
  * alone.
  *
  * GAP, known and tracked: `:hover` combined with a pseudo-ELEMENT —
- * `:hover::after`, `:hover::before` — is left unguarded too, and is NOT
- * autofixed if already unguarded. `@stylexjs/babel-plugin@0.19.0`'s
- * getCompoundPseudoPriority() cannot match the nested parens in
- * `:where(:not(:disabled,[aria-disabled="true"]))` and bails to a wrong
- * priority default, which silently drops the rule's specificity boost and
- * can let an unrelated resting rule win instead — see
+ * `:hover::after`, `:hover::before` — is NOT autofixed, anywhere.
+ * `@stylexjs/babel-plugin@0.19.0`'s getCompoundPseudoPriority() cannot match
+ * the nested parens in `:where(:not(:disabled,[aria-disabled="true"]))` and
+ * bails to a wrong priority default, which silently drops the rule's
+ * specificity boost and can let an unrelated resting rule win instead — see
  * facebook/astryx#5442, where this broke SelectableCard/Thumbnail/
- * ClickableCard's hover overlay. Guarding a `:hover::after` key here would
- * reintroduce that regression, so the exemption stays until the upstream
- * tokenizer is fixed.
+ * ClickableCard's hover overlay. Autofixing a `:hover::after` key would
+ * reintroduce that exact regression, so the fixer stays off for this shape
+ * until the upstream tokenizer is fixed. The key is still REPORTED, though:
+ * an unguarded `:hover::after`/`:hover::before` is real, ordinary lint
+ * output everywhere except the three files below, same as any other
+ * unguarded hover key — only the autofix is withheld.
  *
- * This is a real coverage hole, not a free pass: a `:hover::after`/
- * `:hover::before` key on a component that does NOT already exclude the
- * disabled case some other way (the three components above all gate the
- * whole class in JS — `!isDisabled && styles.hoverOnPointer`) can still ship
- * a hover-while-disabled bug with nothing here to catch it. Verify that
- * gating by hand for anything new in this shape.
+ * EXEMPT_FILES narrows the reported-but-not-flagged case to exactly the
+ * three files where this PR verified, by hand, that JS-level gating already
+ * makes the guard redundant (`!isDisabled && styles.hoverOnPointer`, or
+ * equivalent). Nothing else gets a free pass: a new `:hover::after`/
+ * `:hover::before` key anywhere else is reported (without an autofix) and
+ * needs the same by-hand verification before it's added to this list.
  */
+const EXEMPT_FILES = [
+  /[/\\]SelectableCard[/\\]SelectableCard\.tsx$/,
+  /[/\\]Thumbnail[/\\]Thumbnail\.tsx$/,
+  /[/\\]ClickableCard[/\\]ClickableCard\.tsx$/,
+];
+
+function isExemptFile(filename) {
+  return !!filename && EXEMPT_FILES.some(pattern => pattern.test(filename));
+}
 
 /** Zero-specificity guard appended to a self-hover selector. */
 const GUARD = ':where(:not(:disabled,[aria-disabled="true"]))';
@@ -140,16 +151,31 @@ const rule = {
       unguardedHover:
         "'{{key}}' still matches a disabled element — browsers suppress a disabled control's events, not its hover styling. " +
         "Write '{{fixed}}' instead (`:where()` adds no specificity, so overrides are unaffected).",
+      unguardedHoverPseudoElement:
+        "'{{key}}' still matches a disabled element, and can't be autofixed: guarding a `:hover` + pseudo-element key hits a " +
+        '@stylexjs/babel-plugin@0.19.0 tokenizer bug that silently drops the guard\'s specificity boost (facebook/astryx#5442). ' +
+        "Verify by hand whether this component already excludes the disabled case in JS (e.g. only applying the class when " +
+        "`!isDisabled`) — if so, this key is fine as-is; if not, this is a real hover-while-disabled bug.",
     },
     schema: [],
   },
   create(context) {
+    const filename = context.filename ?? context.getFilename();
     return {
       Property(node) {
         if (!isInsideStylexCreate(node)) return;
         const key = keyOf(node);
         if (!isSelfHoverKey(key) || hasDisabledGuard(key)) return;
-        if (hasPseudoElement(key)) return;
+
+        if (hasPseudoElement(key)) {
+          if (isExemptFile(filename)) return;
+          context.report({
+            node: node.key,
+            messageId: 'unguardedHoverPseudoElement',
+            data: {key},
+          });
+          return;
+        }
 
         const fixed = guardKey(key);
         context.report({
@@ -174,4 +200,11 @@ const rule = {
 };
 
 export default rule;
-export {GUARD, guardKey, isSelfHoverKey, hasDisabledGuard, hasPseudoElement};
+export {
+  GUARD,
+  guardKey,
+  isSelfHoverKey,
+  hasDisabledGuard,
+  hasPseudoElement,
+  isExemptFile,
+};

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.js
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.js
@@ -38,6 +38,25 @@
  * descendant when an ANCESTOR is hovered, which is a different question (a
  * row may legitimately highlight around a disabled control) and is left
  * alone.
+ *
+ * GAP, known and tracked: `:hover` combined with a pseudo-ELEMENT —
+ * `:hover::after`, `:hover::before` — is left unguarded too, and is NOT
+ * autofixed if already unguarded. `@stylexjs/babel-plugin@0.19.0`'s
+ * getCompoundPseudoPriority() cannot match the nested parens in
+ * `:where(:not(:disabled,[aria-disabled="true"]))` and bails to a wrong
+ * priority default, which silently drops the rule's specificity boost and
+ * can let an unrelated resting rule win instead — see
+ * facebook/astryx#5442, where this broke SelectableCard/Thumbnail/
+ * ClickableCard's hover overlay. Guarding a `:hover::after` key here would
+ * reintroduce that regression, so the exemption stays until the upstream
+ * tokenizer is fixed.
+ *
+ * This is a real coverage hole, not a free pass: a `:hover::after`/
+ * `:hover::before` key on a component that does NOT already exclude the
+ * disabled case some other way (the three components above all gate the
+ * whole class in JS — `!isDisabled && styles.hoverOnPointer`) can still ship
+ * a hover-while-disabled bug with nothing here to catch it. Verify that
+ * gating by hand for anything new in this shape.
  */
 
 /** Zero-specificity guard appended to a self-hover selector. */
@@ -57,6 +76,17 @@ function isSelfHoverKey(key) {
 /** Already guarded, in any spelling a hand might use. */
 function hasDisabledGuard(key) {
   return /:not\([^)]*(?::disabled|\[aria-disabled)/.test(key);
+}
+
+/**
+ * Combines `:hover` with a pseudo-ELEMENT (`::after`, `::before`, ...).
+ *
+ * See the GAP note in the file header: guarding this shape hits a StyleX
+ * tokenizer bug that silently breaks the rule it's meant to protect, so it's
+ * deliberately left unguarded and unflagged until that's fixed upstream.
+ */
+function hasPseudoElement(key) {
+  return key.includes('::');
 }
 
 /**
@@ -119,6 +149,7 @@ const rule = {
         if (!isInsideStylexCreate(node)) return;
         const key = keyOf(node);
         if (!isSelfHoverKey(key) || hasDisabledGuard(key)) return;
+        if (hasPseudoElement(key)) return;
 
         const fixed = guardKey(key);
         context.report({
@@ -143,4 +174,4 @@ const rule = {
 };
 
 export default rule;
-export {GUARD, guardKey, isSelfHoverKey, hasDisabledGuard};
+export {GUARD, guardKey, isSelfHoverKey, hasDisabledGuard, hasPseudoElement};

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.js
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.js
@@ -53,21 +53,57 @@
  * output everywhere except the three files below, same as any other
  * unguarded hover key — only the autofix is withheld.
  *
- * EXEMPT_FILES narrows the reported-but-not-flagged case to exactly the
- * three files where this PR verified, by hand, that JS-level gating already
- * makes the guard redundant (`!isDisabled && styles.hoverOnPointer`, or
- * equivalent). Nothing else gets a free pass: a new `:hover::after`/
- * `:hover::before` key anywhere else is reported (without an autofix) and
- * needs the same by-hand verification before it's added to this list.
+ * EXEMPT_SITES narrows the reported-but-not-flagged case to exactly the
+ * three (file, top-level style key) pairs where this PR verified, by hand,
+ * that JS-level gating already makes the guard redundant
+ * (`!isDisabled && styles.hoverOnPointer`, or equivalent). The exemption is
+ * keyed on the style object's own property name, not just the filename: a
+ * new `:hover::after`/`:hover::before` key under any OTHER name in these
+ * same files is still reported, and needs the same by-hand verification
+ * before it's added here.
  */
-const EXEMPT_FILES = [
-  /[/\\]SelectableCard[/\\]SelectableCard\.tsx$/,
-  /[/\\]Thumbnail[/\\]Thumbnail\.tsx$/,
-  /[/\\]ClickableCard[/\\]ClickableCard\.tsx$/,
+const EXEMPT_SITES = [
+  {file: /[/\\]SelectableCard[/\\]SelectableCard\.tsx$/, key: 'hoverOnPointer'},
+  {file: /[/\\]Thumbnail[/\\]Thumbnail\.tsx$/, key: 'hoverOnPointer'},
+  {file: /[/\\]ClickableCard[/\\]ClickableCard\.tsx$/, key: 'hoverOnPointer'},
 ];
 
-function isExemptFile(filename) {
-  return !!filename && EXEMPT_FILES.some(pattern => pattern.test(filename));
+function isExemptSite(filename, styleKeyName) {
+  if (!filename || !styleKeyName) return false;
+  return EXEMPT_SITES.some(
+    site => site.key === styleKeyName && site.file.test(filename),
+  );
+}
+
+/** Is `objectExpr` the object literal passed directly to `stylex.create()`? */
+function isStylexCreateArgument(objectExpr) {
+  const parent = objectExpr?.parent;
+  return (
+    parent?.type === 'CallExpression' &&
+    parent.callee?.type === 'MemberExpression' &&
+    parent.callee.object?.name === 'stylex' &&
+    parent.callee.property?.name === 'create'
+  );
+}
+
+/**
+ * The name of the top-level property passed directly to `stylex.create({})`
+ * that encloses `node` — e.g. `hoverOnPointer` in
+ * `stylex.create({hoverOnPointer: {':hover::after': {...}}})`.
+ */
+function getEnclosingStyleKeyName(node) {
+  let current = node;
+  while (current) {
+    if (
+      current.type === 'Property' &&
+      current.parent?.type === 'ObjectExpression' &&
+      isStylexCreateArgument(current.parent)
+    ) {
+      return keyOf(current);
+    }
+    current = current.parent;
+  }
+  return null;
 }
 
 /** Zero-specificity guard appended to a self-hover selector. */
@@ -168,7 +204,7 @@ const rule = {
         if (!isSelfHoverKey(key) || hasDisabledGuard(key)) return;
 
         if (hasPseudoElement(key)) {
-          if (isExemptFile(filename)) return;
+          if (isExemptSite(filename, getEnclosingStyleKeyName(node))) return;
           context.report({
             node: node.key,
             messageId: 'unguardedHoverPseudoElement',
@@ -206,5 +242,6 @@ export {
   isSelfHoverKey,
   hasDisabledGuard,
   hasPseudoElement,
-  isExemptFile,
+  isExemptSite,
+  getEnclosingStyleKeyName,
 };

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
@@ -68,6 +68,27 @@ ruleTester.run('no-hover-on-disabled', rule, {
     {
       code: `const handlers = {':hover': () => {}};`,
     },
+    // :hover combined with a pseudo-ELEMENT is a known, tracked gap: guarding
+    // it hits a StyleX 0.19.0 tokenizer bug that silently breaks the very
+    // rule this is meant to protect (facebook/astryx#5442). Left unguarded
+    // and unflagged until that's fixed upstream — see the GAP note in
+    // no-hover-on-disabled.js.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          tab: {opacity: {default: 0, ':hover::after': 1}},
+        });
+      `,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          tab: {opacity: {default: 0, ':hover::before': 1}},
+        });
+      `,
+    },
   ],
   invalid: [
     // The bare key, property-first.
@@ -115,22 +136,6 @@ ruleTester.run('no-hover-on-disabled', rule, {
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
           field: {borderColor: {default: 'grey', ':hover:not(:focus-within)${GUARD}': 'black'}},
-        });
-      `,
-    },
-    // A pseudo-ELEMENT has to stay last, so the guard goes before it.
-    {
-      code: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          tab: {opacity: {default: 0, ':hover::after': 1}},
-        });
-      `,
-      errors: [{messageId: 'unguardedHover'}],
-      output: `
-        import * as stylex from '@stylexjs/stylex';
-        const styles = stylex.create({
-          tab: {opacity: {default: 0, ':hover${GUARD}::after': 1}},
         });
       `,
     },

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
@@ -68,26 +68,35 @@ ruleTester.run('no-hover-on-disabled', rule, {
     {
       code: `const handlers = {':hover': () => {}};`,
     },
-    // :hover combined with a pseudo-ELEMENT is a known, tracked gap: guarding
-    // it hits a StyleX 0.19.0 tokenizer bug that silently breaks the very
-    // rule this is meant to protect (facebook/astryx#5442). Left unguarded
-    // and unflagged until that's fixed upstream — see the GAP note in
-    // no-hover-on-disabled.js.
+    // :hover combined with a pseudo-ELEMENT in one of the three files this PR
+    // hand-verified is JS-gated (facebook/astryx#5442) stays unreported —
+    // everywhere else, the same key is reported (see invalid below).
     {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          tab: {opacity: {default: 0, ':hover::after': 1}},
+          overlay: {opacity: {default: 0, ':hover::after': 1}},
         });
       `,
+      filename: '/repo/packages/core/src/SelectableCard/SelectableCard.tsx',
     },
     {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          tab: {opacity: {default: 0, ':hover::before': 1}},
+          overlay: {opacity: {default: 0, ':hover::before': 1}},
         });
       `,
+      filename: '/repo/packages/core/src/Thumbnail/Thumbnail.tsx',
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          overlay: {opacity: {default: 0, ':hover::after': 1}},
+        });
+      `,
+      filename: '/repo/packages/core/src/ClickableCard/ClickableCard.tsx',
     },
   ],
   invalid: [
@@ -155,6 +164,30 @@ ruleTester.run('no-hover-on-disabled', rule, {
           item: {color: {default: 'red', ':hover${GUARD}': 'blue'}},
         });
       `,
+    },
+    // :hover + a pseudo-element outside the three hand-verified files is
+    // reported (unlike the exempt cases above), but not autofixed: the
+    // fixer would hit the tokenizer bug and reintroduce facebook/astryx#5442.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          tab: {opacity: {default: 0, ':hover::after': 1}},
+        });
+      `,
+      filename: '/repo/packages/core/src/Tabs/Tabs.tsx',
+      errors: [{messageId: 'unguardedHoverPseudoElement'}],
+      output: null,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          tab: {opacity: {default: 0, ':hover::before': 1}},
+        });
+      `,
+      errors: [{messageId: 'unguardedHoverPseudoElement'}],
+      output: null,
     },
   ],
 });

--- a/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
+++ b/internal/eslint-plugin-astryx/no-hover-on-disabled.test.mjs
@@ -68,14 +68,17 @@ ruleTester.run('no-hover-on-disabled', rule, {
     {
       code: `const handlers = {':hover': () => {}};`,
     },
-    // :hover combined with a pseudo-ELEMENT in one of the three files this PR
-    // hand-verified is JS-gated (facebook/astryx#5442) stays unreported —
-    // everywhere else, the same key is reported (see invalid below).
+    // :hover combined with a pseudo-ELEMENT, under the exact hand-verified
+    // `hoverOnPointer` style key (facebook/astryx#5442), stays unreported —
+    // everywhere else, and under any OTHER key in these same files, the same
+    // shape is still reported (see invalid below).
     {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          overlay: {opacity: {default: 0, ':hover::after': 1}},
+          hoverOnPointer: {
+            '@media (hover: hover)': {opacity: {default: 0, ':hover::after': 1}},
+          },
         });
       `,
       filename: '/repo/packages/core/src/SelectableCard/SelectableCard.tsx',
@@ -84,7 +87,9 @@ ruleTester.run('no-hover-on-disabled', rule, {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          overlay: {opacity: {default: 0, ':hover::before': 1}},
+          hoverOnPointer: {
+            '@media (hover: hover)': {opacity: {default: 0, ':hover::before': 1}},
+          },
         });
       `,
       filename: '/repo/packages/core/src/Thumbnail/Thumbnail.tsx',
@@ -93,7 +98,9 @@ ruleTester.run('no-hover-on-disabled', rule, {
       code: `
         import * as stylex from '@stylexjs/stylex';
         const styles = stylex.create({
-          overlay: {opacity: {default: 0, ':hover::after': 1}},
+          hoverOnPointer: {
+            '@media (hover: hover)': {opacity: {default: 0, ':hover::after': 1}},
+          },
         });
       `,
       filename: '/repo/packages/core/src/ClickableCard/ClickableCard.tsx',
@@ -186,6 +193,42 @@ ruleTester.run('no-hover-on-disabled', rule, {
           tab: {opacity: {default: 0, ':hover::before': 1}},
         });
       `,
+      errors: [{messageId: 'unguardedHoverPseudoElement'}],
+      output: null,
+    },
+    // The exemption is scoped to the verified `hoverOnPointer` style key,
+    // not the whole file: a second, unrelated `:hover::before` under a
+    // different key in one of the three exempt files is still reported.
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          badge: {opacity: {default: 0, ':hover::before': 1}},
+        });
+      `,
+      filename: '/repo/packages/core/src/SelectableCard/SelectableCard.tsx',
+      errors: [{messageId: 'unguardedHoverPseudoElement'}],
+      output: null,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          badge: {opacity: {default: 0, ':hover::after': 1}},
+        });
+      `,
+      filename: '/repo/packages/core/src/Thumbnail/Thumbnail.tsx',
+      errors: [{messageId: 'unguardedHoverPseudoElement'}],
+      output: null,
+    },
+    {
+      code: `
+        import * as stylex from '@stylexjs/stylex';
+        const styles = stylex.create({
+          badge: {opacity: {default: 0, ':hover::before': 1}},
+        });
+      `,
+      filename: '/repo/packages/core/src/ClickableCard/ClickableCard.tsx',
       errors: [{messageId: 'unguardedHoverPseudoElement'}],
       output: null,
     },

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -80,9 +80,18 @@ const styles = stylex.create({
       backgroundColor: colorVars['--color-overlay-pressed'],
     },
   },
+  // Bare :hover::after, not the guarded form @astryx/no-hover-on-disabled
+  // otherwise wants: this class is only ever applied via `!isDisabled &&
+  // styles.hoverOnPointer` below, so a disabled card never carries it in the
+  // first place, and the CSS-level guard is redundant here. It also actively
+  // broke the overlay — combining a hover pseudo-class with a pseudo-element
+  // selector hits a StyleX 0.19.0 tokenizer bug (nested parens in
+  // `:where(:not(...))` collapse the compound-selector priority lookup to a
+  // wrong default), which dropped this rule's specificity boost and let the
+  // resting `background-color: transparent` win instead. See #5442.
   hoverOnPointer: {
     '@media (hover: hover)': {
-      ':hover:where(:not(:disabled,[aria-disabled="true"]))::after': {
+      ':hover::after': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -86,9 +86,18 @@ const styles = stylex.create({
       backgroundColor: colorVars['--color-overlay-pressed'],
     },
   },
+  // Bare :hover::after, not the guarded form @astryx/no-hover-on-disabled
+  // otherwise wants: this class is only ever applied via `!isDisabled &&
+  // styles.hoverOnPointer` below, so a disabled card never carries it in the
+  // first place, and the CSS-level guard is redundant here. It also actively
+  // broke the overlay — combining a hover pseudo-class with a pseudo-element
+  // selector hits a StyleX 0.19.0 tokenizer bug (nested parens in
+  // `:where(:not(...))` collapse the compound-selector priority lookup to a
+  // wrong default), which dropped this rule's specificity boost and let the
+  // resting `background-color: transparent` win instead. See #5442.
   hoverOnPointer: {
     '@media (hover: hover)': {
-      ':hover:where(:not(:disabled,[aria-disabled="true"]))::after': {
+      ':hover::after': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
     },

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -184,9 +184,19 @@ const styles = stylex.create({
       backgroundColor: colorVars['--color-overlay-pressed'],
     },
   },
+  // Bare :hover::after, not the guarded form @astryx/no-hover-on-disabled
+  // otherwise wants: this class is only ever applied via `isInteractive &&
+  // styles.hoverOnPointer` below, and isInteractive already excludes
+  // isDisabled, so a non-interactive thumbnail never carries it in the first
+  // place — the CSS-level guard is redundant here. It also actively broke
+  // the overlay — combining a hover pseudo-class with a pseudo-element
+  // selector hits a StyleX 0.19.0 tokenizer bug (nested parens in
+  // `:where(:not(...))` collapse the compound-selector priority lookup to a
+  // wrong default), which dropped this rule's specificity boost and let the
+  // resting `background-color: transparent` win instead. See #5442.
   hoverOnPointer: {
     '@media (hover: hover)': {
-      ':hover:where(:not(:disabled,[aria-disabled="true"]))::after': {
+      ':hover::after': {
         backgroundColor: colorVars['--color-overlay-hover'],
       },
     },


### PR DESCRIPTION
Fixes #5442.

Thanks to @brightonvino for the exceptionally well-diagnosed report — the exact `getCompoundPseudoPriority()` root cause, the byte-for-byte `astryx.css` diff between 0.4.5/0.4.6/0.4.7, and both fix options were already worked out in the issue. This implements the "cheap" fix it recommends.

## Root cause

#5247 added a zero-specificity `:where(:not(:disabled,[aria-disabled="true"]))` guard to every self-`:hover` selector, for WCAG 1.4.1. On `SelectableCard`, `Thumbnail`, and `ClickableCard`, the `:hover` key also targets `::after`. Combining a hover pseudo-class with a pseudo-element hits a `@stylexjs/babel-plugin@0.19.0` tokenizer bug: `getCompoundPseudoPriority()`'s regex can't match the nested parens in `:where(:not(...))`, bails to a wrong priority default, and the rule's specificity boost silently dropped from 7 `:not(#\#)`s to 3. The resting `background-color: transparent` rule (still at 7, untouched) then out-specifies the hover rule in the same layer, so the overlay never paints.

## Fix

The guard is redundant on these three components specifically: each already applies the whole `hoverOnPointer` class conditionally in JS —

- `SelectableCard`: `!isDisabled && styles.hoverOnPointer`
- `ClickableCard`: `!isDisabled && styles.hoverOnPointer`
- `Thumbnail`: `isInteractive && styles.hoverOnPointer`, where `isInteractive = onClick != null && !isDisabled && !isLoading`

A disabled/non-interactive card never carries the class that would need CSS-level guarding, so reverting the key to bare `:hover::after` loses none of #5247's protection here — it just stops hitting the StyleX bug.

`@astryx/no-hover-on-disabled` now knows to leave `:hover` + pseudo-element combinations alone, so `eslint --fix` doesn't just re-add the guard and re-break this on the next run. Documented as a real, tracked coverage gap in the rule's own header (not a free pass) — a future `:hover::after`/`:hover::before` key that isn't already JS-gated the way these three are needs manual verification, since the rule can't currently catch it in this shape.

## Verification

Rebuilt `packages/core` and diffed the generated `astryx.css` directly: the hover rule now reads
```css
.xi14tyy.xi14tyy:hover:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::after{background-color:var(--color-overlay-hover)}
```
— 7 boosts, byte-for-byte identical to the issue's cited 0.4.5 (working) output, matching the resting rule's own 7 boosts again.

**Before** (0.4.6/0.4.7, hovering "Basic" — flat, no overlay):
![before](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/selectablecard-hover-overlay/before.png)

**After** (hovering "Basic" — the overlay tints again):
![after](https://raw.githubusercontent.com/HelloOjasMutreja/astryx/assets/selectablecard-hover-overlay/after.png)

Confirmed programmatically too: `getComputedStyle(el, '::after').backgroundColor` reads `rgba(0, 0, 0, 0)` on hover before the fix, `rgba(0, 0, 0, 0.05)` after, on the same Storybook story with transitions disabled (per the issue's own measurement note, to avoid catching a mid-fade frame).

`no-hover-on-disabled.test.mjs` updated: the two cases asserting `:hover::after`/`:hover::before` get autofixed moved from `invalid` to `valid`, since that's exactly the behavior being turned off, with a comment explaining why and linking back to this issue.

Full `SelectableCard`/`Thumbnail`/`ClickableCard`/`eslint-plugin-astryx` suite: 570/570 passing. Typecheck and lint clean.