### PR TITLE
fix(theme): drop the base field #5562 added to the public ThemeCSSOutput

### DIFF
--- a/.changeset/theme-css-output-no-base-field.md
+++ b/.changeset/theme-css-output-no-base-field.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] `generateThemeCSS` returns the two scoped blocks it has always returned — `prose` and `component`. The `--color-data-*` defaults it briefly also returned as a third `base` field are theme-independent, so they are not part of a theme's CSS: the `<Theme>` runtime keeps emitting them at `:root` in `@layer astryx-base`, and `astryx theme build` now formats the same block from the already-public `dataTokenDefaults` export. Output is byte-identical on both paths and no published release ever carried the field.
+
+@cixzhang

--- a/.changeset/theme-css-output-no-base-field.md
+++ b/.changeset/theme-css-output-no-base-field.md
@@ -3,6 +3,6 @@
 '@astryxdesign/cli': patch
 ---
 
-[fix] `generateThemeCSS` returns the two scoped blocks it has always returned — `prose` and `component`. The `--color-data-*` defaults it briefly also returned as a third `base` field are theme-independent, so they are not part of a theme's CSS: the `<Theme>` runtime keeps emitting them at `:root` in `@layer astryx-base`, and `astryx theme build` now formats the same block from the already-public `dataTokenDefaults` export. Output is byte-identical on both paths and no published release ever carried the field.
+[fix] `generateThemeCSS` returns the two scoped blocks it has always returned — `prose` and `component`. The `--color-data-*` defaults it briefly also returned as a third `base` field are theme-independent, so they are not part of a theme's CSS: the `<Theme>` runtime keeps emitting them at `:root` in `@layer astryx-base`, and `astryx theme build` now formats the same block from the already-public `dataTokenDefaults` export. Output is byte-identical on both paths and no stable release ever carried the field.
 
 @cixzhang

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -62,14 +62,14 @@ import {
 /** @type {any} */ let _defineTheme = null;
 /** @type {any} */ let _generateThemeRulesSplit = null;
 /** @type {any} */ let _generateOnMediaCSS = null;
-/** @type {any} */ let _generateThemeCSS = null;
+/** @type {any} */ let _dataTokenDefaults = null;
 /** @type {any} */ let _coreImportError = null;
 try {
   const coreTheme = await import('@astryxdesign/core/theme');
   _defineTheme = coreTheme.defineTheme;
   _generateThemeRulesSplit = coreTheme.generateThemeRulesSplit;
   _generateOnMediaCSS = coreTheme.generateOnMediaCSS;
-  _generateThemeCSS = coreTheme.generateThemeCSS;
+  _dataTokenDefaults = coreTheme.dataTokenDefaults;
 } catch (e) {
   // Capture the reason so the theme action can surface a precise, actionable
   // error. We don't throw here: this module is imported eagerly by the CLI
@@ -1195,14 +1195,17 @@ export async function themeBuild(
       return null;
     }
     // The data-token defaults are theme-independent and go in @layer
-    // astryx-base, below the theme's own overrides. Taken from the runtime's
-    // own generator so the two paths cannot emit different bytes.
+    // astryx-base, below the theme's own overrides. Formatted here from the
+    // public `dataTokenDefaults` export, byte for byte as the `<Theme>`
+    // runtime emits it — build-theme.data-tokens.test.mjs is the drift guard.
     // Placed after the reset block and before the theme block: a layer's order
     // is fixed by where it is first declared, so emitting it anywhere else in
     // the file would invert reset < astryx-base < astryx-theme for a consumer
     // who imports this stylesheet on its own.
-    const baseCss = _generateThemeCSS
-      ? _generateThemeCSS(resolvedTheme).base
+    const baseCss = _dataTokenDefaults
+      ? `:root {\n${Object.entries(_dataTokenDefaults)
+          .map(([name, value]) => `  ${name}: ${value};`)
+          .join('\n')}\n}`
       : '';
     if (baseCss) {
       cssParts.splice(

--- a/packages/cli/clients/cli/commands/build-theme.data-tokens.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.data-tokens.test.mjs
@@ -12,12 +12,20 @@
  *
  * Building requires a compiled @astryxdesign/core, so this suite builds core
  * once in beforeAll via the shared ensureCoreBuilt() helper.
+ *
+ * The build formats the defaults block itself, from the public
+ * `dataTokenDefaults` export; core formats it for the runtime. This suite is
+ * what keeps those two independent formattings byte-identical.
  */
 
 import {describe, it, expect, beforeAll, beforeEach, afterEach} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+// Core's own generator, imported from source rather than from the package: it
+// is deliberately not part of `@astryxdesign/core/theme`'s public surface, and
+// this suite is the guard that the build's independent formatting matches it.
+import {generateDataTokenDefaultsCSS} from '../../../../core/src/theme/generateThemeRules';
 import {ensureCoreBuilt} from './ensure-core-built.mjs';
 import {runCli} from '../../../test-utils/run-cli.mjs';
 
@@ -100,16 +108,23 @@ describe('theme build data token output', () => {
   });
 
   it('emits the bytes the runtime generator emits', async () => {
-    const tokens = {'--color-accent': '#0077B6'};
-    const css = await buildTheme(tmpDir, 'charts-parity', {tokens});
+    const css = await buildTheme(tmpDir, 'charts-parity', {
+      tokens: {'--color-accent': '#0077B6'},
+    });
 
-    const {defineTheme, generateThemeCSS} = await import(
-      '@astryxdesign/core/theme'
-    );
-    const {base} = generateThemeCSS(
-      defineTheme({name: 'charts-parity', tokens}),
-    );
+    // The build formats this block itself, from the public `dataTokenDefaults`
+    // export; the runtime formats it in core. Nothing else holds the two
+    // together, so compare the bytes — a changed indent or separator in either
+    // one fails here.
+    const runtimeBase = generateDataTokenDefaultsCSS();
+    const marker = '@layer astryx-base {\n';
+    const start = css.indexOf(marker);
+    expect(start).toBeGreaterThanOrEqual(0);
 
-    expect(css).toContain(`@layer astryx-base {\n${base}\n}`);
+    const bodyStart = start + marker.length;
+    expect(css.slice(bodyStart, bodyStart + runtimeBase.length)).toBe(
+      runtimeBase,
+    );
+    expect(css.slice(bodyStart + runtimeBase.length)).toMatch(/^\n\}/);
   });
 });

--- a/packages/cli/clients/cli/commands/build-theme.data-tokens.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.data-tokens.test.mjs
@@ -26,6 +26,7 @@ import * as os from 'node:os';
 // is deliberately not part of `@astryxdesign/core/theme`'s public surface, and
 // this suite is the guard that the build's independent formatting matches it.
 import {generateDataTokenDefaultsCSS} from '../../../../core/src/theme/generateThemeRules';
+import {dataTokenDefaults as sourceDataTokenDefaults} from '../../../../core/src/theme/domainTokens/dataTokens';
 import {ensureCoreBuilt} from './ensure-core-built.mjs';
 import {runCli} from '../../../test-utils/run-cli.mjs';
 
@@ -111,6 +112,19 @@ describe('theme build data token output', () => {
     const css = await buildTheme(tmpDir, 'charts-parity', {
       tokens: {'--color-accent': '#0077B6'},
     });
+
+    // The expectation below comes from core's SOURCE; the stylesheet came from
+    // core's dist. ensureCoreBuilt() only checks that dist exists, never that
+    // it is current, so a dist older than the source would fail the byte
+    // comparison with a colour mismatch that reads as formatter drift. Name
+    // that case first.
+    const {dataTokenDefaults: builtDataTokenDefaults} = await import(
+      '@astryxdesign/core/theme'
+    );
+    expect(
+      builtDataTokenDefaults,
+      'packages/core/dist is stale — run `pnpm -F @astryxdesign/core build`',
+    ).toEqual(sourceDataTokenDefaults);
 
     // The build formats this block itself, from the public `dataTokenDefaults`
     // export; the runtime formats it in core. Nothing else holds the two

--- a/packages/core/src/theme/Theme.tsx
+++ b/packages/core/src/theme/Theme.tsx
@@ -42,6 +42,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {ThemeMode} from './types';
 import {colorVars, typographyVars} from './tokens.stylex';
 import {generateThemeCSS, type DefinedTheme} from './defineTheme';
+import {generateDataTokenDefaultsCSS} from './generateThemeRules';
 import {registerTheme} from './themeRegistry';
 import {dataAttr} from '../naming';
 import {ThemeContext} from './useTheme';
@@ -141,7 +142,8 @@ function useThemeStyleInjection(theme: DefinedTheme): void {
         `the built artifacts.`,
     );
 
-    const {prose, component, base} = generateThemeCSS(theme);
+    const {prose, component} = generateThemeCSS(theme);
+    const base = generateDataTokenDefaultsCSS();
     injectedThemes.add(themeKey);
     const cleanups: (() => void)[] = [() => injectedThemes.delete(themeKey)];
 

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -4,6 +4,7 @@ import {describe, it, expect, vi} from 'vitest';
 import type {IconRegistry} from '../Icon/globalIconRegistry';
 import type {DefinedTheme} from './defineTheme';
 import {defineTheme, generateThemeCSS, isDefinedTheme} from './defineTheme';
+import {generateDataTokenDefaultsCSS} from './generateThemeRules';
 
 function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
@@ -117,9 +118,8 @@ describe('generateThemeCSS', () => {
   });
 
   it('declares the data palette for a theme that never mentions it', () => {
-    const {base, component} = generateThemeCSS(
-      defineTheme({name: 'chartless'}),
-    );
+    const {component} = generateThemeCSS(defineTheme({name: 'chartless'}));
+    const base = generateDataTokenDefaultsCSS();
     expect(base).toContain('--color-data-categorical-blue:');
     expect(base).toContain('--color-data-gray-1:');
     expect(component).not.toContain('--color-data-');
@@ -130,7 +130,8 @@ describe('generateThemeCSS', () => {
       name: 'brand-charts',
       tokens: {'--color-data-categorical-blue': '#00A3FF'},
     });
-    const {base, component} = generateThemeCSS(theme);
+    const {component} = generateThemeCSS(theme);
+    const base = generateDataTokenDefaultsCSS();
     expect(component).toContain('--color-data-categorical-blue: #00A3FF;');
     // The siblings the theme did not name stay in the shared base block, so a
     // nested theme inherits the parent's override instead of the default.

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -4,7 +4,6 @@ import {describe, it, expect, vi} from 'vitest';
 import type {IconRegistry} from '../Icon/globalIconRegistry';
 import type {DefinedTheme} from './defineTheme';
 import {defineTheme, generateThemeCSS, isDefinedTheme} from './defineTheme';
-import {generateDataTokenDefaultsCSS} from './generateThemeRules';
 
 function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
@@ -117,26 +116,24 @@ describe('generateThemeCSS', () => {
     expect(css).toContain('font-family: var(--font-family-heading)');
   });
 
-  it('declares the data palette for a theme that never mentions it', () => {
+  it('keeps the data palette out of a theme that never mentions it', () => {
+    // That the palette IS declared is covered by `seeds the whole palette
+    // once, at :root` in generateThemeRules.test.ts. It is theme-independent,
+    // so there is nothing about it a theme can be used to assert.
     const {component} = generateThemeCSS(defineTheme({name: 'chartless'}));
-    const base = generateDataTokenDefaultsCSS();
-    expect(base).toContain('--color-data-categorical-blue:');
-    expect(base).toContain('--color-data-gray-1:');
     expect(component).not.toContain('--color-data-');
   });
 
-  it('keeps the rest of the data palette when one data token is overridden', () => {
+  it('puts only the named data token in the theme block, not its siblings', () => {
     const theme = defineTheme({
       name: 'brand-charts',
       tokens: {'--color-data-categorical-blue': '#00A3FF'},
     });
     const {component} = generateThemeCSS(theme);
-    const base = generateDataTokenDefaultsCSS();
     expect(component).toContain('--color-data-categorical-blue: #00A3FF;');
-    // The siblings the theme did not name stay in the shared base block, so a
-    // nested theme inherits the parent's override instead of the default.
+    // Leaving the siblings out of the theme's own block is what lets a nested
+    // theme inherit a parent's override instead of shadowing it.
     expect(component).not.toContain('--color-data-categorical-orange');
-    expect(base).toContain('--color-data-categorical-orange:');
     // Defaults reach the stylesheet without entering the theme's own tokens,
     // which are what `astryx theme build` reports as overrides.
     expect(theme.tokens['--color-data-categorical-orange']).toBeUndefined();

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -780,10 +780,11 @@ describe('data visualization tokens', () => {
     expect(block).not.toContain('--color-data-categorical-orange');
   });
 
-  it('carries the palette in the base block, not the scoped stylesheet', () => {
-    const {base, component, prose} = generateThemeCSS(
+  it('carries the palette in the defaults block, not the scoped stylesheet', () => {
+    const {component, prose} = generateThemeCSS(
       defineTheme({name: 'data-css'}),
     );
+    const base = generateDataTokenDefaultsCSS();
 
     expect(base).toContain('--color-data-neutral:');
     expect(base).toContain('--color-data-blue-3:');
@@ -791,14 +792,12 @@ describe('data visualization tokens', () => {
     expect(prose).not.toContain('--color-data-');
   });
 
-  it('gives every theme the same base block', () => {
-    expect(generateThemeCSS(defineTheme({name: 'data-a'})).base).toBe(
-      generateThemeCSS(
-        defineTheme({
-          name: 'data-b',
-          tokens: {'--color-data-categorical-blue': '#00A3FF'},
-        }),
-      ).base,
-    );
+  it('keeps generateThemeCSS to its two scoped blocks', () => {
+    // The defaults are theme-independent, so they are not part of the theme
+    // CSS contract: `astryx theme build` formats them from the public
+    // `dataTokenDefaults` export instead.
+    expect(
+      Object.keys(generateThemeCSS(defineTheme({name: 'data-shape'}))).sort(),
+    ).toEqual(['component', 'prose']);
   });
 });

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -780,14 +780,13 @@ describe('data visualization tokens', () => {
     expect(block).not.toContain('--color-data-categorical-orange');
   });
 
-  it('carries the palette in the defaults block, not the scoped stylesheet', () => {
+  it('keeps the palette out of the scoped stylesheet', () => {
+    // The palette's own contents are asserted once, against
+    // `dataTokenDefaults`, in `seeds the whole palette once, at :root` above.
     const {component, prose} = generateThemeCSS(
       defineTheme({name: 'data-css'}),
     );
-    const base = generateDataTokenDefaultsCSS();
 
-    expect(base).toContain('--color-data-neutral:');
-    expect(base).toContain('--color-data-blue-3:');
     expect(component).not.toContain('--color-data-');
     expect(prose).not.toContain('--color-data-');
   });

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -125,7 +125,7 @@ export interface ThemeRulesSplit {
 }
 
 /**
- * Output from generateThemeCSS — three CSS blocks for different layers.
+ * Output from generateThemeCSS — two CSS blocks for different layers.
  */
 export interface ThemeCSSOutput {
   /**
@@ -140,13 +140,6 @@ export interface ThemeCSSOutput {
    * theme component overrides take effect. Empty string if no rules.
    */
   component: string;
-  /**
-   * The `--color-data-*` defaults at `:root`, identical for every theme.
-   * Should be injected into @layer astryx-base — where StyleX puts the core
-   * token defaults — so a theme's own value outranks it and a nested theme
-   * inherits its parent's override.
-   */
-  base: string;
 }
 
 // =============================================================================
@@ -778,7 +771,10 @@ export function generateOnMediaCSS(theme: DefinedTheme): string {
  * specificity. Seeding it per theme scope instead re-declares the default
  * inside every nested theme, which is the shadowing this shape avoids.
  *
- * @internal Reached from outside `packages/core` as `generateThemeCSS().base`.
+ * @internal Not exported from `@astryxdesign/core/theme`: the `<Theme>`
+ * runtime is the only caller. `astryx theme build` formats the same block from
+ * the public `dataTokenDefaults` export, and a CLI test asserts the two are
+ * byte-identical.
  */
 export function generateDataTokenDefaultsCSS(): string {
   const declarations = Object.entries(dataTokenDefaults)
@@ -790,14 +786,16 @@ export function generateDataTokenDefaultsCSS(): string {
 /**
  * Generate layered CSS for a theme — runtime path.
  *
- * Returns three CSS blocks for injection into different layers:
+ * Returns two CSS blocks for injection into different layers:
  * - `prose`: @scope'd element defaults → inject into @layer reset
- * - `base`: the `:root` data-token defaults → inject into @layer astryx-base
  * - `component`: @scope'd token + .astryx-* overrides → inject into @layer astryx-theme
  *
  * This separation ensures prose defaults (what bare HTML looks like in a theme)
  * sit at reset-layer priority where any class-based style wins, while component
  * overrides sit above StyleX so themes can restyle components intentionally.
+ *
+ * The theme-independent `--color-data-*` defaults are not part of this output:
+ * see `generateDataTokenDefaultsCSS`.
  */
 export function generateThemeCSS(theme: DefinedTheme): ThemeCSSOutput {
   const {component, prose} = generateThemeRulesSplit(theme);
@@ -828,6 +826,5 @@ export function generateThemeCSS(theme: DefinedTheme): ThemeCSSOutput {
   return {
     prose: proseCss,
     component: componentCss,
-    base: generateDataTokenDefaultsCSS(),
   };
 }

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -823,8 +823,5 @@ export function generateThemeCSS(theme: DefinedTheme): ThemeCSSOutput {
       : onMediaCss;
   }
 
-  return {
-    prose: proseCss,
-    component: componentCss,
-  };
+  return {prose: proseCss, component: componentCss};
 }


### PR DESCRIPTION
## Why

[#5562](https://github.com/facebook/astryx/pull/5562) fixed a real defect — the 56 `--color-data-*` tokens never reached CSS — but it paid for the fix by widening the public API: it added a third field, `base`, to the exported `ThemeCSSOutput` interface so that `astryx theme build` could take the `:root` defaults block from `generateThemeCSS(theme).base`. A defect fix must not widen the public surface, and this widening was not approved.

**Release-blocking for today's cut.** `base` has never appeared in a published release (0.5.0 predates #5562). If it ships, it becomes a field consumers can depend on and removing it later is a breaking change.

## What

- `ThemeCSSOutput` is back to its pre-#5562 shape: `prose` and `component`. `generateThemeCSS` returns those two blocks and nothing else.
- The defaults block itself is unchanged and still emitted by both paths. The `<Theme>` runtime calls core's own module-internal generator; `astryx theme build` formats the same `:root` block from `dataTokenDefaults`, which core already exports publicly — three lines, the same shape `CodeBlock/highlightStyles.ts` has always used for `syntaxTokenDefaults`.
- No CSS output changes, on either path.

**Net public surface: negative.** Diffed against the tree as it stood before #5562 (`055e75f65f5`, and identically against `9345b268ba6` three commits earlier): `packages/core/src/theme/index.ts`, `packages/core/src/index.ts` and `packages/core/src/theme/defineTheme.ts` are byte-identical to that commit, and in `generateThemeRules.ts` the `ThemeCSSOutput` interface and the body of `generateThemeCSS` are byte-identical too. The only addition anywhere is a module-internal function that is not exported from `@astryxdesign/core/theme`. So this removes one field and adds no public name.

## Risk

Low, and it is the format-drift risk: the runtime and the build now format the defaults block independently, so nothing but a test holds them together. That test is the pre-existing byte-identity check in `build-theme.data-tokens.test.mjs`, rewritten to compare the built stylesheet's `@layer astryx-base` body against core's actual generator (imported from source, since it is deliberately not public) rather than against a value it got from the same call. It is byte-exact, including the surrounding newlines.

## Testing

- **Byte identity, both directions.** Widening the build's indent by two spaces, then separately dropping one space in core's generator, each made the guard fail (1 failed / 3 passed, twice); reverting each restored 4 passed. The revert was confirmed by re-reading the file, not by the command's exit code.
- **Surface guard.** A new assertion pins `generateThemeCSS`'s returned keys to `prose` and `component`. Re-adding `base` to the interface and the return makes it fail (1 failed / 53 passed); removing it again restores 54 passed.
- **Real Chromium.** `theme-layer-cascade.js` (the `theme-layers` CI job, which runs on this PR) passes all nine cases against this branch, including: a default reaches an element, a theme override beats it, a nested theme inherits the parent's override, and both resolve on the dark side.
- **Live page, separately.** A production build of a page with three mounted `<Theme>`s (outer, nested, sibling) shows exactly one injected defaults block and one `:root` rule; after unmounting the sibling it is still exactly one, and the swatches keep their colours. Screenshots taken in light and dark and inspected.
- Suites: 799 core theme tests, 44 CLI theme-build tests, core `tsc --noEmit`, the changeset gate and the repo's pre-commit checks all pass.

## Changeset

`patch` on both packages, `[fix]`. Not `[breaking]`: no published release ever carried `base`, so no consumer can be relying on it, and the repo's rule reserves the minor bump for changes that break someone.


## Follow-up commit

A review pass found two things, both in this PR's own tests, neither reaching a user; both are fixed and the source is untouched, so the CSS comparisons above still stand.

- **The guard failed for the wrong reason on a stale build.** Its expectation comes from core's source while the stylesheet comes from core's dist, and `ensureCoreBuilt()` only checks that dist exists, never that it is current — so editing a data token and running the suite without rebuilding reported formatter drift. The guard now checks that first and names the stale build. Verified: editing `--color-data-gray-1` in source only now fails with ``packages/core/dist is stale — run `pnpm -F @astryxdesign/core build` `` instead of a bare colour mismatch.
- **Three tests were rewired to a constant to keep them green.** They read `generateDataTokenDefaultsCSS()` where they used to read `generateThemeCSS().base`, which is theme-independent — so their titles and comments claimed a relationship to the theme that the assertions under them could no longer fail on. Each now asserts only the part that is about the theme; the palette's own contents are asserted once, against `dataTokenDefaults`, in `seeds the whole palette once, at :root`.

799 core theme tests and 44 CLI theme-build tests still pass.
