### PR TITLE
fix(docsite): stop registering the preview theme's icons globally — it fails hydration on every other page

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-theme.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-theme.test.ts
@@ -1,17 +1,30 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {readFileSync} from 'node:fs';
-import {dirname, join} from 'node:path';
+import {readdirSync, readFileSync} from 'node:fs';
+import {dirname, join, relative} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {describe, expect, it} from 'vitest';
 
-const componentDetailDir = join(
-  dirname(fileURLToPath(import.meta.url)),
-  '../components/component-detail',
-);
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const componentDetailDir = join(srcDir, 'components/component-detail');
 
 function readComponentDetailFile(name: string): string {
   return readFileSync(join(componentDetailDir, name), 'utf8');
+}
+
+// Every hand-written source file in the docsite. `generated/` is skipped: it is
+// machine-written data that embeds core's own docs (which mention the icon API
+// in prose), not code the docsite runs.
+function sourceFiles(dir: string = srcDir): string[] {
+  return readdirSync(dir, {withFileTypes: true}).flatMap(entry => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === 'generated' || entry.name === '__tests__'
+        ? []
+        : sourceFiles(path);
+    }
+    return /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
 }
 
 describe('component detail preview theming', () => {
@@ -37,5 +50,19 @@ describe('component detail preview theming', () => {
     expect(readComponentDetailFile('ExampleBlock.tsx')).not.toContain(
       'Theme theme={neutralTheme}',
     );
+  });
+
+  it('lets <Theme> carry the preview icons instead of registering them globally', () => {
+    // registerIcons() writes to a registry shared by the whole server process,
+    // but on the client it only runs in the bundles that import the calling
+    // module. Calling it from a route-specific module therefore hands SSR a set
+    // of icons the client does not have, and every route that never loads that
+    // module fails hydration with React #418. <Theme> already resolves a
+    // theme's icons by name, so nothing here needs the global registry.
+    const offenders = sourceFiles()
+      .filter(file => /\bregisterIcons\s*\(/.test(readFileSync(file, 'utf8')))
+      .map(file => relative(srcDir, file));
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/apps/docsite/src/components/component-detail/ComponentPreviewTheme.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentPreviewTheme.tsx
@@ -14,17 +14,19 @@
 import {type ReactNode} from 'react';
 import {Theme} from '@astryxdesign/core/theme';
 import {neutralTheme} from '@astryxdesign/theme-neutral/built';
-import {registerIcons} from '@astryxdesign/core/Icon';
 import {useThemeMode} from '../../app/providers';
 
-// Register theme icons at module load time so the globalIconRegistry is
-// consistent between SSR and client hydration. Without this, the server's
-// module-level registry may already have Lucide icons (from a warm process),
-// while the client starts with default icons — causing an SVG strokeWidth
-// mismatch for any Icon that renders before Theme's render-time registerIcons call.
-if (neutralTheme.icons) {
-  registerIcons(neutralTheme.icons);
-}
+// The neutral theme's icons reach the previews through <Theme> alone: it calls
+// registerTheme(theme) as it renders, and every Icon below resolves its
+// semantic name against that theme (useThemeName -> getIcon(name, themeName)).
+//
+// Do NOT add a global icon registration here. That API writes to a process-wide
+// registry, and this module is in the client bundle of the component-detail
+// routes ONLY — while on the server one module registry is shared by every
+// route. Registering here therefore gave the SSR pass of pages that never load
+// this module (the home page, /blog, /templates, /docs/*) the Lucide icons
+// while their client bundle still had the built-in defaults, and hydration
+// failed with React #418 on those routes.
 
 export function ComponentPreviewTheme({children}: {children: ReactNode}) {
   const {mode} = useThemeMode();


### PR DESCRIPTION
## The bug

Every page of the docsite except a component-detail page throws an uncaught error on first load:

```
Uncaught Error: Minified React error #418
  Hydration failed because the server rendered HTML didn't match the client.
  As a result this tree will be regenerated on the client.
```

Live right now on `/`, `/blog`, `/templates`, `/docs/getting-started`; `/components/*` is clean. Besides the console error, React throws the server HTML away and re-renders the entire page on the client.

## Cause

`ComponentPreviewTheme` registered the neutral theme's icons into the **process-global** icon registry, at module scope:

```tsx
if (neutralTheme.icons) {
  registerIcons(neutralTheme.icons);   // module scope
}
```

That registry is global to a process, and the server has one module registry shared by every route. As soon as any component-detail page is rendered in a build worker (or a warm server), every page rendered after it in that process resolves its semantic icons to Lucide.

On the client the module only ships in the component-detail bundles, so the home page hydrates with the built-in defaults against SSR HTML full of Lucide icons. The first registry icon on the page is the canary banner's warning triangle, and that is where hydration dies:

```
<Icon icon="warning" size="md" color="warning">
  <IconFromRegistry name="warning" …>
    <svg
+     fill="currentColor"                        ← client: built-in default
-     fill="none"
-     stroke-width="2"
-     className="lucide lucide-triangle-alert"   ← server: neutral theme's Lucide
```

It also explains why component pages are the only ones that survive: they are the pages whose client bundle *does* load the module, so both sides agree — which is also why their chrome renders in Lucide icons today while the rest of the site renders the built-ins.

**Reproduce it deterministically** (before this change): `pnpm -F @astryxdesign/docsite dev`, open `/components/Button` first so the dev server loads the module, then open `/` — the full React error prints with the diff above. It does not reproduce if you only ever open `/`, which is why it survived local development.

## Fix

Drop the global registration. The previews never needed it: `<Theme>` calls `registerTheme(theme)` as it renders and `Icon` resolves its semantic name against that theme (`useThemeName()` → `getIcon(name, themeName)`), so a preview island keeps the Lucide set and the chrome around it keeps the built-ins. With nothing writing to the global registry, SSR and the client cannot disagree.

The comment left in its place says why, and a test in `component-preview-theme.test.ts` fails if a global icon registration comes back anywhere in the docsite.

## Verification

Local production build (`next build && next start`), each route loaded in a real browser:

| Route | before | after |
| --- | --- | --- |
| `/` | React #418 | clean |
| `/blog` | React #418 | clean |
| `/templates` | React #418 | clean |
| `/docs/getting-started` | React #418 | clean |
| `/components/Banner` | clean, chrome in Lucide | clean, chrome in built-ins |

Preview islands are unchanged: `/components/Banner` still renders 24 Lucide icons inside `[data-astryx-theme="neutral"]`, `/templates` still renders 18.

`pnpm lint:strict` (0 errors), `pnpm test`, `pnpm -F @astryxdesign/docsite typecheck` and `pnpm build` all pass. No changeset — the docsite is not published.

## Where the line came from

It was a workaround for a core behaviour that no longer exists.

- **#3608** (2026-07-09) added it, as one of two "small incidental fixes found while working in the docsite preview code" in a CommandPalette docs PR. At that point `<Theme>` itself called `registerIcons(theme.icons)` during render, into the same process-global registry — so a warm server already held the Lucide icons when a fresh page was server-rendered while a fresh client render started from the defaults, and Icons rendering before the first `<Theme>` mismatched on `strokeWidth`. Registering at module load was meant to make both sides start from the same registry. (The PR describes it as *moving* an existing render-time call, but the diff is a pure addition — the render-time call was core's, not the docsite's.)
- **#4643** (2026-08-02) then made icon resolution theme-scoped: `<Theme>` now calls `registerTheme(theme)` and `Icon` resolves via `getIcon(name, useThemeName())`. That deleted the global write the docsite line was compensating for.

So since #4643 this has been the only thing writing to the global registry, which makes it the sole cause of the asymmetry it was added to prevent — no longer between a warm and a cold process, but between the routes that load this module and the routes that don't.

## Does removing it bring back the bug #3608 was fixing?

No, and this is checked against the actual pre-#3608 tree rather than argued.

#3608's failure mode reduces to one invariant: **does rendering a `<Theme>` that defines icons leave a trace in the process-global registry**, so that a later render elsewhere in the process resolves icons differently from a cold client? A probe renders a `<Theme>` carrying a sentinel icon, then renders a bare `<Icon>` outside any theme and reads which set it got — plus an explicit `registerIcons()` at the end as a control, so a probe that has stopped detecting anything cannot pass quietly.

Same probe, both trees, pinned to each tree's own built `packages/core/dist`:

| tree | `Theme.js` writes the registry | bare Icon after the render | control |
| --- | --- | --- | --- |
| `549e44f9` — the commit #3608 patched (core 0.1.4) | yes | **theme's icons — POLLUTED** | live |
| this PR (core 0.5.0, post-#4643) | no | **built-in — clean** | live |

The old tree reproduces the mechanism and the probe catches it; today's core leaves nothing behind. The bug needed a *writer*, and after #4643 there is none — `registerIcons` survives in the repo only in JSDoc and as a public API for consumers, and core itself `devWarn`s at anyone who calls it ("Prefer `defineTheme({ icons })` for theme-scoped icon overrides"). An empty registry is identical on a warm server and a cold client, so the two sides now agree by construction rather than by timing.

End to end, same conclusion on a real server: fingerprint every route's server HTML on a cold production server, warm the process with `/components/Banner`, fetch them all again. Dynamic and partial-prerender routes are in the set, since those are the ones that can still differ per request.

```
                        after warming
  /themes               IDENTICAL      /components/Button   IDENTICAL
  /templates/ai-chat    IDENTICAL      /                    IDENTICAL
  /docs/getting-started IDENTICAL      /blog                IDENTICAL
```

and every one of them hydrates clean against the warmed server.

## One visible change, on component pages only

Registry icons on a component-detail page outside the previews — sidebar and section chevrons, prop-table status icons — currently render in Lucide because of the pollution, and this returns them to the built-ins:

| `/components/Banner` | page + chrome | preview islands |
| --- | --- | --- |
| live today | 35 Lucide | 24 Lucide |
| this PR | 36 built-in | 24 Lucide |

That is the correction, not a side effect: those icons sit under `<Theme astryx>`, the docsite's own theme defines no `icons`, and every other page on the site already renders them as built-ins. Component pages were the outlier. Preview islands are untouched.

I considered the opposite fix — register the icons in the root layout, symmetric on both sides — and rejected it: it would change the icon set on every page of the site, which is a design decision rather than a bug fix, and it keeps a mutable global in the render path.
