### PR TITLE
fix(storybook): keep AlertDialog references inline

### DIFF
--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -92,6 +92,7 @@ export const Async: Story = {
 export const DesktopFinePointer: Story = {
   args: {
     isOpen: true,
+    isInline: true,
     title: 'Delete item?',
     description:
       'This action cannot be undone. The item and all its data will be permanently removed.',
@@ -108,6 +109,7 @@ export const DesktopFinePointer: Story = {
 export const NarrowFinePointer: Story = {
   args: {
     isOpen: true,
+    isInline: true,
     title: 'Permanently delete this workspace?',
     description:
       'Everyone will lose access to its dashboards, saved queries, and sharing links. This cannot be undone.',


### PR DESCRIPTION
## Why

The responsive AlertDialog reference stories rendered with `isOpen: true`, so Storybook's AlertDialog docs page invoked three modal dialogs immediately and blocked normal page use.

## What

Render the always-visible desktop, narrow, and mobile reference stories through `isInline`. The ordinary interactive stories still exercise real modal behavior after a user action.

## Testing

- `pnpm exec prettier --check apps/storybook/stories/AlertDialog.stories.tsx`
- `pnpm exec eslint apps/storybook/stories/AlertDialog.stories.tsx`
- `pnpm build`
- `pnpm -F @astryxdesign/storybook typecheck`
- Chromium: AlertDialog docs load with 0 open dialogs; each responsive reference renders one inline group and no alertdialog
