### PR TITLE
fix(apps): harden the embed theme-sync channel and theme lookups

### DIFF
--- a/apps/docsite/src/app/playground/PlaygroundClient.tsx
+++ b/apps/docsite/src/app/playground/PlaygroundClient.tsx
@@ -255,7 +255,11 @@ export function PlaygroundClient() {
   const searchParams = useSearchParams();
   const rawThemeParam = searchParams.get('theme');
   const themeParam =
-    rawThemeParam && rawThemeParam in themeByValue ? rawThemeParam : null;
+    // Object.hasOwn (not `in`): the param must match a real playground theme,
+    // not an inherited Object.prototype key like "constructor".
+    rawThemeParam && Object.hasOwn(themeByValue, rawThemeParam)
+      ? rawThemeParam
+      : null;
   const theme = themeParam ?? DEFAULT_PLAYGROUND_THEME;
   // The theme that seeds the Theme editor: the ?theme= theme on first load, then
   // whichever theme the user picks from "Themes". Changing it remounts the

--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -309,9 +309,11 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
     if (!iframe?.contentWindow) {
       return;
     }
+    // The iframe is loaded from a relative src, so its origin is our own —
+    // address it explicitly (and the receiver checks the sender's origin too).
     iframe.contentWindow.postMessage(
       {type: 'astryx-theme-sync', theme: themeName, mode},
-      '*',
+      window.location.origin,
     );
   }, [themeName, mode]);
 

--- a/apps/sandbox/src/app/providers.tsx
+++ b/apps/sandbox/src/app/providers.tsx
@@ -79,8 +79,12 @@ function getEmbedThemeParams(): {
   const paramMode = params.get('mode');
 
   return {
+    // Object.hasOwn (not `in`): the lookup must match a sandbox theme, not an
+    // inherited Object.prototype key like "constructor".
     initialTheme:
-      isEmbed && paramTheme && paramTheme in themes ? paramTheme : 'neutral',
+      isEmbed && paramTheme && Object.hasOwn(themes, paramTheme)
+        ? paramTheme
+        : 'neutral',
     initialMode:
       isEmbed && (paramMode === 'light' || paramMode === 'dark')
         ? (paramMode as ThemeMode)
@@ -106,7 +110,7 @@ export function Providers({children}: {children: React.ReactNode}) {
     try {
       const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
       const storedMode = window.localStorage.getItem(MODE_STORAGE_KEY);
-      if (storedTheme && storedTheme in themes) {
+      if (storedTheme && Object.hasOwn(themes, storedTheme)) {
         setThemeName(storedTheme);
       }
       if (storedMode === 'light' || storedMode === 'dark') {
@@ -149,9 +153,15 @@ export function Providers({children}: {children: React.ReactNode}) {
       return;
     }
     const handler = (event: MessageEvent) => {
+      // The shell that embeds the sandbox is same-origin by design
+      // (PreviewShell renders /?embed=1 from a relative src); no other
+      // window gets to drive theme state.
+      if (event.origin !== window.location.origin) {
+        return;
+      }
       if (event.data?.type === 'astryx-theme-sync') {
         const {theme: newTheme, mode: newMode} = event.data;
-        if (newTheme && newTheme in themes) {
+        if (typeof newTheme === 'string' && Object.hasOwn(themes, newTheme)) {
           setThemeName(newTheme);
         }
         if (newMode === 'light' || newMode === 'dark') {


### PR DESCRIPTION
## Summary

Two related hardenings on the sandbox's embed theme-sync channel and the theme-name lookups around it, in the same pattern as #5263's sender checks on the docsite playground channel.

## Changes

- `apps/sandbox/src/app/providers.tsx`: the embed-mode `message` handler now requires `event.origin === window.location.origin` before acting — the shell that embeds the sandbox (`PreviewShell`) loads it from a relative src, so the legitimate sender is always same-origin. The handler's payload check also requires a string theme name.
- `PreviewShell.tsx`: the shell's own postMessage now addresses the iframe's origin explicitly instead of `'*'`.
- Theme-name lookups switched from the `in` operator to `Object.hasOwn` at all four sites (sandbox URL param, localStorage hydration, postMessage handler; docsite playground `?theme=` param). `in` walks the prototype chain, so a value like `constructor` passed validation and fed a non-theme object (`Object` itself) into `<Theme>`, corrupting the render. `Object.hasOwn` admits only real theme names.

## Test plan

- Prettier + eslint clean; `tsc -p apps/sandbox` has an identical error set to main (40 pre-existing in this environment, none in the changed files).
- Behavior unchanged for every real theme name and mode value; prototype-key values now fall back to the default theme exactly like any other unknown name.

## Notes

- Both apps are private (GitHub Pages deploys): no changeset.
