### PR TITLE
docs(DateInput, TableBody, TableHeader): replace em dashes in doc prose

### DIFF
--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -160,7 +160,7 @@ export const docs = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "Which surface draws the date picker. 'touch' (the default) hands a touch device to the browser/OS \u2014 the field becomes an input type=date and the platform draws the picker (the iOS wheel, the Android calendar dialog); 'always' does that wherever the browser supports input type=date; 'never' keeps Astryx's own pickers everywhere (the bottom-sheet picker on a finger, the calendar popover on a mouse). Use 'never' for a field that needs weekStartsOn, numberOfMonths or dateConstraints, none of which a native picker can express. format and placeholder still apply in native mode; min and max are forwarded, but a native picker may not show them (on iOS an out-of-range date can be selected and is refused on commit rather than greyed out).",
+        "Which surface draws the date picker. 'touch' (the default) hands a touch device to the browser/OS: the field becomes an input type=date and the platform draws the picker (the iOS wheel, the Android calendar dialog); 'always' does that wherever the browser supports input type=date; 'never' keeps Astryx's own pickers everywhere (the bottom-sheet picker on a finger, the calendar popover on a mouse). Use 'never' for a field that needs weekStartsOn, numberOfMonths or dateConstraints, none of which a native picker can express. format and placeholder still apply in native mode; min and max are forwarded, but a native picker may not show them (on iOS an out-of-range date can be selected and is refused on commit rather than greyed out).",
       default: "'touch'",
     },
     {
@@ -552,7 +552,7 @@ export const docsDense = {
     format:
       "committed-value display: 'date_long' (default, March 21, 2026), 'date' (Mar 21, 2026), 'date_weekday' (Wed, Mar 21, 2026), 'system_date' (2026-03-21), or (iso)=>string; reuses Timestamp vocabulary. Committed value only, not while typing.",
     nativePicker:
-      "which surface draws the picker: 'touch' (default) = browser/OS on a coarse pointer, 'always', 'never' = Astryx's own everywhere. use 'never' for weekStartsOn/numberOfMonths/dateConstraints. format+placeholder still apply; min/max forwarded but not necessarily shown by the OS picker \u2014 refused on commit instead.",
+      "which surface draws the picker: 'touch' (default) = browser/OS on a coarse pointer, 'always', 'never' = Astryx's own everywhere. use 'never' for weekStartsOn/numberOfMonths/dateConstraints. format+placeholder still apply; min/max forwarded but not necessarily shown by the OS picker, refused on commit instead.",
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/Table/TableBody.doc.mjs
+++ b/packages/core/src/Table/TableBody.doc.mjs
@@ -8,7 +8,7 @@ export const docs = {
   displayName: 'Table Body',
   isHiddenFromOverview: true,
   description:
-    '<tbody> wrapper for children mode. Holds the data rows. A row must sit inside a section — <table> cannot contain a <tr> directly, because the HTML parser inserts an implied <tbody> when it parses server-rendered markup and React does not when it renders on the client, so rows written straight into Table mismatch on hydration. The data-driven data={...} mode renders this element itself; in children mode it is yours to supply.',
+    '<tbody> wrapper for children mode. Holds the data rows. A row must sit inside a section: <table> cannot contain a <tr> directly, because the HTML parser inserts an implied <tbody> when it parses server-rendered markup and React does not when it renders on the client, so rows written straight into Table mismatch on hydration. The data-driven data={...} mode renders this element itself; in children mode it is yours to supply.',
   props: [
     {
       name: 'children',
@@ -32,7 +32,7 @@ export const docsDense = {
   name: 'TableBody',
   isHiddenFromOverview: true,
   displayName: 'Table Body',
-  description: '<tbody> wrapper for children mode; holds the data rows — children mode does not add one for you',
+  description: '<tbody> wrapper for children mode; holds the data rows; children mode does not add one for you',
   propDescriptions: {
     children: 'The <tbody> rows.',
     xstyle: 'StyleX styles for layout customization',

--- a/packages/core/src/Table/TableHeader.doc.mjs
+++ b/packages/core/src/Table/TableHeader.doc.mjs
@@ -8,7 +8,7 @@ export const docs = {
   displayName: 'Table Header',
   isHiddenFromOverview: true,
   description:
-    '<thead> wrapper for children mode. Holds the header row, whose cells are TableHeaderCell. A row must sit inside a section — <table> cannot contain a <tr> directly, because the HTML parser inserts an implied <tbody> when it parses server-rendered markup and React does not when it renders on the client, so the two trees mismatch on hydration. The data-driven data={...} mode renders this element itself whenever columns are supplied; in children mode it is yours to supply.',
+    '<thead> wrapper for children mode. Holds the header row, whose cells are TableHeaderCell. A row must sit inside a section: <table> cannot contain a <tr> directly, because the HTML parser inserts an implied <tbody> when it parses server-rendered markup and React does not when it renders on the client, so the two trees mismatch on hydration. The data-driven data={...} mode renders this element itself whenever columns are supplied; in children mode it is yours to supply.',
   props: [
     {
       name: 'children',


### PR DESCRIPTION
## What

Replace em dashes in three component doc files with the correct punctuation, per the AI-slop prose check (check 17, tell A1). Typography only; no wording or technical claim changes.

- `DateInput.doc.mjs`: two em dashes, one in the English `nativePicker` description (colon: the second clause explains the OS handoff) and one in the dense overlay (comma before the trailing aside).
- `TableBody.doc.mjs`: em dash in the English description recast as a colon (the `<table>` clause explains why the row needs a section); em dash in the dense description recast as a semicolon (two independent clauses).
- `TableHeader.doc.mjs`: same colon recast as TableBody in the English description.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes.
- `astryx component DateInput --lang dense` and `astryx component TableBody --lang dense` render cleanly with no em dashes and no duplicate `(required)`.
- All three files parse as ES modules.

The pre-existing `theme.template.ts:83` TS2307 in the template-docs tsc project is unrelated to these files.

Night Watch — Doc Reviewer