### PR TITLE
docs(core): correct popup dismissal release note

### DIFF
--- a/.changeset/layer-dismiss-gesture.md
+++ b/.changeset/layer-dismiss-gesture.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Popup triggers no longer fight the browser's own light dismiss: pressing the button of an open Selector, MultiSelector, ComplexSelector, DropdownMenu or Popover closes it once instead of closing and reopening, and a clear or status button sitting on the trigger no longer dismisses the popup it belongs to
+[fix] Popup triggers no longer fight the browser's own light dismiss: pressing the button of an open Selector, MultiSelector, ComplexSelector, DropdownMenu, or Popover closes it once instead of closing and reopening. MultiSelector's clear and status buttons also keep its popup open when pressed.
 
 @cixzhang


### PR DESCRIPTION
## Why

[#5018](https://github.com/facebook/astryx/pull/5018) fixed trigger toggling across five popup components, but only MultiSelector's visible clear/status controls gained the keep-open behavior. Selector's default overlay covers those controls.

## What

Narrow the pending release note so each claim matches shipped behavior.

## Test plan

- `pnpm check:changesets`
- Documentation-only; runtime unchanged
