### PR TITLE
fix(ci): defer broad trusted visual acceptance

### DIFF
--- a/.github/scripts/lib/visual-format.test.mjs
+++ b/.github/scripts/lib/visual-format.test.mjs
@@ -61,6 +61,7 @@ describe('buildVisualSection', () => {
     expect(section).toContain('Skipped');
     expect(section).toContain('900 shots exceeds the 240-shot budget');
     expect(section).toContain('View the report');
+    expect(section).not.toContain('/accept-visual');
   });
 
   it('renders verdict strings as one-line literal text', () => {

--- a/.github/scripts/visual-gate/lib/report.mjs
+++ b/.github/scripts/visual-gate/lib/report.mjs
@@ -140,6 +140,22 @@ function targetingSection(targeting) {
  */
 export function renderReport(verdict, options = {}) {
   const {counts, status} = verdict;
+  if (status === 'skipped') {
+    return `<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Visual gate — skipped</title>
+<style>
+  body { font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 24px; max-width: 720px; }
+  .status { color: #0969da; }
+</style>
+<h1>Visual gate <span class="status">skipped</span></h1>
+<p><b>Capture deferred.</b> ${escapeHtml(verdict.reason)}</p>
+<p>${counts.total} trusted baseline shot(s) remain covered by the daily release gate.</p>
+</html>
+`;
+  }
   const acceptHint =
     options.acceptHint ??
     'node .github/scripts/visual-gate/gate.mjs accept --keys <key,key> --reason "<why the after is correct>"';

--- a/.github/scripts/visual-gate/visual-acceptance.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.mjs
@@ -19,6 +19,7 @@ import {
 } from './authorization.mjs';
 import {canonicalizePng} from './lib/canonical-png.mjs';
 import {readStoryIndex, shotKey, storiesInPackages} from './lib/plan.mjs';
+import {renderReport} from './lib/report.mjs';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -28,6 +29,7 @@ const flag = name => {
 };
 const SHA = /^[0-9a-f]{40}$/;
 const KEY = /^[A-Za-z0-9._-]{1,240}$/;
+const NAME = /^[A-Za-z0-9._-]{1,120}$/;
 const REPO = 'facebook/astryx';
 
 function fail(message) {
@@ -92,9 +94,7 @@ function evidenceAt(pages, pr, head, run, attempt) {
   if (!fs.existsSync(dir))
     fail(`no published evidence for run ${run}/${attempt}`);
   const evidence = readJSON(path.join(dir, 'evidence.json'));
-  validateEvidence(evidence, {pr, head, run});
-  if (evidence.run.attempt !== attempt)
-    fail('evidence attempt identity mismatch');
+  validateEvidence(evidence, {pr, head, run, attempt});
   return {dir, evidence};
 }
 
@@ -170,7 +170,9 @@ function validateEvidence(evidence, expected) {
     !SHA.test(evidence.baseSha ?? '') ||
     evidence.run?.id !== expected.run ||
     !Number.isSafeInteger(evidence.run?.attempt) ||
-    evidence.run.attempt <= 0
+    evidence.run.attempt <= 0 ||
+    (expected.attempt !== undefined &&
+      evidence.run.attempt !== expected.attempt)
   ) {
     fail('evidence identity mismatch');
   }
@@ -183,8 +185,31 @@ function validateEvidence(evidence, expected) {
     fail('evidence delta list is invalid');
   }
   if (evidence.verdict.status === 'skipped') {
+    const counts = evidence.verdict.counts;
     if (evidence.capture !== null || evidence.deltas.length !== 0) {
       fail('skipped evidence must not claim a capture or deltas');
+    }
+    if (
+      typeof evidence.verdict.reason !== 'string' ||
+      !evidence.verdict.reason.trim() ||
+      !Number.isSafeInteger(counts?.total) ||
+      counts.total <= 0 ||
+      ['unchanged', 'changed', 'added', 'removed', 'failed'].some(
+        name => counts[name] !== 0,
+      )
+    ) {
+      fail('skipped evidence must carry a trusted reason and count');
+    }
+    if (
+      evidence.verdict.context?.sha !== evidence.testedSha ||
+      evidence.verdict.context?.headSha !== evidence.headSha ||
+      evidence.verdict.context?.baseSha !== evidence.baseSha ||
+      String(evidence.verdict.context?.runId ?? '') !==
+        String(evidence.run.id) ||
+      String(evidence.verdict.context?.runAttempt ?? '') !==
+        String(evidence.run.attempt)
+    ) {
+      fail('skipped evidence run identity mismatch');
     }
   } else {
     validateCapture(evidence.capture);
@@ -548,33 +573,133 @@ function validateAcceptance(value, expected = {}) {
   }
 }
 
-function trustedPlan() {
+function readTrustedScope() {
   const scope = readJSON(path.resolve(flag('scope')));
-  const baseline = readJSON(
-    path.join(path.resolve(flag('baseline')), 'manifest.json'),
-  );
-  const storybookDir = path.resolve(flag('storybook-dir'));
-  const output = path.resolve(flag('output'));
   if (
     scope?.hasStableVisual !== true ||
     typeof scope.broadStableVisual !== 'boolean' ||
     !Array.isArray(scope.stableComponents) ||
-    !Array.isArray(scope.stableThemes)
+    !Array.isArray(scope.stableThemes) ||
+    !scope.stableComponents.every(name => NAME.test(name)) ||
+    !scope.stableThemes.every(name => NAME.test(name))
   ) {
     fail('trusted visual scope is invalid');
   }
+  return scope;
+}
 
-  const baselineEntries = Object.entries(baseline.shots ?? {});
+function readTrustedBaseline() {
+  const baseline = readJSON(
+    path.join(path.resolve(flag('baseline')), 'manifest.json'),
+  );
+  if (
+    !baseline?.shots ||
+    typeof baseline.shots !== 'object' ||
+    Array.isArray(baseline.shots)
+  ) {
+    fail('trusted visual baseline is invalid');
+  }
+  const entries = Object.entries(baseline.shots);
+  if (entries.length === 0 || entries.length > 5000) {
+    fail(`trusted visual baseline has invalid size ${entries.length}`);
+  }
+  return {baseline, entries};
+}
+
+function trustedDefer() {
+  const scope = readTrustedScope();
+  if (!scope.broadStableVisual) fail('trusted visual scope is not broad');
+
+  const {entries} = readTrustedBaseline();
+  const output = path.resolve(flag('output'));
+  const pr = Number(flag('pr'));
+  const head = flag('head') ?? '';
+  const base = flag('base') ?? '';
+  const runId = Number(flag('run-id'));
+  const runAttempt = Number(flag('run-attempt'));
+  validateIdentity(pr, head);
+  if (!SHA.test(base)) fail('invalid base SHA');
+  if (
+    !Number.isSafeInteger(runId) ||
+    runId <= 0 ||
+    !Number.isSafeInteger(runAttempt) ||
+    runAttempt <= 0
+  ) {
+    fail('invalid evidence run/attempt');
+  }
+
+  const total = entries.length;
+  const reason =
+    'Broad stable scope is deferred to the daily release gate. ' +
+    `It covers ${total} trusted baseline shot${total === 1 ? '' : 's'} ` +
+    'instead of recapturing them for this PR.';
+  const verdict = {
+    version: 1,
+    status: 'skipped',
+    generatedAt: new Date().toISOString(),
+    reason,
+    context: {
+      sha: head,
+      headSha: head,
+      baseSha: base,
+      runId: String(runId),
+      runAttempt: String(runAttempt),
+      trustedScope: scope,
+    },
+    counts: {
+      total,
+      unchanged: 0,
+      changed: 0,
+      added: 0,
+      removed: 0,
+      failed: 0,
+    },
+    components: scope.stableComponents,
+    changes: [],
+    added: [],
+    removed: [],
+    failures: [],
+  };
+  const evidence = {
+    version: 1,
+    repo: REPO,
+    pr,
+    headSha: head,
+    testedSha: head,
+    baseSha: base,
+    run: {id: runId, attempt: runAttempt},
+    capture: null,
+    deltas: [],
+    verdict,
+  };
+  validateEvidence(evidence, {
+    pr,
+    head,
+    run: runId,
+    attempt: runAttempt,
+  });
+
+  fs.rmSync(output, {recursive: true, force: true});
+  writeJSON(path.join(output, 'evidence.json'), evidence);
+  writeJSON(path.join(output, 'verdict.json'), verdict);
+  fs.writeFileSync(path.join(output, 'index.html'), renderReport(verdict));
+  process.stdout.write(
+    `Deferred ${total} trusted baseline shot${total === 1 ? '' : 's'} for PR #${pr}, run ${runId}/${runAttempt}.\n`,
+  );
+}
+
+function trustedPlan() {
+  const scope = readTrustedScope();
+  if (scope.broadStableVisual)
+    fail('broad stable scope must be deferred instead of captured');
+  const {entries: baselineEntries} = readTrustedBaseline();
+  const storybookDir = path.resolve(flag('storybook-dir'));
+  const output = path.resolve(flag('output'));
+
   const baselineThemes = [
     ...new Set(baselineEntries.map(([, shot]) => shot.theme)),
   ].filter(Boolean);
-  const shots = scope.broadStableVisual
-    ? baselineEntries.map(([key, shot]) => ({
-        ...shot,
-        key,
-        reasons: ['trusted:broad'],
-      }))
-    : [];
+  const shots = [];
 
   if (scope.stableComponents.length > 0 || scope.stableThemes.length > 0) {
     const indexed = storiesInPackages(readStoryIndex(storybookDir, []), [
@@ -809,6 +934,9 @@ switch (command) {
   case 'state':
     state();
     break;
+  case 'trusted-defer':
+    trustedDefer();
+    break;
   case 'trusted-plan':
     trustedPlan();
     break;
@@ -820,6 +948,6 @@ switch (command) {
     break;
   default:
     fail(
-      'usage: visual-acceptance.mjs <accept|state|trusted-plan|plan|promote>',
+      'usage: visual-acceptance.mjs <accept|state|trusted-defer|trusted-plan|plan|promote>',
     );
 }

--- a/.github/scripts/visual-gate/visual-acceptance.test.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.test.mjs
@@ -189,7 +189,29 @@ function writeEvidence({
             viewport: {width: 1280, height: 900},
           },
     deltas,
-    verdict: {version: 1, status},
+    verdict:
+      status === 'skipped'
+        ? {
+            version: 1,
+            status,
+            reason: 'Broad stable scope is deferred to the daily release gate.',
+            counts: {
+              total: 1,
+              unchanged: 0,
+              changed: 0,
+              added: 0,
+              removed: 0,
+              failed: 0,
+            },
+            context: {
+              sha: TESTED,
+              headSha: HEAD,
+              baseSha: 'd'.repeat(40),
+              runId: String(run),
+              runAttempt: String(attempt),
+            },
+          }
+        : {version: 1, status},
   });
   return dir;
 }
@@ -393,6 +415,69 @@ describe('visual acceptance', () => {
     });
   });
 
+  it('rejects skipped evidence that claims a capture or deltas', () => {
+    const stateFlags = {pages, pr: 42, head: HEAD};
+    const dir = writeEvidence({run: 126, status: 'skipped'});
+    const file = path.join(dir, 'evidence.json');
+    const evidence = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+    evidence.capture = {
+      platform: 'linux-arm64',
+      browser: 'chromium-140.0',
+      viewport: {width: 1280, height: 900},
+    };
+    writeJSON(file, evidence);
+    expect(fail('state', stateFlags)).toMatch(
+      /skipped evidence must not claim a capture or deltas/,
+    );
+
+    evidence.capture = null;
+    evidence.deltas = [
+      {
+        key: KEY,
+        kind: 'changed',
+        beforeSha256: digest(png(255)),
+        shot: SHOT,
+      },
+    ];
+    writeJSON(file, evidence);
+    expect(fail('state', stateFlags)).toMatch(
+      /skipped evidence must not claim a capture or deltas/,
+    );
+  });
+
+  it('requires skipped evidence to carry its trusted reason and shot count', () => {
+    const stateFlags = {pages, pr: 42, head: HEAD};
+    const dir = writeEvidence({run: 126, status: 'skipped'});
+    const file = path.join(dir, 'evidence.json');
+    const evidence = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+    evidence.verdict.reason = '';
+    writeJSON(file, evidence);
+    expect(fail('state', stateFlags)).toMatch(
+      /skipped evidence must carry a trusted reason and count/,
+    );
+
+    evidence.verdict.reason = 'Broad stable scope is deferred.';
+    evidence.verdict.counts.total = 0;
+    writeJSON(file, evidence);
+    expect(fail('state', stateFlags)).toMatch(
+      /skipped evidence must carry a trusted reason and count/,
+    );
+  });
+
+  it('rejects skipped evidence whose verdict names another run attempt', () => {
+    const dir = writeEvidence({run: 126, attempt: 3, status: 'skipped'});
+    const file = path.join(dir, 'evidence.json');
+    const evidence = JSON.parse(fs.readFileSync(file, 'utf8'));
+    evidence.verdict.context.runAttempt = '2';
+    writeJSON(file, evidence);
+
+    expect(fail('state', {pages, pr: 42, head: HEAD})).toMatch(
+      /skipped evidence run identity mismatch/,
+    );
+  });
+
   it('returns success for a clean trusted capture without acceptance', () => {
     writeEvidence({run: 124, status: 'pass'});
     expect(JSON.parse(run('state', {pages, pr: 42, head: HEAD}))).toMatchObject(
@@ -465,7 +550,7 @@ describe('visual acceptance', () => {
     ]);
   });
 
-  it('uses the full baseline plan for broad stable infrastructure', () => {
+  it('refuses a trusted capture plan for broad stable infrastructure', () => {
     const scope = path.join(root, 'scope-broad.json');
     writeJSON(scope, {
       hasStableVisual: true,
@@ -473,19 +558,103 @@ describe('visual acceptance', () => {
       stableComponents: [],
       stableThemes: [],
     });
-    const output = path.join(root, 'trusted-broad-plan.json');
-    run('trusted-plan', {
-      scope,
-      baseline: path.join(pages, 'visual-gate', 'baseline'),
-      'storybook-dir': root,
-      output,
-    });
     expect(
-      JSON.parse(fs.readFileSync(output, 'utf8')).map(shot => shot.key),
-    ).toEqual([KEY]);
+      fail('trusted-plan', {
+        scope,
+        baseline: path.join(pages, 'visual-gate', 'baseline'),
+        'storybook-dir': root,
+        output: path.join(root, 'trusted-broad-plan.json'),
+      }),
+    ).toMatch(/broad stable scope must be deferred/);
   });
 
-  it('allows the trusted 520-shot broad plan through the capture CLI', () => {
+  it('writes trusted skipped evidence for broad stable scope', () => {
+    const scope = path.join(root, 'scope-broad.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: true,
+      stableComponents: ['Button', 'Card'],
+      stableThemes: [],
+    });
+    const output = path.join(pages, 'pr', '42', 'visual', HEAD, '126', '3');
+    expect(
+      run('trusted-defer', {
+        scope,
+        baseline: path.join(pages, 'visual-gate', 'baseline'),
+        output,
+        pr: 42,
+        head: HEAD,
+        base: 'd'.repeat(40),
+        'run-id': 126,
+        'run-attempt': 3,
+      }),
+    ).toContain('Deferred 1 trusted baseline shot');
+
+    const evidence = JSON.parse(
+      fs.readFileSync(path.join(output, 'evidence.json'), 'utf8'),
+    );
+    expect(evidence).toMatchObject({
+      version: 1,
+      repo: 'facebook/astryx',
+      pr: 42,
+      headSha: HEAD,
+      testedSha: HEAD,
+      baseSha: 'd'.repeat(40),
+      run: {id: 126, attempt: 3},
+      capture: null,
+      deltas: [],
+      verdict: {
+        status: 'skipped',
+        counts: {total: 1, changed: 0, added: 0, removed: 0, failed: 0},
+        context: {
+          sha: HEAD,
+          headSha: HEAD,
+          baseSha: 'd'.repeat(40),
+          runId: '126',
+          runAttempt: '3',
+          trustedScope: {broadStableVisual: true},
+        },
+      },
+    });
+    expect(evidence.verdict.reason).toContain(
+      'Broad stable scope is deferred to the daily release gate',
+    );
+    expect(fs.readFileSync(path.join(output, 'index.html'), 'utf8')).toContain(
+      'Capture deferred',
+    );
+    expect(
+      fs.readFileSync(path.join(output, 'index.html'), 'utf8'),
+    ).not.toContain('/accept-visual');
+    expect(JSON.parse(run('state', {pages, pr: 42, head: HEAD}))).toEqual({
+      state: 'success',
+      reason: 'deferred',
+      description: 'Broad stable scope is deferred to the release gate.',
+    });
+  });
+
+  it('refuses trusted deferral for a narrow component scope', () => {
+    const scope = path.join(root, 'scope-narrow.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: ['Button'],
+      stableThemes: [],
+    });
+    expect(
+      fail('trusted-defer', {
+        scope,
+        baseline: path.join(pages, 'visual-gate', 'baseline'),
+        output: path.join(root, 'trusted-narrow-defer'),
+        pr: 42,
+        head: HEAD,
+        base: 'd'.repeat(40),
+        'run-id': 126,
+        'run-attempt': 1,
+      }),
+    ).toMatch(/scope is not broad/);
+  });
+
+  it('allows a trusted 520-shot exact plan through the capture CLI', () => {
     const plan = Array.from({length: 520}, (_, index) => ({
       key: `story-${index}__neutral-light`,
       storyId: `story-${index}`,
@@ -506,43 +675,6 @@ describe('visual acceptance', () => {
       },
     );
     expect(printed).toContain('520 shots');
-  });
-
-  it('keeps new component stories in a mixed broad plan', () => {
-    const storybook = path.join(root, 'storybook-mixed');
-    fs.mkdirSync(storybook);
-    writeJSON(path.join(storybook, 'index.json'), {
-      entries: {
-        newStory: {
-          type: 'story',
-          id: 'core-new--default',
-          title: 'Core/New',
-          name: 'Default',
-          tags: [],
-        },
-      },
-    });
-    const scope = path.join(root, 'scope-mixed.json');
-    writeJSON(scope, {
-      hasStableVisual: true,
-      broadStableVisual: true,
-      stableComponents: ['New'],
-      stableThemes: [],
-    });
-    const output = path.join(root, 'trusted-mixed-plan.json');
-    run('trusted-plan', {
-      scope,
-      baseline: path.join(pages, 'visual-gate', 'baseline'),
-      'storybook-dir': storybook,
-      output,
-    });
-    expect(
-      JSON.parse(fs.readFileSync(output, 'utf8')).map(shot => shot.key),
-    ).toEqual([
-      KEY,
-      'core-new--default__neutral-light',
-      'core-new--default__neutral-dark',
-    ]);
   });
 
   it('accepts a trusted 520-delta broad bundle', () => {

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -133,6 +133,46 @@ describe('visual acceptance workflow concurrency', () => {
     expect(capture).not.toContain('GITHUB_RUN_ATTEMPT:');
   });
 
+  it('defers broad trusted scopes before downloading or capturing Storybook', () => {
+    const value = workflow('pr-comment.yml');
+    const download = value.slice(
+      value.indexOf(
+        '      - name: Download Storybook for trusted visual capture',
+      ),
+      value.indexOf('      - name: Cross-check artifact identity'),
+    );
+    const capture = value.slice(
+      value.indexOf('      - name: Capture the trusted stable visual scope'),
+      value.indexOf('      - name: Derive trusted broad visual deferral'),
+    );
+    const defer = value.slice(
+      value.indexOf('      - name: Derive trusted broad visual deferral'),
+      value.indexOf('      # The Storybook bundle is untrusted.'),
+    );
+    const derive = value.slice(
+      value.indexOf('      - name: Derive trusted visual evidence and report'),
+      value.indexOf('      - name: Resolve trusted visual evidence path'),
+    );
+
+    const resolve = value.slice(
+      value.indexOf('      - name: Resolve trusted visual evidence path'),
+      value.indexOf('      - name: Publish immutable visual evidence'),
+    );
+
+    expect(download).toContain("steps.scope.outputs.broad != 'true'");
+    expect(capture).toContain("steps.scope.outputs.broad != 'true'");
+    expect(defer).toContain("steps.scope.outputs.broad == 'true'");
+    expect(defer).toContain('visual-acceptance.mjs trusted-defer');
+    expect(defer).toContain('--run-attempt "$RUN_ATTEMPT"');
+    expect(defer).not.toContain('playwright');
+    expect(defer).not.toContain('gate.mjs capture');
+    expect(derive).toContain("steps.scope.outputs.broad != 'true'");
+    expect(resolve).toContain('test -f trusted-visual/evidence.json');
+    expect(resolve).toContain(
+      'path=pr/${PR_NUMBER}/visual/${HEAD_SHA}/${RUN_ID}/${RUN_ATTEMPT}',
+    );
+  });
+
   it('uses the documented collaborator permission response shape', () => {
     const value = workflow('visual-acceptance.yml');
     const authorize = value.slice(

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -253,7 +253,10 @@ jobs:
         continue-on-error: true
 
       - name: Download Storybook for trusted visual capture
-        if: steps.identity.outputs.valid == 'true' && steps.scope.outputs.stable == 'true'
+        if: >-
+          steps.identity.outputs.valid == 'true' &&
+          steps.scope.outputs.stable == 'true' &&
+          steps.scope.outputs.broad != 'true'
         uses: actions/download-artifact@v8
         with:
           pattern: storybook-*
@@ -288,7 +291,10 @@ jobs:
             "https://github.com/${GITHUB_REPOSITORY}.git" /tmp/gh-pages
 
       - name: Capture the trusted stable visual scope
-        if: steps.identity.outputs.valid == 'true' && steps.scope.outputs.stable == 'true'
+        if: >-
+          steps.identity.outputs.valid == 'true' &&
+          steps.scope.outputs.stable == 'true' &&
+          steps.scope.outputs.broad != 'true'
         env:
           ASTRYX_VISUAL_SHA: ${{ steps.identity.outputs.head_sha }}
           ASTRYX_VISUAL_RUN_ID: ${{ steps.identity.outputs.run_id }}
@@ -307,13 +313,37 @@ jobs:
             --out trusted-capture \
             --plan-file trusted-plan.json
 
+      - name: Derive trusted broad visual deferral
+        if: >-
+          steps.identity.outputs.valid == 'true' &&
+          steps.scope.outputs.stable == 'true' &&
+          steps.scope.outputs.broad == 'true'
+        env:
+          PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
+          BASE_SHA: ${{ steps.identity.outputs.base_sha }}
+          RUN_ID: ${{ steps.identity.outputs.run_id }}
+          RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
+        run: |
+          node .github/scripts/visual-gate/visual-acceptance.mjs trusted-defer \
+            --scope trusted-scope.json \
+            --baseline /tmp/gh-pages/visual-gate/baseline \
+            --output trusted-visual \
+            --pr "$PR_NUMBER" \
+            --head "$HEAD_SHA" \
+            --base "$BASE_SHA" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT"
+
       # The Storybook bundle is untrusted. Default-branch code chooses the plan,
       # captures it in an off-origin-blocked browser, derives the comparison,
       # validates/re-encodes PNGs, and generates the report. PR-authored verdicts
       # and job conclusions are never authority for the required status.
       - name: Derive trusted visual evidence and report
-        id: visual
-        if: steps.identity.outputs.valid == 'true' && steps.scope.outputs.stable == 'true'
+        if: >-
+          steps.identity.outputs.valid == 'true' &&
+          steps.scope.outputs.stable == 'true' &&
+          steps.scope.outputs.broad != 'true'
         env:
           PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
           HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
@@ -329,6 +359,21 @@ jobs:
             --head-sha "$HEAD_SHA" \
             --run-id "$RUN_ID" \
             --run-attempt "$RUN_ATTEMPT"
+
+      - name: Resolve trusted visual evidence path
+        id: visual
+        if: >-
+          steps.identity.outputs.valid == 'true' &&
+          steps.scope.outputs.stable == 'true'
+        env:
+          PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
+          RUN_ID: ${{ steps.identity.outputs.run_id }}
+          RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
+        run: |
+          test -f trusted-visual/evidence.json
+          test -f trusted-visual/verdict.json
+          test -f trusted-visual/index.html
           echo "ready=true" >> "$GITHUB_OUTPUT"
           echo "path=pr/${PR_NUMBER}/visual/${HEAD_SHA}/${RUN_ID}/${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Why

Accepted broad component changes can spend about 30 minutes recapturing more than 4,000 frames in the trusted comment workflow and still fail the required `visual-acceptance` status. [PR #5516](https://github.com/facebook/astryx/pull/5516) hit this even though the 240-shot PR policy explicitly delegates broad scope to the daily release gate.

## What

- Emit validated, immutable skipped evidence when trusted scope is broad, bound to the exact PR, head, run, and attempt.
- Publish that evidence through the existing `gh-pages` path and resolve it as successful/deferred.
- Skip Storybook download and browser capture only for broad scope; narrow component and theme recapture is unchanged.
- Render skipped evidence as deferred without an `/accept-visual` command.

## Risk

Workflow-only. Broad scopes no longer get per-PR recapture and remain covered by the daily release gate. Narrow scopes keep the existing capture and acceptance path.

## Testing

- 195 focused visual-gate tests
- `pnpm lint` (passes; existing warnings only)
- `actionlint` on the changed workflow (repository runner label allowlisted)
- Prettier check on changed formatted workflow/test files
- `git diff --check`
