### PR TITLE
fix(storybook): avoid clipping DateTimeInput placeholder

### DIFF
--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -341,7 +341,7 @@ export const SizeVariants: Story = {
           label="Medium (32px)"
           value={md}
           onChange={setMd}
-          placeholder="Medium size (default)"
+          placeholder="Medium size"
           size="md"
         />
         <DateTimeInput


### PR DESCRIPTION
## Summary

- shorten the medium DateTimeInput Size Variants placeholder so it fits after the responsive segment-width correction from #5609
- avoid clipping in Matcha and Y2K, light and dark, without changing component behavior

## Test plan

- built Storybook locally
- audited all 22 DateTimeInput stories for geometry, overflow, and runtime errors
- audited Size Variants and All Variations across seven themes in light and dark (28 frames); no clipped input text or overflow
