### PR TITLE
fix(ci): authorize visual acceptance by capability

### DIFF
--- a/.github/scripts/visual-gate/authorization.mjs
+++ b/.github/scripts/visual-gate/authorization.mjs
@@ -1,29 +1,44 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 const MAINTAINER_PERMISSIONS = new Set(['maintain', 'admin']);
-const REPO_OWNER_ROLE = 'Repo Owner';
+
+function isCapabilityObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
 
 export function visualAcceptanceIdentity(permissionLevel = {}) {
-  const permission = permissionLevel.permission ?? 'none';
-  const effectivePermission = permissionLevel.user?.permissions?.admin
-    ? 'admin'
-    : permissionLevel.user?.permissions?.maintain
-      ? 'maintain'
-      : permission;
+  const capabilities = permissionLevel.user?.permissions;
+  const effectivePermission = isCapabilityObject(capabilities)
+    ? capabilities.admin === true
+      ? 'admin'
+      : capabilities.maintain === true
+        ? 'maintain'
+        : 'none'
+    : 'none';
   return {
-    permission,
-    roleName: permissionLevel.role_name ?? null,
+    permission:
+      typeof permissionLevel.permission === 'string'
+        ? permissionLevel.permission
+        : 'none',
+    roleName:
+      typeof permissionLevel.role_name === 'string'
+        ? permissionLevel.role_name
+        : null,
     effectivePermission,
   };
 }
 
-export function isVisualAcceptanceMaintainer({
-  permission,
-  roleName,
-  effectivePermission = permission,
+export function isVisualAcceptanceEndpointMaintainer({
+  effectivePermission,
 } = {}) {
-  return (
-    MAINTAINER_PERMISSIONS.has(effectivePermission) ||
-    roleName === REPO_OWNER_ROLE
+  return MAINTAINER_PERMISSIONS.has(effectivePermission);
+}
+
+export function isVisualAcceptanceRecordMaintainer({
+  permission,
+  effectivePermission,
+} = {}) {
+  return MAINTAINER_PERMISSIONS.has(
+    effectivePermission === undefined ? permission : effectivePermission,
   );
 }

--- a/.github/scripts/visual-gate/authorization.test.mjs
+++ b/.github/scripts/visual-gate/authorization.test.mjs
@@ -3,60 +3,90 @@
 import {describe, expect, it} from 'vitest';
 
 import {
-  isVisualAcceptanceMaintainer,
+  isVisualAcceptanceEndpointMaintainer,
+  isVisualAcceptanceRecordMaintainer,
   visualAcceptanceIdentity,
 } from './authorization.mjs';
 
-const endpointIdentity = overrides =>
-  visualAcceptanceIdentity({
-    permission: 'write',
-    role_name: 'Custom role',
-    user: {
-      permissions: {
-        admin: false,
-        maintain: false,
-        pull: true,
-        push: true,
-        triage: true,
-      },
-    },
-    ...overrides,
-  });
+const endpointAllows = payload =>
+  isVisualAcceptanceEndpointMaintainer(visualAcceptanceIdentity(payload));
 
-describe('visual acceptance authorization', () => {
+const payload = (permission, permissions, roleName = 'Custom role') => ({
+  permission,
+  role_name: roleName,
+  user: {permissions},
+});
+
+describe('visual acceptance endpoint authorization', () => {
   it.each([
-    ['repository owner', endpointIdentity({role_name: 'Repo Owner'}), true],
     [
-      'effective maintainer',
-      endpointIdentity({user: {permissions: {maintain: true}}}),
+      'repository owner with effective maintain capability',
+      payload('write', {maintain: true}, 'Repo Owner'),
       true,
     ],
+    ['effective maintainer', payload('write', {maintain: true}), true],
+    ['effective administrator', payload('write', {admin: true}), true],
+    ['ordinary writer', payload('write', {admin: false, maintain: false}), false],
     [
-      'effective administrator',
-      endpointIdentity({user: {permissions: {admin: true}}}),
-      true,
+      'top-level admin overridden by nested false capabilities',
+      payload('admin', {admin: false, maintain: false}),
+      false,
     ],
-    ['ordinary writer', endpointIdentity(), false],
-    ['missing collaborator response', visualAcceptanceIdentity(), false],
-    ['unknown permission', {permission: 'unknown'}, false],
-    ['unknown role', {permission: 'write', roleName: 'Owner'}, false],
-    ['legacy maintainer record', {permission: 'maintain'}, true],
-    ['legacy administrator record', {permission: 'admin'}, true],
-  ])('%s', (_label, identity, expected) => {
-    expect(isVisualAcceptanceMaintainer(identity)).toBe(expected);
+    [
+      'top-level maintain overridden by nested false capabilities',
+      payload('maintain', {admin: false, maintain: false}),
+      false,
+    ],
+    [
+      'repository owner role without effective capability',
+      payload('write', {admin: false, maintain: false}, 'Repo Owner'),
+      false,
+    ],
+    ['string true capability', payload('write', {maintain: 'true'}), false],
+    ['string false capability', payload('write', {maintain: 'false'}), false],
+    ['null capabilities', payload('admin', null), false],
+    ['array capabilities', payload('admin', [true]), false],
+    ['missing capability fields', payload('admin', {}), false],
+    ['missing capability object', {permission: 'admin', user: {}}, false],
+    ['unknown collaborator', {}, false],
+  ])('%s', (_label, endpointPayload, expected) => {
+    expect(endpointAllows(endpointPayload)).toBe(expected);
   });
 
-  it('keeps the endpoint permission and role for the acceptance record', () => {
+  it('keeps reported permission and role as provenance', () => {
     expect(
-      visualAcceptanceIdentity({
-        permission: 'write',
-        role_name: 'Repo Owner',
-        user: {permissions: {maintain: true}},
-      }),
-    ).toMatchObject({
+      visualAcceptanceIdentity(
+        payload('write', {maintain: true}, 'Repo Owner'),
+      ),
+    ).toEqual({
       permission: 'write',
       roleName: 'Repo Owner',
       effectivePermission: 'maintain',
     });
+  });
+});
+
+describe('visual acceptance record compatibility', () => {
+  it.each([
+    ['legacy maintainer', {permission: 'maintain'}, true],
+    ['legacy administrator', {permission: 'admin'}, true],
+    ['legacy writer', {permission: 'write'}, false],
+    [
+      'new record never falls back to raw admin',
+      {permission: 'admin', effectivePermission: 'none'},
+      false,
+    ],
+    [
+      'new effective maintainer',
+      {permission: 'write', effectivePermission: 'maintain'},
+      true,
+    ],
+    [
+      'new effective administrator',
+      {permission: 'write', effectivePermission: 'admin'},
+      true,
+    ],
+  ])('%s', (_label, record, expected) => {
+    expect(isVisualAcceptanceRecordMaintainer(record)).toBe(expected);
   });
 });

--- a/.github/scripts/visual-gate/visual-acceptance.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.mjs
@@ -14,7 +14,10 @@ import fs from 'node:fs';
 import {createRequire} from 'node:module';
 import path from 'node:path';
 
-import {isVisualAcceptanceMaintainer} from './authorization.mjs';
+import {
+  isVisualAcceptanceEndpointMaintainer,
+  isVisualAcceptanceRecordMaintainer,
+} from './authorization.mjs';
 import {readStoryIndex, shotKey, storiesInPackages} from './lib/plan.mjs';
 
 const args = process.argv.slice(2);
@@ -277,7 +280,7 @@ function accept() {
   const approver = flag('approver') ?? '';
   const approverId = Number(flag('approver-id'));
   const permission = flag('permission') ?? '';
-  const effectivePermission = flag('effective-permission') ?? permission;
+  const effectivePermission = flag('effective-permission') ?? 'none';
   const roleName = flag('role-name');
   const commentId = Number(flag('comment-id'));
   const reason = validateReason(flag('reason'));
@@ -285,14 +288,8 @@ function accept() {
   validateIdentity(pr, head);
   if (!approver || !Number.isSafeInteger(approverId) || approverId <= 0)
     fail('invalid approver');
-  if (
-    !isVisualAcceptanceMaintainer({
-      permission,
-      effectivePermission,
-      roleName,
-    })
-  ) {
-    fail('approver must have maintain/admin permission or the Repo Owner role');
+  if (!isVisualAcceptanceEndpointMaintainer({effectivePermission})) {
+    fail('approver must have effective maintain/admin permission');
   }
   if (!Number.isSafeInteger(commentId) || commentId <= 0)
     fail('invalid comment id');
@@ -479,10 +476,9 @@ function validateAcceptance(value, expected = {}) {
     !value.decision?.approver ||
     !Number.isSafeInteger(value.decision?.approverId) ||
     value.decision.approverId <= 0 ||
-    !isVisualAcceptanceMaintainer({
+    !isVisualAcceptanceRecordMaintainer({
       permission: value.decision?.permission,
       effectivePermission: value.decision?.effectivePermission,
-      roleName: value.decision?.roleName,
     }) ||
     !Number.isSafeInteger(value.decision?.commentId) ||
     value.decision.commentId <= 0 ||

--- a/.github/scripts/visual-gate/visual-acceptance.test.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.test.mjs
@@ -81,6 +81,7 @@ function acceptanceFlags(overrides = {}) {
     approver: 'maintainer',
     'approver-id': 99,
     permission: 'maintain',
+    'effective-permission': 'maintain',
     'comment-id': 1234,
     reason: 'The new radius matches the approved component design.',
     ...overrides,
@@ -245,7 +246,7 @@ describe('visual acceptance', () => {
     );
   });
 
-  it('accepts a repository owner and records the reported permission and role', () => {
+  it('accepts effective maintain capability and records owner provenance', () => {
     run(
       'accept',
       acceptanceFlags({
@@ -301,13 +302,46 @@ describe('visual acceptance', () => {
     },
   );
 
+  it('rejects a legacy write record without effective capability data', () => {
+    run(
+      'accept',
+      acceptanceFlags({
+        permission: 'write',
+        'effective-permission': 'maintain',
+      }),
+    );
+    const record = JSON.parse(fs.readFileSync(acceptanceFile(), 'utf8'));
+    delete record.decision.roleName;
+    delete record.decision.effectivePermission;
+    writeJSON(acceptanceFile(), record);
+    expect(fail('state', {pages, pr: 42, head: HEAD})).toMatch(
+      /acceptance record is invalid/,
+    );
+  });
+
   it('requires an explanatory reason and maintainer permission', () => {
     expect(fail('accept', acceptanceFlags({reason: 'intentional...'}))).toMatch(
       /reason must explain/,
     );
-    expect(fail('accept', acceptanceFlags({permission: 'write'}))).toMatch(
-      /maintain\/admin/,
-    );
+    expect(
+      fail(
+        'accept',
+        acceptanceFlags({
+          permission: 'write',
+          'effective-permission': 'write',
+          'role-name': 'Repo Owner',
+        }),
+      ),
+    ).toMatch(/effective maintain\/admin/);
+    expect(
+      fail(
+        'accept',
+        acceptanceFlags({
+          permission: 'write',
+          'effective-permission': 'write',
+        }),
+      ),
+    ).toMatch(/effective maintain\/admin/);
   });
 
   it('binds acceptance to the exact reviewed run attempt', () => {

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -41,6 +41,10 @@ describe('visual acceptance workflow concurrency', () => {
       value.indexOf('  authorize:'),
       value.indexOf('  accept:'),
     );
+    const authorizeCheckout = authorize.slice(
+      authorize.indexOf('      - name: Checkout trusted default-branch code'),
+      authorize.indexOf('      - name: Authorize and resolve the decision'),
+    );
     const accept = value.slice(value.indexOf('  accept:'));
 
     expect(initialize).toContain(
@@ -57,8 +61,11 @@ describe('visual acceptance workflow concurrency', () => {
     expect(initialize).toContain("'No stable visual scope.'");
     expect(authorize).not.toContain(': write');
     expect(authorize).toContain('actions/checkout@v7');
+    expect(authorizeCheckout).not.toContain('ref:');
     expect(authorize).toContain('visualAcceptanceIdentity(response.data)');
-    expect(authorize).toContain('isVisualAcceptanceMaintainer(identity)');
+    expect(authorize).toContain(
+      'isVisualAcceptanceEndpointMaintainer(identity)',
+    );
     expect(authorize).toContain(
       "core.setOutput('effective_permission', identity.effectivePermission)",
     );

--- a/.github/workflows/visual-acceptance.yml
+++ b/.github/workflows/visual-acceptance.yml
@@ -127,7 +127,7 @@ jobs:
           script: |
             const {pathToFileURL} = require('node:url');
             const {
-              isVisualAcceptanceMaintainer,
+              isVisualAcceptanceEndpointMaintainer,
               visualAcceptanceIdentity,
             } = await import(
               pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/visual-gate/authorization.mjs`).href,
@@ -186,7 +186,7 @@ jobs:
             } catch (error) {
               if (error.status !== 404) throw error;
             }
-            if (!isVisualAcceptanceMaintainer(identity)) {
+            if (!isVisualAcceptanceEndpointMaintainer(identity)) {
               refuse('only a repository maintainer may accept stable visual changes.');
               return;
             }


### PR DESCRIPTION
## Why

[#5592](https://github.com/facebook/astryx/pull/5592) normalized GitHub's collaborator-permission response but still allowed the reported role name to grant authority. Role names are provenance, not a stable capability boundary. Endpoint authorization must depend only on strict effective `maintain` or `admin` booleans.

## What

- Parse endpoint capabilities fail-closed: only nested `admin === true` or `maintain === true` authorizes.
- Never fall back to top-level permission when handling an endpoint response; false, strings, null, arrays, missing fields, and malformed capability data refuse.
- Keep reported permission and role as immutable-record provenance only.
- Validate legacy records in a separate trust domain: records without `effectivePermission` may use raw `maintain` or `admin`; legacy `write` fails.
- Preserve [#5593](https://github.com/facebook/astryx/pull/5593)'s dependency install and the dependency-free accept path.
- Pin the authorization checkout invariant: trusted default-branch code with no explicit ref.

## Risk

Low and fail-closed. This removes a mutable role-name authorization path without widening the accepted capability set.

## Testing

- Focused authorization, acceptance, and workflow tests: 3 files, 52 tests
- Full visual-gate suite: 14 files, 149 tests
- `actionlint .github/workflows/visual-acceptance.yml`
- `pnpm check:repo`
- Exact [#5162](https://github.com/facebook/astryx/pull/5162) 124-frame dry-run from pre-cleanup gh-pages commit `be6f3351c823f6b62c59eb29507cb4518024eacc`: capability path returns `success:accepted`; role-only and raw-admin fallback attempts fail
- Full CI on the exact head

No live acceptance command was replayed.
