### PR TITLE
chore(i18n): translations update from Crowdin

### DIFF
--- a/packages/core/locales/af-ZA.json
+++ b/packages/core/locales/af-ZA.json
@@ -257,7 +257,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Maak toe",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Vorige maand",

--- a/packages/core/locales/ar-SA.json
+++ b/packages/core/locales/ar-SA.json
@@ -281,7 +281,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "تجاهل",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "الشهر السابق",

--- a/packages/core/locales/ca-ES.json
+++ b/packages/core/locales/ca-ES.json
@@ -273,7 +273,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Descarta",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Mes anterior",

--- a/packages/core/locales/cs-CZ.json
+++ b/packages/core/locales/cs-CZ.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Zavřít",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Předchozí měsíc",

--- a/packages/core/locales/da-DK.json
+++ b/packages/core/locales/da-DK.json
@@ -273,7 +273,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Luk",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Forrige måned",

--- a/packages/core/locales/de-DE.json
+++ b/packages/core/locales/de-DE.json
@@ -273,7 +273,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Schließen",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Vorheriger Monat",

--- a/packages/core/locales/el-GR.json
+++ b/packages/core/locales/el-GR.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Παράβλεψη",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Προηγούμενος μήνας",

--- a/packages/core/locales/es-ES.json
+++ b/packages/core/locales/es-ES.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Descartar",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Mes anterior",

--- a/packages/core/locales/fi-FI.json
+++ b/packages/core/locales/fi-FI.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Hylkää",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Edellinen kuukausi",

--- a/packages/core/locales/fr-FR.json
+++ b/packages/core/locales/fr-FR.json
@@ -257,7 +257,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Ignorer",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Mois précédent",

--- a/packages/core/locales/he-IL.json
+++ b/packages/core/locales/he-IL.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "סגור",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "החודש הקודם",

--- a/packages/core/locales/hu-HU.json
+++ b/packages/core/locales/hu-HU.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Elvetés",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Előző hónap",

--- a/packages/core/locales/it-IT.json
+++ b/packages/core/locales/it-IT.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Ignora",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Mese precedente",

--- a/packages/core/locales/ja-JP.json
+++ b/packages/core/locales/ja-JP.json
@@ -281,7 +281,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "閉じる",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "前月",

--- a/packages/core/locales/ko-KR.json
+++ b/packages/core/locales/ko-KR.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "닫기",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "이전 달",

--- a/packages/core/locales/nl-NL.json
+++ b/packages/core/locales/nl-NL.json
@@ -253,7 +253,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Sluiten",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Vorige maand",

--- a/packages/core/locales/no-NO.json
+++ b/packages/core/locales/no-NO.json
@@ -273,7 +273,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Lukk",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Forrige måned",

--- a/packages/core/locales/pl-PL.json
+++ b/packages/core/locales/pl-PL.json
@@ -273,7 +273,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Zamknij",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Poprzedni miesiąc",

--- a/packages/core/locales/pt-BR.json
+++ b/packages/core/locales/pt-BR.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Dispensar",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Mês anterior",

--- a/packages/core/locales/pt-PT.json
+++ b/packages/core/locales/pt-PT.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Dispensar",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Mês anterior",

--- a/packages/core/locales/ro-RO.json
+++ b/packages/core/locales/ro-RO.json
@@ -273,7 +273,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Închide",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Luna anterioară",

--- a/packages/core/locales/ru-RU.json
+++ b/packages/core/locales/ru-RU.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Закрыть",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Предыдущий месяц",

--- a/packages/core/locales/sr-SP.json
+++ b/packages/core/locales/sr-SP.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Одбаци",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Претходни месец",

--- a/packages/core/locales/sv-SE.json
+++ b/packages/core/locales/sv-SE.json
@@ -273,7 +273,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Stäng",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Föregående månad",

--- a/packages/core/locales/tr-TR.json
+++ b/packages/core/locales/tr-TR.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Kapat",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Önceki ay",

--- a/packages/core/locales/uk-UA.json
+++ b/packages/core/locales/uk-UA.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Закрити",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Попередній місяць",

--- a/packages/core/locales/vi-VN.json
+++ b/packages/core/locales/vi-VN.json
@@ -277,7 +277,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Bỏ qua",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Tháng trước",

--- a/packages/core/locales/zh-CN.json
+++ b/packages/core/locales/zh-CN.json
@@ -281,7 +281,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "关闭",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "上个月",

--- a/packages/core/locales/zh-TW.json
+++ b/packages/core/locales/zh-TW.json
@@ -281,7 +281,7 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "關閉",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "上個月",


### PR DESCRIPTION
Automated translations pulled from Crowdin.

Source: https://crowdin.com/project/astryx

Locale JSON has been normalized with `prettier`. Review the diff
for any strings that shifted meaning or formatting, then merge
when ready.