### PR TITLE
ci: validate Visual Baseline inputs before promotion

### DIFF
--- a/.github/scripts/visual-gate/gate.mjs
+++ b/.github/scripts/visual-gate/gate.mjs
@@ -702,11 +702,22 @@ async function main() {
       const verdict = fs.existsSync(verdictPath)
         ? JSON.parse(fs.readFileSync(verdictPath, 'utf8'))
         : null;
+      // A failed or skipped gate still uploads its capture (if: always()),
+      // and GitHub reports a terminal failure's run as status=completed — the
+      // verdict, not the run state, decides promotability. Never promote a
+      // capture the gate itself could not stand behind.
+      if (verdict && (verdict.status === 'failed' || verdict.status === 'skipped')) {
+        throw new Error(
+          `Refusing to promote from a "${verdict.status}" gate run — promote from a run whose verdict is pass or changed.`,
+        );
+      }
       const requested = flag('keys');
+      // The dispatch form invites "a, b" — trim each key before it meets the
+      // key validation in accept().
       const named =
         !requested || requested === 'all'
           ? Object.keys(currentManifest.shots)
-          : requested.split(',').filter(Boolean);
+          : requested.split(',').map(key => key.trim()).filter(Boolean);
       if (new Set(named).size !== named.length) throw new Error('accept repeats a shot key.');
       const removed = new Set(verdict?.removed ?? []);
       const prune = has('prune') ? named.filter(key => removed.has(key)) : [];

--- a/.github/scripts/visual-gate/lib/baseline.mjs
+++ b/.github/scripts/visual-gate/lib/baseline.mjs
@@ -29,8 +29,12 @@ export const EMPTY_MANIFEST = {version: 1, shots: {}, decisions: []};
  */
 export function readBaseline(baselineDir) {
   const manifestPath = path.join(baselineDir, 'manifest.json');
-  if (!fs.existsSync(manifestPath)) return {manifest: {...EMPTY_MANIFEST}, exists: false};
-  return {manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')), exists: true};
+  if (!fs.existsSync(manifestPath))
+    return {manifest: {...EMPTY_MANIFEST}, exists: false};
+  return {
+    manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+    exists: true,
+  };
 }
 
 /**
@@ -97,7 +101,18 @@ export function accept({
   runId = null,
   prune = [],
 }) {
-  if (!reason?.trim()) throw new Error('accept requires a reason — it is the record of the decision');
+  if (!reason?.trim())
+    throw new Error(
+      'accept requires a reason — it is the record of the decision',
+    );
+  // Shot keys name files inside shots/. A real key is shotKey() output
+  // ([a-zA-Z0-9._-] only, see plan.mjs), never a path — reject anything else
+  // before it is joined into one, whichever manifest or flag it came from.
+  const SHOT_KEY = /^(?!\.+$)[a-zA-Z0-9._-]+$/;
+  const badKey = [...keys, ...prune].find(key => !SHOT_KEY.test(String(key)));
+  if (badKey != null) {
+    throw new Error(`Invalid shot key: ${JSON.stringify(badKey)}`);
+  }
   const {manifest} = readBaseline(baselineDir);
   const shotsDir = path.join(baselineDir, 'shots');
   fs.mkdirSync(shotsDir, {recursive: true});

--- a/.github/scripts/visual-gate/lib/baseline.test.mjs
+++ b/.github/scripts/visual-gate/lib/baseline.test.mjs
@@ -45,17 +45,37 @@ describe('accept', () => {
     expect(() => promote({reason: ' '})).toThrow(/reason/);
   });
 
+  it('refuses keys that are not shot keys — they name files under shots/', () => {
+    // shotKey() output is [a-zA-Z0-9._-] only; anything path-shaped (or
+    // dots-only) must be rejected before it is joined into a path, whichever
+    // list it arrives in.
+    for (const bad of ['../escape', 'a/b', 'a\\b', '..', ' a']) {
+      expect(() => promote({keys: [bad]})).toThrow(/Invalid shot key/);
+      expect(() => promote({keys: [], prune: [bad]})).toThrow(
+        /Invalid shot key/,
+      );
+    }
+  });
+
   it('copies only the named shots into the baseline', () => {
     promote();
-    expect(fs.readFileSync(path.join(baselineDir, 'shots', 'a.png'), 'utf8')).toBe('new-a');
+    expect(
+      fs.readFileSync(path.join(baselineDir, 'shots', 'a.png'), 'utf8'),
+    ).toBe('new-a');
     expect(fs.existsSync(path.join(baselineDir, 'shots', 'b.png'))).toBe(false);
-    expect(Object.keys(readBaseline(baselineDir).manifest.shots)).toEqual(['a']);
+    expect(Object.keys(readBaseline(baselineDir).manifest.shots)).toEqual([
+      'a',
+    ]);
   });
 
   it('records who promoted what, and why', () => {
     promote();
     const [decision] = readBaseline(baselineDir).manifest.decisions;
-    expect(decision).toMatchObject({actor: 'tester', promoted: ['a'], reason: 'Button radius changed on purpose'});
+    expect(decision).toMatchObject({
+      actor: 'tester',
+      promoted: ['a'],
+      reason: 'Button radius changed on purpose',
+    });
   });
 
   it('keeps earlier decisions when promoting again', () => {
@@ -68,13 +88,17 @@ describe('accept', () => {
     promote({keys: ['a', 'b']});
     promote({keys: [], prune: ['b'], reason: 'story deleted'});
     expect(fs.existsSync(path.join(baselineDir, 'shots', 'b.png'))).toBe(false);
-    expect(Object.keys(readBaseline(baselineDir).manifest.shots)).toEqual(['a']);
+    expect(Object.keys(readBaseline(baselineDir).manifest.shots)).toEqual([
+      'a',
+    ]);
   });
 });
 
 describe('incomparable', () => {
   it('refuses a baseline from another platform', () => {
-    expect(incomparable({platform: 'darwin-arm64'}, {platform: 'linux-arm64'})).toMatch(/darwin-arm64/);
+    expect(
+      incomparable({platform: 'darwin-arm64'}, {platform: 'linux-arm64'}),
+    ).toMatch(/darwin-arm64/);
   });
 
   it('refuses a baseline captured at another viewport', () => {

--- a/.github/workflows/visual-baseline.yml
+++ b/.github/workflows/visual-baseline.yml
@@ -55,6 +55,26 @@ jobs:
       - name: Setup Node and pnpm
         uses: ./.github/actions/setup
 
+      - name: Verify the source run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -eu
+          # Promotion pulls shots out of a specific run's capture artifact. The
+          # run id is operator-typed — confirm it names a completed Release Gate
+          # run on main before anything from it is treated as baseline material
+          # (a typo'd id should fail here, not become the baseline).
+          RUN_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}")
+          RUN_PATH=$(printf '%s' "$RUN_JSON" | jq -r '.path')
+          RUN_BRANCH=$(printf '%s' "$RUN_JSON" | jq -r '.head_branch')
+          RUN_STATUS=$(printf '%s' "$RUN_JSON" | jq -r '.status')
+          if [ "$RUN_PATH" != ".github/workflows/release-gate.yml" ] || \
+             [ "$RUN_BRANCH" != "main" ] || [ "$RUN_STATUS" != "completed" ]; then
+            echo "::error::Run ${RUN_ID} is not a completed Release Gate run on main (path=${RUN_PATH}, branch=${RUN_BRANCH}, status=${RUN_STATUS})."
+            exit 1
+          fi
+
       - name: Queue baseline publication
         env:
           GH_TOKEN: ${{ github.token }}
@@ -67,6 +87,22 @@ jobs:
           run-id: ${{ inputs.run_id }}
           github-token: ${{ github.token }}
           path: .visual-run
+
+      - name: Validate the downloaded verdict
+        env:
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -eu
+          # The capture uploads with if: always(), and a terminal gate failure
+          # still reports its run as status=completed — so the run check above
+          # cannot tell a green gate from a failed one. The verdict can: only
+          # a capture the gate stood behind (pass or changed) may become the
+          # baseline. gate.mjs accept enforces the same rule as backstop.
+          STATUS="$(jq -r '.status // "missing"' .visual-run/verdict.json 2>/dev/null || echo missing)"
+          if [ "$STATUS" != "pass" ] && [ "$STATUS" != "changed" ]; then
+            echo "::error::Run ${RUN_ID}'s verdict status is '${STATUS}' — only pass/changed captures may be promoted. Fix or rerun the gate first."
+            exit 1
+          fi
 
       - name: Wait for the baseline publication turn
         env:
@@ -95,11 +131,15 @@ jobs:
         run: node .github/scripts/gh-pages-publisher.mjs release --scope visual-gate/baseline
 
       - name: Summary
+        env:
+          KEYS: ${{ inputs.keys }}
+          RUN_ID: ${{ inputs.run_id }}
+          REASON: ${{ inputs.reason }}
         run: |
           {
             echo "## Visual baseline updated"
             echo ""
-            echo "- promoted: \`${{ inputs.keys }}\`"
-            echo "- from run: ${{ inputs.run_id }}"
-            echo "- reason: ${{ inputs.reason }}"
+            echo "- promoted: \`${KEYS}\`"
+            echo "- from run: ${RUN_ID}"
+            echo "- reason: ${REASON}"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The Visual Baseline promote job took its operator-typed `run_id` straight to `download-artifact`, the shot keys straight into baseline file paths, and any completed run's capture at face value. The capture uploads with `if: always()`, and GitHub reports a terminal gate failure's run as `status=completed`, so a failed gate could replace baseline files. This adds the missing validation on all three.

## Changes

- **Verify the source run** (workflow): the run id must name a completed Release Gate run (`.github/workflows/release-gate.yml`) on `main`, otherwise fail with a clear error.
- **Validate the downloaded verdict** (workflow): after the download, `verdict.json` must have status `pass` or `changed`. A `failed`, `skipped`, missing, unreadable, or unknown verdict fails the job before anything is promoted.
- **`assertPromotableVerdict()`** in `lib/baseline.mjs`: the same rule as a small exported function. `accept()` (the only code that writes baseline files) calls it before touching the baseline, so the boundary also holds for `gate.mjs accept` run by hand or by `visual-baseline-manual`. `gate.mjs accept` reads `verdict.json` with a clear "unreadable" error and passes the verdict through.
- `accept()` validates every promoted and pruned key against the `shotKey()` alphabet (`[a-zA-Z0-9._-]`, not dots-only) before it is joined into a `shots/` path. `shotKey()` can only produce that alphabet, so real keys are unaffected.
- `--keys "a, b"` from the dispatch form is trimmed per key.
- Dispatch inputs route through `env:` in the summary step, matching the Promote step.
- `readBaseline()` deep-copies `EMPTY_MANIFEST`; the shallow spread shared its `shots` object between fresh baselines in one process.

Rebased on current `main`; the canonical-frame and shot-budget behavior in `gate.mjs` is unchanged.

## Test plan

- `lib/baseline.test.mjs`: `assertPromotableVerdict` lets `pass`/`changed` through and refuses `failed`, `skipped`, `null`, `undefined`, non-object, missing/null status, `crashed`, empty, and wrong-case statuses. Through `accept()`, each of those creates no baseline directory, and against an existing baseline neither overwrites a shot, prunes one, nor changes `manifest.json`. Path-shaped and dots-only keys throw for both the promote and prune lists.
- `gate-accept.test.mjs`: drives the real `gate.mjs accept` against a scratch capture. `pass` and `changed` promote; `failed`, `skipped`, missing, non-JSON, no-status, and unknown verdicts exit non-zero with "Refusing to promote" and write nothing. `--keys "a, b"` promotes both.
- Mutation check: removing only the `assertPromotableVerdict` call in `accept()` fails 20 tests; making the guard a no-op fails 35; reverting it to a failed/skipped-only check fails 27 (every missing/unreadable/unknown case); removing the key check or the trim each fails 1.
- Whole `.github/scripts/visual-gate` suite: 19 files, 345 tests pass. `gh-pages-publisher.test.mjs` (which spawns `gate.mjs accept`): 32 pass.
- Workflow YAML parses (js-yaml). The verdict step's shell was exercised locally with bash+jq for pass, changed, failed, skipped, unknown, null/object/numeric status, non-JSON, empty file, and no file: only pass/changed proceed.
- `node --check` on all changed `.mjs` files.

## Notes

- CI-only change: no changeset.
