### PR TITLE
docs(slop): replace em dashes and a curly apostrophe in doc prose

### DIFF
--- a/packages/cli/assets/templates/blocks/components/Step/StepIndicator.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Step/StepIndicator.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'Step — Indicator',
   displayName: 'Step — Indicator',
   description:
-    'Everything the indicator prop accepts: the auto default, an always-number badge, a custom ReactNode, and none — each on its own completed Step so the prop is the only difference between them. Every variant occupies the same 16px box, so a step swapping its number for a check as it completes never shifts the label beside it. The last cell shows that a custom node can be live rather than static: a Spinner on a step that is in progress, shaded `inherit` so it picks up the step\u2019s own tint like any other glyph.',
+    'Everything the indicator prop accepts: the auto default, an always-number badge, a custom ReactNode, and none, each on its own completed Step so the prop is the only difference between them. Every variant occupies the same 16px box, so a step swapping its number for a check as it completes never shifts the label beside it. The last cell shows that a custom node can be live rather than static: a Spinner on a step that is in progress, shaded `inherit` so it picks up the step\'s own tint like any other glyph.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Stepper', 'Step', 'Icon', 'Spinner', 'Text'],

--- a/packages/cli/assets/templates/blocks/components/Step/StepShowcase.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Step/StepShowcase.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'Step',
   displayName: 'Step',
   description:
-    'A single Step, with every part it can render: the indicator, the label with its optional marker and trailing endContent, and the description beneath. A Step never sets its own completed/current state — it declares its index and derives the rest from the parent Stepper, so one Step in one Stepper is a complete example.',
+    'A single Step, with every part it can render: the indicator, the label with its optional marker and trailing endContent, and the description beneath. A Step never sets its own completed/current state. It declares its index and derives the rest from the parent Stepper, so one Step in one Stepper is a complete example.',
   isReady: true,
   isShowcase: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/assets/templates/blocks/components/Stepper/StepperShowcase.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Stepper/StepperShowcase.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'Stepper — Checkout Progress',
   displayName: 'Stepper — Checkout Progress',
   description:
-    'The default stepper: a horizontal track where every step owns an equal segment of the progress bar above its label. The default auto indicator resolves itself per step — a check once the step is done, a ring on the current step, a number for the ones still ahead. Click any step to jump.',
+    'The default stepper: a horizontal track where every step owns an equal segment of the progress bar above its label. The default auto indicator resolves itself per step: a check once the step is done, a ring on the current step, a number for the ones still ahead. Click any step to jump.',
   isReady: true,
   isShowcase: true,
   aspectRatio: 16 / 9,

--- a/packages/cli/clients/cli/commands/theme-targets.doc.mjs
+++ b/packages/cli/clients/cli/commands/theme-targets.doc.mjs
@@ -18,7 +18,7 @@ export const doc = {
   description:
     'Prints every `defineTheme` components key across the system: the stable class it paints, ' +
     'the component that declares it, and the props and states that are legal override keys ' +
-    'under it. This is the whole themeable surface in one command — what auditing a theme, or ' +
+    'under it. This is the whole themeable surface in one command: what auditing a theme, or ' +
     'answering "which key paints this pixel?", used to need one `astryx component <Name>` per ' +
     'component to assemble. Pass a component name to scope it; pass any substring to search ' +
     'keys. `--json` for a list a repo can lint its own theme against.',

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -109,7 +109,7 @@ export const docs = {
     {
       name: 'children',
       type: 'ReactNode',
-      description: 'Children mode: compose the table yourself from TableHeader / TableBody / TableFooter, each holding TableRow and TableCell, instead of using data-driven rendering. The children are passed straight to the <table>, so the section is yours to supply — a TableRow placed directly in Table emits <table><tr>, which is invalid HTML and mismatches on hydration (the parser inserts an implied <tbody> for server-rendered markup; React does not on the client). Data-driven mode renders the sections for you.',
+      description: 'Children mode: compose the table yourself from TableHeader / TableBody / TableFooter, each holding TableRow and TableCell, instead of using data-driven rendering. The children are passed straight to the <table>, so the section is yours to supply. A TableRow placed directly in Table emits <table><tr>, which is invalid HTML and mismatches on hydration (the parser inserts an implied <tbody> for server-rendered markup; React does not on the client). Data-driven mode renders the sections for you.',
     },
     {
       name: 'xstyle',
@@ -189,7 +189,7 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Use density and divider variants to match the information density and scanning needs of your data.' },
       { guidance: true, description: 'Compose rich cell content with Astryx components like Badge, StatusDot, and Avatar via renderCell.' },
-      { guidance: true, description: 'Children mode: wrap rows in TableHeader/TableBody/TableFooter. <table> cannot hold a <tr> directly — parser adds an implied <tbody> for SSR markup, React does not on the client, so unwrapped rows mismatch on hydration.' },
+      { guidance: true, description: 'Children mode: wrap rows in TableHeader/TableBody/TableFooter. <table> cannot hold a <tr> directly; the parser adds an implied <tbody> for SSR markup, React does not on the client, so unwrapped rows mismatch on hydration.' },
       { guidance: true, description: 'Set explicit width on every column via proportional() or pixel(). proportional(1) = equal flex w/ 120px min preventing collapse on narrow viewports. Omitting width skips the minimum.' },
       { guidance: true, description: 'Data-driven API is RSC-safe: proportional(), pixel(), column defs w/o function props work in Server Components. renderCell (any function prop) requires a "use client" wrapper.' },
       { guidance: false, description: 'Use a table for data without consistent columns. Use a list or card layout for heterogeneous content.' },

--- a/packages/core/src/Table/TableFooter.doc.mjs
+++ b/packages/core/src/Table/TableFooter.doc.mjs
@@ -8,7 +8,7 @@ export const docs = {
   displayName: 'Table Footer',
   isHiddenFromOverview: true,
   description:
-    '<tfoot> wrapper for children mode. Holds summary or total rows beneath the body. A row must sit inside a section — <table> cannot contain a <tr> directly, because the HTML parser inserts an implied <tbody> when it parses server-rendered markup and React does not when it renders on the client, so the two trees mismatch on hydration. Children mode only: the data-driven data={...} path renders a header and a body, never a footer.',
+    '<tfoot> wrapper for children mode. Holds summary or total rows beneath the body. A row must sit inside a section: <table> cannot contain a <tr> directly, because the HTML parser inserts an implied <tbody> when it parses server-rendered markup and React does not when it renders on the client, so the two trees mismatch on hydration. Children mode only: the data-driven data={...} path renders a header and a body, never a footer.',
   props: [
     {
       name: 'children',

--- a/packages/core/src/Table/useTableSelection.doc.mjs
+++ b/packages/core/src/Table/useTableSelection.doc.mjs
@@ -65,7 +65,7 @@ export const docs = {
       name: 'hasRowHighlight',
       type: 'boolean',
       description:
-        'Paints checked rows with the accent wash. Set false when the surrounding UI already uses row background to mean something else (a row open in a detail panel, say) — the wash is an inline style, so it cannot be overridden from userland. Only the background is dropped: aria-selected is still set on checked rows either way.',
+        'Paints checked rows with the accent wash. Set false when the surrounding UI already uses row background to mean something else (a row open in a detail panel, say). The wash is an inline style, so it cannot be overridden from userland. Only the background is dropped: aria-selected is still set on checked rows either way.',
       default: 'true',
     },
   ],


### PR DESCRIPTION
## What

Seven doc prose strings carried an em dash (one also a curly apostrophe). Each is recast with plain punctuation, meaning preserved, and no code, identifiers, or `name`/`displayName` convention labels touched.

- `theme-targets.doc.mjs`: command description, em dash to colon
- `Table.doc.mjs`: `children` prop and a best-practice bullet, em dash to period/semicolon
- `TableFooter.doc.mjs`: description, em dash to colon
- `useTableSelection.doc.mjs`: `paintSelectedRows` description, em dash to period
- `Step/StepIndicator` block: em dash to comma, curly apostrophe to straight
- `Step/StepShowcase` block: em dash to period
- `Stepper/StepperShowcase` block: em dash to colon

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] Every changed file parse-checked as an ES module
- [x] `astryx component Table --lang dense` and `--props` render clean
- [x] Prose strings only; meaning preserved

---
Night Watch — Doc Reviewer