### PR TITLE
fix(ci): install visual acceptance dependencies

### DIFF
--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -121,6 +121,18 @@ describe('visual acceptance workflow concurrency', () => {
     expect(authorize).toContain("? 'maintain'");
   });
 
+  it('installs the dependencies used by the acceptance archive script', () => {
+    const value = workflow('visual-acceptance.yml');
+    const accept = value.slice(value.indexOf('  accept:'));
+
+    expect(accept.indexOf('uses: ./.github/actions/setup')).toBeGreaterThan(-1);
+    expect(accept.indexOf('uses: ./.github/actions/setup')).toBeLessThan(
+      accept.indexOf(
+        'node .github/scripts/visual-gate/visual-acceptance.mjs accept',
+      ),
+    );
+  });
+
   it('uses the same head identity for post-merge promotion', () => {
     const value = workflow('visual-acceptance-promote.yml');
 

--- a/.github/workflows/visual-acceptance.yml
+++ b/.github/workflows/visual-acceptance.yml
@@ -226,6 +226,10 @@ jobs:
         if: needs.authorize.outputs.valid == 'true'
         uses: actions/checkout@v7
 
+      - name: Setup Node and pnpm
+        if: needs.authorize.outputs.valid == 'true'
+        uses: ./.github/actions/setup
+
       - name: Archive the acceptance decision
         id: record
         if: needs.authorize.outputs.valid == 'true'


### PR DESCRIPTION
## Why

The signed visual-acceptance command now authorizes correctly, but its archive job fails before writing the immutable record because `visual-acceptance.mjs` imports `pngjs` and the job never installs repository dependencies.

## What

Run the repository's standard Node and pnpm setup after the trusted checkout and before the archive script. A workflow regression test pins that ordering.

## Testing

- `pnpm exec vitest run .github/scripts/visual-gate/workflow-concurrency.test.mjs .github/scripts/visual-gate/visual-acceptance.test.mjs` — 24 tests
- `actionlint .github/workflows/visual-acceptance.yml`
- Live failure reproduced as `ERR_MODULE_NOT_FOUND: pngjs` in the acceptance archive step.
