### PR TITLE
fix(docsite): restore Form Controls on production

### DIFF
--- a/apps/docsite/src/__tests__/component-categories.test.ts
+++ b/apps/docsite/src/__tests__/component-categories.test.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {normalizeComponentCategory} from '../lib/componentCategories';
+
+describe('normalizeComponentCategory', () => {
+  it('maps legacy Data Input metadata to Form Controls', () => {
+    expect(normalizeComponentCategory('Data Input')).toBe('Form Controls');
+  });
+
+  it('preserves current category names', () => {
+    expect(normalizeComponentCategory('Navigation')).toBe('Navigation');
+  });
+});

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -23,6 +23,7 @@ import {docTopics, docsCount} from '../generated/docsRegistry';
 import {showcaseRegistry} from '../generated/showcaseRegistry';
 import {eagerShowcases} from '../components/eagerShowcases';
 import {exampleRegistry} from '../generated/exampleRegistry';
+import {normalizeComponentCategory} from '../lib/componentCategories';
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -1068,7 +1069,9 @@ describe('galleryEagerShowcases', () => {
   /** Gallery render order: categories in display order, then registry order. */
   const galleryOrder = categories.flatMap(cat =>
     (components['@astryxdesign/core'] ?? []).filter(
-      c => c.category === cat && isGalleryComponent(c),
+      c =>
+        normalizeComponentCategory(c.category ?? '') === cat &&
+        isGalleryComponent(c),
     ),
   );
 
@@ -1084,7 +1087,7 @@ describe('galleryEagerShowcases', () => {
     const declared = new Set(
       (components['@astryxdesign/core'] ?? [])
         .filter(isGalleryComponent)
-        .map(c => c.category),
+        .map(c => normalizeComponentCategory(c.category ?? '')),
     );
     for (const cat of declared) {
       expect(

--- a/apps/docsite/src/app/(docs)/components/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/page.tsx
@@ -22,6 +22,7 @@ import {CodeExampleBlock} from '../../../components/CodeExampleBlock';
 import {components as componentRegistry} from '../../../generated/componentRegistry';
 import {showcaseRegistry} from '../../../generated/showcaseRegistry';
 import {ShowcaseThumbnail} from '../../../components/ShowcaseThumbnail';
+import {normalizeComponentCategory} from '../../../lib/componentCategories';
 import {layout} from '../../../layout.stylex';
 
 const FIGMA_LIBRARY_URL =
@@ -113,7 +114,7 @@ export default function ComponentsGalleryPage() {
         displayName: comp.displayName,
         description: comp.description,
         href: `/components/${comp.name}`,
-        category: comp.category,
+        category: normalizeComponentCategory(comp.category),
         hasShowcase: SHOWCASE_NAMES.has(comp.name),
       });
     }

--- a/apps/docsite/src/lib/componentCategories.ts
+++ b/apps/docsite/src/lib/componentCategories.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** Normalize category names emitted by older published package metadata. */
+export function normalizeComponentCategory(category: string): string {
+  return category === 'Data Input' ? 'Form Controls' : category;
+}


### PR DESCRIPTION
## Summary

- normalize legacy `Data Input` metadata to `Form Controls` in the component gallery
- preserve compatibility while production reads the currently published `0.5.1` package metadata
- update gallery-order tests to exercise the same normalization

## Root cause

The category rename merged in #5686 updated the gallery code immediately, while production still sources component metadata from the latest published package release. That release emits `Data Input`, so those components no longer matched any gallery section and disappeared.

## Testing

- `DOCSITE_TARGET=latest pnpm -F @astryxdesign/docsite generate` (confirmed 33 legacy entries)
- `pnpm -F @astryxdesign/docsite test` (429 passed)
- `pnpm -F @astryxdesign/docsite typecheck`
- `DOCSITE_TARGET=latest pnpm -F @astryxdesign/docsite build`
- verified the production-target prerendered `/components` HTML contains `Form Controls`