### PR TITLE
fix(Toast): fit, wrap and animate correctly on a phone

### DIFF
--- a/.changeset/toast-small-screen-fit.md
+++ b/.changeset/toast-small-screen-fit.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Toast on small screens: the viewport's edge gutter now clears the device safe area (notch, home indicator, rounded corner) on all four edges — physically on the inline axis, so RTL gets the gutter on the right edge — and a toast sizes itself against that gutter instead of subtracting a hardcoded 32px from `100vw`. A body with no break opportunity (a URL, a long translated compound) wraps instead of overflowing, and the trailing controls are pinned to one line box so they stay level with the first line when the message wraps. The stack gap tightens from 12px to 8px, and a toast pushed past `maxVisible` collapses out (and expands back in) instead of blinking the stack by its own height. A toast slides in from — and back out towards — the edge its stack is pinned to, rather than always from below. The viewport only advertises its "Notifications" landmark while it is actually holding a toast, which also stops nested viewports from publishing the landmark twice.
+
+@imdreamrunner

--- a/packages/core/src/Toast/Toast.doc.mjs
+++ b/packages/core/src/Toast/Toast.doc.mjs
@@ -70,6 +70,9 @@ export const docs = {
     targets: [
       {className: 'astryx-toast', visualProps: ['type']},
     ],
+    vars: [
+      {name: '--_toast-slide-y', description: 'Distance and direction a toast translates on the block axis as it enters and leaves. ToastViewport sets it from `position` so a stack slides towards the edge it is pinned to: negative for a top-pinned stack, positive for a bottom-pinned one.', default: 'var(--spacing-2)', private: true},
+    ],
   },
 
   usage: {

--- a/packages/core/src/Toast/Toast.tsx
+++ b/packages/core/src/Toast/Toast.tsx
@@ -30,7 +30,13 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-4'],
     borderRadius: radiusVars['--radius-container'],
     width: 400,
-    maxWidth: 'min(100%, calc(100vw - 32px))',
+    // Shrink to whatever the container allows instead of subtracting a
+    // hardcoded gutter from 100vw. Inside ToastViewport the container is the
+    // viewport's content box, which already reserves the edge gutter *and*
+    // the device's safe-area insets — so a notched phone in landscape, a
+    // custom `inset`, and a desktop scrollbar are all accounted for here
+    // without this file knowing any of the numbers.
+    maxWidth: '100%',
     boxShadow: shadowVars['--shadow-med'],
     opacity: 1,
     fontFamily: typographyVars['--font-family-body'],
@@ -43,9 +49,12 @@ const styles = stylex.create({
       '@media (prefers-reduced-motion: reduce)': '0.01ms',
     },
     transitionTimingFunction: easeVars['--ease-standard'],
+    // Slide in from — and back out towards — the edge the stack is pinned to.
+    // ToastViewport sets --_toast-slide-y per position; the fallback keeps a
+    // standalone <Toast> (previews, docs) sliding up from below as before.
     '@starting-style': {
       opacity: 0,
-      transform: 'translateY(8px)',
+      transform: 'translateY(var(--_toast-slide-y, 8px))',
     },
   },
   variantDefault: {
@@ -63,17 +72,27 @@ const styles = stylex.create({
   content: {
     flex: 1,
     minWidth: 0,
+    // A URL, an ID, or a long compound word in a translated string has no
+    // break opportunity of its own and would otherwise spill past the toast's
+    // rounded edge. `anywhere` (not `break-word`) also shrinks the min-content
+    // width, so the flex row can actually reach the narrow size it is given.
+    overflowWrap: 'anywhere',
   },
   exiting: {
     opacity: 0,
-    transform: 'translateY(-8px)',
+    transform: 'translateY(var(--_toast-slide-y, 8px))',
   },
   endContent: {
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
-    marginBlock: `calc(${spacingVars['--spacing-1']} * -1)`,
+    // Reserve exactly one line box so the controls stay optically level with
+    // the FIRST line of the body when the message wraps. Controls taller than
+    // a line (the 28px icon button, an Undo button, a Badge) overflow this box
+    // symmetrically, which centers them on that line — where a plain
+    // flex-start alignment would hang them below it.
+    blockSize: `calc(${typeScaleDefaults['--text-body-size']} * ${typeScaleDefaults['--text-body-leading']})`,
     marginInlineEnd: `calc(${spacingVars['--spacing-1']} * -1)`,
   },
 });

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -255,6 +255,10 @@ describe('Toast blur timer pause', () => {
 describe('ToastViewport region ARIA', () => {
   it('exposes the notifications region without a prohibited aria-modal', () => {
     renderViewport(<ShowToastButton />);
+    // The region only exists once the viewport is holding a toast.
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger'));
+    });
     const region = screen.getByRole('region', {name: 'Notifications'});
     // aria-modal is only valid on role="dialog"/"alertdialog"; a region must
     // not declare it (axe: aria-allowed-attr).
@@ -484,5 +488,304 @@ describe('toast timer lifecycle (#3589)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('small-screen fit and safe areas (#5470)', () => {
+  function viewportEl(): HTMLElement {
+    // The viewport is the fixed container the toast wrappers live in.
+    const wrapper = document.querySelector('[data-toast-id]');
+    return (wrapper?.parentElement ??
+      document.querySelector<HTMLElement>('[role="region"]'))!;
+  }
+
+  it('reserves the device safe area on every edge', () => {
+    renderViewport(<ShowToastButton options={INFO_A} triggerLabel="Show" />);
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    const computed = window.getComputedStyle(viewportEl());
+    // StyleX emits the block longhands physically (padding-top/bottom); the
+    // block axis needs no direction handling, so that is equivalent.
+    expect(computed.paddingTop).toContain('safe-area-inset-top');
+    expect(computed.paddingBottom).toContain('safe-area-inset-bottom');
+    expect(computed.paddingInlineStart).toContain('safe-area-inset-left');
+    expect(computed.paddingInlineEnd).toContain('safe-area-inset-right');
+    // The design gutter is still the floor on a device with no insets.
+    expect(computed.paddingInlineStart).toContain('--spacing-4');
+    // Gutters have to count against the width, not add to it.
+    expect(computed.boxSizing).toBe('border-box');
+  });
+
+  it('swaps which physical inset each inline edge reads under RTL', () => {
+    renderViewport(<ShowToastButton options={INFO_A} triggerLabel="Show" />);
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    // env() insets are physical while the padding is logical, so the RTL rule
+    // has to point inline-start at the RIGHT inset (and vice versa) or the
+    // notch gutter lands on the wrong edge.
+    const rules = [...document.styleSheets]
+      .flatMap(sheet => {
+        try {
+          return [...sheet.cssRules].map(r => r.cssText);
+        } catch {
+          return [];
+        }
+      })
+      .filter(text => text.includes('[dir="rtl"]'));
+    expect(
+      rules.some(
+        text =>
+          text.includes('padding-inline-start') &&
+          text.includes('safe-area-inset-right'),
+      ),
+    ).toBe(true);
+    expect(
+      rules.some(
+        text =>
+          text.includes('padding-inline-end') &&
+          text.includes('safe-area-inset-left'),
+      ),
+    ).toBe(true);
+  });
+
+  it('sizes the toast against its container instead of a hardcoded 100vw gutter', () => {
+    renderViewport(<ShowToastButton options={INFO_A} triggerLabel="Show" />);
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    const toast = document.querySelector('[data-toast-id] [role="status"]')!;
+    const computed = window.getComputedStyle(toast);
+    expect(computed.maxWidth).toBe('100%');
+    expect(computed.maxWidth).not.toContain('vw');
+  });
+});
+
+describe('long and translated message content (#5470)', () => {
+  const LONG_URL: ToastOptions = {
+    body: 'https://example.com/reports/exports/aVeryLongUnbreakableIdentifier',
+  };
+
+  it('breaks a word with no break opportunity instead of overflowing', () => {
+    renderViewport(<ShowToastButton options={LONG_URL} triggerLabel="Show" />);
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    const body = screen.getByText(LONG_URL.body as string);
+    expect(window.getComputedStyle(body).overflowWrap).toBe('anywhere');
+  });
+
+  it('holds the trailing controls to one line box so they stay level with the first line', () => {
+    renderViewport(<ShowToastButton options={INFO_A} triggerLabel="Show" />);
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    const dismiss = screen.getByRole('button', {name: 'Dismiss notification'});
+    const endContent = dismiss.parentElement!;
+    const computed = window.getComputedStyle(endContent);
+    // One body line box — controls taller than a line overflow it centered,
+    // which lands them on the first line however far the body wraps.
+    expect(computed.height).toBe(
+      'calc(var(--text-body-size) * var(--text-body-leading))',
+    );
+    expect(computed.alignItems).toBe('center');
+  });
+});
+
+describe('stack gap and collapse (#5470)', () => {
+  it('separates stacked toasts by 8px, and drops the gap below the last one', () => {
+    renderViewport(
+      <>
+        <ShowToastButton options={INFO_A} triggerLabel="Show A" />
+        <ShowToastButton options={INFO_B} triggerLabel="Show B" />
+      </>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show A'));
+    });
+    act(() => {
+      fireEvent.click(screen.getByText('Show B'));
+    });
+    const wrappers = document.querySelectorAll<HTMLElement>('[data-toast-id]');
+    expect(wrappers).toHaveLength(2);
+    expect(window.getComputedStyle(wrappers[0]).paddingBottom).toBe(
+      'var(--spacing-2)',
+    );
+  });
+
+  it('collapses a dismissed toast rather than removing it outright', () => {
+    renderViewport(<ShowToastButton options={INFO_A} triggerLabel="Show" />);
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    const wrapper = document.querySelector<HTMLElement>('[data-toast-id]')!;
+    const id = wrapper.getAttribute('data-toast-id')!;
+    act(() => {
+      fireEvent.click(
+        screen.getByRole('button', {name: 'Dismiss notification'}),
+      );
+    });
+    // Still mounted, animating its row down to nothing — the stack closes the
+    // space instead of jumping by the toast's height.
+    const dismissing = document.querySelector<HTMLElement>(
+      `[data-toast-id="${id}"]`,
+    )!;
+    const computed = window.getComputedStyle(dismissing);
+    expect(computed.gridTemplateRows).toBe('0fr');
+    expect(computed.paddingBottom).toBe('0px');
+    expect(computed.transitionProperty).toContain('grid-template-rows');
+    act(() => {
+      completeExit(id);
+    });
+    expect(document.querySelector(`[data-toast-id="${id}"]`)).toBeNull();
+  });
+
+  it('collapses a toast pushed past maxVisible instead of blinking it out', () => {
+    render(
+      <ToastViewport isTopLayer={false} maxVisible={2}>
+        <ShowToastButton options={INFO_A} triggerLabel="Show" />
+      </ToastViewport>,
+    );
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        fireEvent.click(screen.getByText('Show'));
+      });
+    }
+    // Three toasts, a window of two: the displaced one stays mounted for one
+    // collapse, and is inert while it has no room.
+    const wrappers = [
+      ...document.querySelectorAll<HTMLElement>('[data-toast-id]'),
+    ];
+    expect(wrappers).toHaveLength(3);
+    expect(wrappers[0]).toHaveAttribute('inert');
+    expect(wrappers[1]).not.toHaveAttribute('inert');
+    expect(window.getComputedStyle(wrappers[0]).gridTemplateRows).toBe('0fr');
+    // Its controls are out of reach while it is collapsed.
+    expect(
+      within(wrappers[0]).getByRole('button', {
+        name: 'Dismiss notification',
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
+
+    // Room opens up: it comes back by expanding, not by popping in.
+    const lastId = wrappers[2].getAttribute('data-toast-id')!;
+    act(() => {
+      fireEvent.click(
+        within(wrappers[2]).getByRole('button', {name: 'Dismiss notification'}),
+      );
+    });
+    act(() => {
+      completeExit(lastId);
+    });
+    const requeued = document.querySelector<HTMLElement>('[data-toast-id]')!;
+    expect(requeued).not.toHaveAttribute('inert');
+    expect(window.getComputedStyle(requeued).gridTemplateRows).toBe('1fr');
+  });
+
+  it('does not burn a queued toast\u2019s auto-hide timer while it is unseen', () => {
+    vi.useFakeTimers();
+    try {
+      const onHide = vi.fn();
+      render(
+        <ToastViewport isTopLayer={false} maxVisible={1}>
+          <ShowToastButton
+            options={{body: 'Queued', autoHideDuration: 3000, onHide}}
+            triggerLabel="Show queued"
+          />
+          <ShowToastButton options={INFO_B} triggerLabel="Show B" />
+        </ToastViewport>,
+      );
+      act(() => {
+        fireEvent.click(screen.getByText('Show queued'));
+      });
+      act(() => {
+        fireEvent.click(screen.getByText('Show B'));
+      });
+      // The first toast is now queued behind the second. Its timer must not
+      // run down while it is collapsed and out of sight.
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(onHide).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('entry direction follows the pinned edge (#5470)', () => {
+  it.each([
+    ['bottomEnd', 'var(--spacing-2)'],
+    ['bottomStart', 'var(--spacing-2)'],
+    ['topEnd', 'calc(var(--spacing-2) * -1)'],
+    ['topStart', 'calc(var(--spacing-2) * -1)'],
+  ] as const)('slides %s toasts from their own edge', (position, expected) => {
+    render(
+      <ToastViewport isTopLayer={false} position={position}>
+        <ShowToastButton options={INFO_A} triggerLabel="Show" />
+      </ToastViewport>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    const viewport = screen.getByRole('region', {name: 'Notifications'});
+    // A top-pinned stack drops in from above (negative), a bottom-pinned one
+    // rises from below (positive). Toast reads this for both enter and exit.
+    expect(
+      window.getComputedStyle(viewport).getPropertyValue('--_toast-slide-y'),
+    ).toBe(expected);
+  });
+});
+
+describe('the notifications landmark (#5470)', () => {
+  it('is absent while the viewport holds no toasts', () => {
+    renderViewport(<ShowToastButton options={INFO_A} triggerLabel="Show" />);
+    // Nothing has been shown: an empty viewport must not add a permanent,
+    // empty "Notifications" landmark to the page.
+    expect(
+      screen.queryByRole('region', {name: 'Notifications'}),
+    ).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    expect(
+      screen.getByRole('region', {name: 'Notifications'}),
+    ).toBeInTheDocument();
+
+    const id = document
+      .querySelector('[data-toast-id]')!
+      .getAttribute('data-toast-id')!;
+    act(() => {
+      fireEvent.click(
+        screen.getByRole('button', {name: 'Dismiss notification'}),
+      );
+    });
+    act(() => {
+      completeExit(id);
+    });
+    expect(
+      screen.queryByRole('region', {name: 'Notifications'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('is not duplicated by a nested viewport', () => {
+    render(
+      <ToastViewport isTopLayer={false}>
+        <ToastViewport isTopLayer={false}>
+          <ShowToastButton options={INFO_A} triggerLabel="Show" />
+        </ToastViewport>
+      </ToastViewport>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    // The inner viewport shadows the outer one's context, so the outer can
+    // never hold a toast — and an empty viewport is no longer a landmark.
+    expect(screen.getAllByRole('region', {name: 'Notifications'})).toHaveLength(
+      1,
+    );
   });
 });

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -28,7 +28,28 @@ const styles = stylex.create({
     zIndex: 500,
     display: 'flex',
     flexDirection: 'column',
-    padding: spacingVars['--spacing-4'],
+    // The edge gutter has to clear the device's safe area — a notch, a home
+    // indicator, or a rounded corner — not just the 16px design gutter.
+    // env() insets are PHYSICAL, so the inline axis cannot just pair
+    // inline-start with inset-left: under `dir="rtl"` inline-start is the
+    // right edge and the gutter would be reserved on the wrong side. The
+    // property stays logical; the inset it reads is what swaps.
+    paddingBlockStart: `max(${spacingVars['--spacing-4']}, env(safe-area-inset-top, 0px))`,
+    paddingBlockEnd: `max(${spacingVars['--spacing-4']}, env(safe-area-inset-bottom, 0px))`,
+    paddingInlineStart: {
+      default: `max(${spacingVars['--spacing-4']}, env(safe-area-inset-left, 0px))`,
+      ':is([dir="rtl"] *)': `max(${spacingVars['--spacing-4']}, env(safe-area-inset-right, 0px))`,
+    },
+    paddingInlineEnd: {
+      default: `max(${spacingVars['--spacing-4']}, env(safe-area-inset-right, 0px))`,
+      ':is([dir="rtl"] *)': `max(${spacingVars['--spacing-4']}, env(safe-area-inset-left, 0px))`,
+    },
+    // Never wider than the screen, gutters included, so the toasts inside get
+    // a content box they can size themselves against (Toast: max-width: 100%).
+    // Stated rather than inherited: core's reset is :where()-scoped, so a
+    // consumer without it would otherwise get content-box here.
+    boxSizing: 'border-box',
+    maxInlineSize: '100%',
     pointerEvents: 'none',
     // Reset popover styles — the popover attribute puts us in the top
     // layer (above dialogs), but we don't want its default styles.
@@ -39,6 +60,13 @@ const styles = stylex.create({
     background: 'none',
     backgroundColor: 'transparent',
     overflow: 'visible',
+  },
+  // Which way a toast slides on enter and exit: towards the edge the stack is
+  // pinned to, so a top stack drops in from the top and a bottom stack rises
+  // from the bottom. Read by Toast's @starting-style and exiting styles.
+  slideFromBottom: {'--_toast-slide-y': spacingVars['--spacing-2']},
+  slideFromTop: {
+    '--_toast-slide-y': `calc(${spacingVars['--spacing-2']} * -1)`,
   },
   bottomEnd: {bottom: 0, insetInlineEnd: 0, alignItems: 'flex-end'},
   bottomStart: {bottom: 0, insetInlineStart: 0, alignItems: 'flex-start'},
@@ -76,10 +104,10 @@ const styles = stylex.create({
   // viewport's own padding. Which child that is flips with the flex direction
   // the position sets.
   toastWrapperGap: {
-    paddingBlockEnd: {default: spacingVars['--spacing-3'], ':last-child': 0},
+    paddingBlockEnd: {default: spacingVars['--spacing-2'], ':last-child': 0},
   },
   toastWrapperGapReversed: {
-    paddingBlockEnd: {default: spacingVars['--spacing-3'], ':first-child': 0},
+    paddingBlockEnd: {default: spacingVars['--spacing-2'], ':first-child': 0},
   },
   toastWrapperExiting: {
     gridTemplateRows: '0fr',
@@ -130,6 +158,10 @@ export interface ToastViewportProps {
  * Container that renders and manages toast notifications. Place at the root
  * of your app to enable useToast(). Toasts stack with enter/exit
  * animations and auto-promote to the CSS top layer.
+ *
+ * The stack's edge gutter clears the device safe area, and toasts slide in
+ * from — and back out towards — the edge `position` pins them to. The
+ * "Notifications" landmark is published only while a toast is on screen.
  *
  * @example
  * ```
@@ -325,7 +357,10 @@ export function ToastViewport({
       const nextNode = el.querySelector<HTMLElement>(
         `[data-toast-id="${target}"]`,
       );
-      const focusable = getFocusable(nextNode) ?? nextNode;
+      // A queued toast is rendered but collapsed and inert — it cannot take
+      // focus, so fall through to restoring the previously-focused element.
+      const candidate = nextNode?.hasAttribute('inert') ? null : nextNode;
+      const focusable = getFocusable(candidate) ?? candidate;
       if (focusable) {
         focusable.focus();
         return;
@@ -351,7 +386,14 @@ export function ToastViewport({
     [addToast, removeToast, findByUniqueID],
   );
 
-  const visibleToasts = toasts.slice(-maxVisible);
+  // Render one toast past the window. A toast pushed out by a newer one then
+  // collapses the way a dismissed one does, instead of blinking out and
+  // snapping the whole stack down by its height; by the time an even newer
+  // toast retires it from the DOM it is already at zero height, so that
+  // removal is invisible. It never leaves `toasts`, so a queued toast still
+  // comes back when room opens up — now by expanding rather than popping in.
+  const renderedToasts = toasts.slice(-(maxVisible + 1));
+  const queuedCount = Math.max(renderedToasts.length - maxVisible, 0);
   const insetStyle: React.CSSProperties = {};
   if (inset?.top) {
     insetStyle.top = inset.top;
@@ -432,38 +474,57 @@ export function ToastViewport({
   const gapStyle = isReversed
     ? styles.toastWrapperGapReversed
     : styles.toastWrapperGap;
+  const slideStyle = isReversed ? styles.slideFromTop : styles.slideFromBottom;
 
   return (
     <ToastContext value={contextValue}>
       {children}
       <div
         ref={viewportRef}
-        role="region"
-        aria-label={t('@astryx.toast.viewport')}
+        // Only a viewport that is actually holding a toast is a landmark. An
+        // empty one would put a permanent, empty "Notifications" region in
+        // every screen reader's landmark list — and since a nested viewport
+        // shadows the outer one's context for its subtree (the outer can then
+        // never receive a toast), it is also what stopped nested providers
+        // from advertising the same landmark twice.
+        role={hasToasts ? 'region' : undefined}
+        aria-label={hasToasts ? t('@astryx.toast.viewport') : undefined}
         tabIndex={-1}
         // popover="manual" promotes to the top layer (above dialogs).
         // Omitted inside dialogs where the viewport is already in a top layer.
         popover={isTopLayer ? 'manual' : undefined}
-        {...mergeProps(stylex.props(styles.viewport, posStyle), {
+        {...mergeProps(stylex.props(styles.viewport, posStyle, slideStyle), {
           style: Object.keys(insetStyle).length > 0 ? insetStyle : undefined,
         })}>
-        {visibleToasts.map(entry => {
+        {renderedToasts.map((entry, index) => {
           const o = entry.options;
           const type = o.type ?? 'info';
-          const isAutoHide = o.isAutoHide ?? (type === 'error' ? false : true);
+          // Beyond the visible window: collapsed to nothing and waiting for
+          // room. Its auto-hide timer must not burn down while it is unseen,
+          // which is what unmounting used to take care of.
+          const isQueued = index < queuedCount;
+          const isAutoHide = isQueued
+            ? false
+            : (o.isAutoHide ?? (type === 'error' ? false : true));
           const dur = o.autoHideDuration ?? 5000;
-          const isExiting = exitingIds.has(entry.id);
+          const isDismissing = exitingIds.has(entry.id);
+          const isExiting = isDismissing || isQueued;
           return (
             <div
               key={entry.id}
               data-toast-id={entry.id}
+              // Collapsed to zero height but still in the DOM — keep it out of
+              // the tab order and the accessibility tree until it is shown.
+              inert={isQueued ? true : undefined}
               {...stylex.props(
                 styles.toastWrapper,
                 gapStyle,
                 isExiting && styles.toastWrapperExiting,
               )}
               onTransitionEnd={
-                isExiting
+                // Only a *dismissed* toast unmounts when its collapse ends; a
+                // queued one has to stay mounted so it can expand again.
+                isDismissing
                   ? (e: React.TransitionEvent) => {
                       if (e.propertyName === 'grid-template-rows') {
                         handleExited(entry.id);

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -274,6 +274,10 @@ const VARS_WITHOUT_DERIVED_MAPPING = new Set([
   '--_avatar-group-overlap',
   '--_codeblock-gutter-width',
   '--_tab-indicator-bottom',
+  // One term inside a composed translateY() on the toast's enter/exit
+  // transition, set per stack position. A theme author writes `transform`
+  // on a toast, not this one offset within it.
+  '--_toast-slide-y',
   // Hit-area outset on a ::after overlay, and whether that overlay is
   // generated at all — `inset` and `content` on a pseudo-element are not
   // properties a theme author sets on the component.


### PR DESCRIPTION
Five rough edges the toast stack has on a phone. No API change, no new props: the
same `useToast()` / `ToastViewport` surface, behaving properly on a small screen.

Everything below is measured in Chromium at 360×740, DPR 2, unless stated.

### 1. Fit on a small screen

The toast was `width: 400px` with `max-width: min(100%, calc(100vw - 32px))` — a
gutter hardcoded into the toast, duplicating the one the viewport already
applies, and blind to the device. The viewport's own `padding: 16px` ignored
safe areas entirely, so in landscape on a notched phone the stack sat under the
notch and the rounded corner.

The viewport now reserves `max(16px, env(safe-area-inset-*))` on all four edges,
and the toast just takes `max-width: 100%` of the content box that leaves. No
`100vw` arithmetic, so a custom `inset`, a desktop scrollbar and a notch all
come out right without this file knowing any of the numbers.

**RTL:** `env()` insets are physical while the padding is logical, so
`inline-start` cannot simply read `inset-left` — under `dir="rtl"` inline-start
*is* the right edge. The property stays logical and the inset it reads swaps,
via `:is([dir="rtl"] *)` (the repo's existing RTL convention, per
`utils/rtlStyles.ts`).

### 2. Cope with long text

- A body with no break opportunity of its own — a URL, an ID, a long compound
  in a translated string — **overflowed the toast by 277px**. `overflow-wrap:
  anywhere` on the content: now 0. `anywhere` rather than `break-word` because
  it also shrinks min-content width, so the flex row can actually reach the
  narrow size it is given.
- The trailing controls hung below the first line once the body wrapped. They
  were top-aligned with a `-4px` block margin, which centres a 28px control on a
  20px line **only because (28−20)/2 happens to be 4** — anything taller drifts.
  With a 36px Undo and a three-line body: control centre **30px vs the first
  line's 26px**. They now sit in a box exactly one line box tall and overflow it
  centred, so they are level whatever their height: **26px vs 26px**. Single-line
  toast height is unchanged (52px).

### 3. Tidy the stack

- Gap between stacked toasts **12px → 8px**.
- A toast pushed past `maxVisible` was dropped from the render in one frame and
  the whole stack snapped down by its height: with `maxVisible: 5`, the stack's
  top edge went **432px → 492px in two frames**. It now stays mounted for one
  collapse (one spare past the window is rendered), so the stack closes the
  space smoothly — **432px → 432.03px** — and by the time an even newer toast
  retires it from the DOM it is already at zero height, so that removal is
  invisible. A queued toast is `inert` while collapsed (its controls were
  otherwise tabbable) and its auto-hide timer is held, which unmounting used to
  take care of. Nothing leaves `toasts`: the queue still behaves as before, and
  a queued toast now comes back by expanding rather than popping in.

Dismissal itself already collapsed smoothly; there is a regression test for it
now (max per-frame movement of a neighbour is the easing curve, not a step).

### 4. Animate from the edge the stack is pinned to

Everything slid in from below and out upwards regardless of `position`. A toast
now enters from — and leaves towards — its own edge: top-pinned stacks
`translateY(-8px) → 0`, bottom-pinned `+8px → 0`. The direction travels as a
private `--_toast-slide-y` the viewport sets from `position`, so `Toast` keeps
its own transform and gains no prop; a standalone `<Toast>` in a docs preview
falls back to the old behaviour.

### 5. Stop announcing an empty region

The viewport rendered `role="region" aria-label="Notifications"` unconditionally,
so every app carried a permanent, empty landmark. It is now published only while
a toast is on screen.

That also fixes the nested-provider duplicate: a nested viewport shadows the
outer one's context for its subtree, so the outer can never receive a toast, and
an empty viewport is no longer a landmark. Nested viewports with one toast
between them: **2 landmarks → 1**. (`LayerProvider` already no-ops when nested;
this is direct `<ToastViewport>` nesting, as in the *Toast over Dialog* story.)

## Test plan

- `packages/core/src/Toast/ToastViewport.test.tsx`: 28 tests, 13 new, covering
  each of the five above — safe-area gutters and their RTL inset swap, the
  container-relative max-width, wrapping, the one-line-box control alignment,
  the 8px gap, the dismissal collapse, the queued-toast collapse/inert/timer,
  the four slide directions, the absent-when-empty landmark, and the nested
  case. One existing test (`region ARIA`) now shows a toast first, since an
  empty viewport is deliberately no longer a region.
- Behaviour measured in Chromium against built `dist` (numbers above), with the
  pre-change build as the control.
- `pnpm lint:strict`, `pnpm test`, `pnpm build`, `pnpm storybook:build`, and the
  `core`/`lab`/`charts`/`cli`/`storybook` typechecks all clean.

