### PR TITLE
fix(storybook): correct Probe Theme heading outline

### DIFF
--- a/apps/storybook/stories/ProbeTheme.stories.tsx
+++ b/apps/storybook/stories/ProbeTheme.stories.tsx
@@ -67,7 +67,9 @@ function AxisCard({
   return (
     <Card>
       <div {...stylex.props(styles.axisCard)}>
-        <Heading level={3}>{title}</Heading>
+        <Heading level={3} accessibilityLevel={2}>
+          {title}
+        </Heading>
         {children}
       </div>
     </Card>

--- a/apps/storybook/stories/ProbeTheme.stories.tsx
+++ b/apps/storybook/stories/ProbeTheme.stories.tsx
@@ -194,7 +194,9 @@ function AllAxesSheet() {
 
         <AxisCard title="5 · Typography">
           <Stack direction="vertical" gap={2}>
-            <Heading level={2}>AstryxProbeFace heading</Heading>
+            <Heading level={2} accessibilityLevel={3}>
+              AstryxProbeFace heading
+            </Heading>
             <Text type="body">Body text inherits the probe font token.</Text>
             <Text type="code">const fontAxis = 'covered';</Text>
           </Stack>


### PR DESCRIPTION
## Summary

- expose the Probe Theme card headings as semantic level 2
- expose the nested typography specimen as semantic level 3
- preserve the existing visual heading styles

## Why

`All Axes` starts with an h1, while the reusable card wrapper rendered h3 headings. That skipped level 2 in the document outline. The typography specimen is nested inside one of those cards, so it remains a semantic level 3 while retaining its level-2 visual treatment.

## Test plan

- `pnpm vitest run packages/core/src/Heading/Heading.test.tsx` — 24 passed
- real Chromium axe run on `Core/Themes/Probe Theme / All Axes` — `heading-order` went from 1 node to 0
- Chromium accessibility outline is 1 → 2 → 3 for the nested typography specimen
- before/after full-page Chromium captures are byte-identical
- `.github/a11y-baseline.json` is unchanged
