### PR TITLE
fix(NumberInput): never commit a valid prefix from an invalid draft

### DIFF
--- a/.changeset/numberinput-invalid-draft-commit.md
+++ b/.changeset/numberinput-invalid-draft-commit.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] NumberInput: commit each text edit as one draft on blur or Enter, so invalid typed and pasted input consistently preserves the prior value instead of committing a valid prefix. This also prevents Pagination from navigating to an intermediate prefix while preserving live inline Table filtering.
+[fix] NumberInput: commit each text edit as one draft on blur or Enter, so invalid typed and pasted input consistently preserves the prior value instead of committing a valid prefix. This also prevents Pagination from navigating to an intermediate prefix while preserving live inline Table filtering and PowerSearch's Enter-to-save behavior.
 
 @cixzhang

--- a/.changeset/numberinput-invalid-draft-commit.md
+++ b/.changeset/numberinput-invalid-draft-commit.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] NumberInput: commit each text edit as one draft on blur or Enter, so invalid typed and pasted input consistently preserves the prior value instead of committing a valid prefix.
+[fix] NumberInput: commit each text edit as one draft on blur or Enter, so invalid typed and pasted input consistently preserves the prior value instead of committing a valid prefix. This also prevents Pagination from navigating to an intermediate prefix while preserving live inline Table filtering.
 
 @cixzhang

--- a/.changeset/numberinput-invalid-draft-commit.md
+++ b/.changeset/numberinput-invalid-draft-commit.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] NumberInput: commit each text edit as one draft on blur or Enter, so invalid typed and pasted input consistently preserves the prior value instead of committing a valid prefix.
+
+@cixzhang

--- a/apps/docsite/src/__tests__/live-number-input.test.ts
+++ b/apps/docsite/src/__tests__/live-number-input.test.ts
@@ -5,31 +5,16 @@ import {readLiveNumberDraft} from '../lib/useLiveNumberInput';
 
 describe('readLiveNumberDraft', () => {
   it('returns an in-range machine number for live preview', () => {
-    expect(readLiveNumberDraft('12.5', {min: 0, max: 20})).toEqual({
-      liveValue: 12.5,
-      shouldRevert: false,
-    });
+    expect(readLiveNumberDraft('12.5', {min: 0, max: 20})).toBe(12.5);
   });
 
-  it('marks unreadable and non-integral drafts for rollback', () => {
-    expect(readLiveNumberDraft('1·234', {})).toEqual({
-      liveValue: null,
-      shouldRevert: true,
-    });
-    expect(readLiveNumberDraft('3.5', {isIntegerOnly: true})).toEqual({
-      liveValue: null,
-      shouldRevert: true,
-    });
+  it('rejects unreadable and non-integral drafts', () => {
+    expect(readLiveNumberDraft('1·234', {})).toBeNull();
+    expect(readLiveNumberDraft('3.5', {isIntegerOnly: true})).toBeNull();
   });
 
   it('leaves empty and out-of-range drafts to NumberInput commit policy', () => {
-    expect(readLiveNumberDraft('', {})).toEqual({
-      liveValue: null,
-      shouldRevert: false,
-    });
-    expect(readLiveNumberDraft('100', {max: 10})).toEqual({
-      liveValue: null,
-      shouldRevert: false,
-    });
+    expect(readLiveNumberDraft('', {})).toBeNull();
+    expect(readLiveNumberDraft('100', {max: 10})).toBeNull();
   });
 });

--- a/apps/docsite/src/__tests__/live-number-input.test.ts
+++ b/apps/docsite/src/__tests__/live-number-input.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {readLiveNumberDraft} from '../lib/useLiveNumberInput';
+
+describe('readLiveNumberDraft', () => {
+  it('returns an in-range machine number for live preview', () => {
+    expect(readLiveNumberDraft('12.5', {min: 0, max: 20})).toEqual({
+      liveValue: 12.5,
+      shouldRevert: false,
+    });
+  });
+
+  it('marks unreadable and non-integral drafts for rollback', () => {
+    expect(readLiveNumberDraft('1·234', {})).toEqual({
+      liveValue: null,
+      shouldRevert: true,
+    });
+    expect(readLiveNumberDraft('3.5', {isIntegerOnly: true})).toEqual({
+      liveValue: null,
+      shouldRevert: true,
+    });
+  });
+
+  it('leaves empty and out-of-range drafts to NumberInput commit policy', () => {
+    expect(readLiveNumberDraft('', {})).toEqual({
+      liveValue: null,
+      shouldRevert: false,
+    });
+    expect(readLiveNumberDraft('100', {max: 10})).toEqual({
+      liveValue: null,
+      shouldRevert: false,
+    });
+  });
+});

--- a/apps/docsite/src/app/playground/propertyEditor/PropertyEditor.tsx
+++ b/apps/docsite/src/app/playground/propertyEditor/PropertyEditor.tsx
@@ -45,6 +45,7 @@ import {
 } from './componentInstances';
 import {isEditable, isSupportedProp} from './isSupportedProp';
 import {getComponentByModule} from './componentLookup';
+import {useLiveNumberInput} from '@/lib/useLiveNumberInput';
 
 const NUMERIC_RE = /^-?\d+(\.\d+)?$/;
 
@@ -71,6 +72,35 @@ interface PropRowProps {
   instance: InstanceInfo;
   code: string;
   onCodeChange: (code: string) => void;
+}
+
+function LiveNumberControl({
+  label,
+  value,
+  isRequired,
+  onChange,
+}: {
+  label: string;
+  value: number | null;
+  isRequired: boolean;
+  onChange: (value: number | null) => void;
+}) {
+  const liveNumber = useLiveNumberInput(value, onChange);
+  return (
+    <NumberInput
+      label={label}
+      isLabelHidden
+      value={value}
+      placeholder={isRequired ? undefined : 'unset'}
+      hasClear={!isRequired}
+      onChange={liveNumber.handleChange}
+      onFocus={liveNumber.handleFocus}
+      onInput={liveNumber.handleInput}
+      onBlur={liveNumber.handleBlur}
+      onKeyDown={liveNumber.handleKeyDown}
+      xstyle={s.inputControl}
+    />
+  );
 }
 
 function PropRow({prop, instance, code, onCodeChange}: PropRowProps) {
@@ -198,14 +228,11 @@ function PropRow({prop, instance, code, onCodeChange}: PropRowProps) {
     // prop like maxWidth render `max-width: 0` with no way back to unset.
     const value = typeof attr?.value === 'number' ? attr.value : (def ?? null);
     controlEl = (
-      <NumberInput
+      <LiveNumberControl
         label={prop.name}
-        isLabelHidden
         value={value}
-        placeholder={prop.required ? undefined : 'unset'}
-        hasClear={!prop.required}
-        onChange={(next: number | null) => commit('number', next)}
-        xstyle={s.inputControl}
+        isRequired={!!prop.required}
+        onChange={next => commit('number', next)}
       />
     );
   }

--- a/apps/docsite/src/app/playground/propertyEditor/PropertyEditor.tsx
+++ b/apps/docsite/src/app/playground/propertyEditor/PropertyEditor.tsx
@@ -90,7 +90,7 @@ function LiveNumberControl({
     <NumberInput
       label={label}
       isLabelHidden
-      value={value}
+      value={liveNumber.value}
       placeholder={isRequired ? undefined : 'unset'}
       hasClear={!isRequired}
       onChange={liveNumber.handleChange}

--- a/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
+++ b/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
@@ -19,6 +19,7 @@ import {ColorSwatch} from './ColorSwatch';
 import {SelectableCard} from '@astryxdesign/core/SelectableCard';
 import {FONT_OPTIONS, RATIO_OPTIONS, UNIFIED_PRESETS} from './constants';
 import {getConcentricityWarning} from './helpers';
+import {useLiveNumberInput} from '@/lib/useLiveNumberInput';
 
 const styles = stylex.create({
   fullWidthField: {width: '100%'},
@@ -70,6 +71,16 @@ function ScaleControl({
   step,
   units,
 }: ScaleControlProps) {
+  const liveNumber = useLiveNumberInput(
+    numberValue,
+    nextValue => {
+      if (nextValue != null) {
+        onNumber(nextValue);
+      }
+    },
+    {min, max},
+  );
+
   return (
     <VStack gap={1}>
       <HStack gap={1} vAlign="center">
@@ -100,7 +111,11 @@ function ScaleControl({
           isLabelHidden
           value={numberValue}
           placeholder="—"
-          onChange={onNumber}
+          onChange={liveNumber.handleChange}
+          onFocus={liveNumber.handleFocus}
+          onInput={liveNumber.handleInput}
+          onBlur={liveNumber.handleBlur}
+          onKeyDown={liveNumber.handleKeyDown}
           min={min}
           max={max}
           step={step}

--- a/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
+++ b/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
@@ -109,7 +109,7 @@ function ScaleControl({
         <NumberInput
           label={controlLabel}
           isLabelHidden
-          value={numberValue}
+          value={liveNumber.value}
           placeholder="—"
           onChange={liveNumber.handleChange}
           onFocus={liveNumber.handleFocus}

--- a/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
+++ b/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
@@ -392,7 +392,7 @@ function NumberControl({
   return (
     <NumberInput
       label=""
-      value={value}
+      value={liveNumber.value}
       placeholder={isRequired ? undefined : 'unset'}
       hasClear={!isRequired}
       onChange={liveNumber.handleChange}

--- a/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
+++ b/apps/docsite/src/components/component-detail/PlaygroundPropsTable.tsx
@@ -34,6 +34,7 @@ import type {
   TypeDefinition,
 } from '../../generated/componentRegistry';
 import {MarkdownText} from '../MarkdownText';
+import {useLiveNumberInput} from '@/lib/useLiveNumberInput';
 
 function formatType(type: string, defaultValue?: string): React.ReactNode {
   const parts = type.split(/\s*\|\s*/);
@@ -378,6 +379,31 @@ function SlotListControl({
   );
 }
 
+function NumberControl({
+  value,
+  isRequired,
+  onChange,
+}: {
+  value: number | null;
+  isRequired: boolean;
+  onChange: (value: number | null) => void;
+}) {
+  const liveNumber = useLiveNumberInput(value, onChange);
+  return (
+    <NumberInput
+      label=""
+      value={value}
+      placeholder={isRequired ? undefined : 'unset'}
+      hasClear={!isRequired}
+      onChange={liveNumber.handleChange}
+      onFocus={liveNumber.handleFocus}
+      onInput={liveNumber.handleInput}
+      onBlur={liveNumber.handleBlur}
+      onKeyDown={liveNumber.handleKeyDown}
+    />
+  );
+}
+
 function InlineControl({
   control,
   value,
@@ -466,12 +492,10 @@ function InlineControl({
       // lets the user return to the original unset render. Required numbers
       // keep their generated fallback and stay non-clearable.
       return (
-        <NumberInput
-          label=""
+        <NumberControl
           value={typeof value === 'number' ? value : null}
-          placeholder={prop.required ? undefined : 'unset'}
-          hasClear={!prop.required}
-          onChange={(next: number | null) => onChange(next ?? undefined)}
+          isRequired={!!prop.required}
+          onChange={next => onChange(next ?? undefined)}
         />
       );
     case 'element':

--- a/apps/docsite/src/lib/useLiveNumberInput.ts
+++ b/apps/docsite/src/lib/useLiveNumberInput.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {
+  useCallback,
+  useRef,
+  type FocusEvent,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
+
+interface LiveNumberInputOptions {
+  min?: number | null;
+  max?: number | null;
+  isIntegerOnly?: boolean;
+}
+
+export function readLiveNumberDraft(
+  text: string,
+  {min, max, isIntegerOnly}: LiveNumberInputOptions,
+): {liveValue: number | null; shouldRevert: boolean} {
+  const trimmed = text.trim();
+  if (trimmed === '') {
+    return {liveValue: null, shouldRevert: false};
+  }
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || (isIntegerOnly && !Number.isInteger(value))) {
+    return {liveValue: null, shouldRevert: true};
+  }
+  if ((min != null && value < min) || (max != null && value > max)) {
+    return {liveValue: null, shouldRevert: false};
+  }
+  return {liveValue: value, shouldRevert: false};
+}
+
+export function useLiveNumberInput(
+  value: number | null,
+  onChange: (value: number | null) => void,
+  options: LiveNumberInputOptions = {},
+) {
+  const editStartValueRef = useRef(value);
+  const lastDraftShouldRevertRef = useRef(false);
+  const committedAtBoundaryRef = useRef(false);
+
+  const handleChange = useCallback(
+    (nextValue: number | null) => {
+      committedAtBoundaryRef.current = true;
+      editStartValueRef.current = nextValue;
+      onChange(nextValue);
+    },
+    [onChange],
+  );
+  const handleFocus = useCallback(() => {
+    editStartValueRef.current = value;
+    lastDraftShouldRevertRef.current = false;
+    committedAtBoundaryRef.current = false;
+  }, [value]);
+  const handleInput = useCallback(
+    (event: FormEvent<HTMLElement>) => {
+      committedAtBoundaryRef.current = false;
+      const {liveValue, shouldRevert} = readLiveNumberDraft(
+        (event.currentTarget as HTMLInputElement).value,
+        options,
+      );
+      lastDraftShouldRevertRef.current = shouldRevert;
+      if (liveValue !== null && liveValue !== value) {
+        onChange(liveValue);
+      }
+    },
+    [onChange, options, value],
+  );
+  const restoreRejectedDraft = useCallback(() => {
+    if (
+      lastDraftShouldRevertRef.current &&
+      !committedAtBoundaryRef.current &&
+      value !== editStartValueRef.current
+    ) {
+      onChange(editStartValueRef.current);
+    }
+    committedAtBoundaryRef.current = false;
+  }, [onChange, value]);
+  const handleBlur = useCallback(
+    (_event: FocusEvent<HTMLInputElement>) => {
+      restoreRejectedDraft();
+    },
+    [restoreRejectedDraft],
+  );
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        restoreRejectedDraft();
+      }
+    },
+    [restoreRejectedDraft],
+  );
+
+  return {handleBlur, handleChange, handleFocus, handleInput, handleKeyDown};
+}

--- a/apps/docsite/src/lib/useLiveNumberInput.ts
+++ b/apps/docsite/src/lib/useLiveNumberInput.ts
@@ -5,6 +5,7 @@
 import {
   useCallback,
   useRef,
+  useState,
   type FocusEvent,
   type FormEvent,
   type KeyboardEvent,
@@ -19,70 +20,69 @@ interface LiveNumberInputOptions {
 export function readLiveNumberDraft(
   text: string,
   {min, max, isIntegerOnly}: LiveNumberInputOptions,
-): {liveValue: number | null; shouldRevert: boolean} {
+): number | null {
   const trimmed = text.trim();
   if (trimmed === '') {
-    return {liveValue: null, shouldRevert: false};
+    return null;
   }
   const value = Number(trimmed);
   if (!Number.isFinite(value) || (isIntegerOnly && !Number.isInteger(value))) {
-    return {liveValue: null, shouldRevert: true};
+    return null;
   }
   if ((min != null && value < min) || (max != null && value > max)) {
-    return {liveValue: null, shouldRevert: false};
+    return null;
   }
-  return {liveValue: value, shouldRevert: false};
+  return value;
 }
 
 export function useLiveNumberInput(
   value: number | null,
   onChange: (value: number | null) => void,
-  options: LiveNumberInputOptions = {},
+  {min, max, isIntegerOnly}: LiveNumberInputOptions = {},
 ) {
-  const editStartValueRef = useRef(value);
-  const lastDraftShouldRevertRef = useRef(false);
+  const [editBase, setEditBase] = useState<number | null | undefined>(
+    undefined,
+  );
+  const editBaseRef = useRef(value);
   const committedAtBoundaryRef = useRef(false);
 
   const handleChange = useCallback(
     (nextValue: number | null) => {
       committedAtBoundaryRef.current = true;
-      editStartValueRef.current = nextValue;
+      editBaseRef.current = nextValue;
+      setEditBase(nextValue);
       onChange(nextValue);
     },
     [onChange],
   );
   const handleFocus = useCallback(() => {
-    editStartValueRef.current = value;
-    lastDraftShouldRevertRef.current = false;
+    editBaseRef.current = value;
     committedAtBoundaryRef.current = false;
+    setEditBase(value);
   }, [value]);
   const handleInput = useCallback(
     (event: FormEvent<HTMLElement>) => {
       committedAtBoundaryRef.current = false;
-      const {liveValue, shouldRevert} = readLiveNumberDraft(
+      const liveValue = readLiveNumberDraft(
         (event.currentTarget as HTMLInputElement).value,
-        options,
+        {min, max, isIntegerOnly},
       );
-      lastDraftShouldRevertRef.current = shouldRevert;
       if (liveValue !== null && liveValue !== value) {
         onChange(liveValue);
       }
     },
-    [onChange, options, value],
+    [isIntegerOnly, max, min, onChange, value],
   );
   const restoreRejectedDraft = useCallback(() => {
-    if (
-      lastDraftShouldRevertRef.current &&
-      !committedAtBoundaryRef.current &&
-      value !== editStartValueRef.current
-    ) {
-      onChange(editStartValueRef.current);
+    if (!committedAtBoundaryRef.current && value !== editBaseRef.current) {
+      onChange(editBaseRef.current);
     }
     committedAtBoundaryRef.current = false;
   }, [onChange, value]);
   const handleBlur = useCallback(
     (_event: FocusEvent<HTMLInputElement>) => {
       restoreRejectedDraft();
+      setEditBase(undefined);
     },
     [restoreRejectedDraft],
   );
@@ -95,5 +95,12 @@ export function useLiveNumberInput(
     [restoreRejectedDraft],
   );
 
-  return {handleBlur, handleChange, handleFocus, handleInput, handleKeyDown};
+  return {
+    value: editBase === undefined ? value : editBase,
+    handleBlur,
+    handleChange,
+    handleFocus,
+    handleInput,
+    handleKeyDown,
+  };
 }

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -35,7 +35,7 @@ export const docs = {
       name: 'onChange',
       type: '(value: number) => void',
       description:
-        'Callback fired when input value changes (only on valid input).',
+        'Callback fired when a valid text edit commits on blur or Enter, or when a step or clear control changes the value.',
       required: true,
     },
     {
@@ -330,7 +330,8 @@ export const docsZh = {
     {
       name: 'onChange',
       type: '(value: number) => void',
-      description: '输入值变化时触发的回调（仅在输入有效时触发）。',
+      description:
+        '有效文本编辑在失焦或按 Enter 时提交；步进或清除控件更改值时也会触发回调。',
       required: true,
     },
     {
@@ -657,7 +658,8 @@ export const docsDense = {
   propDescriptions: {
     label: 'Label text (always rendered for accessibility).',
     value: 'Current input value.',
-    onChange: 'Callback on valid input change.',
+    onChange:
+      'Callback when a valid text edit commits on blur/Enter, or a step/clear control changes the value.',
     size: 'Size variant.',
     isLabelHidden: 'Visually hide label (still accessible to screen readers).',
     description: 'Text between label + input.',

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -1463,18 +1463,23 @@ describe('NumberInput', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('shows the clear button for a pending draft before it commits', () => {
-      const onChange = vi.fn();
+    it('keeps Tab moving forward when an empty field has an invalid draft', async () => {
+      const user = userEvent.setup();
       render(
-        <NumberInput label="Qty" value={null} onChange={onChange} hasClear />,
+        <>
+          <NumberInput label="Qty" value={null} onChange={() => {}} hasClear />
+          <button type="button">Next field</button>
+        </>,
       );
       const input = screen.getByRole('spinbutton');
-      fireEvent.focus(input);
-      fireEvent.input(input, {target: {value: '42'}});
+      await user.click(input);
+      await user.type(input, 'invalid');
+      expect(
+        screen.queryByRole('button', {name: 'Clear Qty'}),
+      ).not.toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole('button', {name: 'Clear Qty'}));
-      expect(input).toHaveValue('');
-      expect(onChange).not.toHaveBeenCalled();
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'Next field'})).toHaveFocus();
     });
 
     it('does not show clear button when hasClear is false', () => {

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -270,6 +270,31 @@ describe('NumberInput', () => {
       expect(input).toHaveAttribute('aria-valuenow', '1234');
     });
 
+    it('keeps ARIA value text on the committed value while an edit is pending', () => {
+      function ControlledNumberInput() {
+        const [controlledValue, setControlledValue] = useState(1234);
+        return (
+          <NumberInput
+            label="Revenue"
+            value={controlledValue}
+            onChange={setControlledValue}
+            formatValue={number => `$${number.toLocaleString('en-US')}`}
+          />
+        );
+      }
+      render(<ControlledNumberInput />);
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      fireEvent.input(input, {target: {value: '4200'}});
+
+      expect(input).toHaveAttribute('aria-valuenow', '1234');
+      expect(input).toHaveAttribute('aria-valuetext', '$1,234');
+
+      fireEvent.blur(input);
+      expect(input).toHaveAttribute('aria-valuenow', '4200');
+      expect(input).toHaveAttribute('aria-valuetext', '$4,200');
+    });
+
     it('shows the raw numeric value while focused and restores formatting on blur', () => {
       render(
         <NumberInput
@@ -1175,6 +1200,32 @@ describe('NumberInput', () => {
       expect(data.get('revenue')).toBe('1234');
     });
 
+    it('submits the committed value until a text edit commits', () => {
+      function ControlledForm() {
+        const [controlledValue, setControlledValue] = useState(7);
+        return (
+          <form>
+            <NumberInput
+              label="Quantity"
+              htmlName="quantity"
+              value={controlledValue}
+              onChange={setControlledValue}
+              formatValue={String}
+            />
+          </form>
+        );
+      }
+      const {container} = render(<ControlledForm />);
+      const form = container.querySelector('form')!;
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      fireEvent.input(input, {target: {value: '42'}});
+
+      expect(new FormData(form).get('quantity')).toBe('7');
+      fireEvent.blur(input);
+      expect(new FormData(form).get('quantity')).toBe('42');
+    });
+
     it('is excluded from form data when disabled', () => {
       const {container} = render(
         <form>
@@ -1410,6 +1461,20 @@ describe('NumberInput', () => {
       expect(
         screen.queryByRole('button', {name: 'Clear Qty'}),
       ).not.toBeInTheDocument();
+    });
+
+    it('shows the clear button for a pending draft before it commits', () => {
+      const onChange = vi.fn();
+      render(
+        <NumberInput label="Qty" value={null} onChange={onChange} hasClear />,
+      );
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      fireEvent.input(input, {target: {value: '42'}});
+
+      fireEvent.click(screen.getByRole('button', {name: 'Clear Qty'}));
+      expect(input).toHaveValue('');
+      expect(onChange).toHaveBeenCalledWith(null);
     });
 
     it('does not show clear button when hasClear is false', () => {

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -14,6 +14,7 @@ import {useState} from 'react';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TestIcon} from '../__tests__/TestIcon';
+import {InternationalizationProvider} from '../i18n';
 import {InputGroup} from '../InputGroup';
 import {NumberInput} from './NumberInput';
 import {defineTheme} from '../theme/defineTheme';
@@ -326,7 +327,7 @@ describe('NumberInput', () => {
   });
 
   describe('onChange validation', () => {
-    it('calls onChange with valid number when typing', async () => {
+    it('commits a valid number on blur', async () => {
       const user = userEvent.setup();
       const handleChange = vi.fn();
       render(
@@ -336,8 +337,10 @@ describe('NumberInput', () => {
       const input = screen.getByRole('spinbutton');
       await user.click(input);
       await user.type(input, '42');
+      expect(handleChange).not.toHaveBeenCalled();
 
-      expect(handleChange).toHaveBeenCalledWith(4);
+      await user.tab();
+      expect(handleChange).toHaveBeenCalledTimes(1);
       expect(handleChange).toHaveBeenCalledWith(42);
     });
 
@@ -357,9 +360,7 @@ describe('NumberInput', () => {
       await user.click(input);
       await user.type(input, '10');
 
-      // 1 is valid (<=5), but 10 is not
-      expect(handleChange).toHaveBeenCalledWith(1);
-      expect(handleChange).not.toHaveBeenCalledWith(10);
+      expect(handleChange).not.toHaveBeenCalled();
     });
 
     it('does not call onChange when value is below min', async () => {
@@ -398,9 +399,7 @@ describe('NumberInput', () => {
       await user.click(input);
       await user.type(input, '3.5');
 
-      // 3 is valid, but 3.5 is not
-      expect(handleChange).toHaveBeenCalledWith(3);
-      expect(handleChange).not.toHaveBeenCalledWith(3.5);
+      expect(handleChange).not.toHaveBeenCalled();
     });
 
     it('calls onChange for decimal when isIntegerOnly is false', async () => {
@@ -413,8 +412,139 @@ describe('NumberInput', () => {
       const input = screen.getByRole('spinbutton');
       await user.click(input);
       await user.type(input, '3.5');
+      expect(handleChange).not.toHaveBeenCalled();
 
+      await user.tab();
       expect(handleChange).toHaveBeenCalledWith(3.5);
+    });
+  });
+
+  describe('invalid draft commit policy', () => {
+    function ControlledNumberInput({
+      initialValue = 7,
+      locale = 'en-US',
+    }: {
+      initialValue?: number | null;
+      locale?: 'en-US' | 'de-DE';
+    }) {
+      const [controlledValue, setControlledValue] = useState<number | null>(
+        initialValue,
+      );
+      return (
+        <InternationalizationProvider locale={locale}>
+          <NumberInput
+            label="Quantity"
+            value={controlledValue}
+            onChange={setControlledValue}
+          />
+          <output data-testid="committed">{String(controlledValue)}</output>
+        </InternationalizationProvider>
+      );
+    }
+
+    async function exerciseInvalidDraft(
+      entry: 'typing' | 'input',
+      commit: 'blur' | 'Enter',
+    ) {
+      const user = userEvent.setup();
+      render(<ControlledNumberInput />);
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.clear(input);
+      if (entry === 'typing') {
+        await user.type(input, '1·234·567');
+      } else {
+        fireEvent.input(input, {target: {value: '1·234·567'}});
+      }
+
+      expect(input).toHaveValue('1·234·567');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByTestId('committed')).toHaveTextContent('7');
+
+      if (commit === 'blur') {
+        await user.tab();
+        expect(input).toHaveValue('7');
+        expect(input).not.toHaveAttribute('aria-invalid');
+      } else {
+        await user.keyboard('{Enter}');
+        expect(input).toHaveValue('1·234·567');
+        expect(input).toHaveAttribute('aria-invalid', 'true');
+      }
+      expect(screen.getByTestId('committed')).toHaveTextContent('7');
+    }
+
+    it('rejects a sequentially typed invalid draft on blur', async () => {
+      await exerciseInvalidDraft('typing', 'blur');
+    });
+
+    it('rejects a one-shot invalid draft on blur', async () => {
+      await exerciseInvalidDraft('input', 'blur');
+    });
+
+    it('rejects a sequentially typed invalid draft on Enter', async () => {
+      await exerciseInvalidDraft('typing', 'Enter');
+    });
+
+    it('rejects a one-shot invalid draft on Enter', async () => {
+      await exerciseInvalidDraft('input', 'Enter');
+    });
+
+    it('commits a valid localized grouped number as one edit', async () => {
+      const user = userEvent.setup();
+      render(<ControlledNumberInput locale="de-DE" />);
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.clear(input);
+      await user.type(input, '1.234.567');
+
+      expect(screen.getByTestId('committed')).toHaveTextContent('7');
+      await user.tab();
+      expect(screen.getByTestId('committed')).toHaveTextContent('1234567');
+      expect(input).toHaveValue('1234567');
+    });
+
+    it('keeps a controlled update behind an invalid focused draft', () => {
+      const onChange = vi.fn();
+      const {rerender} = render(
+        <NumberInput label="Quantity" value={7} onChange={onChange} />,
+      );
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      fireEvent.input(input, {target: {value: '1·234·567'}});
+
+      rerender(<NumberInput label="Quantity" value={9} onChange={onChange} />);
+      expect(input).toHaveValue('1·234·567');
+      fireEvent.blur(input);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('9');
+    });
+
+    it('waits for IME composition to finish before committing', () => {
+      const onChange = vi.fn();
+      render(<NumberInput label="Quantity" value={7} onChange={onChange} />);
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      fireEvent.input(input, {target: {value: '42'}});
+      fireEvent.keyDown(input, {key: 'Enter', isComposing: true});
+      expect(onChange).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(input, {key: 'Enter'});
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(42);
+    });
+
+    it('steps from the committed value when the draft is invalid', () => {
+      const onChange = vi.fn();
+      render(<NumberInput label="Quantity" value={7} onChange={onChange} />);
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      fireEvent.input(input, {target: {value: '1·234·567'}});
+      fireEvent.keyDown(input, {key: 'ArrowUp'});
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(8);
+      expect(input).toHaveValue('7');
     });
   });
 

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -1200,7 +1200,7 @@ describe('NumberInput', () => {
       expect(data.get('revenue')).toBe('1234');
     });
 
-    it('submits the committed value until a text edit commits', () => {
+    it('submits the committed value in formatted mode until an edit commits', () => {
       function ControlledForm() {
         const [controlledValue, setControlledValue] = useState(7);
         return (
@@ -1474,7 +1474,7 @@ describe('NumberInput', () => {
 
       fireEvent.click(screen.getByRole('button', {name: 'Clear Qty'}));
       expect(input).toHaveValue('');
-      expect(onChange).toHaveBeenCalledWith(null);
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('does not show clear button when hasClear is false', () => {

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -677,7 +677,7 @@ export function NumberInput({
   );
 
   const commitPendingInput = useCallback(
-    (preserveDraft: boolean) => {
+    (trigger: 'blur' | 'Enter') => {
       if (pendingInput === null) {
         return;
       }
@@ -690,8 +690,8 @@ export function NumberInput({
         hasClear: !!hasClear,
       });
       if (
-        !preserveDraft ||
-        (decision.type === 'commit' && decision.shouldNormalizeDraft)
+        trigger === 'blur' ||
+        (decision.type === 'commit' && decision.didClamp)
       ) {
         setPendingInput(null);
       }
@@ -710,7 +710,7 @@ export function NumberInput({
   // Blur ends the edit and displays the resulting committed value.
   const handleBlur = useCallback(
     (e: FocusEvent<HTMLInputElement>) => {
-      commitPendingInput(false);
+      commitPendingInput('blur');
       setIsFocused(false);
       onBlur?.(e);
     },
@@ -781,7 +781,7 @@ export function NumberInput({
         return;
       }
       if (e.key === 'Enter') {
-        commitPendingInput(true);
+        commitPendingInput('Enter');
         onEnter?.();
       }
       onKeyDown?.(e);
@@ -909,7 +909,9 @@ export function NumberInput({
         data-autofocus={hasAutoFocus || undefined}
         aria-valuemin={min ?? undefined}
         aria-valuemax={max ?? undefined}
-        aria-valuenow={valueForStepping ?? undefined}
+        // The ARIA value and hidden form input expose the committed value;
+        // pendingInput is still an uncommitted edit and may be invalid.
+        aria-valuenow={value ?? undefined}
         aria-valuetext={
           value == null || !formatValue ? undefined : formattedValue
         }
@@ -945,12 +947,15 @@ export function NumberInput({
       <VisuallyHidden as="div" role="alert" aria-live="assertive">
         {!isInputValid ? 'Invalid number' : ''}
       </VisuallyHidden>
-      {hasClear && value != null && !isDisabled && !isReadOnly && (
-        <InputClearButton
-          label={t('@astryx.numberInput.clearLabel', {label})}
-          onClick={handleClear}
-        />
-      )}
+      {hasClear &&
+        (value != null || (pendingInput !== null && pendingInput !== '')) &&
+        !isDisabled &&
+        !isReadOnly && (
+          <InputClearButton
+            label={t('@astryx.numberInput.clearLabel', {label})}
+            onClick={handleClear}
+          />
+        )}
       {statusIcon}
       {hasNumberSteppers && (
         <div {...stylex.props(styles.numberSteppers)}>

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -834,12 +834,12 @@ export function NumberInput({
 
   // Handle clear button click
   const handleClear = useCallback(() => {
-    if (hasClear && value != null) {
+    if (hasClear) {
       onChange(null);
     }
     setPendingInput(null);
     inputRef.current?.focus();
-  }, [hasClear, onChange, value]);
+  }, [hasClear, onChange]);
 
   // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
   const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
@@ -947,15 +947,12 @@ export function NumberInput({
       <VisuallyHidden as="div" role="alert" aria-live="assertive">
         {!isInputValid ? 'Invalid number' : ''}
       </VisuallyHidden>
-      {hasClear &&
-        (value != null || (pendingInput !== null && pendingInput !== '')) &&
-        !isDisabled &&
-        !isReadOnly && (
-          <InputClearButton
-            label={t('@astryx.numberInput.clearLabel', {label})}
-            onClick={handleClear}
-          />
-        )}
+      {hasClear && value != null && !isDisabled && !isReadOnly && (
+        <InputClearButton
+          label={t('@astryx.numberInput.clearLabel', {label})}
+          onClick={handleClear}
+        />
+      )}
       {statusIcon}
       {hasNumberSteppers && (
         <div {...stylex.props(styles.numberSteppers)}>

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -10,6 +10,7 @@
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/NumberInput/numberParser.ts (locale-aware parsing)
+ * - /packages/core/src/NumberInput/numberInputCommit.ts (draft commit policy)
  * - /packages/core/src/NumberInput/NumberInput.doc.mjs (props table, features, implementation notes)
  * - /packages/core/src/NumberInput/NumberInput.test.tsx (tests for new/changed behavior)
  * - /packages/core/src/NumberInput/index.ts (exports if types change)
@@ -215,8 +216,8 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator, useLocale} from '../i18n';
-import {formatEditableNumber, parseLocaleNumber} from './numberParser';
-import type {Locale} from '../i18n';
+import {formatEditableNumber} from './numberParser';
+import {parseNumberInput, resolveNumberInputCommit} from './numberInputCommit';
 
 interface NumberInputPropsBase extends Omit<
   BaseProps,
@@ -430,124 +431,6 @@ type NumberInputPropsClearable = NumberInputPropsBase & {
 export type NumberInputProps =
   NumberInputPropsNonClearable | NumberInputPropsClearable;
 
-/**
- * Read the typed or pasted text as a number, applying the shape rules (finite,
- * and integral when `isIntegerOnly`) but not the min/max range.
- */
-function parseNumericInput(
-  input: string,
-  options: {
-    isIntegerOnly?: boolean;
-    locale?: Locale;
-  },
-): number | null {
-  const trimmed = input.trim();
-  if (trimmed === '') {
-    return null;
-  }
-
-  const num = parseLocaleNumber(trimmed, options.locale);
-  if (num == null || !Number.isFinite(num)) {
-    return null;
-  }
-
-  if (options.isIntegerOnly && !Number.isInteger(num)) {
-    return null;
-  }
-
-  return num;
-}
-
-/**
- * Parse and validate a string input as a number.
- * Returns null if the input is not a valid number or fails validation.
- */
-function parseNumberInput(
-  input: string,
-  options: {
-    min?: number | null;
-    max?: number | null;
-    isIntegerOnly?: boolean;
-    locale?: Locale;
-  },
-): number | null {
-  const num = parseNumericInput(input, options);
-  if (num === null) {
-    return null;
-  }
-
-  // Check min constraint
-  if (options.min != null && num < options.min) {
-    return null;
-  }
-
-  // Check max constraint
-  if (options.max != null && num > options.max) {
-    return null;
-  }
-
-  return num;
-}
-
-/**
- * Parse a string input for commit (blur/Enter), clamping an out-of-range
- * number to the nearest bound.
- *
- * Rejecting an out-of-range entry outright leaves the last in-range prefix
- * committed, so typing 100 into a [1, 2] field lands on 1; the nearest bound
- * is what the entry actually asked for.
- */
-function parseNumberInputForCommit(
-  input: string,
-  options: {
-    min?: number | null;
-    max?: number | null;
-    isIntegerOnly?: boolean;
-    locale?: Locale;
-  },
-): number | null {
-  const num = parseNumericInput(input, options);
-  if (num === null) {
-    return null;
-  }
-
-  // The bound itself has to satisfy the field's own shape rule, or an
-  // integer-only field commits the fractional `max` it was handed. Round
-  // inwards, the same way stepping from empty does.
-  const {min, max} = getCommittableBounds(options);
-  // No number satisfies both, so there is nothing to clamp to.
-  if (min != null && max != null && min > max) {
-    return null;
-  }
-
-  if (min != null && num < min) {
-    return min;
-  }
-  if (max != null && num > max) {
-    return max;
-  }
-
-  return num;
-}
-
-function getCommittableBounds({
-  min,
-  max,
-  isIntegerOnly,
-}: {
-  min?: number | null;
-  max?: number | null;
-  isIntegerOnly?: boolean;
-}): {min: number | null; max: number | null} {
-  if (!isIntegerOnly) {
-    return {min: min ?? null, max: max ?? null};
-  }
-  return {
-    min: min == null ? null : Math.ceil(min),
-    max: max == null ? null : Math.floor(max),
-  };
-}
-
 type StepDirection = -1 | 1;
 
 function getDecimalPlaces(value: number): number {
@@ -632,7 +515,8 @@ function getSteppedValue({
 
 /**
  * A number input component for collecting numeric user input.
- * Only calls onChange when the entered value passes validation.
+ * Commits text edits on blur or Enter and only calls onChange when the whole
+ * draft passes validation.
  *
  * @example
  * ```
@@ -742,17 +626,6 @@ export function NumberInput({
     [isIntegerOnly, locale, max, min],
   );
 
-  const parseInputForCommit = useCallback(
-    (text: string) =>
-      parseNumberInputForCommit(text, {min, max, isIntegerOnly, locale}),
-    [isIntegerOnly, locale, max, min],
-  );
-
-  const parseNumeric = useCallback(
-    (text: string) => parseNumericInput(text, {isIntegerOnly, locale}),
-    [isIntegerOnly, locale],
-  );
-
   const formattedValue = useMemo(() => {
     if (value == null) {
       return '';
@@ -780,25 +653,18 @@ export function NumberInput({
     return parseInput(pendingInput) !== null;
   }, [pendingInput, parseInput]);
 
-  // Handle input text change - update immediately if valid
+  // Keep the whole text edit as a draft until an explicit commit boundary.
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       // Value can't change while showing a disabled message (the field is
       // read-only and non-native-disabled), but guard the handler too so the
-      // pending value and onChange never fire.
+      // pending value never changes.
       if (isDisabled || isReadOnly) {
         return;
       }
-      const newValue = e.target.value;
-      setPendingInput(newValue);
-
-      // If the input is valid, update immediately
-      const parsed = parseInput(newValue);
-      if (parsed !== null && parsed !== value) {
-        onChange(parsed);
-      }
+      setPendingInput(e.target.value);
     },
-    [value, onChange, parseInput, isDisabled, isReadOnly],
+    [isDisabled, isReadOnly],
   );
 
   // Handle focus
@@ -810,30 +676,45 @@ export function NumberInput({
     [onFocus],
   );
 
-  // Handle blur - validate and clear pending input
-  const handleBlur = useCallback(
-    (e: FocusEvent<HTMLInputElement>) => {
-      if (pendingInput !== null) {
-        if (hasClear && pendingInput.trim() === '') {
-          // Keyboard clearing honors the clearable contract: an emptied
-          // input commits null instead of silently reverting on blur.
-          if (value != null) {
-            onChange(null);
-          }
-        } else {
-          const parsed = parseInputForCommit(pendingInput);
-          if (parsed !== null && parsed !== value) {
-            onChange(parsed);
-          }
-        }
+  const commitPendingInput = useCallback(
+    (preserveDraft: boolean) => {
+      if (pendingInput === null) {
+        return;
       }
 
-      // Clear pending input - display will revert to formatted value
-      setPendingInput(null);
+      const decision = resolveNumberInputCommit(pendingInput, {
+        min,
+        max,
+        isIntegerOnly,
+        locale,
+        hasClear: !!hasClear,
+      });
+      if (
+        !preserveDraft ||
+        (decision.type === 'commit' && decision.shouldNormalizeDraft)
+      ) {
+        setPendingInput(null);
+      }
+
+      if (decision.type === 'clear') {
+        if (hasClear && value != null) {
+          onChange(null);
+        }
+      } else if (decision.type === 'commit' && decision.value !== value) {
+        onChange(decision.value);
+      }
+    },
+    [hasClear, isIntegerOnly, locale, max, min, onChange, pendingInput, value],
+  );
+
+  // Blur ends the edit and displays the resulting committed value.
+  const handleBlur = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      commitPendingInput(false);
       setIsFocused(false);
       onBlur?.(e);
     },
-    [pendingInput, value, onChange, parseInputForCommit, onBlur, hasClear],
+    [commitPendingInput, onBlur],
   );
 
   const valueForStepping = useMemo(() => {
@@ -900,43 +781,12 @@ export function NumberInput({
         return;
       }
       if (e.key === 'Enter') {
-        // Validate and commit on Enter
-        if (pendingInput !== null) {
-          if (hasClear && pendingInput.trim() === '') {
-            // Same clearable contract as blur: Enter on an emptied input
-            // commits null instead of reverting.
-            if (value != null) {
-              onChange(null);
-            }
-          } else {
-            const parsed = parseInputForCommit(pendingInput);
-            if (parsed !== null) {
-              // Enter otherwise keeps the pending text, which would leave a
-              // clamped entry showing the number that was not committed.
-              if (parsed !== parseNumeric(pendingInput)) {
-                setPendingInput(null);
-              }
-              if (parsed !== value) {
-                onChange(parsed);
-              }
-            }
-          }
-        }
+        commitPendingInput(true);
         onEnter?.();
       }
       onKeyDown?.(e);
     },
-    [
-      pendingInput,
-      value,
-      onChange,
-      parseInputForCommit,
-      parseNumeric,
-      onEnter,
-      onKeyDown,
-      hasClear,
-      stepValue,
-    ],
+    [commitPendingInput, onEnter, onKeyDown, stepValue],
   );
 
   // React's delegated wheel listener can be passive, so use a native,
@@ -1059,7 +909,7 @@ export function NumberInput({
         data-autofocus={hasAutoFocus || undefined}
         aria-valuemin={min ?? undefined}
         aria-valuemax={max ?? undefined}
-        aria-valuenow={value ?? undefined}
+        aria-valuenow={valueForStepping ?? undefined}
         aria-valuetext={
           value == null || !formatValue ? undefined : formattedValue
         }

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -834,12 +834,12 @@ export function NumberInput({
 
   // Handle clear button click
   const handleClear = useCallback(() => {
-    if (hasClear) {
+    if (hasClear && value != null) {
       onChange(null);
     }
     setPendingInput(null);
     inputRef.current?.focus();
-  }, [hasClear, onChange]);
+  }, [hasClear, onChange, value]);
 
   // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
   const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =

--- a/packages/core/src/NumberInput/numberInputCommit.test.ts
+++ b/packages/core/src/NumberInput/numberInputCommit.test.ts
@@ -27,7 +27,7 @@ describe('resolveNumberInputCommit', () => {
     ).toEqual({
       type: 'commit',
       value: 1234567,
-      shouldNormalizeDraft: false,
+      didClamp: false,
     });
   });
 
@@ -48,7 +48,7 @@ describe('resolveNumberInputCommit', () => {
         isIntegerOnly: true,
         hasClear: false,
       }),
-    ).toEqual({type: 'commit', value: 2, shouldNormalizeDraft: true});
+    ).toEqual({type: 'commit', value: 2, didClamp: true});
   });
 
   it('distinguishes a clearable empty draft from a revert', () => {

--- a/packages/core/src/NumberInput/numberInputCommit.test.ts
+++ b/packages/core/src/NumberInput/numberInputCommit.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file numberInputCommit.test.ts
+ * @input Uses Vitest and the NumberInput draft commit policy
+ * @output Focused tests for commit, clear, clamp, and revert decisions
+ * @position Testing; validates numberInputCommit.ts independently of React
+ */
+
+import {describe, expect, it} from 'vitest';
+import {parseNumberInput, resolveNumberInputCommit} from './numberInputCommit';
+
+describe('parseNumberInput', () => {
+  it('validates the complete localized draft', () => {
+    expect(parseNumberInput('1.234.567', {locale: 'de-DE'})).toBe(1234567);
+    expect(parseNumberInput('1·234·567', {locale: 'de-DE'})).toBeNull();
+  });
+});
+
+describe('resolveNumberInputCommit', () => {
+  it('commits one valid localized draft', () => {
+    expect(
+      resolveNumberInputCommit('1.234.567', {
+        locale: 'de-DE',
+        hasClear: false,
+      }),
+    ).toEqual({
+      type: 'commit',
+      value: 1234567,
+      shouldNormalizeDraft: false,
+    });
+  });
+
+  it('reverts the whole draft when parsing fails', () => {
+    expect(
+      resolveNumberInputCommit('1·234·567', {
+        locale: 'en-US',
+        hasClear: false,
+      }),
+    ).toEqual({type: 'revert'});
+  });
+
+  it('clamps an out-of-range draft and requests normalization', () => {
+    expect(
+      resolveNumberInputCommit('100', {
+        min: 1,
+        max: 2,
+        isIntegerOnly: true,
+        hasClear: false,
+      }),
+    ).toEqual({type: 'commit', value: 2, shouldNormalizeDraft: true});
+  });
+
+  it('distinguishes a clearable empty draft from a revert', () => {
+    expect(resolveNumberInputCommit('', {hasClear: true})).toEqual({
+      type: 'clear',
+    });
+    expect(resolveNumberInputCommit('', {hasClear: false})).toEqual({
+      type: 'revert',
+    });
+  });
+
+  it('reverts when no value can satisfy the bounds', () => {
+    expect(
+      resolveNumberInputCommit('10', {
+        min: 5,
+        max: 2,
+        hasClear: false,
+      }),
+    ).toEqual({type: 'revert'});
+  });
+});

--- a/packages/core/src/NumberInput/numberInputCommit.ts
+++ b/packages/core/src/NumberInput/numberInputCommit.ts
@@ -22,7 +22,7 @@ interface NumberInputValidationOptions {
 }
 
 export type NumberInputCommitDecision =
-  | {type: 'commit'; value: number; shouldNormalizeDraft: boolean}
+  | {type: 'commit'; value: number; didClamp: boolean}
   | {type: 'clear'}
   | {type: 'revert'};
 
@@ -96,6 +96,6 @@ export function resolveNumberInputCommit(
   return {
     type: 'commit',
     value: committedValue,
-    shouldNormalizeDraft: committedValue !== value,
+    didClamp: committedValue !== value,
   };
 }

--- a/packages/core/src/NumberInput/numberInputCommit.ts
+++ b/packages/core/src/NumberInput/numberInputCommit.ts
@@ -4,7 +4,7 @@
  * @file numberInputCommit.ts
  * @input A NumberInput draft and the field's validation constraints
  * @output A single commit, clear, or revert decision for the whole draft
- * @position Internal NumberInput lifecycle policy; parsing stays in numberParser.ts
+ * @position Internal NumberInput draft validation and commit policy; locale text interpretation stays in numberParser.ts
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/NumberInput/NumberInput.tsx

--- a/packages/core/src/NumberInput/numberInputCommit.ts
+++ b/packages/core/src/NumberInput/numberInputCommit.ts
@@ -4,11 +4,13 @@
  * @file numberInputCommit.ts
  * @input A NumberInput draft and the field's validation constraints
  * @output A single commit, clear, or revert decision for the whole draft
- * @position Internal NumberInput draft validation and commit policy; locale text interpretation stays in numberParser.ts
+ * @position Shared internal draft validation and commit policy for NumberInput and its live consumers
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/NumberInput/NumberInput.tsx
  * - /packages/core/src/NumberInput/numberInputCommit.test.ts
+ * - /packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
+ * - /packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
  */
 
 import type {Locale} from '../i18n';

--- a/packages/core/src/NumberInput/numberInputCommit.ts
+++ b/packages/core/src/NumberInput/numberInputCommit.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file numberInputCommit.ts
+ * @input A NumberInput draft and the field's validation constraints
+ * @output A single commit, clear, or revert decision for the whole draft
+ * @position Internal NumberInput lifecycle policy; parsing stays in numberParser.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/NumberInput/NumberInput.tsx
+ * - /packages/core/src/NumberInput/numberInputCommit.test.ts
+ */
+
+import type {Locale} from '../i18n';
+import {parseLocaleNumber} from './numberParser';
+
+interface NumberInputValidationOptions {
+  min?: number | null;
+  max?: number | null;
+  isIntegerOnly?: boolean;
+  locale?: Locale;
+}
+
+export type NumberInputCommitDecision =
+  | {type: 'commit'; value: number; shouldNormalizeDraft: boolean}
+  | {type: 'clear'}
+  | {type: 'revert'};
+
+function parseNumericInput(
+  input: string,
+  options: Pick<NumberInputValidationOptions, 'isIntegerOnly' | 'locale'>,
+): number | null {
+  const trimmed = input.trim();
+  if (trimmed === '') {
+    return null;
+  }
+
+  const value = parseLocaleNumber(trimmed, options.locale);
+  if (value == null || !Number.isFinite(value)) {
+    return null;
+  }
+  if (options.isIntegerOnly && !Number.isInteger(value)) {
+    return null;
+  }
+  return value;
+}
+
+export function parseNumberInput(
+  input: string,
+  options: NumberInputValidationOptions,
+): number | null {
+  const value = parseNumericInput(input, options);
+  if (value === null) {
+    return null;
+  }
+  if (options.min != null && value < options.min) {
+    return null;
+  }
+  if (options.max != null && value > options.max) {
+    return null;
+  }
+  return value;
+}
+
+export function resolveNumberInputCommit(
+  input: string,
+  options: NumberInputValidationOptions & {hasClear: boolean},
+): NumberInputCommitDecision {
+  if (input.trim() === '') {
+    return options.hasClear ? {type: 'clear'} : {type: 'revert'};
+  }
+
+  const value = parseNumericInput(input, options);
+  if (value === null) {
+    return {type: 'revert'};
+  }
+
+  const min =
+    options.min == null
+      ? null
+      : options.isIntegerOnly
+        ? Math.ceil(options.min)
+        : options.min;
+  const max =
+    options.max == null
+      ? null
+      : options.isIntegerOnly
+        ? Math.floor(options.max)
+        : options.max;
+  if (min != null && max != null && min > max) {
+    return {type: 'revert'};
+  }
+
+  const committedValue =
+    min != null && value < min ? min : max != null && value > max ? max : value;
+  return {
+    type: 'commit',
+    value: committedValue,
+    shouldNormalizeDraft: committedValue !== value,
+  };
+}

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
@@ -286,6 +286,93 @@ describe('PowerSearch', () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
+  it('saves the freshly committed numeric value on Enter', () => {
+    const numericConfig: PowerSearchConfig = {
+      name: 'test-number',
+      fields: [
+        {
+          key: 'level',
+          label: 'Level',
+          operators: [
+            {key: 'equals', label: 'equals', value: {type: 'integer'}},
+          ],
+        },
+      ],
+    };
+    const onSave = vi.fn();
+
+    function NumericValueHarness() {
+      const internalConfig = useInternalConfig(numericConfig);
+      return (
+        <PowerSearchEditPopover
+          config={internalConfig}
+          filter={{
+            field: 'level',
+            operator: 'equals',
+            value: {type: 'integer', value: 5},
+          }}
+          mode="edit"
+          onSave={onSave}
+          onCancel={() => {}}
+        />
+      );
+    }
+
+    render(<NumericValueHarness />);
+    const input = screen.getByRole('spinbutton');
+    fireEvent.focus(input);
+    fireEvent.input(input, {target: {value: '42'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(onSave).toHaveBeenCalledWith({
+      field: 'level',
+      operator: 'equals',
+      value: {type: 'integer', value: 42},
+    });
+  });
+
+  it('does not save an invalid numeric draft on Enter', () => {
+    const numericConfig: PowerSearchConfig = {
+      name: 'test-number',
+      fields: [
+        {
+          key: 'level',
+          label: 'Level',
+          operators: [
+            {key: 'equals', label: 'equals', value: {type: 'integer'}},
+          ],
+        },
+      ],
+    };
+    const onSave = vi.fn();
+
+    function NumericValueHarness() {
+      const internalConfig = useInternalConfig(numericConfig);
+      return (
+        <PowerSearchEditPopover
+          config={internalConfig}
+          filter={{
+            field: 'level',
+            operator: 'equals',
+            value: {type: 'integer', value: 5},
+          }}
+          mode="edit"
+          onSave={onSave}
+          onCancel={() => {}}
+        />
+      );
+    }
+
+    render(<NumericValueHarness />);
+    const input = screen.getByRole('spinbutton');
+    fireEvent.focus(input);
+    fireEvent.input(input, {target: {value: '1·234'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(input).toHaveValue('1·234');
+  });
+
   it('does not save/close on a composing Enter while typing a filter value (#4828)', () => {
     const onSave = vi.fn();
     const onCancel = vi.fn();

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
@@ -182,6 +182,70 @@ describe('StringEditor (#1103)', () => {
   });
 });
 
+describe('numeric editor commit timing', () => {
+  it('saves the committed number when Enter finishes the edit', () => {
+    const onChange = vi.fn();
+    const onEnter = vi.fn();
+    render(
+      <PowerSearchValueEditor
+        operatorValue={{type: 'integer'}}
+        filterValue={{type: 'integer', value: 5}}
+        onChange={onChange}
+        onEnter={onEnter}
+        config={stubConfig}
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+    fireEvent.focus(input);
+    fireEvent.input(input, {target: {value: '42'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      {type: 'integer', value: 42},
+      true,
+    );
+    expect(onEnter).not.toHaveBeenCalled();
+  });
+
+  it('does not save an invalid numeric draft on Enter', () => {
+    const onChange = vi.fn();
+    const onEnter = vi.fn();
+    render(
+      <PowerSearchValueEditor
+        operatorValue={{type: 'integer'}}
+        filterValue={{type: 'integer', value: 5}}
+        onChange={onChange}
+        onEnter={onEnter}
+        config={stubConfig}
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+    fireEvent.focus(input);
+    fireEvent.input(input, {target: {value: '1·234'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onEnter).not.toHaveBeenCalled();
+    expect(input).toHaveValue('1·234');
+  });
+
+  it('keeps the existing Enter callback when there is no pending edit', () => {
+    const onEnter = vi.fn();
+    render(
+      <PowerSearchValueEditor
+        operatorValue={{type: 'float'}}
+        filterValue={{type: 'float', value: 1.5}}
+        onChange={() => {}}
+        onEnter={onEnter}
+        config={stubConfig}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole('spinbutton'), {key: 'Enter'});
+    expect(onEnter).toHaveBeenCalledTimes(1);
+  });
+});
+
 // =============================================================================
 // #1106 — EntityListEditor drops photo, no renderItem
 // =============================================================================

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -12,7 +12,13 @@
  * - /packages/core/src/PowerSearch/index.ts
  */
 
-import React, {useCallback, useMemo} from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  type FormEvent,
+  type KeyboardEvent,
+} from 'react';
 import type {
   OperatorValue,
   FilterValue,
@@ -27,12 +33,16 @@ import type {ISOTimeString} from '../utils';
 // Lazy import to avoid circular deps — these are all from the same package
 import {TextInput} from '../TextInput';
 import {NumberInput} from '../NumberInput';
+import {
+  resolveNumberInputCommit,
+  type NumberInputCommitDecision,
+} from '../NumberInput/numberInputCommit';
 import {DateInput} from '../DateInput';
 import {TimeInput} from '../TimeInput';
 import {Selector} from '../Selector';
 import {Tokenizer} from '../Tokenizer';
 import {Typeahead} from '../Typeahead';
-import {useTranslator} from '../i18n';
+import {useLocale, useTranslator} from '../i18n';
 
 export interface PowerSearchValueEditorProps {
   operatorValue: OperatorValue;
@@ -188,27 +198,102 @@ function StringListEditor({
   );
 }
 
+function useNumberEditorHandlers({
+  valueType,
+  min,
+  max,
+  isIntegerOnly,
+  onChange,
+  onEnter,
+}: {
+  valueType: 'integer' | 'float';
+  min?: number;
+  max?: number;
+  isIntegerOnly: boolean;
+  onChange: (value: FilterValue, shouldSave?: boolean) => void;
+  onEnter?: () => void;
+}) {
+  const locale = useLocale();
+  const pendingDecisionRef = useRef<NumberInputCommitDecision | null>(null);
+  const toFilterValue = useCallback(
+    (value: number): FilterValue =>
+      valueType === 'integer'
+        ? {type: 'integer', value}
+        : {type: 'float', value},
+    [valueType],
+  );
+  const handleChange = useCallback(
+    (value: number) => {
+      onChange(toFilterValue(value));
+    },
+    [onChange, toFilterValue],
+  );
+  const handleFocus = useCallback(() => {
+    pendingDecisionRef.current = null;
+  }, []);
+  const handleInput = useCallback(
+    (event: FormEvent<HTMLElement>) => {
+      pendingDecisionRef.current = resolveNumberInputCommit(
+        (event.currentTarget as HTMLInputElement).value,
+        {min, max, isIntegerOnly, locale, hasClear: false},
+      );
+    },
+    [isIntegerOnly, locale, max, min],
+  );
+  const handleEnter = useCallback(() => {
+    const decision = pendingDecisionRef.current;
+    pendingDecisionRef.current = null;
+    if (decision === null) {
+      onEnter?.();
+    } else if (decision.type === 'commit') {
+      onChange(toFilterValue(decision.value), true);
+    }
+  }, [onChange, onEnter, toFilterValue]);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.stopPropagation();
+      }
+    },
+    [],
+  );
+
+  return {handleChange, handleEnter, handleFocus, handleInput, handleKeyDown};
+}
+
 function IntegerEditor({
   operatorValue,
   filterValue,
   onChange,
+  onEnter,
 }: {
   operatorValue: OperatorValue & {type: 'integer'};
   filterValue: FilterValue | undefined;
-  onChange: (value: FilterValue) => void;
+  onChange: (value: FilterValue, shouldSave?: boolean) => void;
+  onEnter?: () => void;
 }) {
   const t = useTranslator();
   const currentValue =
     filterValue?.type === 'integer' ? filterValue.value : undefined;
+  const handlers = useNumberEditorHandlers({
+    valueType: 'integer',
+    min: operatorValue.minValue,
+    max: operatorValue.maxValue,
+    isIntegerOnly: true,
+    onChange,
+    onEnter,
+  });
 
   return (
     <NumberInput
       label={t('@astryx.powersearch.valueEditor.value')}
       isLabelHidden
       value={currentValue ?? null}
-      onChange={(value: number) => {
-        onChange({type: 'integer', value});
-      }}
+      onChange={handlers.handleChange}
+      onFocus={handlers.handleFocus}
+      onInput={handlers.handleInput}
+      onEnter={handlers.handleEnter}
+      onKeyDown={handlers.handleKeyDown}
       min={operatorValue.minValue}
       max={operatorValue.maxValue}
       units={operatorValue.units}
@@ -222,23 +307,35 @@ function FloatEditor({
   operatorValue,
   filterValue,
   onChange,
+  onEnter,
 }: {
   operatorValue: OperatorValue & {type: 'float'};
   filterValue: FilterValue | undefined;
-  onChange: (value: FilterValue) => void;
+  onChange: (value: FilterValue, shouldSave?: boolean) => void;
+  onEnter?: () => void;
 }) {
   const t = useTranslator();
   const currentValue =
     filterValue?.type === 'float' ? filterValue.value : undefined;
+  const handlers = useNumberEditorHandlers({
+    valueType: 'float',
+    min: operatorValue.minValue,
+    max: operatorValue.maxValue,
+    isIntegerOnly: false,
+    onChange,
+    onEnter,
+  });
 
   return (
     <NumberInput
       label={t('@astryx.powersearch.valueEditor.value')}
       isLabelHidden
       value={currentValue ?? null}
-      onChange={(value: number) => {
-        onChange({type: 'float', value});
-      }}
+      onChange={handlers.handleChange}
+      onFocus={handlers.handleFocus}
+      onInput={handlers.handleInput}
+      onEnter={handlers.handleEnter}
+      onKeyDown={handlers.handleKeyDown}
       min={operatorValue.minValue}
       max={operatorValue.maxValue}
       units={operatorValue.units}
@@ -676,6 +773,7 @@ export function PowerSearchValueEditor({
           operatorValue={operatorValue}
           filterValue={filterValue}
           onChange={onChange}
+          onEnter={onEnter}
         />
       );
 
@@ -685,6 +783,7 @@ export function PowerSearchValueEditor({
           operatorValue={operatorValue}
           filterValue={filterValue}
           onChange={onChange}
+          onEnter={onEnter}
         />
       );
 

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.test.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.test.tsx
@@ -142,12 +142,15 @@ function FilterTable({
   });
 
   return (
-    <Table
-      data={testData}
-      columns={columns}
-      idKey="id"
-      plugins={{filter: filterPlugin}}
-    />
+    <>
+      <Table
+        data={testData}
+        columns={columns}
+        idKey="id"
+        plugins={{filter: filterPlugin}}
+      />
+      <output data-testid="filters">{JSON.stringify(filters)}</output>
+    </>
   );
 }
 
@@ -209,6 +212,41 @@ describe('useTableFiltering', () => {
       const textInputs = screen.getAllByPlaceholderText(/^Filter /);
       await user.type(textInputs[0], 'Alice');
       expect(textInputs[0]).toHaveValue('Alice');
+    });
+
+    it('updates a number filter while typing', async () => {
+      const user = userEvent.setup();
+      render(<FilterTable variant="inline" />);
+      const input = screen.getByRole('spinbutton', {name: 'Filter Age'});
+
+      await user.type(input, '30');
+
+      expect(screen.getByTestId('filters')).toHaveTextContent('{"age":30}');
+    });
+
+    it('restores the pre-edit number filter when an invalid draft blurs', async () => {
+      const user = userEvent.setup();
+      render(<FilterTable variant="inline" />);
+      const input = screen.getByRole('spinbutton', {name: 'Filter Age'});
+
+      await user.type(input, '3·');
+      expect(screen.getByTestId('filters')).toHaveTextContent('{"age":3}');
+      await user.tab();
+
+      expect(screen.getByTestId('filters')).toHaveTextContent('{}');
+    });
+
+    it('restores the pre-edit number filter when Enter rejects a draft', async () => {
+      const user = userEvent.setup();
+      render(<FilterTable variant="inline" />);
+      const input = screen.getByRole('spinbutton', {name: 'Filter Age'});
+
+      await user.type(input, '3·');
+      await user.keyboard('{Enter}');
+
+      expect(input).toHaveValue('3·');
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByTestId('filters')).toHaveTextContent('{}');
     });
   });
 

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
@@ -20,6 +20,9 @@ import {
   useMemo,
   useState,
   useCallback,
+  type FocusEvent,
+  type FormEvent,
+  type KeyboardEvent,
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
@@ -29,6 +32,10 @@ import {Button} from '../../../Button';
 import {Popover} from '../../../Popover';
 import {TextInput} from '../../../TextInput';
 import {NumberInput} from '../../../NumberInput';
+import {
+  parseNumberInput,
+  resolveNumberInputCommit,
+} from '../../../NumberInput/numberInputCommit';
 import {DateInput} from '../../../DateInput';
 import type {ISODateString} from '../../../utils/dateTypes';
 import {TimeInput} from '../../../TimeInput';
@@ -42,7 +49,7 @@ import type {
   HeaderCellRenderProps,
 } from '../../types';
 import {proportional} from '../../columnUtils';
-import {useTranslator} from '../../../i18n';
+import {useLocale, useTranslator} from '../../../i18n';
 import type {
   PowerSearchConfig,
   PowerSearchField,
@@ -445,6 +452,80 @@ function TextFilterControl({
   );
 }
 
+function useLiveNumberFilter({
+  value,
+  min,
+  max,
+  hasClear,
+  onChange,
+}: {
+  value: number | null;
+  min?: number | null;
+  max?: number | null;
+  hasClear: boolean;
+  onChange: (value: number | null) => void;
+}) {
+  const locale = useLocale();
+  const editStartValueRef = useRef(value);
+
+  const handleChange = useCallback(
+    (nextValue: number | null) => {
+      editStartValueRef.current = nextValue;
+      onChange(nextValue);
+    },
+    [onChange],
+  );
+  const handleFocus = useCallback(() => {
+    editStartValueRef.current = value;
+  }, [value]);
+  const handleInput = useCallback(
+    (event: FormEvent<HTMLElement>) => {
+      const nextValue = parseNumberInput(
+        (event.currentTarget as HTMLInputElement).value,
+        {
+          min,
+          max,
+          locale,
+        },
+      );
+      if (nextValue !== null && nextValue !== value) {
+        onChange(nextValue);
+      }
+    },
+    [locale, max, min, onChange, value],
+  );
+  const restoreRejectedDraft = useCallback(
+    (input: HTMLInputElement) => {
+      const decision = resolveNumberInputCommit(input.value, {
+        min,
+        max,
+        locale,
+        hasClear,
+      });
+      if (decision.type === 'revert' && value !== editStartValueRef.current) {
+        onChange(editStartValueRef.current);
+      }
+    },
+    [hasClear, locale, max, min, onChange, value],
+  );
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      restoreRejectedDraft(event.currentTarget);
+    },
+    [restoreRejectedDraft],
+  );
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        restoreRejectedDraft(event.currentTarget);
+      }
+    },
+    [restoreRejectedDraft],
+  );
+
+  return {handleBlur, handleChange, handleFocus, handleInput, handleKeyDown};
+}
+
 function NumberFilterControl({
   columnKey,
   header,
@@ -466,12 +547,19 @@ function NumberFilterControl({
 
   const step = operatorValue.type === 'integer' ? 1 : null;
 
-  const handleChange = useCallback(
+  const updateFilter = useCallback(
     (newValue: number | null) => {
       store.getConfig().onFilterChange(columnKey, newValue);
     },
     [store, columnKey],
   );
+  const liveFilter = useLiveNumberFilter({
+    value: numValue,
+    min: operatorValue.minValue,
+    max: operatorValue.maxValue,
+    hasClear: !!hasClear,
+    onChange: updateFilter,
+  });
 
   if (hasClear) {
     return (
@@ -479,7 +567,11 @@ function NumberFilterControl({
         label={t('@astryx.tableFiltering.filterByColumn', {header})}
         isLabelHidden
         value={numValue}
-        onChange={handleChange}
+        onChange={liveFilter.handleChange}
+        onFocus={liveFilter.handleFocus}
+        onInput={liveFilter.handleInput}
+        onBlur={liveFilter.handleBlur}
+        onKeyDown={liveFilter.handleKeyDown}
         placeholder={t('@astryx.tableFiltering.filterByColumn', {header})}
         min={operatorValue.minValue ?? null}
         max={operatorValue.maxValue ?? null}
@@ -495,7 +587,11 @@ function NumberFilterControl({
       label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       value={numValue}
-      onChange={handleChange}
+      onChange={liveFilter.handleChange}
+      onFocus={liveFilter.handleFocus}
+      onInput={liveFilter.handleInput}
+      onBlur={liveFilter.handleBlur}
+      onKeyDown={liveFilter.handleKeyDown}
       placeholder={t('@astryx.tableFiltering.filterByColumn', {header})}
       min={operatorValue.minValue ?? null}
       max={operatorValue.maxValue ?? null}


### PR DESCRIPTION
## Why

Typing `1·234·567` committed the valid prefix `1` before the full draft became invalid. Pasting the same text committed nothing. Blurring then discarded the draft and left the typed path with a value the person never intended. The same per-keystroke behavior also made Pagination navigate through intermediate prefixes while a page number was still being typed.

## What

- Treat each text edit as one draft and decide `commit`, `clear`, or `revert` only on blur or Enter.
- Keep the invalid draft visible while focused; blur restores the committed value, while Enter leaves the invalid draft available to correct.
- Preserve existing min/max clamping, localized parsing, IME guards, steppers, live inline Table filtering, and PowerSearch Enter-to-save behavior.
- Keep ARIA and formatted form submission anchored to the committed value.

## Architecture

- **OWNER:** `NumberInput` owns the draft-to-committed-value lifecycle; `parseLocaleNumber` owns locale text interpretation.
- **TIER 1:** Field/input anatomy and provider locale are reused.
- **TIER 2:** None.
- **SEAMS:** Sequential typing, one-shot paste/input, blur, Enter, controlled parent updates, IME composition, min/max clamping, localized decimals/grouping, steppers, Table filters, Pagination, and PowerSearch.
- **BEHAVIOR UNIT:** `resolveNumberInputCommit`, a pure utility that returns one commit/clear/revert decision for the whole draft; `NumberInput.commitPendingInput` owns the React lifecycle boundary. Table and PowerSearch reuse the same decision utility for their distinct live-preview/save contracts.

R35: the multi-handler policy is independently testable, remains owned by `NumberInput`, and its consumer seams have explicit regression coverage.

## Compatibility

`onChange` for text entry now fires once when the draft commits on blur or Enter instead of on every parseable keystroke. This timing change is the mechanism that prevents partial prefixes from becoming data. Pagination benefits from it; the in-repo Table, PowerSearch, and docsite playground consumers retain their existing live-filter, Enter-to-save, and live-preview behavior through internal adapters.

## Testing

- New regression matrix: typed and one-shot U+00B7 drafts × blur and Enter.
- Valid en-US and de-DE grouped-number commits.
- Controlled updates, IME composition, min/max clamping, steppers, clear/focus, ARIA/form values, live Table filters, Pagination, and PowerSearch numeric save.
- 447 focused tests passed across NumberInput, parser, Table filtering, Pagination, PowerSearch, and docsite live-preview controls.
- Core typecheck, docs typecheck, ESLint, changesets, sync checks, and package build passed.
- Real Chromium: typed and pasted `1·234·567` both keep `Committed: null`; blur restores the empty committed value, Enter retains the invalid draft. Valid `1,234,567` and `1.234.567` commit as `1234567`. Inline numeric filters remain live and restore their pre-edit filter after an invalid blur.
