### PR TITLE
fix(ci): skip nonvisual acceptance work

### DIFF
--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -31,12 +31,20 @@ describe('visual acceptance workflow concurrency', () => {
     expect(jobs).not.toContain('    concurrency:');
   });
 
+  it('keeps status initialization out of pull-request checks', () => {
+    const acceptance = workflow('visual-acceptance.yml');
+    const publisher = workflow('pr-comment.yml');
+
+    expect(acceptance).not.toContain('pull_request_target:');
+    expect(acceptance).not.toContain('  initialize:');
+    expect(publisher).toContain('types: [requested, in_progress, completed]');
+    expect(publisher).toContain(
+      'description: `CI run ${run.id}/${run.run_attempt} is producing fresh visual evidence.`',
+    );
+  });
+
   it('keeps comment authorization read-only until the shared lock is held', () => {
     const value = workflow('visual-acceptance.yml');
-    const initialize = value.slice(
-      value.indexOf('  initialize:'),
-      value.indexOf('  authorize:'),
-    );
     const authorize = value.slice(
       value.indexOf('  authorize:'),
       value.indexOf('  accept:'),
@@ -47,18 +55,6 @@ describe('visual acceptance workflow concurrency', () => {
     );
     const accept = value.slice(value.indexOf('  accept:'));
 
-    expect(initialize).toContain(
-      'group: visual-acceptance-head-${{ github.event.pull_request.head.repo.id }}-${{ github.event.pull_request.head.ref }}',
-    );
-    expect(initialize).toContain('cancel-in-progress: true');
-    expect(initialize).toContain('pull-requests: read');
-    expect(initialize).not.toContain('pull-requests: write');
-    expect(initialize).not.toContain('issues: write');
-    expect(initialize).not.toContain('removeLabel');
-    expect(initialize).toContain(
-      "state: scope.hasStableVisual ? 'pending' : 'success'",
-    );
-    expect(initialize).toContain("'No stable visual scope.'");
     expect(authorize).not.toContain(': write');
     expect(authorize).toContain('actions/checkout@v7');
     expect(authorizeCheckout).not.toContain('ref:');

--- a/.github/scripts/visual-scope.mjs
+++ b/.github/scripts/visual-scope.mjs
@@ -22,7 +22,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
 
 /** @param {string} file */
 function readJSON(file) {
@@ -63,14 +66,20 @@ export function classifyVisualScope(files, repoRoot = ROOT, manifests = {}) {
   for (const file of paths) {
     const pkgMatch = file.match(/^packages\/([^/]+)\//);
     if (pkgMatch) {
-      const relativeManifest = path.join('packages', pkgMatch[1], 'package.json');
+      const relativeManifest = path.join(
+        'packages',
+        pkgMatch[1],
+        'package.json',
+      );
       const pkg = readPackage(repoRoot, relativeManifest, manifests);
       if (pkg?.astryx?.canaryOnly === true) {
         canaryPackages.add(pkg.name ?? pkgMatch[1]);
       }
     }
 
-    const themeMatch = file.match(/^packages\/themes\/([^/]+)\/(?:src\/|package\.json$)/);
+    const themeMatch = file.match(
+      /^packages\/themes\/([^/]+)\/(src\/|package\.json$)/,
+    );
     if (!themeMatch) continue;
     const relativeManifest = path.join(
       'packages',
@@ -80,13 +89,25 @@ export function classifyVisualScope(files, repoRoot = ROOT, manifests = {}) {
     );
     const baseManifest = path.join(repoRoot, relativeManifest);
     const basePkg = fs.existsSync(baseManifest) ? readJSON(baseManifest) : null;
-    const headPkg = Object.hasOwn(manifests, relativeManifest)
+    const hasTrustedHeadManifest = Object.hasOwn(manifests, relativeManifest);
+    const headPkg = hasTrustedHeadManifest
       ? manifests[relativeManifest]
       : basePkg;
-    const isStable = pkg => pkg && pkg.private !== true && pkg.astryx?.canaryOnly !== true;
-    // Base metadata is the fail-closed floor: a PR may promote a theme into the
-    // stable lane, but cannot escape review by demoting an existing stable one.
-    if (isStable(basePkg) || isStable(headPkg)) {
+    const isStable = pkg =>
+      pkg && pkg.private !== true && pkg.astryx?.canaryOnly !== true;
+    const baseStable = isStable(basePkg);
+    const headStable = isStable(headPkg);
+    const sourceChanged = themeMatch[2] === 'src/';
+    const releaseChannelChanged =
+      hasTrustedHeadManifest && baseStable !== headStable;
+
+    // Theme source affects pixels. A manifest-only edit enters visual scope only
+    // when trusted base/head metadata proves that the release channel changed;
+    // build scripts and dependency cleanup do not alter rendered output.
+    if (
+      (sourceChanged && (baseStable || headStable)) ||
+      releaseChannelChanged
+    ) {
       stableThemes.add(themeMatch[1]);
       continue;
     }
@@ -109,7 +130,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const files = fs.readFileSync(0, 'utf8').split('\n');
   const manifestsFlag = process.argv.indexOf('--manifests');
   const manifests =
-    manifestsFlag === -1 ? {} : readJSON(path.resolve(process.argv[manifestsFlag + 1]));
+    manifestsFlag === -1
+      ? {}
+      : readJSON(path.resolve(process.argv[manifestsFlag + 1]));
   const result = classifyVisualScope(files, ROOT, manifests);
   process.stdout.write(`${JSON.stringify(result)}\n`);
 

--- a/.github/scripts/visual-scope.test.mjs
+++ b/.github/scripts/visual-scope.test.mjs
@@ -49,17 +49,25 @@ afterEach(() => fs.rmSync(root, {recursive: true, force: true}));
 
 describe('classifyVisualScope', () => {
   it('includes stable Core runtime changes', () => {
-    const result = classifyVisualScope(['packages/core/src/Button/Button.tsx'], root);
+    const result = classifyVisualScope(
+      ['packages/core/src/Button/Button.tsx'],
+      root,
+    );
     expect(result).toMatchObject({
       hasStableVisual: true,
       stableComponents: ['Button'],
       broadStableVisual: false,
     });
-    expect(result.stableCoreFiles).toEqual(['packages/core/src/Button/Button.tsx']);
+    expect(result.stableCoreFiles).toEqual([
+      'packages/core/src/Button/Button.tsx',
+    ]);
   });
 
   it('marks shared Core infrastructure as broad stable scope', () => {
-    const result = classifyVisualScope(['packages/core/src/theme/Theme.tsx'], root);
+    const result = classifyVisualScope(
+      ['packages/core/src/theme/Theme.tsx'],
+      root,
+    );
     expect(result).toMatchObject({
       hasStableVisual: true,
       broadStableVisual: true,
@@ -83,7 +91,34 @@ describe('classifyVisualScope', () => {
       ['packages/themes/neutral/src/neutralTheme.ts'],
       root,
     );
-    expect(result).toMatchObject({hasStableVisual: true, stableThemes: ['neutral']});
+    expect(result).toMatchObject({
+      hasStableVisual: true,
+      stableThemes: ['neutral'],
+    });
+  });
+
+  it('ignores build-only metadata in a stable theme package', () => {
+    const result = classifyVisualScope(
+      [
+        'packages/themes/neutral/package.json',
+        'packages/core/package.json',
+        'scripts/clean-dist.mjs',
+        'pnpm-lock.yaml',
+      ],
+      root,
+      {
+        'packages/themes/neutral/package.json': {
+          name: '@astryxdesign/theme-neutral',
+          private: false,
+          scripts: {build: 'node ../../../scripts/clean-dist.mjs && tsup'},
+        },
+      },
+    );
+    expect(result).toMatchObject({
+      hasStableVisual: false,
+      stableComponents: [],
+      stableThemes: [],
+    });
   });
 
   it('keeps a base-stable theme in scope when the PR marks it private', () => {
@@ -98,7 +133,10 @@ describe('classifyVisualScope', () => {
         },
       },
     );
-    expect(result).toMatchObject({hasStableVisual: true, stableThemes: ['neutral']});
+    expect(result).toMatchObject({
+      hasStableVisual: true,
+      stableThemes: ['neutral'],
+    });
   });
 
   it('uses trusted PR-head metadata for a promoted theme', () => {
@@ -112,7 +150,10 @@ describe('classifyVisualScope', () => {
         },
       },
     );
-    expect(result).toMatchObject({hasStableVisual: true, stableThemes: ['probe']});
+    expect(result).toMatchObject({
+      hasStableVisual: true,
+      stableThemes: ['probe'],
+    });
   });
 
   it('excludes the private probe fixture', () => {
@@ -125,7 +166,10 @@ describe('classifyVisualScope', () => {
   });
 
   it('excludes Lab and records its release channel from package metadata', () => {
-    const result = classifyVisualScope(['packages/lab/src/Drawer/Drawer.tsx'], root);
+    const result = classifyVisualScope(
+      ['packages/lab/src/Drawer/Drawer.tsx'],
+      root,
+    );
     expect(result.hasStableVisual).toBe(false);
     expect(result.canaryPackages).toEqual(['@astryxdesign/lab']);
   });

--- a/.github/workflows/visual-acceptance.yml
+++ b/.github/workflows/visual-acceptance.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-# Required status and explicit human decision for stable visual changes.
+# Explicit human decisions for stable visual changes. Initial status creation and
+# rerun invalidation live in the trusted PR Comment workflow_run publisher, so
+# they do not create a cancellable pull-request check that GitHub renders red.
 # This workflow never checks out or executes PR-controlled code. It runs the
 # default-branch implementation, resolves the current PR head through GitHub,
 # and stores the signed decision beside trusted, immutable evidence on gh-pages.
@@ -8,84 +10,12 @@
 name: Visual acceptance
 
 on:
-  pull_request_target:
-    branches: ['main']
-    types: [opened, reopened, synchronize]
   issue_comment:
     types: [created]
 
 permissions: {}
 
 jobs:
-  initialize:
-    if: github.event_name == 'pull_request_target'
-    concurrency:
-      group: visual-acceptance-head-${{ github.event.pull_request.head.repo.id }}-${{ github.event.pull_request.head.ref }}
-      cancel-in-progress: true
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      pull-requests: read
-      statuses: write
-    steps:
-      - name: Checkout trusted default-branch code
-        uses: actions/checkout@v7
-
-      - name: Classify scope and initialize the required status
-        uses: actions/github-script@v9
-        with:
-          retries: 3
-          script: |
-            const fs = require('node:fs');
-            const {spawnSync} = require('node:child_process');
-            const {owner, repo} = context.repo;
-            const pr = context.payload.pull_request;
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner, repo, pull_number: pr.number, per_page: 100,
-            });
-            const manifestPaths = new Set();
-            for (const {filename} of files) {
-              const theme = filename.match(/^packages\/themes\/([^/]+)\//);
-              const pkg = filename.match(/^packages\/([^/]+)\//);
-              if (theme) manifestPaths.add(`packages/themes/${theme[1]}/package.json`);
-              else if (pkg) manifestPaths.add(`packages/${pkg[1]}/package.json`);
-            }
-            const manifests = {};
-            const [headOwner, headRepo] = pr.head.repo.full_name.split('/');
-            for (const manifestPath of manifestPaths) {
-              try {
-                const {data} = await github.rest.repos.getContent({
-                  owner: headOwner, repo: headRepo, path: manifestPath, ref: pr.head.sha,
-                });
-                if (!Array.isArray(data) && data.content) {
-                  manifests[manifestPath] = JSON.parse(Buffer.from(data.content, 'base64').toString());
-                }
-              } catch (error) {
-                if (error.status !== 404) throw error;
-              }
-            }
-            fs.writeFileSync('visual-scope-manifests.json', JSON.stringify(manifests));
-            const result = spawnSync(
-              process.execPath,
-              ['.github/scripts/visual-scope.mjs', '--manifests', 'visual-scope-manifests.json'],
-              {input: `${files.map((file) => file.filename).join('\n')}\n`, encoding: 'utf8'},
-            );
-            if (result.status !== 0) {
-              core.setFailed(result.stderr || 'Stable visual scope classification failed.');
-              return;
-            }
-            const scope = JSON.parse(result.stdout);
-            await github.rest.repos.createCommitStatus({
-              owner,
-              repo,
-              sha: pr.head.sha,
-              context: 'visual-acceptance',
-              state: scope.hasStableVisual ? 'pending' : 'success',
-              description: scope.hasStableVisual
-                ? 'Stable visual capture is still running.'
-                : 'No stable visual scope.',
-            });
-
   authorize:
     if: >-
       github.event_name == 'issue_comment' &&


### PR DESCRIPTION
## Why

[#5624](https://github.com/facebook/astryx/pull/5624) changes build cleanup only, but visual CI treated stable theme `package.json` edits as pixel changes. It also shows `Visual acceptance / initialize` as a red failed check even though that run was intentionally cancelled and the required context correctly remained pending.

## What

- Treat a theme manifest-only edit as visual scope only when trusted base/head metadata proves its release channel changed.
- Keep theme source changes and stable↔private/canary transitions in visual scope.
- Remove the redundant `pull_request_target` initializer. The trusted `PR Comment` publisher already owns initial pending status, rerun invalidation, scope classification, and final reconciliation.
- Add regressions for build-only theme metadata and cancellation-free status ownership.

## Result

The exact #5624 file list now classifies as `hasStableVisual: false`: no screenshot capture or acceptance decision. Its required context resolves green as `No stable visual scope.` Future PRs also avoid the misleading cancelled/red initializer check.

## Testing

- Visual scope + workflow concurrency: 22 tests
- Exact #5624 file-list classification
- `actionlint` on both visual workflows
- Prettier and `git diff --check`
- `pnpm check:repo`
