### PR TITLE
docs(slop): recast em dashes in icons and SideNavItem doc prose

### DIFF
--- a/packages/cli/assets/docs/icons.doc.mjs
+++ b/packages/cli/assets/docs/icons.doc.mjs
@@ -108,7 +108,7 @@ export const brandTheme = defineTheme({
       content: [
         {
           type: 'prose',
-          text: 'A glyph that belongs to one component or library gets a namespaced key (`numberInput:stepperDown`, `richtext:bold`) instead of a new semantic name. It resolves through the same registry and a theme overrides it the same way, but the shared IconName list stays reserved for glyphs the whole system uses — so adding one does not make every downstream icon registry grow a key.',
+          text: 'A glyph that belongs to one component or library gets a namespaced key (`numberInput:stepperDown`, `richtext:bold`) instead of a new semantic name. It resolves through the same registry and a theme overrides it the same way, but the shared IconName list stays reserved for glyphs the whole system uses, so adding one does not make every downstream icon registry grow a key.',
         },
         {
           type: 'code',
@@ -138,7 +138,7 @@ export const brandTheme = defineTheme({
       content: [
         {
           type: 'prose',
-          text: 'To add a new semantic icon name to the design system — only for a glyph the whole system shares; a component-owned one takes a namespaced key instead:',
+          text: 'To add a new semantic icon name to the design system, only for a glyph the whole system shares; a component-owned one takes a namespaced key instead:',
         },
         {
           type: 'list',

--- a/packages/core/src/SideNav/SideNavItem.doc.mjs
+++ b/packages/core/src/SideNav/SideNavItem.doc.mjs
@@ -76,7 +76,7 @@ export const docs = {
       name: 'actions',
       type: 'ReactNode',
       description:
-        'Row-level secondary controls (icon buttons, menus) rendered as siblings of the primary element at the trailing edge of the row — after the expand/collapse toggle, before any nested children in DOM and focus order. Each control owns its accessible name and behavior. Controls inherit the row control size through SizeContext, so an unsized icon button matches the built-in expand/collapse toggle; an explicit size still wins. Hidden while the SideNav rail is collapsed. Use endContent for passive content (badges, counts); use actions for anything interactive.',
+        'Row-level secondary controls (icon buttons, menus) rendered as siblings of the primary element at the trailing edge of the row: after the expand/collapse toggle, before any nested children in DOM and focus order. Each control owns its accessible name and behavior. Controls inherit the row control size through SizeContext, so an unsized icon button matches the built-in expand/collapse toggle; an explicit size still wins. Hidden while the SideNav rail is collapsed. Use endContent for passive content (badges, counts); use actions for anything interactive.',
       slotElements: [
         {
           __element: 'Button',


### PR DESCRIPTION
## What

Three prose em dashes in doc strings, recast with the correct punctuation. Meaning is unchanged; only the dash is replaced.

- `packages/cli/assets/docs/icons.doc.mjs`: two prose paragraphs. The namespaced-icon rationale ("...glyphs the whole system uses, so adding one...") and the add-a-semantic-icon intro ("...to the design system, only for a glyph...") both take a comma.
- `packages/core/src/SideNav/SideNavItem.doc.mjs`: the `actions` prop description takes a colon ("...at the trailing edge of the row: after the expand/collapse toggle...").

Neither file is touched by any other open PR.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] CLI `component SideNavItem --props` and `docs icons` render clean
- [x] Prose strings only; no code, labels, or CJK punctuation changed

---
Night Watch — Doc Reviewer