### PR TITLE
chore(i18n): translations update from Crowdin

### DIFF
--- a/packages/core/locales/af-ZA.json
+++ b/packages/core/locales/af-ZA.json
@@ -623,10 +623,6 @@
     "defaultMessage": "Kies 'n datum",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Kies datum",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(maak in nuwe oortjie oop)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/ar-SA.json
+++ b/packages/core/locales/ar-SA.json
@@ -651,10 +651,6 @@
     "defaultMessage": "حدّد تاريخًا",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "اختر التاريخ",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(يُفتح في علامة تبويب جديدة)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/ca-ES.json
+++ b/packages/core/locales/ca-ES.json
@@ -643,10 +643,6 @@
     "defaultMessage": "Selecciona una data",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Tria una data",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(s’obre en una pestanya nova)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/cs-CZ.json
+++ b/packages/core/locales/cs-CZ.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Vyberte datum",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Zvolit datum",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(otevře se na nové kartě)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/da-DK.json
+++ b/packages/core/locales/da-DK.json
@@ -639,10 +639,6 @@
     "defaultMessage": "Vælg en dato",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Vælg dato",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(åbner i ny fane)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/de-DE.json
+++ b/packages/core/locales/de-DE.json
@@ -639,10 +639,6 @@
     "defaultMessage": "Datum auswählen",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Datum auswählen",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(wird in neuem Tab geöffnet)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/el-GR.json
+++ b/packages/core/locales/el-GR.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Επιλέξτε ημερομηνία",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Επιλογή ημερομηνίας",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(ανοίγει σε νέα καρτέλα)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/es-ES.json
+++ b/packages/core/locales/es-ES.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Selecciona una fecha",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Elige una fecha",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(se abre en una pestaña nueva)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/fi-FI.json
+++ b/packages/core/locales/fi-FI.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Valitse päivämäärä",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Valitse päivämäärä",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(avautuu uuteen välilehteen)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/fr-FR.json
+++ b/packages/core/locales/fr-FR.json
@@ -615,10 +615,6 @@
     "defaultMessage": "Sélectionner une date",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Choisir une date",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(ouvre un nouvel onglet)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/he-IL.json
+++ b/packages/core/locales/he-IL.json
@@ -647,10 +647,6 @@
     "defaultMessage": "בחירת תאריך",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "בחירת תאריך",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(נפתח בכרטיסייה חדשה)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/hu-HU.json
+++ b/packages/core/locales/hu-HU.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Válasszon dátumot",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Dátum kiválasztása",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(új lapon nyílik meg)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/it-IT.json
+++ b/packages/core/locales/it-IT.json
@@ -639,10 +639,6 @@
     "defaultMessage": "Seleziona una data",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Scegli una data",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(si apre in una nuova scheda)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/ja-JP.json
+++ b/packages/core/locales/ja-JP.json
@@ -651,10 +651,6 @@
     "defaultMessage": "日付を選択",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "日付を選択",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "（新しいタブで開く）",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/ko-KR.json
+++ b/packages/core/locales/ko-KR.json
@@ -647,10 +647,6 @@
     "defaultMessage": "날짜 선택",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "날짜 선택",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(새 탭에서 열림)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/nl-NL.json
+++ b/packages/core/locales/nl-NL.json
@@ -615,10 +615,6 @@
     "defaultMessage": "Selecteer een datum",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Datum kiezen",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(opent in nieuw tabblad)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/no-NO.json
+++ b/packages/core/locales/no-NO.json
@@ -643,10 +643,6 @@
     "defaultMessage": "Velg en dato",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Velg dato",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(åpnes i ny fane)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/pl-PL.json
+++ b/packages/core/locales/pl-PL.json
@@ -639,10 +639,6 @@
     "defaultMessage": "Wybierz datę",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Wybierz datę",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(otwiera się w nowej karcie)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/pt-BR.json
+++ b/packages/core/locales/pt-BR.json
@@ -643,10 +643,6 @@
     "defaultMessage": "Selecione uma data",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Escolha uma data",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(abre em uma nova guia)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/pt-PT.json
+++ b/packages/core/locales/pt-PT.json
@@ -643,10 +643,6 @@
     "defaultMessage": "Selecione uma data",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Escolha uma data",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(abre num novo separador)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/ro-RO.json
+++ b/packages/core/locales/ro-RO.json
@@ -643,10 +643,6 @@
     "defaultMessage": "Selectează o dată",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Alege data",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(se deschide într-o filă nouă)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/ru-RU.json
+++ b/packages/core/locales/ru-RU.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Выберите дату",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Выбор даты",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(откроется в новой вкладке)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/sr-SP.json
+++ b/packages/core/locales/sr-SP.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Изаберите датум",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Изаберите датум",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(отвара се у новој картици)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/sv-SE.json
+++ b/packages/core/locales/sv-SE.json
@@ -643,10 +643,6 @@
     "defaultMessage": "Välj ett datum",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Välj datum",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(öppnas i ny flik)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/tr-TR.json
+++ b/packages/core/locales/tr-TR.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Bir tarih seçin",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Tarih seçin",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(yeni sekmede açılır)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/uk-UA.json
+++ b/packages/core/locales/uk-UA.json
@@ -647,10 +647,6 @@
     "defaultMessage": "Виберіть дату",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Виберіть дату",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(відкривається в новій вкладці)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/vi-VN.json
+++ b/packages/core/locales/vi-VN.json
@@ -643,10 +643,6 @@
     "defaultMessage": "Chọn ngày",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "Chọn ngày",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "(mở trong tab mới)",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/zh-CN.json
+++ b/packages/core/locales/zh-CN.json
@@ -651,10 +651,6 @@
     "defaultMessage": "选择日期",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "选择日期",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "（在新标签页中打开）",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."

--- a/packages/core/locales/zh-TW.json
+++ b/packages/core/locales/zh-TW.json
@@ -651,10 +651,6 @@
     "defaultMessage": "選擇日期",
     "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
-  "@astryx.dateTimeInput.dialogLabel": {
-    "defaultMessage": "選擇日期",
-    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
-  },
   "@astryx.link.newTab": {
     "defaultMessage": "（在新分頁中開啟）",
     "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."


### PR DESCRIPTION
Automated translations pulled from Crowdin.

Source: https://crowdin.com/project/astryx

Locale JSON has been normalized with `prettier`. Review the diff
for any strings that shifted meaning or formatting, then merge
when ready.