### PR TITLE
fix(Selector): derive the trigger id from a caller-supplied `id` so the label and listbox wiring resolves

### DIFF
--- a/.changeset/selector-caller-supplied-trigger-id.md
+++ b/.changeset/selector-caller-supplied-trigger-id.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector: a caller-supplied `id` now drives the trigger's whole identity, not just its `id` attribute
+
+`Selector` generated its trigger id with `useId()` and set it on the trigger button before spreading `...rest`, so a caller's `id` — accepted through `BaseProps` — replaced it on the button while the generated value stayed behind as the target of the listbox's `aria-labelledby` and of the `Field` label's `htmlFor`. Passing `id` therefore left the listbox with no accessible name and the field label pointing at an element that does not exist, silently and with a clean typecheck, lint and build.
+
+The internal identity is now derived from the caller's `id` when there is one, so the button, the listbox's `aria-labelledby` (both the plain and the `hasSearch` panel) and `Field`'s `inputID` all name the same element. The trigger's own `id` attribute is unchanged in every case; what changes is that references which used to dangle now resolve — including the field label, which consequently regains its native click-to-focus behaviour. With no `id` supplied the rendered output is identical to before.
+
+@cixzhang

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -2344,6 +2344,55 @@ describe('Selector', () => {
   });
 });
 
+describe('Selector caller-supplied id', () => {
+  it('names the listbox with the id the caller put on the trigger', () => {
+    render(<Selector label="Fruit" options={OPTIONS} id="fruit-picker" />);
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('id', 'fruit-picker');
+
+    const labelledBy = screen
+      .getByRole('listbox', h)
+      .getAttribute('aria-labelledby');
+    expect(document.getElementById(labelledBy!)).toBe(trigger);
+  });
+
+  it('names the search-variant listbox with the caller id', () => {
+    render(
+      <Selector label="Fruit" options={OPTIONS} id="fruit-picker" hasSearch />,
+    );
+
+    const trigger = document.getElementById('fruit-picker');
+    expect(trigger?.tagName).toBe('BUTTON');
+
+    const labelledBy = screen
+      .getByRole('listbox', h)
+      .getAttribute('aria-labelledby');
+    expect(document.getElementById(labelledBy!)).toBe(trigger);
+  });
+
+  it('points the field label at the caller id', () => {
+    render(<Selector label="Fruit" options={OPTIONS} id="fruit-picker" />);
+
+    const trigger = screen.getByRole('combobox', {name: 'Fruit'});
+    expect(trigger).toHaveAttribute('id', 'fruit-picker');
+    expect(screen.getByLabelText('Fruit')).toBe(trigger);
+  });
+
+  it('generates the trigger id when the caller supplies none', () => {
+    render(<Selector label="Fruit" options={OPTIONS} />);
+
+    const trigger = screen.getByRole('combobox', {name: 'Fruit'});
+    expect(trigger.id).not.toBe('');
+    expect(screen.getByLabelText('Fruit')).toBe(trigger);
+
+    const labelledBy = screen
+      .getByRole('listbox', h)
+      .getAttribute('aria-labelledby');
+    expect(document.getElementById(labelledBy!)).toBe(trigger);
+  });
+});
+
 describe('Selector statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -823,6 +823,7 @@ export function Selector<T extends SelectorOptionType>(
     className,
     style,
     hasClear: hasClearProp,
+    id,
     ...rest
   } = props as SelectorPropsClearable<T>;
   const isEffectivelyRequired = useResolvedRequired({isRequired, isOptional});
@@ -841,7 +842,10 @@ export function Selector<T extends SelectorOptionType>(
 
   // Normalize null to undefined for internal use (null is the clear sentinel)
   const normalizedValue = value === null ? undefined : value;
-  const triggerId = useId();
+  const generatedTriggerId = useId();
+  // A caller's `id` lands on the trigger either way, so the internal identity
+  // has to be that same value or the label and listbox point at nothing.
+  const triggerId = id ?? generatedTriggerId;
   const listboxId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();


### PR DESCRIPTION
### Why

`Selector` generated its trigger id with `useId()` and set it on the trigger button *before* `{...rest}`. `id` is accepted publicly through `BaseProps`, so a caller's `id` won on the button — but the generated value was still what the component handed to the listbox's `aria-labelledby` and to `Field`'s `inputID`.

Passing `id` therefore split the component's identity in two: the button carried the caller's id, while the listbox's accessible name and the field label's `htmlFor` pointed at an element that does not exist. The listbox ends up unnamed and the label unassociated — worse than a dropped prop, and invisible to `tsc`, ESLint and the build.

I searched open and closed issues before filing; nothing covers this. [#4450](https://github.com/facebook/astryx/issues/4450) is about the trigger's name in the default (no-`id`) case, and [#5254](https://github.com/facebook/astryx/issues/5254) is the neighbouring "declares `BaseProps`, never spreads rest" class. This is a third shape: the prop *is* forwarded, and that is exactly what breaks the wiring.

### What

The internal trigger identity now derives from the caller's `id` when one is supplied, and falls back to the generated one otherwise, so a single value flows to the button, the `aria-labelledby` of both listbox panels (plain and `hasSearch`) and `Field`'s `inputID` together. Hooks stay unconditional — `useId()` is still called in the same order, so generated ids are unchanged.

No prop added, no public type touched. Every consumer of the trigger id in the file was swept: the button, the two `aria-labelledby` sites, and `Field`'s `inputID`. Option ids (`getItemId`) and the search input derive from `listboxId`/`searchId`, not from the trigger id, and are unaffected.

**Siblings.** `ComplexSelector` and `MultiSelector` have the same generated-`triggerId` shape but not this defect, so they are deliberately out of scope: `ComplexSelector` spreads rest onto the wrapper `<div>`, so a caller's `id` lands there and the trigger's internal wiring stays self-consistent; `MultiSelector` captures no rest at all, so a caller's `id` never reaches the DOM. That second one is a real (different) bug of the [#5254](https://github.com/facebook/astryx/issues/5254) class and belongs with that work, not here — widening this PR to cover it would mean changing what `MultiSelector` forwards, which is a separate decision.

### Risk

Low, and confined to callers who pass `id` today.

- No `id` supplied: byte-identical output.
- `id` supplied: the trigger's own `id` attribute is **unchanged**. What changes is that two references which previously dangled now resolve. The one observable side effect beyond the accessibility fix is that the field label regains its native click-to-focus behaviour, because `htmlFor` finally names a real element.

Changeset is a `patch` under `[fix]` — the repo's 0.x rule reserves the minor bump for `[breaking]`, and this repairs broken references rather than changing an accepted contract.

### Testing

Four colocated Vitest cases in `Selector.test.tsx`. They assert the wiring *resolves* — each looks the referenced id up in the document and checks it is the trigger element — rather than comparing attribute strings:

- a caller `id` reaches the button, and the listbox's `aria-labelledby` resolves to it
- the same holds for the `hasSearch` panel, which is a second, separate render path
- the field label resolves to the trigger (`getByLabelText` finds it)
- with no `id`, the generated identity still wires the label and the listbox

The first three fail on `main` and pass with the change (verified by reverting the source, re-running, and restoring). The fourth is the invariance guard, so it passes either way by design.

Full `Selector`, `MultiSelector` and `ComplexSelector` suites pass (288 tests) and `@astryxdesign/core` typechecks clean locally; CI is the full check.

Pattern reference: [WAI-ARIA APG combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) — this restores the name relationship the pattern requires, it does not change the roles or keyboard behaviour.
