### PR TITLE
Redirect /home to the Astryx homepage

### DIFF
--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -6,6 +6,9 @@ import {resolve} from 'node:path';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   cacheComponents: true,
+  async redirects() {
+    return [{source: '/home', destination: '/', permanent: true}];
+  },
   // A dynamic route segment can't carry a static extension, so the public
   // plaintext URL /blog/<slug>.txt is served by the /blog/txt/[slug] handler.
   async rewrites() {


### PR DESCRIPTION
## Summary
- add a permanent docsite redirect from `/home` to `/`
- keep the redirect on the canonical Astryx origin

## Test plan
- imported `apps/docsite/next.config.mjs` and asserted the configured redirect
- `git diff --check`