### PR TITLE
docs(sandbox): audit Neutral palette and token contrast

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/NeutralContrastComponents.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/NeutralContrastComponents.tsx
@@ -6,7 +6,6 @@ import {useCallback, type CSSProperties, type ReactNode} from 'react';
 
 import {AvatarStatusDot} from '@astryxdesign/core/Avatar';
 import {
-  ChatComposer,
   ChatMessage,
   ChatMessageBubble,
   ChatMessageMetadata,
@@ -182,16 +181,8 @@ export function NeutralContrastComponents() {
         </div>
       </Section>
 
-      <Section title="Chat status surfaces">
+      <Section title="Chat message status surfaces">
         <div style={{display: 'grid', gap: 14}}>
-          <ChatComposer
-            onSubmit={() => {}}
-            status={{type: 'warning', message: 'Approaching the token limit'}}
-          />
-          <ChatComposer
-            onSubmit={() => {}}
-            status={{type: 'error', message: 'Message could not be sent'}}
-          />
           <ChatMessage sender="user">
             <ChatMessageBubble
               metadata={<ChatMessageMetadata status="error" />}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/NeutralContrastComponents.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/NeutralContrastComponents.tsx
@@ -45,12 +45,6 @@ const SECTION_STYLE: CSSProperties = {
   borderTop: '1px solid var(--color-border)',
 };
 
-const GRID_STYLE: CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 280px), 1fr))',
-  gap: 12,
-};
-
 function Section({title, children}: {title: string; children: ReactNode}) {
   return (
     <section style={SECTION_STYLE}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/NeutralContrastComponents.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/NeutralContrastComponents.tsx
@@ -1,0 +1,222 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useCallback, type CSSProperties, type ReactNode} from 'react';
+
+import {AvatarStatusDot} from '@astryxdesign/core/Avatar';
+import {
+  ChatComposer,
+  ChatMessage,
+  ChatMessageBubble,
+  ChatMessageMetadata,
+  ChatToolCalls,
+} from '@astryxdesign/core/Chat';
+import {CodeBlock} from '@astryxdesign/core/CodeBlock';
+import {DropdownMenu, DropdownMenuItem} from '@astryxdesign/core/DropdownMenu';
+import {StatusDot} from '@astryxdesign/core/StatusDot';
+import {Step, Stepper} from '@astryxdesign/core/Stepper';
+import {
+  proportional,
+  Table,
+  type TableColumn,
+  useTableRowStatus,
+} from '@astryxdesign/core/Table';
+
+interface StatusRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  status: 'success' | 'warning' | 'error' | 'blue' | 'gray';
+}
+
+const STATUS_ROWS: StatusRow[] = [
+  {id: 'ready', name: 'Ready', status: 'success'},
+  {id: 'review', name: 'Needs review', status: 'warning'},
+  {id: 'failed', name: 'Failed', status: 'error'},
+  {id: 'running', name: 'Running', status: 'blue'},
+  {id: 'paused', name: 'Paused', status: 'gray'},
+];
+
+const STATUS_COLUMNS: TableColumn<StatusRow>[] = [
+  {key: 'name', header: 'Row status', width: proportional(1)},
+];
+
+const SECTION_STYLE: CSSProperties = {
+  paddingTop: 20,
+  borderTop: '1px solid var(--color-border)',
+};
+
+const GRID_STYLE: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 280px), 1fr))',
+  gap: 12,
+};
+
+function Section({title, children}: {title: string; children: ReactNode}) {
+  return (
+    <section style={SECTION_STYLE}>
+      <h3 style={{fontSize: 13, margin: '0 0 12px'}}>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function CategoryHeading({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <header
+      style={{
+        padding: 16,
+        borderRadius: 12,
+        background: 'var(--color-background-muted)',
+      }}>
+      <h2 style={{fontSize: 18, margin: '0 0 4px'}}>{title}</h2>
+      <p
+        style={{
+          margin: 0,
+          color: 'var(--color-text-secondary)',
+          fontSize: 12,
+          lineHeight: 1.5,
+        }}>
+        {description}
+      </p>
+    </header>
+  );
+}
+
+export function NeutralContrastComponents() {
+  const getRowStatus = useCallback(
+    (row: StatusRow) => ({color: row.status, label: row.name}),
+    [],
+  );
+  const rowStatus = useTableRowStatus<StatusRow>({getStatus: getRowStatus});
+  return (
+    <div style={{display: 'grid', gap: 24}}>
+      <div>
+        <h2 style={{fontSize: 20, margin: '0 0 6px'}}>
+          Additional component coverage
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            color: 'var(--color-text-secondary)',
+            fontSize: 12,
+            lineHeight: 1.5,
+          }}>
+          Components below cover color relationships that do not yet have a
+          dedicated audit section above.
+        </p>
+      </div>
+
+      <CategoryHeading
+        title="Semantic status and feedback"
+        description="Success, warning, error, and accent treatments used for status, progress, and procedural feedback."
+      />
+      <Section title="Status indicators">
+        <div style={{display: 'flex', alignItems: 'center', gap: 14}}>
+          {(['accent', 'success', 'warning', 'error', 'neutral'] as const).map(
+            variant => (
+              <span
+                key={variant}
+                style={{display: 'inline-flex', alignItems: 'center', gap: 5}}>
+                <StatusDot variant={variant} label={variant} />
+                <small>{variant}</small>
+              </span>
+            ),
+          )}
+          <AvatarStatusDot variant="success" label="Online" />
+          <AvatarStatusDot variant="neutral" label="Away" />
+          <AvatarStatusDot variant="error" label="Busy" />
+        </div>
+      </Section>
+
+      <CategoryHeading
+        title="Actions and procedures"
+        description="Destructive actions and procedural feedback across different component structures and surfaces."
+      />
+      <Section title="Stepper and destructive menu">
+        <div style={{display: 'grid', gap: 16}}>
+          <Stepper activeStep={1} orientation="horizontal">
+            <Step step={0} label="Passed" status="success" />
+            <Step step={1} label="Review" status="warning" />
+            <Step step={2} label="Blocked" status="error" />
+          </Stepper>
+          <DropdownMenu button={{label: 'Open contrast menu'}}>
+            <DropdownMenuItem label="Rename" onClick={() => {}} />
+            <DropdownMenuItem
+              label="Delete theme"
+              variant="destructive"
+              onClick={() => {}}
+            />
+          </DropdownMenu>
+        </div>
+      </Section>
+
+      <CategoryHeading
+        title="Data and communication"
+        description="Status colors used inside dense data, code, chat, and messaging contexts."
+      />
+      <Section title="Table row status and syntax colors">
+        <div style={{display: 'grid', gap: 16}}>
+          <Table
+            data={STATUS_ROWS}
+            columns={STATUS_COLUMNS}
+            idKey="id"
+            density="compact"
+            plugins={{rowStatus}}
+          />
+          <CodeBlock
+            language="typescript"
+            title="theme.ts"
+            code={`const palette = {
+  success: '#098123',
+  warning: '#f6d168',
+  error: '#ca3f3e',
+};`}
+          />
+        </div>
+      </Section>
+
+      <Section title="Chat status surfaces">
+        <div style={{display: 'grid', gap: 14}}>
+          <ChatComposer
+            onSubmit={() => {}}
+            status={{type: 'warning', message: 'Approaching the token limit'}}
+          />
+          <ChatComposer
+            onSubmit={() => {}}
+            status={{type: 'error', message: 'Message could not be sent'}}
+          />
+          <ChatMessage sender="user">
+            <ChatMessageBubble
+              metadata={<ChatMessageMetadata status="error" />}>
+              Failed message metadata
+            </ChatMessageBubble>
+          </ChatMessage>
+          <ChatToolCalls
+            calls={[
+              {
+                name: 'edit',
+                target: 'neutralTheme.ts',
+                status: 'complete',
+                additions: 24,
+                deletions: 8,
+              },
+              {
+                name: 'test',
+                target: 'contrast suite',
+                status: 'error',
+                errorMessage: 'Example failure state',
+              },
+            ]}
+          />
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
@@ -2,33 +2,119 @@
 
 'use client';
 
-// =============================================================================
-// Neutral Theme Palette Preview
-// =============================================================================
-
 import {neutralTheme} from '@astryxdesign/theme-neutral/built';
+import {
+  oklchClampedHex,
+  toneToOklabL,
+} from '@/app/(sandbox)/pages/color-studio/colorUtils';
 import {ThemePalettePreview} from '@/components/ThemePalettePreview';
 import type {TonalColor} from '@/components/ThemePalettePreview';
+import {NeutralContrastComponents} from './NeutralContrastComponents';
+
+const TONE_STEPS = [
+  0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
+  100,
+] as const;
+
+function mix(from: number, to: number, progress: number): number {
+  return from + (to - from) * progress;
+}
+
+/**
+ * Preserve vivid middle tones while tapering chroma through the pastel end of
+ * each ramp. Per-hue chroma values balance perceived intensity while keeping
+ * one stable hue from the saturated stops through the lightest pastels.
+ */
+function chromaMultiplier(tone: number): number {
+  if (tone <= 65) {
+    return 2.7;
+  }
+  if (tone <= 70) {
+    return mix(2.7, 2.2, (tone - 65) / 5);
+  }
+  if (tone <= 75) {
+    return mix(2.2, 1.8, (tone - 70) / 5);
+  }
+  if (tone <= 80) {
+    return mix(1.8, 1.4, (tone - 75) / 5);
+  }
+  if (tone <= 85) {
+    return mix(1.4, 1, (tone - 80) / 5);
+  }
+  if (tone <= 90) {
+    return mix(1, 0.65, (tone - 85) / 5);
+  }
+  if (tone <= 95) {
+    return mix(0.65, 0.3, (tone - 90) / 5);
+  }
+  return 0;
+}
+
+function darkTone(tone: number): number {
+  if (tone >= 95) {
+    return tone;
+  }
+  if (tone <= 80) {
+    return tone + 5;
+  }
+  return tone + 5 * ((95 - tone) / 15);
+}
+
+function buildBalancedTones(
+  hue: number,
+  pastelChroma: number,
+  dark = false,
+): Record<string | number, string | number> {
+  const chroma = dark ? pastelChroma * 0.85 : pastelChroma;
+  const tones: Record<string | number, string | number> = {hue, chroma};
+  for (const tone of TONE_STEPS) {
+    const resolvedTone = dark ? darkTone(tone) : tone;
+    tones[tone] = oklchClampedHex(
+      toneToOklabL(resolvedTone),
+      chroma * chromaMultiplier(resolvedTone),
+      hue,
+    );
+  }
+  return tones;
+}
+
+function balancedColor(
+  name: string,
+  hue: number,
+  pastelChroma: number,
+  semantic?: string,
+): TonalColor {
+  const tones = buildBalancedTones(hue, pastelChroma);
+  const darkTones = buildBalancedTones(hue, pastelChroma, true);
+  return {
+    name,
+    sourceHex: String(tones[50]),
+    semantic,
+    note: `OKLCH H${hue} · pastel C${pastelChroma}`,
+    tones,
+    dark: {sourceHex: String(darkTones[50]), tones: darkTones},
+  };
+}
 
 const TONAL_COLORS: TonalColor[] = [
   {name: 'Neutral', sourceHex: '#e5e5e5', note: 'C=0'},
-  {name: 'Red', sourceHex: '#eb183a', semantic: 'Error'},
-  {name: 'Orange', sourceHex: '#d57113'},
-  {name: 'Yellow', sourceHex: '#f8c723', semantic: 'Warning'},
-  {name: 'Green', sourceHex: '#358a3a', semantic: 'Success'},
-  {name: 'Teal', sourceHex: '#0c7365'},
-  {name: 'Cyan', sourceHex: '#0c6f82'},
-  {name: 'Blue', sourceHex: '#1679fa', semantic: 'Info'},
-  {name: 'Purple', sourceHex: '#980fb2'},
-  {name: 'Pink', sourceHex: '#b10e69'},
+  balancedColor('Red', 25, 0.065, 'Error'),
+  balancedColor('Orange', 65, 0.07),
+  balancedColor('Yellow', 90, 0.13, 'Warning'),
+  balancedColor('Green', 145, 0.06, 'Success'),
+  balancedColor('Teal', 180, 0.065),
+  balancedColor('Cyan', 215, 0.065),
+  balancedColor('Blue', 255, 0.085, 'Info'),
+  balancedColor('Purple', 320, 0.06),
+  balancedColor('Pink', 355, 0.06),
 ];
 
 const CORE = [
   {hex: '#fafafa', name: 'Neutral 50'},
-  {hex: '#f5f5f5', name: 'Neutral 100 (body)'},
-  {hex: '#e5e5e5', name: 'Neutral 200'},
-  {hex: '#737373', name: 'Neutral 500'},
-  {hex: '#262626', name: 'Neutral 800 (accent)'},
+  {hex: '#f1f1f1', name: 'Body (T95)'},
+  {hex: '#e2e2e2', name: 'Neutral T90'},
+  {hex: '#777777', name: 'Neutral T50'},
+  {hex: '#262626', name: 'Accent (T15)'},
 ];
 
 export default function NeutralPalettePage() {
@@ -36,9 +122,10 @@ export default function NeutralPalettePage() {
     <ThemePalettePreview
       theme={neutralTheme}
       title="Neutral Theme Palette"
-      subtitle="Pure grayscale spine with an OKLCH-derived palette. Semantic badges use vivid T60 saturated pills (Material You / Linear style); categorical badges and banners use soft T85 pastels. Figtree across body and headings."
+      subtitle="Approved balanced OKLCH palette applied to the neutral theme. The component sections below use the real theme tokens in light and dark mode; the audit drawer reports token usage and contrast."
       tonalColors={TONAL_COLORS}
       coreSwatches={CORE}
+      extraSections={<NeutralContrastComponents />}
     />
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
@@ -3,14 +3,10 @@
 'use client';
 
 import {neutralTheme} from '@astryxdesign/theme-neutral/built';
+import {neutralPalettes} from '../../../../../../../packages/themes/neutral/src/neutralPalettes';
 import {ThemePalettePreview} from '@/components/ThemePalettePreview';
 import type {TonalColor} from '@/components/ThemePalettePreview';
 import {NeutralContrastComponents} from './NeutralContrastComponents';
-
-const palettes = neutralTheme.palettes;
-if (!palettes) {
-  throw new Error('The Neutral theme must ship its approved tonal palettes.');
-}
 
 const PALETTE_ORDER = [
   'neutral',
@@ -26,47 +22,39 @@ const PALETTE_ORDER = [
 ] as const;
 
 const TONAL_COLORS: TonalColor[] = PALETTE_ORDER.map(name => {
-  const family = palettes[name];
-  const dark = family.dark ?? family.light;
-  const metadata = family.light.chroma
-    ? `OKLCH H${family.light.hue} · pastel C${family.light.chroma}`
-    : 'C=0';
+  const family = neutralPalettes[name];
   return {
     name: name[0].toUpperCase() + name.slice(1),
     sourceHex: family.light[50],
-    semantic: family.semantic
-      ? family.semantic[0].toUpperCase() + family.semantic.slice(1)
-      : undefined,
-    note: metadata,
     tones: family.light,
-    dark: {sourceHex: dark[50], tones: dark},
+    dark: {sourceHex: family.dark[50], tones: family.dark},
   };
 });
 
-const darkNeutral = palettes.neutral.dark ?? palettes.neutral.light;
+const darkNeutral = neutralPalettes.neutral.dark;
 const CORE = [
   {
-    hex: palettes.neutral.light[100],
+    hex: neutralPalettes.neutral.light[100],
     name: 'Surface · tone 100',
     dark: {hex: darkNeutral[10], name: 'Surface · tone 10'},
   },
   {
-    hex: palettes.neutral.light[95],
+    hex: neutralPalettes.neutral.light[95],
     name: 'Body · tone 95',
     dark: {hex: darkNeutral[5], name: 'Body · tone 5'},
   },
   {
-    hex: palettes.neutral.light[90],
+    hex: neutralPalettes.neutral.light[90],
     name: 'Neutral · tone 90',
     dark: {hex: darkNeutral[30], name: 'Neutral · tone 30'},
   },
   {
-    hex: palettes.neutral.light[50],
+    hex: neutralPalettes.neutral.light[50],
     name: 'Neutral · tone 50',
     dark: {hex: darkNeutral[45], name: 'Neutral · tone 45'},
   },
   {
-    hex: palettes.neutral.light[15],
+    hex: neutralPalettes.neutral.light[15],
     name: 'Accent · tone 15',
     dark: {hex: darkNeutral[90], name: 'Accent · tone 90'},
   },

--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
@@ -47,28 +47,28 @@ const darkNeutral = palettes.neutral.dark ?? palettes.neutral.light;
 const CORE = [
   {
     hex: palettes.neutral.light[100],
-    name: 'Surface (T100)',
-    dark: {hex: darkNeutral[10], name: 'Surface (T10)'},
+    name: 'Surface · tone 100',
+    dark: {hex: darkNeutral[10], name: 'Surface · tone 10'},
   },
   {
     hex: palettes.neutral.light[95],
-    name: 'Body (T95)',
-    dark: {hex: darkNeutral[5], name: 'Body (T5)'},
+    name: 'Body · tone 95',
+    dark: {hex: darkNeutral[5], name: 'Body · tone 5'},
   },
   {
     hex: palettes.neutral.light[90],
-    name: 'Neutral T90',
-    dark: {hex: darkNeutral[30], name: 'Neutral T30'},
+    name: 'Neutral · tone 90',
+    dark: {hex: darkNeutral[30], name: 'Neutral · tone 30'},
   },
   {
     hex: palettes.neutral.light[50],
-    name: 'Neutral T50',
-    dark: {hex: darkNeutral[45], name: 'Neutral T45'},
+    name: 'Neutral · tone 50',
+    dark: {hex: darkNeutral[45], name: 'Neutral · tone 45'},
   },
   {
     hex: palettes.neutral.light[15],
-    name: 'Accent (T15)',
-    dark: {hex: darkNeutral[90], name: 'Accent (T90)'},
+    name: 'Accent · tone 15',
+    dark: {hex: darkNeutral[90], name: 'Accent · tone 90'},
   },
 ];
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
@@ -3,118 +3,52 @@
 'use client';
 
 import {neutralTheme} from '@astryxdesign/theme-neutral/built';
-import {
-  oklchClampedHex,
-  toneToOklabL,
-} from '@/app/(sandbox)/pages/color-studio/colorUtils';
 import {ThemePalettePreview} from '@/components/ThemePalettePreview';
 import type {TonalColor} from '@/components/ThemePalettePreview';
 import {NeutralContrastComponents} from './NeutralContrastComponents';
 
-const TONE_STEPS = [
-  0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95,
-  100,
+const palettes = neutralTheme.palettes;
+if (!palettes) {
+  throw new Error('The Neutral theme must ship its approved tonal palettes.');
+}
+
+const PALETTE_ORDER = [
+  'neutral',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'teal',
+  'cyan',
+  'blue',
+  'purple',
+  'pink',
 ] as const;
 
-function mix(from: number, to: number, progress: number): number {
-  return from + (to - from) * progress;
-}
-
-/**
- * Preserve vivid middle tones while tapering chroma through the pastel end of
- * each ramp. Per-hue chroma values balance perceived intensity while keeping
- * one stable hue from the saturated stops through the lightest pastels.
- */
-function chromaMultiplier(tone: number): number {
-  if (tone <= 65) {
-    return 2.7;
-  }
-  if (tone <= 70) {
-    return mix(2.7, 2.2, (tone - 65) / 5);
-  }
-  if (tone <= 75) {
-    return mix(2.2, 1.8, (tone - 70) / 5);
-  }
-  if (tone <= 80) {
-    return mix(1.8, 1.4, (tone - 75) / 5);
-  }
-  if (tone <= 85) {
-    return mix(1.4, 1, (tone - 80) / 5);
-  }
-  if (tone <= 90) {
-    return mix(1, 0.65, (tone - 85) / 5);
-  }
-  if (tone <= 95) {
-    return mix(0.65, 0.3, (tone - 90) / 5);
-  }
-  return 0;
-}
-
-function darkTone(tone: number): number {
-  if (tone >= 95) {
-    return tone;
-  }
-  if (tone <= 80) {
-    return tone + 5;
-  }
-  return tone + 5 * ((95 - tone) / 15);
-}
-
-function buildBalancedTones(
-  hue: number,
-  pastelChroma: number,
-  dark = false,
-): Record<string | number, string | number> {
-  const chroma = dark ? pastelChroma * 0.85 : pastelChroma;
-  const tones: Record<string | number, string | number> = {hue, chroma};
-  for (const tone of TONE_STEPS) {
-    const resolvedTone = dark ? darkTone(tone) : tone;
-    tones[tone] = oklchClampedHex(
-      toneToOklabL(resolvedTone),
-      chroma * chromaMultiplier(resolvedTone),
-      hue,
-    );
-  }
-  return tones;
-}
-
-function balancedColor(
-  name: string,
-  hue: number,
-  pastelChroma: number,
-  semantic?: string,
-): TonalColor {
-  const tones = buildBalancedTones(hue, pastelChroma);
-  const darkTones = buildBalancedTones(hue, pastelChroma, true);
+const TONAL_COLORS: TonalColor[] = PALETTE_ORDER.map(name => {
+  const family = palettes[name];
+  const dark = family.dark ?? family.light;
+  const metadata = family.light.chroma
+    ? `OKLCH H${family.light.hue} · pastel C${family.light.chroma}`
+    : 'C=0';
   return {
-    name,
-    sourceHex: String(tones[50]),
-    semantic,
-    note: `OKLCH H${hue} · pastel C${pastelChroma}`,
-    tones,
-    dark: {sourceHex: String(darkTones[50]), tones: darkTones},
+    name: name[0].toUpperCase() + name.slice(1),
+    sourceHex: family.light[50],
+    semantic: family.semantic
+      ? family.semantic[0].toUpperCase() + family.semantic.slice(1)
+      : undefined,
+    note: metadata,
+    tones: family.light,
+    dark: {sourceHex: dark[50], tones: dark},
   };
-}
-
-const TONAL_COLORS: TonalColor[] = [
-  {name: 'Neutral', sourceHex: '#e5e5e5', note: 'C=0'},
-  balancedColor('Red', 25, 0.065, 'Error'),
-  balancedColor('Orange', 65, 0.07),
-  balancedColor('Yellow', 90, 0.13, 'Warning'),
-  balancedColor('Green', 145, 0.06, 'Success'),
-  balancedColor('Teal', 180, 0.065),
-  balancedColor('Cyan', 215, 0.065),
-  balancedColor('Blue', 255, 0.085, 'Info'),
-  balancedColor('Purple', 320, 0.06),
-  balancedColor('Pink', 355, 0.06),
-];
+});
 
 const CORE = [
-  {hex: '#fafafa', name: 'Neutral 50'},
-  {hex: '#f1f1f1', name: 'Body (T95)'},
-  {hex: '#e2e2e2', name: 'Neutral T90'},
-  {hex: '#777777', name: 'Neutral T50'},
-  {hex: '#262626', name: 'Accent (T15)'},
+  {hex: palettes.neutral.light[100], name: 'Surface (T100)'},
+  {hex: palettes.neutral.light[95], name: 'Body (T95)'},
+  {hex: palettes.neutral.light[90], name: 'Neutral T90'},
+  {hex: palettes.neutral.light[50], name: 'Neutral T50'},
+  {hex: palettes.neutral.light[15], name: 'Accent (T15)'},
 ];
 
 export default function NeutralPalettePage() {

--- a/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/neutral-palette/page.tsx
@@ -43,12 +43,33 @@ const TONAL_COLORS: TonalColor[] = PALETTE_ORDER.map(name => {
   };
 });
 
+const darkNeutral = palettes.neutral.dark ?? palettes.neutral.light;
 const CORE = [
-  {hex: palettes.neutral.light[100], name: 'Surface (T100)'},
-  {hex: palettes.neutral.light[95], name: 'Body (T95)'},
-  {hex: palettes.neutral.light[90], name: 'Neutral T90'},
-  {hex: palettes.neutral.light[50], name: 'Neutral T50'},
-  {hex: palettes.neutral.light[15], name: 'Accent (T15)'},
+  {
+    hex: palettes.neutral.light[100],
+    name: 'Surface (T100)',
+    dark: {hex: darkNeutral[10], name: 'Surface (T10)'},
+  },
+  {
+    hex: palettes.neutral.light[95],
+    name: 'Body (T95)',
+    dark: {hex: darkNeutral[5], name: 'Body (T5)'},
+  },
+  {
+    hex: palettes.neutral.light[90],
+    name: 'Neutral T90',
+    dark: {hex: darkNeutral[30], name: 'Neutral T30'},
+  },
+  {
+    hex: palettes.neutral.light[50],
+    name: 'Neutral T50',
+    dark: {hex: darkNeutral[45], name: 'Neutral T45'},
+  },
+  {
+    hex: palettes.neutral.light[15],
+    name: 'Accent (T15)',
+    dark: {hex: darkNeutral[90], name: 'Accent (T90)'},
+  },
 ];
 
 export default function NeutralPalettePage() {

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -4393,9 +4393,9 @@ function TonalSection({
           margin: 0,
           marginBottom: 20,
         }}>
-        Full HCT tonal ramps: 21 perceptually uniform tones from black (tone 0)
-        to white (tone 100). The number keeps the same lightness meaning in both
-        modes.
+        Full tonal ramps: 21 numbered stops ordered from dark (tone 0) to light
+        (tone 100). The number is a stable palette label in both modes, not a
+        promise of identical measured lightness.
         {isDark && (
           <>
             {' '}

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -2,22 +2,29 @@
 
 'use client';
 
-import {useMemo, useReducer} from 'react';
+import {useMemo, useReducer, type CSSProperties} from 'react';
 
-import {Banner} from '@astryxdesign/core/Banner';
+import {Banner, type BannerStatus} from '@astryxdesign/core/Banner';
 import {Spinner} from '@astryxdesign/core/Spinner';
-import {ProgressBar} from '@astryxdesign/core/ProgressBar';
+import {
+  ProgressBar,
+  type ProgressBarVariant,
+} from '@astryxdesign/core/ProgressBar';
 import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
 import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
 import {Switch} from '@astryxdesign/core/Switch';
 import {Card} from '@astryxdesign/core/Card';
+import {SelectableCard} from '@astryxdesign/core/SelectableCard';
 import {TextInput} from '@astryxdesign/core/TextInput';
-import {Badge} from '@astryxdesign/core/Badge';
+import {FieldStatus} from '@astryxdesign/core/FieldStatus';
+import {Badge, type BadgeVariant} from '@astryxdesign/core/Badge';
 import {Button} from '@astryxdesign/core/Button';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Token, type TokenColor} from '@astryxdesign/core/Token';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
 import {Text, Heading} from '@astryxdesign/core/Text';
 import {Theme} from '@astryxdesign/core/theme';
-import type {DefinedTheme} from '@astryxdesign/core/theme';
+import {tokenDefaults, type DefinedTheme} from '@astryxdesign/core/theme';
 import {LayerProvider} from '@astryxdesign/core/Layer';
 import {neutralTheme} from '@astryxdesign/theme-neutral/built';
 
@@ -299,6 +306,9 @@ export interface CoreSwatch {
   dark?: {hex: string; name: string};
 }
 
+type Mode = 'light' | 'dark';
+type ModeSection = React.ReactNode | ((mode: Mode) => React.ReactNode);
+
 export interface ThemePalettePreviewProps {
   /** The Astryx theme object */
   theme: DefinedTheme;
@@ -311,9 +321,9 @@ export interface ThemePalettePreviewProps {
   /** Core palette swatches. When omitted, the Core Palette section is hidden. */
   coreSwatches?: CoreSwatch[];
   /** Additional sections to render at the end of each mode column */
-  extraSections?: React.ReactNode;
+  extraSections?: ModeSection;
   /** Additional sections to render before the headers (TextRampSection) in each mode column */
-  leadingExtras?: React.ReactNode;
+  leadingExtras?: ModeSection;
   /** Hide the title, subtitle, and tonal section (useful when embedded in another layout) */
   componentPreviewOnly?: boolean;
   /**
@@ -331,8 +341,6 @@ export interface ThemePalettePreviewProps {
    */
   shadowDescription?: string;
 }
-
-type Mode = 'light' | 'dark';
 
 const VAR_SURFACES = {
   body: 'var(--color-background-body)',
@@ -359,14 +367,16 @@ const S = {
     background: 'var(--color-background-body)',
     color: 'var(--color-text-primary)',
     fontFamily: 'var(--font-family-body)',
-    padding: '40px 32px',
+    padding: 'clamp(16px, 4vw, 40px) clamp(12px, 3vw, 32px)',
   } satisfies React.CSSProperties,
   inner: {
+    width: '100%',
+    minWidth: 0,
     maxWidth: 1280,
     margin: '0 auto',
   } satisfies React.CSSProperties,
   title: {
-    fontSize: 32,
+    fontSize: 'clamp(24px, 5vw, 32px)',
     fontWeight: 700,
     letterSpacing: '-0.02em',
     margin: 0,
@@ -381,15 +391,16 @@ const S = {
   } satisfies React.CSSProperties,
   twoCol: {
     display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: 24,
+    gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 520px), 1fr))',
+    gap: 'clamp(16px, 2vw, 24px)',
   } satisfies React.CSSProperties,
   modeCol: (bg: string, fg: string): React.CSSProperties => ({
     background: bg,
     color: fg,
     border: '1px solid var(--color-border)',
     borderRadius: 16,
-    padding: 24,
+    padding: 'clamp(16px, 2vw, 24px)',
+    minWidth: 0,
     display: 'flex',
     flexDirection: 'column' as const,
     gap: 28,
@@ -412,7 +423,7 @@ const S = {
   } satisfies React.CSSProperties,
   coreRow: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(5, 1fr)',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 112px), 1fr))',
     gap: 10,
   } satisfies React.CSSProperties,
   coreSwatch: (bg: string): React.CSSProperties => ({
@@ -430,7 +441,7 @@ const S = {
   } satisfies React.CSSProperties,
   surfacesGrid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(5, 1fr)',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 104px), 1fr))',
     gap: 8,
   } satisfies React.CSSProperties,
   surfaceCell: {
@@ -466,12 +477,15 @@ const S = {
   tonalStrip: {
     display: 'flex',
     flex: 1,
+    minWidth: 0,
     borderRadius: 6,
-    overflow: 'hidden',
+    overflowX: 'auto',
+    overflowY: 'hidden',
     border: '1px solid rgba(0,0,0,0.06)',
   } satisfies React.CSSProperties,
   tonalCell: (bg: string): React.CSSProperties => ({
     flex: 1,
+    minWidth: 24,
     height: 36,
     background: bg,
     display: 'flex',
@@ -545,49 +559,47 @@ function CoreSection({swatches, mode}: {swatches: CoreSwatch[]; mode?: Mode}) {
   );
 }
 
-function TextRampSection() {
-  const base = 14;
-  const ratio = 1.25;
+function TextRampSection({theme}: {theme: DefinedTheme}) {
   const sizes = {
-    h1: (base * ratio ** 4).toFixed(1),
-    h2: (base * ratio ** 3).toFixed(1),
-    h3: (base * ratio ** 2).toFixed(1),
-    h4: (base * ratio ** 1).toFixed(1),
-    body: base.toFixed(1),
-    supporting: '12.0',
+    h1: theme.tokens['--text-heading-1-size'],
+    h2: theme.tokens['--text-heading-2-size'],
+    h3: theme.tokens['--text-heading-3-size'],
+    h4: theme.tokens['--text-heading-4-size'],
+    body: theme.tokens['--text-body-size'],
+    supporting: theme.tokens['--text-supporting-size'],
   };
   return (
     <div style={S.section}>
-      <h3 style={S.sectionTitle}>Text Hierarchy (1.25 scale, 14px base)</h3>
+      <h3 style={S.sectionTitle}>Text Hierarchy</h3>
       <VStack gap={2}>
         <HStack gap={2} vAlign="end">
           <Heading level={1}>Heading 1</Heading>
           <Text type="supporting" color="secondary">
-            {sizes.h1}px
+            {sizes.h1}
           </Text>
         </HStack>
         <HStack gap={2} vAlign="end">
           <Heading level={2}>Heading 2</Heading>
           <Text type="supporting" color="secondary">
-            {sizes.h2}px
+            {sizes.h2}
           </Text>
         </HStack>
         <HStack gap={2} vAlign="end">
           <Heading level={3}>Heading 3</Heading>
           <Text type="supporting" color="secondary">
-            {sizes.h3}px
+            {sizes.h3}
           </Text>
         </HStack>
         <HStack gap={2} vAlign="end">
           <Heading level={4}>Heading 4</Heading>
           <Text type="supporting" color="secondary">
-            {sizes.h4}px
+            {sizes.h4}
           </Text>
         </HStack>
         <HStack gap={2} vAlign="end">
           <Text type="body">Body — primary</Text>
           <Text type="supporting" color="secondary">
-            {sizes.body}px
+            {sizes.body}
           </Text>
         </HStack>
         <HStack gap={2} vAlign="end">
@@ -595,13 +607,13 @@ function TextRampSection() {
             Body — secondary
           </Text>
           <Text type="supporting" color="secondary">
-            {sizes.body}px
+            {sizes.body}
           </Text>
         </HStack>
         <HStack gap={2} vAlign="end">
           <Text type="supporting">Supporting</Text>
           <Text type="supporting" color="secondary">
-            {sizes.supporting}px
+            {sizes.supporting}
           </Text>
         </HStack>
         <HStack gap={2} vAlign="end">
@@ -609,7 +621,7 @@ function TextRampSection() {
             Disabled
           </Text>
           <Text type="supporting" color="secondary">
-            {sizes.body}px
+            {sizes.body}
           </Text>
         </HStack>
       </VStack>
@@ -617,169 +629,2523 @@ function TextRampSection() {
   );
 }
 
-function SemanticBadgeSection() {
+const SEMANTIC_BADGE_VARIANTS = [
+  'info',
+  'success',
+  'warning',
+  'error',
+  'neutral',
+] as const satisfies readonly BadgeVariant[];
+
+const CATEGORICAL_BADGE_VARIANTS = [
+  'blue',
+  'cyan',
+  'green',
+  'orange',
+  'pink',
+  'purple',
+  'red',
+  'teal',
+  'yellow',
+] as const satisfies readonly BadgeVariant[];
+
+const TOKEN_COLORS = [
+  'default',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'teal',
+  'cyan',
+  'blue',
+  'purple',
+  'pink',
+  'gray',
+] as const satisfies readonly TokenColor[];
+
+function BadgeContrastSection({
+  title,
+  variants,
+  theme,
+  mode,
+}: {
+  title: string;
+  variants: readonly BadgeVariant[];
+  theme: DefinedTheme;
+  mode: Mode;
+}) {
+  const audit = getBadgeContrast(theme, mode, variants);
   return (
     <div style={S.section}>
-      <h3 style={S.sectionTitle}>Semantic Badges</h3>
-      <HStack gap={2} wrap="wrap">
-        <Badge variant="success" label="Success" />
-        <Badge variant="error" label="Error" />
-        <Badge variant="warning" label="Warning" />
-        <Badge variant="info" label="Info" />
-        <Badge variant="neutral" label="Neutral" />
-      </HStack>
+      <h3 style={S.sectionTitle}>{title}</h3>
+      <div style={{overflowX: 'auto'}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Variant',
+                'Rendered examples',
+                'Worst placement',
+                'Contrast',
+                'Label',
+                'Icon',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign:
+                      label === 'Contrast' ||
+                      label === 'Label' ||
+                      label === 'Icon'
+                        ? 'right'
+                        : 'left',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const labelPasses = row.ratio != null && row.ratio >= 4.5;
+              const iconPasses = row.ratio != null && row.ratio >= 3;
+              return (
+                <tr key={row.variant}>
+                  <td style={{padding: '8px'}}>{row.name}</td>
+                  <td style={{padding: '8px'}}>
+                    <HStack gap={1} wrap="wrap">
+                      <Badge variant={row.variant} label={row.name} />
+                      <Badge
+                        variant={row.variant}
+                        icon={
+                          <Icon
+                            icon={row.variant === 'error' ? 'close' : 'check'}
+                            size="xsm"
+                          />
+                        }
+                        label={row.name}
+                      />
+                    </HStack>
+                  </td>
+                  <td style={{padding: '8px'}}>{row.surface ?? '—'}</td>
+                  <td style={{padding: '8px', textAlign: 'right'}}>
+                    {row.ratio == null ? '—' : `${row.ratio.toFixed(2)}:1`}
+                  </td>
+                  {[
+                    {passes: labelPasses, requirement: '4.5:1'},
+                    {passes: iconPasses, requirement: '3:1'},
+                  ].map(({passes, requirement}) => (
+                    <td
+                      key={requirement}
+                      style={{
+                        padding: '8px',
+                        textAlign: 'right',
+                        color:
+                          row.ratio == null
+                            ? 'var(--color-text-secondary)'
+                            : passes
+                              ? 'var(--color-success)'
+                              : 'var(--color-error)',
+                        fontWeight: 700,
+                      }}>
+                      {row.ratio == null
+                        ? 'Not measured'
+                        : passes
+                          ? `Pass ≥${requirement}`
+                          : `Fail <${requirement}`}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Badge labels require 4.5:1. Meaningful icons require 3:1. Icon defaults
+        to the badge foreground, so both use the measured ratio shown here. The
+        example icon is decorative because its visible label repeats the same
+        meaning. If a consumer overrides the icon color, that color needs its
+        own audit. The pill boundary is not measured separately because the
+        visible label identifies the badge.
+      </p>
     </div>
   );
 }
 
-function CategoricalBadgeSection() {
+function TokenContrastSection({
+  theme,
+  mode,
+}: {
+  theme: DefinedTheme;
+  mode: Mode;
+}) {
+  const audit = getTokenContrast(theme, mode);
   return (
     <div style={S.section}>
-      <h3 style={S.sectionTitle}>Categorical Badges</h3>
-      <HStack gap={2} wrap="wrap">
-        <Badge variant="blue" label="Blue" />
-        <Badge variant="cyan" label="Cyan" />
-        <Badge variant="green" label="Green" />
-        <Badge variant="orange" label="Orange" />
-        <Badge variant="pink" label="Pink" />
-        <Badge variant="purple" label="Purple" />
-        <Badge variant="red" label="Red" />
-        <Badge variant="teal" label="Teal" />
-        <Badge variant="yellow" label="Yellow" />
-      </HStack>
+      <h3 style={S.sectionTitle}>Tokens</h3>
+      <div style={{overflowX: 'auto'}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Color',
+                'Rendered examples',
+                'Rest',
+                'Hover',
+                'Pressed',
+                'WCAG',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign:
+                      label === 'Color' || label === 'Rendered examples'
+                        ? 'left'
+                        : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const ratios = [row.rest, row.hover, row.pressed];
+              const measured = ratios.every(
+                (ratio): ratio is number => ratio != null,
+              );
+              const passes = measured && Math.min(...ratios) >= 4.5;
+              return (
+                <tr key={row.color}>
+                  <td style={{padding: '8px'}}>{row.name}</td>
+                  <td style={{padding: '8px'}}>
+                    <HStack gap={1} wrap="wrap">
+                      <Token color={row.color} label={row.name} />
+                      <Token
+                        color={row.color}
+                        label={row.name}
+                        icon={<Icon icon="check" size="xsm" />}
+                        onClick={() => {}}
+                        onRemove={() => {}}
+                      />
+                    </HStack>
+                  </td>
+                  {ratios.map((ratio, index) => (
+                    <td
+                      key={index}
+                      style={{padding: '8px', textAlign: 'right'}}>
+                      {ratio == null ? '—' : `${ratio.toFixed(2)}:1`}
+                    </td>
+                  ))}
+                  <td
+                    style={{
+                      padding: '8px',
+                      textAlign: 'right',
+                      color: !measured
+                        ? 'var(--color-text-secondary)'
+                        : passes
+                          ? 'var(--color-success)'
+                          : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Colored Tokens use the same background/text pairs as categorical Badges;
+        default and gray match the neutral Badge. Labels require 4.5:1 through
+        rest, hover, and pressed states. Leading and remove icons inherit the
+        same foreground and clear their 3:1 requirement whenever the label
+        passes. Disabled Tokens are contrast-exempt.
+      </p>
     </div>
   );
 }
 
-function ButtonSection() {
+const BUTTON_VARIANTS = [
+  'primary',
+  'secondary',
+  'ghost',
+  'destructive',
+] as const;
+
+const BUTTON_END_BADGES = {
+  primary: 'info',
+  secondary: 'neutral',
+  ghost: 'info',
+  destructive: 'error',
+} as const;
+
+function splitColorArgs(input: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
+
+  for (const char of input) {
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth -= 1;
+    }
+
+    if (char === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current.trim());
+  return parts;
+}
+
+function resolveThemeColor(
+  theme: DefinedTheme,
+  value: string,
+  mode: Mode,
+  local: Record<string, string | undefined> = {},
+): string {
+  const expression = value.trim();
+  if (expression.startsWith('light-dark(')) {
+    const choices = splitColorArgs(expression.slice('light-dark('.length, -1));
+    return resolveThemeColor(
+      theme,
+      choices[mode === 'light' ? 0 : 1],
+      mode,
+      local,
+    );
+  }
+  if (expression.startsWith('var(')) {
+    const [name, fallback] = splitColorArgs(expression.slice(4, -1));
+    const token =
+      local[name] ?? theme.tokens[name] ?? tokenDefaults[name] ?? fallback;
+    if (!token) {
+      throw new Error(`Unable to resolve ${name}`);
+    }
+    return resolveThemeColor(theme, token, mode, local);
+  }
+  return expression;
+}
+
+interface RGBA {
+  rgb: [number, number, number];
+  alpha: number;
+}
+
+function parseColor(value: string): RGBA {
+  const color = value.trim().toLowerCase();
+  if (color === 'transparent') {
+    return {rgb: [0, 0, 0], alpha: 0};
+  }
+  if (color === 'black') {
+    return {rgb: [0, 0, 0], alpha: 1};
+  }
+  if (color === 'white') {
+    return {rgb: [255, 255, 255], alpha: 1};
+  }
+
+  if (color.startsWith('#')) {
+    const hex = color.slice(1);
+    const expanded =
+      hex.length === 3 || hex.length === 4
+        ? [...hex].map(character => character + character).join('')
+        : hex;
+    return {
+      rgb: [0, 2, 4].map(index =>
+        Number.parseInt(expanded.slice(index, index + 2), 16),
+      ) as [number, number, number],
+      alpha:
+        expanded.length === 8
+          ? Number.parseInt(expanded.slice(6, 8), 16) / 255
+          : 1,
+    };
+  }
+
+  const rgbMatch = color.match(/^rgba?\((.+)\)$/);
+  if (rgbMatch) {
+    const channels = rgbMatch[1]
+      .replace('/', ' ')
+      .split(/[\s,]+/)
+      .filter(Boolean);
+    return {
+      rgb: channels.slice(0, 3).map(Number) as [number, number, number],
+      alpha: channels[3] == null ? 1 : Number(channels[3]),
+    };
+  }
+
+  throw new Error(`Unsupported contrast-audit color: ${value}`);
+}
+
+function compositeColor(foreground: string, background: string): string {
+  const fg = parseColor(foreground);
+  const bg = parseColor(background);
+  return `#${fg.rgb
+    .map((channel, index) =>
+      Math.round(channel * fg.alpha + bg.rgb[index] * (1 - fg.alpha))
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')}`;
+}
+
+function mixColors(base: string, tint: string, tintWeight: number): string {
+  const baseColor = parseColor(base);
+  const tintColor = parseColor(tint);
+  return `#${baseColor.rgb
+    .map((channel, index) =>
+      Math.round(channel * (1 - tintWeight) + tintColor.rgb[index] * tintWeight)
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')}`;
+}
+
+function relativeLuminance(color: string): number {
+  const channels = parseColor(color).rgb.map(channel => {
+    const value = channel / 255;
+    return value <= 0.04045
+      ? value / 12.92
+      : Math.pow((value + 0.055) / 1.055, 2.4);
+  });
+  return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const values = [
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  ].sort((a, b) => b - a);
+  return (values[0] + 0.05) / (values[1] + 0.05);
+}
+
+function resolveToken(theme: DefinedTheme, name: string, mode: Mode): string {
+  const value = theme.tokens[name] ?? tokenDefaults[name];
+  if (!value) {
+    throw new Error(`Unable to resolve ${name}`);
+  }
+  return resolveThemeColor(theme, value, mode);
+}
+
+const BADGE_DEFAULTS = {
+  neutral: {
+    backgroundColor: 'var(--color-neutral)',
+    color: 'var(--color-text-primary)',
+  },
+  info: {
+    backgroundColor: 'var(--color-accent)',
+    color: 'var(--color-on-accent)',
+  },
+  success: {
+    backgroundColor: 'var(--color-success)',
+    color: 'var(--color-on-success)',
+  },
+  warning: {
+    backgroundColor: 'var(--color-warning)',
+    color: 'var(--color-on-warning)',
+  },
+  error: {
+    backgroundColor: 'var(--color-error)',
+    color: 'var(--color-on-error)',
+  },
+  blue: {
+    backgroundColor: 'var(--color-background-blue)',
+    color: 'var(--color-text-blue)',
+  },
+  cyan: {
+    backgroundColor: 'var(--color-background-cyan)',
+    color: 'var(--color-text-cyan)',
+  },
+  green: {
+    backgroundColor: 'var(--color-background-green)',
+    color: 'var(--color-text-green)',
+  },
+  orange: {
+    backgroundColor: 'var(--color-background-orange)',
+    color: 'var(--color-text-orange)',
+  },
+  pink: {
+    backgroundColor: 'var(--color-background-pink)',
+    color: 'var(--color-text-pink)',
+  },
+  purple: {
+    backgroundColor: 'var(--color-background-purple)',
+    color: 'var(--color-text-purple)',
+  },
+  red: {
+    backgroundColor: 'var(--color-background-red)',
+    color: 'var(--color-text-red)',
+  },
+  teal: {
+    backgroundColor: 'var(--color-background-teal)',
+    color: 'var(--color-text-teal)',
+  },
+  yellow: {
+    backgroundColor: 'var(--color-background-yellow)',
+    color: 'var(--color-text-yellow)',
+  },
+} as const;
+
+const TOKEN_DEFAULTS = {
+  default: {
+    backgroundColor: 'var(--color-neutral)',
+    color: 'var(--color-text-primary)',
+  },
+  red: BADGE_DEFAULTS.red,
+  orange: BADGE_DEFAULTS.orange,
+  yellow: BADGE_DEFAULTS.yellow,
+  green: BADGE_DEFAULTS.green,
+  teal: BADGE_DEFAULTS.teal,
+  cyan: BADGE_DEFAULTS.cyan,
+  blue: BADGE_DEFAULTS.blue,
+  purple: BADGE_DEFAULTS.purple,
+  pink: BADGE_DEFAULTS.pink,
+  gray: {
+    backgroundColor: 'var(--color-background-gray)',
+    color: 'var(--color-text-gray)',
+  },
+} as const;
+
+function getBadgeContrast(
+  theme: DefinedTheme,
+  mode: Mode,
+  variants: readonly BadgeVariant[],
+) {
+  const surfaces = [
+    ['Body', '--color-background-body'],
+    ['Surface', '--color-background-surface'],
+    ['Card', '--color-background-card'],
+  ] as const;
+
+  return variants.map(variant => {
+    try {
+      const defaults = BADGE_DEFAULTS[variant as keyof typeof BADGE_DEFAULTS];
+      if (!defaults) {
+        throw new Error(`No audit defaults for badge variant ${variant}`);
+      }
+      const badgeBlock = theme.components?.badge ?? {};
+      const override = badgeBlock[`variant:${variant}`] ?? {};
+      const foreground = resolveThemeColor(
+        theme,
+        String(override.color ?? badgeBlock.color ?? defaults.color),
+        mode,
+      );
+      const background = resolveThemeColor(
+        theme,
+        String(
+          override.backgroundColor ??
+            badgeBlock.backgroundColor ??
+            defaults.backgroundColor,
+        ),
+        mode,
+      );
+      const placements = surfaces.map(([name, token]) => {
+        const parent = resolveToken(theme, token, mode);
+        const resolvedBackground = compositeColor(background, parent);
+        const resolvedForeground = compositeColor(
+          foreground,
+          resolvedBackground,
+        );
+        return {
+          name,
+          ratio: contrastRatio(resolvedForeground, resolvedBackground),
+        };
+      });
+      const weakest = placements.reduce((minimum, placement) =>
+        placement.ratio < minimum.ratio ? placement : minimum,
+      );
+
+      return {
+        variant,
+        name: variant[0].toUpperCase() + variant.slice(1),
+        surface: weakest.name,
+        ratio: weakest.ratio,
+      };
+    } catch {
+      // Keep experimental themes renderable when they use CSS color syntax
+      // that this lightweight audit cannot flatten to an sRGB pair.
+      return {
+        variant,
+        name: variant[0].toUpperCase() + variant.slice(1),
+        surface: undefined,
+        ratio: undefined,
+      };
+    }
+  });
+}
+
+function getTokenContrast(theme: DefinedTheme, mode: Mode) {
+  const surfaces = [
+    '--color-background-body',
+    '--color-background-surface',
+    '--color-background-card',
+  ] as const;
+
+  return TOKEN_COLORS.map(color => {
+    try {
+      const defaults = TOKEN_DEFAULTS[color];
+      const tokenBlock = theme.components?.token ?? {};
+      const override = tokenBlock[`color:${color}`] ?? {};
+      const foreground = resolveThemeColor(
+        theme,
+        String(override.color ?? tokenBlock.color ?? defaults.color),
+        mode,
+      );
+      const background = resolveThemeColor(
+        theme,
+        String(
+          override.backgroundColor ??
+            tokenBlock.backgroundColor ??
+            defaults.backgroundColor,
+        ),
+        mode,
+      );
+      const hover = resolveToken(theme, '--color-overlay-hover', mode);
+      const pressed = resolveToken(theme, '--color-overlay-pressed', mode);
+      const ratio = (overlay?: string) =>
+        Math.min(
+          ...surfaces.map(surfaceToken => {
+            const parent = resolveToken(theme, surfaceToken, mode);
+            const base = compositeColor(background, parent);
+            const stateBackground = overlay
+              ? compositeColor(overlay, base)
+              : base;
+            const resolvedForeground = compositeColor(
+              foreground,
+              stateBackground,
+            );
+            return contrastRatio(resolvedForeground, stateBackground);
+          }),
+        );
+
+      return {
+        color,
+        name: color[0].toUpperCase() + color.slice(1),
+        rest: ratio(),
+        hover: ratio(hover),
+        pressed: ratio(pressed),
+      };
+    } catch {
+      return {
+        color,
+        name: color[0].toUpperCase() + color.slice(1),
+        rest: undefined,
+        hover: undefined,
+        pressed: undefined,
+      };
+    }
+  });
+}
+
+const BANNER_DEFAULTS = {
+  info: {
+    backgroundColor: 'var(--color-accent-muted)',
+    iconColor: 'var(--color-accent)',
+  },
+  success: {
+    backgroundColor: 'var(--color-success-muted)',
+    iconColor: 'var(--color-success)',
+  },
+  warning: {
+    backgroundColor: 'var(--color-warning-muted)',
+    iconColor: 'var(--color-warning)',
+  },
+  error: {
+    backgroundColor: 'var(--color-error-muted)',
+    iconColor: 'var(--color-error)',
+  },
+} as const;
+
+const FIELD_STATUS_TYPES = ['success', 'warning', 'error'] as const;
+
+const FIELD_STATUS_DEFAULTS = {
+  success: {
+    backgroundColor: 'var(--color-success-muted)',
+    color: 'var(--color-text-green)',
+  },
+  warning: {
+    backgroundColor: 'var(--color-warning-muted)',
+    color: 'var(--color-text-yellow)',
+  },
+  error: {
+    backgroundColor: 'var(--color-error-muted)',
+    color: 'var(--color-text-red)',
+  },
+} as const;
+
+function getFieldStatusContrast(theme: DefinedTheme, mode: Mode) {
+  const surfaces = [
+    '--color-background-body',
+    '--color-background-surface',
+    '--color-background-card',
+  ] as const;
+
+  return FIELD_STATUS_TYPES.map(status => {
+    try {
+      const fieldStatusBlock = theme.components?.['field-status'] ?? {};
+      const statusOverride = fieldStatusBlock[`type:${status}`] ?? {};
+      const local = Object.fromEntries(
+        Object.entries({...fieldStatusBlock.base, ...statusOverride}).filter(
+          (entry): entry is [string, string] =>
+            entry[0].startsWith('--') && typeof entry[1] === 'string',
+        ),
+      );
+      const foreground = resolveThemeColor(
+        theme,
+        String(
+          statusOverride.color ??
+            fieldStatusBlock.color ??
+            FIELD_STATUS_DEFAULTS[status].color,
+        ),
+        mode,
+        local,
+      );
+      const background = resolveThemeColor(
+        theme,
+        String(
+          statusOverride.backgroundColor ??
+            fieldStatusBlock.backgroundColor ??
+            FIELD_STATUS_DEFAULTS[status].backgroundColor,
+        ),
+        mode,
+        local,
+      );
+      const ratio = Math.min(
+        ...surfaces.map(surfaceToken => {
+          const parent = resolveToken(theme, surfaceToken, mode);
+          const resolvedBackground = compositeColor(background, parent);
+          return contrastRatio(
+            compositeColor(foreground, resolvedBackground),
+            resolvedBackground,
+          );
+        }),
+      );
+
+      const bannerBlock = theme.components?.banner ?? {};
+      const bannerOverride = bannerBlock[`status:${status}`] ?? {};
+      const bannerLocal = Object.fromEntries(
+        Object.entries({...bannerBlock.base, ...bannerOverride}).filter(
+          (entry): entry is [string, string] =>
+            entry[0].startsWith('--') && typeof entry[1] === 'string',
+        ),
+      );
+      const bannerForeground = resolveThemeColor(
+        theme,
+        'var(--color-text-primary)',
+        mode,
+        bannerLocal,
+      );
+      const bannerBackground = resolveThemeColor(
+        theme,
+        BANNER_DEFAULTS[status].backgroundColor,
+        mode,
+        bannerLocal,
+      );
+
+      return {
+        status,
+        name: status[0].toUpperCase() + status.slice(1),
+        ratio,
+        matchesBanner:
+          foreground.toLowerCase() === bannerForeground.toLowerCase() &&
+          background.toLowerCase() === bannerBackground.toLowerCase(),
+      };
+    } catch {
+      return {
+        status,
+        name: status[0].toUpperCase() + status.slice(1),
+        ratio: undefined,
+        matchesBanner: false,
+      };
+    }
+  });
+}
+
+function getInputContrast(theme: DefinedTheme, mode: Mode) {
+  try {
+    const parentTokens = [
+      '--color-background-body',
+      '--color-background-surface',
+      '--color-background-card',
+    ] as const;
+    const parents = parentTokens.map(token => resolveToken(theme, token, mode));
+    const inputBlock = theme.components?.['text-input'] ?? {};
+    const inputLocal = Object.fromEntries(
+      Object.entries(inputBlock.base ?? {}).filter(
+        (entry): entry is [string, string] =>
+          entry[0].startsWith('--') && typeof entry[1] === 'string',
+      ),
+    );
+    const inputBackground = resolveThemeColor(
+      theme,
+      String(
+        inputBlock.base?.backgroundColor ?? 'var(--color-background-surface)',
+      ),
+      mode,
+      inputLocal,
+    );
+    const labelBlock = theme.components?.['field-label'] ?? {};
+    const labelLocal = Object.fromEntries(
+      Object.entries(labelBlock.base ?? {}).filter(
+        (entry): entry is [string, string] =>
+          entry[0].startsWith('--') && typeof entry[1] === 'string',
+      ),
+    );
+    const labelColor = resolveThemeColor(
+      theme,
+      String(labelBlock.base?.color ?? 'var(--color-text-secondary)'),
+      mode,
+      labelLocal,
+    );
+    const valueColor = resolveThemeColor(
+      theme,
+      'var(--color-text-primary)',
+      mode,
+      inputLocal,
+    );
+    const secondaryText = resolveThemeColor(
+      theme,
+      'var(--color-text-secondary)',
+      mode,
+      inputLocal,
+    );
+    const iconColor = resolveThemeColor(
+      theme,
+      'var(--color-icon-secondary)',
+      mode,
+      inputLocal,
+    );
+    const defaultBorder = resolveThemeColor(
+      theme,
+      String(inputBlock.base?.borderColor ?? 'var(--color-border-emphasized)'),
+      mode,
+      inputLocal,
+    );
+    const focusBorder = resolveThemeColor(
+      theme,
+      'var(--color-accent)',
+      mode,
+      inputLocal,
+    );
+    const againstParents = (foreground: string) =>
+      Math.min(...parents.map(parent => contrastRatio(foreground, parent)));
+    const againstInput = (foreground: string) =>
+      contrastRatio(foreground, inputBackground);
+    const boundaryRatio = (foreground: string) =>
+      Math.min(againstInput(foreground), againstParents(foreground));
+
+    const rows = [
+      {
+        key: 'label',
+        relationship: 'Label, description, optional / required',
+        ratio: againstParents(labelColor),
+        minimum: 4.5,
+        note: 'Text',
+      },
+      {
+        key: 'value',
+        relationship: 'Value and read-only value',
+        ratio: againstInput(valueColor),
+        minimum: 4.5,
+        note: 'Text',
+      },
+      {
+        key: 'placeholder',
+        relationship: 'Placeholder',
+        ratio: againstInput(secondaryText),
+        minimum: 4.5,
+        note: 'Text',
+      },
+      {
+        key: 'boundary',
+        relationship: 'Default control boundary',
+        ratio: boundaryRatio(defaultBorder),
+        minimum: 3,
+        note: 'Non-text',
+      },
+      {
+        key: 'focus',
+        relationship: 'Focus border color',
+        ratio: boundaryRatio(focusBorder),
+        minimum: 3,
+        note: 'Color only',
+      },
+      {
+        key: 'icons',
+        relationship: 'Start, clear, and label-info icons',
+        ratio: Math.min(againstInput(iconColor), againstParents(labelColor)),
+        minimum: 3,
+        note: 'When meaningful',
+      },
+      {
+        key: 'spinner',
+        relationship: 'Loading spinner arc',
+        ratio: againstInput(focusBorder),
+        minimum: 3,
+        note: 'Track is decorative',
+      },
+    ];
+
+    const statusRows = FIELD_STATUS_TYPES.map(status => {
+      const statusBlock = inputBlock[`status:${status}`] ?? {};
+      const local = Object.fromEntries(
+        Object.entries({...inputBlock.base, ...statusBlock}).filter(
+          (entry): entry is [string, string] =>
+            entry[0].startsWith('--') && typeof entry[1] === 'string',
+        ),
+      );
+      const color = resolveThemeColor(
+        theme,
+        String(statusBlock.borderColor ?? `var(--color-${status})`),
+        mode,
+        local,
+      );
+      return {
+        key: status,
+        relationship: `${status[0].toUpperCase() + status.slice(1)} border and status icon`,
+        ratio: boundaryRatio(color),
+        minimum: 3,
+        note: 'Non-text',
+      };
+    });
+
+    return [...rows, ...statusRows];
+  } catch {
+    return [
+      ['label', 'Label, description, optional / required', 4.5, 'Text'],
+      ['value', 'Value and read-only value', 4.5, 'Text'],
+      ['placeholder', 'Placeholder', 4.5, 'Text'],
+      ['boundary', 'Default control boundary', 3, 'Non-text'],
+      ['focus', 'Focus border color', 3, 'Color only'],
+      ['icons', 'Start, clear, and label-info icons', 3, 'When meaningful'],
+      ['spinner', 'Loading spinner arc', 3, 'Track is decorative'],
+      ...FIELD_STATUS_TYPES.map(status => [
+        status,
+        `${status[0].toUpperCase() + status.slice(1)} border and status icon`,
+        3,
+        'Non-text',
+      ]),
+    ].map(([key, relationship, minimum, note]) => ({
+      key: String(key),
+      relationship: String(relationship),
+      ratio: undefined,
+      minimum: Number(minimum),
+      note: String(note),
+    }));
+  }
+}
+
+const CONTROL_AUDIT_ROWS = [
+  ['checkbox-label', 'Checkbox', 'Label and description', 4.5, 'Text'],
+  ['checkbox-off', 'Checkbox', 'Unchecked boundary', 3, 'Control boundary'],
+  ['checkbox-on', 'Checkbox', 'Checked fill', 3, 'Control boundary'],
+  ['checkbox-mark', 'Checkbox', 'Check / indeterminate mark', 3, 'State'],
+  ['checkbox-loading', 'Checkbox', 'Loading spinner arc', 3, 'Busy state'],
+  ['checkbox-focus', 'Checkbox', 'Focus indicator', 3, 'Focus'],
+  ['radio-label', 'Radio', 'Label and description', 4.5, 'Text'],
+  ['radio-off', 'Radio', 'Unchecked boundary', 3, 'Control boundary'],
+  ['radio-on', 'Radio', 'Selected fill', 3, 'Control boundary'],
+  ['radio-dot', 'Radio', 'Selected dot', 3, 'State'],
+  ['radio-focus', 'Radio', 'Focus indicator', 3, 'Focus'],
+  ['switch-label', 'Switch', 'Label and description', 4.5, 'Text'],
+  ['switch-off', 'Switch', 'Off track', 3, 'Control boundary'],
+  ['switch-off-thumb', 'Switch', 'Off thumb', 3, 'State'],
+  ['switch-on', 'Switch', 'On track', 3, 'Control boundary'],
+  ['switch-on-thumb', 'Switch', 'On thumb', 3, 'State'],
+  ['switch-loading', 'Switch', 'Loading spinner arc', 3, 'Busy state'],
+  ['switch-focus', 'Switch', 'Focus indicator', 3, 'Focus'],
+] as const;
+
+function getControlContrast(theme: DefinedTheme, mode: Mode) {
+  try {
+    const parents = [
+      '--color-background-body',
+      '--color-background-surface',
+      '--color-background-card',
+    ].map(token => resolveToken(theme, token, mode));
+    const surface = resolveToken(theme, '--color-background-surface', mode);
+    const primary = resolveToken(theme, '--color-text-primary', mode);
+    const secondary = resolveToken(theme, '--color-text-secondary', mode);
+    const emphasized = resolveToken(theme, '--color-border-emphasized', mode);
+    const accent = resolveToken(theme, '--color-accent', mode);
+    const onAccent = resolveToken(theme, '--color-on-accent', mode);
+    const tint = resolveToken(theme, '--color-tint-hover', mode);
+    const focus = resolveToken(theme, '--focus-outline-color', mode);
+    const switchBlock = theme.components?.switch ?? {};
+    const switchLocal = Object.fromEntries(
+      Object.entries(switchBlock.base ?? {}).filter(
+        (entry): entry is [string, string] =>
+          entry[0].startsWith('--') && typeof entry[1] === 'string',
+      ),
+    );
+    const switchOff = resolveThemeColor(
+      theme,
+      String(
+        switchBlock.base?.backgroundColor ?? 'var(--color-background-gray)',
+      ),
+      mode,
+      switchLocal,
+    );
+    const switchThumbBlock = theme.components?.['switch-thumb'] ?? {};
+    const switchThumb = resolveThemeColor(
+      theme,
+      String(
+        switchThumbBlock.base?.backgroundColor ??
+          'var(--color-background-surface)',
+      ),
+      mode,
+      switchLocal,
+    );
+    const uncheckedHoverFill = mixColors(surface, tint, 0.05);
+    const uncheckedHoverBorder = mixColors(emphasized, tint, 0.2);
+    const checkedHoverFill = mixColors(accent, tint, 0.15);
+    const switchOffHover = mixColors(switchOff, tint, 0.05);
+    const againstParents = (foreground: string) =>
+      Math.min(...parents.map(parent => contrastRatio(foreground, parent)));
+    const boundary = (foreground: string, fill: string) =>
+      Math.min(contrastRatio(foreground, fill), againstParents(foreground));
+
+    const values: Record<
+      (typeof CONTROL_AUDIT_ROWS)[number][0],
+      {rest: number; hover?: number}
+    > = {
+      'checkbox-label': {rest: againstParents(secondary)},
+      'checkbox-off': {
+        rest: boundary(emphasized, surface),
+        hover: boundary(uncheckedHoverBorder, uncheckedHoverFill),
+      },
+      'checkbox-on': {
+        rest: againstParents(accent),
+        hover: againstParents(checkedHoverFill),
+      },
+      'checkbox-mark': {
+        rest: contrastRatio(onAccent, accent),
+        hover: contrastRatio(onAccent, checkedHoverFill),
+      },
+      'checkbox-loading': {
+        rest: Math.min(
+          contrastRatio(accent, surface),
+          contrastRatio(onAccent, accent),
+        ),
+        hover: Math.min(
+          contrastRatio(accent, uncheckedHoverFill),
+          contrastRatio(onAccent, checkedHoverFill),
+        ),
+      },
+      'checkbox-focus': {rest: againstParents(focus)},
+      'radio-label': {
+        rest: Math.min(againstParents(primary), againstParents(secondary)),
+      },
+      'radio-off': {
+        rest: boundary(emphasized, surface),
+        hover: boundary(uncheckedHoverBorder, uncheckedHoverFill),
+      },
+      'radio-on': {
+        rest: againstParents(accent),
+        hover: againstParents(checkedHoverFill),
+      },
+      'radio-dot': {
+        rest: contrastRatio(onAccent, accent),
+        hover: contrastRatio(onAccent, checkedHoverFill),
+      },
+      'radio-focus': {rest: againstParents(focus)},
+      'switch-label': {rest: againstParents(secondary)},
+      'switch-off': {
+        rest: againstParents(switchOff),
+        hover: againstParents(switchOffHover),
+      },
+      'switch-off-thumb': {
+        rest: contrastRatio(switchThumb, switchOff),
+        hover: contrastRatio(switchThumb, switchOffHover),
+      },
+      'switch-on': {
+        rest: againstParents(accent),
+        hover: againstParents(checkedHoverFill),
+      },
+      'switch-on-thumb': {
+        rest: contrastRatio(switchThumb, accent),
+        hover: contrastRatio(switchThumb, checkedHoverFill),
+      },
+      'switch-loading': {rest: contrastRatio(accent, switchThumb)},
+      'switch-focus': {rest: againstParents(focus)},
+    };
+
+    return CONTROL_AUDIT_ROWS.map(
+      ([key, component, relationship, minimum, note]) => ({
+        key,
+        component,
+        relationship,
+        minimum,
+        note,
+        ...values[key],
+      }),
+    );
+  } catch {
+    return CONTROL_AUDIT_ROWS.map(
+      ([key, component, relationship, minimum, note]) => ({
+        key,
+        component,
+        relationship,
+        minimum,
+        note,
+        rest: undefined,
+        hover: undefined,
+      }),
+    );
+  }
+}
+
+const PROGRESS_VARIANTS = [
+  'accent',
+  'success',
+  'warning',
+  'error',
+  'neutral',
+] as const satisfies readonly ProgressBarVariant[];
+
+function getSpinnerContrast(theme: DefinedTheme, mode: Mode) {
+  try {
+    const parents = [
+      '--color-background-body',
+      '--color-background-surface',
+      '--color-background-card',
+    ].map(token => resolveToken(theme, token, mode));
+    const minimumOnParents = (foreground: string) =>
+      Math.min(...parents.map(parent => contrastRatio(foreground, parent)));
+    const primary = resolveToken(theme, '--color-text-primary', mode);
+    const label = minimumOnParents(primary);
+    const accent = resolveToken(theme, '--color-accent', mode);
+    const secondary = resolveToken(theme, '--color-text-secondary', mode);
+    const onDark = resolveToken(theme, '--color-on-dark', mode);
+    const media = resolveToken(theme, '--color-on-light', mode);
+    const onAccent = resolveToken(theme, '--color-on-accent', mode);
+
+    return [
+      {
+        shade: 'default',
+        name: 'Default',
+        arc: minimumOnParents(accent),
+        label,
+        context: 'Body / surface / card',
+      },
+      {
+        shade: 'subtle',
+        name: 'Subtle',
+        arc: minimumOnParents(secondary),
+        label,
+        context: 'Body / surface / card',
+      },
+      {
+        shade: 'onMedia',
+        name: 'On media',
+        arc: contrastRatio(onDark, media),
+        label: undefined,
+        context: 'Dark media surface',
+      },
+      {
+        shade: 'inherit',
+        name: 'Inherit',
+        arc: contrastRatio(onAccent, accent),
+        label: undefined,
+        context: 'Accent context shown',
+      },
+    ] as const;
+  } catch {
+    return [
+      ['default', 'Default', 'Body / surface / card'],
+      ['subtle', 'Subtle', 'Body / surface / card'],
+      ['onMedia', 'On media', 'Dark media surface'],
+      ['inherit', 'Inherit', 'Accent context shown'],
+    ].map(([shade, name, context]) => ({
+      shade,
+      name,
+      arc: undefined,
+      label: undefined,
+      context,
+    }));
+  }
+}
+
+function getProgressContrast(
+  theme: DefinedTheme,
+  mode: Mode,
+  overrides?: {
+    track?: string;
+    fills?: Partial<Record<(typeof PROGRESS_VARIANTS)[number], string>>;
+  },
+) {
+  const fallbackRows = PROGRESS_VARIANTS.map(variant => ({
+    variant,
+    name: variant[0].toUpperCase() + variant.slice(1),
+    fillTrack: undefined,
+    trackParent: undefined,
+    markOnFill: undefined,
+    markOnTrack: undefined,
+    markFocus: undefined,
+  }));
+
+  try {
+    const parents = [
+      '--color-background-body',
+      '--color-background-surface',
+      '--color-background-card',
+    ].map(token => resolveToken(theme, token, mode));
+    const progressBlock = theme.components?.['progress-bar'] ?? {};
+    const progressFillBlock = theme.components?.['progress-bar-fill'] ?? {};
+    const progressMarkBlock = theme.components?.['progress-bar-mark'] ?? {};
+    const primary = resolveToken(theme, '--color-text-primary', mode);
+    const secondary = resolveToken(theme, '--color-text-secondary', mode);
+    const labels = Math.min(
+      ...parents.flatMap(parent => [
+        contrastRatio(primary, parent),
+        contrastRatio(secondary, parent),
+      ]),
+    );
+    const fillDefaults = {
+      accent: 'var(--color-accent)',
+      success: 'var(--color-success)',
+      warning: 'var(--color-warning)',
+      error: 'var(--color-error)',
+      neutral: 'var(--color-text-disabled)',
+    } as const;
+    const markDefaults = {
+      accent: 'var(--color-on-accent)',
+      success: 'var(--color-on-success)',
+      warning: 'var(--color-on-warning)',
+      error: 'var(--color-on-error)',
+      neutral: 'var(--color-text-primary)',
+    } as const;
+
+    return {
+      labels,
+      rows: PROGRESS_VARIANTS.map(variant => {
+        const variantBlock = progressBlock[`variant:${variant}`] ?? {};
+        const fillVariantBlock = progressFillBlock[`variant:${variant}`] ?? {};
+        const markFillVariantBlock =
+          progressMarkBlock[`variant:${variant}+placement:fill`] ??
+          progressMarkBlock[`variant:${variant}`] ??
+          {};
+        const local = Object.fromEntries(
+          Object.entries({...progressBlock.base, ...variantBlock}).filter(
+            (entry): entry is [string, string] =>
+              entry[0].startsWith('--') && typeof entry[1] === 'string',
+          ),
+        );
+        const fillLocal = Object.fromEntries(
+          Object.entries({...local, ...fillVariantBlock}).filter(
+            (entry): entry is [string, string] =>
+              entry[0].startsWith('--') && typeof entry[1] === 'string',
+          ),
+        );
+        const markFillLocal = Object.fromEntries(
+          Object.entries({...fillLocal, ...markFillVariantBlock}).filter(
+            (entry): entry is [string, string] =>
+              entry[0].startsWith('--') && typeof entry[1] === 'string',
+          ),
+        );
+        const track =
+          overrides?.track ??
+          resolveThemeColor(
+            theme,
+            'var(--color-background-muted)',
+            mode,
+            local,
+          );
+        const fill =
+          overrides?.fills?.[variant] ??
+          resolveThemeColor(
+            theme,
+            String(fillVariantBlock.backgroundColor ?? fillDefaults[variant]),
+            mode,
+            fillLocal,
+          );
+        const markFill = resolveThemeColor(
+          theme,
+          String(markFillVariantBlock.backgroundColor ?? markDefaults[variant]),
+          mode,
+          markFillLocal,
+        );
+        const markTrack = resolveThemeColor(
+          theme,
+          'var(--color-text-primary)',
+          mode,
+          local,
+        );
+        const focus = resolveThemeColor(
+          theme,
+          'var(--focus-outline-color)',
+          mode,
+          local,
+        );
+
+        return {
+          variant,
+          name: variant[0].toUpperCase() + variant.slice(1),
+          fillTrack: contrastRatio(fill, track),
+          trackParent: Math.min(
+            ...parents.map(parent => contrastRatio(track, parent)),
+          ),
+          markOnFill: contrastRatio(markFill, fill),
+          markOnTrack: contrastRatio(markTrack, track),
+          markFocus: Math.min(
+            contrastRatio(focus, fill),
+            contrastRatio(focus, track),
+          ),
+        };
+      }),
+    };
+  } catch {
+    return {labels: undefined, rows: fallbackRows};
+  }
+}
+
+function getBannerContrast(theme: DefinedTheme, mode: Mode) {
+  const surfaces = [
+    '--color-background-body',
+    '--color-background-surface',
+    '--color-background-card',
+  ] as const;
+
+  return BANNER_STATUSES.map(status => {
+    try {
+      const bannerBlock = theme.components?.banner ?? {};
+      const statusOverride = bannerBlock[`status:${status}`] ?? {};
+      const local = Object.fromEntries(
+        Object.entries({...bannerBlock.base, ...statusOverride}).filter(
+          (entry): entry is [string, string] =>
+            entry[0].startsWith('--') && typeof entry[1] === 'string',
+        ),
+      );
+      const background = resolveThemeColor(
+        theme,
+        String(
+          statusOverride.backgroundColor ??
+            bannerBlock.backgroundColor ??
+            BANNER_DEFAULTS[status].backgroundColor,
+        ),
+        mode,
+        local,
+      );
+      const title = resolveThemeColor(
+        theme,
+        'var(--color-text-primary)',
+        mode,
+        local,
+      );
+      const description = resolveThemeColor(
+        theme,
+        'var(--color-text-secondary)',
+        mode,
+        local,
+      );
+      const statusIcon = resolveThemeColor(
+        theme,
+        BANNER_DEFAULTS[status].iconColor,
+        mode,
+        local,
+      );
+      const hover = resolveThemeColor(
+        theme,
+        theme.tokens['--color-overlay-hover'] ??
+          tokenDefaults['--color-overlay-hover'],
+        mode,
+        local,
+      );
+      const pressed = resolveThemeColor(
+        theme,
+        theme.tokens['--color-overlay-pressed'] ??
+          tokenDefaults['--color-overlay-pressed'],
+        mode,
+        local,
+      );
+      const bannerBackgrounds = surfaces.map(surfaceToken => {
+        const parent = resolveToken(theme, surfaceToken, mode);
+        return compositeColor(background, parent);
+      });
+      const contrastOnHeaders = (foreground: string, overlay?: string) =>
+        Math.min(
+          ...bannerBackgrounds.map(headerBackground => {
+            const stateBackground = overlay
+              ? compositeColor(overlay, headerBackground)
+              : headerBackground;
+            return contrastRatio(
+              compositeColor(foreground, stateBackground),
+              stateBackground,
+            );
+          }),
+        );
+
+      const focusToken =
+        theme.tokens['--focus-outline-color'] ??
+        tokenDefaults['--focus-outline-color'];
+      if (!focusToken) {
+        throw new Error('Unable to resolve --focus-outline-color');
+      }
+      const focusColor = resolveThemeColor(theme, focusToken, mode, local);
+      const focus = contrastOnHeaders(focusColor);
+      const buttonAudit = (variant: 'secondary' | 'ghost') => {
+        const defaults = {
+          secondary: {
+            backgroundColor: 'var(--color-neutral)',
+            color: 'var(--color-text-primary)',
+          },
+          ghost: {
+            backgroundColor: 'transparent',
+            color: 'var(--color-text-primary)',
+          },
+        } as const;
+        const override = theme.components?.button?.[`variant:${variant}`] ?? {};
+        const foreground = resolveThemeColor(
+          theme,
+          String(override.color ?? defaults[variant].color),
+          mode,
+          local,
+        );
+        const backgroundValue = String(
+          override.backgroundColor ?? defaults[variant].backgroundColor,
+        );
+        const background =
+          backgroundValue === 'transparent'
+            ? backgroundValue
+            : resolveThemeColor(theme, backgroundValue, mode, local);
+        const ratio = (overlay?: string) =>
+          Math.min(
+            ...bannerBackgrounds.map(headerBackground => {
+              const base =
+                background === 'transparent'
+                  ? headerBackground
+                  : compositeColor(background, headerBackground);
+              const stateBackground = overlay
+                ? compositeColor(overlay, base)
+                : base;
+              return contrastRatio(
+                compositeColor(foreground, stateBackground),
+                stateBackground,
+              );
+            }),
+          );
+
+        return {
+          variant,
+          name: variant[0].toUpperCase() + variant.slice(1),
+          rest: ratio(),
+          hover: ratio(hover),
+          pressed: ratio(pressed),
+          spinnerOrIcon: ratio(),
+          focus,
+        };
+      };
+
+      return {
+        status,
+        name: status[0].toUpperCase() + status.slice(1),
+        text: Math.min(
+          contrastOnHeaders(title),
+          contrastOnHeaders(description),
+        ),
+        statusIcon: contrastOnHeaders(statusIcon),
+        buttons: [buttonAudit('secondary'), buttonAudit('ghost')],
+      };
+    } catch {
+      return {
+        status,
+        name: status[0].toUpperCase() + status.slice(1),
+        text: undefined,
+        statusIcon: undefined,
+        buttons: [
+          {
+            variant: 'secondary' as const,
+            name: 'Secondary',
+            rest: undefined,
+            hover: undefined,
+            pressed: undefined,
+            spinnerOrIcon: undefined,
+            focus: undefined,
+          },
+          {
+            variant: 'ghost' as const,
+            name: 'Ghost',
+            rest: undefined,
+            hover: undefined,
+            pressed: undefined,
+            spinnerOrIcon: undefined,
+            focus: undefined,
+          },
+        ],
+      };
+    }
+  });
+}
+
+function getButtonContrast(theme: DefinedTheme, mode: Mode) {
+  const body = resolveToken(theme, '--color-background-body', mode);
+  const surface = resolveToken(theme, '--color-background-surface', mode);
+  const hover = resolveToken(theme, '--color-overlay-hover', mode);
+  const pressed = resolveToken(theme, '--color-overlay-pressed', mode);
+  const surfaces = [body, surface];
+  const defaults = {
+    primary: {
+      backgroundColor: 'var(--color-accent)',
+      color: 'var(--color-on-accent)',
+    },
+    secondary: {
+      backgroundColor: 'var(--color-neutral)',
+      color: 'var(--color-text-primary)',
+    },
+    ghost: {
+      backgroundColor: 'transparent',
+      color: 'var(--color-text-primary)',
+    },
+    destructive: {
+      backgroundColor: 'var(--color-error)',
+      color: 'var(--color-on-error)',
+    },
+  } as const;
+  const badgeDefaults = {
+    info: {
+      backgroundColor: 'var(--color-accent)',
+      color: 'var(--color-on-accent)',
+    },
+    neutral: {
+      backgroundColor: 'var(--color-neutral)',
+      color: 'var(--color-text-primary)',
+    },
+    error: {
+      backgroundColor: 'var(--color-error)',
+      color: 'var(--color-on-error)',
+    },
+  } as const;
+
+  const rows = BUTTON_VARIANTS.map(variant => {
+    const override = theme.components?.button?.[`variant:${variant}`] ?? {};
+    const foreground = resolveThemeColor(
+      theme,
+      String(override.color ?? defaults[variant].color),
+      mode,
+    );
+    const backgroundValue = String(
+      override.backgroundColor ?? defaults[variant].backgroundColor,
+    );
+    const background =
+      backgroundValue === 'transparent'
+        ? backgroundValue
+        : resolveThemeColor(theme, backgroundValue, mode);
+    const resolvedBackground = (parent: string) =>
+      background === 'transparent'
+        ? parent
+        : compositeColor(background, parent);
+    const worst = (overlay?: string) =>
+      Math.min(
+        ...surfaces.map(parent => {
+          const base = resolvedBackground(parent);
+          return contrastRatio(
+            foreground,
+            overlay ? compositeColor(overlay, base) : base,
+          );
+        }),
+      );
+    const spinner = Math.min(
+      ...surfaces.map(parent => {
+        const base = resolvedBackground(parent);
+        return contrastRatio(foreground, base);
+      }),
+    );
+    const badgeVariant = BUTTON_END_BADGES[variant];
+    const badgeOverride =
+      theme.components?.badge?.[`variant:${badgeVariant}`] ?? {};
+    let badge: number | undefined;
+    try {
+      const badgeForeground = resolveThemeColor(
+        theme,
+        String(badgeOverride.color ?? badgeDefaults[badgeVariant].color),
+        mode,
+      );
+      const badgeBackground = resolveThemeColor(
+        theme,
+        String(
+          badgeOverride.backgroundColor ??
+            badgeDefaults[badgeVariant].backgroundColor,
+        ),
+        mode,
+      );
+      badge = Math.min(
+        ...surfaces.map(parent => {
+          const buttonBackground = resolvedBackground(parent);
+          return contrastRatio(
+            badgeForeground,
+            compositeColor(badgeBackground, buttonBackground),
+          );
+        }),
+      );
+    } catch {
+      // Diagnostic themes may intentionally use CSS color functions this
+      // lightweight audit cannot resolve. Keep the preview visible without
+      // claiming a numeric badge result.
+      badge = undefined;
+    }
+
+    return {
+      name: variant[0].toUpperCase() + variant.slice(1),
+      rest: worst(),
+      hover: worst(hover),
+      pressed: worst(pressed),
+      spinner,
+      badge,
+    };
+  });
+  return rows;
+}
+
+const buttonRowLabelStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontFamily: MONO,
+  opacity: 0.6,
+  marginBottom: 6,
+};
+
+function ButtonSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
+  const audit = getButtonContrast(theme, mode);
   return (
     <div style={S.section}>
       <h3 style={S.sectionTitle}>Buttons</h3>
       <VStack gap={4}>
         <div>
-          <div
-            style={{
-              fontSize: 10,
-              fontFamily: MONO,
-              opacity: 0.6,
-              marginBottom: 6,
-            }}>
-            Default
-          </div>
-          <HStack gap={3} vAlign="center">
-            <Button label="Primary" variant="primary" />
-            <Button label="Secondary" variant="secondary" />
-            <Button label="Ghost" variant="ghost" />
-            <Button label="Destructive" variant="destructive" />
+          <div style={buttonRowLabelStyle}>Default</div>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            {BUTTON_VARIANTS.map(variant => (
+              <Button key={variant} label={variant} variant={variant} />
+            ))}
           </HStack>
         </div>
         <div>
-          <div
-            style={{
-              fontSize: 10,
-              fontFamily: MONO,
-              opacity: 0.6,
-              marginBottom: 6,
-            }}>
-            Disabled
-          </div>
-          <HStack gap={3} vAlign="center">
-            <Button label="Primary" variant="primary" isDisabled />
-            <Button label="Secondary" variant="secondary" isDisabled />
-            <Button label="Ghost" variant="ghost" isDisabled />
-            <Button label="Destructive" variant="destructive" isDisabled />
+          <div style={buttonRowLabelStyle}>Loading — non-interactive</div>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            {BUTTON_VARIANTS.map(variant => (
+              <Button
+                key={variant}
+                label={`${variant} loading`}
+                variant={variant}
+                isLoading
+              />
+            ))}
           </HStack>
+        </div>
+        <div>
+          <div style={buttonRowLabelStyle}>Icon-only and icon + label</div>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            {BUTTON_VARIANTS.map(variant => (
+              <Button
+                key={variant}
+                label={`${variant} icon button`}
+                variant={variant}
+                icon={
+                  <Icon
+                    icon={variant === 'destructive' ? 'close' : 'check'}
+                    color="inherit"
+                  />
+                }
+                isIconOnly
+              />
+            ))}
+            <Button
+              label="Icon and label"
+              variant="secondary"
+              icon={<Icon icon="check" color="inherit" />}
+            />
+          </HStack>
+        </div>
+        <div>
+          <div style={buttonRowLabelStyle}>Common end content</div>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            <Button
+              label="Messages"
+              variant="primary"
+              endContent={<Badge variant="info" label={3} />}
+            />
+            <Button
+              label="Notifications"
+              variant="secondary"
+              endContent={<Badge variant="neutral" label="New" />}
+            />
+            <Button
+              label="Updates"
+              variant="ghost"
+              endContent={<Badge variant="info" label={5} />}
+            />
+            <Button
+              label="Delete"
+              variant="destructive"
+              endContent={<Badge variant="error" label={5} />}
+            />
+            <Button
+              label="Continue"
+              variant="secondary"
+              endContent={
+                <Icon icon="chevronRight" size="sm" color="inherit" />
+              }
+            />
+          </HStack>
+        </div>
+        <div>
+          <div style={buttonRowLabelStyle}>Sizes and links</div>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            <Button label="Small" variant="primary" size="sm" />
+            <Button label="Medium" variant="primary" size="md" />
+            <Button label="Large" variant="primary" size="lg" />
+            <Button
+              label="Primary link"
+              variant="primary"
+              href="/pages/neutral-palette/"
+            />
+            <Button
+              label="Ghost link"
+              variant="ghost"
+              href="/pages/neutral-palette/"
+            />
+          </HStack>
+        </div>
+        <div>
+          <div style={buttonRowLabelStyle}>
+            Disabled — visual review only; WCAG contrast exempt
+          </div>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            {BUTTON_VARIANTS.map(variant => (
+              <Button
+                key={variant}
+                label={variant}
+                variant={variant}
+                isDisabled
+              />
+            ))}
+          </HStack>
+        </div>
+        <div>
+          <div style={buttonRowLabelStyle}>
+            Measured text contrast — worst of body and surface
+          </div>
+          <div style={{overflowX: 'auto'}}>
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                fontSize: 11,
+                fontVariantNumeric: 'tabular-nums',
+              }}>
+              <thead>
+                <tr>
+                  {[
+                    'Variant',
+                    'Rest',
+                    'Hover',
+                    'Pressed',
+                    'Spinner',
+                    'End badge',
+                    'WCAG',
+                  ].map(label => (
+                    <th
+                      key={label}
+                      style={{
+                        padding: '7px 8px',
+                        borderBottom: '1px solid var(--color-border)',
+                        textAlign: label === 'Variant' ? 'left' : 'right',
+                      }}>
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {audit.map(row => {
+                  const passes =
+                    Math.min(row.rest, row.hover, row.pressed) >= 4.5 &&
+                    row.spinner >= 3 &&
+                    (row.badge == null || row.badge >= 4.5);
+                  return (
+                    <tr key={row.name}>
+                      <td style={{padding: '7px 8px'}}>{row.name}</td>
+                      {[
+                        row.rest,
+                        row.hover,
+                        row.pressed,
+                        row.spinner,
+                        row.badge,
+                      ].map((ratio, index) => (
+                        <td
+                          key={index}
+                          style={{padding: '7px 8px', textAlign: 'right'}}>
+                          {ratio == null ? '—' : `${ratio.toFixed(2)}:1`}
+                        </td>
+                      ))}
+                      <td
+                        style={{
+                          padding: '7px 8px',
+                          textAlign: 'right',
+                          color: passes
+                            ? 'var(--color-success)'
+                            : 'var(--color-error)',
+                          fontWeight: 700,
+                        }}>
+                        {passes ? 'Pass' : 'Fail'}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <p
+            style={{
+              margin: '8px 0 0',
+              color: 'var(--color-text-secondary)',
+              fontSize: 10,
+              lineHeight: 1.5,
+            }}>
+            Labels require 4.5:1. Spinner measures the meaningful arc against
+            the button background; 3:1 is required. End badge measures its label
+            against its composited badge surface; 4.5:1 is required. Trailing
+            icons inherit the button foreground. Disabled controls are exempt.
+          </p>
         </div>
       </VStack>
     </div>
   );
 }
 
-function SpinnerSection() {
+function SpinnerSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
+  const audit = getSpinnerContrast(theme, mode);
+
   return (
-    <div>
+    <div style={S.section}>
       <h3 style={S.sectionTitle}>Spinners</h3>
-      <HStack gap={4} vAlign="center">
-        <Spinner size="sm" />
-        <Spinner size="md" />
-        <Spinner size="lg" />
-      </HStack>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
+          gap: 12,
+        }}>
+        <div style={{padding: 12}}>
+          <div style={buttonRowLabelStyle}>Default</div>
+          <HStack gap={3} vAlign="center">
+            <Spinner size="sm" />
+            <Spinner size="md" label="Loading" />
+          </HStack>
+        </div>
+        <div style={{padding: 12}}>
+          <div style={buttonRowLabelStyle}>Subtle</div>
+          <Spinner shade="subtle" label="Loading" />
+        </div>
+        <div
+          style={{
+            padding: 12,
+            borderRadius: 8,
+            background: 'var(--color-on-light)',
+            color: 'var(--color-on-dark)',
+          }}>
+          <div style={{...buttonRowLabelStyle, opacity: 0.8}}>On media</div>
+          <Spinner shade="onMedia" aria-label="Loading media" />
+        </div>
+        <div
+          style={{
+            padding: 12,
+            borderRadius: 8,
+            background: 'var(--color-accent)',
+            color: 'var(--color-on-accent)',
+          }}>
+          <div style={{...buttonRowLabelStyle, opacity: 0.8}}>Inherited</div>
+          <Spinner shade="inherit" aria-label="Loading action" />
+        </div>
+      </div>
+      <div style={{overflowX: 'auto', marginTop: 12}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {['Shade', 'Context', 'Active arc', 'Visible label', 'WCAG'].map(
+                label => (
+                  <th
+                    key={label}
+                    style={{
+                      padding: '7px 8px',
+                      borderBottom: '1px solid var(--color-border)',
+                      textAlign:
+                        label === 'Shade' || label === 'Context'
+                          ? 'left'
+                          : 'right',
+                    }}>
+                    {label}
+                  </th>
+                ),
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const measured = row.arc != null;
+              const passes =
+                measured &&
+                row.arc >= 3 &&
+                (row.label == null || row.label >= 4.5);
+              return (
+                <tr key={row.shade}>
+                  <td style={{padding: '8px'}}>{row.name}</td>
+                  <td style={{padding: '8px'}}>{row.context}</td>
+                  {[row.arc, row.label].map((ratio, index) => (
+                    <td
+                      key={index}
+                      style={{padding: '8px', textAlign: 'right'}}>
+                      {ratio == null ? '—' : `${ratio.toFixed(2)}:1`}
+                    </td>
+                  ))}
+                  <td
+                    style={{
+                      padding: '8px',
+                      textAlign: 'right',
+                      color: !measured
+                        ? 'var(--color-text-secondary)'
+                        : passes
+                          ? 'var(--color-success)'
+                          : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        The moving arc communicates loading and requires 3:1 against its actual
+        background. The faint circular track is redundant and may be decorative.
+        Visible labels require 4.5:1. Inherit is context-dependent, so the shown
+        result is specifically the accent context above.
+      </p>
     </div>
   );
 }
 
-function ProgressBarSection() {
+function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
+  const marks = [
+    {value: 25, label: 'Quarter'},
+    {value: 80, label: 'Goal'},
+  ];
+  const progressBlock = theme.components?.['progress-bar'] ?? {};
+  const progressFillBlock = theme.components?.['progress-bar-fill'] ?? {};
+  const subtleTrack = resolveToken(theme, '--color-background-muted', mode);
+  const parentSurface = resolveToken(theme, '--color-background-surface', mode);
+  const progressFillDefaults = {
+    accent: 'var(--color-accent)',
+    success: 'var(--color-success)',
+    warning: 'var(--color-warning)',
+    error: 'var(--color-error)',
+    neutral: 'var(--color-text-disabled)',
+  } as const;
+  const progressOptionRows = PROGRESS_VARIANTS.map((variant, index) => {
+    const local = Object.fromEntries(
+      Object.entries({
+        ...progressBlock.base,
+        ...progressBlock[`variant:${variant}`],
+      }).filter(
+        (entry): entry is [string, string] =>
+          entry[0].startsWith('--') && typeof entry[1] === 'string',
+      ),
+    );
+    const fillOverride = progressFillBlock[`variant:${variant}`] ?? {};
+    const fillLocal = Object.fromEntries(
+      Object.entries({...local, ...fillOverride}).filter(
+        (entry): entry is [string, string] =>
+          entry[0].startsWith('--') && typeof entry[1] === 'string',
+      ),
+    );
+
+    return {
+      variant,
+      name: variant[0].toUpperCase() + variant.slice(1),
+      value: 45 + index * 10,
+      fill: resolveThemeColor(
+        theme,
+        String(fillOverride.backgroundColor ?? progressFillDefaults[variant]),
+        mode,
+        fillLocal,
+      ),
+      currentTrack: resolveThemeColor(
+        theme,
+        'var(--color-background-muted)',
+        mode,
+        local,
+      ),
+    };
+  });
+  const standaloneTrack =
+    progressOptionRows.find(row => row.variant === 'accent')?.currentTrack ??
+    subtleTrack;
+  const supplementalTrack = mode === 'light' ? '#e2e2e2' : standaloneTrack;
+  const supplementalWarningFill = mode === 'light' ? '#f6d168' : '#f1d27c';
+  const audit = getProgressContrast(theme, mode, {
+    track: supplementalTrack,
+    fills: {warning: supplementalWarningFill},
+  });
+  const getSupplementalStyle = (variant: (typeof PROGRESS_VARIANTS)[number]) =>
+    ({
+      '--color-background-muted': supplementalTrack,
+      ...(variant === 'warning'
+        ? {
+            '--color-warning': supplementalWarningFill,
+          }
+        : {}),
+    }) as CSSProperties;
+
+  const trackOptions = [
+    {
+      name: 'Standalone',
+      precedent: 'Default · the graphic carries the progress information',
+      description:
+        'Every variant uses the same neutral track and a 3:1 endpoint marker. Light-mode warning moves to the closest darker yellow palette stop that clears 3:1.',
+      getTrack: (_row: (typeof progressOptionRows)[number]) => standaloneTrack,
+      getFill: (row: (typeof progressOptionRows)[number]) =>
+        row.variant === 'warning' && mode === 'light' ? '#927300' : row.fill,
+      showValue: false,
+      hasEndpointGap: false,
+      hasEndMarker: true,
+    },
+    {
+      name: 'Supplemental',
+      precedent: 'Explicit opt-in · an equivalent visible value is nearby',
+      description:
+        'Every fill retains its semantic Badge color. Light mode uses the quieter muted track; dark mode keeps the original neutral track. The nearby value carries the precise progress information.',
+      getTrack: (_row: (typeof progressOptionRows)[number]) =>
+        supplementalTrack,
+      getFill: (row: (typeof progressOptionRows)[number]) =>
+        row.variant === 'warning' ? supplementalWarningFill : row.fill,
+      showValue: true,
+      hasEndpointGap: false,
+      hasEndMarker: false,
+    },
+  ] as const;
+
   return (
-    <div>
-      <h3 style={S.sectionTitle}>Progress</h3>
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Progress bars</h3>
       <VStack gap={3}>
-        <ProgressBar value={75} label="Progress" hasValueLabel />
+        {PROGRESS_VARIANTS.map((variant, index) => (
+          <ProgressBar
+            key={variant}
+            value={45 + index * 10}
+            label={`${variant[0].toUpperCase() + variant.slice(1)} progress`}
+            variant={variant}
+            hasValueLabel
+            marks={marks}
+            style={getSupplementalStyle(variant)}
+          />
+        ))}
         <ProgressBar
-          value={40}
-          label="Upload"
-          variant="success"
-          hasValueLabel
+          isIndeterminate
+          label="Indeterminate progress"
+          variant="accent"
+          style={getSupplementalStyle('accent')}
         />
         <ProgressBar
-          value={90}
-          label="Storage"
-          variant="warning"
+          value={60}
+          label="Disabled progress"
+          variant="neutral"
           hasValueLabel
+          isDisabled
+          style={getSupplementalStyle('neutral')}
         />
-        <ProgressBar isIndeterminate label="Loading..." />
       </VStack>
+      <div style={{...buttonRowLabelStyle, marginTop: 18}}>
+        Proposed contrast presentations across every variant
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: 10,
+        }}>
+        {trackOptions.map(option => (
+          <div
+            key={option.name}
+            style={{
+              padding: 12,
+              border: '1px solid var(--color-border)',
+              borderRadius: 10,
+              background: 'var(--color-background-surface)',
+            }}>
+            <strong style={{display: 'block', fontSize: 12}}>
+              {option.name}
+            </strong>
+            <div
+              style={{
+                margin: '3px 0 10px',
+                color: 'var(--color-text-secondary)',
+                fontSize: 10,
+              }}>
+              {option.precedent}
+            </div>
+            <div style={{display: 'grid', gap: 9}}>
+              {progressOptionRows.map(row => {
+                const track = option.getTrack(row);
+                const fill = option.getFill(row);
+                return (
+                  <div key={row.variant}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        gap: 8,
+                        marginBottom: 4,
+                        fontSize: 10,
+                      }}>
+                      <span>{row.name}</span>
+                      {option.showValue && <span>{row.value}%</span>}
+                    </div>
+                    <div
+                      style={{
+                        display: 'flex',
+                        gap: option.hasEndpointGap ? 4 : 0,
+                        height: 10,
+                        overflow: 'hidden',
+                        boxSizing: 'border-box',
+                        borderRadius: 999,
+                        background: option.hasEndpointGap
+                          ? 'transparent'
+                          : track,
+                        position: 'relative',
+                      }}>
+                      <div
+                        style={{
+                          width: `${row.value}%`,
+                          flexShrink: 0,
+                          height: '100%',
+                          borderRadius: 999,
+                          background: fill,
+                          position: 'relative',
+                        }}
+                      />
+                      {(option.hasEndpointGap || option.hasEndMarker) && (
+                        <div
+                          style={{
+                            flex: 1,
+                            minWidth: 0,
+                            height: '100%',
+                            borderRadius: 999,
+                            background: track,
+                            position: 'relative',
+                          }}>
+                          {option.hasEndMarker && (
+                            <span
+                              style={{
+                                position: 'absolute',
+                                insetInlineEnd: 0,
+                                top: '50%',
+                                width: 10,
+                                height: 10,
+                                borderRadius: '50%',
+                                background: fill,
+                                transform: 'translateY(-50%)',
+                              }}
+                            />
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <div
+                      style={{
+                        marginTop: 3,
+                        color: 'var(--color-text-tertiary)',
+                        fontSize: 9,
+                        fontVariantNumeric: 'tabular-nums',
+                      }}>
+                      Fill/track {contrastRatio(fill, track).toFixed(2)}:1 ·
+                      Track/surface{' '}
+                      {contrastRatio(track, parentSurface).toFixed(2)}:1
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div
+              style={{
+                marginTop: 10,
+                color: 'var(--color-text-secondary)',
+                fontSize: 10,
+                lineHeight: 1.45,
+              }}>
+              <div>{option.description}</div>
+              {option.hasEndMarker && (
+                <div style={{marginTop: 4}}>
+                  Total marker/surface{' '}
+                  {Math.min(
+                    ...progressOptionRows.map(row =>
+                      contrastRatio(option.getFill(row), parentSurface),
+                    ),
+                  ).toFixed(2)}
+                  :1
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div style={{...buttonRowLabelStyle, marginTop: 14}}>
+        Supplemental audit · visible label and value:{' '}
+        {audit.labels == null ? 'not measured' : `${audit.labels.toFixed(2)}:1`}
+        {audit.labels != null && (audit.labels >= 4.5 ? ' · Pass' : ' · Fail')}
+      </div>
+      <div style={{overflowX: 'auto'}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Variant',
+                'Fill / track',
+                'Track / parent*',
+                'Mark / fill',
+                'Mark / track',
+                'Mark focus',
+                'WCAG',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign: label === 'Variant' ? 'left' : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.rows.map(row => {
+              const requiredRatios = [
+                row.markOnFill,
+                row.markOnTrack,
+                row.markFocus,
+              ];
+              const displayedRatios = [
+                row.fillTrack,
+                row.trackParent,
+                row.markOnFill,
+                row.markOnTrack,
+                row.markFocus,
+              ];
+              const measured = requiredRatios.every(
+                (ratio): ratio is number => ratio != null,
+              );
+              const passes =
+                measured &&
+                audit.labels != null &&
+                audit.labels >= 4.5 &&
+                Math.min(...requiredRatios) >= 3;
+              return (
+                <tr key={row.variant}>
+                  <td style={{padding: '8px'}}>{row.name}</td>
+                  {displayedRatios.map((ratio, index) => (
+                    <td
+                      key={index}
+                      style={{padding: '8px', textAlign: 'right'}}>
+                      {ratio == null
+                        ? '—'
+                        : `${ratio.toFixed(2)}:1${index === 1 ? '†' : ''}`}
+                    </td>
+                  ))}
+                  <td
+                    style={{
+                      padding: '8px',
+                      textAlign: 'right',
+                      color: !measured
+                        ? 'var(--color-text-secondary)'
+                        : passes
+                          ? 'var(--color-success)'
+                          : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Fill/track and †track/parent are reported for visibility but are not
+        included in this supplemental result because the visible value provides
+        the equivalent progress information. The proposed standalone treatment
+        instead requires its fill boundary and endpoint marker to reach 3:1.
+        Without a visible value or endpoint marker, the track must itself reach
+        3:1 against its parent. Target marks and their focus indicators are
+        measured separately. An indeterminate track may be decorative when its
+        moving segment independently communicates loading. Disabled progress is
+        an inactive-control exception.
+      </p>
     </div>
   );
 }
 
-function CheckboxRadioSwitchSection() {
+function CheckboxRadioSwitchSection({
+  theme,
+  mode,
+}: {
+  theme: DefinedTheme;
+  mode: Mode;
+}) {
+  const audit = getControlContrast(theme, mode);
+
   return (
-    <div>
+    <div style={S.section}>
       <h3 style={S.sectionTitle}>Controls</h3>
       <VStack gap={4}>
-        <VStack gap={2}>
-          <CheckboxInput
-            label="Enable notifications"
-            value={true}
+        <div>
+          <div style={buttonRowLabelStyle}>Checkbox states</div>
+          <VStack gap={2}>
+            <CheckboxInput
+              label="Unchecked"
+              description="Default boundary and label treatment"
+              value={false}
+              onChange={() => {}}
+            />
+            <CheckboxInput label="Checked" value={true} onChange={() => {}} />
+            <CheckboxInput
+              label="Indeterminate"
+              value="indeterminate"
+              onChange={() => {}}
+            />
+            <CheckboxInput
+              label="Loading"
+              value={true}
+              onChange={() => {}}
+              isLoading
+            />
+            <CheckboxInput
+              label="Read-only"
+              value={true}
+              onChange={() => {}}
+              isReadOnly
+            />
+            <CheckboxInput
+              label="Disabled"
+              value={true}
+              onChange={() => {}}
+              isDisabled
+            />
+            <CheckboxInput
+              label="Error status"
+              value={false}
+              onChange={() => {}}
+              status={{type: 'error', message: 'This choice is required.'}}
+            />
+          </VStack>
+        </div>
+        <div>
+          <div style={buttonRowLabelStyle}>Radio states</div>
+          <RadioList
+            label="Display mode"
+            value="comfortable"
             onChange={() => {}}
-          />
-          <CheckboxInput
-            label="Auto-save drafts"
-            value={false}
-            onChange={() => {}}
-          />
-          <CheckboxInput
-            label="Show previews"
-            value={true}
-            onChange={() => {}}
-            isDisabled
-          />
-        </VStack>
-        <RadioList
-          label="Display mode"
-          value="comfortable"
-          onChange={() => {}}>
-          <RadioListItem value="compact" label="Compact" />
-          <RadioListItem value="comfortable" label="Comfortable" />
-          <RadioListItem value="spacious" label="Spacious" />
-        </RadioList>
-        <VStack gap={2}>
-          <Switch label="Dark mode" value={true} onChange={() => {}} />
-          <Switch label="Reduce motion" value={false} onChange={() => {}} />
-          <Switch
-            label="High contrast"
-            value={false}
-            onChange={() => {}}
-            isDisabled
-          />
-        </VStack>
+            status={{
+              type: 'warning',
+              message: 'This changes the page density.',
+            }}>
+            <RadioListItem
+              value="compact"
+              label="Compact"
+              description="More information in less space"
+            />
+            <RadioListItem value="comfortable" label="Comfortable" />
+            <RadioListItem value="spacious" label="Spacious" isDisabled />
+          </RadioList>
+        </div>
+        <div>
+          <div style={buttonRowLabelStyle}>Switch states</div>
+          <VStack gap={2}>
+            <Switch label="Off" value={false} onChange={() => {}} />
+            <Switch label="On" value={true} onChange={() => {}} />
+            <Switch
+              label="On with description"
+              description="Supporting text uses the secondary text token"
+              value={true}
+              onChange={() => {}}
+            />
+            <Switch
+              label="Loading"
+              value={true}
+              onChange={() => {}}
+              isLoading
+            />
+            <Switch
+              label="Disabled"
+              value={false}
+              onChange={() => {}}
+              isDisabled
+            />
+            <Switch
+              label="Success status"
+              value={true}
+              onChange={() => {}}
+              status={{type: 'success', message: 'Setting saved.'}}
+            />
+          </VStack>
+        </div>
       </VStack>
+      <div style={{overflowX: 'auto', marginTop: 14}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Control',
+                'Relationship',
+                'Rest',
+                'Hover',
+                'Requirement',
+                'Note',
+                'WCAG',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign:
+                      label === 'Control' ||
+                      label === 'Relationship' ||
+                      label === 'Note'
+                        ? 'left'
+                        : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const measured = row.rest != null;
+              const passes =
+                measured &&
+                row.rest >= row.minimum &&
+                (row.hover == null || row.hover >= row.minimum);
+              return (
+                <tr key={row.key}>
+                  <td style={{padding: '8px'}}>{row.component}</td>
+                  <td style={{padding: '8px'}}>{row.relationship}</td>
+                  {[row.rest, row.hover].map((ratio, index) => (
+                    <td
+                      key={index}
+                      style={{padding: '8px', textAlign: 'right'}}>
+                      {ratio == null ? '—' : `${ratio.toFixed(2)}:1`}
+                    </td>
+                  ))}
+                  <td style={{padding: '8px', textAlign: 'right'}}>
+                    {row.minimum}:1
+                  </td>
+                  <td style={{padding: '8px'}}>{row.note}</td>
+                  <td
+                    style={{
+                      padding: '8px',
+                      textAlign: 'right',
+                      color: !measured
+                        ? 'var(--color-text-secondary)'
+                        : passes
+                          ? 'var(--color-success)'
+                          : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Indicators are aria-hidden but visually meaningful: they are the visible
+        control and selected-state representation, so their boundaries and marks
+        require 3:1. Loading arcs remain meaningful while interaction is
+        temporarily blocked; their faint tracks are decorative. Focus rings are
+        measured against every parent surface. Disabled treatment is
+        contrast-exempt; Checkbox read-only remains active-looking and is not
+        exempt. Validation messages reuse the FieldStatus profile above.
+      </p>
     </div>
   );
 }
 
 const CARD_VARIANTS = [
   'default',
+  'transparent',
   'muted',
   'blue',
   'cyan',
@@ -793,14 +3159,149 @@ const CARD_VARIANTS = [
   'yellow',
 ] as const;
 
-function CardVariantsSection() {
+const SELECTABLE_CARD_VARIANTS = CARD_VARIANTS;
+
+const CARD_BACKGROUND_DEFAULTS = {
+  default: 'var(--color-background-card)',
+  transparent: 'transparent',
+  muted: 'var(--color-background-muted)',
+  blue: 'var(--color-background-blue)',
+  cyan: 'var(--color-background-cyan)',
+  gray: 'var(--color-background-gray)',
+  green: 'var(--color-background-green)',
+  orange: 'var(--color-background-orange)',
+  pink: 'var(--color-background-pink)',
+  purple: 'var(--color-background-purple)',
+  red: 'var(--color-background-red)',
+  teal: 'var(--color-background-teal)',
+  yellow: 'var(--color-background-yellow)',
+} as const;
+
+function getCardContrast(theme: DefinedTheme, mode: Mode) {
+  const body = resolveToken(theme, '--color-background-body', mode);
+  const cardBlock = theme.components?.card ?? {};
+  const selectableCardBlock = theme.components?.['selectable-card'] ?? {};
+
+  return CARD_VARIANTS.map(variant => {
+    try {
+      const variantBlock = cardBlock[`variant:${variant}`] ?? {};
+      const local = Object.fromEntries(
+        Object.entries({...cardBlock.base, ...variantBlock}).filter(
+          (entry): entry is [string, string] =>
+            entry[0].startsWith('--') && typeof entry[1] === 'string',
+        ),
+      );
+      const background = compositeColor(
+        resolveThemeColor(
+          theme,
+          String(
+            variantBlock.backgroundColor ??
+              cardBlock.backgroundColor ??
+              CARD_BACKGROUND_DEFAULTS[variant],
+          ),
+          mode,
+          local,
+        ),
+        body,
+      );
+      const foreground = compositeColor(
+        resolveThemeColor(
+          theme,
+          String(
+            variantBlock.color ??
+              cardBlock.color ??
+              'var(--color-text-primary)',
+          ),
+          mode,
+          local,
+        ),
+        background,
+      );
+
+      let boundary: number | undefined;
+      if (variant === 'default') {
+        const border = compositeColor(
+          resolveThemeColor(
+            theme,
+            String(
+              variantBlock.borderColor ??
+                cardBlock.borderColor ??
+                'var(--color-border)',
+            ),
+            mode,
+            local,
+          ),
+          background,
+        );
+        boundary = Math.min(
+          contrastRatio(border, background),
+          contrastRatio(border, body),
+        );
+      }
+
+      const defaultRingToken =
+        variant === 'default' ||
+        variant === 'transparent' ||
+        variant === 'muted'
+          ? 'var(--color-accent)'
+          : `var(--color-border-${variant})`;
+      const selectableVariantBlock =
+        selectableCardBlock[`variant:${variant}`] ?? {};
+      const selectableLocal = Object.fromEntries(
+        Object.entries({
+          ...selectableCardBlock.base,
+          ...selectableVariantBlock,
+        }).filter(
+          (entry): entry is [string, string] =>
+            entry[0].startsWith('--') && typeof entry[1] === 'string',
+        ),
+      );
+      const ring = compositeColor(
+        resolveThemeColor(
+          theme,
+          String(
+            selectableVariantBlock['--selectable-card-ring-color'] ??
+              selectableCardBlock.base?.['--selectable-card-ring-color'] ??
+              defaultRingToken,
+          ),
+          mode,
+          {...local, ...selectableLocal},
+        ),
+        background,
+      );
+
+      return {
+        variant,
+        name: variant[0].toUpperCase() + variant.slice(1),
+        text: contrastRatio(foreground, background),
+        surface: contrastRatio(background, body),
+        boundary,
+        selection: contrastRatio(ring, background),
+      };
+    } catch {
+      return {
+        variant,
+        name: variant[0].toUpperCase() + variant.slice(1),
+        text: undefined,
+        surface: undefined,
+        boundary: undefined,
+        selection: undefined,
+      };
+    }
+  });
+}
+
+function CardVariantsSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
+  const audit = getCardContrast(theme, mode);
   return (
-    <div>
-      <h3 style={S.sectionTitle}>Card Variants</h3>
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Cards</h3>
+      <div style={buttonRowLabelStyle}>Card variants</div>
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(4, 1fr)',
+          gridTemplateColumns:
+            'repeat(auto-fit, minmax(min(100%, 104px), 1fr))',
           gap: 10,
         }}>
         {CARD_VARIANTS.map(v => (
@@ -811,6 +3312,183 @@ function CardVariantsSection() {
           </Card>
         ))}
       </div>
+      <h4 style={{...S.sectionTitle, marginTop: 24, fontSize: 12}}>
+        SelectableCard — every selection ring
+      </h4>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns:
+            'repeat(auto-fit, minmax(min(100%, 104px), 1fr))',
+          gap: 10,
+        }}>
+        {SELECTABLE_CARD_VARIANTS.map(variant => (
+          <SelectableCard
+            key={variant}
+            variant={variant}
+            label={`${variant} selected`}
+            padding={2}
+            isSelected
+            onChange={() => {}}>
+            <Text type="supporting">{variant}</Text>
+          </SelectableCard>
+        ))}
+      </div>
+      <div style={{...buttonRowLabelStyle, marginTop: 24}}>
+        Static Card surfaces
+      </div>
+      <div style={{overflowX: 'auto'}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Variant',
+                'Text / background',
+                'Background / body',
+                'Border / adjacent',
+                'Required result',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign: label === 'Variant' ? 'left' : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const passes = row.text != null && row.text >= 4.5;
+              return (
+                <tr key={row.variant}>
+                  <td style={{padding: '7px 8px'}}>{row.name}</td>
+                  {[row.text, row.surface, row.boundary].map((ratio, index) => (
+                    <td
+                      key={index}
+                      style={{padding: '7px 8px', textAlign: 'right'}}>
+                      {ratio == null ? '—' : `${ratio.toFixed(2)}:1`}
+                    </td>
+                  ))}
+                  <td
+                    style={{
+                      padding: '7px 8px',
+                      textAlign: 'right',
+                      color:
+                        row.text == null
+                          ? 'var(--color-text-secondary)'
+                          : passes
+                            ? 'var(--color-success)'
+                            : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {row.text == null
+                      ? 'Not measured'
+                      : passes
+                        ? 'Text passes'
+                        : 'Text fails'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Card text requires 4.5:1. Background/body and border/adjacent ratios are
+        shown for inspection, but a static Card surface is decorative when
+        spacing, headings, and content already communicate the grouping; those
+        surfaces do not inherently need 3:1. If color communicates a category or
+        status, provide a visible text or non-color cue.
+      </p>
+      <div style={{...buttonRowLabelStyle, marginTop: 18}}>
+        SelectableCard state boundary
+      </div>
+      <div style={{overflowX: 'auto'}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {['Variant', 'Ring / background', 'WCAG 1.4.11'].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign: label === 'Variant' ? 'left' : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const passes = row.selection != null && row.selection >= 3;
+              return (
+                <tr key={row.variant}>
+                  <td style={{padding: '7px 8px'}}>{row.name}</td>
+                  <td style={{padding: '7px 8px', textAlign: 'right'}}>
+                    {row.selection == null
+                      ? '—'
+                      : `${row.selection.toFixed(2)}:1`}
+                  </td>
+                  <td
+                    style={{
+                      padding: '7px 8px',
+                      textAlign: 'right',
+                      color:
+                        row.selection == null
+                          ? 'var(--color-text-secondary)'
+                          : passes
+                            ? 'var(--color-success)'
+                            : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {row.selection == null
+                      ? 'Not measured'
+                      : passes
+                        ? 'Pass'
+                        : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        The SelectableCard ring communicates selected state, so it requires 3:1
+        against its Card background. ClickableCard reuses the same Card surface;
+        its boundary needs 3:1 only when required to identify the target, while
+        its focus indicator is always evaluated separately.
+      </p>
     </div>
   );
 }
@@ -943,58 +3621,423 @@ function ElevationsSection({
   );
 }
 
-function BannerSection() {
+const BANNER_STATUSES = [
+  'info',
+  'success',
+  'warning',
+  'error',
+] as const satisfies readonly BannerStatus[];
+
+function BannerSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
+  const audit = getBannerContrast(theme, mode);
   return (
     <div style={S.section}>
       <h3 style={S.sectionTitle}>Banners</h3>
       <VStack gap={2}>
+        {BANNER_STATUSES.map(status => (
+          <Banner
+            key={status}
+            status={status}
+            title={`${status[0].toUpperCase() + status.slice(1)} banner title`}
+            description={`Description text for the ${status} state.`}
+            endContent={
+              <>
+                <Button label="Details" variant="ghost" size="sm" />
+                <Button label="Review" variant="secondary" size="sm" />
+              </>
+            }
+            isDismissable
+          />
+        ))}
         <Banner
           status="info"
-          title="Info banner title"
-          description="Description text for the info state."
+          title="Loading and disabled actions"
+          description="Loading is measured; disabled contrast is exempt."
+          endContent={
+            <>
+              <Button label="Loading" variant="secondary" size="sm" isLoading />
+              <Button label="Disabled" variant="ghost" size="sm" isDisabled />
+            </>
+          }
         />
         <Banner
-          status="success"
-          title="Success banner title"
-          description="Description text for the success state."
-        />
-        <Banner
-          status="warning"
-          title="Warning banner title"
-          description="Description text for the warning state."
-        />
-        <Banner
-          status="error"
-          title="Error banner title"
-          description="Description text for the error state."
-        />
+          status="info"
+          title="Collapsible content"
+          description="The content area uses the standard card surface."
+          collapsible={{defaultIsOpen: true}}>
+          <Text type="supporting">
+            Rich banner content follows the normal card text requirements.
+          </Text>
+        </Banner>
       </VStack>
+      <div style={{overflowX: 'auto', marginTop: 12}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {['Status', 'Text', 'Status icon', 'WCAG'].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign: label === 'Status' ? 'left' : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const measured = row.text != null && row.statusIcon != null;
+              const passes = measured && row.text >= 4.5;
+              return (
+                <tr key={row.status}>
+                  <td style={{padding: '8px'}}>{row.name}</td>
+                  {[row.text, row.statusIcon].map((ratio, index) => (
+                    <td
+                      key={index}
+                      style={{padding: '8px', textAlign: 'right'}}>
+                      {ratio == null ? '—' : `${ratio.toFixed(2)}:1`}
+                    </td>
+                  ))}
+                  <td
+                    style={{
+                      padding: '8px',
+                      textAlign: 'right',
+                      color: !measured
+                        ? 'var(--color-text-secondary)'
+                        : passes
+                          ? 'var(--color-success)'
+                          : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div style={{...buttonRowLabelStyle, marginTop: 16}}>
+        Button states on the tinted header
+      </div>
+      <div style={{overflowX: 'auto'}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Status',
+                'Button',
+                'Rest',
+                'Hover',
+                'Pressed',
+                'Spinner / icon',
+                'Focus',
+                'WCAG',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign:
+                      label === 'Status' || label === 'Button'
+                        ? 'left'
+                        : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.flatMap(row =>
+              row.buttons.map(button => {
+                const ratios = [
+                  button.rest,
+                  button.hover,
+                  button.pressed,
+                  button.spinnerOrIcon,
+                  button.focus,
+                ];
+                const measured = ratios.every(
+                  (ratio): ratio is number => ratio != null,
+                );
+                const passes =
+                  button.rest != null &&
+                  button.hover != null &&
+                  button.pressed != null &&
+                  button.spinnerOrIcon != null &&
+                  button.focus != null &&
+                  Math.min(button.rest, button.hover, button.pressed) >= 4.5 &&
+                  button.spinnerOrIcon >= 3 &&
+                  button.focus >= 3;
+                return (
+                  <tr key={`${row.status}-${button.variant}`}>
+                    <td style={{padding: '8px'}}>{row.name}</td>
+                    <td style={{padding: '8px'}}>{button.name}</td>
+                    {ratios.map((ratio, index) => (
+                      <td
+                        key={index}
+                        style={{padding: '8px', textAlign: 'right'}}>
+                        {ratio == null ? '—' : `${ratio.toFixed(2)}:1`}
+                      </td>
+                    ))}
+                    <td
+                      style={{
+                        padding: '8px',
+                        textAlign: 'right',
+                        color: !measured
+                          ? 'var(--color-text-secondary)'
+                          : passes
+                            ? 'var(--color-success)'
+                            : 'var(--color-error)',
+                        fontWeight: 700,
+                      }}>
+                      {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                    </td>
+                  </tr>
+                );
+              }),
+            )}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Title, description, and action labels require 4.5:1. Spinner, dismiss,
+        and disclosure glyphs require 3:1; focus indicators require 3:1 against
+        the adjacent header. The default status icon is decorative because the
+        visible title and live region communicate the same status, but its ratio
+        is shown for visual consistency. Disabled actions are exempt from
+        contrast requirements. Content below the header uses the standard card
+        surface.
+      </p>
     </div>
   );
 }
 
-function InputSection() {
+function FieldStatusSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
+  const audit = getFieldStatusContrast(theme, mode);
+  const messages = {
+    success: 'Looks good!',
+    warning: 'This value may cause issues.',
+    error: 'This field is required.',
+  } as const;
+
+  return (
+    <div style={S.section}>
+      <h3 style={S.sectionTitle}>Field status messages</h3>
+      <p
+        style={{
+          margin: '0 0 12px',
+          color: 'var(--color-text-secondary)',
+          fontSize: 11,
+          lineHeight: 1.5,
+        }}>
+        Field validation uses the same success, warning, and error background +
+        foreground pairs as Banner. FieldStatus has no info state.
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: 16,
+        }}>
+        {FIELD_STATUS_TYPES.map(status => (
+          <div key={status}>
+            <div style={buttonRowLabelStyle}>
+              {status[0].toUpperCase() + status.slice(1)} · attached
+            </div>
+            <TextInput
+              label={`${status[0].toUpperCase() + status.slice(1)} field`}
+              value="Example value"
+              onChange={() => {}}
+              status={{type: status, message: messages[status]}}
+            />
+            <div style={{...buttonRowLabelStyle, marginTop: 14}}>
+              {status[0].toUpperCase() + status.slice(1)} · detached
+            </div>
+            <FieldStatus
+              type={status}
+              message={messages[status]}
+              variant="detached"
+            />
+          </div>
+        ))}
+      </div>
+      <div style={{overflowX: 'auto', marginTop: 14}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Status',
+                'Message',
+                'Detached icon',
+                'Banner pair',
+                'WCAG',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign: label === 'Status' ? 'left' : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const measured = row.ratio != null;
+              const passes = measured && row.ratio >= 4.5 && row.matchesBanner;
+              return (
+                <tr key={row.status}>
+                  <td style={{padding: '8px'}}>{row.name}</td>
+                  <td style={{padding: '8px', textAlign: 'right'}}>
+                    {row.ratio == null ? '—' : `${row.ratio.toFixed(2)}:1`}
+                  </td>
+                  <td style={{padding: '8px', textAlign: 'right'}}>
+                    {row.ratio == null ? '—' : `${row.ratio.toFixed(2)}:1`}
+                  </td>
+                  <td style={{padding: '8px', textAlign: 'right'}}>
+                    {row.matchesBanner ? 'Same' : 'Different'}
+                  </td>
+                  <td
+                    style={{
+                      padding: '8px',
+                      textAlign: 'right',
+                      color: !measured
+                        ? 'var(--color-text-secondary)'
+                        : passes
+                          ? 'var(--color-success)'
+                          : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Message text requires 4.5:1. The detached icon inherits the same
+        foreground and is decorative because the visible message carries the
+        status; its ratio is still shown. Attached messages rely on the input’s
+        status icon and border, which are audited with inputs.
+      </p>
+    </div>
+  );
+}
+
+function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
+  const audit = getInputContrast(theme, mode);
+  const inputExampleStyle: React.CSSProperties = {minWidth: 0};
+
   return (
     <div style={S.section}>
       <h3 style={S.sectionTitle}>Inputs</h3>
-      <VStack gap={3}>
-        <TextInput
-          label="Default"
-          placeholder="Placeholder text"
-          value=""
-          onChange={() => {}}
-        />
+      <div style={buttonRowLabelStyle}>Content and behavior</div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))',
+          gap: 16,
+        }}>
+        <div style={inputExampleStyle}>
+          <TextInput
+            label="Default"
+            placeholder="Placeholder text"
+            value=""
+            onChange={() => {}}
+          />
+        </div>
+        <div style={inputExampleStyle}>
+          <TextInput
+            label="With adornments"
+            description="Description and optional indicator"
+            isOptional
+            labelTooltip="More information"
+            startIcon={<Icon icon="search" size="sm" />}
+            value="Search query"
+            onChange={() => {}}
+            hasClear
+          />
+        </div>
+        <div style={inputExampleStyle}>
+          <TextInput
+            label="Read-only"
+            value="Visible, submitted value"
+            onChange={() => {}}
+            isReadOnly
+          />
+        </div>
+        <div style={inputExampleStyle}>
+          <TextInput
+            label="Loading"
+            value="Checking value"
+            onChange={() => {}}
+            isLoading
+          />
+        </div>
+        <div style={inputExampleStyle}>
+          <TextInput
+            label="Disabled"
+            value="Cannot edit"
+            onChange={() => {}}
+            isDisabled
+          />
+        </div>
+      </div>
+      <div style={{...buttonRowLabelStyle, marginTop: 18}}>
+        Validation borders and on-field icons
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(230px, 1fr))',
+          gap: 16,
+        }}>
         <TextInput
           label="Success"
           value="Valid input"
           onChange={() => {}}
           status={{type: 'success', message: 'Looks good!'}}
-        />
-        <TextInput
-          label="Error"
-          value="Invalid input"
-          onChange={() => {}}
-          status={{type: 'error', message: 'This field is required.'}}
         />
         <TextInput
           label="Warning"
@@ -1003,12 +4046,100 @@ function InputSection() {
           status={{type: 'warning', message: 'This value may cause issues.'}}
         />
         <TextInput
-          label="Disabled"
-          value="Cannot edit"
+          label="Error"
+          value="Invalid input"
           onChange={() => {}}
-          isDisabled
+          status={{type: 'error', message: 'This field is required.'}}
         />
-      </VStack>
+        <TextInput
+          label="Tooltip status"
+          value="Focus the status icon"
+          onChange={() => {}}
+          status={{type: 'error', message: 'This field is required.'}}
+          statusVariant="tooltip"
+        />
+      </div>
+      <div style={{overflowX: 'auto', marginTop: 14}}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: 11,
+            fontVariantNumeric: 'tabular-nums',
+          }}>
+          <thead>
+            <tr>
+              {[
+                'Relationship',
+                'Worst contrast',
+                'Requirement',
+                'Note',
+                'WCAG',
+              ].map(label => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '7px 8px',
+                    borderBottom: '1px solid var(--color-border)',
+                    textAlign:
+                      label === 'Relationship' || label === 'Note'
+                        ? 'left'
+                        : 'right',
+                  }}>
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {audit.map(row => {
+              const measured = row.ratio != null;
+              const passes = measured && row.ratio >= row.minimum;
+              return (
+                <tr key={row.key}>
+                  <td style={{padding: '8px'}}>{row.relationship}</td>
+                  <td style={{padding: '8px', textAlign: 'right'}}>
+                    {row.ratio == null ? '—' : `${row.ratio.toFixed(2)}:1`}
+                  </td>
+                  <td style={{padding: '8px', textAlign: 'right'}}>
+                    {row.minimum}:1
+                  </td>
+                  <td style={{padding: '8px'}}>{row.note}</td>
+                  <td
+                    style={{
+                      padding: '8px',
+                      textAlign: 'right',
+                      color: !measured
+                        ? 'var(--color-text-secondary)'
+                        : passes
+                          ? 'var(--color-success)'
+                          : 'var(--color-error)',
+                      fontWeight: 700,
+                    }}>
+                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <p
+        style={{
+          margin: '8px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Active text and placeholders require 4.5:1. Control boundaries,
+        meaningful icons, spinner arcs, and focus indicators require 3:1. The
+        hover inset is supplemental—the persistent border remains the control
+        boundary. The contrasting focus border carries the AA focus-indicator
+        check; its faint 2px inset is supplemental. The two-pixel perimeter-area
+        rule is WCAG 2.2 AAA, not AA. Spinner tracks and redundant status glyphs
+        may be decorative. Disabled controls are exempt from WCAG contrast
+        requirements; read-only controls are not and remain at full contrast.
+      </p>
     </div>
   );
 }
@@ -1044,7 +4175,6 @@ function TonalSection({
           margin: 0,
           marginBottom: 20,
         }}>
-        
         Full HCT tonal ramps: 21 perceptually uniform steps from black (T0) to
         white (T100).
         {isDark && (
@@ -1131,7 +4261,16 @@ function TonalSection({
                 })}
               </div>
               <span style={S.tonalHct}>
-                H:{hct.hue.toFixed(0)} C:{hct.chroma.toFixed(0)}
+                H:
+                {typeof effectiveTones?.hue === 'number'
+                  ? effectiveTones.hue
+                  : hct.hue.toFixed(0)}{' '}
+                C:
+                {typeof effectiveTones?.chroma === 'number'
+                  ? effectiveTones.chroma < 1
+                    ? effectiveTones.chroma.toFixed(3)
+                    : effectiveTones.chroma.toFixed(0)
+                  : hct.chroma.toFixed(0)}
               </span>
             </div>
           );
@@ -1166,8 +4305,8 @@ function ModeColumn({
   theme: DefinedTheme;
   mode: Mode;
   coreSwatches?: CoreSwatch[];
-  extraSections?: React.ReactNode;
-  leadingExtras?: React.ReactNode;
+  extraSections?: ModeSection;
+  leadingExtras?: ModeSection;
   shadowDescription?: string;
   /**
    * Pending-overrides CSS custom properties spread onto the column's
@@ -1206,20 +4345,36 @@ function ModeColumn({
           {coreSwatches && coreSwatches.length > 0 && (
             <CoreSection swatches={coreSwatches} mode={mode} />
           )}
-          {leadingExtras}
-          <TextRampSection />
-          <SemanticBadgeSection />
-          <CategoricalBadgeSection />
-          <BannerSection />
-          <InputSection />
-          <ButtonSection />
-          <SpinnerSection />
-          <ProgressBarSection />
-          <CheckboxRadioSwitchSection />
-          <CardVariantsSection />
+          {typeof leadingExtras === 'function'
+            ? leadingExtras(mode)
+            : leadingExtras}
+          <TextRampSection theme={theme} />
+          <BadgeContrastSection
+            title="Semantic Badges"
+            variants={SEMANTIC_BADGE_VARIANTS}
+            theme={theme}
+            mode={mode}
+          />
+          <BadgeContrastSection
+            title="Categorical Badges"
+            variants={CATEGORICAL_BADGE_VARIANTS}
+            theme={theme}
+            mode={mode}
+          />
+          <TokenContrastSection theme={theme} mode={mode} />
+          <BannerSection theme={theme} mode={mode} />
+          <FieldStatusSection theme={theme} mode={mode} />
+          <InputSection theme={theme} mode={mode} />
+          <ButtonSection theme={theme} mode={mode} />
+          <SpinnerSection theme={theme} mode={mode} />
+          <ProgressBarSection theme={theme} mode={mode} />
+          <CheckboxRadioSwitchSection theme={theme} mode={mode} />
+          <CardVariantsSection theme={theme} mode={mode} />
           <SurfacesSection mode={mode} />
           <ElevationsSection mode={mode} description={shadowDescription} />
-          {extraSections}
+          {typeof extraSections === 'function'
+            ? extraSections(mode)
+            : extraSections}
         </div>
       </LayerProvider>
     </Theme>
@@ -1370,7 +4525,7 @@ export function ThemePalettePreview({
                         background: 'var(--color-background-body)',
                         color: 'var(--color-text-primary)',
                         borderRadius: 16,
-                        padding: 24,
+                        padding: 'clamp(16px, 2vw, 24px)',
                         marginBottom: 16,
                         border: '1px solid var(--color-border)',
                       }}>

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {useCallback, useMemo, useReducer, type CSSProperties} from "react";
+import {useCallback, useMemo, useReducer, type CSSProperties} from 'react';
 
 import {Banner, type BannerStatus} from '@astryxdesign/core/Banner';
 import {ChatComposer} from '@astryxdesign/core/Chat';
@@ -263,7 +263,7 @@ export interface TonalColor {
   semantic?: string;
   note?: string;
   /**
-   * Optional pre-computed canonical ramp keyed by tone (0-100).
+   * Optional pre-computed canonical ramp keyed by palette stop (0-100).
    *
    * Two purposes, both served by the same field:
    *
@@ -280,7 +280,7 @@ export interface TonalColor {
    *      snap-to-ramp matching so tokens whose values come from the
    *      canonical ramp don't show up as "off-ramp".
    *
-   * Numeric keys are interpreted as tone steps; non-numeric keys
+   * Numeric keys are interpreted as palette stop labels; non-numeric keys
    * (e.g. `hue`, `chroma`) are ignored. This permissive shape matches
    * theme palette exports like `stonePalettes.red` (which carry both).
    *
@@ -526,7 +526,7 @@ const S = {
     lineHeight: 1,
   }),
   // Pill shows the token count when more than one token snaps to the same
-  // tone step. Stays inside the marker dot so the strip layout is unchanged.
+  // palette stop. Stays inside the marker dot so the strip layout is unchanged.
   markerCount: (tone: number): React.CSSProperties => ({
     fontSize: 7.5,
     fontWeight: 700,
@@ -4357,7 +4357,7 @@ function TonalSection({
 }: {
   colors: TonalColor[];
   mode?: Mode;
-  /** Audit-derived map of which tone steps are consumed by which tokens. */
+  /** Audit-derived map of which palette stops are consumed by which tokens. */
   usage?: TonalUsageMap;
 }) {
   const isDark = mode === 'dark';
@@ -4381,21 +4381,21 @@ function TonalSection({
           margin: 0,
           marginBottom: 20,
         }}>
-        Full tonal ramps: 21 numbered stops ordered from dark (tone 0) to light
-        (tone 100). The number is a stable palette label in both modes, not a
+        Full tonal ramps: 21 numbered stops ordered from dark (stop 0) to light
+        (stop 100). The number is a stable palette label in both modes, not a
         promise of identical measured lightness.
         {isDark && (
           <>
             {' '}
             Dark mode applies the audit&apos;s &sect;4 transform (
-            <strong>+5 brightness</strong> with taper above tone 80,{' '}
+            <strong>+5 brightness</strong> with taper above palette stop 80,{' '}
             <strong>×0.85 chroma</strong>) so saturated stops don&apos;t vibrate
             against the dark canvas.
           </>
         )}{' '}
         {usage
-          ? 'Markers ● show numbered tones consumed by theme tokens (open the audit drawer for the full report).'
-          : 'The default preview marks the light- and dark-mode tones used by Badge tokens.'}
+          ? 'Markers ● show numbered stops consumed by theme tokens (open the audit drawer for the full report).'
+          : 'The default preview marks the light- and dark-mode stops used by Badge tokens.'}
       </p>
       {colors.map(
         ({name, sourceHex, semantic, note, tones: overrideTones, dark}) => {
@@ -4439,7 +4439,7 @@ function TonalSection({
                   // Title summarises which tokens snap to this step (max 4
                   // listed to keep the native tooltip readable on dense ramps).
                   const titleLines = [
-                    `${name}, ${mode}-mode tone ${t}: ${hex}`,
+                    `${name}, ${mode}-mode stop ${t}: ${hex}`,
                     ...usages
                       .slice(0, 4)
                       .map(u => `· ${u.name} (\u0394E ${u.deltaE.toFixed(1)})`),
@@ -4492,8 +4492,8 @@ function TonalSection({
           fontFamily: MONO,
         }}>
         {usage
-          ? '● = numbered tone consumed by a theme token. Number = count when multiple tokens share the same tone. Hover any cell for details.'
-          : '● = token in use (dark background tone 15 · light text tone 25 · dark text tone 80 · light background tone 90)'}
+          ? '● = numbered stop consumed by a theme token. Number = count when multiple tokens share the same stop. Hover any cell for details.'
+          : '● = token in use (dark background stop 15 · light text stop 25 · dark text stop 80 · light background stop 90)'}
       </p>
     </div>
   );
@@ -4651,7 +4651,7 @@ export function ThemePalettePreview({
   }, [overrideCount, overrideVars, theme]);
 
   // Tonal markers respect pending overrides — every reassignment shows
-  // up as a new marker on the chosen ramp+tone the moment the user
+  // up as a new marker on the chosen ramp+stop the moment the user
   // changes a dropdown. Auto-detected matches still drive markers for
   // tokens that haven't been edited yet.
   const effectiveUsage = useMemo(

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -2712,15 +2712,16 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
     track: supplementalTrack,
     fills: {warning: supplementalWarningFill},
   });
-  const getSupplementalStyle = (variant: (typeof PROGRESS_VARIANTS)[number]) =>
-    ({
-      '--color-background-muted': supplementalTrack,
-      ...(variant === 'warning'
-        ? {
-            '--color-warning': supplementalWarningFill,
-          }
-        : {}),
-    }) as CSSProperties;
+  const getSupplementalStyle = (
+    variant: (typeof PROGRESS_VARIANTS)[number],
+  ): CSSProperties => ({
+    '--color-background-muted': supplementalTrack,
+    ...(variant === 'warning'
+      ? {
+          '--color-warning': supplementalWarningFill,
+        }
+      : {}),
+  });
 
   const trackOptions = [
     {

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -3600,6 +3600,20 @@ function SurfacesSection({mode}: {mode: Mode}) {
           </div>
         ))}
       </div>
+      <p
+        style={{
+          margin: '12px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        These swatches are shown for token and visual-hierarchy review. A static
+        container background or border is decorative when removing it still
+        leaves the grouping clear through spacing, headings, and content, so it
+        does not inherently need 3:1 against the page. If the boundary is
+        required to identify a control, state, or distinct region, it becomes
+        meaningful and must meet its applicable contrast requirement.
+      </p>
     </div>
   );
 }
@@ -3700,6 +3714,20 @@ function ElevationsSection({
           </div>
         ))}
       </div>
+      <p
+        style={{
+          margin: '12px 0 0',
+          color: 'var(--color-text-secondary)',
+          fontSize: 10,
+          lineHeight: 1.5,
+        }}>
+        Elevation is decorative when it only reinforces grouping or visual
+        hierarchy that remains understandable without the shadow. WCAG does not
+        require that optional shadow to reach 3:1. If elevation is the only cue
+        that identifies an interactive target, boundary, or state, it is no
+        longer sufficient by itself; provide a persistent qualifying visual
+        indicator and audit that indicator instead.
+      </p>
     </div>
   );
 }

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -37,6 +37,7 @@ import {
 } from './themePreview/themeAudit';
 import {
   buildOverrideCSSVars,
+  countOverrides,
   overridesReducer,
   type OverridesMap,
   type SerializeContext,
@@ -4565,6 +4566,7 @@ export function ThemePalettePreview({
     overridesReducer,
     emptyOverrides as OverridesMap,
   );
+  const overrideCount = countOverrides(overrides);
 
   // Map of `--token: light-dark(#L, #D)` for every pending override.
   // Spread directly onto the page root so the values cascade into every
@@ -4663,6 +4665,32 @@ export function ThemePalettePreview({
             <div style={S.inner}>
               <h1 style={S.title}>{title}</h1>
               <p style={S.subtitle}>{subtitle}</p>
+              <div
+                role="status"
+                aria-live="polite"
+                style={{
+                  alignItems: 'center',
+                  background: overrideCount
+                    ? 'var(--color-warning-muted)'
+                    : 'var(--color-background-surface)',
+                  border: '1px solid var(--color-border)',
+                  borderRadius: 999,
+                  color: overrideCount
+                    ? 'var(--color-warning)'
+                    : 'var(--color-text-secondary)',
+                  display: 'inline-flex',
+                  fontFamily: 'var(--font-family-code)',
+                  fontSize: 11,
+                  fontWeight: 650,
+                  gap: 6,
+                  marginBottom: 20,
+                  padding: '5px 9px',
+                }}>
+                <span aria-hidden="true">{overrideCount ? '◆' : '●'}</span>
+                {overrideCount
+                  ? `Draft preview · ${overrideCount} pending token ${overrideCount === 1 ? 'override' : 'overrides'}`
+                  : `Built ${theme.name} theme · no pending overrides`}
+              </div>
               {tonalModes.map(m => (
                 <Theme key={m} theme={theme} mode={m}>
                   <LayerProvider>

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -1197,8 +1197,7 @@ function getBadgeContrast(
         ratio: weakest.ratio,
       };
     } catch {
-      // Keep experimental themes renderable when they use CSS color syntax
-      // that this lightweight audit cannot flatten to an sRGB pair.
+      // Keep unsupported color syntax renderable without reporting a ratio.
       return {
         variant,
         name: variant[0].toUpperCase() + variant.slice(1),
@@ -2356,9 +2355,7 @@ function getButtonContrast(theme: DefinedTheme, mode: Mode) {
         }),
       );
     } catch {
-      // Diagnostic themes may intentionally use CSS color functions this
-      // lightweight audit cannot resolve. Keep the preview visible without
-      // claiming a numeric badge result.
+      // Keep unsupported color syntax renderable without reporting a ratio.
       badge = undefined;
     }
 
@@ -3684,16 +3681,7 @@ function SurfacesSection({mode}: {mode: Mode}) {
   );
 }
 
-/**
- * Three shadow levels (low / med / high) rendered as cards over body so
- * the cast shadows have a surface to read against. Each sample is annotated
- * with the components that consume that level — keeps the elevation
- * vocabulary visible alongside the visual treatment.
- *
- * Dark mode swaps the elevated card to `--color-background-surface` (tone 15)
- * so the inset rim used by the figma-style shadow tokens has a slightly
- * lighter base to catch; light mode keeps a white card.
- */
+/** Render each elevation level on the active theme surface. */
 const DEFAULT_SHADOW_DESCRIPTION =
   'Three shadow levels mapped to the components that use them.';
 

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -5,6 +5,7 @@
 import {useMemo, useReducer, type CSSProperties} from 'react';
 
 import {Banner, type BannerStatus} from '@astryxdesign/core/Banner';
+import {ChatComposer} from '@astryxdesign/core/Chat';
 import {Spinner} from '@astryxdesign/core/Spinner';
 import {
   ProgressBar,
@@ -1565,6 +1566,87 @@ function getInputContrast(theme: DefinedTheme, mode: Mode) {
       minimum: Number(minimum),
       note: String(note),
     }));
+  }
+}
+
+function getChatComposerContrast(theme: DefinedTheme, mode: Mode) {
+  try {
+    const parent = resolveToken(theme, '--color-background-body', mode);
+    const background = compositeColor(
+      resolveToken(theme, '--color-background-popover', mode),
+      parent,
+    );
+    const primary = resolveToken(theme, '--color-text-primary', mode);
+    const placeholder = resolveToken(theme, '--color-text-secondary', mode);
+    const warning = resolveToken(theme, '--color-warning', mode);
+    const error = resolveToken(theme, '--color-error', mode);
+    const warningBackground = compositeColor(
+      resolveToken(theme, '--color-warning-muted', mode),
+      parent,
+    );
+    const errorBackground = compositeColor(
+      resolveToken(theme, '--color-error-muted', mode),
+      parent,
+    );
+    const primaryButton = getButtonContrast(theme, mode).find(
+      row => row.name === 'Primary',
+    );
+
+    return [
+      {
+        key: 'composer-value',
+        relationship: 'Composer value text',
+        ratio: contrastRatio(primary, background),
+        minimum: 4.5,
+        note: 'Text',
+      },
+      {
+        key: 'composer-placeholder',
+        relationship: 'Composer placeholder',
+        ratio: contrastRatio(placeholder, background),
+        minimum: 4.5,
+        note: 'Text',
+      },
+      {
+        key: 'composer-send',
+        relationship: 'Composer enabled send icon',
+        ratio: primaryButton?.rest,
+        minimum: 3,
+        note: 'Icon-only control',
+      },
+      {
+        key: 'composer-warning',
+        relationship: 'Composer warning text and icon',
+        ratio: contrastRatio(warning, warningBackground),
+        minimum: 4.5,
+        note: 'Text is the stricter requirement',
+      },
+      {
+        key: 'composer-error',
+        relationship: 'Composer error text and icon',
+        ratio: contrastRatio(error, errorBackground),
+        minimum: 4.5,
+        note: 'Text is the stricter requirement',
+      },
+      {
+        key: 'composer-boundary',
+        relationship: 'Composer body against page',
+        ratio: contrastRatio(background, parent),
+        minimum: 0,
+        note: 'Decorative when visible content identifies the input',
+        exempt: true,
+      },
+      {
+        key: 'composer-focus',
+        relationship: 'Composer keyboard focus — elevated',
+        ratio: undefined,
+        minimum: 3,
+        note: 'Shadow-only change is not a reliable contrast indicator',
+        forceFail: true,
+      },
+    ];
+  } catch {
+    return [];
   }
 }
 
@@ -3966,7 +4048,10 @@ function FieldStatusSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
 }
 
 function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
-  const audit = getInputContrast(theme, mode);
+  const audit = [
+    ...getInputContrast(theme, mode),
+    ...getChatComposerContrast(theme, mode),
+  ];
   const inputExampleStyle: React.CSSProperties = {minWidth: 0};
 
   return (
@@ -4059,6 +4144,24 @@ function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
           statusVariant="tooltip"
         />
       </div>
+      <div style={{...buttonRowLabelStyle, marginTop: 18}}>Chat composer</div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+          gap: 16,
+        }}>
+        <ChatComposer
+          value="Ready to send"
+          onChange={() => {}}
+          onSubmit={() => {}}
+          status={{type: 'warning', message: 'Approaching the token limit'}}
+        />
+        <ChatComposer
+          onSubmit={() => {}}
+          status={{type: 'error', message: 'Message could not be sent'}}
+        />
+      </div>
       <div style={{overflowX: 'auto', marginTop: 14}}>
         <table
           style={{
@@ -4093,8 +4196,13 @@ function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
           </thead>
           <tbody>
             {audit.map(row => {
-              const measured = row.ratio != null;
-              const passes = measured && row.ratio >= row.minimum;
+              const ratio = row.ratio;
+              const measured = ratio != null;
+              const exempt = 'exempt' in row && row.exempt;
+              const forceFail = 'forceFail' in row && row.forceFail;
+              const passes =
+                !forceFail &&
+                (exempt || (ratio != null && ratio >= row.minimum));
               return (
                 <tr key={row.key}>
                   <td style={{padding: '8px'}}>{row.relationship}</td>
@@ -4102,7 +4210,7 @@ function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
                     {row.ratio == null ? '—' : `${row.ratio.toFixed(2)}:1`}
                   </td>
                   <td style={{padding: '8px', textAlign: 'right'}}>
-                    {row.minimum}:1
+                    {exempt ? 'None' : `${row.minimum}:1`}
                   </td>
                   <td style={{padding: '8px'}}>{row.note}</td>
                   <td
@@ -4110,13 +4218,23 @@ function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
                       padding: '8px',
                       textAlign: 'right',
                       color: !measured
-                        ? 'var(--color-text-secondary)'
+                        ? forceFail
+                          ? 'var(--color-error)'
+                          : 'var(--color-text-secondary)'
                         : passes
                           ? 'var(--color-success)'
                           : 'var(--color-error)',
                       fontWeight: 700,
                     }}>
-                    {!measured ? 'Not measured' : passes ? 'Pass' : 'Fail'}
+                    {exempt
+                      ? 'Exempt'
+                      : forceFail
+                        ? 'Needs fix'
+                        : !measured
+                          ? 'Not measured'
+                          : passes
+                            ? 'Pass'
+                            : 'Fail'}
                   </td>
                 </tr>
               );
@@ -4139,6 +4257,10 @@ function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
         rule is WCAG 2.2 AAA, not AA. Spinner tracks and redundant status glyphs
         may be decorative. Disabled controls are exempt from WCAG contrast
         requirements; read-only controls are not and remain at full contrast.
+        The composer shell boundary is optional when its visible content
+        identifies the input. Its elevated keyboard-focus treatment still needs
+        an explicit 3:1 indicator; a shadow-depth change alone is not a reliable
+        AA focus cue.
       </p>
     </div>
   );

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -1578,7 +1578,7 @@ function getChatComposerContrast(theme: DefinedTheme, mode: Mode) {
       parent,
     );
     const primary = resolveToken(theme, '--color-text-primary', mode);
-    const placeholder = resolveToken(theme, '--color-text-secondary', mode);
+    const placeholder = resolveToken(theme, '--color-text-disabled', mode);
     const warning = resolveToken(theme, '--color-warning', mode);
     const error = resolveToken(theme, '--color-error', mode);
     const warningBackground = compositeColor(
@@ -1906,9 +1906,20 @@ function getProgressContrast(
       '--color-background-surface',
       '--color-background-card',
     ].map(token => resolveToken(theme, token, mode));
-    const progressBlock = theme.components?.['progress-bar'] ?? {};
-    const progressFillBlock = theme.components?.['progress-bar-fill'] ?? {};
-    const progressMarkBlock = theme.components?.['progress-bar-mark'] ?? {};
+    const progressBlock =
+      theme.components?.['progress-bar'] ?? theme.components?.progressbar ?? {};
+    const progressTrackBlock =
+      theme.components?.['progress-bar-track'] ??
+      theme.components?.['progressbar-track'] ??
+      {};
+    const progressFillBlock =
+      theme.components?.['progress-bar-fill'] ??
+      theme.components?.['progressbar-fill'] ??
+      {};
+    const progressMarkBlock =
+      theme.components?.['progress-bar-mark'] ??
+      theme.components?.['progressbar-mark'] ??
+      {};
     const primary = resolveToken(theme, '--color-text-primary', mode);
     const secondary = resolveToken(theme, '--color-text-secondary', mode);
     const labels = Math.min(
@@ -1936,13 +1947,20 @@ function getProgressContrast(
       labels,
       rows: PROGRESS_VARIANTS.map(variant => {
         const variantBlock = progressBlock[`variant:${variant}`] ?? {};
+        const trackVariantBlock =
+          progressTrackBlock[`variant:${variant}`] ?? {};
         const fillVariantBlock = progressFillBlock[`variant:${variant}`] ?? {};
         const markFillVariantBlock =
           progressMarkBlock[`variant:${variant}+placement:fill`] ??
           progressMarkBlock[`variant:${variant}`] ??
           {};
         const local = Object.fromEntries(
-          Object.entries({...progressBlock.base, ...variantBlock}).filter(
+          Object.entries({
+            ...progressBlock.base,
+            ...variantBlock,
+            ...progressTrackBlock.base,
+            ...trackVariantBlock,
+          }).filter(
             (entry): entry is [string, string] =>
               entry[0].startsWith('--') && typeof entry[1] === 'string',
           ),
@@ -1963,7 +1981,11 @@ function getProgressContrast(
           overrides?.track ??
           resolveThemeColor(
             theme,
-            'var(--color-background-muted)',
+            String(
+              trackVariantBlock.backgroundColor ??
+                progressTrackBlock.base?.backgroundColor ??
+                'var(--color-background-muted)',
+            ),
             mode,
             local,
           );
@@ -2260,6 +2282,46 @@ function getButtonContrast(theme: DefinedTheme, mode: Mode) {
           );
         }),
       );
+    const stateWorst = (
+      state: ':hover' | ':active',
+      fallbackOverlay: string,
+    ) => {
+      const stateOverride = (override[state] ?? {}) as Record<string, unknown>;
+      const stateLocal = Object.fromEntries(
+        Object.entries({...override, ...stateOverride}).filter(
+          (entry): entry is [string, string] =>
+            entry[0].startsWith('--') && typeof entry[1] === 'string',
+        ),
+      );
+      const stateForeground = resolveThemeColor(
+        theme,
+        String(stateOverride.color ?? foreground),
+        mode,
+        stateLocal,
+      );
+      const stateBackgroundValue = stateOverride.backgroundColor;
+
+      return Math.min(
+        ...surfaces.map(parent => {
+          const base = resolvedBackground(parent);
+          const stateBackground =
+            stateBackgroundValue == null
+              ? compositeColor(fallbackOverlay, base)
+              : String(stateBackgroundValue) === 'transparent'
+                ? base
+                : compositeColor(
+                    resolveThemeColor(
+                      theme,
+                      String(stateBackgroundValue),
+                      mode,
+                      stateLocal,
+                    ),
+                    base,
+                  );
+          return contrastRatio(stateForeground, stateBackground);
+        }),
+      );
+    };
     const spinner = Math.min(
       ...surfaces.map(parent => {
         const base = resolvedBackground(parent);
@@ -2303,8 +2365,8 @@ function getButtonContrast(theme: DefinedTheme, mode: Mode) {
     return {
       name: variant[0].toUpperCase() + variant.slice(1),
       rest: worst(),
-      hover: worst(hover),
-      pressed: worst(pressed),
+      hover: stateWorst(':hover', hover),
+      pressed: stateWorst(':active', pressed),
       spinner,
       badge,
     };
@@ -2657,8 +2719,16 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
     {value: 25, label: 'Quarter'},
     {value: 80, label: 'Goal'},
   ];
-  const progressBlock = theme.components?.['progress-bar'] ?? {};
-  const progressFillBlock = theme.components?.['progress-bar-fill'] ?? {};
+  const progressBlock =
+    theme.components?.['progress-bar'] ?? theme.components?.progressbar ?? {};
+  const progressTrackBlock =
+    theme.components?.['progress-bar-track'] ??
+    theme.components?.['progressbar-track'] ??
+    {};
+  const progressFillBlock =
+    theme.components?.['progress-bar-fill'] ??
+    theme.components?.['progressbar-fill'] ??
+    {};
   const subtleTrack = resolveToken(theme, '--color-background-muted', mode);
   const parentSurface = resolveToken(theme, '--color-background-surface', mode);
   const progressFillDefaults = {
@@ -2669,10 +2739,13 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
     neutral: 'var(--color-text-disabled)',
   } as const;
   const progressOptionRows = PROGRESS_VARIANTS.map((variant, index) => {
+    const trackVariantBlock = progressTrackBlock[`variant:${variant}`] ?? {};
     const local = Object.fromEntries(
       Object.entries({
         ...progressBlock.base,
         ...progressBlock[`variant:${variant}`],
+        ...progressTrackBlock.base,
+        ...trackVariantBlock,
       }).filter(
         (entry): entry is [string, string] =>
           entry[0].startsWith('--') && typeof entry[1] === 'string',
@@ -2698,7 +2771,11 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
       ),
       currentTrack: resolveThemeColor(
         theme,
-        'var(--color-background-muted)',
+        String(
+          trackVariantBlock.backgroundColor ??
+            progressTrackBlock.base?.backgroundColor ??
+            'var(--color-background-muted)',
+        ),
         mode,
         local,
       ),
@@ -4166,7 +4243,8 @@ function InputSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+          gridTemplateColumns:
+            'repeat(auto-fit, minmax(min(100%, 280px), 1fr))',
           gap: 16,
         }}>
         <ChatComposer
@@ -4570,6 +4648,18 @@ export function ThemePalettePreview({
     () => buildOverrideCSSVars(overrides, serializeCtx),
     [overrides, serializeCtx],
   );
+  const effectiveTheme = useMemo<DefinedTheme>(() => {
+    if (overrideCount === 0) {
+      return theme;
+    }
+    return {
+      ...theme,
+      tokens: {
+        ...theme.tokens,
+        ...(overrideVars as Record<string, string>),
+      },
+    };
+  }, [overrideCount, overrideVars, theme]);
 
   // Tonal markers respect pending overrides — every reassignment shows
   // up as a new marker on the chosen ramp+tone the moment the user
@@ -4584,7 +4674,7 @@ export function ThemePalettePreview({
     if (singleMode) {
       return (
         <ModeColumn
-          theme={theme}
+          theme={effectiveTheme}
           mode={singleMode}
           coreSwatches={coreSwatches}
           extraSections={extraSections}
@@ -4598,7 +4688,7 @@ export function ThemePalettePreview({
     return (
       <>
         <ModeColumn
-          theme={theme}
+          theme={effectiveTheme}
           mode="light"
           coreSwatches={coreSwatches}
           extraSections={extraSections}
@@ -4607,7 +4697,7 @@ export function ThemePalettePreview({
           overrideVars={overrideVars}
         />
         <ModeColumn
-          theme={theme}
+          theme={effectiveTheme}
           mode="dark"
           coreSwatches={coreSwatches}
           extraSections={extraSections}
@@ -4640,7 +4730,7 @@ export function ThemePalettePreview({
           CSS vars live here so they cascade into every preview component
           (page background, tonal block, mode columns) but NOT into the
           audit drawer rendered in its own theme below. */}
-      <Theme theme={theme} mode={chromeMode}>
+      <Theme theme={effectiveTheme} mode={chromeMode}>
         <LayerProvider>
           <div
             style={{
@@ -4680,7 +4770,7 @@ export function ThemePalettePreview({
                   : `Built ${theme.name} theme · no pending overrides`}
               </div>
               {tonalModes.map(m => (
-                <Theme key={m} theme={theme} mode={m}>
+                <Theme key={m} theme={effectiveTheme} mode={m}>
                   <LayerProvider>
                     {/* Spread overrideVars *inside* the inner Theme so
                       pending overrides win over the theme's own

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -201,9 +201,9 @@ function tonalPalette(hue: number, chroma: number): Record<number, string> {
  * Two transforms vs the canonical light ramp:
  *
  *   1. Tone lift: every stop shifts up by +5 tone units so mid-tones land
- *      brighter against the dark canvas. The lift tapers off between T80
- *      and T95 and is zero at T95+ so the top of the ramp doesn't collapse
- *      into pure white.
+ *      brighter against the dark canvas. The lift tapers off between tone 80
+ *      and tone 95 and is zero at tone 95+ so the top of the ramp does not
+ *      collapse into pure white.
  *
  *   2. Chroma reduction: chroma multiplied by 0.85 across the whole ramp
  *      so saturated stops don't vibrate against the dark body — full
@@ -3690,7 +3690,7 @@ function SurfacesSection({mode}: {mode: Mode}) {
  * with the components that consume that level — keeps the elevation
  * vocabulary visible alongside the visual treatment.
  *
- * Dark mode swaps the elevated card to `--color-background-surface` (T15)
+ * Dark mode swaps the elevated card to `--color-background-surface` (tone 15)
  * so the inset rim used by the figma-style shadow tokens has a slightly
  * lighter base to catch; light mode keeps a white card.
  */
@@ -4393,20 +4393,21 @@ function TonalSection({
           margin: 0,
           marginBottom: 20,
         }}>
-        Full HCT tonal ramps: 21 perceptually uniform steps from black (T0) to
-        white (T100).
+        Full HCT tonal ramps: 21 perceptually uniform tones from black (tone 0)
+        to white (tone 100). The number keeps the same lightness meaning in both
+        modes.
         {isDark && (
           <>
             {' '}
             Dark mode applies the audit&apos;s &sect;4 transform (
-            <strong>+5 brightness</strong> with taper above T80,{' '}
+            <strong>+5 brightness</strong> with taper above tone 80,{' '}
             <strong>×0.85 chroma</strong>) so saturated stops don&apos;t vibrate
             against the dark canvas.
           </>
         )}{' '}
         {usage
-          ? 'Markers ● show tone steps consumed by theme tokens (open the audit drawer for the full report).'
-          : 'Badge tokens use T90/T30 (light) and T70/T15 (dark).'}
+          ? 'Markers ● show numbered tones consumed by theme tokens (open the audit drawer for the full report).'
+          : 'The default preview marks the light- and dark-mode tones used by Badge tokens.'}
       </p>
       {colors.map(
         ({name, sourceHex, semantic, note, tones: overrideTones, dark}) => {
@@ -4450,7 +4451,7 @@ function TonalSection({
                   // Title summarises which tokens snap to this step (max 4
                   // listed to keep the native tooltip readable on dense ramps).
                   const titleLines = [
-                    `${name} T${t}: ${hex}`,
+                    `${name}, ${mode}-mode tone ${t}: ${hex}`,
                     ...usages
                       .slice(0, 4)
                       .map(u => `· ${u.name} (\u0394E ${u.deltaE.toFixed(1)})`),
@@ -4503,8 +4504,8 @@ function TonalSection({
           fontFamily: MONO,
         }}>
         {usage
-          ? '● = tone step consumed by a theme token. Number = count when multiple tokens share the same step. Hover any cell for details.'
-          : '● = token in use (T15 dark bg · T25 light text · T80 dark text · T90 light bg)'}
+          ? '● = numbered tone consumed by a theme token. Number = count when multiple tokens share the same tone. Hover any cell for details.'
+          : '● = token in use (dark background tone 15 · light text tone 25 · dark text tone 80 · light background tone 90)'}
       </p>
     </div>
   );

--- a/apps/sandbox/src/components/ThemePalettePreview.tsx
+++ b/apps/sandbox/src/components/ThemePalettePreview.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import {useMemo, useReducer, type CSSProperties} from 'react';
+import {useCallback, useMemo, useReducer, type CSSProperties} from "react";
 
 import {Banner, type BannerStatus} from '@astryxdesign/core/Banner';
 import {ChatComposer} from '@astryxdesign/core/Chat';
@@ -2707,32 +2707,22 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
   const standaloneTrack =
     progressOptionRows.find(row => row.variant === 'accent')?.currentTrack ??
     subtleTrack;
-  const supplementalTrack = mode === 'light' ? '#e2e2e2' : standaloneTrack;
-  const supplementalWarningFill = mode === 'light' ? '#f6d168' : '#f1d27c';
+  const supplementalTrack = standaloneTrack;
+  const supplementalWarningFill =
+    progressOptionRows.find(row => row.variant === 'warning')?.fill ??
+    resolveToken(theme, '--color-warning', mode);
   const audit = getProgressContrast(theme, mode, {
     track: supplementalTrack,
     fills: {warning: supplementalWarningFill},
   });
-  const getSupplementalStyle = (
-    variant: (typeof PROGRESS_VARIANTS)[number],
-  ): CSSProperties => ({
-    '--color-background-muted': supplementalTrack,
-    ...(variant === 'warning'
-      ? {
-          '--color-warning': supplementalWarningFill,
-        }
-      : {}),
-  });
-
   const trackOptions = [
     {
       name: 'Standalone',
       precedent: 'Default · the graphic carries the progress information',
       description:
-        'Every variant uses the same neutral track and a 3:1 endpoint marker. Light-mode warning moves to the closest darker yellow palette stop that clears 3:1.',
+        'Uses this theme’s resolved ProgressBar fill and track colors. The reported ratios show whether a standalone graphic needs additional treatment.',
       getTrack: (_row: (typeof progressOptionRows)[number]) => standaloneTrack,
-      getFill: (row: (typeof progressOptionRows)[number]) =>
-        row.variant === 'warning' && mode === 'light' ? '#927300' : row.fill,
+      getFill: (row: (typeof progressOptionRows)[number]) => row.fill,
       showValue: false,
       hasEndpointGap: false,
       hasEndMarker: true,
@@ -2741,7 +2731,7 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
       name: 'Supplemental',
       precedent: 'Explicit opt-in · an equivalent visible value is nearby',
       description:
-        'Every fill retains its semantic Badge color. Light mode uses the quieter muted track; dark mode keeps the original neutral track. The nearby value carries the precise progress information.',
+        'Uses this theme’s resolved semantic fills and neutral track. The nearby value carries the precise progress information.',
       getTrack: (_row: (typeof progressOptionRows)[number]) =>
         supplementalTrack,
       getFill: (row: (typeof progressOptionRows)[number]) =>
@@ -2764,14 +2754,12 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
             variant={variant}
             hasValueLabel
             marks={marks}
-            style={getSupplementalStyle(variant)}
           />
         ))}
         <ProgressBar
           isIndeterminate
           label="Indeterminate progress"
           variant="accent"
-          style={getSupplementalStyle('accent')}
         />
         <ProgressBar
           value={60}
@@ -2779,7 +2767,6 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
           variant="neutral"
           hasValueLabel
           isDisabled
-          style={getSupplementalStyle('neutral')}
         />
       </VStack>
       <div style={{...buttonRowLabelStyle, marginTop: 18}}>
@@ -2881,7 +2868,8 @@ function ProgressBarSection({theme, mode}: {theme: DefinedTheme; mode: Mode}) {
                     <div
                       style={{
                         marginTop: 3,
-                        color: 'var(--color-text-tertiary)',
+                        color:
+                          'var(--color-text-tertiary, var(--color-text-secondary))',
                         fontSize: 9,
                         fontVariantNumeric: 'tabular-nums',
                       }}>


### PR DESCRIPTION
## Summary

- Render Neutral's reviewed light and dark palette from the committed authoring artifact in #5987.
- Show exact family, mode, and tone labels for palette review.
- Audit resolved theme-token usage and contrast against representative components.
- Group component previews and document WCAG requirements and decorative exceptions.

## Source of truth

The Sandbox imports Neutral's committed palette artifact directly. It does not regenerate colors and does not require the full palette to be attached to the production `neutralTheme` runtime object.

The tonal strips therefore match #5987 exactly, while the component previews render the built Neutral theme and the token mappings proposed in #6034.

## Scope

This PR is the review and audit layer only. The generator lives in #5992, the approved Neutral palette lives in #5987, and the runtime token mappings live in #6034.

## Stack

#5992 -> #5987 -> #6034 -> this PR

## Verification

- Core, Lab, and theme dependency builds pass.
- Sandbox generated artifacts are current.
- Sandbox TypeScript passes.
- Formatting, linting, and repository checks pass.
