### PR TITLE
fix(Card): reflect elevation as a theme target, correct the padding default docs

### DIFF
--- a/.changeset/card-nightly-audit-20260825.md
+++ b/.changeset/card-nightly-audit-20260825.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Card: reflect `elevation` as a theme target so a theme can reach it, and correct the documented `padding` default
+
+`elevation` picked a style object but never reached the DOM, so `astryx-card` exposed `data-variant` and nothing for elevation and a theme could not style the four shadow tiers. It now rides `themeProps` alongside `variant`.
+
+The `padding` prop documented `4` as its default. With the prop omitted the card reads the theme's card padding, which every shipped theme but `butter` sets to spacing step 3, so writing the documented default explicitly made the card wider. The prop docs, the JSDoc and the playground default now say what actually happens.
+
+@cixzhang

--- a/.changeset/card-nightly-audit-20260825.md
+++ b/.changeset/card-nightly-audit-20260825.md
@@ -6,6 +6,6 @@
 
 `elevation` picked a style object but never reached the DOM, so `astryx-card` exposed `data-variant` and nothing for elevation and a theme could not style the four shadow tiers. It now rides `themeProps` alongside `variant`.
 
-The `padding` prop documented `4` as its default. With the prop omitted the card reads the theme's card padding, which every shipped theme but `butter` sets to spacing step 3, so writing the documented default explicitly made the card wider. The prop docs, the JSDoc and the playground default now say what actually happens, and the four `effectivePadding !== 4` style branches that encoded the same wrong default in code are gone: `container()` already sets every variable they set, verified identical across all eleven padding steps on both a bordered and a borderless card.
+The `padding` prop documented `4` as its default. With the prop omitted the card reads the theme's card padding, and most shipped themes set that to a different step, so writing the documented default explicitly changed the card's size. The prop docs, the JSDoc and the playground default now say that omitting the prop takes the theme's padding and passing a step overrides it. The four `effectivePadding !== 4` style branches that encoded the same wrong default in code are gone: `container()` already sets every variable they set, verified identical across all eleven padding steps on both a bordered and a borderless card.
 
 @cixzhang

--- a/.changeset/card-nightly-audit-20260825.md
+++ b/.changeset/card-nightly-audit-20260825.md
@@ -6,6 +6,6 @@
 
 `elevation` picked a style object but never reached the DOM, so `astryx-card` exposed `data-variant` and nothing for elevation and a theme could not style the four shadow tiers. It now rides `themeProps` alongside `variant`.
 
-The `padding` prop documented `4` as its default. With the prop omitted the card reads the theme's card padding, which every shipped theme but `butter` sets to spacing step 3, so writing the documented default explicitly made the card wider. The prop docs, the JSDoc and the playground default now say what actually happens.
+The `padding` prop documented `4` as its default. With the prop omitted the card reads the theme's card padding, which every shipped theme but `butter` sets to spacing step 3, so writing the documented default explicitly made the card wider. The prop docs, the JSDoc and the playground default now say what actually happens, and the four `effectivePadding !== 4` style branches that encoded the same wrong default in code are gone: `container()` already sets every variable they set, verified identical across all eleven padding steps on both a bordered and a borderless card.
 
 @cixzhang

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -14,46 +14,6 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Card::Callout::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Card::Color Variants::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Card::Elevations::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Card::Full Bleed::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Card::Mixed Content::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Card::On Backgrounds::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Card::Single Section::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Card::Sizes::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
       "key": "Carousel::Card Content::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -45,6 +45,9 @@ const styles = stylex.create({
     fontSize: 14,
     color: colorVars['--color-text-secondary'],
   },
+  narrowContainer: {
+    width: 320,
+  },
 });
 
 const meta: Meta<typeof Card> = {
@@ -463,6 +466,70 @@ export const ColorVariants: Story = {
           </Card>
         </div>
       ))}
+    </div>
+  ),
+};
+
+/**
+ * A card with no children, and one with a minimum height. An empty card holds
+ * its padding and radius rather than collapsing, so a placeholder or a loading
+ * shell keeps the surrounding layout stable.
+ */
+export const Empty: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>No children</h4>
+        <Card width={250} />
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>No children, minHeight 120</h4>
+        <Card width={250} minHeight={120} />
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * Long prose and a title long enough to wrap, in a fixed-width card. Text wraps
+ * and the card grows to fit. Most languages run longer than English, so this is
+ * the state translated copy lands in.
+ */
+export const LongContent: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <Card width={280}>
+        <VStack gap={2}>
+          <Heading level={3}>
+            A card title long enough to wrap onto several lines
+          </Heading>
+          <p {...stylex.props(styles.text)}>
+            Cards grow to fit their content, so a long description keeps
+            wrapping rather than being cut off. Sibling cards in a grid stay
+            aligned on their top edge and the tallest one sets the row height.
+          </p>
+        </VStack>
+      </Card>
+    </div>
+  ),
+};
+
+/**
+ * A card with no width prop inside a 320px container: the width comes from the
+ * parent, so the card reflows to the container instead of forcing horizontal
+ * scroll on a narrow screen.
+ */
+export const NarrowContainer: Story = {
+  render: () => (
+    <div {...stylex.props(styles.narrowContainer)}>
+      <Card>
+        <VStack gap={2}>
+          <Heading level={3}>Narrow container</Heading>
+          <p {...stylex.props(styles.text)}>
+            The card fills the container it is given.
+          </p>
+        </VStack>
+      </Card>
     </div>
   ),
 };

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -58,8 +58,8 @@ export const docs = {
       name: 'padding',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
-        "Internal padding using the spacing scale. Omit it and the card takes the theme's card padding rather than a step: every shipped theme but `butter` sets that to spacing step 3, so an explicit `padding={4}` is wider than the default rather than equal to it.",
-      default: "the theme's card padding (step 3 in the default theme, step 4 with no theme)",
+        "Internal padding using the spacing scale. Omit it and the card takes the theme's card padding rather than a step, so passing a step is a decision to override the theme, not a way to restate the default.",
+      default: "the theme's card padding (spacing step 4 with no theme)",
     },
     {
       name: 'variant',
@@ -135,7 +135,7 @@ export const docsZh = {
     {name: 'maxWidth', type: 'SizeValue', description: '卡片最大宽度。'},
     {name: 'minHeight', type: 'SizeValue', description: '卡片最小高度。'},
     {name: 'children', type: 'ReactNode', description: '在卡片内部渲染的内容。'},
-    {name: 'padding', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: '使用间距比例的内边距。省略时，卡片采用主题的卡片内边距，而不是某个步进值：除 `butter` 外的所有主题都将其设为间距步进 3，因此显式的 `padding={4}` 比默认值更宽。', default: "the theme's card padding (step 3 in the default theme, step 4 with no theme)"},
+    {name: 'padding', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: '使用间距比例的内边距。省略时，卡片采用主题的卡片内边距，而不是某个步进值；传入步进值意味着覆盖主题，而不是复述默认值。', default: "the theme's card padding (spacing step 4 with no theme)"},
     {name: 'variant', type: "'default' | 'transparent' | 'muted' | 'blue' | 'cyan' | 'gray' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'", description: '背景颜色变体。`default` 使用标准卡片背景；`transparent` 完全去掉背景；`muted` 使用弱化卡片的柔和背景。非语义变体使用对应的 `--color-background-<name>` 令牌。', default: "'default'"},
     {name: 'elevation', type: "'none' | 'low' | 'med' | 'high'", description: '静止阴影深度。`none` 为扁平；`low`/`med`/`high` 对应阴影令牌比例。', default: "'none'"},
   ],
@@ -181,7 +181,7 @@ export const docsDense = {
     maxWidth: 'max card width',
     minHeight: 'min card height',
     children: 'content inside card',
-    padding: "internal padding via spacing scale; omitted = the theme's card padding (step 3 in the default theme), NOT step 4",
+    padding: "internal padding via spacing scale; omitted = the theme's card padding, NOT a fixed step. Passing a step overrides the theme.",
     variant: 'background color variant; `default` = standard card bg, `transparent` = no background at all, `muted` = muted bg for de-emphasised cards; non-semantic variants use the corresponding `--color-background-<name>` token',
     elevation: 'resting shadow depth: none (flat) | low | med | high (shadow token scale). Raise only to float above content.',
   },

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -57,8 +57,9 @@ export const docs = {
     {
       name: 'padding',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
-      description: 'Internal padding using the spacing scale.',
-      default: '4',
+      description:
+        "Internal padding using the spacing scale. Omit it and the card takes the theme's card padding rather than a step: every shipped theme but `butter` sets that to spacing step 3, so an explicit `padding={4}` is wider than the default rather than equal to it.",
+      default: "the theme's card padding (step 3 in the default theme, step 4 with no theme)",
     },
     {
       name: 'variant',
@@ -77,7 +78,6 @@ export const docs = {
   ],
   playground: {
     defaults: {
-      padding: 4,
       children: {
         __element: 'VStack',
         props: {gap: 2},
@@ -91,7 +91,7 @@ export const docs = {
   theming: {
     container: true,
     targets: [
-      {className: 'astryx-card', visualProps: ['variant']},
+      {className: 'astryx-card', visualProps: ['variant', 'elevation']},
     ],
     vars: [
       {name: '--_card-radius', description: 'Border radius of the card', default: 'var(--radius-container)', private: true},
@@ -135,16 +135,19 @@ export const docsZh = {
     {name: 'maxWidth', type: 'SizeValue', description: '卡片最大宽度。'},
     {name: 'minHeight', type: 'SizeValue', description: '卡片最小高度。'},
     {name: 'children', type: 'ReactNode', description: '在卡片内部渲染的内容。'},
-    {name: 'padding', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: '使用间距比例的内边距。', default: '4'},
+    {name: 'padding', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: '使用间距比例的内边距。省略时，卡片采用主题的卡片内边距，而不是某个步进值：除 `butter` 外的所有主题都将其设为间距步进 3，因此显式的 `padding={4}` 比默认值更宽。', default: "the theme's card padding (step 3 in the default theme, step 4 with no theme)"},
+    {name: 'variant', type: "'default' | 'transparent' | 'muted' | 'blue' | 'cyan' | 'gray' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'", description: '背景颜色变体。`default` 使用标准卡片背景；`transparent` 完全去掉背景；`muted` 使用弱化卡片的柔和背景。非语义变体使用对应的 `--color-background-<name>` 令牌。', default: "'default'"},
     {name: 'elevation', type: "'none' | 'low' | 'med' | 'high'", description: '静止阴影深度。`none` 为扁平；`low`/`med`/`high` 对应阴影令牌比例。', default: "'none'"},
   ],
   theming: {
     container: true,
     targets: [
-      {className: 'astryx-card', visualProps: ['variant']},
+      {className: 'astryx-card', visualProps: ['variant', 'elevation']},
     ],
     vars: [
       {name: '--_card-radius', description: 'Border radius of the card', default: 'var(--radius-container)', private: true},
+      {name: '--_card-elevation', description: 'Resting shadow of the card, set from the elevation prop.', default: '0 0 transparent', private: true},
+      {name: '--_card-ring', description: 'Inset ring drawn in the card box-shadow list.', default: '0 0 transparent', private: true},
     ],
     derived: [
       {property: 'borderRadius', vars: ['--_card-radius']},
@@ -178,7 +181,7 @@ export const docsDense = {
     maxWidth: 'max card width',
     minHeight: 'min card height',
     children: 'content inside card',
-    padding: 'internal padding via spacing scale',
+    padding: "internal padding via spacing scale; omitted = the theme's card padding (step 3 in the default theme), NOT step 4",
     variant: 'background color variant; `default` = standard card bg, `transparent` = no background at all, `muted` = muted bg for de-emphasised cards; non-semantic variants use the corresponding `--color-background-<name>` token',
     elevation: 'resting shadow depth: none (flat) | low | med | high (shadow token scale). Raise only to float above content.',
   },

--- a/packages/core/src/Card/Card.test.tsx
+++ b/packages/core/src/Card/Card.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {createRef} from 'react';
 import {describe, it, expect} from 'vitest';
 import {render} from '@testing-library/react';
 import {Card} from './Card';
@@ -10,17 +11,52 @@ describe('Card', () => {
     expect(getByText('Hello')).toBeInTheDocument();
   });
 
-  it('renders astryx-* class names for theme targeting', () => {
-    const {container} = render(<Card>Content</Card>);
-    const root = container.firstElementChild!;
+  it('forwards ref to the rendered element', () => {
+    const ref = createRef<HTMLDivElement>();
+    const {container} = render(<Card ref={ref}>C</Card>);
+    expect(ref.current).toBe(container.firstElementChild);
+  });
+
+  it('spreads unknown props onto the same element that carries the theme target', () => {
+    const {getByTestId} = render(
+      <Card data-testid="card" id="promo" aria-label="Promotion">
+        C
+      </Card>,
+    );
+    const root = getByTestId('card');
+    expect(root).toHaveAttribute('id', 'promo');
+    expect(root).toHaveAttribute('aria-label', 'Promotion');
     expect(root.className).toContain('astryx-card');
   });
 
-  it('renders transparent variant with variant class', () => {
-    const {container} = render(<Card variant="transparent">Content</Card>);
+  it('merges a consumer className instead of replacing the theme target', () => {
+    const {container} = render(<Card className="promo">C</Card>);
     const root = container.firstElementChild!;
     expect(root.className).toContain('astryx-card');
-    expect(root.className).toContain('transparent');
+    expect(root.className).toContain('promo');
+  });
+
+  it('reflects variant as a theme data attribute', () => {
+    const {container} = render(<Card variant="muted">C</Card>);
+    expect(container.firstElementChild).toHaveAttribute(
+      'data-variant',
+      'muted',
+    );
+  });
+
+  it('reflects elevation as a theme data attribute', () => {
+    const {container} = render(<Card elevation="high">C</Card>);
+    expect(container.firstElementChild).toHaveAttribute(
+      'data-elevation',
+      'high',
+    );
+  });
+
+  it('defaults to the default variant at rest elevation', () => {
+    const {container} = render(<Card>C</Card>);
+    const root = container.firstElementChild!;
+    expect(root).toHaveAttribute('data-variant', 'default');
+    expect(root).toHaveAttribute('data-elevation', 'none');
   });
 
   it('applies a distinct class for each elevation level', () => {
@@ -28,18 +64,7 @@ describe('Card', () => {
       const {container} = render(<Card elevation={elevation}>C</Card>);
       return container.firstElementChild!.className;
     };
-    const none = classFor('none');
-    const low = classFor('low');
-    const med = classFor('med');
-    const high = classFor('high');
-    expect(new Set([none, low, med, high]).size).toBe(4);
-  });
-
-  it('defaults to flat (elevation none) — same class as explicit none', () => {
-    const {container: defaultContainer} = render(<Card>C</Card>);
-    const {container: noneContainer} = render(<Card elevation="none">C</Card>);
-    expect(defaultContainer.firstElementChild!.className).toBe(
-      noneContainer.firstElementChild!.className,
-    );
+    const classes = (['none', 'low', 'med', 'high'] as const).map(classFor);
+    expect(new Set(classes).size).toBe(4);
   });
 });

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -177,14 +177,6 @@ export type {SizeValue} from '../utils/types';
 export interface CardProps extends BaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
   /**
-   * CSS class name(s) appended to the root element.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
-  /**
    * Width of the card.
    * Numbers are treated as pixels, strings are used as-is.
    */
@@ -217,7 +209,13 @@ export interface CardProps extends BaseProps<HTMLDivElement> {
   /**
    * Internal padding of the card using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
-   * @default 4 (16px)
+   *
+   * Omit it and the card takes the theme's card padding instead of a step:
+   * every shipped theme but `butter` sets that to spacing step 3, so an
+   * explicit `padding={4}` is wider than the default, not equal to it.
+   *
+   * @default the theme's card padding (spacing step 3 in the default theme;
+   * spacing step 4 with no theme)
    */
   padding?: SpacingStep;
 
@@ -300,7 +298,7 @@ export function Card({
     <div
       ref={ref}
       {...mergeProps(
-        themeProps('card', {variant}),
+        themeProps('card', {variant, elevation}),
         stylex.props(
           styles.card,
           variantStyles[variant],

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -23,13 +23,7 @@ import {
 } from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
 import type {SpacingToken} from '../Layout/container.stylex';
-import {
-  paddingStyles,
-  containerPaddingInlineVarStyles,
-  containerPaddingBlockStartVarStyles,
-  containerPaddingBlockEndVarStyles,
-  spacingStepToToken,
-} from '../Layout/padding.stylex';
+import {spacingStepToToken} from '../Layout/padding.stylex';
 import type {Elevation, SizeValue, SpacingStep} from '../utils/types';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
@@ -291,8 +285,9 @@ export function Card({
 
   // When no explicit padding prop, use theme default (set via container tokens)
   const useThemeDefault = padding == null;
-  const effectivePadding = padding ?? 4;
-  const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
+  const paddingToken = useThemeDefault
+    ? undefined
+    : (spacingStepToToken[padding] as SpacingToken);
 
   return (
     <div
@@ -311,7 +306,7 @@ export function Card({
             minHeight ?? null,
           ),
           ...container(
-            useThemeDefault
+            paddingToken == null
               ? {useThemeDefault: 'card'}
               : {
                   paddingInnerX: paddingToken,
@@ -320,18 +315,6 @@ export function Card({
                   paddingOuterY: paddingToken,
                 },
           ),
-          !useThemeDefault &&
-            effectivePadding !== 4 &&
-            paddingStyles[effectivePadding],
-          !useThemeDefault &&
-            effectivePadding !== 4 &&
-            containerPaddingInlineVarStyles[effectivePadding],
-          !useThemeDefault &&
-            effectivePadding !== 4 &&
-            containerPaddingBlockStartVarStyles[effectivePadding],
-          !useThemeDefault &&
-            effectivePadding !== 4 &&
-            containerPaddingBlockEndVarStyles[effectivePadding],
           // Applied after the container padding so the border-inset calc wins;
           // it reads the --container-padding-* vars set above.
           variant === 'default' && styles.withBorder,

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -204,12 +204,11 @@ export interface CardProps extends BaseProps<HTMLDivElement> {
    * Internal padding of the card using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    *
-   * Omit it and the card takes the theme's card padding instead of a step:
-   * every shipped theme but `butter` sets that to spacing step 3, so an
-   * explicit `padding={4}` is wider than the default, not equal to it.
+   * Omit it and the card takes the theme's card padding rather than a step, so
+   * passing a step is a decision to override the theme, not a way to restate
+   * the default.
    *
-   * @default the theme's card padding (spacing step 3 in the default theme;
-   * spacing step 4 with no theme)
+   * @default the theme's card padding (spacing step 4 with no theme)
    */
   padding?: SpacingStep;
 


### PR DESCRIPTION
First audit of `core/Card`, rubric v1.8. Score **65.1 / D → 74.3 / C** (post-fix; the post-fix row is held until this lands so it records a real `main` commit). The pre-fix row is already in the ledger: [scores: Card D (65.1), rubric 1.8](https://github.com/facebook/astryx/wiki/_compare/0278c85291023acbf07761f9b4f3d29a7a36b58f).

Open BLOCKs 4 → 2. The two that closed are `T6` and `V3`; the two that stay open are decisions, and they are in Needs review below.

## What was wrong, and what changed

**`elevation` never reached the DOM (§2 T6).** `elevationStyles[elevation]` picked a style object inside `stylex.props()`, but `elevation` was missing from the sibling `themeProps('card', {variant})`. Measured in Chromium across all four values before the fix: the box-shadow changes, `data-elevation` is `null` every time. A theme could restyle a card by variant and could not touch its four shadow tiers. It now rides `themeProps` alongside `variant`, and the doc's theming target lists it.

**The documented `padding` default was wrong (§3 P31).** The JSDoc said `@default 4 (16px)` and the prop doc said `default: '4'`. With the prop omitted the card reads the theme's card padding chain, and most shipped themes set `--astryx-card-padding` to a different step. Measured against the default theme: omitted renders 11px of padding, `padding={4}` renders 15px, both after the 1px border inset. Someone writing the documented default explicitly got a different card. The JSDoc, both prop docs, the dense doc and the playground default now say that omitting the prop takes the theme's padding and that passing a step overrides it, without naming a theme that could change under them.

**`padding` encoded the wrong default in code as well as in docs.** `padding ?? 4` and four `effectivePadding !== 4` style branches survived from before `container()` learned to set the container-padding variables itself. The `?? 4` branch was unreachable, since the value is only read when `padding` is non-null, and the four guarded style objects set exactly the variables `container()` already sets. Removed, and verified identical across all eleven padding steps on a bordered and a borderless card: resolved padding, the four `--container-padding-*` variables, `--layout-padding-inner-x`/`-outer-x` and the rendered height, 24 rows, no difference. (Found by the review loop on this PR.)

**`CardProps` re-declared `className` and `style` (§3 P27)**, which `BaseProps` already supplies. Removed; the types are identical, so nothing changes for a caller.

**The tests did not test the contract (§6 V3, V4).** Three of the five assertions were on generated StyleX class names. The elevation test asserted only that four hashed class strings differ, which is why it sat next to the `T6` defect for the component's whole life without noticing it. Replaced with assertions on `...rest` passthrough landing on the theme-target element, `ref` forwarding, `className` merging rather than clobbering, and the variant and elevation data attributes. 5 tests → 8.

**Eight resolved Card entries removed from `.github/a11y-baseline.json` (§1 A18).** The audit reported them resolved; the gate now reports `0 new, 0 baselined, 0 resolved`.

**Stories for empty, long content and a narrow container (§8 X12, §10 R11).** The a11y and RTL sweeps only see what a story renders, and Card had no story for any of the three. All 17 stories are axe-clean.

## Visual evidence

**Nothing rendered changes.** All 38 frames captured against `main` are byte-identical to the same 38 captured at this head, re-checked after the second commit (`cmp`, 38/38 twice). That is the intended result: the elevation axis becomes reachable by a theme without moving a pixel for anyone not using it.

45 frames in total, real Chromium against the built Storybook at deviceScaleFactor 2-3: every story in neutral light and dark, four of them additionally in matcha light and dark, plus 320px reflow, RTL, a forced fixed-height overflow and a long unbroken word.

![contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5491/Card__contact-sheet.png)

## Needs review

Four findings I did not fix, because each is a decision rather than a correction.

**1. A fixed `height` makes the card a scroll container a keyboard cannot reach.** `overflow: auto` goes on the card root whenever `height` is set. Measured at 300x120 with taller content: `scrollHeight` 442, `clientHeight` 118, no `tabindex`, zero focusable descendants, so Tab never stops on it and the content below the fold is pointer-only (WCAG 2.1.1). No story renders real overflow, which is why `pr-a11y` has never had the chance to fire `scrollable-region-focusable` here.

Every fix is a choice, so it is yours: an unconditional `tabIndex={0}` whenever `height` is set adds a tab stop for consumers who are not overflowing; gating on real overflow needs an observer; and the third answer is that Card should not be a scroll container at all and `Layout` should own it. I did not add the overflowing story either, because it would add a baseline entry and fail the a11y gate before the underlying question is settled.

![fixed height overflow](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5491/Card__fixed-height-overflow.png)

**2. `variant` is a closed union, so a theme cannot add a card variant (§2 T19).** `CardVariant` is a 13-member union backed by a `Record<CardVariant, Style>`, and there is no `CardVariantMap` in `packages/core/src/Card/index.ts`. Sixteen core components ship the extensible map, `Section` among them, and its variant axis is the same shape as Card's. Fixing it adds an exported interface and widens the type, and it ripples through `ClickableCard` and `SelectableCard`, which import `CardVariant` and switch on it, so it is not an audit's change to make.

**3. `variant="muted"` is invisible on the default page background.** `--color-background-muted` and `--color-background-body` resolve to the same value in both modes, `light-dark(#f1f1f1, #1b1b1b)`, and the muted variant paints no border and no shadow. On the standard page treatment a muted card has no boundary at all. The `Callout` story recommends exactly that use and renders two callouts as bare text while its own copy says the muted background "provides visual contrast".

The component picked the right role token, so the answer is a token or design one: give `muted` a border, split the two tokens, or change what the docs recommend.

![muted callout, light](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5491/Card__callout-muted-light.png)

**4. A long unbroken string is clipped out of existence.** The root is `overflow: clip` with no wrap policy, so one long token is cut mid-word with no scrollbar, no ellipsis and no wrap. Measured `scrollWidth` 643 against `clientWidth` 300. `Section` and `Dialog` use the same container, so this is very likely a container-wide question rather than Card's, which is why I left it rather than putting an `overflow-wrap` on one of the three.

![long word clipped](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5491/Card__long-word.png)

**5. `ClickableCard` and `SelectableCard` still document and pre-fill the false padding default.** Both forward `padding` straight into `Card` (`ClickableCard.tsx:305`, `SelectableCard.tsx:354`), and both still say `@default 4 (16px)` in their JSDoc, carry `default: '4'` in their `.doc.mjs`, and seed `padding: 4` into their playground defaults. Once this merges, Card says one thing and the two components that render it say another, and a builder starting from either playground ships a card inset differently from the Card beside it.

It is four lines across two files and I would normally take it here. Both files are open ground for [#5487](https://github.com/facebook/astryx/pull/5487), so it goes to you rather than into this PR.

**6. Three components declare `elevation` and none of them reflects it.** `Button.tsx:293`, `Banner.tsx:147` and `ChatComposer.tsx:95` all take a public `elevation` prop; none passes it to `themeProps`, so after this merges Card and `ButtonGroup` reflect elevation and those three do not. A theme author who reads this changelog line and writes the same rule for Button gets a selector that matches nothing, with no error and no warning.

Underneath both of those is one system gap, which is why I would not fix the six instances by hand: **nothing checks either half.** `themingTargets.test.ts` is a subset policy by design, so a component whose docs and source agree on an incomplete list stays green forever, which is how Card shipped an unreachable elevation axis for its whole life. And the `default` field in a `.doc.mjs` is checked by nothing at all: `docPropLiterals.test.ts` and `docPropReferences.test.ts` both derive `type` from the TypeScript sources at test time, and neither reads `default`. A default that comes from a CSS custom-property chain can never be right by hand.

## Also not done

- **The RTL applicability record has nowhere to go.** `rtl:audit --filter Card` returns `AUTO 0 pass / 0 fail / 1 N-A` and `PM 0 pass / 0 fail / 17 N-A`. Card is genuinely not applicable: no directional glyph, no connector, no positioned affordance, no control order, no horizontal keyboard model, and logical properties throughout. Rubric v1.8 asks for that to be recorded as a checked-in verified-N-A reason, but `apps/storybook/rtl-audit/` has no such file and `rtl-audit.mjs` reads nothing of the kind, so there is no place to write it that anything would read. Left as an open finding in the ledger row rather than adding an orphan config file.
- **`docsZh`'s prose is still English** while its prop descriptions are Chinese. I added the missing `variant` entry and the two missing vars, but writing the translation is not an audit's job.
- **The `NestedCards` story demonstrates, approvingly, the nesting the doc's own don't-list forbids**, and two nested cards render the same 12px radius 11px apart, so the pair is not concentric. Card cannot detect that it is nested, so both are notes rather than fixes.

## Checks

`pnpm lint:strict` 0 errors · `pnpm build` green · `pnpm test` 12205 pass, 3 pre-existing failures unrelated to this change (`story-tree` fails on `Core/Icon/Size Theming`, which is on `main`; the two CLI discovery tests fail only on a case-insensitive filesystem, resolving `useMediaquery.doc.mjs`) · `a11y:audit --components Card` 0 violations over 17 stories, 0 new · `check:sync`, `check-use-client`, `sync-exports --check`, `verify-exports`, `check:changesets`, `typecheck:docs`, docsite generate + tests all green.

Night Watch — Component Auditor
