### PR TITLE
ci: promote accepted visuals from main

### DIFF
--- a/.github/scripts/visual-gate/lib/promotion-identity.mjs
+++ b/.github/scripts/visual-gate/lib/promotion-identity.mjs
@@ -18,8 +18,14 @@ const FAILURE_DESCRIPTIONS = {
     'Recovery refused: acceptance is not from the latest completed CI attempt.',
   'active-ci-retry':
     'Visual promotion deferred: a newer CI retry is still active.',
+  'invalid-main': 'Recovery refused: the resolved main commit was invalid.',
+  'main-sha-mismatch':
+    'Recovery refused: the merged PR does not match the trusted main commit.',
   'merge-not-main':
     'Recovery refused: the merge commit is not reachable from main.',
+  'multiple-main-candidates':
+    'Recovery refused: multiple merged PRs matched the same main commit.',
+  'recovery-not-main': 'Recovery must be dispatched from main.',
   'pointer-invalid':
     'Recovery refused: the current acceptance pointer was invalid.',
   'pointer-missing':
@@ -150,6 +156,7 @@ export function resolvePullRequestIdentity({
   repository = REPO,
   baseRef = 'main',
   compareStatus,
+  mainSha = null,
 }) {
   const pr = Number(requestedPr);
   if (!Number.isSafeInteger(pr) || pr <= 0)
@@ -170,6 +177,16 @@ export function resolvePullRequestIdentity({
   if (!SHA.test(pull.merge_commit_sha ?? '')) {
     refuse('invalid-merge', 'resolved merge SHA is invalid');
   }
+  if (mainSha !== null) {
+    if (!SHA.test(mainSha))
+      refuse('invalid-main', 'resolved main SHA is invalid');
+    if (pull.merge_commit_sha !== mainSha) {
+      refuse(
+        'main-sha-mismatch',
+        `PR #${pr} merge ${pull.merge_commit_sha} does not match main ${mainSha}`,
+      );
+    }
+  }
   if (!['ahead', 'identical'].includes(compareStatus)) {
     refuse(
       'merge-not-main',
@@ -180,7 +197,118 @@ export function resolvePullRequestIdentity({
     pr,
     headSha: pull.head.sha,
     mergeSha: pull.merge_commit_sha,
+    mainSha: mainSha ?? pull.merge_commit_sha,
   };
+}
+
+export async function resolveMainPromotionCandidates({
+  eventName,
+  payload = {},
+  requestedPr = null,
+  repository = REPO,
+  baseRef = 'main',
+  currentRef = `refs/heads/${baseRef}`,
+  listPullRequestsAssociatedWithCommit,
+  getPull,
+  compareCommitsWithBasehead,
+}) {
+  if (typeof getPull !== 'function') {
+    refuse('actions-response-invalid', 'GitHub pull resolver is invalid');
+  }
+  const seen = new Set();
+  const pushCandidate = (candidates, identity) => {
+    const key = `${identity.pr}:${identity.headSha}:${identity.mainSha}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      candidates.push(identity);
+    }
+  };
+
+  if (eventName === 'workflow_dispatch') {
+    if (currentRef !== `refs/heads/${baseRef}`) {
+      refuse('recovery-not-main', 'recovery must be dispatched from main');
+    }
+    const pr = Number(requestedPr);
+    if (!Number.isSafeInteger(pr) || pr <= 0) {
+      refuse('invalid-pr', 'invalid PR number');
+    }
+    if (typeof compareCommitsWithBasehead !== 'function') {
+      refuse(
+        'actions-response-invalid',
+        'GitHub comparison resolver is invalid',
+      );
+    }
+    const pull = await getPull(pr);
+    const mainSha = pull?.merge_commit_sha ?? '';
+    if (!SHA.test(mainSha)) {
+      refuse('invalid-merge', 'resolved merge SHA is invalid');
+    }
+    const comparison = await compareCommitsWithBasehead(
+      `${mainSha}...${baseRef}`,
+    );
+    return [
+      resolvePullRequestIdentity({
+        pull,
+        requestedPr: pr,
+        repository,
+        baseRef,
+        compareStatus: comparison?.status,
+        mainSha,
+      }),
+    ];
+  }
+
+  if (eventName !== 'push') return [];
+  if (typeof listPullRequestsAssociatedWithCommit !== 'function') {
+    refuse('actions-response-invalid', 'GitHub commit PR resolver is invalid');
+  }
+  const mainShas = [
+    ...(Array.isArray(payload.commits)
+      ? payload.commits.map(commit => commit?.id)
+      : []),
+    payload.after,
+  ].filter(sha => SHA.test(sha ?? ''));
+  const candidates = [];
+  for (const mainSha of [...new Set(mainShas)]) {
+    const associated = await listPullRequestsAssociatedWithCommit(mainSha);
+    if (!Array.isArray(associated)) {
+      refuse(
+        'actions-response-invalid',
+        'GitHub associated PR response is invalid',
+      );
+    }
+    const matches = [];
+    for (const summary of associated) {
+      const pr = Number(summary?.number);
+      if (!Number.isSafeInteger(pr) || pr <= 0) continue;
+      const pull = await getPull(pr);
+      if (pull?.merge_commit_sha !== mainSha) continue;
+      matches.push(
+        resolvePullRequestIdentity({
+          pull,
+          requestedPr: pr,
+          repository,
+          baseRef,
+          compareStatus: 'identical',
+          mainSha,
+        }),
+      );
+    }
+    const unique = new Map(
+      matches.map(identity => [
+        `${identity.pr}:${identity.headSha}:${identity.mainSha}`,
+        identity,
+      ]),
+    );
+    if (unique.size > 1) {
+      refuse(
+        'multiple-main-candidates',
+        `main commit ${mainSha} matched multiple merged PRs`,
+      );
+    }
+    for (const identity of unique.values()) pushCandidate(candidates, identity);
+  }
+  return candidates;
 }
 
 export function resolveAcceptanceIdentity({

--- a/.github/scripts/visual-gate/lib/promotion-identity.test.mjs
+++ b/.github/scripts/visual-gate/lib/promotion-identity.test.mjs
@@ -15,6 +15,7 @@ import {
   recoveryOperationResult,
   resolveAcceptanceIdentity,
   resolveCIState,
+  resolveMainPromotionCandidates,
   resolvePullRequestIdentity,
 } from './promotion-identity.mjs';
 
@@ -91,6 +92,7 @@ describe('promotion PR identity', () => {
       pr: 42,
       headSha: HEAD,
       mergeSha: MERGE,
+      mainSha: MERGE,
     });
   });
 
@@ -99,6 +101,7 @@ describe('promotion PR identity', () => {
       pr: 42,
       headSha: HEAD,
       mergeSha: MERGE,
+      mainSha: MERGE,
     });
   });
 
@@ -149,6 +152,125 @@ describe('promotion PR identity', () => {
     ],
   ])('fails closed for %s', (_name, value, overrides, error) => {
     expect(() => resolvePull(value, overrides)).toThrow(error);
+  });
+});
+
+describe('main promotion candidate discovery', () => {
+  const MAIN_A = 'c'.repeat(40);
+  const MAIN_B = 'd'.repeat(40);
+  const STALE_MAIN = 'e'.repeat(40);
+  const UNRELATED_MAIN = 'f'.repeat(40);
+  const HEAD_A = '1'.repeat(40);
+  const HEAD_B = '2'.repeat(40);
+  const HEAD_STALE = '3'.repeat(40);
+
+  function mergedPull(number, {head = HEAD_A, merge = MAIN_A} = {}) {
+    return pull({
+      number,
+      head: {sha: head},
+      merge_commit_sha: merge,
+    });
+  }
+
+  async function resolveCandidates({
+    eventName = 'push',
+    payload = {commits: [{id: MAIN_A}], after: MAIN_A},
+    requestedPr = null,
+    currentRef = 'refs/heads/main',
+    associated = {},
+    pulls = {},
+    comparisons = {},
+  }) {
+    return resolveMainPromotionCandidates({
+      eventName,
+      payload,
+      requestedPr,
+      repository: 'facebook/astryx',
+      baseRef: 'main',
+      currentRef,
+      listPullRequestsAssociatedWithCommit: async mainSha =>
+        associated[mainSha] ?? [],
+      getPull: async pullNumber => pulls[pullNumber],
+      compareCommitsWithBasehead: async basehead => ({
+        status: comparisons[basehead] ?? 'identical',
+      }),
+    });
+  }
+
+  it('selects only PRs whose merge commit is in the trusted main push', async () => {
+    await expect(
+      resolveCandidates({
+        payload: {
+          commits: [{id: UNRELATED_MAIN}, {id: MAIN_A}],
+          after: MAIN_B,
+        },
+        associated: {
+          [UNRELATED_MAIN]: [{number: 40}],
+          [MAIN_A]: [{number: 41}, {number: 42}],
+          [MAIN_B]: [{number: 43}],
+        },
+        pulls: {
+          40: mergedPull(40, {merge: STALE_MAIN, head: HEAD_STALE}),
+          41: mergedPull(41, {merge: STALE_MAIN, head: HEAD_STALE}),
+          42: mergedPull(42, {merge: MAIN_A, head: HEAD_A}),
+          43: mergedPull(43, {merge: MAIN_B, head: HEAD_B}),
+        },
+      }),
+    ).resolves.toEqual([
+      {pr: 42, headSha: HEAD_A, mergeSha: MAIN_A, mainSha: MAIN_A},
+      {pr: 43, headSha: HEAD_B, mergeSha: MAIN_B, mainSha: MAIN_B},
+    ]);
+  });
+
+  it('returns no candidates when a main push has no associated PRs', async () => {
+    await expect(resolveCandidates({associated: {}})).resolves.toEqual([]);
+  });
+
+  it('ignores an unrelated main commit associated with a stale PR', async () => {
+    await expect(
+      resolveCandidates({
+        payload: {commits: [{id: UNRELATED_MAIN}], after: UNRELATED_MAIN},
+        associated: {[UNRELATED_MAIN]: [{number: 41}]},
+        pulls: {
+          41: mergedPull(41, {merge: STALE_MAIN, head: HEAD_STALE}),
+        },
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('fails closed when multiple merged PRs claim the same main commit', async () => {
+    await expect(
+      resolveCandidates({
+        associated: {[MAIN_A]: [{number: 42}, {number: 43}]},
+        pulls: {
+          42: mergedPull(42, {merge: MAIN_A, head: HEAD_A}),
+          43: mergedPull(43, {merge: MAIN_A, head: HEAD_B}),
+        },
+      }),
+    ).rejects.toThrow(/multiple merged PRs/);
+  });
+
+  it('fails closed when recovery targets a stale or unreachable merge', async () => {
+    await expect(
+      resolveCandidates({
+        eventName: 'workflow_dispatch',
+        requestedPr: 42,
+        pulls: {42: mergedPull(42, {merge: MAIN_A, head: HEAD_A})},
+        comparisons: {[`${MAIN_A}...main`]: 'diverged'},
+      }),
+    ).rejects.toThrow(/not reachable from main/);
+  });
+
+  it('resolves manual recovery from the PR number on main', async () => {
+    await expect(
+      resolveCandidates({
+        eventName: 'workflow_dispatch',
+        requestedPr: 42,
+        pulls: {42: mergedPull(42, {merge: MAIN_A, head: HEAD_A})},
+      }),
+    ).resolves.toEqual([
+      {pr: 42, headSha: HEAD_A, mergeSha: MAIN_A, mainSha: MAIN_A},
+    ]);
   });
 });
 

--- a/.github/scripts/visual-gate/visual-promotion-workflow.test.mjs
+++ b/.github/scripts/visual-gate/visual-promotion-workflow.test.mjs
@@ -10,6 +10,8 @@ import {fileURLToPath} from 'node:url';
 import {afterEach, describe, expect, it} from 'vitest';
 import {PNG} from 'pngjs';
 
+import {resolvePullRequestIdentity} from './lib/promotion-identity.mjs';
+
 const ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../../..',
@@ -238,10 +240,18 @@ function makeFixture(mutate) {
     path.join(ROOT, '.github', 'scripts', 'visual-gate'),
     path.join(sandbox, '.github', 'scripts', 'visual-gate'),
   );
+  fs.symlinkSync(
+    path.join(ROOT, '.github', 'scripts', 'gh-pages-publisher.mjs'),
+    path.join(sandbox, '.github', 'scripts', 'gh-pages-publisher.mjs'),
+  );
+  fs.symlinkSync(
+    path.join(ROOT, '.github', 'scripts', 'lib'),
+    path.join(sandbox, '.github', 'scripts', 'lib'),
+  );
   const plan = path.join(sandbox, 'accepted-plan.json');
   runAcceptance('plan', {acceptance, output: plan});
 
-  const capture = path.join(sandbox, '.visual-merged');
+  const capture = path.join(sandbox, '.visual-main');
   fs.mkdirSync(path.join(capture, 'shots'), {recursive: true});
   fs.writeFileSync(path.join(capture, 'shots', `${KEY}.png`), after);
   writeJSON(path.join(capture, 'manifest.json'), {
@@ -253,6 +263,16 @@ function makeFixture(mutate) {
     context: {sha: MERGE},
     shots: {[KEY]: {...SHOT, sha256: digest(after), width: 2, height: 2}},
   });
+
+  writeJSON(
+    path.join(pages, '.astryx-gh-pages', 'publication-queue', 'holder.json'),
+    {
+      version: 1,
+      repository: 'facebook/astryx',
+      runId: 931,
+      scope: 'visual-gate/baseline',
+    },
+  );
 
   mutate?.({acceptance, baselineShot, capture, pages});
   git(pages, 'add', '.');
@@ -270,6 +290,7 @@ function runPromotion({
   race = false,
 }) {
   const marker = path.join(fixture.root, 'race-injected');
+  fs.mkdirSync(path.join(fixture.root, 'runner'), {recursive: true});
   const result = spawnSync(
     '/bin/bash',
     ['-c', workflowStepScript('Verify and promote the baseline')],
@@ -283,10 +304,11 @@ function runPromotion({
         GITHUB_REPOSITORY: 'facebook/astryx',
         PR_NUMBER: '42',
         HEAD_SHA: HEAD,
-        MERGE_SHA: MERGE,
+        MAIN_SHA: MERGE,
         RECORD_REL,
         RUNNER_TEMP: path.join(fixture.root, 'runner'),
         GITHUB_OUTPUT: path.join(fixture.root, 'github-output'),
+        GITHUB_RUN_ID: '931',
         GH_RUNS_JSON: JSON.stringify({
           workflow_runs: [{name: 'CI', ...latest}],
         }),
@@ -304,7 +326,7 @@ function runPromotion({
 }
 
 describe('visual acceptance promotion workflow', () => {
-  it('captures the resolved historical merge when workflow main differs', () => {
+  it('captures the resolved historical main commit when workflow main differs', () => {
     const currentMain = 'f'.repeat(40);
     const root = fs.mkdtempSync(
       path.join(os.tmpdir(), 'visual-promotion-capture-identity-'),
@@ -317,7 +339,7 @@ describe('visual acceptance promotion workflow', () => {
     const step = workflowStep('Recapture exactly the accepted shots');
     const gate = fs.readFileSync(GATE, 'utf8');
     expect(step).toContain(
-      'ASTRYX_VISUAL_SHA: ${{ needs.resolve.outputs.merge_sha }}',
+      'ASTRYX_VISUAL_SHA: ${{ matrix.promotion.mainSha }}',
     );
     expect(step).not.toContain('GITHUB_SHA:');
     const manifestContext = gate.slice(
@@ -344,27 +366,27 @@ describe('visual acceptance promotion workflow', () => {
     ).toBe(MERGE);
   });
 
-  it('shares the merge-bound recapture between recovery and normal close', () => {
+  it('shares the main-bound recapture between recovery and normal push', () => {
     const workflow = fs.readFileSync(WORKFLOW, 'utf8');
     const capture = workflowStep('Recapture exactly the accepted shots');
-    const checkout = workflowStep('Checkout the resolved merged result');
+    const checkout = workflowStep('Checkout the resolved main result');
 
     expect(workflow).toContain('workflow_dispatch:');
-    expect(workflow).toContain('types: [closed]');
+    expect(workflow).toContain("branches: ['main']");
     expect(
       workflow.match(/- name: Recapture exactly the accepted shots/g),
     ).toHaveLength(1);
     expect(capture).toContain(
-      'ASTRYX_VISUAL_SHA: ${{ needs.resolve.outputs.merge_sha }}',
+      'ASTRYX_VISUAL_SHA: ${{ matrix.promotion.mainSha }}',
     );
     expect(capture).toContain(
-      '--storybook-dir .visual-merged-source/apps/storybook/dist',
+      '--storybook-dir .visual-main-source/apps/storybook/dist',
     );
     expect(capture).toContain(
       'node .github/scripts/visual-gate/gate.mjs capture',
     );
-    expect(checkout).toContain('ref: ${{ needs.resolve.outputs.merge_sha }}');
-    expect(checkout).toContain('allow-unsafe-pr-checkout: true');
+    expect(checkout).toContain('ref: ${{ matrix.promotion.mainSha }}');
+    expect(checkout).not.toContain('allow-unsafe-pr-checkout: true');
   });
 
   it('retries from the immutable record after cleanup wins the first push race', () => {
@@ -478,7 +500,7 @@ describe('visual acceptance promotion workflow', () => {
       error: /record identity does not match this merged head/,
     },
     {
-      name: 'the wrong merged capture identity',
+      name: 'the wrong main capture identity',
       mutate: ({capture}) => {
         const manifestFile = path.join(capture, 'manifest.json');
         const manifest = JSON.parse(fs.readFileSync(manifestFile, 'utf8'));
@@ -509,11 +531,56 @@ describe('visual acceptance promotion workflow', () => {
     expect(`${result.stdout}\n${result.stderr}`).toMatch(error);
   });
 
+  it('resolves a squash-merged PR to the exact trusted main commit', () => {
+    const pull = {
+      number: 42,
+      state: 'closed',
+      merged: true,
+      merged_at: '2026-08-27T08:00:00Z',
+      base: {ref: 'main', repo: {full_name: 'facebook/astryx'}},
+      head: {sha: HEAD},
+      merge_commit_sha: MERGE,
+    };
+
+    expect(
+      resolvePullRequestIdentity({
+        pull,
+        requestedPr: 42,
+        compareStatus: 'identical',
+        mainSha: MERGE,
+      }),
+    ).toMatchObject({pr: 42, headSha: HEAD, mainSha: MERGE, mergeSha: MERGE});
+    expect(() =>
+      resolvePullRequestIdentity({
+        pull,
+        requestedPr: 42,
+        compareStatus: 'identical',
+        mainSha: 'e'.repeat(40),
+      }),
+    ).toThrow(/does not match main/);
+  });
+
+  it('projects post-merge failures onto main, not the contributor head', () => {
+    const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+    const failure = workflowStep('Mark trusted main promotion failure');
+    const pending = workflowStep('Mark trusted promotion pending');
+
+    expect(workflow).toContain('push:');
+    expect(workflow).not.toContain('pull_request_target:');
+    expect(failure).toContain('sha: process.env.MAIN_SHA');
+    expect(failure).toContain('target_url: process.env.PR_URL');
+    expect(failure).not.toContain('sha: process.env.HEAD_SHA');
+    expect(pending).toContain('sha: process.env.MAIN_SHA');
+    expect(workflow).toContain("workflow_id: 'release-gate.yml'");
+    expect(workflow).toContain("source: 'visual-promotion'");
+    expect(workflow).toContain('source_main_sha: process.env.MAIN_SHA');
+  });
+
   it('does not consult ephemeral PR evidence during promotion', () => {
     const script = workflowStepScript('Verify and promote the baseline');
-    expect(script).toContain('promotion-identity.mjs resolve-acceptance');
+    expect(script).toContain('gh-pages-publisher.mjs visual-baseline-accepted');
+    expect(script).toContain('--merge-sha "$MAIN_SHA"');
     expect(script).toContain('--expected-record-rel "$RECORD_REL"');
-    expect(script).toContain('visual-acceptance.mjs promote');
     expect(script).not.toContain('visual-acceptance.mjs state');
     expect(script).not.toContain('/pr/');
   });

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -192,19 +192,20 @@ describe('visual acceptance workflow concurrency', () => {
     );
   });
 
-  it('serializes normal, recovery, and manual publication without Actions cancellation', () => {
+  it('serializes main-lane, recovery, and manual publication without Actions cancellation', () => {
     const value = workflow('visual-acceptance-promote.yml');
     const manual = workflow('visual-baseline.yml');
     const helper = 'node .github/scripts/gh-pages-publisher.mjs';
 
     expect(value).toContain('workflow_dispatch:');
-    expect(value).toContain("context.ref !== 'refs/heads/main'");
+    expect(value).toContain('currentRef: context.ref');
+    expect(value).toContain('resolveMainPromotionCandidates');
     expect(value).toContain('Checkout trusted current main');
-    expect(value).toContain('Checkout the resolved merged result');
-    expect(value).toContain('allow-unsafe-pr-checkout: true');
-    expect(value.indexOf('compareCommitsWithBasehead')).toBeLessThan(
-      value.indexOf('allow-unsafe-pr-checkout: true'),
-    );
+    expect(value).toContain('push:');
+    expect(value).not.toContain('pull_request_target:');
+    expect(value).toContain('Checkout the resolved main result');
+    expect(value).not.toContain('allow-unsafe-pr-checkout: true');
+    expect(value).toContain('compareCommitsWithBasehead');
     expect(value).toContain('ref: main');
     for (const command of ['enqueue', 'wait', 'release']) {
       expect(
@@ -237,9 +238,10 @@ describe('visual acceptance workflow concurrency', () => {
     expect(workflow('release-gate.yml')).toContain(
       'node .github/scripts/gh-pages-publisher.mjs release-gate --source report',
     );
-    expect(value).toContain(
-      "context.eventName === 'workflow_dispatch' ? 'true' : 'false'",
-    );
+    expect(value).toContain('listPullRequestsAssociatedWithCommit');
+    expect(value).toContain('sha: process.env.MAIN_SHA');
+    expect(value).toContain('target_url: process.env.PR_URL');
+    expect(value).toContain("source: 'visual-promotion'");
   });
 
   it('publishes the stable site and release gate through the shared gh-pages publisher', () => {
@@ -339,63 +341,34 @@ describe('visual acceptance workflow concurrency', () => {
     expect(promoteJob).toContain('contents: write');
   });
 
-  it('projects every known validation or publication failure from an always-running job', () => {
+  it('projects validation and publication failures onto main', () => {
     const value = workflow('visual-acceptance-promote.yml');
-    const status = value.slice(value.indexOf('  project-status:'));
+    const validation = value.slice(
+      value.indexOf('      - name: Mark trusted promotion validation failure'),
+      value.indexOf('      - name: Confirm trusted active-retry deferral'),
+    );
+    const failure = value.slice(
+      value.indexOf('      - name: Mark trusted main promotion failure'),
+    );
+    const promoteJob = value.slice(value.indexOf('  promote:'));
 
-    expect(status).toContain('if: always()');
-    expect(status).toContain('statuses: write');
-    expect(status).toContain('needs: [resolve, promote]');
-    expect(status).toContain('needs.resolve.outputs.failure_description');
-    expect(status).toContain('needs.promote.outputs.failure_description');
-    expect(status).toContain('promotionStatusProjection');
-    expect(status).toContain('target_url: process.env.TARGET_URL');
-    expect(status).toContain("if (projection.state === 'failure')");
-    expect(status).toContain('core.setFailed(projection.description)');
-    expect(value.match(/core\.setOutput\('head_sha'/g)).toHaveLength(1);
-    expect(value.indexOf('compareCommitsWithBasehead')).toBeLessThan(
-      value.indexOf("core.setOutput('head_sha'"),
-    );
-    expect(value).toContain('core.setFailed(failure.description)');
-    const beforeStatus = value.slice(0, value.indexOf('  project-status:'));
-    expect(beforeStatus).toContain("state: 'pending'");
-    expect(beforeStatus).not.toContain("state: 'success'");
-    expect(beforeStatus).not.toContain("state: 'failure'");
-    const promoteJob = value.slice(
-      value.indexOf('  promote:'),
-      value.indexOf('  project-status:'),
-    );
-    expect(promoteJob).toContain(
-      "needs.resolve.outputs.acceptance_found == 'true'",
-    );
-    expect(
-      promoteJob.slice(0, promoteJob.indexOf('    runs-on:')),
-    ).not.toContain('mutation_deferred');
+    expect(promoteJob).toContain('statuses: write');
+    expect(promoteJob).toContain('matrix:');
+    expect(promoteJob).toContain('max-parallel: 1');
+    expect(validation).toContain('sha: process.env.MAIN_SHA');
+    expect(validation).toContain('target_url: process.env.PR_URL');
+    expect(validation).toContain('core.setFailed(description)');
+    expect(failure).toContain('sha: process.env.MAIN_SHA');
+    expect(failure).toContain('target_url: process.env.PR_URL');
+    expect(failure).not.toContain('sha: process.env.HEAD_SHA');
     expect(promoteJob).toContain('Confirm trusted active-retry deferral');
-    expect(promoteJob).toContain('deferred=true');
-    expect(promoteJob).toContain("if: steps.defer.outputs.deferred != 'true'");
-    expect(value).toContain(
-      "mutation_deferred: ${{ steps.defer.outputs.deferred == 'true' || steps.acceptance.outputs.deferred == 'true' || steps.promote.outputs.deferred == 'true' }}",
-    );
-    expect(status).toContain(
-      "MUTATION_DEFERRED: ${{ needs.promote.outputs.mutation_deferred == 'true' }}",
-    );
-    expect(status).not.toContain('needs.resolve.outputs.mutation_deferred');
-    const projectionCall = status.slice(
-      status.indexOf('const projection = promotionStatusProjection({'),
-    );
-    expect(projectionCall).toContain(
-      'promotionResult: recoveryOperationResult({',
-    );
-    expect(projectionCall).toContain(
-      'mutationDeferred: process.env.MUTATION_DEFERRED',
-    );
-    expect(projectionCall).toContain(
-      'failureDescription: process.env.FAILURE_DESCRIPTION',
-    );
+    expect(promoteJob).toContain("core.setOutput('deferred', 'true')");
+    expect(promoteJob).toContain("steps.defer.outputs.deferred != 'true'");
+    expect(value).toContain('resolve-acceptance');
+    expect(value).toContain('--expected-record-rel "$RECORD_REL"');
   });
 
-  it('marks success only after publication, gate dispatch, and lock release finish', () => {
+  it('marks success only after publication, release readiness dispatch, and lock release finish', () => {
     const value = workflow('visual-acceptance-promote.yml');
     const gate = value.slice(
       value.indexOf('      - name: Run a fresh release gate'),
@@ -403,11 +376,11 @@ describe('visual acceptance workflow concurrency', () => {
     );
     const release = value.slice(
       value.indexOf('      - name: Release the baseline publication turn'),
-      value.indexOf('      - name: Mark trusted recovery complete'),
+      value.indexOf('      - name: Mark trusted main promotion complete'),
     );
     const complete = value.slice(
-      value.indexOf('      - name: Mark trusted recovery complete'),
-      value.indexOf('  project-status:'),
+      value.indexOf('      - name: Mark trusted main promotion complete'),
+      value.indexOf('      - name: Mark trusted main promotion failure'),
     );
 
     expect(value).toContain("publication_confirmed == 'true'");
@@ -415,15 +388,15 @@ describe('visual acceptance workflow concurrency', () => {
     expect(gate).toContain(
       "steps.promote.outputs.publication_confirmed == 'true'",
     );
+    expect(gate).toContain("source: 'visual-promotion'");
+    expect(gate).toContain('source_pr: process.env.PR_NUMBER');
+    expect(gate).toContain('source_main_sha: process.env.MAIN_SHA');
     expect(gate).toContain('fresh release gate dispatch failed');
     expect(release).toContain('if: always()');
     expect(release).toContain('lock release failed');
     expect(complete).toContain("steps.gate.outcome == 'success'");
     expect(complete).toContain("steps.release.outcome == 'success'");
-    expect(complete).toContain('recovery_complete=true');
-    expect(value).toContain(
-      'RECOVERY_COMPLETE: ${{ needs.promote.outputs.recovery_complete }}',
-    );
-    expect(value).toContain('recoveryOperationResult({');
+    expect(complete).toContain('sha: process.env.MAIN_SHA');
+    expect(complete).toContain("state: 'success'");
   });
 });

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -41,6 +41,18 @@ on:
         description: 'Shot tiers: surface, theme-matrix, full'
         required: false
         default: 'surface,theme-matrix'
+      source:
+        description: 'Release readiness source'
+        required: false
+        default: ''
+      source_pr:
+        description: 'PR whose post-merge visual promotion requested this run'
+        required: false
+        default: ''
+      source_main_sha:
+        description: 'Main SHA whose post-merge visual promotion requested this run'
+        required: false
+        default: ''
 
 permissions: {}
 
@@ -265,20 +277,40 @@ jobs:
           A11Y_STATUS: ${{ needs.a11y.outputs.status || 'crashed' }}
           A11Y_VIOLATIONS: ${{ needs.a11y.outputs.total_violations || '0' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RELEASE_SOURCE: ${{ inputs.source || '' }}
+          RELEASE_SOURCE_PR: ${{ inputs.source_pr || '' }}
+          RELEASE_SOURCE_MAIN_SHA: ${{ inputs.source_main_sha || '' }}
         run: |
           set -eu
           REPORT_URL="https://facebook.github.io/astryx/visual-gate/${GITHUB_RUN_ID}/"
-          cat > report/release-gate.json <<JSON
-          {
-            "generatedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "sha": "${GITHUB_SHA}",
-            "runId": "${GITHUB_RUN_ID}",
-            "runUrl": "${RUN_URL}",
-            "reportUrl": "${REPORT_URL}",
-            "visual": {"status": "${VISUAL_STATUS}"},
-            "a11y": {"status": "${A11Y_STATUS}", "violations": ${A11Y_VIOLATIONS}}
-          }
-          JSON
+          export REPORT_URL
+          node --input-type=module - <<'NODE'
+          import fs from 'node:fs';
+
+          const number = value => {
+            const parsed = Number(value);
+            return Number.isSafeInteger(parsed) ? parsed : 0;
+          };
+          const source = {
+            kind: process.env.RELEASE_SOURCE || null,
+            pr: process.env.RELEASE_SOURCE_PR || null,
+            mainSha: process.env.RELEASE_SOURCE_MAIN_SHA || null,
+          };
+          const report = {
+            generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+            sha: process.env.GITHUB_SHA,
+            runId: process.env.GITHUB_RUN_ID,
+            runUrl: process.env.RUN_URL,
+            reportUrl: process.env.REPORT_URL,
+            source,
+            visual: {status: process.env.VISUAL_STATUS},
+            a11y: {
+              status: process.env.A11Y_STATUS,
+              violations: number(process.env.A11Y_VIOLATIONS),
+            },
+          };
+          fs.writeFileSync('report/release-gate.json', `${JSON.stringify(report, null, 2)}\n`);
+          NODE
           cat report/release-gate.json
 
       - name: Publish to gh-pages

--- a/.github/workflows/visual-acceptance-promote.yml
+++ b/.github/workflows/visual-acceptance-promote.yml
@@ -1,15 +1,16 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-# Promote a PR acceptance only after the merged commit reproduces every reviewed
-# AFTER frame. Normal closed-PR promotion and explicit recovery both resolve
-# identity from GitHub and converge on this one trusted promotion job.
+# Promote a visual acceptance only after the protected main commit reproduces
+# every reviewed AFTER frame. PR comments only approve the PR head; this workflow
+# resolves the merged main commit from GitHub, revalidates the immutable
+# acceptance, and records the post-merge outcome on main rather than on the
+# contributor PR's head SHA.
 
 name: Visual acceptance promotion
 
 on:
-  pull_request_target:
+  push:
     branches: ['main']
-    types: [closed]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -20,174 +21,209 @@ permissions: {}
 
 jobs:
   resolve:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.merged == true
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
       pull-requests: read
     outputs:
-      pr: ${{ steps.resolve.outputs.pr }}
-      head_sha: ${{ steps.resolve.outputs.head_sha }}
-      merge_sha: ${{ steps.resolve.outputs.merge_sha }}
-      recovery: ${{ steps.resolve.outputs.recovery }}
-      validation_ok: ${{ steps.resolve.outputs.identity_valid == 'true' && steps.acceptance.outputs.validation_ok == 'true' }}
-      acceptance_found: ${{ steps.acceptance.outputs.found }}
-      mutation_deferred: ${{ steps.acceptance.outputs.deferred }}
-      deferred_description: ${{ steps.acceptance.outputs.deferred_description }}
-      record_rel: ${{ steps.acceptance.outputs.record_rel }}
-      failure_description: ${{ steps.acceptance.outputs.failure_description || steps.resolve.outputs.failure_description }}
+      has_promotions: ${{ steps.acceptances.outputs.has_promotions }}
+      promotions: ${{ steps.acceptances.outputs.promotions }}
     steps:
       - name: Checkout trusted current main
         uses: actions/checkout@v7
         with:
           ref: main
 
-      - name: Resolve trusted PR identity
-        id: resolve
-        uses: actions/github-script@v9
-        env:
-          REQUESTED_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
-        with:
-          retries: 3
-          script: |
-            const {pathToFileURL} = require('node:url');
-            const {
-              promotionFailure,
-              resolvePullRequestIdentity,
-            } = await import(
-              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/visual-gate/lib/promotion-identity.mjs`).href,
-            );
-            if (
-              context.eventName === 'workflow_dispatch' &&
-              context.ref !== 'refs/heads/main'
-            ) {
-              core.setFailed('Recovery must be dispatched from main.');
-              return;
-            }
-            const {owner, repo} = context.repo;
-            const requestedPr = Number(process.env.REQUESTED_PR);
-            if (!Number.isSafeInteger(requestedPr) || requestedPr <= 0) {
-              core.setFailed('Recovery requires a positive integer PR number.');
-              return;
-            }
-            let pull;
-            try {
-              ({data: pull} = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: requestedPr,
-              }));
-            } catch (error) {
-              core.setFailed(`Could not resolve PR #${requestedPr}: ${error.message}`);
-              return;
-            }
-            try {
-              resolvePullRequestIdentity({
-                pull,
-                requestedPr,
-                repository: `${owner}/${repo}`,
-                compareStatus: 'identical',
-              });
-              const {data: comparison} =
-                await github.rest.repos.compareCommitsWithBasehead({
-                  owner,
-                  repo,
-                  basehead: `${pull.merge_commit_sha}...main`,
-                });
-              const identity = resolvePullRequestIdentity({
-                pull,
-                requestedPr,
-                repository: `${owner}/${repo}`,
-                compareStatus: comparison.status,
-              });
-              core.setOutput('pr', String(identity.pr));
-              core.setOutput('head_sha', identity.headSha);
-              core.setOutput('merge_sha', identity.mergeSha);
-              core.setOutput('identity_valid', 'true');
-              core.setOutput(
-                'recovery',
-                context.eventName === 'workflow_dispatch' ? 'true' : 'false',
-              );
-            } catch (error) {
-              const failure = promotionFailure(error);
-              core.setOutput('identity_valid', 'false');
-              core.setOutput('failure_code', failure.code);
-              core.setOutput('failure_description', failure.description);
-              core.setFailed(failure.description);
-            }
-
       - name: Setup trusted Node
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
 
-      - name: Resolve the immutable acceptance
-        id: acceptance
-        if: steps.resolve.outputs.identity_valid == 'true'
+      - name: Resolve trusted main promotion candidates
+        id: candidates
+        uses: actions/github-script@v9
+        env:
+          REQUESTED_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
+        with:
+          retries: 3
+          script: |
+            const fs = require('node:fs');
+            const {pathToFileURL} = require('node:url');
+            const {
+              promotionFailure,
+              resolveMainPromotionCandidates,
+            } = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/visual-gate/lib/promotion-identity.mjs`).href,
+            );
+            const {owner, repo} = context.repo;
+            const repository = `${owner}/${repo}`;
+            try {
+              const candidates = await resolveMainPromotionCandidates({
+                eventName: context.eventName,
+                payload: context.payload,
+                requestedPr: process.env.REQUESTED_PR,
+                repository,
+                currentRef: context.ref,
+                baseRef: context.payload.repository.default_branch,
+                listPullRequestsAssociatedWithCommit: async mainSha => {
+                  const {data} =
+                    await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                      owner,
+                      repo,
+                      commit_sha: mainSha,
+                    });
+                  return data;
+                },
+                getPull: async pullNumber => {
+                  const {data} = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: pullNumber,
+                  });
+                  return data;
+                },
+                compareCommitsWithBasehead: async basehead => {
+                  const {data} =
+                    await github.rest.repos.compareCommitsWithBasehead({
+                      owner,
+                      repo,
+                      basehead,
+                    });
+                  return data;
+                },
+              });
+              fs.writeFileSync(
+                'promotion-candidates.json',
+                `${JSON.stringify(candidates)}\n`,
+              );
+              core.setOutput('count', String(candidates.length));
+            } catch (error) {
+              const failure = promotionFailure(error);
+              core.setFailed(`${failure.description} (${error.message})`);
+            }
+
+      - name: Resolve immutable acceptances
+        id: acceptances
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.resolve.outputs.pr }}
-          HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
-          RECOVERY: ${{ steps.resolve.outputs.recovery }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -eu
-          PAGES="$RUNNER_TEMP/visual-acceptance-pages"
-          git clone --depth=1 --filter=blob:none --sparse --single-branch --branch gh-pages \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PAGES"
-          git -C "$PAGES" sparse-checkout set \
-            "visual-gate/acceptances/${PR_NUMBER}/${HEAD_SHA}"
-          MISSING_OK=false
-          if [ "$RECOVERY" != 'true' ]; then MISSING_OK=true; fi
-          RESOLVED=$(node .github/scripts/visual-gate/lib/promotion-identity.mjs resolve-acceptance \
-            --pages "$PAGES" \
-            --pr "$PR_NUMBER" \
-            --head "$HEAD_SHA" \
-            --missing-ok "$MISSING_OK")
-          OK=$(printf '%s' "$RESOLVED" | jq -r '.ok')
-          if [ "$OK" != 'true' ]; then
+          node --input-type=module - <<'NODE'
+          import {spawnSync} from 'node:child_process';
+          import fs from 'node:fs';
+
+          const candidates = JSON.parse(
+            fs.readFileSync('promotion-candidates.json', 'utf8'),
+          );
+          if (candidates.length > 0) {
+            const paths = candidates.map(
+              candidate =>
+                `visual-gate/acceptances/${candidate.pr}/${candidate.headSha}`,
+            );
+            fs.writeFileSync('promotion-sparse-paths.txt', `${paths.join('\n')}\n`);
+          }
+          NODE
+          if [ ! -s promotion-sparse-paths.txt ]; then
             {
-              echo "validation_ok=false"
-              echo "found=false"
-              echo "failure_description=$(printf '%s' "$RESOLVED" | jq -er '.description')"
+              echo "has_promotions=false"
+              echo "promotions=[]"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          FOUND=$(printf '%s' "$RESOLVED" | jq -r '.found')
-          DEFERRED=$(printf '%s' "$RESOLVED" | jq -r '.deferred // false')
-          {
-            echo "validation_ok=true"
-            echo "found=$FOUND"
-            echo "deferred=$DEFERRED"
-          } >> "$GITHUB_OUTPUT"
-          if [ "$DEFERRED" = 'true' ]; then
-            echo "deferred_description=$(printf '%s' "$RESOLVED" | jq -er '.deferredDescription')" >> "$GITHUB_OUTPUT"
-          fi
-          if [ "$FOUND" != 'true' ]; then
-            echo "No visual acceptance was recorded for this merged head."
-            exit 0
-          fi
-          echo "record_rel=$(printf '%s' "$RESOLVED" | jq -er '.recordRel')" >> "$GITHUB_OUTPUT"
+          PAGES="$RUNNER_TEMP/visual-acceptance-pages"
+          git clone --depth=1 --filter=blob:none --sparse --single-branch --branch gh-pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PAGES"
+          git -C "$PAGES" sparse-checkout set --stdin < promotion-sparse-paths.txt
+          node --input-type=module - <<'NODE'
+          import {spawnSync} from 'node:child_process';
+          import fs from 'node:fs';
+
+          const candidates = JSON.parse(
+            fs.readFileSync('promotion-candidates.json', 'utf8'),
+          );
+          const missingOk = process.env.EVENT_NAME === 'push' ? 'true' : 'false';
+          const pages = `${process.env.RUNNER_TEMP}/visual-acceptance-pages`;
+          const promotions = [];
+          for (const candidate of candidates) {
+            const result = spawnSync(
+              process.execPath,
+              [
+                '.github/scripts/visual-gate/lib/promotion-identity.mjs',
+                'resolve-acceptance',
+                '--pages',
+                pages,
+                '--pr',
+                String(candidate.pr),
+                '--head',
+                candidate.headSha,
+                '--missing-ok',
+                missingOk,
+              ],
+              {encoding: 'utf8'},
+            );
+            const resolved = JSON.parse(result.stdout || '{}');
+            if (resolved.ok !== true) {
+              promotions.push({
+                ...candidate,
+                validation_ok: false,
+                acceptance_found: true,
+                failure_description:
+                  resolved.description ??
+                  'Visual promotion validation failed before publication.',
+              });
+              continue;
+            }
+            if (resolved.found !== true) {
+              if (missingOk === 'false') {
+                promotions.push({
+                  ...candidate,
+                  validation_ok: false,
+                  acceptance_found: false,
+                  failure_description:
+                    'Recovery refused: the immutable acceptance record was missing.',
+                });
+              }
+              continue;
+            }
+            promotions.push({
+              ...candidate,
+              validation_ok: true,
+              acceptance_found: true,
+              mutation_deferred: resolved.deferred === true,
+              deferred_description: resolved.deferredDescription ?? null,
+              record_rel: resolved.recordRel,
+            });
+          }
+          const json = JSON.stringify(promotions);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `has_promotions=${promotions.length > 0 ? 'true' : 'false'}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `promotions=${json}\n`);
+          NODE
 
   promote:
     needs: resolve
-    if: >-
-      needs.resolve.outputs.validation_ok == 'true' &&
-      needs.resolve.outputs.acceptance_found == 'true'
+    if: needs.resolve.outputs.has_promotions == 'true'
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        promotion: ${{ fromJson(needs.resolve.outputs.promotions) }}
     runs-on: 2-core-ubuntu-arm
     timeout-minutes: 90
     permissions:
       actions: write
       contents: write
       statuses: write
-    outputs:
-      recovery_complete: ${{ steps.complete.outputs.recovery_complete }}
-      mutation_deferred: ${{ steps.defer.outputs.deferred == 'true' || steps.acceptance.outputs.deferred == 'true' || steps.promote.outputs.deferred == 'true' }}
-      deferred_description: ${{ steps.defer.outputs.deferred_description || steps.acceptance.outputs.deferred_description || steps.promote.outputs.deferred_description }}
-      failure_description: ${{ steps.acceptance.outputs.failure_description || steps.promote.outputs.failure_description || steps.gate.outputs.failure_description || steps.release.outputs.failure_description }}
+    env:
+      PR_NUMBER: ${{ matrix.promotion.pr }}
+      HEAD_SHA: ${{ matrix.promotion.headSha }}
+      MAIN_SHA: ${{ matrix.promotion.mainSha }}
+      RECORD_REL: ${{ matrix.promotion.record_rel }}
+      PR_URL: https://github.com/${{ github.repository }}/pull/${{ matrix.promotion.pr }}
+      STATUS_CONTEXT: visual-acceptance-promotion / PR #${{ matrix.promotion.pr }}
     steps:
       - name: Checkout trusted current main
         uses: actions/checkout@v7
@@ -199,51 +235,78 @@ jobs:
         with:
           install: 'false'
 
-      - name: Confirm trusted active-retry deferral
-        id: defer
-        if: needs.resolve.outputs.mutation_deferred == 'true'
-        env:
-          DEFERRED_DESCRIPTION: ${{ needs.resolve.outputs.deferred_description }}
-        run: |
-          set -eu
-          test -n "$DEFERRED_DESCRIPTION"
-          {
-            echo "deferred=true"
-            echo "deferred_description=$DEFERRED_DESCRIPTION"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Mark trusted promotion pending
-        if: steps.defer.outputs.deferred != 'true'
+      - name: Mark trusted promotion validation failure
+        if: matrix.promotion.validation_ok != true
         uses: actions/github-script@v9
         env:
-          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          FAILURE_DESCRIPTION: ${{ matrix.promotion.failure_description }}
+        with:
+          retries: 3
+          script: |
+            const description = String(
+              process.env.FAILURE_DESCRIPTION ||
+                `Visual promotion failed for PR #${process.env.PR_NUMBER}.`,
+            ).slice(0, 140);
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: process.env.MAIN_SHA,
+              context: process.env.STATUS_CONTEXT,
+              state: 'failure',
+              description,
+              target_url: process.env.PR_URL,
+            });
+            core.setFailed(description);
+
+      - name: Confirm trusted active-retry deferral
+        id: defer
+        if: matrix.promotion.validation_ok == true && matrix.promotion.mutation_deferred == true
+        uses: actions/github-script@v9
+        env:
+          DEFERRED_DESCRIPTION: ${{ matrix.promotion.deferred_description }}
+        with:
+          retries: 3
+          script: |
+            const description = String(
+              process.env.DEFERRED_DESCRIPTION ||
+                'Visual promotion deferred: a newer CI retry is still active.',
+            ).slice(0, 140);
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: process.env.MAIN_SHA,
+              context: process.env.STATUS_CONTEXT,
+              state: 'pending',
+              description,
+              target_url: process.env.PR_URL,
+            });
+            core.setOutput('deferred', 'true');
+
+      - name: Mark trusted promotion pending
+        if: matrix.promotion.validation_ok == true && steps.defer.outputs.deferred != 'true'
+        uses: actions/github-script@v9
         with:
           retries: 3
           script: |
             await github.rest.repos.createCommitStatus({
               ...context.repo,
-              sha: process.env.HEAD_SHA,
-              context: 'visual-acceptance',
+              sha: process.env.MAIN_SHA,
+              context: process.env.STATUS_CONTEXT,
               state: 'pending',
-              description: 'Trusted post-merge visual promotion is running.',
+              description: `Promoting accepted pixels from PR #${process.env.PR_NUMBER}.`,
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
 
       - name: Queue baseline publication
         id: queue
-        if: steps.defer.outputs.deferred != 'true'
+        if: matrix.promotion.validation_ok == true && steps.defer.outputs.deferred != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: node .github/scripts/gh-pages-publisher.mjs enqueue --scope visual-gate/baseline
 
       - name: Load and verify the immutable acceptance
         id: acceptance
-        if: steps.defer.outputs.deferred != 'true'
+        if: steps.queue.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ needs.resolve.outputs.pr }}
-          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
-          EXPECTED_RECORD_REL: ${{ needs.resolve.outputs.record_rel }}
         run: |
           set -eu
           PAGES="$RUNNER_TEMP/visual-acceptance-pages"
@@ -256,7 +319,7 @@ jobs:
             --pr "$PR_NUMBER" \
             --head "$HEAD_SHA" \
             --missing-ok false \
-            --expected-record-rel "$EXPECTED_RECORD_REL")
+            --expected-record-rel "$RECORD_REL")
           OK=$(printf '%s' "$RESOLVED" | jq -r '.ok')
           if [ "$OK" != 'true' ]; then
             DESCRIPTION=$(printf '%s' "$RESOLVED" | jq -er '.description')
@@ -264,17 +327,10 @@ jobs:
             echo "::error::$(printf '%s' "$RESOLVED" | jq -er '.message')"
             exit 1
           fi
-          FOUND=$(printf '%s' "$RESOLVED" | jq -r '.found')
           DEFERRED=$(printf '%s' "$RESOLVED" | jq -r '.deferred // false')
-          {
-            echo "found=$FOUND"
-            echo "deferred=$DEFERRED"
-          } >> "$GITHUB_OUTPUT"
+          echo "deferred=$DEFERRED" >> "$GITHUB_OUTPUT"
           if [ "$DEFERRED" = 'true' ]; then
-            {
-              echo "found=false"
-              echo "deferred_description=$(printf '%s' "$RESOLVED" | jq -er '.deferredDescription')"
-            } >> "$GITHUB_OUTPUT"
+            echo "deferred_description=$(printf '%s' "$RESOLVED" | jq -er '.deferredDescription')" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           {
@@ -282,39 +338,56 @@ jobs:
             echo "record_rel=$(printf '%s' "$RESOLVED" | jq -er '.recordRel')"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Checkout the resolved merged result
-        if: steps.acceptance.outputs.found == 'true'
+      - name: Mark trusted promotion deferred
+        if: steps.acceptance.outputs.deferred == 'true'
+        uses: actions/github-script@v9
+        env:
+          DEFERRED_DESCRIPTION: ${{ steps.acceptance.outputs.deferred_description }}
+        with:
+          retries: 3
+          script: |
+            const description = String(
+              process.env.DEFERRED_DESCRIPTION ||
+                'Visual promotion deferred: a newer CI retry is still active.',
+            ).slice(0, 140);
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: process.env.MAIN_SHA,
+              context: process.env.STATUS_CONTEXT,
+              state: 'pending',
+              description,
+              target_url: process.env.PR_URL,
+            });
+
+      - name: Checkout the resolved main result
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
         uses: actions/checkout@v7
         with:
-          ref: ${{ needs.resolve.outputs.merge_sha }}
-          path: .visual-merged-source
-          # The read-only resolver proved this exact commit is reachable from
-          # current main before the privileged job started. Fork PR merges need
-          # checkout's explicit opt-in even for that trusted merged commit.
-          allow-unsafe-pr-checkout: true
+          ref: ${{ matrix.promotion.mainSha }}
+          path: .visual-main-source
 
       - name: Install trusted visual dependencies
-        if: steps.acceptance.outputs.found == 'true'
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
         run: pnpm install --frozen-lockfile
 
-      - name: Install merged-result dependencies
-        if: steps.acceptance.outputs.found == 'true'
-        working-directory: .visual-merged-source
+      - name: Install main-result dependencies
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
+        working-directory: .visual-main-source
         run: pnpm install --frozen-lockfile
 
-      - name: Build the resolved merged Storybook
-        if: steps.acceptance.outputs.found == 'true'
-        working-directory: .visual-merged-source
+      - name: Build the resolved main Storybook
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
+        working-directory: .visual-main-source
         run: pnpm build && pnpm -F @astryxdesign/storybook build
 
       - name: Install Chromium
-        if: steps.acceptance.outputs.found == 'true'
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
         run: npx playwright install chromium
 
       - name: Recapture exactly the accepted shots
-        if: steps.acceptance.outputs.found == 'true'
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
         env:
-          ASTRYX_VISUAL_SHA: ${{ needs.resolve.outputs.merge_sha }}
+          ASTRYX_VISUAL_SHA: ${{ matrix.promotion.mainSha }}
           ACCEPTANCE: ${{ steps.acceptance.outputs.record }}
         run: |
           set -eu
@@ -322,32 +395,28 @@ jobs:
             --acceptance "$ACCEPTANCE" \
             --output accepted-plan.json
           node .github/scripts/visual-gate/gate.mjs capture \
-            --storybook-dir .visual-merged-source/apps/storybook/dist \
-            --out .visual-merged \
+            --storybook-dir .visual-main-source/apps/storybook/dist \
+            --out .visual-main \
             --plan-file accepted-plan.json
 
       - name: Wait for the baseline publication turn
-        if: steps.acceptance.outputs.found == 'true'
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: node .github/scripts/gh-pages-publisher.mjs wait --scope visual-gate/baseline
 
       - name: Verify and promote the baseline
         id: promote
-        if: steps.acceptance.outputs.found == 'true'
+        if: steps.acceptance.outputs.deferred != 'true' && steps.acceptance.outputs.record != ''
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ needs.resolve.outputs.pr }}
-          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
-          MERGE_SHA: ${{ needs.resolve.outputs.merge_sha }}
-          RECORD_REL: ${{ steps.acceptance.outputs.record_rel }}
-        run: >
-          node .github/scripts/gh-pages-publisher.mjs visual-baseline-accepted
-          --pr "$PR_NUMBER"
-          --head "$HEAD_SHA"
-          --merge-sha "$MERGE_SHA"
-          --expected-record-rel "$RECORD_REL"
-          --capture .visual-merged
+        run: |
+          node .github/scripts/gh-pages-publisher.mjs visual-baseline-accepted \
+            --pr "$PR_NUMBER" \
+            --head "$HEAD_SHA" \
+            --merge-sha "$MAIN_SHA" \
+            --expected-record-rel "$RECORD_REL" \
+            --capture .visual-main
 
       - name: Run a fresh release gate
         id: gate
@@ -361,6 +430,11 @@ jobs:
                 ...context.repo,
                 workflow_id: 'release-gate.yml',
                 ref: context.payload.repository.default_branch,
+                inputs: {
+                  source: 'visual-promotion',
+                  source_pr: process.env.PR_NUMBER,
+                  source_main_sha: process.env.MAIN_SHA,
+                },
               });
             } catch (error) {
               core.setOutput(
@@ -372,7 +446,7 @@ jobs:
 
       - name: Release the baseline publication turn
         id: release
-        if: always() && steps.defer.outputs.deferred != 'true'
+        if: always() && steps.queue.outcome == 'success' && steps.defer.outputs.deferred != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -384,74 +458,41 @@ jobs:
           fi
           printf '%s\n' "$OUTPUT"
 
-      - name: Mark trusted recovery complete
-        id: complete
+      - name: Mark trusted main promotion complete
         if: >-
-          always() &&
           steps.promote.outputs.publication_confirmed == 'true' &&
           steps.gate.outcome == 'success' &&
           steps.release.outcome == 'success'
-        run: echo "recovery_complete=true" >> "$GITHUB_OUTPUT"
-
-  project-status:
-    needs: [resolve, promote]
-    if: always() && needs.resolve.outputs.head_sha != ''
-    runs-on: ubuntu-slim
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      statuses: write
-    steps:
-      - name: Checkout trusted current main
-        uses: actions/checkout@v7
-        with:
-          ref: main
-
-      - name: Project the final visual acceptance status
         uses: actions/github-script@v9
-        env:
-          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
-          VALIDATION_OK: ${{ needs.resolve.outputs.validation_ok }}
-          ACCEPTANCE_FOUND: ${{ needs.resolve.outputs.acceptance_found }}
-          JOB_RESULT: ${{ needs.promote.result }}
-          RECOVERY_COMPLETE: ${{ needs.promote.outputs.recovery_complete }}
-          MUTATION_DEFERRED: ${{ needs.promote.outputs.mutation_deferred == 'true' }}
-          DEFERRED_DESCRIPTION: ${{ needs.promote.outputs.deferred_description }}
-          FAILURE_DESCRIPTION: ${{ needs.resolve.outputs.failure_description || needs.promote.outputs.failure_description }}
-          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           retries: 3
           script: |
-            const {pathToFileURL} = require('node:url');
-            const {
-              promotionStatusProjection,
-              recoveryOperationResult,
-            } = await import(
-              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/visual-gate/lib/promotion-identity.mjs`).href,
-            );
-            const projection = promotionStatusProjection({
-              headKnown: true,
-              validationOk: process.env.VALIDATION_OK === 'true',
-              acceptanceFound: process.env.ACCEPTANCE_FOUND === 'true',
-              promotionResult: recoveryOperationResult({
-                jobResult: process.env.JOB_RESULT,
-                recoveryComplete: process.env.RECOVERY_COMPLETE === 'true',
-                mutationDeferred: process.env.MUTATION_DEFERRED === 'true',
-                failureDescription: process.env.FAILURE_DESCRIPTION,
-              }),
-              mutationDeferred: process.env.MUTATION_DEFERRED === 'true',
-              deferredDescription: process.env.DEFERRED_DESCRIPTION,
-              failureDescription: process.env.FAILURE_DESCRIPTION,
-            });
-            if (!projection) return;
             await github.rest.repos.createCommitStatus({
               ...context.repo,
-              sha: process.env.HEAD_SHA,
-              context: 'visual-acceptance',
-              state: projection.state,
-              description: projection.description,
-              target_url: process.env.TARGET_URL,
+              sha: process.env.MAIN_SHA,
+              context: process.env.STATUS_CONTEXT,
+              state: 'success',
+              description: `Accepted pixels from PR #${process.env.PR_NUMBER} promoted on main.`,
+              target_url: process.env.PR_URL,
             });
-            if (projection.state === 'failure') {
-              core.setFailed(projection.description);
-            }
+
+      - name: Mark trusted main promotion failure
+        if: failure() && matrix.promotion.acceptance_found == true && matrix.promotion.validation_ok == true
+        uses: actions/github-script@v9
+        env:
+          FAILURE_DESCRIPTION: ${{ steps.acceptance.outputs.failure_description || steps.gate.outputs.failure_description || steps.release.outputs.failure_description }}
+        with:
+          retries: 3
+          script: |
+            const description = String(
+              process.env.FAILURE_DESCRIPTION ||
+                `Visual promotion failed for PR #${process.env.PR_NUMBER}.`,
+            ).slice(0, 140);
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: process.env.MAIN_SHA,
+              context: process.env.STATUS_CONTEXT,
+              state: 'failure',
+              description,
+              target_url: process.env.PR_URL,
+            });


### PR DESCRIPTION
## Summary
- move post-merge visual acceptance promotion from the PR close event to protected `main` pushes
- resolve the merged PR/head/main SHA through a tested server-side candidate resolver before loading the immutable acceptance record
- project promotion success/failure onto the exact main commit, with failure status linking back to the merged PR instead of turning the PR head red
- keep accepted baseline promotion behind the shared FIFO and dispatch a release-gate readiness run with source metadata

Depends on [#5631](https://github.com/facebook/astryx/pull/5631), stacked on [#5629](https://github.com/facebook/astryx/pull/5629).

## Test plan
- `pnpm exec vitest run .github/scripts/visual-gate/lib/promotion-identity.test.mjs .github/scripts/lib/gh-pages-publisher.test.mjs .github/scripts/visual-gate/workflow-concurrency.test.mjs .github/scripts/visual-gate/visual-promotion-workflow.test.mjs`
- `actionlint -ignore 'label "2-core-ubuntu-arm" is unknown' -ignore 'shellcheck reported issue' .github/workflows/visual-acceptance-promote.yml .github/workflows/release-gate.yml`
- `pnpm exec prettier --check .github/scripts/visual-gate/lib/promotion-identity.mjs .github/scripts/visual-gate/lib/promotion-identity.test.mjs .github/scripts/visual-gate/visual-promotion-workflow.test.mjs .github/scripts/visual-gate/workflow-concurrency.test.mjs .github/workflows/visual-acceptance-promote.yml .github/workflows/release-gate.yml`
- `node --check .github/scripts/visual-gate/lib/promotion-identity.mjs`
- `node --check .github/scripts/visual-gate/lib/promotion-identity.test.mjs`
- `node --check .github/scripts/visual-gate/visual-promotion-workflow.test.mjs`
- `node --check .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `pnpm check:repo`
