### PR TITLE
docs(templates): recast em dashes in page template descriptions

### DIFF
--- a/packages/cli/assets/templates/pages/ai-chat/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/ai-chat/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'AI Chat Conversation',
   displayName: 'AI Chat Conversation',
-  description: 'Transcript of alternating turns carrying mixed rich content inline — markdown, code blocks, collapsible tool-call output — beside a resizable artifact panel that holds generated output while the stream keeps scrolling. Chat, conversation, assistant, messages, or copilot thread.',
+  description: 'Transcript of alternating turns carrying mixed rich content inline (markdown, code blocks, collapsible tool-call output) beside a resizable artifact panel that holds generated output while the stream keeps scrolling. Chat, conversation, assistant, messages, or copilot thread.',
   isReady: true,
   category: 'AI Chat - Conversation',
 };

--- a/packages/cli/assets/templates/pages/centered-hero/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/centered-hero/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Centered Hero',
   displayName: 'Centered Hero',
-  description: 'Symmetrical centered stack — headline, short blurb, paired call-to-action buttons — resting on one wide full-bleed picture, with nothing on either flank competing. Hero, banner, splash, landing image, or marketing masthead.',
+  description: 'Symmetrical centered stack (headline, short blurb, paired call-to-action buttons) resting on one wide full-bleed picture, with nothing on either flank competing. Hero, banner, splash, landing image, or marketing masthead.',
   isReady: true,
   category: 'Gallery - Hero',
 };

--- a/packages/cli/assets/templates/pages/contact-form/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/contact-form/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Contact Form',
   displayName: 'Contact Form',
-  description: 'Flat single-column form mixing control types — text, pill toggles, dropdowns, long free-text — landing on one full-width submit. No steps, no branching, no summary rail. Contact, lead capture, enquiry, survey, or intake form.',
+  description: 'Flat single-column form mixing control types (text, pill toggles, dropdowns, long free-text) landing on one full-width submit. No steps, no branching, no summary rail. Contact, lead capture, enquiry, survey, or intake form.',
   isReady: true,
   category: 'Form - Basic',
 };

--- a/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Analytics Dashboard',
   displayName: 'Analytics Dashboard',
-  description: 'Three-band analytics: a row of headline tiles, then charts, then supporting tables, all re-reading from one global filter bar. Breadth over depth — a summary surface rather than a drill-down. Dashboard, overview, metrics, stats, analytics, reporting, or insights.',
+  description: 'Three-band analytics: a row of headline tiles, then charts, then supporting tables, all re-reading from one global filter bar. Breadth over depth, a summary surface rather than a drill-down. Dashboard, overview, metrics, stats, analytics, reporting, or insights.',
   isReady: true,
   category: 'Dashboard - Analytics',
   isHiddenFromOverview: true,

--- a/packages/cli/assets/templates/pages/detail-page/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/detail-page/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Order Detail',
   displayName: 'Order Detail',
-  description: 'Single-record detail in two columns: a summary header with status and actions, a repeating line-item list, a totals block that sums it, and a chronological activity timeline in the rail. The shape for any record holding children plus a history — a customer order with shipping, an invoice, a transaction, or a job.',
+  description: 'Single-record detail in two columns: a summary header with status and actions, a repeating line-item list, a totals block that sums it, and a chronological activity timeline in the rail. The shape for any record holding children plus a history: a customer order with shipping, an invoice, a transaction, or a job.',
   isReady: true,
   category: 'Content - Order Detail',
 };

--- a/packages/cli/assets/templates/pages/gallery-hero/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/gallery-hero/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Gallery Hero',
   displayName: 'Gallery Hero',
-  description: 'Centered stack — headline, short blurb, call-to-action buttons — resolving into a multi-image photo grid rather than one wide full-bleed picture, so the imagery reads as a set. Hero, banner, splash, landing image, masthead, or gallery intro.',
+  description: 'Centered stack (headline, short blurb, call-to-action buttons) resolving into a multi-image photo grid rather than one wide full-bleed picture, so the imagery reads as a set. Hero, banner, splash, landing image, masthead, or gallery intro.',
   isReady: true,
   category: 'Gallery - Hero',
 };

--- a/packages/cli/assets/templates/pages/incident-console/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/incident-console/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Incident Console',
   displayName: 'Incident Console',
-  description: 'Dense row queue with an inspector: severity-coded rows grouped by status, a saved-search filter bar, a segmented status control, and a resizable detail pane for the selected row. Rows, not cards — sized for scanning volume. Incident, alert, on-call, outage, ticket, or triage console.',
+  description: 'Dense row queue with an inspector: severity-coded rows grouped by status, a saved-search filter bar, a segmented status control, and a resizable detail pane for the selected row. Rows, not cards, sized for scanning volume. Incident, alert, on-call, outage, ticket, or triage console.',
   isReady: false,
   category: 'Tools - Incident Console',
 };

--- a/packages/cli/assets/templates/pages/login/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/login/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Basic Login',
   displayName: 'Basic Login',
-  description: 'Minimal centered credential form on a plain ground — two fields and a submit, nothing competing for attention. The least-chrome entry surface. Login, sign in, signin, authentication, credentials, or account access.',
+  description: 'Minimal centered credential form on a plain ground: two fields and a submit, nothing competing for attention. The least-chrome entry surface. Login, sign in, signin, authentication, credentials, or account access.',
   isReady: true,
   isHiddenFromOverview: true,
   category: 'Login - Basic',

--- a/packages/cli/assets/templates/pages/messaging-shell/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/messaging-shell/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Messaging Shell',
   displayName: 'Messaging Shell',
-  description: 'Four-column nested navigation narrowing left to right — team workspace, channel list, message stream, thread panel — where each column scopes the next. Dense rows, zero cards. Team messaging, chat, channels, threads, inbox, direct message, or conversation workspace.',
+  description: 'Four-column nested navigation narrowing left to right (team workspace, channel list, message stream, thread panel) where each column scopes the next. Dense rows, zero cards. Team messaging, chat, channels, threads, inbox, direct message, or conversation workspace.',
   isReady: false,
   category: 'Shell - Messaging',
 };

--- a/packages/cli/assets/templates/pages/product-gallery/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/product-gallery/template.doc.mjs
@@ -4,7 +4,7 @@
 export const doc = {
   name: 'Product Gallery',
   displayName: 'Product Gallery',
-  description: 'Uniform card grid where every tile carries media, title, supporting line, and a price. Browse-to-select only — no filtering, no detail surface. Products, catalog, storefront, shop, listings, or ecommerce grid.',
+  description: 'Uniform card grid where every tile carries media, title, supporting line, and a price. Browse-to-select only, with no filtering and no detail surface. Products, catalog, storefront, shop, listings, or ecommerce grid.',
   type: 'page',
   isReady: true,
   category: 'Gallery - Product',

--- a/packages/cli/assets/templates/pages/settings/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/settings/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Settings Form',
   displayName: 'Settings Form',
-  description: 'Preferences as one continuously scrolling form, sections stacked in order with no navigation between them. The simplest settings shape — everything reachable by scrolling. Settings, preferences, configuration, options, or account.',
+  description: 'Preferences as one continuously scrolling form, sections stacked in order with no navigation between them. The simplest settings shape: everything reachable by scrolling. Settings, preferences, configuration, options, or account.',
   isReady: true,
   category: 'Settings - Form',
 };

--- a/packages/cli/assets/templates/pages/table/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table/template.doc.mjs
@@ -5,7 +5,7 @@ export const doc = {
   type: 'page',
   name: 'Simple Table',
   displayName: 'Simple Table',
-  description: 'Flat row collection where columns sort, rows select into a bulk-action toolbar, and each row carries an overflow menu. Sortable but ungrouped, with no detail pane — the baseline shape. Table, list, rows, records, grid, spreadsheet, or roster.',
+  description: 'Flat row collection where columns sort, rows select into a bulk-action toolbar, and each row carries an overflow menu. Sortable but ungrouped, with no detail pane, the baseline shape. Table, list, rows, records, grid, spreadsheet, or roster.',
   isReady: false,
   category: 'Table - Basic',
   isHiddenFromOverview: true,


### PR DESCRIPTION
## What

Recast em dashes in the `description` prose of 12 page templates under `packages/cli/assets/templates/pages/`. Each description used em dashes for appositive asides; they now use parentheses (for the parenthetical list of parts), commas, or a colon (for the list/definition intro). No wording or meaning changed, only the punctuation between clauses.

Files: ai-chat, centered-hero, contact-form, dashboard, detail-page, gallery-hero, incident-console, login, messaging-shell, product-gallery, settings, table.

These strings feed the CLI template list and the doc site, so plain punctuation is the house style (see the Night Watch prose rubric).

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] All 12 files parse-checked as ES modules
- [x] No remaining em/en dashes, curly quotes, or ellipsis chars in the edited files
- [x] Prose strings only; meaning preserved

Night Watch — Doc Reviewer