### PR TITLE
fix(ci): recognize repository maintainers for visual acceptance

### DIFF
--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -70,6 +70,18 @@ describe('visual acceptance workflow concurrency', () => {
     expect(accept).toContain('pull-requests: write');
   });
 
+  it('normalizes GitHub role flags before authorizing a maintainer', () => {
+    const value = workflow('visual-acceptance.yml');
+    const authorize = value.slice(
+      value.indexOf('  authorize:'),
+      value.indexOf('  accept:'),
+    );
+
+    expect(authorize).toContain('actor.permissions?.admin');
+    expect(authorize).toContain('actor.permissions?.maintain');
+    expect(authorize).toContain("? 'maintain'");
+  });
+
   it('uses the same head identity for post-merge promotion', () => {
     const value = workflow('visual-acceptance-promote.yml');
 

--- a/.github/workflows/visual-acceptance.yml
+++ b/.github/workflows/visual-acceptance.yml
@@ -178,7 +178,12 @@ jobs:
               const response = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner, repo, username: context.actor,
               });
-              permission = response.data.user.permission;
+              const actor = response.data.user;
+              permission = actor.permissions?.admin
+                ? 'admin'
+                : actor.permissions?.maintain
+                  ? 'maintain'
+                  : actor.permission;
             } catch (error) {
               if (error.status !== 404) throw error;
             }


### PR DESCRIPTION
## Why

The visual-acceptance command rejects a repository owner as “not a maintainer.” GitHub returns the actor’s coarse permission as `write` even though `user.permissions.maintain` is true, so checking only the coarse string discards an authorized decision.

## What

Normalize the explicit `admin` and `maintain` booleans before falling back to the coarse permission string. The acceptance record still stores only `admin` or `maintain` and keeps the existing authorization threshold.

## Testing

- `pnpm exec vitest run .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `actionlint .github/workflows/visual-acceptance.yml`
- Reproduced live response: coarse `write`, explicit `maintain: true`.
