### PR TITLE
fix(cli): theme loading resolves from the project and obeys the safe-mode gate

### DIFF
--- a/.changeset/cli-theme-package-names-only.md
+++ b/.changeset/cli-theme-package-names-only.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] CLI theme resolution now resolves packages from the project's node_modules instead of the CLI's own install location, loads file themes through the shared module loader (the documented `{"astryx": {"theme": "./src/theme.ts"}}` setup gains the same jiti path configs use), and obeys the ASTRYX_NO_PROJECT_CODE safe-mode gate: under it no theme module — file or package — is loaded, and the CLI renders theme-less with a one-line notice. Default behavior for every documented setup is unchanged.
+
+@bhamodi

--- a/packages/cli/clients/cli/commands/component/index.mjs
+++ b/packages/cli/clients/cli/commands/component/index.mjs
@@ -7,9 +7,7 @@
  */
 
 import {findCoreDir} from '../../../../foundation/fs/paths.mjs';
-import {
-  resolveImportPath,
-} from '../../../../foundation/discovery/component-discovery.mjs';
+import {resolveImportPath} from '../../../../foundation/discovery/component-discovery.mjs';
 import {
   formatFull,
   formatCompact,
@@ -20,7 +18,15 @@ import {
 import {resolveTheme} from '../../lib/resolve-theme.mjs';
 import {getCliInvocation} from '../../../../foundation/env/package-manager.mjs';
 import {jsonOut} from '../../../../foundation/response/json.mjs';
-import {emit, section, text, list, record, records, code} from '../../formatters/index.mjs';
+import {
+  emit,
+  section,
+  text,
+  list,
+  record,
+  records,
+  code,
+} from '../../formatters/index.mjs';
 import {cliError} from '../../lib/cli-error.mjs';
 import {defineCommand} from '../../lib/define-command.mjs';
 import {ERROR_CODES} from '../../../../foundation/response/error-codes.mjs';
@@ -52,7 +58,10 @@ import {doc as componentFn} from '../../../../api/component/component.doc.mjs';
 export function registerComponent(program) {
   defineCommand(program, componentCommand, {
     fn: componentFn,
-    action: async (/** @type {string | undefined} */ name, /** @type {{list?: boolean, category?: string, props?: boolean, source?: boolean, showcase?: boolean, blocks?: boolean, package?: string}} */ options) => {
+    action: async (
+      /** @type {string | undefined} */ name,
+      /** @type {{list?: boolean, category?: string, props?: boolean, source?: boolean, showcase?: boolean, blocks?: boolean, package?: string}} */ options,
+    ) => {
       const run = getCliInvocation();
       const zh = program.opts().zh || false;
       const dense = program.opts().dense || false;
@@ -67,7 +76,10 @@ export function registerComponent(program) {
 
       const validDetails = ['full', 'compact', 'brief'];
       if (!validDetails.includes(detail)) {
-        cliError(`Invalid --detail value "${detail}". Valid levels: ${validDetails.join(', ')}`, {code: ERROR_CODES.ERR_INVALID_DETAIL});
+        cliError(
+          `Invalid --detail value "${detail}". Valid levels: ${validDetails.join(', ')}`,
+          {code: ERROR_CODES.ERR_INVALID_DETAIL},
+        );
         return;
       }
 
@@ -84,20 +96,25 @@ export function registerComponent(program) {
       /** @type {ComponentResult} */
       let result;
       try {
-        result = /** @type {ComponentResult} */ (await componentApi(name, {
-          cwd: process.cwd(),
-          list: options.list,
-          category: options.category,
-          package: options.package,
-          props: options.props,
-          source: options.source,
-          showcase: options.showcase,
-          blocks: options.blocks,
-          detail,
-          lang, zh, dense,
-        }));
+        result = /** @type {ComponentResult} */ (
+          await componentApi(name, {
+            cwd: process.cwd(),
+            list: options.list,
+            category: options.category,
+            package: options.package,
+            props: options.props,
+            source: options.source,
+            showcase: options.showcase,
+            blocks: options.blocks,
+            detail,
+            lang,
+            zh,
+            dense,
+          })
+        );
       } catch (e) {
-        const err = /** @type {import('../../../../api/error.mjs').AstryxError} */ (e);
+        const err =
+          /** @type {import('../../../../api/error.mjs').AstryxError} */ (e);
         cliError(err.message, {suggestions: err.suggestions, code: err.code});
         return;
       }
@@ -108,7 +125,7 @@ export function registerComponent(program) {
       // The api layer already resolved against core (result exists), so core is
       // present on this path; narrow away the null branch findCoreDir allows.
       const coreDir = /** @type {string} */ (findCoreDir(process.cwd()));
-      const themeData = resolveTheme(process.cwd());
+      const themeData = await resolveTheme(process.cwd());
 
       // Footer shared by the compact + names list views (prose → text()).
       const listFooter = text(
@@ -139,9 +156,13 @@ export function registerComponent(program) {
             for (const [cat, items] of entries) {
               // Skip the synthetic group header when there's only one ungrouped category
               const isUngrouped =
-                entries.length === 1 && items.length === 1 && items[0]?.name === cat;
+                entries.length === 1 &&
+                items.length === 1 &&
+                items[0]?.name === cat;
               if (!isUngrouped) out.push(section(cat));
-              out.push(records(items, {fields: ['name', 'import', 'description']}));
+              out.push(
+                records(items, {fields: ['name', 'import', 'description']}),
+              );
             }
             out.push(listFooter);
             emit(...out);
@@ -168,14 +189,19 @@ export function registerComponent(program) {
           const importCell = item => {
             const importPath = resolveImportPath(coreDir, item.name);
             const qualify =
-              item.package !== CORE_PKG || (nameCounts.get(item.name)?.size ?? 0) > 1;
+              item.package !== CORE_PKG ||
+              (nameCounts.get(item.name)?.size ?? 0) > 1;
             return qualify ? `${importPath}  [${item.package}]` : importPath;
           };
 
           const firstGroup = Object.entries(groups)[0];
           const entries =
-            options.category && firstGroup ? firstGroup[1] : Object.values(groups).flat();
-          const sorted = [...entries].sort((a, b) => a.name.localeCompare(b.name));
+            options.category && firstGroup
+              ? firstGroup[1]
+              : Object.values(groups).flat();
+          const sorted = [...entries].sort((a, b) =>
+            a.name.localeCompare(b.name),
+          );
 
           emit(
             options.category && firstGroup
@@ -195,7 +221,11 @@ export function registerComponent(program) {
           const importHint = resolveImportPath(coreDir, resolvedName);
           const doc =
             detail === 'brief'
-              ? code(formatBrief(result.data, resolvedName, importHint, {themeData}))
+              ? code(
+                  formatBrief(result.data, resolvedName, importHint, {
+                    themeData,
+                  }),
+                )
               : detail === 'compact'
                 ? code(formatCompact(result.data, resolvedName, importHint))
                 : code(formatFull(result.data, {themeData, importHint}));
@@ -203,7 +233,8 @@ export function registerComponent(program) {
           emit(
             doc,
             related.length > 0 && section('Related block templates'),
-            related.length > 0 && records(related, {fields: ['dirName', 'description']}),
+            related.length > 0 &&
+              records(related, {fields: ['dirName', 'description']}),
           );
           break;
         }
@@ -242,7 +273,9 @@ export function registerComponent(program) {
           }
           if (related.length > 0) {
             out.push(
-              section(`Related: ${related.length} blocks that use ${result.data.component}`),
+              section(
+                `Related: ${related.length} blocks that use ${result.data.component}`,
+              ),
               list(related.map(b => b.name)),
             );
           }
@@ -257,11 +290,27 @@ export function registerComponent(program) {
   });
 }
 
-
 // Re-export lib functions for backward compatibility
 // (agent-docs.mjs, tests, and generate-skill-doc.sh import from here)
-export {discoverComponents, discoverExternalComponentsGrouped, findComponentReadme, findComponentSource, findExternalComponentDoc, resolveImportPath} from '../../../../foundation/discovery/component-discovery.mjs';
+export {
+  discoverComponents,
+  discoverExternalComponentsGrouped,
+  findComponentReadme,
+  findComponentSource,
+  findExternalComponentDoc,
+  resolveImportPath,
+} from '../../../../foundation/discovery/component-discovery.mjs';
 export {discoverExternalPackages} from '../../../../foundation/fs/paths.mjs';
 export {loadDocs} from '../../../../foundation/discovery/component-loader.mjs';
-export {formatFull, formatCompact, formatBrief, formatProps, formatBriefAll} from '../../lib/component-format.mjs';
-export {levenshteinDistance, findClosestComponents, searchComponents} from '../../../../foundation/text/string-utils.mjs';
+export {
+  formatFull,
+  formatCompact,
+  formatBrief,
+  formatProps,
+  formatBriefAll,
+} from '../../lib/component-format.mjs';
+export {
+  levenshteinDistance,
+  findClosestComponents,
+  searchComponents,
+} from '../../../../foundation/text/string-utils.mjs';

--- a/packages/cli/clients/cli/lib/resolve-theme.mjs
+++ b/packages/cli/clients/cli/lib/resolve-theme.mjs
@@ -5,12 +5,21 @@
  *
  * Resolution sources (in priority order):
  * 1. ASTRYX_THEME environment variable
- * 2. xds.theme field in package.json
+ * 2. astryx.theme field in package.json
  *
  * Resolution strategy for the value:
- * - Starts with `.` or `/` → file path relative to cwd
- * - Starts with `@` → npm package (require/import)
+ * - Starts with `.` or `/` → file module relative to cwd (the documented
+ *   `{"astryx": {"theme": "./src/theme.ts"}}` setup — see the theme guide)
+ * - Starts with `@` → npm package, resolved from the project's node_modules
  * - Otherwise → try `@astryxdesign/theme-{name}`, then try as bare package name
+ *
+ * Loading a theme executes it — a file from the checkout directly, a package
+ * via whatever the checkout installed. Both are project code, so both sit
+ * behind the safe-mode gate: under ASTRYX_NO_PROJECT_CODE=1 no theme module
+ * loads at all and the CLI renders theme-less, the same "built-in data only"
+ * contract the rest of the CLI honors. (The variable is read inline here so
+ * this change stands alone; module-loader's projectCodeAllowed reads the same
+ * switch.)
  *
  * Returns the theme object's `variants` and `fonts` if available,
  * or null if no theme is configured or found.
@@ -19,30 +28,33 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {createRequire} from 'node:module';
-
-const _require = createRequire(import.meta.url);
+import {importUserModule} from '../../../foundation/fs/module-loader.mjs';
 
 /**
- * Try to load a module, returning the default export or the module itself.
+ * Try to load a module, returning its namespace. File specifiers go through
+ * the shared user-module loader (which also gives the documented `.ts` setup
+ * the same jiti path configs use); package specifiers resolve with a require
+ * bound to the PROJECT, not to the CLI's own install location, so
+ * `astryx.theme` names packages out of the project's node_modules.
  * Returns null if the module cannot be found.
  * @param {string} specifier
  * @param {string} cwd
- * @returns {unknown}
+ * @returns {Promise<unknown>}
  */
-function tryLoadModule(specifier, cwd) {
+async function tryLoadModule(specifier, cwd) {
   // For relative/absolute paths, resolve against cwd
   if (specifier.startsWith('.') || specifier.startsWith('/')) {
-    const resolved = path.resolve(cwd, specifier);
     try {
-      return _require(resolved);
+      return await importUserModule(path.resolve(cwd, specifier));
     } catch {
       return null;
     }
   }
 
-  // For package specifiers, try require
+  // For package specifiers, require from the project
   try {
-    return _require(specifier);
+    const projectRequire = createRequire(path.join(cwd, 'package.json'));
+    return projectRequire(specifier);
   } catch {
     return null;
   }
@@ -73,7 +85,11 @@ function extractTheme(mod) {
 
   // Check for any export ending in 'Theme'
   for (const key of Object.keys(mod)) {
-    if (key.endsWith('Theme') && typeof mod[key] === 'object' && mod[key]?.name) {
+    if (
+      key.endsWith('Theme') &&
+      typeof mod[key] === 'object' &&
+      mod[key]?.name
+    ) {
       return mod[key];
     }
   }
@@ -82,12 +98,33 @@ function extractTheme(mod) {
 }
 
 /**
+ * A specifier comes from the environment or the checkout's package.json, so
+ * it goes to the terminal with control characters replaced — a newline or an
+ * escape sequence in `astryx.theme` must not write to the operator's TTY.
+ * @param {string} specifier
+ */
+function printable(specifier) {
+  return specifier.replace(/\p{Cc}/gu, '�');
+}
+
+/** Say once per process why a configured theme is not being loaded. */
+let gateNoted = false;
+/** @param {string} specifier */
+function noteThemeSkipped(specifier) {
+  if (gateNoted) return;
+  gateNoted = true;
+  console.warn(
+    `⚠ theme: ASTRYX_NO_PROJECT_CODE=1 — not loading theme "${printable(specifier)}"; rendering without theme data`,
+  );
+}
+
+/**
  * Resolve the active Astryx theme from config and environment.
  *
  * @param {string} [cwd] - Working directory (defaults to process.cwd())
- * @returns {{ variants?: Record<string, string[]>, fonts?: Record<string, string>, name?: string } | null}
+ * @returns {Promise<{ variants?: Record<string, string[]>, fonts?: Record<string, string>, name?: string } | null>}
  */
-export function resolveTheme(cwd = process.cwd()) {
+export async function resolveTheme(cwd = process.cwd()) {
   // 1. Determine theme specifier
   let specifier = process.env.ASTRYX_THEME || null;
 
@@ -112,31 +149,44 @@ export function resolveTheme(cwd = process.cwd()) {
     return null;
   }
 
+  // Any theme module is project code — a checkout file or a package the
+  // checkout installed. One safe-mode gate covers both (see file header).
+  if (process.env.ASTRYX_NO_PROJECT_CODE === '1') {
+    noteThemeSkipped(specifier);
+    return null;
+  }
+
   // 2. Resolve the specifier to a module
   let mod;
 
   if (specifier.startsWith('.') || specifier.startsWith('/')) {
     // File path
-    mod = tryLoadModule(specifier, cwd);
+    mod = await tryLoadModule(specifier, cwd);
     if (!mod) {
-      console.warn(`⚠ theme: could not resolve file "${specifier}" from ${cwd}`);
+      console.warn(
+        `⚠ theme: could not resolve file "${printable(specifier)}" from ${cwd}`,
+      );
       return null;
     }
   } else if (specifier.startsWith('@')) {
     // Scoped package
-    mod = tryLoadModule(specifier, cwd);
+    mod = await tryLoadModule(specifier, cwd);
     if (!mod) {
-      console.warn(`⚠ theme: could not resolve package "${specifier}"`);
+      console.warn(
+        `⚠ theme: could not resolve package "${printable(specifier)}"`,
+      );
       return null;
     }
   } else {
     // Convention: try @astryxdesign/theme-{name} first, then bare package
-    mod = tryLoadModule(`@astryxdesign/theme-${specifier}`, cwd);
+    mod = await tryLoadModule(`@astryxdesign/theme-${specifier}`, cwd);
     if (!mod) {
-      mod = tryLoadModule(specifier, cwd);
+      mod = await tryLoadModule(specifier, cwd);
     }
     if (!mod) {
-      console.warn(`⚠ theme: could not resolve "${specifier}" (tried @astryxdesign/theme-${specifier} and ${specifier})`);
+      console.warn(
+        `⚠ theme: could not resolve "${printable(specifier)}" (tried @astryxdesign/theme-${printable(specifier)} and ${printable(specifier)})`,
+      );
       return null;
     }
   }
@@ -144,7 +194,9 @@ export function resolveTheme(cwd = process.cwd()) {
   // 3. Extract theme data
   const theme = extractTheme(mod);
   if (!theme) {
-    console.warn(`⚠ theme: loaded "${specifier}" but could not find a theme object`);
+    console.warn(
+      `⚠ theme: loaded "${printable(specifier)}" but could not find a theme object`,
+    );
     return null;
   }
 

--- a/packages/cli/clients/cli/lib/resolve-theme.test.mjs
+++ b/packages/cli/clients/cli/lib/resolve-theme.test.mjs
@@ -1,47 +1,148 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file Tests for resolveTheme's handling of a malformed `astryx.theme`.
- * The field is user/third-party-controlled config, so a non-string value must
- * degrade to null (like an unknown slug) rather than crash `astryx component`
- * with a raw TypeError from specifier.startsWith(...).
+ * @file Tests for resolveTheme: malformed `astryx.theme` values degrade to
+ * null (the field is user/third-party-controlled config, so a non-string must
+ * not crash `astryx component` with a raw TypeError), the documented file and
+ * package setups load and resolve from the PROJECT, and every theme load —
+ * file or package alike — obeys the ASTRYX_NO_PROJECT_CODE safe-mode gate.
  */
 
-import {describe, it, expect, afterEach} from 'vitest';
+import {describe, it, expect, afterEach, vi} from 'vitest';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import {resolveTheme} from './resolve-theme.mjs';
 
 const dirs = [];
 function fixture(pkg) {
-  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'resolve-theme-'));
+  // Repo-local temp dir: Vite blocks dynamic import from /tmp.
+  const d = fs.mkdtempSync(path.join(process.cwd(), '.astryx-resolve-theme-'));
   dirs.push(d);
   fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify(pkg));
   return d;
 }
 afterEach(() => {
   delete process.env.ASTRYX_THEME;
+  delete process.env.ASTRYX_NO_PROJECT_CODE;
+  delete globalThis.__astryxThemeProbe;
+  vi.restoreAllMocks();
   while (dirs.length) fs.rmSync(dirs.pop(), {recursive: true, force: true});
 });
 
 describe('resolveTheme — malformed astryx.theme degrades to null', () => {
-  it('numeric theme → null', () => {
-    expect(resolveTheme(fixture({astryx: {theme: 123}}))).toBeNull();
+  it('numeric theme → null', async () => {
+    expect(await resolveTheme(fixture({astryx: {theme: 123}}))).toBeNull();
   });
-  it('array theme → null', () => {
-    expect(resolveTheme(fixture({astryx: {theme: ['a']}}))).toBeNull();
+  it('array theme → null', async () => {
+    expect(await resolveTheme(fixture({astryx: {theme: ['a']}}))).toBeNull();
   });
-  it('object theme → null', () => {
-    expect(resolveTheme(fixture({astryx: {theme: {x: 1}}}))).toBeNull();
+  it('object theme → null', async () => {
+    expect(await resolveTheme(fixture({astryx: {theme: {x: 1}}}))).toBeNull();
   });
-  it('boolean theme → null', () => {
-    expect(resolveTheme(fixture({astryx: {theme: true}}))).toBeNull();
+  it('boolean theme → null', async () => {
+    expect(await resolveTheme(fixture({astryx: {theme: true}}))).toBeNull();
   });
-  it('empty-string theme → null', () => {
-    expect(resolveTheme(fixture({astryx: {theme: ''}}))).toBeNull();
+  it('empty-string theme → null', async () => {
+    expect(await resolveTheme(fixture({astryx: {theme: ''}}))).toBeNull();
   });
-  it('no theme field → null', () => {
-    expect(resolveTheme(fixture({name: 'p'}))).toBeNull();
+  it('no theme field → null', async () => {
+    expect(await resolveTheme(fixture({name: 'p'}))).toBeNull();
+  });
+});
+
+describe('resolveTheme — documented setups resolve from the project', () => {
+  /** The theme guide's file setup: astryx.theme names a checkout file. */
+  function fileFixture(themeValue = './theme.mjs') {
+    const d = fixture({astryx: {theme: themeValue}});
+    fs.writeFileSync(
+      path.join(d, 'theme.mjs'),
+      `globalThis.__astryxThemeProbe = true;\nexport default {name: 'file-theme', variants: {button: ['solid']}};\n`,
+    );
+    return d;
+  }
+
+  /** A theme package installed in the PROJECT's node_modules. */
+  function packageFixture() {
+    const d = fixture({astryx: {theme: '@acme/theme'}});
+    const pkgDir = path.join(d, 'node_modules', '@acme', 'theme');
+    fs.mkdirSync(pkgDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@acme/theme',
+        version: '1.0.0',
+        main: 'index.cjs',
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, 'index.cjs'),
+      `globalThis.__astryxThemeProbe = true;\nmodule.exports = {name: 'pkg-theme', variants: {badge: ['dot']}};\n`,
+    );
+    return d;
+  }
+
+  it('loads the documented file setup relative to cwd', async () => {
+    const theme = await resolveTheme(fileFixture());
+    expect(theme?.name).toBe('file-theme');
+    expect(theme?.variants).toEqual({button: ['solid']});
+  });
+
+  it("resolves a package from the project's node_modules, not the CLI's", async () => {
+    // The CLI's own dependency tree has no @acme/theme; only the fixture
+    // project does, so a hit proves project-bound resolution.
+    const theme = await resolveTheme(packageFixture());
+    expect(theme?.name).toBe('pkg-theme');
+  });
+
+  it('still loads a file named via ASTRYX_THEME', async () => {
+    const d = fileFixture();
+    fs.writeFileSync(path.join(d, 'package.json'), JSON.stringify({name: 'p'}));
+    process.env.ASTRYX_THEME = './theme.mjs';
+    const theme = await resolveTheme(d);
+    expect(theme?.name).toBe('file-theme');
+  });
+
+  describe('under ASTRYX_NO_PROJECT_CODE=1 no theme module loads at all', () => {
+    it('file setup: skipped without executing, with a notice', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.ASTRYX_NO_PROJECT_CODE = '1';
+      expect(await resolveTheme(fileFixture())).toBeNull();
+      expect(globalThis.__astryxThemeProbe).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('ASTRYX_NO_PROJECT_CODE'),
+      );
+    });
+
+    it('package setup: skipped without executing', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.env.ASTRYX_NO_PROJECT_CODE = '1';
+      expect(await resolveTheme(packageFixture())).toBeNull();
+      expect(globalThis.__astryxThemeProbe).toBeUndefined();
+    });
+
+    it('ASTRYX_THEME too — the gate wins over the operator variable', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const d = fileFixture();
+      process.env.ASTRYX_THEME = './theme.mjs';
+      process.env.ASTRYX_NO_PROJECT_CODE = '1';
+      expect(await resolveTheme(d)).toBeNull();
+      expect(globalThis.__astryxThemeProbe).toBeUndefined();
+    });
+  });
+});
+
+describe('resolveTheme — specifiers print without control characters', () => {
+  it('a checkout-controlled specifier cannot write escape sequences to the TTY', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // `astryx.theme` comes from the checkout; a newline plus an OSC sequence
+    // would otherwise land raw in the operator's terminal via the warning.
+    const d = fixture({astryx: {theme: '@evil/\u001b]0;owned\u0007\npkg'}});
+    expect(await resolveTheme(d)).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    for (const call of warn.mock.calls) {
+      const message = call.join(' ');
+      expect(message).not.toMatch(/\p{Cc}/u);
+      expect(message).toContain('�');
+    }
   });
 });


### PR DESCRIPTION
## Summary

`resolveTheme()` had two problems: its `createRequire` was bound to the CLI's install location, so package themes resolved from the wrong `node_modules`, and it loaded checkout files on every read command with no way to opt out. This keeps every documented setup working exactly as on main, including the theme guide's `{"astryx": {"theme": "./src/theme.ts"}}`, and puts all theme loading, file and package alike, behind the one safe-mode switch.

## Changes

- File specifiers load through the shared `importUserModule` (the documented `.ts` setup now uses the same jiti path configs do, instead of relying on Node's type stripping).
- Package specifiers resolve with a `createRequire` bound to the project (`<cwd>/package.json`), so `astryx.theme` names packages out of the project's own `node_modules`.
- Both are project code, so both obey `ASTRYX_NO_PROJECT_CODE=1`: no theme module loads (file, package, or `ASTRYX_THEME`), a one-line notice printed once per process explains why, and rendering degrades theme-less. The variable is read inline so this change stands alone; it is the same switch #5531's `projectCodeAllowed` reads.
- Every warning that prints the configured specifier routes it through `printable()`, which replaces control and format characters (`\p{Cc}`, `\p{Cf}`) with U+FFFD, so a checkout-controlled value cannot write escape sequences, newlines, or bidi overrides to the terminal.
- `resolveTheme` is now async; its one call site awaits it.

## Test plan

19 tests in `resolve-theme.test.mjs`, each verified to fail when the guard it protects is removed:

- The documented file setup loads relative to cwd, including `./src/theme.ts` with TypeScript syntax; a child-process test uses an `enum` (rejected by Node's built-in type stripping) so only the shared jiti loader can pass it.
- A package fixture that exists only in the project's `node_modules` resolves (fails against a CLI-bound require).
- `ASTRYX_THEME` still loads.
- Under the gate, file, package, and `ASTRYX_THEME` setups all return null with a probe global proving the module never executed; the notice prints once across repeated reads; any other value of the variable leaves loading on.
- Specifiers carrying OSC/CSI sequences, newlines, CR, and U+202E reach none of the five warn sites unescaped (package, file, bare-name, and gate-notice paths covered).

Also: `clients/cli` lib + component suites green (181 tests), `typecheck:strict`, eslint strict, `check:changesets`, `check:cli-structure`, and a manual run of `astryx component Button` against a fixture project with a `.ts` theme, a project-local package theme, and `ASTRYX_THEME`, each with and without `ASTRYX_NO_PROJECT_CODE=1`.

## Notes

- Pairs with #5531 (the gate for config/doc/integration loads); either merge order works. Whichever lands second can swap the inline env read for `projectCodeAllowed()`.
- `astryx doctor` reports the theme field as "wired" from its static presence; under the gate it is configured but not loaded. A follow-up in #5531 (which already touches doctor) can annotate that state.
- Changeset: `@astryxdesign/cli` patch.
