### PR TITLE
fix(eslint-plugin): match no-react-introspection allowFiles on Windows

### DIFF
--- a/internal/eslint-plugin-astryx/no-react-introspection.js
+++ b/internal/eslint-plugin-astryx/no-react-introspection.js
@@ -74,8 +74,13 @@ const noReactIntrospectionRule = {
     const options = context.options[0] || {};
     const allowFiles = options.allowFiles || [];
 
-    // Check if this file is explicitly allowed
-    const filename = context.filename ?? context.getFilename();
+    // Check if this file is explicitly allowed. Patterns are written with
+    // forward slashes; normalize before matching so this also works on
+    // Windows, where context.filename comes back with backslashes.
+    const filename = (context.filename ?? context.getFilename()).replace(
+      /\\/g,
+      '/',
+    );
     if (allowFiles.some(pattern => filename.includes(pattern))) {
       return {};
     }

--- a/internal/eslint-plugin-astryx/no-react-introspection.test.mjs
+++ b/internal/eslint-plugin-astryx/no-react-introspection.test.mjs
@@ -30,6 +30,13 @@ tester.run('no-react-introspection', noReactIntrospectionRule, {
       options: [{allowFiles: ['test-utils']}],
       filename: '/packages/test-utils/src/helpers.tsx',
     },
+    // allowFiles escape hatch on Windows, where ESLint reports filename with
+    // backslash separators against a forward-slash pattern.
+    {
+      code: `import { Children } from 'react'; Children.map(children, c => c);`,
+      options: [{allowFiles: ['test-utils']}],
+      filename: 'D:\\repo\\packages\\test-utils\\src\\helpers.tsx',
+    },
   ],
   invalid: [
     // Children.toArray


### PR DESCRIPTION
## Problem

`no-react-introspection`'s `allowFiles` escape hatch matches with `filename.includes(pattern)`. The configured patterns are written with forward slashes (`'Carousel/Carousel'`, etc, see `eslint.config.js`), but on Windows `context.filename` comes back with backslash separators, so the match never succeeds. The escape hatch is a silent no-op on Windows for every file it's supposed to exempt, including its own configured entries (`OverflowList/OverflowList`, `MetadataList/MetadataList`, `Carousel/Carousel`).

Ran into this directly: linting `Carousel.tsx` on Windows reports a `Children.toArray()` violation that the config explicitly allows for that exact file, and this blocks the local pre-commit hook for anyone on Windows touching it.

## Fix

Normalize backslashes to forward slashes before matching, same approach `no-raw-console-cli.js`'s existing `normalize()` helper already uses for the same class of problem.

## Testing

- Added a `valid` case to the rule's test file using a Windows-style (`D:\...`) filename.
- `npx vitest run internal/eslint-plugin-astryx/no-react-introspection.test.mjs` — 19/19 pass.
- `npx eslint packages/core/src/Carousel/Carousel.tsx` — clean after the fix (previously reported the false violation).

No visual change; this is lint tooling only.