### PR TITLE
fix(docsite): state the playground page's own framing headers

### DIFF
--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -22,6 +22,17 @@ const nextConfig = {
   async headers() {
     return [
       {
+        // The playground page itself also refuses embedding: today the
+        // nested preview's own frame-ancestors already breaks any embedding
+        // chain, but that protection shouldn't hinge on a child frame's
+        // headers — the parent states it directly.
+        source: '/playground',
+        headers: [
+          {key: 'X-Frame-Options', value: 'SAMEORIGIN'},
+          {key: 'Content-Security-Policy', value: "frame-ancestors 'self'"},
+        ],
+      },
+      {
         source: '/playground/preview',
         headers: [
           {key: 'X-Frame-Options', value: 'SAMEORIGIN'},


### PR DESCRIPTION
## Summary

Only `/playground/preview` carried framing headers; the `/playground` page itself had none, and its non-embeddability relied on the nested preview refusing to load when the ancestor chain includes another site. That works (frame-ancestors checks the full chain), but the parent page's protection shouldn't hinge on a child frame's headers — it now states them directly.

## Changes

- `/playground` gets `X-Frame-Options: SAMEORIGIN` and `Content-Security-Policy: frame-ancestors 'self'`, matching the framing posture the preview route already declares. No other CSP directives added — the page's script/style needs (Monaco, fonts) are unchanged.

## Test plan

- Config parses (`node --check`); prettier clean.
- Header shape mirrors the existing `/playground/preview` entry that production already serves.

## Notes

- Docsite is a private app: no changeset.
