### PR TITLE
feat(lint): guard Effect exceptions and long inline comments

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,24 @@ const isStrictMode = process.env.ASTRYX_STRICT_LINT === '1' || process.env.CI ==
 const astryxConfig = isStrictMode ? astryxPlugin.configs.strict : astryxPlugin.configs.recommended;
 const reactSeverity = isStrictMode ? 'error' : 'warn';
 
+const legacyLongInlineCommentAllowlist = [
+  {
+    file: 'packages/core/src/DateInput/MonthScroller.tsx',
+    startsWith: 'Put the scroller back on a pane boundary once the gesture is over.',
+    reason: 'The iOS virtualized-scroll correction from https://github.com/facebook/astryx/pull/5319 still needs a dedicated hook.',
+  },
+  {
+    file: 'packages/core/src/DateInput/TouchDateField.tsx',
+    startsWith: 'The month and year, as one layer that fades in and out on top.',
+    reason: 'The touch-picker cover protocol from https://github.com/facebook/astryx/pull/5243 still needs a focused style abstraction.',
+  },
+  {
+    file: 'packages/core/src/Stepper/Step.tsx',
+    startsWith: '===================== CONNECTOR FILL =====================',
+    reason: 'The shared connector model from https://github.com/facebook/astryx/pull/5201 still needs a focused style abstraction.',
+  },
+];
+
 // The internal plugin is plain untyped JS (kept out of the lint/type surface),
 // so its inferred shape doesn't satisfy ESLint's strict `Plugin` type. One
 // localized assertion here keeps every `plugins` entry below type-checked.
@@ -256,6 +274,9 @@ export default defineConfig(
       // announce() live-region messages are user-facing text; the rule checks
       // them as call arguments (callees defaults to ['announce']).
       '@astryx/no-hardcoded-i18n-string': isStrictMode ? 'error' : 'warn',
+      '@astryx/no-long-inline-comment-block': [reactSeverity, {
+        allow: legacyLongInlineCommentAllowlist,
+      }],
     },
   },
   // What a disabled control says to the pointer is a defect wherever it
@@ -430,6 +451,8 @@ export default defineConfig(
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/consistent-type-assertions": "off",
       "react-compiler/react-compiler": "off",
+      '@astryx/require-effect-disable-reason': 'off',
+      '@astryx/no-long-inline-comment-block': 'off',
       // Test harnesses wrap components in sized/positioned <div>s to set up a
       // scenario; that scaffolding is not shipped DOM.
       "@astryx/no-style-only-wrapper": "off",

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -18,6 +18,48 @@ This plugin implements a two-tier linting strategy:
 
 ## Rules
 
+### `@astryx/require-effect-disable-reason`
+
+Requires every suppression of `@eslint-react/set-state-in-effect` to include a
+non-empty `-- reason`:
+
+```tsx
+// eslint-disable-next-line @eslint-react/set-state-in-effect -- size comes from ResizeObserver after layout
+setSize(measuredSize);
+```
+
+This rule does not decide whether an Effect is justified. It makes each
+exception visible and reviewable; reviewers still decide whether the state
+comes from an external system or whether render/event-time derivation would be
+better. It intentionally does not require a comment on every Effect.
+
+**Scope:** core production source. Tests are excluded. Local lint warns; strict
+lint and CI error. Main had two reasonless suppressions when this rule was
+introduced; both were mechanically annotated.
+
+### `@astryx/no-long-inline-comment-block`
+
+Reports a contiguous implementation comment spanning **20 or more physical
+lines** inside a function or object expression. Adjacent `//` comments count as
+one block when only whitespace separates them; a `/* … */` comment counts by its
+source span.
+
+Move the full protocol to a named hook or file-level docblock and keep only the
+local invariant beside the implementation. File docblocks and docblocks before
+top-level named hooks are outside the rule by construction.
+
+**Scope:** core production source. Tests are excluded. Local lint warns; strict
+lint and CI error. The initial baseline has three exact, documented exceptions,
+tied to their opening text so another long block in the same file still fails:
+
+- `DateInput/MonthScroller.tsx` — iOS virtualized-scroll correction from [PR #5319](https://github.com/facebook/astryx/pull/5319).
+- `DateInput/TouchDateField.tsx` — touch-picker cover protocol from [PR #5243](https://github.com/facebook/astryx/pull/5243).
+- `Stepper/Step.tsx` — shared connector model from [PR #5201](https://github.com/facebook/astryx/pull/5201).
+
+This is a structure rule, not a prose-quality rule. It cannot judge whether a
+short comment is useful or whether extraction belongs in a hook versus a file
+docblock; those remain review decisions.
+
 ### `@astryx/no-raw-intl-locale`
 
 `InternationalizationProvider` is the sole user-facing locale source. This

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -20,6 +20,8 @@
  * - no-unstable-merged-refs: Flags render-time mergeRefs callbacks and unstable callback inputs to useMergedRefs
  * - no-light-dark-outside-theme: Flags CSS light-dark() in component source (a light/dark decision belongs to the theme layer, where a token pair reaches both schemes in every theme)
  * - no-raw-color: Flags a raw colour value (hex, rgb(), hsl(), oklch(), …) anywhere in component source, including inside light-dark()/color-mix(), behind a const, in a template literal, or as a var() fallback — the shapes no-hardcoded-styles cannot see
+ * - require-effect-disable-reason: Requires a reason on every set-state-in-effect suppression
+ * - no-long-inline-comment-block: Redirects 20-line implementation narratives to a named hook or file docblock
  *
  * Philosophy: Strict for agents (CI), lenient for humans (local dev)
  * - "strict" config: All rules as errors - use in CI/agent environments
@@ -47,6 +49,8 @@ import noHoverOnDisabledRule from './no-hover-on-disabled.js';
 import disabledCursorRule from './disabled-cursor.js';
 import noReactNamespaceHooksRule from './no-react-namespace-hooks.js';
 import noUnstableMergedRefsRule from './no-unstable-merged-refs.js';
+import requireEffectDisableReasonRule from './require-effect-disable-reason.js';
+import noLongInlineCommentBlockRule from './no-long-inline-comment-block.js';
 import copyrightHeaderRule from './copyright-header.js';
 import noRawConsoleCliRule from './no-raw-console-cli.js';
 import requireBasePropsRule from './require-base-props.js';
@@ -347,6 +351,8 @@ const plugin = {
     'disabled-cursor': disabledCursorRule,
     'no-react-namespace-hooks': noReactNamespaceHooksRule,
     'no-unstable-merged-refs': noUnstableMergedRefsRule,
+    'require-effect-disable-reason': requireEffectDisableReasonRule,
+    'no-long-inline-comment-block': noLongInlineCommentBlockRule,
     'require-base-props': requireBasePropsRule,
     'require-ref-prop': requireRefPropRule,
     'copyright-header': copyrightHeaderRule,
@@ -418,6 +424,8 @@ plugin.configs.strict = {
     '@astryx/disabled-cursor': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/no-unstable-merged-refs': 'error',
+    '@astryx/require-effect-disable-reason': 'error',
+    '@astryx/no-long-inline-comment-block': 'error',
     '@astryx/require-base-props': 'error',
     '@astryx/require-ref-prop': 'error',
     '@astryx/copyright-header': 'error',
@@ -489,6 +497,8 @@ plugin.configs.recommended = {
     '@astryx/disabled-cursor': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/no-unstable-merged-refs': 'error',
+    '@astryx/require-effect-disable-reason': 'warn',
+    '@astryx/no-long-inline-comment-block': 'warn',
     '@astryx/require-base-props': 'warn',
     '@astryx/require-ref-prop': 'warn',
     '@astryx/copyright-header': 'error',

--- a/internal/eslint-plugin-astryx/no-long-inline-comment-block.js
+++ b/internal/eslint-plugin-astryx/no-long-inline-comment-block.js
@@ -1,0 +1,130 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+const MAX_INLINE_COMMENT_LINES = 19;
+
+function normalizeFilename(filename) {
+  return filename.replaceAll('\\', '/');
+}
+
+function commentText(comments) {
+  return comments
+    .flatMap(comment => comment.value.split(/\r\n|\n|\r/))
+    .map(line => line.trim().replace(/^\*\s?/, ''))
+    .filter(Boolean)
+    .join(' ');
+}
+
+function isAllowed(comments, filename, allow) {
+  const normalizedFilename = normalizeFilename(filename);
+  const text = commentText(comments);
+  return allow.some(
+    entry =>
+      (normalizedFilename === entry.file ||
+        normalizedFilename.endsWith(`/${entry.file}`)) &&
+      text.startsWith(entry.startsWith),
+  );
+}
+
+function groupComments(source) {
+  const groups = [];
+  for (const comment of source
+    .getAllComments()
+    .filter(comment => comment.type === 'Line' || comment.type === 'Block')
+    .sort((left, right) => left.range[0] - right.range[0])) {
+    const previous = groups.at(-1);
+    if (
+      comment.type === 'Line' &&
+      previous?.type === 'Line' &&
+      source.text
+        .slice(previous.comments.at(-1).range[1], comment.range[0])
+        .trim() === ''
+    ) {
+      previous.comments.push(comment);
+    } else {
+      groups.push({type: comment.type, comments: [comment]});
+    }
+  }
+  return groups;
+}
+
+function isInsideContainer(comments, containers) {
+  const start = comments[0].range[0];
+  const end = comments.at(-1).range[1];
+  return containers.some(
+    container => container.range[0] < start && container.range[1] > end,
+  );
+}
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Keep implementation comment blocks under 20 lines; move longer protocols to a named hook or file-level docblock',
+      category: 'Astryx Conventions',
+      recommended: true,
+    },
+    messages: {
+      tooLong:
+        'This inline implementation comment spans {{lineCount}} lines. Keep the local invariant brief and move the full protocol to a named hook or file-level docblock.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allow: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                file: {type: 'string', minLength: 1},
+                startsWith: {type: 'string', minLength: 1},
+                reason: {type: 'string', minLength: 1},
+              },
+              required: ['file', 'startsWith', 'reason'],
+              additionalProperties: false,
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const source = context.sourceCode ?? context.getSourceCode();
+    const containers = [];
+    const allow = context.options[0]?.allow ?? [];
+
+    function rememberContainer(node) {
+      containers.push(node);
+    }
+
+    return {
+      FunctionDeclaration: rememberContainer,
+      FunctionExpression: rememberContainer,
+      ArrowFunctionExpression: rememberContainer,
+      ObjectExpression: rememberContainer,
+      'Program:exit'() {
+        for (const {comments} of groupComments(source)) {
+          const first = comments[0];
+          const last = comments.at(-1);
+          const lineCount = last.loc.end.line - first.loc.start.line + 1;
+          if (
+            lineCount <= MAX_INLINE_COMMENT_LINES ||
+            !isInsideContainer(comments, containers) ||
+            isAllowed(comments, context.filename, allow)
+          ) {
+            continue;
+          }
+          context.report({
+            loc: {start: first.loc.start, end: last.loc.end},
+            messageId: 'tooLong',
+            data: {lineCount},
+          });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/internal/eslint-plugin-astryx/no-long-inline-comment-block.test.mjs
+++ b/internal/eslint-plugin-astryx/no-long-inline-comment-block.test.mjs
@@ -1,0 +1,86 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {RuleTester} from 'eslint';
+import rule from './no-long-inline-comment-block.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+function block(lineCount, firstLine = 'Implementation protocol.') {
+  const body = [firstLine];
+  while (body.length < lineCount - 2) {
+    body.push(`Detail ${body.length}.`);
+  }
+  return ['/**', ...body.map(line => ` * ${line}`), ' */'].join('\n');
+}
+
+function lineBlock(lineCount) {
+  return Array.from(
+    {length: lineCount},
+    (_, index) => `// Implementation detail ${index + 1}.`,
+  ).join('\n');
+}
+
+function indent(text) {
+  return text
+    .split('\n')
+    .map(line => `  ${line}`)
+    .join('\n');
+}
+
+ruleTester.run('no-long-inline-comment-block', rule, {
+  valid: [
+    {
+      code: `function component() {\n${indent(block(19))}\n  return null;\n}`,
+    },
+    {
+      code: `${block(24, 'File-level protocol.')}\nfunction useProtocol() {\n  return null;\n}`,
+    },
+    {
+      code: `${block(24, 'Named hook contract.')}\nconst useProtocol = () => null;`,
+    },
+    {
+      code: `function component() {\n${indent(lineBlock(10))}\n  run();\n${indent(lineBlock(10))}\n}`,
+    },
+    {
+      code: `const styles = {\n${indent(block(20, 'Known legacy protocol.'))}\n  item: {},\n};`,
+      filename: 'packages/core/src/Legacy/Legacy.tsx',
+      options: [
+        {
+          allow: [
+            {
+              file: 'packages/core/src/Legacy/Legacy.tsx',
+              startsWith: 'Known legacy protocol.',
+              reason: 'Tracked legacy protocol from #1234.',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: `function component() {\n${indent(block(20))}\n  return null;\n}`,
+      errors: [{messageId: 'tooLong', data: {lineCount: 20}}],
+    },
+    {
+      code: `const styles = {\n${indent(block(20))}\n  item: {},\n};`,
+      errors: [{messageId: 'tooLong', data: {lineCount: 20}}],
+    },
+    {
+      code: `const component = () => {\n${indent(lineBlock(20))}\n  return null;\n};`,
+      errors: [{messageId: 'tooLong', data: {lineCount: 20}}],
+    },
+    {
+      code: `function component() {\n${indent(block(20))}\n  const styles = {\n${indent(indent(block(21, 'Nested object protocol.')))}\n    item: {},\n  };\n  return styles;\n}`,
+      errors: [
+        {messageId: 'tooLong', data: {lineCount: 20}},
+        {messageId: 'tooLong', data: {lineCount: 21}},
+      ],
+    },
+  ],
+});

--- a/internal/eslint-plugin-astryx/require-effect-disable-reason.js
+++ b/internal/eslint-plugin-astryx/require-effect-disable-reason.js
@@ -1,0 +1,60 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+const EFFECT_STATE_RULE = '@eslint-react/set-state-in-effect';
+const DISABLE_DIRECTIVE =
+  /^\s*eslint-disable(?:-next-line|-line)?\s+([\s\S]*?)\s*$/;
+
+function targetsEffectStateRule(comment) {
+  const match = DISABLE_DIRECTIVE.exec(comment.value);
+  if (match == null) {
+    return false;
+  }
+
+  const separator = match[1].indexOf('--');
+  const ruleList = separator === -1 ? match[1] : match[1].slice(0, separator);
+  return ruleList
+    .split(',')
+    .map(ruleId => ruleId.trim())
+    .includes(EFFECT_STATE_RULE);
+}
+
+function hasReason(comment) {
+  const match = DISABLE_DIRECTIVE.exec(comment.value);
+  if (match == null) {
+    return false;
+  }
+
+  const separator = match[1].indexOf('--');
+  return separator !== -1 && match[1].slice(separator + 2).trim().length > 0;
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require every set-state-in-effect disable to record why the Effect must own that state transition',
+      category: 'Astryx Conventions',
+      recommended: true,
+    },
+    messages: {
+      missingReason:
+        'Explain why this state transition must happen in an Effect after `--`. The reason should name the external system, measurement, or lifecycle boundary that makes render/event-time derivation insufficient.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Program() {
+        const source = context.sourceCode ?? context.getSourceCode();
+        for (const comment of source.getAllComments()) {
+          if (targetsEffectStateRule(comment) && !hasReason(comment)) {
+            context.report({node: comment, messageId: 'missingReason'});
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/internal/eslint-plugin-astryx/require-effect-disable-reason.test.mjs
+++ b/internal/eslint-plugin-astryx/require-effect-disable-reason.test.mjs
@@ -1,0 +1,85 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {RuleTester} from 'eslint';
+import rule from './require-effect-disable-reason.js';
+
+const noopRule = {
+  meta: {schema: []},
+  create() {
+    return {};
+  },
+};
+
+const ruleTester = new RuleTester({
+  linterOptions: {reportUnusedDisableDirectives: false},
+  plugins: {
+    '@eslint-react': {
+      rules: {'set-state-in-effect': noopRule},
+    },
+  },
+});
+
+ruleTester.run('require-effect-disable-reason', rule, {
+  valid: [
+    {
+      code: `
+        // eslint-disable-next-line @eslint-react/set-state-in-effect -- state comes from ResizeObserver measurements
+        setSize(measuredSize);
+      `,
+    },
+    {
+      code: `
+        setSize(measuredSize); // eslint-disable-line @eslint-react/set-state-in-effect -- records post-layout geometry
+      `,
+    },
+    {
+      code: `
+        /* eslint-disable @eslint-react/set-state-in-effect -- bridges an external subscription */
+        setValue(store.getSnapshot());
+        /* eslint-enable @eslint-react/set-state-in-effect */
+      `,
+    },
+    {
+      code: `
+        // eslint-disable-next-line no-console
+        console.log('debug');
+      `,
+    },
+    {
+      code: `
+        // eslint-disable-next-line @eslint-react/set-state-in-effect, no-console -- synchronizes measured browser state
+        setValue(readLayout());
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        // eslint-disable-next-line @eslint-react/set-state-in-effect
+        setValue(value);
+      `,
+      errors: [{messageId: 'missingReason'}],
+    },
+    {
+      code: `
+        setValue(value); // eslint-disable-line @eslint-react/set-state-in-effect
+      `,
+      errors: [{messageId: 'missingReason'}],
+    },
+    {
+      code: `
+        /* eslint-disable @eslint-react/set-state-in-effect */
+        setValue(value);
+        /* eslint-enable @eslint-react/set-state-in-effect */
+      `,
+      errors: [{messageId: 'missingReason'}],
+    },
+    {
+      code: `
+        // eslint-disable-next-line no-console, @eslint-react/set-state-in-effect
+        setValue(value);
+      `,
+      errors: [{messageId: 'missingReason'}],
+    },
+  ],
+});

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -366,9 +366,9 @@ export function Lightbox({
   // Reset zoom on image change
   useEffect(() => {
     // Reset image view state when the active media item changes.
-    // eslint-disable-next-line @eslint-react/set-state-in-effect
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- reset view state when the active media item changes
     setZoom(1);
-    // eslint-disable-next-line @eslint-react/set-state-in-effect
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- reset view state when the active media item changes
     setPan({x: 0, y: 0});
   }, [index, currentItem?.src]);
 


### PR DESCRIPTION
## Why

[PR #5567](https://github.com/facebook/astryx/pull/5567) exposed two review concerns that have narrow syntax-level forms: state-in-Effect exceptions without a recorded reason, and implementation narratives long enough to hide an abstraction boundary.

## What

- Add `@astryx/require-effect-disable-reason` for suppressions of `@eslint-react/set-state-in-effect`.
- Add `@astryx/no-long-inline-comment-block` for 20+ line comment blocks inside functions or object expressions.
- Scope both to core production source: warnings locally, errors in strict/CI mode; tests are excluded.
- Record exact legacy exceptions for the three current long blocks, tied to their opening text and source PR rationale ([#5319](https://github.com/facebook/astryx/pull/5319), [#5243](https://github.com/facebook/astryx/pull/5243), [#5201](https://github.com/facebook/astryx/pull/5201)).
- Add reasons to the two existing reasonless Lightbox suppressions.

Effect necessity, event-known state, React-derived state, and the right extraction boundary remain review decisions; these rules deliberately do not attempt data-flow analysis.

## Risk

Low. Both rules are syntax-only and the strict core baseline is clean. The long-comment allowlist matches both file and opening text, so another long block in an allowed file still fails.

## Testing

- `node internal/eslint-plugin-astryx/require-effect-disable-reason.test.mjs`
- `node internal/eslint-plugin-astryx/no-long-inline-comment-block.test.mjs`
- `CI=true eslint packages/core/src --no-cache --format stylish` (0 errors; 49 pre-existing warnings)
