### PR TITLE
Use semantic icons for status indicators

### DIFF
--- a/.changeset/theme-status-icons.md
+++ b/.changeset/theme-status-icons.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Route table-row outcomes and completed or failed tool calls through the theme's semantic icon registry.
+
+@ernestt

--- a/packages/cli/assets/templates/blocks/components/Table/TableRowStatusTable.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Table/TableRowStatusTable.doc.mjs
@@ -4,10 +4,10 @@
 export const doc = {
   type: 'block',
   exampleFor: 'useTableRowStatus',
-  name: 'useTableRowStatus - Status Dots',
-  displayName: 'useTableRowStatus - Status Dots',
+  name: 'useTableRowStatus - Status Icons',
+  displayName: 'useTableRowStatus - Status Icons',
   description:
-    'A job table using useTableRowStatus to render a colored status dot (or icon) per row (failed / running / queued). Rows with no status show no dot.',
+    'A job table using useTableRowStatus. Semantic outcomes use the themed success, warning, and error icons; a palette-only queued state keeps the neutral dot.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Table'],

--- a/packages/cli/assets/templates/blocks/components/Table/TableRowStatusTable.tsx
+++ b/packages/cli/assets/templates/blocks/components/Table/TableRowStatusTable.tsx
@@ -34,13 +34,13 @@ const columns: TableColumn<Job>[] = [
 function jobStatus(job: Job): TableRowStatus | null {
   switch (job.state) {
     case 'failed':
-      return {color: 'error', icon: 'error', label: 'Failed'};
+      return {color: 'error', label: 'Failed'};
     case 'running':
-      return {color: 'warning', icon: 'warning', label: 'Running'};
+      return {color: 'warning', label: 'Running'};
     case 'queued':
       return {color: 'gray', label: 'Queued'};
-    default:
-      return null; // succeeded: no dot
+    case 'succeeded':
+      return {color: 'success', label: 'Succeeded'};
   }
 }
 

--- a/packages/core/src/Chat/ChatToolCalls.doc.mjs
+++ b/packages/core/src/Chat/ChatToolCalls.doc.mjs
@@ -23,7 +23,7 @@ export const docs = {
       {guidance: false, description: "Don't use custom wrappers around individual calls; the component handles single vs. grouped layout automatically based on the array length."},
     ],
     anatomy: [
-      {name: 'Status icon', required: true, description: 'A colored circle with a check, cross, or spinner indicating whether the call is pending, running, complete, or errored.'},
+      {name: 'Status icon', required: true, description: 'A themed semantic success/error icon, or a spinner while the call is pending or running.'},
       {name: 'Tool name', required: true, description: 'The function or tool name displayed in monospace: bash, edit, read, web_search, etc.'},
       {name: 'Node badge', required: false, description: 'A neutral pill badge showing which sandbox or environment ran the tool, like cli:remote-server or workspace.'},
       {name: 'Target label', required: false, description: 'The target of the action (a file path, command, or search query) shown after the tool name.'},

--- a/packages/core/src/Chat/ChatToolCalls.test.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.test.tsx
@@ -1,7 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {render, screen, fireEvent} from '@testing-library/react';
 import {describe, it, expect} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {Theme} from '../theme/Theme';
+import {defineTheme} from '../theme/defineTheme';
 import {ChatToolCalls} from './ChatToolCalls';
 
 describe('ChatToolCalls', () => {
@@ -20,6 +22,36 @@ describe('ChatToolCalls', () => {
     expect(screen.getByText('1.2s')).toBeInTheDocument();
     // No group header / expand button for single call
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('resolves complete and error marks through the themed semantic icon registry', () => {
+    const theme = defineTheme({
+      name: 'chat-tool-call-semantic-icons',
+      icons: {
+        success: <svg data-testid="themed-success" />,
+        error: <svg data-testid="themed-error" />,
+      },
+    });
+
+    render(
+      <Theme theme={theme}>
+        <ChatToolCalls
+          defaultIsExpanded
+          calls={[
+            {key: 'done', name: 'read', status: 'complete'},
+            {
+              key: 'failed',
+              name: 'bash',
+              status: 'error',
+              errorMessage: 'Command failed',
+            },
+          ]}
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByTestId('themed-success')).toBeInTheDocument();
+    expect(screen.getByTestId('themed-error')).toBeInTheDocument();
   });
 
   it('renders latest call as surface for multiple calls', () => {

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file ChatToolCalls.tsx
- * @input Uses React, StyleX, theme tokens
+ * @input Uses React, StyleX, semantic icon registry, theme tokens
  * @output Exports ChatToolCalls component
  * @position Chat component — displays tool/function call invocations
  *
@@ -224,17 +224,6 @@ const styles = stylex.create({
     height: '16px',
     borderRadius: radiusVars['--radius-full'],
   },
-  statusIconCircle: {
-    position: 'absolute',
-    inset: 0,
-    borderRadius: 'inherit',
-    backgroundColor: 'currentColor',
-    opacity: 0.15,
-  },
-  statusIconInner: {
-    position: 'relative',
-    display: 'inline-flex',
-  },
   callName: {
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
@@ -351,8 +340,8 @@ const styles = stylex.create({
 const STATUS_ICON_NAMES: Record<ChatToolCallStatus, IconName | null> = {
   pending: 'clock',
   running: null,
-  complete: 'check',
-  error: 'close',
+  complete: 'success',
+  error: 'error',
 };
 
 const STATUS_STYLES: Record<
@@ -421,16 +410,11 @@ function CallRow({call}: {call: ChatToolCallItem}) {
         ) : status === 'pending' ? (
           <Spinner size="sm" shade="subtle" />
         ) : (
-          <>
-            <span {...stylex.props(styles.statusIconCircle)} />
-            <span {...stylex.props(styles.statusIconInner)}>
-              <Icon
-                icon={STATUS_ICON_NAMES[status] ?? 'check'}
-                size="xsm"
-                color="inherit"
-              />
-            </span>
-          </>
+          <Icon
+            icon={STATUS_ICON_NAMES[status] ?? 'success'}
+            size="xsm"
+            color="inherit"
+          />
         )}
         {status === 'error' && call.errorMessage != null && (
           // The title attribute above is hover-only; expose the error detail
@@ -624,16 +608,11 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
               ) : latestStatus === 'pending' ? (
                 <Spinner size="sm" shade="subtle" />
               ) : (
-                <>
-                  <span {...stylex.props(styles.statusIconCircle)} />
-                  <span {...stylex.props(styles.statusIconInner)}>
-                    <Icon
-                      icon={STATUS_ICON_NAMES[latestStatus] ?? 'check'}
-                      size="xsm"
-                      color="inherit"
-                    />
-                  </span>
-                </>
+                <Icon
+                  icon={STATUS_ICON_NAMES[latestStatus] ?? 'success'}
+                  size="xsm"
+                  color="inherit"
+                />
               )}
             </span>
             <span {...stylex.props(styles.callName)}>{latestCall.name}</span>

--- a/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx
+++ b/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx
@@ -2,6 +2,8 @@
 
 import {describe, it, expect} from 'vitest';
 import {render, screen, within} from '@testing-library/react';
+import {Theme} from '../../../theme/Theme';
+import {defineTheme} from '../../../theme/defineTheme';
 import {Table} from '../../Table';
 import type {TableColumn} from '../../types';
 import {useTableRowStatus, type TableRowStatus} from './useTableRowStatus';
@@ -22,10 +24,10 @@ const columns: TableColumn<Row>[] = [{key: 'name', header: 'Name'}];
 
 function getStatus(item: Row): TableRowStatus | null {
   if (item.state === 'error') {
-    return {color: 'red', label: 'Error'};
+    return {color: 'error', label: 'Error'};
   }
   if (item.state === 'warning') {
-    return {color: 'orange', label: 'Warning'};
+    return {color: 'warning', label: 'Warning'};
   }
   return null;
 }
@@ -58,17 +60,42 @@ describe('useTableRowStatus', () => {
     expect(hiddenText.className).not.toBe('');
   });
 
-  it('renders a labeled dot for rows with a status', () => {
-    render(<Harness />);
-    expect(screen.getByRole('img', {name: 'Error'})).toBeInTheDocument();
-    expect(screen.getByRole('img', {name: 'Warning'})).toBeInTheDocument();
+  it('renders themed semantic icons by default', () => {
+    const theme = defineTheme({
+      name: 'table-row-status-semantic-icons',
+      icons: {
+        error: <svg data-testid="themed-error" />,
+        warning: <svg data-testid="themed-warning" />,
+      },
+    });
+
+    render(
+      <Theme theme={theme}>
+        <Harness />
+      </Theme>,
+    );
+
+    expect(screen.getByRole('img', {name: 'Error'})).toContainElement(
+      screen.getByTestId('themed-error'),
+    );
+    expect(screen.getByRole('img', {name: 'Warning'})).toContainElement(
+      screen.getByTestId('themed-warning'),
+    );
   });
 
-  it('renders a dot (not an icon) by default', () => {
-    render(<Harness />);
-    // Default (no icon) renders a plain colored dot: no svg in the indicator.
-    const dot = screen.getByRole('img', {name: 'Error'});
-    expect(dot.querySelector('svg')).toBeNull();
+  it('keeps a dot for palette colors without outcome semantics', () => {
+    render(
+      <Harness
+        statusFn={item =>
+          item.state === 'error' ? {color: 'red', label: 'Red'} : null
+        }
+      />,
+    );
+    const indicator = screen.getByRole('img', {name: 'Red'});
+    expect(indicator.querySelector('svg')).toBeNull();
+    expect(indicator.querySelector('span')?.getAttribute('style')).toContain(
+      '--color-icon-red',
+    );
   });
 
   it('renders no indicator for rows returning null', () => {
@@ -78,15 +105,6 @@ describe('useTableRowStatus', () => {
     const bob = rows[2];
     expect(within(bob).getByText('Bob')).toBeInTheDocument();
     expect(within(bob).queryByRole('img')).not.toBeInTheDocument();
-  });
-
-  it('maps a semantic color name to its icon color token', () => {
-    render(<Harness />);
-    const errorDot = screen.getByRole('img', {name: 'Error'});
-    // 'red' resolves to var(--color-icon-red); StyleX emits it on the inline
-    // style of the inner dot element.
-    const dot = errorDot.querySelector('span');
-    expect(dot?.getAttribute('style')).toContain('--color-icon-red');
   });
 
   it('passes through a raw CSS color as an escape hatch', () => {

--- a/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx
+++ b/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx
@@ -64,18 +64,33 @@ const ICON_COLOR_BY_STATUS: Record<TableRowStatusColor, IconColor> = {
 };
 
 /**
- * A row's status indicator. `color` accepts a semantic status color
- * (mapped to a theme token) or any raw CSS color string as an escape hatch.
- * By default the plugin renders a colored status dot. Provide `icon` to signal
- * status by shape as well as color, which is more accessible when several
- * statuses coexist. `label` is required so the status is never conveyed by
- * color alone — it names the indicator for assistive technology and shows on
- * hover. Return `null` for rows with no status.
+ * Semantic statuses resolve through the theme-aware icon registry by default, so
+ * a theme owns both their shape and color. Palette colors and raw CSS values do
+ * not carry outcome semantics, so they retain the neutral dot unless the caller
+ * provides an explicit icon.
+ */
+const DEFAULT_ICON_BY_STATUS: Partial<Record<TableRowStatusColor, IconName>> = {
+  success: 'success',
+  error: 'error',
+  warning: 'warning',
+};
+
+/**
+ * A row's status indicator. Semantic status colors (`success`, `warning`,
+ * `error`) resolve to the matching themed semantic icon by default. Palette
+ * colors and raw CSS values retain the neutral dot because color alone cannot
+ * establish an outcome glyph. Provide `icon` to override either default.
+ * `label` is required so the status is never conveyed by color alone — it names
+ * the indicator for assistive technology and shows on hover. Return `null` for
+ * rows with no status.
  */
 export interface TableRowStatus {
   /** Semantic status color (preferred) or a raw CSS color string. */
   color: TableRowStatusColor | (string & {});
-  /** Optional icon rendered as the signifier instead of the dot (shape as an a11y differentiator). */
+  /**
+   * Optional icon override. Semantic status colors use their matching themed
+   * icon by default; palette/raw colors use a dot.
+   */
   icon?: IconName;
   /**
    * Accessible name for the status, announced to assistive technology and
@@ -127,8 +142,8 @@ const styles = stylex.create({
 
 /**
  * Returns a {@link TablePlugin} that prepends a narrow column signaling per-row
- * status: a colored status dot by default, or an icon when `icon` is provided
- * (shape + color is more accessible than color alone).
+ * status: a themed semantic icon for `success`, `warning`, and `error`; a
+ * colored dot for palette/raw colors; or an explicit icon override.
  *
  * @example
  * ```
@@ -166,9 +181,12 @@ export function useTableRowStatus<T extends Record<string, unknown>>(
             if (!status) {
               return null;
             }
-            const signifier = status.icon ? (
+            const icon =
+              status.icon ??
+              DEFAULT_ICON_BY_STATUS[status.color as TableRowStatusColor];
+            const signifier = icon ? (
               <Icon
-                icon={status.icon}
+                icon={icon}
                 size="xsm"
                 color={
                   ICON_COLOR_BY_STATUS[status.color as TableRowStatusColor] ??

--- a/packages/core/src/Table/useTableRowStatus.doc.mjs
+++ b/packages/core/src/Table/useTableRowStatus.doc.mjs
@@ -13,7 +13,7 @@ export const docs = {
       name: 'getStatus',
       type: "(item: T) => { color: 'accent' | 'success' | 'error' | 'warning' | 'red' | 'orange' | 'green' | 'yellow' | 'blue' | 'gray' | string; icon?: IconName; label: string } | null",
       description:
-        'Derive the status indicator for a row: a semantic color (success, error, warning) uses its matching themed semantic icon by default; accent, palette colors (red, orange, green, yellow, blue, gray), and raw CSS use a dot unless icon overrides the signifier. label is required and is announced via role="img" and shown in a tooltip. Return null for rows with no status. Memoize with useCallback for a stable plugin identity.',
+        'Derive the status indicator for a row: a semantic color (success, error, warning) uses its matching themed semantic icon by default; accent, palette colors (red, orange, green, yellow, blue, gray), and raw CSS use a dot unless icon overrides the signifier. Valid icon names: close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone. label is required and is announced via role="img" and shown in a tooltip. Return null for rows with no status. Memoize with useCallback for a stable plugin identity.',
       required: true,
     },
   ],

--- a/packages/core/src/Table/useTableRowStatus.doc.mjs
+++ b/packages/core/src/Table/useTableRowStatus.doc.mjs
@@ -7,13 +7,13 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableRowStatus',
   description:
-    'Hook that returns a TablePlugin which prepends a narrow column signaling per-row status: a colored status dot by default, or an icon when provided (shape + color is more accessible than color alone). getStatus maps a row to a semantic color (mapped to a theme token) or raw CSS color, an optional icon, and a required accessible label (shown in a tooltip on hover and announced to assistive technology, so status is never color-only); return null for no indicator. The column header is visually blank but carries a screen-reader-only localized name ("Row status", i18n key @astryx.table.rowStatus.columnHeader). Memoize getStatus with useCallback for a stable plugin identity.',
+    'Hook that returns a TablePlugin which prepends a narrow column signaling per-row status. Semantic status colors (success, warning, error) use the matching themed semantic icon by default; palette colors and raw CSS values use a colored dot because they do not establish an outcome glyph. getStatus may override either default with an explicit icon and must provide an accessible label (shown in a tooltip on hover and announced to assistive technology, so status is never color-only); return null for no indicator. The column header is visually blank but carries a screen-reader-only localized name ("Row status", i18n key @astryx.table.rowStatus.columnHeader). Memoize getStatus with useCallback for a stable plugin identity.',
   props: [
     {
       name: 'getStatus',
       type: "(item: T) => { color: 'accent' | 'success' | 'error' | 'warning' | 'red' | 'orange' | 'green' | 'yellow' | 'blue' | 'gray' | string; icon?: IconName; label: string } | null",
       description:
-        'Derive the status indicator for a row: a semantic color (accent, success, error, warning, red, orange, green, yellow, blue, gray, each mapped to a theme token) or a raw CSS color as an escape hatch; an optional icon to signal status by shape instead of the dot (recommended when multiple statuses coexist; valid names: close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone); and a required accessible label (announced via role="img" and shown in a tooltip on hover, so a status is never conveyed by color alone). Return null for rows with no status. Memoize with useCallback for a stable plugin identity.',
+        'Derive the status indicator for a row: a semantic color (success, error, warning) uses its matching themed semantic icon by default; accent, palette colors (red, orange, green, yellow, blue, gray), and raw CSS use a dot unless icon overrides the signifier. label is required and is announced via role="img" and shown in a tooltip. Return null for rows with no status. Memoize with useCallback for a stable plugin identity.',
       required: true,
     },
   ],
@@ -22,9 +22,9 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   description:
-    'Returns a TablePlugin that prepends a narrow per-row status column: a colored dot, or an icon when provided (shape + color beats color alone for a11y). getStatus maps a row to {color, icon?, label} or null. color is a semantic name (success/error/warning/etc.) mapped to a theme token, or a raw CSS color. label is required (tooltip + accessible name). Memoize getStatus with useCallback.',
+    'Returns a TablePlugin that prepends a narrow per-row status column. success/error/warning use the matching themed semantic icon by default; palette/raw colors use a dot unless icon overrides the signifier. label is required (tooltip + accessible name). Memoize getStatus with useCallback.',
   propDescriptions: {
     getStatus:
-      'Map a row to {color, icon?, label} or null. color = semantic status name (mapped to a token) or raw CSS; icon = shape signifier (a11y); label = required accessible name (tooltip + role="img"). Memoize with useCallback.',
+      'Map a row to {color, icon?, label} or null. success/error/warning default to their themed semantic icon; palette/raw colors default to a dot; icon overrides either. label is required (tooltip + role="img"). Memoize with useCallback.',
   },
 };


### PR DESCRIPTION
## Summary

- resolve `success`, `warning`, and `error` table-row statuses through the active theme's semantic icon registry by default
- route completed and failed `ChatToolCalls` through the `success` and `error` semantic icons
- retain explicit icon overrides and dot fallback behavior for palette/raw table-row colors
- update the table-row example and component docs

## Visual comparison

The same Neutral-theme Storybook fixture, at the same viewport, before and after the change.

### Before

![Before: table rows use dots and tool calls use generic check/close marks](https://raw.githubusercontent.com/facebook/astryx/ernestt/pr-5671-assets/.github/pr-assets/5671/before.png)

### After

![After: table rows and tool calls use the theme's semantic status icons](https://raw.githubusercontent.com/facebook/astryx/ernestt/pr-5671-assets/.github/pr-assets/5671/after.png)

## Test plan

- `pnpm exec vitest run packages/core/src/Chat/ChatToolCalls.test.tsx packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx` (25 passed)
- `pnpm build`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm -F @astryxdesign/core lint` (passes with existing warnings)
- pre-commit repository checks (`check:sync`, package boundaries, changesets, demo media, executable bits, CLI structure, client directives, portable scripts, i18n, CLDR, fixtures)
