### PR TITLE
fix(Carousel): flip edge-fade gradient direction under RTL

### DIFF
--- a/.changeset/carousel-rtl-fade-direction.md
+++ b/.changeset/carousel-rtl-fade-direction.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Carousel: the edge-fade gradient now flips to the correct physical side in RTL, so it always sits over the edge with hidden content instead of the empty one.
+
+@HelloOjasMutreja

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -177,11 +177,21 @@ const styles = stylex.create({
     scrollbarWidth: 'none',
     maskImage: 'none',
   },
+  // useScrollOverflow reports logical edges (start = left in LTR, right in
+  // RTL), but a mask-image gradient direction is physical. Flip the two
+  // physical directions under RTL so the fade still lands on the edge that
+  // actually has hidden content (#5622).
   fadeStart: {
-    maskImage: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    maskImage: {
+      default: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+      ':is([dir="rtl"] *)': `linear-gradient(to left, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    },
   },
   fadeEnd: {
-    maskImage: `linear-gradient(to left, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    maskImage: {
+      default: `linear-gradient(to left, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+      ':is([dir="rtl"] *)': `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']})`,
+    },
   },
   fadeBoth: {
     maskImage: `linear-gradient(to right, transparent 0%, rgba(0,0,0,0.3) 2px, black ${spacingVars['--spacing-1']}, black calc(100% - ${spacingVars['--spacing-1']}), rgba(0,0,0,0.3) calc(100% - 2px), transparent 100%)`,


### PR DESCRIPTION
Fixes #5622.

## Problem

`useScrollOverflow` reports **logical** edges (start = left in LTR, right in RTL, per the hook's own docs). `Carousel`'s `fadeStart`/`fadeEnd` styles select a `mask-image` gradient with a hardcoded **physical** direction (`to right` / `to left`). In RTL the two single-edge states are inverted: the fade paints over the edge that has nothing hidden, and the edge that actually clips content gets a hard cutoff.

The rest of the component already mirrors physical values for RTL (button-pill transforms, chevron mirroring, sign-flipped scroll deltas via `isRtlElement`); the fade gradients were the one spot that didn't.

## Fix

Add an RTL variant to `fadeStart`/`fadeEnd`'s `maskImage`, using the same `:is([dir="rtl"] *)` selector pattern `MobileNav.tsx` already uses for its own physical `transform` values. `fadeBoth` is symmetric (both edges fade) so it needs no variant.

## Testing

- `npx vitest run packages/core/src/Carousel/Carousel.test.tsx` — 37/37 pass, no regressions.
- Typecheck clean.
- Verified the actual fix in a running Storybook (`core-carousel--narrow-container`) via computed styles rather than a screenshot — this environment's browser pane isn't compositing frames right now (screenshot capture times out), so I'm disclosing that instead of faking a picture:
  - With the container scrolled to `scrollLeft: 0` and `dir="rtl"` on `<html>`, `overflowEnd` is true (there's still hidden content), and `getComputedStyle(scroller).maskImage` reports `linear-gradient(to right, ...)` — the physical left edge fades, which is where the hidden content actually is in this RTL layout.
  - The same state in LTR reports `linear-gradient(to left, ...)`, i.e. the physical right edge fades — also correct, and unchanged from before this fix.
  - Before this fix, `fadeEnd` always rendered `to left` regardless of `dir`, which is the wrong edge in RTL — exactly the bug in the issue's screenshot.

No new API surface, so this went straight to a fix rather than a spec-proposal comment.