### PR TITLE
fix(DateRangeInput): allow same-day range selection

### DIFF
--- a/.changeset/daterange-same-day-selection.md
+++ b/.changeset/daterange-same-day-selection.md
@@ -5,7 +5,8 @@
 [fix] DateRangeInput: allow a same-day range when `minRangeSpan` is 1
 
 A repeated click on the range start now commits a one-day range when the
-configured minimum permits it. Longer minimum spans keep the existing cancel
-behaviour so the user can move the start date.
+configured minimum permits it, including when a maximum span is also set.
+Longer minimum spans keep the existing cancel behaviour so the user can move
+the start date.
 
 @freddymeta

--- a/.changeset/daterange-same-day-selection.md
+++ b/.changeset/daterange-same-day-selection.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateRangeInput: allow a same-day range when `minRangeSpan` is 1
+
+A repeated click on the range start now commits a one-day range when the
+configured minimum permits it. Longer minimum spans keep the existing cancel
+behaviour so the user can move the start date.
+
+@freddymeta

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -221,7 +221,7 @@ export const docsDense = {
     max: 'maximum selectable date',
     dateConstraints: 'custom constraint fns',
     maxRangeSpan: 'range mode: max days a range may span, both ends counted (7 = 7-day window)',
-    minRangeSpan: 'range mode: min days a range must span, both ends counted (default 1)',
+    minRangeSpan: 'range mode: min days a range must span, both ends counted; repeated start click commits one day when allowed, otherwise cancels (default 1)',
     focusDate: 'controlled visible month (default: selected date, else today clamped into min/max)',
     onFocusDateChange: 'navigation callback',
     handleRef: 'imperative navigation handle',

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -78,7 +78,7 @@ export const docs = {
       name: 'minRangeSpan',
       type: 'number',
       description:
-        'Range mode: min days a range must span, both endpoints counted (2 forbids a single-day range). Default 1.',
+        'Range mode: min days a range must span, both endpoints counted (2 forbids a single-day range). Clicking the start again commits a one-day range when allowed, or cancels the in-progress selection when the minimum is longer. Default 1.',
     },
     {
       name: 'focusDate',
@@ -156,7 +156,7 @@ export const docsZh = {
     {name: 'max', type: 'ISODateString', description: '可选择的最晚日期。'},
     {name: 'dateConstraints', type: 'Array<(date: Date) => boolean>', description: '自定义约束函数。'},
     {name: 'maxRangeSpan', type: 'number', description: '范围模式：范围最多可跨越的天数，含首尾两端（7 = 7 天窗口）。选定起始日后限制窗口大小。'},
-    {name: 'minRangeSpan', type: 'number', description: '范围模式：范围最少需跨越的天数，含首尾两端（2 表示禁止单日范围）。默认为 1。'},
+    {name: 'minRangeSpan', type: 'number', description: '范围模式：范围最少需跨越的天数，含首尾两端（2 表示禁止单日范围）。再次点击开始日期时，若最小范围允许则提交单日范围；否则取消进行中的选择。默认为 1。'},
     {name: 'focusDate', type: 'ISODateString', description: '受控可见月份。未设置时，日历打开时显示已选日期所在月份；若无选中值，则显示今天，并将其限制在 min/max 范围内。'},
     {name: 'onFocusDateChange', type: '(focusDate: ISODateString) => void', description: '导航回调函数。'},
     {name: 'handleRef', type: 'React.Ref<CalendarHandle>', description: '日历导航的命令式句柄，包括 navigateTo()。'},

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -367,12 +367,18 @@ describe('Calendar', () => {
     expect(getDayButton(9)).toBeDisabled(); // 2-day span — too short
   });
 
-  it('commits a same-day range with the default minimum span', async () => {
+  it('commits a same-day range when the minimum permits it, including with a maximum', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
 
     render(
-      <Calendar mode="range" focusDate="2026-01-01" onChange={handleChange} />,
+      <Calendar
+        mode="range"
+        focusDate="2026-01-01"
+        onChange={handleChange}
+        minRangeSpan={1}
+        maxRangeSpan={7}
+      />,
     );
 
     await user.click(getDayButton(10));

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -367,6 +367,23 @@ describe('Calendar', () => {
     expect(getDayButton(9)).toBeDisabled(); // 2-day span — too short
   });
 
+  it('commits a same-day range with the default minimum span', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <Calendar mode="range" focusDate="2026-01-01" onChange={handleChange} />,
+    );
+
+    await user.click(getDayButton(10));
+    await user.click(getDayButton(10));
+
+    expect(handleChange).toHaveBeenCalledWith({
+      start: '2026-01-10',
+      end: '2026-01-10',
+    });
+  });
+
   it('clears the in-progress start when the anchor is clicked again', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -367,6 +367,23 @@ describe('Calendar', () => {
     expect(getDayButton(9)).toBeDisabled(); // 2-day span — too short
   });
 
+  it('commits a same-day range with the default minimum', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <Calendar mode="range" focusDate="2026-01-01" onChange={handleChange} />,
+    );
+
+    await user.click(getDayButton(10));
+    await user.click(getDayButton(10));
+
+    expect(handleChange).toHaveBeenCalledWith({
+      start: '2026-01-10',
+      end: '2026-01-10',
+    });
+  });
+
   it('commits a same-day range when the minimum permits it, including with a maximum', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -137,8 +137,10 @@ interface CalendarBaseProps extends Omit<
    * Range mode only. Minimum number of days a selected range must span,
    * counting both endpoints — `minRangeSpan={2}` forbids a single-day range.
    * Once a start date is picked, days closer than this to it are disabled —
-   * except the start itself, which stays selectable as the active anchor.
-   * Defaults to 1 (a same-day start and end is allowed).
+   * except the start itself, which stays selectable. Clicking the start again
+   * commits a one-day range when the minimum allows it; otherwise it cancels
+   * the in-progress selection so the start can be moved. Defaults to 1 (a
+   * same-day start and end is allowed).
    */
   minRangeSpan?: number;
 
@@ -452,13 +454,12 @@ export function Calendar({ref, ...props}: CalendarProps) {
           // Second click - complete the range
           const startPd = plainDateFromISO(rangeSelectionStart);
 
-          // Clicking the anchor again clears the in-progress start rather than
-          // committing a zero-length range. This is also the escape hatch when
-          // `minRangeSpan` disables the days around the anchor: without it the
-          // anchor would be the only clickable day left and the start could
-          // never be moved. `minRangeSpan` leaves the anchor itself enabled
-          // precisely so this toggle stays reachable.
-          if (plainDateIsEqual(date, startPd)) {
+          // Clicking the anchor again commits a one-day range when the minimum
+          // span allows it. For longer minimum spans, the repeated click clears
+          // the in-progress start instead: the anchor is the only nearby day
+          // that remains enabled, so this preserves an escape hatch for moving
+          // the start without violating the configured minimum.
+          if (plainDateIsEqual(date, startPd) && (minRangeSpan ?? 1) > 1) {
             setRangeSelectionStart(null);
             announce(
               t('@astryx.calendar.rangeClearedAnnounce', {
@@ -503,7 +504,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
         }
       }
     },
-    [mode, onChange, rangeSelectionStart, announce, t, locale],
+    [mode, onChange, rangeSelectionStart, minRangeSpan, announce, t, locale],
   );
 
   return (

--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -108,7 +108,7 @@ export const docs = {
       name: 'minRangeSpan',
       type: 'number',
       description:
-        'Minimum days a selected range must span, counting both endpoints (`2` forbids a single-day range). Once a start is picked, days closer than this are disabled. Defaults to 1 (same-day start and end allowed).',
+        'Minimum days a selected range must span, counting both endpoints (`2` forbids a single-day range). Once a start is picked, days closer than this are disabled. Clicking the start again commits a one-day range when allowed, or cancels the in-progress selection when the minimum is longer. Defaults to 1 (same-day start and end allowed).',
     },
     {
       name: 'presets',
@@ -328,7 +328,7 @@ export const docsDense = {
     maxRangeSpan:
       'max days a range may span, both endpoints counted (7 = a 7-day window); caps the window from the picked start. Selection-only; does not rewrite an over-wide value',
     minRangeSpan:
-      'min days a range must span, both endpoints counted (2 forbids a single-day range); default 1',
+      'min days a range must span, both endpoints counted (2 forbids a single-day range); repeated start click commits one day when allowed, otherwise cancels; default 1',
     presets: 'preset ranges as quick-select options',
     hasClear: 'clear button when range is set (default true)',
     placeholder: 'placeholder when empty',

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -730,6 +730,28 @@ describe('DateRangeInput range-span forwarding', () => {
   const dayButton = (iso: string): HTMLButtonElement | null =>
     document.querySelector<HTMLButtonElement>(`button[data-date="${iso}"]`);
 
+  it('allows selecting a one-day range when minRangeSpan is 1', () => {
+    const handleChange = vi.fn();
+    render(
+      <DateRangeInput
+        label="Reporting period"
+        value={null}
+        onChange={handleChange}
+        minRangeSpan={1}
+        numberOfMonths={1}
+      />,
+    );
+
+    fireEvent.click(getButton('Open calendar'));
+    fireEvent.click(dayButton('2026-01-10') as HTMLButtonElement);
+    fireEvent.click(dayButton('2026-01-10') as HTMLButtonElement);
+
+    expect(handleChange).toHaveBeenCalledWith({
+      start: '2026-01-10',
+      end: '2026-01-10',
+    });
+  });
+
   it('forwards maxRangeSpan so the window caps after a start is picked', () => {
     render(
       <DateRangeInput

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -374,8 +374,10 @@ export interface DateRangeInputProps extends Omit<
    * Minimum number of days the selected range must span, counting both
    * endpoints — `minRangeSpan={2}` forbids a single-day range. Once a start
    * date is picked, days closer than this to it are disabled — except the
-   * start itself, which stays selectable as the active anchor. Defaults to 1
-   * (a same-day start and end is allowed).
+   * start itself, which stays selectable. Clicking the start again commits a
+   * one-day range when the minimum allows it; otherwise it cancels the
+   * in-progress selection so the start can be moved. Defaults to 1 (a
+   * same-day start and end is allowed).
    */
   minRangeSpan?: number;
 


### PR DESCRIPTION
## Summary

- allow a repeated click on the range start to commit a one-day range when `minRangeSpan` is `1` (the documented default)
- preserve the existing cancel behaviour when a longer minimum span makes a one-day range invalid
- add Calendar and DateRangeInput regression coverage and clarify the prop docs

## Root cause

Calendar unconditionally treated a second click on the range anchor as cancellation. That escape hatch is needed when `minRangeSpan > 1`, but it also discarded the valid same-day completion when the minimum is `1`.

## Test plan

- `pnpm exec vitest run packages/core/src/Calendar/Calendar.test.tsx packages/core/src/DateRangeInput/DateRangeInput.test.tsx` — 137 passed
- `pnpm lint:strict` — passed (pre-existing warnings only)
- `pnpm test` — passed
- `pnpm build` — passed
- `pnpm -F @astryxdesign/core typecheck` — passed
- production Storybook build — passed
- Chromium smoke test against the built `Core/DateRangeInput` story with `minRangeSpan=1`: selecting 2026-08-01 twice committed `Date range: Aug 1 – Aug 1` and closed the popover

## AI assistance

Implemented and verified with an AI coding assistant; author reviewed the code and test results.
