### PR TITLE
fix(DateInput): the sheet-backed field is the same height as every other input on touch

### DIFF
--- a/.changeset/dateinput-touch-field-height.md
+++ b/.changeset/dateinput-touch-field-height.md
@@ -1,0 +1,17 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateInput's sheet-backed field is the same height as every other input on touch
+
+`TouchDateField`'s closed field carried a 44px `minBlockSize` floor on a coarse
+pointer, so on a phone it rendered 12px taller than the TextInput beside it —
+and taller than the same component's own native surface, which is what
+`DateInput` renders by default on touch. Two `DateInput`s in one form could
+therefore differ in height purely by `nativePicker`.
+
+The floor is gone from the closed field; every target inside the open sheet
+keeps its 44px. The field's own floor is core's, 24x24 under WCAG 2.5.8 AA,
+which a 32x180 field clears several times over.
+
+@imdreamrunner

--- a/packages/core/src/DateInput/DateInputTouch.test.tsx
+++ b/packages/core/src/DateInput/DateInputTouch.test.tsx
@@ -335,7 +335,12 @@ describe('DateInput — surface selection', () => {
     setViewport('desktop');
     const onChange = vi.fn();
     render(
-      <DateInput nativePicker="never" label="Event date" onChange={onChange} min={undefined} />,
+      <DateInput
+        nativePicker="never"
+        label="Event date"
+        onChange={onChange}
+        min={undefined}
+      />,
     );
     fireEvent.change(field(), {target: {value: '2026-03-25'}});
     expect(onChange).toHaveBeenCalledWith('2026-03-25');
@@ -380,7 +385,12 @@ describe('DateInput — field parity', () => {
     expect(field()).toHaveValue('');
     expect(field()).toHaveAttribute('placeholder', 'Select a date');
     rerender(
-      <DateInput nativePicker="never" label="Ship date" value="2026-03-21" onChange={() => {}} />,
+      <DateInput
+        nativePicker="never"
+        label="Ship date"
+        value="2026-03-21"
+        onChange={() => {}}
+      />,
     );
     expect(field()).toHaveValue('March 21, 2026');
   });
@@ -477,7 +487,13 @@ describe('DateInput — field parity', () => {
 
   it('does not open the picker until the field is tapped', () => {
     withLayout(() => {
-      render(<DateInput nativePicker="never" label="Ship date" onChange={() => {}} />);
+      render(
+        <DateInput
+          nativePicker="never"
+          label="Ship date"
+          onChange={() => {}}
+        />,
+      );
       expect(field()).toHaveAttribute('aria-expanded', 'false');
       expect(screen.queryByRole('grid')).not.toBeInTheDocument();
       fireEvent.click(field());
@@ -495,7 +511,14 @@ describe('DateInput — field parity', () => {
   });
 
   it('is not openable while disabled', () => {
-    render(<DateInput nativePicker="never" label="Ship date" isDisabled onChange={() => {}} />);
+    render(
+      <DateInput
+        nativePicker="never"
+        label="Ship date"
+        isDisabled
+        onChange={() => {}}
+      />,
+    );
     expect(field()).toBeDisabled();
     fireEvent.click(field());
     expect(screen.queryByRole('grid')).not.toBeInTheDocument();
@@ -538,12 +561,21 @@ describe('DateInput — field parity', () => {
   });
 
   it('marks required for assistive technology', () => {
-    render(<DateInput nativePicker="never" label="Ship date" isRequired onChange={() => {}} />);
+    render(
+      <DateInput
+        nativePicker="never"
+        label="Ship date"
+        isRequired
+        onChange={() => {}}
+      />,
+    );
     expect(field()).toHaveAttribute('aria-required', 'true');
   });
 
   it('associates the label natively, so the field is named without ARIA', () => {
-    render(<DateInput nativePicker="never" label="Ship date" onChange={() => {}} />);
+    render(
+      <DateInput nativePicker="never" label="Ship date" onChange={() => {}} />,
+    );
     expect(screen.getByLabelText('Ship date')).toBe(field());
   });
 
@@ -666,7 +698,13 @@ describe('DateInput — calendar surface', () => {
   it('Save closes even with no date chosen, committing nothing', () => {
     const onChange = vi.fn();
     withLayout(() => {
-      render(<DateInput nativePicker="never" label="Ship date" onChange={onChange} />);
+      render(
+        <DateInput
+          nativePicker="never"
+          label="Ship date"
+          onChange={onChange}
+        />,
+      );
       fireEvent.click(field());
       fireEvent.click(screen.getByRole('button', {name: 'Save'}));
     });
@@ -2423,18 +2461,27 @@ describe('DateInput — scroll CSS (definition-level)', () => {
     expect(footer).not.toContain('paddingInline');
   });
 
-  it('floors the touch target without discarding the size prop', () => {
-    const source = read('TouchDateField.tsx');
-    // Each size keeps its own height AND cannot render below a thumb's reach.
-    const sizeMap = source.slice(
-      source.indexOf('const sizeStyles = stylex.create('),
-      source.indexOf('const styles = stylex.create('),
+  it('sizes the closed field the same on both surfaces', () => {
+    // `DateInput` picks a surface from the pointer and `nativePicker`, so a
+    // field that sizes itself differently on one of them changes height for
+    // a reason the call site never asked about.
+    //
+    // Compared with formatting normalized away: the two files write the same
+    // declarations differently, one entry per line against one per size.
+    const sizeMap = (file: string) => {
+      const source = read(file);
+      const start = source.indexOf('const sizeStyles = stylex.create(');
+      expect(start).toBeGreaterThan(-1);
+      return source
+        .slice(start, source.indexOf('});', start))
+        .replace(/\/\/.*$/gm, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\s+/g, '')
+        .replace(/,(?=[}\]])/g, '');
+    };
+    expect(sizeMap('TouchDateField.tsx')).toEqual(
+      sizeMap('NativeDateField.tsx'),
     );
-    expect(
-      sizeMap.match(
-        /minBlockSize: \{default: null, '@media \(pointer: coarse\)': TOUCH_TARGET\}/g,
-      ),
-    ).toHaveLength(3);
   });
 
   it('floors the month arrows too — Button tops out at 36px', () => {

--- a/packages/core/src/DateInput/TouchDateField.tsx
+++ b/packages/core/src/DateInput/TouchDateField.tsx
@@ -122,9 +122,8 @@ import {
 import {dateInputTouchSizes, dateInputTouchGeometry} from './tokens.stylex';
 
 /**
- * The comfortable minimum tap target on both iOS and Android. Applied as a
- * FLOOR under the size prop rather than replacing it: `size` still means what
- * it means, it just cannot produce a control a thumb misses.
+ * The comfortable minimum tap target on both iOS and Android, honoured by
+ * every target inside the sheet.
  */
 const TOUCH_TARGET = dateInputTouchSizes.daySize;
 
@@ -151,17 +150,14 @@ const sizeStyles = stylex.create({
   sm: {
     height: sizeVars['--size-element-sm'],
     minWidth: 180,
-    minBlockSize: {default: null, '@media (pointer: coarse)': TOUCH_TARGET},
   },
   md: {
     height: sizeVars['--size-element-md'],
     minWidth: 180,
-    minBlockSize: {default: null, '@media (pointer: coarse)': TOUCH_TARGET},
   },
   lg: {
     height: sizeVars['--size-element-lg'],
     minWidth: 180,
-    minBlockSize: {default: null, '@media (pointer: coarse)': TOUCH_TARGET},
   },
 });
 
@@ -286,7 +282,7 @@ const styles = stylex.create({
   /**
    * `Button`'s own sizes top out at 36px, which is fine for a mouse and short
    * of the 44px every other target in this sheet honours. Floor it on a
-   * coarse pointer, the same way the field and the day cells do.
+   * coarse pointer, the same way the day cells do.
    */
   monthArrow: {
     minBlockSize: {default: null, '@media (pointer: coarse)': TOUCH_TARGET},


### PR DESCRIPTION
## The report

On https://astryx.atmeta.com/components/DateInput, viewed on a phone, the
min/max example's field is visibly taller than every other `DateInput` on the
page.

Measured on the live site in an iPhone 15 viewport: that field is **44px**
(`min-height: 44px`); the other eleven are **32px** (`min-height: auto`).

## Why

They are not the same surface. `nativePicker` defaults to `'touch'`, so on a
coarse pointer `DateInput` renders `NativeDateField`. The min/max example is
the only one on the page passing `nativePicker="never"`, which routes it to
`TouchDateField` — the bottom sheet.

The two files carry near-identical `sizeStyles`. The sheet's had one extra
line per size:

```js
// TouchDateField.tsx
md: {
  height: sizeVars['--size-element-md'],          // 32px
  minWidth: 180,
  minBlockSize: {default: null, '@media (pointer: coarse)': TOUCH_TARGET},  // 44px
},
```

`TOUCH_TARGET` is `dateInputTouchSizes.daySize` — the *day cell* height from
the picker's internal geometry, reused as a floor on the closed field.

#5243 added it when the sheet was the only touch surface. #5261 added the
native surface and made it the touch default, copying `sizeStyles` without it.

## Is this floor a house pattern? No — it was unique to this one field

Every `minBlockSize` under `@media (pointer: coarse)` in `packages/core/src`
and `packages/lab/src` was in `TouchDateField.tsx`. Nothing else in the
library has one.

What the rest of core actually does:

| | coarse-pointer treatment |
|---|---|
| **Form fields** — TextInput, NumberInput, TimeInput, DateTimeInput, DateRangeInput, Selector, ComplexSelector, FileInput, **NativeDateField** | 16px font-size bump only (stops iOS zooming on focus). Height stays `--size-element-*`. |
| **Small controls** — CheckboxInput, Switch, RadioListItem, Slider, InputClearButton | grow an **invisible** hit area to 24×24, visible box unchanged |
| **Icon-only trigger** — Table filtering | grows the bare glyph button to 44×44 |
| **TouchDateField's closed field** | grew its **visible** box to 44px — the only one |

The documented house floor is 24×24, WCAG 2.5.8 AA — stated in
`InputClearButton.tsx`: *"WCAG 2.5.8 AA is a touch requirement, and its floor
is 24x24"*.

## The fix

Drop the three lines. Not the reverse — adding the floor to `NativeDateField`
would make every `DateInput` on a phone 44px against a 32px `TextInput`, which
is the worse inconsistency. A 32×180 field clears 24×24 several times over.

Every target **inside** the open sheet keeps its 44px: day cells, month
arrows, the header's Reset. Verified after the change — the sheet's minimum
tap target is unchanged.

`sizeStyles` has exactly one call site, the closed field wrapper, so nothing
else moves.

## Verification

Built core, rendered both surfaces in an iPhone 15 context:

| | before | after |
|---|---|---|
| native (`<input type=date>`) | 32px | 32px |
| sheet (`nativePicker="never"`) | **44px** | **32px** |
| in-sheet day cells / arrows / Reset | 44px | 44px |

## Test

Replaced *"floors the touch target without discarding the size prop"* with
*"sizes the closed field like every other input, on every pointer"*, which
asserts **both** size maps together — the regression was the two surfaces
disagreeing, so that is what is now pinned.

## Gates

`lint:strict` (0 errors) · `test` (12223 passed) · `build` · all six
`typecheck:*` · `lab:readiness:check` · `storybook build`
