### PR TITLE
docs(DateInput): add nativePicker modes story

### DIFF
--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -107,6 +107,12 @@ const meta: Meta<typeof DateInput> = {
       description:
         "Display format for the committed value, reusing Timestamp's vocabulary. Defaults to 'date_long' (long-month date).",
     },
+    nativePicker: {
+      control: 'radio',
+      options: ['touch', 'always', 'never'],
+      description:
+        'Whether the browser or Astryx draws the picker for each pointer type',
+    },
   },
 };
 
@@ -195,6 +201,40 @@ export const Formats: Story = {
               new Date(iso + 'T00:00'),
             )
           }
+        />
+      </div>
+    );
+  },
+};
+
+export const NativePickerModes: Story = {
+  name: 'Native picker modes',
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(
+      '2026-03-21' as ISODateString,
+    );
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+        <DateInput
+          label="nativePicker='touch' (default)"
+          description="Native picker on a coarse pointer; Astryx picker otherwise"
+          value={value}
+          onChange={setValue}
+          nativePicker="touch"
+        />
+        <DateInput
+          label="nativePicker='always'"
+          description="Native picker wherever the browser supports it"
+          value={value}
+          onChange={setValue}
+          nativePicker="always"
+        />
+        <DateInput
+          label="nativePicker='never'"
+          description="Astryx picker on every pointer type"
+          value={value}
+          onChange={setValue}
+          nativePicker="never"
         />
       </div>
     );


### PR DESCRIPTION
## Summary

- add a DateInput Storybook comparison for `nativePicker="touch"`, `"always"`, and `"never"`
- expose the three `nativePicker` values as a radio control

## Test plan

- `pnpm lint:strict`
- `pnpm build`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm -F @astryxdesign/storybook build`
- DateInput accessibility audit (0 violations)
- `pnpm test` (5 known CLI full-run timeouts; all 51 affected tests pass in isolation)