### PR TITLE
fix(TransferList): clear the three open audit BLOCKs (A10, T17, I1)

### DIFF
--- a/.changeset/transfer-list-audit-fixes.md
+++ b/.changeset/transfer-list-audit-fixes.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `TransferList` clears its three remaining audit BLOCKs: the `Clear` and `Add all` header actions now meet the 24px touch-target minimum (WCAG 2.5.8) while keeping their text-link look, the add/remove/reorder glyphs render through the shared `Icon` primitive (remove reuses the registry `close` icon) instead of inline `<svg>`, and the fallback heading for ungrouped options is localized through the i18n catalog.
+
+@ernestt

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1255,6 +1255,10 @@
     "defaultMessage": "Available",
     "description": "Default heading above the left-hand panel of a lab TransferList, which holds the options not yet chosen. Consumers usually override this with a domain noun (e.g. \"Hidden columns\")."
   },
+  "@astryx.transferList.ungroupedLabel": {
+    "defaultMessage": "Other",
+    "description": "Heading for the bucket of available options that have no `group` set, shown only when some options are grouped and some are not so the ungrouped ones still have a heading."
+  },
   "@astryx.transferList.searchPlaceholder": {
     "defaultMessage": "Search…",
     "description": "Placeholder in the single search field that filters both panels of a lab TransferList. Same English as `selector.searchPlaceholder` but a separate key so it can be phrased for two lists."

--- a/packages/lab/src/TransferList/TransferList.test.tsx
+++ b/packages/lab/src/TransferList/TransferList.test.tsx
@@ -187,8 +187,14 @@ describe('TransferList', () => {
       );
       const addButton = screen.getByRole('button', {name: 'Add Owner'});
       const removeButton = screen.getByRole('button', {name: 'Remove Name'});
-      expect(addButton.querySelector('svg')).toHaveClass('lucide-plus');
-      expect(removeButton.querySelector('svg')).toHaveClass('lucide-x');
+      // Glyphs render through the shared Icon primitive rather than a raw
+      // inline <svg>: the add glyph is an icon component (astryx-icon on the
+      // svg) and remove reuses the registry `close` glyph (astryx-icon on its
+      // wrapping span). Assert the icon primitive is present and a glyph drew.
+      expect(addButton.querySelector('.astryx-icon')).toBeInTheDocument();
+      expect(addButton.querySelector('svg')).toBeInTheDocument();
+      expect(removeButton.querySelector('.astryx-icon')).toBeInTheDocument();
+      expect(removeButton.querySelector('svg')).toBeInTheDocument();
 
       const selectedList = screen.getByRole('list', {
         name: 'Selected columns',
@@ -199,9 +205,7 @@ describe('TransferList', () => {
         'button',
       );
       expect(rowButtons[0]).toHaveAccessibleName('Reorder Name');
-      expect(rowButtons[0].querySelector('svg')).toHaveClass(
-        'lucide-grip-vertical',
-      );
+      expect(rowButtons[0].querySelector('.astryx-icon')).toBeInTheDocument();
       expect(rowButtons[1]).toHaveAccessibleName('Remove Name');
     });
 

--- a/packages/lab/src/TransferList/TransferList.tsx
+++ b/packages/lab/src/TransferList/TransferList.tsx
@@ -26,6 +26,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type SVGProps,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {flushSync} from 'react-dom';
@@ -44,6 +45,7 @@ import {useTranslator} from '@astryxdesign/core/i18n';
 import {
   borderVars,
   colorVars,
+  sizeVars,
   spacingVars,
   typeScaleVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
@@ -56,57 +58,36 @@ import {
 import {reorderStyles} from '../reorderStyles';
 import {transferListVars} from './tokens.stylex';
 
-function PlusIcon() {
+// Lucide glyphs the shared icon registry does not carry (there is no `add` or
+// `grip` semantic name). Typed as icon components and rendered through `Icon`
+// so sizing, colour and a11y come from the icon pipeline rather than a raw
+// inline `<svg>`. Removal reuses the registry `close` glyph instead.
+function PlusIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      className="lucide lucide-plus"
-      width={16}
-      height={16}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
       strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
-      aria-hidden>
+      {...props}>
       <path d="M5 12h14" />
       <path d="M12 5v14" />
     </svg>
   );
 }
 
-function RemoveIcon() {
+function GripVerticalIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
-      className="lucide lucide-x"
-      width={16}
-      height={16}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
       strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
-      aria-hidden>
-      <path d="M18 6 6 18" />
-      <path d="m6 6 12 12" />
-    </svg>
-  );
-}
-
-function GripVerticalIcon() {
-  return (
-    <svg
-      className="lucide lucide-grip-vertical"
-      width={16}
-      height={16}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={1.5}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden>
+      {...props}>
       <circle cx="9" cy="5" r="1" />
       <circle cx="9" cy="12" r="1" />
       <circle cx="9" cy="19" r="1" />
@@ -276,7 +257,13 @@ const styles = stylex.create({
     borderBlockEndColor: colorVars['--color-border'],
   },
   headerAction: {
+    // A text-link treatment, but the hit target still has to clear the WCAG
+    // 2.5.8 24px floor. The link keeps `height: auto` so its baseline aligns
+    // with the panel heading; `minBlockSize` gives the button a >=24px target
+    // (the sm element height) without changing where the text sits, and the
+    // width already exceeds 24px.
     height: 'auto',
+    minBlockSize: sizeVars['--size-element-sm'],
     paddingBlock: 0,
     paddingInline: 0,
     borderRadius: 0,
@@ -1036,7 +1023,7 @@ export function TransferList<T extends string = string>({
       return (
         <IconButton
           label={t('@astryx.transferList.addOption', {label: option.label})}
-          icon={<PlusIcon />}
+          icon={<Icon icon={PlusIcon} size="sm" />}
           size="sm"
           variant="ghost"
           isDisabled={isTransferDisabled}
@@ -1049,7 +1036,7 @@ export function TransferList<T extends string = string>({
     return (
       <IconButton
         label={t('@astryx.transferList.removeOption', {label: option.label})}
-        icon={<RemoveIcon />}
+        icon={<Icon icon="close" size="sm" />}
         size="sm"
         variant="ghost"
         isDisabled={isTransferDisabled}
@@ -1096,7 +1083,7 @@ export function TransferList<T extends string = string>({
         label={t('@astryx.transferList.reorderOption', {label: option.label})}
         aria-describedby={reorderInstructionsId}
         aria-pressed={active}
-        icon={<GripVerticalIcon />}
+        icon={<Icon icon={GripVerticalIcon} size="sm" />}
         size="sm"
         variant="ghost"
         isDisabled={isReorderDisabled}
@@ -1346,7 +1333,7 @@ export function TransferList<T extends string = string>({
                         role="presentation"
                         {...stylex.props(styles.groupHeading)}>
                         <Text type="body" weight="bold" color="primary">
-                          {group || 'Other'}
+                          {group || t('@astryx.transferList.ungroupedLabel')}
                         </Text>
                       </li>
                     )}


### PR DESCRIPTION
## What this does

Clears the three open audit BLOCKs on `lab/TransferList` (recorded C 78.6 under rubric v1.8), so it can promote to core as a near-pure rename.

| Rule | Finding | Fix |
|---|---|---|
| **A10** — target size | `Clear` (35×20) and `Add all` (47×20) rendered below the WCAG 2.5.8 24px floor, no coarse-pointer expansion | Added `min-block-size: --size-element-sm` (28px) to the header-action style. They keep `height: auto` so the text baseline still aligns with the panel heading; only the hit target grows. Width already exceeded 24px. Now **35×28 / 47×28**. |
| **T17** — icon registry | Three inline `<svg>` glyphs bypassed the icon system; the remove `<svg>` (an X) shadowed the registry `close` glyph | `remove` now uses `<Icon icon="close">` (registry). `add`/`reorder` route through `<Icon icon={PlusIcon}>` / `<Icon icon={GripVerticalIcon}>` — the registry has no `add`/`grip` name, so these stay local icon components, matching the sibling `ListInput` convention. No new dependency (the system ships no icon library). |
| **I1** — i18n | The ungrouped-bucket fallback heading rendered a hardcoded `'Other'` literal | Routed through the catalog: new `@astryx.transferList.ungroupedLabel` key. It was the only string the previous localization pass missed. |

## Visual results (before / after)

The fixes are visually invisible at rest — the header actions keep their text-link look (the larger hit area is transparent) and the registry `close` / local `plus`+`grip` glyphs render identically to the removed inline SVGs. RTL still mirrors.

![before/after](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/transferlist-audit-fix-before-after.png)

## Verification

All measured against a real Chromium build of Storybook:

- **A10**: header actions measure `Clear 35×28`, `Add all 47×28` — both axes ≥24px, confirmed under `any-pointer: coarse`.
- **T17**: add/remove/reorder each render a glyph through the `astryx-icon` pipeline; no `lucide-*` inline classes remain.
- **I1**: mixed grouped + ungrouped options render a localized "Other" heading via `useTranslator`.
- axe: **0 violations** across the TransferList stories (unchanged).
- 38/38 unit tests pass, `lint:strict` clean, `typecheck:docs` clean, `check:sync` / `check:changesets` / `check:i18n-catalog` all green.

## Re-audit

Fixing all three lifts the ceilings on §1 (Accessibility), §2 (Theming) and §9 (i18n & RTL), which were otherwise strong. Projected: **~89 (B)** with zero open BLOCKs — clearing the promotion gate. The ledger will be updated with the re-audit once this lands.
