### PR TITLE
fix(core): make BottomSheet text keyboard-scrollable

### DIFF
--- a/.changeset/bottom-sheet-keyboard-scroll.md
+++ b/.changeset/bottom-sheet-keyboard-scroll.md
@@ -2,5 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Make text-only Bottom Sheets keyboard-scrollable (#5207)
+[fix] Make text-only Bottom Sheets keyboard-scrollable: the scroll body becomes a Tab stop only while it actually overflows and contains no visible sequentially focusable control, so short sheets never gain a dead stop and sheets whose only controls are CSS-hidden or tabindex="-1" keep one (#5207)
+
 @jiunshinn

--- a/.changeset/bottom-sheet-keyboard-scroll.md
+++ b/.changeset/bottom-sheet-keyboard-scroll.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Make text-only Bottom Sheets keyboard-scrollable (#5207)
+@jiunshinn

--- a/apps/storybook/stories/BottomSheet.stories.tsx
+++ b/apps/storybook/stories/BottomSheet.stories.tsx
@@ -240,6 +240,44 @@ export const TallSheet: Story = {
   },
 };
 
+export const KeyboardScrollableText: Story = {
+  name: 'Keyboard scroll — Text only',
+  render: () => {
+    const [isOpen, setIsOpen] = useState(true);
+    return (
+      <>
+        <Button label="Open release notes" onClick={() => setIsOpen(true)} />
+        <BottomSheet
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          label="Release notes"
+          height="capped">
+          <Section padding={4}>
+            <VStack gap={3}>
+              <Heading level={3}>Release notes</Heading>
+              <Text type="supporting" color="secondary">
+                This sheet opens for the accessibility audit. Its body has no
+                controls, so keyboard users reach the body itself and scroll it
+                with arrow keys or Page Down.
+              </Text>
+              <Divider />
+              {Array.from({length: 18}, (_, i) => (
+                <VStack key={i} gap={1}>
+                  <Text type="label">Update {i + 1}</Text>
+                  <Text type="supporting" color="secondary">
+                    Details about this release remain readable without a mouse
+                    or touch gesture.
+                  </Text>
+                </VStack>
+              ))}
+            </VStack>
+          </Section>
+        </BottomSheet>
+      </>
+    );
+  },
+};
+
 export const SnapPoints: Story = {
   render: () => {
     const [isOpen, setIsOpen] = useState(false);

--- a/packages/core/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.test.tsx
@@ -1757,10 +1757,17 @@ describe('BottomSheet', () => {
       expect(body.scrollTop).toBe(248);
 
       layoutShift = 200;
-      const observer = observers.find(instance => instance.observed.has(input));
-      expect(observer).toBeDefined();
+      // The keyboard reveal machinery and the panel's overflow tracker both
+      // size-observe the input, so notify every observer the way a real
+      // engine would.
+      const inputObservers = observers.filter(instance =>
+        instance.observed.has(input),
+      );
+      expect(inputObservers.length).toBeGreaterThan(0);
       act(() => {
-        observer?.callback([], observer as unknown as ResizeObserver);
+        for (const instance of inputObservers) {
+          instance.callback([], instance as unknown as ResizeObserver);
+        }
       });
 
       expect(body.scrollTop).toBe(448);

--- a/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
@@ -40,7 +40,62 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
+
+interface ScrollMetrics {
+  clientHeight: number;
+  scrollHeight: number;
+}
+
+// jsdom performs no layout, so scroll metrics are always 0 and overflow must
+// be mocked. Prototype getters (rather than instance properties) take effect
+// before the panel's first layout-effect read during render. Returns the
+// mutable metrics object so a test can change the reported sizes later.
+function mockScrollMetrics(initial: ScrollMetrics): ScrollMetrics {
+  const metrics = {...initial};
+  vi.spyOn(Element.prototype, 'clientHeight', 'get').mockImplementation(
+    () => metrics.clientHeight,
+  );
+  vi.spyOn(Element.prototype, 'scrollHeight', 'get').mockImplementation(
+    () => metrics.scrollHeight,
+  );
+  return metrics;
+}
+
+const OVERFLOWING: ScrollMetrics = {clientHeight: 400, scrollHeight: 800};
+
+interface ResizeObserverRecord {
+  callback: ResizeObserverCallback;
+  observed: Set<Element>;
+}
+
+function mockResizeObserverInstances(): ResizeObserverRecord[] {
+  const observers: ResizeObserverRecord[] = [];
+  class ResizeObserverMock {
+    callback: ResizeObserverCallback;
+    observed = new Set<Element>();
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+      observers.push(this);
+    }
+
+    observe(target: Element) {
+      this.observed.add(target);
+    }
+
+    unobserve(target: Element) {
+      this.observed.delete(target);
+    }
+
+    disconnect() {
+      this.observed.clear();
+    }
+  }
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  return observers;
+}
 
 function renderPanel(
   state: BottomSheetPanelState,
@@ -247,10 +302,18 @@ describe('BottomSheetPanel', () => {
     expect(panelRef).toHaveBeenCalledTimes(2);
   });
 
-  it('makes a text-only scrolling body keyboard-focusable', () => {
+  it('makes an overflowing text-only body keyboard-focusable', () => {
+    mockScrollMetrics(OVERFLOWING);
     renderPanel({kind: 'open', entering: false});
 
     expect(getBody()).toHaveAttribute('tabindex', '0');
+  });
+
+  it('does not leave a dead tab stop on a short sheet that cannot scroll', () => {
+    // No metrics mock: scrollHeight equals clientHeight, so nothing to scroll.
+    renderPanel({kind: 'open', entering: false});
+
+    expect(getBody()).not.toHaveAttribute('tabindex');
   });
 
   it('server-renders the body with a conservative keyboard tab stop', () => {
@@ -273,6 +336,7 @@ describe('BottomSheetPanel', () => {
   });
 
   it('does not add an extra tab stop when the body has a focusable control', () => {
+    mockScrollMetrics(OVERFLOWING);
     render(
       <BottomSheetPanel
         state={{kind: 'open', entering: false}}
@@ -287,6 +351,7 @@ describe('BottomSheetPanel', () => {
   });
 
   it('tracks focusable controls added and removed by a nested child', async () => {
+    mockScrollMetrics(OVERFLOWING);
     const panel = (content: React.ReactNode) => (
       <BottomSheetPanel
         state={{kind: 'open', entering: false}}
@@ -307,6 +372,7 @@ describe('BottomSheetPanel', () => {
   });
 
   it('keeps the body focusable when its only control is hidden', () => {
+    mockScrollMetrics(OVERFLOWING);
     render(
       <BottomSheetPanel
         state={{kind: 'open', entering: false}}
@@ -320,6 +386,75 @@ describe('BottomSheetPanel', () => {
     );
 
     expect(getBody()).toHaveAttribute('tabindex', '0');
+  });
+
+  it('keeps the body focusable when its only control is inside display:none', () => {
+    mockScrollMetrics(OVERFLOWING);
+    render(
+      <BottomSheetPanel
+        state={{kind: 'open', entering: false}}
+        height="hug"
+        onDismiss={() => {}}
+        onScrimOpacity={() => {}}>
+        <div style={{display: 'none'}}>
+          <button type="button">CSS-hidden action</button>
+        </div>
+      </BottomSheetPanel>,
+    );
+
+    expect(getBody()).toHaveAttribute('tabindex', '0');
+  });
+
+  it('keeps the body focusable when its only control has tabindex="-1"', () => {
+    mockScrollMetrics(OVERFLOWING);
+    render(
+      <BottomSheetPanel
+        state={{kind: 'open', entering: false}}
+        height="hug"
+        onDismiss={() => {}}
+        onScrimOpacity={() => {}}>
+        <button type="button" tabIndex={-1}>
+          Programmatic-only action
+        </button>
+      </BottomSheetPanel>,
+    );
+
+    expect(getBody()).toHaveAttribute('tabindex', '0');
+  });
+
+  it('follows overflow changes reported by the resize observer', () => {
+    const observers = mockResizeObserverInstances();
+    const metrics = mockScrollMetrics({clientHeight: 400, scrollHeight: 400});
+    renderPanel({kind: 'open', entering: false});
+    const body = getBody();
+    expect(body).not.toHaveAttribute('tabindex');
+
+    // More than one sheet-internal observer may watch the body (the mobile
+    // keyboard machinery observes it too), so notify every one of them the
+    // way a real engine would.
+    const bodyObservers = observers.filter(instance =>
+      instance.observed.has(body),
+    );
+    if (bodyObservers.length === 0) {
+      throw new Error('scroll body is not size-observed');
+    }
+    const notifyBodyResize = () => {
+      act(() => {
+        for (const instance of bodyObservers) {
+          instance.callback([], instance as unknown as ResizeObserver);
+        }
+      });
+    };
+
+    // Content grows past the sheet's height without any DOM mutation.
+    metrics.scrollHeight = 800;
+    notifyBodyResize();
+    expect(body).toHaveAttribute('tabindex', '0');
+
+    // And shrinks back, so the stop must not go dead.
+    metrics.scrollHeight = 400;
+    notifyBodyResize();
+    expect(body).not.toHaveAttribute('tabindex');
   });
 
   it('floats the handle bar over content that starts at the sheet top edge', () => {

--- a/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.test.tsx
@@ -7,7 +7,8 @@
  * @position Internal presentation tests shared by standalone and switcher modes
  */
 
-import {act, fireEvent, render, screen} from '@testing-library/react';
+import {act, fireEvent, render, waitFor} from '@testing-library/react';
+import {renderToString} from 'react-dom/server';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {
   BottomSheetPanel,
@@ -63,13 +64,21 @@ function renderPanel(
 }
 
 function getPanel(): HTMLElement {
-  const panel = screen
-    .getByText('Panel content')
-    .closest<HTMLElement>('.astryx-bottom-sheet');
+  const panel = document.querySelector<HTMLElement>('.astryx-bottom-sheet');
   if (panel == null) {
     throw new Error('BottomSheetPanel surface not found');
   }
   return panel;
+}
+
+function getBody(): HTMLElement {
+  const body = getPanel().querySelector<HTMLElement>(
+    ':scope > div[aria-hidden="true"] + div',
+  );
+  if (body == null) {
+    throw new Error('BottomSheetPanel scrolling body not found');
+  }
+  return body;
 }
 
 describe('BottomSheetPanel', () => {
@@ -236,6 +245,81 @@ describe('BottomSheetPanel', () => {
     unmount();
     expect(panelRef).toHaveBeenLastCalledWith(null);
     expect(panelRef).toHaveBeenCalledTimes(2);
+  });
+
+  it('makes a text-only scrolling body keyboard-focusable', () => {
+    renderPanel({kind: 'open', entering: false});
+
+    expect(getBody()).toHaveAttribute('tabindex', '0');
+  });
+
+  it('server-renders the body with a conservative keyboard tab stop', () => {
+    const html = renderToString(
+      <BottomSheetPanel
+        state={{kind: 'open', entering: false}}
+        height="hug"
+        onDismiss={() => {}}
+        onScrimOpacity={() => {}}>
+        Panel content
+      </BottomSheetPanel>,
+    );
+    const root = document.createElement('div');
+    root.innerHTML = html;
+    const body = root.querySelector<HTMLElement>(
+      '.astryx-bottom-sheet > div[aria-hidden="true"] + div',
+    );
+
+    expect(body).toHaveAttribute('tabindex', '0');
+  });
+
+  it('does not add an extra tab stop when the body has a focusable control', () => {
+    render(
+      <BottomSheetPanel
+        state={{kind: 'open', entering: false}}
+        height="hug"
+        onDismiss={() => {}}
+        onScrimOpacity={() => {}}>
+        <button type="button">Panel action</button>
+      </BottomSheetPanel>,
+    );
+
+    expect(getBody()).not.toHaveAttribute('tabindex');
+  });
+
+  it('tracks focusable controls added and removed by a nested child', async () => {
+    const panel = (content: React.ReactNode) => (
+      <BottomSheetPanel
+        state={{kind: 'open', entering: false}}
+        height="hug"
+        onDismiss={() => {}}
+        onScrimOpacity={() => {}}>
+        {content}
+      </BottomSheetPanel>
+    );
+    const {rerender} = render(panel('Panel content'));
+    expect(getBody()).toHaveAttribute('tabindex', '0');
+
+    rerender(panel(<button type="button">Panel action</button>));
+    await waitFor(() => expect(getBody()).not.toHaveAttribute('tabindex'));
+
+    rerender(panel('Panel content'));
+    await waitFor(() => expect(getBody()).toHaveAttribute('tabindex', '0'));
+  });
+
+  it('keeps the body focusable when its only control is hidden', () => {
+    render(
+      <BottomSheetPanel
+        state={{kind: 'open', entering: false}}
+        height="hug"
+        onDismiss={() => {}}
+        onScrimOpacity={() => {}}>
+        <button type="button" hidden>
+          Hidden action
+        </button>
+      </BottomSheetPanel>,
+    );
+
+    expect(getBody()).toHaveAttribute('tabindex', '0');
   });
 
   it('floats the handle bar over content that starts at the sheet top edge', () => {

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -28,11 +28,13 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {useDevWarning} from '../hooks';
+import {getFocusableElements} from '../hooks/focusableSelector';
 import {
   borderVars,
   colorVars,
@@ -71,6 +73,21 @@ const TRANSITION_BACKSTOP_BUFFER_MS = 50;
 // from the sheet's top edge, inside the space a content wrapper's own top
 // padding already provides.
 const HANDLE_BAR_HEIGHT = spacingVars['--spacing-6'];
+
+const FOCUSABILITY_ATTRIBUTES = [
+  'aria-hidden',
+  'class',
+  'contenteditable',
+  'controls',
+  'disabled',
+  'hidden',
+  'href',
+  'inert',
+  'open',
+  'style',
+  'tabindex',
+  'type',
+] as const;
 
 // Measure the same viewport the height budgets are written against. Those are
 // `dvh`, which the virtual keyboard does not shrink, so reading
@@ -490,6 +507,55 @@ export function BottomSheetPanel({
     onScrimOpacity,
   });
 
+  // The body is the only element that can scroll, so it needs a tab stop when
+  // its content offers no other keyboard route. Start in the accessible state
+  // for server rendering, then remove the extra stop before paint when the DOM
+  // contains a focusable descendant. Observe the subtree because a lazy child
+  // can add, remove, enable, or reveal a control without rerendering this panel.
+  const [bodyNeedsTabIndex, setBodyNeedsTabIndex] = useState(true);
+  useLayoutEffect(() => {
+    const body = bodyElementRef.current;
+    if (body == null) {
+      return;
+    }
+    const syncTabIndex = () => {
+      const needsTabIndex = getFocusableElements(body).length === 0;
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- synchronizes focusability with rendered descendants
+      setBodyNeedsTabIndex(current =>
+        current === needsTabIndex ? current : needsTabIndex,
+      );
+    };
+
+    syncTabIndex();
+    if (typeof MutationObserver === 'undefined') {
+      return;
+    }
+    const observer = new MutationObserver(records => {
+      // React owns the body's tabIndex. Ignore the attribute write caused by
+      // this state update so it cannot feed back into another scan.
+      if (
+        records.every(
+          record =>
+            record.type === 'attributes' &&
+            record.target === body &&
+            record.attributeName === 'tabindex',
+        )
+      ) {
+        return;
+      }
+      syncTabIndex();
+    });
+    observer.observe(body, {
+      attributes: true,
+      attributeFilter: [...FOCUSABILITY_ATTRIBUTES],
+      childList: true,
+      subtree: true,
+    });
+    return () => {
+      observer.disconnect();
+    };
+  }, [bodyElementRef]);
+
   const setElement = useCallback(
     (element: HTMLDivElement | null) => {
       sheetRef(element);
@@ -656,6 +722,7 @@ export function BottomSheetPanel({
         <div {...stylex.props(styles.handlePill)} />
       </div>
       <div
+        tabIndex={bodyNeedsTabIndex ? 0 : undefined}
         {...mergeProps(
           stylex.props(
             styles.body,

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -508,10 +508,15 @@ export function BottomSheetPanel({
   });
 
   // The body is the only element that can scroll, so it needs a tab stop when
-  // its content offers no other keyboard route. Start in the accessible state
-  // for server rendering, then remove the extra stop before paint when the DOM
-  // contains a focusable descendant. Observe the subtree because a lazy child
-  // can add, remove, enable, or reveal a control without rerendering this panel.
+  // it actually overflows and its content offers no other keyboard route. A
+  // sheet that fits its content must not gain a dead Tab stop, and one whose
+  // only controls are CSS-hidden or tabindex="-1" must keep the explicit stop
+  // for engines that never focus scroll containers on their own. Overflow is
+  // unknowable during server rendering, so start in the accessible state and
+  // reconcile before first paint. Observe the subtree because a lazy child can
+  // add, remove, enable, or reveal a control without rerendering this panel,
+  // and observe box sizes because overflow can change with no DOM mutation at
+  // all (a snap drag, an image decoding, a viewport resize).
   const [bodyNeedsTabIndex, setBodyNeedsTabIndex] = useState(true);
   useLayoutEffect(() => {
     const body = bodyElementRef.current;
@@ -519,16 +524,41 @@ export function BottomSheetPanel({
       return;
     }
     const syncTabIndex = () => {
-      const needsTabIndex = !hasFocusableDescendant(body);
+      // Overflow first: a constant-time read that skips the descendant scan
+      // entirely for the common short sheet.
+      const needsTabIndex =
+        body.scrollHeight > body.clientHeight && !hasFocusableDescendant(body);
       // eslint-disable-next-line @eslint-react/set-state-in-effect -- synchronizes focusability with rendered descendants
       setBodyNeedsTabIndex(current =>
         current === needsTabIndex ? current : needsTabIndex,
       );
     };
+    // The body's box decides clientHeight; a direct child's box decides
+    // scrollHeight (a grandchild cannot change the scroll range without its
+    // parent's box changing too). Re-registered only from mutation callbacks,
+    // never from the resize callback itself — observe() replays an initial
+    // notification, which would loop.
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(syncTabIndex);
+    const observeSizes = () => {
+      if (resizeObserver == null) {
+        return;
+      }
+      resizeObserver.disconnect();
+      resizeObserver.observe(body);
+      for (const child of body.children) {
+        resizeObserver.observe(child);
+      }
+    };
 
     syncTabIndex();
+    observeSizes();
     if (typeof MutationObserver === 'undefined') {
-      return;
+      return () => {
+        resizeObserver?.disconnect();
+      };
     }
     const observer = new MutationObserver(records => {
       // React owns the body's tabIndex. Ignore the attribute write caused by
@@ -543,16 +573,21 @@ export function BottomSheetPanel({
       ) {
         return;
       }
+      if (records.some(record => record.type === 'childList')) {
+        observeSizes();
+      }
       syncTabIndex();
     });
     observer.observe(body, {
       attributes: true,
       attributeFilter: [...FOCUSABILITY_ATTRIBUTES],
+      characterData: true,
       childList: true,
       subtree: true,
     });
     return () => {
       observer.disconnect();
+      resizeObserver?.disconnect();
     };
   }, [bodyElementRef]);
 

--- a/packages/core/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetPanel.tsx
@@ -34,7 +34,7 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {useDevWarning} from '../hooks';
-import {getFocusableElements} from '../hooks/focusableSelector';
+import {hasFocusableDescendant} from '../hooks/focusableSelector';
 import {
   borderVars,
   colorVars,
@@ -519,7 +519,7 @@ export function BottomSheetPanel({
       return;
     }
     const syncTabIndex = () => {
-      const needsTabIndex = getFocusableElements(body).length === 0;
+      const needsTabIndex = !hasFocusableDescendant(body);
       // eslint-disable-next-line @eslint-react/set-state-in-effect -- synchronizes focusability with rendered descendants
       setBodyNeedsTabIndex(current =>
         current === needsTabIndex ? current : needsTabIndex,

--- a/packages/core/src/BottomSheet/BottomSheetSwitcher.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetSwitcher.test.tsx
@@ -582,7 +582,7 @@ describe('BottomSheetSwitcher', () => {
     expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps focus in a modal sheet that has no tabbable controls', () => {
+  it('keeps focus on the scroll body in a modal sheet with read-only content', () => {
     render(
       <>
         <button type="button">Background action</button>
@@ -598,9 +598,22 @@ describe('BottomSheetSwitcher', () => {
 
     const dialog = screen.getByRole('dialog', {name: 'Read-only details'});
     const panel = getSheetPanel(dialog);
+    const scrollBody = panel.querySelector<HTMLElement>('[tabindex="0"]');
     expect(panel).toHaveFocus();
-    expect(fireEvent.keyDown(panel, {key: 'Tab'})).toBe(false);
-    expect(panel).toHaveFocus();
+    if (scrollBody == null) {
+      throw new Error('keyboard-focusable scroll body not found');
+    }
+
+    // jsdom does not perform native Tab navigation, so emulate the browser's
+    // move after verifying the trap allows it to reach the scroll region.
+    expect(fireEvent.keyDown(panel, {key: 'Tab'})).toBe(true);
+    scrollBody.focus();
+    expect(scrollBody).toHaveFocus();
+
+    // With no other controls, the trap wraps at the scroll region rather than
+    // allowing the next Tab press to reach the background.
+    expect(fireEvent.keyDown(scrollBody, {key: 'Tab'})).toBe(false);
+    expect(scrollBody).toHaveFocus();
     expect(
       screen.getByRole('button', {name: 'Background action'}),
     ).not.toHaveFocus();

--- a/packages/core/src/BottomSheet/BottomSheetSwitcher.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetSwitcher.test.tsx
@@ -47,7 +47,16 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
+
+// jsdom performs no layout, so the scroll body only earns its keyboard tab
+// stop (which requires real overflow) when the metrics are mocked. Prototype
+// getters take effect before the panel's first layout-effect read.
+function mockOverflowingScrollMetrics() {
+  vi.spyOn(Element.prototype, 'clientHeight', 'get').mockReturnValue(400);
+  vi.spyOn(Element.prototype, 'scrollHeight', 'get').mockReturnValue(800);
+}
 
 function Flow() {
   const [activeSheet, setActiveSheet] = useState<string | null>(null);
@@ -583,6 +592,7 @@ describe('BottomSheetSwitcher', () => {
   });
 
   it('keeps focus on the scroll body in a modal sheet with read-only content', () => {
+    mockOverflowingScrollMetrics();
     render(
       <>
         <button type="button">Background action</button>

--- a/packages/core/src/hooks/focusableSelector.ts
+++ b/packages/core/src/hooks/focusableSelector.ts
@@ -23,6 +23,26 @@
 export const FOCUSABLE_SELECTOR =
   'button:not([disabled]), a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';
 
+function isVisiblyFocusable(element: HTMLElement): boolean {
+  if (element.hasAttribute('inert') || element.closest('[inert]')) {
+    return false;
+  }
+  if (element.hidden || element.closest('[hidden]')) {
+    return false;
+  }
+  // closest() matches the element itself as well as any ancestor.
+  if (element.closest('[aria-hidden="true"]')) {
+    return false;
+  }
+  if (typeof window !== 'undefined' && window.getComputedStyle) {
+    const style = window.getComputedStyle(element);
+    if (style.visibility === 'hidden' || style.display === 'none') {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Get the currently perceivable focusable descendants of a container.
  *
@@ -35,23 +55,23 @@ export const FOCUSABLE_SELECTOR =
 export function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(
     container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-  ).filter(element => {
-    if (element.hasAttribute('inert') || element.closest('[inert]')) {
-      return false;
+  ).filter(isVisiblyFocusable);
+}
+
+/**
+ * Whether a container has any perceivable focusable descendant.
+ *
+ * This intentionally stops at the first match. Consumers that only need a
+ * boolean can run after subtree mutations without repeatedly computing styles
+ * for every control in a large, virtualized surface.
+ */
+export function hasFocusableDescendant(container: HTMLElement): boolean {
+  const candidates =
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+  for (const candidate of candidates) {
+    if (isVisiblyFocusable(candidate)) {
+      return true;
     }
-    if (element.hidden || element.closest('[hidden]')) {
-      return false;
-    }
-    // closest() matches the element itself as well as any ancestor.
-    if (element.closest('[aria-hidden="true"]')) {
-      return false;
-    }
-    if (typeof window !== 'undefined' && window.getComputedStyle) {
-      const style = window.getComputedStyle(element);
-      if (style.visibility === 'hidden' || style.display === 'none') {
-        return false;
-      }
-    }
-    return true;
-  });
+  }
+  return false;
 }

--- a/packages/core/src/hooks/focusableSelector.ts
+++ b/packages/core/src/hooks/focusableSelector.ts
@@ -2,8 +2,8 @@
 
 /**
  * @file focusableSelector.ts
- * @input Uses DOM visibility and descendant queries
- * @output Exports the canonical focusable selector and query helper
+ * @input Uses DOM visibility, tab-order, and descendant queries
+ * @output Exports the canonical focusable selector and query helpers
  * @position Internal utility; shared by focus-management hooks and components
  *   so their focusable-element model stays aligned. Not exported from the
  *   public barrel — internal implementation detail.
@@ -23,7 +23,41 @@
 export const FOCUSABLE_SELECTOR =
   'button:not([disabled]), a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';
 
-function isVisiblyFocusable(element: HTMLElement): boolean {
+/**
+ * Whether an element opts out of sequential focus with an explicit negative
+ * tabindex. The selector alone cannot express this: its `[tabindex]` clause
+ * excludes `tabindex="-1"`, but natively focusable elements (button, a[href],
+ * input, ...) match their own clause, so `<button tabindex="-1">` slips
+ * through and must be filtered here. Parsed rather than string-matched so
+ * `tabindex=" -1"` and other negative values are also caught.
+ */
+function hasNegativeTabIndex(element: HTMLElement): boolean {
+  const explicit = element.getAttribute('tabindex');
+  if (explicit == null) {
+    return false;
+  }
+  const parsed = Number.parseInt(explicit, 10);
+  return !Number.isNaN(parsed) && parsed < 0;
+}
+
+/**
+ * Whether an element is a visible sequential-focus stop — one the browser
+ * offers to a Tab press. Excludes:
+ *
+ * - explicit `tabindex="-1"`, which is focusable only programmatically;
+ * - `inert`/`hidden` subtrees, which keyboard navigation skips;
+ * - `aria-hidden="true"` subtrees, which sighted keyboard users must not
+ *   reach while assistive technology cannot perceive them (WCAG 4.1.2);
+ * - CSS-hidden elements. `display: none` does not inherit, so a hidden
+ *   ancestor never shows up in the descendant's own computed style — the
+ *   ancestor chain is walked explicitly. `visibility` does inherit (and a
+ *   visible descendant of a hidden ancestor genuinely is focusable), so the
+ *   element's own computed value is already the whole answer there.
+ */
+function isVisibleSequentialFocusStop(element: HTMLElement): boolean {
+  if (hasNegativeTabIndex(element)) {
+    return false;
+  }
   if (element.hasAttribute('inert') || element.closest('[inert]')) {
     return false;
   }
@@ -36,30 +70,40 @@ function isVisiblyFocusable(element: HTMLElement): boolean {
   }
   if (typeof window !== 'undefined' && window.getComputedStyle) {
     const style = window.getComputedStyle(element);
-    if (style.visibility === 'hidden' || style.display === 'none') {
+    if (style.visibility === 'hidden' || style.visibility === 'collapse') {
       return false;
+    }
+    for (
+      let node: HTMLElement | null = element;
+      node != null;
+      node = node.parentElement
+    ) {
+      if (window.getComputedStyle(node).display === 'none') {
+        return false;
+      }
     }
   }
   return true;
 }
 
 /**
- * Get the currently perceivable focusable descendants of a container.
+ * Get the visible, sequentially focusable descendants of a container.
  *
- * Selector matches alone are insufficient: hidden elements and descendants of
- * `inert` or `hidden` subtrees stay in the DOM but are skipped by keyboard
- * navigation. Descendants of `aria-hidden="true"` are also excluded because
- * sighted keyboard users must not reach controls that assistive technology
- * cannot perceive (WCAG 4.1.2).
+ * Selector matches alone are insufficient: CSS-hidden elements, descendants
+ * of `inert` or `hidden` subtrees, and natives carrying `tabindex="-1"` stay
+ * in the DOM but are skipped by sequential keyboard navigation. Descendants
+ * of `aria-hidden="true"` are also excluded because sighted keyboard users
+ * must not reach controls that assistive technology cannot perceive
+ * (WCAG 4.1.2).
  */
 export function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(
     container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-  ).filter(isVisiblyFocusable);
+  ).filter(isVisibleSequentialFocusStop);
 }
 
 /**
- * Whether a container has any perceivable focusable descendant.
+ * Whether a container has any visible sequential-focus descendant.
  *
  * This intentionally stops at the first match. Consumers that only need a
  * boolean can run after subtree mutations without repeatedly computing styles
@@ -69,7 +113,7 @@ export function hasFocusableDescendant(container: HTMLElement): boolean {
   const candidates =
     container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
   for (const candidate of candidates) {
-    if (isVisiblyFocusable(candidate)) {
+    if (isVisibleSequentialFocusStop(candidate)) {
       return true;
     }
   }

--- a/packages/core/src/hooks/focusableSelector.ts
+++ b/packages/core/src/hooks/focusableSelector.ts
@@ -2,11 +2,10 @@
 
 /**
  * @file focusableSelector.ts
- * @input None (a plain CSS selector string constant)
- * @output Exports FOCUSABLE_SELECTOR
- * @position Internal utility; the canonical CSS selector for focusable
- *   elements, shared by focus-management hooks (e.g. useFocusTrap) so the
- *   selector isn't duplicated across components/hooks. Not exported from the
+ * @input Uses DOM visibility and descendant queries
+ * @output Exports the canonical focusable selector and query helper
+ * @position Internal utility; shared by focus-management hooks and components
+ *   so their focusable-element model stays aligned. Not exported from the
  *   public barrel — internal implementation detail.
  */
 
@@ -23,3 +22,36 @@
  */
 export const FOCUSABLE_SELECTOR =
   'button:not([disabled]), a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';
+
+/**
+ * Get the currently perceivable focusable descendants of a container.
+ *
+ * Selector matches alone are insufficient: hidden elements and descendants of
+ * `inert` or `hidden` subtrees stay in the DOM but are skipped by keyboard
+ * navigation. Descendants of `aria-hidden="true"` are also excluded because
+ * sighted keyboard users must not reach controls that assistive technology
+ * cannot perceive (WCAG 4.1.2).
+ */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter(element => {
+    if (element.hasAttribute('inert') || element.closest('[inert]')) {
+      return false;
+    }
+    if (element.hidden || element.closest('[hidden]')) {
+      return false;
+    }
+    // closest() matches the element itself as well as any ancestor.
+    if (element.closest('[aria-hidden="true"]')) {
+      return false;
+    }
+    if (typeof window !== 'undefined' && window.getComputedStyle) {
+      const style = window.getComputedStyle(element);
+      if (style.visibility === 'hidden' || style.display === 'none') {
+        return false;
+      }
+    }
+    return true;
+  });
+}

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -18,7 +18,7 @@
 
 import {useCallback, useEffect, useRef} from 'react';
 
-import {FOCUSABLE_SELECTOR} from './focusableSelector';
+import {getFocusableElements} from './focusableSelector';
 import {useLayerDismissal} from '../Layer/useLayerDismissal';
 
 // Escape-dismissible focus traps currently mounted. This is the whole state
@@ -39,44 +39,6 @@ let activeEscapeTrapCount = 0;
  */
 export function hasActiveFocusTrapEscape(): boolean {
   return activeEscapeTrapCount > 0;
-}
-
-/**
- * Whether an element is currently perceivable/focusable — excludes ones hidden
- * via `display:none`/`visibility:hidden` or inside an `inert`/`hidden` subtree,
- * which the browser skips for Tab, and ones inside an `aria-hidden="true"`
- * subtree, which sighted-keyboard users could Tab to while AT skips them
- * (WCAG 4.1.2 — focusable content must be exposed to assistive tech).
- */
-function isVisiblyFocusable(el: HTMLElement): boolean {
-  if (el.hasAttribute('inert') || el.closest('[inert]')) {
-    return false;
-  }
-  if (el.hidden || el.closest('[hidden]')) {
-    return false;
-  }
-  // closest() matches the element itself as well as any ancestor.
-  if (el.closest('[aria-hidden="true"]')) {
-    return false;
-  }
-  // offsetParent is null for display:none (and fixed elements); pair with a
-  // visibility check via getComputedStyle when available.
-  if (typeof window !== 'undefined' && window.getComputedStyle) {
-    const style = window.getComputedStyle(el);
-    if (style.visibility === 'hidden' || style.display === 'none') {
-      return false;
-    }
-  }
-  return true;
-}
-
-/**
- * Get all focusable elements within a container.
- */
-function getFocusableElements(container: HTMLElement): HTMLElement[] {
-  return Array.from(
-    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-  ).filter(isVisiblyFocusable);
 }
 
 /**


### PR DESCRIPTION
## Summary

- make the BottomSheet scroll body a tab stop only when it has no visible focusable descendant
- keep that decision synchronized for lazy, nested, enabled, disabled, hidden, and removed controls while preserving an SSR-safe initial tab stop
- short-circuit boolean focusability checks at the first visible control so mutation observation stays cheap for large virtualized sheets
- add focused regressions and an open-by-default text-only Storybook case so the scoped axe audit exercises the rendered sheet

## Testing

- `pnpm exec vitest run packages/core/src/DateInput/DateInputTouch.test.tsx -t "does not report a scroll it was told to make"` (11 consecutive passes after the short-circuit fix)
- `pnpm exec vitest run packages/core/src/DateInput/DateInputTouch.test.tsx` (135 passed)
- `pnpm exec vitest run packages/core/src/BottomSheet packages/core/src/hooks/useFocusTrap.test.tsx` (227 passed)
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm lint:strict` (passes; existing warnings only)
- `pnpm build`
- `pnpm storybook:build`
- `pnpm a11y:audit -- --storybook-dir apps/storybook/dist --components BottomSheet --output /tmp/astryx-5207-a11y.json` (11 stories, 0 violations)
- Chromium keyboard check: text-only body focused with `tabindex="0"`; Page Down moved `scrollTop` from 0 to 317; control-bearing story retained no body `tabindex`

Fixes #5207