### PR TITLE
feat(i18n): introduce new design for IntlProvider and useIntl

### DIFF
--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -29,7 +29,7 @@ import {Button, type ButtonVariant} from '../Button';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
-import {useTranslator} from '../i18n';
+import {useIntl} from '../intl';
 import {useMediaQuery} from '../hooks';
 
 const SMALL_SCREEN_QUERY = '(max-width: 640px)';
@@ -157,7 +157,7 @@ export function AlertDialog({
   'data-testid': testId,
   ...rest
 }: AlertDialogProps) {
-  const t = useTranslator();
+  const {t} = useIntl();
   const cancelLabel = cancelLabelFromProps ?? t('@astryx.alertDialog.cancel');
   const titleId = useId();
   const descriptionId = useId();

--- a/packages/core/src/i18n/InternationalizationProvider.tsx
+++ b/packages/core/src/i18n/InternationalizationProvider.tsx
@@ -23,7 +23,8 @@ import {useMemo, type ReactNode} from 'react';
 import {InternationalizationContext} from './InternationalizationContext';
 import {getLocaleDirection} from './getLocaleDirection';
 import type {Locale, MessagesByLocale, Overrides} from './types';
-import {getResolve} from './resolve';
+import {getIntlContextValue, getResolve} from './resolve';
+import {IntlProvider} from '../intl';
 
 export interface InternationalizationProviderProps {
   /**
@@ -95,9 +96,19 @@ export function InternationalizationProvider({
     }),
     [locale, direction, messages, overrides],
   );
+  const {intlMessages, intlOverrides} = useMemo(
+    () => getIntlContextValue(locale, messages ?? {}, overrides),
+    [locale, messages, overrides],
+  );
   return (
     <InternationalizationContext value={value}>
-      {children}
+      <IntlProvider
+        locale={locale}
+        messages={intlMessages}
+        overrides={intlOverrides}
+        dir={dir}>
+        {children}
+      </IntlProvider>
     </InternationalizationContext>
   );
 }

--- a/packages/core/src/i18n/resolve.ts
+++ b/packages/core/src/i18n/resolve.ts
@@ -44,6 +44,23 @@ function getFormatter(message: string, locale: Locale): IntlMessageFormat {
   return f;
 }
 
+export function formatter(
+  message: string,
+  locale: string,
+  values?: Record<string, unknown>,
+) {
+  if (!values) {
+    // Static string — skip the parser entirely for the common case
+    return message;
+  }
+
+  const formatted = getFormatter(message, locale).format(values);
+  // IntlMessageFormat.format returns string | (string | React elements) — we
+  // only ever pass string values so it will be a string; assert for the type
+  // system.
+  return formatted as string;
+}
+
 /**
  * Walk a BCP 47 tag from most-specific to least-specific.
  * Input is canonicalized via `Intl.Locale.baseName` so `pt-br` and `PT-BR`
@@ -105,6 +122,27 @@ function getLookup(
   return lookup;
 }
 
+export function getIntlContextValue(
+  locale: Locale,
+  messages: MessagesByLocale,
+  overrides?: Overrides,
+) {
+  const lookup = getLookup(locale, messages, overrides);
+  const intlMessages: Record<string, unknown> = {};
+  const intlOverrides: Partial<typeof enSource> = {};
+  for (const [key, value] of Object.entries(lookup)) {
+    if (key in enSource) {
+      intlOverrides[key as keyof typeof intlOverrides] = {
+        defaultMessage: value,
+        description: '',
+      };
+    } else {
+      intlMessages[key] = value;
+    }
+  }
+  return {intlMessages, intlOverrides};
+}
+
 export function getResolve(
   locale: Locale,
   messages: MessagesByLocale,
@@ -126,17 +164,7 @@ export function getResolve(
       );
       return key;
     }
-
-    if (values === undefined) {
-      // Static string — skip the parser entirely for the common case
-      return result;
-    }
-
-    const formatted = getFormatter(result, locale).format(values);
-    // IntlMessageFormat.format returns string | (string | React elements) — we
-    // only ever pass string values so it will be a string; assert for the type
-    // system.
-    return formatted as string;
+    return formatter(result, locale, values);
   };
 }
 

--- a/packages/core/src/intl/IntlContext.ts
+++ b/packages/core/src/intl/IntlContext.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file IntlContext.ts
+ * @input React createContext
+ * @output Exports IntlContext and IntlContextValue
+ * @position Context definition for client-side locale + messages
+ *
+ * Separated from IntlProvider.tsx so components can consume
+ * the context without pulling in the full provider implementation.
+ * Follows the LinkContext.ts / ThemeContext.ts pattern.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/intl/IntlProvider.tsx
+ * - /packages/core/src/intl/useIntl.ts
+ * - /packages/core/src/intl/index.ts
+ */
+
+import {createContext} from 'react';
+import enSource from '../../locales/en.json' with {type: 'json'};
+import {formatter} from '../i18n/resolve';
+
+/**
+ * A BCP 47 language tag. Examples: `'en'`, `'pt'`, `'pt-BR'`, `'zh-Hans'`.
+ *
+ * Regional tags are meaningful — `pt-BR` and `pt` are different catalogs.
+ */
+export type Locale = string;
+
+/**
+ * This is used for i18n in `astryx/core` components.
+ * The `key` argument is type-checked and provides autocompletion hints.
+ * Safe to call from event handlers and effects.
+ */
+export type TranslatorFn = (
+  key: keyof typeof enSource,
+  values?: Record<string, unknown>,
+) => string;
+
+export interface IntlContextValue<Messages = Record<string, never>> {
+  locale: Locale;
+  messages: Messages;
+  direction: 'ltr' | 'rtl';
+  t: TranslatorFn;
+}
+
+/**
+ * Default value falls through to the shipped en catalog in resolve().
+ * A consumer that doesn't render a provider still gets English defaults.
+ */
+export const IntlContext = createContext<IntlContextValue>({
+  locale: 'en',
+  direction: 'ltr',
+  messages: {},
+  t: (key, values) => formatter(enSource[key].defaultMessage, 'en', values),
+});
+
+IntlContext.displayName = 'IntlContext';

--- a/packages/core/src/intl/IntlProvider.tsx
+++ b/packages/core/src/intl/IntlProvider.tsx
@@ -1,0 +1,142 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file IntlProvider.tsx
+ * @input React, IntlContext
+ * @output Exports IntlProvider component and props type
+ * @position Provider component for astryx intl locale + messages
+ *
+ * Wraps a subtree with a locale and (optional) additional message catalogs +
+ * overrides. Astryx components inside the subtree resolve their strings via
+ * this context. If a consumer never renders a provider, astryx components
+ * still work — they use the shipped en catalog directly.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/intl/IntlContext.ts
+ * - /packages/core/src/intl/index.ts
+ */
+
+import {useMemo, type ReactNode} from 'react';
+import {IntlContext, type IntlContextValue, type Locale} from './IntlContext';
+import enSource from '../../locales/en.json' with {type: 'json'};
+import {getLocaleDirection} from '../i18n';
+import {formatter} from '../i18n/resolve';
+
+export type Overrides = Partial<typeof enSource>;
+
+export interface IntlProviderProps<Messages = Record<string, unknown>> {
+  /**
+   * BCP 47 language tag. Examples: `'en'`, `'pt'`, `'pt-BR'`, `'zh-Hans'`.
+   */
+  locale: Locale;
+
+  /**
+   * Additional shipped catalogs to make available for the selected locale.
+   * `en` is bundled with astryx and never needs to be listed here.
+   *
+   * @example
+   * ```
+   * import {fr} from '@astryxdesign/core/locales/fr.json';
+   * <IntlProvider locale="fr" messages={fr}>
+   * ```
+   *
+   * If you want overrides some keys in the shipped catalogs,
+   * only the keys you want override need to be listed.
+   *
+   * @example
+   * ```
+   * <IntlProvider
+   *   locale="fr"
+   *   overrides={{...fr, '@astryx.pagination.next': 'Suivant'}}>
+   * ```
+   */
+  overrides?: Overrides;
+  /**
+   * You can use `astryx` as your i18n library.
+   * You are free to define your own `MyCatalog` and pass it as `messages`.
+   * By calling `useIntl<MyCatalog>()`, you get your catalog back unchanged,
+   * with full type safety—no loss of types, and no need to avoid
+   * colliding with astryx's built-in keys.
+   *
+   * @example
+   * ```
+   * interface MyCatalog {
+   *   currency: React.ReactNode;
+   *   discount: (percent: number) => React.ReactNode;
+   * }
+   *
+   * const en: MyCatalog = {
+   *   currency: <DollarIcon />,
+   *   discount: percent => `${100 - percent}% Off`,
+   * };
+   * const zh: MyCatalog = {
+   *   currency: <ChinaYuan />,
+   *   discount: percent => `${percent / 10} 折`,
+   * };
+   *
+   * const messages = {en, zh};
+   * const locale = 'zh';
+   *
+   * <IntlProvider locale={locale} messages={messages[locale]}>
+   *   <MyComponent price={10} percent={30} />
+   * </IntlProvider>;
+   *
+   * const MyComponent = ({price, percent}: {price: number; percent: number}) => {
+   *   const {messages} = ustIntl<MyCatalog>();
+   *   const {currency, discount} = messages;
+   *   return (
+   *     <span>
+   *       {price}
+   *       {currency}, {discount(percent)}
+   *     </span>
+   *   );
+   * };
+   * ```
+   */
+  messages?: Messages;
+  /**
+   * Optional explicit text direction override. When omitted, direction is derived
+   * from `locale` via `Intl.Locale.getTextInfo()`. Provide this to force a
+   * direction (e.g. RTL layout testing under an English catalog) or to skip the
+   * derivation when you already know the direction.
+   *
+   * This sets the direction astryx reads via context; it does NOT set the DOM
+   * `dir` attribute. You must set `dir` on `<html>` (or a wrapping element)
+   * yourself — astryx components mirror layout and directional icons from the
+   * DOM `dir`, so an RTL locale won't visually mirror without it. Keep the two
+   * in sync (e.g. `dir={getLocaleDirection(locale)}` on both).
+   */
+  dir?: 'ltr' | 'rtl';
+  children: ReactNode;
+}
+
+/**
+ * Provides locale + additional messages + overrides to all astryx
+ * components in the subtree.
+ */
+export function IntlProvider<Messages = Record<string, never>>({
+  locale,
+  messages,
+  overrides,
+  children,
+  dir,
+}: IntlProviderProps<Messages>) {
+  const value = useMemo<IntlContextValue>(() => {
+    return {
+      locale,
+      direction: dir ?? getLocaleDirection(locale),
+      messages: messages ?? {},
+      t: (key, values) =>
+        formatter(
+          (overrides?.[key] || enSource[key]).defaultMessage,
+          locale,
+          values,
+        ),
+    };
+  }, [locale, dir, messages, overrides]);
+  return <IntlContext value={value}>{children}</IntlContext>;
+}
+
+IntlProvider.displayName = 'IntlProvider';

--- a/packages/core/src/intl/index.ts
+++ b/packages/core/src/intl/index.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file index.ts
+ * @input Imports from IntlProvider, IntlContext and useIntl
+ * @output Public surface for the intl subpackage
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * The public API is deliberately small:
+ *   - IntlProvider         — provider component
+ *   - useIntl              — hook returning a translator function
+ */
+
+export {
+  type Locale,
+  type TranslatorFn,
+  type IntlContextValue,
+  IntlContext,
+} from './IntlContext';
+export {
+  type Overrides,
+  type IntlProviderProps,
+  IntlProvider,
+} from './IntlProvider';
+export {useIntl} from './useIntl';

--- a/packages/core/src/intl/useIntl.ts
+++ b/packages/core/src/intl/useIntl.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useIntl.ts
+ * @input IntlContext (via use())
+ * @output Exports useIntl hook returning the IntlContextValue
+ * @position Client-side hook for translating outside of render (event handlers,
+ *   effects, non-component code) while still resolving against the current
+ *   provider's locale.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/intl/index.ts
+ * - /packages/core/src/intl/IntlProvider.ts
+ * - /packages/core/src/intl/IntlContext.ts
+ */
+
+import {use} from 'react';
+import {IntlContext, type IntlContextValue} from './IntlContext';
+
+/**
+ * Returns the IntlContextValue bound to the current provider's locale.
+ *
+ * @example
+ * ```
+ * function AstryxCoreComponent() {
+ *   const {t} = useIntl();
+ *   const onClick = () => announce(translate('@astryx.pagination.pageAnnounce', {current: 1}));
+ * }
+ * ```
+ *
+ * @example
+ * ```
+ * function UserComponent() {
+ *   const {messages} = useIntl<MyCatalog>();
+ *   const {currency, discount} = messages;
+ *   return (
+ *     <span>
+ *       {price}
+ *       {currency}, {discount(percent)}
+ *     </span>
+ *   );
+ * }
+ * ```
+ */
+export function useIntl<
+  Messages = Record<string, never>,
+>(): IntlContextValue<Messages> {
+  return use(IntlContext) as IntlContextValue<Messages>;
+}


### PR DESCRIPTION
- Introduce a dedicated new design of the intl subpackage with IntlProvider, IntlContext and useIntl
- Show how to achieve compatibility between InternationalizationContext and IntlProvider via getIntlContextValue
- Demonstrate how to migrate from useTranslator to useIntl using AlertDialog
