### PR TITLE
fix(Markdown): apply the URL safety rule to every image path

### DIFF
--- a/.changeset/markdown-image-url-parity.md
+++ b/.changeset/markdown-image-url-parity.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Markdown now applies the same URL safety rule to every image path it parses: reference-style images (`![alt][label]` and the shortcut form) and standalone block images pass through the check inline images and links already used, and the render-side guard normalizes control characters before testing so both layers see a URL the way a browser will.
+
+@bhamodi

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -561,14 +561,19 @@ const headingStyles = {
 const DANGEROUS_URL_PATTERN = /^(javascript|data|vbscript):/i;
 
 function sanitizeUrl(url: string): string | null {
-  const trimmed = url.trim();
-  if (trimmed.length === 0) {
+  // Strip control characters before testing, the same normalization the
+  // parser's isSafeUrl applies — the anchored pattern must see the URL the
+  // way a browser will. Return the normalized value so the stripped
+  // characters don't ride along into an attribute or component override.
+  // eslint-disable-next-line no-control-regex -- control chars are the bypass
+  const normalized = url.replace(/[\x00-\x1f\x7f]/g, '').trim();
+  if (normalized.length === 0) {
     return null;
   }
-  if (DANGEROUS_URL_PATTERN.test(trimmed)) {
+  if (DANGEROUS_URL_PATTERN.test(normalized)) {
     return null;
   }
-  return trimmed;
+  return normalized;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/Markdown/parser.test.ts
+++ b/packages/core/src/Markdown/parser.test.ts
@@ -454,6 +454,14 @@ describe('parseMarkdown', () => {
     }
   });
 
+  it('rejects a standalone image with an unsafe scheme as literal text (XSS prevention)', () => {
+    // Same rule as inline images: the line falls through to the paragraph
+    // path and stays literal text instead of becoming an image node.
+    const result = parseMarkdown('![alt](vbscript:msgbox)');
+    expect(result[0].type).toBe('paragraph');
+    expect(JSON.stringify(result)).not.toContain('"type":"image"');
+  });
+
   it('parses complex AI response', () => {
     const input = [
       '# Analysis',
@@ -1148,6 +1156,31 @@ describe('link reference definitions', () => {
   it('resolves a reference image `![alt][label]`', () => {
     const {links} = paragraphLinks('![logo][l]\n\n[l]: /logo.png');
     expect(links).toEqual([{type: 'image', src: '/logo.png', text: 'logo'}]);
+  });
+
+  it('rejects a reference image whose definition has an unsafe scheme (XSS prevention)', () => {
+    const {links} = paragraphLinks('![logo][l]\n\n[l]: <javascript:alert(1)>');
+    expect(links).toEqual([]);
+  });
+
+  it('rejects a shortcut reference image with an unsafe definition (XSS prevention)', () => {
+    const {links} = paragraphLinks('![logo]\n\n[logo]: <javascript:alert(1)>');
+    expect(links).toEqual([]);
+  });
+
+  it('rejects definitions that hide the scheme behind control chars (XSS prevention)', () => {
+    // isSafeUrl strips control characters before testing; the angle-bracket
+    // destination form is the only definition shape that can contain them.
+    // Both consumers of a definition — reference images and reference links —
+    // must apply it.
+    const {links: imageLinks} = paragraphLinks(
+      '![logo][l]\n\n[l]: <java\tscript:alert(1)>',
+    );
+    expect(imageLinks).toEqual([]);
+    const {links: refLinks} = paragraphLinks(
+      '[click][l]\n\n[l]: <java\tscript:alert(1)>',
+    );
+    expect(refLinks).toEqual([]);
   });
 
   it('does not treat a whitespace-only second label as collapsed', () => {

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -369,7 +369,7 @@ function matchReferenceImage(
       const rawLabel = text.slice(altClose + 2, labelClose);
       const label = rawLabel === '' ? alt : rawLabel;
       const src = linkDefs.get(normalizeLinkLabel(label));
-      if (src != null) {
+      if (src != null && isSafeUrl(src)) {
         return {node: {type: 'image', src, alt}, end: labelClose + 1};
       }
       // No match — fall back to a shortcut `![alt]`.
@@ -379,7 +379,7 @@ function matchReferenceImage(
     return null;
   }
   const src = linkDefs.get(normalizeLinkLabel(alt));
-  if (src == null) {
+  if (src == null || !isSafeUrl(src)) {
     return null;
   }
   return {node: {type: 'image', src, alt}, end: altClose + 1};
@@ -1416,8 +1416,14 @@ function parseMarkdownImpl(
     }
 
     // --- Standalone image ---
+    // An unsafe src falls through to the paragraph path and renders as
+    // literal text, the same rule the inline image path applies.
     const imageMatch = line.match(/^!\[([^\]]*)\]\(([^)]+)\)/);
-    if (imageMatch && line.trim() === imageMatch[0]) {
+    if (
+      imageMatch &&
+      line.trim() === imageMatch[0] &&
+      isSafeUrl(imageMatch[2])
+    ) {
       pushBlock({type: 'image', alt: imageMatch[1], src: imageMatch[2]});
       index++;
       continue;


### PR DESCRIPTION
## Summary

The Markdown parser checks every link destination with `isSafeUrl` — inline, reference (full/collapsed/shortcut), and autolinks — and inline image srcs too. But reference-style images (`![alt][label]`, `![alt]`) and standalone block images emitted their src without it. This routes those three emit sites through the same check, and normalizes control characters in the render-side `sanitizeUrl` the way `isSafeUrl` already does, so both layers apply one rule and see a URL the way a browser will.

## Changes

- `matchReferenceImage`: both emit sites now require `isSafeUrl(src)`, mirroring `matchReferenceLink` (parser.ts:295).
- Standalone block image branch: unsafe srcs fall through to the paragraph path and render as literal text — the same behavior as an unsafe inline image or link.
- `sanitizeUrl` (Markdown.tsx) strips `[\x00-\x1f\x7f]` before testing (the normalization `isSafeUrl` performs, with the same in-code rationale comment) and returns the normalized value, so stripped characters don't ride along into an attribute or a `components.image`/`components.link` override.
- Four new parser tests alongside the existing `(XSS prevention)` cases, covering the reference forms, block images, and control-character normalization for definitions.

## Test plan

- The 4 new tests fail on the previous parser and pass with the change (verified both ways).
- Full Markdown suites: parser 126/126, incremental, streaming, and `Markdown.test.tsx` component tests all green.
- Full `packages/core` suite: 7893/7893 passed.
- Prettier + eslint clean on the changed files.

## Notes

- Changeset included (`@astryxdesign/core` patch).
- Follows the precedent of the existing `isSafeUrl` normalization and its tests — this just closes the asymmetry between the link paths and the image paths.
