### PR TITLE
fix(DateInput): move the mobile picker's Reset into the header corner

### DIFF
--- a/.changeset/date-input-touch-reset-in-header.md
+++ b/.changeset/date-input-touch-reset-in-header.md
@@ -1,0 +1,19 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateInput: move the mobile picker's Reset into the header's trailing
+corner
+
+On a touch device the picker's footer held Reset and Save side by side, two
+half-width buttons of equal weight — so the row that ends the task also
+offered the one action that throws the work away, a thumb's width from it.
+
+Reset now sits at the top of the sheet, trailing of the month arrows: chrome,
+in the band of controls that move the calendar without finishing anything.
+The footer is Save alone, full width. Nothing about what Reset does changed —
+it still clears the date and returns the calendar to the current month — and
+it still leaves with the arrows when the month and year wheels come up, since
+there is no date to clear on that surface.
+
+@imdreamrunner

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -725,7 +725,7 @@
   },
   "@astryx.dateInput.resetPicking": {
     "defaultMessage": "Reset",
-    "description": "Secondary button in the mobile date picker's footer, beside Save. Removes the chosen date AND returns the calendar to the current month — it undoes the picking done so far and puts the picker back to how it opens, so prefer a word covering both, not one that only means emptying a field. Not cancel: the picker stays open afterwards and nothing is dismissed."
+    "description": "Ghost button in the mobile date picker's header, at the trailing corner beside the month arrows. Removes the chosen date AND returns the calendar to the current month — it undoes the picking done so far and puts the picker back to how it opens, so prefer a word covering both, not one that only means emptying a field. Not cancel: the picker stays open afterwards and nothing is dismissed. Keep it short; it shares one line with the month title and two arrows."
   },
   "@astryx.dateInput.savePicking": {
     "defaultMessage": "Save",

--- a/packages/core/src/DateInput/DateInputTouch.test.tsx
+++ b/packages/core/src/DateInput/DateInputTouch.test.tsx
@@ -1542,12 +1542,22 @@ describe('DateInput — month/year wheels', () => {
     expect(title()).toHaveTextContent('May 2027');
   });
 
-  it('offers Reset only on the calendar, beside Save', () => {
+  it('offers Reset only on the calendar, in the header corner', () => {
     renderAndOpen();
-    expect(screen.getByRole('button', {name: 'Reset'})).toBeInTheDocument();
+    const reset = screen.getByRole('button', {name: 'Reset'});
+    // The trailing-most thing in the header, past the arrows — not the
+    // footer, which is Save's alone.
+    const header = reset.closest('[data-action="reset"]')!.parentElement!;
+    expect(header.querySelector('[data-title="month-year"]')).not.toBeNull();
+    expect(header.lastElementChild).toHaveAttribute('data-action', 'reset');
+
     openWheels();
     // The wheels choose a month; there is no date there to clear.
     expect(screen.queryByRole('button', {name: 'Reset'})).toBeNull();
+    // Hidden, not unmounted, so the header cannot change height mid-swap.
+    expect(
+      document.querySelector('dialog[open] [data-action="reset"]'),
+    ).toHaveAttribute('inert');
   });
 
   it('Save closes the whole picker; Done only leaves the wheels', () => {
@@ -2546,16 +2556,14 @@ describe('DateInput — scroll CSS (definition-level)', () => {
   });
 
   /**
-   * Both footer actions span the sheet. A full-width primary is the shape a
+   * The footer action spans the sheet. A full-width primary is the shape a
    * phone form ends with, and it puts the target under the thumb wherever
    * the hand is.
    */
-  it('spans the footer with its actions', () => {
+  it('spans the footer with its action', () => {
     const source = read('TouchDateField.tsx');
-    // Reset + Save share the calendar's cell; Done is the wheels'. Each
-    // fills the space it is given, so the row divides evenly rather than by
-    // label length.
-    expect(source.match(/width="100%"/g)).toHaveLength(3);
+    // One per surface: Save on the calendar, Done on the wheels.
+    expect(source.match(/width="100%"/g)).toHaveLength(2);
   });
 
   /**
@@ -2604,7 +2612,7 @@ describe('DateInput — scroll CSS (definition-level)', () => {
     expect(
       styles.match(/transitionTimingFunction: easeVars\['--ease-standard'\]/g),
     ).toHaveLength(1);
-    expect(styles.match(/transitionTimingFunction: 'linear'/g)).toHaveLength(3);
+    expect(styles.match(/transitionTimingFunction: 'linear'/g)).toHaveLength(4);
   });
 
   /**
@@ -2622,9 +2630,9 @@ describe('DateInput — scroll CSS (definition-level)', () => {
     const styles = source.slice(
       source.indexOf('const styles = stylex.create('),
     );
-    // The arrows, the weekday row, the layer beneath, the layer above, and
-    // the chevron.
-    expect(styles.match(/transitionDuration: SWAP_DURATION/g)).toHaveLength(5);
+    // The arrows, Reset, the weekday row, the layer beneath, the layer
+    // above, and the chevron.
+    expect(styles.match(/transitionDuration: SWAP_DURATION/g)).toHaveLength(6);
     // And no leftover hand-rolled timing beside them.
     expect(styles).not.toContain('PANEL_FADE_MS');
     expect(source).toContain(

--- a/packages/core/src/DateInput/TouchDateField.tsx
+++ b/packages/core/src/DateInput/TouchDateField.tsx
@@ -38,6 +38,10 @@
  * 3. The title is the escape hatch. Tap it and the same box becomes a month
  *    wheel and a year wheel — a flick each to reach 2019 instead of forty.
  *
+ * Reset is chrome, so it sits in the header beside the arrows rather than in
+ * the footer: the footer is where the task ends, and an undo of equal weight
+ * beside Save is a mis-tap that throws away the date just chosen.
+ *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/DateInput/DateInput.tsx
  * - /packages/core/src/DateInput/DateInput.doc.mjs
@@ -298,6 +302,34 @@ const styles = stylex.create({
     display: 'inline-flex',
   },
   /**
+   * Reset, past the arrows. It fades on their timing for their reason: the
+   * plate starts below the header, so the two of them are what the layer
+   * above cannot cover, and they have to leave together.
+   */
+  headerReset: {
+    display: 'flex',
+    alignItems: 'center',
+    transitionProperty: 'opacity, visibility',
+    transitionDuration: SWAP_DURATION,
+    transitionTimingFunction: 'linear',
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.01s',
+    },
+  },
+  headerResetHidden: {
+    visibility: 'hidden',
+    opacity: 0,
+    pointerEvents: 'none',
+  },
+  /**
+   * The same 44px floor the arrows take. `Button`'s `sm` is 32px, which is
+   * fine beside a mouse and short of what every other target in this sheet
+   * honours.
+   */
+  resetButton: {
+    minBlockSize: {default: null, '@media (pointer: coarse)': TOUCH_TARGET},
+  },
+  /**
    * The month and year, and the toggle into the wheels. Leading, so it reads
    * first and sits on the same line as the day grid below it.
    */
@@ -330,9 +362,19 @@ const styles = stylex.create({
       ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     whiteSpace: 'nowrap',
+    // The header now ends with Reset, so the title is the part that gives:
+    // it ellipses rather than pushing the corner off a narrow screen.
+    minInlineSize: 0,
+    overflow: 'hidden',
+  },
+  titleText: {
+    minInlineSize: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
   titleChevron: {
     display: 'inline-flex',
+    flexShrink: 0,
     // The one part of the swap that keeps `--ease-standard`, because it is
     // the one part that travels: a rotation has a distance to cover, and
     // fast-out-slow-in is what that curve is for. Same duration as the
@@ -479,16 +521,14 @@ const styles = stylex.create({
   },
   /**
    * One footer action. Both occupy the same cell, and the wheels' one is a
-   * layer over the calendar's pair exactly as the panels above are. The row
+   * layer over the calendar's, exactly as the panels above are. The row
    * never changes height either way.
    */
   footerAction: {
     gridArea: '1 / 1',
-    // Side by side and equal: the calendar's cell holds Reset and Save, the
-    // wheels' holds one button. `1fr` each rather than content width, so
-    // neither label's length decides how the row is divided.
+    // One button per surface, filling the row: Save on the calendar, Done on
+    // the wheels.
     display: 'flex',
-    gap: spacingVars['--spacing-2'],
   },
   sheetBody: {
     // One inset on every edge. The block-start is the exception and has to
@@ -919,7 +959,7 @@ export function TouchDateField({
           // withdrawing one is not.
           data-title="month-year"
           {...stylex.props(styles.title, focusOutlineStyles.focusVisible)}>
-          <span>{monthYearLabel}</span>
+          <span {...stylex.props(styles.titleText)}>{monthYearLabel}</span>
           <Icon
             icon="chevronDown"
             size="sm"
@@ -981,6 +1021,27 @@ export function TouchDateField({
                 <Icon icon="chevronRight" size="sm" color="inherit" />
               </span>
             }
+          />
+        </span>
+        {/* Reset, past the arrows, and gone with them on the wheels: the
+            wheels choose a month, and there is no date there to put back.
+            Hidden rather than unmounted, for the arrows' reason — the corner
+            keeps its size, so the header cannot change height mid-swap. */}
+        <span
+          data-action="reset"
+          inert={isWheelOpen ? true : undefined}
+          {...stylex.props(
+            styles.headerReset,
+            isWheelOpen && styles.headerResetHidden,
+          )}>
+          <Button
+            // ghost: a filled button up here would outrank the Save that
+            // finishes the task.
+            variant="ghost"
+            size="sm"
+            xstyle={styles.resetButton}
+            label={t('@astryx.dateInput.resetPicking')}
+            onClick={handleResetInSheet}
           />
         </span>
       </div>
@@ -1077,13 +1138,6 @@ export function TouchDateField({
             styles.panelBeneath,
             isWheelOpen && styles.panelBeneathHidden,
           )}>
-          <Button
-            variant="secondary"
-            size="md"
-            width="100%"
-            label={t('@astryx.dateInput.resetPicking')}
-            onClick={handleResetInSheet}
-          />
           <Button
             variant="primary"
             // md, not sm: it is the action a thumb reaches for, so it gets


### PR DESCRIPTION
## What

On a touch device the date picker's footer held **Reset** and **Save** side by side — two half-width buttons of equal weight, so the row that ends the task sat a thumb's width from the one action that throws the work away.

Reset now sits at the **header's trailing corner**, past the month arrows: chrome, in the band of controls that move the calendar without finishing anything. The footer is Save alone, full width.

- `variant="ghost"`, `size="sm"`, with the same 44px coarse-pointer floor the arrows take.
- It still leaves with the arrows while the month/year wheels are up — there is no date to clear on that surface — hidden rather than unmounted, so the header cannot change height mid-cross-fade, and `inert` while it fades.
- The month title now shrinks and ellipses instead of pushing the corner off a narrow screen.

Behaviour is unchanged: Reset still clears the date **and** returns the calendar to the current month.

## Before / after

```
before   [ August 2026 ⌄ ]            [ ‹ ][ › ]
         …calendar…
         [    Reset    ][     Save    ]

after    [ August 2026 ⌄ ]   [ ‹ ][ › ]  [ Reset ]
         …calendar…
         [            Save              ]
```

## Test plan

- `packages/core/src/DateInput` suite updated and green (264 tests): Reset is asserted to be the header's last child, still gone from the a11y tree on the wheels, and the footer's full-width count drops to two.
- Gates: `pnpm lint:strict` (0 errors), `pnpm test` (only the known `packages/cli` full-run flake on a devserver; `vitest run --project node packages/cli` is 205/205), `pnpm build`, `core`/`lab`/`charts` `typecheck:docs`, `cli typecheck:strict` + `typecheck:template-docs`, `storybook typecheck` + `build`, `lab:readiness:check` — all clean.
- Rendered the built component in Chromium on an iPhone 15 profile: Reset's trailing edge lands on the sheet's content inset, 44px tall.