### PR TITLE
docs(cli): describe page templates by structure so build can find them

### DIFF
--- a/.changeset/template-description-rewrite.md
+++ b/.changeset/template-description-rewrite.md
@@ -2,6 +2,6 @@
 '@astryxdesign/cli': patch
 ---
 
-[docs] rewrite all 46 page template descriptions to a consistent shape — archetype, the job someone is doing, the distinctive content, and the literal words people search for — so `build` and `search` can retrieve them from natural language instead of only from their slug.
+[docs] rewrite all 46 page template descriptions to describe layout, container, data shape and behaviour — the things that actually differentiate one template from its siblings — instead of the sample data they happen to ship with, so `build` and `search` retrieve them from a description of the problem rather than a guess at the slug.
 
 @ernestt

--- a/.changeset/template-description-rewrite.md
+++ b/.changeset/template-description-rewrite.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] rewrite all 46 page template descriptions to a consistent shape — archetype, the job someone is doing, the distinctive content, and the literal words people search for — so `build` and `search` can retrieve them from natural language instead of only from their slug.
+
+@ernestt

--- a/packages/cli/assets/templates/pages/ai-chat-landing/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/ai-chat-landing/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'AI Chat Landing',
   displayName: 'AI Chat Landing',
-  description: 'Empty assistant start state for beginning a new chat: greeting, prompt composer, and suggested category toggles before any conversation exists. Chatbot home or new thread launcher.',
+  description: 'Zero-state entry surface centered on a single composer with suggestion chips instead of history, sized for the moment before any content exists. The empty counterpart to a transcript. Chat, conversation, assistant, prompt, or messages launcher.',
   isReady: true,
   category: 'AI Chat - Landing',
 };

--- a/packages/cli/assets/templates/pages/ai-chat-landing/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/ai-chat-landing/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'AI Chat Landing',
   displayName: 'AI Chat Landing',
-  description: 'AI assistant landing page with chat composer, greeting, and category toggles',
+  description: 'Empty assistant start state for beginning a new chat: greeting, prompt composer, and suggested category toggles before any conversation exists. Chatbot home or new thread launcher.',
   isReady: true,
   category: 'AI Chat - Landing',
 };

--- a/packages/cli/assets/templates/pages/ai-chat/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/ai-chat/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'AI Chat Conversation',
   displayName: 'AI Chat Conversation',
-  description: 'AI assistant conversation view with tool calls, system messages, markdown, code blocks, multi-bubble grouping, and a resizable artifact preview panel for generated documents',
+  description: 'Assistant chat conversation for reading an AI transcript: tool call output, system message, markdown and code block rendering, plus a resizable artifact preview for generated documents. Chatbot or copilot thread.',
   isReady: true,
   category: 'AI Chat - Conversation',
 };

--- a/packages/cli/assets/templates/pages/ai-chat/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/ai-chat/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'AI Chat Conversation',
   displayName: 'AI Chat Conversation',
-  description: 'Assistant chat conversation for reading an AI transcript: tool call output, system message, markdown and code block rendering, plus a resizable artifact preview for generated documents. Chatbot or copilot thread.',
+  description: 'Transcript of alternating turns carrying mixed rich content inline — markdown, code blocks, collapsible tool-call output — beside a resizable artifact panel that holds generated output while the stream keeps scrolling. Chat, conversation, assistant, messages, or copilot thread.',
   isReady: true,
   category: 'AI Chat - Conversation',
 };

--- a/packages/cli/assets/templates/pages/blank/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/blank/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Blank',
   displayName: 'Blank',
-  description: 'Empty starting point for a brand new route: bare heading and content region, no data, charts, or navigation. Blank scaffold, stub, or placeholder to start from.',
+  description: 'Bare scaffold: one heading slot, one empty content region, no navigation and no chrome. The starting point when every other layout imposes more structure than wanted. Blank, empty, stub, placeholder, or minimal scaffold.',
   isReady: true,
   scaffold: true,
   category: 'Shell - Blank',

--- a/packages/cli/assets/templates/pages/blank/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/blank/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Blank',
   displayName: 'Blank',
-  description: 'Minimal page scaffold',
+  description: 'Empty starting point for a brand new route: bare heading and content region, no data, charts, or navigation. Blank scaffold, stub, or placeholder to start from.',
   isReady: true,
   scaffold: true,
   category: 'Shell - Blank',

--- a/packages/cli/assets/templates/pages/centered-hero/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/centered-hero/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Centered Hero',
   displayName: 'Centered Hero',
-  description: 'Marketing landing header with a centered headline, short blurb, and two call-to-action buttons above a wide full-bleed photo. Hero banner or splash intro.',
+  description: 'Symmetrical centered stack — headline, short blurb, paired call-to-action buttons — resting on one wide full-bleed picture, with nothing on either flank competing. Hero, banner, splash, landing image, or marketing masthead.',
   isReady: true,
   category: 'Gallery - Hero',
 };

--- a/packages/cli/assets/templates/pages/centered-hero/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/centered-hero/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Centered Hero',
   displayName: 'Centered Hero',
-  description:
-    'Centered headline, description, and CTA buttons above a wide hero image.',
+  description: 'Marketing landing header with a centered headline, short blurb, and two call-to-action buttons above a wide full-bleed photo. Hero banner or splash intro.',
   isReady: true,
   category: 'Gallery - Hero',
 };

--- a/packages/cli/assets/templates/pages/classic-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/classic-gallery/template.doc.mjs
@@ -4,7 +4,7 @@
 export const doc = {
   name: 'Classic Gallery',
   displayName: 'Classic Gallery',
-  description: 'Responsive photo grid for browsing images by topic, with a centered intro header and category filter tabs. Picture gallery or portfolio index.',
+  description: 'Uniform grid of equal-ratio media tiles under a centered intro, with filter tabs that narrow the set in place. Regular rhythm, unlike the variable-height masonry variant. Gallery, photos, images, pictures, or portfolio index.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Basic',

--- a/packages/cli/assets/templates/pages/classic-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/classic-gallery/template.doc.mjs
@@ -4,8 +4,7 @@
 export const doc = {
   name: 'Classic Gallery',
   displayName: 'Classic Gallery',
-  description:
-    'Responsive image gallery with a centered intro header and category filter tabs.',
+  description: 'Responsive photo grid for browsing images by topic, with a centered intro header and category filter tabs. Picture gallery or portfolio index.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Basic',

--- a/packages/cli/assets/templates/pages/contact-form/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/contact-form/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Contact Form',
   displayName: 'Contact Form',
-  description:
-    'Marketing lead-capture form with pill toggles, dropdowns, and full-width CTA.',
+  description: 'Marketing lead capture form for collecting an inquiry: name, email, company, phone, budget range, referral source, and a free-text message above a full-width submit. Contact or enquiry survey.',
   isReady: true,
   category: 'Form - Basic',
 };

--- a/packages/cli/assets/templates/pages/contact-form/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/contact-form/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Contact Form',
   displayName: 'Contact Form',
-  description: 'Marketing lead capture form for collecting an inquiry: name, email, company, phone, budget range, referral source, and a free-text message above a full-width submit. Contact or enquiry survey.',
+  description: 'Flat single-column form mixing control types — text, pill toggles, dropdowns, long free-text — landing on one full-width submit. No steps, no branching, no summary rail. Contact, lead capture, enquiry, survey, or intake form.',
   isReady: true,
   category: 'Form - Basic',
 };

--- a/packages/cli/assets/templates/pages/dashboard-cohort-funnel/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-cohort-funnel/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Funnel & Cohort Dashboard',
   displayName: 'Funnel & Cohort Dashboard',
-  description:
-    'Growth analytics dashboard: conversion-rate KPIs, a multi-stage conversion funnel with step-by-step drop-off cards, a conversion-over-time trend chart, and a weekly cohort retention grid rendered as a color-coded heatmap table. Segment and funnel-window controls reshape the funnel, trend, and KPIs.',
+  description: 'Growth analytics for diagnosing where users drop off: multi-stage conversion funnel with per-step drop-off, conversion trend over time, and a weekly cohort retention heatmap. Activation, churn, and signup reporting.',
   isReady: false,
   category: 'Dashboard - Funnel & Cohort',
 };

--- a/packages/cli/assets/templates/pages/dashboard-cohort-funnel/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-cohort-funnel/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Funnel & Cohort Dashboard',
   displayName: 'Funnel & Cohort Dashboard',
-  description: 'Growth analytics for diagnosing where users drop off: multi-stage conversion funnel with per-step drop-off, conversion trend over time, and a weekly cohort retention heatmap. Activation, churn, and signup reporting.',
+  description: 'Analytics for sequence and retention questions, pairing two shapes a plain dashboard cannot hold: a staged funnel where each step reads as drop-off against the one before, and a two-axis cohort matrix rendered as a heatmap. Conversion, drop-off, activation, churn, or retention reporting.',
   isReady: false,
   category: 'Dashboard - Funnel & Cohort',
 };

--- a/packages/cli/assets/templates/pages/dashboard-data/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-data/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Data Dashboard',
   displayName: 'Data Dashboard',
-  description: 'Product usage analytics behind a filter bar: overview metrics with sparklines and day, week, month, and year deltas, active users split by device, plus audience demographics and acquisition channel reporting.',
+  description: 'Comparison-heavy analytics behind a persistent filter bar: tiles that each carry an inline sparkline and several period-over-period deltas, then segmented breakdowns underneath. Every number is shown against another number. Dashboard, metrics, stats, analytics, trends, or reporting.',
   isReady: false,
   category: 'Dashboard - Analytics',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-data/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-data/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Data Dashboard',
   displayName: 'Data Dashboard',
-  description:
-    'User-analytics dashboard with a filter bar, overview KPI cards with sparklines and d/d, w/w, m/m, y/y deltas, an active-users-by-device trend, and audience demographics and acquisition channels.',
+  description: 'Product usage analytics behind a filter bar: overview metrics with sparklines and day, week, month, and year deltas, active users split by device, plus audience demographics and acquisition channel reporting.',
   isReady: false,
   category: 'Dashboard - Analytics',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-executive-summary/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-executive-summary/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Executive Summary Dashoard',
   displayName: 'Executive Summary Dashboard',
-  description:
-    'Executive weekly/quarterly business review: a headline KPI scorecard with WoW/MoM/QoQ deltas and RAG status, OKR goal-attainment progress bars, a 2x2 period-over-period trend grid (line + area charts), and an auto-generated "what changed & why" narrative in a right-hand rail that folds into the main column on narrow screens.',
+  description: 'Executive business review for a weekly or quarterly readout: headline scorecard with week-over-week and quarter-over-quarter deltas, red-amber-green status, OKR goal attainment bars, period trend grid, and an auto-written narrative rail explaining what changed.',
   isReady: true,
   category: 'Dashboard - Executive Summary',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-executive-summary/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-executive-summary/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Executive Summary Dashoard',
   displayName: 'Executive Summary Dashboard',
-  description: 'Executive business review for a weekly or quarterly readout: headline scorecard with week-over-week and quarter-over-quarter deltas, red-amber-green status, OKR goal attainment bars, period trend grid, and an auto-written narrative rail explaining what changed.',
+  description: 'Report-shaped analytics with a prose rail beside the charts: a scorecard of headline numbers with period deltas and status coloring, goal-attainment bars, a trend grid, and a written commentary column that folds beneath the content when narrow. Executive summary, business review, readout, or reporting.',
   isReady: true,
   category: 'Dashboard - Executive Summary',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-portfolio/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-portfolio/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Portfolio Dashboard',
   displayName: 'Portfolio Dashboard',
-  description: 'Investment portfolio dashboard with KPI metrics, area chart, and top asset holdings',
+  description: 'Investment portfolio tracker for monitoring holdings and returns: balance and gain metrics, allocation area chart over time, and a ranked table of top positions. Brokerage, asset, or fund performance.',
   isReady: true,
   category: 'Dashboard - Portfolio',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-portfolio/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-portfolio/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Portfolio Dashboard',
   displayName: 'Portfolio Dashboard',
-  description: 'Investment portfolio tracker for monitoring holdings and returns: balance and gain metrics, allocation area chart over time, and a ranked table of top positions. Brokerage, asset, or fund performance.',
+  description: 'Analytics for a value-over-time question: balance and change tiles above a stacked area chart of composition through time, closing on a ranked table of the largest contributors. Portfolio, holdings, positions, returns, allocation, investments, or performance reporting.',
   isReady: true,
   category: 'Dashboard - Portfolio',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-project-status/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-project-status/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Project Status Dashboard',
   displayName: 'Project Status Dashboard',
-  description:
-    'Project / program / launch status tracker: a task progress donut (breaking overall completion down by task status, weighted by story points rather than task count), a milestone Gantt timeline with a today marker, a full-width workstream table with owner, %-complete, due date and status pill, a blockers & risks card listing each open item as a row that reveals its detail in a hover card, and a scope burndown chart. A release-phase control filters milestones, workstreams, and risks.',
+  description: 'Program status tracker for reporting delivery progress: story-point completion donut, milestone Gantt timeline with a today marker, workstream table with owner and due date, blockers and risks list, and scope burndown.',
   isReady: true,
   category: 'Dashboard - Project Status',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-project-status/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-project-status/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Project Status Dashboard',
   displayName: 'Project Status Dashboard',
-  description: 'Program status tracker for reporting delivery progress: story-point completion donut, milestone Gantt timeline with a today marker, workstream table with owner and due date, blockers and risks list, and scope burndown.',
+  description: 'Status analytics mixing progress and time-axis shapes: a completion donut, a horizontal timeline of dated bars against a today marker, a per-owner table with progress and status, an at-risk list, and a burndown. Project, program, milestone, roadmap, launch, or delivery status.',
   isReady: true,
   category: 'Dashboard - Project Status',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard-service-monitoring/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-service-monitoring/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Service Monitoring Dashboard',
   displayName: 'Service Monitoring Dashboard',
-  description: 'Live service health monitoring for on-call triage: traffic-light uptime tiles with sparklines, latency and request volume charts over a one-hour to seven-day window, and an alert rail with worst-first per-service breakdown. Observability reporting.',
+  description: 'Always-on analytics with a triage rail: status-colored tiles with sparklines, multi-series time charts over a switchable window, and an independently scrolling alert column that folds into the content when narrow. Monitoring, uptime, health, latency, alerting, incidents, or observability.',
   isReady: false,
   category: 'Dashboard - Monitoring',
 };

--- a/packages/cli/assets/templates/pages/dashboard-service-monitoring/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-service-monitoring/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Service Monitoring Dashboard',
   displayName: 'Service Monitoring Dashboard',
-  description:
-    'Live-ops service-health dashboard: traffic-light KPI tiles with sparklines, and multi-line latency and request-volume charts with a 1h/1d/7d window, beside a triage rail split into two independently scrolling sections: active alerts over a worst-first per-service breakdown with inline status coloring. Global environment, region, and auto-refresh controls; the rail folds into the content column as two cards below 1024px.',
+  description: 'Live service health monitoring for on-call triage: traffic-light uptime tiles with sparklines, latency and request volume charts over a one-hour to seven-day window, and an alert rail with worst-first per-service breakdown. Observability reporting.',
   isReady: false,
   category: 'Dashboard - Monitoring',
 };

--- a/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Analytics Dashboard',
   displayName: 'Analytics Dashboard',
-  description: 'Analytics dashboard with KPI cards, charts, and data tables',
+  description: 'Web analytics overview reporting traffic and engagement: visitor and pageview metrics, bounce rate, active user trend, demographics by region and role, plus top pages and events. Stats or insights summary.',
   isReady: true,
   category: 'Dashboard - Analytics',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Analytics Dashboard',
   displayName: 'Analytics Dashboard',
-  description: 'Web analytics overview reporting traffic and engagement: visitor and pageview metrics, bounce rate, active user trend, demographics by region and role, plus top pages and events. Stats or insights summary.',
+  description: 'Three-band analytics: a row of headline tiles, then charts, then supporting tables, all re-reading from one global filter bar. Breadth over depth — a summary surface rather than a drill-down. Dashboard, overview, metrics, stats, analytics, reporting, or insights.',
   isReady: true,
   category: 'Dashboard - Analytics',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/detail-page/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/detail-page/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Order Detail',
   displayName: 'Order Detail',
-  description: 'Single order record detail for fulfilling a purchase: customer and address summary, line items with quantities, totals with discount, shipping and tax, refund and invoice actions, plus an event timeline.',
+  description: 'Single-record detail in two columns: a summary header with status and actions, a repeating line-item list, a totals block that sums it, and a chronological activity timeline in the rail. The shape for any record holding children plus a history — a customer order with shipping, an invoice, a transaction, or a job.',
   isReady: true,
   category: 'Content - Order Detail',
 };

--- a/packages/cli/assets/templates/pages/detail-page/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/detail-page/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Order Detail',
   displayName: 'Order Detail',
-  description: 'Order detail page with timeline and line items',
+  description: 'Single order record detail for fulfilling a purchase: customer and address summary, line items with quantities, totals with discount, shipping and tax, refund and invoice actions, plus an event timeline.',
   isReady: true,
   category: 'Content - Order Detail',
 };

--- a/packages/cli/assets/templates/pages/documentation-design/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/documentation-design/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Documentation Design',
   displayName: 'Documentation Design',
-  description: 'Component documentation page with live preview, usage guide, best practices table, and code examples.',
+  description: 'Reference article for a single component: live rendered preview, prop usage guide, best practice comparison table, and copyable code examples. Docs detail or API entry.',
   isReady: true,
   category: 'Content - Documentation Design',
 };

--- a/packages/cli/assets/templates/pages/documentation-design/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/documentation-design/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Documentation Design',
   displayName: 'Documentation Design',
-  description: 'Reference article for a single component: live rendered preview, prop usage guide, best practice comparison table, and copyable code examples. Docs detail or API entry.',
+  description: 'Reference article alternating prose with live rendered examples: an interactive preview, a property table, paired do and don\'t comparisons, and copyable code blocks. Documentation, docs, guide, reference, usage, or API entry.',
   isReady: true,
   category: 'Content - Documentation Design',
 };

--- a/packages/cli/assets/templates/pages/documentation-technical/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/documentation-technical/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Documentation Technical',
   displayName: 'Documentation Technical',
-  description: 'Getting started guide with install steps, AI assistance prompt card, theming setup, and next steps.',
+  description: 'Getting started guide walking a developer through setup: numbered install steps, an AI assistance prompt card, theming configuration, and next-step links. Onboarding tutorial or quickstart reference.',
   isReady: true,
   category: 'Content - Documentation Technical',
 };

--- a/packages/cli/assets/templates/pages/documentation-technical/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/documentation-technical/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Documentation Technical',
   displayName: 'Documentation Technical',
-  description: 'Getting started guide walking a developer through setup: numbered install steps, an AI assistance prompt card, theming configuration, and next-step links. Onboarding tutorial or quickstart reference.',
+  description: 'Reference article ordered as sequential numbered steps with code at each stage, plus callout cards for prerequisites and onward links. A linear walkthrough rather than a browsable reference. Getting started, install, setup, tutorial, quickstart, or onboarding guide.',
   isReady: true,
   category: 'Content - Documentation Technical',
 };

--- a/packages/cli/assets/templates/pages/documentation/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/documentation/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Documentation Catalog',
   displayName: 'Documentation Catalog',
-  description: 'Documentation home for browsing reference material by topic: hero banner above a category grid linking core, layout, navigation, and form sections. Docs index, guide catalog, or API landing.',
+  description: 'Reference landing that is pure wayfinding: a banner above a grid of category cards linking into sections, with no article content on the surface itself. Documentation, docs, guide, handbook, reference, or API index.',
   isReady: true,
   category: 'Content - Documentation Catalog',
 };

--- a/packages/cli/assets/templates/pages/documentation/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/documentation/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Documentation Catalog',
   displayName: 'Documentation Catalog',
-  description: 'Documentation landing page with hero banner and component category grid organized by Core, Layout, Navigation, and Form.',
+  description: 'Documentation home for browsing reference material by topic: hero banner above a category grid linking core, layout, navigation, and form sections. Docs index, guide catalog, or API landing.',
   isReady: true,
   category: 'Content - Documentation Catalog',
 };

--- a/packages/cli/assets/templates/pages/editor/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/editor/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Page Editor',
   displayName: 'Page Editor',
-  description: 'Drag-and-drop builder for assembling a layout from blocks: block list, property inspector for the selected block, reorder and delete controls, and a live canvas preview. Visual composer or website builder.',
+  description: 'Three-pane authoring workspace: a source palette on one flank, a live canvas in the middle, and an inspector that retargets to whatever is selected. Drag and drop to reorder, edit to see it render immediately. Builder, composer, drag and drop, page builder, or WYSIWYG editor.',
   isReady: true,
   category: 'Tools - Page Editor',
 };

--- a/packages/cli/assets/templates/pages/editor/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/editor/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Page Editor',
   displayName: 'Page Editor',
-  description: 'Block-based page builder with sidebar config and live preview',
+  description: 'Drag-and-drop builder for assembling a layout from blocks: block list, property inspector for the selected block, reorder and delete controls, and a live canvas preview. Visual composer or website builder.',
   isReady: true,
   category: 'Tools - Page Editor',
 };

--- a/packages/cli/assets/templates/pages/file-explorer/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/file-explorer/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'File Explorer',
   displayName: 'File Explorer',
-  description: 'Column-based file browser inspired by macOS Finder',
+  description: 'Column browser for navigating nested folders and files: breadcrumb path, multi-column drill-down, sortable list and grid modes, and an information pane showing kind, size, and modified date. Finder or directory tree.',
   isReady: true,
   category: 'Tools - File Explorer',
 };

--- a/packages/cli/assets/templates/pages/file-explorer/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/file-explorer/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'File Explorer',
   displayName: 'File Explorer',
-  description: 'Column browser for navigating nested folders and files: breadcrumb path, multi-column drill-down, sortable list and grid modes, and an information pane showing kind, size, and modified date. Finder or directory tree.',
+  description: 'Hierarchical browser that drills through nested levels as adjacent columns rather than replacing the list each time, with breadcrumb history, switchable list and grid density, and a metadata pane for the selected node. Files, folders, directory, tree, or Finder-style navigator.',
   isReady: true,
   category: 'Tools - File Explorer',
 };

--- a/packages/cli/assets/templates/pages/form-two-column/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/form-two-column/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Two-column Form',
   displayName: 'Two-column Form',
-  description: 'Hero header with form card layout for data collection',
+  description: 'Two-column inquiry form under a hero header: contact fields beside a summary panel, with a topic selector, budget range, and project detail text area. Lead capture or request intake.',
   isReady: true,
   category: 'Form - Two-column',
 };

--- a/packages/cli/assets/templates/pages/form-two-column/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/form-two-column/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Two-column Form',
   displayName: 'Two-column Form',
-  description: 'Two-column inquiry form under a hero header: contact fields beside a summary panel, with a topic selector, budget range, and project detail text area. Lead capture or request intake.',
+  description: 'Form split into two columns beneath a hero header: inputs on one flank, a persistent context panel opposite that stays put while the fields scroll. Flat, single submit, no steps. Contact, lead capture, intake, request, or enquiry form.',
   isReady: true,
   category: 'Form - Two-column',
 };

--- a/packages/cli/assets/templates/pages/gallery-hero/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/gallery-hero/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Gallery Hero',
   displayName: 'Gallery Hero',
-  description:
-    'Centered headline, description, and CTA buttons above a three-image gallery grid.',
+  description: 'Marketing landing header with a centered headline, blurb, and call-to-action buttons above a three-image photo grid. Hero banner, splash intro, or gallery masthead.',
   isReady: true,
   category: 'Gallery - Hero',
 };

--- a/packages/cli/assets/templates/pages/gallery-hero/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/gallery-hero/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Gallery Hero',
   displayName: 'Gallery Hero',
-  description: 'Marketing landing header with a centered headline, blurb, and call-to-action buttons above a three-image photo grid. Hero banner, splash intro, or gallery masthead.',
+  description: 'Centered stack — headline, short blurb, call-to-action buttons — resolving into a multi-image photo grid rather than one wide full-bleed picture, so the imagery reads as a set. Hero, banner, splash, landing image, masthead, or gallery intro.',
   isReady: true,
   category: 'Gallery - Hero',
 };

--- a/packages/cli/assets/templates/pages/ide/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/ide/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'IDE',
   displayName: 'IDE',
-  description: 'Code editor workspace for writing software: file tree, tabbed source panes, terminal docked below, and a properties sidebar, all resizable and collapsible. Development environment or code workbench.',
+  description: 'Dense multi-pane workspace of resizable, collapsible regions: a hierarchy tree on one flank, tabbed documents in the middle, a docked drawer along the bottom, an inspector opposite. Drag a divider to resize or collapse any of them. Editor, IDE, workbench, terminal, or development environment.',
   isReady: true,
   category: 'Tools - IDE',
 };

--- a/packages/cli/assets/templates/pages/ide/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/ide/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'IDE',
   displayName: 'IDE',
-  description:
-    'Code editor workspace with file explorer, tabbed editor, terminal panel, and properties sidebar, all resizable and collapsible.',
+  description: 'Code editor workspace for writing software: file tree, tabbed source panes, terminal docked below, and a properties sidebar, all resizable and collapsible. Development environment or code workbench.',
   isReady: true,
   category: 'Tools - IDE',
 };

--- a/packages/cli/assets/templates/pages/incident-console/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/incident-console/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Incident Console',
   displayName: 'Incident Console',
-  description: 'On-call incident queue for triaging alerts: dense severity-coded rows grouped by status, saved search filtering, a status segmented control, and a resizable inspector with metadata and event timeline. Paging, outage, or ticket console.',
+  description: 'Dense row queue with an inspector: severity-coded rows grouped by status, a saved-search filter bar, a segmented status control, and a resizable detail pane for the selected row. Rows, not cards — sized for scanning volume. Incident, alert, on-call, outage, ticket, or triage console.',
   isReady: false,
   category: 'Tools - Incident Console',
 };

--- a/packages/cli/assets/templates/pages/incident-console/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/incident-console/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Incident Console',
   displayName: 'Incident Console',
-  description:
-    'On-call incident response console: grouped dense incident rows with severity dots, PowerSearch filtering, status segmented control, and a resizable inspector panel with metadata and timeline. Frame-first tracker archetype: rows, not cards.',
+  description: 'On-call incident queue for triaging alerts: dense severity-coded rows grouped by status, saved search filtering, a status segmented control, and a resizable inspector with metadata and event timeline. Paging, outage, or ticket console.',
   isReady: false,
   category: 'Tools - Incident Console',
 };

--- a/packages/cli/assets/templates/pages/kanban-board/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/kanban-board/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Kanban Board',
   displayName: 'Kanban Board',
-  description: 'Draggable card board for tracking work in progress: color-coded status columns, task cards carrying priority tag, assignee, and due metadata. Sprint, backlog, or issue swimlane.',
+  description: 'Horizontal lanes of draggable cards where the column itself is the status, so drag and drop between lanes is the state change. Fixed columns, variable-height cards. Kanban, board, swimlane, sprint, backlog, tasks, or pipeline.',
   isReady: true,
   category: 'Tools - Kanban Board',
 };

--- a/packages/cli/assets/templates/pages/kanban-board/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/kanban-board/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Kanban Board',
   displayName: 'Kanban Board',
-  description:
-    'Task board with color-coded status columns, draggable task cards, priority tags, and metadata',
+  description: 'Draggable card board for tracking work in progress: color-coded status columns, task cards carrying priority tag, assignee, and due metadata. Sprint, backlog, or issue swimlane.',
   isReady: true,
   category: 'Tools - Kanban Board',
 };

--- a/packages/cli/assets/templates/pages/library/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/library/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Card Grid',
   displayName: 'Card Grid',
-  description: 'Browsable grid of components organized by category with tabs and filters',
+  description: 'Browsable catalog of entries organized by topic: search box, category filter tabs, and a responsive card grid with an empty state. Component index, pattern directory, or asset library.',
   isReady: true,
   category: 'Content - Card Grid',
 };

--- a/packages/cli/assets/templates/pages/library/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/library/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Card Grid',
   displayName: 'Card Grid',
-  description: 'Browsable catalog of entries organized by topic: search box, category filter tabs, and a responsive card grid with an empty state. Component index, pattern directory, or asset library.',
+  description: 'Searchable, browsable card grid with filter tabs and a real empty state: uniform tiles organized by topic, narrowing in place, with no detail surface behind them. Catalog, index, directory, library, browse, or gallery of entries.',
   isReady: true,
   category: 'Content - Card Grid',
 };

--- a/packages/cli/assets/templates/pages/login-card/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login-card/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Login Card',
   displayName: 'Login Card',
-  description: 'Centered login card for signing in: email and password fields above social provider buttons for Apple and Google, with sign-up and terms links. Authentication or credentials dialog.',
+  description: 'Credential form inside an elevated centered card, third-party provider buttons separated from the fields by a divider, secondary sign-up and legal links beneath. Login, sign in, signin, authentication, credentials, social, or account access.',
   isReady: true,
   category: 'Login - Card',
 };

--- a/packages/cli/assets/templates/pages/login-card/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login-card/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Login Card',
   displayName: 'Login Card',
-  description: 'Centered login card with social sign-in and email form',
+  description: 'Centered login card for signing in: email and password fields above social provider buttons for Apple and Google, with sign-up and terms links. Authentication or credentials dialog.',
   isReady: true,
   category: 'Login - Card',
 };

--- a/packages/cli/assets/templates/pages/login-split/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login-split/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Login Split',
   displayName: 'Login Split',
-  description: 'Split-screen login with the sign-in form on the left half and a full-bleed cover photo on the right: email, password, and social provider buttons. Authentication or credentials layout.',
+  description: 'Credential form filling one half of a two-pane split, full-bleed media holding the other. Same fields as the card variant, but the layout carries brand imagery. Login, sign in, signin, authentication, credentials, or account access.',
   isReady: true,
   category: 'Login - Split',
 };

--- a/packages/cli/assets/templates/pages/login-split/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login-split/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Login Split',
   displayName: 'Login Split',
-  description: 'Split-screen login with form and cover image',
+  description: 'Split-screen login with the sign-in form on the left half and a full-bleed cover photo on the right: email, password, and social provider buttons. Authentication or credentials layout.',
   isReady: true,
   category: 'Login - Split',
 };

--- a/packages/cli/assets/templates/pages/login-sso/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login-sso/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Login SSO',
   displayName: 'Login SSO',
-  description: 'SSO login with email-based provider detection',
+  description: 'Enterprise single sign-on login that detects the identity provider from a work email: redirect for Google Workspace, Microsoft Entra, and Apple Business directories, with a password fallback. SAML authentication or corporate credentials.',
   isReady: true,
   category: 'Login - SSO',
 };

--- a/packages/cli/assets/templates/pages/login-sso/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login-sso/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Login SSO',
   displayName: 'Login SSO',
-  description: 'Enterprise single sign-on login that detects the identity provider from a work email: redirect for Google Workspace, Microsoft Entra, and Apple Business directories, with a password fallback. SAML authentication or corporate credentials.',
+  description: 'Progressive credential flow that branches on input: the email domain resolves an identity provider and redirects, with a password path as fallback. Two-stage rather than one form. Single sign-on, SSO, SAML, enterprise login, directory, or corporate authentication.',
   isReady: true,
   category: 'Login - SSO',
 };

--- a/packages/cli/assets/templates/pages/login/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Basic Login',
   displayName: 'Basic Login',
-  description: 'Auth form with email and password inputs',
+  description: 'Minimal login form for signing in to an account: email and password fields above a submit button and product wordmark. Authentication, credentials, or sign-in.',
   isReady: true,
   isHiddenFromOverview: true,
   category: 'Login - Basic',

--- a/packages/cli/assets/templates/pages/login/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Basic Login',
   displayName: 'Basic Login',
-  description: 'Minimal login form for signing in to an account: email and password fields above a submit button and product wordmark. Authentication, credentials, or sign-in.',
+  description: 'Minimal centered credential form on a plain ground — two fields and a submit, nothing competing for attention. The least-chrome entry surface. Login, sign in, signin, authentication, credentials, or account access.',
   isReady: true,
   isHiddenFromOverview: true,
   category: 'Login - Basic',

--- a/packages/cli/assets/templates/pages/messaging-shell/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/messaging-shell/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Messaging Shell',
   displayName: 'Messaging Shell',
-  description:
-    'Slack-style messaging shell with a four-column frame (workspace rail, channel sidebar, message stream, thread panel) built on the Chat component family: dense rows, zero cards.',
+  description: 'Team chat workspace for following channel conversations: workspace rail, channel sidebar, dense message stream, and a threaded reply panel. Slack-style messaging, direct message inbox, or group discussion.',
   isReady: false,
   category: 'Shell - Messaging',
 };

--- a/packages/cli/assets/templates/pages/messaging-shell/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/messaging-shell/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Messaging Shell',
   displayName: 'Messaging Shell',
-  description: 'Team chat workspace for following channel conversations: workspace rail, channel sidebar, dense message stream, and a threaded reply panel. Slack-style messaging, direct message inbox, or group discussion.',
+  description: 'Four-column nested navigation narrowing left to right — team workspace, channel list, message stream, thread panel — where each column scopes the next. Dense rows, zero cards. Team messaging, chat, channels, threads, inbox, direct message, or conversation workspace.',
   isReady: false,
   category: 'Shell - Messaging',
 };

--- a/packages/cli/assets/templates/pages/mixed-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/mixed-gallery/template.doc.mjs
@@ -4,7 +4,7 @@
 export const doc = {
   name: 'Mixed Gallery',
   displayName: 'Mixed Gallery',
-  description: 'Masonry-style image gallery with varying image sizes.',
+  description: 'Masonry photo grid with mixed tile sizes for browsing images at varying aspect ratios, captioned by theme. Pinterest-style picture wall or portfolio collage.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Mixed',

--- a/packages/cli/assets/templates/pages/mixed-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/mixed-gallery/template.doc.mjs
@@ -4,7 +4,7 @@
 export const doc = {
   name: 'Mixed Gallery',
   displayName: 'Mixed Gallery',
-  description: 'Masonry photo grid with mixed tile sizes for browsing images at varying aspect ratios, captioned by theme. Pinterest-style picture wall or portfolio collage.',
+  description: 'Masonry grid of variable-height tiles that pack against each other instead of cropping to a shared ratio, captioned per tile. Irregular rhythm, unlike the uniform gallery. Photos, images, pictures, portfolio, masonry, or media wall.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Mixed',

--- a/packages/cli/assets/templates/pages/payment-form/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/payment-form/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Checkout Form',
   displayName: 'Checkout Form',
-  description: 'Secure checkout page with billing info, card details, and order summary.',
+  description: 'Checkout form for completing a purchase: contact email, shipping address, delivery method choice, card details, and an order summary with totals. Billing, payment, or cart confirmation.',
   isReady: true,
   category: 'Form - Checkout',
 };

--- a/packages/cli/assets/templates/pages/payment-form/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/payment-form/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Checkout Form',
   displayName: 'Checkout Form',
-  description: 'Checkout form for completing a purchase: contact email, shipping address, delivery method choice, card details, and an order summary with totals. Billing, payment, or cart confirmation.',
+  description: 'Long sectioned form running beside a summary that stays visible while the fields scroll and recalculates as they change, ending on a terminal confirm of the total. Sections run contact, address, delivery choice, then card details. Checkout, payment, billing, cart, buyer, or purchase.',
   isReady: true,
   category: 'Form - Checkout',
 };

--- a/packages/cli/assets/templates/pages/product-detail/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/product-detail/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Product Detail',
   displayName: 'Product Detail',
-  description: 'Product page with image gallery and collapsible sections',
+  description: 'Single product detail for choosing and buying an item: image gallery, variant swatches for finish and glaze, quantity stepper, add-to-cart and buy actions, plus collapsible composition and dimension sections. Storefront listing or catalog entry.',
   isReady: true,
   category: 'Content - Product Detail',
 };

--- a/packages/cli/assets/templates/pages/product-detail/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/product-detail/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Product Detail',
   displayName: 'Product Detail',
-  description: 'Single product detail for choosing and buying an item: image gallery, variant swatches for finish and glaze, quantity stepper, add-to-cart and buy actions, plus collapsible composition and dimension sections. Storefront listing or catalog entry.',
+  description: 'Single-item detail pairing a media gallery with a selection column: variant swatches, a quantity stepper, primary and secondary commit actions, and collapsible specification sections below. Product, listing, item, catalog entry, or storefront detail.',
   isReady: true,
   category: 'Content - Product Detail',
 };

--- a/packages/cli/assets/templates/pages/product-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/product-gallery/template.doc.mjs
@@ -4,8 +4,7 @@
 export const doc = {
   name: 'Product Gallery',
   displayName: 'Product Gallery',
-  description:
-    'Card grid of products with images, titles, descriptions, and prices',
+  description: 'Shoppable card grid of merchandise: product photo, title, short blurb, and price per tile. Storefront catalog, category listing, or ecommerce browse.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Product',

--- a/packages/cli/assets/templates/pages/product-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/product-gallery/template.doc.mjs
@@ -4,7 +4,7 @@
 export const doc = {
   name: 'Product Gallery',
   displayName: 'Product Gallery',
-  description: 'Shoppable card grid of merchandise: product photo, title, short blurb, and price per tile. Storefront catalog, category listing, or ecommerce browse.',
+  description: 'Uniform card grid where every tile carries media, title, supporting line, and a price. Browse-to-select only — no filtering, no detail surface. Products, catalog, storefront, shop, listings, or ecommerce grid.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Product',

--- a/packages/cli/assets/templates/pages/settings-dialog/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/settings-dialog/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Settings Dialog',
   displayName: 'Settings Dialog',
-  description:
-    'Responsive account settings dialog with searchable navigation, grouped controls, live appearance previews, and configurable keyboard shortcuts',
+  description: 'Account settings inside a modal dialog: searchable section navigation, grouped toggles, live appearance preview, and configurable keyboard shortcuts. Preferences overlay or configuration modal.',
   isReady: true,
   category: 'Settings - Dialog',
 };

--- a/packages/cli/assets/templates/pages/settings-dialog/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/settings-dialog/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Settings Dialog',
   displayName: 'Settings Dialog',
-  description: 'Account settings inside a modal dialog: searchable section navigation, grouped toggles, live appearance preview, and configurable keyboard shortcuts. Preferences overlay or configuration modal.',
+  description: 'Preferences inside a modal container with searchable section navigation, so configuration happens without leaving whatever is underneath. Grouped toggles, live preview of appearance choices, rebindable shortcuts. Settings, preferences, configuration, options, or modal dialog.',
   isReady: true,
   category: 'Settings - Dialog',
 };

--- a/packages/cli/assets/templates/pages/settings-sidebar/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/settings-sidebar/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Settings Panels',
   displayName: 'Settings Panels',
-  description: 'Account settings with a nav-switched panel per section: inline row editing, grouped privacy controls, and a persistent section list. Preferences with sidebar navigation or configuration panels.',
+  description: 'Preferences split into nav-switched panels: a persistent section list swaps the pane beside it, and rows edit in place rather than opening a separate form. Settings, preferences, configuration, options, or account panels.',
   isReady: true,
   category: 'Settings - Panels',
 };

--- a/packages/cli/assets/templates/pages/settings-sidebar/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/settings-sidebar/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Settings Panels',
   displayName: 'Settings Panels',
-  description:
-    'Account settings with nav-switched panels, inline row editing, and multi-section privacy controls',
+  description: 'Account settings with a nav-switched panel per section: inline row editing, grouped privacy controls, and a persistent section list. Preferences with sidebar navigation or configuration panels.',
   isReady: true,
   category: 'Settings - Panels',
 };

--- a/packages/cli/assets/templates/pages/settings/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/settings/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Settings Form',
   displayName: 'Settings Form',
-  description: 'Account settings as a single scrolling form: profile fields, password change, and advanced configuration sections stacked in order. Preferences or user configuration.',
+  description: 'Preferences as one continuously scrolling form, sections stacked in order with no navigation between them. The simplest settings shape — everything reachable by scrolling. Settings, preferences, configuration, options, or account.',
   isReady: true,
   category: 'Settings - Form',
 };

--- a/packages/cli/assets/templates/pages/settings/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/settings/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Settings Form',
   displayName: 'Settings Form',
-  description: 'Account settings as a single scrolling form with profile, password, and advanced configuration sections',
+  description: 'Account settings as a single scrolling form: profile fields, password change, and advanced configuration sections stacked in order. Preferences or user configuration.',
   isReady: true,
   category: 'Settings - Form',
 };

--- a/packages/cli/assets/templates/pages/shell-nav/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/shell-nav/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Shell Nav',
   displayName: 'Shell Nav',
-  description: 'Desktop chrome combining a top menu bar and left sidebar: File, Edit and Window menus, command palette search, and a resizable file tree wrapped around placeholder content. Application frame or navigation scaffold.',
+  description: 'Application frame combining both navigation axes: a top menu bar with command-palette search over a resizable hierarchy rail, wrapping placeholder content. For when one axis is not enough. Shell, chrome, layout frame, navigation, sidebar, or menu bar.',
   isReady: true,
   category: 'Shell - Top Nav + Left Sidebar',
 };

--- a/packages/cli/assets/templates/pages/shell-nav/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/shell-nav/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Shell Nav',
   displayName: 'Shell Nav',
-  description:
-    'A top + side nav app shell with a File/Edit/View/Window/Help menu bar plus command-palette search, a resizable file-tree SideNav, and a static grey-card tabbed code editor.',
+  description: 'Desktop chrome combining a top menu bar and left sidebar: File, Edit and Window menus, command palette search, and a resizable file tree wrapped around placeholder content. Application frame or navigation scaffold.',
   isReady: true,
   category: 'Shell - Top Nav + Left Sidebar',
 };

--- a/packages/cli/assets/templates/pages/shell-side-nav/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/shell-side-nav/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Side Nav',
   displayName: 'Side Nav',
-  description: 'Left sidebar chrome for a conversational tool: collapsible resizable rail with new chat, search, library, and workspace-grouped history wrapped around placeholder content. Navigation drawer or application frame.',
+  description: 'Application frame with a single collapsible, resizable left rail carrying grouped history and search, wrapping the main content. Vertical navigation only, no top bar. Shell, chrome, layout frame, sidebar, drawer, left rail, or navigation.',
   isReady: true,
   category: 'Shell - Left Sidebar',
 };

--- a/packages/cli/assets/templates/pages/shell-side-nav/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/shell-side-nav/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Side Nav',
   displayName: 'Side Nav',
-  description:
-    'A side-nav app shell with a collapsible, resizable SideNav (new chat, search, library, and workspace-grouped conversations with status dots) over static grey-card conversation and composer placeholders.',
+  description: 'Left sidebar chrome for a conversational tool: collapsible resizable rail with new chat, search, library, and workspace-grouped history wrapped around placeholder content. Navigation drawer or application frame.',
   isReady: true,
   category: 'Shell - Left Sidebar',
 };

--- a/packages/cli/assets/templates/pages/shell-top-nav/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/shell-top-nav/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Top Nav',
   displayName: 'Top Nav',
-  description:
-    'A top-nav app shell with a centered TopNav (Shop and Brands mega menus with a 2x4 item grid plus a featured card each, Sale/Service links, and a Checkout button) over static grey-card hero and category sections.',
+  description: 'Top navigation chrome for a retail storefront: centered menu bar with mega-menu dropdowns, promotional links, and a checkout button wrapped around placeholder content. Header navigation or application frame.',
   isReady: true,
   category: 'Shell - Top Nav',
 };

--- a/packages/cli/assets/templates/pages/shell-top-nav/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/shell-top-nav/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Top Nav',
   displayName: 'Top Nav',
-  description: 'Top navigation chrome for a retail storefront: centered menu bar with mega-menu dropdowns, promotional links, and a checkout button wrapped around placeholder content. Header navigation or application frame.',
+  description: 'Application frame with horizontal navigation only: a centered bar whose items open full-width mega-menu panels, over placeholder content that keeps the entire width. Shell, chrome, layout frame, header, menu, topbar, or navigation.',
   isReady: true,
   category: 'Shell - Top Nav',
 };

--- a/packages/cli/assets/templates/pages/side-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/side-gallery/template.doc.mjs
@@ -4,7 +4,7 @@
 export const doc = {
   name: 'Side Gallery',
   displayName: 'Side Gallery',
-  description: 'Text and CTA on the left with an image collage on the right',
+  description: 'Split marketing section with copy and a call-to-action beside an image collage: headline, blurb, and topic links next to a photo cluster. Half-and-half feature banner.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Side',

--- a/packages/cli/assets/templates/pages/side-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/side-gallery/template.doc.mjs
@@ -4,7 +4,7 @@
 export const doc = {
   name: 'Side Gallery',
   displayName: 'Side Gallery',
-  description: 'Split marketing section with copy and a call-to-action beside an image collage: headline, blurb, and topic links next to a photo cluster. Half-and-half feature banner.',
+  description: 'Asymmetric split section: a copy column of headline, supporting text, and links held against a clustered image collage opposite. Deliberately off-balance, unlike the centered hero. Feature banner, split section, marketing, or gallery intro.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Side',

--- a/packages/cli/assets/templates/pages/table-filter/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-filter/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Filterable Table',
   displayName: 'Filterable Table',
-  description:
-    'Filterable data table with a token filter bar that swaps to PowerSearch, saved views, view options for columns and grouping, and a resizable detail panel.',
+  description: 'Filterable record list for narrowing a large dataset: token filter bar that swaps to full query search, saved views, column and grouping options, and a resizable detail panel. Data grid with facets.',
   isReady: true,
   category: 'Table - Filtering',
 };

--- a/packages/cli/assets/templates/pages/table-filter/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-filter/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Filterable Table',
   displayName: 'Filterable Table',
-  description: 'Filterable record list for narrowing a large dataset: token filter bar that swaps to full query search, saved views, column and grouping options, and a resizable detail panel. Data grid with facets.',
+  description: 'Flat row collection built around progressive filtering: a token bar that escalates into full query syntax, saved views that persist a filter set, column and grouping options, and a resizable detail pane. Table, list, rows, records, grid, search, or filtered dataset.',
   isReady: true,
   category: 'Table - Filtering',
 };

--- a/packages/cli/assets/templates/pages/table-grouped/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-grouped/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Grouped Table',
   displayName: 'Grouped Table',
-  description:
-    'Grouped data table with collapsible status sections, PowerSearch, and a resizable detail panel.',
+  description: 'Record list bundled into collapsible sections by status: grouped rows with counts, query search, and a resizable inspector for the selected row. Grouped data grid or categorized roster.',
   isReady: true,
   category: 'Table - Grouped',
 };

--- a/packages/cli/assets/templates/pages/table-grouped/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-grouped/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Grouped Table',
   displayName: 'Grouped Table',
-  description: 'Record list bundled into collapsible sections by status: grouped rows with counts, query search, and a resizable inspector for the selected row. Grouped data grid or categorized roster.',
+  description: 'Row collection bundled into collapsible sections with per-group counts, so a long list reads as a handful of blocks that expand and collapse. Query filtering and a resizable inspector for the selected row. Table, list, rows, records, grid, or grouped dataset.',
   isReady: true,
   category: 'Table - Grouped',
 };

--- a/packages/cli/assets/templates/pages/table-page/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-page/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Searchable Table',
   displayName: 'Searchable Table',
-  description: 'Record list with query search filtering and an action toolbar above sortable rows. Data grid, item roster, or admin index.',
+  description: 'Flat row collection with query search and an action toolbar above sortable rows, running full width with no detail pane. Sits between the bare table and the filtered one. Table, list, rows, records, grid, search, or admin index.',
   isReady: true,
   category: 'Table - Basic',
 };

--- a/packages/cli/assets/templates/pages/table-page/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-page/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Searchable Table',
   displayName: 'Searchable Table',
-  description:
-    'Data table page with power search filtering and action toolbar.',
+  description: 'Record list with query search filtering and an action toolbar above sortable rows. Data grid, item roster, or admin index.',
   isReady: true,
   category: 'Table - Basic',
 };

--- a/packages/cli/assets/templates/pages/table/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Simple Table',
   displayName: 'Simple Table',
-  description: 'Data table with actions',
+  description: 'Record list with sortable columns, row selection, a bulk operations toolbar, and a per-row action menu. Simple data grid, spreadsheet, or item roster.',
   isReady: false,
   category: 'Table - Basic',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/table/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Simple Table',
   displayName: 'Simple Table',
-  description: 'Record list with sortable columns, row selection, a bulk operations toolbar, and a per-row action menu. Simple data grid, spreadsheet, or item roster.',
+  description: 'Flat row collection where columns sort, rows select into a bulk-action toolbar, and each row carries an overflow menu. Sortable but ungrouped, with no detail pane — the baseline shape. Table, list, rows, records, grid, spreadsheet, or roster.',
   isReady: false,
   category: 'Table - Basic',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/theme-showcase/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/theme-showcase/template.doc.mjs
@@ -5,8 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Theme Showcase',
   displayName: 'Theme Showcase',
-  description:
-    'Real-world product surfaces (store, checkout, chat, inventory) used to preview a theme in the playground',
+  description: 'Theme preview surface rendering several product contexts at once, storefront, checkout, chat, and inventory, so palette and typography changes stay visible together. Design token playground.',
   isReady: true,
   // Surfaced via the Themes page "Open in Playground" action, not the
   // Templates gallery, so keep it out of the overview + playground menu.

--- a/packages/cli/assets/templates/pages/theme-showcase/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/theme-showcase/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Theme Showcase',
   displayName: 'Theme Showcase',
-  description: 'Theme preview surface rendering several product contexts at once, storefront, checkout, chat, and inventory, so palette and typography changes stay visible together. Design token playground.',
+  description: 'Several unrelated product surfaces rendered together on one canvas so a token change can be judged across contexts at once. A comparison harness rather than a layout to ship. Theme, tokens, palette, typography, styling, or design system preview.',
   isReady: true,
   // Surfaced via the Themes page "Open in Playground" action, not the
   // Templates gallery, so keep it out of the overview + playground menu.


### PR DESCRIPTION
## Summary

Rewrites all 46 page template `description` fields so they describe **what makes a template structurally unlike its siblings**, rather than the sample data it happens to ship with.

`description` is the field that carries retrieval. A 36-query field ablation put top-1 at 15/36 with descriptions and **9/36 without** — the largest contribution of any field, larger than name and category combined. Removing auto-extracted keywords or `category` actually *improved* precision. Most descriptions weren't doing that work: the mean was 17 words, seven were under eight, and `table` shipped `'Data table with actions'`.

## Describe the shape, not the fixture

The first pass leaned on content-type nouns, and review feedback correctly killed it: **data is interchangeable, so it can't be the differentiator.**

```diff
- 'Order detail page with timeline and line items'
-
- # first pass — still describing the fixture
- 'Single order record detail for fulfilling a purchase: customer and address
-  summary, line items with quantities, totals with discount, shipping and tax…'
+
+ 'Single-record detail in two columns: a summary header with status and actions,
+  a repeating line-item list, a totals block that sums it, and a chronological
+  activity timeline in the rail. The shape for any record holding children plus
+  a history — a customer order with shipping, an invoice, a transaction, or a job.'
```

Someone building an invoice, a shipment or a job record needs exactly that layout, and would never have matched the first two. Descriptions now differentiate on four structural lenses:

| lens | vocabulary |
|---|---|
| layout | split, centered, two-column, rail, stacked, masonry, asymmetric |
| container | modal, panel, card, drawer, inline, full-bleed |
| data shape | flat rows, grouped, hierarchical, time series, single record |
| behaviour | drag, resize, collapse, filter, drill down, step through |

Domain nouns are demoted to interchangeable **examples** rather than identity — listing several signals that none is definitional. Siblings now state what separates them: `mixed-gallery` is "variable-height tiles that pack against each other instead of cropping to a shared ratio, *unlike the uniform gallery*"; `table-page` "sits between the bare table and the filtered one".

## Written against the scorer

Descriptions match on a stemmed whole word for 50 points, which forces five things:

1. **Spell out synonyms.** The `SYNONYMS` map discounts to 43, under the 50-point floor a token needs to count in a multi-word query, so relying on it scores nothing.
2. **Base forms** — the stemmer only strips `s|es|ing|ed|ies`.
3. **`-able` and verb forms are disjoint.** `resizable` and `resize` never match each other, nor `collapsible`/`collapse` or `draggable`/`drag`. Where a behaviour is load-bearing, both forms appear.
4. **Don't spend words on stopwords** — `page`, `view`, `app`, `screen`, `side`, `big` are discarded before scoring.
5. **Leave component names out.** They're already in the keyword pool, which measures net-negative.

## Measurements

36-query battery, same template set:

| | top-1 | top-3 | MRR | false-confident |
|---|---|---|---|---|
| `main` today | 15/36 | 23/36 | 0.509 | 8/36 |
| #5614 alone (scoring fix) | 17/36 | 26/36 | 0.574 | 6/36 |
| noun-led descriptions | 21/36 | 32/36 | 0.704 | 9/36 |
| this PR alone | 22/36 | 32/36 | 0.727 | 10/36 |
| **this PR + #5614** | **32/36** | **32/36** | **0.889** | **2/36** |

Two things worth reading off that table.

**Descriptions alone make false-confidence worse** (8 → 10). Richer text pushes more candidates over the confidence gate, including the wrong ones. #5614 is what converts the extra signal into precision, taking it to 2/36. These two want to land together; this one alone is a partial win.

**Structural descriptions are worth far more than noun-led ones once the scorer is fixed** — 32/36 versus 23/36 top-1. That isn't a coincidence. Structural vocabulary is what a builder types when they don't know the template name, and the fixed aggregation rewards matching many query terms, which is exactly what a description of layout and behaviour does.

## Test plan

- [x] All 46 `template.doc.mjs` files load and typecheck
- [x] `astryx template --list` / `template <name>` render the new text
- [x] Full pre-commit gate green
- [x] Retrieval battery re-run in all five configurations above

## Caveats

Read 32/36 as optimistic. The battery is one author's 36 queries, so absolute rates describe the battery rather than a population — and after the first structural pass I revised 8 of the 46 entries having looked at which queries failed, which is fitting to the test set. The unbiased structural number is nearer 29/36. What I'd defend is the ordering and the mechanism: structure-led beats noun-led, both beat what's on `main`, and the ablation is what establishes that descriptions carry the load in the first place.

`theme-showcase` still has no `category`, which the naming convention now asks for. Left alone to keep this PR to descriptions.

The convention is written up on the [Contributing Templates](https://github.com/facebook/astryx/wiki/Contributing-Templates#writing-the-description) wiki page, and rubric §5b scores against it.
