### PR TITLE
ci: add protected main quality shadow workflow

### DIFF
--- a/.github/scripts/accessibility-audit.js
+++ b/.github/scripts/accessibility-audit.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-
 /**
  * @description Runs accessibility audits on component stories using axe-core
  * @input --storybook-dir <path> --output <file> --components <comma-separated>
@@ -15,8 +14,8 @@
  *   state.
  */
 
-const { chromium } = require('playwright');
-const { AxeBuilder } = require('@axe-core/playwright');
+const {chromium} = require('playwright');
+const {AxeBuilder} = require('@axe-core/playwright');
 const fs = require('node:fs');
 const path = require('node:path');
 const http = require('node:http');
@@ -27,11 +26,11 @@ const {
 } = require('./lib/a11y-baseline');
 
 const args = process.argv.slice(2);
-const getArg = (name) => {
+const getArg = name => {
   const idx = args.indexOf(`--${name}`);
   return idx !== -1 ? args[idx + 1] : null;
 };
-const hasFlag = (name) => args.includes(`--${name}`);
+const hasFlag = name => args.includes(`--${name}`);
 
 const storybookDir = getArg('storybook-dir') || 'apps/storybook/dist';
 const outputFile = getArg('output') || 'a11y-report.json';
@@ -63,16 +62,16 @@ const FREEZE_CSS = `
 
 // Rules to disable — these are Storybook-context false positives, not component issues
 const DISABLED_RULES = [
-  'html-has-lang',        // Storybook controls <html>, not the component
-  'document-title',       // iframe has no <title>, irrelevant for components
-  'landmark-one-main',    // component stories are fragments, not full pages
+  'html-has-lang', // Storybook controls <html>, not the component
+  'document-title', // iframe has no <title>, irrelevant for components
+  'landmark-one-main', // component stories are fragments, not full pages
   'page-has-heading-one', // same — not a full page
-  'region',               // content doesn't need to be in landmarks in story isolation
+  'region', // content doesn't need to be in landmarks in story isolation
 ];
 
 // Simple static file server
 function createServer(dir, port) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
       let filePath = path.join(dir, req.url === '/' ? 'index.html' : req.url);
       filePath = filePath.split('?')[0];
@@ -101,29 +100,77 @@ function createServer(dir, port) {
           res.end('Not found');
           return;
         }
-        res.writeHead(200, { 'Content-Type': contentTypes[ext] || 'text/plain' });
+        res.writeHead(200, {'Content-Type': contentTypes[ext] || 'text/plain'});
         res.end(data);
       });
     });
 
+    server.once('error', reject);
     server.listen(port, () => {
+      server.off('error', reject);
       console.log(`Storybook server running on http://localhost:${port}`);
       resolve(server);
     });
   });
 }
 
+function emptyReport({error, indexStatus, scanStatus, scope}) {
+  return {
+    ...(error ? {error} : {}),
+    components: {},
+    summary: {
+      scope,
+      indexStatus,
+      componentsAudited: 0,
+      totalViolations: 0,
+      expectedStories: 0,
+      auditedStories: 0,
+      failedStories: 0,
+      resultStories: 0,
+      uniqueResultStories: 0,
+      scanStatus,
+    },
+  };
+}
+
+function writeReport(report) {
+  const outputPath = path.resolve(outputFile);
+  const tempPath = `${outputPath}.${process.pid}.tmp`;
+  fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+  fs.writeFileSync(tempPath, JSON.stringify(report, null, 2));
+  fs.renameSync(tempPath, outputPath);
+}
+
 // Get stories from storybook
-async function getStories(storybookPath) {
+function readStoriesIndex(storybookPath) {
   const storiesJsonPath = path.join(storybookPath, 'index.json');
+
+  if (!fs.existsSync(storiesJsonPath)) {
+    return {
+      entries: {},
+      indexStatus: 'missing',
+      error: `Storybook index not found at ${storiesJsonPath}`,
+    };
+  }
 
   try {
     const content = fs.readFileSync(storiesJsonPath, 'utf8');
     const data = JSON.parse(content);
-    return data.entries || data.stories || {};
+    const entries = data.entries || data.stories;
+    if (!entries || typeof entries !== 'object' || Array.isArray(entries)) {
+      return {
+        entries: {},
+        indexStatus: 'malformed',
+        error: 'Storybook index has no entries object',
+      };
+    }
+    return {entries, indexStatus: 'parsed', error: null};
   } catch (e) {
-    console.error('Could not read stories index:', e.message);
-    return {};
+    return {
+      entries: {},
+      indexStatus: 'malformed',
+      error: `Could not read stories index: ${e.message}`,
+    };
   }
 }
 
@@ -132,57 +179,85 @@ async function runAccessibilityAudit() {
 
   if (emptyComponentSet) {
     console.log('No components to audit (--components is empty) — skipping.');
-    const report = {
-      components: {},
-      summary: { componentsAudited: 0, totalViolations: 0 },
-    };
-    fs.writeFileSync(outputFile, JSON.stringify(report, null, 2));
+    const report = emptyReport({
+      indexStatus: 'not-read',
+      scanStatus: 'complete',
+      scope: 'explicit-empty-components',
+    });
+    writeReport(report);
     return report;
   }
 
-  console.log(`Components to audit: ${components.length > 0 ? components.join(', ') : 'all affected'}`);
+  console.log(
+    `Components to audit: ${components.length > 0 ? components.join(', ') : 'all affected'}`,
+  );
 
   const storybookPath = path.resolve(process.cwd(), storybookDir);
 
   if (!fs.existsSync(storybookPath)) {
     console.error(`Storybook build not found at ${storybookPath}`);
-    const report = {
+    const report = emptyReport({
       error: 'Storybook not built',
-      components: {},
-      summary: { total: 0, violations: 0 },
-    };
-    fs.writeFileSync(outputFile, JSON.stringify(report, null, 2));
+      indexStatus: 'missing',
+      scanStatus: 'crashed',
+      scope: components.length > 0 ? 'components' : 'full',
+    });
+    writeReport(report);
     return report;
   }
 
-  // Start server
-  const port = 6007;
-  const server = await createServer(storybookPath, port);
-
-  // Get stories
-  const stories = await getStories(storybookPath);
+  // Get stories before starting the server. A full-suite audit without a
+  // readable index is infrastructure failure, not an empty successful scan.
+  const {
+    entries: stories,
+    indexStatus,
+    error: indexError,
+  } = readStoriesIndex(storybookPath);
+  if (indexError) {
+    console.error(indexError);
+    const report = emptyReport({
+      error: indexError,
+      indexStatus,
+      scanStatus: 'crashed',
+      scope: components.length > 0 ? 'components' : 'full',
+    });
+    writeReport(report);
+    return report;
+  }
   const storyIds = Object.keys(stories);
 
   console.log(`Found ${storyIds.length} stories`);
 
   // Filter stories for relevant components
-  const relevantStories = storyIds.filter((id) => {
+  const relevantStories = storyIds.filter(id => {
+    const story = stories[id];
     // Skip docs pages
+    if (story.type && story.type !== 'story') return false;
     if (id.endsWith('--docs')) return false;
 
     if (components.length === 0) return true;
-    const story = stories[id];
     const title = story.title || '';
 
     // Titles are like "Core/XDSButton" or "Layout/XDSCard"
     const titleParts = title.split('/');
     const componentPart = titleParts.length > 1 ? titleParts[1] : titleParts[0];
-    const normalizedComponent = componentPart.replace(/^XDS/i, '').toLowerCase();
+    const normalizedComponent = componentPart
+      .replace(/^XDS/i, '')
+      .toLowerCase();
 
-    return components.some(
-      (comp) => normalizedComponent === comp.toLowerCase()
-    );
+    return components.some(comp => normalizedComponent === comp.toLowerCase());
   });
+
+  if (components.length === 0 && relevantStories.length === 0) {
+    const report = emptyReport({
+      error: 'Storybook index contains no eligible stories',
+      indexStatus,
+      scanStatus: 'crashed',
+      scope: 'full',
+    });
+    writeReport(report);
+    return report;
+  }
 
   // Group stories by component
   const storyGroups = {};
@@ -192,18 +267,24 @@ async function runAccessibilityAudit() {
     if (!storyGroups[component]) {
       storyGroups[component] = [];
     }
-    storyGroups[component].push({ id: storyId, ...story });
+    storyGroups[component].push({id: storyId, ...story});
   }
 
   console.log(`Auditing ${Object.keys(storyGroups).length} components`);
 
-  const browser = await chromium.launch();
   const componentResults = {};
   let totalViolations = 0;
+  let auditedStories = 0;
+  let failedStories = 0;
+  let server = null;
+  let browser = null;
 
   try {
+    const port = 6007;
+    server = await createServer(storybookPath, port);
+    browser = await chromium.launch();
     const context = await browser.newContext({
-      viewport: { width: 1280, height: 720 },
+      viewport: {width: 1280, height: 720},
       reducedMotion: 'reduce',
     });
 
@@ -216,31 +297,33 @@ async function runAccessibilityAudit() {
         try {
           const url = `http://localhost:${port}/iframe.html?id=${story.id}&viewMode=story`;
           // Higher timeout to accommodate axe-core's heavier DOM analysis
-          await page.goto(url, { waitUntil: 'networkidle', timeout: 15000 });
-          await page.addStyleTag({ content: FREEZE_CSS }).catch(() => {});
+          await page.goto(url, {waitUntil: 'networkidle', timeout: 15000});
+          await page.addStyleTag({content: FREEZE_CSS}).catch(() => {});
           // Brief wait for any post-load rendering before axe-core scans the DOM
           await page.waitForTimeout(500);
 
           // Run axe-core accessibility analysis
-          const results = await new AxeBuilder({ page })
+          const results = await new AxeBuilder({page})
             .disableRules(DISABLED_RULES)
             .analyze();
 
-          if (results.violations.length > 0) {
-            componentViolations.push({
-              story: story.name || story.id,
-              violations: results.violations,
-            });
-            totalViolations += results.violations.length;
-          }
+          componentViolations.push({
+            id: story.id,
+            story: story.name || story.id,
+            violations: results.violations,
+          });
+          totalViolations += results.violations.length;
 
+          auditedStories++;
           console.log(
-            `✓ Audited: ${component} / ${story.name} - ${results.violations.length} issues`
+            `✓ Audited: ${component} / ${story.name} - ${results.violations.length} issues`,
           );
         } catch (e) {
           console.error(`✗ Failed: ${story.id} - ${e.message}`);
+          failedStories++;
           // Record the failure but continue
           componentViolations.push({
+            id: story.id,
             story: story.name || story.id,
             error: e.message,
             violations: [],
@@ -276,10 +359,10 @@ async function runAccessibilityAudit() {
           // Keep first 3 nodes for display (cap to avoid bloat)
           if (agg.nodes.length < 3) {
             agg.nodes.push(
-              ...violation.nodes.slice(0, 3 - agg.nodes.length).map((n) => ({
+              ...violation.nodes.slice(0, 3 - agg.nodes.length).map(n => ({
                 html: n.html.substring(0, 200),
                 target: n.target,
-              }))
+              })),
             );
           }
         }
@@ -291,22 +374,66 @@ async function runAccessibilityAudit() {
         storyDetails: componentViolations,
       };
     }
+  } catch (e) {
+    console.error('Accessibility audit failed:', e.message);
+    const resultStoryIds = Object.values(componentResults).flatMap(component =>
+      (component.storyDetails || []).map(story => story.id),
+    );
+    const report = {
+      error: e.message,
+      components: componentResults,
+      summary: {
+        scope: components.length > 0 ? 'components' : 'full',
+        indexStatus,
+        componentsAudited: Object.keys(componentResults).length,
+        totalViolations,
+        expectedStories: relevantStories.length,
+        auditedStories,
+        failedStories,
+        resultStories: resultStoryIds.length,
+        uniqueResultStories: new Set(resultStoryIds).size,
+        scanStatus: 'crashed',
+        auditedAt: new Date().toISOString(),
+      },
+    };
+    writeReport(report);
+    return report;
   } finally {
-    await browser.close();
-    server.close();
+    if (browser) await browser.close();
+    if (server) server.close();
   }
 
+  const expectedStories = relevantStories.length;
+  const resultStoryIds = Object.values(componentResults).flatMap(component =>
+    (component.storyDetails || []).map(story => story.id),
+  );
+  const scanStatus =
+    failedStories === 0 &&
+    auditedStories === expectedStories &&
+    resultStoryIds.length === expectedStories &&
+    new Set(resultStoryIds).size === expectedStories
+      ? 'complete'
+      : 'incomplete';
   const report = {
     components: componentResults,
     summary: {
+      scope: components.length > 0 ? 'components' : 'full',
+      indexStatus,
       componentsAudited: Object.keys(componentResults).length,
       totalViolations,
+      expectedStories,
+      auditedStories,
+      failedStories,
+      resultStories: resultStoryIds.length,
+      uniqueResultStories: new Set(resultStoryIds).size,
+      scanStatus,
       auditedAt: new Date().toISOString(),
     },
   };
 
-  fs.writeFileSync(outputFile, JSON.stringify(report, null, 2));
-  console.log(`\nAudit complete: ${totalViolations} total violations found`);
+  writeReport(report);
+  console.log(`
+Audit complete: ${totalViolations} total violations found`);
   console.log(`Report written to ${outputFile}`);
 
   return report;
@@ -317,7 +444,7 @@ async function runAccessibilityAudit() {
 function loadBaselineFile(filePath) {
   if (!fs.existsSync(filePath)) {
     console.warn(`Baseline file not found at ${filePath} — treating as empty`);
-    return { version: 1, entries: [] };
+    return {version: 1, entries: []};
   }
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
@@ -325,6 +452,7 @@ function loadBaselineFile(filePath) {
 // Compare the report against the checked-in baseline (or rewrite it with
 // --update-baseline). Returns the exit code for the process.
 function applyBaselineGate(report) {
+  if (report?.summary?.scanStatus !== 'complete') return 1;
   if (!baselineFile) return 0;
 
   if (updateBaseline) {
@@ -335,7 +463,7 @@ function applyBaselineGate(report) {
       : null;
     fs.writeFileSync(
       baselineFile,
-      JSON.stringify(buildBaseline(report, { existing }), null, 2) + '\n'
+      JSON.stringify(buildBaseline(report, {existing}), null, 2) + '\n',
     );
     console.log(`Baseline written to ${baselineFile}`);
     return 0;
@@ -343,11 +471,11 @@ function applyBaselineGate(report) {
 
   const baseline = loadBaselineFile(baselineFile);
   const diff = diffAgainstBaseline(report, baseline);
-  console.log(formatDiffSummary(diff, { baselinePath: baselineFile }));
+  console.log(formatDiffSummary(diff, {baselinePath: baselineFile}));
 
   if (diff.newViolations.length > 0 && failOnNew) {
     console.error(
-      `\nFailing: ${diff.newViolations.length} accessibility violation(s) not in baseline.`
+      `\nFailing: ${diff.newViolations.length} accessibility violation(s) not in baseline.`,
     );
     return 1;
   }
@@ -355,11 +483,11 @@ function applyBaselineGate(report) {
 }
 
 runAccessibilityAudit()
-  .then((report) => {
+  .then(report => {
     const code = applyBaselineGate(report);
     if (code !== 0) process.exitCode = code;
   })
-  .catch((e) => {
+  .catch(e => {
     console.error('Accessibility audit failed:', e);
     process.exit(1);
   });

--- a/.github/scripts/accessibility-audit.test.mjs
+++ b/.github/scripts/accessibility-audit.test.mjs
@@ -11,7 +11,8 @@
  * a11y-weekly contract: audit all stories.
  */
 
-import {execFileSync} from 'node:child_process';
+import {spawnSync} from 'node:child_process';
+import http from 'node:http';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -22,54 +23,183 @@ const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.join(SCRIPTS_DIR, 'accessibility-audit.js');
 const BASELINE = path.resolve(SCRIPTS_DIR, '..', 'a11y-baseline.json');
 
-/** Run the audit CLI in an empty temp cwd; return {stdout, report}. */
-function runAudit(args) {
+/** Run the audit CLI in a temp cwd; return {status, stdout, stderr, report}. */
+function runAudit(args, setup) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'a11y-audit-'));
   try {
-    const stdout = execFileSync(
+    setup?.(dir);
+    const result = spawnSync(
       process.execPath,
       [SCRIPT, '--output', 'report.json', ...args],
       {cwd: dir, encoding: 'utf8'},
     );
-    const report = JSON.parse(
-      fs.readFileSync(path.join(dir, 'report.json'), 'utf8'),
-    );
-    return {stdout, report};
+    const reportPath = path.join(dir, 'report.json');
+    const report = fs.existsSync(reportPath)
+      ? JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+      : null;
+    return {
+      status: result.status,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      report,
+    };
   } finally {
     fs.rmSync(dir, {recursive: true, force: true});
   }
 }
 
+function storybookDist(root) {
+  return path.join(root, 'apps', 'storybook', 'dist');
+}
+
+function writeStorybookIndex(root, value) {
+  const dist = storybookDist(root);
+  fs.mkdirSync(dist, {recursive: true});
+  fs.writeFileSync(
+    path.join(dist, 'index.json'),
+    typeof value === 'string' ? value : JSON.stringify(value),
+  );
+}
+
+function writeOneStory(root) {
+  const dist = storybookDist(root);
+  writeStorybookIndex(root, {
+    entries: {
+      'core-button--default': {
+        type: 'story',
+        id: 'core-button--default',
+        title: 'Core/Button',
+        name: 'Default',
+      },
+    },
+  });
+  fs.writeFileSync(
+    path.join(dist, 'iframe.html'),
+    '<!doctype html><html><body><button>OK</button></body></html>',
+  );
+}
+
 describe('accessibility-audit --components contract', () => {
   it('audits nothing and passes when --components is explicitly empty', () => {
     // The exact pr-a11y invocation shape for a PR whose analysis found no
-    // new or modified components. execFileSync throws on a non-zero exit,
-    // so reaching the assertions proves the gate passed.
-    const {stdout, report} = runAudit([
+    // new or modified components.
+    const {status, stdout, report} = runAudit([
       '--components',
       '',
       '--baseline',
       BASELINE,
       '--fail-on-new',
     ]);
+    expect(status).toBe(0);
     expect(stdout).toContain('No components to audit');
     expect(report.components).toEqual({});
     expect(report.summary.totalViolations).toBe(0);
+    expect(report.summary).toMatchObject({
+      expectedStories: 0,
+      auditedStories: 0,
+      failedStories: 0,
+      scanStatus: 'complete',
+    });
   });
 
   it('still audits all stories when the flag is absent (a11y-weekly)', () => {
     // No storybook build exists in the temp cwd, so the all-stories path
     // reports the missing build instead of skipping — absent ≠ empty.
-    const {stdout, report} = runAudit([]);
+    const {status, stdout, report} = runAudit([]);
+    expect(status).toBe(1);
     expect(stdout).not.toContain('No components to audit');
     expect(stdout).toContain('all affected');
     expect(report.error).toBe('Storybook not built');
+    expect(report.summary.scanStatus).toBe('crashed');
   });
 
   it('proceeds to audit when --components names components', () => {
-    const {stdout, report} = runAudit(['--components', 'Text,Heading']);
+    const {status, stdout, report} = runAudit(['--components', 'Text,Heading']);
+    expect(status).toBe(1);
     expect(stdout).not.toContain('No components to audit');
     expect(stdout).toContain('Text, Heading');
     expect(report.error).toBe('Storybook not built');
+  });
+
+  it('fails closed when the Storybook index file is missing', () => {
+    const {status, report} = runAudit([], root => {
+      fs.mkdirSync(path.join(root, 'apps', 'storybook', 'dist'), {
+        recursive: true,
+      });
+    });
+    expect(status).toBe(1);
+    expect(report.summary).toMatchObject({
+      scope: 'full',
+      indexStatus: 'missing',
+      scanStatus: 'crashed',
+      expectedStories: 0,
+    });
+  });
+
+  it('fails closed when the Storybook index JSON is malformed', () => {
+    const {status, report} = runAudit([], root => {
+      writeStorybookIndex(root, '{not json');
+    });
+    expect(status).toBe(1);
+    expect(report.summary.indexStatus).toBe('malformed');
+    expect(report.summary.scanStatus).toBe('crashed');
+  });
+
+  it('fails closed when a full-suite index has zero eligible stories', () => {
+    const {status, report} = runAudit([], root => {
+      writeStorybookIndex(root, {
+        entries: {
+          docs: {type: 'docs', id: 'core-button--docs', title: 'Core/Button'},
+        },
+      });
+    });
+    expect(status).toBe(1);
+    expect(report.error).toBe('Storybook index contains no eligible stories');
+    expect(report.summary).toMatchObject({
+      indexStatus: 'parsed',
+      scanStatus: 'crashed',
+      expectedStories: 0,
+    });
+  });
+
+  it('audits one valid Storybook story, writes a complete report, and closes the server', () => {
+    const first = runAudit([], writeOneStory);
+    expect(first.status).toBe(0);
+    expect(first.report.summary).toMatchObject({
+      scope: 'full',
+      indexStatus: 'parsed',
+      expectedStories: 1,
+      auditedStories: 1,
+      failedStories: 0,
+      resultStories: 1,
+      uniqueResultStories: 1,
+      scanStatus: 'complete',
+      totalViolations: 0,
+    });
+    expect(first.report.components.Button.storyDetails).toEqual([
+      {id: 'core-button--default', story: 'Default', violations: []},
+    ]);
+
+    const second = runAudit([], writeOneStory);
+    expect(second.status).toBe(0);
+    expect(second.report.summary.scanStatus).toBe('complete');
+  });
+
+  it('writes a crashed report when scan infrastructure throws', async () => {
+    const blocker = http.createServer((_, res) => res.end('busy'));
+    await new Promise(resolve => blocker.listen(6007, resolve));
+    try {
+      const {status, report} = runAudit([], writeOneStory);
+      expect(status).toBe(1);
+      expect(report.error).toMatch(/EADDRINUSE|address already in use/i);
+      expect(report.summary).toMatchObject({
+        indexStatus: 'parsed',
+        expectedStories: 1,
+        auditedStories: 0,
+        scanStatus: 'crashed',
+      });
+    } finally {
+      await new Promise(resolve => blocker.close(resolve));
+    }
   });
 });

--- a/.github/scripts/lib/gh-pages-publisher.mjs
+++ b/.github/scripts/lib/gh-pages-publisher.mjs
@@ -1611,6 +1611,142 @@ function pruneReleaseGateRuns(visualGateRoot) {
   }
 }
 
+function assertCommitSha(value, name) {
+  if (!/^[0-9a-f]{40}$/i.test(String(value ?? ''))) {
+    refuse(`${name} must be a full 40-character commit SHA`);
+  }
+}
+
+function compareMainCommits(repository, base, head) {
+  assertCommitSha(base, 'latest main-quality SHA');
+  assertCommitSha(head, '--sha');
+  const result = tryRun('gh', [
+    'api',
+    `repos/${repository}/compare/${base}...${head}`,
+  ]);
+  if (result.status !== 0) {
+    refuse(
+      `cannot compare main-quality SHAs: ${
+        result.stderr?.trim() ||
+        result.stdout?.trim() ||
+        `exit ${result.status}`
+      }`,
+    );
+  }
+  try {
+    return JSON.parse(result.stdout).status;
+  } catch (error) {
+    refuse(`cannot parse main-quality SHA comparison: ${error.message}`);
+  }
+}
+
+export function shouldAdvanceMainQualityLatest({
+  repository,
+  currentSha,
+  currentRunId,
+  latest,
+  compare = compareMainCommits,
+}) {
+  assertCommitSha(currentSha, '--sha');
+  if (!latest?.sha || !latest?.runId) return true;
+  assertCommitSha(latest.sha, 'latest main-quality SHA');
+  const latestRunId = Number(latest.runId);
+  if (!Number.isSafeInteger(latestRunId) || latestRunId <= 0) return true;
+  if (latest.sha.toLowerCase() === currentSha.toLowerCase()) {
+    return currentRunId > latestRunId;
+  }
+  return compare(repository, latest.sha, currentSha) === 'ahead';
+}
+
+function readLatestMainQuality(root) {
+  return readJSON(path.join(root, 'latest', 'main-quality.json'));
+}
+
+export async function publishMainQualityReport({
+  repository,
+  token,
+  tempRoot,
+  remoteURL,
+  source,
+  sha,
+  runId,
+  maxAttempts = 5,
+  beforePush,
+  compareMain = compareMainCommits,
+}) {
+  const sourceDir = path.resolve(source);
+  assertCommitSha(sha, '--sha');
+  if (!fs.existsSync(sourceDir) || !fs.statSync(sourceDir).isDirectory()) {
+    refuse('--source must be a directory');
+  }
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const checkout = checkoutPages({
+      repository,
+      token,
+      tempRoot,
+      remoteURL,
+      sparsePaths: [path.join('main-quality')],
+      prefix: 'gh-pages-main-quality-',
+    });
+    try {
+      const root = path.join(checkout, 'main-quality');
+      const runDir = path.join(root, sha, String(runId));
+      const latestDir = path.join(root, 'latest');
+      const latest = readLatestMainQuality(root);
+      fs.rmSync(runDir, {recursive: true, force: true});
+      copyContents(sourceDir, runDir);
+      if (
+        shouldAdvanceMainQualityLatest({
+          repository,
+          currentSha: sha,
+          currentRunId: runId,
+          latest,
+          compare: compareMain,
+        })
+      ) {
+        fs.rmSync(latestDir, {recursive: true, force: true});
+        copyContents(sourceDir, latestDir);
+      } else {
+        process.stdout.write(
+          `Preserved newer main-quality latest while publishing ${sha}/${runId}.\n`,
+        );
+      }
+      const commit = commitIfNeeded(
+        checkout,
+        `main quality: ${sha.slice(0, 7)} ${runId}`,
+        ['-A', 'main-quality'],
+      );
+      if (commit === null) {
+        process.stdout.write('Nothing to publish.\n');
+        output('published', 'true');
+        return {published: true};
+      }
+      await beforePush?.({attempt, checkout, commit});
+      const pushed = tryRun('git', [
+        '-C',
+        checkout,
+        'push',
+        'origin',
+        PAGES_BRANCH,
+      ]);
+      if (pushOrRetry(pushed)) {
+        const url = `https://facebook.github.io/astryx/main-quality/${sha}/${runId}/`;
+        output('published', 'true');
+        output('report_url', url);
+        process.stdout.write(`Published ${url}\n`);
+        return {published: true, commit, url};
+      }
+    } finally {
+      fs.rmSync(checkout, {recursive: true, force: true});
+    }
+    process.stdout.write(
+      `Push rejected; retrying main-quality publish (${attempt}/${maxAttempts}).\n`,
+    );
+    await sleep(attempt * 2000);
+  }
+  refuse(`could not publish main-quality report after ${maxAttempts} attempts`);
+}
+
 export async function publishStableSite({
   repository,
   token,
@@ -1786,6 +1922,15 @@ export async function main(argv = process.argv.slice(2)) {
       scope: 'visual-gate/reports',
       publish: () => publishReleaseGateReport({...context, source}),
     });
+  } else if (command === 'main-quality') {
+    const source = flag(argv, '--source');
+    const sha = flag(argv, '--sha', process.env.GITHUB_SHA ?? '');
+    if (!source) refuse('--source is required');
+    await withPublicationTurn({
+      ...context,
+      scope: 'main-quality/reports',
+      publish: () => publishMainQualityReport({...context, source, sha}),
+    });
   } else if (command === 'immutable-path') {
     const source = flag(argv, '--source');
     const destination = flag(argv, '--destination');
@@ -1844,7 +1989,7 @@ export async function main(argv = process.argv.slice(2)) {
     });
   } else {
     refuse(
-      'usage: gh-pages-publisher.mjs <enqueue|wait|release|stable-site|release-gate|immutable-path|visual-acceptance-record|visual-baseline-accepted|visual-baseline-manual>',
+      'usage: gh-pages-publisher.mjs <enqueue|wait|release|stable-site|release-gate|main-quality|immutable-path|visual-acceptance-record|visual-baseline-accepted|visual-baseline-manual>',
     );
   }
 }

--- a/.github/scripts/lib/gh-pages-publisher.test.mjs
+++ b/.github/scripts/lib/gh-pages-publisher.test.mjs
@@ -14,7 +14,9 @@ import {
   enqueuePublication,
   publishAcceptedVisualBaseline,
   publishImmutablePath,
+  publishMainQualityReport,
   publishReleaseGateReport,
+  shouldAdvanceMainQualityLatest,
   publishVisualAcceptanceRecord,
   publishStableSite,
   releasePublication,
@@ -457,6 +459,130 @@ describe('gh-pages publisher', () => {
       ),
     ).toContain('whole-tree');
     expect(git(final, 'rev-list', '--count', 'HEAD')).toBe('1');
+  });
+
+  it('publishes main-quality reports by exact SHA without touching release assets', async () => {
+    const fx = fixture();
+    const report = path.join(fx.root, 'main-quality-report');
+    const sha = 'e'.repeat(40);
+    writeFile(path.join(report, 'index.html'), 'quality');
+    writeJSON(path.join(report, 'main-quality.json'), {
+      sha,
+      aggregate: {verdict: 'debt'},
+    });
+
+    await publishMainQualityReport({
+      ...context(fx, 950, 'main-quality/reports'),
+      source: report,
+      sha,
+      runId: 950,
+    });
+
+    const final = cloneRemote(fx.remote, fx.root);
+    expect(
+      fs.readFileSync(
+        path.join(final, 'main-quality', sha, '950', 'index.html'),
+        'utf8',
+      ),
+    ).toBe('quality');
+    expect(
+      fs.readFileSync(
+        path.join(final, 'main-quality', 'latest', 'index.html'),
+        'utf8',
+      ),
+    ).toBe('quality');
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(final, 'visual-gate', 'baseline', 'manifest.json'),
+          'utf8',
+        ),
+      ).version,
+    ).toBe(1);
+    expect(
+      fs.readFileSync(path.join(final, 'storybook', 'old.html'), 'utf8'),
+    ).toBe('old storybook');
+  });
+
+  it('keeps main-quality latest monotonic when an older main run finishes late', async () => {
+    const fx = fixture();
+    const oldSha = '1'.repeat(40);
+    const newSha = '2'.repeat(40);
+    const seed = cloneRemote(fx.remote, fx.root, 'seed-main-quality-latest');
+    git(seed, 'config', 'user.name', 'Test');
+    git(seed, 'config', 'user.email', 'test@example.com');
+    writeFile(
+      path.join(seed, 'main-quality', 'latest', 'index.html'),
+      'new latest',
+    );
+    writeJSON(path.join(seed, 'main-quality', 'latest', 'main-quality.json'), {
+      sha: newSha,
+      runId: 200,
+      aggregate: {verdict: 'clean'},
+    });
+    git(seed, 'add', '.');
+    git(seed, 'commit', '-qm', 'seed main quality latest');
+    git(seed, 'push', '-q', 'origin', 'gh-pages');
+
+    const report = path.join(fx.root, 'stale-main-quality-report');
+    writeFile(path.join(report, 'index.html'), 'old late report');
+    writeJSON(path.join(report, 'main-quality.json'), {
+      sha: oldSha,
+      runId: 150,
+      aggregate: {verdict: 'debt'},
+    });
+
+    await publishMainQualityReport({
+      ...context(fx, 150, 'main-quality/reports'),
+      source: report,
+      sha: oldSha,
+      runId: 150,
+      compareMain: () => 'behind',
+    });
+
+    const final = cloneRemote(fx.remote, fx.root);
+    expect(
+      fs.readFileSync(
+        path.join(final, 'main-quality', oldSha, '150', 'index.html'),
+        'utf8',
+      ),
+    ).toBe('old late report');
+    expect(
+      fs.readFileSync(
+        path.join(final, 'main-quality', 'latest', 'index.html'),
+        'utf8',
+      ),
+    ).toBe('new latest');
+  });
+
+  it('orders main-quality latest by SHA first, then run id for the same SHA', () => {
+    const latest = {sha: '1'.repeat(40), runId: 200};
+    expect(
+      shouldAdvanceMainQualityLatest({
+        repository: REPO,
+        currentSha: '2'.repeat(40),
+        currentRunId: 150,
+        latest,
+        compare: () => 'ahead',
+      }),
+    ).toBe(true);
+    expect(
+      shouldAdvanceMainQualityLatest({
+        repository: REPO,
+        currentSha: '0'.repeat(40),
+        currentRunId: 250,
+        latest,
+        compare: () => 'behind',
+      }),
+    ).toBe(false);
+    expect(
+      shouldAdvanceMainQualityLatest({
+        repository: REPO,
+        currentSha: latest.sha,
+        currentRunId: 199,
+        latest,
+      }),
+    ).toBe(false);
   });
 
   it('publishes release-gate reports without touching the stable site or baseline', async () => {

--- a/.github/scripts/main-quality-report.mjs
+++ b/.github/scripts/main-quality-report.mjs
@@ -1,0 +1,553 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Compose the protected-main quality report and commit-status projection.
+ * @input Suite reports from the protected-main quality workflow.
+ * @output A self-contained report directory and status payload.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const STATUS_CONTEXT = 'protected-main-quality';
+const CLEAN = new Set(['pass', 'clean']);
+const MAX_DESCRIPTION = 140;
+
+function arg(name, fallback = null) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+function bool(value) {
+  return String(value ?? '').toLowerCase() === 'true';
+}
+
+function readJSON(file) {
+  if (!file) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function readText(file) {
+  if (!file) return '';
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function writeJSON(file, value) {
+  fs.mkdirSync(path.dirname(file), {recursive: true});
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function copyIfPresent(source, destination) {
+  if (!fs.existsSync(source)) return false;
+  fs.rmSync(destination, {recursive: true, force: true});
+  fs.mkdirSync(path.dirname(destination), {recursive: true});
+  fs.cpSync(source, destination, {recursive: true});
+  return true;
+}
+
+function writeOutput(file, values) {
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`);
+  if (file) fs.appendFileSync(file, `${lines.join('\n')}\n`);
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+function html(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function markdownToHtml(markdown) {
+  if (!markdown) return '<p>No summary was produced.</p>';
+  const lines = markdown.trim().split(/\r?\n/);
+  const out = [];
+  let inTable = false;
+  let inList = false;
+  let inPre = false;
+  for (const line of lines) {
+    if (line.startsWith('```')) {
+      out.push(inPre ? '</code></pre>' : '<pre><code>');
+      inPre = !inPre;
+      continue;
+    }
+    if (inPre) {
+      out.push(`${html(line)}\n`);
+      continue;
+    }
+    if (line.startsWith('## ')) {
+      if (inTable) out.push('</tbody></table>');
+      if (inList) out.push('</ul>');
+      inTable = false;
+      inList = false;
+      out.push(`<h2>${html(line.slice(3))}</h2>`);
+    } else if (line.startsWith('### ')) {
+      if (inTable) out.push('</tbody></table>');
+      if (inList) out.push('</ul>');
+      inTable = false;
+      inList = false;
+      out.push(`<h3>${html(line.slice(4))}</h3>`);
+    } else if (line.startsWith('|') && line.endsWith('|')) {
+      if (line.replace(/[|\-: ]/g, '') === '') continue;
+      const cells = line
+        .slice(1, -1)
+        .split('|')
+        .map(cell => html(cell.trim()));
+      if (!inTable) {
+        if (inList) out.push('</ul>');
+        inList = false;
+        out.push('<table><tbody>');
+        inTable = true;
+      }
+      out.push(`<tr>${cells.map(cell => `<td>${cell}</td>`).join('')}</tr>`);
+    } else if (line.startsWith('- ')) {
+      if (inTable) out.push('</tbody></table>');
+      inTable = false;
+      if (!inList) {
+        out.push('<ul>');
+        inList = true;
+      }
+      out.push(`<li>${html(line.slice(2))}</li>`);
+    } else if (line.trim() === '') {
+      if (inTable) {
+        out.push('</tbody></table>');
+        inTable = false;
+      }
+      if (inList) {
+        out.push('</ul>');
+        inList = false;
+      }
+    } else {
+      if (inTable) out.push('</tbody></table>');
+      if (inList) out.push('</ul>');
+      inTable = false;
+      inList = false;
+      out.push(`<p>${html(line)}</p>`);
+    }
+  }
+  if (inTable) out.push('</tbody></table>');
+  if (inList) out.push('</ul>');
+  if (inPre) out.push('</code></pre>');
+  return out.join('\n');
+}
+
+function summarizeVisual(verdict) {
+  if (!verdict)
+    return {status: 'crashed', details: 'No visual verdict was produced.'};
+  const counts = verdict.counts ?? {};
+  const bits = [
+    `${counts.total ?? 0} shot(s)`,
+    `${counts.changed ?? 0} changed`,
+    `${counts.added ?? 0} added`,
+    `${counts.removed ?? 0} removed`,
+    `${counts.failed ?? 0} failed`,
+  ];
+  return {status: verdict.status ?? 'crashed', details: bits.join(' · ')};
+}
+
+function a11yIntegrity(report) {
+  const summary = report?.summary;
+  if (!summary || summary.scanStatus !== 'complete') {
+    return {ok: false, reason: 'scan did not complete'};
+  }
+  if (summary.indexStatus !== 'parsed') {
+    return {ok: false, reason: 'Storybook index was not parsed'};
+  }
+  if (
+    !Number.isSafeInteger(summary.expectedStories) ||
+    summary.expectedStories <= 0
+  ) {
+    return {ok: false, reason: 'no eligible stories were found'};
+  }
+  for (const field of [
+    'auditedStories',
+    'failedStories',
+    'resultStories',
+    'uniqueResultStories',
+  ]) {
+    if (!Number.isSafeInteger(summary[field])) {
+      return {ok: false, reason: `${field} is missing`};
+    }
+  }
+  if (summary.failedStories !== 0) {
+    return {ok: false, reason: `${summary.failedStories} story/stories failed`};
+  }
+  if (summary.auditedStories !== summary.expectedStories) {
+    return {ok: false, reason: 'audited story count does not match expected'};
+  }
+  if (
+    summary.resultStories !== summary.expectedStories ||
+    summary.uniqueResultStories !== summary.expectedStories
+  ) {
+    return {ok: false, reason: 'per-story result integrity mismatch'};
+  }
+  const seen = new Set();
+  let details = 0;
+  for (const [componentName, component] of Object.entries(
+    report.components || {},
+  )) {
+    const storyDetails = component.storyDetails;
+    if (!Array.isArray(storyDetails)) {
+      return {ok: false, reason: `${componentName} has no story details`};
+    }
+    if (component.storiesAudited !== storyDetails.length) {
+      return {ok: false, reason: `${componentName} story count mismatch`};
+    }
+    for (const story of storyDetails) {
+      if (!story?.id || !Array.isArray(story.violations)) {
+        return {
+          ok: false,
+          reason: `${componentName} has malformed story result`,
+        };
+      }
+      if (seen.has(story.id)) {
+        return {ok: false, reason: `duplicate story result ${story.id}`};
+      }
+      seen.add(story.id);
+      details++;
+    }
+  }
+  if (
+    details !== summary.resultStories ||
+    seen.size !== summary.uniqueResultStories
+  ) {
+    return {ok: false, reason: 'reported story totals do not match details'};
+  }
+  return {ok: true, reason: 'complete'};
+}
+
+function summarizeA11y(report, fallbackStatus) {
+  if (!report || report.error) {
+    return {status: 'crashed', details: 'No usable a11y report was produced.'};
+  }
+  const integrity = a11yIntegrity(report);
+  if (!integrity.ok) {
+    return {
+      status: 'crashed',
+      details: `${integrity.reason}; ${report.summary?.auditedStories ?? 0}/${report.summary?.expectedStories ?? 0} story/stories audited`,
+    };
+  }
+  const violations = report.summary?.totalViolations ?? 0;
+  const components = report.summary?.componentsAudited ?? 0;
+  return {
+    status: fallbackStatus || (violations > 0 ? 'violations' : 'clean'),
+    details: `${violations} violation(s) across ${components} component(s)`,
+    violations,
+  };
+}
+
+function summarizeRtl(report, fallbackStatus) {
+  if (!report || report.error)
+    return {status: 'crashed', details: 'No usable RTL report was produced.'};
+  const auto = report.autoDiscovery ?? {};
+  const positional = report.positionalMirror ?? {};
+  const curated = report.curated?.results ?? [];
+  const findings =
+    (auto.results ?? []).filter(
+      r => r.verdict === 'fail' || r.verdict === 'ERROR',
+    ).length +
+    (positional.results ?? []).filter(
+      r => r.verdict === 'fail' || r.verdict === 'ERROR',
+    ).length +
+    curated.filter(r =>
+      ['not-RTL', 'ERROR', 'MISSING-STORY'].includes(r.rollup),
+    ).length;
+  return {
+    status: fallbackStatus || (findings > 0 ? 'findings' : 'clean'),
+    details: `${findings} finding(s); ${auto.total ?? 0} D1 component(s), ${positional.total ?? 0} D5 story/stories`,
+    findings,
+  };
+}
+
+export function summarizeForcedColors(report, outcome = 'success') {
+  if (!report)
+    return {status: 'crashed', details: 'No Vitest report was produced.'};
+  const failed = Number(report.numFailedTests ?? 0);
+  const passed = Number(report.numPassedTests ?? 0);
+  const total = passed + failed;
+  const status =
+    total === 0
+      ? 'crashed'
+      : outcome === 'success' && failed === 0
+        ? 'clean'
+        : failed > 0
+          ? 'failed'
+          : 'crashed';
+  return {
+    status,
+    details: `${passed}/${total} matching test(s) passed`,
+    failed,
+    passed,
+    total,
+  };
+}
+
+export function aggregateVerdict(suites) {
+  const statuses = Object.values(suites).map(suite => suite.status);
+  if (statuses.some(status => status === 'crashed')) return 'crashed';
+  return statuses.every(status => CLEAN.has(status)) ? 'clean' : 'debt';
+}
+
+export function buildCommitStatus(report, {publicationState = 'success'} = {}) {
+  if (publicationState !== 'success') {
+    return {
+      state: 'failure',
+      context: STATUS_CONTEXT,
+      description: 'Protected-main quality report publication failed.',
+      target_url: report.runUrl,
+    };
+  }
+
+  const verdict = report.aggregate.verdict;
+  const clean = verdict === 'clean';
+  const state = report.shadowMode || clean ? 'success' : 'failure';
+  const prefix = report.shadowMode ? 'Shadow' : 'Enforced';
+  const parts = Object.entries(report.suites)
+    .filter(([, suite]) => suite.status !== 'clean' && suite.status !== 'pass')
+    .map(([name, suite]) => `${name}: ${suite.status}`);
+  const tail = parts.length ? parts.join(' · ') : 'all suites clean';
+  let description = `${prefix}: ${tail}`;
+  if (description.length > MAX_DESCRIPTION) {
+    description = `${description.slice(0, MAX_DESCRIPTION - 1)}…`;
+  }
+  return {
+    state,
+    context: STATUS_CONTEXT,
+    description,
+    target_url: report.reportUrl,
+  };
+}
+
+function buildReport({
+  sha,
+  runId,
+  runUrl,
+  reportUrl,
+  shadowMode,
+  visualVerdict,
+  a11yReport,
+  a11yStatus,
+  rtlReport,
+  rtlStatus,
+  forcedColorsReport,
+  forcedColorsOutcome,
+}) {
+  const suites = {
+    visual: summarizeVisual(visualVerdict),
+    accessibility: summarizeA11y(a11yReport, a11yStatus),
+    rtl: summarizeRtl(rtlReport, rtlStatus),
+    forcedColors: summarizeForcedColors(
+      forcedColorsReport,
+      forcedColorsOutcome,
+    ),
+  };
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    sha,
+    runId,
+    runUrl,
+    reportUrl,
+    shadowMode,
+    rollout: {
+      switch:
+        'QUALITY_SHADOW_MODE in .github/workflows/protected-main-quality.yml',
+      criteria:
+        'After one clean run on the current main SHA, set QUALITY_SHADOW_MODE=false and add the protected-main-quality status context to the main branch required checks.',
+      dependency:
+        'Visual baseline ownership and pruning remain in #5608; this workflow only reads the existing baseline.',
+    },
+    suites,
+    aggregate: {verdict: aggregateVerdict(suites)},
+  };
+}
+
+function buildHtml(report, summaries) {
+  const rows = Object.entries(report.suites)
+    .map(
+      ([name, suite]) =>
+        `<tr><td>${html(name)}</td><td><strong>${html(suite.status)}</strong></td><td>${html(suite.details)}</td></tr>`,
+    )
+    .join('\n');
+  const summarySections = Object.entries(summaries)
+    .map(
+      ([name, markdown]) =>
+        `<section><h2>${html(name)}</h2>${markdownToHtml(markdown)}</section>`,
+    )
+    .join('\n');
+  const visualLink = [
+    '<p><a href="visual-report/">Open visual diff report</a></p>',
+    '<p><a href="visual-capture/">Open complete visual capture artifact</a></p>',
+  ].join('\n');
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Protected main quality</title>
+<style>
+body{font:16px/1.45 system-ui,-apple-system,Segoe UI,sans-serif;margin:2rem;max-width:1100px;color:#1f2328}
+table{border-collapse:collapse;width:100%;margin:1rem 0}td,th{border:1px solid #d0d7de;padding:.45rem;text-align:left;vertical-align:top}code,pre{background:#f6f8fa;border-radius:6px}pre{padding:1rem;overflow:auto}.badge{display:inline-block;padding:.2rem .5rem;border-radius:999px;background:#fff4ce}.clean{background:#dafbe1}.debt{background:#fff4ce}.crashed{background:#ffebe9}
+</style>
+</head>
+<body>
+<h1>Protected main quality <span class="badge ${html(report.aggregate.verdict)}">${html(report.aggregate.verdict)}</span></h1>
+<p><strong>Mode:</strong> ${report.shadowMode ? 'shadow — non-blocking' : 'enforced'} · <strong>Main SHA:</strong> <code>${html(report.sha)}</code> · <a href="${html(report.runUrl)}">workflow run</a></p>
+<table><thead><tr><th>Suite</th><th>Verdict</th><th>Details</th></tr></thead><tbody>${rows}</tbody></table>
+${visualLink}
+<h2>Rollout</h2>
+<p>${html(report.rollout.criteria)}</p>
+<p>${html(report.rollout.dependency)}</p>
+${summarySections}
+</body>
+</html>
+`;
+}
+
+export function stageVisualResult({sourceDir, outDir, summaryFile}) {
+  const source = path.resolve(sourceDir);
+  const out = path.resolve(outDir);
+  fs.rmSync(out, {recursive: true, force: true});
+  fs.mkdirSync(path.join(out, 'capture'), {recursive: true});
+  const copied = [
+    copyIfPresent(
+      path.join(source, 'verdict.json'),
+      path.join(out, 'verdict.json'),
+    ),
+    copyIfPresent(
+      path.join(source, 'verdict.json'),
+      path.join(out, 'capture', 'verdict.json'),
+    ),
+    copyIfPresent(
+      path.join(source, 'manifest.json'),
+      path.join(out, 'capture', 'manifest.json'),
+    ),
+    copyIfPresent(
+      path.join(source, 'shots'),
+      path.join(out, 'capture', 'shots'),
+    ),
+    copyIfPresent(path.join(source, 'report'), path.join(out, 'report')),
+  ];
+  if (summaryFile) copyIfPresent(summaryFile, path.join(out, 'summary.md'));
+  return copied.some(Boolean);
+}
+
+function compose() {
+  const outDir = path.resolve(arg('out-dir', 'main-quality-report'));
+  const report = buildReport({
+    sha: arg('sha', ''),
+    runId: arg('run-id', ''),
+    runUrl: arg('run-url', ''),
+    reportUrl: arg('report-url', ''),
+    shadowMode: bool(arg('shadow-mode', 'true')),
+    visualVerdict: readJSON(arg('visual-verdict')),
+    a11yReport: readJSON(arg('a11y-report')),
+    a11yStatus: arg('a11y-status'),
+    rtlReport: readJSON(arg('rtl-report')),
+    rtlStatus: arg('rtl-status'),
+    forcedColorsReport: readJSON(arg('forced-colors-report')),
+    forcedColorsOutcome: arg('forced-colors-outcome', 'success'),
+  });
+  fs.mkdirSync(outDir, {recursive: true});
+  writeJSON(path.join(outDir, 'main-quality.json'), report);
+
+  const summaries = {
+    visual: readText(arg('visual-summary')),
+    accessibility: readText(arg('a11y-summary')),
+    rtl: readText(arg('rtl-summary')),
+    'forced colors':
+      readText(arg('forced-colors-summary')) ||
+      readText(arg('forced-colors-log')),
+  };
+  fs.writeFileSync(
+    path.join(outDir, 'index.html'),
+    buildHtml(report, summaries),
+  );
+  const stepSummary = [
+    `## Protected main quality: ${report.aggregate.verdict}`,
+    '',
+    `Exact main SHA: \`${report.sha}\``,
+    `Report: ${report.reportUrl}`,
+    '',
+    '| suite | verdict | details |',
+    '|---|---|---|',
+    ...Object.entries(report.suites).map(
+      ([name, suite]) => `| ${name} | ${suite.status} | ${suite.details} |`,
+    ),
+    '',
+    `Mode: ${report.shadowMode ? 'shadow — suite debt does not fail the status' : 'enforced'}.`,
+    `Rollout: ${report.rollout.criteria}`,
+    `Dependency: ${report.rollout.dependency}`,
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(outDir, 'summary.md'), stepSummary);
+  process.stdout.write(stepSummary);
+}
+
+function forcedColorsSummary() {
+  const report = readJSON(arg('report'));
+  const summary = summarizeForcedColors(report, arg('outcome', 'success'));
+  const lines = [
+    '## Forced-colors suite',
+    '',
+    `**Status:** ${summary.status}`,
+    '',
+    `Vitest: ${summary.details}.`,
+    '',
+  ];
+  fs.writeFileSync(
+    arg('summary-output', 'forced-colors-summary.md'),
+    lines.join('\n'),
+  );
+  writeOutput(arg('github-output'), {
+    status: summary.status,
+    total_tests: summary.total ?? 0,
+    failed_tests: summary.failed ?? 0,
+  });
+}
+
+function statusCommand() {
+  const report = readJSON(arg('report'));
+  if (!report) throw new Error('--report must name a valid report JSON file');
+  const status = buildCommitStatus(report, {
+    publicationState: arg('publication-state', 'success'),
+  });
+  writeJSON(arg('output', 'commit-status.json'), status);
+  process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+}
+
+async function main() {
+  const command = process.argv[2];
+  if (command === 'compose') return compose();
+  if (command === 'stage-visual') {
+    stageVisualResult({
+      sourceDir: arg('source', '.visual-run'),
+      outDir: arg('out-dir', 'visual-result'),
+      summaryFile: arg('summary'),
+    });
+    return;
+  }
+  if (command === 'forced-colors-summary') return forcedColorsSummary();
+  if (command === 'status') return statusCommand();
+  throw new Error(
+    'usage: main-quality-report.mjs <compose|stage-visual|forced-colors-summary|status>',
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/main-quality-report.test.mjs
+++ b/.github/scripts/main-quality-report.test.mjs
@@ -1,0 +1,342 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {
+  aggregateVerdict,
+  buildCommitStatus,
+  stageVisualResult,
+  summarizeForcedColors,
+} from './main-quality-report.mjs';
+
+const ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+const SCRIPT = path.join(ROOT, '.github', 'scripts', 'main-quality-report.mjs');
+const roots = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    fs.rmSync(root, {recursive: true, force: true});
+});
+
+function tempRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'main-quality-report-'));
+  roots.push(root);
+  return root;
+}
+
+function writeJSON(file, value) {
+  fs.mkdirSync(path.dirname(file), {recursive: true});
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function completeA11y(overrides = {}) {
+  return {
+    summary: {
+      scope: 'full',
+      indexStatus: 'parsed',
+      totalViolations: 0,
+      componentsAudited: 1,
+      expectedStories: 1,
+      auditedStories: 1,
+      failedStories: 0,
+      resultStories: 1,
+      uniqueResultStories: 1,
+      scanStatus: 'complete',
+      ...overrides.summary,
+    },
+    components: {
+      Button: {
+        storiesAudited: 1,
+        violations: [],
+        storyDetails: [
+          {id: 'core-button--default', story: 'Default', violations: []},
+        ],
+      },
+      ...overrides.components,
+    },
+  };
+}
+
+function composeWithA11y(a11yReport) {
+  const root = tempRoot();
+  writeJSON(path.join(root, 'visual.json'), {
+    status: 'pass',
+    counts: {total: 1},
+  });
+  writeJSON(path.join(root, 'a11y.json'), a11yReport);
+  writeJSON(path.join(root, 'rtl.json'), {
+    autoDiscovery: {results: []},
+    positionalMirror: {results: []},
+    curated: {results: []},
+  });
+  writeJSON(path.join(root, 'forced.json'), {
+    numPassedTests: 8,
+    numFailedTests: 0,
+  });
+  const out = path.join(root, 'out');
+  execFileSync(
+    process.execPath,
+    [
+      SCRIPT,
+      'compose',
+      '--out-dir',
+      out,
+      '--sha',
+      'b'.repeat(40),
+      '--run-id',
+      '124',
+      '--run-url',
+      'https://github.com/facebook/astryx/actions/runs/124',
+      '--report-url',
+      'https://facebook.github.io/astryx/main-quality/b/124/',
+      '--shadow-mode',
+      'true',
+      '--visual-verdict',
+      path.join(root, 'visual.json'),
+      '--a11y-report',
+      path.join(root, 'a11y.json'),
+      '--a11y-status',
+      'clean',
+      '--rtl-report',
+      path.join(root, 'rtl.json'),
+      '--forced-colors-report',
+      path.join(root, 'forced.json'),
+    ],
+    {encoding: 'utf8'},
+  );
+  return JSON.parse(
+    fs.readFileSync(path.join(out, 'main-quality.json'), 'utf8'),
+  );
+}
+
+function baseReport(overrides = {}) {
+  return {
+    runUrl: 'https://github.com/facebook/astryx/actions/runs/1',
+    reportUrl: 'https://facebook.github.io/astryx/main-quality/abc/1/',
+    shadowMode: true,
+    suites: {
+      visual: {status: 'changed', details: '2 changed'},
+      accessibility: {status: 'violations', details: '108 violations'},
+      rtl: {status: 'clean', details: '0 findings'},
+      forcedColors: {status: 'clean', details: '8 passed'},
+    },
+    aggregate: {verdict: 'debt'},
+    ...overrides,
+  };
+}
+
+describe('main quality report', () => {
+  it('keeps suite debt green only in shadow mode', () => {
+    expect(buildCommitStatus(baseReport()).state).toBe('success');
+    expect(buildCommitStatus(baseReport({shadowMode: false})).state).toBe(
+      'failure',
+    );
+  });
+
+  it('lets publication health fail independently of suite verdicts', () => {
+    const status = buildCommitStatus(baseReport(), {
+      publicationState: 'failed',
+    });
+    expect(status.state).toBe('failure');
+    expect(status.description).toContain('publication failed');
+    expect(status.target_url).toBe(baseReport().runUrl);
+  });
+
+  it('aggregates clean, debt, and crashed suite verdicts', () => {
+    expect(
+      aggregateVerdict({
+        visual: {status: 'pass'},
+        accessibility: {status: 'clean'},
+      }),
+    ).toBe('clean');
+    expect(
+      aggregateVerdict({
+        visual: {status: 'changed'},
+        accessibility: {status: 'clean'},
+      }),
+    ).toBe('debt');
+    expect(
+      aggregateVerdict({
+        visual: {status: 'crashed'},
+        accessibility: {status: 'clean'},
+      }),
+    ).toBe('crashed');
+  });
+
+  it('counts only matching forced-colors tests from Vitest JSON', () => {
+    const summary = summarizeForcedColors(
+      {numPassedTests: 8, numFailedTests: 0, numTotalTests: 200},
+      'success',
+    );
+    expect(summary).toMatchObject({
+      status: 'clean',
+      passed: 8,
+      failed: 0,
+      total: 8,
+    });
+  });
+
+  it('fails closed when an a11y report is missing completeness', () => {
+    const report = composeWithA11y({
+      summary: {totalViolations: 0, componentsAudited: 1},
+      components: {
+        Button: {storyDetails: [{story: 'Default', error: 'timeout'}]},
+      },
+    });
+    expect(report.suites.accessibility.status).toBe('crashed');
+    expect(report.aggregate.verdict).toBe('crashed');
+  });
+
+  it('fails closed when a11y reports duplicate story results', () => {
+    const report = composeWithA11y(
+      completeA11y({
+        summary: {
+          expectedStories: 2,
+          auditedStories: 2,
+          resultStories: 2,
+          uniqueResultStories: 1,
+        },
+        components: {
+          Button: {
+            storiesAudited: 2,
+            violations: [],
+            storyDetails: [
+              {id: 'core-button--default', story: 'Default', violations: []},
+              {
+                id: 'core-button--default',
+                story: 'Default again',
+                violations: [],
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(report.suites.accessibility.status).toBe('crashed');
+  });
+
+  it('fails closed when a11y summary totals disagree with story details', () => {
+    const report = composeWithA11y(
+      completeA11y({
+        summary: {
+          expectedStories: 2,
+          auditedStories: 2,
+          resultStories: 2,
+          uniqueResultStories: 2,
+        },
+      }),
+    );
+    expect(report.suites.accessibility.status).toBe('crashed');
+  });
+
+  it('accepts a complete zero-violation a11y report as clean', () => {
+    const report = composeWithA11y(completeA11y());
+    expect(report.suites.accessibility.status).toBe('clean');
+  });
+
+  it('stages visual capture and report without hidden artifact paths', () => {
+    const root = tempRoot();
+    const source = path.join(root, '.visual-run');
+    writeJSON(path.join(source, 'verdict.json'), {status: 'changed'});
+    writeJSON(path.join(source, 'manifest.json'), {shots: {one: {}}});
+    fs.mkdirSync(path.join(source, 'shots'), {recursive: true});
+    fs.writeFileSync(path.join(source, 'shots', 'one.png'), 'png');
+    fs.mkdirSync(path.join(source, 'report', 'diff'), {recursive: true});
+    fs.writeFileSync(
+      path.join(source, 'report', 'index.html'),
+      '<p>report</p>',
+    );
+    fs.writeFileSync(path.join(source, 'report', 'diff', 'one.png'), 'diff');
+    fs.writeFileSync(path.join(root, 'visual-summary.md'), 'summary');
+
+    const out = path.join(root, 'visual-result');
+    stageVisualResult({
+      sourceDir: source,
+      outDir: out,
+      summaryFile: path.join(root, 'visual-summary.md'),
+    });
+
+    expect(fs.existsSync(path.join(out, 'verdict.json'))).toBe(true);
+    expect(fs.existsSync(path.join(out, 'capture', 'shots', 'one.png'))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(out, 'capture', 'manifest.json'))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(out, 'report', 'diff', 'one.png'))).toBe(
+      true,
+    );
+    expect(fs.readFileSync(path.join(out, 'summary.md'), 'utf8')).toBe(
+      'summary',
+    );
+  });
+
+  it('composes a self-contained report with rollout dependency text', () => {
+    const root = tempRoot();
+    writeJSON(path.join(root, 'visual.json'), {
+      status: 'changed',
+      counts: {total: 4, changed: 1, added: 0, removed: 0, failed: 0},
+    });
+    writeJSON(
+      path.join(root, 'a11y.json'),
+      completeA11y({summary: {totalViolations: 108}}),
+    );
+    writeJSON(path.join(root, 'rtl.json'), {
+      autoDiscovery: {total: 2, results: []},
+      positionalMirror: {total: 3, results: []},
+      curated: {results: []},
+    });
+    writeJSON(path.join(root, 'forced.json'), {
+      numPassedTests: 8,
+      numFailedTests: 0,
+    });
+    const out = path.join(root, 'out');
+    execFileSync(
+      process.execPath,
+      [
+        SCRIPT,
+        'compose',
+        '--out-dir',
+        out,
+        '--sha',
+        'a'.repeat(40),
+        '--run-id',
+        '123',
+        '--run-url',
+        'https://github.com/facebook/astryx/actions/runs/123',
+        '--report-url',
+        'https://facebook.github.io/astryx/main-quality/a/123/',
+        '--shadow-mode',
+        'true',
+        '--visual-verdict',
+        path.join(root, 'visual.json'),
+        '--a11y-report',
+        path.join(root, 'a11y.json'),
+        '--rtl-report',
+        path.join(root, 'rtl.json'),
+        '--forced-colors-report',
+        path.join(root, 'forced.json'),
+      ],
+      {encoding: 'utf8'},
+    );
+
+    const report = JSON.parse(
+      fs.readFileSync(path.join(out, 'main-quality.json'), 'utf8'),
+    );
+    expect(report.aggregate.verdict).toBe('debt');
+    expect(report.rollout.criteria).toContain('one clean run');
+    expect(report.rollout.dependency).toContain('#5608');
+    expect(fs.readFileSync(path.join(out, 'index.html'), 'utf8')).toContain(
+      'Protected main quality',
+    );
+  });
+});

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -244,6 +244,28 @@ describe('visual acceptance workflow concurrency', () => {
     expect(value).toContain("source: 'visual-promotion'");
   });
 
+  it('runs protected-main quality in shadow mode on an exact main SHA', () => {
+    const value = workflow('protected-main-quality.yml');
+    const publish = value.slice(value.indexOf('  publish:'));
+
+    expect(value).toContain('push:');
+    expect(value).toContain('branches: [main]');
+    expect(value).toContain("QUALITY_SHADOW_MODE: 'true'");
+    expect(value).toContain('one clean run on the current main SHA');
+    expect(value).toContain('owned by #5608');
+    expect(value).toContain('ref: ${{ needs.resolve.outputs.main_sha }}');
+    expect(value).toContain('--tiers full,theme-matrix,probe');
+    expect(value).toContain('node .github/scripts/weekly-a11y-summary.js');
+    expect(value).toContain('node .github/scripts/weekly-rtl-summary.js');
+    expect(value).toContain('-t "forced colors|Windows High Contrast"');
+    expect(publish).toContain('gh-pages-publisher.mjs main-quality');
+    expect(publish).toContain('statuses: write');
+    expect(publish).toContain('createCommitStatus');
+    expect(publish).toContain('publicationState');
+    expect(value).not.toContain('required_status_checks');
+    expect(value).not.toContain('branches/update-protection');
+  });
+
   it('publishes the stable site and release gate through the shared gh-pages publisher', () => {
     const deploy = workflow('deploy.yml');
     const releaseGate = workflow('release-gate.yml');

--- a/.github/scripts/weekly-a11y-summary.js
+++ b/.github/scripts/weekly-a11y-summary.js
@@ -47,8 +47,80 @@ function readReport(file) {
   }
 }
 
+function a11yIntegrity(report) {
+  const summary = report?.summary;
+  if (!summary || summary.scanStatus !== 'complete') {
+    return {ok: false, reason: 'scan did not complete'};
+  }
+  if (summary.indexStatus !== 'parsed') {
+    return {ok: false, reason: 'Storybook index was not parsed'};
+  }
+  if (
+    !Number.isSafeInteger(summary.expectedStories) ||
+    summary.expectedStories <= 0
+  ) {
+    return {ok: false, reason: 'no eligible stories were found'};
+  }
+  for (const field of [
+    'auditedStories',
+    'failedStories',
+    'resultStories',
+    'uniqueResultStories',
+  ]) {
+    if (!Number.isSafeInteger(summary[field])) {
+      return {ok: false, reason: `${field} is missing`};
+    }
+  }
+  if (summary.failedStories !== 0) {
+    return {ok: false, reason: `${summary.failedStories} story/stories failed`};
+  }
+  if (summary.auditedStories !== summary.expectedStories) {
+    return {ok: false, reason: 'audited story count does not match expected'};
+  }
+  if (
+    summary.resultStories !== summary.expectedStories ||
+    summary.uniqueResultStories !== summary.expectedStories
+  ) {
+    return {ok: false, reason: 'per-story result integrity mismatch'};
+  }
+  const seen = new Set();
+  let details = 0;
+  for (const [componentName, component] of Object.entries(
+    report.components || {},
+  )) {
+    const storyDetails = component.storyDetails;
+    if (!Array.isArray(storyDetails)) {
+      return {ok: false, reason: `${componentName} has no story details`};
+    }
+    if (component.storiesAudited !== storyDetails.length) {
+      return {ok: false, reason: `${componentName} story count mismatch`};
+    }
+    for (const story of storyDetails) {
+      if (!story?.id || !Array.isArray(story.violations)) {
+        return {
+          ok: false,
+          reason: `${componentName} has malformed story result`,
+        };
+      }
+      if (seen.has(story.id)) {
+        return {ok: false, reason: `duplicate story result ${story.id}`};
+      }
+      seen.add(story.id);
+      details++;
+    }
+  }
+  if (
+    details !== summary.resultStories ||
+    seen.size !== summary.uniqueResultStories
+  ) {
+    return {ok: false, reason: 'reported story totals do not match details'};
+  }
+  return {ok: true, reason: 'complete'};
+}
+
 function computeStatus(report, outcome) {
   if (!report || report.error) return 'crashed';
+  if (!a11yIntegrity(report).ok) return 'crashed';
   if (outcome !== 'success') return 'failed';
   const total = report.summary?.totalViolations ?? 0;
   return total > 0 ? 'violations' : 'clean';
@@ -67,7 +139,7 @@ function countStoryErrors(report) {
 function buildSummary(report, status) {
   const lines = ['## Weekly full-suite accessibility scan', ''];
 
-  if (status === 'crashed') {
+  if (status === 'crashed' && (!report || report.error)) {
     lines.push(
       '**Status:** the audit did not produce a usable report — the audit ' +
         'script crashed or the Storybook build was missing. See the workflow ' +
@@ -82,6 +154,19 @@ function buildSummary(report, status) {
   const componentsAudited = report.summary?.componentsAudited ?? 0;
   const auditedAt = report.summary?.auditedAt || 'unknown';
   const storyErrors = countStoryErrors(report);
+  const integrity = a11yIntegrity(report);
+
+  if (status === 'crashed') {
+    lines.push(
+      '**Status:** the audit did not complete every expected story. Zero ' +
+        'violations is only clean when the scan is complete.',
+      '',
+      `**Reason:** ${integrity.reason}.`,
+      `**Coverage:** ${report.summary?.auditedStories ?? 0}/${report.summary?.expectedStories ?? 0} story/stories audited; ${report.summary?.failedStories ?? storyErrors} failed.`,
+      '',
+    );
+    return lines.join('\n') + '\n';
+  }
 
   lines.push(
     `**Scope:** full component library — ${componentsAudited} component(s) audited (${auditedAt}).`,

--- a/.github/scripts/weekly-a11y-summary.test.mjs
+++ b/.github/scripts/weekly-a11y-summary.test.mjs
@@ -1,0 +1,175 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {afterEach, describe, expect, it} from 'vitest';
+
+const SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'weekly-a11y-summary.js',
+);
+const roots = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    fs.rmSync(root, {recursive: true, force: true});
+});
+
+function tempRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'weekly-a11y-summary-'));
+  roots.push(root);
+  return root;
+}
+
+function writeJSON(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function completeReport(overrides = {}) {
+  return {
+    components: {
+      Button: {
+        storiesAudited: 1,
+        violations: [],
+        storyDetails: [
+          {id: 'core-button--default', story: 'Default', violations: []},
+        ],
+      },
+      ...overrides.components,
+    },
+    summary: {
+      scope: 'full',
+      indexStatus: 'parsed',
+      totalViolations: 0,
+      componentsAudited: 1,
+      expectedStories: 1,
+      auditedStories: 1,
+      failedStories: 0,
+      resultStories: 1,
+      uniqueResultStories: 1,
+      scanStatus: 'complete',
+      ...overrides.summary,
+    },
+  };
+}
+
+function summarize(report) {
+  const root = tempRoot();
+  writeJSON(path.join(root, 'report.json'), report);
+  const output = path.join(root, 'outputs.txt');
+  execFileSync(process.execPath, [
+    SCRIPT,
+    '--report',
+    path.join(root, 'report.json'),
+    '--audit-outcome',
+    'success',
+    '--summary-output',
+    path.join(root, 'summary.md'),
+    '--github-output',
+    output,
+  ]);
+  return {
+    output: fs.readFileSync(output, 'utf8'),
+    summary: fs.readFileSync(path.join(root, 'summary.md'), 'utf8'),
+  };
+}
+
+describe('weekly a11y summary completeness', () => {
+  it('does not call a partial zero-violation report clean', () => {
+    const {output, summary} = summarize(
+      completeReport({
+        summary: {
+          expectedStories: 2,
+          auditedStories: 1,
+          failedStories: 1,
+          resultStories: 1,
+          scanStatus: 'incomplete',
+        },
+        components: {
+          Button: {
+            storiesAudited: 1,
+            storyDetails: [
+              {
+                id: 'core-button--default',
+                story: 'Default',
+                error: 'timeout',
+                violations: [],
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(output).toContain('status=crashed');
+    expect(summary).toContain('did not complete');
+  });
+
+  it('does not call missing, malformed, or empty story indexes clean', () => {
+    for (const report of [
+      completeReport({summary: {indexStatus: 'missing'}}),
+      completeReport({summary: {indexStatus: 'malformed'}}),
+      completeReport({
+        summary: {
+          expectedStories: 0,
+          auditedStories: 0,
+          resultStories: 0,
+          uniqueResultStories: 0,
+        },
+        components: {},
+      }),
+    ]) {
+      expect(summarize(report).output).toContain('status=crashed');
+    }
+  });
+
+  it('does not call duplicate or mismatched story results clean', () => {
+    expect(
+      summarize(
+        completeReport({
+          summary: {
+            expectedStories: 2,
+            auditedStories: 2,
+            resultStories: 2,
+            uniqueResultStories: 1,
+          },
+          components: {
+            Button: {
+              storiesAudited: 2,
+              storyDetails: [
+                {id: 'core-button--default', story: 'Default', violations: []},
+                {
+                  id: 'core-button--default',
+                  story: 'Default duplicate',
+                  violations: [],
+                },
+              ],
+            },
+          },
+        }),
+      ).output,
+    ).toContain('status=crashed');
+
+    expect(
+      summarize(
+        completeReport({
+          summary: {
+            expectedStories: 2,
+            auditedStories: 2,
+            resultStories: 2,
+            uniqueResultStories: 2,
+          },
+        }),
+      ).output,
+    ).toContain('status=crashed');
+  });
+
+  it('calls a complete zero-violation report clean', () => {
+    const {output, summary} = summarize(completeReport());
+    expect(output).toContain('status=clean');
+    expect(summary).toContain('No accessibility violations detected');
+  });
+});

--- a/.github/workflows/protected-main-quality.yml
+++ b/.github/workflows/protected-main-quality.yml
@@ -1,0 +1,540 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Protected-main full quality sweep.
+#
+# Shadow mode: this workflow publishes a single aggregate status/report for the
+# exact main commit it tested, but suite debt does not fail the status yet. The
+# current full sweep is known to have unresolved visual deltas and 108 a11y
+# violations, so making it required today would only strand main.
+#
+# Rollout switch: after one clean run on the current main SHA, set
+# QUALITY_SHADOW_MODE=false and add the `protected-main-quality` status context
+# to main's required checks. Do not change baseline ownership or pruning here;
+# that remains owned by #5608.
+
+name: Protected Main Quality
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      main_sha:
+        description: 'Exact main commit SHA to test (defaults to current main)'
+        required: false
+        default: ''
+
+permissions: {}
+
+env:
+  QUALITY_SHADOW_MODE: 'true'
+  QUALITY_STATUS_CONTEXT: protected-main-quality
+
+concurrency:
+  group: protected-main-quality-${{ github.event_name == 'workflow_dispatch' && inputs.main_sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve exact main SHA
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      main_sha: ${{ steps.resolve.outputs.main_sha }}
+      short_sha: ${{ steps.resolve.outputs.short_sha }}
+    steps:
+      - name: Checkout main metadata
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve and validate SHA
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_SHA: ${{ github.sha }}
+          INPUT_SHA: ${{ inputs.main_sha || '' }}
+        run: |
+          set -eu
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_SHA" ]; then
+            MAIN_SHA="$INPUT_SHA"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            MAIN_SHA="$PUSH_SHA"
+          else
+            MAIN_SHA="$(git rev-parse origin/main)"
+          fi
+          if ! printf '%s' "$MAIN_SHA" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+            echo "::error::main_sha must be a full 40-character commit SHA"
+            exit 1
+          fi
+          git cat-file -e "$MAIN_SHA^{commit}"
+          git merge-base --is-ancestor "$MAIN_SHA" origin/main
+          {
+            echo "main_sha=$MAIN_SHA"
+            echo "short_sha=${MAIN_SHA:0:7}"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build exact main Storybook
+    needs: resolve
+    runs-on: 2-core-ubuntu-arm
+    permissions:
+      contents: read
+    outputs:
+      storybook_built: ${{ steps.build.outputs.storybook_built }}
+      short_sha: ${{ needs.resolve.outputs.short_sha }}
+    steps:
+      - name: Checkout exact main result
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.main_sha }}
+
+      - name: Setup Node and pnpm
+        uses: ./.github/actions/setup
+
+      - name: Build packages and Storybook
+        id: build
+        run: |
+          set +e
+          pnpm build && pnpm -F @astryxdesign/storybook build
+          code=$?
+          if [ "$code" -eq 0 ]; then
+            echo "storybook_built=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "storybook_built=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Storybook build failed; aggregate report will mark dependent suites crashed."
+          fi
+          exit 0
+
+      - name: Upload Storybook artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-quality-storybook-${{ needs.resolve.outputs.short_sha }}
+          path: apps/storybook/dist/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload built themes and core
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-quality-dists-${{ needs.resolve.outputs.short_sha }}
+          path: |
+            packages/themes/*/dist/
+            packages/core/dist/
+          retention-days: 1
+          if-no-files-found: ignore
+
+  visual:
+    name: Full stable visual
+    needs: [resolve, build]
+    if: needs.build.outputs.storybook_built == 'true'
+    runs-on: 2-core-ubuntu-arm
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.summarize.outputs.status }}
+    steps:
+      - name: Checkout exact main result
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.main_sha }}
+
+      - name: Setup Node and pnpm
+        uses: ./.github/actions/setup
+        with:
+          install: 'false'
+
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-storybook-${{ needs.resolve.outputs.short_sha }}
+          path: apps/storybook/dist
+
+      - name: Download built themes and core
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-dists-${{ needs.resolve.outputs.short_sha }}
+          path: packages
+
+      - name: Install Playwright browser
+        run: pnpm install --frozen-lockfile && npx playwright install chromium
+
+      - name: Fetch visual baseline from gh-pages
+        run: |
+          set -eu
+          rm -rf /tmp/gh-pages
+          git clone --depth=1 --filter=blob:none --sparse --single-branch --branch gh-pages \
+            "https://github.com/${GITHUB_REPOSITORY}.git" /tmp/gh-pages
+          git -C /tmp/gh-pages sparse-checkout set visual-gate/baseline
+          mkdir -p .visual-baseline
+          if [ -d /tmp/gh-pages/visual-gate/baseline ]; then
+            cp -r /tmp/gh-pages/visual-gate/baseline/. .visual-baseline/
+          fi
+
+      - name: Run full stable visual gate
+        id: visual
+        env:
+          ASTRYX_VISUAL_SHA: ${{ needs.resolve.outputs.main_sha }}
+        run: |
+          set +e
+          node .github/scripts/visual-gate/gate.mjs check \
+            --storybook-dir apps/storybook/dist \
+            --baseline .visual-baseline \
+            --out .visual-run \
+            --tiers full,theme-matrix,probe \
+            --summary-output visual-summary.md
+          code=$?
+          [ -f visual-summary.md ] && cat visual-summary.md >> "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Summarize visual verdict
+        id: summarize
+        run: |
+          if [ -f .visual-run/verdict.json ]; then
+            status=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(".visual-run/verdict.json", "utf8")).status || "crashed")')
+          else
+            status=crashed
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Stage visual result artifact
+        if: always()
+        run: |
+          node .github/scripts/main-quality-report.mjs stage-visual \
+            --source .visual-run \
+            --summary visual-summary.md \
+            --out-dir visual-result
+
+      - name: Upload visual result
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-quality-visual
+          path: visual-result/
+          retention-days: 14
+          if-no-files-found: warn
+
+  accessibility:
+    name: Full accessibility
+    needs: [resolve, build]
+    if: needs.build.outputs.storybook_built == 'true'
+    runs-on: 2-core-ubuntu-arm
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.summarize.outputs.status }}
+      total_violations: ${{ steps.summarize.outputs.total_violations }}
+    steps:
+      - name: Checkout exact main result
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.main_sha }}
+
+      - name: Setup Node and pnpm
+        uses: ./.github/actions/setup
+        with:
+          install: 'false'
+
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-storybook-${{ needs.resolve.outputs.short_sha }}
+          path: apps/storybook/dist
+
+      - name: Install Playwright browser
+        run: pnpm install --frozen-lockfile && npx playwright install chromium
+
+      - name: Run full-suite accessibility audit
+        id: audit
+        continue-on-error: true
+        run: |
+          BASELINE_FLAGS=""
+          if [ -f .github/a11y-baseline.json ]; then
+            BASELINE_FLAGS="--baseline .github/a11y-baseline.json --fail-on-new"
+          fi
+          node .github/scripts/accessibility-audit.js \
+            --storybook-dir apps/storybook/dist \
+            --output a11y-report.json \
+            $BASELINE_FLAGS
+
+      - name: Summarize report
+        id: summarize
+        env:
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+        run: |
+          node .github/scripts/weekly-a11y-summary.js \
+            --report a11y-report.json \
+            --audit-outcome "$AUDIT_OUTCOME" \
+            --summary-output a11y-summary.md \
+            --github-output "$GITHUB_OUTPUT"
+          cat a11y-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload accessibility result
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-quality-accessibility
+          path: |
+            a11y-report.json
+            a11y-summary.md
+          retention-days: 14
+          if-no-files-found: ignore
+
+  rtl:
+    name: Full RTL
+    needs: [resolve, build]
+    if: needs.build.outputs.storybook_built == 'true'
+    runs-on: 2-core-ubuntu-arm
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.summarize.outputs.status }}
+      total_findings: ${{ steps.summarize.outputs.total_findings }}
+    steps:
+      - name: Checkout exact main result
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.main_sha }}
+
+      - name: Setup Node and pnpm
+        uses: ./.github/actions/setup
+        with:
+          install: 'false'
+
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-storybook-${{ needs.resolve.outputs.short_sha }}
+          path: apps/storybook/dist
+
+      - name: Install Playwright browser
+        run: pnpm install --frozen-lockfile && npx playwright install chromium
+
+      - name: Run full-suite RTL audit
+        id: audit
+        continue-on-error: true
+        run: |
+          node apps/storybook/rtl-audit/rtl-audit.mjs \
+            --storybook-dir apps/storybook/dist \
+            --output rtl-report.json \
+            --concurrency 4
+
+      - name: Summarize report
+        id: summarize
+        env:
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+        run: |
+          node .github/scripts/weekly-rtl-summary.js \
+            --report rtl-report.json \
+            --audit-outcome "$AUDIT_OUTCOME" \
+            --summary-output rtl-summary.md \
+            --github-output "$GITHUB_OUTPUT"
+          cat rtl-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload RTL result
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-quality-rtl
+          path: |
+            rtl-report.json
+            rtl-summary.md
+          retention-days: 14
+          if-no-files-found: ignore
+
+  forced_colors:
+    name: Forced-colors unit suite
+    needs: resolve
+    runs-on: 2-core-ubuntu-arm
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.summarize.outputs.status }}
+    steps:
+      - name: Checkout exact main result
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.main_sha }}
+
+      - name: Setup Node and pnpm
+        uses: ./.github/actions/setup
+
+      - name: Run forced-colors tests
+        id: test
+        run: |
+          set +e
+          pnpm exec vitest run \
+            packages/core/src/Calendar/Calendar.test.tsx \
+            packages/core/src/CheckboxInput/CheckboxInput.test.tsx \
+            packages/core/src/RadioList/RadioList.test.tsx \
+            packages/core/src/SegmentedControl/SegmentedControl.test.tsx \
+            packages/core/src/SideNav/SideNav.test.tsx \
+            packages/core/src/Skeleton/Skeleton.test.tsx \
+            packages/core/src/Switch/Switch.test.tsx \
+            packages/core/src/ToggleButton/ToggleButton.test.tsx \
+            -t "forced colors|Windows High Contrast" \
+            --reporter=json \
+            --outputFile forced-colors-report.json > forced-colors.log 2>&1
+          code=$?
+          cat forced-colors.log
+          echo "outcome=$([ "$code" -eq 0 ] && echo success || echo failure)" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Summarize forced-colors result
+        id: summarize
+        run: |
+          node .github/scripts/main-quality-report.mjs forced-colors-summary \
+            --report forced-colors-report.json \
+            --outcome "${{ steps.test.outputs.outcome }}" \
+            --summary-output forced-colors-summary.md \
+            --github-output "$GITHUB_OUTPUT"
+          cat forced-colors-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload forced-colors result
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: main-quality-forced-colors
+          path: |
+            forced-colors-report.json
+            forced-colors-summary.md
+            forced-colors.log
+          retention-days: 14
+          if-no-files-found: ignore
+
+  publish:
+    name: Publish aggregate result
+    needs: [resolve, build, visual, accessibility, rtl, forced_colors]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-slim
+    permissions:
+      actions: read
+      contents: write
+      statuses: write
+    steps:
+      - name: Checkout publisher
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.main_sha }}
+
+      - name: Download visual result
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-visual
+          path: suites/visual
+
+      - name: Download accessibility result
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-accessibility
+          path: suites/accessibility
+
+      - name: Download RTL result
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-rtl
+          path: suites/rtl
+
+      - name: Download forced-colors result
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: main-quality-forced-colors
+          path: suites/forced-colors
+
+      - name: Compose aggregate report
+        env:
+          MAIN_SHA: ${{ needs.resolve.outputs.main_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPORT_URL: https://facebook.github.io/astryx/main-quality/${{ needs.resolve.outputs.main_sha }}/${{ github.run_id }}/
+          A11Y_STATUS: ${{ needs.accessibility.outputs.status || 'crashed' }}
+          RTL_STATUS: ${{ needs.rtl.outputs.status || 'crashed' }}
+          FORCED_COLORS_OUTCOME: ${{ needs.forced_colors.outputs.status == 'clean' && 'success' || 'failure' }}
+        run: |
+          set -eu
+          mkdir -p report/visual-report report/visual-capture
+          if [ -d suites/visual/report ]; then
+            cp -R suites/visual/report/. report/visual-report/
+          else
+            printf '<!doctype html><title>No visual report</title><p>No visual report was produced.</p>\n' > report/visual-report/index.html
+          fi
+          if [ -d suites/visual/capture ]; then
+            cp -R suites/visual/capture/. report/visual-capture/
+          else
+            printf '{"error":"No visual capture was produced"}\n' > report/visual-capture/missing.json
+          fi
+          node .github/scripts/main-quality-report.mjs compose \
+            --out-dir report \
+            --sha "$MAIN_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-url "$RUN_URL" \
+            --report-url "$REPORT_URL" \
+            --shadow-mode "$QUALITY_SHADOW_MODE" \
+            --visual-verdict suites/visual/verdict.json \
+            --visual-summary suites/visual/summary.md \
+            --a11y-report suites/accessibility/a11y-report.json \
+            --a11y-summary suites/accessibility/a11y-summary.md \
+            --a11y-status "$A11Y_STATUS" \
+            --rtl-report suites/rtl/rtl-report.json \
+            --rtl-summary suites/rtl/rtl-summary.md \
+            --rtl-status "$RTL_STATUS" \
+            --forced-colors-report suites/forced-colors/forced-colors-report.json \
+            --forced-colors-summary suites/forced-colors/forced-colors-summary.md \
+            --forced-colors-log suites/forced-colors/forced-colors.log \
+            --forced-colors-outcome "$FORCED_COLORS_OUTCOME"
+          cat report/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish to gh-pages
+        id: publish
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node .github/scripts/gh-pages-publisher.mjs main-quality \
+            --source report \
+            --sha "${{ needs.resolve.outputs.main_sha }}"
+
+      - name: Project aggregate status
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          MAIN_SHA: ${{ needs.resolve.outputs.main_sha }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          retries: 3
+          script: |
+            const fs = require('node:fs');
+            const {pathToFileURL} = require('node:url');
+            const {buildCommitStatus} = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/main-quality-report.mjs`).href,
+            );
+            const report = JSON.parse(fs.readFileSync('report/main-quality.json', 'utf8'));
+            const status = buildCommitStatus(report, {
+              publicationState: process.env.PUBLISH_OUTCOME === 'success' ? 'success' : 'failure',
+            });
+            await github.rest.repos.createCommitStatus({
+              ...context.repo,
+              sha: process.env.MAIN_SHA,
+              state: status.state,
+              context: status.context,
+              description: status.description,
+              target_url: status.target_url || process.env.RUN_URL,
+            });
+            await core.summary.addRaw(`Projected ${status.context}: ${status.state} — ${status.description}\n`).write();
+            if (process.env.PUBLISH_OUTCOME !== 'success') {
+              core.setFailed('Protected-main quality report publication failed.');
+            }


### PR DESCRIPTION
## Summary
- add a protected-main quality workflow that binds every run to an exact main SHA and projects one `protected-main-quality` commit status
- run the full stable visual sweep (`full,theme-matrix,probe`), full accessibility audit, full RTL audit, and existing forced-colors unit suite in shadow mode
- publish one aggregate GitHub Pages report through the shared gh-pages publisher, retaining complete visual capture/report outputs and keeping `latest` monotonic by main SHA
- require a parsed non-empty Storybook index, terminal scan success, and complete per-story a11y result integrity before zero violations can be clean
- document the rollout switch: after one clean current-main run, flip shadow mode off and add the status context to required checks

Depends on [#5635](https://github.com/facebook/astryx/pull/5635), stacked on [#5631](https://github.com/facebook/astryx/pull/5631) and [#5629](https://github.com/facebook/astryx/pull/5629).

Baseline ownership and pruning remain owned by [#5608](https://github.com/facebook/astryx/pull/5608); this PR only reads the current baseline.

## Test plan
- `pnpm exec vitest run .github/scripts/main-quality-report.test.mjs .github/scripts/lib/gh-pages-publisher.test.mjs .github/scripts/visual-gate/workflow-concurrency.test.mjs .github/scripts/accessibility-audit.test.mjs .github/scripts/weekly-a11y-summary.test.mjs`
- `pnpm exec vitest run packages/core/src/Calendar/Calendar.test.tsx packages/core/src/CheckboxInput/CheckboxInput.test.tsx packages/core/src/RadioList/RadioList.test.tsx packages/core/src/SegmentedControl/SegmentedControl.test.tsx packages/core/src/SideNav/SideNav.test.tsx packages/core/src/Skeleton/Skeleton.test.tsx packages/core/src/Switch/Switch.test.tsx packages/core/src/ToggleButton/ToggleButton.test.tsx -t "forced colors|Windows High Contrast"`
- `actionlint -ignore 'label "2-core-ubuntu-arm" is unknown' -ignore 'shellcheck reported issue' .github/workflows/protected-main-quality.yml .github/workflows/release-gate.yml .github/workflows/a11y-weekly.yml .github/workflows/rtl-weekly.yml`
- `pnpm exec prettier --check` on changed workflow/script files
- `git diff --check`
- `pnpm check:repo`
