### PR TITLE
ci: render report fields in the PR comment as literal text

### DIFF
--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -11,6 +11,9 @@
 const fs = require('node:fs');
 const { buildA11ySection } = require('./lib/a11y-format');
 const { buildVisualSection } = require('./lib/visual-format');
+// Report-file strings render as literal inline text, report numbers as
+// numbers — the comment's structure comes only from this file's literals.
+const { inline, num } = require('./lib/report-text');
 
 const args = process.argv.slice(2);
 const getArg = (name) => {
@@ -48,14 +51,17 @@ function getStorybookLink(storybookBaseUrl, storyTitle) {
   // storyTitle may be a single string or an array when multiple story files match
   const title = Array.isArray(storyTitle) ? storyTitle[0] : storyTitle;
   if (!title) return null;
-  // Storybook converts "Core/XDSButton" to "core-xdsbutton" as the story ID prefix
-  const storyPath = title.toLowerCase().replace(/\//g, '-');
+  // Storybook converts "Core/XDSButton" to "core-xdsbutton" as the story ID
+  // prefix. Story ids only ever contain [a-z0-9_-]; the title came from a
+  // report file, so drop anything outside that alphabet before it lands in
+  // the href.
+  const storyPath = title.toLowerCase().replace(/\//g, '-').replace(/[^a-z0-9_-]/g, '');
   return `${storybookBaseUrl}?path=/docs/${storyPath}--docs`;
 }
 
 // Build an external link that opens in a new tab
 function extLink(text, url) {
-  return `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+  return `<a href="${String(url).replace(/"/g, '%22')}" target="_blank" rel="noopener noreferrer">${text}</a>`;
 }
 
 // Build component stats section
@@ -66,16 +72,16 @@ if (analysis.newComponents && analysis.newComponents.length > 0) {
     const stats = analysis.componentStats[comp] || {};
     const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
     const sbBadge = sbLink ? ` · ${extLink('View in Storybook', sbLink)}` : '';
-    const pkgBadge = stats.package ? ` <sub>(${stats.package})</sub>` : '';
-    componentSection += `<details>\n<summary><strong>${comp}</strong>${pkgBadge}${sbBadge}</summary>\n\n`;
+    const pkgBadge = stats.package ? ` <sub>(${inline(stats.package)})</sub>` : '';
+    componentSection += `<details>\n<summary><strong>${inline(comp)}</strong>${pkgBadge}${sbBadge}</summary>\n\n`;
     componentSection += `| Metric | Value |\n|--------|-------|\n`;
-    componentSection += `| Bundle Size (ESM) | ${stats.esmSize || 'N/A'} |\n`;
-    componentSection += `| Bundle Size (CJS) | ${stats.cjsSize || 'N/A'} |\n`;
-    componentSection += `| Lines of Code | ${stats.linesOfCode || 'N/A'} |\n`;
-    componentSection += `| Source Files | ${stats.fileCount || 'N/A'} |\n`;
-    componentSection += `| Complexity | ${stats.complexityRating || 'N/A'} (${stats.complexity || 0}) |\n`;
-    componentSection += `| Exports | ${stats.exports?.join(', ') || 'N/A'} |\n`;
-    componentSection += `| Props Count | ${stats.propsCount || 'N/A'} |\n`;
+    componentSection += `| Bundle Size (ESM) | ${inline(stats.esmSize) || 'N/A'} |\n`;
+    componentSection += `| Bundle Size (CJS) | ${inline(stats.cjsSize) || 'N/A'} |\n`;
+    componentSection += `| Lines of Code | ${inline(stats.linesOfCode) || 'N/A'} |\n`;
+    componentSection += `| Source Files | ${inline(stats.fileCount) || 'N/A'} |\n`;
+    componentSection += `| Complexity | ${inline(stats.complexityRating) || 'N/A'} (${num(stats.complexity)}) |\n`;
+    componentSection += `| Exports | ${stats.exports?.map(inline).join(', ') || 'N/A'} |\n`;
+    componentSection += `| Props Count | ${inline(stats.propsCount) || 'N/A'} |\n`;
     componentSection += `| Has Tests | ${stats.hasTests ? 'Yes' : 'No'} |\n`;
     componentSection += `| Has Stories | ${stats.hasStories ? 'Yes' : 'No'} |\n`;
     componentSection += `\n</details>\n\n`;
@@ -94,22 +100,22 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
     const newExports = analysis.newExports || [];
     const compExports = stats.exports || [];
     const newInComp = compExports.filter(e => newExports.includes(e));
-    const newBadge = newInComp.length > 0 ? ` · 🆕 ${newInComp.join(', ')}` : '';
-    const pkgBadge = stats.package ? ` <sub>(${stats.package})</sub>` : '';
+    const newBadge = newInComp.length > 0 ? ` · 🆕 ${newInComp.map(inline).join(', ')}` : '';
+    const pkgBadge = stats.package ? ` <sub>(${inline(stats.package)})</sub>` : '';
 
-    componentSection += `<details>\n<summary><strong>${comp}</strong>${pkgBadge}${sbBadge}${newBadge}</summary>\n\n`;
+    componentSection += `<details>\n<summary><strong>${inline(comp)}</strong>${pkgBadge}${sbBadge}${newBadge}</summary>\n\n`;
     componentSection += `| Metric | Before | After | Delta |\n|--------|--------|-------|-------|\n`;
 
-    const esmDelta = stats.esmBytes && baseStats.esmBytes
-      ? (stats.esmBytes - baseStats.esmBytes)
+    const esmDelta = Number.isFinite(Number(stats.esmBytes)) && Number.isFinite(Number(baseStats.esmBytes))
+      ? (Number(stats.esmBytes) - Number(baseStats.esmBytes))
       : null;
     const esmDeltaStr = esmDelta !== null
       ? (esmDelta > 0 ? `+${esmDelta}B` : `${esmDelta}B`)
       : 'N/A';
 
-    componentSection += `| Bundle Size (ESM) | ${baseStats.esmSize || 'N/A'} | ${stats.esmSize || 'N/A'} | ${esmDeltaStr} |\n`;
-    componentSection += `| Lines of Code | ${baseStats.linesOfCode || 'N/A'} | ${stats.linesOfCode || 'N/A'} | - |\n`;
-    componentSection += `| Complexity | ${baseStats.complexityRating || 'N/A'} | ${stats.complexityRating || 'N/A'} (${stats.complexity || 0}) | - |\n`;
+    componentSection += `| Bundle Size (ESM) | ${inline(baseStats.esmSize) || 'N/A'} | ${inline(stats.esmSize) || 'N/A'} | ${esmDeltaStr} |\n`;
+    componentSection += `| Lines of Code | ${inline(baseStats.linesOfCode) || 'N/A'} | ${inline(stats.linesOfCode) || 'N/A'} | - |\n`;
+    componentSection += `| Complexity | ${inline(baseStats.complexityRating) || 'N/A'} | ${inline(stats.complexityRating) || 'N/A'} (${num(stats.complexity)}) | - |\n`;
     componentSection += `\n</details>\n\n`;
   }
 }
@@ -144,7 +150,7 @@ if (bundlePackages.length > 0) {
   bundleSection += `| Package | Size (ESM) | Size (CJS) | Gzipped |\n`;
   bundleSection += `|---------|------------|------------|----------|\n`;
   for (const b of bundlePackages) {
-    bundleSection += `| ${b.package} | ${b.esmSize || 'N/A'} | ${b.cjsSize || 'N/A'} | ${b.gzipSize || 'N/A'} |\n`;
+    bundleSection += `| ${inline(b.package)} | ${inline(b.esmSize) || 'N/A'} | ${inline(b.cjsSize) || 'N/A'} | ${inline(b.gzipSize) || 'N/A'} |\n`;
   }
   bundleSection += `\n`;
 } else {
@@ -152,7 +158,7 @@ if (bundlePackages.length > 0) {
 }
 
 if (analysis.bundleDelta) {
-  const delta = analysis.bundleDelta;
+  const delta = num(analysis.bundleDelta);
   const direction = delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'unchanged';
   bundleSection += `**Bundle size ${direction}:** ${delta > 0 ? '+' : ''}${delta} bytes\n\n`;
 }

--- a/.github/scripts/lib/a11y-format.js
+++ b/.github/scripts/lib/a11y-format.js
@@ -5,6 +5,8 @@
  * Used by generate-pr-comment.js and test-pr-enrichment.js.
  */
 
+const {inline, num, safeUrl} = require('./report-text');
+
 // Impact emoji badges
 const impactEmoji = {
   critical: '🔴',
@@ -69,24 +71,31 @@ function buildA11ySection(a11yReport, storiesAuditedByComponent) {
 
   for (const [compName, compReport] of Object.entries(a11yReport.components || {})) {
     if (compReport.violations?.length > 0) {
-      a11ySection += `<details>\n<summary><strong>${compName}</strong> - ${compReport.violations.length} issue(s)</summary>\n\n`;
+      // Report fields are display data — render them as literal inline text
+      // (rule ids down to their own alphabet, counts as numbers, the help URL
+      // only when it is a plain https URL). See report-text.js.
+      a11ySection += `<details>\n<summary><strong>${inline(compName)}</strong> - ${compReport.violations.length} issue(s)</summary>\n\n`;
       for (const violation of compReport.violations) {
         const emoji = impactEmoji[violation.impact] || '';
         const prefix = emoji ? `${emoji} ` : '';
-        a11ySection += `- ${prefix}**${violation.impact}**: ${violation.description}\n`;
+        a11ySection += `- ${prefix}**${inline(violation.impact)}**: ${inline(violation.description)}\n`;
 
-        // Build detail line: Rule · story count · learn more
-        const detailParts = [`Rule: \`${violation.id}\``];
+        // Build detail line: Rule · story count · learn more. Axe rule ids
+        // are lowercase-alphanumeric-with-dashes; anything else has no
+        // business inside the code span.
+        const ruleId = String(violation.id ?? '').replace(/[^\w-]/g, '');
+        const detailParts = [`Rule: \`${ruleId}\``];
 
         if (violation.storyCount != null && compReport.storiesAudited) {
           detailParts.push(
-            `Affects ${violation.storyCount}/${compReport.storiesAudited} stories`
+            `Affects ${num(violation.storyCount)}/${num(compReport.storiesAudited)} stories`
           );
         }
 
-        if (violation.helpUrl) {
+        const helpUrl = safeUrl(violation.helpUrl);
+        if (helpUrl) {
           detailParts.push(
-            `[Learn more](${violation.helpUrl})`
+            `[Learn more](${helpUrl})`
           );
         }
 

--- a/.github/scripts/lib/a11y-format.test.mjs
+++ b/.github/scripts/lib/a11y-format.test.mjs
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {createRequire} from 'node:module';
+
+const {buildA11ySection, formatWcagTags} = createRequire(import.meta.url)('./a11y-format.js');
+
+const report = (violations) => ({
+  components: {Button: {storiesAudited: 4, violations}},
+});
+
+describe('buildA11ySection', () => {
+  it('says so plainly when there is nothing to report', () => {
+    expect(buildA11ySection({components: {}})).toContain('No accessibility violations detected');
+  });
+
+  it('lists a violation with its rule, story count, and help link', () => {
+    const section = buildA11ySection(
+      report([
+        {
+          impact: 'serious',
+          description: 'Elements must have sufficient color contrast',
+          id: 'color-contrast',
+          storyCount: 2,
+          helpUrl: 'https://dequeuniversity.com/rules/axe/4.10/color-contrast',
+          tags: ['wcag2aa', 'wcag143'],
+        },
+      ]),
+    );
+    expect(section).toContain('**serious**: Elements must have sufficient color contrast');
+    expect(section).toContain('Rule: `color-contrast`');
+    expect(section).toContain('Affects 2/4 stories');
+    expect(section).toContain('[Learn more](https://dequeuniversity.com/rules/axe/4.10/color-contrast)');
+    expect(section).toContain('WCAG: 1.4.3 (Level AA)');
+  });
+
+  it('renders report strings as text, one line, markup kept literal', () => {
+    const section = buildA11ySection(
+      report([
+        {
+          impact: 'minor',
+          description: 'line one\nline two with <em>markup</em> and [brackets]',
+          id: 'rule`odd`name',
+          helpUrl: 'not a url',
+        },
+      ]),
+    );
+    expect(section).toContain('line one line two with &lt;em&gt;markup&lt;/em&gt; and \\[brackets\\]');
+    // Rule ids keep their own alphabet only, so the code span stays a code span.
+    expect(section).toContain('Rule: `ruleoddname`');
+    // A help value that is not a plain https URL renders no link at all.
+    expect(section).not.toContain('Learn more');
+  });
+});
+
+describe('formatWcagTags', () => {
+  it('extracts dotted criteria from axe tags', () => {
+    expect(formatWcagTags(['wcag412', 'wcag2a'])).toBe('WCAG: 4.1.2 (Level A)');
+    expect(formatWcagTags(['wcag1411'])).toBe('WCAG: 1.4.11');
+    expect(formatWcagTags([])).toBe('');
+  });
+});

--- a/.github/scripts/lib/report-text.js
+++ b/.github/scripts/lib/report-text.js
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Render report-file strings as display text in the PR comment.
+ *
+ * The comment's structure — headings, tables, <details>, links — is built
+ * from literals in the generator; strings that arrive via report files
+ * (analysis.json, a11y-report.json, verdict.json) are display data and should
+ * render exactly as written, not as markup. `inline()` keeps such a value on
+ * one line with markdown and HTML characters rendered literally, `num()`
+ * keeps a numeric field numeric, and `safeUrl()` admits only plain absolute
+ * http(s) URLs for the few report fields that become link targets.
+ */
+
+/** One line of literal text: no HTML tags, no markdown structure. */
+function inline(value) {
+  return String(value ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/\s*[\r\n]+\s*/g, ' ')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/[|[\]`*_~]/g, (ch) => `\\${ch}`);
+}
+
+/** A finite number, or the fallback. */
+function num(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * A URL that is safe as a markdown link target or href attribute: absolute
+ * http(s), no whitespace, quotes, angle brackets, parens, or backslashes.
+ * Returns null (drop the link, keep the text) for anything else.
+ */
+function safeUrl(value) {
+  const url = String(value ?? '').trim();
+  return /^https?:\/\/[^\s<>"'()\\]+$/.test(url) ? url : null;
+}
+
+module.exports = {inline, num, safeUrl};

--- a/.github/scripts/lib/report-text.test.mjs
+++ b/.github/scripts/lib/report-text.test.mjs
@@ -1,0 +1,66 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {createRequire} from 'node:module';
+
+const {inline, num, safeUrl} = createRequire(import.meta.url)('./report-text.js');
+
+describe('inline', () => {
+  it('passes ordinary values through', () => {
+    expect(inline('core-button--default')).toBe('core-button--default');
+    expect(inline(42)).toBe('42');
+  });
+
+  it('renders empty for missing values', () => {
+    expect(inline(null)).toBe('');
+    expect(inline(undefined)).toBe('');
+  });
+
+  it('keeps a multi-line value on one line', () => {
+    expect(inline('first\nsecond\r\nthird')).toBe('first second third');
+  });
+
+  it('renders HTML tags as literal text', () => {
+    expect(inline('<b>bold</b>')).toBe('&lt;b&gt;bold&lt;/b&gt;');
+  });
+
+  it('renders markdown punctuation as literal text', () => {
+    expect(inline('a|b')).toBe('a\\|b');
+    expect(inline('`code`')).toBe('\\`code\\`');
+    expect(inline('[text]')).toBe('\\[text\\]');
+    expect(inline('**loud**')).toBe('\\*\\*loud\\*\\*');
+  });
+});
+
+describe('num', () => {
+  it('passes finite numbers through', () => {
+    expect(num(7)).toBe(7);
+    expect(num('7')).toBe(7);
+    expect(num(0)).toBe(0);
+  });
+
+  it('falls back for everything else', () => {
+    expect(num('seven')).toBe(0);
+    expect(num(undefined)).toBe(0);
+    expect(num(Infinity, 3)).toBe(3);
+  });
+});
+
+describe('safeUrl', () => {
+  it('accepts a plain absolute URL', () => {
+    expect(safeUrl('https://dequeuniversity.com/rules/axe/4.10/list')).toBe(
+      'https://dequeuniversity.com/rules/axe/4.10/list',
+    );
+    expect(safeUrl('  https://example.com/a?b=c#d  ')).toBe('https://example.com/a?b=c#d');
+  });
+
+  it('rejects anything that is not one', () => {
+    expect(safeUrl('not a url')).toBeNull();
+    expect(safeUrl('ftp://example.com/x')).toBeNull();
+    expect(safeUrl('/relative/path')).toBeNull();
+    expect(safeUrl('https://example.com/a"b')).toBeNull();
+    expect(safeUrl('https://example.com/a)b')).toBeNull();
+    expect(safeUrl('https://example.com/a b')).toBeNull();
+    expect(safeUrl(null)).toBeNull();
+  });
+});

--- a/.github/scripts/lib/visual-format.js
+++ b/.github/scripts/lib/visual-format.js
@@ -5,6 +5,8 @@
  * Used by generate-pr-comment.js and test-pr-enrichment.js.
  */
 
+const {inline, num, safeUrl} = require('./report-text');
+
 /**
  * Build the visual-regression section of the PR comment.
  *
@@ -20,24 +22,27 @@
 function buildVisualSection(verdict, reportUrl) {
   if (!verdict) return '';
 
-  const link = reportUrl
-    ? ` <a href="${reportUrl}" target="_blank" rel="noopener noreferrer">View the report</a>`
+  // Verdict fields are report data: render them as literal inline text (and
+  // counts as numbers), never as markup — see report-text.js.
+  const safeReportUrl = reportUrl ? safeUrl(reportUrl) : null;
+  const link = safeReportUrl
+    ? ` <a href="${safeReportUrl}" target="_blank" rel="noopener noreferrer">View the report</a>`
     : '';
 
   if (verdict.status === 'skipped') {
-    return `### Visual Regression\n\n**Status:** Skipped — ${verdict.reason}\n\n`;
+    return `### Visual Regression\n\n**Status:** Skipped — ${inline(verdict.reason)}\n\n`;
   }
   if (verdict.status === 'failed') {
-    return `### Visual Regression\n\n**Status:** ${verdict.counts.failed} shot(s) could not be captured.${link}\n\n`;
+    return `### Visual Regression\n\n**Status:** ${num(verdict.counts?.failed)} shot(s) could not be captured.${link}\n\n`;
   }
   if (!verdict.changes || verdict.changes.length === 0) {
-    const compared = verdict.counts.total - (verdict.counts.added ?? 0);
+    const compared = num(verdict.counts?.total) - num(verdict.counts?.added);
     // A PR-scoped run shoots every story of the touched component in every
     // theme that styles it, which is deeper than the daily gate's baseline
     // reaches — so some shots legitimately have nothing to compare against.
     // Saying "added" there reads as a problem; saying it plainly does not.
-    const unbaselined = verdict.counts?.added
-      ? ` ${verdict.counts.added} shot(s) have no baseline yet and were not compared.`
+    const unbaselined = num(verdict.counts?.added)
+      ? ` ${num(verdict.counts?.added)} shot(s) have no baseline yet and were not compared.`
       : '';
     return `### Visual Regression\n\n**Status:** No visual change across ${compared} compared shot(s).${unbaselined}\n\n`;
   }
@@ -46,7 +51,7 @@ function buildVisualSection(verdict, reportUrl) {
     .slice(0, 20)
     .map(
       change =>
-        `| ${change.component || change.title} | ${change.name} | ${change.theme} | ${change.mode} | ${change.diffPixels.toLocaleString()} |`,
+        `| ${inline(change.component || change.title)} | ${inline(change.name)} | ${inline(change.theme)} | ${inline(change.mode)} | ${num(change.diffPixels).toLocaleString()} |`,
     )
     .join('\n');
   const more =
@@ -56,7 +61,7 @@ function buildVisualSection(verdict, reportUrl) {
 
   return `### Visual Regression
 
-**${verdict.changes.length} of ${verdict.counts.total} shot(s) changed.**${link}
+**${verdict.changes.length} of ${num(verdict.counts?.total)} shot(s) changed.**${link}
 
 A change here is a question, not a failure: check whether the *after* is the
 picture you intended. If it is, say so in the PR — the release gate's baseline

--- a/.github/scripts/lib/visual-format.test.mjs
+++ b/.github/scripts/lib/visual-format.test.mjs
@@ -37,6 +37,33 @@ describe('buildVisualSection', () => {
     expect(section).toContain('900 shots exceeds the 240-shot budget');
   });
 
+  it('renders verdict strings as one-line literal text', () => {
+    const section = buildVisualSection(
+      verdict({status: 'skipped', reason: 'first line\n## not a heading, just <em>text</em>'}),
+    );
+    expect(section).toContain('first line ## not a heading, just &lt;em&gt;text&lt;/em&gt;');
+    expect(section).not.toContain('\n## not a heading');
+  });
+
+  it('keeps a change row a single table row whatever the field contents', () => {
+    const section = buildVisualSection(
+      verdict({
+        counts: {total: 2, unchanged: 1, changed: 1, added: 0, removed: 0, failed: 0},
+        changes: [
+          {component: 'Cell | with pipes', name: 'story\nnewline', theme: 'y2k', mode: 'light', diffPixels: '1234'},
+        ],
+      }),
+    );
+    expect(section).toContain('| Cell \\| with pipes | story newline | y2k | light | 1,234 |');
+  });
+
+  it('drops a report link that is not a plain https URL', () => {
+    const good = buildVisualSection(verdict({status: 'failed', counts: {total: 1, failed: 1}}), 'https://example.com/report');
+    expect(good).toContain('href="https://example.com/report"');
+    const bad = buildVisualSection(verdict({status: 'failed', counts: {total: 1, failed: 1}}), 'report.html" onmouseover="x');
+    expect(bad).not.toContain('View the report');
+  });
+
   it('lists each changed shot with the theme and mode it changed in', () => {
     const section = buildVisualSection(
       verdict({


### PR DESCRIPTION
## Summary

The PR Analysis comment is assembled from report files (`analysis.json`, `a11y-report.json`, `verdict.json`) by string interpolation, so a stray newline, pipe, backtick, or angle bracket in any report string could reshape the comment's own structure — a multi-line a11y description breaks out of its list item, a pipe in a story name adds table cells, a non-URL `helpUrl` makes a broken link. This makes the boundary explicit: comment structure comes only from the generator's literals; report fields render as data.

## Changes

- New `lib/report-text.js` with three helpers: `inline()` (one line, markdown/HTML characters render literally), `num()` (finite number or fallback), `safeUrl()` (plain absolute http(s) URL or `null` → link dropped, text kept).
- Applied at every report-field interpolation in `visual-format.js`, `a11y-format.js`, and `generate-pr-comment.js` (component names/stats, bundle rows, a11y descriptions/rule ids/help links, visual verdict reason/change rows/counts).
- Axe rule ids are reduced to their own `[\w-]` alphabet so the surrounding code span stays a code span; Storybook deep-link paths are reduced to the story-id alphabet before landing in the href.
- `extLink()` percent-encodes quotes in the href attribute.

## Test plan

- 25 tests pass across `report-text.test.mjs` (new), `a11y-format.test.mjs` (new), and `visual-format.test.mjs` (extended): ordinary values render byte-identically; multi-line/markup/pipe-bearing values render one-line and literal; non-URL help/report links are dropped. The literal-rendering cases were confirmed failing before the change.
- End-to-end smoke of `generate-pr-comment.js` with representative fixtures: output for normal inputs is unchanged (story deep link, a11y rows, bundle table all byte-identical).
- `node --check` on all four touched scripts.

## Notes

- CI-scripts-only change: no changeset.
