### PR TITLE
build: replace rimraf cleanup with Node fs

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rimraf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
+    "build": "node ../../scripts/clean-dist.mjs && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
     "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.json",
     "build:css": "node ../../scripts/build-css.mjs --package charts",
     "dev": "babel src --watch --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*\" --config-file ./babel.config.json",
@@ -70,7 +70,6 @@
   "devDependencies": {
     "@astryxdesign/cli": "workspace:*",
     "@types/d3-scale": "^4.0.9",
-    "@types/d3-shape": "^3.1.8",
-    "rimraf": "^6.0.1"
+    "@types/d3-shape": "^3.1.8"
   }
 }

--- a/packages/cli/clients/cli/commands/ensure-core-built.mjs
+++ b/packages/cli/clients/cli/commands/ensure-core-built.mjs
@@ -9,10 +9,9 @@
  * and Vitest runs test files in parallel worker forks. When two build-theme
  * suites each ran `if (!exists) pnpm -F @astryxdesign/core build` in their own
  * beforeAll, both workers saw dist missing and launched concurrent builds that
- * collided on the shared packages/core/dist (core's build starts with
- * `rimraf dist`): one worker wiped dist while the other was mid-write, failing
- * nondeterministically ("Could not resolve dist/index.js" / "ENOTEMPTY rmdir
- * dist/hooks").
+ * collided on the shared packages/core/dist: one worker cleaned dist while the
+ * other was mid-write, failing nondeterministically ("Could not resolve
+ * dist/index.js" / "ENOTEMPTY rmdir dist/hooks").
  *
  * This serializes the build behind a filesystem lock so exactly one worker
  * builds and the rest wait for it to finish before reading dist.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -658,7 +658,7 @@
   "scripts": {
     "prepack": "pnpm build",
     "postinstall": "node scripts/postinstall.mjs",
-    "build": "rimraf dist && pnpm build:i18n && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
+    "build": "node ../../scripts/clean-dist.mjs && pnpm build:i18n && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
     "build:i18n": "node scripts/build-pseudo-locale.mjs",
     "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.json",
     "build:css": "node ../../scripts/build-css.mjs",
@@ -683,8 +683,7 @@
     "@stylexjs/babel-plugin": "catalog:",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.6.0",
-    "@testing-library/react": "^16.3.2",
-    "rimraf": "^6.0.1"
+    "@testing-library/react": "^16.3.2"
   },
   "dependencies": {
     "intl-messageformat": "^11.2.9"

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rimraf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
+    "build": "node ../../scripts/clean-dist.mjs && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
     "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.json",
     "build:css": "node ../../scripts/build-css.mjs --package lab",
     "dev": "babel src --watch --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*\" --config-file ./babel.config.json",
@@ -71,7 +71,6 @@
     "@astryxdesign/cli": "workspace:*",
     "@types/d3-array": "^3.2.2",
     "@types/d3-scale": "^4.0.9",
-    "@types/d3-shape": "^3.1.8",
-    "rimraf": "^6.0.1"
+    "@types/d3-shape": "^3.1.8"
   }
 }

--- a/packages/richtext/package.json
+++ b/packages/richtext/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rimraf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
+    "build": "node ../../scripts/clean-dist.mjs && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs && node ../../scripts/check-fully-specified.mjs",
     "build:esm": "babel src --out-dir dist --extensions \".ts,.tsx\" --out-file-extension \".js\" --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.json",
     "build:css": "node ../../scripts/build-css.mjs --package richtext",
     "dev": "babel src --watch --out-dir dist --extensions \".ts,.tsx\" --out-file-extension \".js\" --ignore \"**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*\" --config-file ./babel.config.json",
@@ -122,7 +122,6 @@
     "@lexical/rich-text": "^0.46.0",
     "@lexical/selection": "^0.46.0",
     "@lexical/utils": "^0.46.0",
-    "lexical": "^0.46.0",
-    "rimraf": "^6.0.1"
+    "lexical": "^0.46.0"
   }
 }

--- a/packages/themes/butter/package.json
+++ b/packages/themes/butter/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/butterTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/butterTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,8 +56,7 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.5.0",
-    "rimraf": "^6.0.1"
+    "@astryxdesign/cli": "0.5.0"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/chocolate/package.json
+++ b/packages/themes/chocolate/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/chocolateTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/chocolateTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,8 +56,7 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.5.0",
-    "rimraf": "^6.0.1"
+    "@astryxdesign/cli": "0.5.0"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/gothic/package.json
+++ b/packages/themes/gothic/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/gothicTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/gothicTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,8 +56,7 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.5.0",
-    "rimraf": "^6.0.1"
+    "@astryxdesign/cli": "0.5.0"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/matcha/package.json
+++ b/packages/themes/matcha/package.json
@@ -45,7 +45,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/matchaTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/matchaTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -55,8 +55,7 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.5.0",
-    "rimraf": "^6.0.1"
+    "@astryxdesign/cli": "0.5.0"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/neutralTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/neutralTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,8 +56,7 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.5.0",
-    "rimraf": "^6.0.1"
+    "@astryxdesign/cli": "0.5.0"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/probe/package.json
+++ b/packages/themes/probe/package.json
@@ -20,14 +20,13 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/probeTheme.ts -o dist/theme.css --icons-specifier ./registries.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/probeTheme.ts -o dist/theme.css --icons-specifier ./registries.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "peerDependencies": {
     "@astryxdesign/core": "0.5.0",
     "react": ">=19"
   },
   "devDependencies": {
-    "rimraf": "^6.0.1",
     "tsup": "^8.3.0",
     "@astryxdesign/cli": "0.5.0"
   },

--- a/packages/themes/stone/package.json
+++ b/packages/themes/stone/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/stoneTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/stoneTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,8 +56,7 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.5.0",
-    "rimraf": "^6.0.1"
+    "@astryxdesign/cli": "0.5.0"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/y2k/package.json
+++ b/packages/themes/y2k/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && astryx theme build src/y2kTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "node ../../../scripts/clean-dist.mjs && astryx theme build src/y2kTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,8 +56,7 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.5.0",
-    "rimraf": "^6.0.1"
+    "@astryxdesign/cli": "0.5.0"
   },
   "module": "./dist/source.mjs"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,9 +620,6 @@ importers:
       '@types/d3-shape':
         specifier: ^3.1.8
         version: 3.1.8
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/cli:
     dependencies:
@@ -697,9 +694,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/lab:
     dependencies:
@@ -737,9 +731,6 @@ importers:
       '@types/d3-shape':
         specifier: ^3.1.8
         version: 3.1.8
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/richtext:
     dependencies:
@@ -792,9 +783,6 @@ importers:
       lexical:
         specifier: ^0.46.0
         version: 0.46.0(typescript@6.0.3)
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/themes/butter:
     dependencies:
@@ -811,9 +799,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/themes/chocolate:
     dependencies:
@@ -830,9 +815,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/themes/gothic:
     dependencies:
@@ -849,9 +831,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/themes/matcha:
     dependencies:
@@ -868,9 +847,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/themes/neutral:
     dependencies:
@@ -887,9 +863,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/themes/probe:
     dependencies:
@@ -903,9 +876,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.0)(typescript@6.0.3)(yaml@2.9.0)
@@ -925,9 +895,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/themes/y2k:
     dependencies:
@@ -944,9 +911,6 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.5.0
         version: link:../../cli
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
 
   packages/vega:
     dependencies:
@@ -5326,9 +5290,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -5625,11 +5586,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rimraf@6.1.3:
-    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
-    engines: {node: 20 || >=22}
-    hasBin: true
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -10725,8 +10681,6 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-json-from-dist@1.0.1: {}
-
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -10994,11 +10948,6 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rimraf@6.1.3:
-    dependencies:
-      glob: 13.0.6
-      package-json-from-dist: 1.0.1
 
   robust-predicates@3.0.3: {}
 

--- a/scripts/check-portable-scripts.mjs
+++ b/scripts/check-portable-scripts.mjs
@@ -10,7 +10,8 @@
  * packages/lab and packages/charts, which regressed both (#3637):
  *
  *   1. `rm -rf dist` — cmd.exe has no `rm`, so the build dies at the first
- *      step. Use `rimraf`, the ecosystem's cross-platform recursive delete.
+ *      step. Use the repo's Node cleanup helper, which is portable and does not
+ *      depend on a package-local binary.
  *   2. Single-quoted args (`--extensions '.ts,.tsx'`) — cmd.exe does not strip
  *      single quotes, so babel receives them as LITERAL characters, matches
  *      zero files, exits 0, and leaves dist/ empty. Use double quotes, which
@@ -78,7 +79,7 @@ export function findOffences(scripts = {}, deps = {}) {
       if (binary) {
         offences.push({
           name,
-          detail: `POSIX-only command \`${binary}\` — cmd.exe has no such binary; use rimraf or a node script`,
+          detail: `POSIX-only command \`${binary}\` — cmd.exe has no such binary; use the shared Node cleanup script`,
         });
       }
       if (invokes(command, 'rimraf') && !('rimraf' in deps)) {
@@ -135,7 +136,7 @@ function main() {
       console.error(`    ${detail}`);
     }
     console.error(
-      `\n${errors.length} error(s). Fix: replace \`rm -rf\` with \`rimraf\`, and single quotes with double quotes.`,
+      `\n${errors.length} error(s). Fix: replace \`rm -rf\` with the shared Node cleanup script, and single quotes with double quotes.`,
     );
     process.exit(1);
   }

--- a/scripts/check-portable-scripts.test.mjs
+++ b/scripts/check-portable-scripts.test.mjs
@@ -39,8 +39,7 @@ describe('findOffences — POSIX-only commands', () => {
   });
 
   it('does not flag a command that merely starts with those letters', () => {
-    // `rimraf` — the prescribed fix — starts with "rm"'s letters, and
-    // `concat` with "cat"'s.
+    // `rimraf` starts with "rm"'s letters, and `concat` with "cat"'s.
     expect(
       findOffences({build: 'rimraf dist', gen: 'concat a b'}, {rimraf: '^6'}),
     ).toEqual([]);
@@ -124,8 +123,10 @@ describe('the repo itself (#3637)', () => {
    * cleanup (#5125); lab and charts are the two that regressed in #3637.
    */
   const cleansDist = () => [
+    'packages/core',
     'packages/lab',
     'packages/charts',
+    'packages/richtext',
     ...trackedPackageJsonFiles()
       .filter(file => /^packages\/themes\/[^/]+\/package\.json$/.test(file))
       .map(file => path.posix.dirname(file)),
@@ -137,18 +138,15 @@ describe('the repo itself (#3637)', () => {
     expect(cleansDist()).toContain('packages/themes/neutral');
   });
 
-  it.each(cleansDist())(
-    '%s clears dist with the same portable rimraf as packages/core',
-    dir => {
-      // Default the block: a package with no devDependencies should fail this
-      // assertion by name, not throw on a property of undefined.
-      const {scripts, devDependencies = {}} = read(`${dir}/package.json`);
-      const core = read('packages/core/package.json');
+  it.each(cleansDist())('%s uses the shared portable dist cleaner', dir => {
+    const {scripts, devDependencies = {}} = read(`${dir}/package.json`);
+    const helper = dir.startsWith('packages/themes/')
+      ? '../../../scripts/clean-dist.mjs'
+      : '../../scripts/clean-dist.mjs';
 
-      expect(scripts.build).toMatch(/^rimraf dist && /);
-      expect(devDependencies.rimraf).toBe(core.devDependencies.rimraf);
-    },
-  );
+    expect(scripts.build.startsWith(`node ${helper} && `)).toBe(true);
+    expect(devDependencies.rimraf).toBeUndefined();
+  });
 
   it.each(['packages/lab', 'packages/charts'])(
     '%s runs babel with the same flags and quoting as packages/core',

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Remove a workspace package's generated distribution directory.
+ * @input The package directory as the current working directory.
+ * @output Removes ./dist when present.
+ * @position Shared, cross-platform build cleanup used by package build scripts.
+ */
+
+import {rmSync} from 'node:fs';
+
+rmSync('dist', {force: true, recursive: true});

--- a/scripts/clean-dist.test.mjs
+++ b/scripts/clean-dist.test.mjs
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Verifies the shared package build cleanup.
+ * @input A temporary package directory containing dist and an unrelated file.
+ * @output Confirms only dist is removed.
+ * @position Regression coverage for dependency-free, cross-platform cleanup.
+ */
+
+import {execFileSync} from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {expect, it} from 'vitest';
+
+const SCRIPT = fileURLToPath(new URL('./clean-dist.mjs', import.meta.url));
+
+it('removes dist without touching sibling files', () => {
+  const cwd = mkdtempSync(path.join(tmpdir(), 'astryx-clean-dist-'));
+
+  try {
+    mkdirSync(path.join(cwd, 'dist'));
+    writeFileSync(path.join(cwd, 'dist', 'generated.js'), 'generated');
+    writeFileSync(path.join(cwd, 'keep.txt'), 'keep');
+
+    execFileSync(process.execPath, [SCRIPT], {cwd});
+
+    expect(existsSync(path.join(cwd, 'dist'))).toBe(false);
+    expect(existsSync(path.join(cwd, 'keep.txt'))).toBe(true);
+  } finally {
+    rmSync(cwd, {force: true, recursive: true});
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -138,8 +138,8 @@ export default defineConfig({
           hookTimeout: 30_000,
           // Build @astryxdesign/core once before workers fork. The build-theme
           // suites need a compiled core; doing it here (not per-suite in
-          // parallel workers) avoids concurrent `rimraf dist && build`
-          // collisions that flake under Vitest 4's reworked pool.
+          // parallel workers) avoids concurrent clean-and-build collisions that
+          // flake under Vitest 4's reworked pool.
           globalSetup: ['./vitest.global-setup.node.mjs'],
           include: [
             'packages/**/src/**/*.test.{ts,tsx,mjs}',

--- a/vitest.global-setup.node.mjs
+++ b/vitest.global-setup.node.mjs
@@ -8,10 +8,9 @@
  *   suites need a compiled @astryxdesign/core (`astryx theme build` imports its
  *   compiled theme entry). Building here — once, in the main process, before
  *   Vitest spawns parallel workers — means every suite's beforeAll sees dist
- *   already present and short-circuits, so no two workers ever run core's
- *   `rimraf dist && build` concurrently. That concurrent-build collision is
- *   what nondeterministically broke a build-theme suite under Vitest 4's
- *   reworked pool scheduling ("Could not resolve dist/index.js").
+ *   already present and short-circuits, so no two workers ever clean and build
+ *   core concurrently. That collision is what nondeterministically broke a
+ *   build-theme suite under Vitest 4's reworked pool scheduling ("Could not resolve dist/index.js").
  *
  * SYNC: When modified, update this header.
  */


### PR DESCRIPTION
## Why

Package builds only need a cross-platform recursive delete before writing `dist`. Node provides that operation directly, so carrying a package-local `rimraf` binary adds an avoidable dependency and failure point.

## What

Use one shared `fs.rmSync` cleanup helper across core, canary packages, and themes; remove `rimraf` from their manifests and lockfile; keep the portability guard aligned.

## Risk

Build tooling only. The helper removes only the current package’s `dist` directory with the same recursive, force semantics.

## Testing

- `pnpm exec vitest run --project node scripts/clean-dist.test.mjs scripts/check-portable-scripts.test.mjs`
- `pnpm check:portable-scripts`
- `pnpm install --frozen-lockfile`