### PR TITLE
feat(PowerSearch): add popoverMaxWidth prop

### DIFF
--- a/.changeset/powersearch-popover-max-width.md
+++ b/.changeset/powersearch-popover-max-width.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add `popoverMaxWidth` prop to PowerSearch, allowing consumers to cap the filter-editor popover width while ensuring it never exceeds the anchor width.
+
+@athz

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -132,6 +132,12 @@ export const docs = {
         'Width in pixels for the main field/search menu. Does not affect field value editors.',
     },
     {
+      name: 'popoverMaxWidth',
+      type: 'number',
+      description:
+        'Maximum width in pixels for the filter-editor popover. Clamped to never exceed the anchor width. When omitted the popover stretches to the full anchor width.',
+    },
+    {
       name: 'popoverSaveButtonLabel',
       type: 'string',
       description: 'Label for the save button in the edit popover.',
@@ -174,6 +180,12 @@ export const docs = {
       name: 'menuWidth',
       type: 'number',
       description: 'Maximum width for the operator/value dropdown menu in pixels.',
+    },
+    {
+      name: 'popoverMaxWidth',
+      type: 'number',
+      description:
+        'Maximum width in pixels for the filter-editor popover. Clamped to never exceed the anchor width.',
     },
     {
       name: 'maxOperatorMenuItems',
@@ -356,6 +368,12 @@ export const docsZh = {
       description: '主字段/搜索菜单的像素宽度。不影响字段值编辑器。',
     },
     {
+      name: 'popoverMaxWidth',
+      type: 'number',
+      description:
+        '筛选编辑器弹出层的最大像素宽度。不会超过锚点宽度。未设置时弹出层与锚点同宽。',
+    },
+    {
       name: 'popoverSaveButtonLabel',
       type: 'string',
       description: '编辑弹出窗口中保存按钮的标签。',
@@ -476,6 +494,8 @@ export const docsDense = {
     maxSearchResults:
       'Max ranked results for a non-empty query; excludes value editors.',
     menuWidth: 'Main field/search menu width in pixels.',
+    popoverMaxWidth:
+      'Max width for filter-editor popover in pixels; clamped to anchor width.',
     popoverSaveButtonLabel: 'Label for save button in edit popover.',
     timezoneID: 'Timezone ID for date formatting (e.g. "America/New_York").',
     handleRef:

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -649,6 +649,38 @@ describe('field menu sizing', () => {
       '480px',
     );
   });
+
+  it('applies popoverMaxWidth as a clamped max-width on the editor popover', async () => {
+    const user = userEvent.setup();
+    render(
+      <PowerSearch
+        config={manyFields}
+        filters={[]}
+        onChange={() => {}}
+        popoverMaxWidth={720}
+      />,
+    );
+    // Open the field menu and select a field to open the editor popover
+    await user.click(screen.getByRole('combobox'));
+    await waitFor(() => {
+      expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
+    });
+    const options = screen.getAllByRole('option', {hidden: true});
+    await user.click(options[0]);
+    // The editor popover should have the clamped max-width style
+    await waitFor(() => {
+      const popovers = document.querySelectorAll('[popover]');
+      const editorPopover = Array.from(popovers).find(
+        el =>
+          el.querySelector('[data-testid]') ||
+          el.querySelectorAll('select, button').length > 1,
+      );
+      expect(editorPopover).toBeTruthy();
+      expect((editorPopover as HTMLElement).style.maxWidth).toBe(
+        'min(720px, anchor-size(width))',
+      );
+    });
+  });
 });
 
 describe('field menu grouping', () => {

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -412,6 +412,14 @@ export interface PowerSearchProps extends Omit<
   statusVariant?: FieldStatusVariant;
   /** Max width for dropdown menu. */
   menuWidth?: number;
+  /**
+   * Maximum width (in px) for the filter-editor popover. Clamped to never
+   * exceed the anchor width — so the popover is always
+   * `min(popoverMaxWidth, anchor-size(width))`.
+   *
+   * When omitted the popover stretches to the full anchor width.
+   */
+  popoverMaxWidth?: number;
   /** Max display length for filter token values. @default 40 */
   maxTokenLength?: number;
   /** Max suggestions in string and entity value typeaheads. @default 10 */
@@ -562,6 +570,7 @@ export function PowerSearch({
   status,
   statusVariant = 'attached',
   menuWidth,
+  popoverMaxWidth,
   maxTokenLength = 40,
   maxOperatorMenuItems,
   maxSearchResults = DEFAULT_MAX_SEARCH_RESULTS,
@@ -1095,6 +1104,10 @@ export function PowerSearch({
         alignment: 'start',
         offset: spacingVars['--spacing-1'],
         xstyle: [popoverLayerStyles.layer, layerAnimations.below],
+        style:
+          popoverMaxWidth != null
+            ? {maxWidth: `min(${popoverMaxWidth}px, anchor-size(width))`}
+            : undefined,
       })}
     </>
   );


### PR DESCRIPTION
## Summary

Adds an optional `popoverMaxWidth` prop to `PowerSearch` that caps the filter-editor popover width while ensuring it never exceeds the anchor width.

## Problem

When `PowerSearch` is anchored to a full-width bar (e.g. a page-wide filter bar), the editor popover stretches to match the bar — often 1000px+ — making the 2–3 field form inside it needlessly wide and harder to scan.

There is currently no way for consumers to constrain this: `menuWidth` only affects the field/search dropdown, not the editor popover. The popover layer styles are hardcoded with no prop or CSS variable escape hatch.

## Solution

A single optional prop:

```tsx
<PowerSearch popoverMaxWidth={720} ... />
```

When set, applies `max-width: min(Npx, anchor-size(width))` to the editor popover layer. This means:

- **Narrow anchor** (e.g. 400px): popover = 400px (anchor wins, unchanged)
- **Wide anchor** (e.g. 1400px), maxWidth=720: popover = 720px (cap wins)
- **Prop omitted**: no max-width, current behavior preserved

The `min()` clamp guarantees the popover never exceeds its anchor regardless of the value passed.

## Changes

- `PowerSearch.tsx`: new `popoverMaxWidth` prop, applied as inline `style.maxWidth` on the popover render call
- `PowerSearch.test.tsx`: test verifying the style is applied
- `PowerSearch.doc.mjs`: prop documented in all locale sections