### PR TITLE
fix(cli): keep the theme-showcase checkout from clipping its own fields

### DIFF
--- a/.changeset/theme-showcase-checkout-clipping.md
+++ b/.changeset/theme-showcase-checkout-clipping.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] The theme-showcase checkout card no longer clips its own fields. The card number field truncated mid-number (`1234 1234 12`), the country selector ellipsized, and the pay button was left with only a few pixels of slack.
+
+@rubyycheung
+
+The checkout sat in a grid track with a 200px minimum, so its width was a fraction of however many tracks happened to fit — it swung between 208px and 328px as the viewport resized, and the narrow end is well under what the form needs. Themes with a large spacing scale suffered most: Matcha's `--spacing-5` card padding alone spends 60px of that budget.
+
+The checkout and chat panels are now a wrapping flex row. They share a row at roughly 1:2 while both flex bases fit, then the chat drops to its own full-width row, which makes 300px a floor for the checkout rather than an accident of the track count. Raising the track minimum instead would have left a tall gap beside the checkout at mid widths, since a two-track row can't hold a two-track span.
+
+Two narrower fixes ride along, both text the card was breaking rather than fitting: the payment-method grid's minimum goes 70px to 80px so "Google" stops breaking mid-word on Matcha and Y2K, and on phones the card drops one padding step and sheds the card number's decorative start icon, which together buy back the room a 16-digit number needs at 360px.

--- a/.changeset/theme-showcase-checkout-clipping.md
+++ b/.changeset/theme-showcase-checkout-clipping.md
@@ -2,9 +2,11 @@
 '@astryxdesign/cli': patch
 ---
 
-[fix] The theme-showcase checkout card no longer clips its own fields. The card number field truncated mid-number (`1234 1234 12`), the country selector ellipsized, and the pay button was left with only a few pixels of slack.
+[fix] The theme-showcase page no longer clips its own controls. In the store's product cards the quantity field and "Add to cart" button spilled out of both sides of the card; in the checkout card the card number truncated mid-number (`1234 1234 12`), the country selector ellipsized, and the pay button was left with only a few pixels of slack.
 
 @rubyycheung
+
+The product-card row is the more visible of the two. It had no width of its own — the enclosing stack centers rather than stretches its children — so it sized to its contents and, being centered, overflowed the card at both edges once those contents outgrew it. That stayed hidden while the quantity field was narrow, and surfaced when `NumberInput` moved to `type="text"` for formatted display: a text input's default `size=20` made the field ~200px instead of ~65px, and the template was pinning it with a `style` `minWidth` (a floor, not a cap) plus `flexShrink: 0`. The field now uses `NumberInput`'s `width` prop, which is what actually sizes a field, and the row is pinned to the card width and allowed to wrap so the button drops to its own full-width line instead of ellipsizing on a narrow card.
 
 The checkout sat in a grid track with a 200px minimum, so its width was a fraction of however many tracks happened to fit — it swung between 208px and 328px as the viewport resized, and the narrow end is well under what the form needs. Themes with a large spacing scale suffered most: Matcha's `--spacing-5` card padding alone spends 60px of that budget.
 

--- a/packages/cli/assets/templates/pages/theme-showcase/page.tsx
+++ b/packages/cli/assets/templates/pages/theme-showcase/page.tsx
@@ -152,28 +152,14 @@ const styles: Record<string, CSSProperties> = {
   cardDescription: {
     flex: 1,
   },
-  // The quantity field is sized by NumberInput's `width` prop, not from here —
-  // a `style` width only reaches the control, so the label and status would
-  // stay their own width and the field would come apart. All this adds is the
-  // flex behaviour: hold the assigned width rather than absorbing the row's
-  // slack, since a two-digit quantity needs far less room than the button.
   quantityInput: {
     flexShrink: 0,
   },
-  // `auto` basis, not 0: flex breaks lines on the basis, so the button asks for
-  // its label's full width and drops to its own line when the card can't give
-  // it. A 0 basis would keep it on the row and ellipsize the label instead.
-  // Shrink stays enabled only as a floor for a card too narrow even for the
-  // wrapped button.
+  // `auto` basis so the button wraps to its own line rather than ellipsizing.
   cartButton: {
     flex: '1 1 auto',
     minWidth: 0,
   },
-  // Without an explicit width this row is shrink-to-fit, because the enclosing
-  // VStack centers rather than stretches its children. It would then size to
-  // its contents and, being centered, overflow the card at BOTH edges once
-  // those contents outgrew it. Pinning it to the card width makes the row the
-  // constraint the two controls resolve against.
   cartRow: {
     width: '100%',
     minWidth: 0,
@@ -252,17 +238,8 @@ const inlineStyles: Record<string, CSSProperties> = {
     display: 'flex',
     flexDirection: 'column',
   },
-  // Checkout + chat share a row at roughly 1:2 while both flex bases fit, then
-  // the chat drops to its own full-width row. A grid track can't express that:
-  // its width is a fraction of however many tracks happen to fit, so the
-  // checkout column swings with the track count and lands anywhere from 200px
-  // up. The checkout form is the densest content in the showcase — a card
-  // number, an expiry/CVC pair, a country selector, and a labelled pay button —
-  // and below ~300px those fields clip their own text, worst on themes with a
-  // larger spacing scale (Matcha's --spacing-5 card padding alone eats 60px).
-  // A flex basis makes 300px the floor instead of the accident: the row wraps
-  // before the checkout is squeezed under it. display:grid matches GridSpan so
-  // the card still stretches to the row height.
+  // Flex bases, not grid tracks: the checkout form needs a width floor, and the
+  // chat wraps to its own row rather than squeezing it under one.
   checkoutColumn: {
     flex: '1 1 300px',
     minWidth: 0,
@@ -548,10 +525,6 @@ function StorePreview({
 
 function CheckoutCard({isMobile}: {isMobile: boolean}) {
   return (
-    // A phone gives this card ~340px to work with, and on themes with a large
-    // spacing scale --spacing-5 of padding per side spends enough of it that
-    // the card number field can no longer show a full 16-digit number. One step
-    // down buys that room back where it is scarcest.
     <Card padding={isMobile ? 4 : 5} style={styles.card}>
       <VStack gap={4} style={styles.checkoutStack}>
         <Heading level={2}>Checkout</Heading>
@@ -606,11 +579,6 @@ function CheckoutCard({isMobile}: {isMobile: boolean}) {
             <Text type="supporting" weight="bold">
               Payment method
             </Text>
-            {/* 80, not 70: a 70px track leaves too little room inside the
-                card's own padding for "Google" to sit on one line once the
-                theme's spacing scale is large (Matcha, Y2K), so the word broke
-                mid-glyph. At 80 the three cards drop to 2 + 1 instead of
-                breaking, and still sit three-across wherever they fit. */}
             <Grid columns={isMobile ? 1 : {minWidth: 80, max: 3}} gap={2}>
               <SelectableCard
                 label="Pay with card"
@@ -665,9 +633,6 @@ function CheckoutCard({isMobile}: {isMobile: boolean}) {
             placeholder="1234 1234 1234 1234"
             value=""
             onChange={() => {}}
-            // The icon is decorative — the label already names the field — and
-            // it plus its gap costs more width than a 16-digit number can spare
-            // on a small phone. Drop it there rather than truncate the number.
             startIcon={isMobile ? undefined : <CreditCard size={16} />}
             size="lg"
           />

--- a/packages/cli/assets/templates/pages/theme-showcase/page.tsx
+++ b/packages/cli/assets/templates/pages/theme-showcase/page.tsx
@@ -152,15 +152,31 @@ const styles: Record<string, CSSProperties> = {
   cardDescription: {
     flex: 1,
   },
+  // The quantity field is sized by NumberInput's `width` prop, not from here —
+  // a `style` width only reaches the control, so the label and status would
+  // stay their own width and the field would come apart. All this adds is the
+  // flex behaviour: hold the assigned width rather than absorbing the row's
+  // slack, since a two-digit quantity needs far less room than the button.
   quantityInput: {
-    // minWidth (not a hard width) so the field grows to fit the digit + the
-    // theme's input padding. A fixed 40px was too tight on themes with larger
-    // padding / bigger type scale (e.g. Matcha, Y2K), clipping the value.
-    minWidth: 64,
     flexShrink: 0,
   },
+  // `auto` basis, not 0: flex breaks lines on the basis, so the button asks for
+  // its label's full width and drops to its own line when the card can't give
+  // it. A 0 basis would keep it on the row and ellipsize the label instead.
+  // Shrink stays enabled only as a floor for a card too narrow even for the
+  // wrapped button.
   cartButton: {
-    flex: 1,
+    flex: '1 1 auto',
+    minWidth: 0,
+  },
+  // Without an explicit width this row is shrink-to-fit, because the enclosing
+  // VStack centers rather than stretches its children. It would then size to
+  // its contents and, being centered, overflow the card at BOTH edges once
+  // those contents outgrew it. Pinning it to the card width makes the row the
+  // constraint the two controls resolve against.
+  cartRow: {
+    width: '100%',
+    minWidth: 0,
   },
 };
 
@@ -492,7 +508,12 @@ function StorePreview({
                           }}>
                           {p.description}
                         </Text>
-                        <HStack gap={2} vAlign="center" hAlign="center">
+                        <HStack
+                          gap={2}
+                          vAlign="center"
+                          hAlign="center"
+                          wrap="wrap"
+                          style={styles.cartRow}>
                           <NumberInput
                             label="Quantity"
                             isLabelHidden
@@ -501,6 +522,7 @@ function StorePreview({
                             min={1}
                             max={99}
                             size="sm"
+                            width={72}
                             style={styles.quantityInput}
                           />
                           <Button

--- a/packages/cli/assets/templates/pages/theme-showcase/page.tsx
+++ b/packages/cli/assets/templates/pages/theme-showcase/page.tsx
@@ -236,6 +236,27 @@ const inlineStyles: Record<string, CSSProperties> = {
     display: 'flex',
     flexDirection: 'column',
   },
+  // Checkout + chat share a row at roughly 1:2 while both flex bases fit, then
+  // the chat drops to its own full-width row. A grid track can't express that:
+  // its width is a fraction of however many tracks happen to fit, so the
+  // checkout column swings with the track count and lands anywhere from 200px
+  // up. The checkout form is the densest content in the showcase — a card
+  // number, an expiry/CVC pair, a country selector, and a labelled pay button —
+  // and below ~300px those fields clip their own text, worst on themes with a
+  // larger spacing scale (Matcha's --spacing-5 card padding alone eats 60px).
+  // A flex basis makes 300px the floor instead of the accident: the row wraps
+  // before the checkout is squeezed under it. display:grid matches GridSpan so
+  // the card still stretches to the row height.
+  checkoutColumn: {
+    flex: '1 1 300px',
+    minWidth: 0,
+    display: 'grid',
+  },
+  chatColumn: {
+    flex: '2 1 520px',
+    minWidth: 0,
+    display: 'grid',
+  },
 };
 
 const PRODUCT_IMAGE_KEYS = ['watch', 'headphones', 'backpack'];
@@ -284,8 +305,7 @@ const DEFAULT_PRODUCTS: ProductSpec[] = [
 // scaffolded template renders real imagery without needing local public assets.
 const DEFAULT_IMAGES: Record<string, string> = {
   watch: '/template-assets/Neutral-Watch.png',
-  headphones:
-    '/template-assets/Neutral-Headphones.png',
+  headphones: '/template-assets/Neutral-Headphones.png',
   backpack: '/template-assets/Neutral-Backpack.png',
   wallet: '/template-assets/Neutral-Wallet.png',
   tumbler: '/template-assets/Neutral-Tumbler.png',
@@ -350,14 +370,14 @@ function CardShowcase({
 
   return (
     <VStack gap={8}>
-      <Grid columns={columns} gap={4}>
-        <GridSpan columns={1}>
+      <HStack gap={4} wrap="wrap">
+        <div style={inlineStyles.checkoutColumn}>
           <CheckoutCard isMobile={isMobile} />
-        </GridSpan>
-        <GridSpan columns={isMobile ? 1 : 2}>
+        </div>
+        <div style={inlineStyles.chatColumn}>
           <ChatCard />
-        </GridSpan>
-      </Grid>
+        </div>
+      </HStack>
       <Grid columns={columns} gap={4}>
         <GridSpan columns={isMobile ? 1 : 3}>
           <InventoryCard images={images} inventory={inventory} />
@@ -506,7 +526,11 @@ function StorePreview({
 
 function CheckoutCard({isMobile}: {isMobile: boolean}) {
   return (
-    <Card padding={5} style={styles.card}>
+    // A phone gives this card ~340px to work with, and on themes with a large
+    // spacing scale --spacing-5 of padding per side spends enough of it that
+    // the card number field can no longer show a full 16-digit number. One step
+    // down buys that room back where it is scarcest.
+    <Card padding={isMobile ? 4 : 5} style={styles.card}>
       <VStack gap={4} style={styles.checkoutStack}>
         <Heading level={2}>Checkout</Heading>
 
@@ -560,7 +584,12 @@ function CheckoutCard({isMobile}: {isMobile: boolean}) {
             <Text type="supporting" weight="bold">
               Payment method
             </Text>
-            <Grid columns={isMobile ? 1 : {minWidth: 70, max: 3}} gap={2}>
+            {/* 80, not 70: a 70px track leaves too little room inside the
+                card's own padding for "Google" to sit on one line once the
+                theme's spacing scale is large (Matcha, Y2K), so the word broke
+                mid-glyph. At 80 the three cards drop to 2 + 1 instead of
+                breaking, and still sit three-across wherever they fit. */}
+            <Grid columns={isMobile ? 1 : {minWidth: 80, max: 3}} gap={2}>
               <SelectableCard
                 label="Pay with card"
                 isSelected={true}
@@ -614,7 +643,10 @@ function CheckoutCard({isMobile}: {isMobile: boolean}) {
             placeholder="1234 1234 1234 1234"
             value=""
             onChange={() => {}}
-            startIcon={<CreditCard size={16} />}
+            // The icon is decorative — the label already names the field — and
+            // it plus its gap costs more width than a 16-digit number can spare
+            // on a small phone. Drop it there rather than truncate the number.
+            startIcon={isMobile ? undefined : <CreditCard size={16} />}
             size="lg"
           />
 


### PR DESCRIPTION
## Summary

On `/themes?theme=matcha` the checkout card clipped its own contents: the card number rendered as `1234 1234 12`, the country selector ellipsized to `United St…`, and the pay button was down to a few pixels of slack.

The card sat in a grid track with a 200px minimum, so its width was a fraction of however many tracks happened to fit — it swung between 208px and 328px as the viewport resized, and the narrow end is well under what the form needs. Themes with a large spacing scale suffered most: Matcha's `--spacing-5` card padding alone spends 60px of that budget.

- **Checkout + chat are now a wrapping flex row** rather than grid spans. They share a row at roughly 1:2 while both flex bases fit, then the chat drops to its own full-width row. That makes 300px a floor for the checkout instead of an accident of the track count. Raising the track minimum on its own was not enough — a two-track row can't hold a two-track span, so it left a tall gap beside the checkout at mid widths.
- **Payment-method grid minimum 70px → 80px**, so "Google" stops breaking mid-word into `Googl / e Pay` on Matcha and Y2K. Those three cards now drop to 2 + 1 instead of breaking, and still sit three-across wherever they fit.
- **On phones the card drops one padding step and sheds the card number's decorative start icon**, which together buy back the room a 16-digit number needs at 360px.

Only the showcase template changes; no component or public API is touched.

## Before / after

Matcha at 1080px wide, the worst case:

| | checkout content width | card number |
| --- | --- | --- |
| before | 149px | clipped, 63px short |
| after | 614px | fits |

## Test plan

- [x] Measured rendered text against each field's box (inputs, buttons, and mid-word breaks) across all six themes at 13 widths from 360px to 1920px — all clean.
- [x] Confirmed the bug still reproduces on unpatched `main` at the same commit, so this is not fixing something already gone.
- [x] Visual check at 1080 / 1280 / 1440 on Matcha, plus phone widths.
- [x] `eslint` clean on the changed file; pre-commit `lint-staged` + `check:repo` pass.
- [ ] Reviewer: sanity-check the 1:2 balance at your own window width — the row wraps at roughly 1250px viewport in the docsite layout.

## Notes

Known floor: at a 320px viewport the card number is still ~34px too wide on Matcha and Y2K. That is narrower than any current phone and fixing it would mean changing the placeholder itself, so I left it.

Adjacent and untouched: in the second row the Revenue card still wraps to its own row and leaves a gap beside it at some widths — same root cause, happy to give it the same treatment in a follow-up.

Made with [Cursor](https://cursor.com)