### PR TITLE
perf(markdown): bound incremental parsing to stream tail

### DIFF
--- a/.changeset/markdown-stream-tail-cache.md
+++ b/.changeset/markdown-stream-tail-cache.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[perf] Markdown streaming now scans and replaces only the mutable tail of an incremental parse. Splitting, fence detection, link-definition collection, and result assembly no longer grow with the already-settled document.
+
+@jiunshinn

--- a/.changeset/markdown-stream-tail-cache.md
+++ b/.changeset/markdown-stream-tail-cache.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[perf] Markdown streaming now parses only the mutable tail of an incremental parse. Splitting, fence detection, link-definition collection, and block re-parsing no longer grow with the already-settled document. The parser contract is unchanged: each call returns a fresh, never-mutated snapshot, and replacing already-settled text still re-parses the document.
+[perf] Markdown streaming bounds four incremental-parse operations by the mutable tail: splitting, fence/boundary detection, link-definition collection, and block re-parsing no longer grow with the already-settled document. The parser contract is unchanged: each call returns a fresh, never-mutated snapshot, and replacing already-settled text still re-parses the document. Two costs intentionally remain proportional to the whole input on each call because that contract requires them — the settled-prefix comparison that detects a replaced document, and the pointer-per-block copy behind each returned snapshot.
 
 @jiunshinn

--- a/.changeset/markdown-stream-tail-cache.md
+++ b/.changeset/markdown-stream-tail-cache.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[perf] Markdown streaming now scans and replaces only the mutable tail of an incremental parse. Splitting, fence detection, link-definition collection, and result assembly no longer grow with the already-settled document.
+[perf] Markdown streaming now parses only the mutable tail of an incremental parse. Splitting, fence detection, link-definition collection, and block re-parsing no longer grow with the already-settled document. The parser contract is unchanged: each call returns a fresh, never-mutated snapshot, and replacing already-settled text still re-parses the document.
 
 @jiunshinn

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -1677,6 +1677,9 @@ export function Markdown({
   // NOTE: must stay above the `display === 'inline'` early return below —
   // hooks cannot be conditional.
   const headingIdMap = useMemo(() => {
+    // Incremental parsing keeps the blocks array stable while replacing its
+    // tail, so streamed text is the version signal for this derived map.
+    void smoothedText;
     if (display === 'inline' || blocks.length === 0) {
       return undefined;
     }
@@ -1689,7 +1692,7 @@ export function Markdown({
       }
     }
     return map;
-  }, [display, blocks]);
+  }, [display, blocks, smoothedText]);
 
   const inlineNodes = useMemo(() => {
     if (display !== 'inline') {
@@ -1713,17 +1716,17 @@ export function Markdown({
     return Math.min(Math.ceil(duration / tickMs), 12);
   }, [token]);
 
-  const prevBlocksRef = useRef<BlockNode[]>([]);
-  const prevInlineNodesRef = useRef<InlineNode[]>([]);
+  const prevTextLengthRef = useRef(0);
   const boundariesRef = useRef<number[]>([]);
   const smoothedLen = smoothedText.length;
   const boundaries = useMemo(() => {
+    void display; // dep trigger when switching inline/block rendering
     void smoothedLen; // dep trigger
-    const prevLen =
-      display === 'inline'
-        ? countInlineTextLength(prevInlineNodesRef.current)
-        : countBlockTextLength(prevBlocksRef.current);
-    const next = computeBoundaries(boundariesRef.current, prevLen, maxSpans);
+    const next = computeBoundaries(
+      boundariesRef.current,
+      prevTextLengthRef.current,
+      maxSpans,
+    );
     boundariesRef.current = next;
     return next;
   }, [display, smoothedLen, maxSpans]);
@@ -1766,9 +1769,8 @@ export function Markdown({
       </span>
     );
 
-    // Store current inline nodes for next render's boundary calculation.
-    prevInlineNodesRef.current = inlineNodes;
-    prevBlocksRef.current = [];
+    // Store current inline length for next render's boundary calculation.
+    prevTextLengthRef.current = countInlineTextLength(inlineNodes);
 
     return renderedInline;
   }
@@ -1810,11 +1812,11 @@ export function Markdown({
     </div>
   );
 
-  // Store current blocks for next render's boundary calculation.
-  // This ref write is safe under StrictMode: both invocations produce the same
-  // blocks (same smoothedText → same useMemo result), so both write the same value.
-  prevBlocksRef.current = blocks;
-  prevInlineNodesRef.current = [];
+  // Store the length rather than the mutable incremental result array: the
+  // parser updates that array's tail in place on the next streamed chunk.
+  // This ref write is safe under StrictMode: both invocations parse the same
+  // smoothedText and therefore write the same value.
+  prevTextLengthRef.current = countBlockTextLength(blocks);
 
   return rendered;
 }

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -1677,9 +1677,6 @@ export function Markdown({
   // NOTE: must stay above the `display === 'inline'` early return below —
   // hooks cannot be conditional.
   const headingIdMap = useMemo(() => {
-    // Incremental parsing keeps the blocks array stable while replacing its
-    // tail, so streamed text is the version signal for this derived map.
-    void smoothedText;
     if (display === 'inline' || blocks.length === 0) {
       return undefined;
     }
@@ -1692,7 +1689,7 @@ export function Markdown({
       }
     }
     return map;
-  }, [display, blocks, smoothedText]);
+  }, [display, blocks]);
 
   const inlineNodes = useMemo(() => {
     if (display !== 'inline') {
@@ -1716,17 +1713,17 @@ export function Markdown({
     return Math.min(Math.ceil(duration / tickMs), 12);
   }, [token]);
 
-  const prevTextLengthRef = useRef(0);
+  const prevBlocksRef = useRef<BlockNode[]>([]);
+  const prevInlineNodesRef = useRef<InlineNode[]>([]);
   const boundariesRef = useRef<number[]>([]);
   const smoothedLen = smoothedText.length;
   const boundaries = useMemo(() => {
-    void display; // dep trigger when switching inline/block rendering
     void smoothedLen; // dep trigger
-    const next = computeBoundaries(
-      boundariesRef.current,
-      prevTextLengthRef.current,
-      maxSpans,
-    );
+    const prevLen =
+      display === 'inline'
+        ? countInlineTextLength(prevInlineNodesRef.current)
+        : countBlockTextLength(prevBlocksRef.current);
+    const next = computeBoundaries(boundariesRef.current, prevLen, maxSpans);
     boundariesRef.current = next;
     return next;
   }, [display, smoothedLen, maxSpans]);
@@ -1769,8 +1766,9 @@ export function Markdown({
       </span>
     );
 
-    // Store current inline length for next render's boundary calculation.
-    prevTextLengthRef.current = countInlineTextLength(inlineNodes);
+    // Store current inline nodes for next render's boundary calculation.
+    prevInlineNodesRef.current = inlineNodes;
+    prevBlocksRef.current = [];
 
     return renderedInline;
   }
@@ -1812,11 +1810,11 @@ export function Markdown({
     </div>
   );
 
-  // Store the length rather than the mutable incremental result array: the
-  // parser updates that array's tail in place on the next streamed chunk.
-  // This ref write is safe under StrictMode: both invocations parse the same
-  // smoothedText and therefore write the same value.
-  prevTextLengthRef.current = countBlockTextLength(blocks);
+  // Store current blocks for next render's boundary calculation.
+  // This ref write is safe under StrictMode: both invocations produce the same
+  // blocks (same smoothedText → same useMemo result), so both write the same value.
+  prevBlocksRef.current = blocks;
+  prevInlineNodesRef.current = [];
 
   return rendered;
 }

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -209,24 +209,52 @@ describe('parseMarkdownIncremental', () => {
     expect(state.settledBlocks).toBe(cachedBlocks);
   });
 
-  it('updates one result array while preserving its immutable block prefix', () => {
+  it('returns a fresh array and leaves earlier snapshots untouched', () => {
     const state = createIncrementalState();
     const first = parseMarkdownIncremental(
       '# Stable\n\nFirst paragraph\n\nTail',
       state,
     );
     const stableHeading = first[0];
+    const snapshot = structuredClone(first);
 
     const second = parseMarkdownIncremental(
       '# Stable\n\nFirst paragraph\n\nTail grows',
       state,
     );
 
-    expect(second).toBe(first);
+    // Call 1's return is a stable snapshot: a later call neither replaces it
+    // in place nor edits the block nodes it holds.
+    expect(second).not.toBe(first);
+    expect(first).toEqual(snapshot);
+    // Settled block objects are reused across calls by reference.
     expect(second[0]).toBe(stableHeading);
     expect(second).toEqual(
       parseMarkdown('# Stable\n\nFirst paragraph\n\nTail grows'),
     );
+  });
+
+  it('re-parses when settled text is replaced at the same length', () => {
+    const state = createIncrementalState();
+    const before = '# Alpha\n\nOld body copy';
+    const after = '# Bravo\n\nNew body copy';
+    expect(after).toHaveLength(before.length);
+
+    parseMarkdownIncremental(before, state);
+    const blocks = parseMarkdownIncremental(after, state);
+
+    expect(blocks).toEqual(parseMarkdown(after));
+  });
+
+  it('re-parses when settled text is replaced by longer content', () => {
+    const state = createIncrementalState();
+    parseMarkdownIncremental('# Alpha\n\nOld body copy', state);
+
+    const after =
+      '# Bravo heading\n\nNew body copy, longer than before\n\nTail';
+    const blocks = parseMarkdownIncremental(after, state);
+
+    expect(blocks).toEqual(parseMarkdown(after));
   });
 
   it('keeps the prefix settled while a long fence streams and closes', () => {

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -209,6 +209,48 @@ describe('parseMarkdownIncremental', () => {
     expect(state.settledBlocks).toBe(cachedBlocks);
   });
 
+  it('updates one result array while preserving its immutable block prefix', () => {
+    const state = createIncrementalState();
+    const first = parseMarkdownIncremental(
+      '# Stable\n\nFirst paragraph\n\nTail',
+      state,
+    );
+    const stableHeading = first[0];
+
+    const second = parseMarkdownIncremental(
+      '# Stable\n\nFirst paragraph\n\nTail grows',
+      state,
+    );
+
+    expect(second).toBe(first);
+    expect(second[0]).toBe(stableHeading);
+    expect(second).toEqual(
+      parseMarkdown('# Stable\n\nFirst paragraph\n\nTail grows'),
+    );
+  });
+
+  it('keeps the prefix settled while a long fence streams and closes', () => {
+    const state = createIncrementalState();
+    const prefix = '# Stable\n\n';
+    const fence = '```ts\nconst a = 1;\n\nconst b = 2;';
+    let stableHeading: BlockNode | undefined;
+
+    for (let end = 1; end <= fence.length; end++) {
+      const blocks = parseMarkdownIncremental(
+        prefix + fence.slice(0, end),
+        state,
+      );
+      stableHeading ??= blocks[0];
+      expect(blocks[0]).toBe(stableHeading);
+      expect(state.settledText).toBe('# Stable');
+    }
+
+    const complete = `${prefix}${fence}\n\`\`\`\n\nAfter`;
+    const blocks = parseMarkdownIncremental(complete, state);
+    expect(blocks[0]).toBe(stableHeading);
+    expect(blocks).toEqual(parseMarkdown(complete));
+  });
+
   it('tracks settledText correctly', () => {
     const state = createIncrementalState();
     parseMarkdownIncremental('# Hello\n\nWorld', state);
@@ -698,5 +740,18 @@ describe('parseMarkdownIncremental link reference definitions', () => {
       state,
     );
     expect(firstLinkHref(after)).toBe('/docs');
+  });
+
+  it('keeps first-definition-wins when definitions move into the settled prefix', () => {
+    const state = createIncrementalState();
+    const first = 'See [d].\n\n[d]: /first\n\nMiddle paragraph\n\n[d]: /second';
+    expect(firstLinkHref(parseMarkdownIncremental(first, state))).toBe(
+      '/first',
+    );
+
+    const complete = `${first}\n\nAfter`;
+    const blocks = parseMarkdownIncremental(complete, state);
+    expect(blocks).toEqual(parseMarkdown(complete));
+    expect(firstLinkHref(blocks)).toBe('/first');
   });
 });

--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -248,7 +248,7 @@ describe('parseMarkdown performance', () => {
 // integers that come out the same on a loaded CI box as on an idle laptop,
 // unlike the wall-clock budgets above.
 describe('parseMarkdownIncremental cache', () => {
-  it('bounds every whole-input operation by the unsettled tail', () => {
+  it('bounds the four measured parser operations by the unsettled tail', () => {
     const section =
       'Fixed-length paragraph with enough text to cross a stream boundary.\n\n';
     const worstWork = (sections: number) => {
@@ -286,14 +286,58 @@ describe('parseMarkdownIncremental cache', () => {
     console.log(
       `  worst tail work (20/200 sections): ${JSON.stringify(short)} / ${JSON.stringify(long)}`,
     );
-    // Ten times the document length does not change splitting, boundary
-    // scanning, definition collection, or per-chunk block construction.
-    // Two whole-prefix operations are deliberately outside these counters
-    // because the public contract requires them and neither parses nor
-    // allocates per settled character: the memcmp-speed prefix comparison
-    // that detects a replaced document, and the pointer-per-block copy that
-    // keeps every returned array a stable snapshot.
+    // Ten times the document length does not change the four operations this
+    // cache bounds: splitting (splitCharacters), boundary/fence scanning
+    // (boundaryLines), definition collection (definitionCharacters), and
+    // per-chunk block construction (renderedBlocks). This is deliberately NOT
+    // a claim about every whole-input operation. Two costs stay linear in the
+    // whole input on every call, by design, and are outside these counters:
+    // the settled-prefix `startsWith` comparison that detects a replaced
+    // document (replacement correctness cannot be decided without reading the
+    // prefix), and the one-pointer-per-block copy that assembles each
+    // returned array (snapshot semantics require a fresh array per call).
+    // Both are tracked — not bounded — by the next test.
     expect(long).toEqual(short);
+  });
+
+  it('tracks the two whole-prefix costs kept linear by the public contract', () => {
+    // Tracked, not bounded. These two operations intentionally remain
+    // proportional to the settled prefix on each call and are OUT of the
+    // scope of the tail-bounding above (see #5406 for the broader issue):
+    //
+    // 1. `prefixCharacters` — the memcmp-speed `startsWith` scan over the
+    //    settled prefix that detects a replaced document. When the check
+    //    passes it inspects exactly the settled prefix, so sampling
+    //    `state.settledText.length` before each call counts it.
+    // 2. `copiedEntries` — one pointer per returned block, copied so every
+    //    call hands back a fresh array that later calls never mutate. The
+    //    returned array's length counts it.
+    //
+    // The totals below grow quadratically across a stream because each call
+    // pays a cost linear in the document parsed so far. They are asserted
+    // exactly so that any change to either cost — bounding it, or accidentally
+    // making it heavier — shows up here and updates this record.
+    const section =
+      'Fixed-length paragraph with enough text to cross a stream boundary.\n\n';
+    const trackedWork = (sections: number) => {
+      const state = createIncrementalState();
+      const tracked = {prefixCharacters: 0, copiedEntries: 0};
+      let input = '';
+      for (let i = 0; i < sections; i++) {
+        input += section;
+        tracked.prefixCharacters += state.settledText.length;
+        tracked.copiedEntries += parseMarkdownIncremental(input, state).length;
+      }
+      return tracked;
+    };
+
+    const short = trackedWork(20);
+    const long = trackedWork(200);
+    console.log(
+      `  tracked whole-prefix work (20/200 sections): ${JSON.stringify(short)} / ${JSON.stringify(long)}`,
+    );
+    expect(short).toEqual({prefixCharacters: 13072, copiedEntries: 210});
+    expect(long).toEqual({prefixCharacters: 1372702, copiedEntries: 20100});
   });
 
   it('builds a bounded number of blocks per chunk however long the document is', () => {

--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -5,6 +5,7 @@ import {
   parseMarkdown,
   parseMarkdownIncremental,
   createIncrementalState,
+  getIncrementalParseWork,
 } from './parser';
 import type {BlockNode, ParseOptions} from './parser';
 
@@ -247,6 +248,49 @@ describe('parseMarkdown performance', () => {
 // integers that come out the same on a loaded CI box as on an idle laptop,
 // unlike the wall-clock budgets above.
 describe('parseMarkdownIncremental cache', () => {
+  it('bounds every whole-input operation by the unsettled tail', () => {
+    const section =
+      'Fixed-length paragraph with enough text to cross a stream boundary.\n\n';
+    const worstWork = (sections: number) => {
+      const state = createIncrementalState();
+      const worst = {
+        splitCharacters: 0,
+        boundaryLines: 0,
+        definitionCharacters: 0,
+        renderedBlocks: 0,
+      };
+      let input = '';
+      for (let i = 0; i < sections; i++) {
+        input += section;
+        parseMarkdownIncremental(input, state);
+        const work = getIncrementalParseWork(state);
+        worst.splitCharacters = Math.max(
+          worst.splitCharacters,
+          work.splitCharacters,
+        );
+        worst.boundaryLines = Math.max(worst.boundaryLines, work.boundaryLines);
+        worst.definitionCharacters = Math.max(
+          worst.definitionCharacters,
+          work.definitionCharacters,
+        );
+        worst.renderedBlocks = Math.max(
+          worst.renderedBlocks,
+          work.renderedBlocks,
+        );
+      }
+      return worst;
+    };
+
+    const short = worstWork(20);
+    const long = worstWork(200);
+    console.log(
+      `  worst tail work (20/200 sections): ${JSON.stringify(short)} / ${JSON.stringify(long)}`,
+    );
+    // Ten times the document length does not change splitting, boundary
+    // scanning, definition collection, or result-array replacement work.
+    expect(long).toEqual(short);
+  });
+
   it('builds a bounded number of blocks per chunk however long the document is', () => {
     const chunkSize = 50;
     const medians = [50, 200, 500].map(paragraphs =>

--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -287,7 +287,12 @@ describe('parseMarkdownIncremental cache', () => {
       `  worst tail work (20/200 sections): ${JSON.stringify(short)} / ${JSON.stringify(long)}`,
     );
     // Ten times the document length does not change splitting, boundary
-    // scanning, definition collection, or result-array replacement work.
+    // scanning, definition collection, or per-chunk block construction.
+    // Two whole-prefix operations are deliberately outside these counters
+    // because the public contract requires them and neither parses nor
+    // allocates per settled character: the memcmp-speed prefix comparison
+    // that detects a replaced document, and the pointer-per-block copy that
+    // keeps every returned array a stable snapshot.
     expect(long).toEqual(short);
   });
 

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -1587,7 +1587,7 @@ type IncrementalWork = {
   readonly boundaryLines: number;
   /** Characters visited while collecting document-global definitions. */
   readonly definitionCharacters: number;
-  /** Entries replaced in the stable result array. */
+  /** Block nodes parsed anew this call (settled delta + unsettled tail). */
   readonly renderedBlocks: number;
 };
 
@@ -1601,9 +1601,6 @@ type IncrementalCache = {
   /** The effective document-global definitions used by slice parses. */
   linkDefs: ReadonlyMap<string, string>;
   linkDefsKey: string;
-  /** Stable array handed back on every call; only its mutable suffix changes. */
-  result: BlockNode[];
-  renderedSettledBlocks: number;
   work: IncrementalWork;
 };
 
@@ -1617,8 +1614,6 @@ function makeIncrementalCache(state: IncrementalState): IncrementalCache {
     tailLinkDefs: new Map(),
     linkDefs: defs,
     linkDefsKey: linkDefsSignature(defs),
-    result: [...state.settledBlocks],
-    renderedSettledBlocks: state.settledBlocks.length,
     work: {
       splitCharacters: 0,
       boundaryLines: 0,
@@ -2052,8 +2047,6 @@ function resetIncrementalCache(
   cache.tailLinkDefs = new Map();
   cache.linkDefs = new Map();
   cache.linkDefsKey = '';
-  cache.result.length = 0;
-  cache.renderedSettledBlocks = 0;
   cache.work = {
     splitCharacters: 0,
     boundaryLines: 0,
@@ -2065,11 +2058,13 @@ function resetIncrementalCache(
 /**
  * Parse one cumulative snapshot of a streaming Markdown document.
  *
- * A state belongs to one stream: callers may rewrite its unsettled tail, but
- * must create a new state before changing text that has already settled. The
- * returned array is likewise owned by that state and updated in place on the
- * next call so work stays proportional to the mutable tail; copy it if a
- * historical snapshot must be retained.
+ * Every call returns a fresh array, and later calls never mutate a
+ * previously returned array or the block nodes inside it, so results are
+ * stable snapshots. Settled block objects are shared across calls by
+ * reference, which is safe because they are replaced — never edited in
+ * place — when adjacent content changes them. When the input no longer
+ * starts with the settled prefix (a replacement rather than an append),
+ * the cache is discarded and the whole document is re-parsed.
  */
 export function parseMarkdownIncremental(
   input: string,
@@ -2103,22 +2098,28 @@ export function parseMarkdownIncremental(
   }
   if (input === '') {
     resetIncrementalCache(state, cache);
-    return cache.result;
+    return [];
   }
 
-  // A state owns one stream. The mutable tail may be rewritten (for example
-  // by trimStreamingArtifacts), but text that has crossed a blank-line
-  // boundary is immutable. A shorter input cannot contain that prefix, so
-  // start a new stream. Callers making an arbitrary document edit likewise
-  // create a fresh state.
-  if (input.length < cache.settledEnd) {
+  // The settled prefix is only reusable while the input still contains it
+  // verbatim. Lengths alone cannot tell: a same-length or longer replacement
+  // (new args after reusing a state) disagrees with the prefix without ever
+  // being shorter, so compare content. `startsWith` is a memcmp-speed scan
+  // with no allocation and is the one whole-prefix operation retained per
+  // call — the contract that a replaced document renders the new content
+  // cannot be honored without looking at the prefix. A shorter input can
+  // never contain the prefix and fails the same check.
+  if (
+    state.settledText.length !== cache.settledEnd ||
+    !input.startsWith(state.settledText)
+  ) {
     resetIncrementalCache(state, cache);
     state.autolink = opts.autolink;
     state.sourceRanges = opts.sourceRanges;
   }
 
-  // All four recurring costs are confined to the mutable suffix: splitting,
-  // fence/boundary detection, definition collection, and result replacement.
+  // The recurring parse costs are confined to the mutable suffix: splitting,
+  // fence/boundary detection, definition collection, and block construction.
   // An open fence simply keeps the suffix growing until its closing marker.
   const oldSettledEnd = cache.settledEnd;
   const tailRaw = input.slice(oldSettledEnd);
@@ -2184,15 +2185,19 @@ export function parseMarkdownIncremental(
     ? unsettledRaw
     : trimUnsettledStructural(unsettledRaw);
 
+  let parsedSettledBlocks = 0;
   if (reparseSettled) {
     state.settledBlocks = state.settledText
       ? parseMarkdownImpl(state.settledText, parseOpts)
       : [];
+    parsedSettledBlocks = state.settledBlocks.length;
   } else if (settledDelta !== '') {
-    appendSettledBlocks(
-      state.settledBlocks,
-      parseMarkdownImpl(settledDelta, atOffset(parseOpts, oldSettledEnd)),
+    const deltaBlocks = parseMarkdownImpl(
+      settledDelta,
+      atOffset(parseOpts, oldSettledEnd),
     );
+    appendSettledBlocks(state.settledBlocks, deltaBlocks);
+    parsedSettledBlocks = deltaBlocks.length;
   }
 
   // The unsettled tail is trimmed before parsing, so its offset in the
@@ -2215,26 +2220,18 @@ export function parseMarkdownIncremental(
 
   state.prevInput = input;
 
-  // Keep the returned array itself stable. At most the previous last settled
-  // block is revisited because it may merge with a same-style list in the
-  // mutable tail; every earlier entry is an immutable prefix.
-  const replaceFrom = reparseSettled
-    ? 0
-    : Math.max(0, cache.renderedSettledBlocks - 1);
-  cache.result.length = replaceFrom;
-  const renderedSuffix = mergeSettledBlocks(
-    state.settledBlocks.slice(replaceFrom),
-    unsettledBlocks,
-  );
-  cache.result.push(...renderedSuffix);
-  cache.renderedSettledBlocks = state.settledBlocks.length;
+  // Snapshot semantics: hand back a fresh array so later calls never mutate
+  // an earlier return. The settled block objects inside it are reused by
+  // reference — they are immutable, so sharing them is what keeps this cheap:
+  // assembling the result copies one pointer per settled block and never
+  // re-visits the settled characters.
   cache.work = {
     splitCharacters: tailRaw.length,
     boundaryLines: tailLines.length,
     definitionCharacters: settledDelta.length + unsettledInput.length,
-    renderedBlocks: renderedSuffix.length,
+    renderedBlocks: parsedSettledBlocks + unsettledBlocks.length,
   };
-  return cache.result;
+  return mergeSettledBlocks(state.settledBlocks, unsettledBlocks);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -1580,8 +1580,82 @@ export interface IncrementalState {
   linkDefsKey?: string;
 }
 
+type IncrementalWork = {
+  /** Characters copied into the tail line array. */
+  readonly splitCharacters: number;
+  /** Tail lines visited by fence and blank-boundary detection. */
+  readonly boundaryLines: number;
+  /** Characters visited while collecting document-global definitions. */
+  readonly definitionCharacters: number;
+  /** Entries replaced in the stable result array. */
+  readonly renderedBlocks: number;
+};
+
+type IncrementalCache = {
+  /** Character offset immediately after the immutable settled prefix. */
+  settledEnd: number;
+  /** Definitions whose complete block is in the settled prefix. */
+  settledLinkDefs: Map<string, string>;
+  /** Definitions still in the mutable tail on the preceding call. */
+  tailLinkDefs: ReadonlyMap<string, string>;
+  /** The effective document-global definitions used by slice parses. */
+  linkDefs: ReadonlyMap<string, string>;
+  linkDefsKey: string;
+  /** Stable array handed back on every call; only its mutable suffix changes. */
+  result: BlockNode[];
+  renderedSettledBlocks: number;
+  work: IncrementalWork;
+};
+
+const incrementalCaches = new WeakMap<IncrementalState, IncrementalCache>();
+
+function makeIncrementalCache(state: IncrementalState): IncrementalCache {
+  const {defs} = extractLinkDefinitions(state.settledText);
+  const cache: IncrementalCache = {
+    settledEnd: state.settledText.length,
+    settledLinkDefs: new Map(defs),
+    tailLinkDefs: new Map(),
+    linkDefs: defs,
+    linkDefsKey: linkDefsSignature(defs),
+    result: [...state.settledBlocks],
+    renderedSettledBlocks: state.settledBlocks.length,
+    work: {
+      splitCharacters: 0,
+      boundaryLines: 0,
+      definitionCharacters: 0,
+      renderedBlocks: 0,
+    },
+  };
+  incrementalCaches.set(state, cache);
+  return cache;
+}
+
 export function createIncrementalState(): IncrementalState {
-  return {prevInput: '', settledText: '', settledBlocks: [], settledUpTo: 0};
+  const state: IncrementalState = {
+    prevInput: '',
+    settledText: '',
+    settledBlocks: [],
+    settledUpTo: 0,
+  };
+  makeIncrementalCache(state);
+  return state;
+}
+
+/**
+ * Deterministic work counters for the most recent incremental parse.
+ * @internal Exported from this module for performance regression tests only.
+ */
+export function getIncrementalParseWork(
+  state: IncrementalState,
+): IncrementalWork {
+  return (
+    incrementalCaches.get(state)?.work ?? {
+      splitCharacters: 0,
+      boundaryLines: 0,
+      definitionCharacters: 0,
+      renderedBlocks: 0,
+    }
+  );
 }
 
 /**
@@ -1912,6 +1986,91 @@ function mergeSettledBlocks(
   return [...prev, ...delta];
 }
 
+/** Append a newly-settled slice without copying the already-settled prefix. */
+function appendSettledBlocks(prev: BlockNode[], delta: BlockNode[]): void {
+  if (delta.length === 0) {
+    return;
+  }
+  if (prev.length === 0) {
+    prev.push(...delta);
+    return;
+  }
+  const prevLast = prev[prev.length - 1];
+  const deltaFirst = delta[0];
+  if (
+    prevLast.type === 'list' &&
+    deltaFirst.type === 'list' &&
+    prevLast.ordered === deltaFirst.ordered &&
+    prevLast.delimiter === deltaFirst.delimiter
+  ) {
+    prev[prev.length - 1] = {
+      type: 'list',
+      ordered: prevLast.ordered,
+      start: prevLast.start,
+      delimiter: prevLast.delimiter,
+      loose: true,
+      items: [...prevLast.items, ...deltaFirst.items],
+      ...(prevLast.range != null && deltaFirst.range != null
+        ? {range: {start: prevLast.range.start, end: deltaFirst.range.end}}
+        : null),
+    };
+    prev.push(...delta.slice(1));
+    return;
+  }
+  prev.push(...delta);
+}
+
+function sameUnsettledDefinitions(
+  previous: ReadonlyMap<string, string>,
+  next: ReadonlyMap<string, string>,
+  settled: ReadonlyMap<string, string>,
+): boolean {
+  for (const [label, destination] of previous) {
+    if (!settled.has(label) && next.get(label) !== destination) {
+      return false;
+    }
+  }
+  for (const [label, destination] of next) {
+    if (!settled.has(label) && previous.get(label) !== destination) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function resetIncrementalCache(
+  state: IncrementalState,
+  cache: IncrementalCache,
+): void {
+  state.prevInput = '';
+  state.settledText = '';
+  state.settledBlocks = [];
+  state.settledUpTo = 0;
+  state.linkDefsKey = undefined;
+  cache.settledEnd = 0;
+  cache.settledLinkDefs.clear();
+  cache.tailLinkDefs = new Map();
+  cache.linkDefs = new Map();
+  cache.linkDefsKey = '';
+  cache.result.length = 0;
+  cache.renderedSettledBlocks = 0;
+  cache.work = {
+    splitCharacters: 0,
+    boundaryLines: 0,
+    definitionCharacters: 0,
+    renderedBlocks: 0,
+  };
+}
+
+/**
+ * Parse one cumulative snapshot of a streaming Markdown document.
+ *
+ * A state belongs to one stream: callers may rewrite its unsettled tail, but
+ * must create a new state before changing text that has already settled. The
+ * returned array is likewise owned by that state and updated in place on the
+ * next call so work stays proportional to the mutable tail; copy it if a
+ * historical snapshot must be retained.
+ */
 export function parseMarkdownIncremental(
   input: string,
   state: IncrementalState,
@@ -1928,6 +2087,9 @@ export function parseMarkdownIncremental(
   arg?: ReadonlySet<string> | ParseOptions,
 ): BlockNode[] {
   const opts = resolveOptions(arg);
+  const cache = incrementalCaches.get(state) ?? makeIncrementalCache(state);
+  let reparseSettled = false;
+
   // Invalidate cache when the autolink or sourceRanges option flips — cached
   // settled blocks were parsed with the previous setting and would otherwise
   // be reused unchanged.
@@ -1935,50 +2097,86 @@ export function parseMarkdownIncremental(
     state.autolink !== opts.autolink ||
     Boolean(state.sourceRanges) !== Boolean(opts.sourceRanges)
   ) {
-    state.prevInput = '';
-    state.settledText = '';
-    state.settledBlocks = [];
-    state.settledUpTo = 0;
+    reparseSettled = true;
     state.autolink = opts.autolink;
     state.sourceRanges = opts.sourceRanges;
   }
   if (input === '') {
-    state.prevInput = '';
-    state.settledText = '';
-    state.settledBlocks = [];
-    state.settledUpTo = 0;
-    state.linkDefsKey = undefined;
-    return [];
+    resetIncrementalCache(state, cache);
+    return cache.result;
   }
 
-  // Link reference definitions are document-global and usually stream in
-  // (as a footer) after the references that use them, so collect them from the
-  // whole input and pass them into every slice parse. When the set changes,
-  // invalidate the settled cache so already-settled references re-resolve.
-  const {defs: linkDefs} = extractLinkDefinitions(input);
-  const linkDefsKey = linkDefsSignature(linkDefs);
-  if (state.linkDefsKey !== linkDefsKey) {
-    state.prevInput = '';
-    state.settledText = '';
-    state.settledBlocks = [];
-    state.settledUpTo = 0;
-    state.linkDefsKey = linkDefsKey;
+  // A state owns one stream. The mutable tail may be rewritten (for example
+  // by trimStreamingArtifacts), but text that has crossed a blank-line
+  // boundary is immutable. A shorter input cannot contain that prefix, so
+  // start a new stream. Callers making an arbitrary document edit likewise
+  // create a fresh state.
+  if (input.length < cache.settledEnd) {
+    resetIncrementalCache(state, cache);
+    state.autolink = opts.autolink;
+    state.sourceRanges = opts.sourceRanges;
   }
+
+  // All four recurring costs are confined to the mutable suffix: splitting,
+  // fence/boundary detection, definition collection, and result replacement.
+  // An open fence simply keeps the suffix growing until its closing marker.
+  const oldSettledEnd = cache.settledEnd;
+  const tailRaw = input.slice(oldSettledEnd);
+  const tailLines = tailRaw.split('\n');
+  const {boundary, openFence} = findSettledBoundary(tailLines);
+  const settledDelta =
+    boundary >= 0 ? tailLines.slice(0, boundary).join('\n') : '';
+  const nextSettledEnd = oldSettledEnd + settledDelta.length;
+  const unsettledInput = input.slice(nextSettledEnd);
+
+  // Promote definitions only when their entire block becomes immutable.
+  // Tail definitions are re-collected because the tail is allowed to change.
+  // Changes that affect the effective set intentionally reparse settled
+  // blocks: document-global references may precede their footer definition.
+  let definitionsChanged = false;
+  if (settledDelta !== '') {
+    const {defs: deltaDefs} = extractLinkDefinitions(settledDelta);
+    for (const [label, destination] of deltaDefs) {
+      if (!cache.settledLinkDefs.has(label)) {
+        cache.settledLinkDefs.set(label, destination);
+        if (cache.linkDefs.get(label) !== destination) {
+          definitionsChanged = true;
+        }
+      }
+    }
+  }
+  const {defs: tailLinkDefs} = extractLinkDefinitions(unsettledInput);
+  if (
+    !sameUnsettledDefinitions(
+      cache.tailLinkDefs,
+      tailLinkDefs,
+      cache.settledLinkDefs,
+    )
+  ) {
+    definitionsChanged = true;
+  }
+  cache.tailLinkDefs = tailLinkDefs;
+
+  if (definitionsChanged) {
+    // Later entries are overwritten, so settled (earlier) definitions win.
+    cache.linkDefs = new Map([...tailLinkDefs, ...cache.settledLinkDefs]);
+    cache.linkDefsKey = linkDefsSignature(cache.linkDefs);
+    reparseSettled = true;
+  }
+  state.linkDefsKey = cache.linkDefsKey;
   const parseOpts: ResolvedOptions =
-    linkDefs.size > 0 ? {...opts, linkDefs} : opts;
+    cache.linkDefs.size > 0 ? {...opts, linkDefs: cache.linkDefs} : opts;
 
-  const lines = input.split('\n');
-  const {boundary, openFence} = findSettledBoundary(lines);
-
-  if (boundary < 0) {
-    // Nothing settled yet — no blank line, or a fence opened before the first
-    // one — so there is no prefix to keep and the whole input is re-parsed.
-    state.prevInput = input;
-    return parseMarkdownImpl(input, parseOpts);
+  if (settledDelta !== '') {
+    state.settledText += settledDelta;
+    state.settledUpTo += settledDelta.split('\n').length - 1;
+    if (oldSettledEnd === 0) {
+      state.settledUpTo++;
+    }
+    cache.settledEnd = nextSettledEnd;
   }
 
-  const settledText = lines.slice(0, boundary).join('\n');
-  const unsettledRaw = lines.slice(boundary).join('\n').trim();
+  const unsettledRaw = unsettledInput.trim();
   // Structural trimming holds back lines that look like an incomplete list or
   // table, which inside a fence is ordinary code: a TypeScript union or a `- `
   // would disappear from the code block as it streams.
@@ -1986,25 +2184,15 @@ export function parseMarkdownIncremental(
     ? unsettledRaw
     : trimUnsettledStructural(unsettledRaw);
 
-  let settledBlocks: BlockNode[];
-
-  if (settledText === state.settledText) {
-    // Settled portion unchanged — reuse cached blocks
-    settledBlocks = state.settledBlocks;
-  } else if (
-    state.settledText.length > 0 &&
-    settledText.startsWith(state.settledText)
-  ) {
-    // Settled portion grew — parse only the new delta
-    const delta = settledText.slice(state.settledText.length);
-    const deltaBlocks = parseMarkdownImpl(
-      delta,
-      atOffset(parseOpts, state.settledText.length),
+  if (reparseSettled) {
+    state.settledBlocks = state.settledText
+      ? parseMarkdownImpl(state.settledText, parseOpts)
+      : [];
+  } else if (settledDelta !== '') {
+    appendSettledBlocks(
+      state.settledBlocks,
+      parseMarkdownImpl(settledDelta, atOffset(parseOpts, oldSettledEnd)),
     );
-    settledBlocks = mergeSettledBlocks(state.settledBlocks, deltaBlocks);
-  } else {
-    // Content before the boundary changed — full re-parse of settled portion
-    settledBlocks = parseMarkdownImpl(settledText, parseOpts);
   }
 
   // The unsettled tail is trimmed before parsing, so its offset in the
@@ -2014,7 +2202,7 @@ export function parseMarkdownIncremental(
   // ranges were asked for: this runs on every streamed chunk.
   const unsettledStart =
     unsettledText && opts.sourceRanges
-      ? input.indexOf(unsettledText, settledText.length)
+      ? input.indexOf(unsettledText, cache.settledEnd)
       : -1;
   const unsettledBlocks = unsettledText
     ? parseMarkdownImpl(
@@ -2025,12 +2213,28 @@ export function parseMarkdownIncremental(
       )
     : [];
 
-  state.settledText = settledText;
-  state.settledBlocks = settledBlocks;
-  state.settledUpTo = boundary;
   state.prevInput = input;
 
-  return mergeSettledBlocks(settledBlocks, unsettledBlocks);
+  // Keep the returned array itself stable. At most the previous last settled
+  // block is revisited because it may merge with a same-style list in the
+  // mutable tail; every earlier entry is an immutable prefix.
+  const replaceFrom = reparseSettled
+    ? 0
+    : Math.max(0, cache.renderedSettledBlocks - 1);
+  cache.result.length = replaceFrom;
+  const renderedSuffix = mergeSettledBlocks(
+    state.settledBlocks.slice(replaceFrom),
+    unsettledBlocks,
+  );
+  cache.result.push(...renderedSuffix);
+  cache.renderedSettledBlocks = state.settledBlocks.length;
+  cache.work = {
+    splitCharacters: tailRaw.length,
+    boundaryLines: tailLines.length,
+    definitionCharacters: settledDelta.length + unsettledInput.length,
+    renderedBlocks: renderedSuffix.length,
+  };
+  return cache.result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- retain the settled character boundary, link-definition layers, and returned block array in a private incremental cache
- split, scan fences/boundaries, and collect definitions only from the mutable tail
- append newly settled blocks to the state-owned array and assemble each returned array as a fresh per-call snapshot (one pointer per block), keeping Markdown heading IDs and fade boundaries correct
- preserve global first-definition-wins behavior, source ranges, loose-list merging, and open fences across chunks

## Root cause and invariant

`parseMarkdownIncremental` cached parsed blocks, but four operations still traversed the cumulative input on every chunk: link-definition extraction, `split('\n')`, settled-boundary/fence detection, and output-array assembly. For a stream delivered in fixed-size chunks, repeating work proportional to the already-settled prefix produces a quadratic total even when only 1–3 blocks are parsed per chunk.

The cache now maintains this invariant for ordinary chunks, scoped to the four measured parser operations:

> Splitting, settled-boundary/fence detection, link-definition collection, and per-chunk block construction are bounded by the mutable suffix after the last settled boundary, independent of the immutable prefix length.

The deterministic regression streams 20 and 200 fixed-size sections and observes the same worst operation counts in both cases:

| operation | 20 sections | 200 sections |
| --- | ---: | ---: |
| split characters | 71 | 71 |
| boundary lines | 5 | 5 |
| definition characters | 71 | 71 |
| rendered suffix blocks | 1 | 1 |

A newly appearing or disappearing document-global link definition remains an intentional exception: it can change references in already-settled blocks, so those blocks must be re-parsed for correctness. Promotion of an unchanged definition from tail to settled state does not invalidate them.

Two whole-input costs remain intentionally out of this PR's scope and stay linear per call: the settled-prefix `startsWith` comparison that detects a replaced document, and the one-pointer-per-block copy that keeps each returned array a stable snapshot. Both are required by the replacement/snapshot contract preserved in the previous review round — replacement correctness cannot be decided without reading the prefix, and snapshot semantics require a fresh array per call. The regression suite now tracks their exact totals (13,072/1,372,702 prefix characters inspected and 210/20,100 entries copied across 20/200 sections) without bounding them, so the remaining costs of #5406 stay visible.

## Benchmark

Best of 5, Node 24, 50-character chunks, same mixed Markdown fixture on the same machine:

| paragraphs | chars | main total | this PR total | main last chunk | this PR last chunk |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 50 | 6,607 | 4.992 ms | 1.506 ms | 0.0545 ms | 0.0025 ms |
| 200 | 26,351 | 65.918 ms | 4.864 ms | 0.2174 ms | 0.0030 ms |
| 500 | 65,951 | 384.394 ms | 10.113 ms | 0.5125 ms | 0.0025 ms |
| 1,000 | 131,915 | 1,490.782 ms | 18.937 ms | 1.0600 ms | 0.0083 ms |

These timings illustrate the change; the operation-count invariant above is the non-flaky regression gate.

## Tests

- `pnpm vitest run packages/core/src/Markdown` — 281 passed
- `pnpm vitest run packages/core/src/Markdown/parser.perf.test.ts --reporter=verbose` — 16 passed
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm lint:strict`
- `pnpm build`

The repository-wide `pnpm test` completed with 12,224 passing tests and 3 unrelated failures in existing CLI case-sensitive discovery/file naming checks and a SideNav focus-timing test; all Markdown projects passed.

References #5406 — this PR bounds the four parsing-side operations; the whole-prefix comparison and per-call snapshot copy described above are intentionally left linear and tracked, so the issue stays open for that remainder.

