### PR TITLE
fix(cli): stop build ranking partial query matches above full ones

### DIFF
--- a/.changeset/build-retrieval-scoring.md
+++ b/.changeset/build-retrieval-scoring.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `build`/`search` no longer rank a partially-matched template above one matching every term, no longer index TypeScript generic arguments as rendered components, and no longer treat breadth of rendered components as full-strength relevance.
+
+@ernestt

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -21,13 +21,24 @@
  *    80  name Levenshtein distance 1
  *    70  keyword substring / distance 1
  *    60  name substring (>=4 chars, >=50% coverage)
+ *    60  exact weak-keyword match
  *    50  description / prose mentions the term
  *    40  name Levenshtein distance 2
+ *    40  weak-keyword substring
  *    30  keyword Levenshtein distance 2
  *    20  name Levenshtein distance 3
  *
  * Name + keyword signals always outweigh description/prose, so an exact match
  * sorts above an incidental mention.
+ *
+ * `keywords` carry AUTHORED intent — a block's `componentsUsed`, a page's
+ * `category` words. `weakKeywords` are DERIVED: the components a page template
+ * happens to render, scraped out of its JSX. Derived signal is deliberately
+ * capped below the confident-match gate on its own, because breadth is not
+ * relevance. At full keyword strength every rendered component is an
+ * independent 90-point shot with no penalty for how many a template has, so
+ * the broadest pages (a theme showcase rendering one of everything) win
+ * queries they have nothing to do with.
  */
 
 import {pathToFileURL} from 'node:url';
@@ -53,6 +64,7 @@ import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
  * @property {'component'|'hook'|'doc'|'template'} domain
  * @property {string} name
  * @property {string[]} [keywords]
+ * @property {string[]} [weakKeywords]
  * @property {string} [description]
  * @property {string[]} [prose]
  * @property {string} [_import]
@@ -222,28 +234,39 @@ export function scoreQuery(term, tokens, candidate) {
 
   // Multi-word natural language: score each content token, counting only
   // strong hits, then reward coverage so candidates matching more terms win.
-  let sum = 0;
+  let strongest = 0;
   let matched = 0;
   /** @type {string[]} */
   const hitTerms = [];
   for (const tok of tokens) {
     const h = bestForToken(tok, candidate);
     if (h && h.score >= MIN_TOKEN_SCORE) {
-      sum += h.score;
+      if (h.score > strongest) strongest = h.score;
       matched++;
       hitTerms.push(tok);
     }
   }
   if (matched === 0) return full;
 
-  // Reward the AVERAGE strength of the concepts that matched (not divided by
-  // total query length — that penalizes verbose / low-fidelity prompts), plus
-  // a bonus per additional matched concept and a coverage term. A candidate
-  // that matches several of the query's concepts beats one matching a single
-  // incidental word.
-  const avgMatched = sum / matched;
+  // Base the score on the STRONGEST concept that matched, plus a bonus per
+  // additional matched concept and a coverage term.
+  //
+  // Deliberately not the mean, and deliberately not divided by total query
+  // length. Dividing by total length penalizes verbose / low-fidelity prompts.
+  // Dividing by the number of MATCHED tokens (what this used to do) made the
+  // score non-monotonic: a second, weaker hit could drag the mean down by more
+  // than the coverage bonus added it back, so matching fewer terms well beat
+  // matching more terms partially. Concretely, `build "file browser"` scored
+  // two form wizards matching only "file" at 98, above the actual file browser
+  // matching both terms at 97 — and 98 clears the PAGE_DIRECT gate, so the
+  // wrong template was returned as a confident match.
+  //
+  // Taking the max keeps both properties: a verbose prompt is still scored on
+  // the concepts it did hit, and matching a superset of another candidate's
+  // terms can never score lower, since every term of the expression is
+  // non-decreasing in the set of matched tokens.
   const coverage = matched / tokens.length;
-  const tokenScore = Math.round(avgMatched + Math.min(matched - 1, 3) * 12 + coverage * 15);
+  const tokenScore = Math.round(strongest + Math.min(matched - 1, 3) * 12 + coverage * 15);
 
   if (full && full.score >= tokenScore) return full;
   return {
@@ -260,12 +283,16 @@ export function scoreQuery(term, tokens, candidate) {
  * @param {string} term - Lowercased search term.
  * @param {object} candidate
  * @param {string} candidate.name - Primary identifier (component/hook name, topic, template name).
- * @param {string[]} [candidate.keywords]
+ * @param {string[]} [candidate.keywords] - Authored intent (componentsUsed, category words).
+ * @param {string[]} [candidate.weakKeywords] - Derived signal (components a page renders).
  * @param {string} [candidate.description]
  * @param {string[]} [candidate.prose] - Extra free-text blobs (doc section text, best practices).
  * @returns {{score: number, reason: string} | null}
  */
-export function scoreCandidate(term, {name, keywords = [], description = '', prose = []}) {
+export function scoreCandidate(
+  term,
+  {name, keywords = [], weakKeywords = [], description = '', prose = []},
+) {
   let best = 0;
   let reason = '';
   /**
@@ -312,6 +339,24 @@ export function scoreCandidate(term, {name, keywords = [], description = '', pro
     const dist = levenshteinDistance(term, kwLower);
     if (dist === 1) consider(70, `keyword "${kw}" (distance ${dist})`);
     else if (dist === 2) consider(30, `keyword "${kw}" (distance ${dist})`);
+  }
+
+  // ── Weak keyword signals (derived, not authored) ─────────────────
+  // Capped at 60 so one incidental component match cannot clear the
+  // confident-match gate on its own; it still counts toward multi-term
+  // coverage, which is where "this page renders that" is real evidence.
+  // No Levenshtein tier — fuzzy matching a derived signal is pure noise.
+  for (const kw of weakKeywords) {
+    const kwLower = String(kw).toLowerCase();
+    if (kwLower === term) {
+      consider(60, `renders ${kw}`);
+      continue;
+    }
+    const s = term.length < kwLower.length ? term : kwLower;
+    const l = term.length < kwLower.length ? kwLower : term;
+    if (s.length >= 4 && l.includes(s) && s.length / l.length >= 0.5) {
+      consider(40, `renders ${kw}`);
+    }
   }
 
   // ── Prose / description signals (stem-tolerant whole word) ──────
@@ -529,24 +574,33 @@ async function gatherTemplates(cwd) {
     return [];
   }
   return templates.map(t => {
-    // Blocks ship componentsUsed; page templates don't, so derive them from the
-    // source. Category words (e.g. "Dashboard - Analytics") are strong intent
-    // signal for pages, which otherwise only index on name + description.
-    let keywords = Array.isArray(t.componentsUsed) ? [...t.componentsUsed] : [];
+    // Blocks ship an authored componentsUsed; page templates don't, so derive
+    // them from the source. Category words (e.g. "Dashboard - Analytics") are
+    // strong intent signal for pages, which otherwise only index on name +
+    // description.
+    //
+    // Authored signal and derived signal are kept apart: componentsUsed and
+    // category words are a deliberate statement of what the template is for,
+    // while scraped JSX tags only say what it happens to render. See the
+    // scoring table at the top of this file for why the derived set is capped.
+    const keywords = Array.isArray(t.componentsUsed) ? [...t.componentsUsed] : [];
+    /** @type {string[]} */
+    let weakKeywords = [];
     if (t.type === 'page') {
       if (t.filePath) {
         try {
-          keywords = keywords.concat(extractComponents(t.filePath));
+          weakKeywords = extractComponents(t.filePath);
         } catch {
           // Best-effort: skip keyword enrichment if the source can't be read.
         }
       }
-      if (t.category) keywords = keywords.concat(t.category.split(/[^A-Za-z0-9]+/).filter(Boolean));
+      if (t.category) keywords.push(...t.category.split(/[^A-Za-z0-9]+/).filter(Boolean));
     }
     return {
       domain: 'template',
       name: t.dirName,
       keywords,
+      weakKeywords,
       description: t.description || '',
       _displayName: t.name,
       _kind: t.type, // 'page' | 'block'

--- a/packages/cli/api/search/search.test.mjs
+++ b/packages/cli/api/search/search.test.mjs
@@ -23,7 +23,13 @@ import {describe, it, expect} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {search, SEARCH_DOMAINS} from './search.mjs';
+import {
+  search,
+  scoreCandidate,
+  scoreQuery,
+  tokenizeQuery,
+  SEARCH_DOMAINS,
+} from './search.mjs';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 const cwd = REPO;
@@ -162,4 +168,76 @@ describe('search leaf — integration components', () => {
       fs.rmSync(dir, {recursive: true, force: true});
     }
   }, SLOW);
+});
+
+describe('search scoring — multi-token aggregation is monotonic', () => {
+  /**
+   * @param {string} q
+   * @param {object} candidate
+   * @returns {number}
+   */
+  const score = (q, candidate) => scoreQuery(q, tokenizeQuery(q), candidate)?.score ?? 0;
+
+  it('ranks matching both terms above matching only the stronger one', () => {
+    // The shipped regression: scoring averaged over MATCHED tokens, so the
+    // weaker second hit pulled the mean down further than the coverage bonus
+    // pushed it up. `build "file browser"` put two form wizards that matched
+    // only "file" (98) above the actual file browser that matched both (97),
+    // and 98 clears the confident-match gate.
+    const partial = {name: 'form-wizard-vertical', keywords: ['file']};
+    const complete = {
+      name: 'file-explorer',
+      keywords: ['file'],
+      description: 'Column browser for nested folders',
+    };
+    expect(score('file browser', complete)).toBeGreaterThan(score('file browser', partial));
+  });
+
+  it('never scores a superset of matched terms below a subset', () => {
+    const subset = {name: 'zzz-none', keywords: ['alpha']};
+    const supersets = [
+      {name: 'zzz-none', keywords: ['alpha'], description: 'beta things'},
+      {name: 'zzz-none', keywords: ['alpha', 'beta']},
+      {name: 'zzz-none', keywords: ['alpha'], weakKeywords: ['beta']},
+    ];
+    for (const superset of supersets) {
+      expect(score('alpha beta', superset)).toBeGreaterThanOrEqual(score('alpha beta', subset));
+    }
+  });
+
+  it('still scores a verbose prompt on the concepts it did hit', () => {
+    // Guards the reason the mean was used: a long prompt matching one concept
+    // strongly must not be crushed by dividing across every query token.
+    const candidate = {name: 'kanban', keywords: ['kanban']};
+    expect(score('i need a kanban somewhere in this rambling request', candidate))
+      .toBeGreaterThanOrEqual(90);
+  });
+});
+
+describe('search scoring — derived keywords rank below authored ones', () => {
+  it('scores an authored keyword above a derived one', () => {
+    const authored = scoreCandidate('dialog', {name: 'x', keywords: ['Dialog']});
+    const derived = scoreCandidate('dialog', {name: 'x', weakKeywords: ['Dialog']});
+    expect(authored?.score).toBe(90);
+    expect(derived?.score).toBe(60);
+  });
+
+  it('keeps one incidental derived match below the confident-match gate', () => {
+    // PAGE_DIRECT in api/build/kit is 95: at full keyword strength a page that
+    // renders one of everything got a 90-point shot per component and was
+    // returned as a confident match for queries it had nothing to do with.
+    const derived = scoreCandidate('dialog', {name: 'x', weakKeywords: ['Dialog']});
+    expect(derived?.score).toBeLessThan(95);
+  });
+
+  it('still surfaces a derived match above the page floor', () => {
+    // PAGE_FLOOR is 50 — weakening the signal must not make it invisible.
+    const derived = scoreCandidate('dialog', {name: 'x', weakKeywords: ['Dialog']});
+    expect(derived?.score).toBeGreaterThanOrEqual(50);
+  });
+
+  it('explains a derived hit as something the template renders', () => {
+    const derived = scoreCandidate('dialog', {name: 'x', weakKeywords: ['Dialog']});
+    expect(derived?.reason).toMatch(/renders Dialog/);
+  });
 });

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -672,7 +672,15 @@ export function extractComponents(pagePath) {
   // (P2380608025), so the `XDS` prefix is optional. Anchoring on the `<`
   // JSX-tag boundary keeps this precise (avoids matching imports/comments/
   // identifiers) while remaining prefix-agnostic.
-  const tagRegex = /<(XDS)?([A-Z]\w+)/g;
+  //
+  // The lookbehind additionally requires that the `<` NOT follow an identifier
+  // character, which is what separates a JSX tag from a TypeScript generic
+  // argument list. `return <Dialog` and `rows.map(r => <ListItem` match;
+  // `useState<ReadonlySet<string>>`, `ComponentType<SVGProps<SVGSVGElement>>`
+  // and `Record<string, Phase>` no longer do. Those were being indexed as
+  // rendered components, putting type names like `Record`, `SVGProps` and
+  // `ReadonlySet` into template keyword and "components used" output.
+  const tagRegex = /(?<![\w$.])<(XDS)?([A-Z]\w+)/g;
   /** @type {string[]} */
   const matches = [];
   let m;

--- a/packages/cli/foundation/discovery/template-adapter.test.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.test.mjs
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Colocated tests for template-adapter's `extractComponents`.
+ *
+ * `extractComponents` scrapes the components a page template renders out of its
+ * JSX. Three callers depend on it: `template <name>` and `template --skeleton`
+ * print it as "components used", and `search`/`build` index it as keywords.
+ * It had no test coverage, and the tag regex was matching TypeScript generic
+ * argument lists as if they were JSX tags — so type names (`Record`,
+ * `SVGProps`, `ReadonlySet`, and every local type alias) were being reported as
+ * rendered components and indexed as search keywords.
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {extractComponents} from './template-adapter.mjs';
+
+/** @type {string} */
+let dir;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-extract-'));
+});
+
+afterAll(() => {
+  fs.rmSync(dir, {recursive: true, force: true});
+});
+
+/**
+ * @param {string} name
+ * @param {string} src
+ * @returns {string}
+ */
+function writePage(name, src) {
+  const file = path.join(dir, `${name}.tsx`);
+  fs.writeFileSync(file, src);
+  return file;
+}
+
+describe('extractComponents — JSX tags', () => {
+  it('extracts rendered components', () => {
+    const file = writePage(
+      'basic',
+      `'use client';
+      export default function Page() {
+        return (
+          <Layout content={<Dialog><TreeList /></Dialog>} />
+        );
+      }`,
+    );
+    const got = extractComponents(file);
+    expect(got).toContain('Layout');
+    expect(got).toContain('Dialog');
+    expect(got).toContain('TreeList');
+  });
+
+  it('extracts a component opening a JSX expression, not just a statement', () => {
+    const file = writePage(
+      'mapped',
+      `export default function Page() {
+        return <List>{rows.map(r => <ListRow key={r.id} />)}</List>;
+      }`,
+    );
+    expect(extractComponents(file)).toContain('ListRow');
+  });
+
+  it('drops ubiquitous primitives so they do not drown the signal', () => {
+    const file = writePage(
+      'ubiquitous',
+      `export default function Page() {
+        return <VStack><Text>hi</Text><Button /><Kanban /></VStack>;
+      }`,
+    );
+    const got = extractComponents(file);
+    expect(got).not.toContain('VStack');
+    expect(got).not.toContain('Text');
+    expect(got).not.toContain('Button');
+    expect(got).toContain('Kanban');
+  });
+});
+
+describe('extractComponents — TypeScript generics are not components', () => {
+  it('ignores generic argument lists', () => {
+    const file = writePage(
+      'generics',
+      `import type {ComponentType, SVGProps} from 'react';
+      type Phase = 'a' | 'b';
+      export default function Page() {
+        const [sel, setSel] = useState<ReadonlySet<string>>(new Set());
+        const rows = useMemo<Array<StockRow>>(() => [], []);
+        const icon: ComponentType<SVGProps<SVGSVGElement>> = Placeholder;
+        const byPhase: Record<string, Phase> = {};
+        return <Dialog />;
+      }`,
+    );
+    const got = extractComponents(file);
+    for (const typeName of [
+      'ReadonlySet',
+      'Array',
+      'StockRow',
+      'SVGProps',
+      'SVGSVGElement',
+      'Record',
+      'Phase',
+    ]) {
+      expect(got).not.toContain(typeName);
+    }
+    expect(got).toContain('Dialog');
+  });
+
+  it('still ignores a generic when the JSX it precedes is valid', () => {
+    const file = writePage(
+      'mixed',
+      `export default function Page() {
+        const m = new Map<string, Severity>();
+        return <Banner />;
+      }`,
+    );
+    const got = extractComponents(file);
+    expect(got).not.toContain('Severity');
+    expect(got).toEqual(['Banner']);
+  });
+
+  it('does not treat a closing tag as a component', () => {
+    const file = writePage(
+      'closing',
+      `export default function Page() {
+        return <Card>x</Card>;
+      }`,
+    );
+    expect(extractComponents(file)).toEqual(['Card']);
+  });
+});


### PR DESCRIPTION
## Summary

`astryx build "file browser"` returns two form wizards above the actual file browser — and reports one as a confident direct match, so an agent scaffolds the wrong template:

```
form-wizard-vertical  98  matches 1/2 terms: file
import-wizard         98  matches 1/2 terms: file
file-explorer         97  matches 2/2 terms: file, browser
```

After this change:

```
file-explorer  117  matches 2/2 terms: file, browser
ide             58  matches 1/2 terms: file
shell-nav       58  matches 1/2 terms: file
```

Three independent causes in the retrieval path.

### 1. Multi-token scoring was not monotonic

`scoreQuery` averaged over **matched** tokens (`sum / matched`), so a second, weaker hit could pull the mean down further than the coverage bonus pushed it up. Solving the aggregation: against a first hit of `s1`, a second hit only helps if it scores above `s1 − 39`. So against a 90-point keyword a second term has to beat 51 — and a description hit is exactly 50. Matching fewer terms well beat matching more terms partially.

The score is now based on the **strongest** matched concept plus the existing per-concept and coverage bonuses. That preserves the reason the mean was there in the first place — a verbose, low-fidelity prompt is still scored on the concepts it did hit, rather than divided across every token — while making the score monotonic: a candidate matching a superset of another's terms can no longer rank below it.

### 2. TypeScript generics were indexed as rendered components

`extractComponents`' tag regex `/<(XDS)?([A-Z]\w+)/g` matched generic argument lists. `useState<ReadonlySet<string>>`, `ComponentType<SVGProps<SVGSVGElement>>` and `Record<string, Phase>` were all reported as rendered components — 82 bogus entries across the 51 page templates, including `Record` (9 templates), `ReadonlySet` (5), `Array` (5), and every local type alias (`TaskRow`, `Severity`, `Segment`, …).

A lookbehind now requires the `<` not to follow an identifier character. Since `template <name>` and `template --skeleton` share this extractor, it also cleans up their user-facing "components used" output.

### 3. Derived keywords scored the same as authored ones

Every component a page rendered became a full-strength keyword (90), with no penalty for how many a template had. Breadth is not relevance: `theme-showcase` accrues 50 and `settings-dialog` 45 against a median of 14, so the broadest pages became noise magnets and won queries they had nothing to do with.

Derived signal now lands in a separate `weakKeywords` tier capped at 60 — below `PAGE_DIRECT` (95) on its own, so one incidental component match cannot produce a confidently wrong answer, but above `PAGE_FLOOR` (50), so it still surfaces as a reference. Authored signal (a block's `componentsUsed`, a page's `category` words) keeps its 90.

## Measurements

36-query battery, same template set, baseline = this branch's merge base:

| | top-1 | top-3 | MRR | false-confident | no results |
|---|---|---|---|---|---|
| before | 15/36 | 23/36 | 0.509 | 8/36 | 1/36 |
| after | **17/36** | **26/36** | **0.574** | **6/36** | 3/36 |

"false-confident" = `build` reports `directMatch` on the wrong template, which is the failure mode that actively misleads an agent.

Both queries that now return nothing previously returned *wrong* pages — three dashboards for "collecting information across several steps with a progress indicator", and a confidently-wrong `dashboard-executive-summary` for "drag and drop builder where you assemble a layout". Returning nothing is the honest answer; getting them right is a description problem, not a scoring one.

I swept the derived tier rather than picking 60 by feel:

| tier | top-1 | top-3 | MRR | false-confident |
|---|---|---|---|---|
| 90 (before) | 15 | 23 | 0.509 | 8 |
| **60 (this PR)** | 17 | 26 | 0.574 | **6** |
| 65 / 70 | 18 | 27 | 0.602 | 7 |
| 80 | 17 | 25 | 0.560 | 9 |

65/70 buy one top-1 for one false-confident. That is inside this battery's authoring noise (±2 queries), so I took the conservative end: at 60 two derived matches still cannot clear the confidence gate, at 70 they can. Trivial to change if you'd rather have the ranking.

## Test plan

- [x] `vitest run packages/cli/api/search/search.test.mjs packages/cli/foundation/discovery/template-adapter.test.mjs` — 26 pass
- [x] New scoring tests: the `file browser` inversion, a superset-never-ranks-lower property, and a verbose-prompt guard for the behaviour the mean was protecting
- [x] New `template-adapter.test.mjs` — first coverage for `extractComponents`: generics excluded, JSX tags and closing tags still handled
- [x] New derived-vs-authored tier assertions, pinned against `PAGE_DIRECT` / `PAGE_FLOOR`
- [x] `astryx build "file browser"` returns `file-explorer` as the direct match
- [x] eslint clean; full pre-commit gate (`check:sync`, `check:package-boundaries`, `check:changesets`, `check:cli-structure`, …) green

## Caveats

The 36-query battery is one author's, so the absolute rates reflect that battery rather than a population, and each ranking delta is 1–3 queries. The two things that are exact and independently reproducible are the `file browser` inversion and the 82 bogus keywords. The battery harness is not in this PR to keep it reviewable — happy to land it separately if it's useful to you.
