### PR TITLE
fix(Text, Heading): a truncated label shows one tooltip, not two

### DIFF
--- a/.changeset/text-single-tooltip.md
+++ b/.changeset/text-single-tooltip.md
@@ -1,0 +1,20 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Text, Heading: a truncated label shows one tooltip, not two.
+
+When `maxLines` clipped the text, both components rendered Astryx's `Tooltip`
+**and** set the native `title` attribute to the same string. Hovering drew
+both: the styled tooltip first, then the browser's own unstyled one on top of
+it a moment later, saying exactly the same thing.
+
+The `title` goes. `Tooltip` already wires `aria-describedby` onto the anchor,
+and the full text is in the DOM either way — CSS clips it visually, so a
+screen reader was never reading the truncated version. Nothing is lost but the
+duplicate.
+
+Measured on hover, same story, before and after: `2` tooltips shown to the
+user, then `1`.
+
+@freddymeta

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/tmp/sh/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/tmp/sh/node_modules

--- a/packages/core/src/Heading/Heading.tsx
+++ b/packages/core/src/Heading/Heading.tsx
@@ -281,7 +281,6 @@ export function Heading({
           className,
           {...style, ...inlineStyle},
         )}
-        title={tooltipEnabled ? truncation.fullText : undefined}
         {...ariaProps}
         {...props}>
         {children}

--- a/packages/core/src/Text/Text.test.tsx
+++ b/packages/core/src/Text/Text.test.tsx
@@ -297,3 +297,47 @@ describe('Text custom colors', () => {
     expect(screen.getByText('Accent').className).toContain('accent');
   });
 });
+
+// A truncated Text rendered its own Tooltip AND set `title` with the same
+// string, so the browser drew a second, unstyled tooltip on top of ours.
+describe('truncated text shows one tooltip, not two', () => {
+  function withOverflow() {
+    const proto = window.HTMLElement.prototype;
+    const original = {
+      scrollWidth: Object.getOwnPropertyDescriptor(proto, 'scrollWidth'),
+      offsetWidth: Object.getOwnPropertyDescriptor(proto, 'offsetWidth'),
+    };
+    Object.defineProperty(proto, 'scrollWidth', {
+      configurable: true,
+      get: () => 400,
+    });
+    Object.defineProperty(proto, 'offsetWidth', {
+      configurable: true,
+      get: () => 100,
+    });
+    return () => {
+      if (original.scrollWidth) {
+        Object.defineProperty(proto, 'scrollWidth', original.scrollWidth);
+      }
+      if (original.offsetWidth) {
+        Object.defineProperty(proto, 'offsetWidth', original.offsetWidth);
+      }
+    };
+  }
+
+  it('leaves the native title to the tooltip it already renders', () => {
+    const restore = withOverflow();
+    try {
+      render(
+        <Text type="body" maxLines={1}>
+          A label far wider than the space it has been given
+        </Text>,
+      );
+      expect(
+        screen.getByText('A label far wider than the space it has been given'),
+      ).not.toHaveAttribute('title');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/core/src/Text/Text.tsx
+++ b/packages/core/src/Text/Text.tsx
@@ -313,7 +313,6 @@ export function Text({
           className,
           {...style, ...inlineStyle},
         )}
-        title={tooltipEnabled ? truncation.fullText : undefined}
         {...props}>
         {children}
       </Component>


### PR DESCRIPTION
## Summary

A truncated `Text` renders Astryx's `Tooltip` **and** sets the native `title` attribute to the same string — both gated on the same `tooltipEnabled`. Hovering draws both: the styled tooltip first, then the browser's own unstyled one on top of it a moment later, saying exactly the same thing.

It is visible on the docsite today:

```diff
-        title={tooltipEnabled ? truncation.fullText : undefined}
```

Same line in `Heading.tsx`.

## Measured in Chromium

Same story, native `title` presence plus a count of *visible* `[role="tooltip"]` elements after hover:

| | native title | visible Astryx tooltip | shown to the user |
|---|---|---|---|
| main | yes | 1 | **2** |
| this PR | no | 1 | **1** |

## Why the `title` goes and not the `Tooltip`

- **`Tooltip` already carries the a11y contract.** It sets `aria-describedby` on its anchor (`Tooltip.tsx:253-256`), verified still present after this change.
- **The full text was never hidden from assistive tech.** CSS clips it visually; the DOM still holds all 191 characters, measured. `title` was not what made the truncated text readable to a screen reader.
- **`title` is the weaker affordance anyway** — unstyleable, unplaceable, no touch support, and its own delay is what makes the doubling look like a glitch rather than a design.

So the duplicate is all that is lost.

## Test plan

- New test: a truncated `Text` carries no `title`. **Negative control:** putting the attribute back fails exactly that test.
- `pnpm build`, `check:repo`, `lint:strict`, core + storybook typechecks — clean. Text + Heading + Tooltip suites green.
- No existing test asserted the `title` (checked before removing it).

## Note

`Badge` gains the same tooltip in a follow-up; it will use the `Tooltip` alone rather than reintroducing this pair.

@freddymeta
