### PR TITLE
fix(cli): ASTRYX_NO_PROJECT_CODE=1 keeps the CLI on built-in data

### DIFF
--- a/.changeset/cli-no-project-code-gate.md
+++ b/.changeset/cli-no-project-code-gate.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] New ASTRYX_NO_PROJECT_CODE=1 gate for running the CLI in checkouts you don't trust (CI, triage, agent runs): a present astryx.config.* is acknowledged and skipped instead of executed, and every other workspace-module import (integration manifests, doc modules, codemods) refuses with an error naming the variable. Default behavior is unchanged.
+
+@bhamodi

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -522,6 +522,22 @@ The config is validated against a strict schema when the CLI loads it, so an
 unknown field is a hard error rather than a silent no-op. `astryx doctor`
 reports whether the config loads cleanly.
 
+### Running in checkouts you don't trust
+
+Loading a config executes it, and so does loading the integration manifests
+and doc modules it leads to — which is what makes the config useful, and also
+means discovery-backed commands run code from whatever checkout they're
+invoked in. For CI, triage, and agent runs over arbitrary checkouts, set:
+
+```bash
+ASTRYX_NO_PROJECT_CODE=1 astryx component Button
+```
+
+Under this gate the CLI runs on built-in data only: a present
+`astryx.config.*` is acknowledged on stderr and skipped, and any command that
+would have to import a workspace module fails with an error naming the
+variable instead of executing it.
+
 ## Core codemod authoring
 
 Core codemods live under `packages/cli/assets/codemods/transforms/`. Released

--- a/packages/cli/api/docs/_adapter.mjs
+++ b/packages/cli/api/docs/_adapter.mjs
@@ -18,7 +18,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL} from 'node:url';
+import {importUserModule} from '../../foundation/fs/module-loader.mjs';
 import {Project} from '../../foundation/config/project.mjs';
 import {
   DocsCatalog,
@@ -55,8 +55,11 @@ export async function loadDocsCatalog(cwd = process.cwd()) {
  * @returns {Promise<import('./docs.type.mjs').DocsDetailResponse['data']>}
  */
 export async function loadReferenceDocs(docPath, {lang} = {}) {
-  const mod = await import(pathToFileURL(docPath).href);
-  const docs = mod.docs ?? mod.default;
+  // Gated loader: built-in topics live under the CLI package and always
+  // load; integration topic modules execute on import and must honor
+  // ASTRYX_NO_PROJECT_CODE.
+  const mod = await importUserModule(docPath);
+  const docs = /** @type {any} */ (mod.docs ?? mod.default);
   if (!lang || lang === 'en') return docs;
 
   const dir = path.dirname(docPath);
@@ -65,8 +68,10 @@ export async function loadReferenceDocs(docPath, {lang} = {}) {
   const translationPath = path.join(dir, `${base}.doc.${locale}.mjs`);
   if (!fs.existsSync(translationPath)) return docs;
 
-  const translationMod = await import(pathToFileURL(translationPath).href);
-  const translation = translationMod.docsZh || translationMod.docsDense;
+  const translationMod = await importUserModule(translationPath);
+  const translation = /** @type {any} */ (
+    translationMod.docsZh || translationMod.docsDense
+  );
   if (!translation) return docs;
 
   // Overlays are keyed to a base section by title (`section`), not by array
@@ -86,7 +91,9 @@ export async function loadReferenceDocs(docPath, {lang} = {}) {
     ...docs,
     description: translation.description || docs.description,
     sections: docs.sections.map(
-      (/** @type {import('@astryxdesign/cli/authoring').ReferenceSection} */ section) => {
+      (
+        /** @type {import('@astryxdesign/cli/authoring').ReferenceSection} */ section,
+      ) => {
         const ts = bySection.get(section.title);
         if (!ts) return section;
         return {
@@ -99,8 +106,10 @@ export async function loadReferenceDocs(docPath, {lang} = {}) {
             ) => {
               const tb = ts.content?.[bi];
               if (!tb) return block;
-              if (tb.type === 'prose' && block.type === 'prose') return {...block, text: tb.text};
-              if (tb.type === 'list' && block.type === 'list') return {...block, items: tb.items};
+              if (tb.type === 'prose' && block.type === 'prose')
+                return {...block, text: tb.text};
+              if (tb.type === 'list' && block.type === 'list')
+                return {...block, items: tb.items};
               return block;
             },
           ),

--- a/packages/cli/api/docs/list/list.mjs
+++ b/packages/cli/api/docs/list/list.mjs
@@ -14,7 +14,7 @@
  * @position Leaf under api/docs. Sibling of detail; both share _adapter.mjs.
  */
 
-import {pathToFileURL} from 'node:url';
+import {importUserModule} from '../../../foundation/fs/module-loader.mjs';
 import {loadDocsCatalog} from '../_adapter.mjs';
 
 /**
@@ -30,7 +30,7 @@ export async function list({cwd} = {}) {
     let description = entry.description ?? '';
     if (entry.description == null) {
       try {
-        const mod = await import(pathToFileURL(entry.path).href);
+        const mod = /** @type {any} */ (await importUserModule(entry.path));
         description = (mod.docs ?? mod.default)?.description ?? '';
       } catch {
         description = '';

--- a/packages/cli/api/doctor/doctor.mjs
+++ b/packages/cli/api/doctor/doctor.mjs
@@ -24,11 +24,25 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {createRequire} from 'node:module';
 
-import {MIN_NODE_VERSION, isNodeVersionSupported} from '../../foundation/env/node-version.mjs';
+import {
+  MIN_NODE_VERSION,
+  isNodeVersionSupported,
+} from '../../foundation/env/node-version.mjs';
+import {
+  importUserModule,
+  projectCodeAllowed,
+} from '../../foundation/fs/module-loader.mjs';
 import {CLI_ROOT, findCoreDir} from '../../foundation/fs/paths.mjs';
-import {detectPackageManager, getCliInvocation} from '../../foundation/env/package-manager.mjs';
+import {
+  detectPackageManager,
+  getCliInvocation,
+} from '../../foundation/env/package-manager.mjs';
 import {findConfigPath, Project} from '../../foundation/config/project.mjs';
-import {semverCompare, isValidSemver, satisfiesRange} from '../../foundation/env/semver.mjs';
+import {
+  semverCompare,
+  isValidSemver,
+  satisfiesRange,
+} from '../../foundation/env/semver.mjs';
 
 const _require = createRequire(import.meta.url);
 
@@ -145,11 +159,13 @@ function findThemePackages(cwd) {
  * @returns {{wired: boolean, source: string|null}}
  */
 function detectThemeWiring(cwd) {
-  if (process.env.ASTRYX_THEME) return {wired: true, source: 'ASTRYX_THEME env var'};
+  if (process.env.ASTRYX_THEME)
+    return {wired: true, source: 'ASTRYX_THEME env var'};
   const nm = findNodeModules(cwd);
   const projectDir = nm ? path.dirname(nm) : cwd;
   const pkg = readPkg(path.join(projectDir, 'package.json'));
-  if (pkg?.astryx?.theme) return {wired: true, source: 'package.json astryx.theme'};
+  if (pkg?.astryx?.theme)
+    return {wired: true, source: 'package.json astryx.theme'};
   return {wired: false, source: null};
 }
 
@@ -192,7 +208,9 @@ export function checkCoreInstalled(ctx) {
       : '@astryxdesign/core could not be resolved from this project.',
     ...(found
       ? {}
-      : {fix: 'Install the design system: `npm install @astryxdesign/core` (or yarn/pnpm/bun).'}),
+      : {
+          fix: 'Install the design system: `npm install @astryxdesign/core` (or yarn/pnpm/bun).',
+        }),
   };
 }
 
@@ -211,7 +229,8 @@ export function checkVersionAlignment(ctx) {
       id: 'version-alignment',
       label: '@astryxdesign/core <-> @astryxdesign/cli alignment',
       status: 'info',
-      message: 'Skipped — could not read both @astryxdesign/core and @astryxdesign/cli versions.',
+      message:
+        'Skipped — could not read both @astryxdesign/core and @astryxdesign/cli versions.',
     };
   }
 
@@ -320,14 +339,28 @@ export async function checkConfig(ctx) {
     };
   }
 
+  // Under the project-code gate the config must not run, doctor included —
+  // report the state instead of executing the file it just said it ignored.
+  if (!projectCodeAllowed()) {
+    return {
+      id: 'config',
+      label: 'astryx.config.mjs',
+      status: 'info',
+      message:
+        'ASTRYX_NO_PROJECT_CODE=1 — config present but not loaded; running on built-in data only.',
+    };
+  }
+
   // Project.load swallows nothing — it surfaces a genuine load failure — but
   // the config check wants to report a bad default export precisely, so we
   // re-import directly to surface a genuine load failure as a FAIL.
   try {
-    const {pathToFileURL} = await import('node:url');
-    const mod = await import(pathToFileURL(ctx.configPath).href);
+    const mod = await importUserModule(ctx.configPath);
     const config = mod.default;
-    if (config !== undefined && (typeof config !== 'object' || config === null)) {
+    if (
+      config !== undefined &&
+      (typeof config !== 'object' || config === null)
+    ) {
       return {
         id: 'config',
         label: 'astryx.config.mjs',
@@ -365,7 +398,9 @@ export function checkAgentDocs(ctx) {
     path.join('.claude', 'CLAUDE.md'),
     '.cursorrules',
   ];
-  const present = candidates.filter(rel => fs.existsSync(path.join(ctx.cwd, rel)));
+  const present = candidates.filter(rel =>
+    fs.existsSync(path.join(ctx.cwd, rel)),
+  );
 
   if (present.length === 0) {
     return {
@@ -381,8 +416,10 @@ export function checkAgentDocs(ctx) {
     try {
       const content = fs.readFileSync(path.join(ctx.cwd, rel), 'utf-8');
       return (
-        (content.includes('<!-- ASTRYX:START -->') || content.includes('<!-- XDS:START -->')) &&
-        (content.includes('<!-- ASTRYX:END -->') || content.includes('<!-- XDS:END -->'))
+        (content.includes('<!-- ASTRYX:START -->') ||
+          content.includes('<!-- XDS:START -->')) &&
+        (content.includes('<!-- ASTRYX:END -->') ||
+          content.includes('<!-- XDS:END -->'))
       );
     } catch {
       return false;
@@ -442,7 +479,9 @@ export function checkPeerDeps(ctx) {
     const want = peers[name];
     let pkgJsonPath;
     try {
-      pkgJsonPath = _require.resolve(`${name}/package.json`, {paths: [ctx.cwd]});
+      pkgJsonPath = _require.resolve(`${name}/package.json`, {
+        paths: [ctx.cwd],
+      });
     } catch {
       // package.json isn't exported — fall back to entry resolution for
       // presence only (we then can't read the version to range-check it).
@@ -475,8 +514,12 @@ export function checkPeerDeps(ctx) {
     // Pin the required range for anything wrong so the hint fixes it even when a
     // stale consumer range would otherwise resolve an incompatible version.
     // Quote targets containing shell metacharacters (e.g. `react@>=19.0.0`).
-    const quote = (/** @type {string} */ s) => (/[<>|() ]/.test(s) ? `'${s}'` : s);
-    const targets = [...missing, ...mismatched.map(m => `${m.name}@${m.want}`)].map(quote);
+    const quote = (/** @type {string} */ s) =>
+      /[<>|() ]/.test(s) ? `'${s}'` : s;
+    const targets = [
+      ...missing,
+      ...mismatched.map(m => `${m.name}@${m.want}`),
+    ].map(quote);
     return {
       id: 'peer-deps',
       label: '@astryxdesign/core peer dependencies',

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -41,15 +41,18 @@
  * queries they have nothing to do with.
  */
 
-import {pathToFileURL} from 'node:url';
 import {findCoreDir} from '../../foundation/fs/paths.mjs';
+import {importUserModule} from '../../foundation/fs/module-loader.mjs';
 import {
   discoverComponents,
   discoverIntegrationComponents,
   findComponentReadme,
   resolveImportPath,
 } from '../../foundation/discovery/component-discovery.mjs';
-import {discoverHooks, findHookDoc} from '../../foundation/discovery/hook-discovery.mjs';
+import {
+  discoverHooks,
+  findHookDoc,
+} from '../../foundation/discovery/hook-discovery.mjs';
 import {loadIntegrationsSafely} from '../component/_adapter.mjs';
 import {levenshteinDistance} from '../../foundation/text/string-utils.mjs';
 import {discoverTemplates, extractComponents} from '../template/template.mjs';
@@ -80,7 +83,17 @@ import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
  * and its siblings). Lowercase, single words or short phrases.
  */
 const SYNONYMS = {
-  dashboard: ['overview', 'analytics', 'kpi', 'kpis', 'metrics', 'stats', 'reporting', 'insights', 'control'],
+  dashboard: [
+    'overview',
+    'analytics',
+    'kpi',
+    'kpis',
+    'metrics',
+    'stats',
+    'reporting',
+    'insights',
+    'control',
+  ],
   login: ['signin', 'auth', 'authentication', 'sso', 'credentials', 'account'],
   signup: ['register', 'registration', 'onboarding'],
   payment: ['checkout', 'billing', 'card', 'pay', 'purchase', 'order'],
@@ -141,7 +154,6 @@ export function stem(w) {
   return s;
 }
 
-
 /** Valid domain filters for `--type`. */
 export const SEARCH_DOMAINS = ['component', 'hook', 'doc', 'template'];
 
@@ -150,12 +162,66 @@ export const SEARCH_DOMAINS = ['component', 'hook', 'doc', 'template'];
  * ("a page where you can see business stats") ranks on its content words.
  */
 const STOPWORDS = new Set([
-  'a', 'an', 'the', 'of', 'for', 'to', 'with', 'and', 'or', 'in', 'on', 'at',
-  'by', 'that', 'this', 'my', 'your', 'our', 'their', 'is', 'are', 'be', 'it',
-  'its', 'as', 'from', 'page', 'screen', 'app', 'application', 'view', 'where',
-  'you', 'can', 'some', 'like', 'just', 'basically', 'kinda', 'want', 'wants',
-  'need', 'needs', 'something', 'thing', 'things', 'build', 'make', 'create',
-  'i', 'me', 'we', 'us', 'so', 'up', 'out', 'over', 'side', 'one', 'big',
+  'a',
+  'an',
+  'the',
+  'of',
+  'for',
+  'to',
+  'with',
+  'and',
+  'or',
+  'in',
+  'on',
+  'at',
+  'by',
+  'that',
+  'this',
+  'my',
+  'your',
+  'our',
+  'their',
+  'is',
+  'are',
+  'be',
+  'it',
+  'its',
+  'as',
+  'from',
+  'page',
+  'screen',
+  'app',
+  'application',
+  'view',
+  'where',
+  'you',
+  'can',
+  'some',
+  'like',
+  'just',
+  'basically',
+  'kinda',
+  'want',
+  'wants',
+  'need',
+  'needs',
+  'something',
+  'thing',
+  'things',
+  'build',
+  'make',
+  'create',
+  'i',
+  'me',
+  'we',
+  'us',
+  'so',
+  'up',
+  'out',
+  'over',
+  'side',
+  'one',
+  'big',
 ]);
 
 /**
@@ -166,12 +232,14 @@ const STOPWORDS = new Set([
  * @returns {string[]}
  */
 export function tokenizeQuery(term) {
-  return term
-    .split(/\s+/)
-    // Strip only leading/trailing punctuation; keep joined identifiers intact
-    // (e.g. "foo_bar" stays one token) so gibberish stays gibberish.
-    .map(t => t.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ''))
-    .filter(t => t.length >= 2 && !STOPWORDS.has(t));
+  return (
+    term
+      .split(/\s+/)
+      // Strip only leading/trailing punctuation; keep joined identifiers intact
+      // (e.g. "foo_bar" stays one token) so gibberish stays gibberish.
+      .map(t => t.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ''))
+      .filter(t => t.length >= 2 && !STOPWORDS.has(t))
+  );
 }
 
 /**
@@ -207,7 +275,8 @@ function bestForToken(tok, candidate) {
       const h = scoreCandidate(s, candidate);
       if (h) {
         const score = Math.round(h.score * 0.85);
-        if (!best || score > best.score) best = {score, reason: `${h.reason} (~${tok})`};
+        if (!best || score > best.score)
+          best = {score, reason: `${h.reason} (~${tok})`};
       }
     }
   }
@@ -227,7 +296,8 @@ export function scoreQuery(term, tokens, candidate) {
   // single words), but if stopwords left exactly one DIFFERENT token (e.g.
   // "pricing page" → "pricing"), score that token too and take the stronger.
   if (tokens.length <= 1) {
-    const single = tokens.length === 1 ? bestForToken(tokens[0], candidate) : null;
+    const single =
+      tokens.length === 1 ? bestForToken(tokens[0], candidate) : null;
     if (full && (!single || full.score >= single.score)) return full;
     return single;
   }
@@ -315,7 +385,11 @@ export function scoreCandidate(
     // Substring (both directions), min 4 chars, >=50% coverage.
     const shorter = term.length < nameLower.length ? term : nameLower;
     const longer = term.length < nameLower.length ? nameLower : term;
-    if (shorter.length >= 4 && longer.includes(shorter) && shorter.length / longer.length >= 0.5) {
+    if (
+      shorter.length >= 4 &&
+      longer.includes(shorter) &&
+      shorter.length / longer.length >= 0.5
+    ) {
       consider(60, `name contains "${shorter}"`);
     }
     const dist = levenshteinDistance(term, nameLower);
@@ -389,7 +463,7 @@ export function scoreCandidate(
  */
 async function loadModuleDoc(docPath, exportName = 'docs') {
   try {
-    const mod = await import(pathToFileURL(docPath).href);
+    const mod = await importUserModule(docPath);
     return mod[exportName] ?? null;
   } catch {
     return null;
@@ -688,10 +762,7 @@ export async function search(query, options = {}) {
   // Validate limit here (not just in the CLI) so direct API callers get the same
   // contract: a non-positive or non-integer limit is an error, never a silent
   // "return everything". (Previously `limit <= 0` fell through to the full set.)
-  if (
-    limit != null &&
-    (!Number.isInteger(limit) || limit <= 0)
-  ) {
+  if (limit != null && (!Number.isInteger(limit) || limit <= 0)) {
     throw new AstryxError(
       `Invalid limit "${limit}". Must be a positive integer.`,
       undefined,
@@ -741,5 +812,8 @@ export async function search(query, options = {}) {
 
   const limited = scored.slice(0, limit);
 
-  return {type: 'search', data: {query: String(query).trim(), results: limited}};
+  return {
+    type: 'search',
+    data: {query: String(query).trim(), results: limited},
+  };
 }

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -30,10 +30,11 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL, fileURLToPath} from 'node:url';
+import {fileURLToPath} from 'node:url';
 import {createJiti} from 'jiti';
 import {getCliInvocation} from '../../../foundation/env/package-manager.mjs';
 import {CLI_ROOT, findCoreDir} from '../../../foundation/fs/paths.mjs';
+import {importUserModule} from '../../../foundation/fs/module-loader.mjs';
 import {
   assertWithin,
   sanitizeName,
@@ -47,10 +48,7 @@ import {
   collectThemingTargets,
   targetsByKey,
 } from '../../../foundation/discovery/theming-targets.mjs';
-import {
-  collectUnloadedFonts,
-  formatFontLoadingHelp,
-} from './font-warning.mjs';
+import {collectUnloadedFonts, formatFontLoadingHelp} from './font-warning.mjs';
 
 // Import shared theme processing from core. `astryx theme build` MUST produce the
 // exact same CSS as the `<Theme>` runtime, so it has exactly one generation
@@ -232,8 +230,8 @@ async function loadKnownValues(componentName) {
   if (!fs.existsSync(docPath)) return {};
 
   try {
-    const docModule = await import(pathToFileURL(docPath).href);
-    const doc = docModule.docs;
+    const docModule = await importUserModule(docPath);
+    const doc = /** @type {any} */ (docModule.docs);
     if (!doc?.theming?.targets) return {};
 
     // Collect all props — from doc.props or doc.components[].props
@@ -343,7 +341,6 @@ function readComponentDeclarations(pascalName) {
   return contents;
 }
 
-
 /** @type {Map<string, Array<{moduleName: string, interfacePrefix: string}>>} */
 const _augmentationTargetCache = new Map();
 
@@ -402,7 +399,8 @@ async function resolveAugmentationTargetCandidates(componentName) {
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        if (entry.name === 'node_modules' || entry.name === '__tests__')
+          continue;
         await scan(full);
         continue;
       }
@@ -539,12 +537,13 @@ async function generateVariantDeclarationsAsync(themeDef) {
       if (values.size === 0) continue;
 
       const propPascal = prop.charAt(0).toUpperCase() + prop.slice(1);
-      const target = (await resolveAugmentationTargetCandidates(component)).find(
-        candidate =>
-          componentHasAugmentableInterface(
-            candidate.moduleName,
-            `${candidate.interfacePrefix}${propPascal}Map`,
-          ),
+      const target = (
+        await resolveAugmentationTargetCandidates(component)
+      ).find(candidate =>
+        componentHasAugmentableInterface(
+          candidate.moduleName,
+          `${candidate.interfacePrefix}${propPascal}Map`,
+        ),
       );
 
       // Only augment interfaces that actually exist as an extension point in

--- a/packages/cli/clients/cli/commands/no-project-code.test.mjs
+++ b/packages/cli/clients/cli/commands/no-project-code.test.mjs
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file End-to-end probes for the ASTRYX_NO_PROJECT_CODE gate.
+ *
+ * Unit tests on importUserModule prove the loader refuses; these prove the
+ * COMMANDS do — a checkout module plants a global on execution, the real CLI
+ * runs against the fixture, and the global must still be unset afterwards.
+ * `astryx doctor` (which re-imports the config for its own diagnostics) and
+ * `astryx component` (which imports checkout doc modules) each had a loader
+ * that bypassed the gate when it was first added.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {runCli} from '../../../test-utils/run-cli.mjs';
+
+let tmpDir;
+
+beforeEach(() => {
+  // Repo-local temp dir: Vite blocks dynamic import from /tmp.
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-no-project-code-'));
+  process.env.ASTRYX_NO_PROJECT_CODE = '1';
+});
+
+afterEach(() => {
+  delete process.env.ASTRYX_NO_PROJECT_CODE;
+  delete globalThis.__astryxDoctorProbe;
+  delete globalThis.__astryxDocProbe;
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('ASTRYX_NO_PROJECT_CODE end-to-end', () => {
+  it('astryx doctor reports the config without executing it', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: 'consumer'}),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `globalThis.__astryxDoctorProbe = true;\nexport default {integrations: []};\n`,
+    );
+
+    const {stdout, stderr} = await runCli(['doctor'], tmpDir);
+
+    expect(globalThis.__astryxDoctorProbe).toBeUndefined();
+    expect(`${stdout}\n${stderr}`).toContain('ASTRYX_NO_PROJECT_CODE');
+  });
+
+  it('astryx component does not execute a checkout doc module', async () => {
+    // A repo-layout checkout: findCoreDir resolves packages/core from cwd, and
+    // the doc-view path would import Button.doc.mjs from it.
+    const buttonDir = path.join(tmpDir, 'packages', 'core', 'src', 'Button');
+    fs.mkdirSync(buttonDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: 'consumer'}),
+    );
+    fs.writeFileSync(
+      path.join(buttonDir, 'Button.doc.mjs'),
+      `globalThis.__astryxDocProbe = true;\nexport const docs = {name: 'Button', usage: {description: 'x'}};\n`,
+    );
+
+    await runCli(['component', 'Button'], tmpDir);
+
+    expect(globalThis.__astryxDocProbe).toBeUndefined();
+  });
+});

--- a/packages/cli/foundation/config/project.mjs
+++ b/packages/cli/foundation/config/project.mjs
@@ -32,7 +32,22 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {findPresentFiles, loadModuleWithParser} from '../fs/module-loader.mjs';
+import {
+  findPresentFiles,
+  loadModuleWithParser,
+  projectCodeAllowed,
+} from '../fs/module-loader.mjs';
+
+/** Say once per process why a present config is being ignored. */
+let configSkipNoted = false;
+/** @param {string} configPath */
+function noteConfigSkipped(configPath) {
+  if (configSkipNoted) return;
+  configSkipNoted = true;
+  console.error(
+    `astryx: ASTRYX_NO_PROJECT_CODE=1 — ignoring ${configPath}; running on built-in data only`,
+  );
+}
 import {parseConfig} from '../../authoring/config/parse.mjs';
 import {loadIntegrations} from '../integrations/integrations.mjs';
 import {
@@ -199,7 +214,14 @@ export class Project {
    */
   static async load(cwd = process.cwd(), {cache} = {}) {
     const resolvedCache = cache ?? new InMemoryConfigCache();
-    const configPath = findConfigPath(cwd);
+    let configPath = findConfigPath(cwd);
+    // Loading the config executes it (and every integration it names).
+    // Under the project-code gate the whole invocation runs on built-ins:
+    // present config acknowledged once on stderr, never imported.
+    if (configPath && !projectCodeAllowed()) {
+      noteConfigSkipped(configPath);
+      configPath = null;
+    }
     const hash = configContentHash(configPath);
 
     /** @type {import('../../authoring/config/type').AstryxConfig} */

--- a/packages/cli/foundation/config/project.test.mjs
+++ b/packages/cli/foundation/config/project.test.mjs
@@ -124,7 +124,9 @@ function topicDoc(fields) {
     name: 'deploying',
     title: 'Deploying',
     description: 'How to ship it.',
-    sections: [{title: 'Overview', content: [{type: 'prose', text: 'Ship it.'}]}],
+    sections: [
+      {title: 'Overview', content: [{type: 'prose', text: 'Ship it.'}]},
+    ],
     ...fields,
   };
 }
@@ -174,6 +176,32 @@ describe('Project.load', () => {
     );
     await expect(Project.load(tmpDir)).rejects.toThrow(/integrations/);
   });
+
+  it('skips a present config (never executing it) under ASTRYX_NO_PROJECT_CODE=1', async () => {
+    scaffold();
+    // Loading a config executes it — plant a probe so "skipped" is
+    // observable as "never ran", not just "not reflected in the result".
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `globalThis.__astryxConfigProbe = true;\nexport default {integrations: []};\n`,
+    );
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.ASTRYX_NO_PROJECT_CODE = '1';
+    try {
+      const project = await Project.load(tmpDir);
+      expect(project.config).toEqual({integrations: []});
+      expect(project.integrations).toEqual([]);
+      expect(project.loadedIntegrations).toEqual([]);
+      expect(globalThis.__astryxConfigProbe).toBeUndefined();
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining('ASTRYX_NO_PROJECT_CODE'),
+      );
+    } finally {
+      delete process.env.ASTRYX_NO_PROJECT_CODE;
+      delete globalThis.__astryxConfigProbe;
+      error.mockRestore();
+    }
+  });
 });
 
 describe('findConfigPath', () => {
@@ -190,7 +218,9 @@ describe('findConfigPath', () => {
       path.join(tmpDir, 'astryx.config.js'),
       `module.exports = {};\n`,
     );
-    expect(() => findConfigPath(tmpDir)).toThrow(/Multiple Astryx config files/);
+    expect(() => findConfigPath(tmpDir)).toThrow(
+      /Multiple Astryx config files/,
+    );
   });
 });
 
@@ -261,7 +291,9 @@ describe('Project discovery', () => {
     const catalog = await project.docs();
     expect(catalog.resolve('deploying')).toBeUndefined();
     const issues = await project.issues();
-    expect(issues.some(i => i.code === 'invalid_doc' && i.severity === 'error')).toBe(true);
+    expect(
+      issues.some(i => i.code === 'invalid_doc' && i.severity === 'error'),
+    ).toBe(true);
   });
 
   it('memoizes components() — the second call does not re-walk', async () => {
@@ -308,7 +340,9 @@ describe('Project issues (skip + warn)', () => {
     const b = await project.issues();
     expect(a).toEqual(b);
     // No duplicate (package, code, message) tuples.
-    const seen = new Set(a.map(i => `${i.package}\u0000${i.code}\u0000${i.message}`));
+    const seen = new Set(
+      a.map(i => `${i.package}\u0000${i.code}\u0000${i.message}`),
+    );
     expect(seen.size).toBe(a.length);
   });
 

--- a/packages/cli/foundation/discovery/component-loader.mjs
+++ b/packages/cli/foundation/discovery/component-loader.mjs
@@ -4,7 +4,6 @@
  * @file Component doc loader — load and merge translations
  */
 
-import {pathToFileURL} from 'node:url';
 import {importUserModule} from '../fs/module-loader.mjs';
 import {parseDoc} from '../../authoring/doctypes/parse.mjs';
 
@@ -77,7 +76,8 @@ export function mergeTranslation(docs, translation) {
   }
 
   // Legacy top-level fields (for docsZh that are full ComponentDoc clones)
-  if (translation.description && !merged.usage) merged.description = translation.description;
+  if (translation.description && !merged.usage)
+    merged.description = translation.description;
 
   // Merge prop descriptions for single-component docs
   if (translation.propDescriptions && merged.props) {
@@ -109,21 +109,25 @@ export function mergeTranslation(docs, translation) {
 
   // Merge sub-component translations
   if (translation.components && merged.components) {
-    merged.components = merged.components.map((/** @type {any} */ comp, /** @type {any} */ i) => {
-      const trans = translation.components.find((/** @type {any} */ t) => t.name === comp.name)
-        || translation.components[i];
-      if (!trans) return comp;
+    merged.components = merged.components.map(
+      (/** @type {any} */ comp, /** @type {any} */ i) => {
+        const trans =
+          translation.components.find(
+            (/** @type {any} */ t) => t.name === comp.name,
+          ) || translation.components[i];
+        if (!trans) return comp;
 
-      const mergedComp = {...comp};
-      if (trans.description) mergedComp.description = trans.description;
-      if (trans.propDescriptions && comp.props) {
-        mergedComp.props = comp.props.map((/** @type {any} */ prop) => {
-          const desc = trans.propDescriptions[prop.name];
-          return desc != null ? {...prop, description: desc} : prop;
-        });
-      }
-      return mergedComp;
-    });
+        const mergedComp = {...comp};
+        if (trans.description) mergedComp.description = trans.description;
+        if (trans.propDescriptions && comp.props) {
+          mergedComp.props = comp.props.map((/** @type {any} */ prop) => {
+            const desc = trans.propDescriptions[prop.name];
+            return desc != null ? {...prop, description: desc} : prop;
+          });
+        }
+        return mergedComp;
+      },
+    );
   }
 
   return merged;
@@ -138,17 +142,24 @@ export function mergeTranslation(docs, translation) {
  * @param {{zh?: boolean, dense?: boolean, lang?: string}} [opts]
  * @returns {Promise<any>}
  */
-export async function loadDocs(readmePath, {zh = false, dense = false, lang} = {}) {
-  const mod = await import(pathToFileURL(readmePath).href);
+export async function loadDocs(
+  readmePath,
+  {zh = false, dense = false, lang} = {},
+) {
+  // Through the gated loader: doc modules from a checkout execute on import,
+  // and this path must honor ASTRYX_NO_PROJECT_CODE like loadComponentDoc.
+  const mod = await importUserModule(readmePath);
   const docs = mod.docs;
 
   // Resolve which translation to use (--lang takes priority over legacy flags)
   const locale = lang || (dense ? 'dense' : zh ? 'zh' : null);
   if (!locale) return docs;
 
-  const translationKey = locale === 'zh' ? 'docsZh' : locale === 'dense' ? 'docsDense' : null;
+  const translationKey =
+    locale === 'zh' ? 'docsZh' : locale === 'dense' ? 'docsDense' : null;
   if (!translationKey || !mod[translationKey]) return docs;
 
+  /** @type {any} */
   const translation = mod[translationKey];
 
   // A full ComponentDoc-shaped translation (legacy docsZh shape) used to be
@@ -158,7 +169,10 @@ export async function loadDocs(readmePath, {zh = false, dense = false, lang} = {
   // `isIconOnly`. A reader of the translated docs cannot discover a prop that
   // is not there. Overlay it instead, so an untranslated prop falls back to
   // its English entry. (Same principle as the reference-doc overlays, #2182.)
-  if (translation.props || translation.components?.some((/** @type {any} */ c) => c.props)) {
+  if (
+    translation.props ||
+    translation.components?.some((/** @type {any} */ c) => c.props)
+  ) {
     return overlayComponentDoc(docs, translation);
   }
 
@@ -185,7 +199,9 @@ function overlayComponentDoc(docs, translation) {
    */
   const overlayProps = (baseProps, tProps) => {
     if (!baseProps) return baseProps;
-    const byName = new Map((tProps ?? []).map((/** @type {any} */ p) => [p.name, p]));
+    const byName = new Map(
+      (tProps ?? []).map((/** @type {any} */ p) => [p.name, p]),
+    );
     return baseProps.map((/** @type {any} */ prop) => {
       const t = byName.get(prop.name);
       // Take the translated text, but never let it drop the prop's contract

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -24,7 +24,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {createJiti} from 'jiti';
-import {loadModuleWithParser} from '../fs/module-loader.mjs';
+import {
+  isCliShippedPath,
+  loadModuleWithParser,
+  projectCodeAllowed,
+} from '../fs/module-loader.mjs';
 import {parseTemplate} from '../../authoring/doctypes/template/parse.mjs';
 import {CLI_ROOT, discoverExternalPackages} from '../fs/paths.mjs';
 import {Project} from '../config/project.mjs';
@@ -223,6 +227,11 @@ export function stripTemplateAssetRefs(source) {
  */
 async function loadDocModule(docPath) {
   if (!fs.existsSync(docPath)) return null;
+  // Importing executes the spec. Shipped template specs stay loadable under
+  // the project-code gate; checkout/integration ones are skipped like a
+  // missing file. (The JSX-capable jiti here is why this doesn't route
+  // through importUserModule wholesale.)
+  if (!projectCodeAllowed() && !isCliShippedPath(docPath)) return null;
   const docModule = docPath.endsWith('.ts')
     ? await getJiti().import(docPath)
     : await import(`file://${docPath}`);
@@ -322,7 +331,9 @@ async function discoverBlocks() {
     const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
     if (!fs.existsSync(tsxPath)) continue;
     const doc = await loadDocModule(docPath);
-    const relPath = toPosixPath(path.relative(BLOCKS_DIR, path.dirname(docPath)));
+    const relPath = toPosixPath(
+      path.relative(BLOCKS_DIR, path.dirname(docPath)),
+    );
     blocks.push({
       type: 'block',
       dirName: basename,
@@ -339,7 +350,6 @@ async function discoverBlocks() {
   }
   return blocks;
 }
-
 
 /**
  * Discover blocks from external packages that declare `astryx.blocks` in
@@ -362,7 +372,9 @@ async function discoverExternalBlocks(cwd = process.cwd()) {
       const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
       if (!fs.existsSync(tsxPath)) continue;
       const doc = await loadDocModule(docPath);
-      const relPath = toPosixPath(path.relative(ext.blocksDir, path.dirname(docPath)));
+      const relPath = toPosixPath(
+        path.relative(ext.blocksDir, path.dirname(docPath)),
+      );
       blocks.push({
         type: 'block',
         dirName: basename,
@@ -449,7 +461,9 @@ function findIntegrationDocFiles(root) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (ALL_TEMPLATE_SUFFIXES.some(suffix => entry.name.endsWith(suffix))) {
+      } else if (
+        ALL_TEMPLATE_SUFFIXES.some(suffix => entry.name.endsWith(suffix))
+      ) {
         results.push(full);
       }
     }
@@ -604,7 +618,9 @@ export async function discoverIntegrationTemplatesForOne(integration) {
 export async function findRelatedBlocks(componentName, cwd) {
   const blocks = await discoverAllBlocks(cwd);
   return blocks.filter(b =>
-    (b.componentsUsed ?? []).some(c => c.toLowerCase() === componentName.toLowerCase()),
+    (b.componentsUsed ?? []).some(
+      c => c.toLowerCase() === componentName.toLowerCase(),
+    ),
   );
 }
 

--- a/packages/cli/foundation/fs/module-loader.mjs
+++ b/packages/cli/foundation/fs/module-loader.mjs
@@ -13,10 +13,18 @@
  * load/validation boundary shared by config, integration, codemod, and
  * template discovery: import the module, take its default export, and hand it
  * to the authoring parser (which seals its own zod schema).
+ *
+ * Because every user-authored module flows through here, this is also where
+ * the project-code gate lives: importing a module executes it, which is the
+ * right trade in a workspace the operator trusts and the wrong one in CI,
+ * triage, or agent runs over arbitrary checkouts. ASTRYX_NO_PROJECT_CODE=1
+ * keeps the whole CLI on built-in data — config loading skips cleanly
+ * (Project.load checks the gate first) and any other user-module import
+ * fails with an error that names the variable.
  */
 
 import * as path from 'node:path';
-import {pathToFileURL} from 'node:url';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 import * as fs from 'node:fs';
 import {createJiti} from 'jiti';
 
@@ -30,12 +38,48 @@ function getJiti() {
 }
 
 /**
+ * True unless this invocation opted out of executing code found in the
+ * workspace (ASTRYX_NO_PROJECT_CODE=1).
+ */
+export function projectCodeAllowed() {
+  return process.env.ASTRYX_NO_PROJECT_CODE !== '1';
+}
+
+// The CLI's own package root. Modules under it (assets/docs topics, shipped
+// templates, command modules) are shipped code, not project code — the gate
+// must not touch them, or "runs on built-in data" would break the built-ins.
+const CLI_PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+
+/**
+ * True when `file` is one of the CLI's own shipped modules.
+ * @param {string} file
+ */
+export function isCliShippedPath(file) {
+  const resolved = path.resolve(file);
+  return (
+    resolved === CLI_PACKAGE_ROOT ||
+    resolved.startsWith(CLI_PACKAGE_ROOT + path.sep)
+  );
+}
+
+/**
  * Import a user-authored module. `.ts` is loaded via jiti; `.mjs`/`.js` via
  * native dynamic import (file:// URL). Returns the full module namespace.
+ * Under ASTRYX_NO_PROJECT_CODE=1 this refuses everything except the CLI's own
+ * shipped modules — importing executes the module.
  * @param {string} file absolute path
  * @returns {Promise<Record<string, unknown>>}
  */
 export async function importUserModule(file) {
+  if (!projectCodeAllowed() && !isCliShippedPath(file)) {
+    throw new Error(
+      `ASTRYX_NO_PROJECT_CODE=1 — refusing to import ${file}; unset the variable to let astryx load modules from this workspace`,
+    );
+  }
   if (file.endsWith('.ts')) {
     return await getJiti().import(file);
   }

--- a/packages/cli/foundation/fs/module-loader.test.mjs
+++ b/packages/cli/foundation/fs/module-loader.test.mjs
@@ -13,7 +13,9 @@ import {
 let tmpDir;
 
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-module-loader-test-'));
+  tmpDir = fs.mkdtempSync(
+    path.join(process.cwd(), '.astryx-module-loader-test-'),
+  );
 });
 
 afterEach(() => {
@@ -61,6 +63,24 @@ describe('importUserModule', () => {
     expect(mod.default).toEqual({answer: 42});
     expect(mod.named).toBe('hi');
   });
+
+  it('refuses to import (and so execute) anything under ASTRYX_NO_PROJECT_CODE=1', async () => {
+    const file = path.join(tmpDir, 'mod.mjs');
+    fs.writeFileSync(
+      file,
+      `globalThis.__astryxGateProbe = true;\nexport default {};\n`,
+    );
+    process.env.ASTRYX_NO_PROJECT_CODE = '1';
+    try {
+      await expect(importUserModule(file)).rejects.toThrow(
+        /ASTRYX_NO_PROJECT_CODE/,
+      );
+      expect(globalThis.__astryxGateProbe).toBeUndefined();
+    } finally {
+      delete process.env.ASTRYX_NO_PROJECT_CODE;
+      delete globalThis.__astryxGateProbe;
+    }
+  });
 });
 
 describe('loadModuleWithParser', () => {
@@ -84,7 +104,9 @@ describe('loadModuleWithParser', () => {
     const result = schema.safeParse(input);
     if (!result.success) {
       const issues = result.error.issues
-        .map(i => `${i.path.length ? i.path.join('.') : '(root)'}: ${i.message}`)
+        .map(
+          i => `${i.path.length ? i.path.join('.') : '(root)'}: ${i.message}`,
+        )
         .join('; ');
       throw new Error(`${label} is invalid: ${issues}`);
     }

--- a/packages/cli/foundation/text/string-utils.mjs
+++ b/packages/cli/foundation/text/string-utils.mjs
@@ -8,6 +8,7 @@
 // (the XLE/XLO language) can use it without this file's dynamic node:fs/path
 // imports landing in the webpack graph. Re-exported for existing consumers.
 import {levenshteinDistance} from './levenshtein.mjs';
+import {importUserModule} from '../fs/module-loader.mjs';
 export {levenshteinDistance} from './levenshtein.mjs';
 
 /**
@@ -56,7 +57,6 @@ export function findClosestComponents(name, components, maxDistance = 3) {
  * @returns {Promise<{name: string, score: number, reason: string}[]>}
  */
 export async function searchComponents(needle, coreDir, components) {
-  const {pathToFileURL} = await import('node:url');
   const fs = await import('node:fs');
   const path = await import('node:path');
 
@@ -100,8 +100,10 @@ export async function searchComponents(needle, coreDir, components) {
     // Levenshtein on name
     const dist = levenshteinDistance(term, compLower);
     if (dist === 1) addMatch(comp, 80, 'similar name (distance ' + dist + ')');
-    else if (dist === 2) addMatch(comp, 40, 'similar name (distance ' + dist + ')');
-    else if (dist === 3) addMatch(comp, 20, 'similar name (distance ' + dist + ')');
+    else if (dist === 2)
+      addMatch(comp, 40, 'similar name (distance ' + dist + ')');
+    else if (dist === 3)
+      addMatch(comp, 20, 'similar name (distance ' + dist + ')');
   }
 
   // --- Pass 2: Keyword + description matching (async, reads doc files) ---
@@ -124,15 +126,20 @@ export async function searchComponents(needle, coreDir, components) {
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
         const nested = path.join(srcDir, entry.name, comp, comp + '.doc.mjs');
-        if (fs.existsSync(nested)) { docPath = nested; break; }
+        if (fs.existsSync(nested)) {
+          docPath = nested;
+          break;
+        }
       }
     }
 
     if (!docPath) continue;
 
     try {
-      const mod = await import(pathToFileURL(docPath).href);
-      const docs = mod.docs;
+      // Gated loader: consumer doc modules execute on import and must
+      // honor ASTRYX_NO_PROJECT_CODE (throws are swallowed below).
+      const mod = await importUserModule(docPath);
+      const docs = /** @type {any} */ (mod.docs);
       if (!docs) continue;
 
       // Keyword matching
@@ -157,8 +164,10 @@ export async function searchComponents(needle, coreDir, components) {
           }
 
           const dist = levenshteinDistance(term, kwLower);
-          if (dist === 1) addMatch(comp, 70, 'keyword "' + kw + '" (distance ' + dist + ')');
-          else if (dist === 2) addMatch(comp, 30, 'keyword "' + kw + '" (distance ' + dist + ')');
+          if (dist === 1)
+            addMatch(comp, 70, 'keyword "' + kw + '" (distance ' + dist + ')');
+          else if (dist === 2)
+            addMatch(comp, 30, 'keyword "' + kw + '" (distance ' + dist + ')');
         }
       }
 
@@ -191,8 +200,9 @@ export async function searchComponents(needle, coreDir, components) {
     }
   }
 
-  const results = Array.from(scored.values())
-    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+  const results = Array.from(scored.values()).sort(
+    (a, b) => b.score - a.score || a.name.localeCompare(b.name),
+  );
 
   return results;
 }


### PR DESCRIPTION
## Summary

Discovery-backed commands (`component`, `search`, `docs`, `discover`, `template`, `doctor`, `layout`, ...) load the checkout's `astryx.config.*`, the integration manifests it names (and the installed ones autolink finds), doc modules, template specs, codemods, and theme sources. All of those execute on import. That is the right trade in a workspace the operator trusts and the wrong one in CI, triage, and agent runs over arbitrary checkouts. This adds the opt-out: `ASTRYX_NO_PROJECT_CODE=1` keeps the whole CLI on built-in data.

## Changes

- `importUserModule` (the chokepoint every user-authored module flows through) refuses under the gate before any of its loaders (jiti, fresh jiti, CommonJS `require`, native import) runs, with an error naming the variable. It carves out the CLI's own package root (`isCliShippedPath`) so built-in topics, templates, and command modules keep loading. `isProjectCodeGated` and `projectCodeGateMessage` are exported for the two loaders that need a different jiti.
- `Project.load` checks the gate before touching a config: a present `astryx.config.*` is acknowledged once on stderr and skipped, and no integration manifest is loaded (configured, autolinked, or the package being authored), so read commands degrade to built-ins instead of erroring.
- Every remaining checkout-path loader routes through the gate: `loadDocs` (component-loader), the docs catalog detail and list loaders, `search`'s doc loader, string-utils' keyword scan, and `doctor`'s config re-import (which now reports "config present but not loaded" instead of executing the file it just said it ignored). `template-adapter` keeps its JSX-capable jiti but asks the gate itself and skips external blocks entirely.
- `astryx theme build` refuses a theme source outside the CLI before any loader runs (jiti sync and async paths, the family preloader, the legacy eval fallback): exit 1, `ERR_THEME_LOAD`, one-line message, nothing written. Covers `--check`, `--family`, and `--watch`.
- README section "Running in checkouts you don't trust" describes exactly what is gated, and that the CLI's own runtime dependencies (`@astryxdesign/core`, `jscodeshift`) are not in scope.
- Default behavior (variable unset) is unchanged.

## Audit of checkout-backed import sites in `packages/cli`

Non-test, non-dist code. "Gated" means the site cannot execute a checkout module under `ASTRYX_NO_PROJECT_CODE=1`.

| Site | Status |
|---|---|
| `foundation/fs/module-loader.mjs` `importUserModule` (jiti, fresh jiti, CommonJS `require`, native import) | Gated at entry, before any loader path |
| `foundation/fs/module-loader.mjs` `loadModuleWithParser` | Gated via `importUserModule` |
| `foundation/config/project.mjs` config load, `autolinkIntegrations`, `loadLocalIntegration` | Gated before load: config nulled with a stderr notice; autolink and local package skipped |
| `foundation/integrations/integrations.mjs` manifest import | Gated via `importUserModule`; never reached under the gate |
| `foundation/integrations/autolink.mjs` | Calls `loadIntegrations`; skipped by `Project.load` under the gate |
| `foundation/discovery/component-loader.mjs` `loadComponentDoc` | Gated via `importUserModule` (already so on main) |
| `foundation/discovery/component-loader.mjs` `loadDocs` | Now gated (was a bare `import()`) |
| `foundation/discovery/docs-discovery.mjs` topic import | Gated via `importUserModule`; only reached for integrations, which never load under the gate |
| `foundation/discovery/template-adapter.mjs` `loadIntegrationDoc` | Gated via `loadModuleWithParser` |
| `foundation/discovery/template-adapter.mjs` `loadDocModule` (JSX jiti and `import()`) | Now gated: returns null for a non-shipped path; shipped core templates still load |
| `foundation/discovery/template-adapter.mjs` `discoverExternalBlocks` | Now gated: returns `[]` under the gate |
| `foundation/text/string-utils.mjs` keyword scan | Now gated via the loader (imported dynamically so the browser bundle stays free of node builtins) |
| `api/docs/_adapter.mjs` topic and translation import | Now gated via `importUserModule` |
| `api/docs/list/list.mjs` description import | Now gated (defense in depth; the catalog holds no project topic under the gate) |
| `api/search/search.mjs` `loadModuleDoc` | Now gated |
| `api/doctor/doctor.mjs` config re-import | Now gated: info row returned before the import; the re-import itself goes through `importUserModule` |
| `api/doctor/doctor.mjs` `_require.resolve` peer-dep checks | Not applicable: resolution only, nothing executes |
| `api/theme/build/build.mjs` jiti theme import, `evalModule`, `eval` fallback, family registry `import()`, `preloadFamilySource`; `core-interception.mjs` `createRequire(fromFile)(specifier)` | Gated upstream by `refuseGatedThemeSource` before any loader is created |
| `api/theme/build/build.mjs` `createJiti(...).resolve` calls | Not applicable: resolution only |
| `api/theme/build/build.mjs` `import('@astryxdesign/core/theme')`; `import('jscodeshift')` in codemods, upgrade, theme-discovery; babel plugin require in `authoring/shadcn` | Not applicable: CLI runtime dependencies resolved by package resolution, not checkout-authored code (stated as a limit in the README) |
| `assets/codemods/integration-discovery.mjs` codemod load | Gated via `loadModuleWithParser`; integrations never load under the gate |
| `api/upgrade/_adapter.mjs` post-codemod hook `execFile` | The command comes from a codemod module, which is gated above |
| `api/gap-report/gap-report-worker.mjs` handler import | Gated via `importUserModule`; the worker shares `process.env`, and handler entries derive from the config and loaded integrations, both empty under the gate |
| `api/gap-report/gap-report.mjs` `execFile('gh', ...)`, `api/swizzle/_github.mjs` | Not applicable: fixed external binary, not checkout code |
| `clients/cli/index.mjs` command module imports, `commands/template.mjs` lazy imports, `foundation/fs/paths.mjs` `pnpapi` | Not applicable: the CLI's own modules and the Yarn PnP runtime |
| `scripts/*.mjs`, `test/drift/docs-drift.mjs` | Not applicable: dev scripts, not CLI runtime |
| `clients/cli/lib/resolve-theme.mjs` `require` of `package.json` `astryx.theme` / `ASTRYX_THEME` | Not modified here; owned by #5525, which adds its own check of the variable. Follow-up there: use `isProjectCodeGated` from `module-loader.mjs` so the carve-out and message stay shared |

## Test plan

- `packages/cli/clients/cli/commands/no-project-code.test.mjs` (12 end-to-end probes): every fixture module sets a global when it executes; the real CLI runs in-process against it and the global must stay unset, so a loader that slips past the gate fails the suite. Covers `doctor` (text and `--json`), `component <Name>` from a repo-layout checkout, the fuzzy-match path (`component Buton`), `search` (with and without `--type`), `component` and `component --list` with a hostile integration that is both configured and declared as a dependency (so autolink is exercised), `docs` list plus a built-in detail, `template --list` with a hostile external block, `theme build` (text, `--json` code, `--family` with a preloaded intermediary), plus a control proving the same theme fixture executes and builds with the variable unset.
- Unit probes: `module-loader.test.mjs` (refusal for `.mjs`, `.js`, and `.ts` including `fresh`, shipped-path carve-out, exact-value check), `project.test.mjs` (config skip with stderr notice, no autolink, no local integration; spies prove the loaders are not even called), `integrationDocs.test.mjs` (`loadReferenceDocs` refuses a project topic and still loads a built-in with `--lang dense`).
- Each guard was mutation-tested: removing it fails the corresponding test(s). Removing the `importUserModule` gate fails 6, the config skip 1, the autolink guard 1, the local-integration guard 1, the doctor early return 2 (also with the old raw import restored), the `loadDocs`, search, string-utils, and docs-adapter rewrites 1 each, the external-blocks guard 1, the theme member gate 2, both theme gates 3. The family-level loop in `themeBuildFamily` is redundant with the member-level refusal (the plan always orders a selected member first) and is kept as belt-and-braces.
- CI-equivalent checks run locally: `pnpm -F @astryxdesign/cli typecheck:strict`, `typecheck:template-docs`, `node .github/scripts/cli-api-types-verify.mjs` (regenerates the api types), `ASTRYX_STRICT_LINT=1 eslint` and plain `eslint` on every changed file, `pnpm check:cli-structure`, `pnpm check:changesets`, `readme:check`, the copyright check, and `pnpm vitest run --project node packages/cli` (4031 passed, 6 skipped; the only failures were environment-specific `pnpm exec tsc` invocations and load timeouts that pass on rerun).

## Notes

- The gate covers code the checkout authors or contributes. A hostile package installed under `node_modules` that the CLI itself depends on (for example `@astryxdesign/core`) is out of scope, since refusing it would break every command; the README says so.
- Read commands that can only be answered by importing a project module fail with the loader's error (`ERR_UNKNOWN` in the JSON envelope). A dedicated error code is a small follow-up if wanted; `theme build` uses the existing `ERR_THEME_LOAD`.
- Changeset included (`@astryxdesign/cli` patch).
