### PR TITLE
fix(ci): preserve trusted visual run identity

### DIFF
--- a/.github/scripts/visual-gate/gate-context.test.mjs
+++ b/.github/scripts/visual-gate/gate-context.test.mjs
@@ -1,0 +1,95 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'gate.mjs',
+);
+const IDENTITY_ENV = [
+  'ASTRYX_VISUAL_RUN_ID',
+  'ASTRYX_VISUAL_RUN_ATTEMPT',
+  'GITHUB_RUN_ID',
+  'GITHUB_RUN_ATTEMPT',
+];
+
+let root;
+let plan;
+let output;
+
+function captureContext(overrides = {}) {
+  const env = {...process.env};
+  for (const name of IDENTITY_ENV) delete env[name];
+  Object.assign(env, overrides);
+
+  execFileSync(
+    process.execPath,
+    [SCRIPT, 'check', '--plan-file', plan, '--max-shots', '0', '--out', output],
+    {env, encoding: 'utf8'},
+  );
+  return JSON.parse(fs.readFileSync(path.join(output, 'verdict.json'), 'utf8'))
+    .context;
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'visual-gate-context-'));
+  plan = path.join(root, 'plan.json');
+  output = path.join(root, 'output');
+  fs.writeFileSync(
+    plan,
+    JSON.stringify([
+      {
+        key: 'core-button--default__neutral-light',
+        storyId: 'core-button--default',
+        theme: 'neutral',
+        mode: 'light',
+        reasons: ['trusted:pr-scope'],
+      },
+    ]),
+  );
+});
+
+afterEach(() => fs.rmSync(root, {recursive: true, force: true}));
+
+describe('visual gate capture identity', () => {
+  it('records the GitHub run identity by default', () => {
+    expect(
+      captureContext({GITHUB_RUN_ID: '123', GITHUB_RUN_ATTEMPT: '2'}),
+    ).toMatchObject({
+      runId: '123',
+      runAttempt: '2',
+    });
+  });
+
+  it('records an explicit trusted recapture identity ahead of workflow defaults', () => {
+    expect(
+      captureContext({
+        GITHUB_RUN_ID: '999',
+        GITHUB_RUN_ATTEMPT: '4',
+        ASTRYX_VISUAL_RUN_ID: '123',
+        ASTRYX_VISUAL_RUN_ATTEMPT: '2',
+      }),
+    ).toMatchObject({runId: '123', runAttempt: '2'});
+  });
+
+  it('records missing identity as null', () => {
+    expect(captureContext()).toMatchObject({runId: null, runAttempt: null});
+  });
+
+  it('preserves invalid explicit identity for downstream rejection', () => {
+    expect(
+      captureContext({
+        GITHUB_RUN_ID: '999',
+        GITHUB_RUN_ATTEMPT: '4',
+        ASTRYX_VISUAL_RUN_ID: '',
+        ASTRYX_VISUAL_RUN_ATTEMPT: 'invalid',
+      }),
+    ).toMatchObject({runId: '', runAttempt: 'invalid'});
+  });
+});

--- a/.github/scripts/visual-gate/gate.mjs
+++ b/.github/scripts/visual-gate/gate.mjs
@@ -47,6 +47,11 @@ const flag = name => {
   return index === -1 ? null : argv[index + 1];
 };
 const has = name => argv.includes(`--${name}`);
+const captureRunIdentity = () => ({
+  runId: process.env.ASTRYX_VISUAL_RUN_ID ?? process.env.GITHUB_RUN_ID ?? null,
+  runAttempt:
+    process.env.ASTRYX_VISUAL_RUN_ATTEMPT ?? process.env.GITHUB_RUN_ATTEMPT ?? null,
+});
 
 const config = loadConfig(REPO_ROOT);
 const storybookDir = path.resolve(flag('storybook-dir') ?? 'apps/storybook/dist');
@@ -201,8 +206,7 @@ async function runCapture(shots) {
     headSha: process.env.ASTRYX_PR_HEAD_SHA ?? null,
     baseSha: process.env.ASTRYX_PR_BASE_SHA ?? null,
     ref: process.env.GITHUB_REF ?? null,
-    runId: process.env.GITHUB_RUN_ID ?? null,
-    runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
+    ...captureRunIdentity(),
   };
   fs.writeFileSync(
     path.join(outDir, 'manifest.json'),
@@ -242,8 +246,7 @@ async function check() {
         headSha: process.env.ASTRYX_PR_HEAD_SHA ?? null,
         baseSha: process.env.ASTRYX_PR_BASE_SHA ?? null,
         ref: process.env.GITHUB_REF ?? null,
-        runId: process.env.GITHUB_RUN_ID ?? null,
-        runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
+        ...captureRunIdentity(),
         tiers,
         scoped: components.length > 0,
         components,

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -58,6 +58,18 @@ describe('visual acceptance workflow concurrency', () => {
     expect(accept).toContain('cancel-in-progress: false');
   });
 
+  it('grants PR mutation permission wherever labels and comments are projected', () => {
+    const value = workflow('visual-acceptance.yml');
+    const initialize = value.slice(
+      value.indexOf('  initialize:'),
+      value.indexOf('  authorize:'),
+    );
+    const accept = value.slice(value.indexOf('  accept:'));
+
+    expect(initialize).toContain('pull-requests: write');
+    expect(accept).toContain('pull-requests: write');
+  });
+
   it('uses the same head identity for post-merge promotion', () => {
     const value = workflow('visual-acceptance-promote.yml');
 
@@ -65,5 +77,22 @@ describe('visual acceptance workflow concurrency', () => {
       'group: visual-acceptance-head-${{ github.event.pull_request.head.repo.id }}-${{ github.event.pull_request.head.ref }}',
     );
     expect(value).not.toContain('visual-acceptance-pr-');
+  });
+
+  it('passes triggering CI identity through dedicated capture variables', () => {
+    const value = workflow('pr-comment.yml');
+    const capture = value.slice(
+      value.indexOf('      - name: Capture the trusted stable visual scope'),
+      value.indexOf('      # The Storybook bundle is untrusted.'),
+    );
+
+    expect(capture).toContain(
+      'ASTRYX_VISUAL_RUN_ID: ${{ steps.identity.outputs.run_id }}',
+    );
+    expect(capture).toContain(
+      'ASTRYX_VISUAL_RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}',
+    );
+    expect(capture).not.toContain('GITHUB_RUN_ID:');
+    expect(capture).not.toContain('GITHUB_RUN_ATTEMPT:');
   });
 });

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -270,8 +270,8 @@ jobs:
         if: steps.identity.outputs.valid == 'true' && steps.scope.outputs.stable == 'true'
         env:
           GITHUB_SHA: ${{ steps.identity.outputs.head_sha }}
-          GITHUB_RUN_ID: ${{ steps.identity.outputs.run_id }}
-          GITHUB_RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
+          ASTRYX_VISUAL_RUN_ID: ${{ steps.identity.outputs.run_id }}
+          ASTRYX_VISUAL_RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
           ASTRYX_PR_HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
           ASTRYX_PR_BASE_SHA: ${{ steps.identity.outputs.base_sha }}
         run: |

--- a/.github/workflows/visual-acceptance.yml
+++ b/.github/workflows/visual-acceptance.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
       statuses: write
     steps:
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      pull-requests: read
+      pull-requests: write
       issues: write
       statuses: write
     steps:


### PR DESCRIPTION
## Why

Accepted visual PRs such as [#5214](https://github.com/facebook/astryx/pull/5214) and [#5558](https://github.com/facebook/astryx/pull/5558) cannot merge because immutable visual evidence rejects its own trusted recapture.

The reproduced publisher logs show:

```text
RUN_ID: 33039803616
RUN_ATTEMPT: 2
Error: visual evidence rejected: trusted capture identity mismatch

RUN_ID: 33039815281
RUN_ATTEMPT: 2
Error: visual evidence rejected: trusted capture identity mismatch
```

`pr-comment.yml` attempted to replace `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT` with those triggering CI identities. GitHub's default `GITHUB_*` variables are immutable, so `gate.mjs` instead recorded the PR Comment workflow identities in `trusted-capture/manifest.json`; `publish-pr-report.mjs` then correctly rejected the mismatch.

The same required gate had a second live permission blocker on [#5162](https://github.com/facebook/astryx/pull/5162):

```text
DELETE /repos/facebook/astryx/issues/5162/labels/visual-approved - 403
Resource not accessible by integration
```

Both affected jobs mutate a label on a pull request, so they need job-scoped `pull-requests: write`; `issues: write` alone did not authorize that API call.

## What

- Pass the triggering CI identity through dedicated `ASTRYX_VISUAL_RUN_ID` / `ASTRYX_VISUAL_RUN_ATTEMPT` variables.
- Prefer those variables only when present; normal GitHub and local capture behavior is unchanged.
- Grant PR mutation permission only to the two acceptance jobs that add/remove `visual-approved`.
- Cover default, trusted override, missing, invalid, workflow wiring, and permission behavior.

## Tests

- `pnpm exec vitest run .github/scripts/visual-gate` — 13 files, 117 tests
- `actionlint` on the changed workflows (ignoring the existing custom-runner label warning)
- targeted ESLint and Prettier checks
- repository pre-commit checks

