### PR TITLE
fix(Table): drop aria-expanded from groupedRows header rows

### DIFF
--- a/.changeset/a11y-table-groupedrows-aria-expanded.md
+++ b/.changeset/a11y-table-groupedrows-aria-expanded.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table groupedRows plugin: group header rows no longer carry `aria-expanded`. On a native table that attribute is invalid on a row (axe `aria-conditional-attr`: rows may only expand inside a treegrid), and a group header is a section separator of flat data, not a tree parent. The collapse state stays announced by the group's chevron button, which already carries `aria-expanded`. If a test queried `tr[aria-expanded]` on a grouped table, target the button instead.
+@AKnassa

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -794,24 +794,9 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "TableGroupedRows::Custom Order And Header::aria-conditional-attr",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-conditional-attr?application=playwright"
-    },
-    {
-      "key": "TableGroupedRows::Default::aria-conditional-attr",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-conditional-attr?application=playwright"
-    },
-    {
       "key": "TableGroupedRows::Default::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "TableGroupedRows::Initially Collapsed::aria-conditional-attr",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-conditional-attr?application=playwright"
     },
     {
       "key": "TableGroupedRows::Initially Collapsed::color-contrast",

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
@@ -119,12 +119,19 @@ describe('useTableGroupedRows', () => {
     expect(coreToggle).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('sets aria-expanded on the header row reflecting collapse state', () => {
+  it('keeps aria-expanded off header rows — the chevron button carries it (axe aria-conditional-attr: rows outside a treegrid)', () => {
     render(<Harness initialCollapsed={new Set(['Core'])} />);
     const rows = screen.getAllByRole('row');
     // rows[1] = Core header (collapsed), rows[2] = Infra header (expanded).
-    expect(rows[1]).toHaveAttribute('aria-expanded', 'false');
-    expect(rows[2]).toHaveAttribute('aria-expanded', 'true');
+    expect(rows[1]).not.toHaveAttribute('aria-expanded');
+    expect(rows[2]).not.toHaveAttribute('aria-expanded');
+    // The collapse state lives on the chevron buttons instead.
+    expect(
+      screen.getByRole('button', {name: 'Expand group Core'}),
+    ).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.getByRole('button', {name: 'Collapse group Infra'}),
+    ).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('respects groupOrder in the flattened data', () => {

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -376,7 +376,6 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
             // button below is the accessible, keyboard-operable control, so the
             // row keeps its implicit `row` role (no role override here).
             onClick: toggle,
-            'aria-expanded': !collapsed,
           },
           xstyle: [...props.xstyle, styles.headerRow],
           children: (


### PR DESCRIPTION
Part of #4681 (weekly a11y scan). Split out of #4690 as agreed in review: groupedRows is flat data with section headers, not a tree, so it does not ride along with the treegrid work.

## What this does

The groupedRows plugin set `aria-expanded` on each group header `<tr>`. On a native table that attribute is invalid on a row (axe `aria-conditional-attr`: rows may only expand inside a treegrid), and a group header is a section separator of flat data, not a tree parent, so a treegrid is the wrong fix here. The header row no longer carries it. The collapse state stays announced by the group's chevron button, which already carries `aria-expanded` with the "Expand group X" / "Collapse group X" name.

## What changed

- `useTableGroupedRows.tsx`: one attribute removed from the header row.
- Test rewritten to assert the row carries no `aria-expanded` and the chevron button does.
- Baseline: the 3 `TableGroupedRows::*::aria-conditional-attr` entries removed, deletions only.
- Changeset (patch) with a `tr[aria-expanded]` test-migration hint.

## Verification

- 15/15 groupedRows tests; eslint and prettier clean on the changed files.
- Repo axe audit with `--fail-on-new` on the built Storybook: 0 issues across all 3 TableGroupedRows stories.

## Observation for a follow-up

The audit reports `TableGroupedRows::Default::color-contrast` and `TableGroupedRows::Initially Collapsed::color-contrast` as no longer occurring (stale baseline entries). Left untouched here; contrast entries are out of this PR's scope.
