### PR TITLE
fix(ci): trace affected PR check dependencies

### DIFF
--- a/.github/actions/affected-scope/action.yml
+++ b/.github/actions/affected-scope/action.yml
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+name: Affected scope
+description: Resolve exact affected components and broad/deferred PR-check inputs.
+
+inputs:
+  changed-files:
+    description: Newline-separated changed paths. Ignored when analysis-file is set.
+    required: false
+    default: ''
+  analysis-file:
+    description: analysis.json file containing changedFiles.
+    required: false
+    default: ''
+
+outputs:
+  affected_components:
+    description: Comma-separated exact affected component names.
+  affected_core_components:
+    description: Comma-separated exact affected Core component names.
+  affected_deferred_reasons:
+    description: Comma-separated broad/deferred reason keys.
+  a11y_deferred:
+    description: Whether a11y also needs protected main/full coverage.
+  has_components:
+    description: Whether exact affected components exist.
+  rtl_deferred:
+    description: Whether RTL also needs protected main/full coverage.
+  json:
+    description: Path to the canonical affected-scope JSON file.
+
+runs:
+  using: node20
+  main: index.mjs

--- a/.github/actions/affected-scope/index.mjs
+++ b/.github/actions/affected-scope/index.mjs
@@ -1,0 +1,98 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {appendFileSync, readFileSync, writeFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import process from 'node:process';
+import {error as logError} from 'node:console';
+
+const require = createRequire(import.meta.url);
+const {
+  classifyAffectedDependencies,
+} = require('../../scripts/lib/affected-scope.js');
+
+function input(name) {
+  return process.env[`INPUT_${name.toUpperCase()}`] ?? '';
+}
+
+function appendOutput(name, value) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}
+
+function hasControlCharacter(value) {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value.charCodeAt(index) < 32) return true;
+  }
+  return false;
+}
+
+function validateChangedPath(file) {
+  if (
+    typeof file !== 'string' ||
+    file.length === 0 ||
+    file.startsWith('/') ||
+    file.split('/').includes('..') ||
+    hasControlCharacter(file)
+  ) {
+    throw new Error(`malformed changed path ${JSON.stringify(file)}`);
+  }
+  return file;
+}
+
+function changedFiles() {
+  const analysisFile = input('ANALYSIS-FILE');
+  const changedFilesInput = input('CHANGED-FILES');
+  if (analysisFile && changedFilesInput) {
+    throw new Error('choose exactly one affected-scope input');
+  }
+  if (analysisFile) {
+    const analysis = JSON.parse(readFileSync(analysisFile, 'utf8'));
+    if (!Array.isArray(analysis.changedFiles)) {
+      throw new Error('analysis file has no changedFiles array');
+    }
+    return analysis.changedFiles.map(validateChangedPath);
+  }
+  return changedFilesInput.split('\n').filter(Boolean).map(validateChangedPath);
+}
+
+function csv(values) {
+  return values.join(',');
+}
+
+function main() {
+  if (!process.env.GITHUB_OUTPUT) {
+    throw new Error('GITHUB_OUTPUT is required');
+  }
+  const result = classifyAffectedDependencies(changedFiles());
+  const jsonPath = join(
+    process.env.RUNNER_TEMP || tmpdir(),
+    `affected-scope-${process.env.GITHUB_RUN_ID || 'local'}-${process.env.GITHUB_RUN_ATTEMPT || '1'}.json`,
+  );
+  writeFileSync(jsonPath, `${JSON.stringify(result)}\n`);
+  appendOutput('has_components', String(result.components.length > 0));
+  appendOutput('a11y_deferred', String(result.a11y.deferToMain));
+  appendOutput('rtl_deferred', String(result.rtl.deferToMain));
+  appendOutput(
+    'affected_components',
+    csv(result.components.map(entry => entry.component)),
+  );
+  appendOutput(
+    'affected_core_components',
+    csv(
+      result.components
+        .filter(entry => entry.packageName === '@astryxdesign/core')
+        .map(entry => entry.component),
+    ),
+  );
+  appendOutput('affected_deferred_reasons', csv(result.visual.reasons));
+  appendOutput('json', jsonPath);
+}
+
+try {
+  main();
+} catch (caught) {
+  const message = caught instanceof Error ? caught.message : String(caught);
+  logError(message);
+  process.exit(1);
+}

--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-
 /**
  * @description Analyzes PR changes to detect new/modified components and gather stats
  * @input --base <branch> --head <ref> --output <file>
@@ -10,10 +9,11 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { execSync } = require('node:child_process');
+const {execSync} = require('node:child_process');
+const {classifyAffectedDependencies} = require('./lib/affected-scope');
 
 const args = process.argv.slice(2);
-const getArg = (name) => {
+const getArg = name => {
   const idx = args.indexOf(`--${name}`);
   return idx !== -1 ? args[idx + 1] : null;
 };
@@ -35,14 +35,14 @@ const STORYBOOK_STORIES = 'apps/storybook/stories';
 //              package to its documented component(s) downstream, so listing
 //              the internal helpers here is harmless — they get filtered out.
 const PACKAGES = [
-  { name: '@astryxdesign/core', dir: 'packages/core', layout: 'nested' },
-  { name: '@astryxdesign/lab', dir: 'packages/lab', layout: 'nested' },
-  { name: '@astryxdesign/charts', dir: 'packages/charts', layout: 'flat' },
-  { name: '@astryxdesign/richtext', dir: 'packages/richtext', layout: 'flat' },
+  {name: '@astryxdesign/core', dir: 'packages/core', layout: 'nested'},
+  {name: '@astryxdesign/lab', dir: 'packages/lab', layout: 'nested'},
+  {name: '@astryxdesign/charts', dir: 'packages/charts', layout: 'flat'},
+  {name: '@astryxdesign/richtext', dir: 'packages/richtext', layout: 'flat'},
 ];
 
-const pkgSrc = (pkg) => `${pkg.dir}/src`;
-const pkgDist = (pkg) => `${pkg.dir}/dist`;
+const pkgSrc = pkg => `${pkg.dir}/src`;
+const pkgDist = pkg => `${pkg.dir}/dist`;
 
 // Directories under a package's src that are not components.
 const EXCLUDED_DIRS = ['hooks', 'theme', 'utils', 'i18n', '__tests__'];
@@ -51,24 +51,24 @@ const EXCLUDED_DIRS = ['hooks', 'theme', 'utils', 'i18n', '__tests__'];
 function getComponentNames(pkg) {
   const srcPath = path.join(process.cwd(), pkgSrc(pkg));
   try {
-    const entries = fs.readdirSync(srcPath, { withFileTypes: true });
+    const entries = fs.readdirSync(srcPath, {withFileTypes: true});
     if (pkg.layout === 'flat') {
       // Flat: each PascalCase *.tsx (not a test/story/context) is a component.
       return entries
         .filter(
-          (e) =>
+          e =>
             e.isFile() &&
             /^[A-Z]\w+\.tsx$/.test(e.name) &&
             !e.name.includes('.test.') &&
             !e.name.includes('.stories.') &&
             !e.name.endsWith('Context.tsx'),
         )
-        .map((e) => e.name.replace(/\.tsx$/, ''));
+        .map(e => e.name.replace(/\.tsx$/, ''));
     }
     // Nested: each non-excluded directory is a component.
     return entries
-      .filter((e) => e.isDirectory() && !EXCLUDED_DIRS.includes(e.name))
-      .map((e) => e.name);
+      .filter(e => e.isDirectory() && !EXCLUDED_DIRS.includes(e.name))
+      .map(e => e.name);
   } catch {
     return [];
   }
@@ -114,14 +114,16 @@ function componentIndexRef(pkg, componentName) {
 function getChangedFiles() {
   const threeDot = `${baseBranch}...${headRef}`;
   const tryThreeDot = () => {
-    const output = execSync(`git diff --name-only ${threeDot}`, { encoding: 'utf8' });
+    const output = execSync(`git diff --name-only ${threeDot}`, {
+      encoding: 'utf8',
+    });
     return output.trim().split('\n').filter(Boolean);
   };
   try {
-    return { files: tryThreeDot(), diffMode: 'three-dot' };
+    return {files: tryThreeDot(), diffMode: 'three-dot'};
   } catch (e) {
     console.warn(
-      `::warning::three-dot diff ${threeDot} failed - attempting to deepen the clone and retry`
+      `::warning::three-dot diff ${threeDot} failed - attempting to deepen the clone and retry`,
     );
     console.warn(diffErrorDetail(e));
   }
@@ -137,12 +139,12 @@ function getChangedFiles() {
     const baseName = baseBranch.replace(/^origin\//, '');
     execSync(
       `git fetch --deepen=200 origin ${baseName}:refs/remotes/origin/${baseName}`,
-      { encoding: 'utf8', stdio: 'pipe' },
+      {encoding: 'utf8', stdio: 'pipe'},
     );
-    return { files: tryThreeDot(), diffMode: 'three-dot' };
+    return {files: tryThreeDot(), diffMode: 'three-dot'};
   } catch (e) {
     console.warn(
-      `::warning::deepen failed (${diffErrorDetail(e)}) - falling back to two-dot diff`
+      `::warning::deepen failed (${diffErrorDetail(e)}) - falling back to two-dot diff`,
     );
   }
 
@@ -152,14 +154,21 @@ function getChangedFiles() {
   // with diffMode: 'two-dot' for any consumer to caveat.
   const twoDot = `${baseBranch}..${headRef}`;
   try {
-    const output = execSync(`git diff --name-only ${twoDot}`, { encoding: 'utf8' });
-    return { files: output.trim().split('\n').filter(Boolean), diffMode: 'two-dot' };
+    const output = execSync(`git diff --name-only ${twoDot}`, {
+      encoding: 'utf8',
+    });
+    return {
+      files: output.trim().split('\n').filter(Boolean),
+      diffMode: 'two-dot',
+    };
   } catch (e) {
     // A failed diff (e.g. base ref missing on a too-shallow clone) is not the
     // same as "no changes" — fail loudly instead of publishing an empty
     // analysis report that looks legitimate.
     console.error(`::error::git diff ${twoDot} failed: ${e.message}`);
-    console.error('The clone is likely too shallow to contain the base ref (see fetch-depth in ci.yml).');
+    console.error(
+      'The clone is likely too shallow to contain the base ref (see fetch-depth in ci.yml).',
+    );
     process.exit(1);
   }
 }
@@ -174,10 +183,13 @@ function diffErrorDetail(e) {
 // Check if a component exists in the base branch.
 function componentExistsInBase(pkg, componentName) {
   try {
-    execSync(`git show ${baseBranch}:${componentIndexRef(pkg, componentName)}`, {
-      encoding: 'utf8',
-      stdio: 'pipe',
-    });
+    execSync(
+      `git show ${baseBranch}:${componentIndexRef(pkg, componentName)}`,
+      {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      },
+    );
     return true;
   } catch {
     return false;
@@ -189,7 +201,7 @@ function parseExportsFromSource(content) {
   const exports = [];
   for (const match of exportMatches) {
     const inner = match.replace(/export\s*{\s*/, '').replace(/\s*}/, '');
-    exports.push(...inner.split(',').map((e) => e.trim().split(' ')[0]));
+    exports.push(...inner.split(',').map(e => e.trim().split(' ')[0]));
   }
   if (content.includes('export default')) {
     exports.push('default');
@@ -202,7 +214,7 @@ function getBaseExports(pkg, componentName) {
   try {
     const content = execSync(
       `git show ${baseBranch}:${componentIndexRef(pkg, componentName)}`,
-      { encoding: 'utf8', stdio: 'pipe' }
+      {encoding: 'utf8', stdio: 'pipe'},
     );
     return parseExportsFromSource(content);
   } catch {
@@ -237,7 +249,9 @@ function getFileSizeBytes(filePath) {
 function getGzipSize(filePath) {
   if (!filePath || !fs.existsSync(filePath)) return null;
   try {
-    const output = execSync(`gzip -c "${filePath}" | wc -c`, { encoding: 'utf8' });
+    const output = execSync(`gzip -c "${filePath}" | wc -c`, {
+      encoding: 'utf8',
+    });
     const bytes = parseInt(output.trim(), 10);
     if (!Number.isFinite(bytes) || bytes <= 0) return null;
     if (bytes < 1024) return `${bytes}B`;
@@ -278,11 +292,13 @@ function getExports(pkg, componentName) {
 function componentSourceFiles(pkg, componentName) {
   if (pkg.layout === 'flat') {
     const file = componentSrcPath(pkg, componentName);
-    return fs.existsSync(file) ? [{ dir: path.dirname(file), name: path.basename(file) }] : [];
+    return fs.existsSync(file)
+      ? [{dir: path.dirname(file), name: path.basename(file)}]
+      : [];
   }
   const dir = componentSrcPath(pkg, componentName);
   try {
-    return fs.readdirSync(dir).map((name) => ({ dir, name }));
+    return fs.readdirSync(dir).map(name => ({dir, name}));
   } catch {
     return [];
   }
@@ -293,11 +309,13 @@ function getPropsCount(pkg, componentName) {
   const files = componentSourceFiles(pkg, componentName);
   if (files.length === 0) return null;
   // Prefer the file named after the component (bare or XDS-prefixed).
-  const names = files.map((f) => f.name);
+  const names = files.map(f => f.name);
   const mainName =
-    [`XDS${componentName}.tsx`, `${componentName}.tsx`].find((f) => names.includes(f)) ||
+    [`XDS${componentName}.tsx`, `${componentName}.tsx`].find(f =>
+      names.includes(f),
+    ) ||
     names.find(
-      (f) =>
+      f =>
         (/^XDS[A-Z]\w+\.tsx$/.test(f) || /^[A-Z]\w+\.tsx$/.test(f)) &&
         !f.includes('.test.') &&
         !f.includes('Context.'),
@@ -305,12 +323,14 @@ function getPropsCount(pkg, componentName) {
   if (!mainName) return null;
   try {
     const content = fs.readFileSync(path.join(files[0].dir, mainName), 'utf8');
-    const propsMatch = content.match(/(?:type|interface)\s+\w*Props\w*\s*=?\s*{([^}]+)}/);
+    const propsMatch = content.match(
+      /(?:type|interface)\s+\w*Props\w*\s*=?\s*{([^}]+)}/,
+    );
     if (propsMatch) {
       return propsMatch[1]
         .split('\n')
         .filter(
-          (line) =>
+          line =>
             line.trim() &&
             !line.trim().startsWith('//') &&
             !line.trim().startsWith('*') &&
@@ -326,7 +346,7 @@ function getPropsCount(pkg, componentName) {
 // Check if component has tests
 function hasTests(pkg, componentName) {
   return componentSourceFiles(pkg, componentName).some(
-    (f) => f.name.endsWith('.test.ts') || f.name.endsWith('.test.tsx'),
+    f => f.name.endsWith('.test.ts') || f.name.endsWith('.test.tsx'),
   );
 }
 
@@ -337,17 +357,20 @@ function hasStories(pkg, componentName) {
     const files = fs.readdirSync(storiesDir);
     if (
       files.some(
-        (f) =>
-          f.toLowerCase().includes(componentName.toLowerCase()) && f.endsWith('.stories.tsx'),
+        f =>
+          f.toLowerCase().includes(componentName.toLowerCase()) &&
+          f.endsWith('.stories.tsx'),
       )
     )
       return true;
     const exports = getExports(pkg, componentName);
-    const xdsComponents = exports.filter((e) => e.startsWith('XDS'));
-    return xdsComponents.some((comp) => {
+    const xdsComponents = exports.filter(e => e.startsWith('XDS'));
+    return xdsComponents.some(comp => {
       const name = comp.replace(/^XDS/, '');
       return files.some(
-        (f) => f.toLowerCase().includes(name.toLowerCase()) && f.endsWith('.stories.tsx'),
+        f =>
+          f.toLowerCase().includes(name.toLowerCase()) &&
+          f.endsWith('.stories.tsx'),
       );
     });
   } catch {
@@ -363,23 +386,30 @@ function getStoryTitle(pkg, componentName) {
     const exports = getExports(pkg, componentName);
     const searchNames = [
       componentName,
-      ...exports.filter((e) => e.startsWith('XDS')).map((e) => e.replace(/^XDS/, '')),
+      ...exports
+        .filter(e => e.startsWith('XDS'))
+        .map(e => e.replace(/^XDS/, '')),
     ];
     const storyFiles = files.filter(
-      (f) =>
+      f =>
         f.endsWith('.stories.tsx') &&
-        searchNames.some((name) => f.toLowerCase().includes(name.toLowerCase())),
+        searchNames.some(name => f.toLowerCase().includes(name.toLowerCase())),
     );
     if (storyFiles.length === 0) return null;
-    const exactMatch = storyFiles.find((f) =>
-      searchNames.some((name) => f.toLowerCase() === `${name.toLowerCase()}.stories.tsx`),
+    const exactMatch = storyFiles.find(f =>
+      searchNames.some(
+        name => f.toLowerCase() === `${name.toLowerCase()}.stories.tsx`,
+      ),
     );
     const orderedFiles = exactMatch
-      ? [exactMatch, ...storyFiles.filter((f) => f !== exactMatch)]
+      ? [exactMatch, ...storyFiles.filter(f => f !== exactMatch)]
       : storyFiles;
     const titles = orderedFiles
-      .map((storyFile) => {
-        const content = fs.readFileSync(path.join(storiesDir, storyFile), 'utf8');
+      .map(storyFile => {
+        const content = fs.readFileSync(
+          path.join(storiesDir, storyFile),
+          'utf8',
+        );
         const titleMatch = content.match(/title:\s*['"]([^'"]+)['"]/);
         return titleMatch ? titleMatch[1] : null;
       })
@@ -427,7 +457,7 @@ function getComponentLOC(pkg, componentName) {
     totalLOC += countLOC(path.join(f.dir, f.name));
     fileCount++;
   }
-  return { totalLOC, fileCount };
+  return {totalLOC, fileCount};
 }
 
 // Calculate cyclomatic complexity (simplified - counts decision points)
@@ -462,9 +492,9 @@ function getComplexity(pkg, componentName) {
     else if (complexity <= 15) rating = 'Medium';
     else if (complexity <= 30) rating = 'High';
     else rating = 'Very High';
-    return { score: complexity, rating };
+    return {score: complexity, rating};
   } catch {
-    return { score: 0, rating: 'Unknown' };
+    return {score: 0, rating: 'Unknown'};
   }
 }
 
@@ -477,7 +507,9 @@ function getComponentStats(pkg, componentName) {
     pkg.layout === 'flat'
       ? null
       : path.join(process.cwd(), pkgDist(pkg), componentName);
-  const entries = distDir ? resolveEntries(distDir) : { esmPath: null, cjsPath: null };
+  const entries = distDir
+    ? resolveEntries(distDir)
+    : {esmPath: null, cjsPath: null};
   const loc = getComponentLOC(pkg, componentName);
   const complexity = getComplexity(pkg, componentName);
 
@@ -502,7 +534,7 @@ function getComponentStats(pkg, componentName) {
 // Get total bundle stats for a package's published entry.
 function getPackageBundleStats(pkg) {
   const distDir = path.join(process.cwd(), pkgDist(pkg));
-  const { esmPath, cjsPath } = resolveEntries(distDir);
+  const {esmPath, cjsPath} = resolveEntries(distDir);
   // Gzip the primary published entry — prefer ESM if it exists, else the CJS
   // `.js` the build actually emits today. Never gzip a missing path.
   const primary = esmPath || cjsPath;
@@ -519,11 +551,13 @@ function getPackageBundleStats(pkg) {
 // Main analysis
 function analyze() {
   console.log(`Analyzing changes from ${baseBranch} to ${headRef}...`);
-  const { files: changedFiles, diffMode } = getChangedFiles();
-  console.log(`Found ${changedFiles.length} changed files (diff mode: ${diffMode})`);
+  const {files: changedFiles, diffMode} = getChangedFiles();
+  console.log(
+    `Found ${changedFiles.length} changed files (diff mode: ${diffMode})`,
+  );
   if (diffMode === 'two-dot') {
     console.warn(
-      '::warning::using approximate two-dot diff - the file list may include base-only churn and may miss the PR\'s own changes when they also exist on base'
+      "::warning::using approximate two-dot diff - the file list may include base-only churn and may miss the PR's own changes when they also exist on base",
     );
   }
 
@@ -535,16 +569,26 @@ function analyze() {
   // Stable theme packages are a visual surface of their own. They do not own
   // component source dirs, so the component loop below cannot discover them;
   // without this, changing a published theme silently skips pr-visual.
-  const changedStableThemes = [...new Set(
-    changedFiles.flatMap((file) => {
-      const match = file.match(/^packages\/themes\/([^/]+)\/src\//);
-      if (!match) return [];
-      const manifest = path.join(process.cwd(), 'packages', 'themes', match[1], 'package.json');
-      if (!fs.existsSync(manifest)) return [];
-      const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
-      return pkg.private === true || pkg.astryx?.canaryOnly === true ? [] : [match[1]];
-    }),
-  )].sort();
+  const changedStableThemes = [
+    ...new Set(
+      changedFiles.flatMap(file => {
+        const match = file.match(/^packages\/themes\/([^/]+)\/src\//);
+        if (!match) return [];
+        const manifest = path.join(
+          process.cwd(),
+          'packages',
+          'themes',
+          match[1],
+          'package.json',
+        );
+        if (!fs.existsSync(manifest)) return [];
+        const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+        return pkg.private === true || pkg.astryx?.canaryOnly === true
+          ? []
+          : [match[1]];
+      }),
+    ),
+  ].sort();
 
   for (const pkg of PACKAGES) {
     const allComponents = getComponentNames(pkg);
@@ -576,28 +620,55 @@ function analyze() {
 
   console.log(`Changed packages: ${[...changedPackages].join(', ') || 'none'}`);
   console.log(`New components: ${newComponents.join(', ') || 'none'}`);
-  console.log(`Modified components: ${modifiedComponents.join(', ') || 'none'}`);
+  console.log(
+    `Modified components: ${modifiedComponents.join(', ') || 'none'}`,
+  );
 
   // Detect new exports in modified components (a dir may be "modified" yet add
   // brand-new exports alongside existing ones).
   const newExports = [];
   for (const key of modifiedComponents) {
-    const pkg = PACKAGES.find((p) => p.name === componentStats[key].package);
+    const pkg = PACKAGES.find(p => p.name === componentStats[key].package);
     const headExports = componentStats[key]?.exports || [];
     const baseExports = getBaseExports(pkg, key);
-    newExports.push(...headExports.filter((e) => e.startsWith('XDS') && !baseExports.includes(e)));
+    newExports.push(
+      ...headExports.filter(
+        e => e.startsWith('XDS') && !baseExports.includes(e),
+      ),
+    );
   }
   for (const key of newComponents) {
-    newExports.push(...(componentStats[key]?.exports || []).filter((e) => e.startsWith('XDS')));
+    newExports.push(
+      ...(componentStats[key]?.exports || []).filter(e => e.startsWith('XDS')),
+    );
   }
-  if (newExports.length > 0) console.log(`New exports: ${newExports.join(', ')}`);
+  if (newExports.length > 0)
+    console.log(`New exports: ${newExports.join(', ')}`);
 
   // Bundle sizes: report every package the PR actually touched. If none of the
   // component packages changed (e.g. a docs- or tooling-only PR that still runs
   // analysis), report no bundle rows rather than a stale, misattributed core row.
-  const bundlePackages = PACKAGES.filter((p) => changedPackages.has(p.name)).map((p) =>
-    getPackageBundleStats(p),
+  const bundlePackages = PACKAGES.filter(p => changedPackages.has(p.name)).map(
+    p => getPackageBundleStats(p),
   );
+
+  const affectedScope = classifyAffectedDependencies(changedFiles);
+  if (changedStableThemes.length > 0) {
+    affectedScope.visual.deferToMain = true;
+    affectedScope.visual.reasons = [
+      ...new Set([...affectedScope.visual.reasons, 'stable-theme-package']),
+    ].sort();
+    affectedScope.a11y.deferToMain = true;
+    affectedScope.a11y.reasons = [
+      ...new Set([...affectedScope.a11y.reasons, 'stable-theme-package']),
+    ].sort();
+    affectedScope.globalInputs.push(
+      ...changedStableThemes.map(theme => ({
+        file: `packages/themes/${theme}/`,
+        kind: 'stable-theme-package',
+      })),
+    );
+  }
 
   const result = {
     newComponents,
@@ -606,6 +677,8 @@ function analyze() {
     componentStats,
     changedPackages: [...changedPackages],
     changedStableThemes,
+    changedFiles,
+    affectedScope,
     // Records whether the file list is exact (three-dot) or approximate
     // (two-dot fallback). Consumers that gate on the component list (pr-a11y)
     // or render it in the report should caveat when this is 'two-dot'.
@@ -613,7 +686,8 @@ function analyze() {
     bundlePackages,
     // Back-compat: keep totalBundle pointed at core when core changed, so any
     // older consumer of this field still resolves.
-    totalBundle: bundlePackages.find((b) => b.package === '@astryxdesign/core') || null,
+    totalBundle:
+      bundlePackages.find(b => b.package === '@astryxdesign/core') || null,
     analyzedAt: new Date().toISOString(),
   };
 

--- a/.github/scripts/analyze-pr.test.mjs
+++ b/.github/scripts/analyze-pr.test.mjs
@@ -53,37 +53,72 @@ function buildFixture() {
   const upstream = path.join(base, 'upstream');
   const clone = path.join(base, 'clone');
 
-  fs.mkdirSync(path.join(upstream, 'packages/core/src/Card'), {recursive: true});
-  fs.mkdirSync(path.join(upstream, 'packages/core/src/Button'), {recursive: true});
-  fs.mkdirSync(path.join(upstream, 'packages/core/src/Line'), {recursive: true});
-  fs.mkdirSync(path.join(upstream, 'packages/themes/neutral/src'), {recursive: true});
-  fs.mkdirSync(path.join(upstream, 'packages/themes/probe/src'), {recursive: true});
+  fs.mkdirSync(path.join(upstream, 'packages/core/src/Card'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(upstream, 'packages/core/src/Button'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(upstream, 'packages/core/src/Line'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(upstream, 'packages/themes/neutral/src'), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(upstream, 'packages/themes/probe/src'), {
+    recursive: true,
+  });
 
   git(upstream, ['init', '-q', '-b', 'main']);
   git(upstream, ['config', 'user.email', 'test@test.co']);
   git(upstream, ['config', 'user.name', 'Test']);
   fs.writeFileSync(path.join(upstream, 'package.json'), '{}');
-  fs.writeFileSync(path.join(upstream, 'packages/core/src/Card/index.ts'), 'export {}\n');
-  fs.writeFileSync(path.join(upstream, 'packages/core/src/Button/index.ts'), 'export {}\n');
-  fs.writeFileSync(path.join(upstream, 'packages/core/src/Line/index.ts'), 'export {}\n');
+  fs.writeFileSync(
+    path.join(upstream, 'packages/core/src/Card/index.ts'),
+    'export {}\n',
+  );
+  fs.writeFileSync(
+    path.join(upstream, 'packages/core/src/Card/Card.tsx'),
+    'export const Card = () => null;\n',
+  );
+  fs.writeFileSync(
+    path.join(upstream, 'packages/core/src/Button/index.ts'),
+    'export {}\n',
+  );
+  fs.writeFileSync(
+    path.join(upstream, 'packages/core/src/Line/index.ts'),
+    'export {}\n',
+  );
   fs.writeFileSync(
     path.join(upstream, 'packages/themes/neutral/package.json'),
     JSON.stringify({name: '@astryxdesign/theme-neutral', private: false}),
   );
-  fs.writeFileSync(path.join(upstream, 'packages/themes/neutral/src/theme.ts'), 'export {}\n');
+  fs.writeFileSync(
+    path.join(upstream, 'packages/themes/neutral/src/theme.ts'),
+    'export {}\n',
+  );
   fs.writeFileSync(
     path.join(upstream, 'packages/themes/probe/package.json'),
     JSON.stringify({name: '@astryxdesign/theme-probe', private: true}),
   );
-  fs.writeFileSync(path.join(upstream, 'packages/themes/probe/src/theme.ts'), 'export {}\n');
+  fs.writeFileSync(
+    path.join(upstream, 'packages/themes/probe/src/theme.ts'),
+    'export {}\n',
+  );
   git(upstream, ['add', '-A']);
   git(upstream, ['commit', '-qm', 'branch point']);
   const branchPoint = git(upstream, ['rev-parse', 'HEAD']);
 
   // 60 churn commits on main so the branch point is beyond any small depth.
   for (let i = 1; i <= 60; i++) {
-    fs.appendFileSync(path.join(upstream, 'packages/core/src/Button/index.ts'), `b${i}\n`);
-    fs.appendFileSync(path.join(upstream, 'packages/core/src/Line/index.ts'), `l${i}\n`);
+    fs.appendFileSync(
+      path.join(upstream, 'packages/core/src/Button/index.ts'),
+      `b${i}\n`,
+    );
+    fs.appendFileSync(
+      path.join(upstream, 'packages/core/src/Line/index.ts'),
+      `l${i}\n`,
+    );
     git(upstream, ['add', '-A']);
     git(upstream, ['commit', '-qm', `churn ${i}`]);
   }
@@ -91,16 +126,30 @@ function buildFixture() {
   // Feature branch off the branch point, touching only Card.
   git(upstream, ['branch', 'feature', branchPoint]);
   git(upstream, ['checkout', '-q', 'feature']);
-  fs.appendFileSync(path.join(upstream, 'packages/core/src/Card/index.ts'), 'export const Card = {}\n');
-  fs.appendFileSync(path.join(upstream, 'packages/themes/neutral/src/theme.ts'), 'export const changed = true\n');
-  fs.appendFileSync(path.join(upstream, 'packages/themes/probe/src/theme.ts'), 'export const changed = true\n');
+  fs.appendFileSync(
+    path.join(upstream, 'packages/core/src/Card/Card.tsx'),
+    'export const touched = true;\n',
+  );
+  fs.appendFileSync(
+    path.join(upstream, 'packages/themes/neutral/src/theme.ts'),
+    'export const changed = true\n',
+  );
+  fs.appendFileSync(
+    path.join(upstream, 'packages/themes/probe/src/theme.ts'),
+    'export const changed = true\n',
+  );
   git(upstream, ['add', '-A']);
   git(upstream, ['commit', '-qm', 'touch Card only']);
 
   // Shallow single-branch clone of the feature branch.
   git(null, [
-    'clone', '-q', '--depth=5', '--single-branch', '--branch=feature',
-    `file://${upstream}`, clone,
+    'clone',
+    '-q',
+    '--depth=5',
+    '--single-branch',
+    '--branch=feature',
+    `file://${upstream}`,
+    clone,
   ]);
 
   return {base, clone, branchPoint};
@@ -116,7 +165,15 @@ describe('analyze-pr shallow-clone recovery', () => {
 
       const stdout = execFileSync(
         process.execPath,
-        [SCRIPT, '--base', 'origin/main', '--head', 'HEAD', '--output', 'analysis.json'],
+        [
+          SCRIPT,
+          '--base',
+          'origin/main',
+          '--head',
+          'HEAD',
+          '--output',
+          'analysis.json',
+        ],
         {cwd: clone, encoding: 'utf8'},
       );
       const analysis = JSON.parse(
@@ -129,6 +186,14 @@ describe('analyze-pr shallow-clone recovery', () => {
       expect(analysis.modifiedComponents).toEqual(['Card']);
       expect(analysis.changedPackages).toEqual(['@astryxdesign/core']);
       expect(analysis.changedStableThemes).toEqual(['neutral']);
+      expect(analysis.affectedScope.components).toContainEqual({
+        packageName: '@astryxdesign/core',
+        component: 'Card',
+      });
+      expect(analysis.affectedScope.visual).toMatchObject({
+        deferToMain: true,
+        reasons: ['stable-theme-package'],
+      });
     } finally {
       fs.rmSync(base, {recursive: true, force: true});
     }

--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-
 /**
  * @description Generates and posts PR comment with analysis results
  * @input --analysis <file> --a11y <file> --visual <file> --storybook-url <url> --run-url <url>
@@ -9,14 +8,14 @@
  */
 
 const fs = require('node:fs');
-const { buildA11ySection } = require('./lib/a11y-format');
-const { buildVisualSection } = require('./lib/visual-format');
+const {buildA11ySection} = require('./lib/a11y-format');
+const {buildVisualSection} = require('./lib/visual-format');
 // Report-file strings render as literal inline text, report numbers as
 // numbers — the comment's structure comes only from this file's literals.
-const { inline, num } = require('./lib/report-text');
+const {inline, num} = require('./lib/report-text');
 
 const args = process.argv.slice(2);
-const getArg = (name) => {
+const getArg = name => {
   const idx = args.indexOf(`--${name}`);
   return idx !== -1 ? args[idx + 1] : null;
 };
@@ -30,8 +29,13 @@ const storybookUrl = getArg('storybook-url') || '';
 const sandboxUrl = getArg('sandbox-url') || '';
 
 // Read analysis results
-let analysis = { newComponents: [], modifiedComponents: [], componentStats: {}, totalBundle: {} };
-let a11yReport = { components: {} };
+let analysis = {
+  newComponents: [],
+  modifiedComponents: [],
+  componentStats: {},
+  totalBundle: {},
+};
+let a11yReport = {components: {}};
 try {
   analysis = JSON.parse(fs.readFileSync(analysisFile, 'utf8'));
 } catch (e) {
@@ -55,7 +59,10 @@ function getStorybookLink(storybookBaseUrl, storyTitle) {
   // prefix. Story ids only ever contain [a-z0-9_-]; the title came from a
   // report file, so drop anything outside that alphabet before it lands in
   // the href.
-  const storyPath = title.toLowerCase().replace(/\//g, '-').replace(/[^a-z0-9_-]/g, '');
+  const storyPath = title
+    .toLowerCase()
+    .replace(/\//g, '-')
+    .replace(/[^a-z0-9_-]/g, '');
   return `${storybookBaseUrl}?path=/docs/${storyPath}--docs`;
 }
 
@@ -72,7 +79,9 @@ if (analysis.newComponents && analysis.newComponents.length > 0) {
     const stats = analysis.componentStats[comp] || {};
     const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
     const sbBadge = sbLink ? ` · ${extLink('View in Storybook', sbLink)}` : '';
-    const pkgBadge = stats.package ? ` <sub>(${inline(stats.package)})</sub>` : '';
+    const pkgBadge = stats.package
+      ? ` <sub>(${inline(stats.package)})</sub>`
+      : '';
     componentSection += `<details>\n<summary><strong>${inline(comp)}</strong>${pkgBadge}${sbBadge}</summary>\n\n`;
     componentSection += `| Metric | Value |\n|--------|-------|\n`;
     componentSection += `| Bundle Size (ESM) | ${inline(stats.esmSize) || 'N/A'} |\n`;
@@ -100,18 +109,26 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
     const newExports = analysis.newExports || [];
     const compExports = stats.exports || [];
     const newInComp = compExports.filter(e => newExports.includes(e));
-    const newBadge = newInComp.length > 0 ? ` · 🆕 ${newInComp.map(inline).join(', ')}` : '';
-    const pkgBadge = stats.package ? ` <sub>(${inline(stats.package)})</sub>` : '';
+    const newBadge =
+      newInComp.length > 0 ? ` · 🆕 ${newInComp.map(inline).join(', ')}` : '';
+    const pkgBadge = stats.package
+      ? ` <sub>(${inline(stats.package)})</sub>`
+      : '';
 
     componentSection += `<details>\n<summary><strong>${inline(comp)}</strong>${pkgBadge}${sbBadge}${newBadge}</summary>\n\n`;
     componentSection += `| Metric | Before | After | Delta |\n|--------|--------|-------|-------|\n`;
 
-    const esmDelta = Number.isFinite(Number(stats.esmBytes)) && Number.isFinite(Number(baseStats.esmBytes))
-      ? (Number(stats.esmBytes) - Number(baseStats.esmBytes))
-      : null;
-    const esmDeltaStr = esmDelta !== null
-      ? (esmDelta > 0 ? `+${esmDelta}B` : `${esmDelta}B`)
-      : 'N/A';
+    const esmDelta =
+      Number.isFinite(Number(stats.esmBytes)) &&
+      Number.isFinite(Number(baseStats.esmBytes))
+        ? Number(stats.esmBytes) - Number(baseStats.esmBytes)
+        : null;
+    const esmDeltaStr =
+      esmDelta !== null
+        ? esmDelta > 0
+          ? `+${esmDelta}B`
+          : `${esmDelta}B`
+        : 'N/A';
 
     componentSection += `| Bundle Size (ESM) | ${inline(baseStats.esmSize) || 'N/A'} | ${inline(stats.esmSize) || 'N/A'} | ${esmDeltaStr} |\n`;
     componentSection += `| Lines of Code | ${inline(baseStats.linesOfCode) || 'N/A'} | ${inline(stats.linesOfCode) || 'N/A'} | - |\n`;
@@ -120,8 +137,15 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
   }
 }
 
-// Build accessibility section using shared module
-const a11ySection = buildA11ySection(a11yReport);
+// Build accessibility section using shared module. Global or uncertain inputs
+// defer to protected main rather than expanding an ordinary PR audit.
+const a11yDeferred = analysis.affectedScope?.a11y?.deferToMain === true;
+const a11yReasons = (analysis.affectedScope?.a11y?.reasons || [])
+  .map(inline)
+  .join(', ');
+const a11ySection = a11yDeferred
+  ? `### Accessibility Audit\n\n**Status:** Deferred to protected main/nightly coverage${a11yReasons ? ` (${a11yReasons})` : ''}.\n\n`
+  : buildA11ySection(a11yReport);
 
 // Visual regression is optional: the pr-visual job is skipped when no
 // components changed, and absent entirely on older runs.
@@ -147,7 +171,7 @@ const bundlePackages =
   analysis.bundlePackages && analysis.bundlePackages.length > 0
     ? analysis.bundlePackages
     : analysis.totalBundle
-      ? [{ package: '@astryxdesign/core', ...analysis.totalBundle }]
+      ? [{package: '@astryxdesign/core', ...analysis.totalBundle}]
       : [];
 
 if (bundlePackages.length > 0) {
@@ -163,7 +187,8 @@ if (bundlePackages.length > 0) {
 
 if (analysis.bundleDelta) {
   const delta = num(analysis.bundleDelta);
-  const direction = delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'unchanged';
+  const direction =
+    delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'unchanged';
   bundleSection += `**Bundle size ${direction}:** ${delta > 0 ? '+' : ''}${delta} bytes\n\n`;
 }
 
@@ -194,7 +219,8 @@ let footerLinks = [];
 if (storybookUrl) footerLinks.push(extLink('Storybook', storybookUrl));
 if (sandboxUrl) footerLinks.push(extLink('Sandbox', sandboxUrl));
 if (runUrl) footerLinks.push(extLink('View full report', runUrl));
-const footerLinksStr = footerLinks.length > 0 ? ` | ${footerLinks.join(' | ')}` : '';
+const footerLinksStr =
+  footerLinks.length > 0 ? ` | ${footerLinks.join(' | ')}` : '';
 
 // A one-line caveat shown when the analysis fell back to the approximate
 // two-dot diff. The file list may include base-only churn and, worse, may

--- a/.github/scripts/generate-pr-comment.test.mjs
+++ b/.github/scripts/generate-pr-comment.test.mjs
@@ -25,10 +25,14 @@ function runComment(analysis) {
   try {
     const analysisFile = path.join(dir, 'analysis.json');
     fs.writeFileSync(analysisFile, JSON.stringify(analysis));
-    return execFileSync(process.execPath, [SCRIPT, '--analysis', analysisFile], {
-      cwd: dir,
-      encoding: 'utf8',
-    });
+    return execFileSync(
+      process.execPath,
+      [SCRIPT, '--analysis', analysisFile],
+      {
+        cwd: dir,
+        encoding: 'utf8',
+      },
+    );
   } finally {
     fs.rmSync(dir, {recursive: true, force: true});
   }
@@ -53,6 +57,19 @@ describe('generate-pr-comment diffMode caveat', () => {
   it('does not caveat an exact three-dot analysis', () => {
     const stdout = runComment({...baseAnalysis, diffMode: 'three-dot'});
     expect(stdout).not.toContain('Approximate analysis');
+  });
+
+  it('reports a11y deferral for global affected inputs', () => {
+    const stdout = runComment({
+      ...baseAnalysis,
+      affectedScope: {
+        a11y: {deferToMain: true, reasons: ['lockfile-ambiguity']},
+      },
+    });
+
+    expect(stdout).toContain('Accessibility Audit');
+    expect(stdout).toContain('Deferred to protected main/nightly coverage');
+    expect(stdout).toContain('lockfile-ambiguity');
   });
 
   it('treats a missing diffMode (older analysis.json) as exact', () => {

--- a/.github/scripts/lib/affected-scope.js
+++ b/.github/scripts/lib/affected-scope.js
@@ -1,0 +1,312 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Shared changed-file dependency classifier for PR-scoped checks.
+ *
+ * PR checks should stay exact and reviewable. Component files map to component
+ * scopes; shared rendering inputs and ambiguous dependency inputs defer to the
+ * protected main/nightly checks instead of expanding an ordinary PR to a global
+ * sweep.
+ */
+
+const SCHEMA_VERSION = 1;
+const CONSUMERS = [
+  'ci.check-components',
+  'ci.pr-a11y',
+  'ci.pr-rtl',
+  'pr-comment.visual',
+  'lab-readiness',
+];
+const COMPONENT_ROOTS = ['packages/core/src/', 'packages/lab/src/'];
+
+const COMPONENT_PACKAGES = new Map([
+  ['core', '@astryxdesign/core'],
+  ['lab', '@astryxdesign/lab'],
+]);
+
+const RUNTIME_EXT = /\.(ts|tsx|css)$/;
+const NON_RUNTIME = /\.(test|doc)\./;
+const TYPE_METADATA = /(^|\/)types\.ts$/;
+const NON_COMPONENT_DIRS = new Set([
+  'hooks',
+  'theme',
+  'utils',
+  'i18n',
+  '__tests__',
+]);
+const STATIC_ASSET = /\.(avif|gif|jpe?g|mp4|otf|png|svg|ttf|webp|woff2?)$/;
+
+function componentSource(file) {
+  const match = file.match(/^packages\/(core|lab)\/src\/([^/]+)\//);
+  if (!match || !RUNTIME_EXT.test(file) || NON_RUNTIME.test(file)) return null;
+  const [, packageLeaf, component] = match;
+  if (!/^[A-Z]/.test(component) || NON_COMPONENT_DIRS.has(component))
+    return null;
+  if (TYPE_METADATA.test(file)) return null;
+  return {component, packageName: COMPONENT_PACKAGES.get(packageLeaf)};
+}
+
+function inputKind(file) {
+  if (file === '.nvmrc') {
+    return {kind: 'browser-version-input', certainty: 'global'};
+  }
+  if (
+    file === 'pnpm-lock.yaml' ||
+    file === 'pnpm-workspace.yaml' ||
+    file === 'package.json'
+  ) {
+    return {kind: 'lockfile-ambiguity', certainty: 'uncertain'};
+  }
+  if (
+    /^(packages\/[^/]+|packages\/themes\/[^/]+|apps\/storybook)\/package\.json$/.test(
+      file,
+    )
+  ) {
+    return {kind: 'package-manifest', certainty: 'uncertain'};
+  }
+  if (NON_RUNTIME.test(file)) return null;
+  if (
+    /^apps\/storybook\/rtl-audit\//.test(file) ||
+    file === '.github/workflows/rtl-weekly.yml' ||
+    file === '.github/scripts/weekly-rtl-summary.js' ||
+    /^packages\/core\/src\/utils\/rtlStyles\./.test(file)
+  ) {
+    return {kind: 'rtl-harness-input', certainty: 'global'};
+  }
+  if (
+    /^apps\/storybook\/(\.storybook\/|vite\.config\.ts$|tsconfig\.json$)/.test(
+      file,
+    )
+  ) {
+    return {kind: 'storybook-config', certainty: 'global'};
+  }
+  if (/^apps\/storybook\/(public|assets|static)\//.test(file)) {
+    return {kind: 'storybook-static-asset', certainty: 'global'};
+  }
+  if (
+    /^packages\/core\/src\/theme\//.test(file) ||
+    /^packages\/core\/src\/(reset|tailwind-theme)\.css$/.test(file) ||
+    /^packages\/core\/src\/utils\/(themeProps|parseStyleKey)\./.test(file) ||
+    /^packages\/cli\/foundation\/discovery\/theming-targets\./.test(file) ||
+    /^packages\/build\//.test(file)
+  ) {
+    return {kind: 'shared-theme-token-infrastructure', certainty: 'global'};
+  }
+  if (
+    /^packages\/core\/src\/(hooks|utils|focus|runtime|i18n)\//.test(file) ||
+    file === 'packages/core/src/naming.ts'
+  ) {
+    return {kind: 'shared-core-runtime-infrastructure', certainty: 'global'};
+  }
+  if (
+    /^(packages\/(core|themes\/[^/]+)|apps\/storybook)\//.test(file) &&
+    STATIC_ASSET.test(file)
+  ) {
+    return {kind: 'font-static-asset', certainty: 'global'};
+  }
+  if (
+    file === '.github/actions/setup/action.yml' ||
+    /^\.github\/workflows\/(ci|pr-comment|visual-acceptance|release-gate)\.yml$/.test(
+      file,
+    ) ||
+    /^\.github\/scripts\/(accessibility-audit\.js|visual-gate\/(gate|visual-acceptance|publish-pr-report)\.mjs|visual-gate\/lib\/(capture|canonical-png|compare|plan)\.mjs)$/.test(
+      file,
+    )
+  ) {
+    return {kind: 'browser-version-input', certainty: 'global'};
+  }
+  return null;
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function classifyAffectedDependencies(files) {
+  const paths = files.map(file => String(file).trim()).filter(Boolean);
+  const componentFiles = [];
+  const globalInputs = [];
+  const uncertainInputs = [];
+
+  for (const file of paths) {
+    const component = componentSource(file);
+    if (component) componentFiles.push({file, ...component});
+
+    const input = inputKind(file);
+    if (!input) continue;
+    const entry = {file, kind: input.kind};
+    if (input.certainty === 'uncertain') uncertainInputs.push(entry);
+    else globalInputs.push(entry);
+  }
+
+  const components = uniqueSorted(
+    componentFiles.map(entry => `${entry.packageName}:${entry.component}`),
+  ).map(value => {
+    const [packageName, component] = value.split(':');
+    return {packageName, component};
+  });
+  const reasonKinds = uniqueSorted([
+    ...globalInputs.map(input => input.kind),
+    ...uncertainInputs.map(input => input.kind),
+  ]);
+  const deferToMain = globalInputs.length > 0 || uncertainInputs.length > 0;
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    consumers: [...CONSUMERS],
+    componentRoots: componentRoots(),
+    components,
+    componentFiles,
+    globalInputs,
+    uncertainInputs,
+    visual: {deferToMain, reasons: reasonKinds},
+    a11y: {deferToMain, reasons: reasonKinds},
+    rtl: {deferToMain, reasons: reasonKinds},
+  };
+}
+
+function componentRoots() {
+  return [...COMPONENT_ROOTS];
+}
+
+function failCli(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function readValue(args, name) {
+  const indexes = args.flatMap((arg, index) => (arg === name ? [index] : []));
+  if (indexes.length > 1) failCli(`duplicate ${name}`);
+  if (indexes.length === 0) return null;
+  return args[indexes[0] + 1];
+}
+
+function assertNoUnknownArgs(args, valueArgs, booleanArgs) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith('--')) failCli(`unexpected positional argument ${arg}`);
+    if (valueArgs.has(arg)) {
+      index += 1;
+      if (index >= args.length || args[index].startsWith('--')) {
+        failCli(`missing value for ${arg}`);
+      }
+      continue;
+    }
+    if (booleanArgs.has(arg)) continue;
+    failCli(`unknown argument ${arg}`);
+  }
+}
+
+function validateOutputPath(file, name) {
+  if (file === null) return null;
+  if (/[\x00-\x1f]/.test(file)) failCli(`malformed ${name}`);
+  return file;
+}
+
+function validateChangedPath(file) {
+  if (
+    typeof file !== 'string' ||
+    file.length === 0 ||
+    file.startsWith('/') ||
+    file.split('/').includes('..') ||
+    /[\x00-\x1f]/.test(file)
+  ) {
+    failCli(`malformed changed path ${JSON.stringify(file)}`);
+  }
+  return file;
+}
+
+function readChangedFilesFromArgs(args) {
+  const analysisFile = validateOutputPath(
+    readValue(args, '--analysis-file'),
+    'analysis path',
+  );
+  const stdinRequested = args.includes('--changed-files-stdin');
+  if (args.filter(arg => arg === '--changed-files-stdin').length > 1) {
+    failCli('duplicate --changed-files-stdin');
+  }
+  if (analysisFile && stdinRequested) {
+    failCli('choose exactly one changed-file input');
+  }
+  if (!analysisFile && !stdinRequested) {
+    failCli('missing changed-file input');
+  }
+  if (analysisFile) {
+    let analysis;
+    try {
+      analysis = JSON.parse(
+        require('node:fs').readFileSync(analysisFile, 'utf8'),
+      );
+    } catch {
+      failCli('malformed analysis JSON');
+    }
+    if (!Array.isArray(analysis.changedFiles)) {
+      failCli('analysis file has no changedFiles array');
+    }
+    return analysis.changedFiles.map(validateChangedPath);
+  }
+  return require('node:fs')
+    .readFileSync(0, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map(validateChangedPath);
+}
+
+function runClassify(args) {
+  assertNoUnknownArgs(
+    args,
+    new Set(['--analysis-file', '--github-output', '--json-output']),
+    new Set(['--changed-files-stdin']),
+  );
+  const result = classifyAffectedDependencies(readChangedFilesFromArgs(args));
+  const output = validateOutputPath(
+    readValue(args, '--github-output'),
+    'GitHub output path',
+  );
+  const jsonOutput = validateOutputPath(
+    readValue(args, '--json-output'),
+    'JSON output path',
+  );
+  if (output) writeGithubOutput(output, result);
+  const json = `${JSON.stringify(result)}\n`;
+  if (jsonOutput) require('node:fs').writeFileSync(jsonOutput, json);
+  process.stdout.write(json);
+}
+
+function writeGithubOutput(file, result) {
+  const csv = values => values.join(',');
+  const lines = [
+    `has_components=${result.components.length > 0}`,
+    `a11y_deferred=${result.a11y.deferToMain}`,
+    `rtl_deferred=${result.rtl.deferToMain}`,
+    `affected_components=${csv(result.components.map(entry => entry.component))}`,
+    `affected_core_components=${csv(
+      result.components
+        .filter(entry => entry.packageName === '@astryxdesign/core')
+        .map(entry => entry.component),
+    )}`,
+    `affected_deferred_reasons=${csv(result.visual.reasons)}`,
+  ];
+  require('node:fs').appendFileSync(file, `${lines.join('\n')}\n`);
+}
+
+if (require.main === module) {
+  const [, , command, ...args] = process.argv;
+  if (command === 'component-roots') {
+    if (args.length > 0) failCli('component-roots takes no arguments');
+    process.stdout.write(`${componentRoots().join(' ')}
+`);
+  } else if (command === 'classify') {
+    runClassify(args);
+  } else {
+    failCli('usage: affected-scope.js <component-roots|classify>');
+  }
+}
+
+module.exports = {
+  CONSUMERS,
+  SCHEMA_VERSION,
+  classifyAffectedDependencies,
+  componentRoots,
+  componentSource,
+};

--- a/.github/scripts/lib/affected-scope.test.mjs
+++ b/.github/scripts/lib/affected-scope.test.mjs
@@ -1,0 +1,358 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {execFileSync, spawnSync} from 'node:child_process';
+import fs from 'node:fs';
+import {createRequire} from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import {describe, expect, it} from 'vitest';
+
+const HELPER = new URL('./affected-scope.js', import.meta.url).pathname;
+const ACTION_ENTRY = new URL(
+  '../../actions/affected-scope/index.mjs',
+  import.meta.url,
+).pathname;
+
+const {classifyAffectedDependencies, componentRoots} = createRequire(
+  import.meta.url,
+)('./affected-scope.js');
+
+describe('classifyAffectedDependencies', () => {
+  it('exposes the shared component roots for CI wiring', () => {
+    expect(componentRoots()).toEqual([
+      'packages/core/src/',
+      'packages/lab/src/',
+    ]);
+  });
+
+  it('writes JSON and GitHub outputs for workflow consumers', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'affected-scope-'));
+    try {
+      const output = path.join(root, 'github-output');
+      const stdout = execFileSync(
+        process.execPath,
+        [
+          HELPER,
+          'classify',
+          '--changed-files-stdin',
+          '--github-output',
+          output,
+        ],
+        {
+          input: 'packages/core/src/Button/Button.tsx\n.nvmrc\n',
+          encoding: 'utf8',
+        },
+      );
+      expect(JSON.parse(stdout)).toMatchObject({
+        components: [{packageName: '@astryxdesign/core', component: 'Button'}],
+        visual: {deferToMain: true},
+      });
+      const values = fs.readFileSync(output, 'utf8');
+      expect(values).toContain('has_components=true');
+      expect(values).toContain('a11y_deferred=true');
+      expect(values).toContain('rtl_deferred=true');
+      expect(values).toContain('affected_core_components=Button');
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  it('reads changedFiles from analysis artifacts', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'affected-analysis-'));
+    try {
+      const analysis = path.join(root, 'analysis.json');
+      fs.writeFileSync(
+        analysis,
+        JSON.stringify({changedFiles: ['packages/lab/src/Drawer/index.ts']}),
+      );
+      const stdout = execFileSync(
+        process.execPath,
+        [HELPER, 'classify', '--analysis-file', analysis],
+        {
+          encoding: 'utf8',
+        },
+      );
+      expect(JSON.parse(stdout).components).toEqual([
+        {packageName: '@astryxdesign/lab', component: 'Drawer'},
+      ]);
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  it('executes the JavaScript action entrypoint end-to-end', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'affected-action-'));
+    try {
+      const output = path.join(root, 'github-output');
+      const result = spawnSync(process.execPath, [ACTION_ENTRY], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: output,
+          RUNNER_TEMP: root,
+          'INPUT_CHANGED-FILES':
+            'packages/core/src/Button/Button.tsx\n.nvmrc\n',
+          'INPUT_ANALYSIS-FILE': '',
+        },
+      });
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      const values = fs.readFileSync(output, 'utf8');
+      expect(values).toContain('has_components=true');
+      expect(values).toContain('a11y_deferred=true');
+      expect(values).toContain('affected_core_components=Button');
+      const jsonPath = values.match(/^json=(.*)$/m)?.[1];
+      expect(JSON.parse(fs.readFileSync(jsonPath, 'utf8')).components).toEqual([
+        {packageName: '@astryxdesign/core', component: 'Button'},
+      ]);
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  it('maps component source files to exact PR scopes', () => {
+    const result = classifyAffectedDependencies([
+      'packages/core/src/Button/Button.tsx',
+      'packages/lab/src/Drawer/Drawer.tsx',
+      'packages/core/src/Button/index.ts',
+    ]);
+
+    expect(result.components).toEqual([
+      {packageName: '@astryxdesign/core', component: 'Button'},
+      {packageName: '@astryxdesign/lab', component: 'Drawer'},
+    ]);
+    expect(result.visual.deferToMain).toBe(false);
+    expect(result.a11y.deferToMain).toBe(false);
+  });
+
+  it('rejects malformed CLI invocations with the specific grammar error', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'affected-bad-cli-'));
+    try {
+      const malformedJson = path.join(root, 'malformed.json');
+      fs.writeFileSync(malformedJson, '{not-json');
+      const malformedPaths = path.join(root, 'malformed-paths.json');
+      fs.writeFileSync(
+        malformedPaths,
+        JSON.stringify({changedFiles: ['../bad/path.ts']}),
+      );
+      const validAnalysis = path.join(root, 'analysis.json');
+      fs.writeFileSync(
+        validAnalysis,
+        JSON.stringify({changedFiles: ['packages/core/src/Button/Button.tsx']}),
+      );
+      const validInput = 'packages/core/src/Button/Button.tsx\n';
+      const cases = [
+        {
+          args: [],
+          input: '',
+          stderr: /usage: affected-scope\.js <component-roots\|classify>/,
+        },
+        {
+          args: ['unknown'],
+          input: '',
+          stderr: /usage: affected-scope\.js <component-roots\|classify>/,
+        },
+        {
+          args: [
+            'component-roots',
+            '--json-output',
+            path.join(root, 'out.json'),
+          ],
+          input: '',
+          stderr: /component-roots takes no arguments/,
+        },
+        {args: ['classify'], input: '', stderr: /missing changed-file input/},
+        {
+          args: ['classify', '--changed-files-stdin', '--changed-files-stdin'],
+          input: validInput,
+          stderr: /duplicate --changed-files-stdin/,
+        },
+        {
+          args: [
+            'classify',
+            '--changed-files-stdin',
+            '--analysis-file',
+            validAnalysis,
+          ],
+          input: validInput,
+          stderr: /choose exactly one changed-file input/,
+        },
+        {
+          args: ['classify', '--changed-files-stdin', '--unknown', 'x'],
+          input: validInput,
+          stderr: /unknown argument --unknown/,
+        },
+        {
+          args: ['classify', '--changed-files-stdin', '--json-output'],
+          input: validInput,
+          stderr: /missing value for --json-output/,
+        },
+        {
+          args: ['classify', 'stray-before', '--changed-files-stdin'],
+          input: validInput,
+          stderr: /unexpected positional argument stray-before/,
+        },
+        {
+          args: ['classify', '--changed-files-stdin', 'stray-after'],
+          input: validInput,
+          stderr: /unexpected positional argument stray-after/,
+        },
+        {
+          args: ['classify', 'one', 'two'],
+          input: validInput,
+          stderr: /unexpected positional argument one/,
+        },
+        {
+          args: [
+            'classify',
+            '--changed-files-stdin',
+            '--json-output',
+            path.join(root, 'a.json'),
+            '--json-output',
+            path.join(root, 'b.json'),
+          ],
+          input: validInput,
+          stderr: /duplicate --json-output/,
+        },
+        {
+          args: ['classify', '--analysis-file', malformedJson],
+          input: '',
+          stderr: /malformed analysis JSON/,
+        },
+        {
+          args: ['classify', '--analysis-file', malformedPaths],
+          input: '',
+          stderr: /malformed changed path/,
+        },
+        {
+          args: ['classify', '--changed-files-stdin'],
+          input: '../bad/path.ts\n',
+          stderr: /malformed changed path/,
+        },
+      ];
+      for (const {args, input, stderr} of cases) {
+        const result = spawnSync(process.execPath, [HELPER, ...args], {
+          input,
+          encoding: 'utf8',
+        });
+        expect(result.status).not.toBe(0);
+        expect(result.stdout).toBe('');
+        expect(result.stderr).toMatch(stderr);
+      }
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  it.each([
+    ['packages/core/src/theme/tokens.ts', 'shared-theme-token-infrastructure'],
+    ['apps/storybook/.storybook/preview.tsx', 'storybook-config'],
+    ['apps/storybook/public/demo.woff2', 'storybook-static-asset'],
+    [
+      'packages/core/src/theme/fonts/Astryx.woff2',
+      'shared-theme-token-infrastructure',
+    ],
+    ['.github/actions/setup/action.yml', 'browser-version-input'],
+    ['.github/scripts/visual-gate/lib/capture.mjs', 'browser-version-input'],
+    ['.nvmrc', 'browser-version-input'],
+    [
+      'packages/core/src/utils/parseStyleKey.ts',
+      'shared-theme-token-infrastructure',
+    ],
+    ['apps/storybook/rtl-audit/rtl-audit.mjs', 'rtl-harness-input'],
+    ['apps/storybook/rtl-audit/targets.json', 'rtl-harness-input'],
+    ['.github/workflows/rtl-weekly.yml', 'rtl-harness-input'],
+    ['packages/core/src/utils/rtlStyles.ts', 'rtl-harness-input'],
+    [
+      'packages/core/src/runtime/portal.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+    [
+      'packages/core/src/focus/FocusScope.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+    [
+      'packages/core/src/utils/focusReturn.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+    [
+      'packages/core/src/hooks/useFocusTrap.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+  ])('defers known global input %s', (file, kind) => {
+    const result = classifyAffectedDependencies([file]);
+
+    expect(result.globalInputs).toEqual([{file, kind}]);
+    expect(result.visual).toMatchObject({deferToMain: true, reasons: [kind]});
+    expect(result.a11y).toMatchObject({deferToMain: true, reasons: [kind]});
+    expect(result.rtl).toMatchObject({deferToMain: true, reasons: [kind]});
+  });
+
+  it('maps nested component barrels to exact component scope', () => {
+    const result = classifyAffectedDependencies([
+      'packages/core/src/Button/index.ts',
+    ]);
+
+    expect(result.components).toEqual([
+      {packageName: '@astryxdesign/core', component: 'Button'},
+    ]);
+    expect(result.visual.deferToMain).toBe(false);
+    expect(result.a11y.deferToMain).toBe(false);
+  });
+
+  it('ignores tests and docs as dependency inputs', () => {
+    const result = classifyAffectedDependencies([
+      'packages/core/src/theme/Theme.test.tsx',
+      'packages/core/src/theme/Theme.doc.mjs',
+    ]);
+
+    expect(result.globalInputs).toEqual([]);
+    expect(result.visual.deferToMain).toBe(false);
+    expect(result.a11y.deferToMain).toBe(false);
+  });
+
+  it.each([
+    'packages/core/src/i18n/getMessage.ts',
+    'packages/core/src/naming.ts',
+  ])(
+    'defers shared unowned Core infrastructure without exact component scope: %s',
+    file => {
+      const result = classifyAffectedDependencies([file]);
+
+      expect(result.components).toEqual([]);
+      expect(result.visual.deferToMain).toBe(true);
+      expect(result.a11y.deferToMain).toBe(true);
+      expect(result.rtl.deferToMain).toBe(true);
+      expect(result.globalInputs).toEqual([
+        {file, kind: 'shared-core-runtime-infrastructure'},
+      ]);
+    },
+  );
+
+  it('keeps exact components when global inputs also defer', () => {
+    const result = classifyAffectedDependencies([
+      'packages/core/src/Button/Button.tsx',
+      '.nvmrc',
+    ]);
+
+    expect(result.components).toEqual([
+      {packageName: '@astryxdesign/core', component: 'Button'},
+    ]);
+    expect(result.visual.deferToMain).toBe(true);
+    expect(result.a11y.deferToMain).toBe(true);
+  });
+
+  it.each([
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+    'package.json',
+    'packages/core/package.json',
+  ])('defers uncertain dependency input %s', file => {
+    const result = classifyAffectedDependencies([file]);
+
+    expect(result.uncertainInputs[0]).toMatchObject({file});
+    expect(result.visual.deferToMain).toBe(true);
+    expect(result.a11y.deferToMain).toBe(true);
+  });
+});

--- a/.github/scripts/visual-gate/README.md
+++ b/.github/scripts/visual-gate/README.md
@@ -70,26 +70,30 @@ Exit codes are the contract: `0` pass, `1` crashed, `2` changed.
 
 ### PR scope follows the release channel
 
-`pr-visual` compares only the stable published visual surface:
+`pr-visual` compares only a human-sized stable visual contract:
 
-- Core component change → every story of that component, light/dark, in every
-  shipped theme that styles it.
-- Published theme change → that theme's relevant target/story matrix.
-- Shared stable theming/token infrastructure → the full plan, which declines
-  visibly at the 240-shot review budget and defers to the daily gate.
+- Core component change → that component's mandatory `Theme Sheet` story in
+  Neutral and Probe, light and dark. Missing `Theme Sheet` is a setup error with
+  one message naming the component(s) to add.
+- Story changes tagged `stable-visual` → that changed story in Neutral, light and
+  dark. Untagged story-only edits are not stable visual scope.
+- Published theme or shared stable infrastructure changes → deferred to the
+  protected daily release gate; PR scope should not truncate a global review.
+- More than 24 PR shots warns reviewers; more than 40 defers to the daily gate.
 - A package with `package.json.astryx.canaryOnly: true` → no visual comparison,
   no visual baseline, no capture-only smoke job. It still typechecks, unit-tests,
   builds Storybook, and publishes to canary. Experimental pixels are not a
   stable release decision and should not create a red check people learn to
   ignore.
 
-The daily gate uses the same boundary: `stableStoryPackages` in
+The daily gate uses the same stable-package boundary: `stableStoryPackages` in
 `visual-gate.config.json` is currently `["Core"]`, so Lab/canary stories cannot
 hold a stable release. Pass `--story-packages '*'` only for an explicit
 non-release audit.
 
 `.github/scripts/visual-scope.mjs` owns that classification from package
-metadata; workflow YAML does not hard-code today's package names.
+metadata and Storybook `stable-visual` tags; workflow YAML does not hard-code
+package names.
 
 `--sample 24` takes an even slice of the plan for a quick smoke test.
 `--observations <file>` caches the scout pass between runs.

--- a/.github/scripts/visual-gate/gate.mjs
+++ b/.github/scripts/visual-gate/gate.mjs
@@ -50,9 +50,16 @@ import {READ_TARGETS, emptyAccumulator, fold} from './lib/probe-reach.mjs';
 import {AXES, PROBE_TOKENS, READ_AXES} from './lib/probe-axes.mjs';
 import {renderReport} from './lib/report.mjs';
 import {accept, incomparable, readBaseline} from './lib/baseline.mjs';
-import {loadConfig, loadThemeOverrides, loadThemingTargets} from './lib/sources.mjs';
+import {
+  loadConfig,
+  loadThemeOverrides,
+  loadThemingTargets,
+} from './lib/sources.mjs';
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
 
 const EXIT = {clean: 0, crashed: 1, changed: 2};
 const RELEASE_TIERS = ['surface', 'theme-matrix'];
@@ -68,13 +75,17 @@ const captureIdentity = () => ({
   sha: process.env.ASTRYX_VISUAL_SHA ?? process.env.GITHUB_SHA ?? null,
   runId: process.env.ASTRYX_VISUAL_RUN_ID ?? process.env.GITHUB_RUN_ID ?? null,
   runAttempt:
-    process.env.ASTRYX_VISUAL_RUN_ATTEMPT ?? process.env.GITHUB_RUN_ATTEMPT ?? null,
+    process.env.ASTRYX_VISUAL_RUN_ATTEMPT ??
+    process.env.GITHUB_RUN_ATTEMPT ??
+    null,
 });
 
 const config = loadConfig(REPO_ROOT);
 const releaseMode = command === 'release';
 const themeCatalog = readThemeCatalog(REPO_ROOT);
-const storybookDir = path.resolve(flag('storybook-dir') ?? 'apps/storybook/dist');
+const storybookDir = path.resolve(
+  flag('storybook-dir') ?? 'apps/storybook/dist',
+);
 const baselineDir = path.resolve(flag('baseline') ?? '.visual-baseline');
 let outDir = path.resolve(flag('out') ?? '.visual-run');
 const tiers = releaseMode
@@ -88,7 +99,9 @@ const components = (flag('components') ?? '').split(',').filter(Boolean);
 /** For the `theme-matrix` tier: only these shipped themes changed. */
 const matrixThemes = (flag('themes') ?? '').split(',').filter(Boolean);
 const maxShots = flag('max-shots') ? Number(flag('max-shots')) : Infinity;
-const storyPackages = (flag('story-packages') ?? config.stableStoryPackages.join(','))
+const storyPackages = (
+  flag('story-packages') ?? config.stableStoryPackages.join(',')
+)
   .split(',')
   .filter(Boolean);
 /** A trusted, exact shot list used only to recapture an accepted merged result. */
@@ -106,13 +119,21 @@ if (
     only.length ||
     sample)
 ) {
-  throw new Error('The stable release plan is internal and cannot be scoped by CLI flags.');
+  throw new Error(
+    'The stable release plan is internal and cannot be scoped by CLI flags.',
+  );
 }
 
 function readExactPlan(file) {
-  const shots = JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
+  const value = JSON.parse(fs.readFileSync(path.resolve(file), 'utf8'));
+  const shots = Array.isArray(value) ? value : value?.shots;
+  const expectedRemoved = Array.isArray(value)
+    ? []
+    : (value?.expectedRemoved ?? value?.expectedRemovals ?? []);
   if (!Array.isArray(shots) || shots.length > 5000) {
-    throw new Error('Exact visual plan must contain at most 5000 trusted shots.');
+    throw new Error(
+      'Exact visual plan must contain at most 5000 trusted shots.',
+    );
   }
   const keys = new Set();
   for (const shot of shots) {
@@ -125,12 +146,34 @@ function readExactPlan(file) {
       !['light', 'dark'].includes(shot.mode) ||
       !Array.isArray(shot.reasons)
     ) {
-      throw new Error(`Exact visual plan contains an invalid shot: ${JSON.stringify(shot)}`);
+      throw new Error(
+        `Exact visual plan contains an invalid shot: ${JSON.stringify(shot)}`,
+      );
     }
-    if (keys.has(shot.key)) throw new Error(`Exact visual plan repeats ${shot.key}.`);
+    if (keys.has(shot.key))
+      throw new Error(`Exact visual plan repeats ${shot.key}.`);
     keys.add(shot.key);
   }
-  return shots;
+  const removalKeys = new Set();
+  for (const removal of expectedRemoved) {
+    if (
+      !/^[A-Za-z0-9._-]{1,240}$/.test(removal?.key ?? '') ||
+      typeof removal.storyId !== 'string' ||
+      !removal.storyId ||
+      typeof removal.theme !== 'string' ||
+      !removal.theme ||
+      !['light', 'dark'].includes(removal.mode)
+    ) {
+      throw new Error(
+        `Exact visual plan contains an invalid expected removal: ${JSON.stringify(removal)}`,
+      );
+    }
+    if (keys.has(removal.key) || removalKeys.has(removal.key)) {
+      throw new Error(`Exact visual plan repeats ${removal.key}.`);
+    }
+    removalKeys.add(removal.key);
+  }
+  return {shots, expectedRemoved};
 }
 
 /**
@@ -144,19 +187,27 @@ function readExactPlan(file) {
  * @returns {string[]}
  */
 function storiesToScout(stories, targets, themeOverrides) {
-  const overridden = new Set(Object.values(themeOverrides).flatMap(keys => Object.keys(keys)));
-  const components = new Set(
-    targets.filter(target => overridden.has(target.key)).map(target => target.component),
+  const overridden = new Set(
+    Object.values(themeOverrides).flatMap(keys => Object.keys(keys)),
   );
-  return stories.filter(story => components.has(story.component)).map(story => story.id);
+  const components = new Set(
+    targets
+      .filter(target => overridden.has(target.key))
+      .map(target => target.component),
+  );
+  return stories
+    .filter(story => components.has(story.component))
+    .map(story => story.id);
 }
 
 /** @returns {Promise<{shots: import('./lib/plan.mjs').Shot[], stories: ReturnType<typeof readStoryIndex>}>} */
 async function plan() {
   if (planFile) {
+    const exact = readExactPlan(planFile);
     return {
-      shots: withThemeMetadata(readExactPlan(planFile), themeCatalog),
+      shots: withThemeMetadata(exact.shots, themeCatalog),
       stories: [],
+      expectedRemoved: exact.expectedRemoved,
     };
   }
   const [targets, allThemeOverrides] = await Promise.all([
@@ -178,7 +229,10 @@ async function plan() {
   const stories = storiesInPackages(indexedStories, storyPackages);
 
   let observations;
-  if (!has('no-scout') && (tiers.includes('theme-matrix') || tiers.includes('probe'))) {
+  if (
+    !has('no-scout') &&
+    (tiers.includes('theme-matrix') || tiers.includes('probe'))
+  ) {
     const cachePath = flag('observations');
     if (cachePath && fs.existsSync(cachePath)) {
       observations = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
@@ -186,14 +240,17 @@ async function plan() {
       const storyIds = tiers.includes('probe')
         ? stories.map(story => story.id)
         : storiesToScout(stories, targets, themeOverrides);
-      process.stderr.write(`Scouting ${storyIds.length} stories for theming targets…\n`);
+      process.stderr.write(
+        `Scouting ${storyIds.length} stories for theming targets…\n`,
+      );
       observations = await scout({
         storyIds,
         storybookDir,
         theme: config.defaultTheme,
         viewport: config.viewport,
       });
-      if (cachePath) fs.writeFileSync(cachePath, `${JSON.stringify(observations)}\n`);
+      if (cachePath)
+        fs.writeFileSync(cachePath, `${JSON.stringify(observations)}\n`);
     }
   }
 
@@ -211,7 +268,12 @@ async function plan() {
   let baselineAccount = null;
   if (releaseMode) {
     const {manifest} = readBaseline(baselineDir);
-    baselineAccount = accountBaseline(manifest, indexedStories, themeCatalog, REPO_ROOT);
+    baselineAccount = accountBaseline(
+      manifest,
+      indexedStories,
+      themeCatalog,
+      REPO_ROOT,
+    );
     shots = withBaselineCoverage(shots, {
       stories,
       baselineManifest: baselineAccount.manifest,
@@ -222,7 +284,9 @@ async function plan() {
   // A sample is for trying the rig out, never for a gate run: it is taken
   // evenly across the plan so it spans components rather than the first few.
   const filtered = only.length
-    ? shots.filter(shot => only.some(fragment => shot.storyId.includes(fragment)))
+    ? shots.filter(shot =>
+        only.some(fragment => shot.storyId.includes(fragment)),
+      )
     : shots;
   if (!sample || sample >= filtered.length) {
     return {shots: filtered, stories: indexedStories, baselineAccount};
@@ -238,7 +302,7 @@ async function plan() {
   };
 }
 
-async function runCapture(shots, releasePlan = null) {
+async function runCapture(shots, releasePlan = null, extraContext = {}) {
   fs.rmSync(outDir, {recursive: true, force: true});
   fs.mkdirSync(outDir, {recursive: true});
   let last = 0;
@@ -278,6 +342,9 @@ async function runCapture(shots, releasePlan = null) {
     baseSha: process.env.ASTRYX_PR_BASE_SHA ?? null,
     ref: process.env.GITHUB_REF ?? null,
     ...(releasePlan ? {releasePlan} : {}),
+    ...(extraContext.expectedRemoved?.length
+      ? {expectedRemoved: extraContext.expectedRemoved}
+      : {}),
   };
   fs.writeFileSync(
     path.join(outDir, 'manifest.json'),
@@ -295,7 +362,8 @@ function stageReportImages({reportDir, keys, currentDir, baselinePath}) {
     fs.mkdirSync(path.join(reportDir, name), {recursive: true});
     for (const key of keys) {
       const from = path.join(source, `${key}.png`);
-      if (fs.existsSync(from)) fs.copyFileSync(from, path.join(reportDir, name, `${key}.png`));
+      if (fs.existsSync(from))
+        fs.copyFileSync(from, path.join(reportDir, name, `${key}.png`));
     }
   }
 }
@@ -311,7 +379,10 @@ async function check() {
     : [];
   if (ineligible.length) {
     throw new Error(
-      `Canonical stable release plan contains ${ineligible.length} ineligible shot(s): ${ineligible.slice(0, 5).map(shot => shot.key).join(', ')}`,
+      `Canonical stable release plan contains ${ineligible.length} ineligible shot(s): ${ineligible
+        .slice(0, 5)
+        .map(shot => shot.key)
+        .join(', ')}`,
     );
   }
 
@@ -333,7 +404,14 @@ async function check() {
         components,
         ...(releasePlan ? {releasePlan} : {}),
       },
-      counts: {total: shots.length, unchanged: 0, changed: 0, added: 0, removed: 0, failed: 0},
+      counts: {
+        total: shots.length,
+        unchanged: 0,
+        changed: 0,
+        added: 0,
+        removed: 0,
+        failed: 0,
+      },
       components,
       changes: [],
       added: [],
@@ -341,10 +419,14 @@ async function check() {
       failures: [],
     };
     fs.mkdirSync(outDir, {recursive: true});
-    fs.writeFileSync(path.join(outDir, 'verdict.json'), `${JSON.stringify(verdict, null, 2)}\n`);
+    fs.writeFileSync(
+      path.join(outDir, 'verdict.json'),
+      `${JSON.stringify(verdict, null, 2)}\n`,
+    );
     const summary = `## Visual gate: skipped\n\n${verdict.reason}\n`;
     process.stdout.write(summary);
-    if (flag('summary-output')) fs.writeFileSync(flag('summary-output'), summary);
+    if (flag('summary-output'))
+      fs.writeFileSync(flag('summary-output'), summary);
     if (process.env.GITHUB_OUTPUT) {
       fs.appendFileSync(
         process.env.GITHUB_OUTPUT,
@@ -354,8 +436,13 @@ async function check() {
     return EXIT.clean;
   }
 
-  process.stderr.write(`Visual gate: ${shots.length} shots (${tiers.join(', ')})\n`);
-  const {manifest, failures: captureFailures} = await runCapture(shots, releasePlan);
+  process.stderr.write(
+    `Visual gate: ${shots.length} shots (${tiers.join(', ')})\n`,
+  );
+  const {manifest, failures: captureFailures} = await runCapture(
+    shots,
+    releasePlan,
+  );
   let failures = [
     ...captureFailures,
     ...(baselineAccounting?.unclassifiedKeys ?? []).map(key => ({
@@ -376,13 +463,13 @@ async function check() {
   let comparison;
   try {
     comparison = await compare({
-    baselineDir: path.join(baselineDir, 'shots'),
-    currentDir: path.join(outDir, 'shots'),
-    baselineManifest,
-    currentManifest: manifest,
-    diffDir: path.join(reportDir, 'diff'),
-    threshold: config.threshold,
-    maxDiffPixels: config.maxDiffPixels,
+      baselineDir: path.join(baselineDir, 'shots'),
+      currentDir: path.join(outDir, 'shots'),
+      baselineManifest,
+      currentManifest: manifest,
+      diffDir: path.join(reportDir, 'diff'),
+      threshold: config.threshold,
+      maxDiffPixels: config.maxDiffPixels,
       failures,
     });
   } catch (error) {
@@ -464,7 +551,10 @@ async function check() {
 function summarize(verdict, baselineExists) {
   const lines = [`## Visual gate: ${verdict.status}`, ''];
   if (!baselineExists) {
-    lines.push('No baseline existed — this run establishes one. Nothing was compared.', '');
+    lines.push(
+      'No baseline existed — this run establishes one. Nothing was compared.',
+      '',
+    );
   }
   lines.push(
     `| shots | changed | added | removed | failed |`,
@@ -487,13 +577,19 @@ function summarize(verdict, baselineExists) {
     }
   }
   if (verdict.changes.length > 0) {
-    lines.push('### Changed', '', '| shot | theme | mode | diff px | why it is in the plan |', '|---|---|---|---|---|');
+    lines.push(
+      '### Changed',
+      '',
+      '| shot | theme | mode | diff px | why it is in the plan |',
+      '|---|---|---|---|---|',
+    );
     for (const change of verdict.changes.slice(0, 40)) {
       lines.push(
         `| \`${change.key}\` | ${change.theme} | ${change.mode} | ${change.diffPixels} | ${(change.reasons ?? []).join(', ')} |`,
       );
     }
-    if (verdict.changes.length > 40) lines.push(`| … | | | | ${verdict.changes.length - 40} more |`);
+    if (verdict.changes.length > 40)
+      lines.push(`| … | | | | ${verdict.changes.length - 40} more |`);
     lines.push('');
   }
   const unexercised = verdict.targeting?.unexercisedOverrides ?? [];
@@ -503,7 +599,10 @@ function summarize(verdict, baselineExists) {
       '',
       ...unexercised
         .slice(0, 25)
-        .map(finding => `- \`${finding.theme}\` → \`${finding.key}${finding.selector ? `.${finding.selector}` : ''}\``),
+        .map(
+          finding =>
+            `- \`${finding.theme}\` → \`${finding.key}${finding.selector ? `.${finding.selector}` : ''}\``,
+        ),
       '',
     );
   }
@@ -526,15 +625,19 @@ async function main() {
         }
       }
       process.stdout.write(`${shots.length} shots\n`);
-      for (const [reason, count] of Object.entries(byReason).sort((a, b) => b[1] - a[1])) {
+      for (const [reason, count] of Object.entries(byReason).sort(
+        (a, b) => b[1] - a[1],
+      )) {
         process.stdout.write(`  ${String(count).padStart(5)}  ${reason}\n`);
       }
       return EXIT.clean;
     }
     case 'capture': {
-      const {shots} = await plan();
-      const {failures} = await runCapture(shots);
-      process.stdout.write(`Captured ${shots.length - failures.length}/${shots.length} into ${outDir}\n`);
+      const {shots, expectedRemoved} = await plan();
+      const {failures} = await runCapture(shots, null, {expectedRemoved});
+      process.stdout.write(
+        `Captured ${shots.length - failures.length}/${shots.length} into ${outDir}\n`,
+      );
       return failures.length > 0 ? EXIT.crashed : EXIT.clean;
     }
     case 'check':
@@ -555,7 +658,9 @@ async function main() {
         ['*'],
       );
       const subject = only.length
-        ? stories.filter(story => only.some(f => story.storyId ?? story.id.includes(f)))
+        ? stories.filter(story =>
+            only.some(f => story.storyId ?? story.id.includes(f)),
+          )
         : stories;
       const server = await serveDirectory(storybookDir);
       const origin = `http://127.0.0.1:${server.port}`;
@@ -584,10 +689,12 @@ async function main() {
           // accumulate across the walk.
           const axes = await page.evaluate(READ_AXES);
           for (const [name, value] of Object.entries(axes.tokens)) {
-            if (value && value === PROBE_TOKENS[name]) axisHits.tokens.add(name);
+            if (value && value === PROBE_TOKENS[name])
+              axisHits.tokens.add(name);
           }
           for (const kind of Object.keys(axes.swaps)) axisHits[kind]?.add(kind);
-          if (/AstryxProbeFace/.test(axes.fontFamily)) axisHits.fonts.add('body');
+          if (/AstryxProbeFace/.test(axes.fontFamily))
+            axisHits.fonts.add('body');
           for (const color of axes.syntax) {
             if (/^rgb\(/.test(color)) axisHits.syntax.add(color);
           }
@@ -595,14 +702,18 @@ async function main() {
           // A story that will not render contributes no readings; the visual
           // tier reports it as a capture failure.
         }
-        if (++done % 100 === 0) process.stderr.write(`  read ${done}/${subject.length}\n`);
+        if (++done % 100 === 0)
+          process.stderr.write(`  read ${done}/${subject.length}\n`);
       }
       await browser.close();
       await server.close();
 
       const declared = (await loadThemingTargets(REPO_ROOT)).map(t => t.key);
       const unseen = [...new Set(declared)].filter(
-        key => !acc.verified.has(key) && !acc.failures.has(key) && !acc.shadowed.has(key),
+        key =>
+          !acc.verified.has(key) &&
+          !acc.failures.has(key) &&
+          !acc.shadowed.has(key),
       );
       // An axis with nothing rendering it is UNVERIFIABLE, not passing — the
       // difference is the whole point, and reporting it as green is how a
@@ -613,7 +724,11 @@ async function main() {
           missed: acc.failures.size,
           ...AXES.components,
         },
-        tokens: {verified: axisHits.tokens.size, of: Object.keys(PROBE_TOKENS).length, ...AXES.tokens},
+        tokens: {
+          verified: axisHits.tokens.size,
+          of: Object.keys(PROBE_TOKENS).length,
+          ...AXES.tokens,
+        },
         icons: {verified: axisHits.icon.size > 0, ...AXES.icons},
         indicators: {verified: axisHits.indicator.size > 0, ...AXES.indicators},
         fonts: {verified: axisHits.fonts.size > 0, ...AXES.fonts},
@@ -630,7 +745,10 @@ async function main() {
         neverRendered: unseen.sort(),
       };
       fs.mkdirSync(outDir, {recursive: true});
-      fs.writeFileSync(path.join(outDir, 'reach.json'), `${JSON.stringify(out, null, 2)}\n`);
+      fs.writeFileSync(
+        path.join(outDir, 'reach.json'),
+        `${JSON.stringify(out, null, 2)}\n`,
+      );
 
       process.stdout.write('theme axes:\n');
       for (const [name, info] of Object.entries(axisReport)) {
@@ -680,7 +798,9 @@ async function main() {
       const unstable = [...seen.entries()]
         .filter(([, hashes]) => hashes.size > 1)
         .map(([key]) => key);
-      const stories = [...new Set(unstable.map(key => key.split('__')[0]))].sort();
+      const stories = [
+        ...new Set(unstable.map(key => key.split('__')[0])),
+      ].sort();
       process.stdout.write(
         `${unstable.length} unstable shot(s) across ${passes} passes, in ${stories.length} stor${stories.length === 1 ? 'y' : 'ies'}\n`,
       );
@@ -695,7 +815,9 @@ async function main() {
     case 'accept': {
       const manifestPath = path.join(outDir, 'manifest.json');
       if (!fs.existsSync(manifestPath)) {
-        throw new Error(`No capture at ${outDir} — run check or capture first.`);
+        throw new Error(
+          `No capture at ${outDir} — run check or capture first.`,
+        );
       }
       const currentManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
       const verdictPath = path.join(outDir, 'verdict.json');
@@ -707,12 +829,16 @@ async function main() {
         !requested || requested === 'all'
           ? Object.keys(currentManifest.shots)
           : requested.split(',').filter(Boolean);
-      if (new Set(named).size !== named.length) throw new Error('accept repeats a shot key.');
+      if (new Set(named).size !== named.length)
+        throw new Error('accept repeats a shot key.');
       const removed = new Set(verdict?.removed ?? []);
       const prune = has('prune') ? named.filter(key => removed.has(key)) : [];
       const keys = named.filter(key => currentManifest.shots[key]);
-      const unknown = named.filter(key => !currentManifest.shots[key] && !removed.has(key));
-      if (unknown.length) throw new Error(`accept names unknown shot(s): ${unknown.join(', ')}`);
+      const unknown = named.filter(
+        key => !currentManifest.shots[key] && !removed.has(key),
+      );
+      if (unknown.length)
+        throw new Error(`accept names unknown shot(s): ${unknown.join(', ')}`);
       if (prune.length) {
         if (verdict?.status === 'failed') {
           throw new Error('Refusing to prune from a failed visual verdict.');
@@ -721,8 +847,12 @@ async function main() {
           currentManifest.context?.releasePlan,
           currentManifest,
         );
-        if (JSON.stringify(verdict?.context?.releasePlan) !== JSON.stringify(plan)) {
-          throw new Error('Refusing to prune without the capture’s canonical release plan.');
+        if (
+          JSON.stringify(verdict?.context?.releasePlan) !== JSON.stringify(plan)
+        ) {
+          throw new Error(
+            'Refusing to prune without the capture’s canonical release plan.',
+          );
         }
       }
       const baselineManifest = {
@@ -737,7 +867,11 @@ async function main() {
         currentManifest: baselineManifest,
         keys,
         reason: flag('reason') ?? '',
-        actor: flag('actor') ?? process.env.GITHUB_ACTOR ?? process.env.USER ?? 'unknown',
+        actor:
+          flag('actor') ??
+          process.env.GITHUB_ACTOR ??
+          process.env.USER ??
+          'unknown',
         runId: process.env.GITHUB_RUN_ID ?? null,
         prune,
       });

--- a/.github/scripts/visual-gate/lib/plan.mjs
+++ b/.github/scripts/visual-gate/lib/plan.mjs
@@ -41,16 +41,26 @@ import * as path from 'node:path';
 export const MODES = ['light', 'dark'];
 
 /** Story names preferred as a component's representative, most preferred first. */
-const REPRESENTATIVE_NAMES = ['Default', 'Basic', 'Primary', 'Overview', 'Example'];
+const REPRESENTATIVE_NAMES = [
+  'Default',
+  'Basic',
+  'Primary',
+  'Overview',
+  'Example',
+];
 
 /** A story carrying this tag is never captured (see visual-gate.config.json for the reasoned list). */
 export const SKIP_TAG = 'no-visual';
-
+export const STABLE_VISUAL_TAG = 'stable-visual';
+export const THEME_SHEET_NAME = 'Theme Sheet';
 
 /** Workspace package manifests are the only package eligibility source. */
 export function readPackageCatalog(repoRoot) {
   const files = [];
-  for (const parent of [path.join(repoRoot, 'packages'), path.join(repoRoot, 'packages/themes')]) {
+  for (const parent of [
+    path.join(repoRoot, 'packages'),
+    path.join(repoRoot, 'packages/themes'),
+  ]) {
     if (!fs.existsSync(parent)) continue;
     for (const entry of fs.readdirSync(parent, {withFileTypes: true})) {
       if (!entry.isDirectory()) continue;
@@ -58,27 +68,35 @@ export function readPackageCatalog(repoRoot) {
       if (fs.existsSync(file)) files.push(file);
     }
   }
-  return new Map(files.map(file => {
-    const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
-    return [manifest.name, manifest];
-  }));
+  return new Map(
+    files.map(file => {
+      const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+      return [manifest.name, manifest];
+    }),
+  );
 }
 
 export function packageFromComponentPath(componentPath) {
   if (!componentPath) return null;
   const normalized = componentPath.replaceAll('\\', '/');
   const names = new Set();
-  for (const match of normalized.matchAll(/(?:^|\/)node_modules\/(@[^/]+\/[^/]+|[^/]+)(?=\/|$)/g)) {
+  for (const match of normalized.matchAll(
+    /(?:^|\/)node_modules\/(@[^/]+\/[^/]+|[^/]+)(?=\/|$)/g,
+  )) {
     names.add(match[1]);
   }
-  for (const match of normalized.matchAll(/(?:^|\/)packages\/(themes\/[^/]+|[^/]+)(?=\/|$)/g)) {
+  for (const match of normalized.matchAll(
+    /(?:^|\/)packages\/(themes\/[^/]+|[^/]+)(?=\/|$)/g,
+  )) {
     const [group, leaf] = match[1].split('/');
     names.add(leaf ? `@astryxdesign/theme-${leaf}` : `@astryxdesign/${group}`);
   }
   const bare = normalized.match(/^(@[^/]+\/[^/]+)(?:\/.*)?$/);
   if (bare) names.add(bare[1]);
-  if (names.size > 1) throw new Error(`Ambiguous Storybook componentPath: ${componentPath}`);
-  if (names.size === 0) throw new Error(`Unsupported Storybook componentPath: ${componentPath}`);
+  if (names.size > 1)
+    throw new Error(`Ambiguous Storybook componentPath: ${componentPath}`);
+  if (names.size === 0)
+    throw new Error(`Unsupported Storybook componentPath: ${componentPath}`);
   return [...names][0];
 }
 
@@ -87,14 +105,25 @@ function eligible(manifest) {
 }
 
 function titlePackage(title, catalog, candidates = null) {
-  const parts = String(title ?? '').split('/').filter(Boolean);
+  const parts = String(title ?? '')
+    .split('/')
+    .filter(Boolean);
   const wanted = [];
   if (parts[0]) wanted.push(`@astryxdesign/${parts[0].toLowerCase()}`);
   if (parts.at(-1)?.endsWith(' Theme')) {
-    const slug = parts.at(-1).slice(0, -6).trim().toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+    const slug = parts
+      .at(-1)
+      .slice(0, -6)
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/g, '-');
     wanted.unshift(`@astryxdesign/theme-${slug}`);
   }
-  return wanted.find(name => catalog.has(name) && (!candidates || candidates.includes(name))) ?? null;
+  return (
+    wanted.find(
+      name => catalog.has(name) && (!candidates || candidates.includes(name)),
+    ) ?? null
+  );
 }
 
 function storyPackageNames(entry, storybookDir, repoRoot, catalog) {
@@ -102,12 +131,21 @@ function storyPackageNames(entry, storybookDir, repoRoot, catalog) {
   let names = fromComponent ? [fromComponent] : [];
   if (!fromComponent) {
     const relative = entry.importPath?.replace(/^\.\//, '');
-    const source = relative && path.resolve(path.dirname(storybookDir), relative);
+    const source =
+      relative && path.resolve(path.dirname(storybookDir), relative);
     if (!source || !fs.existsSync(source)) {
       throw new Error(`Story ${entry.id} has no resolvable package metadata.`);
     }
     const text = fs.readFileSync(source, 'utf8');
-    names = [...new Set([...text.matchAll(/(?:from\s+|import\s*)['"](@astryxdesign\/[^/'"]+)/g)].map(match => match[1]))].sort();
+    names = [
+      ...new Set(
+        [
+          ...text.matchAll(
+            /(?:from\s+|import\s*)['"](@astryxdesign\/[^/'"]+)/g,
+          ),
+        ].map(match => match[1]),
+      ),
+    ].sort();
   }
   const titleOwner = titlePackage(entry.title, catalog, names);
   const themeOwner = titlePackage(entry.title, catalog);
@@ -116,9 +154,13 @@ function storyPackageNames(entry, storybookDir, repoRoot, catalog) {
     (themeOwner?.startsWith('@astryxdesign/theme-') ? themeOwner : null) ??
     titleOwner ??
     (names.length === 1 ? names[0] : null);
-  if (!owner) throw new Error(`Story ${entry.id} has ambiguous package ownership: ${names.join(', ')}.`);
+  if (!owner)
+    throw new Error(
+      `Story ${entry.id} has ambiguous package ownership: ${names.join(', ')}.`,
+    );
   for (const name of new Set([...names, owner])) {
-    if (!catalog.has(name)) throw new Error(`Story ${entry.id} names unknown package ${name}.`);
+    if (!catalog.has(name))
+      throw new Error(`Story ${entry.id} names unknown package ${name}.`);
   }
   return {
     packageNames: names.length ? names : [owner],
@@ -138,7 +180,8 @@ export function readThemeCatalog(repoRoot) {
     if (!manifest) continue;
     themes[entry.name] = {
       packageName: manifest.name,
-      stableVisual: manifest.private !== true && manifest.astryx?.canaryOnly !== true,
+      stableVisual:
+        manifest.private !== true && manifest.astryx?.canaryOnly !== true,
     };
   }
   return themes;
@@ -147,8 +190,13 @@ export function readThemeCatalog(repoRoot) {
 export function withThemeMetadata(shots, themes) {
   return shots.map(shot => {
     const theme = themes[shot.theme];
-    if (!theme) throw new Error(`Shot ${shot.key} names unknown theme ${shot.theme}.`);
-    return {...shot, themePackageName: theme.packageName, stableThemeVisual: theme.stableVisual};
+    if (!theme)
+      throw new Error(`Shot ${shot.key} names unknown theme ${shot.theme}.`);
+    return {
+      ...shot,
+      themePackageName: theme.packageName,
+      stableThemeVisual: theme.stableVisual,
+    };
   });
 }
 
@@ -159,11 +207,15 @@ function baselinePackage(shot, repoRoot, catalog) {
   const component = String(shot.component ?? '').trim();
   if (component) {
     const owners = [...catalog.keys()].filter(name => {
-      if (!name.startsWith('@astryxdesign/') || name.includes('/theme-')) return false;
+      if (!name.startsWith('@astryxdesign/') || name.includes('/theme-'))
+        return false;
       const leaf = name.slice('@astryxdesign/'.length);
-      return fs.existsSync(path.join(repoRoot, 'packages', leaf, 'src', component));
+      return fs.existsSync(
+        path.join(repoRoot, 'packages', leaf, 'src', component),
+      );
     });
-    if (owners.length === 1) return {packageName: owners[0], source: 'stored-component'};
+    if (owners.length === 1)
+      return {packageName: owners[0], source: 'stored-component'};
   }
   const fromTitle = titlePackage(shot.title, catalog);
   return fromTitle ? {packageName: fromTitle, source: 'stored-title'} : null;
@@ -181,14 +233,15 @@ export function accountBaseline(manifest, stories, themes, repoRoot) {
   };
   for (const [key, shot] of Object.entries(manifest.shots ?? {})) {
     const currentStory = byId.get(shot.storyId);
-    const owner = shot.packageName && catalog.has(shot.packageName)
-      ? {
-          packageName: shot.packageName,
-          source: shot.membershipSource ?? 'stored-package',
-        }
-      : currentStory
-        ? {packageName: currentStory.packageName, source: 'current-story'}
-        : baselinePackage(shot, repoRoot, catalog);
+    const owner =
+      shot.packageName && catalog.has(shot.packageName)
+        ? {
+            packageName: shot.packageName,
+            source: shot.membershipSource ?? 'stored-package',
+          }
+        : currentStory
+          ? {packageName: currentStory.packageName, source: 'current-story'}
+          : baselinePackage(shot, repoRoot, catalog);
     const storedTheme = shot.themePackageName
       ? catalog.get(shot.themePackageName)
       : null;
@@ -202,9 +255,10 @@ export function accountBaseline(manifest, stories, themes, repoRoot) {
       categories.unclassified.push(key);
       continue;
     }
-    const state = eligible(catalog.get(owner.packageName)) && theme.stableVisual
-      ? 'stable'
-      : 'ineligible';
+    const state =
+      eligible(catalog.get(owner.packageName)) && theme.stableVisual
+        ? 'stable'
+        : 'ineligible';
     if (state === 'ineligible') {
       categories.intentionallyExcluded.push(key);
       continue;
@@ -224,16 +278,27 @@ export function accountBaseline(manifest, stories, themes, repoRoot) {
   }
   for (const values of Object.values(categories)) values.sort();
   const total = Object.keys(manifest.shots ?? {}).length;
-  const classified = Object.values(categories).reduce((sum, values) => sum + values.length, 0);
-  if (classified !== total) throw new Error(`Baseline accounting overlap: ${classified} states for ${total} keys.`);
+  const classified = Object.values(categories).reduce(
+    (sum, values) => sum + values.length,
+    0,
+  );
+  if (classified !== total)
+    throw new Error(
+      `Baseline accounting overlap: ${classified} states for ${total} keys.`,
+    );
   return {manifest: {...manifest, shots: stable}, categories, total};
 }
 
 export function summarizeBaselineAccounting(account, releaseShots) {
   const planned = new Set(releaseShots.map(shot => shot.key));
-  const missing = account.categories.currentStable.filter(key => !planned.has(key));
-  const unclassified = [...new Set([...account.categories.unclassified, ...missing])].sort();
-  const plannedCurrentStable = account.categories.currentStable.length - missing.length;
+  const missing = account.categories.currentStable.filter(
+    key => !planned.has(key),
+  );
+  const unclassified = [
+    ...new Set([...account.categories.unclassified, ...missing]),
+  ].sort();
+  const plannedCurrentStable =
+    account.categories.currentStable.length - missing.length;
   const counts = {
     total: account.total,
     plannedCurrentStable,
@@ -241,41 +306,145 @@ export function summarizeBaselineAccounting(account, releaseShots) {
     preservedLegacy: account.categories.preservedLegacy.length,
     unclassified: unclassified.length,
   };
-  const sum = counts.plannedCurrentStable + counts.intentionallyExcluded + counts.preservedLegacy + counts.unclassified;
-  if (sum !== counts.total) throw new Error(`Baseline accounting overlap: ${sum} states for ${counts.total} keys.`);
-  return {...counts, ...(unclassified.length ? {unclassifiedKeys: unclassified} : {})};
+  const sum =
+    counts.plannedCurrentStable +
+    counts.intentionallyExcluded +
+    counts.preservedLegacy +
+    counts.unclassified;
+  if (sum !== counts.total)
+    throw new Error(
+      `Baseline accounting overlap: ${sum} states for ${counts.total} keys.`,
+    );
+  return {
+    ...counts,
+    ...(unclassified.length ? {unclassifiedKeys: unclassified} : {}),
+  };
 }
 
 export function stableBaseline(manifest, stories, themes, repoRoot) {
   return accountBaseline(manifest, stories, themes, repoRoot).manifest;
 }
 
-export function withBaselineCoverage(plan, {stories, baselineManifest, themes}) {
+export function withBaselineCoverage(
+  plan,
+  {stories, baselineManifest, themes},
+) {
   const planned = new Map(plan.map(shot => [shot.key, shot]));
   const byId = new Map(stories.map(story => [story.id, story]));
   for (const [key, baseline] of Object.entries(baselineManifest.shots ?? {})) {
     const story = byId.get(baseline.storyId);
-    if (!story || !themes[baseline.theme] || !MODES.includes(baseline.mode)) continue;
-    const shot = {...toShotBase(story), theme: baseline.theme, mode: baseline.mode};
+    if (!story || !themes[baseline.theme] || !MODES.includes(baseline.mode))
+      continue;
+    const shot = {
+      ...toShotBase(story),
+      theme: baseline.theme,
+      mode: baseline.mode,
+    };
     if (shotKey(shot) !== key) continue;
     const existing = planned.get(key);
-    planned.set(key, existing
-      ? {...existing, reasons: [...new Set([...existing.reasons, 'baseline'])]}
-      : {...shot, key, reasons: ['baseline']});
+    planned.set(
+      key,
+      existing
+        ? {
+            ...existing,
+            reasons: [...new Set([...existing.reasons, 'baseline'])],
+          }
+        : {...shot, key, reasons: ['baseline']},
+    );
   }
   return [...planned.values()].sort((a, b) => a.key.localeCompare(b.key));
 }
 
 export function createReleasePlan(shots) {
   const keys = shots.map(shot => shot.key).sort();
-  if (new Set(keys).size !== keys.length) throw new Error('Canonical release plan repeats a shot key.');
+  if (new Set(keys).size !== keys.length)
+    throw new Error('Canonical release plan repeats a shot key.');
   return {
     version: 1,
     lane: 'stable-release',
     authority: 'report-removals',
     keys,
-    digest: crypto.createHash('sha256').update(JSON.stringify(keys)).digest('hex'),
+    digest: crypto
+      .createHash('sha256')
+      .update(JSON.stringify(keys))
+      .digest('hex'),
   };
+}
+
+/**
+ * Compact PR visual plan: the required Theme Sheet for touched components, plus
+ * explicitly tagged stable-visual stories. Probe stays a private test fixture;
+ * release planning decides separately which shipped themes own the baseline.
+ *
+ * @param {object} options
+ * @param {ReturnType<typeof readStoryIndex>} options.stories
+ * @param {string[]} options.components
+ * @param {string[]} options.stableStoryIds
+ * @param {string} options.defaultTheme
+ * @param {string} options.probeTheme
+ * @returns {Shot[]}
+ */
+export function buildPrVisualPlan({
+  stories,
+  components = [],
+  stableStoryIds = [],
+  defaultTheme,
+  probeTheme,
+}) {
+  const shots = new Map();
+  const storyIds = new Set(stableStoryIds);
+  const wantedComponents = [...new Set(components)].sort();
+  const byComponent = new Map();
+  for (const story of stories) {
+    if (!byComponent.has(story.component)) byComponent.set(story.component, []);
+    byComponent.get(story.component).push(story);
+  }
+
+  /** @param {ReturnType<typeof readStoryIndex>[number]} story @param {string[]} themes @param {string} reason */
+  const add = (story, themes, reason) => {
+    for (const theme of themes) {
+      for (const mode of MODES) {
+        const shot = {
+          ...toShotBase(story),
+          theme,
+          mode,
+          ...(theme === probeTheme ? {baselinePolicy: 'current-only'} : {}),
+        };
+        const key = shotKey(shot);
+        const existing = shots.get(key);
+        if (existing) {
+          if (!existing.reasons.includes(reason)) existing.reasons.push(reason);
+        } else {
+          shots.set(key, {...shot, key, reasons: [reason]});
+        }
+      }
+    }
+  };
+
+  const missing = [];
+  for (const component of wantedComponents) {
+    const themeSheet = (byComponent.get(component) ?? []).find(
+      story => story.name === THEME_SHEET_NAME,
+    );
+    if (!themeSheet) {
+      missing.push(component);
+      continue;
+    }
+    add(themeSheet, [defaultTheme, probeTheme], 'trusted:theme-sheet');
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing Theme Sheet for stable visual component${missing.length === 1 ? '' : 's'} ${missing.join(', ')}. Add a Storybook story named "Theme Sheet" under Core/<Component>; it is the required compact PR visual contract.`,
+    );
+  }
+
+  for (const story of stories) {
+    if (!storyIds.has(story.id)) continue;
+    if (!(story.tags ?? []).includes(STABLE_VISUAL_TAG)) continue;
+    add(story, [defaultTheme], 'trusted:stable-visual');
+  }
+
+  return [...shots.values()].sort((a, b) => a.key.localeCompare(b.key));
 }
 
 /**
@@ -288,11 +457,13 @@ export function createReleasePlan(shots) {
  * @property {string} packageName
  * @property {string[]} packageNames
  * @property {boolean} stableVisual
+ * @property {string | null} [sourcePath]
  * @property {string} theme
  * @property {string} themePackageName
  * @property {boolean} stableThemeVisual
  * @property {'light'|'dark'} mode
  * @property {string[]} reasons - why the shot is in the plan
+ * @property {'current-only'} [baselinePolicy] - current evidence that must not become a stable baseline
  */
 
 /**
@@ -331,9 +502,19 @@ export function readStoryIndex(storybookDir, excluded = [], repoRoot) {
       title: entry.title ?? '',
       name: entry.name ?? '',
       component: componentOf(entry),
+      importPath: entry.importPath ?? null,
+      sourcePath: sourcePathFor(entry, storybookDir, repoRoot),
       tags: entry.tags ?? [],
       ...storyPackageNames(entry, storybookDir, repoRoot, catalog),
     }));
+}
+
+function sourcePathFor(entry, storybookDir, repoRoot) {
+  if (!entry.importPath) return null;
+  const raw = entry.importPath.replace(/^\.\//, '');
+  const absolute = path.resolve(path.dirname(storybookDir), raw);
+  const relative = path.relative(repoRoot, absolute).replaceAll(path.sep, '/');
+  return relative.startsWith('..') ? raw.replaceAll('\\', '/') : relative;
 }
 
 /**
@@ -361,8 +542,15 @@ function componentOf(entry) {
  */
 export function storiesInPackages(stories, packages) {
   if (packages.includes('*')) return stories;
-  const wanted = new Set(packages.map(name => name.startsWith('@') ? name : `@astryxdesign/${name.toLowerCase()}`));
-  return stories.filter(story => story.stableVisual && story.packageNames.some(name => wanted.has(name)));
+  const wanted = new Set(
+    packages.map(name =>
+      name.startsWith('@') ? name : `@astryxdesign/${name.toLowerCase()}`,
+    ),
+  );
+  return stories.filter(
+    story =>
+      story.stableVisual && story.packageNames.some(name => wanted.has(name)),
+  );
 }
 
 /**
@@ -377,7 +565,8 @@ export function representativeStories(stories) {
   for (const story of stories) {
     if (!story.component) continue;
     const current = byComponent.get(story.component);
-    if (!current || rank(story.name) < rank(current.name)) byComponent.set(story.component, story);
+    if (!current || rank(story.name) < rank(current.name))
+      byComponent.set(story.component, story);
   }
   return byComponent;
 }
@@ -433,7 +622,9 @@ export function buildPlan({
   };
 
   if (tiers.includes('surface') || tiers.includes('full')) {
-    const subject = tiers.includes('full') ? stories : [...representatives.values()];
+    const subject = tiers.includes('full')
+      ? stories
+      : [...representatives.values()];
     for (const story of subject) {
       for (const mode of MODES) {
         add({...toShotBase(story), theme: defaultTheme, mode}, 'surface');
@@ -442,35 +633,22 @@ export function buildPlan({
   }
 
   if (tiers.includes('component')) {
-    // The PR tier: every story of the named components, in the default theme
-    // and in every theme that styles them. Deeper than `surface` (which shoots
-    // one story per component), and narrow enough to run per PR.
-    const themesByComponent = new Map();
-    for (const target of targets) {
-      for (const [theme, keys] of Object.entries(themeOverrides)) {
-        if (!Object.hasOwn(keys, target.key)) continue;
-        if (!themesByComponent.has(target.component)) {
-          themesByComponent.set(target.component, new Set());
-        }
-        themesByComponent.get(target.component).add(theme);
-      }
-    }
-    for (const story of stories) {
-      if (!components.includes(story.component)) continue;
-      for (const mode of MODES) {
-        add({...toShotBase(story), theme: defaultTheme, mode}, 'component');
-        for (const theme of themesByComponent.get(story.component) ?? []) {
-          if (theme === defaultTheme) continue;
-          add({...toShotBase(story), theme, mode}, `theme:${theme}`);
-        }
-      }
+    for (const shot of buildPrVisualPlan({
+      stories,
+      components,
+      defaultTheme,
+      probeTheme,
+    })) {
+      for (const reason of shot.reasons) add(shot, reason);
     }
   }
 
   if (tiers.includes('theme-matrix')) {
     const matrixOverrides = matrixThemes.length
       ? Object.fromEntries(
-          Object.entries(themeOverrides).filter(([theme]) => matrixThemes.includes(theme)),
+          Object.entries(themeOverrides).filter(([theme]) =>
+            matrixThemes.includes(theme),
+          ),
         )
       : themeOverrides;
     for (const shot of themeMatrix({
@@ -522,7 +700,9 @@ function probeShots({stories, targets, observations, probeTheme}) {
   const wanted = new Set(targets.map(target => target.key));
   const byStory = new Map();
   for (const story of stories) {
-    const rendered = Object.keys(observations[story.id] ?? {}).filter(key => wanted.has(key));
+    const rendered = Object.keys(observations[story.id] ?? {}).filter(key =>
+      wanted.has(key),
+    );
     if (rendered.length > 0) byStory.set(story, new Set(rendered));
   }
 
@@ -542,7 +722,10 @@ function probeShots({stories, targets, observations, probeTheme}) {
     if (!best) break;
     for (const key of byStory.get(best)) uncovered.delete(key);
     for (const mode of MODES) {
-      planned.push({shot: {...toShotBase(best), theme: probeTheme, mode}, reason: 'probe'});
+      planned.push({
+        shot: {...toShotBase(best), theme: probeTheme, mode},
+        reason: 'probe',
+      });
     }
     byStory.delete(best);
   }
@@ -572,13 +755,15 @@ function probeShots({stories, targets, observations, probeTheme}) {
 function themeMatrix({stories, targets, themeOverrides, observations}) {
   const componentsByKey = new Map();
   for (const target of targets) {
-    if (!componentsByKey.has(target.key)) componentsByKey.set(target.key, new Set());
+    if (!componentsByKey.has(target.key))
+      componentsByKey.set(target.key, new Set());
     componentsByKey.get(target.key).add(target.component);
   }
   const representatives = representativeStories(stories);
   const storiesByComponent = new Map();
   for (const story of stories) {
-    if (!storiesByComponent.has(story.component)) storiesByComponent.set(story.component, []);
+    if (!storiesByComponent.has(story.component))
+      storiesByComponent.set(story.component, []);
     storiesByComponent.get(story.component).push(story);
   }
 
@@ -624,7 +809,9 @@ function chooseStories({candidates, fallback, key, selectors, observations}) {
   // `base` and pseudo-class overrides need no particular state — any story
   // rendering the target proves they had something to bind to.
   const wanted = new Set(
-    selectors.filter(selector => selector !== 'base' && !selector.startsWith(':')),
+    selectors.filter(
+      selector => selector !== 'base' && !selector.startsWith(':'),
+    ),
   );
   const chosen = [];
   const covers = story => new Set(observations[story.id]?.[key] ?? []);
@@ -633,7 +820,9 @@ function chooseStories({candidates, fallback, key, selectors, observations}) {
     let best = null;
     let bestCount = 0;
     for (const story of rendering) {
-      const count = [...covers(story)].filter(selector => wanted.has(selector)).length;
+      const count = [...covers(story)].filter(selector =>
+        wanted.has(selector),
+      ).length;
       if (count > bestCount) {
         best = story;
         bestCount = count;
@@ -660,6 +849,7 @@ function toShotBase(story) {
     packageName: story.packageName,
     packageNames: story.packageNames,
     stableVisual: story.stableVisual,
+    sourcePath: story.sourcePath ?? null,
   };
 }
 

--- a/.github/scripts/visual-gate/lib/plan.test.mjs
+++ b/.github/scripts/visual-gate/lib/plan.test.mjs
@@ -9,6 +9,7 @@ import {describe, expect, it} from 'vitest';
 import {
   accountBaseline,
   buildPlan,
+  buildPrVisualPlan,
   createReleasePlan,
   readStoryIndex,
   readThemeCatalog,
@@ -19,7 +20,11 @@ import {
   uncoveredTargets,
 } from './plan.mjs';
 
-const story = (value, packageName = '@astryxdesign/core', stableVisual = true) => ({
+const story = (
+  value,
+  packageName = '@astryxdesign/core',
+  stableVisual = true,
+) => ({
   tags: [],
   packageName,
   packageNames: [packageName],
@@ -27,15 +32,54 @@ const story = (value, packageName = '@astryxdesign/core', stableVisual = true) =
   ...value,
 });
 const stories = [
-  story({id: 'core-button--primary', title: 'Core/Button', name: 'Primary', component: 'Button'}),
-  story({id: 'core-button--default', title: 'Core/Button', name: 'Default', component: 'Button'}),
-  story({id: 'core-badge--solid', title: 'Core/Badge', name: 'Solid', component: 'Badge'}),
+  story({
+    id: 'core-button--primary',
+    title: 'Core/Button',
+    name: 'Primary',
+    component: 'Button',
+  }),
+  story({
+    id: 'core-button--default',
+    title: 'Core/Button',
+    name: 'Default',
+    component: 'Button',
+  }),
+  story({
+    id: 'core-button--theme-sheet',
+    title: 'Core/Button',
+    name: 'Theme Sheet',
+    component: 'Button',
+  }),
+  story({
+    id: 'core-badge--solid',
+    title: 'Core/Badge',
+    name: 'Solid',
+    component: 'Badge',
+  }),
 ];
 
 const targets = [
-  {key: 'button', className: 'astryx-button', component: 'Button', props: ['variant:primary'], states: []},
-  {key: 'badge', className: 'astryx-badge', component: 'Badge', props: [], states: []},
-  {key: 'tooltip', className: 'astryx-tooltip', component: 'Tooltip', props: [], states: []},
+  {
+    key: 'button',
+    className: 'astryx-button',
+    component: 'Button',
+    props: ['variant:primary'],
+    states: [],
+  },
+  {
+    key: 'badge',
+    className: 'astryx-badge',
+    component: 'Badge',
+    props: [],
+    states: [],
+  },
+  {
+    key: 'tooltip',
+    className: 'astryx-tooltip',
+    component: 'Tooltip',
+    props: [],
+    states: [],
+  },
 ];
 
 const themeOverrides = {
@@ -46,8 +90,26 @@ const themeOverrides = {
 describe('storiesInPackages', () => {
   const mixed = [
     ...stories,
-    story({id: 'lab-drawer--default', title: 'Lab/Drawer', name: 'Default', component: 'Drawer'}, '@astryxdesign/lab', false),
-    story({id: 'charts-bar--default', title: 'Charts/Bar', name: 'Default', component: 'Bar'}, '@astryxdesign/charts', false),
+    story(
+      {
+        id: 'lab-drawer--default',
+        title: 'Lab/Drawer',
+        name: 'Default',
+        component: 'Drawer',
+      },
+      '@astryxdesign/lab',
+      false,
+    ),
+    story(
+      {
+        id: 'charts-bar--default',
+        title: 'Charts/Bar',
+        name: 'Default',
+        component: 'Bar',
+      },
+      '@astryxdesign/charts',
+      false,
+    ),
   ];
 
   it('keeps only the stable Storybook package groups', () => {
@@ -63,17 +125,27 @@ describe('storiesInPackages', () => {
 
 describe('representativeStories', () => {
   it('prefers a conventionally named story over source order', () => {
-    expect(representativeStories(stories).get('Button').id).toBe('core-button--default');
+    expect(representativeStories(stories).get('Button').id).toBe(
+      'core-button--default',
+    );
   });
 
   it('falls back to the first story when no name is conventional', () => {
-    expect(representativeStories(stories).get('Badge').id).toBe('core-badge--solid');
+    expect(representativeStories(stories).get('Badge').id).toBe(
+      'core-badge--solid',
+    );
   });
 });
 
 describe('buildPlan', () => {
   it('photographs one story per component in the default theme for the surface tier', () => {
-    const plan = buildPlan({stories, targets, themeOverrides, defaultTheme: 'neutral', tiers: ['surface']});
+    const plan = buildPlan({
+      stories,
+      targets,
+      themeOverrides,
+      defaultTheme: 'neutral',
+      tiers: ['surface'],
+    });
     expect(plan.map(shot => shot.key).sort()).toEqual([
       'core-badge--solid__neutral-dark',
       'core-badge--solid__neutral-light',
@@ -83,7 +155,13 @@ describe('buildPlan', () => {
   });
 
   it('adds a shot for every theme that overrides a component the story renders', () => {
-    const plan = buildPlan({stories, targets, themeOverrides, defaultTheme: 'neutral', tiers: ['theme-matrix']});
+    const plan = buildPlan({
+      stories,
+      targets,
+      themeOverrides,
+      defaultTheme: 'neutral',
+      tiers: ['theme-matrix'],
+    });
     const y2k = plan.filter(shot => shot.theme === 'y2k').map(shot => shot.key);
     expect(y2k).toContain('core-button--default__y2k-light');
     expect(y2k).toContain('core-badge--solid__y2k-dark');
@@ -99,32 +177,54 @@ describe('buildPlan', () => {
       matrixThemes: ['y2k'],
     });
     expect(new Set(plan.map(shot => shot.theme))).toEqual(new Set(['y2k']));
-    expect(plan.map(shot => shot.key)).toContain('core-badge--solid__y2k-light');
+    expect(plan.map(shot => shot.key)).toContain(
+      'core-badge--solid__y2k-light',
+    );
   });
 
-  it('keeps every shipped theme for touched Core components even when the matrix is scoped', () => {
+  it('keeps the PR component tier compact: Theme Sheet in Neutral and Probe only', () => {
     const plan = buildPlan({
       stories,
       targets,
       themeOverrides,
       defaultTheme: 'neutral',
-      tiers: ['component', 'theme-matrix'],
+      tiers: ['component'],
       components: ['Button'],
-      matrixThemes: ['y2k'],
+      probeTheme: 'probe',
     });
-    expect(plan.some(shot => shot.theme === 'neutral' && shot.component === 'Button')).toBe(true);
-    expect(plan.some(shot => shot.theme === 'y2k' && shot.component === 'Button')).toBe(true);
+    expect(plan.map(shot => shot.key)).toEqual([
+      'core-button--theme-sheet__neutral-dark',
+      'core-button--theme-sheet__neutral-light',
+      'core-button--theme-sheet__probe-dark',
+      'core-button--theme-sheet__probe-light',
+    ]);
   });
 
   it('records why a shot is in the plan, merging the reasons of a shot both tiers want', () => {
-    const plan = buildPlan({stories, targets, themeOverrides, defaultTheme: 'neutral', tiers: ['surface', 'theme-matrix']});
-    const shot = plan.find(candidate => candidate.key === 'core-button--default__neutral-light');
+    const plan = buildPlan({
+      stories,
+      targets,
+      themeOverrides,
+      defaultTheme: 'neutral',
+      tiers: ['surface', 'theme-matrix'],
+    });
+    const shot = plan.find(
+      candidate => candidate.key === 'core-button--default__neutral-light',
+    );
     expect(shot.reasons).toEqual(['surface', 'theme:neutral:button']);
   });
 
   it('captures every story, not just the representative, in the full tier', () => {
-    const plan = buildPlan({stories, targets, themeOverrides, defaultTheme: 'neutral', tiers: ['full']});
-    expect(plan.filter(shot => shot.component === 'Button' && shot.mode === 'light')).toHaveLength(2);
+    const plan = buildPlan({
+      stories,
+      targets,
+      themeOverrides,
+      defaultTheme: 'neutral',
+      tiers: ['full'],
+    });
+    expect(
+      plan.filter(shot => shot.component === 'Button' && shot.mode === 'light'),
+    ).toHaveLength(3);
   });
 
   it('skips a target whose component has no story rather than planning an unshootable shot', () => {
@@ -139,14 +239,80 @@ describe('buildPlan', () => {
   });
 
   it('is deterministic — same input, same order', () => {
-    const args = {stories, targets, themeOverrides, defaultTheme: 'neutral', tiers: ['surface', 'theme-matrix']};
+    const args = {
+      stories,
+      targets,
+      themeOverrides,
+      defaultTheme: 'neutral',
+      tiers: ['surface', 'theme-matrix'],
+    };
     expect(buildPlan(args)).toEqual(buildPlan(args));
+  });
+});
+
+describe('buildPrVisualPlan', () => {
+  const themeSheet = story({
+    id: 'core-button--theme-sheet',
+    title: 'Core/Button',
+    name: 'Theme Sheet',
+    component: 'Button',
+  });
+  const stableStory = story({
+    id: 'core-button--visual-regression',
+    title: 'Core/Button',
+    name: 'Visual Regression',
+    component: 'Button',
+    tags: ['stable-visual'],
+  });
+
+  it('uses only the component Theme Sheet in Neutral and Probe for changed components', () => {
+    const plan = buildPrVisualPlan({
+      stories: [...stories, themeSheet],
+      components: ['Button'],
+      defaultTheme: 'neutral',
+      probeTheme: 'probe',
+    });
+    expect(plan.map(shot => shot.key)).toEqual([
+      'core-button--theme-sheet__neutral-dark',
+      'core-button--theme-sheet__neutral-light',
+      'core-button--theme-sheet__probe-dark',
+      'core-button--theme-sheet__probe-light',
+    ]);
+    expect(new Set(plan.map(shot => shot.storyId))).toEqual(
+      new Set(['core-button--theme-sheet']),
+    );
+  });
+
+  it('adds stable-visual opt-in stories in Neutral only', () => {
+    const plan = buildPrVisualPlan({
+      stories: [...stories, themeSheet, stableStory],
+      stableStoryIds: ['core-button--visual-regression'],
+      defaultTheme: 'neutral',
+      probeTheme: 'probe',
+    });
+    expect(plan.map(shot => shot.key)).toEqual([
+      'core-button--visual-regression__neutral-dark',
+      'core-button--visual-regression__neutral-light',
+    ]);
+  });
+
+  it('fails with one actionable message when a changed component has no Theme Sheet', () => {
+    expect(() =>
+      buildPrVisualPlan({
+        stories,
+        components: ['Tooltip'],
+        defaultTheme: 'neutral',
+        probeTheme: 'probe',
+      }),
+    ).toThrow(/Missing Theme Sheet for stable visual component Tooltip/);
   });
 });
 
 describe('shotKey', () => {
   it('stays filesystem-safe', () => {
-    expect(shotKey({storyId: 'core-a/b--c d', theme: 'y2k', mode: 'light'})).toBe('core-a_b--c_d__y2k-light');
+    expect(
+      shotKey({storyId: 'core-a/b--c d', theme: 'y2k', mode: 'light'}),
+    ).toBe('core-a_b--c_d__y2k-light');
   });
 });
 
@@ -155,31 +321,111 @@ describe('readStoryIndex package metadata', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'visual-index-'));
     for (const [dir, manifest] of [
       ['packages/core', {name: '@astryxdesign/core'}],
-      ['packages/charts', {name: '@astryxdesign/charts', private: true, astryx: {canaryOnly: true}}],
-      ['packages/lab', {name: '@astryxdesign/lab', private: true, astryx: {canaryOnly: true}}],
-      ['packages/themes/neutral', {name: '@astryxdesign/theme-neutral', private: false}],
-      ['packages/themes/probe', {name: '@astryxdesign/theme-probe', private: true}],
+      [
+        'packages/charts',
+        {
+          name: '@astryxdesign/charts',
+          private: true,
+          astryx: {canaryOnly: true},
+        },
+      ],
+      [
+        'packages/lab',
+        {name: '@astryxdesign/lab', private: true, astryx: {canaryOnly: true}},
+      ],
+      [
+        'packages/themes/neutral',
+        {name: '@astryxdesign/theme-neutral', private: false},
+      ],
+      [
+        'packages/themes/probe',
+        {name: '@astryxdesign/theme-probe', private: true},
+      ],
     ]) {
       fs.mkdirSync(path.join(root, dir), {recursive: true});
-      fs.writeFileSync(path.join(root, dir, 'package.json'), JSON.stringify(manifest));
+      fs.writeFileSync(
+        path.join(root, dir, 'package.json'),
+        JSON.stringify(manifest),
+      );
     }
     const storybook = path.join(root, 'apps/storybook');
     const dist = path.join(storybook, 'dist');
     fs.mkdirSync(path.join(storybook, 'stories'), {recursive: true});
     fs.mkdirSync(dist);
-    fs.writeFileSync(path.join(storybook, 'stories/Composite.stories.tsx'), "import {Table} from '@astryxdesign/core/Table';");
-    fs.writeFileSync(path.join(storybook, 'stories/Lab.stories.tsx'), "import {Thing} from '@astryxdesign/lab'; import {Button} from '@astryxdesign/core/Button';");
-    fs.writeFileSync(path.join(storybook, 'stories/CoreMixed.stories.tsx'), "import {Thing} from '@astryxdesign/lab'; import {Layer} from '@astryxdesign/core/Layer';");
-    fs.writeFileSync(path.join(storybook, 'stories/Probe.stories.tsx'), "import {Button} from '@astryxdesign/core/Button';");
-    fs.writeFileSync(path.join(dist, 'index.json'), JSON.stringify({entries: {
-      core: {type: 'story', id: 'core-button--default', title: 'Core/Button', name: 'Default', componentPath: '../../packages/core/src/Button/index.ts', importPath: './stories/Button.stories.tsx'},
-      composite: {type: 'story', id: 'core-composite--default', title: 'Core/Composite', name: 'Default', importPath: './stories/Composite.stories.tsx'},
-      charts: {type: 'story', id: 'charts-bar--default', title: 'Charts/Bar', name: 'Default', componentPath: '@astryxdesign/charts/Bar', importPath: './stories/Bar.stories.tsx'},
-      lab: {type: 'story', id: 'lab-thing--default', title: 'Lab/Thing', name: 'Default', importPath: './stories/Lab.stories.tsx'},
-      mixed: {type: 'story', id: 'core-layer--default', title: 'Core/Layer', name: 'Default', importPath: './stories/CoreMixed.stories.tsx'},
-      probe: {type: 'story', id: 'core-probe--default', title: 'Core/Themes/Probe Theme', name: 'Default', importPath: './stories/Probe.stories.tsx'},
-      skipped: {type: 'story', id: 'core-skip--default', title: 'Core/Skip', name: 'Default', tags: ['no-visual']},
-    }}));
+    fs.writeFileSync(
+      path.join(storybook, 'stories/Composite.stories.tsx'),
+      "import {Table} from '@astryxdesign/core/Table';",
+    );
+    fs.writeFileSync(
+      path.join(storybook, 'stories/Lab.stories.tsx'),
+      "import {Thing} from '@astryxdesign/lab'; import {Button} from '@astryxdesign/core/Button';",
+    );
+    fs.writeFileSync(
+      path.join(storybook, 'stories/CoreMixed.stories.tsx'),
+      "import {Thing} from '@astryxdesign/lab'; import {Layer} from '@astryxdesign/core/Layer';",
+    );
+    fs.writeFileSync(
+      path.join(storybook, 'stories/Probe.stories.tsx'),
+      "import {Button} from '@astryxdesign/core/Button';",
+    );
+    fs.writeFileSync(
+      path.join(dist, 'index.json'),
+      JSON.stringify({
+        entries: {
+          core: {
+            type: 'story',
+            id: 'core-button--default',
+            title: 'Core/Button',
+            name: 'Default',
+            componentPath: '../../packages/core/src/Button/index.ts',
+            importPath: './stories/Button.stories.tsx',
+          },
+          composite: {
+            type: 'story',
+            id: 'core-composite--default',
+            title: 'Core/Composite',
+            name: 'Default',
+            importPath: './stories/Composite.stories.tsx',
+          },
+          charts: {
+            type: 'story',
+            id: 'charts-bar--default',
+            title: 'Charts/Bar',
+            name: 'Default',
+            componentPath: '@astryxdesign/charts/Bar',
+            importPath: './stories/Bar.stories.tsx',
+          },
+          lab: {
+            type: 'story',
+            id: 'lab-thing--default',
+            title: 'Lab/Thing',
+            name: 'Default',
+            importPath: './stories/Lab.stories.tsx',
+          },
+          mixed: {
+            type: 'story',
+            id: 'core-layer--default',
+            title: 'Core/Layer',
+            name: 'Default',
+            importPath: './stories/CoreMixed.stories.tsx',
+          },
+          probe: {
+            type: 'story',
+            id: 'core-probe--default',
+            title: 'Core/Themes/Probe Theme',
+            name: 'Default',
+            importPath: './stories/Probe.stories.tsx',
+          },
+          skipped: {
+            type: 'story',
+            id: 'core-skip--default',
+            title: 'Core/Skip',
+            name: 'Default',
+            tags: ['no-visual'],
+          },
+        },
+      }),
+    );
     return {root, dist};
   }
 
@@ -187,13 +433,36 @@ describe('readStoryIndex package metadata', () => {
     const {root, dist} = fixture();
     try {
       const indexed = readStoryIndex(dist, [], root);
-      expect(indexed.find(value => value.id === 'core-button--default')).toMatchObject({packageName: '@astryxdesign/core', stableVisual: true});
-      expect(indexed.find(value => value.id === 'core-composite--default')).toMatchObject({packageNames: ['@astryxdesign/core'], stableVisual: true});
-      expect(indexed.find(value => value.id === 'charts-bar--default')).toMatchObject({packageName: '@astryxdesign/charts', stableVisual: false});
-      expect(indexed.find(value => value.id === 'lab-thing--default')).toMatchObject({packageName: '@astryxdesign/lab', stableVisual: false});
-      expect(indexed.find(value => value.id === 'core-layer--default')).toMatchObject({packageName: '@astryxdesign/core', stableVisual: true});
-      expect(indexed.find(value => value.id === 'core-probe--default')).toMatchObject({packageName: '@astryxdesign/theme-probe', stableVisual: false});
-      expect(indexed.some(value => value.id === 'core-skip--default')).toBe(false);
+      expect(
+        indexed.find(value => value.id === 'core-button--default'),
+      ).toMatchObject({packageName: '@astryxdesign/core', stableVisual: true});
+      expect(
+        indexed.find(value => value.id === 'core-composite--default'),
+      ).toMatchObject({
+        packageNames: ['@astryxdesign/core'],
+        stableVisual: true,
+      });
+      expect(
+        indexed.find(value => value.id === 'charts-bar--default'),
+      ).toMatchObject({
+        packageName: '@astryxdesign/charts',
+        stableVisual: false,
+      });
+      expect(
+        indexed.find(value => value.id === 'lab-thing--default'),
+      ).toMatchObject({packageName: '@astryxdesign/lab', stableVisual: false});
+      expect(
+        indexed.find(value => value.id === 'core-layer--default'),
+      ).toMatchObject({packageName: '@astryxdesign/core', stableVisual: true});
+      expect(
+        indexed.find(value => value.id === 'core-probe--default'),
+      ).toMatchObject({
+        packageName: '@astryxdesign/theme-probe',
+        stableVisual: false,
+      });
+      expect(indexed.some(value => value.id === 'core-skip--default')).toBe(
+        false,
+      );
     } finally {
       fs.rmSync(root, {recursive: true, force: true});
     }
@@ -202,11 +471,24 @@ describe('readStoryIndex package metadata', () => {
   it('accounts for a live-shaped 974-key baseline without dropping legacy keys', () => {
     const {root} = fixture();
     for (const [dir, manifest] of [
-      ['packages/vega', {name: '@astryxdesign/vega', private: true, astryx: {canaryOnly: true}}],
-      ['packages/richtext', {name: '@astryxdesign/richtext', private: true, astryx: {canaryOnly: true}}],
+      [
+        'packages/vega',
+        {name: '@astryxdesign/vega', private: true, astryx: {canaryOnly: true}},
+      ],
+      [
+        'packages/richtext',
+        {
+          name: '@astryxdesign/richtext',
+          private: true,
+          astryx: {canaryOnly: true},
+        },
+      ],
     ]) {
       fs.mkdirSync(path.join(root, dir), {recursive: true});
-      fs.writeFileSync(path.join(root, dir, 'package.json'), JSON.stringify(manifest));
+      fs.writeFileSync(
+        path.join(root, dir, 'package.json'),
+        JSON.stringify(manifest),
+      );
     }
     const baselineShots = {};
     const current = [];
@@ -336,15 +618,35 @@ describe('readStoryIndex package metadata', () => {
   });
 
   it('canonicalizes release keys and rejects duplicates', () => {
-    const shot = {...stories[0], storyId: stories[0].id, key: 'b', theme: 'neutral', mode: 'light', reasons: []};
-    expect(createReleasePlan([{...shot, key: 'b'}, {...shot, key: 'a'}]).keys).toEqual(['a', 'b']);
+    const shot = {
+      ...stories[0],
+      storyId: stories[0].id,
+      key: 'b',
+      theme: 'neutral',
+      mode: 'light',
+      reasons: [],
+    };
+    expect(
+      createReleasePlan([
+        {...shot, key: 'b'},
+        {...shot, key: 'a'},
+      ]).keys,
+    ).toEqual(['a', 'b']);
     expect(() => createReleasePlan([shot, shot])).toThrow(/repeats/);
   });
 });
 
 describe('uncoveredTargets', () => {
   it('names targets no shot can reach', () => {
-    const plan = buildPlan({stories, targets, themeOverrides, defaultTheme: 'neutral', tiers: ['surface']});
-    expect(uncoveredTargets(targets, plan)).toEqual([{key: 'tooltip', component: 'Tooltip'}]);
+    const plan = buildPlan({
+      stories,
+      targets,
+      themeOverrides,
+      defaultTheme: 'neutral',
+      tiers: ['surface'],
+    });
+    expect(uncoveredTargets(targets, plan)).toEqual([
+      {key: 'tooltip', component: 'Tooltip'},
+    ]);
   });
 });

--- a/.github/scripts/visual-gate/publish-pr-report.mjs
+++ b/.github/scripts/visual-gate/publish-pr-report.mjs
@@ -140,13 +140,34 @@ if (
   fail('trusted capture identity mismatch');
 }
 
+const expectedRemoved =
+  manifest.context?.expectedRemoved ?? manifest.context?.expectedRemovals ?? [];
+if (!Array.isArray(expectedRemoved) || expectedRemoved.length > MAX_SHOTS) {
+  fail('trusted expected removal list is invalid');
+}
+for (const removal of expectedRemoved) {
+  if (
+    !KEY.test(removal?.key ?? '') ||
+    typeof removal.storyId !== 'string' ||
+    !removal.storyId ||
+    typeof removal.theme !== 'string' ||
+    !NAME.test(removal.theme) ||
+    !['light', 'dark'].includes(removal.mode)
+  ) {
+    fail(`expected removal metadata is invalid for ${JSON.stringify(removal)}`);
+  }
+}
+
 const rawBaselineManifest = readJSON(path.join(baseline, 'manifest.json'));
 const capturedKeys = new Set(Object.keys(manifest.shots));
+const expectedRemovalKeys = new Set(
+  expectedRemoved.map(removal => removal.key),
+);
 const baselineManifest = {
   ...rawBaselineManifest,
   shots: Object.fromEntries(
-    Object.entries(rawBaselineManifest.shots ?? {}).filter(([key]) =>
-      capturedKeys.has(key),
+    Object.entries(rawBaselineManifest.shots ?? {}).filter(
+      ([key]) => capturedKeys.has(key) || expectedRemovalKeys.has(key),
     ),
   ),
 };
@@ -156,6 +177,14 @@ if (blocker) fail(`baseline is not comparable: ${blocker}`);
 const entries = Object.entries(manifest.shots);
 if (entries.length > MAX_SHOTS)
   fail(`trusted capture exceeds ${MAX_SHOTS} shots`);
+function isAllowedPrTheme(shot, metadata) {
+  return (
+    metadata?.stableVisual === true ||
+    (shot?.theme === config.probeTheme &&
+      metadata?.packageName === shot.themePackageName)
+  );
+}
+
 for (const [key, shot] of entries) {
   const themeMetadata = themeCatalog[shot?.theme];
   if (
@@ -168,9 +197,9 @@ for (const [key, shot] of entries) {
     !PACKAGE_NAME.test(shot.packageName ?? '') ||
     shot.stableVisual !== true ||
     !PACKAGE_NAME.test(shot.themePackageName ?? '') ||
-    shot.stableThemeVisual !== true ||
+    typeof shot.stableThemeVisual !== 'boolean' ||
     themeMetadata?.packageName !== shot.themePackageName ||
-    themeMetadata?.stableVisual !== true ||
+    !isAllowedPrTheme(shot, themeMetadata) ||
     !['light', 'dark'].includes(shot.mode) ||
     !Array.isArray(shot.reasons) ||
     shotKey(shot) !== key
@@ -220,7 +249,7 @@ for (const [key, shot] of entries) {
   };
 }
 
-if (entries.length === 0) {
+if (entries.length === 0 && expectedRemoved.length === 0) {
   fail('stable visual scope produced no trusted shots');
 }
 
@@ -233,6 +262,7 @@ const comparison = await compareCaptures({
   threshold: config.threshold,
   maxDiffPixels: config.maxDiffPixels,
 });
+comparison.removed = expectedRemoved.map(removal => removal.key);
 
 const verdict = buildVerdict({
   comparison,
@@ -246,6 +276,7 @@ const verdict = buildVerdict({
   failures: [],
   context: {...manifest.context, trustedScope: scope},
 });
+verdict.counts.total += expectedRemoved.length;
 
 const beforeSha256 = {};
 for (const change of verdict.changes) {

--- a/.github/scripts/visual-gate/publish-pr-report.test.mjs
+++ b/.github/scripts/visual-gate/publish-pr-report.test.mjs
@@ -323,13 +323,115 @@ describe('trusted PR visual publisher', () => {
     const other = 'core-card--default__neutral-light';
     writeBaseline({
       [KEY]: {shot: SHOT, bytes: png()},
-      [other]: {shot: {...SHOT, storyId: 'core-card--default', component: 'Card'}, bytes: png()},
+      [other]: {
+        shot: {...SHOT, storyId: 'core-card--default', component: 'Card'},
+        bytes: png(),
+      },
     });
     run();
     const verdict = JSON.parse(
       fs.readFileSync(path.join(output, 'verdict.json'), 'utf8'),
     );
     expect(verdict.removed).toEqual([]);
+  });
+
+  it('allows the private Probe theme only as PR visual evidence', () => {
+    const key = 'core-button--theme-sheet__probe-light';
+    const shot = {
+      ...SHOT,
+      key,
+      storyId: 'core-button--theme-sheet',
+      name: 'Theme Sheet',
+      theme: 'probe',
+      themePackageName: '@astryxdesign/theme-probe',
+      stableThemeVisual: false,
+    };
+    writeBaseline({[key]: {shot, bytes: png()}});
+    writeCapture({[key]: {shot, bytes: png()}});
+    run();
+    expect(
+      JSON.parse(fs.readFileSync(path.join(output, 'verdict.json'), 'utf8')),
+    ).toMatchObject({status: 'pass', counts: {total: 1}});
+  });
+
+  it('derives before-only removal evidence from trusted expected removals', () => {
+    const removed = 'core-button--deleted-story__neutral-light';
+    const shot = {
+      ...SHOT,
+      key: removed,
+      storyId: 'core-button--deleted-story',
+      name: 'Deleted Story',
+      sourcePath: 'stories/Button.stories.tsx',
+    };
+    writeBaseline({[removed]: {shot, bytes: png()}});
+    writeCapture(
+      {},
+      {
+        context: {
+          sha: 'b'.repeat(40),
+          headSha: HEAD,
+          baseSha: 'c'.repeat(40),
+          runId: RUN,
+          runAttempt: '1',
+          expectedRemovals: [shot],
+        },
+      },
+    );
+    run();
+    const evidence = JSON.parse(
+      fs.readFileSync(path.join(output, 'evidence.json'), 'utf8'),
+    );
+    expect(evidence).toMatchObject({
+      verdict: {status: 'changed', removed: [removed], counts: {total: 1}},
+      deltas: [{key: removed, kind: 'removed', shot: null}],
+    });
+    expect(fs.existsSync(path.join(output, 'before', `${removed}.png`))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(output, 'after', `${removed}.png`))).toBe(
+      false,
+    );
+  });
+
+  it('mixes current shots with expected removals without reporting unrelated baseline keys', () => {
+    const removed = 'core-button--deleted-story__neutral-light';
+    const unrelated = 'core-button--unrelated-story__neutral-light';
+    writeBaseline({
+      [KEY]: {shot: SHOT, bytes: png()},
+      [removed]: {
+        shot: {...SHOT, key: removed, storyId: 'core-button--deleted-story'},
+        bytes: png(),
+      },
+      [unrelated]: {
+        shot: {
+          ...SHOT,
+          key: unrelated,
+          storyId: 'core-button--unrelated-story',
+        },
+        bytes: png(),
+      },
+    });
+    writeCapture(
+      {[KEY]: {shot: SHOT, bytes: png()}},
+      {
+        context: {
+          sha: 'b'.repeat(40),
+          headSha: HEAD,
+          baseSha: 'c'.repeat(40),
+          runId: RUN,
+          runAttempt: '1',
+          expectedRemovals: [
+            {...SHOT, key: removed, storyId: 'core-button--deleted-story'},
+          ],
+        },
+      },
+    );
+    run();
+    const verdict = JSON.parse(
+      fs.readFileSync(path.join(output, 'verdict.json'), 'utf8'),
+    );
+    expect(verdict.removed).toEqual([removed]);
+    expect(verdict.removed).not.toContain(unrelated);
   });
 
   it('rejects a trusted capture that claims another run', () => {

--- a/.github/scripts/visual-gate/visual-acceptance.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.mjs
@@ -20,9 +20,9 @@ import {
 } from './authorization.mjs';
 import {canonicalizePng} from './lib/canonical-png.mjs';
 import {
+  buildPrVisualPlan,
   readStoryIndex,
   readThemeCatalog,
-  shotKey,
   stableBaseline,
   storiesInPackages,
   withThemeMetadata,
@@ -46,6 +46,7 @@ const flag = name => {
 const SHA = /^[0-9a-f]{40}$/;
 const KEY = /^[A-Za-z0-9._-]{1,240}$/;
 const NAME = /^[A-Za-z0-9._-]{1,120}$/;
+const REPO_PATH = /^[A-Za-z0-9._/-]{1,240}$/;
 const REPO = 'facebook/astryx';
 
 function fail(message) {
@@ -364,9 +365,6 @@ function accept() {
   if (evidence.verdict.status !== 'changed' || evidence.deltas.length === 0) {
     fail('current visual bundle has no delta to accept');
   }
-  if (evidence.deltas.some(delta => delta.kind === 'removed')) {
-    fail('scoped PR acceptance cannot authorize baseline removals');
-  }
   const manifestFile = path.join(
     pages,
     'visual-gate',
@@ -470,7 +468,7 @@ function state() {
     result = {
       state: 'success',
       reason: 'deferred',
-      description: 'Broad stable scope is deferred to the release gate.',
+      description: 'Stable visual scope is deferred to the release gate.',
     };
   } else {
     let current;
@@ -592,6 +590,15 @@ function validateAcceptance(value, expected = {}) {
   }
 }
 
+function isSafeRepoPath(value) {
+  return (
+    typeof value === 'string' &&
+    REPO_PATH.test(value) &&
+    !value.startsWith('/') &&
+    !value.split('/').includes('..')
+  );
+}
+
 function readTrustedScope() {
   const scope = readJSON(path.resolve(flag('scope')));
   if (
@@ -599,12 +606,14 @@ function readTrustedScope() {
     typeof scope.broadStableVisual !== 'boolean' ||
     !Array.isArray(scope.stableComponents) ||
     !Array.isArray(scope.stableThemes) ||
+    !Array.isArray(scope.stableStoryFiles ?? []) ||
     !scope.stableComponents.every(name => NAME.test(name)) ||
-    !scope.stableThemes.every(name => NAME.test(name))
+    !scope.stableThemes.every(name => NAME.test(name)) ||
+    !(scope.stableStoryFiles ?? []).every(isSafeRepoPath)
   ) {
     fail('trusted visual scope is invalid');
   }
-  return scope;
+  return {...scope, stableStoryFiles: scope.stableStoryFiles ?? []};
 }
 
 function readTrustedBaseline(stories = null) {
@@ -628,11 +637,42 @@ function readTrustedBaseline(stories = null) {
   return {baseline, entries};
 }
 
+function normalizeTrustedPlan(value) {
+  if (Array.isArray(value)) return {shots: value, expectedRemoved: []};
+  return {
+    shots: Array.isArray(value?.shots) ? value.shots : [],
+    expectedRemoved: Array.isArray(value?.expectedRemoved)
+      ? value.expectedRemoved
+      : (value?.expectedRemovals ?? []),
+  };
+}
+
+function readPlanSize() {
+  const planFile = flag('plan-file');
+  if (!planFile) return null;
+  const plan = readJSON(path.resolve(planFile));
+  if (!Array.isArray(plan) || plan.length === 0 || plan.length > 5000) {
+    fail(
+      `trusted visual plan has invalid size ${Array.isArray(plan) ? plan.length : 'unknown'}`,
+    );
+  }
+  return plan.length;
+}
+
 function trustedDefer() {
   const scope = readTrustedScope();
-  if (!scope.broadStableVisual) fail('trusted visual scope is not broad');
+  const planFile = flag('plan-file');
+  const normalizedPlan = planFile
+    ? normalizeTrustedPlan(readJSON(path.resolve(planFile)))
+    : null;
+  const planSize = normalizedPlan
+    ? normalizedPlan.shots.length + normalizedPlan.expectedRemoved.length
+    : null;
+  if (!scope.broadStableVisual && planSize == null) {
+    fail('trusted visual scope is not broad');
+  }
 
-  const {entries} = readTrustedBaseline();
+  const {entries} = planSize == null ? readTrustedBaseline() : {entries: []};
   const output = path.resolve(flag('output'));
   const pr = Number(flag('pr'));
   const head = flag('head') ?? '';
@@ -650,11 +690,14 @@ function trustedDefer() {
     fail('invalid evidence run/attempt');
   }
 
-  const total = entries.length;
+  const total = planSize ?? entries.length;
   const reason =
-    'Broad stable scope is deferred to the daily release gate. ' +
-    `It covers ${total} trusted baseline shot${total === 1 ? '' : 's'} ` +
-    'instead of recapturing them for this PR.';
+    planSize == null
+      ? 'Broad stable scope is deferred to the daily release gate. ' +
+        `It covers ${total} trusted baseline shot${total === 1 ? '' : 's'} ` +
+        'instead of recapturing them for this PR.'
+      : `Trusted PR visual scope has ${total} shots, above the 40-shot human-review cap. ` +
+        'It is deferred to the protected daily release gate instead of truncating the review set.';
   const verdict = {
     version: 1,
     status: 'skipped',
@@ -667,6 +710,9 @@ function trustedDefer() {
       runId: String(runId),
       runAttempt: String(runAttempt),
       trustedScope: scope,
+      ...(normalizedPlan?.expectedRemoved.length
+        ? {expectedRemoved: normalizedPlan.expectedRemoved}
+        : {}),
     },
     counts: {
       total,
@@ -706,8 +752,16 @@ function trustedDefer() {
   writeJSON(path.join(output, 'verdict.json'), verdict);
   fs.writeFileSync(path.join(output, 'index.html'), renderReport(verdict));
   process.stdout.write(
-    `Deferred ${total} trusted baseline shot${total === 1 ? '' : 's'} for PR #${pr}, run ${runId}/${runAttempt}.\n`,
+    `Deferred ${total} trusted visual shot${total === 1 ? '' : 's'} for PR #${pr}, run ${runId}/${runAttempt}.\n`,
   );
+}
+
+function storySourcePaths(story, storybookDir) {
+  if (!story.importPath) return [];
+  const raw = story.importPath.replace(/^\.\//, '').replaceAll('\\', '/');
+  const absolute = path.resolve(path.dirname(storybookDir), raw);
+  const relative = path.relative(REPO_ROOT, absolute).replaceAll(path.sep, '/');
+  return [raw, ...(relative.startsWith('..') ? [] : [relative])];
 }
 
 function trustedPlan() {
@@ -717,84 +771,76 @@ function trustedPlan() {
   const storybookDir = path.resolve(flag('storybook-dir'));
   const output = path.resolve(flag('output'));
   const allIndexed = readStoryIndex(storybookDir, [], REPO_ROOT);
-  const indexed = storiesInPackages(
-    allIndexed,
-    config.stableStoryPackages,
-  );
+  const indexed = storiesInPackages(allIndexed, config.stableStoryPackages);
+  const changedStoryFiles = new Set(scope.stableStoryFiles);
+  const headStoryIds = new Set(indexed.map(story => story.id));
+  const stableStoryIds = indexed
+    .filter(story =>
+      storySourcePaths(story, storybookDir).some(file =>
+        changedStoryFiles.has(file),
+      ),
+    )
+    .map(story => story.id);
   const {entries: baselineEntries} = readTrustedBaseline(allIndexed);
+  const expectedRemoved = baselineEntries
+    .filter(
+      ([, shot]) =>
+        changedStoryFiles.has(shot.sourcePath) &&
+        !headStoryIds.has(shot.storyId),
+    )
+    .map(([key, shot]) => ({...shot, key}));
 
-  const baselineThemes = [
-    ...new Set(baselineEntries.map(([, shot]) => shot.theme)),
-  ].filter(Boolean);
-  const shots = [];
-
-  if (scope.stableComponents.length > 0 || scope.stableThemes.length > 0) {
-    const indexedStories = new Map(indexed.map(story => [story.id, story]));
-    const add = (story, theme) => {
-      for (const mode of ['light', 'dark']) {
-        const shot = {
-          storyId: story.storyId ?? story.id,
-          title: story.title,
-          name: story.name,
-          component: story.component,
-          packageName: story.packageName,
-          packageNames: story.packageNames,
-          stableVisual: story.stableVisual,
-          theme,
-          mode,
-          reasons: ['trusted:pr-scope'],
-        };
-        shots.push({...shot, key: shotKey(shot)});
-      }
-    };
-
-    const componentStories = new Map();
-    for (const story of indexedStories.values()) {
-      if (scope.stableComponents.includes(story.component)) {
-        componentStories.set(story.storyId ?? story.id, story);
-      }
-    }
-    for (const story of componentStories.values()) {
-      for (const theme of baselineThemes) add(story, theme);
-    }
-
-    for (const theme of scope.stableThemes) {
-      const isNew = !baselineThemes.includes(theme);
-      const themeStories = new Map();
-      for (const [, shot] of baselineEntries) {
-        const story = indexedStories.get(shot.storyId) ?? shot;
-        if (isNew || shot.theme === theme) {
-          themeStories.set(shot.storyId, story);
-        }
-      }
-      for (const story of themeStories.values()) add(story, theme);
-    }
-  }
   const unique = withThemeMetadata(
-    [...new Map(shots.map(shot => [shot.key, shot])).values()],
+    buildPrVisualPlan({
+      stories: indexed,
+      components: scope.stableComponents,
+      stableStoryIds,
+      defaultTheme: config.defaultTheme,
+      probeTheme: config.probeTheme,
+    }),
     themeCatalog,
   );
-  if (unique.some(shot => shot.stableThemeVisual !== true)) {
+  if (
+    unique.some(
+      shot =>
+        shot.stableThemeVisual !== true && shot.theme !== config.probeTheme,
+    )
+  ) {
     fail('trusted stable plan includes a private or canary theme');
   }
-  if (unique.length === 0 || unique.length > 5000) {
-    fail(`trusted visual plan has invalid size ${unique.length}`);
+  const planSize = unique.length + expectedRemoved.length;
+  if (planSize === 0 || planSize > 5000) {
+    fail(`trusted visual plan has invalid size ${planSize}`);
   }
-  writeJSON(output, unique);
+  writeJSON(
+    output,
+    expectedRemoved.length > 0 ? {shots: unique, expectedRemoved} : unique,
+  );
   process.stdout.write(
-    `Wrote ${unique.length} trusted PR shot(s) to ${output}.\n`,
+    `Wrote ${unique.length} trusted PR shot(s) and ${expectedRemoved.length} expected removal(s) to ${output}.\n`,
+  );
+}
+
+function isCurrentOnlyEvidence(value) {
+  const shot = value?.shot ?? value;
+  return (
+    shot?.baselinePolicy === 'current-only' || shot?.theme === config.probeTheme
   );
 }
 
 function acceptedStableShots(acceptance) {
-  if (acceptance.keys.some(entry => entry.kind === 'removed')) {
-    fail('scoped PR promotion cannot remove baseline keys');
-  }
   const shots = withThemeMetadata(
-    acceptance.keys.map(entry => ({...entry.shot, key: entry.key})),
+    acceptance.keys
+      .filter(entry => entry.kind !== 'removed')
+      .map(entry => ({...entry.shot, key: entry.key})),
     themeCatalog,
   );
-  if (shots.some(shot => shot.stableThemeVisual !== true)) {
+  if (
+    shots.some(
+      shot =>
+        shot.stableThemeVisual !== true && shot.theme !== config.probeTheme,
+    )
+  ) {
     fail('accepted stable plan includes a private or canary theme');
   }
   return shots;
@@ -858,15 +904,21 @@ function promote() {
 
   const actions = [];
   for (const entry of acceptance.keys) {
+    if (entry.kind === 'removed') continue;
     const baselineFile = path.join(baselineShots, `${entry.key}.png`);
+    const currentOnly = isCurrentOnlyEvidence(entry);
     const currentBefore = fs.existsSync(baselineFile)
       ? shaFile(baselineFile)
       : null;
-    if (currentBefore === entry.afterSha256 && alreadyRecorded) {
-      actions.push({entry, baselineFile, alreadyPromoted: true});
+    if (
+      !currentOnly &&
+      currentBefore === entry.afterSha256 &&
+      alreadyRecorded
+    ) {
+      actions.push({entry, baselineFile, currentOnly, alreadyPromoted: true});
       continue;
     }
-    if (currentBefore !== entry.beforeSha256) {
+    if (!currentOnly && currentBefore !== entry.beforeSha256) {
       fail(
         `baseline conflict for ${entry.key}: expected ${entry.beforeSha256}, found ${currentBefore}`,
       );
@@ -920,19 +972,29 @@ function promote() {
     actions.push({
       entry,
       baselineFile,
+      currentOnly,
       canonicalBytes: canonical.bytes,
       capturedShot: {...capturedShot, sha256: canonicalSha256},
     });
   }
 
-  if (actions.every(action => action.alreadyPromoted)) {
+  const baselineActions = actions.filter(action => !action.currentOnly);
+
+  if (baselineActions.length === 0) {
+    process.stdout.write(
+      `Accepted visual bundle for PR #${acceptance.pr} contained only current evidence; no stable baseline changed.\n`,
+    );
+    return;
+  }
+
+  if (baselineActions.every(action => action.alreadyPromoted)) {
     process.stdout.write(
       `Accepted visual bundle for PR #${acceptance.pr} was already promoted.\n`,
     );
     return;
   }
 
-  for (const action of actions) {
+  for (const action of baselineActions) {
     if (action.alreadyPromoted) continue;
     fs.writeFileSync(action.baselineFile, action.canonicalBytes);
     manifest.shots[action.entry.key] = action.capturedShot;
@@ -952,7 +1014,10 @@ function promote() {
       pr: acceptance.pr,
       headSha: acceptance.headSha,
       mergeSha,
-      promoted: acceptance.keys.map(entry => entry.key),
+      promoted: baselineActions.map(action => action.entry.key),
+      reviewedCurrentOnly: actions
+        .filter(action => action.currentOnly)
+        .map(action => action.entry.key),
       pruned: [],
     },
   ].slice(-200);

--- a/.github/scripts/visual-gate/visual-acceptance.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.mjs
@@ -766,8 +766,13 @@ function storySourcePaths(story, storybookDir) {
 
 function trustedPlan() {
   const scope = readTrustedScope();
-  if (scope.broadStableVisual)
+  if (
+    scope.broadStableVisual &&
+    scope.stableComponents.length === 0 &&
+    scope.stableStoryFiles.length === 0
+  ) {
     fail('broad stable scope must be deferred instead of captured');
+  }
   const storybookDir = path.resolve(flag('storybook-dir'));
   const output = path.resolve(flag('output'));
   const allIndexed = readStoryIndex(storybookDir, [], REPO_ROOT);

--- a/.github/scripts/visual-gate/visual-acceptance.test.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.test.mjs
@@ -24,6 +24,22 @@ const HEAD = 'a'.repeat(40);
 const TESTED = 'b'.repeat(40);
 const MERGE = 'c'.repeat(40);
 const KEY = 'core-button--default__neutral-light';
+const PROBE_KEY = 'core-button--theme-sheet__probe-light';
+const PROBE_SHOT = {
+  storyId: 'core-button--theme-sheet',
+  title: 'Core/Button',
+  name: 'Theme Sheet',
+  component: 'Button',
+  packageName: '@astryxdesign/core',
+  packageNames: ['@astryxdesign/core'],
+  stableVisual: true,
+  theme: 'probe',
+  themePackageName: '@astryxdesign/theme-probe',
+  stableThemeVisual: false,
+  mode: 'light',
+  reasons: ['trusted:theme-sheet'],
+  baselinePolicy: 'current-only',
+};
 const SHOT = {
   storyId: 'core-button--default',
   title: 'Core/Button',
@@ -110,7 +126,8 @@ function acceptanceFile(run = 123, attempt = 1) {
 
 function writeBaseline(entries = {[KEY]: png(255)}) {
   const shots = {};
-  for (const [key, bytes] of Object.entries(entries)) {
+  for (const [key, value] of Object.entries(entries)) {
+    const payload = Buffer.isBuffer(value) ? {shot: SHOT, bytes: value} : value;
     const file = path.join(
       pages,
       'visual-gate',
@@ -119,8 +136,14 @@ function writeBaseline(entries = {[KEY]: png(255)}) {
       `${key}.png`,
     );
     fs.mkdirSync(path.dirname(file), {recursive: true});
-    fs.writeFileSync(file, bytes);
-    shots[key] = {...SHOT, key, sha256: digest(bytes), width: 2, height: 2};
+    fs.writeFileSync(file, payload.bytes);
+    shots[key] = {
+      ...payload.shot,
+      key,
+      sha256: digest(payload.bytes),
+      width: 2,
+      height: 2,
+    };
   }
   writeJSON(path.join(pages, 'visual-gate', 'baseline', 'manifest.json'), {
     version: 1,
@@ -493,16 +516,24 @@ describe('visual acceptance', () => {
     );
   });
 
-  it('derives a trusted component plan from baseline themes and the Storybook index', () => {
+  it('derives a compact trusted component plan from the Theme Sheet story', () => {
     const storybook = path.join(root, 'storybook');
     fs.mkdirSync(storybook);
     writeJSON(path.join(storybook, 'index.json'), {
       entries: {
-        button: {
+        default: {
           type: 'story',
           id: 'core-button--default',
           title: 'Core/Button',
           name: 'Default',
+          componentPath: '../../packages/core/src/Button/index.ts',
+          tags: [],
+        },
+        sheet: {
+          type: 'story',
+          id: 'core-button--theme-sheet',
+          title: 'Core/Button',
+          name: 'Theme Sheet',
           componentPath: '../../packages/core/src/Button/index.ts',
           tags: [],
         },
@@ -514,6 +545,7 @@ describe('visual acceptance', () => {
       broadStableVisual: false,
       stableComponents: ['Button'],
       stableThemes: [],
+      stableStoryFiles: [],
     });
     const output = path.join(root, 'trusted-plan.json');
     run('trusted-plan', {
@@ -525,23 +557,38 @@ describe('visual acceptance', () => {
     expect(
       JSON.parse(fs.readFileSync(output, 'utf8')).map(shot => shot.key),
     ).toEqual([
-      'core-button--default__neutral-light',
-      'core-button--default__neutral-dark',
+      'core-button--theme-sheet__neutral-dark',
+      'core-button--theme-sheet__neutral-light',
+      'core-button--theme-sheet__probe-dark',
+      'core-button--theme-sheet__probe-light',
     ]);
   });
 
-  it('plans every baseline story for a newly promoted stable theme', () => {
-    const storybook = path.join(root, 'storybook-new-theme');
+  it('adds changed stable-visual story files in Neutral only', () => {
+    const storybook = path.join(root, 'storybook-stable-story');
     fs.mkdirSync(storybook);
-    writeJSON(path.join(storybook, 'index.json'), {entries: {}});
-    const scope = path.join(root, 'scope-new-theme.json');
+    writeJSON(path.join(storybook, 'index.json'), {
+      entries: {
+        focused: {
+          type: 'story',
+          id: 'core-button--focused-regression',
+          title: 'Core/Button',
+          name: 'Focused Regression',
+          componentPath: '../../packages/core/src/Button/index.ts',
+          importPath: './stories/Button.stories.tsx',
+          tags: ['stable-visual'],
+        },
+      },
+    });
+    const scope = path.join(root, 'scope-stable-story.json');
     writeJSON(scope, {
       hasStableVisual: true,
       broadStableVisual: false,
       stableComponents: [],
-      stableThemes: ['y2k'],
+      stableThemes: [],
+      stableStoryFiles: ['stories/Button.stories.tsx'],
     });
-    const output = path.join(root, 'trusted-theme-plan.json');
+    const output = path.join(root, 'trusted-story-plan.json');
     run('trusted-plan', {
       scope,
       baseline: path.join(pages, 'visual-gate', 'baseline'),
@@ -551,9 +598,164 @@ describe('visual acceptance', () => {
     expect(
       JSON.parse(fs.readFileSync(output, 'utf8')).map(shot => shot.key),
     ).toEqual([
-      'core-button--default__y2k-light',
-      'core-button--default__y2k-dark',
+      'core-button--focused-regression__neutral-dark',
+      'core-button--focused-regression__neutral-light',
     ]);
+  });
+
+  it('proves the PR plan shrinks a #5510-shaped component from hundreds of shots', () => {
+    const storybook = path.join(root, 'storybook-large-component');
+    fs.mkdirSync(storybook);
+    const entries = {
+      sheet: {
+        type: 'story',
+        id: 'core-button--theme-sheet',
+        title: 'Core/Button',
+        name: 'Theme Sheet',
+        componentPath: '../../packages/core/src/Button/index.ts',
+        tags: [],
+      },
+    };
+    for (let index = 0; index < 120; index += 1) {
+      entries[`story-${index}`] = {
+        type: 'story',
+        id: `core-button--case-${index}`,
+        title: 'Core/Button',
+        name: `Case ${index}`,
+        componentPath: '../../packages/core/src/Button/index.ts',
+        tags: [],
+      };
+    }
+    writeJSON(path.join(storybook, 'index.json'), {entries});
+    const scope = path.join(root, 'scope-large-component.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: ['Button'],
+      stableThemes: [],
+      stableStoryFiles: [],
+    });
+    const output = path.join(root, 'trusted-large-plan.json');
+    run('trusted-plan', {
+      scope,
+      baseline: path.join(pages, 'visual-gate', 'baseline'),
+      'storybook-dir': storybook,
+      output,
+    });
+    expect(JSON.parse(fs.readFileSync(output, 'utf8'))).toHaveLength(4);
+  });
+
+  it('plans deleted stable-visual stories as before-only removals without substituting base content', () => {
+    const storybook = path.join(root, 'storybook-deleted-story');
+    fs.mkdirSync(storybook);
+    writeJSON(path.join(storybook, 'index.json'), {entries: {}});
+    const deletedLight = 'core-button--deleted-story__neutral-light';
+    const deletedDark = 'core-button--deleted-story__neutral-dark';
+    writeBaseline({
+      [deletedLight]: {
+        shot: {
+          ...SHOT,
+          key: deletedLight,
+          storyId: 'core-button--deleted-story',
+          name: 'Deleted Story',
+          sourcePath: 'stories/Button.stories.tsx',
+        },
+        bytes: png(),
+      },
+      [deletedDark]: {
+        shot: {
+          ...SHOT,
+          key: deletedDark,
+          storyId: 'core-button--deleted-story',
+          name: 'Deleted Story',
+          sourcePath: 'stories/Button.stories.tsx',
+          mode: 'dark',
+        },
+        bytes: png(),
+      },
+    });
+    const scope = path.join(root, 'scope-deleted-story.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: [],
+      stableThemes: [],
+      stableStoryFiles: ['stories/Button.stories.tsx'],
+    });
+    const output = path.join(root, 'trusted-deleted-plan.json');
+    run('trusted-plan', {
+      scope,
+      baseline: path.join(pages, 'visual-gate', 'baseline'),
+      'storybook-dir': storybook,
+      output,
+    });
+    expect(JSON.parse(fs.readFileSync(output, 'utf8'))).toMatchObject({
+      shots: [],
+      expectedRemoved: [{key: deletedLight}, {key: deletedDark}],
+    });
+  });
+
+  it('plans remaining stable-visual stories and removals from the same changed file only', () => {
+    const storybook = path.join(root, 'storybook-mixed-story');
+    fs.mkdirSync(storybook);
+    writeJSON(path.join(storybook, 'index.json'), {
+      entries: {
+        remaining: {
+          type: 'story',
+          id: 'core-button--remaining-story',
+          title: 'Core/Button',
+          name: 'Remaining Story',
+          componentPath: '../../packages/core/src/Button/index.ts',
+          importPath: './stories/Button.stories.tsx',
+          tags: ['stable-visual'],
+        },
+      },
+    });
+    const deleted = 'core-button--deleted-story__neutral-light';
+    const unrelated = 'core-button--unrelated-story__neutral-light';
+    writeBaseline({
+      [deleted]: {
+        shot: {
+          ...SHOT,
+          key: deleted,
+          storyId: 'core-button--deleted-story',
+          name: 'Deleted Story',
+          sourcePath: 'stories/Button.stories.tsx',
+        },
+        bytes: png(),
+      },
+      [unrelated]: {
+        shot: {
+          ...SHOT,
+          key: unrelated,
+          storyId: 'core-button--unrelated-story',
+          name: 'Unrelated Story',
+          sourcePath: 'stories/Other.stories.tsx',
+        },
+        bytes: png(),
+      },
+    });
+    const scope = path.join(root, 'scope-mixed-story.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: [],
+      stableThemes: [],
+      stableStoryFiles: ['stories/Button.stories.tsx'],
+    });
+    const output = path.join(root, 'trusted-mixed-plan.json');
+    run('trusted-plan', {
+      scope,
+      baseline: path.join(pages, 'visual-gate', 'baseline'),
+      'storybook-dir': storybook,
+      output,
+    });
+    const plan = JSON.parse(fs.readFileSync(output, 'utf8'));
+    expect(plan.shots.map(shot => shot.key)).toEqual([
+      'core-button--remaining-story__neutral-dark',
+      'core-button--remaining-story__neutral-light',
+    ]);
+    expect(plan.expectedRemoved.map(removal => removal.key)).toEqual([deleted]);
   });
 
   it('refuses a trusted capture plan for broad stable infrastructure', () => {
@@ -594,7 +796,7 @@ describe('visual acceptance', () => {
         'run-id': 126,
         'run-attempt': 3,
       }),
-    ).toContain('Deferred 1 trusted baseline shot');
+    ).toContain('Deferred 1 trusted visual shot');
 
     const evidence = JSON.parse(
       fs.readFileSync(path.join(output, 'evidence.json'), 'utf8'),
@@ -634,8 +836,115 @@ describe('visual acceptance', () => {
     expect(JSON.parse(run('state', {pages, pr: 42, head: HEAD}))).toEqual({
       state: 'success',
       reason: 'deferred',
-      description: 'Broad stable scope is deferred to the release gate.',
+      description: 'Stable visual scope is deferred to the release gate.',
     });
+  });
+
+  it('writes trusted skipped evidence for an over-budget compact plan', () => {
+    const scope = path.join(root, 'scope-over-budget.json');
+    const plan = path.join(root, 'over-budget-plan.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: ['Button'],
+      stableThemes: [],
+      stableStoryFiles: [],
+    });
+    writeJSON(
+      plan,
+      Array.from({length: 41}, (_, index) => ({
+        ...SHOT,
+        key: `core-button--case-${index}__neutral-light`,
+        storyId: `core-button--case-${index}`,
+      })),
+    );
+    const output = path.join(pages, 'pr', '42', 'visual', HEAD, '127', '1');
+    expect(
+      run('trusted-defer', {
+        scope,
+        baseline: path.join(pages, 'visual-gate', 'baseline'),
+        'plan-file': plan,
+        output,
+        pr: 42,
+        head: HEAD,
+        base: 'd'.repeat(40),
+        'run-id': 127,
+        'run-attempt': 1,
+      }),
+    ).toContain('Deferred 41 trusted visual shots');
+    const evidence = JSON.parse(
+      fs.readFileSync(path.join(output, 'evidence.json'), 'utf8'),
+    );
+    expect(evidence.verdict).toMatchObject({
+      status: 'skipped',
+      counts: {total: 41},
+    });
+    expect(evidence.verdict.reason).toContain('40-shot human-review cap');
+  });
+
+  it('counts object plans with before-only removals for review budgets', () => {
+    const scope = path.join(root, 'scope-object-budget.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: ['Button'],
+      stableThemes: [],
+      stableStoryFiles: [],
+    });
+    const plan = path.join(root, 'object-budget-plan.json');
+    writeJSON(plan, {
+      shots: Array.from({length: 24}, (_, index) => ({
+        ...SHOT,
+        key: `core-button--case-${index}__neutral-light`,
+        storyId: `core-button--case-${index}`,
+      })),
+      expectedRemoved: [{...SHOT, key: 'core-button--deleted__neutral-light'}],
+    });
+    const output25 = path.join(pages, 'pr', '42', 'visual', HEAD, '131', '1');
+    expect(
+      run('trusted-defer', {
+        scope,
+        baseline: path.join(pages, 'visual-gate', 'baseline'),
+        'plan-file': plan,
+        output: output25,
+        pr: 42,
+        head: HEAD,
+        base: 'd'.repeat(40),
+        'run-id': 131,
+        'run-attempt': 1,
+      }),
+    ).toContain('Deferred 25 trusted visual shots');
+    expect(
+      JSON.parse(fs.readFileSync(path.join(output25, 'evidence.json'), 'utf8'))
+        .verdict.context.expectedRemoved,
+    ).toHaveLength(1);
+
+    writeJSON(plan, {
+      shots: Array.from({length: 40}, (_, index) => ({
+        ...SHOT,
+        key: `core-button--case-${index}__neutral-light`,
+        storyId: `core-button--case-${index}`,
+      })),
+      expectedRemoved: [{...SHOT, key: 'core-button--deleted__neutral-light'}],
+    });
+    const output41 = path.join(pages, 'pr', '42', 'visual', HEAD, '132', '1');
+    expect(
+      run('trusted-defer', {
+        scope,
+        baseline: path.join(pages, 'visual-gate', 'baseline'),
+        'plan-file': plan,
+        output: output41,
+        pr: 42,
+        head: HEAD,
+        base: 'd'.repeat(40),
+        'run-id': 132,
+        'run-attempt': 1,
+      }),
+    ).toContain('Deferred 41 trusted visual shots');
+    expect(
+      JSON.parse(fs.readFileSync(path.join(output41, 'evidence.json'), 'utf8'))
+        .verdict.reason,
+    ).toContain('40-shot human-review cap');
   });
 
   it('refuses trusted deferral for a narrow component scope', () => {
@@ -753,6 +1062,216 @@ describe('visual acceptance', () => {
     expect(JSON.parse(printed)).toEqual([{...SHOT, key: KEY}]);
   });
 
+  it('promotes Neutral while keeping Probe current-only evidence out of the stable baseline', () => {
+    const neutralAfter = png(0, 0, 255);
+    const probeAfter = png(0, 255, 0);
+    const dir = path.join(pages, 'pr', '42', 'visual', HEAD, '128', '1');
+    fs.mkdirSync(path.join(dir, 'after'), {recursive: true});
+    fs.writeFileSync(path.join(dir, 'after', `${KEY}.png`), neutralAfter);
+    fs.writeFileSync(path.join(dir, 'after', `${PROBE_KEY}.png`), probeAfter);
+    writeJSON(path.join(dir, 'evidence.json'), {
+      version: 1,
+      repo: 'facebook/astryx',
+      pr: 42,
+      headSha: HEAD,
+      testedSha: TESTED,
+      baseSha: 'd'.repeat(40),
+      run: {id: 128, attempt: 1},
+      capture: {
+        platform: 'linux-arm64',
+        browser: 'chromium-140.0',
+        viewport: {width: 1280, height: 900},
+      },
+      deltas: [
+        {
+          key: KEY,
+          kind: 'changed',
+          beforeSha256: digest(png(255)),
+          shot: SHOT,
+        },
+        {
+          key: PROBE_KEY,
+          kind: 'added',
+          beforeSha256: null,
+          shot: PROBE_SHOT,
+        },
+      ],
+      verdict: {version: 1, status: 'changed'},
+    });
+    run('accept', acceptanceFlags({'run-id': 128}));
+
+    const plan = path.join(root, 'accepted-neutral-probe-plan.json');
+    run('plan', {acceptance: acceptanceFile(128), output: plan});
+    expect(
+      JSON.parse(fs.readFileSync(plan, 'utf8')).map(shot => shot.key),
+    ).toEqual([KEY, PROBE_KEY]);
+
+    const capture = path.join(root, 'capture-neutral-probe');
+    fs.mkdirSync(path.join(capture, 'shots'), {recursive: true});
+    fs.writeFileSync(path.join(capture, 'shots', `${KEY}.png`), neutralAfter);
+    fs.writeFileSync(
+      path.join(capture, 'shots', `${PROBE_KEY}.png`),
+      probeAfter,
+    );
+    writeJSON(path.join(capture, 'manifest.json'), {
+      version: 1,
+      platform: 'linux-arm64',
+      browser: 'chromium-140.0',
+      viewport: {width: 1280, height: 900},
+      capturedAt: '2026-08-26T22:00:00.000Z',
+      context: {sha: MERGE},
+      shots: {
+        [KEY]: {...SHOT, sha256: digest(neutralAfter), width: 2, height: 2},
+        [PROBE_KEY]: {
+          ...PROBE_SHOT,
+          sha256: digest(probeAfter),
+          width: 2,
+          height: 2,
+        },
+      },
+    });
+
+    run('promote', {
+      pages,
+      acceptance: acceptanceFile(128),
+      capture,
+      'merge-sha': MERGE,
+    });
+    const baselineManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(pages, 'visual-gate', 'baseline', 'manifest.json'),
+        'utf8',
+      ),
+    );
+    expect(baselineManifest.shots[KEY].sha256).toBe(digest(neutralAfter));
+    expect(baselineManifest.shots[PROBE_KEY]).toBeUndefined();
+    expect(
+      fs.existsSync(
+        path.join(
+          pages,
+          'visual-gate',
+          'baseline',
+          'shots',
+          `${PROBE_KEY}.png`,
+        ),
+      ),
+    ).toBe(false);
+    expect(baselineManifest.decisions.at(-1)).toMatchObject({
+      promoted: [KEY],
+      reviewedCurrentOnly: [PROBE_KEY],
+      pruned: [],
+    });
+  });
+
+  it('keeps Probe Theme Sheet shots as current evidence for each new PR plan', () => {
+    const storybook = path.join(root, 'storybook-next-probe');
+    fs.mkdirSync(storybook);
+    writeJSON(path.join(storybook, 'index.json'), {
+      entries: {
+        sheet: {
+          type: 'story',
+          id: 'core-button--theme-sheet',
+          title: 'Core/Button',
+          name: 'Theme Sheet',
+          componentPath: '../../packages/core/src/Button/index.ts',
+          tags: [],
+        },
+      },
+    });
+    const scope = path.join(root, 'scope-next-probe.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: ['Button'],
+      stableThemes: [],
+      stableStoryFiles: [],
+    });
+    const output = path.join(root, 'trusted-next-probe-plan.json');
+    run('trusted-plan', {
+      scope,
+      baseline: path.join(pages, 'visual-gate', 'baseline'),
+      'storybook-dir': storybook,
+      output,
+    });
+    const shots = JSON.parse(fs.readFileSync(output, 'utf8'));
+    expect(
+      shots.filter(shot => shot.theme === 'probe').map(shot => shot.key),
+    ).toEqual([
+      'core-button--theme-sheet__probe-dark',
+      'core-button--theme-sheet__probe-light',
+    ]);
+    expect(shots.filter(shot => shot.theme === 'probe')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({baselinePolicy: 'current-only'}),
+      ]),
+    );
+  });
+
+  it('accepts removed Probe evidence without pruning the stable baseline', () => {
+    const before = png(9);
+    writeBaseline({
+      [KEY]: png(255),
+      [PROBE_KEY]: {shot: PROBE_SHOT, bytes: before},
+    });
+    const dir = path.join(pages, 'pr', '42', 'visual', HEAD, '129', '1');
+    fs.mkdirSync(dir, {recursive: true});
+    writeJSON(path.join(dir, 'evidence.json'), {
+      version: 1,
+      repo: 'facebook/astryx',
+      pr: 42,
+      headSha: HEAD,
+      testedSha: TESTED,
+      baseSha: 'd'.repeat(40),
+      run: {id: 129, attempt: 1},
+      capture: {
+        platform: 'linux-arm64',
+        browser: 'chromium-140.0',
+        viewport: {width: 1280, height: 900},
+      },
+      deltas: [
+        {
+          key: PROBE_KEY,
+          kind: 'removed',
+          beforeSha256: digest(before),
+          shot: null,
+        },
+      ],
+      verdict: {version: 1, status: 'changed'},
+    });
+
+    run('accept', acceptanceFlags({'run-id': 129}));
+    expect(JSON.parse(run('state', {pages, pr: 42, head: HEAD}))).toMatchObject(
+      {
+        state: 'success',
+        reason: 'accepted',
+      },
+    );
+    const capture = path.join(root, 'capture-removed-probe');
+    fs.mkdirSync(path.join(capture, 'shots'), {recursive: true});
+    writeJSON(path.join(capture, 'manifest.json'), {
+      version: 1,
+      platform: 'linux-arm64',
+      browser: 'chromium-140.0',
+      viewport: {width: 1280, height: 900},
+      capturedAt: '2026-08-26T22:00:00.000Z',
+      context: {sha: MERGE},
+      shots: {},
+    });
+    run('promote', {
+      pages,
+      acceptance: acceptanceFile(129),
+      capture,
+      'merge-sha': MERGE,
+    });
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(pages, 'visual-gate', 'baseline', 'manifest.json'),
+        'utf8',
+      ),
+    );
+    expect(manifest.shots[KEY]).toBeDefined();
+  });
+
   it('promotes only when merged pixels equal the reviewed after image', () => {
     run('accept', acceptanceFlags());
     const after = fs.readFileSync(
@@ -867,13 +1386,37 @@ describe('visual acceptance', () => {
     },
   );
 
-  it('rejects removed PR evidence and preserves the baseline', () => {
+  it('accepts removed PR evidence but promotion never prunes the stable baseline', () => {
     writeEvidence({kind: 'removed', run: 125});
-    expect(fail('accept', acceptanceFlags({'run-id': 125}))).toMatch(
-      /scoped PR acceptance cannot authorize baseline removals/,
+    run('accept', acceptanceFlags({'run-id': 125}));
+    expect(JSON.parse(run('state', {pages, pr: 42, head: HEAD}))).toMatchObject(
+      {
+        state: 'success',
+        reason: 'accepted',
+      },
     );
-    expect(fs.existsSync(acceptanceFile(125))).toBe(false);
-    expect(fs.existsSync(path.join(pages, 'visual-gate', 'baseline', 'shots', `${KEY}.png`))).toBe(true);
+    const capture = path.join(root, 'capture-removed-stable');
+    fs.mkdirSync(path.join(capture, 'shots'), {recursive: true});
+    writeJSON(path.join(capture, 'manifest.json'), {
+      version: 1,
+      platform: 'linux-arm64',
+      browser: 'chromium-140.0',
+      viewport: {width: 1280, height: 900},
+      capturedAt: '2026-08-26T22:00:00.000Z',
+      context: {sha: MERGE},
+      shots: {},
+    });
+    run('promote', {
+      pages,
+      acceptance: acceptanceFile(125),
+      capture,
+      'merge-sha': MERGE,
+    });
+    expect(
+      fs.existsSync(
+        path.join(pages, 'visual-gate', 'baseline', 'shots', `${KEY}.png`),
+      ),
+    ).toBe(true);
   });
 
   it('rejects a merged recapture whose canonical pixels changed', () => {
@@ -965,19 +1508,30 @@ describe('visual acceptance', () => {
     ).toMatch(/baseline conflict/);
   });
 
-  it('records added shots but rejects removed evidence', () => {
+  it('records added and removed evidence shapes', () => {
     const added = 'core-new--default__neutral-light';
     writeEvidence({kind: 'added', key: added, run: 124});
     run('accept', acceptanceFlags({'run-id': 124}));
-    expect(JSON.parse(fs.readFileSync(acceptanceFile(124), 'utf8')).keys[0]).toMatchObject({
+    expect(
+      JSON.parse(fs.readFileSync(acceptanceFile(124), 'utf8')).keys[0],
+    ).toMatchObject({
       key: added,
       kind: 'added',
       beforeSha256: null,
     });
-    fs.rmSync(path.join(pages, 'visual-gate', 'acceptances'), {recursive: true, force: true});
+    fs.rmSync(path.join(pages, 'visual-gate', 'acceptances'), {
+      recursive: true,
+      force: true,
+    });
     writeEvidence({kind: 'removed', run: 125});
-    expect(fail('accept', acceptanceFlags({'comment-id': 1235, 'run-id': 125}))).toMatch(
-      /scoped PR acceptance cannot authorize baseline removals/,
-    );
+    run('accept', acceptanceFlags({'comment-id': 1235, 'run-id': 125}));
+    expect(
+      JSON.parse(fs.readFileSync(acceptanceFile(125), 'utf8')).keys[0],
+    ).toMatchObject({
+      key: KEY,
+      kind: 'removed',
+      afterSha256: null,
+      shot: null,
+    });
   });
 });

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -155,8 +155,8 @@ describe('visual acceptance workflow concurrency', () => {
       value.indexOf('      - name: Publish immutable visual evidence'),
     );
 
-    expect(download).toContain("steps.scope.outputs.broad != 'true'");
-    expect(capture).toContain("steps.scope.outputs.broad != 'true'");
+    expect(download).toContain("steps.scope.outputs.exact == 'true'");
+    expect(capture).toContain("steps.scope.outputs.exact == 'true'");
     expect(capture).toContain('trusted-plan');
     expect(capture).toContain('"$SHOTS" -gt 24');
     expect(capture).toContain('"$SHOTS" -gt 40');
@@ -168,16 +168,102 @@ describe('visual acceptance workflow concurrency', () => {
       capture.indexOf('npx playwright install chromium'),
     );
     expect(defer).toContain("steps.scope.outputs.broad == 'true'");
+    expect(defer).toContain("steps.scope.outputs.exact != 'true'");
     expect(defer).toContain('visual-acceptance.mjs trusted-defer');
     expect(defer).toContain('--run-attempt "$RUN_ATTEMPT"');
     expect(defer).not.toContain('playwright');
     expect(defer).not.toContain('gate.mjs capture');
-    expect(derive).toContain("steps.scope.outputs.broad != 'true'");
+    expect(derive).toContain("steps.scope.outputs.exact == 'true'");
     expect(derive).toContain("steps.plan.outputs.deferred != 'true'");
+    expect(value).toContain(
+      "core.setOutput('exact', String(scope.exactStableVisual))",
+    );
     expect(resolve).toContain('test -f trusted-visual/evidence.json');
     expect(resolve).toContain(
       'path=pr/${PR_NUMBER}/visual/${HEAD_SHA}/${RUN_ID}/${RUN_ATTEMPT}',
     );
+  });
+
+  it('uses affected dependency tracing for PR a11y scope instead of broad sweeps', () => {
+    const value = workflow('ci.yml');
+    const check = value.slice(
+      value.indexOf('  check-components:'),
+      value.indexOf('  # Run tests'),
+    );
+    const prA11y = value.slice(
+      value.indexOf('  pr-a11y:'),
+      value.indexOf('  # The layer order'),
+    );
+
+    expect(check).toContain(
+      'a11y_deferred: ${{ steps.files.outputs.a11y_deferred || steps.affected.outputs.a11y_deferred }}',
+    );
+    expect(check).toContain('uses: ./.github/actions/affected-scope');
+    expect(check).toContain(
+      'changed-files: ${{ steps.files.outputs.changed_files }}',
+    );
+    expect(check).toContain('visual-scope.mjs --github-output');
+    expect(check).toContain('has_components=false');
+    expect(check).toContain('has_stable_visual=false');
+    expect(check).toContain('stable_visual_deferred=true');
+    expect(check).toContain('a11y_deferred=true');
+    expect(check).toContain(
+      'deferring PR-scoped a11y and visual review to protected main',
+    );
+    expect(check).not.toContain(
+      'assuming components changed so pr-a11y still runs',
+    );
+    expect(prA11y).toContain(
+      "needs.check-components.outputs.has_components == 'true'",
+    );
+  });
+
+  it('routes every PR-scope consumer through the shared affected-scope action', () => {
+    const ci = workflow('ci.yml');
+    const action = fs.readFileSync(
+      path.join(ROOT, '.github/actions/affected-scope/action.yml'),
+      'utf8',
+    );
+    const check = ci.slice(
+      ci.indexOf('  check-components:'),
+      ci.indexOf('  # Run tests'),
+    );
+    const prA11y = ci.slice(
+      ci.indexOf('  pr-a11y:'),
+      ci.indexOf('  # The layer order'),
+    );
+    const prVisual = ci.slice(
+      ci.indexOf('  pr-visual:'),
+      ci.indexOf('  # RTL semantic audit'),
+    );
+    const prRtl = ci.slice(
+      ci.indexOf('  pr-rtl:'),
+      ci.indexOf('      - name: Write scorecard summary'),
+    );
+
+    for (const block of [check, prA11y, prVisual, prRtl]) {
+      expect(block).toContain('uses: ./.github/actions/affected-scope');
+      expect(block).not.toContain('node .github/scripts/lib/affected-scope.js');
+      expect(block).not.toContain('.newComponents + .modifiedComponents');
+      expect(block).not.toContain("jq -r '[.affectedScope.components");
+    }
+    expect(check).toContain(
+      'changed-files: ${{ steps.files.outputs.changed_files }}',
+    );
+    for (const block of [prA11y, prVisual, prRtl]) {
+      expect(block).toContain('analysis-file: analysis.json');
+      expect(block).toContain('steps.affected.outputs.affected_');
+    }
+    expect(action).toContain('inputs:');
+    expect(action).toContain('changed-files:');
+    expect(action).toContain('analysis-file:');
+    expect(action).toContain('outputs:');
+    expect(action).toContain('affected_components:');
+    expect(action).toContain('affected_core_components:');
+    expect(action).toContain('rtl_deferred:');
+    expect(action).toContain('using: node20');
+    expect(action).toContain('main: index.mjs');
+    expect(action).not.toContain('run:');
   });
 
   it('uses the documented collaborator permission response shape', () => {

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -157,12 +157,23 @@ describe('visual acceptance workflow concurrency', () => {
 
     expect(download).toContain("steps.scope.outputs.broad != 'true'");
     expect(capture).toContain("steps.scope.outputs.broad != 'true'");
+    expect(capture).toContain('trusted-plan');
+    expect(capture).toContain('"$SHOTS" -gt 24');
+    expect(capture).toContain('"$SHOTS" -gt 40');
+    expect(capture).toContain('--plan-file trusted-plan.json');
+    expect(capture.indexOf('trusted-plan')).toBeLessThan(
+      capture.indexOf('"$SHOTS" -gt 40'),
+    );
+    expect(capture.indexOf('"$SHOTS" -gt 40')).toBeLessThan(
+      capture.indexOf('npx playwright install chromium'),
+    );
     expect(defer).toContain("steps.scope.outputs.broad == 'true'");
     expect(defer).toContain('visual-acceptance.mjs trusted-defer');
     expect(defer).toContain('--run-attempt "$RUN_ATTEMPT"');
     expect(defer).not.toContain('playwright');
     expect(defer).not.toContain('gate.mjs capture');
     expect(derive).toContain("steps.scope.outputs.broad != 'true'");
+    expect(derive).toContain("steps.plan.outputs.deferred != 'true'");
     expect(resolve).toContain('test -f trusted-visual/evidence.json');
     expect(resolve).toContain(
       'path=pr/${PR_NUMBER}/visual/${HEAD_SHA}/${RUN_ID}/${RUN_ATTEMPT}',

--- a/.github/scripts/visual-scope.mjs
+++ b/.github/scripts/visual-scope.mjs
@@ -32,6 +32,8 @@ function readJSON(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
+const STORY_FILE = /^apps\/storybook\/stories\/.*\.stories\.(tsx|ts|mdx)$/;
+
 /** @param {string} repoRoot @param {string} file @param {Record<string, object>} manifests */
 function readPackage(repoRoot, file, manifests) {
   if (Object.hasOwn(manifests, file)) return manifests[file];
@@ -39,18 +41,41 @@ function readPackage(repoRoot, file, manifests) {
   return fs.existsSync(absolute) ? readJSON(absolute) : null;
 }
 
+function readTextSnapshot(repoRoot, file, fileSnapshots) {
+  if (Object.hasOwn(fileSnapshots, file)) return String(fileSnapshots[file]);
+  const absolute = path.join(repoRoot, file);
+  return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : '';
+}
+
+function hasStableVisualTag(text) {
+  return /['"`]stable-visual['"`]/.test(text);
+}
+
+function isRuntimeCoreFile(file) {
+  if (!/^packages\/core\/src\/.*\.(ts|tsx|css)$/.test(file)) return false;
+  if (/\.(test|doc)\./.test(file)) return false;
+  if (/(^|\/)(index|types)\.ts$/.test(file)) return false;
+  return true;
+}
+
 /**
  * @param {string[]} files
  * @param {string} repoRoot
  * @param {Record<string, object>} manifests - trusted snapshots keyed by repo-relative path
  */
-export function classifyVisualScope(files, repoRoot = ROOT, manifests = {}) {
+export function classifyVisualScope(
+  files,
+  repoRoot = ROOT,
+  manifests = {},
+  fileSnapshots = {},
+) {
   const paths = files.map(file => file.trim()).filter(Boolean);
-  const stableCoreFiles = paths.filter(
-    file =>
-      /^packages\/core\/src\/.*\.(ts|tsx|css)$/.test(file) &&
-      !/\.(test|doc)\./.test(file),
-  );
+  const stableCoreFiles = paths.filter(isRuntimeCoreFile);
+  const stableStoryFiles = paths
+    .filter(file => STORY_FILE.test(file))
+    .filter(file =>
+      hasStableVisualTag(readTextSnapshot(repoRoot, file, fileSnapshots)),
+    );
 
   const stableThemes = new Set();
   const stableComponents = new Set();
@@ -117,11 +142,15 @@ export function classifyVisualScope(files, repoRoot = ROOT, manifests = {}) {
   }
 
   return {
-    hasStableVisual: stableCoreFiles.length > 0 || stableThemes.size > 0,
-    broadStableVisual,
+    hasStableVisual:
+      stableCoreFiles.length > 0 ||
+      stableThemes.size > 0 ||
+      stableStoryFiles.length > 0,
+    broadStableVisual: broadStableVisual || stableThemes.size > 0,
     stableComponents: [...stableComponents].sort(),
     stableCoreFiles,
     stableThemes: [...stableThemes].sort(),
+    stableStoryFiles: stableStoryFiles.sort(),
     canaryPackages: [...canaryPackages].sort(),
   };
 }
@@ -133,7 +162,12 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     manifestsFlag === -1
       ? {}
       : readJSON(path.resolve(process.argv[manifestsFlag + 1]));
-  const result = classifyVisualScope(files, ROOT, manifests);
+  const snapshotsFlag = process.argv.indexOf('--file-snapshots');
+  const fileSnapshots =
+    snapshotsFlag === -1
+      ? {}
+      : readJSON(path.resolve(process.argv[snapshotsFlag + 1]));
+  const result = classifyVisualScope(files, ROOT, manifests, fileSnapshots);
   process.stdout.write(`${JSON.stringify(result)}\n`);
 
   const output = process.argv[process.argv.indexOf('--github-output') + 1];
@@ -148,6 +182,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       output,
       [
         `stable_themes=${outputValue(result.stableThemes)}`,
+        `stable_story_files=${outputValue(result.stableStoryFiles)}`,
         `canary_packages=${outputValue(result.canaryPackages)}`,
         `has_stable_visual=${result.hasStableVisual}`,
       ].join('\n') + '\n',

--- a/.github/scripts/visual-scope.mjs
+++ b/.github/scripts/visual-scope.mjs
@@ -2,7 +2,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file Classify changed files by release channel for visual CI.
+ * @file Classify changed files by release channel and affected dependency scope
+ *       for PR visual/a11y CI.
  *
  * @input  newline-separated paths on stdin (normally a base...head git diff)
  * @output JSON, and optionally GitHub outputs
@@ -19,6 +20,7 @@
  */
 
 import fs from 'node:fs';
+import {createRequire} from 'node:module';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -26,6 +28,9 @@ const ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../..',
 );
+const {classifyAffectedDependencies, componentSource} = createRequire(
+  import.meta.url,
+)('./lib/affected-scope.js');
 
 /** @param {string} file */
 function readJSON(file) {
@@ -70,6 +75,7 @@ export function classifyVisualScope(
   fileSnapshots = {},
 ) {
   const paths = files.map(file => file.trim()).filter(Boolean);
+  const affected = classifyAffectedDependencies(paths);
   const stableCoreFiles = paths.filter(isRuntimeCoreFile);
   const stableStoryFiles = paths
     .filter(file => STORY_FILE.test(file))
@@ -80,12 +86,17 @@ export function classifyVisualScope(
   const stableThemes = new Set();
   const stableComponents = new Set();
   const canaryPackages = new Set();
+  const visualDeferredReasons = new Set(affected.visual.reasons);
+  const a11yDeferredReasons = new Set(affected.a11y.reasons);
   let broadStableVisual = false;
+  for (const component of affected.components) {
+    if (component.packageName === '@astryxdesign/core') {
+      stableComponents.add(component.component);
+    }
+  }
 
   for (const file of stableCoreFiles) {
-    const match = file.match(/^packages\/core\/src\/([^/]+)\//);
-    if (match && /^[A-Z]/.test(match[1])) stableComponents.add(match[1]);
-    else broadStableVisual = true;
+    if (!componentSource(file)) broadStableVisual = true;
   }
 
   for (const file of paths) {
@@ -134,6 +145,8 @@ export function classifyVisualScope(
       releaseChannelChanged
     ) {
       stableThemes.add(themeMatch[1]);
+      visualDeferredReasons.add('stable-theme-package');
+      a11yDeferredReasons.add('stable-theme-package');
       continue;
     }
     if (headPkg?.astryx?.canaryOnly === true) {
@@ -141,17 +154,26 @@ export function classifyVisualScope(
     }
   }
 
+  const exactStableVisual =
+    stableComponents.size > 0 || stableStoryFiles.length > 0;
+  const broadVisual =
+    broadStableVisual || stableThemes.size > 0 || affected.visual.deferToMain;
+
   return {
-    hasStableVisual:
-      stableCoreFiles.length > 0 ||
-      stableThemes.size > 0 ||
-      stableStoryFiles.length > 0,
-    broadStableVisual: broadStableVisual || stableThemes.size > 0,
+    hasStableVisual: exactStableVisual || broadVisual,
+    exactStableVisual,
+    broadStableVisual: broadVisual,
     stableComponents: [...stableComponents].sort(),
     stableCoreFiles,
     stableThemes: [...stableThemes].sort(),
     stableStoryFiles: stableStoryFiles.sort(),
     canaryPackages: [...canaryPackages].sort(),
+    affectedDependencies: affected,
+    hasA11yComponents: affected.components.length > 0,
+    a11yComponents: affected.components,
+    broadA11yScope: affected.a11y.deferToMain || stableThemes.size > 0,
+    visualDeferredReasons: [...visualDeferredReasons].sort(),
+    a11yDeferredReasons: [...a11yDeferredReasons].sort(),
   };
 }
 
@@ -184,7 +206,10 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
         `stable_themes=${outputValue(result.stableThemes)}`,
         `stable_story_files=${outputValue(result.stableStoryFiles)}`,
         `canary_packages=${outputValue(result.canaryPackages)}`,
-        `has_stable_visual=${result.hasStableVisual}`,
+        `visual_deferred_reasons=${outputValue(result.visualDeferredReasons)}`,
+        `a11y_deferred_reasons=${outputValue(result.a11yDeferredReasons)}`,
+        `has_stable_visual=${result.exactStableVisual}`,
+        `stable_visual_deferred=${result.broadStableVisual}`,
       ].join('\n') + '\n',
     );
   }

--- a/.github/scripts/visual-scope.test.mjs
+++ b/.github/scripts/visual-scope.test.mjs
@@ -63,15 +63,38 @@ describe('classifyVisualScope', () => {
     ]);
   });
 
-  it('skips component metadata-only files as non-rendering changes', () => {
+  it('skips type-only component metadata as non-rendering changes', () => {
     const result = classifyVisualScope(
-      [
-        'packages/core/src/Button/index.ts',
-        'packages/core/src/Button/types.ts',
-      ],
+      ['packages/core/src/Button/types.ts'],
       root,
     );
     expect(result.hasStableVisual).toBe(false);
+  });
+
+  it('maps component source to exact a11y scope', () => {
+    const result = classifyVisualScope(
+      ['packages/lab/src/Drawer/Drawer.tsx'],
+      root,
+    );
+    expect(result).toMatchObject({
+      hasA11yComponents: true,
+      broadA11yScope: false,
+      a11yComponents: [{packageName: '@astryxdesign/lab', component: 'Drawer'}],
+    });
+  });
+
+  it('maps a nested component barrel to exact a11y scope', () => {
+    const result = classifyVisualScope(
+      ['packages/core/src/Button/index.ts'],
+      root,
+    );
+    expect(result).toMatchObject({
+      hasA11yComponents: true,
+      broadA11yScope: false,
+      a11yComponents: [
+        {packageName: '@astryxdesign/core', component: 'Button'},
+      ],
+    });
   });
 
   it('marks shared Core infrastructure as broad stable scope', () => {
@@ -83,6 +106,8 @@ describe('classifyVisualScope', () => {
       hasStableVisual: true,
       broadStableVisual: true,
       stableComponents: [],
+      broadA11yScope: true,
+      visualDeferredReasons: ['shared-theme-token-infrastructure'],
     });
   });
 
@@ -105,11 +130,12 @@ describe('classifyVisualScope', () => {
     expect(result).toMatchObject({
       hasStableVisual: true,
       broadStableVisual: true,
+      broadA11yScope: true,
       stableThemes: ['neutral'],
     });
   });
 
-  it('ignores build-only metadata in a stable theme package', () => {
+  it('defers build-only metadata in a stable theme package as ambiguous dependency input', () => {
     const result = classifyVisualScope(
       [
         'packages/themes/neutral/package.json',
@@ -127,10 +153,13 @@ describe('classifyVisualScope', () => {
       },
     );
     expect(result).toMatchObject({
-      hasStableVisual: false,
+      hasStableVisual: true,
+      broadStableVisual: true,
       stableComponents: [],
       stableThemes: [],
     });
+    expect(result.visualDeferredReasons).toContain('lockfile-ambiguity');
+    expect(result.visualDeferredReasons).toContain('package-manifest');
   });
 
   it('keeps a base-stable theme in scope when the PR marks it private', () => {
@@ -148,6 +177,7 @@ describe('classifyVisualScope', () => {
     expect(result).toMatchObject({
       hasStableVisual: true,
       broadStableVisual: true,
+      broadA11yScope: true,
       stableThemes: ['neutral'],
     });
   });
@@ -232,6 +262,110 @@ describe('classifyVisualScope', () => {
       {'apps/storybook/stories/Button.stories.tsx': 'export const Demo = {};'},
     );
     expect(result.hasStableVisual).toBe(false);
+  });
+
+  it.each([
+    ['apps/storybook/.storybook/preview.tsx', 'storybook-config'],
+    ['apps/storybook/public/demo.woff2', 'storybook-static-asset'],
+    ['.github/actions/setup/action.yml', 'browser-version-input'],
+    ['.nvmrc', 'browser-version-input'],
+    [
+      'packages/core/src/utils/parseStyleKey.ts',
+      'shared-theme-token-infrastructure',
+    ],
+    ['pnpm-lock.yaml', 'lockfile-ambiguity'],
+    ['pnpm-workspace.yaml', 'lockfile-ambiguity'],
+    ['apps/storybook/rtl-audit/targets.json', 'rtl-harness-input'],
+    [
+      'packages/core/src/runtime/portal.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+    [
+      'packages/core/src/focus/FocusScope.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+    [
+      'packages/core/src/utils/focusReturn.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+    [
+      'packages/core/src/hooks/useFocusTrap.ts',
+      'shared-core-runtime-infrastructure',
+    ],
+  ])(
+    'defers global or uncertain input %s to protected main',
+    (file, reason) => {
+      const result = classifyVisualScope([file], root);
+      expect(result).toMatchObject({
+        hasStableVisual: true,
+        broadStableVisual: true,
+        hasA11yComponents: false,
+        broadA11yScope: true,
+      });
+      expect(result.visualDeferredReasons).toContain(reason);
+      expect(result.a11yDeferredReasons).toContain(reason);
+    },
+  );
+
+  it.each([
+    'packages/core/src/i18n/getMessage.ts',
+    'packages/core/src/naming.ts',
+  ])(
+    'cross-checks shared unowned Core infrastructure as broad visual scope: %s',
+    file => {
+      const result = classifyVisualScope([file], root);
+
+      expect(result).toMatchObject({
+        hasA11yComponents: false,
+        broadA11yScope: true,
+        hasStableVisual: true,
+        exactStableVisual: false,
+        broadStableVisual: true,
+        stableComponents: [],
+      });
+      expect(result.visualDeferredReasons).toContain(
+        'shared-core-runtime-infrastructure',
+      );
+    },
+  );
+
+  it('keeps exact component scope when another input defers broadly', () => {
+    const result = classifyVisualScope(
+      ['packages/core/src/Button/Button.tsx', '.nvmrc'],
+      root,
+    );
+    expect(result).toMatchObject({
+      hasA11yComponents: true,
+      broadA11yScope: true,
+      hasStableVisual: true,
+      exactStableVisual: true,
+      broadStableVisual: true,
+      stableComponents: ['Button'],
+    });
+  });
+
+  it('writes mixed-scope outputs that keep exact component checks', () => {
+    const output = path.join(root, 'github-output-mixed');
+    execFileSync(process.execPath, [SCRIPT, '--github-output', output], {
+      input: 'packages/core/src/Button/Button.tsx\n.nvmrc\n',
+    });
+    const values = fs.readFileSync(output, 'utf8');
+    expect(values).toContain('has_stable_visual=true');
+    expect(values).toContain('stable_visual_deferred=true');
+    expect(values).not.toContain('has_components=');
+    expect(values).not.toContain('a11y_deferred=');
+  });
+
+  it('writes PR-capture outputs that skip deferred broad scopes', () => {
+    const output = path.join(root, 'github-output');
+    execFileSync(process.execPath, [SCRIPT, '--github-output', output], {
+      input: 'pnpm-lock.yaml\n',
+    });
+    const values = fs.readFileSync(output, 'utf8');
+    expect(values).toContain('has_stable_visual=false');
+    expect(values).toContain('stable_visual_deferred=true');
+    expect(values).not.toContain('has_components=');
+    expect(values).not.toContain('a11y_deferred=');
   });
 
   it('does not hardcode package names — any canaryOnly package is excluded', () => {

--- a/.github/scripts/visual-scope.test.mjs
+++ b/.github/scripts/visual-scope.test.mjs
@@ -63,6 +63,17 @@ describe('classifyVisualScope', () => {
     ]);
   });
 
+  it('skips component metadata-only files as non-rendering changes', () => {
+    const result = classifyVisualScope(
+      [
+        'packages/core/src/Button/index.ts',
+        'packages/core/src/Button/types.ts',
+      ],
+      root,
+    );
+    expect(result.hasStableVisual).toBe(false);
+  });
+
   it('marks shared Core infrastructure as broad stable scope', () => {
     const result = classifyVisualScope(
       ['packages/core/src/theme/Theme.tsx'],
@@ -93,6 +104,7 @@ describe('classifyVisualScope', () => {
     );
     expect(result).toMatchObject({
       hasStableVisual: true,
+      broadStableVisual: true,
       stableThemes: ['neutral'],
     });
   });
@@ -135,6 +147,7 @@ describe('classifyVisualScope', () => {
     );
     expect(result).toMatchObject({
       hasStableVisual: true,
+      broadStableVisual: true,
       stableThemes: ['neutral'],
     });
   });
@@ -193,6 +206,32 @@ describe('classifyVisualScope', () => {
         {input: 'packages/lab/src/Drawer/Drawer.tsx\n'},
       ),
     ).toThrow();
+  });
+
+  it('includes changed stable-visual stories by trusted head content', () => {
+    const result = classifyVisualScope(
+      ['apps/storybook/stories/Button.stories.tsx'],
+      root,
+      {},
+      {
+        'apps/storybook/stories/Button.stories.tsx':
+          "export const Focused = { tags: ['stable-visual'] };",
+      },
+    );
+    expect(result).toMatchObject({
+      hasStableVisual: true,
+      stableStoryFiles: ['apps/storybook/stories/Button.stories.tsx'],
+    });
+  });
+
+  it('skips changed stories without the stable-visual tag', () => {
+    const result = classifyVisualScope(
+      ['apps/storybook/stories/Button.stories.tsx'],
+      root,
+      {},
+      {'apps/storybook/stories/Button.stories.tsx': 'export const Demo = {};'},
+    );
+    expect(result.hasStableVisual).toBe(false);
   });
 
   it('does not hardcode package names — any canaryOnly package is excluded', () => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,44 +84,57 @@ jobs:
     permissions:
       contents: read
     outputs:
-      has_components: ${{ steps.check.outputs.has_components }}
+      has_components: ${{ steps.files.outputs.has_components || steps.affected.outputs.has_components }}
       # Stable visual scope is separate from component scope: Core and the
       # non-private shipped themes participate; canaryOnly packages do not.
-      has_stable_visual: ${{ steps.check.outputs.has_stable_visual }}
+      has_stable_visual: ${{ steps.files.outputs.has_stable_visual || steps.visual.outputs.has_stable_visual }}
+      stable_visual_deferred: ${{ steps.files.outputs.stable_visual_deferred || steps.visual.outputs.stable_visual_deferred }}
+      a11y_deferred: ${{ steps.files.outputs.a11y_deferred || steps.affected.outputs.a11y_deferred }}
+      rtl_deferred: ${{ steps.files.outputs.a11y_deferred || steps.affected.outputs.rtl_deferred }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           # Depth 50 (same as check-scope) so the three-dot diff below can find
-          # a merge base. With the default depth of 1 the diff fails with
-          # "no merge base", the error is swallowed by the pipeline, and
-          # has_components silently becomes false — skipping pr-a11y entirely.
+          # a merge base. If it still cannot, PR-scoped checks defer to protected
+          # main instead of guessing a component set or sweeping everything.
           fetch-depth: 50
 
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }} --depth=50
 
-      - name: Check for component changes
-        id: check
+      - name: Resolve changed files
+        id: files
         run: |
           if ! git merge-base HEAD origin/${{ github.base_ref }} >/dev/null 2>&1; then
-            echo "::warning::No merge base between HEAD and origin/${{ github.base_ref }} (clone too shallow) — assuming components changed so pr-a11y still runs"
-            echo "has_components=true" >> "$GITHUB_OUTPUT"
-            # Fail closed for the stable lane too: without a merge base we do
-            # not know whether a stable package changed.
-            echo "has_stable_visual=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::No merge base between HEAD and origin/${{ github.base_ref }} (clone too shallow) — deferring PR-scoped a11y and visual review to protected main"
+            echo "has_components=false" >> "$GITHUB_OUTPUT"
+            echo "a11y_deferred=true" >> "$GITHUB_OUTPUT"
+            echo "has_stable_visual=false" >> "$GITHUB_OUTPUT"
+            echo "stable_visual_deferred=true" >> "$GITHUB_OUTPUT"
+            echo "deferred=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          CHANGED=$(printf '%s\n' "$FILES" | grep -E '^packages/(core|lab)/src/' | grep -v -E '(hooks|theme|utils|i18n|__tests__)/' | head -1 || true)
-          echo "has_components=$( [ -n "$CHANGED" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          {
+            echo 'changed_files<<EOF'
+            printf '%s\n' "$FILES"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
-          # One classifier owns the release-channel rule. It reads each
-          # package's `astryx.canaryOnly` metadata rather than hard-coding
-          # today's Lab/charts/richtext/vega list.
-          printf '%s\n' "$FILES" \
+      - name: Classify affected scope
+        id: affected
+        if: steps.files.outputs.deferred != 'true'
+        uses: ./.github/actions/affected-scope
+        with:
+          changed-files: ${{ steps.files.outputs.changed_files }}
+
+      - name: Classify stable visual scope
+        id: visual
+        if: steps.files.outputs.deferred != 'true'
+        run: |
+          printf '%s\n' '${{ steps.files.outputs.changed_files }}' \
             | node .github/scripts/visual-scope.mjs --github-output "$GITHUB_OUTPUT"
-
   # Run tests (parallel with build)
   test:
     needs: [check-scope]
@@ -463,6 +476,12 @@ jobs:
         with:
           name: pr-analysis
 
+      - name: Classify affected scope
+        id: affected
+        uses: ./.github/actions/affected-scope
+        with:
+          analysis-file: analysis.json
+
       - name: Download Storybook artifact
         uses: actions/download-artifact@v8
         with:
@@ -477,7 +496,11 @@ jobs:
       # audits" for the baseline workflow.
       - name: Run accessibility audit
         run: |
-          COMPONENTS=$(cat analysis.json | jq -r '(.newComponents + .modifiedComponents) | join(",")')
+          COMPONENTS="${{ steps.affected.outputs.affected_components }}"
+          if [ -z "$COMPONENTS" ]; then
+            echo "No exact affected components from affectedScope — skipping accessibility audit."
+            exit 0
+          fi
           node .github/scripts/accessibility-audit.js \
             --storybook-dir apps/storybook/dist \
             --output a11y-report.json \
@@ -565,19 +588,13 @@ jobs:
       - name: Verify guest fixture contrast
         run: pnpm -F @astryxdesign/vibe-tests fixtures:contrast
 
-  # Stable-package visual regression. Core components get every story in
-  # every shipped theme that styles them; a changed shipped theme gets its
-  # relevant matrix. Packages marked `astryx.canaryOnly` (Lab, charts,
-  # richtext, vega) do not compare pixels and do not own a baseline.
+  # Stable-package visual regression. Core component changes get their Theme
+  # Sheet in Neutral and Probe; stable-visual story changes opt into Neutral.
+  # Shared, theme-wide, browser, asset, or lockfile inputs defer to protected
+  # main rather than expanding an ordinary PR into a global visual review.
   #
-  # Deeper than the daily gate where it looks: the release gate shoots ONE
-  # representative story per component, this shoots EVERY story of the touched
-  # component in EVERY theme that styles it.
-  #
-  # SKIPS ITSELF WHEN A PR IS TOO BROAD (--max-shots). A token or shared-hook
-  # change puts hundreds of diffs in front of a reviewer who cannot judge them
-  # one by one, and a per-PR check is the wrong instrument for that change —
-  # the daily gate reviews it against the whole baseline instead. The skip
+  # The trusted workflow_run publisher builds the plan before enforcing the
+  # review budget: >24 warns, >40 defers cleanly to protected main. The skip
   # states its reason in the PR comment rather than vanishing.
   #
   # SOFT / NON-BLOCKING (continue-on-error) while the suite earns trust: the
@@ -604,6 +621,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: pr-analysis
+
+      - name: Classify affected scope
+        id: affected
+        uses: ./.github/actions/affected-scope
+        with:
+          analysis-file: analysis.json
 
       - name: Download Storybook artifact
         uses: actions/download-artifact@v8
@@ -652,24 +675,15 @@ jobs:
           set -eu
           # Component names are not globally unique, so filter by the package
           # recorded in componentStats — never infer stability from a name.
-          COMPONENTS=$(jq -r '. as $root | [(.newComponents + .modifiedComponents)[] | select($root.componentStats[.].package == "@astryxdesign/core")] | unique | join(",")' analysis.json)
-          THEMES=$(jq -r '(.changedStableThemes // []) | join(",")' analysis.json)
+          COMPONENTS="${{ steps.affected.outputs.affected_core_components }}"
+          THEMES=""
 
-          if [ -n "$COMPONENTS" ] && [ -n "$THEMES" ]; then
-            TIERS="component,theme-matrix"
-            SCOPE_ARGS=(--components "$COMPONENTS" --themes "$THEMES")
-          elif [ -n "$COMPONENTS" ]; then
+          if [ -n "$COMPONENTS" ]; then
             TIERS="component"
             SCOPE_ARGS=(--components "$COMPONENTS" --no-scout)
-          elif [ -n "$THEMES" ]; then
-            TIERS="theme-matrix"
-            SCOPE_ARGS=(--themes "$THEMES")
           else
-            # Shared Core theming/tokens/hooks are stable but broad. Let the
-            # gate plan the full stable surface and decline visibly at the shot
-            # budget; the daily stable gate owns the exhaustive comparison.
-            TIERS="surface,theme-matrix,probe"
-            SCOPE_ARGS=()
+            echo "No exact stable Core components from affected scope — skipping visual capture."
+            exit 0
           fi
 
           echo "Stable Core components: ${COMPONENTS:-none}"
@@ -736,6 +750,12 @@ jobs:
         with:
           name: pr-analysis
 
+      - name: Classify affected scope
+        id: affected
+        uses: ./.github/actions/affected-scope
+        with:
+          analysis-file: analysis.json
+
       - name: Download Storybook artifact
         uses: actions/download-artifact@v8
         with:
@@ -751,9 +771,9 @@ jobs:
       - name: Run RTL audit
         id: rtl
         run: |
-          COMPONENTS=$(jq -r '(.newComponents + .modifiedComponents) | join(",")' analysis.json)
+          COMPONENTS="${{ steps.affected.outputs.affected_components }}"
           if [ -z "$COMPONENTS" ]; then
-            echo "No component changes resolved from analysis.json — skipping RTL audit."
+            echo "No exact affected components from affectedScope — skipping RTL audit."
             echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -200,13 +200,18 @@ jobs:
               owner, repo, pull_number: pullNumber, per_page: 100,
             });
             const manifestPaths = new Set();
+            const snapshotPaths = new Set();
             for (const {filename} of files) {
               const theme = filename.match(/^packages\/themes\/([^/]+)\//);
               const pkg = filename.match(/^packages\/([^/]+)\//);
               if (theme) manifestPaths.add(`packages/themes/${theme[1]}/package.json`);
               else if (pkg) manifestPaths.add(`packages/${pkg[1]}/package.json`);
+              if (/^apps\/storybook\/stories\/.*\.stories\.(tsx|ts|mdx)$/.test(filename)) {
+                snapshotPaths.add(filename);
+              }
             }
             const manifests = {};
+            const fileSnapshots = {};
             const [headOwner, headRepo] = pr.head.repo.full_name.split('/');
             for (const manifestPath of manifestPaths) {
               try {
@@ -220,10 +225,29 @@ jobs:
                 if (error.status !== 404) throw error;
               }
             }
+            for (const filePath of snapshotPaths) {
+              try {
+                const {data} = await github.rest.repos.getContent({
+                  owner: headOwner, repo: headRepo, path: filePath, ref: pr.head.sha,
+                });
+                if (!Array.isArray(data) && data.content) {
+                  fileSnapshots[filePath] = Buffer.from(data.content, 'base64').toString();
+                }
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
             fs.writeFileSync('visual-scope-manifests.json', JSON.stringify(manifests));
+            fs.writeFileSync('visual-scope-files.json', JSON.stringify(fileSnapshots));
             const result = spawnSync(
               process.execPath,
-              ['.github/scripts/visual-scope.mjs', '--manifests', 'visual-scope-manifests.json'],
+              [
+                '.github/scripts/visual-scope.mjs',
+                '--manifests',
+                'visual-scope-manifests.json',
+                '--file-snapshots',
+                'visual-scope-files.json',
+              ],
               {input: `${files.map((file) => file.filename).join('\n')}\n`, encoding: 'utf8'},
             );
             if (result.status !== 0) {
@@ -294,6 +318,7 @@ jobs:
             "https://github.com/${GITHUB_REPOSITORY}.git" /tmp/gh-pages
 
       - name: Capture the trusted stable visual scope
+        id: plan
         if: >-
           steps.identity.outputs.valid == 'true' &&
           steps.scope.outputs.stable == 'true' &&
@@ -304,13 +329,38 @@ jobs:
           ASTRYX_VISUAL_RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
           ASTRYX_PR_HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
           ASTRYX_PR_BASE_SHA: ${{ steps.identity.outputs.base_sha }}
+          PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
+          BASE_SHA: ${{ steps.identity.outputs.base_sha }}
+          RUN_ID: ${{ steps.identity.outputs.run_id }}
+          RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
         run: |
-          npx playwright install chromium
           node .github/scripts/visual-gate/visual-acceptance.mjs trusted-plan \
             --scope trusted-scope.json \
             --baseline /tmp/gh-pages/visual-gate/baseline \
             --storybook-dir apps/storybook/dist \
             --output trusted-plan.json
+          SHOTS=$(node -e "const p=JSON.parse(require('fs').readFileSync('trusted-plan.json', 'utf8')); console.log(Array.isArray(p) ? p.length : ((p.shots||[]).length + (p.expectedRemoved||p.expectedRemovals||[]).length))")
+          echo "shots=$SHOTS" >> "$GITHUB_OUTPUT"
+          if [ "$SHOTS" -gt 24 ]; then
+            echo "::warning::Trusted PR visual plan has $SHOTS shots; above 24 requires close human review."
+          fi
+          if [ "$SHOTS" -gt 40 ]; then
+            node .github/scripts/visual-gate/visual-acceptance.mjs trusted-defer \
+              --scope trusted-scope.json \
+              --baseline /tmp/gh-pages/visual-gate/baseline \
+              --plan-file trusted-plan.json \
+              --output trusted-visual \
+              --pr "$PR_NUMBER" \
+              --head "$HEAD_SHA" \
+              --base "$BASE_SHA" \
+              --run-id "$RUN_ID" \
+              --run-attempt "$RUN_ATTEMPT"
+            echo "deferred=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "deferred=false" >> "$GITHUB_OUTPUT"
+          npx playwright install chromium
           node .github/scripts/visual-gate/gate.mjs capture \
             --storybook-dir apps/storybook/dist \
             --out trusted-capture \
@@ -346,7 +396,8 @@ jobs:
         if: >-
           steps.identity.outputs.valid == 'true' &&
           steps.scope.outputs.stable == 'true' &&
-          steps.scope.outputs.broad != 'true'
+          steps.scope.outputs.broad != 'true' &&
+          steps.plan.outputs.deferred != 'true'
         env:
           PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
           HEAD_SHA: ${{ steps.identity.outputs.head_sha }}

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -257,6 +257,7 @@ jobs:
             const scope = JSON.parse(result.stdout);
             fs.writeFileSync('trusted-scope.json', JSON.stringify(scope));
             core.setOutput('stable', String(scope.hasStableVisual));
+            core.setOutput('exact', String(scope.exactStableVisual));
             core.setOutput('broad', String(scope.broadStableVisual));
 
       - name: Download analysis artifact from the CI run
@@ -282,8 +283,7 @@ jobs:
       - name: Download Storybook for trusted visual capture
         if: >-
           steps.identity.outputs.valid == 'true' &&
-          steps.scope.outputs.stable == 'true' &&
-          steps.scope.outputs.broad != 'true'
+          steps.scope.outputs.exact == 'true'
         uses: actions/download-artifact@v8
         with:
           pattern: storybook-*
@@ -321,8 +321,7 @@ jobs:
         id: plan
         if: >-
           steps.identity.outputs.valid == 'true' &&
-          steps.scope.outputs.stable == 'true' &&
-          steps.scope.outputs.broad != 'true'
+          steps.scope.outputs.exact == 'true'
         env:
           ASTRYX_VISUAL_SHA: ${{ steps.identity.outputs.head_sha }}
           ASTRYX_VISUAL_RUN_ID: ${{ steps.identity.outputs.run_id }}
@@ -370,7 +369,8 @@ jobs:
         if: >-
           steps.identity.outputs.valid == 'true' &&
           steps.scope.outputs.stable == 'true' &&
-          steps.scope.outputs.broad == 'true'
+          steps.scope.outputs.broad == 'true' &&
+          steps.scope.outputs.exact != 'true'
         env:
           PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
           HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
@@ -395,8 +395,7 @@ jobs:
       - name: Derive trusted visual evidence and report
         if: >-
           steps.identity.outputs.valid == 'true' &&
-          steps.scope.outputs.stable == 'true' &&
-          steps.scope.outputs.broad != 'true' &&
+          steps.scope.outputs.exact == 'true' &&
           steps.plan.outputs.deferred != 'true'
         env:
           PR_NUMBER: ${{ steps.identity.outputs.pr_number }}

--- a/apps/storybook/README.md
+++ b/apps/storybook/README.md
@@ -21,13 +21,15 @@ find it:
   builder sees.
 - **`Theme Sheet` comes second** — every themeable target of that component, in
   every variant and state its `.doc.mjs` declares, on one page. It is the
-  reference for theme authors and the surface the visual gate photographs under
-  the probe theme, which is how a theming target is proven to still reach the
-  pixels. A component whose sheet is missing a target has a target nothing can
-  verify.
+  reference for theme authors and the required compact PR visual surface: changed
+  stable components are photographed here in Neutral and Probe, light and dark.
+  A component whose sheet is missing a target has a target nothing can verify.
 - **Hooks and theme-level features are not components** and do not sit beside
   them. Icon and indicator registries, `MediaTheme`, `CodeTheme` and the like
   live under `Themes/`.
+
+- **`stable-visual` is opt-in.** Add this tag only to extra stories that must
+  run in PR visual coverage; they are photographed in Neutral, light and dark.
 
 ### A Theme Sheet must not pin its own theme
 

--- a/internal/lab-readiness/audit.test.mjs
+++ b/internal/lab-readiness/audit.test.mjs
@@ -41,7 +41,10 @@ let root;
 function scaffold(overrides = {}) {
   const files = {
     '.github/workflows/ci.yml':
-      'CHANGED=$(git diff --name-only origin/main...HEAD -- packages/core/src/ packages/lab/src/ | grep -v x)\n',
+      '  check-components:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          changed-files: ${{ steps.files.outputs.changed_files }}\n' +
+      '  pr-a11y:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          analysis-file: analysis.json\n' +
+      '  pr-visual:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          analysis-file: analysis.json\n' +
+      '  pr-rtl:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          analysis-file: analysis.json\n',
     'apps/storybook/rtl-audit/rtl-audit.mjs':
       "const AUDITED_STORY_PREFIXES = ['core-', 'lab-'];\n",
     'packages/lab/package.json': JSON.stringify({
@@ -73,6 +76,58 @@ function scaffold(overrides = {}) {
     fs.mkdirSync(path.dirname(abs), {recursive: true});
     fs.writeFileSync(abs, contents);
   }
+  writeScopeHelper(root);
+  writeScopeAction(root);
+}
+
+function writeScopeHelper(repoRoot, body = null) {
+  const helper = path.join(repoRoot, '.github/scripts/lib/affected-scope.js');
+  fs.mkdirSync(path.dirname(helper), {recursive: true});
+  fs.writeFileSync(
+    helper,
+    body ??
+      `const roots = ['packages/core/src/', 'packages/lab/src/'];
+const consumers = ['ci.check-components', 'ci.pr-a11y', 'ci.pr-rtl', 'pr-comment.visual', 'lab-readiness'];
+function componentRoots() { return roots; }
+function classifyAffectedDependencies(files = []) { return {schemaVersion: 1, consumers, componentRoots: roots, components: files.includes('packages/core/src/Button/Button.tsx') ? [{packageName: '@astryxdesign/core', component: 'Button'}] : [], visual: {deferToMain: false, reasons: []}, a11y: {deferToMain: false, reasons: []}, rtl: {deferToMain: false, reasons: []}}; }
+if (require.main === module && process.argv[2] === 'component-roots') process.stdout.write(roots.join(' ') + '\\n');
+module.exports = {SCHEMA_VERSION: 1, CONSUMERS: consumers, componentRoots, classifyAffectedDependencies};
+`,
+  );
+  return helper;
+}
+
+function writeScopeAction(repoRoot, body = null, entry = null) {
+  const action = path.join(
+    repoRoot,
+    '.github/actions/affected-scope/action.yml',
+  );
+  fs.mkdirSync(path.dirname(action), {recursive: true});
+  fs.writeFileSync(
+    action,
+    body ??
+      `inputs:
+  changed-files:
+  analysis-file:
+outputs:
+  affected_components:
+  affected_core_components:
+  affected_deferred_reasons:
+  a11y_deferred:
+  has_components:
+  json:
+  rtl_deferred:
+runs:
+  using: node20
+  main: index.mjs
+`,
+  );
+  fs.writeFileSync(
+    path.join(path.dirname(action), 'index.mjs'),
+    entry ??
+      'const {classifyAffectedDependencies} = ../../scripts/lib/affected-scope.js;\nclassifyAffectedDependencies([]);\n',
+  );
+  return action;
 }
 
 beforeAll(() => {
@@ -99,7 +154,9 @@ describe('automated derivation', () => {
     });
     const derived = deriveChecks(root, candidate);
     expect(derived.accessibilityContracts.state).not.toBe('passed');
-    expect(derived.accessibilityContracts.note).toMatch(/excludes packages\/lab/);
+    expect(derived.accessibilityContracts.note).toMatch(
+      /excludes packages\/lab/,
+    );
   });
 
   it('fails the keyboard check when the RTL sweep stops covering lab', () => {
@@ -119,7 +176,9 @@ describe('automated derivation', () => {
     });
     const derived = deriveChecks(root, candidate);
     expect(derived.accessibilityContracts.state).not.toBe('passed');
-    expect(derived.accessibilityContracts.note).toMatch(/resolves to the analyzer/);
+    expect(derived.accessibilityContracts.note).toMatch(
+      /resolves to the analyzer/,
+    );
   });
 
   it('requires an advertised state to appear in both a story and a test', () => {
@@ -215,7 +274,9 @@ describe('automated derivation', () => {
         "import {scaleLinear} from 'd3-scale';\n" +
         'export function Widget() { return <Text>{String(scaleLinear)}</Text>; }\n',
     });
-    expect(deriveChecks(root, candidate).systemIntegration.state).toBe('passed');
+    expect(deriveChecks(root, candidate).systemIntegration.state).toBe(
+      'passed',
+    );
   });
 
   it('accepts inline type modifiers in the barrel', () => {
@@ -343,11 +404,170 @@ describe('report shape', () => {
 });
 
 describe('CI wiring parsers', () => {
+  const goodWorkflow = () =>
+    '  check-components:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          changed-files: ${{ steps.files.outputs.changed_files }}\n' +
+    '  pr-a11y:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          analysis-file: analysis.json\n' +
+    '  pr-visual:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          analysis-file: analysis.json\n' +
+    '  pr-rtl:\n    steps:\n      - uses: ./.github/actions/affected-scope\n        with:\n          analysis-file: analysis.json\n';
+
   it('reads the component roots out of the real ci.yml', () => {
     const repoRoot = path.resolve(import.meta.dirname, '..', '..');
     const roots = _internal.ciComponentRoots(repoRoot);
     expect(roots).toContain('packages/core/src/');
     expect(roots).toContain('packages/lab/src/');
+  });
+
+  it('matches the shared affected-scope consumer inventory', () => {
+    const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+    const contract = _internal.loadAffectedScopeContract(repoRoot);
+    expect(contract.module.CONSUMERS).toEqual([
+      'ci.check-components',
+      'ci.pr-a11y',
+      'ci.pr-rtl',
+      'pr-comment.visual',
+      'lab-readiness',
+    ]);
+    expect(_internal.affectedScopeWorkflowContract(repoRoot).jobs).toEqual([
+      'check-components',
+      'pr-a11y',
+      'pr-visual',
+      'pr-rtl',
+    ]);
+  });
+
+  it('parses legacy pathspec and shared action component scope syntax', () => {
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-roots-'));
+    try {
+      const ci = path.join(scratch, '.github/workflows/ci.yml');
+      fs.mkdirSync(path.dirname(ci), {recursive: true});
+      fs.writeFileSync(
+        ci,
+        'CHANGED=$(git diff --name-only origin/main...HEAD -- packages/core/src/ packages/lab/src/ | grep -v x)\n',
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([
+        'packages/core/src/',
+        'packages/lab/src/',
+      ]);
+
+      writeScopeHelper(scratch);
+      writeScopeAction(scratch);
+      fs.writeFileSync(ci, goodWorkflow());
+      expect(_internal.ciComponentRoots(scratch)).toEqual([
+        'packages/core/src/',
+        'packages/lab/src/',
+      ]);
+    } finally {
+      fs.rmSync(scratch, {recursive: true, force: true});
+    }
+  });
+
+  it('fails closed when the shared scope helper is missing, malformed, or throws', () => {
+    const scratch = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'ci-roots-bad-helper-'),
+    );
+    try {
+      const ci = path.join(scratch, '.github/workflows/ci.yml');
+      fs.mkdirSync(path.dirname(ci), {recursive: true});
+      fs.writeFileSync(ci, goodWorkflow());
+      writeScopeAction(scratch);
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+
+      writeScopeHelper(scratch, 'module.exports = {SCHEMA_VERSION: 1};\n');
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+
+      writeScopeHelper(scratch, 'throw new Error("boom");\n');
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+    } finally {
+      fs.rmSync(scratch, {recursive: true, force: true});
+    }
+  });
+
+  it('observes executable helper roots instead of a parallel workflow string', () => {
+    const scratch = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'ci-roots-altered-helper-'),
+    );
+    try {
+      const ci = path.join(scratch, '.github/workflows/ci.yml');
+      fs.mkdirSync(path.dirname(ci), {recursive: true});
+      fs.writeFileSync(ci, goodWorkflow());
+      writeScopeAction(scratch);
+      writeScopeHelper(
+        scratch,
+        `const roots = ['packages/core/src/'];
+const consumers = ['ci.check-components', 'ci.pr-a11y', 'ci.pr-rtl', 'pr-comment.visual', 'lab-readiness'];
+function componentRoots() { return roots; }
+function classifyAffectedDependencies(files = []) { return {schemaVersion: 1, consumers, componentRoots: roots, components: files.includes('packages/core/src/Button/Button.tsx') ? [{packageName: '@astryxdesign/core', component: 'Button'}] : [], visual: {deferToMain: false, reasons: []}, a11y: {deferToMain: false, reasons: []}, rtl: {deferToMain: false, reasons: []}}; }
+if (require.main === module && process.argv[2] === 'component-roots') process.stdout.write(roots.join(' ') + '\\n');
+module.exports = {SCHEMA_VERSION: 1, CONSUMERS: consumers, componentRoots, classifyAffectedDependencies};
+`,
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([
+        'packages/core/src/',
+      ]);
+    } finally {
+      fs.rmSync(scratch, {recursive: true, force: true});
+    }
+  });
+
+  it('rejects wrong action path, missing inputs, missing outputs, and shadow commands', () => {
+    const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-action-drift-'));
+    try {
+      const ci = path.join(scratch, '.github/workflows/ci.yml');
+      fs.mkdirSync(path.dirname(ci), {recursive: true});
+      writeScopeHelper(scratch);
+      writeScopeAction(scratch);
+      fs.writeFileSync(ci, goodWorkflow());
+      expect(_internal.ciComponentRoots(scratch)).toEqual([
+        'packages/core/src/',
+        'packages/lab/src/',
+      ]);
+
+      fs.writeFileSync(
+        ci,
+        goodWorkflow().replace(
+          'uses: ./.github/actions/affected-scope',
+          'uses: ./.github/actions/wrong-scope',
+        ),
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+
+      fs.writeFileSync(ci, goodWorkflow());
+      writeScopeAction(
+        scratch,
+        'inputs:\n  changed-files:\noutputs:\n  affected_components:\nruns:\n  using: composite\n  steps: []\n',
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+
+      writeScopeAction(
+        scratch,
+        'inputs:\n  changed-files:\n  analysis-file:\noutputs:\n  affected_components:\n  affected_core_components:\n  affected_deferred_reasons:\n  a11y_deferred:\n  has_components:\n  json:\n  rtl_deferred:\nruns:\n  using: node16\n  main: index.mjs\n',
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+
+      writeScopeAction(
+        scratch,
+        'inputs:\n  changed-files:\n  analysis-file:\noutputs:\n  affected_components:\n  affected_core_components:\n  affected_deferred_reasons:\n  a11y_deferred:\n  has_components:\n  json:\n  rtl_deferred:\nruns:\n  using: node20\n  main: wrong.js\n',
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+
+      writeScopeAction(
+        scratch,
+        'inputs:\n  changed-files:\n  analysis-file:\noutputs:\n  affected_components:\n  affected_core_components:\n  affected_deferred_reasons:\n  a11y_deferred:\n  has_components:\n  json:\n  rtl_deferred:\nruns:\n  using: node20\n  main: index.mjs\n  steps:\n    - run: echo bad\n',
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+
+      writeScopeAction(scratch);
+      fs.writeFileSync(
+        ci,
+        goodWorkflow().replace(
+          '  pr-a11y:\n',
+          '      - run: node .github/scripts/lib/affected-scope.js component-roots\n  pr-a11y:\n',
+        ),
+      );
+      expect(_internal.ciComponentRoots(scratch)).toEqual([]);
+    } finally {
+      fs.rmSync(scratch, {recursive: true, force: true});
+    }
   });
 
   it('reads the audited story prefixes out of the real rtl-audit', () => {

--- a/internal/lab-readiness/automated.mjs
+++ b/internal/lab-readiness/automated.mjs
@@ -18,13 +18,24 @@
  * good". Quality judgements belong to the human review stage.
  */
 
+import {execFileSync} from 'node:child_process';
 import fs from 'node:fs';
+import {createRequire} from 'node:module';
 import path from 'node:path';
 
 const LAB_SRC = 'packages/lab/src';
 const STORIES_DIR = 'apps/storybook/stories';
 const CI_WORKFLOW = '.github/workflows/ci.yml';
+const SCOPE_ACTION = '.github/actions/affected-scope/action.yml';
 const RTL_AUDIT = 'apps/storybook/rtl-audit/rtl-audit.mjs';
+const require = createRequire(import.meta.url);
+const EXPECTED_SCOPE_CONSUMERS = [
+  'ci.check-components',
+  'ci.pr-a11y',
+  'ci.pr-rtl',
+  'pr-comment.visual',
+  'lab-readiness',
+];
 
 /** Read a repo-relative file, or null when it does not exist. */
 function read(repoRoot, relPath) {
@@ -94,14 +105,146 @@ function a11yComponentFromTitle(title) {
   return componentPart.replace(/^XDS/i, '').toLowerCase();
 }
 
+function hasYamlKey(content, key) {
+  return new RegExp(`^  ${key}:`, 'm').test(content);
+}
+
+function affectedScopeActionContract(repoRoot) {
+  const action = read(repoRoot, SCOPE_ACTION);
+  if (!action) return null;
+  const requiredInputs = ['changed-files', 'analysis-file'];
+  const requiredOutputs = [
+    'affected_components',
+    'affected_core_components',
+    'affected_deferred_reasons',
+    'a11y_deferred',
+    'has_components',
+    'json',
+    'rtl_deferred',
+  ];
+  const main = action.match(/^  main: ['"]?([^'"\n]+)['"]?$/m)?.[1];
+  if (
+    requiredInputs.some(input => !hasYamlKey(action, input)) ||
+    requiredOutputs.some(output => !hasYamlKey(action, output)) ||
+    !/^  using: node20$/m.test(action) ||
+    main !== 'index.mjs' ||
+    /\n\s+(?:-\s+)?run:/.test(action)
+  ) {
+    return null;
+  }
+  const entry = read(repoRoot, path.join(path.dirname(SCOPE_ACTION), main));
+  if (
+    !entry ||
+    !entry.includes('../../scripts/lib/affected-scope.js') ||
+    !entry.includes('classifyAffectedDependencies')
+  ) {
+    return null;
+  }
+  return {inputs: requiredInputs, outputs: requiredOutputs, main};
+}
+
+function workflowJob(content, jobName) {
+  const start = content.indexOf(`  ${jobName}:`);
+  if (start === -1) return '';
+  const rest = content.slice(start + 1);
+  const next = rest.search(/\n  [A-Za-z0-9_-]+:\n/);
+  return next === -1
+    ? content.slice(start)
+    : content.slice(start, start + 1 + next);
+}
+
+function affectedScopeWorkflowContract(repoRoot) {
+  const ci = read(repoRoot, CI_WORKFLOW);
+  if (!ci || !affectedScopeActionContract(repoRoot)) return null;
+  const consumers = [
+    [
+      'check-components',
+      'changed-files: ${{ steps.files.outputs.changed_files }}',
+    ],
+    ['pr-a11y', 'analysis-file: analysis.json'],
+    ['pr-visual', 'analysis-file: analysis.json'],
+    ['pr-rtl', 'analysis-file: analysis.json'],
+  ];
+  for (const [job, input] of consumers) {
+    const block = workflowJob(ci, job);
+    if (
+      !block.includes('uses: ./.github/actions/affected-scope') ||
+      !block.includes(input) ||
+      /node .*affected-scope\.js/.test(block) ||
+      /jq -r .*newComponents.*modifiedComponents/.test(block) ||
+      /jq -r .*affectedScope\.components/.test(block)
+    ) {
+      return null;
+    }
+  }
+  return {jobs: consumers.map(([job]) => job)};
+}
+
+function loadAffectedScopeContract(repoRoot) {
+  const helperRel = '.github/scripts/lib/affected-scope.js';
+  const helper = path.join(repoRoot, helperRel);
+  if (!exists(repoRoot, helperRel)) return null;
+  try {
+    delete require.cache[require.resolve(helper)];
+    const mod = require(helper);
+    if (
+      mod.SCHEMA_VERSION !== 1 ||
+      typeof mod.classifyAffectedDependencies !== 'function' ||
+      typeof mod.componentRoots !== 'function' ||
+      !Array.isArray(mod.CONSUMERS) ||
+      EXPECTED_SCOPE_CONSUMERS.some(
+        consumer => !mod.CONSUMERS.includes(consumer),
+      )
+    ) {
+      return null;
+    }
+    const roots = mod.componentRoots();
+    if (!Array.isArray(roots) || roots.some(root => typeof root !== 'string')) {
+      return null;
+    }
+    const stdout = execFileSync(process.execPath, [helper, 'component-roots'], {
+      encoding: 'utf8',
+    }).trim();
+    if (stdout !== roots.join(' ')) return null;
+    const sample = mod.classifyAffectedDependencies([
+      'packages/core/src/Button/Button.tsx',
+    ]);
+    if (
+      sample?.schemaVersion !== 1 ||
+      !Array.isArray(sample.consumers) ||
+      EXPECTED_SCOPE_CONSUMERS.some(
+        consumer => !sample.consumers.includes(consumer),
+      ) ||
+      !Array.isArray(sample.componentRoots) ||
+      !Array.isArray(sample.components) ||
+      typeof sample.visual?.deferToMain !== 'boolean' ||
+      typeof sample.a11y?.deferToMain !== 'boolean' ||
+      typeof sample.rtl?.deferToMain !== 'boolean'
+    ) {
+      return null;
+    }
+    return {module: mod, roots};
+  } catch {
+    return null;
+  }
+}
+
 /** Roots the ci.yml `check-components` gate diffs against. */
 function ciComponentRoots(repoRoot) {
   const ci = read(repoRoot, CI_WORKFLOW);
   if (!ci) return [];
-  const pathspec = ci.match(/git diff --name-only [^\n]*?\.\.\.HEAD --([^|\n]+)/);
+  if (/uses:\s+\.\/.github\/actions\/affected-scope/.test(ci)) {
+    if (!affectedScopeWorkflowContract(repoRoot)) return [];
+    return loadAffectedScopeContract(repoRoot)?.roots ?? [];
+  }
+  const pathspec = ci.match(
+    /git diff --name-only [^\n]*?\.\.\.HEAD --([^|\n]+)/,
+  );
   if (pathspec) return pathspec[1].trim().split(/\s+/).filter(Boolean);
   const filtered = ci.match(/grep -E ['"]\^packages\/\(([^)]+)\)\/src\/['"]/);
-  return filtered ? filtered[1].split('|').map(name => `packages/${name}/src/`) : [];
+  return filtered
+    ? filtered[1].split('|').map(name => `packages/${name}/src/`)
+    : [];
 }
 
 /** Story-id prefixes the RTL auto-discovery sweep covers. */
@@ -128,7 +271,11 @@ function importedPackages(source) {
       specifiers
         .filter(s => !s.startsWith('.') && !s.startsWith('node:'))
         // Scoped packages keep two segments, everything else keeps one.
-        .map(s => (s.startsWith('@') ? s.split('/').slice(0, 2).join('/') : s.split('/')[0])),
+        .map(s =>
+          s.startsWith('@')
+            ? s.split('/').slice(0, 2).join('/')
+            : s.split('/')[0],
+        ),
     ),
   ];
 }
@@ -232,13 +379,13 @@ export function deriveChecks(repoRoot, candidate) {
       const ariaLiveLine = lineOf(source, /aria-live/);
       if (ariaLiveLine && !/useAnnounce/.test(source)) {
         failures.push('hand-rolls a live region instead of useAnnounce');
-        evidence.push(
-          ev('Ad hoc aria-live node.', p.source, ariaLiveLine),
-        );
+        evidence.push(ev('Ad hoc aria-live node.', p.source, ariaLiveLine));
       }
       const undeclared = undeclaredDependencies(repoRoot, source);
       if (undeclared.length > 0) {
-        failures.push(`imports undeclared package(s): ${undeclared.join(', ')}`);
+        failures.push(
+          `imports undeclared package(s): ${undeclared.join(', ')}`,
+        );
         evidence.push(
           ev(
             `Not listed in the lab package's dependencies or peerDependencies, so a consumer installing @astryxdesign/lab would not get ${undeclared.join(', ')}.`,
@@ -324,7 +471,9 @@ export function deriveChecks(repoRoot, candidate) {
       const hexLine = lineOf(source, /:\s*'#[0-9a-fA-F]{3,8}'/);
       if (hexLine) {
         failures.push('hardcoded hex color');
-        evidence.push(ev('Raw hex instead of a color token.', p.source, hexLine));
+        evidence.push(
+          ev('Raw hex instead of a color token.', p.source, hexLine),
+        );
       }
     }
     add(
@@ -350,7 +499,9 @@ export function deriveChecks(repoRoot, candidate) {
     // finding. What matters is that the glyph does not arrive from an
     // undeclared package, which systemIntegration already asserts.
     if (source && /from ['"]lucide-react['"]/.test(source)) {
-      failures.push('imports icons from lucide-react rather than defining them locally');
+      failures.push(
+        'imports icons from lucide-react rather than defining them locally',
+      );
     }
     add(
       'reuseNaming',
@@ -446,7 +597,9 @@ export function deriveChecks(repoRoot, candidate) {
     // reviewer can see it (a story) and somewhere regression-proof (a test).
     const missing = [];
     for (const state of candidate.stateProps) {
-      const inStories = stories ? new RegExp(`\\b${state}\\b`).test(stories) : false;
+      const inStories = stories
+        ? new RegExp(`\\b${state}\\b`).test(stories)
+        : false;
       const inTests = test ? new RegExp(`\\b${state}\\b`).test(test) : false;
       if (!inStories || !inTests) {
         missing.push(
@@ -480,7 +633,10 @@ export function deriveChecks(repoRoot, candidate) {
   {
     const failures = [];
     const evidence = [];
-    if (!test || !/\bkeyboard\b|\bArrow|\bTab\b|\bEnter\b|\bEscape\b/i.test(test)) {
+    if (
+      !test ||
+      !/\bkeyboard\b|\bArrow|\bTab\b|\bEnter\b|\bEscape\b/i.test(test)
+    ) {
       failures.push('no keyboard interaction tests');
     }
     const prefixes = rtlAuditedPrefixes(repoRoot);
@@ -522,9 +678,7 @@ export function deriveChecks(repoRoot, candidate) {
     if (/\bEmptyState\b/.test(source) || /\w*[eE]mptyText\??:/.test(source)) {
       expected.push('empty');
     }
-    const missing = expected.filter(
-      kind => !new RegExp(kind, 'i').test(names),
-    );
+    const missing = expected.filter(kind => !new RegExp(kind, 'i').test(names));
     add(
       'edgeCases',
       verdict(missing),
@@ -535,7 +689,10 @@ export function deriveChecks(repoRoot, candidate) {
           : `No dedicated story for: ${missing.join(', ')}.`,
       [
         ev(`Story names: ${names || 'none'}.`, p.stories),
-        ev(`Edge cases the prop surface implies: ${expected.join(', ') || 'none'}.`, p.source),
+        ev(
+          `Edge cases the prop surface implies: ${expected.join(', ') || 'none'}.`,
+          p.source,
+        ),
       ],
     );
   }
@@ -543,7 +700,12 @@ export function deriveChecks(repoRoot, candidate) {
   {
     // Story completeness is the roll-up of the three story-shaped checks — it
     // passes only when the matrix a reviewer needs is actually reviewable.
-    const dependencies = ['stories', 'visualThemes', 'edgeCases', 'stateCoverage'];
+    const dependencies = [
+      'stories',
+      'visualThemes',
+      'edgeCases',
+      'stateCoverage',
+    ];
     const unmet = dependencies.filter(key => results[key]?.state !== 'passed');
     add(
       'storyCompleteness',
@@ -561,7 +723,10 @@ export function deriveChecks(repoRoot, candidate) {
 /** Exported for tests. */
 export const _internal = {
   a11yComponentFromTitle,
+  affectedScopeActionContract,
+  affectedScopeWorkflowContract,
   ciComponentRoots,
+  loadAffectedScopeContract,
   rtlAuditedPrefixes,
   storyExports,
   storyTitles,


### PR DESCRIPTION
## Summary

- add one local Node affected-scope action backed by the executable shared module
- route check-components, pr-a11y, pr-visual, and pr-rtl through that action instead of per-job component parsing
- keep component source and nested component barrels on exact PR scope, while shared Core hooks/utils/focus/runtime/i18n/naming, theme/token infra, Storybook config/static assets, browser/RTL harness inputs, package manifests, and lockfile ambiguity defer to protected main
- preserve exact changed component checks in mixed component + broad/global scopes; broad/global deferral no longer suppresses component a11y/RTL scope
- make the affected-scope CLI strict: exactly one known subcommand/input path, no stray positionals, malformed args/JSON/paths fail nonzero
- teach lab-readiness to import/execute/validate the shared helper and Node action contract, and fail closed on missing/malformed/shadow-command drift

#5608 has landed. This branch is rebuilt on current main `1b706d5d2d35cf141fd8384ce9952d660d0a9221`, carries an exact-patch copy of #5630 as `6413ca02d148085ae130f282d7304437d09e7589`, then the #5632 delta as `ad79df2334de751fa54586ce17afb5985b4cee0f`. #5630 itself remains unchanged at `04246c0051029d017e6aa76b3b649bc55bb622dc`.

## Test plan

- `npx --yes pnpm@11.10.0 vitest run .github/scripts/lib/affected-scope.test.mjs`
- `npx --yes pnpm@11.10.0 exec eslint --no-ignore .github/actions/affected-scope/index.mjs`
- `actionlint -shellcheck= -ignore 'label .* is unknown' .github/workflows/ci.yml .github/workflows/pr-comment.yml .github/workflows/visual-acceptance.yml`
- `npx --yes pnpm@11.10.0 check:repo`
