### PR TITLE
fix(DateTimeInput): stack fields in narrow containers

### DIFF
--- a/.changeset/responsive-date-time-input.md
+++ b/.changeset/responsive-date-time-input.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Stack DateTimeInput's date and time fields when its container is narrower than 400px.
+
+@imdreamrunner

--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -103,6 +103,23 @@ export const Default: Story = {
   },
 };
 
+export const NarrowContainer: Story = {
+  render: args => {
+    const [value, setValue] = useState<ISODateTimeString | undefined>(
+      '2026-03-15T14:30' as ISODateTimeString,
+    );
+    return (
+      <div style={{width: '320px', maxWidth: '100%'}}>
+        <DateTimeInput {...args} value={value} onChange={setValue} />
+      </div>
+    );
+  },
+  args: {
+    label: 'Meeting time',
+    hasClear: true,
+  },
+};
+
 export const WithValue: Story = {
   render: args => {
     const [value, setValue] = useState<ISODateTimeString | undefined>(

--- a/packages/cli/assets/templates/blocks/components/DateTimeInput/DateTimeInputWithValidation.tsx
+++ b/packages/cli/assets/templates/blocks/components/DateTimeInput/DateTimeInputWithValidation.tsx
@@ -3,9 +3,17 @@
 'use client';
 
 import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {DateTimeInput} from '@astryxdesign/core/DateTimeInput';
 import type {ISODateTimeString} from '@astryxdesign/core/DateTimeInput';
 import {Stack} from '@astryxdesign/core/Layout';
+
+const styles = stylex.create({
+  container: {
+    width: {default: '100%', '@media (min-width: 480px)': 400},
+    maxWidth: '100%',
+  },
+});
 
 export default function DateTimeInputWithValidation() {
   const [errorVal, setErrorVal] = useState<ISODateTimeString | undefined>(
@@ -19,7 +27,7 @@ export default function DateTimeInputWithValidation() {
   );
 
   return (
-    <Stack direction="vertical" gap={4} width="100%" style={{maxWidth: 400}}>
+    <Stack direction="vertical" gap={4} xstyle={styles.container}>
       <DateTimeInput
         label="Meeting time"
         value={errorVal}

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -223,7 +223,7 @@ export const docs = {
   },
   usage: {
     description:
-      'DateTimeInput combines date and time selection in one field. On mouse/trackpad devices it uses a calendar popover plus text time input; on coarse-pointer devices the closed control still has separate Date and Time segments, and either segment opens a bottom sheet with Date and Time sections, a swipable month calendar, and accessible time wheels. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
+      'DateTimeInput combines date and time selection in one field. On mouse/trackpad devices it uses a calendar popover plus text time input; on coarse-pointer devices the closed control still has separate Date and Time segments, and either segment opens a bottom sheet with Date and Time sections, a swipable month calendar, and accessible time wheels. The closed date and time segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
     bestPractices: [
       {
         guidance: true,
@@ -322,7 +322,7 @@ export const docsZh = {
   displayName: 'Date Time Input',
   usage: {
     description:
-      'DateTimeInput combines date and time selection in one field. On mouse/trackpad devices it uses a calendar popover plus text time input; on coarse-pointer devices the closed control still has separate Date and Time segments, and either segment opens a bottom sheet with Date and Time sections, a swipable month calendar, and accessible time wheels. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
+      'DateTimeInput combines date and time selection in one field. On mouse/trackpad devices it uses a calendar popover plus text time input; on coarse-pointer devices the closed control still has separate Date and Time segments, and either segment opens a bottom sheet with Date and Time sections, a swipable month calendar, and accessible time wheels. The closed date and time segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
     bestPractices: [
       {
         guidance: true,
@@ -551,7 +551,7 @@ export const docsDense = {
     'combined date + time picker with calendar popover and time input',
   usage: {
     description:
-      'DateTimeInput combines date and time selection. Desktop uses a calendar popover plus time input; coarse pointers show separate Date/Time closed segments that open a bottom sheet with matching sections, a Save date step, and final time-wheel Save. Use for scheduling, events, deadlines, or any form field needing a datetime.',
+      'DateTimeInput combines date and time selection. Desktop uses a calendar popover plus time input; coarse pointers show separate Date/Time closed segments that open a bottom sheet with matching sections, a Save date step, and final time-wheel Save. Closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of the viewport. Use for scheduling, events, deadlines, or any form field needing a datetime.',
     bestPractices: [
       {
         guidance: true,

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -12,6 +12,7 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as stylex from '@stylexjs/stylex';
 import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateTimeInput} from './DateTimeInput';
 import type {ISODateTimeString} from './DateTimeInput';
@@ -33,6 +34,32 @@ function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
   return [prose, component].filter(Boolean).join('\n\n');
 }
+
+// jsdom does not perform flex layout, so these probe classes verify the
+// declarations that switch between horizontal and stacked intrinsic layouts.
+const responsiveLayoutProbe = stylex.create({
+  responsiveRow: {
+    flexWrap: 'wrap',
+  },
+  responsiveSegment: {
+    flexBasis: 196,
+    minWidth: 0,
+  },
+});
+
+function expectResponsiveProbeClasses(
+  element: HTMLElement,
+  style: (typeof responsiveLayoutProbe)[keyof typeof responsiveLayoutProbe],
+): void {
+  const classes = (stylex.props(style).className ?? '')
+    .split(' ')
+    .filter(className => className !== '' && !className.includes('__'));
+  expect(classes.length).toBeGreaterThan(0);
+  for (const className of classes) {
+    expect(element).toHaveClass(className);
+  }
+}
+
 describe('DateTimeInput', () => {
   it('renders with label', () => {
     render(<DateTimeInput label="Meeting time" onChange={() => {}} />);
@@ -113,6 +140,37 @@ describe('DateTimeInput', () => {
     render(<DateTimeInput label="Meeting" onChange={() => {}} />);
     expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(screen.getByLabelText('Meeting time')).toBeInTheDocument();
+  });
+
+  it('allows the date and time segments to wrap when they no longer fit', () => {
+    const {container} = render(
+      <DateTimeInput label="Meeting" onChange={() => {}} />,
+    );
+    const row = container.querySelector(
+      '.astryx-date-time-input',
+    ) as HTMLElement;
+    expect(row).not.toBeNull();
+    expectResponsiveProbeClasses(row, responsiveLayoutProbe.responsiveRow);
+  });
+
+  it('gives both segments the intrinsic wrap threshold and allows them to shrink', () => {
+    const {container} = render(
+      <DateTimeInput label="Meeting" onChange={() => {}} />,
+    );
+    const dateSegment = container.querySelector(
+      '.astryx-date-time-input-date-segment',
+    ) as HTMLElement;
+    const timeSegment = container.querySelector(
+      '.astryx-date-time-input-time-segment',
+    ) as HTMLElement;
+    expectResponsiveProbeClasses(
+      dateSegment,
+      responsiveLayoutProbe.responsiveSegment,
+    );
+    expectResponsiveProbeClasses(
+      timeSegment,
+      responsiveLayoutProbe.responsiveSegment,
+    );
   });
 
   it('does not commit the date on a composing Enter (IME)', () => {

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file DateTimeInput.tsx
- * @input Uses React, Field, Calendar, usePopover, useAnnounce, time parsing utilities, TouchDateTimeField
+ * @input Uses React, Field, Calendar, usePopover, useAnnounce, time parsing utilities, TouchDateTimeField, StyleX intrinsic flex layout
  * @output Exports DateTimeInput component, DateTimeInputProps
  * @position Core implementation; consumed by index.ts, tested by DateTimeInput.test.tsx
  *
@@ -118,9 +118,14 @@ export type {
   InputStatusType as DateTimeInputStatusType,
 } from '../Field';
 
+// Two 196px segments plus the 8px gap fit at exactly 400px. Below that,
+// flex wrapping moves each growing segment onto its own full-width row.
+const HORIZONTAL_SEGMENT_BASIS = 196;
+
 const styles = stylex.create({
   row: {
     display: 'flex',
+    flexWrap: 'wrap',
     gap: spacingVars['--spacing-2'],
   },
   iconButton: {
@@ -175,11 +180,13 @@ const styles = stylex.create({
   },
   dateWrapper: {
     flex: 1,
-    flexBasis: 0,
+    flexBasis: HORIZONTAL_SEGMENT_BASIS,
+    minWidth: 0,
   },
   timeWrapper: {
     flex: 1,
-    flexBasis: 0,
+    flexBasis: HORIZONTAL_SEGMENT_BASIS,
+    minWidth: 0,
   },
   // Preset-time list. Paddings and states mirror BaseTypeahead's dropdown and
   // Selector's options so every list in the system reads the same.

--- a/packages/core/src/DateTimeInput/DateTimeInputTouch.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInputTouch.test.tsx
@@ -22,6 +22,7 @@ import {
   afterEach,
 } from 'vitest';
 import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {readFileSync} from 'node:fs';
 import {render, screen, fireEvent, within} from '@testing-library/react';
 import {DateTimeInput} from './DateTimeInput';
@@ -35,6 +36,24 @@ class MockResizeObserver {
 
 const HOVER_CAPABLE = /\(\s*hover\s*:\s*hover\s*\)/;
 const SCROLLPORT_WIDTH = 360;
+
+const responsiveLayoutProbe = stylex.create({
+  row: {flexWrap: 'wrap'},
+  segment: {flexBasis: 196, minInlineSize: 0},
+});
+
+function expectResponsiveProbeClasses(
+  element: HTMLElement,
+  style: (typeof responsiveLayoutProbe)[keyof typeof responsiveLayoutProbe],
+): void {
+  const classes = (stylex.props(style).className ?? '')
+    .split(' ')
+    .filter(className => className !== '' && !className.includes('__'));
+  expect(classes.length).toBeGreaterThan(0);
+  for (const className of classes) {
+    expect(element).toHaveClass(className);
+  }
+}
 
 function stubMedia(pointer: 'coarse' | 'fine', anyPointer = pointer): void {
   vi.stubGlobal('matchMedia', (query: string) => ({
@@ -182,6 +201,18 @@ describe('DateTimeInput touch surface', () => {
         'true',
       );
     });
+  });
+
+  it('uses intrinsic wrapping for the closed touch segments', () => {
+    const {container} = render(
+      <DateTimeInput label="Meeting" onChange={() => {}} />,
+    );
+    const row = container.querySelector(
+      '.astryx-date-time-input',
+    ) as HTMLElement;
+    expectResponsiveProbeClasses(row, responsiveLayoutProbe.row);
+    expectResponsiveProbeClasses(dateSegment(), responsiveLayoutProbe.segment);
+    expectResponsiveProbeClasses(timeSegment(), responsiveLayoutProbe.segment);
   });
 
   it('keeps the desktop two-field surface on a fine primary pointer', () => {

--- a/packages/core/src/DateTimeInput/TouchDateTimeField.tsx
+++ b/packages/core/src/DateTimeInput/TouchDateTimeField.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file TouchDateTimeField.tsx
- * @input Uses React, Field, BottomSheet, SegmentedControl, DateInput month picker primitives, Wheel
+ * @input Uses React, Field, BottomSheet, SegmentedControl, DateInput month picker primitives, Wheel, StyleX intrinsic flex layout
  * @output Exports TouchDateTimeField — the coarse-pointer surface behind DateTimeInput
  * @position Internal component; consumed by DateTimeInput.tsx
  *
@@ -153,6 +153,8 @@ const sizeStyles = stylex.create({
   },
 });
 
+const HORIZONTAL_SEGMENT_BASIS = 196;
+
 const styles = stylex.create({
   iconButton: {
     display: 'flex',
@@ -197,18 +199,19 @@ const styles = stylex.create({
   },
   touchRow: {
     display: 'flex',
+    flexWrap: 'wrap',
     inlineSize: '100%',
     minInlineSize: 0,
     gap: spacingVars['--spacing-2'],
   },
   touchDateWrapper: {
     flex: 1,
-    flexBasis: 0,
+    flexBasis: HORIZONTAL_SEGMENT_BASIS,
     minInlineSize: 0,
   },
   touchTimeWrapper: {
     flex: 1,
-    flexBasis: 0,
+    flexBasis: HORIZONTAL_SEGMENT_BASIS,
     minInlineSize: 0,
   },
   touchInput: {


### PR DESCRIPTION
## Summary

- use intrinsic flex wrapping so the date and time segments stay side by side when at least 400px is available and stack below 400px
- preserve natural sizing in `fit-content`, `inline-flex`, and max-content grid layouts without size containment
- let both horizontal segments shrink within the row instead of overflowing at the boundary
- preserve the new coarse-pointer bottom-sheet picker from `main` and apply the same responsive wrapping to its closed Date/Time segments
- add component regression tests, a narrow-container Storybook story, docs, and a patch changeset

## Responsive layout

![DateTimeInput at 400px and 320px available widths](https://raw.githubusercontent.com/facebook/astryx/16487cce494d1a5edef0a4c4c5ceb6963d56ca78/pr/5609/assets/datetime-input-responsive.png)

## Test plan

- `pnpm exec vitest run packages/core/src/DateTimeInput/DateTimeInput.test.tsx packages/core/src/DateTimeInput/DateTimeInputTouch.test.tsx` (177 passed)
- `pnpm -F @astryxdesign/docsite test` (427 passed)
- `pnpm lint:strict` (passed; existing warnings only)
- core and docsite typechecks
- core, Storybook, and docsite production builds
- Chromium fine- and coarse-pointer matrices: 400px stays horizontal with two 196px segments; 399px and 320px wrap into full-width rows
- Chromium intrinsic-sizing matrix: `fit-content`, `inline-flex`, and max-content grid retain a natural 454px horizontal field with no overflow
- production docsite at 1440px / 1024px: Validation fields are 400px and horizontal; at 390px they are 286px and stacked, with no overflow



