### PR TITLE
Catch docs that omit a public component prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "check:executable-bits": "node scripts/check-executable-bits.mjs",
     "check:demo-media": "node scripts/check-demo-media.mjs",
     "check:i18n-catalog": "node scripts/check-i18n-catalog.mjs",
+    "check:contract": "node scripts/check-contract.mjs",
     "check:sync": "node scripts/check-sync.js",
     "check:use-client": "node scripts/check-use-client.mjs",
     "lint": "pnpm check:repo && eslint . --cache",

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -29,8 +29,15 @@
  * filtering by name regex would hide it.
  *
  * Key lookup uses one `ts.Program` over the source tree so `extends` /
- * `Omit` / `Pick` / unions resolve. A program-per-file is correct but ~40×
- * slower.
+ * `Omit` / `Pick` resolve. A program-per-file is correct but ~40× slower.
+ * A union `{Name}Props` (`SliderSingleProps | SliderRangeProps`) is walked
+ * per member, since the union's own property list holds only the common
+ * props. A prop is platform passthrough only when every declaration behind
+ * it is platform — an intersection redeclaring `onClick` over BaseProps
+ * carries both declarations and stays public.
+ *
+ * The scan itself is gated: zero `.doc.mjs` found, or a doc that cannot be
+ * imported or exports no `docs`, fails the run instead of passing vacuously.
  *
  * Not yet in `check:repo`: core still has pre-existing drift this gate
  * reports. Wire it next to `check:i18n-catalog` once that count is zero
@@ -153,6 +160,21 @@ export function buildProgram(filePaths) {
   return {program, checker: program.getTypeChecker()};
 }
 
+/**
+ * Property symbols of `type`. On a union (`SliderSingleProps |
+ * SliderRangeProps`) `getProperties()` reports only the members' common
+ * props, so a variant-only prop (`minStepsBetweenThumbs`) would never be
+ * required. Walk each member instead.
+ *
+ * @param {import('typescript').Type} type
+ * @returns {import('typescript').Symbol[]}
+ */
+function propertySymbols(type) {
+  return type.isUnion()
+    ? type.types.flatMap(propertySymbols)
+    : type.getProperties();
+}
+
 function isInheritedPlatformDecl(declFile) {
   return /\/BaseProps\.ts$|node_modules|[\\/]lib\.dom|@types\/react/.test(
     declFile,
@@ -193,20 +215,29 @@ export function extractPublicPropNames(
   }
   if (matches.length === 0) return null;
 
-  const prefix = preferDir.endsWith(path.sep) ? preferDir : preferDir + path.sep;
+  const prefix = preferDir.endsWith(path.sep)
+    ? preferDir
+    : preferDir + path.sep;
   const target =
     matches.find(node => node.getSourceFile().fileName.startsWith(prefix)) ??
     matches[0];
 
   const type = checker.getTypeAtLocation(target);
   const props = new Set();
-  for (const symbol of type.getProperties()) {
+  for (const symbol of propertySymbols(type)) {
     const name = symbol.getName();
     if (name.startsWith('__')) continue;
     if (isSkippedProp(name)) continue;
-    const decl = (symbol.getDeclarations() ?? [])[0];
-    const declFile = decl?.getSourceFile()?.fileName ?? '';
-    if (isInheritedPlatformDecl(declFile)) continue;
+    // An intersection (`BaseProps & {onClick}`) yields one synthetic symbol
+    // carrying every constituent's declaration; a prop is passthrough only
+    // when all of them are platform. A declaration-less (remapped) prop is
+    // component API.
+    const declFiles = (symbol.getDeclarations() ?? []).map(
+      decl => decl.getSourceFile().fileName,
+    );
+    if (declFiles.length > 0 && declFiles.every(isInheritedPlatformDecl)) {
+      continue;
+    }
     props.add(name);
   }
   return props;
@@ -265,7 +296,14 @@ export async function checkContract(srcDir) {
       continue;
     }
     const docs = mod.default ?? mod.docs;
-    if (!docs?.name) continue;
+    if (!docs) {
+      unreadable.push({
+        file: docFile,
+        reason: 'exports neither `docs` nor a default export',
+      });
+      continue;
+    }
+    if (!docs.name) continue;
     // Hooks document params/returns, not props.
     if (docs.name.startsWith('use') && !Array.isArray(docs.props)) continue;
 
@@ -291,58 +329,88 @@ export async function checkContract(srcDir) {
   }
 
   missing.sort(
-    (a, b) => a.component.localeCompare(b.component) || a.prop.localeCompare(b.prop),
+    (a, b) =>
+      a.component.localeCompare(b.component) || a.prop.localeCompare(b.prop),
+  );
+  unresolved.sort(
+    (a, b) =>
+      a.component.localeCompare(b.component) || a.file.localeCompare(b.file),
   );
   unreadable.sort((a, b) => a.file.localeCompare(b.file));
   return {missing, unresolved, unreadable, docCount: docFiles.length};
 }
 
-async function main() {
+/**
+ * Scan `srcDir`, print the report through `io`, return the exit code. The
+ * CLI entry below passes `console`; tests pass a capturing `io` instead of
+ * spawning a process.
+ *
+ * @param {string} [srcDir]
+ * @param {{log?: (line: string) => void, error?: (line: string) => void}} [io]
+ * @returns {Promise<0 | 1>}
+ */
+export async function run(
+  srcDir = CORE_SRC,
+  {log = console.log, error = console.error} = {},
+) {
   const {missing, unresolved, unreadable, docCount} =
-    await checkContract(CORE_SRC);
+    await checkContract(srcDir);
+
+  if (docCount === 0) {
+    error(
+      `\n✗ check:contract found no .doc.mjs under ${path.relative(ROOT, srcDir) || '.'} — nothing was checked, so this is not a pass.\n`,
+    );
+    return 1;
+  }
 
   if (unreadable.length > 0 || missing.length > 0) {
     if (unreadable.length > 0) {
-      console.error(
+      error(
         `\n✗ check:contract could not load ${unreadable.length} doc file(s):\n`,
       );
       for (const {file, reason} of unreadable) {
-        console.error(`  ${path.relative(ROOT, file)}`);
-        console.error(`    ${reason}`);
+        error(`  ${path.relative(ROOT, file)}`);
+        error(`    ${reason}`);
       }
-      console.error(
-        '\n    → Fix the syntax/import error in that .doc.mjs. A broken doc is not skipped.\n',
+      error(
+        '\n    → Fix the syntax, import, or `docs` export of that .doc.mjs. A broken doc is not skipped.\n',
       );
     }
     if (missing.length > 0) {
-      console.error(
+      error(
         `\n✗ check:contract found ${missing.length} undocumented public prop(s):\n`,
       );
       for (const {component, prop, file} of missing) {
         const rel = path.relative(ROOT, file);
-        console.error(`  ${component}.${prop}  (${rel})`);
+        error(`  ${component}.${prop}  (${rel})`);
       }
-      console.error(
-        '\n    → Document the prop in that component\'s .doc.mjs `props[]`, or it is not part of the public contract.\n',
+      error(
+        "\n    → Document the prop in that component's .doc.mjs `props[]`, or it is not part of the public contract.\n",
       );
     }
-    process.exit(1);
+    return 1;
   }
 
-  console.log(
+  log(
     `✓ check:contract — ${docCount} doc(s) checked, 0 undocumented public props` +
       (unresolved.length > 0
         ? `; ${unresolved.length} unresolved {Name}Props (informational)`
         : ''),
   );
   for (const {component} of unresolved) {
-    console.log(`  · ${component}: no resolvable ${component}Props in source`);
+    log(`  · ${component}: no resolvable ${component}Props in source`);
   }
+  return 0;
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch(err => {
-    console.error(err);
-    process.exit(2);
-  });
+  run().then(
+    code => {
+      process.exitCode = code;
+    },
+    err => {
+      console.error(err);
+      process.exitCode = 2;
+    },
+  );
 }

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * CI gate for component API-contract drift — `node scripts/check-contract.mjs`.
+ *
+ * `{Name}.doc.mjs` `props[]` is what agents and consumers read. The truth is
+ * the component's `{Name}Props` type. A test written in the same PR as the
+ * doc it asserts only proves the author typed both (#5382). This derives the
+ * public prop names from the TypeScript checker and fails when a source prop
+ * is missing from the doc, the way `themingTargets.test.ts` derives
+ * `themeProps()` classes (#3741 / #4163 / #5421).
+ *
+ * Policy is SUBSET, not equality:
+ *
+ *   1. Source ⊆ docs. Every component-declared public prop must appear in
+ *      `props[]`.
+ *   2. Docs MAY list more — forwarded subcomponent props, extras the author
+ *      wants in the table. Extra documented names are not drift.
+ *
+ * Deliberately NOT checked (v1): required/optional mismatch, phantom-in-doc
+ * names, prop *types*, or prose. Those are later classes.
+ *
+ * Public = a property on `{Name}Props` whose declaration is not BaseProps,
+ * `@types/react`, or `lib.dom`. Inherited HTML / `aria-*` / `data-*`
+ * passthrough is the shared platform surface and must not be enumerated.
+ * A handler *redeclared* on the component (TextInput `onKeyDown`, Button
+ * `onClick` / `href` / `as`) is component API and MUST be documented —
+ * filtering by name regex would hide it.
+ *
+ * Key lookup uses one `ts.Program` over the source tree so `extends` /
+ * `Omit` / `Pick` / unions resolve. A program-per-file is correct but ~40×
+ * slower.
+ *
+ * Not yet in `check:repo`: core still has pre-existing drift this gate
+ * reports. Wire it next to `check:i18n-catalog` once that count is zero
+ * (#4163). Until then: `pnpm check:contract`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CORE_SRC = path.join(ROOT, 'packages/core/src');
+
+/**
+ * Props ComponentPropDoc tells authors to omit, even when a component
+ * redeclares them (`ref` on Button). Sibling of UNIVERSAL_PROPS in
+ * `docPropReferences.test.ts`.
+ */
+export const SKIPPED_PROPS = new Set([
+  'xstyle',
+  'className',
+  'style',
+  'ref',
+  'data-testid',
+]);
+
+/** True when `name` is platform surface, not component-authored API. */
+export function isSkippedProp(name) {
+  return SKIPPED_PROPS.has(name);
+}
+
+/**
+ * Every prop name a doc file lists — top-level `props[]` plus inline
+ * `components[].props`. Name-only ComponentRefs contribute nothing; those
+ * names live in the sibling `{Name}.doc.mjs`.
+ *
+ * @param {{props?: {name: string}[], components?: {props?: {name: string}[]}[]}} docs
+ * @returns {Set<string>}
+ */
+export function documentedPropNames(docs) {
+  const names = new Set();
+  for (const prop of docs?.props ?? []) {
+    if (prop?.name) names.add(prop.name);
+  }
+  for (const entry of docs?.components ?? []) {
+    for (const prop of entry?.props ?? []) {
+      if (prop?.name) names.add(prop.name);
+    }
+  }
+  return names;
+}
+
+/**
+ * Source names that do not appear in the documented set. Extra documented
+ * names are ignored (subset policy).
+ *
+ * @param {Iterable<string>} sourceNames
+ * @param {Iterable<string>} documentedNames
+ * @returns {string[]}
+ */
+export function findUndocumented(sourceNames, documentedNames) {
+  const documented = new Set(documentedNames);
+  return [...sourceNames].filter(name => !documented.has(name)).sort();
+}
+
+/** Source files only — no tests, stories, docs, or perf fixtures. */
+function walkSource(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      walkSource(full, out);
+    } else if (
+      /\.[jt]sx?$/.test(entry.name) &&
+      !entry.name.includes('.test.') &&
+      !entry.name.includes('.stories.') &&
+      !entry.name.includes('.doc.') &&
+      !entry.name.includes('.perf.') &&
+      !entry.name.endsWith('.d.ts')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function walkDocs(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      walkDocs(full, out);
+    } else if (entry.name.endsWith('.doc.mjs')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * One program over `filePaths` so `extends`/`Omit`/`Pick` resolve.
+ *
+ * @param {string[]} filePaths
+ * @returns {{program: import('typescript').Program, checker: import('typescript').TypeChecker}}
+ */
+export function buildProgram(filePaths) {
+  const program = ts.createProgram(filePaths, {
+    jsx: ts.JsxEmit.Preserve,
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+  });
+  return {program, checker: program.getTypeChecker()};
+}
+
+function isInheritedPlatformDecl(declFile) {
+  return /\/BaseProps\.ts$|node_modules|[\\/]lib\.dom|@types\/react/.test(
+    declFile,
+  );
+}
+
+/**
+ * Component-declared prop names on `{symbolName}`. `preferDir` disambiguates
+ * when the same symbol is declared in more than one file — the declaration
+ * in or under the doc's own directory wins.
+ *
+ * @param {import('typescript').Program} program
+ * @param {import('typescript').TypeChecker} checker
+ * @param {string} symbolName
+ * @param {string} preferDir
+ * @returns {Set<string> | null} null when no matching source symbol exists
+ */
+export function extractPublicPropNames(
+  program,
+  checker,
+  symbolName,
+  preferDir,
+) {
+  const matches = [];
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.fileName.includes(`${path.sep}node_modules${path.sep}`)) {
+      continue;
+    }
+    ts.forEachChild(sourceFile, function find(node) {
+      if (
+        (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
+        node.name.text === symbolName
+      ) {
+        matches.push(node);
+      }
+      ts.forEachChild(node, find);
+    });
+  }
+  if (matches.length === 0) return null;
+
+  const prefix = preferDir.endsWith(path.sep) ? preferDir : preferDir + path.sep;
+  const target =
+    matches.find(node => node.getSourceFile().fileName.startsWith(prefix)) ??
+    matches[0];
+
+  const type = checker.getTypeAtLocation(target);
+  const props = new Set();
+  for (const symbol of type.getProperties()) {
+    const name = symbol.getName();
+    if (name.startsWith('__')) continue;
+    if (isSkippedProp(name)) continue;
+    const decl = (symbol.getDeclarations() ?? [])[0];
+    const declFile = decl?.getSourceFile()?.fileName ?? '';
+    if (isInheritedPlatformDecl(declFile)) continue;
+    props.add(name);
+  }
+  return props;
+}
+
+/**
+ * Entries this doc file is the source of truth for: the top-level component
+ * when it has `props[]`, plus any inline `components[]` entry that carries
+ * its own `props[]`.
+ *
+ * @param {{name?: string, props?: {name: string}[], components?: {name?: string, props?: {name: string}[]}[]}} docs
+ * @returns {{name: string, documented: string[]}[]}
+ */
+function contractEntries(docs) {
+  const entries = [];
+  if (Array.isArray(docs.props) && docs.name) {
+    entries.push({
+      name: docs.name,
+      documented: docs.props.map(prop => prop.name).filter(Boolean),
+    });
+  }
+  for (const entry of docs.components ?? []) {
+    if (Array.isArray(entry.props) && entry.name) {
+      entries.push({
+        name: entry.name,
+        documented: entry.props.map(prop => prop.name).filter(Boolean),
+      });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Compare every `{Name}.doc.mjs` under `srcDir` to the matching `{Name}Props`.
+ *
+ * @param {string} srcDir
+ * @returns {Promise<{missing: {component: string, prop: string, file: string}[], unresolved: {component: string, file: string}[]}>}
+ */
+export async function checkContract(srcDir) {
+  const sourceFiles = walkSource(srcDir);
+  const {program, checker} = buildProgram(sourceFiles);
+  const missing = [];
+  const unresolved = [];
+
+  for (const docFile of walkDocs(srcDir)) {
+    let mod;
+    try {
+      mod = await import(pathToFileURL(docFile).href);
+    } catch {
+      continue;
+    }
+    const docs = mod.default ?? mod.docs;
+    if (!docs?.name) continue;
+    // Hooks document params/returns, not props.
+    if (docs.name.startsWith('use') && !Array.isArray(docs.props)) continue;
+
+    const entries = contractEntries(docs);
+    if (entries.length === 0) continue;
+
+    const preferDir = path.dirname(docFile);
+    for (const {name, documented} of entries) {
+      const source = extractPublicPropNames(
+        program,
+        checker,
+        `${name}Props`,
+        preferDir,
+      );
+      if (!source) {
+        unresolved.push({component: name, file: docFile});
+        continue;
+      }
+      for (const prop of findUndocumented(source, documented)) {
+        missing.push({component: name, prop, file: docFile});
+      }
+    }
+  }
+
+  missing.sort(
+    (a, b) => a.component.localeCompare(b.component) || a.prop.localeCompare(b.prop),
+  );
+  return {missing, unresolved};
+}
+
+async function main() {
+  const {missing, unresolved} = await checkContract(CORE_SRC);
+
+  if (missing.length > 0) {
+    console.error(
+      `\n✗ check:contract found ${missing.length} undocumented public prop(s):\n`,
+    );
+    for (const {component, prop, file} of missing) {
+      const rel = path.relative(ROOT, file);
+      console.error(`  ${component}.${prop}  (${rel})`);
+    }
+    console.error(
+      '\n    → Document the prop in that component\'s .doc.mjs `props[]`, or it is not part of the public contract.\n',
+    );
+    process.exit(1);
+  }
+
+  const docCount = walkDocs(CORE_SRC).length;
+  console.log(
+    `✓ check:contract — ${docCount} doc(s) checked, 0 undocumented public props` +
+      (unresolved.length > 0
+        ? `; ${unresolved.length} unresolved {Name}Props (informational)`
+        : ''),
+  );
+  for (const {component} of unresolved) {
+    console.log(`  · ${component}: no resolvable ${component}Props in source`);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -21,23 +21,45 @@
  * Deliberately NOT checked (v1): required/optional mismatch, phantom-in-doc
  * names, prop *types*, or prose. Those are later classes.
  *
- * Public = a property on `{Name}Props` whose declaration is not BaseProps,
- * `@types/react`, or `lib.dom`. Inherited HTML / `aria-*` / `data-*`
- * passthrough is the shared platform surface and must not be enumerated.
- * A handler *redeclared* on the component (TextInput `onKeyDown`, Button
- * `onClick` / `href` / `as`) is component API and MUST be documented —
- * filtering by name regex would hide it.
+ * Public = a property on the entry's prop bag whose declaration is not
+ * BaseProps, `@types/react`, `csstype`, or the TypeScript libs. Inherited
+ * HTML / `aria-*` / `data-*` passthrough is the shared platform surface and
+ * must not be enumerated. The rest of node_modules IS public: a third-party
+ * component re-exported under a core name has that library's bag as its
+ * whole API. A handler *redeclared* on the component (TextInput `onKeyDown`,
+ * Button `onClick` / `href` / `as`) is component API and MUST be documented
+ * — filtering by name regex would hide it.
+ *
+ * The bag comes from one of two routes, ranked by proximity to the doc
+ * (`createResolver`): an exported, top-level `{Name}Props` declaration, or
+ * the signatures of the exported `{Name}` value — every bag parameter of
+ * every overload, a class's constructor parameter, aliases followed. Plenty
+ * of public entries only have the second: the three indicators share one
+ * generic `IndicatorProps<F>`, `ContextMenuItem` is `DropdownMenuItem`
+ * re-exported under another name, every Table plugin hook takes a
+ * `{...}Config`. A file-private or nested lookalike never counts, and the
+ * verdict does not depend on directory read order. What will not resolve —
+ * no exported declaration or value, or a bag typed `any` — FAILS the run:
+ * an entry that publishes a `props[]` contract nothing checked is the #5382
+ * problem wearing a green tick.
  *
  * Key lookup uses one `ts.Program` over the source tree so `extends` /
  * `Omit` / `Pick` resolve. A program-per-file is correct but ~40× slower.
  * A union `{Name}Props` (`SliderSingleProps | SliderRangeProps`) is walked
  * per member, since the union's own property list holds only the common
- * props. A prop is platform passthrough only when every declaration behind
- * it is platform — an intersection redeclaring `onClick` over BaseProps
- * carries both declarations and stays public.
+ * props; an overloaded signature is walked the same way, every overload
+ * being public API. A prop is platform passthrough only when every
+ * declaration behind it is platform — an intersection redeclaring `onClick`
+ * over BaseProps carries both declarations and stays public.
  *
- * The scan itself is gated: zero `.doc.mjs` found, or a doc that cannot be
- * imported or exports no `docs`, fails the run instead of passing vacuously.
+ * The scan itself is gated: zero `.doc.mjs` found, a program that cannot
+ * resolve `react` (every passthrough verdict rests on `@types/react`; without
+ * it each `Omit<…>` over BaseProps collapses to nothing), a doc that cannot
+ * be imported, exports no `docs`, or publishes `props[]` without a `name`,
+ * or an entry whose props could not be resolved at all — each fails the run
+ * instead of passing vacuously. A doc's `docs` export is what is checked
+ * (a lone default export is accepted as a fallback), because `docs` is what
+ * `astryx component <Name>` serves.
  *
  * Not yet in `check:repo`: core still has pre-existing drift this gate
  * reports. Wire it next to `check:i18n-catalog` once that count is zero
@@ -107,7 +129,11 @@ export function findUndocumented(sourceNames, documentedNames) {
   return [...sourceNames].filter(name => !documented.has(name)).sort();
 }
 
-/** Source files only — no tests, stories, docs, or perf fixtures. */
+/**
+ * Source files only — no tests, stories, docs, or perf fixtures. Neither
+ * walker follows a directory symlink (a `Dirent` reports it as a link, not a
+ * directory), which is also what keeps a symlink loop harmless.
+ */
 function walkSource(dir, out = []) {
   for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
     const full = path.join(dir, entry.name);
@@ -148,16 +174,47 @@ function walkDocs(dir, out = []) {
  * @returns {{program: import('typescript').Program, checker: import('typescript').TypeChecker}}
  */
 export function buildProgram(filePaths) {
-  const program = ts.createProgram(filePaths, {
-    jsx: ts.JsxEmit.Preserve,
-    target: ts.ScriptTarget.Latest,
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    noEmit: true,
-    skipLibCheck: true,
-    strict: true,
-  });
+  const program = ts.createProgram(
+    filePaths,
+    COMPILER_OPTIONS,
+    libCachingHost(),
+  );
   return {program, checker: program.getTypeChecker()};
+}
+
+const COMPILER_OPTIONS = {
+  jsx: ts.JsxEmit.Preserve,
+  target: ts.ScriptTarget.Latest,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  noEmit: true,
+  skipLibCheck: true,
+  strict: true,
+};
+
+/** Parsed TypeScript lib files, shared by every program this process builds. */
+const libFiles = new Map();
+
+/**
+ * The default host, except that `lib.*.d.ts` parse once per process. The
+ * gate builds one program, so this changes nothing for it; the test suite
+ * builds one per fixture, and re-parsing ~90 lib files each time was most of
+ * its wall time. Lib files are immutable and every program here uses the
+ * same options, so sharing them is safe.
+ */
+function libCachingHost() {
+  const host = ts.createCompilerHost(COMPILER_OPTIONS);
+  const getSourceFile = host.getSourceFile;
+  host.getSourceFile = (fileName, ...rest) => {
+    if (!/\/typescript\/lib\//.test(fileName)) {
+      return getSourceFile.call(host, fileName, ...rest);
+    }
+    if (!libFiles.has(fileName)) {
+      libFiles.set(fileName, getSourceFile.call(host, fileName, ...rest));
+    }
+    return libFiles.get(fileName);
+  };
+  return host;
 }
 
 /**
@@ -175,72 +232,339 @@ function propertySymbols(type) {
     : type.getProperties();
 }
 
+/**
+ * Platform surface: BaseProps, the DOM / ES libs, `@types/react` (and
+ * `@types/react-dom`), and `csstype` behind React's style types. Not the rest
+ * of node_modules — a third-party component's bag re-exported under a core
+ * name IS that component's API. TS file names are always `/`-separated.
+ */
 function isInheritedPlatformDecl(declFile) {
-  return /\/BaseProps\.ts$|node_modules|[\\/]lib\.dom|@types\/react/.test(
+  return /\/BaseProps\.ts$|\/typescript\/lib\/|\/@types\/react|\/csstype\//.test(
     declFile,
   );
 }
 
 /**
- * Component-declared prop names on `{symbolName}`. `preferDir` disambiguates
- * when the same symbol is declared in more than one file — the declaration
- * in or under the doc's own directory wins.
+ * Add every component-declared prop name on `type` to `into`.
  *
- * @param {import('typescript').Program} program
- * @param {import('typescript').TypeChecker} checker
- * @param {string} symbolName
- * @param {string} preferDir
- * @returns {Set<string> | null} null when no matching source symbol exists
+ * An intersection (`BaseProps & {onClick}`) yields one synthetic symbol
+ * carrying every constituent's declaration, so a prop is passthrough only
+ * when all of them are platform. A declaration-less (key-remapped) prop is
+ * component API.
+ *
+ * @param {import('typescript').Type} type
+ * @param {Set<string>} into
+ * @returns {Set<string>}
  */
-export function extractPublicPropNames(
-  program,
-  checker,
-  symbolName,
-  preferDir,
-) {
-  const matches = [];
-  for (const sourceFile of program.getSourceFiles()) {
-    if (sourceFile.fileName.includes(`${path.sep}node_modules${path.sep}`)) {
-      continue;
-    }
-    ts.forEachChild(sourceFile, function find(node) {
-      if (
-        (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) &&
-        node.name.text === symbolName
-      ) {
-        matches.push(node);
-      }
-      ts.forEachChild(node, find);
-    });
-  }
-  if (matches.length === 0) return null;
-
-  const prefix = preferDir.endsWith(path.sep)
-    ? preferDir
-    : preferDir + path.sep;
-  const target =
-    matches.find(node => node.getSourceFile().fileName.startsWith(prefix)) ??
-    matches[0];
-
-  const type = checker.getTypeAtLocation(target);
-  const props = new Set();
+function collectPublicProps(type, into) {
   for (const symbol of propertySymbols(type)) {
     const name = symbol.getName();
     if (name.startsWith('__')) continue;
     if (isSkippedProp(name)) continue;
-    // An intersection (`BaseProps & {onClick}`) yields one synthetic symbol
-    // carrying every constituent's declaration; a prop is passthrough only
-    // when all of them are platform. A declaration-less (remapped) prop is
-    // component API.
     const declFiles = (symbol.getDeclarations() ?? []).map(
       decl => decl.getSourceFile().fileName,
     );
     if (declFiles.length > 0 && declFiles.every(isInheritedPlatformDecl)) {
       continue;
     }
-    props.add(name);
+    into.add(name);
   }
-  return props;
+  return into;
+}
+
+/** A parameter typed so loosely that no contract can be read off it. */
+const UNDERIVABLE = Symbol('underivable');
+
+/**
+ * The type whose properties are a parameter's prop bag; `null` when the
+ * parameter is not a bag at all (`useThing(id: string)`, a bare callback —
+ * a function type's only members come from lib and are filtered, a tuple or
+ * array's are positions); or UNDERIVABLE for `any`, `unknown`, `object`, and
+ * an unconstrained type parameter. A constrained type parameter
+ * (`<P extends SharedProps>(props: P)`) reads as its constraint, so a union
+ * constraint is still walked per member. A union or intersection is a bag
+ * when any member is.
+ *
+ * @param {import('typescript').TypeChecker} checker
+ * @param {import('typescript').Type} type
+ * @returns {import('typescript').Type | null | typeof UNDERIVABLE}
+ */
+function asPropBag(checker, type) {
+  if (
+    type.flags &
+    (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.NonPrimitive)
+  ) {
+    return UNDERIVABLE;
+  }
+  // A tuple or array's members (`0`, `length`) are not props.
+  if (checker.isTupleType(type) || checker.isArrayType(type)) return null;
+  if (type.isTypeParameter()) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    if (!constraint) return UNDERIVABLE;
+    return asPropBag(checker, constraint);
+  }
+  if (type.isUnion() || type.isIntersection()) {
+    const members = type.types.map(member => asPropBag(checker, member));
+    if (members.some(member => member && member !== UNDERIVABLE)) return type;
+    return members.includes(UNDERIVABLE) ? UNDERIVABLE : null;
+  }
+  return type.flags & ts.TypeFlags.Object ? type : null;
+}
+
+/**
+ * Prop names of an exported value, read off its signatures: every parameter
+ * of every overload that is a bag. A component's one parameter is its props;
+ * a hook's parameters are its config — `useThing(id, options)` reads
+ * `options`. A class component has construct signatures instead of call
+ * signatures, and its constructor parameter is the same bag. A rest tuple
+ * (`...args: [Opts]`) contributes its elements, not the tuple. `null` when
+ * the value is not callable, or when the only bag it takes is untyped
+ * (`props: any`): an entry the checker cannot read is UNDERIVABLE — unresolved,
+ * not empty, and not something a farther candidate may paper over.
+ *
+ * @param {import('typescript').TypeChecker} checker
+ * @param {import('typescript').Symbol} symbol
+ * @returns {Set<string> | null | typeof UNDERIVABLE}
+ */
+function propsFromSignature(checker, symbol) {
+  const declaration = symbol.valueDeclaration ?? symbol.getDeclarations()?.[0];
+  if (!declaration) return null;
+  const type = checker.getTypeOfSymbolAtLocation(symbol, declaration);
+  const signatures =
+    type.getCallSignatures().length > 0
+      ? type.getCallSignatures()
+      : type.getConstructSignatures();
+  if (signatures.length === 0) return null;
+
+  const props = new Set();
+  let underivable = false;
+  for (const signature of signatures) {
+    for (const parameter of signature.getParameters()) {
+      const decl =
+        parameter.valueDeclaration ?? parameter.getDeclarations()?.[0];
+      if (!decl) continue;
+      const declared = checker.getTypeOfSymbolAtLocation(parameter, decl);
+      const types =
+        decl.dotDotDotToken && checker.isTupleType(declared)
+          ? checker.getTypeArguments(declared)
+          : [declared];
+      for (const candidate of types) {
+        const bag = asPropBag(checker, candidate);
+        if (bag === UNDERIVABLE) underivable = true;
+        else if (bag) collectPublicProps(bag, props);
+      }
+    }
+  }
+  return props.size === 0 && underivable ? UNDERIVABLE : props;
+}
+
+/**
+ * Prop names of an exported `{Name}Props` declaration: `null` when the alias
+ * is not a bag at all (`type WidgetProps = string` — the next candidate may
+ * be), UNDERIVABLE when it is `any` / `unknown` / `object`. That alias IS the
+ * published contract, so nothing else may stand in for it.
+ *
+ * @param {import('typescript').TypeChecker} checker
+ * @param {import('typescript').Node} node
+ * @returns {Set<string> | null | typeof UNDERIVABLE}
+ */
+function propsFromDeclaration(checker, node) {
+  const bag = asPropBag(checker, checker.getTypeAtLocation(node));
+  return bag && bag !== UNDERIVABLE ? collectPublicProps(bag, new Set()) : bag;
+}
+
+/**
+ * A TypeScript file name is `/`-separated on every platform; a Node path is
+ * not. Compare like with like.
+ */
+function toTsPath(file) {
+  return file.split(path.sep).join('/');
+}
+
+/** Path depth, so a nested internal copy never outranks the file beside the doc. */
+function depth(file) {
+  return file.split('/').length;
+}
+
+/**
+ * Builds the resolver that maps a documented entry to its prop bag. Two
+ * routes, indexed once per program: an exported, top-level `{Name}Props`
+ * declaration, or the signatures of an exported `{Name}` value (the checker
+ * resolves `export {X as Y}` aliases). Candidates rank by proximity — in or
+ * under the doc's own directory first, then the shallower path, then a
+ * declaration over a signature, then path order — so the file beside the
+ * doc wins, a nested internal copy does not shadow it, a file-private
+ * lookalike never counts, and the verdict does not depend on directory
+ * read order. The first candidate that yields a bag is the contract.
+ *
+ * @param {import('typescript').Program} program
+ * @param {import('typescript').TypeChecker} checker
+ * @returns {(name: string, preferDir: string) => {props: Set<string>, route: 'declaration' | 'signature', file: string} | null}
+ */
+export function createResolver(program, checker) {
+  const declarations = new Map();
+  const values = new Map();
+  const add = (index, name, entry) => {
+    if (!index.has(name)) index.set(name, []);
+    index.get(name).push(entry);
+  };
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.isDeclarationFile) continue;
+    if (sourceFile.fileName.includes('/node_modules/')) continue;
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+    if (!moduleSymbol) continue;
+    const exported = new Map(
+      checker
+        .getExportsOfModule(moduleSymbol)
+        .map(symbol => [symbol.getName(), symbol]),
+    );
+    for (const statement of sourceFile.statements) {
+      if (
+        !ts.isInterfaceDeclaration(statement) &&
+        !ts.isTypeAliasDeclaration(statement)
+      ) {
+        continue;
+      }
+      // The export carrying this name must be THIS declaration — a file that
+      // `export *`s a module with the same name still keeps its own private
+      // lookalike private.
+      const exportedSymbol = exported.get(statement.name.text);
+      if (!exportedSymbol) continue;
+      const owner =
+        exportedSymbol.flags & ts.SymbolFlags.Alias
+          ? checker.getAliasedSymbol(exportedSymbol)
+          : exportedSymbol;
+      if (!(owner.getDeclarations() ?? []).includes(statement)) continue;
+      add(declarations, statement.name.text, {
+        file: sourceFile.fileName,
+        node: statement,
+      });
+    }
+    for (const [name, symbol] of exported) {
+      add(values, name, {file: sourceFile.fileName, symbol});
+    }
+  }
+
+  return function resolve(name, preferDir) {
+    const prefix = toTsPath(preferDir).replace(/\/?$/, '/');
+    const candidates = [
+      ...(declarations.get(`${name}Props`) ?? []).map(entry => ({
+        ...entry,
+        route: 'declaration',
+      })),
+      ...(values.get(name) ?? []).map(entry => ({
+        ...entry,
+        route: 'signature',
+      })),
+    ].sort(
+      (a, b) =>
+        Number(b.file.startsWith(prefix)) - Number(a.file.startsWith(prefix)) ||
+        depth(a.file) - depth(b.file) ||
+        Number(a.route === 'signature') - Number(b.route === 'signature') ||
+        a.file.localeCompare(b.file),
+    );
+    for (const candidate of candidates) {
+      const props =
+        candidate.route === 'declaration'
+          ? propsFromDeclaration(checker, candidate.node)
+          : propsFromSignature(checker, candidate.symbol);
+      if (props === UNDERIVABLE) return null;
+      if (props) return {props, route: candidate.route, file: candidate.file};
+    }
+    return null;
+  };
+}
+
+/** Bare specifiers the platform filter cannot do without. */
+const REQUIRED_MODULES = ['react'];
+
+/**
+ * Which of `specifiers` some source file imports but the program could not
+ * resolve. Every passthrough verdict rests on `@types/react` being in the
+ * program: without it the `Omit<HTMLAttributes…>` base of BaseProps degrades
+ * to a string index signature, every `Omit<{Name}Props, …>` over it collapses
+ * to zero named props, and the tree passes unchecked. A tree that never
+ * imports the module is not asked for it.
+ *
+ * @param {import('typescript').Program} program
+ * @param {string} srcDir
+ * @param {string[]} specifiers
+ * @returns {string[]} one message per unresolvable import
+ */
+function unresolvableImports(program, srcDir, specifiers) {
+  const options = program.getCompilerOptions();
+  const problems = [];
+  for (const specifier of specifiers) {
+    const importer = program
+      .getSourceFiles()
+      .find(
+        sourceFile =>
+          !sourceFile.isDeclarationFile &&
+          sourceFile.statements.some(
+            statement =>
+              ts.isImportDeclaration(statement) &&
+              ts.isStringLiteral(statement.moduleSpecifier) &&
+              statement.moduleSpecifier.text === specifier,
+          ),
+      );
+    if (!importer) continue;
+    const {resolvedModule} = ts.resolveModuleName(
+      specifier,
+      importer.fileName,
+      options,
+      ts.sys,
+    );
+    const importedBy = path.relative(srcDir, importer.fileName);
+    if (!resolvedModule) {
+      problems.push(
+        `'${specifier}' (imported by ${importedBy}) could not be resolved`,
+      );
+    } else if (!/\.[cm]?tsx?$/.test(resolvedModule.resolvedFileName)) {
+      // `react` installed but `@types/react` absent: the checker sees JS and
+      // every React type is `any` — the same collapse as no react at all.
+      problems.push(
+        `'${specifier}' (imported by ${importedBy}) could not be resolved to types; found untyped ${path.relative(srcDir, resolvedModule.resolvedFileName)}`,
+      );
+    }
+  }
+  return problems;
+}
+
+/**
+ * Why `docs` cannot be checked, or `null` when its shape is usable. A doc
+ * that throws mid-scan would abort the run with a stack and hide every doc
+ * after it; a shape problem is reported like any other unreadable doc.
+ *
+ * @param {unknown} docs
+ * @returns {string | null}
+ */
+function docShapeProblem(docs) {
+  const isObject = value => typeof value === 'object' && value !== null;
+  const nonObject = list => list?.some(item => !isObject(item));
+  if (!isObject(docs)) return '`docs` is not an object';
+  if (docs.name !== undefined && typeof docs.name !== 'string') {
+    return '`name` is not a string';
+  }
+  if (docs.props !== undefined && !Array.isArray(docs.props)) {
+    return '`props` is not an array';
+  }
+  if (nonObject(docs.props)) return '`props[]` holds a non-object entry';
+  if (docs.components !== undefined && !Array.isArray(docs.components)) {
+    return '`components` is not an array';
+  }
+  for (const entry of docs.components ?? []) {
+    if (!isObject(entry)) return '`components[]` holds a non-object entry';
+    if (entry.name !== undefined && typeof entry.name !== 'string') {
+      return '`components[].name` is not a string';
+    }
+    if (entry.props !== undefined && !Array.isArray(entry.props)) {
+      return '`components[].props` is not an array';
+    }
+    if (nonObject(entry.props)) {
+      return '`components[].props[]` holds a non-object entry';
+    }
+  }
+  return null;
 }
 
 /**
@@ -271,14 +595,18 @@ function contractEntries(docs) {
 }
 
 /**
- * Compare every `{Name}.doc.mjs` under `srcDir` to the matching `{Name}Props`.
+ * Compare every `{Name}.doc.mjs` under `srcDir` to the prop bag source
+ * declares for it — see `createResolver` for which bag wins. An entry no
+ * route resolves is `unresolved`, which fails the run.
  *
  * @param {string} srcDir
- * @returns {Promise<{missing: {component: string, prop: string, file: string}[], unresolved: {component: string, file: string}[], unreadable: {file: string, reason: string}[], docCount: number}>}
+ * @returns {Promise<{missing: {component: string, prop: string, file: string}[], unresolved: {component: string, file: string}[], unreadable: {file: string, reason: string}[], unresolvable: string[], docCount: number}>}
  */
 export async function checkContract(srcDir) {
   const sourceFiles = walkSource(srcDir);
   const {program, checker} = buildProgram(sourceFiles);
+  const unresolvable = unresolvableImports(program, srcDir, REQUIRED_MODULES);
+  const resolve = createResolver(program, checker);
   const missing = [];
   const unresolved = [];
   const unreadable = [];
@@ -295,7 +623,8 @@ export async function checkContract(srcDir) {
       });
       continue;
     }
-    const docs = mod.default ?? mod.docs;
+    // What `astryx component <Name>` serves: `loadDocs` reads `mod.docs`.
+    const docs = mod.docs ?? mod.default;
     if (!docs) {
       unreadable.push({
         file: docFile,
@@ -303,26 +632,33 @@ export async function checkContract(srcDir) {
       });
       continue;
     }
-    if (!docs.name) continue;
+    const shapeProblem = docShapeProblem(docs);
+    if (shapeProblem) {
+      unreadable.push({file: docFile, reason: shapeProblem});
+      continue;
+    }
+    if (!docs.name && Array.isArray(docs.props)) {
+      unreadable.push({
+        file: docFile,
+        reason:
+          'publishes props[] but has no `name`, so nothing can be checked against it',
+      });
+      continue;
+    }
     // Hooks document params/returns, not props.
-    if (docs.name.startsWith('use') && !Array.isArray(docs.props)) continue;
+    if (docs.name?.startsWith('use') && !Array.isArray(docs.props)) continue;
 
     const entries = contractEntries(docs);
     if (entries.length === 0) continue;
 
     const preferDir = path.dirname(docFile);
     for (const {name, documented} of entries) {
-      const source = extractPublicPropNames(
-        program,
-        checker,
-        `${name}Props`,
-        preferDir,
-      );
-      if (!source) {
+      const resolved = resolve(name, preferDir);
+      if (!resolved) {
         unresolved.push({component: name, file: docFile});
         continue;
       }
-      for (const prop of findUndocumented(source, documented)) {
+      for (const prop of findUndocumented(resolved.props, documented)) {
         missing.push({component: name, prop, file: docFile});
       }
     }
@@ -337,7 +673,13 @@ export async function checkContract(srcDir) {
       a.component.localeCompare(b.component) || a.file.localeCompare(b.file),
   );
   unreadable.sort((a, b) => a.file.localeCompare(b.file));
-  return {missing, unresolved, unreadable, docCount: docFiles.length};
+  return {
+    missing,
+    unresolved,
+    unreadable,
+    unresolvable,
+    docCount: docFiles.length,
+  };
 }
 
 /**
@@ -353,7 +695,7 @@ export async function run(
   srcDir = CORE_SRC,
   {log = console.log, error = console.error} = {},
 ) {
-  const {missing, unresolved, unreadable, docCount} =
+  const {missing, unresolved, unreadable, unresolvable, docCount} =
     await checkContract(srcDir);
 
   if (docCount === 0) {
@@ -363,7 +705,16 @@ export async function run(
     return 1;
   }
 
-  if (unreadable.length > 0 || missing.length > 0) {
+  if (unresolvable.length > 0) {
+    error('\n✗ check:contract cannot trust this program:\n');
+    for (const problem of unresolvable) error(`  ${problem}`);
+    error(
+      '\n    → Every platform-passthrough verdict depends on those types. Install dependencies (pnpm install) and rerun; an unchecked tree is not a pass.\n',
+    );
+    return 1;
+  }
+
+  if (unreadable.length > 0 || unresolved.length > 0 || missing.length > 0) {
     if (unreadable.length > 0) {
       error(
         `\n✗ check:contract could not load ${unreadable.length} doc file(s):\n`,
@@ -373,7 +724,18 @@ export async function run(
         error(`    ${reason}`);
       }
       error(
-        '\n    → Fix the syntax, import, or `docs` export of that .doc.mjs. A broken doc is not skipped.\n',
+        '\n    → Fix the syntax, import, `docs` export, shape, or missing `name` of that .doc.mjs. A broken doc is not skipped.\n',
+      );
+    }
+    if (unresolved.length > 0) {
+      error(
+        `\n✗ check:contract could not resolve the public props of ${unresolved.length} documented entr${unresolved.length === 1 ? 'y' : 'ies'}:\n`,
+      );
+      for (const {component, file} of unresolved) {
+        error(`  ${component}  (${path.relative(ROOT, file)})`);
+      }
+      error(
+        '\n    → The doc claims a props[] contract, but source offers nothing to check it against: no exported {Name}Props type, and no exported {Name} whose parameters are typed. Export the component or its Props type, type the bag (not any / unknown), or drop props[] from the doc. An unchecked entry is not a pass.\n',
       );
     }
     if (missing.length > 0) {
@@ -392,18 +754,28 @@ export async function run(
   }
 
   log(
-    `✓ check:contract — ${docCount} doc(s) checked, 0 undocumented public props` +
-      (unresolved.length > 0
-        ? `; ${unresolved.length} unresolved {Name}Props (informational)`
-        : ''),
+    `✓ check:contract — ${docCount} doc(s) checked, 0 undocumented public props`,
   );
-  for (const {component} of unresolved) {
-    log(`  · ${component}: no resolvable ${component}Props in source`);
-  }
   return 0;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+/**
+ * True when this file is the script node was asked to run. Both sides are
+ * real paths: node resolves symlinks for `import.meta.url`, argv[1] keeps
+ * whatever was typed, and a mismatch would silently run nothing.
+ */
+function isCliEntry() {
+  try {
+    return (
+      process.argv[1] !== undefined &&
+      fs.realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isCliEntry()) {
   run().then(
     code => {
       process.exitCode = code;

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -243,19 +243,25 @@ function contractEntries(docs) {
  * Compare every `{Name}.doc.mjs` under `srcDir` to the matching `{Name}Props`.
  *
  * @param {string} srcDir
- * @returns {Promise<{missing: {component: string, prop: string, file: string}[], unresolved: {component: string, file: string}[]}>}
+ * @returns {Promise<{missing: {component: string, prop: string, file: string}[], unresolved: {component: string, file: string}[], unreadable: {file: string, reason: string}[], docCount: number}>}
  */
 export async function checkContract(srcDir) {
   const sourceFiles = walkSource(srcDir);
   const {program, checker} = buildProgram(sourceFiles);
   const missing = [];
   const unresolved = [];
+  const unreadable = [];
+  const docFiles = walkDocs(srcDir);
 
-  for (const docFile of walkDocs(srcDir)) {
+  for (const docFile of docFiles) {
     let mod;
     try {
       mod = await import(pathToFileURL(docFile).href);
-    } catch {
+    } catch (err) {
+      unreadable.push({
+        file: docFile,
+        reason: err instanceof Error ? err.message : String(err),
+      });
       continue;
     }
     const docs = mod.default ?? mod.docs;
@@ -287,27 +293,42 @@ export async function checkContract(srcDir) {
   missing.sort(
     (a, b) => a.component.localeCompare(b.component) || a.prop.localeCompare(b.prop),
   );
-  return {missing, unresolved};
+  unreadable.sort((a, b) => a.file.localeCompare(b.file));
+  return {missing, unresolved, unreadable, docCount: docFiles.length};
 }
 
 async function main() {
-  const {missing, unresolved} = await checkContract(CORE_SRC);
+  const {missing, unresolved, unreadable, docCount} =
+    await checkContract(CORE_SRC);
 
-  if (missing.length > 0) {
-    console.error(
-      `\n✗ check:contract found ${missing.length} undocumented public prop(s):\n`,
-    );
-    for (const {component, prop, file} of missing) {
-      const rel = path.relative(ROOT, file);
-      console.error(`  ${component}.${prop}  (${rel})`);
+  if (unreadable.length > 0 || missing.length > 0) {
+    if (unreadable.length > 0) {
+      console.error(
+        `\n✗ check:contract could not load ${unreadable.length} doc file(s):\n`,
+      );
+      for (const {file, reason} of unreadable) {
+        console.error(`  ${path.relative(ROOT, file)}`);
+        console.error(`    ${reason}`);
+      }
+      console.error(
+        '\n    → Fix the syntax/import error in that .doc.mjs. A broken doc is not skipped.\n',
+      );
     }
-    console.error(
-      '\n    → Document the prop in that component\'s .doc.mjs `props[]`, or it is not part of the public contract.\n',
-    );
+    if (missing.length > 0) {
+      console.error(
+        `\n✗ check:contract found ${missing.length} undocumented public prop(s):\n`,
+      );
+      for (const {component, prop, file} of missing) {
+        const rel = path.relative(ROOT, file);
+        console.error(`  ${component}.${prop}  (${rel})`);
+      }
+      console.error(
+        '\n    → Document the prop in that component\'s .doc.mjs `props[]`, or it is not part of the public contract.\n',
+      );
+    }
     process.exit(1);
   }
 
-  const docCount = walkDocs(CORE_SRC).length;
   console.log(
     `✓ check:contract — ${docCount} doc(s) checked, 0 undocumented public props` +
       (unresolved.length > 0
@@ -320,5 +341,8 @@ async function main() {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main();
+  main().catch(err => {
+    console.error(err);
+    process.exit(2);
+  });
 }

--- a/scripts/check-contract.test.mjs
+++ b/scripts/check-contract.test.mjs
@@ -336,4 +336,231 @@ describe('checkContract — public props derived from the type checker', () => {
     expect(missing).toEqual([]);
     expect(unresolved.some(u => u.component === 'useTableSortable')).toBe(false);
   });
+
+  it('records unresolved when a component doc has props[] but no matching {Name}Props', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(missing).toEqual([]);
+    expect(unresolved).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'Widget'}),
+      ]),
+    );
+  });
+
+  it('reads a stamped default export, not only `export const docs`', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          width?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export default {
+          type: 'component',
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'Widget', prop: 'width'}),
+      ]),
+    );
+  });
+
+  it('reports a .doc.mjs that cannot be imported instead of swallowing it', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {`,
+    });
+    const result = await checkContract(src);
+    expect(result.unreadable).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: expect.stringContaining('Widget.doc.mjs'),
+        }),
+      ]),
+    );
+  });
+
+  it('still skips ref and xstyle when the component redeclares them', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          ref?: unknown;
+          xstyle?: unknown;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).not.toEqual(
+      expect.arrayContaining(['ref', 'xstyle']),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('derives props from a type alias, not only an interface', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        export type WidgetProps = {
+          label: string;
+          width?: string;
+        };
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'Widget', prop: 'width'}),
+      ]),
+    );
+  });
+
+  it('follows Pick<ParentProps> the same way it follows Omit', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Button/Button.tsx': `
+        export interface ButtonProps {
+          label: string;
+          href?: string;
+          size?: string;
+        }
+      `,
+      'LinkButton/LinkButton.tsx': `
+        import type {ButtonProps} from '../Button/Button';
+        export type LinkButtonProps = Pick<ButtonProps, 'label' | 'href'> & {
+          icon: unknown;
+        };
+      `,
+      'LinkButton/LinkButton.doc.mjs': `
+        export const docs = {
+          name: 'LinkButton',
+          props: [{name: 'icon', type: 'unknown', description: 'Glyph'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    const props = missing
+      .filter(m => m.component === 'LinkButton')
+      .map(m => m.prop)
+      .sort();
+    expect(props).toEqual(expect.arrayContaining(['label', 'href']));
+    expect(props).not.toContain('size');
+  });
+
+  it('does not treat colocated .test / .stories files as the source of truth', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.test.tsx': `
+        export interface WidgetProps { leakedFromTest: string }
+      `,
+      'Widget/Widget.stories.tsx': `
+        export interface WidgetProps { leakedFromStory: string }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).not.toEqual(
+      expect.arrayContaining(['leakedFromTest', 'leakedFromStory']),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('checks inline components[].props against that sub-component, not the parent', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Layout/Stack.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface StackProps extends BaseProps {
+          gap?: number;
+          direction?: string;
+        }
+      `,
+      'Layout/Layout.doc.mjs': `
+        export const docs = {
+          name: 'Layout',
+          components: [
+            {
+              name: 'Stack',
+              props: [{name: 'gap', type: 'number', description: 'Space between children'}],
+            },
+          ],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'Stack', prop: 'direction'}),
+      ]),
+    );
+    expect(missing.map(m => m.component)).not.toContain('Layout');
+  });
+});
+
+describe('documentedPropNames / findUndocumented — empty and nameless input', () => {
+  it('returns an empty set for a missing or empty doc', () => {
+    expect(documentedPropNames(undefined)).toEqual(new Set());
+    expect(documentedPropNames({name: 'X'})).toEqual(new Set());
+  });
+
+  it('skips a props[] entry that has no name', () => {
+    expect(
+      documentedPropNames({
+        name: 'X',
+        props: [{type: 'string'}, {name: 'label'}],
+      }),
+    ).toEqual(new Set(['label']));
+  });
+
+  it('returns empty when the source side is empty, even if docs list extras', () => {
+    expect(findUndocumented([], ['label'])).toEqual([]);
+  });
 });

--- a/scripts/check-contract.test.mjs
+++ b/scripts/check-contract.test.mjs
@@ -1,0 +1,339 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file check-contract.test.mjs
+ * Unit tests for the API-contract gate (#5421 / #4163). The behaviour worth
+ * pinning is what counts as a public prop: the type checker has to see props
+ * a regex would miss (`extends`/`Omit`/`Pick`) and ignore the ones a regex
+ * would invent (BaseProps HTML passthrough, raw DOM `on*`), and it has to
+ * require a redeclared handler (`onKeyDown` on an input) rather than strip
+ * it by name.
+ *
+ * Policy is SUBSET, not equality: every public source prop must be documented.
+ * Docs may list more (forwarded subcomponent props). Required/optional and
+ * phantom-doc props are out of scope for v1.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, it, expect, afterEach} from 'vitest';
+import {
+  isSkippedProp,
+  documentedPropNames,
+  findUndocumented,
+  checkContract,
+} from './check-contract.mjs';
+
+const tmpDirs = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+function fixture(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-contract-'));
+  tmpDirs.push(dir);
+  for (const [rel, source] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), {recursive: true});
+    fs.writeFileSync(full, source);
+  }
+  return dir;
+}
+
+const BASE_PROPS = `export interface BaseProps {
+  id?: string;
+  className?: string;
+  style?: unknown;
+  xstyle?: unknown;
+  onClick?: () => void;
+}
+`;
+
+describe('isSkippedProp — platform surface docs must not enumerate', () => {
+  it('skips the universal styling / ref props ComponentPropDoc tells authors to omit', () => {
+    expect(isSkippedProp('xstyle')).toBe(true);
+    expect(isSkippedProp('className')).toBe(true);
+    expect(isSkippedProp('style')).toBe(true);
+    expect(isSkippedProp('ref')).toBe(true);
+    expect(isSkippedProp('data-testid')).toBe(true);
+  });
+
+  it('does not skip redeclared HTML-ish props that are part of the component contract', () => {
+    expect(isSkippedProp('href')).toBe(false);
+    expect(isSkippedProp('as')).toBe(false);
+    expect(isSkippedProp('target')).toBe(false);
+    expect(isSkippedProp('rel')).toBe(false);
+    expect(isSkippedProp('onKeyDown')).toBe(false);
+    expect(isSkippedProp('onClick')).toBe(false);
+    expect(isSkippedProp('label')).toBe(false);
+  });
+});
+
+describe('documentedPropNames — every props[] the doc file owns', () => {
+  it('reads top-level props on a single-component doc', () => {
+    expect(
+      documentedPropNames({
+        name: 'Button',
+        props: [{name: 'label'}, {name: 'href'}],
+      }),
+    ).toEqual(new Set(['label', 'href']));
+  });
+
+  it('reads inline components[].props on a multi-component doc', () => {
+    expect(
+      documentedPropNames({
+        name: 'Layout',
+        components: [
+          {name: 'Stack', props: [{name: 'gap'}, {name: 'direction'}]},
+          {name: 'LayoutPanel'},
+        ],
+      }),
+    ).toEqual(new Set(['gap', 'direction']));
+  });
+
+  it('unions top-level props with inline component props', () => {
+    expect(
+      documentedPropNames({
+        name: 'Dialog',
+        props: [{name: 'padding'}],
+        components: [{name: 'DialogHeader', props: [{name: 'title'}]}],
+      }),
+    ).toEqual(new Set(['padding', 'title']));
+  });
+});
+
+describe('findUndocumented — subset, not equality', () => {
+  it('lists a source prop the doc omitted', () => {
+    expect(findUndocumented(['label', 'href'], ['label'])).toEqual(['href']);
+  });
+
+  it('accepts extra documented props (forwarded / subcomponent surface)', () => {
+    expect(findUndocumented(['label'], ['label', 'type', 'color'])).toEqual([]);
+  });
+
+  it('returns empty when every source prop is documented', () => {
+    expect(findUndocumented(['label', 'href'], ['href', 'label'])).toEqual([]);
+  });
+});
+
+describe('checkContract — public props derived from the type checker', () => {
+  it('flags an own prop that the doc omitted', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          width?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'Widget', prop: 'width'}),
+      ]),
+    );
+  });
+
+  it('does not require BaseProps passthrough (id, onClick)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).not.toEqual(
+      expect.arrayContaining(['id', 'onClick', 'className', 'style', 'xstyle']),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it('requires a redeclared onKeyDown (component-owned, not raw DOM passthrough)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          onKeyDown?: (e: unknown) => void;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'Widget', prop: 'onKeyDown'}),
+      ]),
+    );
+  });
+
+  it('follows Omit<ParentProps> so IconButton still requires label and href', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Button/Button.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface ButtonProps extends BaseProps {
+          label: string;
+          href?: string;
+          isIconOnly?: boolean;
+          children?: unknown;
+        }
+      `,
+      'IconButton/IconButton.tsx': `
+        import type {ButtonProps} from '../Button/Button';
+        export interface IconButtonProps extends Omit<ButtonProps, 'isIconOnly' | 'children'> {
+          icon: unknown;
+        }
+      `,
+      'IconButton/IconButton.doc.mjs': `
+        export const docs = {
+          name: 'IconButton',
+          props: [{name: 'icon', type: 'unknown', description: 'Glyph'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    const props = missing
+      .filter(m => m.component === 'IconButton')
+      .map(m => m.prop)
+      .sort();
+    expect(props).toEqual(expect.arrayContaining(['label', 'href']));
+    expect(props).not.toEqual(expect.arrayContaining(['isIconOnly', 'children']));
+  });
+
+  it('accepts extra documented props (subset policy)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          format?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [
+            {name: 'format', type: 'string', description: 'Format string'},
+            {name: 'type', type: 'string', description: 'Forwarded from a child'},
+            {name: 'color', type: 'string', description: 'Forwarded from a child'},
+          ],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual([]);
+  });
+
+  it('prefers the {Name}Props declared in the doc directory when the name collides', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Other/Other.tsx': `
+        export interface WidgetProps {
+          alien: string;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).not.toContain('alien');
+    expect(missing).toEqual([]);
+  });
+
+  it('scans a sibling sub-component doc (subComponentOf) as its own contract', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Dialog/Dialog.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface DialogProps extends BaseProps {
+          padding?: number;
+        }
+      `,
+      'Dialog/DialogHeader.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface DialogHeaderProps extends BaseProps {
+          title: string;
+        }
+      `,
+      'Dialog/Dialog.doc.mjs': `
+        export const docs = {
+          name: 'Dialog',
+          props: [{name: 'padding', type: 'number', description: 'Inset'}],
+          components: [{name: 'DialogHeader'}],
+        };
+      `,
+      'Dialog/DialogHeader.doc.mjs': `
+        export const docs = {
+          name: 'DialogHeader',
+          subComponentOf: 'Dialog',
+          description: 'Title row',
+          props: [],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({component: 'DialogHeader', prop: 'title'}),
+      ]),
+    );
+  });
+
+  it('does not fail a hook doc that has no {Name}Props (unresolved, not drift)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Table/useTableSortable.ts': `
+        export interface UseTableSortableConfig {
+          column: string;
+        }
+      `,
+      'Table/useTableSortable.doc.mjs': `
+        export const docs = {
+          name: 'useTableSortable',
+          params: [{name: 'column', type: 'string', description: 'Sort key'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(missing).toEqual([]);
+    expect(unresolved.some(u => u.component === 'useTableSortable')).toBe(false);
+  });
+});

--- a/scripts/check-contract.test.mjs
+++ b/scripts/check-contract.test.mjs
@@ -12,17 +12,25 @@
  * Policy is SUBSET, not equality: every public source prop must be documented.
  * Docs may list more (forwarded subcomponent props). Required/optional and
  * phantom-doc props are out of scope for v1.
+ *
+ * Edge classes pinned after the original set: union member-only props,
+ * intersection redeclares (either constituent order), `@types/react`
+ * inheritance, generic and key-remapped Props, `__tests__/` leakage, docs
+ * that cannot be loaded or export no `docs`, report order under any
+ * directory read order, and the `run()` exit codes CI sees — including a
+ * zero-doc scan failing rather than passing.
  */
 
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {describe, it, expect, afterEach} from 'vitest';
+import {describe, it, expect, afterEach, vi} from 'vitest';
 import {
   isSkippedProp,
   documentedPropNames,
   findUndocumented,
   checkContract,
+  run,
 } from './check-contract.mjs';
 
 const tmpDirs = [];
@@ -225,7 +233,9 @@ describe('checkContract — public props derived from the type checker', () => {
       .map(m => m.prop)
       .sort();
     expect(props).toEqual(expect.arrayContaining(['label', 'href']));
-    expect(props).not.toEqual(expect.arrayContaining(['isIconOnly', 'children']));
+    expect(props).not.toEqual(
+      expect.arrayContaining(['isIconOnly', 'children']),
+    );
   });
 
   it('accepts extra documented props (subset policy)', async () => {
@@ -334,7 +344,9 @@ describe('checkContract — public props derived from the type checker', () => {
     });
     const {missing, unresolved} = await checkContract(src);
     expect(missing).toEqual([]);
-    expect(unresolved.some(u => u.component === 'useTableSortable')).toBe(false);
+    expect(unresolved.some(u => u.component === 'useTableSortable')).toBe(
+      false,
+    );
   });
 
   it('records unresolved when a component doc has props[] but no matching {Name}Props', async () => {
@@ -350,9 +362,7 @@ describe('checkContract — public props derived from the type checker', () => {
     const {missing, unresolved} = await checkContract(src);
     expect(missing).toEqual([]);
     expect(unresolved).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({component: 'Widget'}),
-      ]),
+      expect.arrayContaining([expect.objectContaining({component: 'Widget'})]),
     );
   });
 
@@ -562,5 +572,430 @@ describe('documentedPropNames / findUndocumented — empty and nameless input', 
 
   it('returns empty when the source side is empty, even if docs list extras', () => {
     expect(findUndocumented([], ['label'])).toEqual([]);
+  });
+});
+
+describe('checkContract — union, intersection, and inheritance edges', () => {
+  it('requires a prop that only one member of a union {Name}Props declares (Slider range mode)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Slider/Slider.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface SliderBaseProps extends BaseProps {
+          step?: number;
+        }
+        export interface SliderSingleProps extends SliderBaseProps {
+          value: number;
+        }
+        export interface SliderRangeProps extends SliderBaseProps {
+          value: [number, number];
+          minStepsBetweenThumbs?: number;
+        }
+        export type SliderProps = SliderSingleProps | SliderRangeProps;
+      `,
+      'Slider/Slider.doc.mjs': `
+        export const docs = {
+          name: 'Slider',
+          props: [
+            {name: 'step', type: 'number', description: 'Increment'},
+            {name: 'value', type: 'number | [number, number]', description: 'Current value'},
+          ],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual([
+      expect.objectContaining({
+        component: 'Slider',
+        prop: 'minStepsBetweenThumbs',
+      }),
+    ]);
+  });
+
+  it('requires a prop redeclared over BaseProps in an intersection, whichever side BaseProps is on', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export type WidgetProps = BaseProps & {
+          label: string;
+          /** Component-owned, not the BaseProps passthrough. */
+          onClick?: () => void;
+        };
+      `,
+      'Gadget/Gadget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export type GadgetProps = {
+          label: string;
+          onClick?: () => void;
+        } & BaseProps;
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+      'Gadget/Gadget.doc.mjs': `
+        export const docs = {
+          name: 'Gadget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual([
+      expect.objectContaining({component: 'Gadget', prop: 'onClick'}),
+      expect.objectContaining({component: 'Widget', prop: 'onClick'}),
+    ]);
+  });
+});
+
+describe('checkContract — doc loading and report determinism', () => {
+  it('reports a .doc.mjs that exports neither `docs` nor a default, instead of silently skipping it', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const doc = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {unreadable, missing} = await checkContract(src);
+    expect(unreadable).toEqual([
+      expect.objectContaining({
+        file: expect.stringContaining('Widget.doc.mjs'),
+        reason: expect.stringMatching(/docs/),
+      }),
+    ]);
+    expect(missing).toEqual([]);
+  });
+
+  it('sorts missing and unresolved by name, not by directory read order', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Alpha/Alpha.doc.mjs': `
+        export const docs = {name: 'Alpha', props: [{name: 'x', type: 'string', description: 'x'}]};
+      `,
+      'Beta/Beta.doc.mjs': `
+        export const docs = {name: 'Beta', props: [{name: 'x', type: 'string', description: 'x'}]};
+      `,
+      'Yak/Yak.tsx': `export interface YakProps { b: string; a: string }`,
+      'Yak/Yak.doc.mjs': `export const docs = {name: 'Yak', props: []};`,
+      'Zed/Zed.tsx': `export interface ZedProps { z: string }`,
+      'Zed/Zed.doc.mjs': `export const docs = {name: 'Zed', props: []};`,
+    });
+    const natural = fs.readdirSync.bind(fs);
+    const reversed = (dir, opts) => {
+      const entries = natural(dir, opts);
+      return String(dir).startsWith(src) ? [...entries].reverse() : entries;
+    };
+    const spy = vi.spyOn(fs, 'readdirSync');
+    try {
+      for (const walkOrder of [natural, reversed]) {
+        spy.mockImplementation(walkOrder);
+        const {missing, unresolved} = await checkContract(src);
+        expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+          'Yak.a',
+          'Yak.b',
+          'Zed.z',
+        ]);
+        expect(unresolved.map(u => u.component)).toEqual(['Alpha', 'Beta']);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('run — the CI-facing report', () => {
+  function capture() {
+    const out = {log: [], error: []};
+    return {
+      out,
+      io: {
+        log: line => out.log.push(line),
+        error: line => out.error.push(line),
+      },
+    };
+  }
+
+  it('prints each undocumented prop with its doc path and returns 1', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          width?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    expect(out.error.join('\n')).toMatch(/1 undocumented public prop/);
+    expect(out.error.join('\n')).toMatch(
+      /Widget\.width\s+\(.*Widget\.doc\.mjs\)/,
+    );
+    expect(out.log).toEqual([]);
+  });
+
+  it('returns 1 when the scan finds no .doc.mjs at all — an empty scan is a misconfigured gate, not a pass', async () => {
+    const src = fixture({'BaseProps.ts': BASE_PROPS});
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    expect(out.error.join('\n')).toMatch(/no \.doc\.mjs/);
+    expect(out.log).toEqual([]);
+  });
+
+  it('returns 0 with the checked count and lists unresolved {Name}Props as informational', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+      'Ghost/Ghost.doc.mjs': `
+        export const docs = {
+          name: 'Ghost',
+          props: [{name: 'boo', type: 'string', description: 'No GhostProps in source'}],
+        };
+      `,
+    });
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(0);
+    expect(out.log).toEqual([
+      '✓ check:contract — 2 doc(s) checked, 0 undocumented public props; 1 unresolved {Name}Props (informational)',
+      '  · Ghost: no resolvable GhostProps in source',
+    ]);
+    expect(out.error).toEqual([]);
+  });
+
+  it('returns 1 and names the file and reason when a doc cannot be loaded', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.doc.mjs': `export const docs = {`,
+    });
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    const report = out.error.join('\n');
+    expect(report).toMatch(/could not load 1 doc file\(s\)/);
+    expect(report).toMatch(/Widget\.doc\.mjs\n\s+\S/);
+    expect(report).toMatch(/A broken doc is not skipped/);
+    expect(out.log).toEqual([]);
+  });
+});
+
+describe('checkContract — inheritance and file-walk edges', () => {
+  it('requires onClick when the component interface redeclares it over BaseProps', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          /** Component-owned: part of the documented contract. */
+          onClick?: () => void;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing).toEqual([
+      expect.objectContaining({component: 'Widget', prop: 'onClick'}),
+    ]);
+  });
+
+  it('does not require BaseProps passthrough that arrives through Omit<ParentProps>', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Button/Button.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface ButtonProps extends BaseProps {
+          label: string;
+          href?: string;
+          isIconOnly?: boolean;
+        }
+      `,
+      'IconButton/IconButton.tsx': `
+        import type {ButtonProps} from '../Button/Button';
+        export interface IconButtonProps extends Omit<ButtonProps, 'isIconOnly'> {
+          icon: unknown;
+        }
+      `,
+      'IconButton/IconButton.doc.mjs': `
+        export const docs = {
+          name: 'IconButton',
+          props: [{name: 'icon', type: 'unknown', description: 'Glyph'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).toEqual(['href', 'label']);
+  });
+
+  it('does not require attributes inherited from @types/react (HTMLAttributes)', async () => {
+    const src = fixture({
+      'node_modules/@types/react/index.d.ts': `
+        export interface HTMLAttributes<T> {
+          id?: string;
+          role?: string;
+          'aria-label'?: string;
+          onKeyDown?: (event: T) => void;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        import type {HTMLAttributes} from 'react';
+        export interface WidgetProps extends HTMLAttributes<unknown> {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+
+  it('derives props from a generic {Name}Props, interface or alias', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps<T> extends BaseProps {
+          value: T;
+          onChange?: (next: T) => void;
+        }
+      `,
+      'Gadget/Gadget.tsx': `
+        export type GadgetProps<T = string> = {
+          items: T[];
+          label: string;
+        };
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'value', type: 'T', description: 'Current value'}],
+        };
+      `,
+      'Gadget/Gadget.doc.mjs': `
+        export const docs = {
+          name: 'Gadget',
+          props: [{name: 'items', type: 'T[]', description: 'Rows'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Gadget.label',
+      'Widget.onChange',
+    ]);
+  });
+
+  it('ignores a {Name}Props declared under __tests__/ (unresolved, not a leaked contract)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/__tests__/Widget.tsx': `
+        export interface WidgetProps { leakedFromTestDir: string }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(missing).toEqual([]);
+    expect(unresolved).toEqual([
+      expect.objectContaining({component: 'Widget'}),
+    ]);
+  });
+
+  it('reports a doc whose import fails at runtime and still checks the other docs', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Broken/Broken.tsx': `export interface BrokenProps { a: string }`,
+      'Broken/Broken.doc.mjs': `
+        import {shared} from './shared-examples.mjs';
+        export const docs = {name: 'Broken', props: shared};
+      `,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          width?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {unreadable, missing} = await checkContract(src);
+    expect(unreadable).toEqual([
+      expect.objectContaining({
+        file: expect.stringContaining('Broken.doc.mjs'),
+        reason: expect.stringContaining('shared-examples'),
+      }),
+    ]);
+    expect(missing).toEqual([
+      expect.objectContaining({component: 'Widget', prop: 'width'}),
+    ]);
+  });
+
+  it('requires declaration-less props from a key-remapped mapped type (they are component API)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        type Phase = 'open' | 'close';
+        export type WidgetProps = BaseProps & {
+          [K in Phase as \`on\${Capitalize<K>}\`]?: () => void;
+        } & {label: string};
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).toEqual(['onClose', 'onOpen']);
   });
 });

--- a/scripts/check-contract.test.mjs
+++ b/scripts/check-contract.test.mjs
@@ -19,11 +19,37 @@
  * that cannot be loaded or export no `docs`, report order under any
  * directory read order, and the `run()` exit codes CI sees — including a
  * zero-doc scan failing rather than passing.
+ *
+ * Then the shared/aliased bags: an entry with no `{Name}Props` of its own
+ * resolves through the exported `{Name}` signature (generic shared bag,
+ * `export {X as Y}` alias, every overload, zero-parameter hook), and an
+ * entry that resolves neither way fails the run instead of sitting in an
+ * informational list. Those last two are pinned against REAL core
+ * components — the indicator family and `ContextMenuItem` — because a
+ * fixture proves the mechanism and only real source proves the coverage.
+ *
+ * Then which bag wins: only an exported, top-level `{Name}Props` counts,
+ * the doc's own directory beats a foreign one, a shallower path beats a
+ * nested copy, and the answer holds under any directory read order. Then
+ * the parameter forms the signature route must read (class constructors,
+ * rest tuples, every bag parameter, constrained type parameters, destructured
+ * defaults, optional and Readonly / Partial / Omit / Pick parameters, unions
+ * with primitives, index-signature-only bags, Parameters<typeof> and
+ * ComponentProps<typeof>, bare callbacks; `any` / `unknown` / `object` are
+ * unresolved, not empty), the declaration forms (memo / forwardRef / FC,
+ * arrow consts, deferred and default exports, barrel chains), the platform
+ * filter through that route (and that node_modules outside @types/react and
+ * csstype is public API), the report shape, the resolver's route report, and
+ * the remaining gates: the `docs` export is the one checked, a doc that
+ * publishes props[] without a name fails, a malformed doc is unreadable
+ * rather than a crash, and a program that cannot resolve `react` — or
+ * resolves it to untyped JavaScript — fails before any verdict.
  */
 
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {describe, it, expect, afterEach, vi} from 'vitest';
 import {
   isSkippedProp,
@@ -31,6 +57,8 @@ import {
   findUndocumented,
   checkContract,
   run,
+  buildProgram,
+  createResolver,
 } from './check-contract.mjs';
 
 const tmpDirs = [];
@@ -170,19 +198,25 @@ describe('checkContract — public props derived from the type checker', () => {
         };
       `,
     });
-    const {missing} = await checkContract(src);
-    expect(missing.map(m => m.prop)).not.toEqual(
-      expect.arrayContaining(['id', 'onClick', 'className', 'style', 'xstyle']),
-    );
+    const {missing, unresolved, unreadable} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(unreadable).toEqual([]);
     expect(missing).toEqual([]);
   });
 
   it('requires a redeclared onKeyDown (component-owned, not raw DOM passthrough)', async () => {
     const src = fixture({
       'BaseProps.ts': BASE_PROPS,
+      'node_modules/@types/react/index.d.ts': `
+        export interface HTMLAttributes<T> {
+          onKeyDown?: (event: T) => void;
+          onFocus?: (event: T) => void;
+        }
+      `,
       'Widget/Widget.tsx': `
         import type {BaseProps} from '../BaseProps';
-        export interface WidgetProps extends BaseProps {
+        import type {HTMLAttributes} from 'react';
+        export interface WidgetProps extends BaseProps, HTMLAttributes<unknown> {
           label: string;
           onKeyDown?: (e: unknown) => void;
         }
@@ -194,48 +228,11 @@ describe('checkContract — public props derived from the type checker', () => {
         };
       `,
     });
-    const {missing} = await checkContract(src);
-    expect(missing).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({component: 'Widget', prop: 'onKeyDown'}),
-      ]),
-    );
-  });
-
-  it('follows Omit<ParentProps> so IconButton still requires label and href', async () => {
-    const src = fixture({
-      'BaseProps.ts': BASE_PROPS,
-      'Button/Button.tsx': `
-        import type {BaseProps} from '../BaseProps';
-        export interface ButtonProps extends BaseProps {
-          label: string;
-          href?: string;
-          isIconOnly?: boolean;
-          children?: unknown;
-        }
-      `,
-      'IconButton/IconButton.tsx': `
-        import type {ButtonProps} from '../Button/Button';
-        export interface IconButtonProps extends Omit<ButtonProps, 'isIconOnly' | 'children'> {
-          icon: unknown;
-        }
-      `,
-      'IconButton/IconButton.doc.mjs': `
-        export const docs = {
-          name: 'IconButton',
-          props: [{name: 'icon', type: 'unknown', description: 'Glyph'}],
-        };
-      `,
-    });
-    const {missing} = await checkContract(src);
-    const props = missing
-      .filter(m => m.component === 'IconButton')
-      .map(m => m.prop)
-      .sort();
-    expect(props).toEqual(expect.arrayContaining(['label', 'href']));
-    expect(props).not.toEqual(
-      expect.arrayContaining(['isIconOnly', 'children']),
-    );
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    // onFocus reaches WidgetProps only through @types/react and stays
+    // passthrough; onKeyDown is declared there AND on the component: API.
+    expect(missing.map(m => m.prop)).toEqual(['onKeyDown']);
   });
 
   it('accepts extra documented props (subset policy)', async () => {
@@ -258,7 +255,9 @@ describe('checkContract — public props derived from the type checker', () => {
         };
       `,
     });
-    const {missing} = await checkContract(src);
+    const {missing, unresolved, unreadable} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(unreadable).toEqual([]);
     expect(missing).toEqual([]);
   });
 
@@ -283,8 +282,9 @@ describe('checkContract — public props derived from the type checker', () => {
         };
       `,
     });
-    const {missing} = await checkContract(src);
-    expect(missing.map(m => m.prop)).not.toContain('alien');
+    const {missing, unresolved, unreadable} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(unreadable).toEqual([]);
     expect(missing).toEqual([]);
   });
 
@@ -327,7 +327,7 @@ describe('checkContract — public props derived from the type checker', () => {
     );
   });
 
-  it('does not fail a hook doc that has no {Name}Props (unresolved, not drift)', async () => {
+  it('skips a hook doc that documents params, not props[]: no entry, so neither unresolved nor drift', async () => {
     const src = fixture({
       'BaseProps.ts': BASE_PROPS,
       'Table/useTableSortable.ts': `
@@ -431,10 +431,9 @@ describe('checkContract — public props derived from the type checker', () => {
         };
       `,
     });
-    const {missing} = await checkContract(src);
-    expect(missing.map(m => m.prop)).not.toEqual(
-      expect.arrayContaining(['ref', 'xstyle']),
-    );
+    const {missing, unresolved, unreadable} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(unreadable).toEqual([]);
     expect(missing).toEqual([]);
   });
 
@@ -516,10 +515,9 @@ describe('checkContract — public props derived from the type checker', () => {
         };
       `,
     });
-    const {missing} = await checkContract(src);
-    expect(missing.map(m => m.prop)).not.toEqual(
-      expect.arrayContaining(['leakedFromTest', 'leakedFromStory']),
-    );
+    const {missing, unresolved, unreadable} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(unreadable).toEqual([]);
     expect(missing).toEqual([]);
   });
 
@@ -761,7 +759,7 @@ describe('run — the CI-facing report', () => {
     expect(out.log).toEqual([]);
   });
 
-  it('returns 0 with the checked count and lists unresolved {Name}Props as informational', async () => {
+  it('returns 1 and names an entry whose public props could not be resolved from source', async () => {
     const src = fixture({
       'BaseProps.ts': BASE_PROPS,
       'Widget/Widget.tsx': `
@@ -784,10 +782,67 @@ describe('run — the CI-facing report', () => {
       `,
     });
     const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    const report = out.error.join('\n');
+    expect(report).toMatch(
+      /could not resolve the public props of 1 documented entr/,
+    );
+    expect(report).toMatch(/Ghost\s+\(.*Ghost\.doc\.mjs\)/);
+    expect(out.log).toEqual([]);
+  });
+
+  it('reports unresolved entries in the same run as undocumented props, not only on the pass path', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          width?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+      'Ghost/Ghost.doc.mjs': `
+        export const docs = {
+          name: 'Ghost',
+          props: [{name: 'boo', type: 'string', description: 'No GhostProps in source'}],
+        };
+      `,
+    });
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    const report = out.error.join('\n');
+    expect(report).toMatch(/Widget\.width/);
+    expect(report).toMatch(
+      /could not resolve the public props of 1 documented entr/,
+    );
+  });
+
+  it('returns 0 with the checked count when every documented entry resolved', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {out, io} = capture();
     await expect(run(src, io)).resolves.toBe(0);
     expect(out.log).toEqual([
-      '✓ check:contract — 2 doc(s) checked, 0 undocumented public props; 1 unresolved {Name}Props (informational)',
-      '  · Ghost: no resolvable GhostProps in source',
+      '\u2713 check:contract \u2014 1 doc(s) checked, 0 undocumented public props',
     ]);
     expect(out.error).toEqual([]);
   });
@@ -832,7 +887,7 @@ describe('checkContract — inheritance and file-walk edges', () => {
     ]);
   });
 
-  it('does not require BaseProps passthrough that arrives through Omit<ParentProps>', async () => {
+  it('follows Omit<ParentProps>: IconButton still requires label and href, not the omitted props nor BaseProps passthrough', async () => {
     const src = fixture({
       'BaseProps.ts': BASE_PROPS,
       'Button/Button.tsx': `
@@ -841,11 +896,12 @@ describe('checkContract — inheritance and file-walk edges', () => {
           label: string;
           href?: string;
           isIconOnly?: boolean;
+          children?: unknown;
         }
       `,
       'IconButton/IconButton.tsx': `
         import type {ButtonProps} from '../Button/Button';
-        export interface IconButtonProps extends Omit<ButtonProps, 'isIconOnly'> {
+        export interface IconButtonProps extends Omit<ButtonProps, 'isIconOnly' | 'children'> {
           icon: unknown;
         }
       `,
@@ -856,7 +912,8 @@ describe('checkContract — inheritance and file-walk edges', () => {
         };
       `,
     });
-    const {missing} = await checkContract(src);
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
     expect(missing.map(m => m.prop)).toEqual(['href', 'label']);
   });
 
@@ -942,6 +999,8 @@ describe('checkContract — inheritance and file-walk edges', () => {
     expect(unresolved).toEqual([
       expect.objectContaining({component: 'Widget'}),
     ]);
+    // Not trusted, and not silently passed either.
+    await expect(run(src, {log: () => {}, error: () => {}})).resolves.toBe(1);
   });
 
   it('reports a doc whose import fails at runtime and still checks the other docs', async () => {
@@ -997,5 +1056,1631 @@ describe('checkContract — inheritance and file-walk edges', () => {
     });
     const {missing} = await checkContract(src);
     expect(missing.map(m => m.prop)).toEqual(['onClose', 'onOpen']);
+  });
+});
+
+describe('checkContract — shared and aliased prop bags', () => {
+  it('checks a component whose props come from a shared generic bag with no {Name}Props of its own', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Indicator/types.ts': `
+        import type {BaseProps} from '../BaseProps';
+        export interface IndicatorProps<F extends 'single' | 'multi' = 'single'>
+          extends BaseProps {
+          state: F extends 'multi' ? 'on' | 'off' | 'mixed' : 'on' | 'off';
+          size?: 'sm' | 'md';
+          isDisabled?: boolean;
+        }
+      `,
+      'Indicator/CheckboxIndicator.tsx': `
+        import type {IndicatorProps} from './types';
+        export function CheckboxIndicator({state}: IndicatorProps<'multi'>) {
+          return null;
+        }
+      `,
+      'Indicator/Indicator.doc.mjs': `
+        export const docs = {
+          name: 'Indicator',
+          components: [
+            {
+              name: 'CheckboxIndicator',
+              props: [{name: 'state', type: 'string', description: 'Which state to draw'}],
+            },
+          ],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'CheckboxIndicator.isDisabled',
+      'CheckboxIndicator.size',
+    ]);
+  });
+
+  it('follows an export alias so a re-exported component is checked against the props it really takes', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'DropdownMenu/DropdownMenuItem.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface DropdownMenuItemProps extends BaseProps {
+          label: string;
+          icon?: string;
+        }
+        export function DropdownMenuItem(props: DropdownMenuItemProps) {
+          return null;
+        }
+      `,
+      'ContextMenu/index.ts': `
+        export {
+          DropdownMenuItem as ContextMenuItem,
+          type DropdownMenuItemProps as ContextMenuItemProps,
+        } from '../DropdownMenu/DropdownMenuItem';
+      `,
+      'ContextMenu/ContextMenuItem.doc.mjs': `
+        export const docs = {
+          name: 'ContextMenuItem',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'ContextMenuItem.icon',
+    ]);
+  });
+
+  it('requires the props of every overload, not just the first', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Resizable/useResizable.ts': `
+        export interface SingleConfig { defaultSize?: number }
+        export interface MultiConfig { regions: string[] }
+        export function useResizable(config: SingleConfig): number;
+        export function useResizable(config: MultiConfig): number;
+        export function useResizable(config: SingleConfig | MultiConfig): number {
+          return 0;
+        }
+      `,
+      'Resizable/useResizable.doc.mjs': `
+        export const docs = {
+          name: 'useResizable',
+          props: [{name: 'defaultSize', type: 'number', description: 'Initial size'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'useResizable.regions',
+    ]);
+  });
+
+  it('resolves a zero-parameter hook to an empty contract instead of leaving it unresolved', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'AlertDialog/useImperativeAlertDialog.ts': `
+        export function useImperativeAlertDialog(): {show: () => void} {
+          return {show: () => {}};
+        }
+      `,
+      'AlertDialog/useImperativeAlertDialog.doc.mjs': `
+        export const docs = {
+          name: 'useImperativeAlertDialog',
+          props: [{name: 'title', type: 'string', description: 'Documented show() option'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+
+  it('prefers the exported component in the doc directory when the name collides', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Other/Widget.tsx': `
+        export function Widget(props: {fromOtherDir: string}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        export function Widget(props: {fromWidgetDir: string}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {name: 'Widget', props: []};
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).toEqual(['fromWidgetDir']);
+  });
+
+  it('picks the same colliding export under any directory read order', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Beta/Widget.tsx': `
+        export function Widget(props: {fromBeta: string}) {
+          return null;
+        }
+      `,
+      'Alpha/Widget.tsx': `
+        export function Widget(props: {fromAlpha: string}) {
+          return null;
+        }
+      `,
+      'Zeta/Widget.doc.mjs': `
+        export const docs = {name: 'Widget', props: []};
+      `,
+    });
+    const natural = fs.readdirSync.bind(fs);
+    const reversed = (dir, opts) => {
+      const entries = natural(dir, opts);
+      return String(dir).startsWith(src) ? [...entries].reverse() : entries;
+    };
+    const spy = vi.spyOn(fs, 'readdirSync');
+    try {
+      for (const walkOrder of [natural, reversed]) {
+        spy.mockImplementation(walkOrder);
+        const {missing} = await checkContract(src);
+        expect(missing.map(m => m.prop)).toEqual(['fromAlpha']);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('prefers a declared {Name}Props over the exported signature when both exist', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          fromDeclaration: string;
+        }
+        export function Widget(props: {fromSignature: string}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {name: 'Widget', props: []};
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).toEqual(['fromDeclaration']);
+  });
+});
+
+// These tests pin real core identifiers by name. A rename of any of them
+// must land here too: packages/core/src/BaseProps.ts; Indicator/types.ts
+// `IndicatorProps` and the three indicator entries in Indicator.doc.mjs;
+// DropdownMenu/DropdownMenuItem.tsx `DropdownMenuItemProps` and the
+// ContextMenu re-export; Dialog/Dialog.tsx `DialogProps` behind
+// useImperativeDialog; Resizable/useResizable.ts `UseResizableMultiConfig`;
+// Code/Code.tsx `CodeProps` documented from CodeBlock/Code.doc.mjs; and the
+// Table/ plugin hook docs.
+describe('checkContract — real components, not fixtures', () => {
+  const REPO_ROOT = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+  );
+  const CORE_SRC = path.join(REPO_ROOT, 'packages/core/src');
+
+  /**
+   * Real core sources copied into a scratch tree at their own relative paths,
+   * with the repo's node_modules linked in so `react` resolves exactly as it
+   * does for the real gate.
+   */
+  function realFixture(relPaths) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-contract-real-'));
+    tmpDirs.push(dir);
+    // 'junction' needs no privilege on Windows and is a plain symlink elsewhere.
+    fs.symlinkSync(
+      path.join(REPO_ROOT, 'node_modules'),
+      path.join(dir, 'node_modules'),
+      'junction',
+    );
+    for (const rel of relPaths) {
+      const dest = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(dest), {recursive: true});
+      fs.cpSync(path.join(CORE_SRC, rel), dest, {recursive: true});
+    }
+    return dir;
+  }
+
+  /** Add a member to a real interface — "a new public member on that shared contract". */
+  function addMemberTo(file, interfaceName, member) {
+    const source = fs.readFileSync(file, 'utf8');
+    const at = source.indexOf(`export interface ${interfaceName}`);
+    expect(
+      at,
+      `export interface ${interfaceName} not found in ${path.relative(REPO_ROOT, file)}`,
+    ).toBeGreaterThan(-1);
+    const open = source.indexOf('{', at);
+    expect(open).toBeGreaterThan(at);
+    fs.writeFileSync(
+      file,
+      `${source.slice(0, open + 1)}\n  ${member}\n${source.slice(open + 1)}`,
+    );
+  }
+
+  it('resolves the real indicator family through its shared IndicatorProps', async () => {
+    const {unresolved} = await checkContract(path.join(CORE_SRC, 'Indicator'));
+    // CheckboxIndicator / CheckIndicator / RadioIndicator declare no
+    // {Name}Props of their own — they take IndicatorProps<F>. Whether the
+    // live docs are complete is the gate's verdict, not this suite's.
+    expect(unresolved).toEqual([]);
+  });
+
+  it('reports a new member of the real shared IndicatorProps against every indicator that documents it', async () => {
+    const src = realFixture(['BaseProps.ts', 'Indicator']);
+    addMemberTo(
+      path.join(src, 'Indicator/types.ts'),
+      'IndicatorProps',
+      'brandNewSharedProp?: string;',
+    );
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'CheckboxIndicator.brandNewSharedProp',
+      'CheckIndicator.brandNewSharedProp',
+      'RadioIndicator.brandNewSharedProp',
+    ]);
+  });
+
+  it('resolves the real ContextMenuItem through its re-exported prop alias', async () => {
+    const {unresolved} = await checkContract(
+      path.join(CORE_SRC, 'ContextMenu'),
+    );
+    // ContextMenuItem is DropdownMenuItem re-exported; the only
+    // `ContextMenuItemProps` is an alias, never a declaration.
+    expect(unresolved).toEqual([]);
+  });
+
+  it('reports a new member of the real aliased DropdownMenuItemProps against ContextMenuItem', async () => {
+    const src = realFixture([
+      'BaseProps.ts',
+      'DropdownMenu/DropdownMenuItem.tsx',
+      'ContextMenu/index.ts',
+      'ContextMenu/ContextMenuItem.doc.mjs',
+    ]);
+    addMemberTo(
+      path.join(src, 'DropdownMenu/DropdownMenuItem.tsx'),
+      'DropdownMenuItemProps',
+      'brandNewAliasedProp?: string;',
+    );
+    const {missing} = await checkContract(src);
+    expect(
+      missing.filter(m => m.component === 'ContextMenuItem').map(m => m.prop),
+    ).toContain('brandNewAliasedProp');
+  });
+
+  it('reports a new DialogProps member against the real useImperativeDialog through its Omit<DialogProps> option bag', async () => {
+    const src = realFixture(['BaseProps.ts', 'Dialog']);
+    addMemberTo(
+      path.join(src, 'Dialog/Dialog.tsx'),
+      'DialogProps',
+      'brandNewDialogProp?: string;',
+    );
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    const reported = missing.map(m => `${m.component}.${m.prop}`);
+    expect(reported).toContain('Dialog.brandNewDialogProp');
+    expect(reported).toContain('useImperativeDialog.brandNewDialogProp');
+  });
+
+  it('reports a new member of the real second useResizable overload, not only the first', async () => {
+    const src = realFixture(['BaseProps.ts', 'Resizable']);
+    addMemberTo(
+      path.join(src, 'Resizable/useResizable.ts'),
+      'UseResizableMultiConfig',
+      'brandNewMultiProp?: string;',
+    );
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(
+      missing.filter(m => m.component === 'useResizable').map(m => m.prop),
+    ).toContain('brandNewMultiProp');
+  });
+
+  it('checks the real Code doc that lives in CodeBlock/ against CodeProps declared in Code/', async () => {
+    const src = realFixture(['BaseProps.ts', 'Code', 'CodeBlock/Code.doc.mjs']);
+    addMemberTo(
+      path.join(src, 'Code/Code.tsx'),
+      'CodeProps',
+      'brandNewCodeProp?: string;',
+    );
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(
+      missing.filter(m => m.component === 'Code').map(m => m.prop),
+    ).toContain('brandNewCodeProp');
+  });
+
+  it('resolves every real Table plugin hook through its Config parameter; a Record parameter yields an empty contract', async () => {
+    const {missing, unresolved} = await checkContract(
+      path.join(CORE_SRC, 'Table'),
+    );
+    // Every use* doc under Table/ carries props[] and none declares a
+    // {Name}Props: all of them resolve off the exported signature.
+    expect(unresolved).toEqual([]);
+    // useTableFilterState(initialState?: Record<string, …>) has no named
+    // member to require; an empty contract there is genuine, not vacuous.
+    expect(missing.filter(m => m.component === 'useTableFilterState')).toEqual(
+      [],
+    );
+  });
+});
+
+describe('checkContract — which bag wins', () => {
+  /** Run `check` on the scan under natural AND reversed readdir order. */
+  async function underBothReadOrders(src, check) {
+    const natural = fs.readdirSync.bind(fs);
+    const reversed = (dir, opts) => {
+      const entries = natural(dir, opts);
+      return String(dir).startsWith(src) ? [...entries].reverse() : entries;
+    };
+    const spy = vi.spyOn(fs, 'readdirSync');
+    try {
+      for (const walkOrder of [natural, reversed]) {
+        spy.mockImplementation(walkOrder);
+        check(await checkContract(src));
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  it('treats only an exported {Name}Props as the contract; a file-private one defers to the exported signature', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        /** Internal scratch type, not the public contract. */
+        interface WidgetProps extends BaseProps {
+          internalOnly: string;
+        }
+        export interface WidgetPublicProps extends BaseProps {
+          label: string;
+          size?: 'sm' | 'md';
+        }
+        export function Widget(props: WidgetPublicProps) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.size',
+    ]);
+  });
+
+  it('ignores a {Name}Props nested in a namespace or a function body', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Other/helpers.ts': `
+        export function make() {
+          interface WidgetProps { localOnly: string }
+          const x: WidgetProps = {localOnly: ''};
+          return x;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export namespace Legacy {
+          export interface WidgetProps extends BaseProps {
+            legacyOnly: string;
+          }
+        }
+        export interface Props extends BaseProps {
+          label: string;
+          size?: 'sm' | 'md';
+        }
+        export function Widget(props: Props) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.size',
+    ]);
+  });
+
+  it('prefers the exported {Name} signature in the doc directory over a {Name}Props declared elsewhere', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Other/legacy.ts': `
+        export interface WidgetProps {
+          alien: string;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        export function Widget(props: {a: string}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {name: 'Widget', props: []};
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual(['Widget.a']);
+  });
+
+  it('picks the shallowest {Name}Props under the doc directory, under any read order', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/internal/Widget.tsx': `
+        export interface WidgetProps {internalImpl: string}
+      `,
+      'Widget/Widget.tsx': `
+        export interface WidgetProps {label: string; size?: string}
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    await underBothReadOrders(src, ({missing}) => {
+      expect(missing.map(m => m.prop)).toEqual(['size']);
+    });
+  });
+
+  it('picks the same foreign {Name}Props under any read order when none is in the doc directory', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Beta/b.ts': `export interface WidgetProps {fromBeta: string}`,
+      'Alpha/a.ts': `export interface WidgetProps {fromAlpha: string}`,
+      'Zeta/Widget.doc.mjs': `
+        export const docs = {name: 'Widget', props: []};
+      `,
+    });
+    await underBothReadOrders(src, ({missing}) => {
+      expect(missing.map(m => m.prop)).toEqual(['fromAlpha']);
+    });
+  });
+
+  it('prefers the shallower exported {Name} over a nested internal copy of the same name', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/internal/Widget.tsx': `
+        export function Widget(props: {internalImpl: string}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        export function Widget(props: {label: string; size?: string}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    await underBothReadOrders(src, ({missing}) => {
+      expect(missing.map(m => m.prop)).toEqual(['size']);
+    });
+  });
+
+  it('is not fooled by a file-private {Name}Props beside the exported one (the TableRow / BaseTable shape)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Table/BaseTable.tsx': `
+        interface TableRowProps<T> {
+          item: T;
+          columns: string[];
+        }
+        function InternalRow<T>({item, columns}: TableRowProps<T>) {
+          return null;
+        }
+        export function BaseTable() {
+          return InternalRow({item: 1, columns: []});
+        }
+      `,
+      'Table/TableRow.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface TableRowProps extends BaseProps {
+          isHeaderRow?: boolean;
+        }
+        export function TableRow(props: TableRowProps) {
+          return null;
+        }
+      `,
+      'Table/TableRow.doc.mjs': `
+        export const docs = {
+          name: 'TableRow',
+          props: [{name: 'isHeaderRow', type: 'boolean', description: 'Header row'}],
+        };
+      `,
+    });
+    await underBothReadOrders(src, ({missing, unresolved}) => {
+      expect(unresolved).toEqual([]);
+      expect(missing).toEqual([]);
+    });
+  });
+
+  it('checks a doc outside its component directory against the exported {Name}Props, not a private decoy (the CodeBlock / Code shape)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Alpha/Alpha.tsx': `
+        interface CodeProps {
+          decoy: string;
+        }
+        function Inner({decoy}: CodeProps) {
+          return null;
+        }
+        export function Alpha() {
+          return Inner({decoy: 'x'});
+        }
+      `,
+      'Code/Code.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface CodeProps extends BaseProps {
+          children: string;
+          size?: 'sm' | 'md';
+        }
+        export function Code(props: CodeProps) {
+          return null;
+        }
+      `,
+      'CodeBlock/Code.doc.mjs': `
+        export const docs = {
+          name: 'Code',
+          props: [{name: 'children', type: 'string', description: 'Source text'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual(['Code.size']);
+  });
+});
+
+describe('checkContract — parameter shapes the signature route must read', () => {
+  it('resolves a class component through its construct signature (props is the constructor parameter)', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'node_modules/@types/react/index.d.ts': `
+        export type ReactNode = unknown;
+        export class Component<P = {}, S = {}> {
+          constructor(props: P);
+          props: Readonly<P>;
+          state: Readonly<S>;
+          render(): ReactNode;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        import {Component} from 'react';
+        import type {BaseProps} from '../BaseProps';
+        interface Opts extends BaseProps {
+          label: string;
+          size?: 'sm' | 'md';
+        }
+        export class Widget extends Component<Opts, {open: boolean}> {
+          state = {open: false};
+          render() {
+            return null;
+          }
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.size',
+    ]);
+  });
+
+  it('reads the elements of a rest tuple, never the tuple itself', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        interface WidgetOptions { size?: number; label?: string }
+        export function Widget(...args: [WidgetOptions]) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {name: 'Widget', props: []};
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => m.prop)).toEqual(['label', 'size']);
+  });
+
+  it('reads every bag parameter of a hook, so `useThing(id, options)` and `useThing(callback, options)` reach options', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Keyed/useKeyed.ts': `
+        interface KeyedOptions { size?: number; label?: string }
+        export function useKeyed(id: string, options: KeyedOptions) {
+          return 0;
+        }
+      `,
+      'Keyed/useKeyed.doc.mjs': `
+        export const docs = {
+          name: 'useKeyed',
+          props: [{name: 'size', type: 'number', description: 'Documented option'}],
+        };
+      `,
+      'Debounced/useDebounced.ts': `
+        interface DebounceOptions { wait: number; leading?: boolean }
+        export function useDebounced(fn: () => void, options: DebounceOptions) {
+          return 0;
+        }
+      `,
+      'Debounced/useDebounced.doc.mjs': `
+        export const docs = {name: 'useDebounced', props: []};
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'useDebounced.leading',
+      'useDebounced.wait',
+      'useKeyed.label',
+    ]);
+  });
+
+  it('reads a constrained type parameter as its constraint', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        interface SharedProps extends BaseProps { alpha: string; beta?: number }
+        export function Widget<P extends SharedProps>(props: P) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'alpha', type: 'string', description: 'Documented'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => m.prop)).toEqual(['beta']);
+  });
+
+  it('skips a union of primitives and treats a union of unconstrained generics as underivable', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Keyed/useKeyed.ts': `
+        interface Opts { label?: string }
+        export function useKeyed(id: string | number, options: Opts) {
+          return 0;
+        }
+      `,
+      'Keyed/useKeyed.doc.mjs': `export const docs = {name: 'useKeyed', props: []};`,
+      'Free/Free.tsx': `
+        export function Free<P, Q>(props: P | Q) {
+          return null;
+        }
+      `,
+      'Free/Free.doc.mjs': `export const docs = {name: 'Free', props: [{name: 'label'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved.map(u => u.component)).toEqual(['Free']);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'useKeyed.label',
+    ]);
+  });
+
+  it('leaves a bag typed any / unknown / unconstrained generic unresolved: nothing can be read off it', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Loose/Loose.tsx': `export function Loose(props: any) { return null; }`,
+      'Loose/Loose.doc.mjs': `export const docs = {name: 'Loose', props: [{name: 'label'}]};`,
+      'Opaque/Opaque.tsx': `export function Opaque(props: unknown) { return null; }`,
+      'Opaque/Opaque.doc.mjs': `export const docs = {name: 'Opaque', props: [{name: 'label'}]};`,
+      'Free/Free.tsx': `export function Free<P>(props: P) { return null; }`,
+      'Free/Free.doc.mjs': `export const docs = {name: 'Free', props: [{name: 'label'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(missing).toEqual([]);
+    expect(unresolved.map(u => u.component)).toEqual([
+      'Free',
+      'Loose',
+      'Opaque',
+    ]);
+    await expect(run(src, {log: () => {}, error: () => {}})).resolves.toBe(1);
+  });
+});
+
+describe('checkContract — doc loading edges', () => {
+  it('checks the `docs` export the CLI serves, not a differing default export', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          width?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+        export default {
+          name: 'Widget',
+          props: [
+            {name: 'label', type: 'string', description: 'Visible text'},
+            {name: 'width', type: 'string', description: 'Only the default lists width'},
+          ],
+        };
+      `,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.width',
+    ]);
+  });
+
+  it('reports a doc that publishes props[] without a name instead of skipping it', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          props: [{name: 'label', type: 'string', description: 'Visible text'}],
+        };
+      `,
+    });
+    const {unreadable} = await checkContract(src);
+    expect(unreadable).toEqual([
+      expect.objectContaining({
+        file: expect.stringContaining('Widget.doc.mjs'),
+        reason: expect.stringMatching(/name/),
+      }),
+    ]);
+    await expect(run(src, {log: () => {}, error: () => {}})).resolves.toBe(1);
+  });
+});
+
+describe('checkContract — what counts as platform surface', () => {
+  it('requires the props of a third-party component re-exported under a core name; node_modules is not platform surface', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'node_modules/some-lib/package.json': `{"name":"some-lib","types":"index.d.ts"}`,
+      'node_modules/some-lib/index.d.ts': `
+        export interface ThirdPartyProps {
+          spec: object;
+          renderer?: 'svg' | 'canvas';
+          onNewView?: () => void;
+        }
+        export function ThirdParty(props: ThirdPartyProps): null;
+      `,
+      'Chart/index.ts': `export {ThirdParty as Chart} from 'some-lib';`,
+      'Chart/Chart.doc.mjs': `
+        export const docs = {name: 'Chart', props: [{name: 'spec'}]};
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => m.prop)).toEqual(['onNewView', 'renderer']);
+  });
+});
+
+describe('run — the program itself is checked before any verdict', () => {
+  const REACT_DEPENDENT_TREE = {
+    'BaseProps.ts': `
+      import type React from 'react';
+      export interface BaseProps<T extends HTMLElement = HTMLElement>
+        extends Omit<React.HTMLAttributes<T>, 'title' | 'children'> {
+        xstyle?: unknown;
+      }
+    `,
+    'Button/Button.tsx': `
+      import type {BaseProps} from '../BaseProps';
+      export interface ButtonProps extends BaseProps<HTMLButtonElement> {
+        label: string;
+        width?: string;
+      }
+    `,
+    'IconButton/IconButton.tsx': `
+      import type {ButtonProps} from '../Button/Button';
+      export interface IconButtonProps extends Omit<ButtonProps, 'label'> {
+        icon: string;
+      }
+    `,
+    'IconButton/IconButton.doc.mjs': `
+      export const docs = {name: 'IconButton', props: [{name: 'icon'}]};
+    `,
+  };
+  const REACT_STUB = `
+    export interface HTMLAttributes<T> {
+      id?: string;
+      role?: string;
+      title?: string;
+      children?: unknown;
+      onKeyDown?: (event: T) => void;
+    }
+  `;
+
+  it('fails when a source imports react and the program cannot resolve it — an Omit over BaseProps would collapse to nothing', async () => {
+    const src = fixture(REACT_DEPENDENT_TREE);
+    const errors = [];
+    await expect(
+      run(src, {log: () => {}, error: line => errors.push(line)}),
+    ).resolves.toBe(1);
+    expect(errors.join('\n')).toMatch(/'react'.*could not be resolved/);
+  });
+
+  it('catches the prop behind that Omit once react resolves', async () => {
+    const src = fixture({
+      ...REACT_DEPENDENT_TREE,
+      'node_modules/@types/react/index.d.ts': REACT_STUB,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'IconButton.width',
+    ]);
+  });
+});
+
+describe('checkContract — declaration forms the signature route reads', () => {
+  it('reads the props through memo(), forwardRef() and a React.FC annotation, not only a bare function', async () => {
+    const react = `
+      export type ReactNode = unknown;
+      export interface HTMLAttributes<T> { id?: string; role?: string }
+      export interface FC<P> { (props: P): ReactNode; displayName?: string }
+      export interface ForwardRefExoticComponent<P> { (props: P): ReactNode; displayName?: string }
+      export interface NamedExoticComponent<P> { (props: P): ReactNode; displayName?: string }
+      export type PropsWithoutRef<P> = P extends any ? ('ref' extends keyof P ? Omit<P, 'ref'> : P) : P;
+      export interface RefAttributes<T> { ref?: T }
+      export function forwardRef<T, P = {}>(
+        render: (props: P, ref: T) => ReactNode,
+      ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+      export function memo<P extends object>(c: (props: P) => ReactNode): NamedExoticComponent<P>;
+    `;
+    const doc = name => `
+      export const docs = {
+        name: '${name}',
+        props: [{name: 'label', type: 'string', description: 'Visible text'}],
+      };
+    `;
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'node_modules/@types/react/index.d.ts': react,
+      'Opts.ts': `
+        import type {BaseProps} from './BaseProps';
+        export interface Opts extends BaseProps {
+          label: string;
+          size?: 'sm' | 'md';
+        }
+      `,
+      'Memoed/Memoed.tsx': `
+        import {memo} from 'react';
+        import type {Opts} from '../Opts';
+        export const Memoed = memo(function Memoed(props: Opts) {
+          return null;
+        });
+      `,
+      'Memoed/Memoed.doc.mjs': doc('Memoed'),
+      'Forwarded/Forwarded.tsx': `
+        import {forwardRef} from 'react';
+        import type {Opts} from '../Opts';
+        export const Forwarded = forwardRef<HTMLDivElement, Opts>(
+          function Forwarded(props, ref) {
+            return null;
+          },
+        );
+      `,
+      'Forwarded/Forwarded.doc.mjs': doc('Forwarded'),
+      'Typed/Typed.tsx': `
+        import type {FC} from 'react';
+        import type {Opts} from '../Opts';
+        export const Typed: FC<Opts> = props => null;
+      `,
+      'Typed/Typed.doc.mjs': doc('Typed'),
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Forwarded.size',
+      'Memoed.size',
+      'Typed.size',
+    ]);
+  });
+
+  it('reads an arrow const, a generic function, and a function exported on a later line', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Opts.ts': `
+        import type {BaseProps} from './BaseProps';
+        export interface Opts extends BaseProps { label: string; size?: 'sm' | 'md' }
+      `,
+      'Arrow/Arrow.tsx': `
+        import type {Opts} from '../Opts';
+        export const Arrow = (props: Opts) => null;
+      `,
+      'Arrow/Arrow.doc.mjs': `export const docs = {name: 'Arrow', props: [{name: 'label'}]};`,
+      'Generic/Generic.tsx': `
+        import type {Opts} from '../Opts';
+        export function Generic<T>(props: Opts & {items: T[]}) {
+          return null;
+        }
+      `,
+      'Generic/Generic.doc.mjs': `export const docs = {name: 'Generic', props: [{name: 'label'}, {name: 'items'}]};`,
+      'Later/Later.tsx': `
+        import type {Opts} from '../Opts';
+        function Later(props: Opts) {
+          return null;
+        }
+        export {Later};
+      `,
+      'Later/Later.doc.mjs': `export const docs = {name: 'Later', props: [{name: 'label'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Arrow.size',
+      'Generic.size',
+      'Later.size',
+    ]);
+  });
+
+  it('follows `export {default as X}` to a default-exported function, and leaves a bare default unresolved', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        interface Opts extends BaseProps {
+          label: string;
+          size?: 'sm' | 'md';
+        }
+        export default function Widget(props: Opts) {
+          return null;
+        }
+      `,
+      'Widget/index.ts': `export {default as Widget} from './Widget';`,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: [{name: 'label'}]};`,
+      'Orphan/Orphan.tsx': `
+        export default function Orphan(props: {label: string}) {
+          return null;
+        }
+      `,
+      'Orphan/Orphan.doc.mjs': `export const docs = {name: 'Orphan', props: [{name: 'label'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved.map(u => u.component)).toEqual(['Orphan']);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.size',
+    ]);
+  });
+
+  it('resolves through a chain of `export *` barrels and through an alias of an alias', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Menu/MenuItem.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        interface Opts extends BaseProps {
+          label: string;
+          size?: 'sm' | 'md';
+        }
+        export function MenuItem(props: Opts) {
+          return null;
+        }
+      `,
+      'Menu/index.ts': `export * from './MenuItem';`,
+      'ContextMenu/index.ts': `export * from '../Menu';`,
+      'index.ts': `export * from './ContextMenu';`,
+      'ContextMenu/MenuItem.doc.mjs': `export const docs = {name: 'MenuItem', props: [{name: 'label'}]};`,
+      'Renamed/index.ts': `export {MenuItem as Renamed} from '../Menu';`,
+      'Twice/index.ts': `export {Renamed as Twice} from '../Renamed';`,
+      'Twice/Twice.doc.mjs': `export const docs = {name: 'Twice', props: [{name: 'label'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'MenuItem.size',
+      'Twice.size',
+    ]);
+  });
+
+  it('leaves a type-only alias with no value export unresolved: a Props name alone is not a component', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        export interface WidgetProps {label: string}
+        export function Widget(props: WidgetProps) {
+          return null;
+        }
+      `,
+      'Alias/index.ts': `export type {WidgetProps as AliasProps} from '../Widget/Widget';`,
+      'Alias/Alias.doc.mjs': `export const docs = {name: 'Alias', props: [{name: 'label'}]};`,
+    });
+    const {unresolved} = await checkContract(src);
+    expect(unresolved.map(u => u.component)).toEqual(['Alias']);
+  });
+});
+
+describe('checkContract — parameter forms the signature route reads', () => {
+  it('reaches the bag through a destructured default and through an optional parameter', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        interface Opts { size?: number; label?: string }
+        export function Widget({size = 1, ...rest}: Opts = {}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: []};`,
+      'Dialog/useImperativeDialog.ts': `
+        interface DialogOptions { title?: string; width?: number }
+        export function useImperativeDialog(defaultOptions?: DialogOptions) {
+          return 0;
+        }
+      `,
+      'Dialog/useImperativeDialog.doc.mjs': `export const docs = {name: 'useImperativeDialog', props: [{name: 'title'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'useImperativeDialog.width',
+      'Widget.label',
+      'Widget.size',
+    ]);
+  });
+
+  it('sees through Readonly / Partial / Omit / Pick on a parameter and still drops BaseProps passthrough', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        interface SharedProps extends BaseProps { alpha: string; beta?: number; gamma?: boolean }
+        export function Widget(props: Readonly<Partial<Omit<SharedProps, 'gamma'>>>) {
+          return null;
+        }
+        export function WidgetSlim(props: Pick<SharedProps, 'alpha' | 'onClick'>) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [],
+          components: [{name: 'WidgetSlim', props: []}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.alpha',
+      'Widget.beta',
+      'WidgetSlim.alpha',
+    ]);
+  });
+
+  it('walks the object member of a union with primitives and does not invent String members', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Input/useInput.ts': `
+        interface Opts { value: string; onChange?: () => void }
+        export function useInput(input: Opts | string | null) {
+          return 0;
+        }
+      `,
+      'Input/useInput.doc.mjs': `export const docs = {name: 'useInput', props: [{name: 'value'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'useInput.onChange',
+    ]);
+  });
+
+  it('resolves an index-signature-only bag to an empty contract, not to unresolved', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Filter/useFilterState.ts': `
+        export function useFilterState(initial?: Record<string, unknown>) {
+          return 0;
+        }
+      `,
+      'Filter/useFilterState.doc.mjs': `export const docs = {name: 'useFilterState', props: [{name: 'anything'}]};`,
+      'Map/useMapState.ts': `
+        export function useMapState(initial: {[key: string]: unknown}) {
+          return 0;
+        }
+      `,
+      'Map/useMapState.doc.mjs': `export const docs = {name: 'useMapState', props: []};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+
+  it('follows Parameters<typeof Other>[0] and ComponentProps<typeof Other>, dropping RefAttributes from @types/react', async () => {
+    const src = fixture({
+      'node_modules/@types/react/index.d.ts': `
+        export interface RefAttributes<T> { ref?: T }
+        export type ComponentProps<T> = T extends (props: infer P) => any ? P : never;
+      `,
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Other.tsx': `
+        export function Other(props: {fromOther: string; extra?: number}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        import type {ComponentProps, RefAttributes} from 'react';
+        import {Other} from './Other';
+        export function Widget(props: Parameters<typeof Other>[0]) {
+          return null;
+        }
+        export function WidgetAlt(props: ComponentProps<typeof Other> & RefAttributes<HTMLDivElement>) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `
+        export const docs = {
+          name: 'Widget',
+          props: [{name: 'fromOther'}],
+          components: [{name: 'WidgetAlt', props: [{name: 'fromOther'}]}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.extra',
+      'WidgetAlt.extra',
+    ]);
+  });
+
+  it('resolves a bare callback parameter to an empty contract but requires members declared on a callable', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Effect/useEffectOnce.ts': `
+        export function useEffectOnce(effect: () => void) {
+          return 0;
+        }
+      `,
+      'Effect/useEffectOnce.doc.mjs': `export const docs = {name: 'useEffectOnce', props: []};`,
+      'Tagged/useTagged.ts': `
+        export function useTagged(handler: (() => void) & {displayLabel: string}) {
+          return 0;
+        }
+      `,
+      'Tagged/useTagged.doc.mjs': `export const docs = {name: 'useTagged', props: []};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'useTagged.displayLabel',
+    ]);
+  });
+});
+
+describe('checkContract — platform passthrough through the signature route', () => {
+  it('lets a component whose whole bag is HTMLAttributes pass with nothing documented — every member is platform', async () => {
+    const src = fixture({
+      'node_modules/@types/react/index.d.ts': `
+        export interface HTMLAttributes<T> { id?: string; role?: string; title?: string }
+      `,
+      'Box/Box.tsx': `
+        import type {HTMLAttributes} from 'react';
+        export function Box(props: HTMLAttributes<HTMLDivElement>) {
+          return null;
+        }
+      `,
+      'Box/Box.doc.mjs': `export const docs = {name: 'Box', props: []};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+
+  it('filters per prop, not per type: a node_modules bag intersected with a local literal keeps the local prop', async () => {
+    const src = fixture({
+      'node_modules/@types/react/index.d.ts': `
+        export interface HTMLAttributes<T> { id?: string; role?: string }
+      `,
+      'Box/Box.tsx': `
+        import type {HTMLAttributes} from 'react';
+        export function Box(props: HTMLAttributes<HTMLDivElement> & {local: string}) {
+          return null;
+        }
+      `,
+      'Box/Box.doc.mjs': `export const docs = {name: 'Box', props: []};`,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).toEqual(['local']);
+  });
+
+  it('skips ref / className / style redeclared on a shared bag and @types/react Attributes.key', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'node_modules/@types/react/index.d.ts': `
+        export interface Attributes { key?: string | number | null }
+      `,
+      'Shared/types.ts': `
+        import type {BaseProps} from '../BaseProps';
+        import type {Attributes} from 'react';
+        export interface SharedProps extends BaseProps, Attributes {
+          label: string;
+          ref?: unknown;
+          className?: string;
+          style?: unknown;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        import type {SharedProps} from '../Shared/types';
+        export function Widget(props: SharedProps) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: []};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => m.prop)).toEqual(['label']);
+  });
+
+  it('requires onClick redeclared over Omit<BaseProps, "onClick">, and skips __internal members', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export function Widget(props: Omit<BaseProps, 'onClick'> & {onClick?: () => void; __internal?: string}) {
+          return null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: []};`,
+    });
+    const {missing} = await checkContract(src);
+    expect(missing.map(m => m.prop)).toEqual(['onClick']);
+  });
+
+  it('resolves `(props: {})` to an empty contract; documented extras are allowed', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Spacer/Spacer.tsx': `
+        export function Spacer(props: {}) {
+          return null;
+        }
+      `,
+      'Spacer/Spacer.doc.mjs': `export const docs = {name: 'Spacer', props: [{name: 'gap'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('run — report shape', () => {
+  function capture() {
+    const out = {log: [], error: []};
+    return {
+      out,
+      io: {
+        log: line => out.log.push(line),
+        error: line => out.error.push(line),
+      },
+    };
+  }
+
+  it('prints every section — unreadable, then unresolved, then undocumented — in one failing run', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Broken/Broken.doc.mjs': `export const docs = {`,
+      'Ghost/Ghost.doc.mjs': `export const docs = {name: 'Ghost', props: [{name: 'boo'}]};`,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends BaseProps {
+          label: string;
+          width?: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: [{name: 'label'}]};`,
+    });
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    const report = out.error.join('\n');
+    const at = pattern => {
+      const index = report.search(pattern);
+      expect(index, String(pattern)).toBeGreaterThan(-1);
+      return index;
+    };
+    const unreadable = at(/could not load 1 doc file\(s\)/);
+    const unresolved = at(
+      /could not resolve the public props of 1 documented entry:/,
+    );
+    const missing = at(/found 1 undocumented public prop\(s\)/);
+    expect(unreadable).toBeLessThan(unresolved);
+    expect(unresolved).toBeLessThan(missing);
+    expect(report).toMatch(/Broken\.doc\.mjs\n\s+\S/);
+    expect(report).toMatch(/Ghost\s+\(.*Ghost\.doc\.mjs\)/);
+    expect(report).toMatch(/Widget\.width\s+\(.*Widget\.doc\.mjs\)/);
+    expect(out.log).toEqual([]);
+  });
+
+  it('lists the same unresolved name once per doc file that claims it, in file order, and pluralises', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'B/Ghost.doc.mjs': `export const docs = {name: 'Ghost', props: [{name: 'boo'}]};`,
+      'A/Ghost.doc.mjs': `export const docs = {name: 'Ghost', props: [{name: 'boo'}]};`,
+    });
+    const {unresolved} = await checkContract(src);
+    expect(unresolved.map(u => path.relative(src, u.file))).toEqual([
+      'A/Ghost.doc.mjs',
+      'B/Ghost.doc.mjs',
+    ]);
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    expect(out.error.join('\n')).toMatch(/of 2 documented entries:/);
+  });
+
+  it('fails a use* doc that publishes props[] with no source at all; hooks are not exempt from fail-closed', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Thing/useThing.doc.mjs': `export const docs = {name: 'useThing', props: [{name: 'option'}]};`,
+    });
+    const {unresolved} = await checkContract(src);
+    expect(unresolved.map(u => u.component)).toEqual(['useThing']);
+    const {out, io} = capture();
+    await expect(run(src, io)).resolves.toBe(1);
+    expect(out.log).toEqual([]);
+  });
+
+  it('does not partially match a dotted components[] name like Menu.Item', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Menu/MenuItem.tsx': `
+        export function MenuItem(props: {label: string}) {
+          return null;
+        }
+      `,
+      'Menu/Menu.doc.mjs': `
+        export const docs = {
+          name: 'Menu',
+          components: [{name: 'Menu.Item', props: [{name: 'label'}]}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(missing).toEqual([]);
+    expect(unresolved.map(u => u.component)).toEqual(['Menu.Item']);
+  });
+
+  it('checks a components[] entry with props: [] and leaves a name-only sibling to its own doc', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Layout/Layout.tsx': `
+        export function Panel(props: {title: string}) {
+          return null;
+        }
+        export function Rail(props: {width: number}) {
+          return null;
+        }
+      `,
+      'Layout/Layout.doc.mjs': `
+        export const docs = {
+          name: 'Layout',
+          components: [{name: 'Panel', props: []}, {name: 'Rail'}],
+        };
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Panel.title',
+    ]);
+  });
+});
+
+describe('checkContract — review round: fail-closed holes the skeptics found', () => {
+  it('runs a declared {Name}Props through the same bag test as a signature: any / unknown / object are unresolved, a primitive alias falls through', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Any/Any.tsx': `
+        export type AnyProps = any;
+        export function Any(props: {label: string}) { return null; }
+      `,
+      'Any/Any.doc.mjs': `export const docs = {name: 'Any', props: []};`,
+      'Unk/Unk.tsx': `
+        export type UnkProps = unknown;
+        export function Unk(props: {label: string}) { return null; }
+      `,
+      'Unk/Unk.doc.mjs': `export const docs = {name: 'Unk', props: []};`,
+      'Obj/Obj.tsx': `
+        export function Obj(props: object) { return null; }
+      `,
+      'Obj/Obj.doc.mjs': `export const docs = {name: 'Obj', props: [{name: 'label'}]};`,
+      'Str/Str.tsx': `
+        export type StrProps = string;
+        export function Str(props: {label: string}) { return null; }
+      `,
+      'Str/Str.doc.mjs': `export const docs = {name: 'Str', props: []};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    // A primitive alias is not a bag: the exported signature is the next
+    // candidate. An any / unknown alias is underivable: nothing can be read
+    // off it, and the signature beside it must not paper over that.
+    expect(unresolved.map(u => u.component)).toEqual(['Any', 'Obj', 'Unk']);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual(['Str.label']);
+  });
+
+  it('reads a type parameter constrained to a union per member, so a variant-only prop is still required', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Slider/Slider.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        interface SingleProps extends BaseProps { value: number; onChange?: () => void }
+        interface RangeProps extends BaseProps { values: number[]; minStepsBetweenThumbs?: number }
+        export function Slider<P extends SingleProps | RangeProps>(props: P) {
+          return null;
+        }
+      `,
+      'Slider/Slider.doc.mjs': `
+        export const docs = {name: 'Slider', props: [{name: 'value'}, {name: 'values'}]};
+      `,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => m.prop)).toEqual([
+      'minStepsBetweenThumbs',
+      'onChange',
+    ]);
+  });
+
+  it('does not let `export *` of a same-named type turn a file-private {Name}Props into the contract', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Other/helpers.ts': `export interface WidgetProps {fromHelpers: string}`,
+      'Widget/Widget.tsx': `
+        export * from '../Other/helpers';
+        interface WidgetProps { privateOnly: string }
+        const scratch: WidgetProps = {privateOnly: ''};
+        export function Widget(props: {label: string; size?: string}) {
+          return scratch ? null : null;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: [{name: 'label'}]};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => m.prop)).toEqual(['size']);
+  });
+
+  it('treats a react that resolves to untyped JavaScript (no @types/react) as unresolvable', async () => {
+    const src = fixture({
+      'node_modules/react/package.json': `{"name":"react","main":"index.js"}`,
+      'node_modules/react/index.js': `module.exports = {};`,
+      'BaseProps.ts': `
+        import type React from 'react';
+        export interface BaseProps<T extends HTMLElement = HTMLElement>
+          extends Omit<React.HTMLAttributes<T>, 'title'> {
+          xstyle?: unknown;
+        }
+      `,
+      'Widget/Widget.tsx': `
+        import type {BaseProps} from '../BaseProps';
+        export interface WidgetProps extends Omit<BaseProps, 'xstyle'> {
+          label: string;
+        }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: []};`,
+    });
+    const errors = [];
+    await expect(
+      run(src, {log: () => {}, error: line => errors.push(line)}),
+    ).resolves.toBe(1);
+    expect(errors.join('\n')).toMatch(/'react'.*could not be resolved/);
+  });
+
+  it('reports a malformed doc shape as unreadable and keeps scanning, instead of throwing', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'NumName/NumName.doc.mjs': `export const docs = {name: 42, props: []};`,
+      'NullProp/NullProp.doc.mjs': `export const docs = {name: 'NullProp', props: [null, {name: 'a'}]};`,
+      'BadComponents/BadComponents.doc.mjs': `export const docs = {name: 'BadComponents', components: 'nope'};`,
+      'NullEntry/NullEntry.doc.mjs': `export const docs = {name: 'NullEntry', components: [null, {name: 7, props: []}]};`,
+      'Widget/Widget.tsx': `
+        export interface WidgetProps { label: string; width?: string }
+      `,
+      'Widget/Widget.doc.mjs': `export const docs = {name: 'Widget', props: [{name: 'label'}]};`,
+    });
+    const {missing, unreadable} = await checkContract(src);
+    expect(unreadable.map(u => path.basename(u.file))).toEqual([
+      'BadComponents.doc.mjs',
+      'NullEntry.doc.mjs',
+      'NullProp.doc.mjs',
+      'NumName.doc.mjs',
+    ]);
+    for (const {reason} of unreadable)
+      expect(reason).toMatch(/name|props|components/);
+    expect(missing.map(m => `${m.component}.${m.prop}`)).toEqual([
+      'Widget.width',
+    ]);
+  });
+
+  it('does not read tuple or array members as props when the parameter is not a rest parameter', async () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Pair/usePair.ts': `
+        interface Opts { label?: string }
+        export function usePair(pair: [Opts, number], list: string[], options: Opts) {
+          return 0;
+        }
+      `,
+      'Pair/usePair.doc.mjs': `export const docs = {name: 'usePair', props: []};`,
+    });
+    const {missing, unresolved} = await checkContract(src);
+    expect(unresolved).toEqual([]);
+    expect(missing.map(m => m.prop)).toEqual(['label']);
+  });
+});
+
+describe('createResolver — which route answered', () => {
+  it('reports the route and file behind each resolved entry, and null for none', () => {
+    const src = fixture({
+      'BaseProps.ts': BASE_PROPS,
+      'Widget/Widget.tsx': `
+        export interface WidgetProps { label: string }
+        export function Widget(props: WidgetProps) { return null; }
+      `,
+      'Hook/useHook.ts': `
+        export function useHook(options: {wait: number}) { return 0; }
+      `,
+    });
+    const {program, checker} = buildProgram(
+      ['BaseProps.ts', 'Widget/Widget.tsx', 'Hook/useHook.ts'].map(file =>
+        path.join(src, file),
+      ),
+    );
+    const resolve = createResolver(program, checker);
+
+    const widget = resolve('Widget', path.join(src, 'Widget'));
+    expect(widget.route).toBe('declaration');
+    expect(path.relative(src, widget.file)).toBe('Widget/Widget.tsx');
+    expect([...widget.props]).toEqual(['label']);
+
+    const hook = resolve('useHook', path.join(src, 'Hook'));
+    expect(hook.route).toBe('signature');
+    expect([...hook.props]).toEqual(['wait']);
+
+    expect(resolve('Ghost', src)).toBeNull();
   });
 });


### PR DESCRIPTION
## What this does

Adds a check that reads each component's real TypeScript props and fails when the docs left one out.

## Why

The docs are what people actually read. The old contract tests only looked at the docs themselves, so they stayed green even when source and docs drifted apart. This check derives the public prop list from the component's TypeScript type and compares it to the component's `.doc.mjs` file.

## What changed

- New command: `pnpm check:contract`
- The prop list comes from an exported `{Name}Props` type, or, when a component has none, from the exported component or hook itself: every parameter of every overload, a class's constructor parameter, re-export aliases followed. That reaches the shared `IndicatorProps` behind the three indicators, the `DropdownMenuItemProps` behind `ContextMenuItem`, and every Table plugin hook's config. When more than one candidate exists, the one in the doc's own directory wins, then the shallower path, then the named type; only exported top-level types count, and the result does not depend on directory read order.
- Fails closed: an entry whose props cannot be read (nothing exported, or a bag typed `any`), a doc with `props[]` but no `name` or a malformed shape, a `.doc.mjs` that cannot load, a scan that finds no docs, and a program that cannot resolve `react` to types all exit 1 with their own section in the report. Invoking the script through a symlink runs it instead of silently doing nothing.
- The `docs` export is the one checked, matching what `astryx component <Name>` serves.
- Platform passthrough is BaseProps, `@types/react`, `csstype` and the TypeScript libs. A third-party component re-exported under a core name has its bag required.
- Not turned on as a required repo check yet. Running it against core today finds 87 existing gaps; wiring it into `check:repo` would fail every PR until those docs are filled in.

## How to see it

```
pnpm exec vitest run scripts/check-contract.test.mjs
pnpm check:contract
```

The second command should exit 1 and print the current undocumented props.

## Test plan

- [ ] `pnpm exec vitest run scripts/check-contract.test.mjs` — 105 tests pass in about two seconds, including regressions against the real indicator family, `ContextMenuItem`, `useResizable`, `useImperativeDialog` and the Table plugin hooks
- [ ] `pnpm check:contract` — reports the 87 existing gaps, 0 unresolved entries, and exits 1
- [ ] `pnpm check:repo` still passes (this check is not in that suite yet)
- [ ] A fixture with a syntax-error `.doc.mjs` is reported as unreadable, not skipped
- [ ] A fixture with no `.doc.mjs` at all exits 1 (an empty scan is not a pass)
- [ ] A fixture whose component has no `{Name}Props` and no exported binding exits 1 (an unchecked entry is not a pass)

Fixes #5421

https://claude.ai/code/session_01Ybs7buLRQUtDoYAf7Zo4Zz
