### PR TITLE
feat(cli): theme build --family builds a base and its extending themes as one unit

### DIFF
--- a/.changeset/theme-build-family.md
+++ b/.changeset/theme-build-family.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[feat] `astryx theme build --family <base> <children...>` builds a base theme and the themes that `extends` it as one unit: the base stylesheet restates the shared declarations once, scoped to every member (token block at zero specificity via `:where(:scope)`), and each member stylesheet carries only its own deltas — instead of every member restating the whole resolved token set. `defineTheme` records the resolved base as `__extends` to make the relationship visible to the build. Standalone and batch builds are unchanged.
+
+@bmaurer

--- a/packages/cli/api/theme/build/build.family.test.mjs
+++ b/packages/cli/api/theme/build/build.family.test.mjs
@@ -1,0 +1,164 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * `--family` builds: a base plus the themes that `extends` it, built as one
+ * unit. The base stylesheet restates its declarations ONCE, scoped to every
+ * member (`@scope` over the member value list, token block wrapped in the
+ * zero-specificity `:where(:scope)`), and each member stylesheet carries only
+ * its own deltas — instead of every member restating the whole resolved token
+ * set it inherited.
+ *
+ * These drive `resolveThemeFamily()` + `themeBuild({family})`, the API pair
+ * behind `astryx theme build --family`.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {themeBuild} from './build.mjs';
+import {resolveThemeFamily} from './build.mjs';
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-theme-family-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+/**
+ * Write the ocean base + a member that changes exactly one colour.
+ *
+ * The fixtures are RESOLVED theme objects (what defineTheme returns), plain
+ * enough for the loader's object path: `__extends` carries the base the way
+ * defineTheme records it (defineTheme.test.ts covers that recording). Keeping
+ * them import-free lets the fixtures live in the system temp dir, outside the
+ * package tree the manifest/docs walkers scan.
+ */
+function writeFamily() {
+  fs.writeFileSync(
+    path.join(tmpDir, 'ocean.mjs'),
+    `export default {\n` +
+      `  name: 'ocean',\n` +
+      `  tokens: {'--color-accent': '#0077b6', '--radius-container': '16px'},\n` +
+      `};\n`,
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'ocean-deep.mjs'),
+    `const base = {\n` +
+      `  name: 'ocean',\n` +
+      `  tokens: {'--color-accent': '#0077b6', '--radius-container': '16px'},\n` +
+      `};\n` +
+      `export default {\n` +
+      `  name: 'ocean-deep',\n` +
+      `  tokens: {'--color-accent': '#48cae4', '--radius-container': '16px'},\n` +
+      `  __extends: base,\n` +
+      `};\n`,
+  );
+  return ['ocean.mjs', 'ocean-deep.mjs'];
+}
+
+async function buildFamily(files) {
+  const roles = await resolveThemeFamily(files, {cwd: tmpDir});
+  for (const file of files) {
+    await themeBuild(
+      file,
+      {family: roles.get(path.resolve(tmpDir, file))},
+      {cwd: tmpDir},
+    );
+  }
+}
+
+describe('resolveThemeFamily()', () => {
+  it('classifies the base and its members from `extends`, not argument order', async () => {
+    const [base, member] = writeFamily();
+    // Member first: the roles must still come out right.
+    const roles = await resolveThemeFamily([member, base], {cwd: tmpDir});
+    expect(roles.get(path.resolve(tmpDir, base))?.role).toBe('base');
+    expect(roles.get(path.resolve(tmpDir, member))?.role).toBe('child');
+    // And the canonical invocation is base-first, members sorted.
+    expect(roles.get(path.resolve(tmpDir, base))?.files).toEqual([base, member]);
+  });
+
+  it('refuses a set whose members do not all extend the one base', async () => {
+    writeFamily();
+    fs.writeFileSync(
+      path.join(tmpDir, 'stray.mjs'),
+      `export default {name: 'stray', tokens: {'--color-accent': '#111111'}};\n`,
+    );
+    await expect(
+      resolveThemeFamily(['ocean.mjs', 'ocean-deep.mjs', 'stray.mjs'], {cwd: tmpDir}),
+    ).rejects.toThrow(/exactly one base theme/);
+  });
+});
+
+describe('themeBuild({family}) — emitted CSS', () => {
+  it('the base restates its declarations once for every member, at zero specificity', async () => {
+    const files = writeFamily();
+    await buildFamily(files);
+
+    const baseCss = fs.readFileSync(path.join(tmpDir, 'ocean.css'), 'utf8');
+    // The base's own scope is untouched...
+    expect(baseCss).toContain('@scope ([data-astryx-theme="ocean"]) to ([data-astryx-theme])');
+    // ...and the family block names the member and holds the shared tokens in
+    // :where(:scope), so a member's own `:scope` block wins regardless of
+    // stylesheet load order.
+    expect(baseCss).toContain('@scope ([data-astryx-theme="ocean-deep"]) to ([data-astryx-theme])');
+    expect(baseCss).toContain(':where(:scope) {');
+    // The command header is the whole invocation, reproducible as typed.
+    expect(baseCss).toContain('astryx theme build --family ocean.mjs ocean-deep.mjs');
+  });
+
+  it('a member carries only its own deltas', async () => {
+    const files = writeFamily();
+    await buildFamily(files);
+
+    const memberCss = fs.readFileSync(path.join(tmpDir, 'ocean-deep.css'), 'utf8');
+    // The changed token ships...
+    expect(memberCss).toContain('--color-accent: #48cae4');
+    // ...the inherited-unchanged one does not (the family block carries it)...
+    expect(memberCss).not.toContain('--radius-container');
+    // ...and neither do the prose defaults or the data-token defaults, which
+    // regenerate byte-identical to the base's family block.
+    expect(memberCss).not.toContain(':where(h1');
+    expect(memberCss).not.toContain('@layer astryx-base');
+    // Same reproducible whole-family command in the member's header.
+    expect(memberCss).toContain('astryx theme build --family ocean.mjs ocean-deep.mjs');
+  });
+
+  it('the same file set builds byte-identical output whatever the argument order', async () => {
+    const files = writeFamily();
+    await buildFamily(files);
+    const first = fs.readFileSync(path.join(tmpDir, 'ocean.css'), 'utf8');
+
+    await buildFamily([...files].reverse());
+    const second = fs.readFileSync(path.join(tmpDir, 'ocean.css'), 'utf8');
+    expect(second).toBe(first);
+  });
+
+  it('refuses a member that drops a token its base declares', async () => {
+    writeFamily();
+    fs.writeFileSync(
+      path.join(tmpDir, 'ocean-broken.mjs'),
+      `const base = {\n` +
+        `  name: 'ocean',\n` +
+        `  tokens: {'--color-accent': '#0077b6', '--radius-container': '16px'},\n` +
+        `};\n` +
+        `export default {\n` +
+        `  name: 'ocean-broken',\n` +
+        `  tokens: {'--color-accent': '#0077b6'},\n` +
+        `  __extends: base,\n` +
+        `};\n`,
+    );
+    const files = ['ocean.mjs', 'ocean-broken.mjs'];
+    const roles = await resolveThemeFamily(files, {cwd: tmpDir});
+    await expect(
+      themeBuild(
+        'ocean-broken.mjs',
+        {family: roles.get(path.resolve(tmpDir, 'ocean-broken.mjs'))},
+        {cwd: tmpDir},
+      ),
+    ).rejects.toThrow(/drops 1 token/);
+  });
+});

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -597,6 +597,13 @@ const themeScopeStart = (/** @type {string} */ name) =>
   `[data-astryx-theme="${name}"]`;
 const THEME_SCOPE_TO = `[data-astryx-theme]`;
 
+// #3658: attribute-specific rules so <Theme mode> can override color-scheme.
+// Emitted once per document: by a standalone theme whose own values use
+// light-dark(), or once per family (the base, or a child whose delta
+// introduces light-dark() the base did not have).
+const COLOR_SCHEME_DECL =
+  '  :root { color-scheme: light dark; }\n  html[data-theme="light"] { color-scheme: light; }\n  html[data-theme="dark"] { color-scheme: dark; }\n\n';
+
 /**
  * Module extensions the theme loader resolves, source before artifact.
  *
@@ -1024,7 +1031,7 @@ function validatePrivateVars(themeDef) {
  * `logger` (silent by default).
  *
  * @param {string} file - Theme file path, resolved against `cwd`.
- * @param {{out?: string, check?: boolean, iconsSpecifier?: string}} [options] -
+ * @param {{out?: string, check?: boolean, iconsSpecifier?: string, family?: {role: 'base', memberNames: string[], files: string[]} | {role: 'child', files: string[]}}} [options] -
  *   `out` overrides the output CSS path; `check` compares against on-disk outputs
  *   instead of writing. `iconsSpecifier` overrides the icon registry import
  *   specifier in the generated module (e.g. `./icons.mjs`); when omitted, the
@@ -1153,8 +1160,112 @@ export async function themeBuild(
     const scopeSelector = themeScopeStart(themeDef.name);
     const scopeTo = THEME_SCOPE_TO;
 
-    const {component, prose} = _generateThemeRulesSplit(resolvedTheme);
+    const family = options.family;
     const cssParts = [];
+    if (family?.role === 'child') {
+      // ---- family child: emit only what this theme changes. The base's
+      // stylesheet (built in the same --family invocation) restates its own
+      // declarations once, scoped to every member, so anything the child
+      // repeats verbatim is dead weight in every document that loads both.
+      const base = resolvedTheme.__extends;
+      if (!base) {
+        throw new AstryxError(
+          `theme "${themeDef.name}" does not extend anything — a --family build needs every member except the base to \`extends\` the base.`,
+          undefined,
+          ERROR_CODES.ERR_THEME_INVALID,
+        );
+      }
+      const baseTokens = base.tokens ?? {};
+      const childTokens = resolvedTheme.tokens ?? {};
+      const missing = Object.keys(baseTokens).filter(k => !(k in childTokens));
+      if (missing.length > 0) {
+        throw new AstryxError(
+          `theme "${themeDef.name}" drops ${missing.length} token(s) its base declares (e.g. ${missing[0]}). ` +
+            'A family build cannot express an unset token — declare it, or build without --family.',
+          undefined,
+          ERROR_CODES.ERR_THEME_INVALID,
+        );
+      }
+      /** @type {Record<string, string>} */
+      const deltaTokens = {};
+      for (const [key, value] of Object.entries(childTokens)) {
+        if (baseTokens[key] !== value) deltaTokens[key] = value;
+      }
+      /** @type {Record<string, any>} */
+      const deltaComponents = {};
+      for (const [name, rules] of Object.entries(resolvedTheme.components ?? {})) {
+        if (JSON.stringify(base.components?.[name]) !== JSON.stringify(rules)) {
+          deltaComponents[name] = rules;
+        }
+      }
+      const deltaTheme = {
+        name: resolvedTheme.name,
+        tokens: deltaTokens,
+        ...(Object.keys(deltaComponents).length > 0
+          ? {components: deltaComponents}
+          : {}),
+      };
+      const {component: deltaComponent} = _generateThemeRulesSplit(deltaTheme);
+      const {component: baseComponent, prose: baseProse} =
+        _generateThemeRulesSplit(base);
+      // Prose is compared whole (it inlines token values, so a type-scale
+      // change surfaces here) and emitted only when it differs from what the
+      // base's family block already carries.
+      const {prose: childProse} = _generateThemeRulesSplit(resolvedTheme);
+      if (childProse.join('\n') !== baseProse.join('\n')) {
+        cssParts.push(
+          `@layer reset {\n@scope (${scopeSelector}) to (${scopeTo}) {\n${childProse.join('\n\n')}\n}\n}`,
+        );
+      }
+      // Generated prop-override rules (size/color) regenerate byte-identical
+      // for identical component sets — the base's family block carries those.
+      // The theme-independent data-token defaults (@layer astryx-base) ride
+      // the base's stylesheet for the same reason: a child stylesheet is only
+      // ever loaded beside the base's.
+      const baseRules = new Set(baseComponent);
+      const deltaRules = deltaComponent.filter(
+        (/** @type {string} */ rule) => !baseRules.has(rule),
+      );
+      if (deltaRules.length > 0) {
+        const componentScope = `@scope (${scopeSelector}) to (${scopeTo}) {\n${deltaRules.join('\n\n')}\n}`;
+        // #3658 color-scheme preamble: the base emits it for the family when
+        // ITS OWN values use light-dark(); a child re-emits only when its
+        // delta introduces light-dark() that the base did not have.
+        const baseEmitsColorScheme = JSON.stringify([
+          base.tokens ?? {},
+          base.components ?? {},
+        ]).includes('light-dark(');
+        const childIntroducesColorScheme = JSON.stringify([
+          deltaTokens,
+          deltaComponents,
+        ]).includes('light-dark(');
+        const colorSchemeDecl =
+          !baseEmitsColorScheme && childIntroducesColorScheme
+            ? COLOR_SCHEME_DECL
+            : '';
+        cssParts.push(
+          `@layer astryx-theme {\n${colorSchemeDecl}${componentScope}\n}`,
+        );
+      }
+      // On-media surface overrides: identical resolved surfaces are covered
+      // by the base's family block; only a child that changes them re-emits.
+      if (_generateOnMediaCSS) {
+        const childOnMedia = _generateOnMediaCSS(resolvedTheme);
+        const baseOnMedia = _generateOnMediaCSS(base);
+        const normalized = childOnMedia
+          ? childOnMedia.split(scopeSelector).join(themeScopeStart(base.name))
+          : '';
+        if (childOnMedia && normalized !== baseOnMedia) {
+          cssParts.push(`@layer astryx-theme {\n${childOnMedia}\n}`);
+        }
+      }
+      if (cssParts.length === 0) {
+        logger.log('No overrides found — nothing to build.');
+        return null;
+      }
+      css = cssParts.join('\n\n') + '\n';
+    } else {
+    const {component, prose} = _generateThemeRulesSplit(resolvedTheme);
     // Prose element defaults always ship — the `<Theme>` runtime
     // (generateThemeCSS) always emits them, so the build must too, or the
     // CLI output would diverge from runtime. They go in @layer reset
@@ -1177,7 +1288,7 @@ export async function themeBuild(
         resolvedTheme.components ?? {},
       ]);
       const colorSchemeDecl = themeOwnValues.includes('light-dark(')
-        ? '  :root { color-scheme: light dark; }\n  html[data-theme="light"] { color-scheme: light; }\n  html[data-theme="dark"] { color-scheme: dark; }\n\n'
+        ? COLOR_SCHEME_DECL
         : '';
       cssParts.push(
         `@layer astryx-theme {\n${colorSchemeDecl}${componentScope}\n}`,
@@ -1214,12 +1325,54 @@ export async function themeBuild(
         `@layer astryx-base {\n${baseCss}\n}`,
       );
     }
+    if (family?.role === 'base' && family.memberNames.length > 0) {
+      // ---- family base: restate this theme's declarations once, scoped to
+      // every member, so a member's stylesheet only carries its own deltas.
+      // The token block is wrapped in :where(:scope) — zero specificity — so
+      // a member's own `:scope` block wins no matter which stylesheet the
+      // document loaded first.
+      const familyScope = family.memberNames
+        .map(name => themeScopeStart(name))
+        .join(', ');
+      if (prose.length > 0) {
+        cssParts.push(
+          `@layer reset {\n@scope (${familyScope}) to (${scopeTo}) {\n${prose.join('\n\n')}\n}\n}`,
+        );
+      }
+      if (component.length > 0) {
+        const familyInner = component
+          .map((/** @type {string} */ rule) =>
+            rule.startsWith('  :scope {')
+              ? rule.replace('  :scope {', '  :where(:scope) {')
+              : rule,
+          )
+          .join('\n\n');
+        cssParts.push(
+          `@layer astryx-theme {\n@scope (${familyScope}) to (${scopeTo}) {\n${familyInner}\n}\n}`,
+        );
+      }
+      if (_generateOnMediaCSS) {
+        const onMediaCss = _generateOnMediaCSS(resolvedTheme);
+        if (onMediaCss) {
+          cssParts.push(
+            `@layer astryx-theme {\n${onMediaCss.split(scopeSelector).join(familyScope)}\n}`,
+          );
+        }
+      }
+    }
     css = cssParts.join('\n\n') + '\n';
+    }
   }
 
   // Source path relative to cwd — used in @generated headers
   const sourceRelative = path.relative(cwd, filePath);
-  const buildCommand = `astryx theme build ${sourceRelative}${options.out ? ' --out ' + path.relative(cwd, path.resolve(cwd, options.out)) : ''}`;
+  // A family artifact's bytes depend on every member, so its header records
+  // the WHOLE invocation (base first, members sorted) — identical in every
+  // member's header, reproducible as typed, and byte-stable across rebuilds.
+  // A per-file spelling would not even run: --family refuses <2 files.
+  const buildCommand = options.family
+    ? `astryx theme build --family ${options.family.files.join(' ')}`
+    : `astryx theme build ${sourceRelative}${options.out ? ' --out ' + path.relative(cwd, path.resolve(cwd, options.out)) : ''}`;
   // Stable provenance recorded in @generated headers — versions, not a
   // timestamp, so identical inputs produce byte-identical output.
   const versions = resolveToolVersions(cwd);
@@ -1450,3 +1603,84 @@ Or with a <link> tag:
     },
   };
 }
+
+/**
+ * Classify a `--family` build's inputs: exactly one base plus the themes that
+ * `extends` it. Loads each file the same way `themeBuild` does and reads the
+ * `__extends` provenance defineTheme records, so the relationship comes from
+ * the sources themselves, never from argument order.
+ *
+ * Returns a map of absolute file path -> the `options.family` value
+ * `themeBuild` takes for that file. Every option carries `files`: the
+ * canonical invocation list (base first, members sorted by their given path),
+ * which the `@generated` header records identically in every member. BOTH the
+ * recorded command and the base's family-scope selector list derive from that
+ * canonical order, so the same file set builds byte-identical output whatever
+ * the argument order.
+ *
+ * @param {string[]} files - Theme file paths, resolved against `cwd`.
+ * @param {{cwd?: string}} [ctx]
+ * @returns {Promise<Map<string, {role: 'base', memberNames: string[], files: string[]} | {role: 'child', files: string[]}>>}
+ */
+export async function resolveThemeFamily(files, {cwd = process.cwd()} = {}) {
+  /** @type {Array<{filePath: string, theme: any}>} */
+  const loaded = [];
+  for (const file of files) {
+    const filePath = path.resolve(cwd, file);
+    let theme;
+    try {
+      theme = await extractThemeDefinition(filePath);
+    } catch (e) {
+      const err = /** @type {Error} */ (e);
+      throw new AstryxError(err.message, undefined, ERROR_CODES.ERR_THEME_LOAD);
+    }
+    loaded.push({filePath, theme});
+  }
+  const names = new Set(loaded.map(entry => entry.theme?.name));
+  const bases = loaded.filter(
+    entry => !names.has(entry.theme?.__extends?.name),
+  );
+  if (bases.length !== 1) {
+    const description =
+      bases.length === 0
+        ? 'every file extends another file in the set (a cycle)'
+        : `${bases.map(entry => `"${entry.theme?.name}"`).join(', ')} do not extend any theme in the set`;
+    throw new AstryxError(
+      `--family needs exactly one base theme plus the themes that \`extends\` it: ${description}.`,
+      undefined,
+      ERROR_CODES.ERR_THEME_INVALID,
+    );
+  }
+  const base = bases[0];
+  const children = loaded.filter(entry => entry !== base);
+  for (const child of children) {
+    if (child.theme?.__extends?.name !== base.theme?.name) {
+      throw new AstryxError(
+        `--family: theme "${child.theme?.name}" extends "${child.theme?.__extends?.name ?? 'nothing'}", not the family base "${base.theme?.name}".`,
+        undefined,
+        ERROR_CODES.ERR_THEME_INVALID,
+      );
+    }
+  }
+  /** @type {Map<string, {role: 'base', memberNames: string[], files: string[]} | {role: 'child', files: string[]}>} */
+  const roles = new Map();
+  const byPath = new Map(loaded.map((entry, i) => [entry.filePath, files[i]]));
+  // Canonical member order: sorted by the invocation path (see the doc block).
+  const sortedChildren = [...children].sort((a, b) =>
+    String(byPath.get(a.filePath)).localeCompare(String(byPath.get(b.filePath))),
+  );
+  const invocation = [
+    byPath.get(base.filePath),
+    ...sortedChildren.map(child => byPath.get(child.filePath)),
+  ].map(String);
+  roles.set(base.filePath, {
+    role: 'base',
+    memberNames: sortedChildren.map(entry => String(entry.theme.name)),
+    files: invocation,
+  });
+  for (const child of children) {
+    roles.set(child.filePath, {role: 'child', files: invocation});
+  }
+  return roles;
+}
+

--- a/packages/cli/api/theme/theme.mjs
+++ b/packages/cli/api/theme/theme.mjs
@@ -9,7 +9,7 @@
  * leaf it wants.
  */
 
-export {themeBuild, importSpecifier} from './build/build.mjs';
+export {themeBuild, importSpecifier, resolveThemeFamily} from './build/build.mjs';
 export {themeAdd} from './add/add.mjs';
 export {themeTemplate} from './template/template.mjs';
 export {themeTargets} from './targets/targets.mjs';

--- a/packages/cli/api/theme/themeBuild.doc.mjs
+++ b/packages/cli/api/theme/themeBuild.doc.mjs
@@ -63,6 +63,12 @@ export const doc = {
         'Override the icon-registry import specifier in the generated JS module, for example ./icons.mjs. When omitted, the source specifier is preserved.',
     },
     {
+      name: 'options.family',
+      type: 'object',
+      description:
+        "This file's role in a --family build, from resolveThemeFamily(): {role: 'base', memberNames, files} restates the base's declarations once, scoped to every member; {role: 'child', files} emits only the deltas against the base recorded on the theme's __extends. Omitted for a standalone build.",
+    },
+    {
       name: 'ctx.cwd',
       type: 'string',
       description:

--- a/packages/cli/clients/cli/commands/build-theme.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.mjs
@@ -39,7 +39,7 @@ import {themeAdd} from '../../../api/theme/add/add.mjs';
 import {themeTemplate} from '../../../api/theme/template/template.mjs';
 import {themeList} from '../../../api/theme/list/list.mjs';
 import {themeTargets} from '../../../api/theme/targets/targets.mjs';
-import {themeBuild, importSpecifier} from '../../../api/theme/build/build.mjs';
+import {themeBuild, importSpecifier, resolveThemeFamily} from '../../../api/theme/build/build.mjs';
 import {defineCommand} from '../lib/define-command.mjs';
 import {doc as themeGroup} from './theme.doc.mjs';
 import {doc as themeBuildCommand} from './theme-build.doc.mjs';
@@ -324,6 +324,37 @@ export function registerTheme(program) {
         return;
       }
 
+      // --family builds the set as one unit (a base plus its extends
+      // children), so the modes that build files independently refuse it.
+      if (options.family && options.watch) {
+        cliError('--family cannot be combined with --watch', {
+          code: ERROR_CODES.ERR_THEME_INVALID,
+        });
+        return;
+      }
+      if (options.family && entries.length < 2) {
+        cliError(
+          '--family needs at least two theme files: the base and the themes that extends it.',
+          {code: ERROR_CODES.ERR_THEME_INVALID},
+        );
+        return;
+      }
+      /** @type {Map<string, {role: 'base', memberNames: string[]} | {role: 'child'}> | null} */
+      let familyRoles = null;
+      if (options.family) {
+        try {
+          familyRoles = await resolveThemeFamily(
+            entries.map(entry => entry.file),
+            {cwd: process.cwd()},
+          );
+        } catch (e) {
+          const err =
+            /** @type {import('../../../api/error.mjs').AstryxError} */ (e);
+          cliError(err.message, {suggestions: err.suggestions, code: err.code});
+          return;
+        }
+      }
+
       // Watch mode: run an initial build, then rebuild on every change to the
       // theme file. Watch is a human-interactive, long-running mode — it is not
       // supported in --json (machine) mode, which expects a single envelope.
@@ -355,6 +386,7 @@ export function registerTheme(program) {
               out: options.out,
               check: options.check,
               iconsSpecifier: options.iconsSpecifier,
+              family: familyRoles?.get(entry.filePath),
             },
             {cwd: process.cwd()},
           );

--- a/packages/cli/clients/cli/commands/theme-build.doc.mjs
+++ b/packages/cli/clients/cli/commands/theme-build.doc.mjs
@@ -43,6 +43,15 @@ export const doc = {
       description:
         'Verify the committed outputs match the source without writing; exit non-zero if stale',
     },
+    {
+      flag: '--family',
+      param: 'options.family',
+      description:
+        'Build the files as one theme family: a base plus the themes that extends it. ' +
+        'The base stylesheet restates its declarations once, scoped to every member, and each ' +
+        'member stylesheet carries only its own changes — instead of every member restating ' +
+        'the whole resolved token set',
+    },
   ],
   examples: [
     {
@@ -56,6 +65,10 @@ export const doc = {
     {
       label: 'Check for drift (CI)',
       cli: 'astryx theme build ./src/themes/ocean.ts --check',
+    },
+    {
+      label: 'Build a base and its variants as one family (shared tokens emitted once)',
+      cli: 'astryx theme build --family ./src/themes/ocean.ts ./src/themes/ocean-*.ts',
     },
     {
       label: 'Build against a separately compiled icon registry',

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -414,6 +414,14 @@ export interface DefinedTheme {
    * @internal
    */
   __onLight?: ResolvedOnMedia;
+  /**
+   * The theme this one `extends`, resolved. defineTheme flattens the base's
+   * tokens/components into this theme, which erases the relationship; tools
+   * that emit the shared declarations once per family (`astryx theme build
+   * --family`) need it recorded.
+   * @internal
+   */
+  __extends?: DefinedTheme;
 }
 
 // =============================================================================
@@ -695,6 +703,7 @@ export function defineTheme(input: DefineThemeInput): DefinedTheme {
         : undefined,
     __onDark,
     __onLight,
+    __extends: base,
   };
 
   registerTheme(theme);


### PR DESCRIPTION
## Problem

`defineTheme({extends: base})` flattens the base's tokens into the child by design — the runtime needs a resolved theme — and `astryx theme build` emits that resolved set, so every extending theme's stylesheet restates the whole base. Measured in an app that ships 14 themes off one base: 147 of ~177 custom properties per theme are byte-identical restatements of the base (~18.5KB per theme, ~230KB of render-blocking CSS). Component overrides are the mirror problem: `extends` never lands them in the child stylesheet at all, so apps copy them into every child source by hand.

## Change

**core**: `defineTheme` records the resolved base as `__extends` on the returned theme (internal, beside `__inputTokens`). Flattening previously erased the relationship, so no tool could know what was inherited.

**cli**: `astryx theme build --family <base> <children...>` builds the set as one unit:

- the base stylesheet gains a family block: its prose/token/component/on-media rules restated once, `@scope`d to the value list of every member, with the token block wrapped in `:where(:scope)` — zero specificity, so a member's own `:scope` block wins regardless of stylesheet load order;
- each child emits only its deltas: tokens that differ from the base, component overrides the base does not carry, prose only when the inlined type values differ, on-media only when the resolved surfaces differ, and the `color-scheme` preamble only when the child's delta introduces `light-dark()` the base did not have;
- a child that drops a base token is refused (a family build cannot express an unset);
- member order is canonicalized (base first, children sorted by invocation path): the family scope AND the recorded `@generated Command:` header both derive from it, so the same file set builds byte-identical output whatever the argument order, and the header stays reproducible as typed;
- `--check`, multi-file batch, `--out` guards, and single-file builds are unchanged; `--family` is refused with `--watch` and with fewer than two files.

In the measuring app this took each extending theme's stylesheet from ~20KB to ~2.1KB and let the app delete its hand-copied component-override blocks.

## Correctness

For any element under a member's scope root, each custom property resolves to the same value as before: the member's delta block (`:scope`, specificity 0-1-0) beats the family block's `:where(:scope)` (0-0-0) in the same layer, and properties the member does not change come from the family block, which restates the base's values verbatim. The theme-independent data-token defaults (`@layer astryx-base`) ride the base's stylesheet only — a member stylesheet is only ever loaded beside its base's. Nested theme roots keep today's semantics: the family block re-applies at any member root, and the `to ([data-astryx-theme])` limit still fences inner themes.

## Tests

`packages/cli/api/theme/build/build.family.test.mjs` (new): role classification from `extends` rather than argument order; refusal of a set with no unique base; the base's family block (member scope, `:where(:scope)`, whole-invocation header); a member carrying only its deltas; byte-identical output across shuffled argument orders; refusal of a dropped base token. Full `@astryxdesign/cli` suite run: the only failures are 7 pre-existing on `main` (reproduced on a pristine checkout).
