### PR TITLE
ci: re-deploy previews from CI artifacts instead of rebuilding

### DIFF
--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -2,9 +2,18 @@
 
 # Re-deploy Preview
 #
-# Manually re-deploys a PR's preview build (Storybook + Sandbox) to GitHub Pages.
-# Uses a retry-based git push instead of peaceiris/actions-gh-pages to avoid
-# concurrency conflicts with the main deploy workflow.
+# Manually re-deploys a PR's preview (Storybook + Sandbox) to GitHub Pages by
+# re-publishing the static artifacts its CI run already built — the same
+# artifacts deploy-preview.yml publishes automatically. Uses a retry-based git
+# push instead of peaceiris/actions-gh-pages to avoid concurrency conflicts
+# with the main deploy workflow.
+#
+# Safety: this NEVER checks out or runs PR-controlled code (mirroring
+# deploy-preview.yml and pr-comment.yml). It locates the PR's latest CI run for
+# its current head commit, downloads the pre-built storybook-<hash> /
+# sandbox-<hash> artifacts, and copies them into gh-pages. If the artifacts
+# have expired past retention, the fix is to re-run CI on the PR (which also
+# re-deploys the preview via deploy-preview.yml) — not to rebuild here.
 
 name: Re-deploy Preview
 
@@ -24,7 +33,7 @@ concurrency:
 
 jobs:
   redeploy-preview:
-    runs-on: 2-core-ubuntu-arm
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       pull-requests: read
@@ -34,40 +43,69 @@ jobs:
       PR_NUMBER: ${{ github.event.inputs.pr_number }}
 
     steps:
-      - name: Get PR head SHA
+      - name: Locate the PR's CI run
         id: pr-info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          HEAD_SHA=$(gh pr view $PR_NUMBER --repo ${{ github.repository }} --json headRefOid --jq '.headRefOid')
+          # The PR number is an operator-typed input — require digits before it
+          # names a gh-pages path.
+          if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "::error::PR number must be numeric, got: $PR_NUMBER"
+            exit 1
+          fi
+
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json headRefOid --jq '.headRefOid')
+          SHORT_HASH="${HEAD_SHA:0:7}"
+
+          # Latest CI run for the PR's current head commit — its artifacts are
+          # what deploy-preview.yml published (or would have published).
+          RUN_ID=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=50" \
+            --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml")][0].id // empty')
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::No CI run found for PR #${PR_NUMBER} head ${HEAD_SHA} — re-run CI on the PR instead."
+            exit 1
+          fi
+
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "short_hash=$SHORT_HASH" >> "$GITHUB_OUTPUT"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout PR head commit
-        uses: actions/checkout@v7
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v8
         with:
-          ref: ${{ steps.pr-info.outputs.head_sha }}
+          name: storybook-${{ steps.pr-info.outputs.short_hash }}
+          path: storybook-dist
+          run-id: ${{ steps.pr-info.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
-      - name: Setup Node and pnpm
-        uses: ./.github/actions/setup
+      - name: Download Sandbox artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: sandbox-${{ steps.pr-info.outputs.short_hash }}
+          path: sandbox-dist
+          run-id: ${{ steps.pr-info.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
-      - name: Build core
-        run: pnpm build
-
-      - name: Build Storybook
-        run: pnpm -F @astryxdesign/storybook build
-
-      - name: Build Sandbox
-        env:
-          # GitHub Pages serves at <owner>.github.io/<repo>/, so the sandbox base
-          # path must include the repo name — otherwise root-absolute asset URLs
-          # drop the /<repo> segment and 404, breaking the preview's styles/JS.
-          SANDBOX_BASE_PATH: /${{ github.event.repository.name }}/pr/${{ github.event.inputs.pr_number }}/sandbox
-        run: pnpm -F @astryxdesign/sandbox build
+      - name: Verify preview artifacts are present
+        run: |
+          # Unlike deploy-preview.yml (best-effort on every CI completion), a
+          # manual re-deploy that can't find its artifacts should fail loudly
+          # with the actionable fix.
+          if [ -d storybook-dist ] && [ -n "$(ls -A storybook-dist 2>/dev/null)" ] && \
+             [ -d sandbox-dist ] && [ -n "$(ls -A sandbox-dist 2>/dev/null)" ]; then
+            exit 0
+          fi
+          echo "::error::Preview artifacts for run ${{ steps.pr-info.outputs.run_id }} are missing or expired — re-run CI on PR #${PR_NUMBER}; deploy-preview will publish the fresh preview automatically."
+          exit 1
 
       - name: Deploy to GitHub Pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Copies pre-built static output only — never builds or runs PR code.
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           MAX_ATTEMPTS=5
           WORK_DIR="$PWD"
@@ -84,9 +122,9 @@ jobs:
 
             rm -rf /tmp/gh-pages/pr/${PR_NUMBER}
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
-            cp -r apps/storybook/dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
+            cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
-            cp -r apps/sandbox/out/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
+            cp -r sandbox-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
 
             cd /tmp/gh-pages
             git add -A


### PR DESCRIPTION
## Summary

Re-deploy Preview checked out the PR head and ran the full monorepo build inside the deploy job — a second build pipeline that has to be kept in sync with ci.yml (Node/pnpm setup, base-path env, build order). deploy-preview.yml already publishes previews by copying the static `storybook-<hash>`/`sandbox-<hash>` artifacts CI built, so this makes the manual re-deploy do exactly the same thing.

## Changes

- Replace the checkout + `pnpm build` + Storybook/Sandbox build steps with: resolve the PR's current head SHA, locate its latest CI run (`actions/runs?head_sha=...` filtered to ci.yml), and download that run's preview artifacts.
- Keep the deploy step byte-identical to deploy-preview.yml's (retry-based gh-pages push, artifact copy only).
- Validate the operator-typed PR number is numeric before it names a gh-pages path.
- Expired/missing artifacts now fail loudly with the actionable fix: re-run CI on the PR, which re-publishes the preview automatically via deploy-preview.yml.
- Runner drops from `2-core-ubuntu-arm` to `ubuntu-slim` — the job no longer builds anything.

## Test plan

- Workflow YAML parses (js-yaml); step outputs wiring checked (`pr-info` → downloads → verify → deploy).
- Confirmed the artifact names match ci.yml's uploads (`storybook-${short_hash}` / `sandbox-${short_hash}`, short hash = first 7 of the PR head SHA) and that CI builds the sandbox with the PR-specific base path, so a republished artifact serves correctly under `/pr/<n>/`.
- Deploy step is unchanged from the version deploy-preview.yml runs on every PR merge-completion, i.e. already exercised in production.

## Notes

- Sibling of #5518: both workflows now source everything from the run/PR payloads plus CI's static artifacts.
- CI-only change: no changeset.
