### PR TITLE
test(layer): cover body type contexts and xstyle precedence

### DIFF
--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -12,7 +12,9 @@
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, act, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as stylex from '@stylexjs/stylex';
 import {useLayer, getPositionTryFallbacks} from './useLayer';
+import {typeScaleVars} from '../theme/tokens.stylex';
 import type {
   LayerPlacement,
   LayerAlignment,
@@ -500,20 +502,6 @@ describe('useLayer', () => {
   });
 
   describe('when the Popover API is supported', () => {
-    it('declares body type instead of inheriting the host context', () => {
-      const {container} = render(
-        <div style={{fontSize: '30px', lineHeight: '3'}}>
-          <LayerHarness onReady={() => {}} />
-        </div>,
-      );
-
-      const layer = container.querySelector('[popover]') as HTMLElement;
-      expect(layer).toHaveStyle({
-        fontSize: 'var(--text-body-size)',
-        lineHeight: 'var(--text-body-leading)',
-      });
-    });
-
     it('calls showPopover/hidePopover on show/hide', () => {
       const showSpy = vi.fn();
       const hideSpy = vi.fn();
@@ -613,6 +601,66 @@ async function openAndGetStyle(ui: React.ReactElement): Promise<string> {
   const popover = container.querySelector('[popover]');
   return popover?.getAttribute('style') ?? '';
 }
+
+describe('typography baseline', () => {
+  const overrideStyles = stylex.create({
+    supporting: {fontSize: typeScaleVars['--text-supporting-size']},
+  });
+
+  function TypographyHarness({
+    ambientFontSize,
+    xstyle,
+  }: {
+    ambientFontSize: string;
+    xstyle?: ContextRenderProps['xstyle'];
+  }) {
+    const layer = useLayer({mode: 'context'});
+    return (
+      <div style={{fontSize: ambientFontSize, lineHeight: '3'}}>
+        <button type="button" ref={layer.ref} onClick={layer.show}>
+          trigger
+        </button>
+        {layer.render(<span>content</span>, {xstyle})}
+      </div>
+    );
+  }
+
+  async function openAndGetType(ui: React.ReactElement) {
+    const user = userEvent.setup();
+    const {container, getByRole} = render(ui);
+    await user.click(getByRole('button', {name: 'trigger'}));
+    const el = container.querySelector('[popover]') as HTMLElement;
+    const computed = window.getComputedStyle(el);
+    return {fontSize: computed.fontSize, lineHeight: computed.lineHeight};
+  }
+
+  // jsdom resolves no var() indirection, so the token reference is what the
+  // assertion can see — the point is that a declaration exists at all, since
+  // an absent one is exactly what let the ambient size through.
+  it.each(['13px', '20px'])(
+    'takes the body role rather than the surrounding %s',
+    async ambientFontSize => {
+      expect(
+        await openAndGetType(
+          <TypographyHarness ambientFontSize={ambientFontSize} />,
+        ),
+      ).toEqual({
+        fontSize: 'var(--text-body-size)',
+        lineHeight: 'var(--text-body-leading)',
+      });
+    },
+  );
+
+  it('still lets a consumer xstyle set its own size', async () => {
+    const {fontSize} = await openAndGetType(
+      <TypographyHarness
+        ambientFontSize="13px"
+        xstyle={overrideStyles.supporting}
+      />,
+    );
+    expect(fontSize).toBe('var(--text-supporting-size)');
+  });
+});
 
 describe('useLayer context positioning', () => {
   // The mapping uses the self-* logical keyword family, so the emitted


### PR DESCRIPTION
## Context

#5064 merged the Layer body-typography production fix, but auto-merge completed before the stronger test update was included. As a result, main retained only one fixed-mode assertion with a 30px host, while the two ambient-size cases and the consumer override case from #5066 never landed.

## What changed

- parameterize the Layer body-type assertion over 13px and 20px ambient contexts
- assert both the body size and body leading token declarations
- assert that a consumer-provided supporting-size xstyle still wins over the Layer baseline

This is test coverage only; there is no production or public-surface change, so no changeset is needed.

## Testing

- pnpm vitest run packages/core/src/Layer/useLayer.test.tsx — 45 passed
- pnpm -F @astryxdesign/core typecheck — passed
- ASTRYX_STRICT_LINT=1 pnpm exec eslint packages/core/src/Layer/useLayer.test.tsx — passed
- pnpm exec prettier --check packages/core/src/Layer/useLayer.test.tsx — passed
- pnpm check:changesets — passed
- pre-commit repository checks — passed

Fixes #5424
