### PR TITLE
ci(visual-gate): build the theme dists the gate needs instead of crashing

### DIFF
--- a/.github/scripts/visual-gate/lib/sources.mjs
+++ b/.github/scripts/visual-gate/lib/sources.mjs
@@ -17,9 +17,48 @@
  * two lists.
  */
 
+import {execFileSync} from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
+
+/** The compiled entry a built theme's own `@astryxdesign/core/theme` import resolves to. */
+const CORE_THEME_ENTRY = 'packages/core/dist/theme/index.js';
+
+const BUILD_TIMEOUT_MS = 300_000;
+
+/**
+ * @param {string} repoRoot
+ * @param {string} pkg
+ */
+function pnpmBuild(repoRoot, pkg) {
+  execFileSync('pnpm', ['-F', pkg, 'build'], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    timeout: BUILD_TIMEOUT_MS,
+  });
+}
+
+/**
+ * @param {string} file
+ * @param {string} [query] - cache-buster, so a post-build retry is a fresh import
+ * @returns {Promise<{ok: true, module: Record<string, any>} | {ok: false, error: Error}>}
+ */
+async function importBuilt(file, query = '') {
+  try {
+    return {ok: true, module: await import(pathToFileURL(file).href + query)};
+  } catch (error) {
+    return {ok: false, error: /** @type {Error} */ (error)};
+  }
+}
+
+/**
+ * @param {string} dir
+ * @returns {string}
+ */
+function packageName(dir) {
+  return JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).name;
+}
 
 /**
  * @param {string} repoRoot
@@ -48,25 +87,59 @@ export async function loadThemingTargets(repoRoot) {
  * probe tier answers in 128 with a set cover. It is a coverage instrument, not
  * a theme someone ships.
  *
+ * Builds what it cannot read. On CI these dists arrive as an artifact from the
+ * job that already built them, and three changes in one day to how that
+ * artifact is named and filled each reddened the gate on every open component
+ * PR with a missing-file error about something no PR had touched. The gate owns its own
+ * prerequisites now, so how they get onto the runner is an optimisation rather
+ * than a correctness dependency.
+ *
  * @param {string} repoRoot
  * @param {string} [probeTheme] - name of the coverage fixture to leave out
+ * @param {(repoRoot: string, pkg: string) => void} [build] - seam for tests
  * @returns {Promise<Record<string, Record<string, string[]>>>}
  */
-export async function loadThemeOverrides(repoRoot, probeTheme = 'probe') {
+export async function loadThemeOverrides(repoRoot, probeTheme = 'probe', build = pnpmBuild) {
   const themesDir = path.join(repoRoot, 'packages/themes');
   /** @type {Record<string, Record<string, string[]>>} */
   const overrides = {};
+  /** @type {string[]} */
+  const rebuilt = [];
+
+  /**
+   * @param {string} pkg
+   * @param {string} why
+   */
+  const buildOnce = (pkg, why) => {
+    if (rebuilt.includes(pkg)) return;
+    rebuilt.push(pkg);
+    console.log(`visual gate: ${why}; building ${pkg} here rather than failing.`);
+    build(repoRoot, pkg);
+  };
 
   for (const entry of fs.readdirSync(themesDir, {withFileTypes: true}).sort()) {
     if (!entry.isDirectory()) continue;
-    const built = path.join(themesDir, entry.name, 'dist/source.mjs');
-    if (!fs.existsSync(built)) {
-      throw new Error(
-        `Theme ${entry.name} is not built (${built} missing) — run pnpm build before the visual gate.`,
-      );
+    const dir = path.join(themesDir, entry.name);
+    const built = path.join(dir, 'dist/source.mjs');
+
+    let loaded = await importBuilt(built);
+    if (!loaded.ok) {
+      if (!fs.existsSync(path.join(repoRoot, CORE_THEME_ENTRY))) {
+        buildOnce(
+          '@astryxdesign/core',
+          `${CORE_THEME_ENTRY} is missing and every built theme imports it`,
+        );
+      }
+      if (!fs.existsSync(built)) {
+        buildOnce(packageName(dir), `${path.relative(repoRoot, built)} is missing`);
+      }
+      loaded = await importBuilt(built, '?rebuilt');
+      if (!loaded.ok) {
+        throw unreadableTheme(repoRoot, entry.name, built, loaded.error, rebuilt);
+      }
     }
-    const module = await import(pathToFileURL(built).href);
-    const theme = Object.values(module).find(value => value?.name && value?.components);
+
+    const theme = Object.values(loaded.module).find(value => value?.name && value?.components);
     if (!theme || theme.name === probeTheme) continue;
     overrides[theme.name] = Object.fromEntries(
       Object.entries(theme.components).map(([key, styles]) => [key, Object.keys(styles ?? {})]),
@@ -74,6 +147,29 @@ export async function loadThemeOverrides(repoRoot, probeTheme = 'probe') {
   }
 
   return overrides;
+}
+
+/**
+ * @param {string} repoRoot
+ * @param {string} name
+ * @param {string} built
+ * @param {Error} error
+ * @param {string[]} rebuilt
+ * @returns {Error}
+ */
+function unreadableTheme(repoRoot, name, built, error, rebuilt) {
+  const rel = path.relative(repoRoot, built);
+  return new Error(
+    [
+      `The visual gate could not load theme ${name} from ${rel}.`,
+      `  ${error.message}`,
+      rebuilt.length
+        ? `  The gate rebuilt ${rebuilt.join(' and ')} here and the import still fails, so this is a broken build rather than a missing one.`
+        : `  Both ${rel} and ${CORE_THEME_ENTRY} are present, so this is not a missing build.`,
+      `The gate reads each theme's BUILT source because a theme's component map is what defineTheme returns, not a literal in its source.`,
+    ].join('\n'),
+    {cause: error},
+  );
 }
 
 /**

--- a/.github/scripts/visual-gate/lib/sources.test.mjs
+++ b/.github/scripts/visual-gate/lib/sources.test.mjs
@@ -1,0 +1,94 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {loadThemeOverrides} from './sources.mjs';
+
+/** @type {string[]} */
+const made = [];
+
+/**
+ * A repo root with `packages/core/dist` present and one theme package, whose
+ * built source is written only when `built` is true.
+ *
+ * @param {{built: boolean}} options
+ */
+function fixture({built}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'visual-gate-sources-'));
+  made.push(root);
+  fs.mkdirSync(path.join(root, 'packages/core/dist/theme'), {recursive: true});
+  fs.writeFileSync(path.join(root, 'packages/core/dist/theme/index.js'), '');
+  const dir = path.join(root, 'packages/themes/butter');
+  fs.mkdirSync(path.join(dir, 'dist'), {recursive: true});
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name: '@astryxdesign/theme-butter'}),
+  );
+  if (built) writeBuilt(dir);
+  return {root, dir};
+}
+
+/** @param {string} dir */
+function writeBuilt(dir) {
+  fs.writeFileSync(
+    path.join(dir, 'dist/source.mjs'),
+    "export const theme = {name: 'butter', components: {badge: {base: {}, 'variant:info': {}}}};\n",
+  );
+}
+
+afterEach(() => {
+  for (const root of made.splice(0)) fs.rmSync(root, {recursive: true, force: true});
+});
+
+describe('loadThemeOverrides', () => {
+  it('reads a built theme without building anything', async () => {
+    const {root} = fixture({built: true});
+    /** @type {string[]} */
+    const builds = [];
+
+    const overrides = await loadThemeOverrides(root, 'probe', (_root, pkg) => builds.push(pkg));
+
+    expect(overrides).toEqual({butter: {badge: ['base', 'variant:info']}});
+    expect(builds).toEqual([]);
+  });
+
+  it('builds the theme it cannot read, so a missing CI artifact is not a failure', async () => {
+    const {root, dir} = fixture({built: false});
+    /** @type {string[]} */
+    const builds = [];
+
+    const overrides = await loadThemeOverrides(root, 'probe', (_root, pkg) => {
+      builds.push(pkg);
+      writeBuilt(dir);
+    });
+
+    expect(builds).toEqual(['@astryxdesign/theme-butter']);
+    expect(overrides).toEqual({butter: {badge: ['base', 'variant:info']}});
+  });
+
+  it('builds core first when its dist is the thing missing', async () => {
+    const {root, dir} = fixture({built: false});
+    fs.rmSync(path.join(root, 'packages/core/dist'), {recursive: true});
+    /** @type {string[]} */
+    const builds = [];
+
+    await loadThemeOverrides(root, 'probe', (_root, pkg) => {
+      builds.push(pkg);
+      if (pkg === '@astryxdesign/theme-butter') writeBuilt(dir);
+    });
+
+    expect(builds).toEqual(['@astryxdesign/core', '@astryxdesign/theme-butter']);
+  });
+
+  it('says it tried when the rebuild does not produce a loadable theme', async () => {
+    const {root} = fixture({built: false});
+
+    await expect(loadThemeOverrides(root, 'probe', () => {})).rejects.toThrow(
+      /could not load theme butter[\s\S]*rebuilt @astryxdesign\/theme-butter here and the import still fails/,
+    );
+  });
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,12 @@ jobs:
           name: storybook-${{ needs.build-storybook.outputs.short_hash }}
           path: apps/storybook/dist
 
+      # Non-fatal: if this artifact is ever missing, renamed, or produced under
+      # a different key, the gate builds the themes itself. A crash here would
+      # be before the gate ever runs, which is how an artifact-wiring change
+      # reddened every open component PR twice in one day.
       - name: Download built themes and core
+        continue-on-error: true
         uses: actions/download-artifact@v8
         with:
           name: dists-${{ needs.build-storybook.outputs.short_hash }}


### PR DESCRIPTION
## Problem

`pr-visual` is red on **15 of the 21 open PRs where it ran** (71%), and none of
the failures are about anything those PRs changed. Two different errors, both
naming a file the contributor never touched:

```
Error: Theme butter is not built (packages/themes/butter/dist/source.mjs missing) — run pnpm build before the visual gate.
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../@astryxdesign/core/dist/theme/index.js'
```

It is a soft gate, so people merge through it — which is worse than the gate not
existing, because a red check nobody reads is a red check nobody reads when it is
right.

### Why, exactly

The gate needs two build products it does not produce: each theme's
`dist/source.mjs` (a theme's component map is what `defineTheme` returns, not a
literal in its source) and `packages/core/dist`, which a built theme's own
`import '@astryxdesign/core/theme'` resolves into through the workspace link.
They reach the runner as an artifact from `build-storybook`, and how that
artifact is named and filled changed three times in twenty-four hours
([#5477](https://github.com/facebook/astryx/pull/5477),
[#5481](https://github.com/facebook/astryx/pull/5481),
[#5482](https://github.com/facebook/astryx/pull/5482)). Each intermediate shape
left the gate with nothing to read, and the gate's response to that was to
throw.

**A PR does not run the `ci.yml` on `main`. It runs the one on its own merge
commit, and that merge commit is frozen when the `pull_request` event fires.**
Re-running the job replays the same payload, so a PR whose last push predates a
fix re-runs the pre-fix CI forever, and the error tells you which snapshot it is
stuck on. This is *not* base staleness:
[#5455](https://github.com/facebook/astryx/pull/5455) is 25 commits behind main
and green, because it was pushed after the last fix landed; the failing PRs are
10–14 behind. Any push refreshes the snapshot — merging main is just one kind of
push.

So the backlog drains itself as people push. The defect worth fixing is that a
wiring change to a CI artifact can redden a gate at all.

<details>
<summary>The two <code>digest-mismatch: error</code> lines are a red herring</summary>

They are `actions/download-artifact@v8` echoing its own `digest-mismatch` input
(default `error`) in the `with:` block it prints before every download. Nothing
mismatched — both digests verified. The lines are worth exactly one thing:
**count them.** Two means the run is on the pre-#5477 workflow; three means
post-#5477. Not ours to fix, and nothing in this PR touches it.
</details>

## Solution

Four decisions:

- **The gate builds what it cannot import, instead of throwing.** Core first,
  since every built theme imports it; then only the themes actually missing.
- **Per-package, not a root `pnpm build`.** The gate needs eight small packages,
  not the whole workspace, and it says which one it is building and why.
- **The error, when a rebuild does not help, says it tried** — and distinguishes
  a broken build from a missing one, which the old message could not.
- **The artifact download is `continue-on-error`.** A crash there happens before
  the gate runs, so the recovery would never get its turn — that is precisely how
  a rename reddened every open component PR.

The artifact stays: it is the fast path. It is now an optimisation rather than a
correctness dependency.

## Impact

Every component PR, contributor and maintainer alike. The gate stops being able
to fail for a reason that is not about the PR.

Already-red PRs are **not** retroactively fixed — nothing landed on `main` can
reach a run frozen to an older merge commit. They go green on their next push.

## API

None. `loadThemeOverrides` gained an optional third parameter as a test seam;
it is an internal CI script with two call sites, both in `gate.mjs`.

## Usage

```js
// production — unchanged
const overrides = await loadThemeOverrides(REPO_ROOT, config.probeTheme);

// tests inject the builder instead of spawning pnpm
await loadThemeOverrides(root, 'probe', (_root, pkg) => builds.push(pkg));
```

## Theme targets

None.

## Ossification

The build seam is a third positional parameter on a module under
`.github/scripts/`, imported by one file in this repo and published nowhere. If
it is wrong, changing it costs one call site and a test. Not a class decision —
"inject the expensive side effect" is what the existing `ensureCoreBuilt` helper
does for the same build, and I deliberately did not import that one: it is
declared a test helper and locks against parallel Vitest workers, a hazard the
gate does not have.

## Breaking

- **API** — none.
- **Visual** — none. The gate's verdict is computed from the same theme data.
- **Theme** — none.
- **Behaviour** — one: a gate run that used to abort with "not built" now builds
  and continues. That is the point of the change.

## Performance & resources

Effects: one `pnpm -F <pkg> build` per missing package, on the failure path only.

Measured on this branch, from a fully bare tree (a state CI never actually
reaches, since `build-storybook`'s artifact or the job's own core build normally
covers it):

| starting state | what the gate builds | wall clock |
| --- | --- | --- |
| everything present | nothing | 0s |
| no theme dists | 8 themes | **9.5s** |
| no theme dists, no core dist | core + 8 themes | **20.8s** |

No cost on the happy path — the first import succeeds and nothing is spawned.

## Visual evidence

None; this is CI plumbing and changes no rendered pixel. The evidence is the job
log, in a comment below.

## Judgement

| Slot | Verdict |
| --- | --- |
| Problem | clear |
| Solution | clear |
| Impact | clear |
| API | clear |
| Theme targets | none |
| Ossification | note |
| Breaking | clear |
| Performance | clear |
| Visual evidence | none |

## What I could not verify

- Whether `build-storybook`'s core dist in the artifact is now dead weight.
  [#5482](https://github.com/facebook/astryx/pull/5482) rebuilds core in
  `pr-visual` unconditionally, which makes
  [#5481](https://github.com/facebook/astryx/pull/5481)'s core half redundant —
  ~12s and an artifact's worth of bytes on every component PR. Flagging rather
  than removing: dropping a safety step in a PR about not depending on that step
  is the wrong trade, and it is a clean follow-up.
- Nothing retroactive. The 15 red PRs stay red until each is pushed.
