### PR TITLE
fix(Selector): collapse empty mark column, add selector-list theme target

### DIFF
--- a/.changeset/selector-theming-gaps.md
+++ b/.changeset/selector-theming-gaps.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector: collapse the mark column when the indicator renders nothing, and expose a `selector-list` theme target on the scrolling listbox.
+
+The default check indicator returns `null` when unchecked, but the wrapping column still reserved space — themes that need edge-to-edge option content had to work around it with structural CSS. The column now carries `:empty { display: none }` so it self-collapses without affecting indicators that draw in both states (e.g. a radio replacement).
+
+The new `selector-list` target lets a theme restyle the listbox padding directly via `defineTheme`, removing the need for `[role="listbox"]` structural selectors.
+
+@athz

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -41,6 +41,7 @@ export const docs = {
       },
       {className: 'astryx-selector-indicator-icon', states: ['state']},
       {className: 'astryx-selector-check'},
+      {className: 'astryx-selector-list'},
       {className: 'astryx-selector-popup'},
     ],
   },

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -3242,6 +3242,31 @@ describe('Selector indicatorPosition', () => {
     }
   });
 
+  it('mark column is empty on unselected rows so :empty collapses it', () => {
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        indicatorPosition="end"
+        isDefaultOpen
+      />,
+    );
+    for (const row of openRows()) {
+      const isSelected = row.getAttribute('aria-selected') === 'true';
+      // The mark column is the last child when indicatorPosition="end"
+      const markColumn = row.lastElementChild!;
+      if (isSelected) {
+        // Selected row: indicator renders its check icon
+        expect(markColumn.children.length).toBeGreaterThan(0);
+      } else {
+        // Unselected row: CheckIndicator returns null, column is empty
+        expect(markColumn.children).toHaveLength(0);
+      }
+    }
+  });
+
   it('positions a themed replacement indicator the same way', () => {
     const theme = defineTheme({
       name: 'selector-start-radio-mark-test',
@@ -3303,6 +3328,33 @@ describe('Selector popup theme target', () => {
       expect(popup).not.toBeNull();
       expect(popup).toHaveClass('astryx-popover-surface');
       expect(popup?.querySelector('[role="listbox"]')).not.toBeNull();
+    },
+  );
+
+  it.each([
+    ['without search', false],
+    ['with search', true],
+  ])(
+    'puts astryx-selector-list on the scrolling listbox, %s',
+    async (_label, hasSearch) => {
+      const user = userEvent.setup();
+      render(
+        <Selector
+          label="Fruit"
+          options={['Apple', 'Banana']}
+          value="Apple"
+          onChange={() => {}}
+          hasSearch={hasSearch}
+        />,
+      );
+      await user.click(
+        screen.queryByRole('combobox') ??
+          screen.getByRole('button', {name: /Fruit/}),
+      );
+
+      const listbox = document.querySelector('[role="listbox"]');
+      expect(listbox).not.toBeNull();
+      expect(listbox).toHaveClass('astryx-selector-list');
     },
   );
 

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -354,12 +354,21 @@ const styles = stylex.create({
   // would indent (or truncate) its chosen row differently from the rest.
   // `minWidth` rather than `width`: a theme can replace `check` with a larger
   // indicator (a radio is 20px at `sm`), and the column has to grow with it.
+  //
+  // `:empty` collapses the column when the indicator returns nothing (the
+  // default check draws null when unchecked). Without it, the column's
+  // min-width reserves ~24 px of dead space on unselected rows, pushing the
+  // option content away from the row's trailing edge. A replacement indicator
+  // that renders in both states (a radio) is unaffected — it is never empty.
   itemMarkColumn: {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
     minWidth: '1rem',
+    ':empty': {
+      display: 'none',
+    },
   },
   itemCheckmark: {
     flexShrink: 0,
@@ -1731,9 +1740,12 @@ export function Selector<T extends SelectorOptionType>(
               id={listboxId}
               role="listbox"
               aria-labelledby={triggerId}
-              {...stylex.props(
-                styles.dropdown,
-                variant !== 'ghost' && styles.dropdownInput,
+              {...mergeProps(
+                themeProps('selector-list'),
+                stylex.props(
+                  styles.dropdown,
+                  variant !== 'ghost' && styles.dropdownInput,
+                ),
               )}>
               {renderOptions()}
             </div>
@@ -1744,10 +1756,13 @@ export function Selector<T extends SelectorOptionType>(
             id={listboxId}
             role="listbox"
             aria-labelledby={triggerId}
-            {...stylex.props(
-              styles.dropdown,
-              variant !== 'ghost' && styles.dropdownInput,
-              !isPositioned && styles.dropdownHidden,
+            {...mergeProps(
+              themeProps('selector-list'),
+              stylex.props(
+                styles.dropdown,
+                variant !== 'ghost' && styles.dropdownInput,
+                !isPositioned && styles.dropdownHidden,
+              ),
             )}>
             {renderOptions()}
           </div>


### PR DESCRIPTION
## Summary

Two small theming gaps in Selector that force downstream theme consumers to carry co-located structural CSS. Both are independent and minimal.

### 1. Mark column reserves space when the indicator renders nothing

The default `CheckIndicator` returns `null` when unchecked, but the wrapping `<span>` (`itemMarkColumn`) still reserves ~24px via `min-width: 1rem` + the row's gap. This pushes option content away from the row's trailing edge on unselected rows.

**Fix:** Add `:empty { display: none }` to `itemMarkColumn`. When the indicator returns null the span is empty in the DOM — the pseudo-class collapses it. Indicators that render in both states (e.g. `RadioIndicator`) are unaffected because they're never empty.

### 2. No theme target on the popup's scrolling list

Selector exposes `selector-popup` on the popover surface, but the listbox `<div>` inside it — which carries the scroll container padding — has no target. Its inline padding includes a `border-width` correction (for non-ghost variants) that differs from what some themes want, and the only way to override it today is a structural `[role="listbox"]` selector.

**Fix:** Add `selector-list` theme target on the listbox element, so a theme can restyle its padding via `defineTheme` without structural selectors.

## Test plan

- Existing test suite passes (162 tests in `Selector.test.tsx`).
- Added test: verifies the mark column is empty (no children) on unselected rows when using the default check indicator.
- Added test: verifies `astryx-selector-list` class is present on the listbox element (with and without search).
