### PR TITLE
fix(Toast): the viewport is a landmark only while it holds a toast

### DIFF
--- a/.changeset/toast-viewport-landmark.md
+++ b/.changeset/toast-viewport-landmark.md
@@ -1,0 +1,18 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Toast: the viewport is a landmark only while it holds a toast.
+
+`ToastViewport` rendered `role="region"` with a fixed accessible name at all
+times, and `LayerProvider` mounts one for every app whether or not a toast is
+ever shown. So every app carried an empty named region in the screen reader's
+landmark list, and a second viewport anywhere — a dialog's, or one a sub-tree
+mounts to configure position — produced two identically named landmarks, which
+is an axe `landmark-unique` violation.
+
+The role and its label now appear with the first toast and go with the last
+one, including across the exit transition. F6 is unaffected: the handler works
+off the ref, not the role.
+
+@freddymeta

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -255,10 +255,29 @@ describe('Toast blur timer pause', () => {
 describe('ToastViewport region ARIA', () => {
   it('exposes the notifications region without a prohibited aria-modal', () => {
     renderViewport(<ShowToastButton />);
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger'));
+    });
     const region = screen.getByRole('region', {name: 'Notifications'});
     // aria-modal is only valid on role="dialog"/"alertdialog"; a region must
     // not declare it (axe: aria-allowed-attr).
     expect(region).not.toHaveAttribute('aria-modal');
+  });
+
+  it('is not a landmark until it holds a toast', () => {
+    // An empty viewport used to be an empty named region in every screen
+    // reader's landmark list. LayerProvider mounts one for every app whether
+    // a toast is ever shown, so a second viewport — a dialog's, or one a
+    // sub-tree mounts to configure it — produced two identically named
+    // landmarks (axe: landmark-unique).
+    renderViewport(<ShowToastButton />);
+    expect(screen.queryByRole('region')).not.toBeInTheDocument();
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger'));
+    });
+    expect(
+      screen.getByRole('region', {name: 'Notifications'}),
+    ).toBeInTheDocument();
   });
 });
 

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -438,8 +438,16 @@ export function ToastViewport({
       {children}
       <div
         ref={viewportRef}
-        role="region"
-        aria-label={t('@astryx.toast.viewport')}
+        // A landmark only while it holds something. An empty viewport is an
+        // empty named region in every screen reader's landmark list, and
+        // `LayerProvider` mounts one for every app whether or not a toast is
+        // ever shown — so a second viewport (a dialog's, or one a sub-tree
+        // mounts to configure it) made two identically named landmarks, which
+        // is an axe `landmark-unique` violation and a real navigation
+        // annoyance. F6 still reaches it either way: the handler works off
+        // the ref, not the role.
+        role={hasToasts ? 'region' : undefined}
+        aria-label={hasToasts ? t('@astryx.toast.viewport') : undefined}
         tabIndex={-1}
         // popover="manual" promotes to the top layer (above dialogs).
         // Omitted inside dialogs where the viewport is already in a top layer.


### PR DESCRIPTION
## Summary

`ToastViewport` renders `role="region"` with a fixed accessible name at all times. `LayerProvider` mounts one for every app whether or not a toast is ever shown, so **every app carries an empty named landmark**, and a second viewport anywhere — a dialog's, or one a sub-tree mounts to configure `position` — makes **two identically named landmarks**, which is an axe `landmark-unique` violation.

The role and its label now arrive with the first toast and leave with the last.

```diff
-        role="region"
-        aria-label={t('@astryx.toast.viewport')}
+        role={hasToasts ? 'region' : undefined}
+        aria-label={hasToasts ? t('@astryx.toast.viewport') : undefined}
```

`hasToasts` already existed on `main` and counts toasts that are still animating out, so the landmark survives the exit transition rather than vanishing under a visible toast. F6 is unaffected — the handler works off `viewportRef`, not the role.

## Verified in Chromium

Same story (`Core/Toast → Default`), same probe, against two Storybook builds. Each row lists every `[role="region"]` on the page and how many toasts it holds:

| | `main` | this branch |
|---|---|---|
| no toast shown | `[{label: "Notifications", toasts: 0}]` | `[]` |
| one toast shown | `[{label: "Notifications", toasts: 1}]` | `[{label: "Notifications", toasts: 1}]` |
| after dismiss | `[{label: "Notifications", toasts: 0}]` | `[]` |

The middle row is the point: while a toast is there, nothing changes.

## Test plan

- New unit test asserts the landmark is absent until a toast arrives, then present and correctly named. **Negative control:** reverting the two lines fails exactly that test and nothing else.
- One existing test (`exposes the notifications region without a prohibited aria-modal`) asserted the region with no toast shown. Its real subject is `aria-modal`, not the empty region, so it shows a toast first now.
- `pnpm build`, `pnpm lint:strict`, `pnpm check:repo`, `pnpm -F @astryxdesign/core typecheck`, `pnpm -F @astryxdesign/storybook typecheck` — clean. Toast + Layer: 156 tests green.
- `pnpm a11y:audit -- --components Toast`: 10 stories, 0 violations, no baseline entries added.

## Where this came from

Split out of #5428 at @cixzhang's request — it is a behaviour change to shipped `Toast` and had no business riding inside a feature PR. The a11y gate on that branch is what surfaced it: a story mounting its own viewport under Storybook's `LayerProvider` tripped `landmark-unique`, which is not a story artifact but the two-viewport case any app can hit.

@freddymeta
