### PR TITLE
fix(Carousel): mirror single-edge fade gradients under RTL

### DIFF
--- a/.changeset/carousel-rtl-edge-fade.md
+++ b/.changeset/carousel-rtl-edge-fade.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Carousel: mirror the single-edge fade gradients under RTL so the mask fades the physical edge that actually hides content (overflowStart/overflowEnd are logical edges, the gradients were always physical left/right)
+
+@mattandryc

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -850,4 +850,87 @@ describe('Carousel', () => {
       expect(scroller).not.toHaveAttribute('data-padding');
     });
   });
+
+  describe('edge fade', () => {
+    function getScroller() {
+      const region = screen.getByRole('region');
+      return region.firstElementChild as HTMLElement;
+    }
+
+    function makeOverflowing(el: HTMLElement, scrollLeft: number) {
+      Object.defineProperty(el, 'scrollWidth', {
+        value: 500,
+        configurable: true,
+      });
+      Object.defineProperty(el, 'clientWidth', {
+        value: 200,
+        configurable: true,
+      });
+      Object.defineProperty(el, 'scrollLeft', {
+        value: scrollLeft,
+        writable: true,
+        configurable: true,
+      });
+      fireEvent.scroll(el);
+    }
+
+    function injectedCss(): string {
+      let out = '';
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          for (const rule of Array.from(sheet.cssRules)) {
+            out += rule.cssText + '\n';
+          }
+        } catch {
+          // Ignore cross-origin sheets.
+        }
+      }
+      return out;
+    }
+
+    it('fades the physical left edge when only the start overflows (LTR)', () => {
+      render(
+        <Carousel aria-label="Fade">
+          <div>Item 1</div>
+          <div>Item 2</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      makeOverflowing(scroller, 300);
+      expect(getComputedStyle(scroller).maskImage).toContain(
+        'linear-gradient(to right',
+      );
+    });
+
+    it('fades the physical right edge when only the end overflows (LTR)', () => {
+      render(
+        <Carousel aria-label="Fade">
+          <div>Item 1</div>
+          <div>Item 2</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      makeOverflowing(scroller, 0);
+      expect(getComputedStyle(scroller).maskImage).toContain(
+        'linear-gradient(to left',
+      );
+    });
+
+    it('mirrors both single-edge fade gradients under RTL', () => {
+      render(
+        <Carousel aria-label="Fade">
+          <div>Item 1</div>
+          <div>Item 2</div>
+        </Carousel>,
+      );
+      const css = injectedCss();
+      expect(css).toMatch(
+        /:is\(\[dir="rtl"\][^)]*\)[^{]*\{\s*mask-image:\s*linear-gradient\(to left/,
+      );
+      expect(css).toMatch(
+        /:is\(\[dir="rtl"\][^)]*\)[^{]*\{\s*mask-image:\s*linear-gradient\(to right/,
+      );
+    });
+  });
+
 });

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -177,11 +177,20 @@ const styles = stylex.create({
     scrollbarWidth: 'none',
     maskImage: 'none',
   },
+  // fadeStart/fadeEnd are selected by the logical overflowStart/overflowEnd
+  // flags (start = right edge in RTL), but gradient directions are physical —
+  // mirror them under RTL so the fade paints the edge that hides content.
   fadeStart: {
-    maskImage: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    maskImage: {
+      default: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+      ':is([dir="rtl"] *)': `linear-gradient(to left, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    },
   },
   fadeEnd: {
-    maskImage: `linear-gradient(to left, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    maskImage: {
+      default: `linear-gradient(to left, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+      ':is([dir="rtl"] *)': `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    },
   },
   fadeBoth: {
     maskImage: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']}, black calc(100% - ${spacingVars['--spacing-1']}), rgba(0,0,0,0.3) calc(100% - 2px), transparent 100%)`,

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -177,9 +177,6 @@ const styles = stylex.create({
     scrollbarWidth: 'none',
     maskImage: 'none',
   },
-  // fadeStart/fadeEnd are selected by the logical overflowStart/overflowEnd
-  // flags (start = right edge in RTL), but gradient directions are physical —
-  // mirror them under RTL so the fade paints the edge that hides content.
   fadeStart: {
     maskImage: {
       default: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,


### PR DESCRIPTION
Fixes #5622

## Summary

Carousel's edge-fade masked paint on the wrong physical side in RTL.

`overflowStart`/`overflowEnd` from `useScrollOverflow` are **logical** edges ("start = left in LTR, right in RTL", per the hook's own docs), but the `fadeStart`/`fadeEnd` styles they select use hardcoded physical gradients (`to right` / `to left`). 

In an RTL document both one-sided states are inverted: scroll the carousel fully toward the content end and `fadeStart` fades the physical **left** edge, which hides nothing, while the right edge, which actually hides content, gets no fade. Only the symmetric `fadeBoth` state happens to look right. This defeats the fade's stated purpose ("signalling that more items exist off-screen").

The rest of the component already mirrors physical values for RTL (button-pill transforms via `:is([dir="rtl"] *)`, chevron mirroring, sign-flipped scroll deltas via `isRtlElement`). The gradients were the one oversight.

## Fix

| Before | After |
|---|---|
| <img width="458" height="138" alt="Screenshot 2026-08-26 at 9 42 09 PM" src="https://github.com/user-attachments/assets/7c281339-619c-409c-b8a2-2388c9336d20" /> | <img width="458" height="138" alt="Screenshot 2026-08-26 at 9 42 24 PM" src="https://github.com/user-attachments/assets/b95b469b-36f4-49b8-ae2b-d27909dca815" /> |

Swap each single-edge gradient's direction under `:is([dir="rtl"] *)`, matching the button-pill pattern already used in the same file. `fadeBoth` is symmetric and unchanged.

## Tests

- Two LTR regression tests: start-only overflow fades the physical left edge, end-only overflow fades the physical right edge (via `getComputedStyle().maskImage`).
- An RTL test asserting both mirrored gradient rules exist under `[dir="rtl"]`, scanning the injected StyleX CSS (same approach as ProgressBar's RTL keyframe test). Verified it fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

