### PR TITLE
fix(ci): stop shipping template-assets into every PR preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
       - name: Build core package
         run: pnpm build
 
-      - name: Compute sandbox preview path
+      - name: Compute sandbox preview paths
         id: urls
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -346,8 +346,11 @@ jobs:
           SHORT_HASH="${COMMIT_HASH:0:7}"
           REPO_NAME="${{ github.event.repository.name }}"
 
-          echo "short_hash=${SHORT_HASH}" >> $GITHUB_OUTPUT
-          echo "sandbox_base_path=/${REPO_NAME}/pr/${PR_NUMBER}/sandbox" >> $GITHUB_OUTPUT
+          {
+            echo "short_hash=${SHORT_HASH}"
+            echo "sandbox_base_path=/${REPO_NAME}/pr/${PR_NUMBER}/sandbox"
+            echo "template_assets_base_path=/${REPO_NAME}/sandbox/template-assets"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Cache Next.js build
         uses: actions/cache@v6
@@ -378,7 +381,11 @@ jobs:
           # Built without the /<repo> prefix, the sandbox's root-absolute asset URLs
           # drop that segment and 404 — breaking all styles/JS on the preview.
           SANDBOX_BASE_PATH: ${{ steps.urls.outputs.sandbox_base_path }}
+          SANDBOX_TEMPLATE_ASSETS_BASE_PATH: ${{ steps.urls.outputs.template_assets_base_path }}
           NODE_OPTIONS: '--max-old-space-size=8192'
+
+      - name: Remove shared assets from preview artifact
+        run: rm -rf apps/sandbox/out/template-assets
 
       - name: Upload Sandbox artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -153,6 +153,29 @@ jobs:
             echo ""
           fi
 
+          # ----- Drop template-assets from previews -----
+          # deploy-preview.yml no longer ships sandbox/template-assets/ into a
+          # preview: 125MB of demo media that no preview page ever requests
+          # (templates use the root-absolute /template-assets/*, outside the
+          # preview basePath). Sweep the copies earlier deploys left behind.
+          if [ -d "pr" ]; then
+            TA_PURGED=0
+            for ta in pr/*/sandbox/template-assets; do
+              [ -d "$ta" ] || continue
+              echo "  DELETE ${ta} (unused preview media)"
+              if [ "$DRY_RUN" != "true" ]; then
+                git rm -rf --quiet "$ta"
+              fi
+              DELETED_PATHS+=("$ta")
+              TA_PURGED=$((TA_PURGED + 1))
+              DELETED=$((DELETED + 1))
+            done
+            if [ "$TA_PURGED" -gt 0 ]; then
+              echo "Purged template-assets from ${TA_PURGED} preview(s)"
+              echo ""
+            fi
+          fi
+
           # ----- Clean stale root-level files -----
           # Leftovers from old Storybook-at-root deploy format
           ROOT_STALE=0

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -154,15 +154,13 @@ jobs:
           fi
 
           # ----- Drop template-assets from previews -----
-          # deploy-preview.yml no longer ships sandbox/template-assets/ into a
-          # preview: 125MB of demo media that no preview page ever requests
-          # (templates use the root-absolute /template-assets/*, outside the
-          # preview basePath). Sweep the copies earlier deploys left behind.
+          # Every preview uses the one shared /sandbox/template-assets copy.
+          # Sweep duplicate copies left by earlier deploys.
           if [ -d "pr" ]; then
             TA_PURGED=0
             for ta in pr/*/sandbox/template-assets; do
               [ -d "$ta" ] || continue
-              echo "  DELETE ${ta} (unused preview media)"
+              echo "  DELETE ${ta} (duplicate preview copy)"
               if [ "$DRY_RUN" != "true" ]; then
                 git rm -rf --quiet "$ta"
               fi

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -148,9 +148,7 @@ jobs:
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
             cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
-            # Skip sandbox/template-assets/: 125MB per preview that no page
-            # loads anyway (templates request root-absolute /template-assets/*,
-            # outside the basePath) — 41 copies overflowed the Pages artifact.
+            # Every preview points at the one shared main-sandbox asset copy.
             find sandbox-dist -mindepth 1 -maxdepth 1 ! -name template-assets \
               -exec cp -r {} /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/ \;
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -148,7 +148,11 @@ jobs:
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
             cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
-            cp -r sandbox-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
+            # Skip sandbox/template-assets/: 125MB per preview that no page
+            # loads anyway (templates request root-absolute /template-assets/*,
+            # outside the basePath) — 41 copies overflowed the Pages artifact.
+            find sandbox-dist -mindepth 1 -maxdepth 1 ! -name template-assets \
+              -exec cp -r {} /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/ \;
 
             cd /tmp/gh-pages
             git add -A

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,6 +169,7 @@ jobs:
           # otherwise its root-absolute asset URLs (/sandbox/_next/...) drop the
           # /<repo> segment and 404. Derived from the repo name so it survives renames.
           SANDBOX_BASE_PATH: /${{ github.event.repository.name }}/sandbox
+          SANDBOX_TEMPLATE_ASSETS_BASE_PATH: /${{ github.event.repository.name }}/sandbox/template-assets
           NODE_OPTIONS: '--max-old-space-size=4096'
 
       # The landing page (assembled in `deploy`) links these straight out of

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -124,9 +124,7 @@ jobs:
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
             cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
-            # Skip sandbox/template-assets/: 125MB per preview that no page
-            # loads anyway (templates request root-absolute /template-assets/*,
-            # outside the basePath) — 41 copies overflowed the Pages artifact.
+            # Every preview points at the one shared main-sandbox asset copy.
             find sandbox-dist -mindepth 1 -maxdepth 1 ! -name template-assets \
               -exec cp -r {} /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/ \;
 

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -124,7 +124,11 @@ jobs:
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
             cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
             mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
-            cp -r sandbox-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
+            # Skip sandbox/template-assets/: 125MB per preview that no page
+            # loads anyway (templates request root-absolute /template-assets/*,
+            # outside the basePath) — 41 copies overflowed the Pages artifact.
+            find sandbox-dist -mindepth 1 -maxdepth 1 ! -name template-assets \
+              -exec cp -r {} /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/ \;
 
             cd /tmp/gh-pages
             git add -A

--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -6,7 +6,17 @@ const {babel} = require('@astryxdesign/build');
 
 // Use the dist build pattern: library files keep default 'x' prefix (matching
 // the pre-built astryx.css), product files use 'p' prefix to avoid collisions.
-module.exports = babel(path.resolve(__dirname, '../..'), {
+const config = babel(path.resolve(__dirname, '../..'), {
   libraryPrefix: 'x',
   classNamePrefix: 'p',
 });
+
+// Template source stays portable with /template-assets/* URLs. Hosted sandbox
+// builds rewrite only executable string literals to their deployed asset path;
+// sourceRegistry's embedded code samples remain unchanged.
+config.plugins.push([
+  path.resolve(__dirname, 'scripts/rewrite-template-asset-paths.cjs'),
+  {basePath: process.env.SANDBOX_TEMPLATE_ASSETS_BASE_PATH || ''},
+]);
+
+module.exports = config;

--- a/apps/sandbox/scripts/rewrite-template-asset-paths.cjs
+++ b/apps/sandbox/scripts/rewrite-template-asset-paths.cjs
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use strict';
+
+module.exports = function rewriteTemplateAssetPaths({types: t}, options) {
+  const basePath = options.basePath || '';
+
+  return {
+    visitor: {
+      StringLiteral(path) {
+        if (
+          basePath !== '' &&
+          path.node.value.startsWith('/template-assets/')
+        ) {
+          path.replaceWith(
+            t.stringLiteral(
+              basePath + path.node.value.slice('/template-assets'.length),
+            ),
+          );
+        }
+      },
+    },
+  };
+};

--- a/apps/sandbox/scripts/rewrite-template-asset-paths.cjs
+++ b/apps/sandbox/scripts/rewrite-template-asset-paths.cjs
@@ -2,6 +2,7 @@
 
 'use strict';
 
+/* global module */
 module.exports = function rewriteTemplateAssetPaths({types: t}, options) {
   const basePath = options.basePath || '';
 

--- a/scripts/rewrite-template-asset-paths.test.mjs
+++ b/scripts/rewrite-template-asset-paths.test.mjs
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {transformSync} from '@babel/core';
+import {describe, expect, it} from 'vitest';
+
+import rewriteTemplateAssetPaths from '../apps/sandbox/scripts/rewrite-template-asset-paths.cjs';
+
+function transform(source, basePath = '/astryx/sandbox/template-assets') {
+  return transformSync(source, {
+    configFile: false,
+    plugins: [[rewriteTemplateAssetPaths, {basePath}]],
+  }).code;
+}
+
+describe('rewriteTemplateAssetPaths', () => {
+  it('points template media at the configured shared path', () => {
+    const output = transform(`
+      const image = '/template-assets/image.png';
+      const untouched = '/images/image.png';
+    `);
+
+    expect(output).toContain('/astryx/sandbox/template-assets/image.png');
+    expect(output).toContain('/images/image.png');
+  });
+
+  it('leaves embedded source examples portable', () => {
+    const output = transform(
+      `const source = "const image = '/template-assets/image.png';";`,
+    );
+
+    expect(output).toContain('/template-assets/image.png');
+    expect(output).not.toContain('/astryx/sandbox/template-assets/image.png');
+  });
+
+  it('is a no-op without a configured path', () => {
+    expect(
+      transform(`const image = '/template-assets/image.png';`, ''),
+    ).toContain('/template-assets/image.png');
+  });
+});


### PR DESCRIPTION
## Why

GitHub Pages failed after its artifact grew to 7.5 GB. The `gh-pages` branch was ~8.4 GB: 41 PR previews each carried a 125 MB copy of `sandbox/template-assets/`, accounting for ~5.1 GB.

Those copies also did not work. Portable CLI templates use `/template-assets/*`; under Pages that resolved to `facebook.github.io/template-assets/*` and returned 404.

## What

- Rewrite `/template-assets/*` only in executable sandbox bundles to `/astryx/sandbox/template-assets/*`. Portable CLI source and displayed source examples stay unchanged.
- Keep **one** asset copy in `gh-pages/sandbox/template-assets`, owned by the main deploy.
- Strip the mirrored directory from every PR artifact and prevent both preview deployment paths from copying it.
- Sweep duplicate copies already under `gh-pages/pr/*`.

Asset-file changes appear in previews after merge, when the main deploy replaces the shared copy. PRs never publish or retain their own copy.

Expected size: `gh-pages` ~8.4 GB → ~3.3 GB; Pages artifact 7.5 GB → ~2.4 GB.

## History

The sandbox mirror was added in [#2610](https://github.com/facebook/astryx/pull/2610) for local `/template-assets/*` URLs. The canonical self-hosted files moved under the docsite in [#3973](https://github.com/facebook/astryx/pull/3973). That local-dev setup was later copied wholesale into every Pages preview without accounting for the Pages base path.

## Test plan

- New Babel regression tests: shared URL rewrite, portable embedded source, local-dev no-op.
- Existing repo checks pass via commit hook.
- `actionlint`: no new findings; two existing shellcheck findings removed.
- CI builds this PR's sandbox with the shared URL and strips `out/template-assets` before upload.
- After preview deployment, verify the real PR page and image requests in Chromium.
