### PR TITLE
feat(TextInput,TextArea): add autoComplete prop

### DIFF
--- a/.changeset/textinput-textarea-autocomplete.md
+++ b/.changeset/textinput-textarea-autocomplete.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add an `autoComplete` prop to TextInput and TextArea, forwarded to the native control unchanged.
+
+@HelloOjasMutreja

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -256,6 +256,12 @@ export const docs = {
       description: 'Callback fired when the textarea loses focus.',
     },
     {
+      name: 'autoComplete',
+      type: 'string',
+      description:
+        'The native autocomplete attribute, forwarded to the textarea unchanged. Does not affect the controlled value.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -507,6 +513,11 @@ export const docsZh = {
       description: '文本域失去焦点时触发的回调。',
     },
     {
+      name: 'autoComplete',
+      type: 'string',
+      description: '原生 autocomplete 属性，原样转发给文本域。不影响受控的值。',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -678,6 +689,7 @@ export const docsDense = {
     htmlName: 'HTML name attr for form submissions.',
     onFocus: 'Callback on focus.',
     onBlur: 'Callback on blur.',
+    autoComplete: 'Native autocomplete attr, forwarded unchanged. Does not affect the controlled value.',
     xstyle:
       'StyleX styles for layout customization. Must be stylex.create() value, not inline style.',
   },

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -871,6 +871,28 @@ describe('TextArea', () => {
     });
   });
 
+  describe('autoComplete prop (#5638)', () => {
+    it('forwards autoComplete to the native textarea unchanged', () => {
+      render(
+        <TextArea
+          label="Reason"
+          value=""
+          onChange={() => {}}
+          autoComplete="off"
+        />,
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'autocomplete',
+        'off',
+      );
+    });
+
+    it('does not set autocomplete when not provided', () => {
+      render(<TextArea label="Description" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('autocomplete');
+    });
+  });
+
   describe('click-to-focus', () => {
     it('focuses textarea when clicking the start icon', () => {
       render(

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -349,6 +349,13 @@ export interface TextAreaProps extends Omit<
    * Callback fired when the textarea loses focus.
    */
   onBlur?: (e: FocusEvent<HTMLTextAreaElement>) => void;
+  /**
+   * The native `autocomplete` attribute, forwarded to the textarea unchanged.
+   * The value stays React-controlled regardless — this only hints the
+   * browser/password manager's suggestion behavior (e.g. `'off'` for a
+   * session-scoped field that must not reuse a prior value).
+   */
+  autoComplete?: React.TextareaHTMLAttributes<HTMLTextAreaElement>['autoComplete'];
 }
 
 /**

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -163,6 +163,12 @@ export const docs = {
       description:
         'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
     },
+    {
+      name: 'autoComplete',
+      type: 'string',
+      description:
+        'The native autocomplete attribute, forwarded to the input unchanged. Does not affect the controlled value.',
+    },
   ],
   theming: {
     targets: [
@@ -336,6 +342,12 @@ export const docsZh = {
       description:
         '输入框的 HTML name 属性，用于表单提交。',
     },
+    {
+      name: 'autoComplete',
+      type: 'string',
+      description:
+        '原生 autocomplete 属性，原样转发给输入框。不影响受控的值。',
+    },
   ],
   theming: {
     targets: [
@@ -418,5 +430,6 @@ export const docsDense = {
     hasClear: 'Shows clear button when input has value. Clears value on click.',
     hasAutoFocus: 'Auto-focus input on mount.',
     htmlName: 'HTML name attr for form submissions.',
+    autoComplete: 'Native autocomplete attr, forwarded unchanged. Does not affect the controlled value.',
   },
 };

--- a/packages/core/src/TextInput/TextInput.test.tsx
+++ b/packages/core/src/TextInput/TextInput.test.tsx
@@ -520,6 +520,28 @@ describe('TextInput', () => {
     });
   });
 
+  describe('autoComplete prop (#5638)', () => {
+    it('forwards autoComplete to the native input unchanged', () => {
+      render(
+        <TextInput
+          label="Reason"
+          value=""
+          onChange={() => {}}
+          autoComplete="off"
+        />,
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'autocomplete',
+        'off',
+      );
+    });
+
+    it('does not set autocomplete when not provided', () => {
+      render(<TextInput label="Name" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('autocomplete');
+    });
+  });
+
   describe('onEnter', () => {
     it('calls onEnter when Enter key is pressed', async () => {
       const user = userEvent.setup();

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -259,6 +259,13 @@ export interface TextInputProps extends Omit<
    * Callback fired on keydown events on the input.
    */
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  /**
+   * The native `autocomplete` attribute, forwarded to the input unchanged.
+   * The value stays React-controlled regardless — this only hints the
+   * browser/password manager's suggestion behavior (e.g. `'off'` for a
+   * session-scoped field that must not reuse a prior value).
+   */
+  autoComplete?: React.InputHTMLAttributes<HTMLInputElement>['autoComplete'];
 }
 
 /**


### PR DESCRIPTION
Fixes #5638.

## Problem

`TextAreaProps`/`TextInputProps` extend `BaseProps`, which is `Omit<React.HTMLAttributes<T>, ...>` — the generic HTML attributes interface, not the element-specific `TextareaHTMLAttributes`/`InputHTMLAttributes` that carry `autoComplete`. Neither component could express the native `autocomplete` attribute without mutating the forwarded ref after mount.

## Direction

Posted a spec-proposal comment on the issue first (new public prop). The reporter confirmed: add it to both components together rather than one alone, since `TextInput` had the same gap and this shouldn't create an inconsistent contract between the two.

## Fix

Added a typed `autoComplete` prop to both `TextInputProps` and `TextAreaProps`:
- `TextInput`: `React.InputHTMLAttributes<HTMLInputElement>['autoComplete']`
- `TextArea`: `React.TextareaHTMLAttributes<HTMLTextAreaElement>['autoComplete']`

Neither component destructures it explicitly — both already spread `{...rest}` onto their native element, so declaring the type is sufficient for it to flow through unchanged. The controlled value is untouched either way.

Updated both `.doc.mjs` prop tables (English + Chinese variants, plus the flat `propDescriptions` map) to match.

## Testing

- `npx vitest run packages/core/src/TextInput/TextInput.test.tsx packages/core/src/TextArea/TextArea.test.tsx` — 161/161 pass (includes upstream's new `isReadOnly`/form-participation tests from a rebase; kept both, no conflict).
- Typecheck and lint clean (one pre-existing, unrelated `no-nullish-jsx-guard` warning confirmed present on upstream/main before this change).

No visual change — this is a native-attribute pass-through only.