### PR TITLE
fix(Button): reflect elevation as a theme target (nightly audit of core/Button)

### DIFF
--- a/.changeset/button-elevation-theme-target.md
+++ b/.changeset/button-elevation-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] `Button` now reflects `elevation` as a theme target. The prop selected between four StyleX style objects but was missing from the sibling `themeProps('button')` call, so `data-elevation` never reached the DOM and no theme could style the axis — the same defect fixed on `Card` in #5491, and one `ButtonGroup` already had right. A button inside a `ButtonGroup` reports `none`, because the group owns the surface's elevation and the member paints flat. Nothing about the rendered button changes: 60 of 64 captured frames are byte-identical, and the four that differ do so only inside the loading spinner's own box.
+[fix] `Button` now reflects `elevation` as a theme target. The prop selected between four StyleX style objects but was missing from the sibling `themeProps('button')` call, so `data-elevation` never reached the DOM and no theme could style the axis — the same defect fixed on `Card` in #5491, and one `ButtonGroup` already had right. A button inside a `ButtonGroup` reports `none`, because the group owns the surface's elevation and the member paints flat. Every wrapper that forwards `ButtonProps` through to `Button` — `IconButton` — picks the reflection up with it. (`ToggleButton` does not: its props extend `BaseProps`, not `ButtonProps`, so it has no `elevation` to forward and keeps reporting `none`.) Nothing about the rendered button changes: 60 of 64 captured frames are byte-identical, and the four that differ do so only inside the loading spinner's own box.
 
 @cixzhang

--- a/.changeset/button-elevation-theme-target.md
+++ b/.changeset/button-elevation-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Button` now reflects `elevation` as a theme target. The prop selected between four StyleX style objects but was missing from the sibling `themeProps('button')` call, so `data-elevation` never reached the DOM and no theme could style the axis — the same defect fixed on `Card` in #5491, and one `ButtonGroup` already had right. A button inside a `ButtonGroup` reports `none`, because the group owns the surface's elevation and the member paints flat. Nothing about the rendered button changes: 60 of 64 captured frames are byte-identical, and the four that differ do so only inside the loading spinner's own box.
+
+@cixzhang

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -181,7 +181,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-button', visualProps: ['size', 'variant']},
+      {className: 'astryx-button', visualProps: ['size', 'variant', 'elevation']},
     ],
     vars: [
       {name: '--_button-radius', description: 'Border radius', default: 'var(--radius-element)', private: true},
@@ -262,6 +262,7 @@ export const docsZh = {
         visualProps: [
           'size',
           'variant',
+          'elevation',
         ],
       },
     ],

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -476,6 +476,21 @@ describe('Button', () => {
   });
 
   describe('elevation', () => {
+    it('reflects each elevation level as a theme attribute', () => {
+      const attrFor = (elevation: 'none' | 'low' | 'med' | 'high') => {
+        const {container} = render(
+          <Button label="Save" elevation={elevation} />,
+        );
+        return container
+          .querySelector('button')!
+          .getAttribute('data-elevation');
+      };
+      expect(attrFor('none')).toBe('none');
+      expect(attrFor('low')).toBe('low');
+      expect(attrFor('med')).toBe('med');
+      expect(attrFor('high')).toBe('high');
+    });
+
     it('renders a distinct class for each elevation level', () => {
       const classFor = (elevation: 'none' | 'low' | 'med' | 'high') => {
         const {container} = render(
@@ -493,13 +508,13 @@ describe('Button', () => {
     });
 
     it('defaults to flat (elevation none)', () => {
-      const {container: def} = render(<Button label="Save" />);
+      const {container} = render(<Button label="Save" />);
+      const button = container.querySelector('button')!;
+      expect(button).toHaveAttribute('data-elevation', 'none');
       const {container: none} = render(
         <Button label="Save" elevation="none" />,
       );
-      expect(def.querySelector('button')!.className).toBe(
-        none.querySelector('button')!.className,
-      );
+      expect(button.className).toBe(none.querySelector('button')!.className);
     });
   });
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -689,7 +689,13 @@ export function Button({
   );
 
   const sharedMergedProps = mergeProps(
-    themeProps('button', {variant, size}),
+    // Inside a group the group owns the surface's elevation, so the button
+    // reflects the tier it actually paints rather than the prop it was handed.
+    themeProps('button', {
+      variant,
+      size,
+      elevation: buttonGroup ? 'none' : elevation,
+    }),
     sharedStylexProps,
     className,
     style,

--- a/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
@@ -626,6 +626,19 @@ describe('ButtonGroup', () => {
         'high',
       );
     });
+
+    it('reports flat on a member, since the group owns the surface', () => {
+      render(
+        <ButtonGroup label="Actions" elevation="high">
+          <Button label="One" elevation="high" />
+        </ButtonGroup>,
+      );
+
+      expect(screen.getByRole('button', {name: 'One'})).toHaveAttribute(
+        'data-elevation',
+        'none',
+      );
+    });
   });
 
   // ===========================================================================


### PR DESCRIPTION
# Nightly component audit — `core/Button`

Full re-grading under rubric **1.11.1**, mode N, on `58f9542`. One fix: `elevation` now reaches the DOM as a theme target. Three findings are left open on purpose and are in **Needs Review** below.

## Score

| | Before (recorded row) | This audit, pre-fix | This audit, post-fix |
|---|---|---|---|
| Score | 62.6 **D** | 73.9 **C** | 78.3 **C** |
| Rubric | 1.1 | 1.11.1 | 1.11.1 |
| Sections scored | **2 of 11** | 11 of 11 | 11 of 11 |
| Open BLOCKs | 6 claimed / 4 listed | 4 | 3 |

**The D was not a measurement of Button.** The recorded row was taken on 2026-08-10 under rubric 1.1, and only `design_objective` and `design_rendered` were ever scored — the other nine sections read `unpublished`, so 62.6 came from a fifth of the checklist. Scores under different rubric versions are not comparable, which is why this is a fresh grading rather than a delta.

**The `blocks.count` of 6 against 4 listed entries is resolved as 4.** The ledger's own caveat says that count was the union of two calibration passes; only four entries were written down and the other two were never published, so they cannot be reconstructed. This audit records the four it can stand behind, all four re-verified against current `main`.

Sensitivity: close the three still open and change nothing else → **85.1, B**.

<details>
<summary>Section scores, post-fix</summary>

| Section | Weight | Score | |
|---|---|---|---|
| §1 Accessibility | 16 | 3.0 | 1 BLOCK — A11 |
| §2 Theming | 14 | 4.5 | fixed here |
| §3 Public API | 14 | 4.0 | |
| §4 Behavior | 12 | 4.0 | |
| §5a Design — objective | 6 | 4.5 | |
| §5b Design — rendered | 4 | 2.5 | 2 BLOCKs — D7, D13 |
| §6 Testing | 8 | 4.0 | |
| §7 Code health | 8 | 4.5 | zero Effects in 819 lines |
| §8 Docs | 8 | 4.0 | X10 open |
| §9 i18n & RTL | 5 | 4.0 | |
| §10 Responsive & touch | 5 | `limited` | 3 of 11 items non-vacuous; weight redistributed |

</details>

## What this PR fixes

**T6 (§2, BLOCK) — `elevation` was unthemeable.** `elevationStyles[elevation]` selected between four StyleX style objects inside `stylex.props()`, but `elevation` was absent from the `themeProps('button')` call beside it. `data-elevation` therefore never rendered, and a theme had no selector to reach the axis with. Same class of defect as `Card` in #5491; `ButtonGroup` already passed its own `elevation` through.

A button inside a `ButtonGroup` reports `none`, because the group owns the surface's elevation and the member paints flat — reflecting the prop it was handed would have told a theme something untrue.

### Proof: the rule a theme compiles to, injected at runtime

`generateThemeRules` was asked what `components.button['elevation:high']` compiles to, rather than assuming:

```
.astryx-button.high { box-shadow: 0 0 0 4px rgb(0, 200, 0); }
```

The class token, not the data attribute — the generator's own docblock says the move to data-attribute selectors is a later step. `themeProps` adds both, so both were injected against the four buttons in `core-button--elevations`, the class rule as a `box-shadow` and the data-attribute rule as an `outline`:

| | `data-elevation` rendered | `high` class token | `.astryx-button.high` reaches paint | `[data-elevation="high"]` reaches paint |
|---|---|---|---|---|
| `main` (`58f9542`) | *(absent on all four)* | no | **no** | **no** |
| this branch | `none, low, med, high` | yes | **yes** | **yes** |

Both halves of the selector surface were unreachable before and are reachable now, so the fix holds under today's generator and under the one the migration is heading to.

### Proof: nothing else moved

64 frames re-captured on the fixed build and compared byte-for-byte with the pre-fix set: **60 identical, 4 differ.** All four contain a loading spinner, and the differing pixels are confined to the spinner's own 14×14 box — its rotation phase, not the change. 0.04–0.18% of pixels, bounding boxes `[54,25,67,38]` and `[54,69,370,82]`.

`IconButton` picks the reflection up for free — it spreads `Omit<ButtonProps, …>` straight into `Button`, so `data-elevation` now renders there too. `ToggleButton` does not: its props extend `BaseProps` rather than `ButtonProps`, so there is no `elevation` to forward and it keeps reporting `none`.

Tests: the two elevation cases asserted generated StyleX class names, which pass whether or not the axis is themeable. The reflected attribute is now asserted alongside them, and `ButtonGroup` covers the grouped member. All three new assertions were red on the parent commit (`expected null to be 'none'`) and green here; 88 Button + ButtonGroup tests pass.

## Needs Review — deliberately not fixed

**A11 (§1, BLOCK) — busy sets native `disabled`, so focus drops mid-action.** Open as #4871 (bug + accessibility). The wiki contradicts itself on busy-vs-disabled, so this is a ruling, not a correction. `isInterruptible` already opts out, which is part of what has to be decided: whether the default should flip, or whether the opt-out is the answer.

**D13 (§5b, BLOCK) — the `primary` hover overlay is below the just-noticeable difference.** Measured, and the recorded row overstated it: it is *not* 0.00% of pixels. 26.6% of pixels change in neutral light — but the largest channel moves by **2 of 255**, and by 2 in neutral dark and 1 in y2k, against 10–25 for the other three variants. So the mechanism is right and the amplitude is ~6× too small: a 5% black tint over a near-black accent, and a 5% white tint over a near-white one.

**Does #5516 close it? No.** That PR makes `:active` out-specify the media-nested `:hover` so the pressed overlay paints (#5451, which I also reproduced here — under simultaneous hover+active the computed `background-image` is still the hover token). It does not change which token hover uses or how it composites against an inverted base, so `primary` hover stays invisible after it lands. It does rewrite the exact `backgroundImage` block this finding lives in, into a shared `interactionOverlay.stylex.ts`, so any fix belongs on top of it, not underneath.

**D7 (§5b, BLOCK) — the `destructive` focus ring fails WCAG 2.4.11 in one theme.** `destructive` opts out of the shared focus ring and pins `outlineColor` to `--color-error`. That token's *role* differs by theme: in `neutral` it is the saturated text/icon stop, in `y2k` light it is a pale surface tint. Measured under real `:focus-visible` across all seven shipped themes in both modes:

- the destructive ring clears 3:1 in **13 of 14** theme × mode pairs — **y2k light is 1.5:1**
- the shared accent ring clears 3:1 in **14 of 14**

So this is the component's own token choice, not the palette — the token layer ships a ring colour that works everywhere and `destructive` declines it. That makes it a real finding against Button rather than a `#4652` systemic one. It is **not fixed here** because the remedy is a visual decision with a deliberate rationale already in the source (an accent ring on a red button reads as another control's focus): either the ring takes the shared accent everywhere, or `destructive` needs a token whose role is "a boundary that contrasts with the page". Changing it would repaint the ring in the 13 pairs that are fine today.

**X10 (§8, FIX) — nine documented props are in no story.** `type`, `name`, `value`, `form`, `isInterruptible`, `tooltip`, `as`, `clickAction`, `children` appear in no `args`, `argTypes` or JSX attribute, so neither the a11y nor the RTL sweep ever reaches them. Left open rather than padding this PR with ten stories.

**I17 (§9, FIX) — RTL is unmeasurable by the harness.** `pnpm rtl:audit -- --filter Button` reports `0 pass / 0 fail / 1 N-A`, and the `verified-not-applicable.json` the protocol names does not exist on `main`. Harness coverage gap, #5364. Button's RTL correctness is verified from a rendered frame instead (icon, label and end content reorder correctly under `direction: rtl`).

**Two siblings still ship an unthemeable `elevation`, and no guard catches the class.** `Banner` and `ChatComposer` apply `elevationStyles[elevation]` with the prop absent from their `themeProps()` call, exactly as Button did. `themingTargets.test.ts` is a subset policy so it cannot see a prop the source never passes, and `extensibleAxes.test.ts` only covers extensible `*VariantMap` axes — `Elevation` is a closed union and falls between them, which is why this shipped five times. Filed as **#5556**, one system-level issue rather than two component bugs, because the guard is the part that matters. Not fixed here: on both components the element that paints the shadow carries no stable class for an axis to hang on, so it is not a copy of this change.

**Off-limits and untouched:** #3379 (Button hard-codes a fixed height per size, overriding theme `paddingBlock`), #5451/#5516 (the pressed overlay), #4871.

## Visual evidence

Every frame carries a fail-closed sensor receipt (`<shot>.png.sensors.json`) asserting build SHA, story id, rendered theme and colour mode, computed direction, viewport, semantic state, subject geometry, settled fonts and absence of page errors. Captured with `captureWithSensors()` against `storybook dev` on `58f9542`.

Coverage: 4 variants × {rest, hover, active, focus-visible} × {neutral light, neutral dark, y2k light}, plus disabled, loading, sizes, icon-only, overflow, elevations in both modes, plus RTL and 320 px.

### States — neutral light

![states neutral light](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5552/shots/sheet-states-neutral-light.png)

### States — neutral dark

![states neutral dark](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5552/shots/sheet-states-neutral-dark.png)

### States — y2k light (D7 is visible here)

![states y2k light](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5552/shots/sheet-states-y2k-light.png)

The destructive ring is a pale halo you have to look for; the other three variants get a crisp near-black ring in the same theme.

### Anatomy — neutral light

![anatomy neutral light](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5552/shots/sheet-anatomy-neutral-light.png)

### RTL and 320 px

![rtl and narrow](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5552/shots/sheet-rtl-narrow.png)

<details>
<summary>State-visual conformance matrix</summary>

| State | Approved representation | Token signature present? | Verdict |
|---|---|---|---|
| rest | — | base tokens per variant | pass |
| hover | Hovered — Overlay style | alpha tint over the component's own base ✓ | **BLOCK on `primary`** (D13): mechanism right, amplitude 2/255 |
| pressed | Pressed — overlay, plus `scale(0.98)` for the button archetype | transform ✓, overlay ✗ | FIX — overlay never paints (#5451, #5516 open) |
| focus-visible | Focused — Outline style, offset outline visible in every theme | offset ✓, colour ✗ in y2k light | **BLOCK** (D7) |
| disabled | native `disabled`, not a visual alone | native `disabled` ✓, muted ✓, no hover paint (A20) ✓, `cursor: default` (A21) ✓ | pass |
| loading | `aria-busy`, never `disabled`, dimensions stable | dimensions stable ✓, `aria-busy` ✓, but also `disabled` | **BLOCK** — scored at A11 |
| overflow | — | ellipsis, no layout break | pass |
| selected / status / empty | — | — | N/A — Button has no such state |

</details>

## Verification

- `vitest` Button + ButtonGroup — 88 passed; the three new assertions red on the parent commit
- `themingTargets.test.ts` (294), `derivedVarRegistry.test.ts` (74), `docPropLiterals` (20), `docPropReferences` (2) — green
- `eslint` at CI severity over `Button/` and the story file — clean
- all ten repo checks green in the commit hook (sync, package boundaries, changesets, demo media, executable bits, CLI structure, use-client, portable scripts, i18n catalog, CLDR weekdays)
- `pnpm build` green

The pre-fix score was recorded to the ledger before any code changed. The post-fix row goes in once this is on `main`, so its `commit` names a real main commit.
