### PR TITLE
fix(HoverCard): only put aria-expanded on a trigger whose role supports it

### DIFF
--- a/.changeset/hovercard-aria-expanded-role-gate.md
+++ b/.changeset/hovercard-aria-expanded-role-gate.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] HoverCard: a labelled card no longer puts `aria-expanded` on a trigger whose role cannot carry it
+
+Since the dialog-popup contract landed, a labelled HoverCard set `aria-haspopup`, `aria-controls` and `aria-expanded` on its trigger whatever that trigger was. The first two are global ARIA attributes and are valid anywhere; `aria-expanded` is supported on a fixed set of roles, and a role-less trigger is not one of them. Every Timestamp with a hover card is a role-less trigger, so nine Timestamp stories reported a critical axe `aria-allowed-attr` violation across twenty-nine nodes.
+
+`aria-expanded` is now emitted only when the trigger's role supports it. A role-less trigger keeps `aria-haspopup="dialog"` and `aria-controls`, so the popup relationship is still advertised — only the state the element could never have expressed is dropped. A trigger that carried its own `aria-expanded` keeps it untouched.
+
+@cixzhang

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -400,6 +400,46 @@ describe('HoverCard', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('omits aria-expanded on a trigger whose role does not support it', () => {
+    render(
+      <HoverCard content={<span>Card content</span>} label="Timestamp details">
+        <time dateTime="2026-08-25" tabIndex={0}>
+          2 hours ago
+        </time>
+      </HoverCard>,
+    );
+    const trigger = screen.getByText('2 hours ago');
+    expect(trigger.tagName).toBe('TIME');
+    // Global attributes are valid on any element, so the popup relationship is
+    // still advertised.
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    // aria-expanded is not: <time> has no role that supports it, and emitting
+    // it is a critical axe aria-allowed-attr violation.
+    expect(trigger).not.toHaveAttribute('aria-expanded');
+  });
+
+  it('keeps aria-expanded on a role-less trigger that declares a supporting role', () => {
+    render(
+      <HoverCard content={<span>Card content</span>} label="Profile actions">
+        <span role="button" tabIndex={0}>
+          Trigger
+        </span>
+      </HoverCard>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('leaves a role-less trigger own aria-expanded untouched', () => {
+    render(
+      <HoverCard content={<span>Card content</span>} label="Profile actions">
+        <span aria-expanded="true">Trigger</span>
+      </HoverCard>,
+    );
+    const trigger = screen.getByText('Trigger');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
   it('keeps aria-describedby on the trigger when no label is provided', () => {
     render(
       <HoverCard content={<span>Card content</span>}>
@@ -503,7 +543,8 @@ describe('HoverCard', () => {
     const wrapper = screen.getByText('Just text, no element');
     expect(wrapper.tagName).toBe('SPAN');
     expect(wrapper).toHaveAttribute('aria-haspopup', 'dialog');
-    expect(wrapper).toHaveAttribute('aria-expanded', 'false');
+    // The wrapper is a role-less <span>; aria-expanded is invalid there.
+    expect(wrapper).not.toHaveAttribute('aria-expanded');
     // While closed, the layer is not in the DOM, so aria-controls is unset.
     expect(wrapper).not.toHaveAttribute('aria-controls');
     expect(wrapper).not.toHaveAttribute('aria-describedby');

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -32,6 +32,51 @@ export type {
   HoverCardTouchTrigger,
 } from './useHoverCard';
 
+// `aria-haspopup` and `aria-controls` are global, so any trigger may carry
+// them. `aria-expanded` is not: ARIA 1.2 supports it on this set of roles only,
+// and on anything else it is invalid and user agents ignore it. The same rule
+// is applied in Chat/useTriggerMenu.tsx, which only emits the combobox
+// attributes once the element is actually a combobox.
+const EXPANDABLE_ROLES = new Set([
+  'application',
+  'button',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'gridcell',
+  'link',
+  'listbox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'row',
+  'rowheader',
+  'switch',
+  'tab',
+  'treeitem',
+]);
+
+// Deliberately partial, and unlisted elements are read as role-less: dropping
+// aria-expanded where it might have been legal costs an AT user a state they
+// can still infer, whereas emitting it where it is illegal is a critical
+// aria-allowed-attr defect.
+function supportsAriaExpanded(el: HTMLElement): boolean {
+  const explicit = el.getAttribute('role')?.trim().split(/\s+/)[0];
+  if (explicit) {
+    return EXPANDABLE_ROLES.has(explicit);
+  }
+  switch (el.tagName) {
+    case 'BUTTON':
+    case 'SUMMARY':
+      return true;
+    case 'A':
+    case 'AREA':
+      return el.hasAttribute('href');
+    default:
+      return false;
+  }
+}
+
 const styles = stylex.create({
   wrapperContents: {
     display: 'contents',
@@ -265,12 +310,17 @@ export function HoverCard({
       // trigger with the dialog's content (aria-describedby is for plain-text
       // descriptions, not navigable regions). See #5049.
       //
+      // aria-expanded only goes on a trigger whose role permits it. A role-less
+      // trigger (Timestamp's <time>/<span>) gets haspopup + controls, which are
+      // global, and no expanded state.
+      //
       // Merge rather than overwrite: the trigger may already carry its own
       // popup semantics (e.g. a menu button wrapped in a labelled HoverCard),
       // so preserve the existing values and restore them on cleanup.
       const existingHaspopup = firstChild.getAttribute('aria-haspopup');
       const existingControls = firstChild.getAttribute('aria-controls');
       const existingExpanded = firstChild.getAttribute('aria-expanded');
+      const canExpand = supportsAriaExpanded(firstChild);
 
       firstChild.setAttribute('aria-haspopup', 'dialog');
       // Only point aria-controls at the layer while it is open and in the DOM.
@@ -287,7 +337,13 @@ export function HoverCard({
       } else {
         firstChild.removeAttribute('aria-controls');
       }
-      firstChild.setAttribute('aria-expanded', String(hoverCard.isOpen));
+      if (canExpand) {
+        firstChild.setAttribute('aria-expanded', String(hoverCard.isOpen));
+      } else if (existingExpanded) {
+        firstChild.setAttribute('aria-expanded', existingExpanded);
+      } else {
+        firstChild.removeAttribute('aria-expanded');
+      }
 
       return () => {
         hoverCard.ref(null);
@@ -354,7 +410,8 @@ export function HoverCard({
           tabIndex={0}
           aria-haspopup={label ? 'dialog' : undefined}
           aria-controls={label && hoverCard.isOpen ? hoverCard.id : undefined}
-          aria-expanded={label ? hoverCard.isOpen : undefined}
+          // No aria-expanded: this wrapper is a role-less <span>, and
+          // aria-expanded is invalid on it (see EXPANDABLE_ROLES above).
           aria-describedby={label ? undefined : hoverCard.describedBy}
           {...stylex.props(
             styles.wrapperInline,

--- a/packages/core/src/HoverCard/useHoverCard.tsx
+++ b/packages/core/src/HoverCard/useHoverCard.tsx
@@ -202,7 +202,10 @@ export interface HoverCardReturn {
 
   /**
    * Whether the hover card is currently open.
-   * Useful for driving `aria-expanded` on the trigger.
+   * Useful for driving `aria-expanded` on the trigger — but only when the
+   * trigger's role permits it (`button`, `link`, `combobox`, …). On a role-less
+   * trigger `aria-expanded` is invalid; use `aria-haspopup`/`aria-controls`
+   * alone there.
    */
   isOpen: boolean;
 

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -673,6 +673,24 @@ describe('Timestamp', () => {
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
     });
 
+    it('does not put aria-expanded on the role-less hover-card trigger', async () => {
+      render(
+        <Timestamp
+          value={Date.now() / 1000 - 3600}
+          format="relative"
+          data-testid="ts"
+        />,
+      );
+      const trigger = screen.getByTestId('ts').parentElement;
+      // The trigger is Text's <span>, which has no role, so aria-expanded is
+      // invalid on it (axe aria-allowed-attr, critical). aria-haspopup is
+      // global and still advertises the dialog.
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+      });
+      expect(trigger).not.toHaveAttribute('aria-expanded');
+    });
+
     it('shows the hover card when the timestamp receives keyboard focus', async () => {
       const user = userEvent.setup();
       render(


### PR DESCRIPTION
Holds today's release: the daily accessibility gate is red on this.

## Problem

Release gate run [32852474090](https://github.com/facebook/astryx/actions/runs/32852474090) reported a **new critical** axe `aria-allowed-attr` violation on Timestamp — 9 stories, 29 nodes, none of them in `.github/a11y-baseline.json`.

[#5419](https://github.com/facebook/astryx/pull/5419) gave a labelled HoverCard the correct dialog-popup contract, and set `aria-haspopup`, `aria-controls` and `aria-expanded` on the trigger to express it. `aria-haspopup` and `aria-controls` are **global** ARIA attributes and are valid on any element. `aria-expanded` is not — ARIA 1.2 supports it on a fixed set of roles, and a role-less element is not one of them.

Timestamp is the only component in the repo that passes `label` to a HoverCard, and its trigger is `Text`'s `<span>` — no role. Every axe node reports exactly one thing:

```
ARIA attribute is not allowed: aria-expanded="false"
```

on

```html
<span class="astryx-text supporting secondary … astryx-timestamp relative"
      data-format="relative" aria-haspopup="dialog" aria-expanded="false" …>
```

## Approach

Gate `aria-expanded` on whether the trigger's role supports it, in HoverCard rather than in Timestamp. A role-less trigger keeps `aria-haspopup="dialog"` and `aria-controls`, so the popup relationship is still advertised to AT — it loses only the state the element could never have expressed. The text-only wrapper `<span>` is equally role-less and gets the same treatment. A trigger carrying its own `aria-expanded` is left untouched.

This is the convention already in the codebase, not a new one. `Chat/useTriggerMenu.tsx:608`:

> Combobox attributes (aria-expanded/haspopup/controls/activedescendant) are only valid on `role="combobox"`, so we only switch to that role — and only emit those attributes — when triggers are actually configured.

The role test is deliberately conservative: an element it does not recognise is read as role-less. Dropping `aria-expanded` where it might have been legal costs a user a state they can still infer; emitting it where it is illegal is a critical defect.

**Not reverting or amending #5419.** Its contract is right and it fixed a real bug ([#5049](https://github.com/facebook/astryx/issues/5049)); it was only over-broad about what vocabulary a role-less trigger can carry.

**Considered and rejected:** giving the trigger `role="button"`. The card opens on hover and focus, not activation, so declaring it a button promises Enter/Space behaviour that does not exist. That silences axe without fixing anything.

## Test plan

Real Chromium, `accessibility-audit.js` against a freshly built Storybook on this branch, diffed unbounded against the full 189-entry baseline:

| | new keys | new nodes |
|---|---|---|
| before | 9 | 29 |
| after | **0** | **0** |

The 9 keys before are an exact match for the gate's set (Relative Format 7 · Relative Short Format 7 · Hover card — configuration examples 4 · Future Dates 3 · Per-entry copyable 3 · Copyable hover card 2 · All Formats 1 · Live Updating 1 · Auto Format 1).

- `packages/core/src/HoverCard` + `packages/core/src/Timestamp` — 170 tests passing.
- Three new HoverCard tests (role-less trigger drops it, declared `role="button"` keeps it, the trigger's own value survives), one new Timestamp regression test, and the text-only test updated. **All four changed assertions verified to fail without the source change** (edit-and-revert).
- Full-suite audit over all 185 components running; will post the result.
- `pnpm -F @astryxdesign/core typecheck`, `pnpm lint` — clean.

## Blast radius

`label` is what arms this path, and only Timestamp passes it. Checked every consumer, not just the ones the gate captures: `ChatPastedTextToken` and all four CLI HoverCard templates pass no label (`aria-describedby` path, untouched); the `useHoverCard` template wires the attributes onto a `<Button>`; HoverCard's own 20 stories all use `<Button>` triggers, whose role supports `aria-expanded` — which is why HoverCard itself is green in the gate and Timestamp is the only component that shows the bug.

## Known, separate, not fixed here

The popup attributes sit on Timestamp's `Text` `<span>` while the tab stop is on the inner `<time>` (`Timestamp.tsx:550`), so a screen-reader user who tabs to a timestamp lands on the `<time>` and hears nothing about a dialog. **Not a #5419 regression** — the old `aria-describedby` sat on the same span and had the same problem. Out of scope for a release-blocking fix; filed as [#5497](https://github.com/facebook/astryx/issues/5497).
