### PR TITLE
fix(Slider): ignore modifier-only focus ring activation

### DIFF
--- a/.changeset/interaction-modality-ignores-modifier-only-key-p-jc25.md
+++ b/.changeset/interaction-modality-ignores-modifier-only-key-p-jc25.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Slider keeps its focus ring hidden for modifier-only key presses after a pointer drag while preserving keyboard navigation (#5469)
+@jiunshinn

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -3322,6 +3322,35 @@ describe('Selector search focus ring', () => {
     await waitForSearchFocus();
     expect(field()).toHaveAttribute('data-keyboard-focus', 'true');
   });
+
+  it('rings when Shift+Tab returns from clear to the search input', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value={undefined}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    await waitForSearchFocus();
+    const search = screen.getByRole('combobox', {hidden: true});
+    await user.type(search, 'a');
+
+    await user.tab();
+    expect(
+      screen.getByRole('button', {
+        name: 'Clear Search options',
+        hidden: true,
+      }),
+    ).toHaveFocus();
+
+    await user.tab({shift: true});
+    expect(search).toHaveFocus();
+    expect(field()).toHaveAttribute('data-keyboard-focus', 'true');
+  });
 });
 
 describe('Selector search affordances', () => {

--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file Slider.test.tsx
  * @input Uses vitest, @testing-library/react, userEvent, Slider component
- * @output Unit tests for Slider component behavior
+ * @output Unit tests for Slider behavior and modifier-only focus-ring suppression
  * @position Testing; validates Slider.tsx implementation
  *
  * SYNC: When Slider.tsx changes, update tests to match new behavior
@@ -16,7 +16,10 @@ import userEvent from '@testing-library/user-event';
 import * as stylex from '@stylexjs/stylex';
 import {Slider} from './Slider';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
-import {__resetInteractionModalityForTest} from '../utils/interactionModality';
+import {
+  __resetInteractionModalityForTest,
+  getInteractionModality,
+} from '../utils/interactionModality';
 
 // Mock showPopover/hidePopover (not implemented in jsdom) so the tooltip layer
 // reflects its open state via a `popover-open` attribute the tests can assert.
@@ -978,6 +981,78 @@ describe('Slider', () => {
       // Copying or reloading is not navigation, and the mouse is still on it.
       fireEvent.keyDown(thumb, {key: 'c', metaKey: true});
       expect(isRinged(thumb)).toBe(false);
+    });
+
+    it('leaves the ring off for a bare Shift press after a mouse drag', () => {
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      const thumb = screen.getByRole('slider');
+      grabTrack(thumb);
+      fireEvent.keyDown(thumb, {key: 'Shift', shiftKey: true});
+      expect(getInteractionModality()).toBe('keyboard');
+      expect(isRinged(thumb)).toBe(false);
+    });
+
+    it.each([
+      ['Meta', {metaKey: true}],
+      ['Alt', {altKey: true}],
+      ['Control', {ctrlKey: true}],
+    ])(
+      'leaves the ring off for %s and its chord after bare Shift',
+      (key, flags) => {
+        render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+        const thumb = screen.getByRole('slider');
+        grabTrack(thumb);
+        fireEvent.keyDown(thumb, {key: 'Shift', shiftKey: true});
+        fireEvent.keyUp(thumb, {key: 'Shift'});
+        fireEvent.keyDown(thumb, {key, ...flags});
+        expect(isRinged(thumb)).toBe(false);
+        fireEvent.keyDown(thumb, {key: 'c', ...flags});
+        expect(getInteractionModality()).toBe('keyboard');
+        expect(isRinged(thumb)).toBe(false);
+      },
+    );
+
+    it('restores the ring and changes value for Shift+Arrow after bare Shift', () => {
+      const onChange = vi.fn();
+      render(<Slider label="Volume" value={50} onChange={onChange} />);
+      const thumb = screen.getByRole('slider');
+      grabTrack(thumb);
+      onChange.mockClear();
+      fireEvent.keyDown(thumb, {key: 'Shift', shiftKey: true});
+      expect(isRinged(thumb)).toBe(false);
+      expect(onChange).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(thumb, {key: 'ArrowRight', shiftKey: true});
+      expect(isRinged(thumb)).toBe(true);
+      expect(onChange).toHaveBeenCalledWith(51);
+    });
+
+    it('preserves an existing keyboard ring when Shift is pressed', async () => {
+      const user = userEvent.setup();
+      render(<Slider label="Volume" value={50} onChange={vi.fn()} />);
+      await user.tab();
+      const thumb = screen.getByRole('slider');
+
+      fireEvent.keyDown(thumb, {key: 'Shift', shiftKey: true});
+      expect(isRinged(thumb)).toBe(true);
+    });
+
+    it('rings when Shift+Tab returns to a mouse-focused thumb', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <Slider label="Volume" value={50} onChange={vi.fn()} />
+          <button type="button">After slider</button>
+        </>,
+      );
+      const thumb = screen.getByRole('slider');
+      grabTrack(thumb);
+      expect(isRinged(thumb)).toBe(false);
+      await user.click(screen.getByRole('button', {name: 'After slider'}));
+
+      await user.tab({shift: true});
+      expect(thumb).toHaveFocus();
+      expect(isRinged(thumb)).toBe(true);
     });
 
     it('drops the ring on blur', async () => {

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -5,7 +5,7 @@
 /**
  * @file Slider.tsx
  * @input Uses React, useId, useRef, useCallback, Field, Tooltip, useTooltip, VisuallyHidden
- * @output Exports Slider component, SliderProps, SliderSingleProps, SliderRangeProps, SliderBaseProps
+ * @output Exports Slider and its props; modifier-only key presses do not restore the thumb focus ring
  * @position Core implementation; consumed by index.ts, tested by Slider.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -756,9 +756,17 @@ export function Slider({ref, ...props}: SliderProps) {
       }
       // Unlike a text field, a thumb has no caret to show where input is
       // going, so a keypress after a mouse drag must bring the ring back.
-      // Ask the utility rather than assuming: a modifier chord (⌘R, ⌃C) is
-      // not navigation and must not re-ring a thumb the mouse is holding.
-      if (getInteractionModality() === 'keyboard') {
+      // Bare Shift changes shared modality to keyboard, but is not itself
+      // navigation for the thumb. Check this event's modifier flags too: a
+      // later chord must not restore the ring using that keyboard history.
+      // Shift+Tab and Shift+Arrow still count because their key is not Shift.
+      if (
+        e.key !== 'Shift' &&
+        !e.metaKey &&
+        !e.altKey &&
+        !e.ctrlKey &&
+        getInteractionModality() === 'keyboard'
+      ) {
         setKeyboardFocusThumb(thumbIndex);
       }
       const currentVal = values[thumbIndex];

--- a/packages/core/src/utils/interactionModality.test.ts
+++ b/packages/core/src/utils/interactionModality.test.ts
@@ -3,7 +3,7 @@
 /**
  * @file interactionModality.test.ts
  * @input The interaction-modality utility loaded more than once
- * @output Verifies document-wide listener and modality state continuity
+ * @output Verifies document-wide continuity and shared Shift-key modality policy
  * @position Unit coverage for interactionModality.ts
  */
 
@@ -22,6 +22,23 @@ afterEach(() => {
 });
 
 describe('interactionModality', () => {
+  it.each(['Shift', 'Tab', 'ArrowRight'])(
+    'counts %s with Shift held as keyboard input',
+    async key => {
+      const targetDocument = document.implementation.createHTMLDocument();
+      vi.stubGlobal('document', targetDocument);
+      const tracker = await loadTracker();
+      tracker.__startInteractionModalityTrackingForTest();
+      targetDocument.dispatchEvent(new Event('pointerdown'));
+      expect(tracker.getInteractionModality()).toBe('pointer');
+
+      targetDocument.dispatchEvent(
+        new KeyboardEvent('keydown', {key, shiftKey: true}),
+      );
+      expect(tracker.getInteractionModality()).toBe('keyboard');
+    },
+  );
+
   it('does not touch the document when the module loads', async () => {
     vi.stubGlobal('document', isolatedDocument);
     const addEventListener = vi.spyOn(isolatedDocument, 'addEventListener');


### PR DESCRIPTION
After a mouse drag, pressing Shift on a Slider thumb restores its keyboard focus ring even though the user has not navigated. Slider now checks the current key and modifier flags before restoring that ring. Bare Shift and Meta/Alt/Control chords keep a pointer-focused thumb unringed, including a chord after Shift has changed the shared modality to keyboard.

The document-wide modality tracker keeps its existing policy: bare Shift counts as keyboard input. Shift+Arrow still adjusts the value and restores the ring, Shift+Tab still restores keyboard focus, and pressing Shift preserves an already visible keyboard ring. The changeset describes the Slider behavior.

Validation:

- Focused Slider, Selector, and interaction-modality tests: 264 passed, including the existing document-wide singleton and listener-lifetime tests.
- `pnpm -F @astryxdesign/core typecheck`: passed.
- `pnpm -F @astryxdesign/core build`: passed.
- `pnpm lint:strict`: passed with 0 errors and 89 warnings outside the changed files.
- Chromium against local Storybook: a real pointer drag followed by bare Shift and Cmd/Ctrl/Alt+C leaves the thumb focused with no outline; Shift+ArrowRight restores a solid outline and increments the value from 55 to 56; subsequent bare Shift preserves the outline. Shift+Tab from the pointer-focused maximum range thumb moves focus and the visible outline to the minimum thumb.

Fixes #5469
