### PR TITLE
fix(Carousel): keep focus inside the carousel at a scroll edge, and expose the scroll container to themes

### DIFF
--- a/.changeset/carousel-edge-focus-and-theme-target.md
+++ b/.changeset/carousel-edge-focus-and-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Carousel keeps keyboard focus inside the component when a nav button press runs the content to an edge and disables that button, instead of letting focus fall to the document body. The scroll container is also now a documented theme target, `astryx-carousel-scroller`, carrying the gap, padding, snap and edge-fade props it styles, so a theme can reach the spacing and the fade it could not see before.
+
+@cixzhang

--- a/.changeset/carousel-edge-focus-and-theme-target.md
+++ b/.changeset/carousel-edge-focus-and-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Carousel keeps keyboard focus inside the component when a nav button press runs the content to an edge and disables that button, instead of letting focus fall to the document body. The scroll container is also now a documented theme target, `astryx-carousel-scroller`, carrying the gap, padding, snap and edge-fade props it styles, so a theme can reach the spacing and the fade it could not see before.
+[fix] Carousel no longer drops keyboard focus to the document body when reaching a scroll edge disables the nav button in use. Focus moves to the opposite arrow instead, on the state transition that disables the button rather than on a prediction from the press, so it holds under reduced motion, under scroll-snap, and on browsers without `scrollend`. The scroll container is also now a documented theme target, `astryx-carousel-scroller`, carrying the gap, padding, snap and edge-fade props it styles, so a theme can reach the spacing and the fade it could not see before.
 
 @cixzhang

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -14,46 +14,6 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Carousel::Card Content::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Carousel::Custom Content (Swatches)::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Carousel::Default::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Carousel::Few Items (No Overflow)::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Carousel::Large Gap::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Carousel::Scroll Snap::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Carousel::Thumbnails with Remove::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Carousel::Without Buttons::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
       "key": "Chat::Message Status::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
@@ -529,42 +489,42 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — Both Panels::color-contrast",
+      "key": "Layout::Content Width \u2014 Both Panels::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — Dividers, No Panels::color-contrast",
+      "key": "Layout::Content Width \u2014 Dividers, No Panels::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — Narrower Than Container::color-contrast",
+      "key": "Layout::Content Width \u2014 Narrower Than Container::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — Nested in AppShell::color-contrast",
+      "key": "Layout::Content Width \u2014 Nested in AppShell::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — No Dividers::color-contrast",
+      "key": "Layout::Content Width \u2014 No Dividers::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — Responsive Panels::color-contrast",
+      "key": "Layout::Content Width \u2014 Responsive Panels::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — Start Panel::color-contrast",
+      "key": "Layout::Content Width \u2014 Start Panel::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width — Wider Than Container::color-contrast",
+      "key": "Layout::Content Width \u2014 Wider Than Container::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
@@ -804,12 +764,12 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Stepper::Edge — Disabled Steps::color-contrast",
+      "key": "Stepper::Edge \u2014 Disabled Steps::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Stepper::Slots — endContent (trailing badges)::color-contrast",
+      "key": "Stepper::Slots \u2014 endContent (trailing badges)::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -489,42 +489,42 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 Both Panels::color-contrast",
+      "key": "Layout::Content Width — Both Panels::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 Dividers, No Panels::color-contrast",
+      "key": "Layout::Content Width — Dividers, No Panels::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 Narrower Than Container::color-contrast",
+      "key": "Layout::Content Width — Narrower Than Container::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 Nested in AppShell::color-contrast",
+      "key": "Layout::Content Width — Nested in AppShell::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 No Dividers::color-contrast",
+      "key": "Layout::Content Width — No Dividers::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 Responsive Panels::color-contrast",
+      "key": "Layout::Content Width — Responsive Panels::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 Start Panel::color-contrast",
+      "key": "Layout::Content Width — Start Panel::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Layout::Content Width \u2014 Wider Than Container::color-contrast",
+      "key": "Layout::Content Width — Wider Than Container::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
@@ -764,12 +764,12 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Stepper::Edge \u2014 Disabled Steps::color-contrast",
+      "key": "Stepper::Edge — Disabled Steps::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Stepper::Slots \u2014 endContent (trailing badges)::color-contrast",
+      "key": "Stepper::Slots — endContent (trailing badges)::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },

--- a/apps/storybook/stories/Carousel.stories.tsx
+++ b/apps/storybook/stories/Carousel.stories.tsx
@@ -24,6 +24,9 @@ const styles = stylex.create({
   constrainedWidth: {
     maxWidth: 400,
   },
+  narrowWidth: {
+    maxWidth: 240,
+  },
   card: {
     width: 160,
     flexShrink: 0,
@@ -81,7 +84,12 @@ const meta: Meta<typeof Carousel> = {
     },
     hasButtons: {
       control: 'boolean',
-      description: 'Show navigation buttons on hover',
+      description: 'Show navigation buttons when the content can scroll',
+    },
+    padding: {
+      control: {type: 'select'},
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description: 'Inline padding inside the scroll container',
     },
     hasEdgeFade: {
       control: 'boolean',
@@ -364,4 +372,99 @@ export const ImperativeControl: Story = {
       </div>
     );
   },
+};
+
+export const WithPadding: Story = {
+  name: 'Inline Padding',
+  render: () => (
+    <div {...stylex.props(styles.constrainedWidth)}>
+      <p {...stylex.props(styles.label)}>
+        padding=3 puts the gutter inside the scroll area, and scroll-padding
+        keeps snap points on the content edge
+      </p>
+      <Carousel gap={1} padding={3} hasSnap aria-label="Padded gallery">
+        {IMAGES.map(img => (
+          <Thumbnail
+            key={img.id}
+            src={img.src}
+            alt={img.label}
+            label={img.label}
+          />
+        ))}
+      </Carousel>
+    </div>
+  ),
+};
+
+export const NarrowContainer: Story = {
+  name: 'Narrow Container',
+  render: () => (
+    <div {...stylex.props(styles.narrowWidth)}>
+      <p {...stylex.props(styles.label)}>240px container</p>
+      <Carousel gap={1} aria-label="Narrow gallery">
+        {IMAGES.map(img => (
+          <Thumbnail
+            key={img.id}
+            src={img.src}
+            alt={img.label}
+            label={img.label}
+          />
+        ))}
+      </Carousel>
+    </div>
+  ),
+};
+
+export const LongTextItems: Story = {
+  name: 'Long Text Items',
+  render: () => (
+    <div {...stylex.props(styles.constrainedWidth)}>
+      <p {...stylex.props(styles.label)}>
+        One very long item among short ones, and a word with no break
+        opportunity
+      </p>
+      <Carousel gap={2} aria-label="Text items">
+        <Card xstyle={styles.card}>
+          <div {...stylex.props(styles.cardInner)}>
+            <p {...stylex.props(styles.cardDesc)}>Short</p>
+          </div>
+        </Card>
+        <Card xstyle={styles.card}>
+          <div {...stylex.props(styles.cardInner)}>
+            <p {...stylex.props(styles.cardDesc)}>
+              A much longer description that runs well past the width of its
+              neighbours and has to wrap inside a fixed-width card without
+              pushing the row out of shape.
+            </p>
+          </div>
+        </Card>
+        <Card xstyle={styles.card}>
+          <div {...stylex.props(styles.cardInner)}>
+            <p {...stylex.props(styles.cardDesc)}>
+              Unbreakable:
+              Donaudampfschiffahrtselektrizitaetenhauptbetriebswerkbauunterbeamtengesellschaft
+            </p>
+          </div>
+        </Card>
+      </Carousel>
+    </div>
+  ),
+};
+
+export const SingleItem: Story = {
+  name: 'Single Item',
+  render: () => (
+    <div {...stylex.props(styles.constrainedWidth)}>
+      <p {...stylex.props(styles.label)}>
+        One child: no overflow, no fade, no buttons
+      </p>
+      <Carousel gap={1} aria-label="Single item">
+        <Thumbnail
+          src={IMAGES[0].src}
+          alt={IMAGES[0].label}
+          label={IMAGES[0].label}
+        />
+      </Carousel>
+    </div>
+  ),
 };

--- a/packages/core/src/Carousel/Carousel.doc.mjs
+++ b/packages/core/src/Carousel/Carousel.doc.mjs
@@ -70,6 +70,7 @@ export const docsZh = {
       {guidance: true, description: '当每个项目应精确对齐到起始边缘时启用滚动吸附，例如画廊或产品列表。'},
       {guidance: true, description: '在小型可循环的集合（如照片画廊）上使用 hasLoop，此时从最后一项绕回第一项的滚动更自然。'},
       {guidance: true, description: '始终提供描述轮播内容的 aria-label，例如"精选产品"或"团队成员"。'},
+      {guidance: true, description: 'Carousel 实现不含自动轮播的 WAI-ARIA APG carousel 模式（https://www.w3.org/WAI/ARIA/apg/patterns/carousel/）：区域带有标签和 aria-roledescription="carousel"，每个项目是名为“第 N 张，共 M 张”的 group，滚动容器可获得焦点，键盘用户可用方向键平移。'},
       {guidance: true, description: '使用一致的间距和项目宽度，让轮播看起来是有意为之，而不是内容意外溢出。'},
       {guidance: true, description: '信任内置导航：触控板用户可水平滑动，鼠标用户可按住 Shift 滚动滚轮来浏览项目。'},
       {guidance: false, description: '将每位用户都必须看到的内容放入轮播。并非所有人都会水平滚动，关键内容应放在首屏。'},

--- a/packages/core/src/Carousel/Carousel.doc.mjs
+++ b/packages/core/src/Carousel/Carousel.doc.mjs
@@ -14,6 +14,7 @@ export const docs = {
       {guidance: true, description: 'Enable scroll-snap when each item should land precisely at the start edge, like a gallery or product list.'},
       {guidance: true, description: 'Reach for hasLoop on small, cyclable sets like a photo gallery, where wrapping past the last item back to the first feels natural.'},
       {guidance: true, description: 'Always provide an aria-label that describes what the carousel contains, like "Featured products" or "Team members".'},
+      {guidance: true, description: 'Carousel implements the WAI-ARIA APG carousel pattern (https://www.w3.org/WAI/ARIA/apg/patterns/carousel/) without auto-rotation: the region is labelled and carries aria-roledescription="carousel", each item is a group named "Slide N of M", and the scroll container is a tab stop so keyboard users can pan it with the arrow keys.'},
       {guidance: true, description: 'Use a consistent gap and item width so the carousel looks intentional, not like content overflowing by accident.'},
       {guidance: true, description: 'Trust the built-in navigation: trackpad users can swipe horizontally, and mouse users can hold Shift while scrolling the wheel to move through items.'},
       {guidance: false, description: 'Use a carousel for content every user must see. Not everyone scrolls horizontally, so put critical content above the fold.'},
@@ -55,6 +56,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-carousel'},
+      {className: 'astryx-carousel-scroller', visualProps: ['gap', 'padding', 'snap', 'edgeFade']},
     ],
   },
 };

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -3,6 +3,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {createRef} from 'react';
 import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {Carousel, type CarouselHandle} from './Carousel';
 
 // Mock ResizeObserver (not available in jsdom)
@@ -488,6 +489,131 @@ describe('Carousel', () => {
       expect(scrollBy).toHaveBeenCalledTimes(1);
       // Uses scrollBy (contained to the carousel), never scrollIntoView.
       expect(scrollBy.mock.calls[0][0]).toHaveProperty('left');
+    });
+  });
+
+  describe('keyboard focus at the edges', () => {
+    function getScroller() {
+      const region = screen.getByRole('region');
+      return region.firstElementChild as HTMLElement;
+    }
+
+    // jsdom doesn't lay out elements, so fake an overflowing scroll container
+    // whose scrollLeft actually moves when scrollBy is called. The component
+    // predicts the edge from these numbers, which is what the hand-off uses.
+    function makeScrollable(el: HTMLElement, scrollWidth: number) {
+      const clientWidth = 200;
+      Object.defineProperty(el, 'scrollWidth', {
+        value: scrollWidth,
+        configurable: true,
+      });
+      Object.defineProperty(el, 'clientWidth', {
+        value: clientWidth,
+        configurable: true,
+      });
+      Object.defineProperty(el, 'scrollLeft', {
+        value: 0,
+        writable: true,
+        configurable: true,
+      });
+      el.scrollBy = ((options: ScrollToOptions) => {
+        el.scrollLeft = Math.max(
+          0,
+          Math.min(
+            scrollWidth - clientWidth,
+            el.scrollLeft + (options.left ?? 0),
+          ),
+        );
+        fireEvent.scroll(el);
+      }) as HTMLElement['scrollBy'];
+      fireEvent.scroll(el);
+    }
+
+    it('keeps focus inside the carousel when a press disables the pressed button', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      // clientWidth 200 and a 200px step, so one press lands exactly on the
+      // trailing edge and the trailing button disables.
+      makeScrollable(getScroller(), 400);
+
+      const next = screen.getByLabelText('Scroll right');
+      await user.click(next);
+
+      // The press ran the content to the end, so `next` is now disabled. It
+      // must not be left holding focus, and focus must not fall to <body>.
+      expect(next).toBeDisabled();
+      expect(document.activeElement).toBe(getScroller());
+      expect(document.activeElement).not.toBe(document.body);
+    });
+
+    it('does not move focus on a press that leaves the direction available', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      // Far more content than one step, so the trailing edge stays reachable.
+      makeScrollable(getScroller(), 2000);
+
+      const next = screen.getByLabelText('Scroll right');
+      await user.click(next);
+
+      expect(next).toBeEnabled();
+      expect(document.activeElement).toBe(next);
+    });
+
+    it('leaves focus alone when the imperative handle drives the scroll', () => {
+      const handle = createRef<CarouselHandle>();
+      render(
+        <Carousel handleRef={handle} aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+        </Carousel>,
+      );
+      makeScrollable(getScroller(), 400);
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+      outside.focus();
+
+      handle.current?.scrollNext();
+
+      expect(document.activeElement).toBe(outside);
+      outside.remove();
+    });
+
+    it('reflects the scroll container as a theme target carrying its style-driving props', () => {
+      render(
+        <Carousel gap={2} padding={3} hasSnap aria-label="Gallery">
+          <div>Item 1</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      expect(scroller).toHaveClass('astryx-carousel-scroller');
+      expect(scroller).toHaveAttribute('data-gap', '2');
+      expect(scroller).toHaveAttribute('data-padding', '3');
+      expect(scroller).toHaveAttribute('data-snap', 'snap');
+      expect(scroller).toHaveAttribute('data-edge-fade', 'edge-fade');
+    });
+
+    it('omits the opt-out attributes a theme should not see', () => {
+      render(
+        <Carousel hasEdgeFade={false} aria-label="Gallery">
+          <div>Item 1</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      expect(scroller).not.toHaveAttribute('data-edge-fade');
+      expect(scroller).not.toHaveAttribute('data-snap');
+      expect(scroller).not.toHaveAttribute('data-padding');
     });
   });
 });

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -672,6 +672,52 @@ describe('Carousel', () => {
       expect(document.activeElement).not.toBe(document.body);
     });
 
+    it('does not pull focus back after the person has left the button', () => {
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      makeScrollable(scroller, 400);
+
+      // Touch an arrow, then leave it without pressing it. Landing on <body> is
+      // the case that matters: focus somewhere else is already ignored, so a
+      // stale tracker only bites when there is nothing else holding focus.
+      const next = screen.getByLabelText('Scroll right');
+      next.focus();
+      next.blur();
+      expect(document.activeElement).toBe(document.body);
+
+      // The carousel reaches the edge on its own: a swipe, a resize, anything
+      // that is not this person. Their focus is not the carousel's to take.
+      scroller.scrollLeft = 200;
+      fireEvent.scroll(scroller);
+
+      expect(screen.getByLabelText('Scroll right')).toBeDisabled();
+      expect(document.activeElement).toBe(document.body);
+    });
+
+    it('still hands off when the disable is what blurred the button', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      makeScrollable(getScroller(), 400);
+
+      // The blur the commit causes must not read as the person leaving, or the
+      // hand-off never fires at all.
+      await user.click(screen.getByLabelText('Scroll right'));
+
+      expect(document.activeElement).toBe(screen.getByLabelText('Scroll left'));
+    });
+
     it('does not move focus on a press that leaves the direction available', async () => {
       const user = userEvent.setup();
       render(

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -498,14 +498,12 @@ describe('Carousel', () => {
       return region.firstElementChild as HTMLElement;
     }
 
-    // jsdom doesn't lay out elements, so fake an overflowing scroll container
-    // whose scrollLeft actually moves when scrollBy is called. The component
-    // predicts the edge from these numbers, which is what the hand-off uses.
-    // jsdom has no layout and no scrollend, so fake an overflowing container
-    // whose scrollBy moves scrollLeft and then settles, the way a browser does.
-    // `land` decides where the container comes to rest: the default clamps to
-    // the requested delta, and the snap arm overrides it to model mandatory
-    // scroll-snap carrying the container past what the press asked for.
+    // jsdom has no layout, so fake an overflowing container whose scrollBy
+    // moves scrollLeft and fires scroll, which is what drives the overflow
+    // state the buttons and the focus hand-off both read. `land` decides where
+    // the container comes to rest: the default clamps to the requested delta,
+    // and the snap arm overrides it to model mandatory scroll-snap carrying the
+    // container past what the press asked for.
     function makeScrollable(
       el: HTMLElement,
       scrollWidth: number,
@@ -533,12 +531,11 @@ describe('Carousel', () => {
         );
         el.scrollLeft = land ? land(requested, maxScroll) : requested;
         fireEvent.scroll(el);
-        el.dispatchEvent(new Event('scrollend'));
       }) as HTMLElement['scrollBy'];
       fireEvent.scroll(el);
     }
 
-    it('keeps focus inside the carousel when a press disables the pressed button', async () => {
+    it('hands focus to the opposite button when the edge disables the one in use', async () => {
       const user = userEvent.setup();
       render(
         <Carousel aria-label="Gallery">
@@ -547,21 +544,19 @@ describe('Carousel', () => {
           <div>Item 3</div>
         </Carousel>,
       );
-      // clientWidth 200 and a 200px step, so one press lands exactly on the
+      // clientWidth 200 against a 200px step, so one press lands exactly on the
       // trailing edge and the trailing button disables.
       makeScrollable(getScroller(), 400);
 
       const next = screen.getByLabelText('Scroll right');
       await user.click(next);
 
-      // The press ran the content to the end, so `next` is now disabled. It
-      // must not be left holding focus, and focus must not fall to <body>.
       expect(next).toBeDisabled();
-      expect(document.activeElement).toBe(getScroller());
+      expect(document.activeElement).toBe(screen.getByLabelText('Scroll left'));
       expect(document.activeElement).not.toBe(document.body);
     });
 
-    it('does not move focus on a press that leaves the direction available', async () => {
+    it('hands off in the leading direction too', async () => {
       const user = userEvent.setup();
       render(
         <Carousel aria-label="Gallery">
@@ -570,16 +565,63 @@ describe('Carousel', () => {
           <div>Item 3</div>
         </Carousel>,
       );
-      // 600 gives 400 of travel against a 200 step, so the press lands mid-run
-      // with the trailing edge still two steps away. Tight on purpose: a loose
-      // fixture hides a prediction that counts the step twice.
-      makeScrollable(getScroller(), 600);
+      const scroller = getScroller();
+      makeScrollable(scroller, 400);
+      // Park at the far end so the leading button is the one that runs out.
+      scroller.scrollLeft = 200;
+      fireEvent.scroll(scroller);
+
+      const previous = screen.getByLabelText('Scroll left');
+      await user.click(previous);
+
+      expect(previous).toBeDisabled();
+      expect(document.activeElement).toBe(
+        screen.getByLabelText('Scroll right'),
+      );
+    });
+
+    it('hands off under RTL, where the scroll axis is inverted', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      // The component resolves direction with getComputedStyle, and jsdom does
+      // not inherit `dir` down to it, so set it on the element itself. RTL then
+      // scrolls negative, which the mock below mirrors.
+      scroller.style.direction = 'rtl';
+      const maxScroll = 200;
+      Object.defineProperty(scroller, 'scrollWidth', {
+        value: 400,
+        configurable: true,
+      });
+      Object.defineProperty(scroller, 'clientWidth', {
+        value: 200,
+        configurable: true,
+      });
+      Object.defineProperty(scroller, 'scrollLeft', {
+        value: 0,
+        writable: true,
+        configurable: true,
+      });
+      scroller.scrollBy = ((options: ScrollToOptions) => {
+        scroller.scrollLeft = Math.max(
+          -maxScroll,
+          Math.min(0, scroller.scrollLeft + (options.left ?? 0)),
+        );
+        fireEvent.scroll(scroller);
+      }) as HTMLElement['scrollBy'];
+      fireEvent.scroll(scroller);
 
       const next = screen.getByLabelText('Scroll right');
       await user.click(next);
 
-      expect(next).toBeEnabled();
-      expect(document.activeElement).toBe(next);
+      expect(next).toBeDisabled();
+      expect(document.activeElement).toBe(screen.getByLabelText('Scroll left'));
     });
 
     it('hands off when scroll-snap carries the container past what the press asked for', async () => {
@@ -593,15 +635,59 @@ describe('Carousel', () => {
       );
       // 700 gives 500 of travel against a 200 step, so the press alone lands
       // mid-run. Mandatory snapping then carries it to the end, which is the
-      // case a press cannot predict.
+      // landing position no press can predict.
       makeScrollable(getScroller(), 700, (_requested, maxScroll) => maxScroll);
 
       const next = screen.getByLabelText('Scroll right');
       await user.click(next);
 
       expect(next).toBeDisabled();
-      expect(document.activeElement).toBe(getScroller());
+      expect(document.activeElement).toBe(screen.getByLabelText('Scroll left'));
+    });
+
+    it('falls back to the scroll container when the carousel stops overflowing', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      // The content shrinks to fit during the press, so BOTH buttons disable
+      // and there is no opposite control left to receive focus.
+      makeScrollable(scroller, 400, () => {
+        Object.defineProperty(scroller, 'scrollWidth', {
+          value: 200,
+          configurable: true,
+        });
+        return 0;
+      });
+
+      await user.click(screen.getByLabelText('Scroll right'));
+
+      expect(screen.getByLabelText('Scroll right')).toBeDisabled();
+      expect(screen.getByLabelText('Scroll left')).toBeDisabled();
+      expect(document.activeElement).toBe(scroller);
       expect(document.activeElement).not.toBe(document.body);
+    });
+
+    it('does not move focus on a press that leaves the direction available', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      makeScrollable(getScroller(), 600);
+
+      const next = screen.getByLabelText('Scroll right');
+      await user.click(next);
+
+      expect(next).toBeEnabled();
+      expect(document.activeElement).toBe(next);
     });
 
     it('does not move focus when hasLoop keeps both buttons enabled', async () => {
@@ -617,12 +703,11 @@ describe('Carousel', () => {
       const next = screen.getByLabelText('Scroll right');
       await user.click(next);
 
-      // Looping never disables a button, so there is nothing to rescue from.
       expect(next).toBeEnabled();
       expect(document.activeElement).toBe(next);
     });
 
-    it('takes focus without scrolling the container into view', async () => {
+    it('takes focus without scrolling the receiver into view', async () => {
       const user = userEvent.setup();
       render(
         <Carousel aria-label="Gallery">
@@ -630,14 +715,14 @@ describe('Carousel', () => {
           <div>Item 2</div>
         </Carousel>,
       );
-      const scroller = getScroller();
-      makeScrollable(scroller, 400);
-      const focus = vi.spyOn(scroller, 'focus');
+      makeScrollable(getScroller(), 400);
+      const previous = screen.getByLabelText('Scroll left');
+      const focus = vi.spyOn(previous, 'focus');
 
       await user.click(screen.getByLabelText('Scroll right'));
 
-      // A plain focus() scrolls the element into view, which cancels the smooth
-      // scroll the same press just started.
+      // A plain focus() scrolls its element into view, which on the scroll
+      // container cancels the scroll the same press started.
       expect(focus).toHaveBeenCalledWith({preventScroll: true});
     });
 
@@ -655,6 +740,37 @@ describe('Carousel', () => {
       outside.focus();
 
       handle.current?.scrollNext();
+
+      expect(document.activeElement).toBe(outside);
+      outside.remove();
+    });
+
+    it('does not move focus a second time for one transition', async () => {
+      const user = userEvent.setup();
+      const {rerender} = render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      makeScrollable(getScroller(), 400);
+      await user.click(screen.getByLabelText('Scroll right'));
+
+      const previous = screen.getByLabelText('Scroll left');
+      expect(document.activeElement).toBe(previous);
+      // Park focus outside and re-render: the transition is spent, so nothing
+      // may pull focus back in.
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+      outside.focus();
+      rerender(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
 
       expect(document.activeElement).toBe(outside);
       outside.remove();

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -571,6 +571,43 @@ describe('Carousel', () => {
       expect(document.activeElement).toBe(next);
     });
 
+    it('does not move focus when hasLoop keeps both buttons enabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel hasLoop aria-label="Looping">
+          <div>Item 1</div>
+          <div>Item 2</div>
+        </Carousel>,
+      );
+      makeScrollable(getScroller(), 400);
+
+      const next = screen.getByLabelText('Scroll right');
+      await user.click(next);
+
+      // Looping never disables a button, so there is nothing to rescue from.
+      expect(next).toBeEnabled();
+      expect(document.activeElement).toBe(next);
+    });
+
+    it('takes focus without scrolling the container into view', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+        </Carousel>,
+      );
+      const scroller = getScroller();
+      makeScrollable(scroller, 400);
+      const focus = vi.spyOn(scroller, 'focus');
+
+      await user.click(screen.getByLabelText('Scroll right'));
+
+      // A plain focus() scrolls the element into view, which cancels the smooth
+      // scroll the same press just started.
+      expect(focus).toHaveBeenCalledWith({preventScroll: true});
+    });
+
     it('leaves focus alone when the imperative handle drives the scroll', () => {
       const handle = createRef<CarouselHandle>();
       render(

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -501,8 +501,18 @@ describe('Carousel', () => {
     // jsdom doesn't lay out elements, so fake an overflowing scroll container
     // whose scrollLeft actually moves when scrollBy is called. The component
     // predicts the edge from these numbers, which is what the hand-off uses.
-    function makeScrollable(el: HTMLElement, scrollWidth: number) {
+    // jsdom has no layout and no scrollend, so fake an overflowing container
+    // whose scrollBy moves scrollLeft and then settles, the way a browser does.
+    // `land` decides where the container comes to rest: the default clamps to
+    // the requested delta, and the snap arm overrides it to model mandatory
+    // scroll-snap carrying the container past what the press asked for.
+    function makeScrollable(
+      el: HTMLElement,
+      scrollWidth: number,
+      land?: (requested: number, maxScroll: number) => number,
+    ) {
       const clientWidth = 200;
+      const maxScroll = scrollWidth - clientWidth;
       Object.defineProperty(el, 'scrollWidth', {
         value: scrollWidth,
         configurable: true,
@@ -517,14 +527,13 @@ describe('Carousel', () => {
         configurable: true,
       });
       el.scrollBy = ((options: ScrollToOptions) => {
-        el.scrollLeft = Math.max(
+        const requested = Math.max(
           0,
-          Math.min(
-            scrollWidth - clientWidth,
-            el.scrollLeft + (options.left ?? 0),
-          ),
+          Math.min(maxScroll, el.scrollLeft + (options.left ?? 0)),
         );
+        el.scrollLeft = land ? land(requested, maxScroll) : requested;
         fireEvent.scroll(el);
+        el.dispatchEvent(new Event('scrollend'));
       }) as HTMLElement['scrollBy'];
       fireEvent.scroll(el);
     }
@@ -571,6 +580,28 @@ describe('Carousel', () => {
 
       expect(next).toBeEnabled();
       expect(document.activeElement).toBe(next);
+    });
+
+    it('hands off when scroll-snap carries the container past what the press asked for', async () => {
+      const user = userEvent.setup();
+      render(
+        <Carousel hasSnap aria-label="Gallery">
+          <div>Item 1</div>
+          <div>Item 2</div>
+          <div>Item 3</div>
+        </Carousel>,
+      );
+      // 700 gives 500 of travel against a 200 step, so the press alone lands
+      // mid-run. Mandatory snapping then carries it to the end, which is the
+      // case a press cannot predict.
+      makeScrollable(getScroller(), 700, (_requested, maxScroll) => maxScroll);
+
+      const next = screen.getByLabelText('Scroll right');
+      await user.click(next);
+
+      expect(next).toBeDisabled();
+      expect(document.activeElement).toBe(getScroller());
+      expect(document.activeElement).not.toBe(document.body);
     });
 
     it('does not move focus when hasLoop keeps both buttons enabled', async () => {

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -561,8 +561,10 @@ describe('Carousel', () => {
           <div>Item 3</div>
         </Carousel>,
       );
-      // Far more content than one step, so the trailing edge stays reachable.
-      makeScrollable(getScroller(), 2000);
+      // 600 gives 400 of travel against a 200 step, so the press lands mid-run
+      // with the trailing edge still two steps away. Tight on purpose: a loose
+      // fixture hides a prediction that counts the step twice.
+      makeScrollable(getScroller(), 600);
 
       const next = screen.getByLabelText('Scroll right');
       await user.click(next);

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -700,7 +700,7 @@ describe('Carousel', () => {
       expect(document.activeElement).toBe(document.body);
     });
 
-    it('still hands off when the disable is what blurred the button', async () => {
+    it('hands off on a press, with the blur handlers in place', async () => {
       const user = userEvent.setup();
       render(
         <Carousel aria-label="Gallery">
@@ -711,8 +711,10 @@ describe('Carousel', () => {
       );
       makeScrollable(getScroller(), 400);
 
-      // The blur the commit causes must not read as the person leaving, or the
-      // hand-off never fires at all.
+      // The Effect clears the tracker itself before focusing, so the commit's
+      // own blur finds nothing left to clear and the guard is not what makes
+      // this pass. It is here so that deleting the blur handlers outright --
+      // rather than loosening the guard -- is caught.
       await user.click(screen.getByLabelText('Scroll right'));
 
       expect(document.activeElement).toBe(screen.getByLabelText('Scroll left'));

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -150,6 +150,12 @@ export interface CarouselProps extends BaseProps<HTMLDivElement> {
 // Styles
 // =============================================================================
 
+// The overflow hook calls a sub-pixel remainder "no more scroll". The focus
+// hand-off in scrollBy has to use the same threshold, or it moves focus a
+// press early or a press late.
+// SYNC: /packages/core/src/hooks/useScrollOverflow.ts
+const SCROLL_EDGE_TOLERANCE = 1;
+
 const styles = stylex.create({
   root: {
     position: 'relative',
@@ -176,12 +182,6 @@ const styles = stylex.create({
     },
     scrollbarWidth: 'none',
     maskImage: 'none',
-    transitionProperty: 'mask-image',
-    transitionDuration: {
-      default: durationVars['--duration-medium'],
-      '@media (prefers-reduced-motion: reduce)': '0ms',
-    },
-    transitionTimingFunction: easeVars['--ease-standard'],
   },
   fadeStart: {
     maskImage: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
@@ -341,6 +341,8 @@ export function Carousel({
   const t = useTranslator();
   const ariaLabel = ariaLabelFromProps ?? t('@astryx.carousel.label');
   const scrollElRef = useRef<HTMLElement | null>(null);
+  const startButtonRef = useRef<HTMLButtonElement>(null);
+  const endButtonRef = useRef<HTMLButtonElement>(null);
   const {scrollRef, overflowStart, overflowEnd, hasOverflow} =
     useScrollOverflow();
 
@@ -396,10 +398,10 @@ export function Carousel({
   }, []);
 
   const scrollBy = useCallback(
-    (direction: -1 | 1) => {
+    (direction: -1 | 1): boolean => {
       const el = scrollElRef.current;
       if (!el) {
-        return;
+        return false;
       }
       // Respect the user's reduced-motion preference — mirrors the CSS
       // scroll-behavior override so button-driven scrolling doesn't animate
@@ -423,21 +425,60 @@ export function Carousel({
         const atStart = direction === -1 && !overflowStart;
         if (atEnd || atStart) {
           el.scrollBy({left: rtlSign * -direction * el.scrollWidth, behavior});
-          return;
+          return false;
         }
       }
 
       const firstChild = el.firstElementChild as HTMLElement | null;
       const itemWidth = firstChild ? firstChild.offsetWidth : 0;
       const amount = el.clientWidth - itemWidth * 0.5;
+      const distance = Math.max(amount, itemWidth);
       el.scrollBy({
         // `direction` is the logical intent (-1 = toward content start, +1 =
         // toward content end).
-        left: rtlSign * direction * Math.max(amount, itemWidth),
+        left: rtlSign * direction * distance,
         behavior,
       });
+
+      // Report whether this press uses up the direction it went in. The button
+      // that drove it disables on that transition, and the browser drops focus
+      // off a control it disables, so the caller hands focus to the opposite
+      // button first. Predicted here rather than watched from an effect,
+      // because the scroll is smooth and the overflow state lands frames later.
+      // scrollLeft is negative under RTL, so compare logical distance travelled.
+      const maxScroll = el.scrollWidth - el.clientWidth;
+      const next = Math.abs(el.scrollLeft) + direction * distance;
+      return direction === 1
+        ? next >= maxScroll - SCROLL_EDGE_TOLERANCE
+        : next <= SCROLL_EDGE_TOLERANCE;
     },
     [hasLoop, hasOverflow, overflowStart, overflowEnd],
+  );
+
+  // Keep the keyboard user where they are. Without this, pressing the trailing
+  // button on the last slide disables it under them and focus falls to <body>,
+  // so the next Tab restarts from the top of the document. Focus goes to the
+  // scroll container rather than the opposite button: at the moment of the
+  // press that button is still disabled (its enabling state lands with the
+  // next render), and focus() on a disabled control is a no-op. The container
+  // is a permanent tab stop inside the labelled region and pans with the
+  // arrow keys, so the user keeps both their place and a way to scroll.
+  const scrollFromButton = useCallback(
+    (direction: -1 | 1) => {
+      const pressed =
+        direction === 1 ? endButtonRef.current : startButtonRef.current;
+      const exhausted = scrollBy(direction);
+      if (!exhausted || !pressed) {
+        return;
+      }
+      // Only rescue focus the press itself is about to lose. A programmatic
+      // click from elsewhere must not pull focus into the carousel.
+      if (pressed.ownerDocument.activeElement !== pressed) {
+        return;
+      }
+      scrollElRef.current?.focus();
+    },
+    [scrollBy],
   );
 
   const scrollToIndex = useCallback((index: number) => {
@@ -523,12 +564,20 @@ export function Carousel({
         ref={composedRef}
         tabIndex={0}
         onWheel={handleWheel}
-        {...stylex.props(
-          styles.scroller,
-          gapStyles[gap],
-          padding != null && paddingStyles[padding],
-          hasSnap && styles.snap,
-          fadeStyle,
+        {...mergeProps(
+          themeProps('carousel-scroller', {
+            gap,
+            padding,
+            snap: hasSnap ? 'snap' : null,
+            edgeFade: hasEdgeFade ? 'edge-fade' : null,
+          }),
+          stylex.props(
+            styles.scroller,
+            gapStyles[gap],
+            padding != null && paddingStyles[padding],
+            hasSnap && styles.snap,
+            fadeStyle,
+          ),
         )}>
         {slides.map((child, index) => (
           // APG carousel pattern: each slide container is a group with
@@ -560,6 +609,7 @@ export function Carousel({
                 !canScrollStart && styles.buttonHidden,
               )}>
               <Button
+                ref={startButtonRef}
                 icon={
                   <Icon
                     icon="chevronLeft"
@@ -572,11 +622,13 @@ export function Carousel({
                 size="sm"
                 isIconOnly
                 // Disabled when there's nothing to scroll toward. Keeps the
-                // button mounted (stable layout/focus) but removes it from the
-                // tab order and a11y tree while it's visually hidden, so
-                // keyboard users don't land on an invisible control.
+                // button mounted (stable layout) but removes it from the tab
+                // order and a11y tree while it's visually hidden, so keyboard
+                // users don't land on an invisible control. scrollFromButton
+                // hands focus to the opposite button when a press is what
+                // disables this one.
                 isDisabled={!canScrollStart}
-                onClick={() => scrollBy(-1)}
+                onClick={() => scrollFromButton(-1)}
                 xstyle={styles.buttonRadiusOverride}
               />
             </div>
@@ -587,6 +639,7 @@ export function Carousel({
                 !canScrollEnd && styles.buttonHidden,
               )}>
               <Button
+                ref={endButtonRef}
                 icon={
                   <Icon
                     icon="chevronRight"
@@ -601,7 +654,7 @@ export function Carousel({
                 // See "Scroll left" — disabled while visually hidden so the
                 // button stays mounted but out of the tab order / a11y tree.
                 isDisabled={!canScrollEnd}
-                onClick={() => scrollBy(1)}
+                onClick={() => scrollFromButton(1)}
                 xstyle={styles.buttonRadiusOverride}
               />
             </div>

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -425,8 +425,18 @@ export function Carousel({
         const atStart = direction === -1 && !overflowStart;
         if (atEnd || atStart) {
           el.scrollBy({left: rtlSign * -direction * el.scrollWidth, behavior});
-          return false;
+        } else {
+          const firstChild = el.firstElementChild as HTMLElement | null;
+          const itemWidth = firstChild ? firstChild.offsetWidth : 0;
+          const amount = el.clientWidth - itemWidth * 0.5;
+          el.scrollBy({
+            left: rtlSign * direction * Math.max(amount, itemWidth),
+            behavior,
+          });
         }
+        // Looping keeps both buttons enabled at both edges, so no press can
+        // disable the control the user is on and there is nothing to rescue.
+        return false;
       }
 
       const firstChild = el.firstElementChild as HTMLElement | null;
@@ -476,7 +486,10 @@ export function Carousel({
       if (pressed.ownerDocument.activeElement !== pressed) {
         return;
       }
-      scrollElRef.current?.focus();
+      // preventScroll matters: focus() otherwise scrolls the container into
+      // view, which cancels the smooth scroll this very press just started and
+      // leaves the carousel where it was.
+      scrollElRef.current?.focus({preventScroll: true});
     },
     [scrollBy],
   );

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -151,10 +151,16 @@ export interface CarouselProps extends BaseProps<HTMLDivElement> {
 // =============================================================================
 
 // The overflow hook calls a sub-pixel remainder "no more scroll". The focus
-// hand-off in scrollBy has to use the same threshold, or it moves focus a
-// press early or a press late.
+// hand-off reads the settled position against the same threshold, or it
+// disagrees with the state that actually disables the button.
 // SYNC: /packages/core/src/hooks/useScrollOverflow.ts
 const SCROLL_EDGE_TOLERANCE = 1;
+
+// How long to wait for a scroll to settle when `scrollend` never arrives:
+// either the browser does not support it, or the press moved nothing so no
+// scroll events were emitted at all. Matches Outline's navigation settle.
+// SYNC: /packages/core/src/Outline/useScrollSpy.ts
+const SCROLL_SETTLE_TIMEOUT_MS = 1200;
 
 const styles = stylex.create({
   root: {
@@ -343,6 +349,9 @@ export function Carousel({
   const scrollElRef = useRef<HTMLElement | null>(null);
   const startButtonRef = useRef<HTMLButtonElement>(null);
   const endButtonRef = useRef<HTMLButtonElement>(null);
+  // Cancels a pending focus hand-off: the settle listener and its fallback
+  // timer, which outlive the press that armed them.
+  const teardownRef = useRef<(() => void) | null>(null);
   const {scrollRef, overflowStart, overflowEnd, hasOverflow} =
     useScrollOverflow();
 
@@ -363,6 +372,8 @@ export function Carousel({
       layer.hide();
     }
   }, [hasButtons, layer]);
+
+  useEffect(() => () => teardownRef.current?.(), []);
 
   const composedRef = useCallback(
     (el: HTMLDivElement | null) => {
@@ -398,10 +409,10 @@ export function Carousel({
   }, []);
 
   const scrollBy = useCallback(
-    (direction: -1 | 1): boolean => {
+    (direction: -1 | 1) => {
       const el = scrollElRef.current;
       if (!el) {
-        return false;
+        return;
       }
       // Respect the user's reduced-motion preference — mirrors the CSS
       // scroll-behavior override so button-driven scrolling doesn't animate
@@ -425,77 +436,91 @@ export function Carousel({
         const atStart = direction === -1 && !overflowStart;
         if (atEnd || atStart) {
           el.scrollBy({left: rtlSign * -direction * el.scrollWidth, behavior});
-        } else {
-          const firstChild = el.firstElementChild as HTMLElement | null;
-          const itemWidth = firstChild ? firstChild.offsetWidth : 0;
-          const amount = el.clientWidth - itemWidth * 0.5;
-          el.scrollBy({
-            left: rtlSign * direction * Math.max(amount, itemWidth),
-            behavior,
-          });
+          return;
         }
-        // Looping keeps both buttons enabled at both edges, so no press can
-        // disable the control the user is on and there is nothing to rescue.
-        return false;
       }
 
       const firstChild = el.firstElementChild as HTMLElement | null;
       const itemWidth = firstChild ? firstChild.offsetWidth : 0;
       const amount = el.clientWidth - itemWidth * 0.5;
-      const distance = Math.max(amount, itemWidth);
-      // Read the position BEFORE scrolling. Under reduced motion the scroll is
-      // instant, so reading it afterwards counts this step twice and the edge
-      // looks one press nearer than it is. scrollLeft is negative under RTL, so
-      // this is the logical distance travelled from the start.
-      const from = Math.abs(el.scrollLeft);
       el.scrollBy({
         // `direction` is the logical intent (-1 = toward content start, +1 =
         // toward content end).
-        left: rtlSign * direction * distance,
+        left: rtlSign * direction * Math.max(amount, itemWidth),
         behavior,
       });
-
-      // Report whether this press uses up the direction it went in. The button
-      // that drove it disables on that transition, and the browser drops focus
-      // off a control it disables, so the caller rescues focus first. Predicted
-      // here rather than watched from an effect, because the overflow state
-      // lands frames after a smooth scroll.
-      const maxScroll = el.scrollWidth - el.clientWidth;
-      const next = from + direction * distance;
-      return direction === 1
-        ? next >= maxScroll - SCROLL_EDGE_TOLERANCE
-        : next <= SCROLL_EDGE_TOLERANCE;
     },
     [hasLoop, hasOverflow, overflowStart, overflowEnd],
   );
+
+  // Is the container resting against the edge it was pushed toward? Read from
+  // the element rather than predicted from the press: reduced motion lands the
+  // scroll instantly and mandatory scroll-snap lands it somewhere the press did
+  // not ask for, and a prediction was wrong about each in turn. scrollLeft is
+  // negative under RTL, so this is the logical distance from the start.
+  const isRestingAtEdge = useCallback((el: HTMLElement, direction: -1 | 1) => {
+    const position = Math.abs(el.scrollLeft);
+    return direction === 1
+      ? position >= el.scrollWidth - el.clientWidth - SCROLL_EDGE_TOLERANCE
+      : position <= SCROLL_EDGE_TOLERANCE;
+  }, []);
 
   // Keep the keyboard user where they are. Without this, pressing the trailing
   // button on the last slide disables it under them and focus falls to <body>,
   // so the next Tab restarts from the top of the document. Focus goes to the
   // scroll container rather than the opposite button: at the moment of the
-  // press that button is still disabled (its enabling state lands with the
-  // next render), and focus() on a disabled control is a no-op. The container
-  // is a permanent tab stop inside the labelled region and pans with the
-  // arrow keys, so the user keeps both their place and a way to scroll.
+  // press that button is still disabled (its enabling state lands with the next
+  // render), and focus() on a disabled control is a no-op. The container is a
+  // permanent tab stop inside the labelled region and pans with the arrow keys,
+  // so the user keeps both their place and a way to scroll.
   const scrollFromButton = useCallback(
     (direction: -1 | 1) => {
+      const el = scrollElRef.current;
       const pressed =
         direction === 1 ? endButtonRef.current : startButtonRef.current;
-      const exhausted = scrollBy(direction);
-      if (!exhausted || !pressed) {
+      // Only rescue focus this press is about to lose. A programmatic click
+      // from elsewhere must not pull focus into the carousel, and looping keeps
+      // both buttons enabled at both edges so no press can disable one.
+      const shouldRescue =
+        el != null &&
+        pressed != null &&
+        pressed.ownerDocument.activeElement === pressed &&
+        !(hasLoop && hasOverflow);
+      if (!shouldRescue) {
+        scrollBy(direction);
         return;
       }
-      // Only rescue focus the press itself is about to lose. A programmatic
-      // click from elsewhere must not pull focus into the carousel.
-      if (pressed.ownerDocument.activeElement !== pressed) {
-        return;
-      }
-      // preventScroll matters: focus() otherwise scrolls the container into
-      // view, which cancels the smooth scroll this very press just started and
-      // leaves the carousel where it was.
-      scrollElRef.current?.focus({preventScroll: true});
+
+      // Arm settle detection BEFORE scrolling: under reduced motion the scroll
+      // lands instantly, so a listener attached afterwards never hears it.
+      const settle = () => {
+        teardownRef.current?.();
+        if (!isRestingAtEdge(el, direction)) {
+          return;
+        }
+        // React disables the button from the same measurement, which may
+        // already have dropped focus to the body. Rescue either state and leave
+        // anywhere else alone: the user has moved on.
+        const active = pressed.ownerDocument.activeElement;
+        if (active !== pressed && active !== pressed.ownerDocument.body) {
+          return;
+        }
+        // preventScroll matters: a plain focus() scrolls the container into
+        // view, which cancels the smooth scroll this press just started.
+        el.focus({preventScroll: true});
+      };
+      const timer = window.setTimeout(settle, SCROLL_SETTLE_TIMEOUT_MS);
+      el.addEventListener('scrollend', settle, {once: true});
+      teardownRef.current?.();
+      teardownRef.current = () => {
+        window.clearTimeout(timer);
+        el.removeEventListener('scrollend', settle);
+        teardownRef.current = null;
+      };
+
+      scrollBy(direction);
     },
-    [scrollBy],
+    [scrollBy, isRestingAtEdge, hasLoop, hasOverflow],
   );
 
   const scrollToIndex = useCallback((index: number) => {

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -443,6 +443,11 @@ export function Carousel({
       const itemWidth = firstChild ? firstChild.offsetWidth : 0;
       const amount = el.clientWidth - itemWidth * 0.5;
       const distance = Math.max(amount, itemWidth);
+      // Read the position BEFORE scrolling. Under reduced motion the scroll is
+      // instant, so reading it afterwards counts this step twice and the edge
+      // looks one press nearer than it is. scrollLeft is negative under RTL, so
+      // this is the logical distance travelled from the start.
+      const from = Math.abs(el.scrollLeft);
       el.scrollBy({
         // `direction` is the logical intent (-1 = toward content start, +1 =
         // toward content end).
@@ -452,12 +457,11 @@ export function Carousel({
 
       // Report whether this press uses up the direction it went in. The button
       // that drove it disables on that transition, and the browser drops focus
-      // off a control it disables, so the caller hands focus to the opposite
-      // button first. Predicted here rather than watched from an effect,
-      // because the scroll is smooth and the overflow state lands frames later.
-      // scrollLeft is negative under RTL, so compare logical distance travelled.
+      // off a control it disables, so the caller rescues focus first. Predicted
+      // here rather than watched from an effect, because the overflow state
+      // lands frames after a smooth scroll.
       const maxScroll = el.scrollWidth - el.clientWidth;
-      const next = Math.abs(el.scrollLeft) + direction * distance;
+      const next = from + direction * distance;
       return direction === 1
         ? next >= maxScroll - SCROLL_EDGE_TOLERANCE
         : next <= SCROLL_EDGE_TOLERANCE;
@@ -638,7 +642,7 @@ export function Carousel({
                 // button mounted (stable layout) but removes it from the tab
                 // order and a11y tree while it's visually hidden, so keyboard
                 // users don't land on an invisible control. scrollFromButton
-                // hands focus to the opposite button when a press is what
+                // moves focus to the scroll container when a press is what
                 // disables this one.
                 isDisabled={!canScrollStart}
                 onClick={() => scrollFromButton(-1)}

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -504,6 +504,11 @@ export function Carousel({
   // maintainer, 2026-08-27, on the conditions encoded below: it acts only on
   // the transition that newly disables the focused button, it moves focus and
   // nothing else, and it cannot fire twice for one transition.
+  //
+  // Which button the person is on is tracked by the buttons' own focus and blur
+  // handlers, and the blur has to ignore the one the commit itself causes: a
+  // tracker that outlived the person let a later edge -- a swipe, a resize, no
+  // press at all -- pull their focus back onto a control they never chose.
   useEffect(() => {
     const previous = prevCanScrollRef.current;
     prevCanScrollRef.current = {start: canScrollStart, end: canScrollEnd};
@@ -657,13 +662,7 @@ export function Carousel({
                   focusedNavRef.current = 'start';
                 }}
                 onBlur={event => {
-                  // Forget the person once they leave. React sets `disabled`
-                  // before the browser blurs the button, so the blur the commit
-                  // caused is distinguishable from the one they caused, and
-                  // only theirs clears the tracker. Without this the tracker
-                  // outlives them and a later edge -- reached by a swipe, a
-                  // resize, anything -- pulls focus back onto a control they
-                  // did not choose.
+                  // A disabled button was blurred by the commit, not the person.
                   if (!event.currentTarget.disabled) {
                     focusedNavRef.current = null;
                   }
@@ -698,13 +697,7 @@ export function Carousel({
                   focusedNavRef.current = 'end';
                 }}
                 onBlur={event => {
-                  // Forget the person once they leave. React sets `disabled`
-                  // before the browser blurs the button, so the blur the commit
-                  // caused is distinguishable from the one they caused, and
-                  // only theirs clears the tracker. Without this the tracker
-                  // outlives them and a later edge -- reached by a swipe, a
-                  // resize, anything -- pulls focus back onto a control they
-                  // did not choose.
+                  // A disabled button was blurred by the commit, not the person.
                   if (!event.currentTarget.disabled) {
                     focusedNavRef.current = null;
                   }

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -150,18 +150,6 @@ export interface CarouselProps extends BaseProps<HTMLDivElement> {
 // Styles
 // =============================================================================
 
-// The overflow hook calls a sub-pixel remainder "no more scroll". The focus
-// hand-off reads the settled position against the same threshold, or it
-// disagrees with the state that actually disables the button.
-// SYNC: /packages/core/src/hooks/useScrollOverflow.ts
-const SCROLL_EDGE_TOLERANCE = 1;
-
-// How long to wait for a scroll to settle when `scrollend` never arrives:
-// either the browser does not support it, or the press moved nothing so no
-// scroll events were emitted at all. Matches Outline's navigation settle.
-// SYNC: /packages/core/src/Outline/useScrollSpy.ts
-const SCROLL_SETTLE_TIMEOUT_MS = 1200;
-
 const styles = stylex.create({
   root: {
     position: 'relative',
@@ -349,9 +337,11 @@ export function Carousel({
   const scrollElRef = useRef<HTMLElement | null>(null);
   const startButtonRef = useRef<HTMLButtonElement>(null);
   const endButtonRef = useRef<HTMLButtonElement>(null);
-  // Cancels a pending focus hand-off: the settle listener and its fallback
-  // timer, which outlive the press that armed them.
-  const teardownRef = useRef<(() => void) | null>(null);
+  // Which nav button last held focus, and what the overflow state was on the
+  // previous render. Together they are how the Effect below recognises the one
+  // transition it is allowed to act on.
+  const focusedNavRef = useRef<'start' | 'end' | null>(null);
+  const prevCanScrollRef = useRef<{start: boolean; end: boolean} | null>(null);
   const {scrollRef, overflowStart, overflowEnd, hasOverflow} =
     useScrollOverflow();
 
@@ -372,8 +362,6 @@ export function Carousel({
       layer.hide();
     }
   }, [hasButtons, layer]);
-
-  useEffect(() => () => teardownRef.current?.(), []);
 
   const composedRef = useCallback(
     (el: HTMLDivElement | null) => {
@@ -453,76 +441,6 @@ export function Carousel({
     [hasLoop, hasOverflow, overflowStart, overflowEnd],
   );
 
-  // Is the container resting against the edge it was pushed toward? Read from
-  // the element rather than predicted from the press: reduced motion lands the
-  // scroll instantly and mandatory scroll-snap lands it somewhere the press did
-  // not ask for, and a prediction was wrong about each in turn. scrollLeft is
-  // negative under RTL, so this is the logical distance from the start.
-  const isRestingAtEdge = useCallback((el: HTMLElement, direction: -1 | 1) => {
-    const position = Math.abs(el.scrollLeft);
-    return direction === 1
-      ? position >= el.scrollWidth - el.clientWidth - SCROLL_EDGE_TOLERANCE
-      : position <= SCROLL_EDGE_TOLERANCE;
-  }, []);
-
-  // Keep the keyboard user where they are. Without this, pressing the trailing
-  // button on the last slide disables it under them and focus falls to <body>,
-  // so the next Tab restarts from the top of the document. Focus goes to the
-  // scroll container rather than the opposite button: at the moment of the
-  // press that button is still disabled (its enabling state lands with the next
-  // render), and focus() on a disabled control is a no-op. The container is a
-  // permanent tab stop inside the labelled region and pans with the arrow keys,
-  // so the user keeps both their place and a way to scroll.
-  const scrollFromButton = useCallback(
-    (direction: -1 | 1) => {
-      const el = scrollElRef.current;
-      const pressed =
-        direction === 1 ? endButtonRef.current : startButtonRef.current;
-      // Only rescue focus this press is about to lose. A programmatic click
-      // from elsewhere must not pull focus into the carousel, and looping keeps
-      // both buttons enabled at both edges so no press can disable one.
-      const shouldRescue =
-        el != null &&
-        pressed != null &&
-        pressed.ownerDocument.activeElement === pressed &&
-        !(hasLoop && hasOverflow);
-      if (!shouldRescue) {
-        scrollBy(direction);
-        return;
-      }
-
-      // Arm settle detection BEFORE scrolling: under reduced motion the scroll
-      // lands instantly, so a listener attached afterwards never hears it.
-      const settle = () => {
-        teardownRef.current?.();
-        if (!isRestingAtEdge(el, direction)) {
-          return;
-        }
-        // React disables the button from the same measurement, which may
-        // already have dropped focus to the body. Rescue either state and leave
-        // anywhere else alone: the user has moved on.
-        const active = pressed.ownerDocument.activeElement;
-        if (active !== pressed && active !== pressed.ownerDocument.body) {
-          return;
-        }
-        // preventScroll matters: a plain focus() scrolls the container into
-        // view, which cancels the smooth scroll this press just started.
-        el.focus({preventScroll: true});
-      };
-      const timer = window.setTimeout(settle, SCROLL_SETTLE_TIMEOUT_MS);
-      el.addEventListener('scrollend', settle, {once: true});
-      teardownRef.current?.();
-      teardownRef.current = () => {
-        window.clearTimeout(timer);
-        el.removeEventListener('scrollend', settle);
-        teardownRef.current = null;
-      };
-
-      scrollBy(direction);
-    },
-    [scrollBy, isRestingAtEdge, hasLoop, hasOverflow],
-  );
-
   const scrollToIndex = useCallback((index: number) => {
     const el = scrollElRef.current;
     const items = el?.children;
@@ -569,6 +487,71 @@ export function Carousel({
   // something to scroll; without loop they follow the per-edge overflow state.
   const canScrollStart = hasLoop && hasOverflow ? true : overflowStart;
   const canScrollEnd = hasLoop && hasOverflow ? true : overflowEnd;
+
+  // Keep the keyboard user where they are when a nav button disables under
+  // them. The browser drops focus off a control it disables, so reaching an
+  // edge used to land the user on <body> and cost them their place in the page.
+  //
+  // This is an Effect on purpose, and the exception is narrow. The thing that
+  // disables the button IS this state transition, so it is the only correct
+  // trigger: three attempts to predict it from the press -- the position after
+  // the scroll, the position before it plus the step, and the settled position
+  // reported by `scrollend` -- were each wrong somewhere, under reduced motion,
+  // under mandatory scroll-snap, and on a browser that never fires the event.
+  // Running after the commit also makes the opposite button a valid receiver,
+  // which it is not during the press: at that moment it is still disabled and
+  // focus() on a disabled control does nothing. Ruled acceptable by the
+  // maintainer, 2026-08-27, on the conditions encoded below: it acts only on
+  // the transition that newly disables the focused button, it moves focus and
+  // nothing else, and it cannot fire twice for one transition.
+  useEffect(() => {
+    const previous = prevCanScrollRef.current;
+    prevCanScrollRef.current = {start: canScrollStart, end: canScrollEnd};
+    const side = focusedNavRef.current;
+    if (previous == null || side == null) {
+      return;
+    }
+
+    // Only the edge that just ran out, and only while it held focus. An edge
+    // that was already disabled, or one the user was not on, is not ours.
+    const wasEnabled = side === 'start' ? previous.start : previous.end;
+    const isEnabled = side === 'start' ? canScrollStart : canScrollEnd;
+    if (!wasEnabled || isEnabled) {
+      return;
+    }
+
+    const pressed =
+      side === 'start' ? startButtonRef.current : endButtonRef.current;
+    if (pressed == null) {
+      return;
+    }
+    // The browser has already blurred it, so focus reads as the body. Anything
+    // else means the user moved on themselves and this is not ours to redirect.
+    const active = pressed.ownerDocument.activeElement;
+    if (active !== pressed && active !== pressed.ownerDocument.body) {
+      return;
+    }
+
+    const opposite =
+      side === 'start' ? endButtonRef.current : startButtonRef.current;
+    // The opposite button is the receiver. It is disabled only when the
+    // carousel stopped overflowing entirely, which happens when its content
+    // shrinks; the scroll container is then the nearest tab stop still inside
+    // the labelled region.
+    const receiver =
+      opposite != null && !opposite.disabled ? opposite : scrollElRef.current;
+    if (receiver == null) {
+      return;
+    }
+
+    // One move per transition: clearing the tracker first means a re-render or
+    // a StrictMode double-invoke re-runs this and returns at the `side == null`
+    // guard above. Focusing the receiver sets it again, to the other side.
+    focusedNavRef.current = null;
+    // preventScroll: a plain focus() scrolls its element into view, which on
+    // the scroll container cancels the scroll the press just started.
+    receiver.focus({preventScroll: true});
+  }, [canScrollStart, canScrollEnd]);
 
   const fadeStyle = hasEdgeFade
     ? (hasLoop && hasOverflow) || (overflowStart && overflowEnd)
@@ -666,11 +649,14 @@ export function Carousel({
                 // Disabled when there's nothing to scroll toward. Keeps the
                 // button mounted (stable layout) but removes it from the tab
                 // order and a11y tree while it's visually hidden, so keyboard
-                // users don't land on an invisible control. scrollFromButton
-                // moves focus to the scroll container when a press is what
-                // disables this one.
+                // users don't land on an invisible control. The Effect above
+                // hands focus to the other button when the state behind this
+                // one flips it disabled.
                 isDisabled={!canScrollStart}
-                onClick={() => scrollFromButton(-1)}
+                onFocus={() => {
+                  focusedNavRef.current = 'start';
+                }}
+                onClick={() => scrollBy(-1)}
                 xstyle={styles.buttonRadiusOverride}
               />
             </div>
@@ -696,7 +682,10 @@ export function Carousel({
                 // See "Scroll left" — disabled while visually hidden so the
                 // button stays mounted but out of the tab order / a11y tree.
                 isDisabled={!canScrollEnd}
-                onClick={() => scrollFromButton(1)}
+                onFocus={() => {
+                  focusedNavRef.current = 'end';
+                }}
+                onClick={() => scrollBy(1)}
                 xstyle={styles.buttonRadiusOverride}
               />
             </div>

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -656,6 +656,18 @@ export function Carousel({
                 onFocus={() => {
                   focusedNavRef.current = 'start';
                 }}
+                onBlur={event => {
+                  // Forget the person once they leave. React sets `disabled`
+                  // before the browser blurs the button, so the blur the commit
+                  // caused is distinguishable from the one they caused, and
+                  // only theirs clears the tracker. Without this the tracker
+                  // outlives them and a later edge -- reached by a swipe, a
+                  // resize, anything -- pulls focus back onto a control they
+                  // did not choose.
+                  if (!event.currentTarget.disabled) {
+                    focusedNavRef.current = null;
+                  }
+                }}
                 onClick={() => scrollBy(-1)}
                 xstyle={styles.buttonRadiusOverride}
               />
@@ -684,6 +696,18 @@ export function Carousel({
                 isDisabled={!canScrollEnd}
                 onFocus={() => {
                   focusedNavRef.current = 'end';
+                }}
+                onBlur={event => {
+                  // Forget the person once they leave. React sets `disabled`
+                  // before the browser blurs the button, so the blur the commit
+                  // caused is distinguishable from the one they caused, and
+                  // only theirs clears the tracker. Without this the tracker
+                  // outlives them and a later edge -- reached by a swipe, a
+                  // resize, anything -- pulls focus back onto a control they
+                  // did not choose.
+                  if (!event.currentTarget.disabled) {
+                    focusedNavRef.current = null;
+                  }
                 }}
                 onClick={() => scrollBy(1)}
                 xstyle={styles.buttonRadiusOverride}


### PR DESCRIPTION
> **Ruled and rebuilt.** The review loop blocked three times, each on the same parent: the focus hand-off was driven by something other than the thing that disables the button. Predict the landing (wrong under Reduce Motion), predict it better (wrong under mandatory scroll-snap), wait for `scrollend` (right everywhere it fires, 1.03s late where it does not). The remedy needed a state-transition watcher, which means an Effect, and moving focus from an Effect is a house rule — so it went to Cindy as a ruling rather than a correction.
>
> She ruled the Effect acceptable here, narrowly, on stated conditions. It is implemented at `a64ea2821f7` and reviewed again below.

Night Watch component audit of `core/Carousel`, rubric v1.13. First audit of this component.

**Before: 69.2 / D (3 open BLOCKs) → After: 83.7 / C (1 open BLOCK).** The grade is capped at C by the one BLOCK left open, not by the arithmetic; close it and nothing else and the projection is 85.2 / B.

Ledger row: https://github.com/facebook/astryx/wiki/_compare/36b52ac3f6d4b2792761811e26e23a3ee6d04279

## What this fixes

**A5 — keyboard focus is dropped at a scroll edge.** The trailing nav button is disabled the moment its direction runs out. The browser drops focus off a control it disables, so a keyboard user who pressed Next on the last slide landed on `<body>` and had to Tab from the top of the document. Measured in Chromium: focus "Scroll right" on the Default story, press Enter once, `document.activeElement` is `BODY`. The `hasLoop` story never disables its buttons and never drops focus, which isolates the cause.

The transition that disables the button is the thing to watch, so an Effect watches it. It acts only when overflow newly disables the nav button that held focus, moves focus and nothing else, and cannot fire twice for one transition: it clears its tracker before focusing, so a re-render or a StrictMode double invoke returns at the first guard.

Running after the commit is also what makes the opposite button a valid receiver, which it never was during the press: at that moment it is still disabled, and `focus()` on a disabled control does nothing. So focus lands on a real control carrying the shared 2px accent ring, and never passes through the body at all. The scroll container is the fallback for the one case with no opposite control left, when content shrinks until the carousel stops overflowing.

Three earlier attempts predicted the landing position from the press instead, and the loop proved each wrong in turn: after the scroll (Reduce Motion lands it instantly), before the scroll plus the step (mandatory snap lands it further), and the settled position from `scrollend` (1.03s late on a browser that never fires it). Watching the transition also makes the opposite arrow a valid receiver, which it never is during the press: at that instant it is still disabled, and `focus()` on a disabled control does nothing. The scroll container is the fallback for the one case with no opposite arrow left, when content shrinks until the carousel stops overflowing.

Swept in Chromium: 10 stories x normal, reduced motion and RTL, plus the leading direction seeded to the far edge. Focus lands on the opposite arrow within 2ms of the button disabling, and never passes through the body at all. The buttons' own focus and blur handlers track who is on them, and the blur ignores the one the commit itself causes, so a tracker cannot outlive the person and pull their focus back on a later edge; that case is driven by wheel, by a real touch drag and by a content reflow, in both directions, against a main control. Regression tests included; the jsdom mock takes a landing function, so a snap that overshoots what the press asked for is modelled, and that case fails under either prediction.

**T6/T7 — no style-driving prop reaches a theme target.** `gap`, `padding`, `hasSnap` and `hasEdgeFade` all select StyleX style objects applied to the scroll container, and that element carried no target at all; `themeProps('carousel')` sits on the outer positioning div, which paints nothing, and passed no props. A theme could select `.astryx-carousel` and reach none of the component's spacing, inline padding or edge fade. The scroll container now carries `astryx-carousel-scroller` with those four props, matching what the sibling with the same anatomy, `TabList`, already exposes as `astryx-tab-strip`.

System-level finding filed as one issue rather than four: https://github.com/facebook/astryx/issues/5602 . The same edge-nav shape drops focus in Pagination, Calendar and Lightbox, driven and confirmed in Chromium; no single component's PR closes it.

**A18** — the eight `Carousel::*::color-contrast` baseline entries no longer occur; `a11y:audit` reports them resolved, so they are deleted.

**D12** — the scroll container declared `transition-property: mask-image`. None of the mask values it moves between can interpolate: `none` to a gradient is discrete, and the four gradients differ in direction or stop count. Measured with `getAnimations()` across every transition the component can make, and no animation ever runs. Dead declaration, removed.

**Docs and stories** — `padding` had no story, and there was no narrow-container, long-text or single-item story, so the a11y and RTL sweeps could not see those states. The story file's own `argTypes` said `hasButtons` means "Show navigation buttons on hover", which the component does not do. The implemented APG carousel pattern is now named in the docs rather than only in a source header.


## Visual evidence

`before/` is `origin/main`'s `Carousel.tsx` built in the same worktree with the same pipeline as `after/`, so the pair differs only by this diff. Every frame carries a sensor receipt (build SHA, story id, theme, colour mode, direction, viewport, semantic state, geometry, settled render, zero page errors) as a `.sensors.json` beside it. Light and dark were verified byte-different before use.

**25 of 25 comparable frames are byte-identical.** Nothing here changes a rendered pixel in any state main can also reach.

The one frame with no `before` twin is the fix itself. On main that capture cannot be taken: the sensor reads focus as `BODY`, so the state does not exist.

After pressing Next on the last slide, the carousel has scrolled and focus is on the opposite arrow, carrying the shared accent ring:

![After an edge press](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5601/after/Carousel__default__after-edge-press__light.png)

The scroll container, unchanged in appearance from main:

| Before | After |
|---|---|
| ![Before](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5601/before/Carousel__default__focus-scroller__light.png) | ![After](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5601/after/Carousel__default__focus-scroller__light.png) |

All 26 frames, both sets, with receipts: https://github.com/cixzhang/astryx/tree/assets/pr-5601

## Needs Review

Not fixed here, and each left open in the ledger row.

- **I10 — the nav buttons announce a fixed physical direction.** `@astryx.carousel.scrollLeft` / `.scrollRight` are hard-wired to the two buttons, so their accessible names never follow direction. Under `dir="rtl"` the visible pill sits on the left, its chevron points left and it scrolls left, and it is announced "Scroll right". Both shipped RTL locales carry the physical wording (`ar-SA`, `he-IL`; 2 of 30 locales), and the catalog `description` asks translators to swap them, which neither has. The remedy is direction-neutral keys (previous / next), which retires two shipped catalog keys and changes user-visible text in 30 locales. That is a decision, not a correction.
- **A15 — the scroll container's focus ring is the browser default**, `1px auto` Chromium blue, not `--color-accent`, so no theme can restyle it and it does not follow colour mode. Pre-existing; this PR routes focus there, which makes it easier to hit. A remedy was tried and backed out: the shared ring sits 3px outside its element and the root clips to a 1px bleed, so it has to be inset, and inset it paints under the slides and reads fainter than the browser default it replaced. Left open rather than closed with something worse.
- **The button pill is unthemeable.** Its background, radius and shadow are on a wrapper with no target. `TabList` exposes the equivalent as `astryx-tab-scroll-button`. Adding it is additive theme surface that no blocking finding forces, so it is your call rather than the audit's.
- **The edge fade is `--spacing-1` wide, about 4px**, which is close to invisible at rest and undercuts the affordance the docs describe. Visual taste.
- **`useLayer` has no declarative initial-open option**, so Carousel re-implements one in a mount Effect. Six of the seven sanctioned-exception conditions hold; it fails only "lives in the primitive that owns the system". Same shape as the Tooltip `isDefaultOpen` case the rubric already worked. Routes to `useLayer`.
- **The pressed overlay never paints** while the pointer is also hovering. Library-wide root, already tracked in #5451 / #5516, not scored against Carousel.

## Testing

`pnpm vitest run packages/core/src/Carousel` (37 cases; 9 new or rewritten), `a11y:audit --components Carousel` (0 violations), `rtl:audit --filter Carousel` (measured, 1 auto pass, no N/A rollup), `check:sync`, `check:changesets`, `check:i18n-catalog`, `typecheck:docs`, docsite `generate` + `test`. Frames captured in real Chromium with sensor receipts, light and dark verified byte-different before use.

Night Watch - Component Auditor
