### PR TITLE
fix(Toast): preserve native multitouch and clear swipe state

### DIFF
--- a/.changeset/toast-swipe-regressions.md
+++ b/.changeset/toast-swipe-regressions.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Reset Toast swipe state when a second touch begins so native pinch and two-finger gestures remain available, and clear transient drag styles before a successful swipe dismissal.
+
+@rubyycheung

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -793,6 +793,11 @@ describe('Toast swipe dismissal', () => {
     expect(visualToast.style.getPropertyValue('--_toast-swipe-exit-y')).toBe(
       '120%',
     );
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-y')).toBe('');
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-opacity')).toBe(
+      '',
+    );
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-scale')).toBe('');
     expect(getComputedStyle(visualToast).transform).not.toContain('translateX');
   });
 
@@ -1147,11 +1152,9 @@ describe('Toast swipe dismissal', () => {
 
     expect(onHide).toHaveBeenCalledWith('manual');
     expect(visualToast.style.getPropertyValue('--_toast-swipe-opacity')).toBe(
-      '0.700',
+      '',
     );
-    expect(visualToast.style.getPropertyValue('--_toast-swipe-scale')).toBe(
-      '0.985',
-    );
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-scale')).toBe('');
     expect(visualToast.style.getPropertyValue('--_toast-swipe-exit-y')).toBe(
       'calc(-1 * 120%)',
     );
@@ -1246,6 +1249,41 @@ describe('Toast swipe dismissal', () => {
     expect(visualToast.style.getPropertyValue('--_toast-swipe-opacity')).toBe(
       '',
     );
+  });
+
+  it('abandons a one-finger swipe when a second touch starts', () => {
+    const {visualToast, onHide} = renderSwipeToast();
+    const dispatchTouch = (
+      type: 'touchstart' | 'touchmove',
+      touches: {identifier: number; clientX: number; clientY: number}[],
+      changedTouches = touches,
+    ) => {
+      const event = new Event(type, {bubbles: true, cancelable: true});
+      Object.defineProperty(event, 'touches', {value: touches});
+      Object.defineProperty(event, 'changedTouches', {value: changedTouches});
+      visualToast.dispatchEvent(event);
+      return event;
+    };
+    const first = {identifier: 51, clientX: 10, clientY: 0};
+    const second = {identifier: 52, clientX: 30, clientY: 40};
+
+    act(() => {
+      dispatchTouch('touchstart', [first]);
+      dispatchTouch('touchmove', [{...first, clientY: 40}]);
+    });
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-y')).toBe('40px');
+
+    act(() => {
+      dispatchTouch('touchstart', [first, second], [second]);
+    });
+    const multitouchMove = dispatchTouch('touchmove', [first, second]);
+
+    expect(multitouchMove.defaultPrevented).toBe(false);
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-y')).toBe('');
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-opacity')).toBe(
+      '',
+    );
+    expect(onHide).not.toHaveBeenCalled();
   });
 
   it('removes native touch listeners when a Toast unmounts', () => {

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -1286,6 +1286,82 @@ describe('Toast swipe dismissal', () => {
     expect(onHide).not.toHaveBeenCalled();
   });
 
+  it('does not dismiss when another touch remains outside the Toast', () => {
+    const {visualToast, onHide} = renderSwipeToast();
+    const first = {identifier: 61, clientX: 10, clientY: 0};
+    const second = {identifier: 62, clientX: 200, clientY: 200};
+    const dispatchTouch = (
+      type: 'touchstart' | 'touchmove' | 'touchend',
+      touches: (typeof first)[],
+      changedTouches: (typeof first)[],
+    ) => {
+      const event = new Event(type, {bubbles: true, cancelable: true});
+      Object.defineProperty(event, 'touches', {value: touches});
+      Object.defineProperty(event, 'changedTouches', {value: changedTouches});
+      visualToast.dispatchEvent(event);
+      return event;
+    };
+
+    act(() => {
+      dispatchTouch('touchstart', [first], [first]);
+      dispatchTouch(
+        'touchmove',
+        [{...first, clientY: 60}],
+        [{...first, clientY: 60}],
+      );
+    });
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-y')).toBe('60px');
+
+    // The second contact began outside the Toast, so its touchstart did not
+    // reach the Toast listener. Ending the tracked finger must still cancel
+    // while that other contact remains active.
+    act(() => {
+      dispatchTouch('touchend', [second], [{...first, clientY: 60}]);
+    });
+
+    expect(onHide).not.toHaveBeenCalled();
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-y')).toBe('');
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-opacity')).toBe(
+      '',
+    );
+  });
+
+  it('does not let a pen event with the same numeric ID control a touch gesture', () => {
+    const {visualToast, onHide} = renderSwipeToast();
+    const touch = {identifier: 7, clientX: 10, clientY: 0};
+    const touchStart = new Event('touchstart', {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(touchStart, 'touches', {value: [touch]});
+    Object.defineProperty(touchStart, 'changedTouches', {value: [touch]});
+
+    act(() => {
+      visualToast.dispatchEvent(touchStart);
+      fireEvent.pointerMove(visualToast, {
+        pointerId: 7,
+        pointerType: 'pen',
+        clientX: 10,
+        clientY: 60,
+      });
+      fireEvent.pointerUp(visualToast, {
+        pointerId: 7,
+        pointerType: 'pen',
+        clientX: 10,
+        clientY: 60,
+      });
+    });
+
+    expect(onHide).not.toHaveBeenCalled();
+    expect(visualToast.style.getPropertyValue('--_toast-swipe-y')).toBe('');
+
+    act(() => {
+      visualToast.dispatchEvent(
+        new Event('touchcancel', {bubbles: true, cancelable: true}),
+      );
+    });
+  });
+
   it('removes native touch listeners when a Toast unmounts', () => {
     const {visualToast, unmount} = renderSwipeToast();
     const removeListener = vi.spyOn(visualToast, 'removeEventListener');

--- a/packages/core/src/Toast/useToastGesture.ts
+++ b/packages/core/src/Toast/useToastGesture.ts
@@ -25,12 +25,14 @@ const SWIPE_ACTIVE_SCALE_MAX = 0.02;
 export type ToastGestureDirection = 1 | -1;
 
 interface GesturePoint {
+  source: 'touch' | 'pen';
   pointerId: number;
   clientX: number;
   clientY: number;
 }
 
 interface GestureState {
+  source: GesturePoint['source'];
   pointerId: number;
   startX: number;
   startY: number;
@@ -126,6 +128,7 @@ export function useToastGesture({
       }
       const surfaceSize = Math.max(root.getBoundingClientRect().height, 1);
       gestureRef.current = {
+        source: point.source,
         pointerId: point.pointerId,
         startX: point.clientX,
         startY: point.clientY,
@@ -159,7 +162,12 @@ export function useToastGesture({
     ) => {
       const state = gestureRef.current;
       const root = rootRef.current;
-      if (!state || !root || point.pointerId !== state.pointerId) {
+      if (
+        !state ||
+        !root ||
+        point.source !== state.source ||
+        point.pointerId !== state.pointerId
+      ) {
         return;
       }
       const deltaX = point.clientX - state.startX;
@@ -209,7 +217,12 @@ export function useToastGesture({
     (point: GesturePoint) => {
       const state = gestureRef.current;
       const root = rootRef.current;
-      if (!state || !root || point.pointerId !== state.pointerId) {
+      if (
+        !state ||
+        !root ||
+        point.source !== state.source ||
+        point.pointerId !== state.pointerId
+      ) {
         return;
       }
       const travel = Math.max(
@@ -251,7 +264,15 @@ export function useToastGesture({
       if (
         event.pointerType === 'pen' &&
         (event.button == null || event.button === 0) &&
-        beginGesture(event, event.target)
+        beginGesture(
+          {
+            source: 'pen',
+            pointerId: event.pointerId,
+            clientX: event.clientX,
+            clientY: event.clientY,
+          },
+          event.target,
+        )
       ) {
         rootRef.current?.setPointerCapture?.(event.pointerId);
       }
@@ -265,7 +286,12 @@ export function useToastGesture({
         return;
       }
       moveGesture(
-        event,
+        {
+          source: 'pen',
+          pointerId: event.pointerId,
+          clientX: event.clientX,
+          clientY: event.clientY,
+        },
         () => event.preventDefault(),
         () => rootRef.current?.releasePointerCapture?.(event.pointerId),
       );
@@ -279,7 +305,12 @@ export function useToastGesture({
         return;
       }
       rootRef.current?.releasePointerCapture?.(event.pointerId);
-      endGesture(event);
+      endGesture({
+        source: 'pen',
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+      });
     },
     [endGesture],
   );
@@ -288,6 +319,7 @@ export function useToastGesture({
     (event: ReactPointerEvent<HTMLDivElement>) => {
       if (
         event.pointerType === 'pen' &&
+        gestureRef.current?.source === 'pen' &&
         gestureRef.current?.pointerId === event.pointerId
       ) {
         resetGesture(true);
@@ -302,12 +334,14 @@ export function useToastGesture({
       return;
     }
     const point = (touch: Touch): GesturePoint => ({
+      source: 'touch',
       pointerId: touch.identifier,
       clientX: touch.clientX,
       clientY: touch.clientY,
     });
     const changedTouch = (event: TouchEvent) => {
-      const pointerId = gestureRef.current?.pointerId;
+      const state = gestureRef.current;
+      const pointerId = state?.source === 'touch' ? state.pointerId : null;
       return pointerId == null
         ? undefined
         : [...event.changedTouches].find(
@@ -342,6 +376,10 @@ export function useToastGesture({
       }
     };
     const handleTouchEnd = (event: TouchEvent) => {
+      if (event.touches.length > 0) {
+        resetGesture(true);
+        return;
+      }
       const touch = changedTouch(event);
       if (touch) {
         endGesture(point(touch));

--- a/packages/core/src/Toast/useToastGesture.ts
+++ b/packages/core/src/Toast/useToastGesture.ts
@@ -225,6 +225,10 @@ export function useToastGesture({
       gestureRef.current = null;
       root.style.removeProperty('transition-duration');
       if (isDismissed) {
+        // The exit animation owns the final translation. Clear the live-drag
+        // transform/fade/scale first so a standalone Toast does not remain
+        // partially translated or faded after its dismiss callback fires.
+        clearTransientStyles(root);
         root.style.setProperty(
           '--_toast-swipe-exit-y',
           state.direction === 1
@@ -311,12 +315,23 @@ export function useToastGesture({
           );
     };
     const handleTouchStart = (event: TouchEvent) => {
-      const touch = event.touches.length === 1 ? event.changedTouches[0] : null;
-      if (touch) {
+      if (event.touches?.length !== 1) {
+        // A second contact means the browser may be handling pinch zoom or
+        // two-finger scrolling. Abandon any accepted one-finger swipe before
+        // touchmove can suppress that native gesture.
+        resetGesture(true);
+        return;
+      }
+      const touch = event.changedTouches[0];
+      if (touch != null) {
         beginGesture(point(touch), event.target);
       }
     };
     const handleTouchMove = (event: TouchEvent) => {
+      if (event.touches?.length !== 1) {
+        resetGesture(true);
+        return;
+      }
       const touch = changedTouch(event);
       if (touch) {
         moveGesture(point(touch), () => {


### PR DESCRIPTION
Follow-up to #5375, which merged while the final accessibility review fixes were being verified.

## Why
- A second touch could leave the accepted one-finger swipe active, allowing the subsequent touchmove to suppress native pinch zoom or two-finger scrolling.
- Successful standalone Toast dismissal retained live drag translation, opacity, and scale variables after the dismiss callback.

## Changes
- Cancel and reset the swipe gesture whenever touch count is not exactly one.
- Clear transient drag styles before applying the exit-direction variable.
- Add focused regressions for multitouch cancellation and post-dismiss style cleanup.
- Add a core patch changeset.

## Verification
- ToastViewport focused suite: 56 passed
- Core typecheck: passed