### PR TITLE
fix(Dialog): capture the external trigger before descendant mount effects

### DIFF
--- a/.changeset/dialog-trigger-capture-order.md
+++ b/.changeset/dialog-trigger-capture-order.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Dialog: focus now restores to the element that actually opened it, even when a DialogHeader (or other autofocusing content) mounts as the dialog opens.
+
+@HelloOjasMutreja

--- a/packages/core/src/Dialog/Dialog.test.tsx
+++ b/packages/core/src/Dialog/Dialog.test.tsx
@@ -969,4 +969,57 @@ describe('Dialog', () => {
       );
     });
   });
+
+  describe('trigger capture (#5637)', () => {
+    it('restores focus to the external trigger, not a child that autofocuses on open', () => {
+      const opener = document.createElement('button');
+      opener.type = 'button';
+      document.body.appendChild(opener);
+      opener.focus();
+
+      const {rerender} = render(
+        <Dialog isOpen={false} onOpenChange={() => {}}>
+          {null}
+        </Dialog>,
+      );
+      expect(opener).toHaveFocus();
+
+      // Content (including DialogHeader's autofocusing title) mounts only
+      // once isOpen flips true — the shape from the issue repro.
+      rerender(
+        <Dialog isOpen={true} onOpenChange={() => {}}>
+          <DialogHeader title="Review" />
+        </Dialog>,
+      );
+
+      // DialogHeader's own mount effect focuses the title; Dialog must still
+      // have captured `opener`, not the title, as the trigger to restore to.
+      expect(screen.getByRole('heading', {name: 'Review'})).toHaveFocus();
+
+      rerender(
+        <Dialog isOpen={false} onOpenChange={() => {}}>
+          {null}
+        </Dialog>,
+      );
+
+      expect(opener).toHaveFocus();
+      opener.remove();
+    });
+
+    it('does not autofocus a DialogHeader mounted while the dialog is still closed', () => {
+      const opener = document.createElement('button');
+      opener.type = 'button';
+      document.body.appendChild(opener);
+      opener.focus();
+
+      render(
+        <Dialog isOpen={false} onOpenChange={() => {}}>
+          <DialogHeader title="Review" />
+        </Dialog>,
+      );
+
+      expect(opener).toHaveFocus();
+      opener.remove();
+    });
+  });
 });

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -459,8 +459,8 @@ export function Dialog({
   const titleId = useId();
 
   const dialogContextValue = useMemo(
-    () => ({isInline, titleId}),
-    [isInline, titleId],
+    () => ({isInline, isOpen, titleId}),
+    [isInline, isOpen, titleId],
   );
 
   // Consumer-provided labels always win over the DialogHeader default.
@@ -495,6 +495,17 @@ export function Dialog({
   // for directional animation origin and focus restoration on close.
   const triggerElementRef = useRef<HTMLElement | null>(null);
 
+  // Capture the rising edge here, during render, not in the effect below.
+  // React runs child mount effects (e.g. DialogHeader's autofocus) before
+  // this component's own effects, so by the time an effect read
+  // document.activeElement it would already be the dialog's own newly
+  // focused content instead of the external trigger (#5637).
+  const wasOpenRef = useRef(isOpen);
+  if (isOpen && !wasOpenRef.current) {
+    triggerElementRef.current = document.activeElement as HTMLElement | null;
+  }
+  wasOpenRef.current = isOpen;
+
   // Derive dismissal behavior from purpose
   const allowEscape = purpose !== 'required';
   const allowBackdropClick = purpose === 'info';
@@ -510,9 +521,8 @@ export function Dialog({
     }
 
     if (isOpen) {
-      // Capture the currently focused element as the trigger — used for
-      // directional animation origin and focus restoration on close.
-      triggerElementRef.current = document.activeElement as HTMLElement | null;
+      // The trigger was already captured during render, above — before any
+      // child mount effect could move focus onto the dialog's own content.
 
       // Set directional CSS custom properties before opening
       const trigger = triggerElementRef.current;

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -500,7 +500,11 @@ export function Dialog({
   // this component's own effects, so by the time an effect read
   // document.activeElement it would already be the dialog's own newly
   // focused content instead of the external trigger (#5637).
-  const wasOpenRef = useRef(isOpen);
+  //
+  // Starts false rather than isOpen: a Dialog first mounted with
+  // isOpen={true} (e.g. AlertDialog) still needs its rising edge to fire
+  // on that very first render, not be treated as already-open.
+  const wasOpenRef = useRef(false);
   if (isOpen && !wasOpenRef.current) {
     triggerElementRef.current = document.activeElement as HTMLElement | null;
   }

--- a/packages/core/src/Dialog/DialogContext.ts
+++ b/packages/core/src/Dialog/DialogContext.ts
@@ -14,6 +14,8 @@ import {createContext, use} from 'react';
 export interface DialogContextValue {
   /** Whether the dialog is rendered inline for docs/showcases. */
   isInline: boolean;
+  /** Whether the dialog is currently open. */
+  isOpen: boolean;
   /**
    * Id the DialogHeader title should render with so the dialog can name
    * itself via aria-labelledby. The dialog detects the title element's

--- a/packages/core/src/Dialog/DialogHeader.tsx
+++ b/packages/core/src/Dialog/DialogHeader.tsx
@@ -139,12 +139,16 @@ export function DialogHeader({
   const t = useTranslator();
   const titleRef = useRef<HTMLHeadingElement>(null);
   const dialogContext = useDialogContext();
-  const shouldAutoFocus = dialogContext?.isInline !== true;
+  const shouldAutoFocus =
+    dialogContext?.isInline !== true && dialogContext?.isOpen !== false;
   const titleId = dialogContext?.titleId;
 
   // Auto-focus the title when mounted for screen reader accessibility.
   // Inline dialogs are documentation/showcase previews, so suppress focus to
-  // avoid stealing scroll position from the surrounding page.
+  // avoid stealing scroll position from the surrounding page. A dialog whose
+  // content mounts before it opens (isOpen === false) must not steal focus
+  // either — nothing is visible yet, and it would corrupt the trigger Dialog
+  // captures for focus restoration on close (#5637).
   // The parent Dialog detects this title (by `titleId`) via a callback ref to
   // set its default aria-labelledby — no registration handshake needed here.
   useEffect(() => {


### PR DESCRIPTION
## Problem

A controlled `Dialog` can restore focus to `<body>` instead of its opener when its content is mounted only while `isOpen` is true.

`Dialog`'s own effect read `document.activeElement` to capture the trigger for focus restoration on close. React runs child mount effects before the parent's own effects, so when `DialogHeader`'s mount effect focuses its heading first, `Dialog`'s effect reads that heading back as the "trigger" instead of the real external opener. If the closed state removes that content, the captured node is even detached by the time restoration runs.

## Fix

Capture the trigger during `Dialog`'s own render, on the `isOpen` false→true edge (`wasOpenRef`), instead of inside the effect. Render happens before any descendant can mount and run an effect, so this is unconditionally before `DialogHeader`'s autofocus. Guarded the capture against a missing `document` so an initially open `Dialog`/`AlertDialog` no longer throws during server rendering.

An earlier revision of this PR also gated `DialogHeader`'s `shouldAutoFocus` on `isOpen`, to stop a header mounted under a closed dialog from stealing focus for nothing (a separate part of #5637). That gate shifted when the header's mount-focus effect fires relative to the native dialog becoming `:modal`, which failed the `modal-dialog.focus.enters-after-modal` Chromium a11y contract on two other Dialog states (`labelled-described-default-title`, `explicit-descendant-focus`). It has been reverted here. **The closed-dialog header focus-theft half of #5637 is therefore not fixed by this PR** and remains open; only the wrong-trigger-capture half (and its own SSR-safety regression) is addressed.

## Testing

- `npx vitest run packages/core/src/Dialog packages/core/src/AlertDialog` — all pass, including a regression test for the trigger-capture fix and one asserting `renderToString` on an initially open `Dialog` no longer throws.
- `pnpm test:a11y-contract` (Chromium) — all 5 Dialog modal-dialog states pass.
- Fail-first verified: temporarily reverted just the source changes and confirmed the new tests fail with exactly the symptom in the issue (the dialog's own heading has focus instead of the opener button) before re-applying the fix.
- Typecheck and lint clean.
