### PR TITLE
fix(vercel): rebuild cached workspace installs

### DIFF
--- a/apps/docsite/vercel.json
+++ b/apps/docsite/vercel.json
@@ -1,4 +1,4 @@
 {
-  "installCommand": "cd ../.. && pnpm install",
+  "installCommand": "cd ../.. && node scripts/clean-workspace-node-modules.mjs && pnpm install --force --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm build && pnpm -F @astryxdesign/docsite build"
 }

--- a/scripts/clean-workspace-node-modules.mjs
+++ b/scripts/clean-workspace-node-modules.mjs
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Remove cached workspace installs before Vercel runs pnpm.
+ * @input The repository root as the current working directory.
+ * @output Removes root and workspace-package node_modules directories.
+ * @position Vercel install cache recovery; pnpm recreates the directories next.
+ */
+
+import {existsSync, readdirSync, rmSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath, pathToFileURL} from 'node:url';
+
+const WORKSPACE_PARENTS = ['apps', 'packages', 'packages/themes', 'internal'];
+
+export function cleanWorkspaceNodeModules(root = process.cwd()) {
+  if (!existsSync(path.join(root, 'pnpm-workspace.yaml'))) {
+    throw new Error('Run clean-workspace-node-modules.mjs from the repo root');
+  }
+
+  rmSync(path.join(root, 'node_modules'), {force: true, recursive: true});
+
+  for (const parent of WORKSPACE_PARENTS) {
+    const parentPath = path.join(root, parent);
+    if (!existsSync(parentPath)) continue;
+
+    for (const entry of readdirSync(parentPath, {withFileTypes: true})) {
+      if (!entry.isDirectory()) continue;
+      rmSync(path.join(parentPath, entry.name, 'node_modules'), {
+        force: true,
+        recursive: true,
+      });
+    }
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  cleanWorkspaceNodeModules();
+}

--- a/scripts/clean-workspace-node-modules.test.mjs
+++ b/scripts/clean-workspace-node-modules.test.mjs
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests Vercel's workspace install-cache cleanup.
+ * @input A temporary repository-shaped directory.
+ * @output Confirms workspace node_modules are removed without broad traversal.
+ * @position Regression coverage for incomplete Vercel dependency caches.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {expect, it} from 'vitest';
+import {cleanWorkspaceNodeModules} from './clean-workspace-node-modules.mjs';
+
+it('removes only root and direct workspace node_modules directories', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'astryx-clean-install-'));
+
+  try {
+    writeFileSync(path.join(root, 'pnpm-workspace.yaml'), 'packages: []\n');
+    for (const relative of [
+      'node_modules/broken',
+      'apps/docsite/node_modules/broken',
+      'packages/core/node_modules/broken',
+      'packages/themes/stone/node_modules/broken',
+      'internal/tool/node_modules/broken',
+      'apps/docsite/fixtures/node_modules/keep',
+    ]) {
+      mkdirSync(path.join(root, relative), {recursive: true});
+    }
+
+    cleanWorkspaceNodeModules(root);
+
+    expect(existsSync(path.join(root, 'node_modules'))).toBe(false);
+    expect(existsSync(path.join(root, 'apps/docsite/node_modules'))).toBe(
+      false,
+    );
+    expect(existsSync(path.join(root, 'packages/core/node_modules'))).toBe(
+      false,
+    );
+    expect(
+      existsSync(path.join(root, 'packages/themes/stone/node_modules')),
+    ).toBe(false);
+    expect(existsSync(path.join(root, 'internal/tool/node_modules'))).toBe(
+      false,
+    );
+    expect(
+      existsSync(path.join(root, 'apps/docsite/fixtures/node_modules/keep')),
+    ).toBe(true);
+  } finally {
+    rmSync(root, {force: true, recursive: true});
+  }
+});


### PR DESCRIPTION
## Why

Vercel can restore an incomplete `node_modules` tree, and a normal frozen pnpm install reports it as up to date without restoring missing package files. That made preview builds fail before compilation.

## What

For Vercel installs only, remove root and direct workspace `node_modules` directories, then run a forced frozen install from the pnpm store. The cleanup refuses to run outside the repository root and does not recursively walk arbitrary directories.

## Risk

Preview installs do more linking work. Package contents and runtime behavior are unchanged.

## Testing

- `pnpm exec vitest run --project node scripts/clean-workspace-node-modules.test.mjs`
- Vercel preview validation on the original failure: https://vercel.com/fbopensource/astryx/7rBN9r4hH98L8xp3CXyrPDrRLPV2