### PR TITLE
fix(docsite): pin the desktop hero with sticky so overscroll can bounce again

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
@@ -34,12 +34,14 @@ const REWARD_MEMBER_NAME = 'Ami Pena';
 const REWARD_MEMBER_AVATAR = '/images/avatars/DATA-Ami-Pena.png';
 
 const styles = stylex.create({
-  // Desktop overlap stage: fixed, viewport-centered 1200px box (shared with the
-  // aurora blobs) so cards track the blobs on resize. Capped to 100vw to avoid
-  // horizontal scroll. Hidden <1024px, where the collage takes over.
+  // Desktop overlap stage: the 1200px art box (shared with the aurora blobs, so
+  // cards track the blobs on resize). Absolute inside the hero's sticky pin
+  // layer rather than fixed to the viewport — see HeroPinRail. Capped to 100vw
+  // to avoid horizontal scroll. Hidden <1024px, where the collage takes over.
   stage: {
-    position: 'fixed',
-    top: 'var(--appshell-header-height, 0px)',
+    position: 'absolute',
+    // The pin layer is already offset a header-height down.
+    top: 0,
     left: '50%',
     transform: 'translateX(-50%)',
     width: 'min(1200px, 100vw)',
@@ -564,7 +566,7 @@ export function HeroFloatingCards({
     );
   }
 
-  // ── Overlap layout (desktop): fixed art composition ───────────────────
+  // ── Overlap layout (desktop): pinned art composition ──────────────────
   return (
     <div {...stylex.props(styles.stage)} aria-hidden="true" inert>
       {/* Leading pill */}

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroPinRail.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroPinRail.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file HeroPinRail.tsx
+ * @input one pinned hero layer as children
+ * @output a hero-scope-sized containing block for it (≥1024px only)
+ * @position Home hero — the box that lets the pinned layers be `sticky`
+ *           rather than `fixed`.
+ *
+ * The desktop hero pins its art behind the showcase surface, which then scrolls
+ * up over it (pin-and-cover). `fixed` is the obvious way to pin, but a fixed
+ * layer is glued to the viewport and is NOT part of the document: when the
+ * document rubber-bands past its own bottom edge, the layer does not lift with
+ * it and paints in the exposed gap. That is what forced
+ * `overscroll-behavior-y: none` onto `html` (#3032) and, until #5415 scoped it,
+ * cost mobile its pull-to-refresh (#5392).
+ *
+ * `position: sticky` pins the same way but stays in the document, so it lifts
+ * with the page and cannot paint below the document's own bottom edge — no
+ * suppression rule needed. The catch is that sticky is clamped to its
+ * containing block, and the pinned layers live inside the 760px hero band, so
+ * on their own they would unpin the moment the band scrolls past.
+ *
+ * This rail is that containing block: `absolute; inset: 0` against `heroScope`
+ * (hero + showcase), so a sticky child stays pinned for exactly as long as the
+ * pin-and-cover effect runs, and releases where the opaque showcase already
+ * covers it. Being absolute, the rail contributes no height — the document is
+ * the same size with it as without, and `heroSpacer` goes on reserving the band.
+ *
+ * Below 1024px the rail is `display: contents`: it generates no box at all, so
+ * the narrow hero lays out exactly as if it were not in the tree. Nothing pins
+ * there — the mobile hero is taller than the viewport and scrolls away.
+ *
+ * ⚠️ Sticky dies silently if any ancestor becomes a scroll container. `fixed`
+ * only broke on an ancestor `transform`/`filter`; `sticky` additionally breaks
+ * on `overflow: hidden|auto|scroll`. `.astryx-layout-content` (AppShell) already
+ * carries `overflow: clip`, which is safe — clip creates no scroll container —
+ * but it is one property *value* away from un-pinning the whole landing page.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import type {ReactNode} from 'react';
+
+const styles = stylex.create({
+  rail: {
+    // <1024px: no box, so the narrow layout is untouched by the rail existing.
+    display: {
+      default: 'contents',
+      '@media (min-width: 1024px)': 'block',
+    },
+    // heroScope is the nearest positioned ancestor, so inset:0 sizes the rail
+    // to hero + showcase. Ignored while display is contents.
+    position: {
+      default: 'static',
+      '@media (min-width: 1024px)': 'absolute',
+    },
+    inset: 0,
+    // Purely a containing block — it must not swallow hover/clicks over the
+    // hero gutters (which would pause the reel's auto-advance) or over the
+    // showcase's rounded top corners. Layers that need input opt back in.
+    pointerEvents: 'none',
+  },
+});
+
+/** Bounds one pinned hero layer to `heroScope` so it can be `sticky`. */
+export function HeroPinRail({children}: {children: ReactNode}) {
+  return <div {...stylex.props(styles.rail)}>{children}</div>;
+}

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -42,6 +42,7 @@ import {
 } from './heroThemeContent';
 import {AstryxLogo} from '../../../../components/logos';
 import {HeroFloatingCards} from './HeroFloatingCards';
+import {HeroPinRail} from './HeroPinRail';
 
 // How long each theme stays on screen before auto-advancing (ms).
 const ADVANCE_INTERVAL_MS = 4500;
@@ -123,10 +124,21 @@ const styles = stylex.create({
     },
     height: 'auto',
   },
-  // Sticky, zero-height layer hosting the overlap cards so they pin with the
-  // hero and don't intercept clicks.
-  cardsLayer: {
-    position: 'sticky',
+  // Zero-height layer hosting the desktop pinned art (aurora glow + overlap
+  // cards) so they pin together and don't intercept clicks. Sticky rather than
+  // fixed so the art lifts with the document during overscroll instead of
+  // painting in the exposed gap — see HeroPinRail, which supplies the
+  // containing block that keeps it pinned past the hero band.
+  //
+  // Static below 1024px: nothing pins there (the overlap stage is display:none
+  // and the glow scrolls away with the hero), and staying unpositioned is what
+  // keeps this layer OUT of the glow's containing-block chain, so the glow
+  // resolves against heroScope exactly as it did before (#5392).
+  pinLayer: {
+    position: {
+      default: 'static',
+      '@media (min-width: 1024px)': 'sticky',
+    },
     top: 'var(--appshell-header-height, 0px)',
     height: 0,
     width: '100%',
@@ -156,7 +168,11 @@ const styles = stylex.create({
     pointerEvents: 'none',
     transition: 'background-color 600ms ease',
   },
-  // Per-slide band behind the transparent top nav so it retints too.
+  // Per-slide band behind the transparent top nav so it retints too. Fixed, not
+  // sticky like the layers below: the band has to cover the header strip, and
+  // the header sits ABOVE heroScope in flow — so there is no box inside the
+  // hero for a sticky band to stick to. It is only a header-height tall, so it
+  // never reaches the bottom-overscroll gap the pinned art used to bleed into.
   navBackdrop: {
     position: 'fixed',
     top: 0,
@@ -168,31 +184,24 @@ const styles = stylex.create({
     transition: 'background-color 600ms ease',
     zIndex: 0,
   },
-  // Blurred aurora glow — in the same 1200px box as the cards so blobs and
-  // cards stay aligned; pinned at >=1024px and scrolling away with the hero
-  // below that (see `position`). Capped to 100vw to avoid horizontal scroll.
-  // Blob centers sit under the card clusters; colors come from --aurora-* per
-  // slide.
+  // Blurred aurora glow — in the same 1200px box as the cards (it shares their
+  // pin layer) so blobs and cards stay aligned. Capped to 100vw to avoid
+  // horizontal scroll. Blob centers sit under the card clusters; colors come
+  // from --aurora-* per slide.
   backdropGlow: {
-    // Desktop: fixed, part of the pin-and-cover effect alongside heroContent
-    // and the cards stage. Narrow: absolute within heroScope (position:
-    // relative), so it scrolls away with the hero instead of staying pinned
-    // for the whole page — a fixed glow below 1024px reached past the footer
-    // into the bottom-overscroll gap. That exposure is what the app-global
-    // `overscroll-behavior-y: none` in globals.css was suppressing, at the
-    // cost of pull-to-refresh on every route on mobile; bounding the glow
-    // here is what lets that rule scope to desktop widths (#5392).
-    position: {
-      default: 'absolute',
-      '@media (min-width: 1024px)': 'fixed',
-    },
-    // heroScope already starts below the header (it's the sibling after
-    // navBackdrop in document flow), so the absolute case needs no offset;
-    // only the fixed case has to clear the header itself.
-    top: {
-      default: 0,
-      '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
-    },
+    // Absolute at every width; what changes is the box it resolves against.
+    // ≥1024px that is pinLayer, which is sticky, so the glow pins with the
+    // hero. Below 1024px pinLayer is unpositioned and the glow resolves
+    // against heroScope instead, so it scrolls away with the hero rather than
+    // staying pinned for the whole page — a pinned glow down there reached past
+    // the footer into the bottom-overscroll gap, and suppressing that with an
+    // app-global `overscroll-behavior-y: none` cost pull-to-refresh on every
+    // route on mobile (#5392).
+    position: 'absolute',
+    // Both containing blocks already start where the glow should: pinLayer is
+    // pinned a header-height down, and heroScope begins below the header (it is
+    // the sibling after navBackdrop in document flow).
+    top: 0,
     left: '50%',
     transform: 'translateX(-50%)',
     width: 'min(1200px, 100vw)',
@@ -451,21 +460,25 @@ export function HeroReelCards() {
     <Theme theme={active.theme} mode={effectiveMode(active, reel.userMode)}>
       <div {...stylex.props(styles.themeFill)} aria-hidden="true" />
       <div {...stylex.props(styles.navBackdrop)} aria-hidden="true" />
-      <div
-        aria-hidden="true"
-        {...stylex.props(
-          styles.backdropGlow,
-          dynamic.aurora(
-            active.aurora.left,
-            active.aurora.center,
-            active.aurora.right,
-          ),
-        )}
-      />
-      {/* Floating cards layer */}
-      <div {...stylex.props(styles.cardsLayer)}>
-        <HeroFloatingCards content={active.content} mounted={shown} />
-      </div>
+      {/* Desktop pin layer: the rail bounds it to heroScope so it stays pinned
+          for the whole pin-and-cover run without going `fixed`. */}
+      <HeroPinRail>
+        <div {...stylex.props(styles.pinLayer)}>
+          <div
+            aria-hidden="true"
+            {...stylex.props(
+              styles.backdropGlow,
+              dynamic.aurora(
+                active.aurora.left,
+                active.aurora.center,
+                active.aurora.right,
+              ),
+            )}
+          />
+          {/* Floating cards layer */}
+          <HeroFloatingCards content={active.content} mounted={shown} />
+        </div>
+      </HeroPinRail>
     </Theme>
   );
 }

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -23,6 +23,7 @@ import {
   HeroReelDots,
   useHeroReelIsDark,
 } from './_landing/hero/HeroThemeReel';
+import {HeroPinRail} from './_landing/hero/HeroPinRail';
 import {FeaturesShowcase} from './_landing/FeaturesShowcase';
 import {AboutShowcase} from './_landing/AboutShowcase';
 import {BlogShowcase} from './_landing/BlogShowcase';
@@ -39,24 +40,26 @@ const styles = stylex.create({
     // Shared by the nav→wordmark gap and the text→cards gap so they match.
     '--hero-gap': 'calc(var(--spacing-12) * 2)',
   },
-  // Desktop: fixed for pin-and-cover (heroSpacer reserves its height). Narrow:
-  // in flow — the mobile hero is taller than the viewport, so pinning stranded
-  // the lower collage below the fold.
+  // Desktop: pinned for pin-and-cover (heroSpacer reserves its height, and
+  // HeroPinRail bounds the pin to heroScope). Narrow: in flow — the mobile hero
+  // is taller than the viewport, so pinning stranded the lower collage below
+  // the fold.
   heroContent: {
     position: {
       default: 'relative',
-      '@media (min-width: 1024px)': 'fixed',
+      '@media (min-width: 1024px)': 'sticky',
     },
-    // top offset only matters when fixed; in flow it would leave a gap.
+    // top offset only matters when pinned; in flow it would leave a gap.
     top: {
       default: 0,
       '@media (min-width: 1024px)': 'var(--appshell-header-height, 0px)',
     },
-    left: 0,
-    right: 0,
-    // Desktop: fixed band, centered (cards are a separate overlap layer).
-    // Narrow: auto height (sizes to text + collage); a ResizeObserver applies it
-    // to heroSpacer so the showcase starts right after the cards.
+    // The rail is pointer-events: none so it can't swallow hover over the hero
+    // gutters; the content column itself has to stay interactive (CTAs, links).
+    pointerEvents: 'auto',
+    // Desktop: fixed-height band, centered (cards are a separate overlap
+    // layer). Narrow: auto height (sizes to text + collage); a ResizeObserver
+    // applies it to heroSpacer so the showcase starts right after the cards.
     height: {
       default: 'auto',
       '@media (min-width: 1024px)': `calc(${HERO_BAND_HEIGHT}px - var(--appshell-header-height, 0px))`,
@@ -68,7 +71,7 @@ const styles = stylex.create({
       '@media (min-width: 1024px)': 'center',
     },
     // Narrow: in flow under the transparent nav, so pad by nav height to clear
-    // it. Desktop is fixed + centered, so none.
+    // it. Desktop is pinned + centered, so none.
     paddingBlockStart: {
       default: 'calc(var(--appshell-header-height, 0px) + var(--spacing-8))',
       '@media (min-width: 768px)':
@@ -81,11 +84,13 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-6'],
     textAlign: 'center',
     gap: spacingVars['--spacing-6'],
-    // Decorative-position layer; never intercept clicks outside its actual
-    // content (the buttons/links re-enable pointer events on themselves).
+    // Above the hero's decorative layers but below the showcase surface, which
+    // scrolls over it.
     zIndex: 0,
   },
-  // Reserves the fixed hero's height (desktop); 0 on narrow (hero is in flow).
+  // Reserves the pinned hero's height (desktop); 0 on narrow (hero is in flow).
+  // The pin rail is absolute, so it adds no height of its own — this is still
+  // the only thing holding the band open.
   heroSpacer: {
     height: {
       default: 0,
@@ -344,9 +349,13 @@ export default function HomePage() {
       <HeroReelProvider>
         {/* Desktop overlap cards layer (the gutters). */}
         <HeroReelCards />
-        {/* Reserves the fixed hero's height so the showcase starts below it. */}
+        {/* Reserves the pinned hero's height so the showcase starts below it. */}
         <div {...stylex.props(styles.heroSpacer)} aria-hidden="true" />
-        <HeroContent contentRef={heroContentRef} />
+        {/* Rail bounds the pin to heroScope so the hero can be sticky, not
+            fixed — a fixed hero paints in the overscroll gap. */}
+        <HeroPinRail>
+          <HeroContent contentRef={heroContentRef} />
+        </HeroPinRail>
       </HeroReelProvider>
       <VStack ref={showcaseRef} xstyle={styles.showcaseOverlay}>
         <FeaturesShowcase />

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -12,18 +12,6 @@
    reset, astryx-base, astryx-theme so product styles always win. */
 @stylex;
 
-/* Disable overscroll bounce so the home hero's still-fixed (>=1024px) layers
-   can't show through past the top/bottom of the page. Below 1024px the hero
-   no longer pins anything past the fold (see HeroThemeReel's backdropGlow),
-   so this rule only needs to apply at desktop widths — leaving it unscoped
-   also silently disabled pull-to-refresh on every route, everywhere on
-   mobile, which is not what it was written for (#5392). */
-@media (min-width: 1024px) {
-  html {
-    overscroll-behavior-y: none;
-  }
-}
-
 /* Marketing-only custom properties for the docsite home page. These are
    NOT Astryx theming tokens — they're docsite-specific values that back the
    landing page's bento feature cards + section rhythm — so they live here


### PR DESCRIPTION
## Summary

Step 2 of #5392 — closes #5470. Desktop gets its native overscroll bounce back, and `overscroll-behavior-y: none` is **deleted** rather than narrowed.

#5415 fixed the mobile half and left the suppression gated to desktop:

```css
@media (min-width: 1024px) {
  html { overscroll-behavior-y: none; }
}
```

That rule exists because three home-hero layers were `position: fixed` — `heroContent`, `HeroFloatingCards.stage` and `HeroThemeReel.backdropGlow`. A fixed layer is glued to the viewport and is not part of the document, so when the document rubber-bands past its own bottom edge the layer does not lift with it. At max scroll the fixed glow occupies the whole viewport, so **any** bottom overscroll paints hero art in the exposed gap.

## The fix

`position: sticky` pins identically but stays *in* the document: it lifts with the page and cannot paint below the document's own bottom edge. That is structural, not empirical, which is why the rule can go entirely.

Sticky is clamped to its containing block, and the pinned layers live inside the 760px hero band, so on their own they would unpin the moment the band scrolled past. The new **`HeroPinRail`** is that containing block: `absolute; inset: 0` against `heroScope` (hero + showcase), so a sticky child stays pinned for exactly as long as the pin-and-cover effect runs and releases where the opaque showcase already covers it. Being absolute it contributes no height — `heroSpacer` still reserves the band and the document is the same size.

Below 1024px the rail is `display: contents`: no box at all, so the narrow hero lays out exactly as if it were not in the tree. **Nothing about mobile changes.**

Two simplifications fall out:

- the glow now shares the cards' pin layer instead of pinning itself, which drops **both** of its media-query branches (`position` and `top` become unconditional);
- `stage` becomes `absolute` inside that layer instead of `fixed`.

`navBackdrop` stays `fixed` on purpose: it covers the header strip, and the header sits *above* `heroScope` in flow, so there is no box inside the hero for a sticky band to stick to. At a header-height tall it never reaches the bottom gap.

## Verification

Production builds of `main` and this branch served side by side (`NEXT_PUBLIC_DOCS_TARGET=latest`, so no canary banner), driven with Playwright at DPR 1 with transitions disabled.

**Pixel-identical to `fixed` at every scroll position and viewport:**

| scroll | 0 | 100 | 200 | 400 | 760 | 1400 | 2200 | max |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1280×900 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| 1024×768 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| 1440×1400 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| 1280×600 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| 768×1024 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| 390×844 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

(differing pixels; repeated in dark mode with the same result. A handful of 4/255 antialiasing pixels turn up nondeterministically, including at 390px where the change applies to nothing.) Every layer's rect matches to the tenth of a pixel — only the `position` keyword differs. Document height, `scrollWidth` and CTA hit-testing are unchanged at every sample.

**The gap.** A bottom rubber-band is emulated by appending an N-px transparent spacer and scrolling N further, which reproduces the frame exactly: the scrolled content lifts, `fixed` layers stay put.

| | before | after |
| --- | --- | --- |
| `html` `overscroll-behavior-y` ≥1024px | `none` | **`auto`** |
| fixed layers painting into the gap (1280×900) | 2 — glow + card stage | **0** |
| pixels of the gap strip that changed | — | 74% at 1280×900, 54% at 1024×768, 43% at 1280×600 |

Before, the exposed strip shows the aurora glow, a floating card and the theme dots below the footer. After, it is the page background and nothing else.

**Nothing else on the site bleeds.** The rule was app-global, so I checked every route for `fixed` chrome that would now show in the gap: `/`, `/docs/getting-started`, `/components`, `/components/Button`, `/templates`, `/themes`, `/blog`, `/changelog`, `/community`, `/playground` — 0 painters on all ten. The docs sidebar is sticky, not fixed.

**Live behaviour matches `main`** — theme swap mid-scroll (layers hold at 33,48 through the swap), resize while scrolled and back, `prefers-reduced-motion`, auto-advance, hover-to-pause over both the hero column and the gutters, and the CTA hit test.

Gates: `pnpm -F @astryxdesign/docsite test` (403 passing), `typecheck`, `build`, eslint and prettier on every changed file. Docsite-only, so `check-scope` skips the heavy jobs and no changeset is required.

## The trap this leaves behind, and where it is written down

`fixed` broke if an ancestor gained `transform` or `filter`. `sticky` breaks **additionally** on an ancestor `overflow: hidden|auto|scroll` — silently, with no error: the hero just stops pinning and nobody notices until they look at the home page. `.astryx-layout-content` (AppShell) already carries `overflow: clip`, which is safe (clip creates no scroll container) but is one property *value* away from un-pinning the whole landing page. That warning is in `HeroPinRail`'s file header, which is where anyone touching this will be.

## Not covered

Chromium only, and no real trackpad. The emulation matches Chromium's model and proves layout equivalence; the *feel* of the restored bounce, and Safari, want a look on a Mac — the preview deploy is the place to do it.
