### PR TITLE
ci: point Dependabot at the setup composite action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,12 @@ updates:
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      # "/" covers workflows only — composite actions need their own entry.
+      # Without it, the SHA-pinned pnpm/action-setup in the setup composite
+      # (which runs inside the npm publish jobs) would never get bump PRs.
+      - "/.github/actions/setup"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
## Summary

Follow-up to #5526's review note: Dependabot's `github-actions` ecosystem only scans workflows under `/` — it doesn't look inside `.github/actions/`. That made the SHA pin on `pnpm/action-setup` permanent (nothing would ever propose moving it), and left `actions/setup-node` in the composite outside the repo's monthly bump cadence.

## Changes

- `dependabot.yml`'s github-actions entry switches `directory: "/"` to `directories: ["/", "/.github/actions/setup"]`, with a comment explaining why the composite needs its own entry.

## Test plan

- YAML parses; `directories` is the documented multi-directory form for a single update config, so grouping/labels/schedule apply unchanged.

## Notes

- CI-config-only: no changeset.
