### PR TITLE
fix(theme-neutral): apply component contrast treatments

### DIFF
--- a/.changeset/neutral-component-contrast.md
+++ b/.changeset/neutral-component-contrast.md
@@ -1,0 +1,12 @@
+---
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[fix] Apply the Neutral palette to component-specific contrast treatments for
+buttons, badges, status indicators, tokens, banners, progress bars, and
+selectable cards. Remove redundant radius overrides and support explicit
+SelectableCard selection-ring colors without changing card backgrounds.
+
+@rubyycheung

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -611,6 +611,40 @@ const neutralSyntax = defineSyntaxTheme({
   },
 });
 
+/**
+ * Filled semantic colors are shared by Badge and StatusDot. ProgressBar uses
+ * the same colors except where its fill-on-track relationship needs a
+ * contrast-specific stop (light-mode warning).
+ */
+const FILLED_STATE_COLORS = {
+  info: lightDark(palette('blue', 45), palette('blue', 60, 'dark')),
+  success: lightDark(palette('green', 45), palette('green', 60, 'dark')),
+  warning: lightDark(palette('yellow', 80), palette('yellow', 75, 'dark')),
+  error: lightDark(palette('red', 50), palette('red', 60, 'dark')),
+} as const;
+
+const FILLED_STATE_TEXT = {
+  standard: lightDark(palette('neutral', 100), palette('neutral', 10)),
+  onBright: palette('neutral', 10),
+} as const;
+
+/**
+ * Progress is a fill-on-track relationship, not a control boundary. Every
+ * variant uses the same neutral track so the remaining range has one stable
+ * visual treatment.
+ */
+const PROGRESS_TRACK = lightDark(
+  palette('neutral', 85),
+  palette('neutral', 20, 'dark'),
+);
+// The bright Badge yellow is only 1.01:1 against the light neutral track.
+// Progress therefore uses yellow, light-mode tone 50, the closest darker tone
+// that clears 3:1. Dark mode keeps the brighter semantic yellow.
+const PROGRESS_WARNING_FILL = lightDark(
+  palette('yellow', 50),
+  palette('yellow', 80, 'dark'),
+);
+
 export const neutralTheme = defineTheme({
   name: 'neutral',
   palettes: neutralPalettes,
@@ -984,17 +1018,13 @@ export const neutralTheme = defineTheme({
     ],
 
     // =========================================================================
-    // Radius — slightly larger than default (kept as-is)
-    // --radius-none and --radius-full are always fixed and must never be
-    // scaled by a theme (see defineTheme's radius config docs) — 0 and
-    // 9999px respectively, matching @astryxdesign/core's own defaults.
+    // Radius — a deliberately non-linear adjustment. The higher-order radius
+    // config cannot produce inner=6px and element=10px while preserving the
+    // default 12px container and 28px page steps, so only the two values that
+    // differ from the defaults are overridden explicitly.
     // =========================================================================
-    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
-    '--radius-container': '0.75rem',
-    '--radius-page': '1.75rem',
-    '--radius-full': '9999px',
 
     // =========================================================================
     // Shadows
@@ -1035,31 +1065,32 @@ export const neutralTheme = defineTheme({
 
   components: {
     // =========================================================================
-    // Button — primary gets white text, secondary gets a border, destructive
-    // uses the OKLCH red filled treatment.
+    // Button — primary/secondary/ghost inherit the semantic global tokens.
+    // Destructive uses the status surface/text pair rather than inventing a
+    // component-local red.
     // =========================================================================
     button: {
       'variant:destructive': {
-        backgroundColor: 'var(--color-error-muted)', // locked pastel red bg
-        color: 'var(--color-error)', // locked T30 red — matches banner/input error text
+        backgroundColor: 'var(--color-error-muted)',
+        color: 'var(--color-error)',
       },
     },
 
     // =========================================================================
     // Badge —
-    //   Semantic (info/success/warning/error): filled saturated T50 + contrasting
+    //   Semantic (info/success/warning/error): filled saturated tone 50 + contrasting
     //     text (white, or dark on yellow). The filled-button rule from #2150
     //     §3 — text contrast locks the bg stop, so this stays at T50 in
     //     BOTH modes, unlike pastel surfaces which invert by mode.
     //   Categorical (blue/green/red/orange/etc.): pastel-tinted hue surface +
-    //     colored text — light mode = soft T87-T90 + dark T30 text; dark mode
-    //     = T20 tinted + T80 light pastel text (sources: --color-background-X
+    //     colored text — light mode = soft tones 87-90 + dark tone 30 text; dark mode
+    //     = tone 20 tinted + tone 80 light pastel text (sources: --color-background-X
     //     and --color-text-X tokens).
     //   Neutral: light gray bg + dark text (or inverted in dark mode).
     // =========================================================================
     badge: {
       // Semantic — filled saturated bg + contrasting text.
-      //   Light: vivid T45-T55 from the OKLCH palette + white text
+      //   Light: vivid tones 45-55 from the OKLCH palette + white text
       //          (~4.5-5:1 — Material/Linear/Vercel pop).
       //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
       //          +5 stop-lift taper from issue #2150 §4) + DARK text.
@@ -1067,48 +1098,40 @@ export const neutralTheme = defineTheme({
       //          and tames the §4 vibration. Same dark-text-on-bright-bg
       //          treatment that warning yellow uses in both modes.
       'variant:info': {
-        // Light: T50 #0074e2 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #0074e2
-        backgroundColor: 'light-dark(#0074e2, #6d9cfe)',
-        color: 'light-dark(#ffffff, #171717)',
+        // Blue: light-mode tone 45 / dark-mode tone 60.
+        backgroundColor: FILLED_STATE_COLORS.info,
+        color: FILLED_STATE_TEXT.standard,
       },
       'variant:neutral': {
         // Mirrors the gray categorical badge — same neutral chip treatment
-        // (Neutral 200 light / semi-transparent white wash dark) sourced
+        // (Neutral light-mode tone 90 / semi-transparent white wash in dark
+        // mode) sourced
         // from the gray hue tokens, so a single change at the token layer
         // updates both variants.
         backgroundColor: 'var(--color-background-gray)',
         color: 'var(--color-text-gray)',
       },
       'variant:success': {
-        // Light: T45 #198100 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #198100
-        backgroundColor: 'light-dark(#198100, #64af4c)',
-        color: 'light-dark(#ffffff, #171717)',
+        // Green: light-mode tone 45 / dark-mode tone 60.
+        backgroundColor: FILLED_STATE_COLORS.success,
+        color: FILLED_STATE_TEXT.standard,
       },
       'variant:warning': {
-        // Yellow stays at the same hex in both modes — chroma reduction
-        // is barely visible at T85, and dark text on yellow doesn't
-        // suffer from the §4 vibration concern.
-        backgroundColor: '#ffce2f',
-        color: '#171717',
+        // Yellow: light-mode tone 80 / dark-mode tone 75, both with dark text.
+        backgroundColor: FILLED_STATE_COLORS.warning,
+        color: FILLED_STATE_TEXT.onBright,
       },
       'variant:error': {
-        // Light: T58 #c9303a. The T55 stop #e33f4a pairs with white at only
-        //        4.14:1 — the label is 12px/500, so AA wants 4.5, not the 3:1
-        //        large-text allowance. One tonal step down holds the hue
-        //        (OKLCH H 21.9 -> 22.8, C 0.200 -> 0.189) and reaches 5.29:1.
-        // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
-        //        source #dc2626 (kept on H=27 alarm-red rather than coral).
-        //        Dark text on it is 6.60:1 and unchanged.
-        backgroundColor: 'light-dark(#c9303a, #ff705d)',
-        color: 'light-dark(#ffffff, #171717)',
+        // Red: light-mode tone 50 / dark-mode tone 60. The light-mode tone is
+        // the brightest red that still clears AA with the badge's white label.
+        backgroundColor: FILLED_STATE_COLORS.error,
+        color: FILLED_STATE_TEXT.standard,
       },
 
       // Categorical — bg + text reference the per-hue tokens, so behavior
       // tracks the categorical palette automatically:
-      //   Light: pastel T87-T90 bg + dark T30 colored text (low-key chip)
-      //   Dark : tinted T20 bg + light T80 colored text (per #2150 §5,
+      //   Light: pastel tones 87-90 bg + dark tone 30 colored text (low-key chip)
+      //   Dark : tinted tone 20 bg + light tone 80 colored text (per #2150 §5,
       //          inverted from light to avoid the "pastel-in-both-modes"
       //          anti-pattern that makes locked light pastels glow on a
       //          dark body)
@@ -1154,55 +1177,91 @@ export const neutralTheme = defineTheme({
       },
     },
 
+    // Token uses the same categorical color language as Badge. Core already
+    // maps red–pink and gray to the shared --color-background-X / --color-text-X
+    // pairs, so those variants stay aligned automatically. Only the default
+    // Token needs a redirect: match Badge neutral to the gray palette pair
+    // instead of using the generic translucent --color-neutral wash.
+    token: {
+      'color:default': {
+        backgroundColor: 'var(--color-background-gray)',
+        color: 'var(--color-text-gray)',
+      },
+    },
+
     // =========================================================================
     // StatusDot — fill uses the SAME vivid stops as the filled semantic Badge
     // (and ProgressBar), so a dot and its badge read as one status language.
     //
     // The default component maps each variant to a raw semantic token
     // (--color-success / --color-error / --color-warning / --color-icon-
-    // secondary), which in light mode are the dark T30/T40 stops meant to
+    // secondary), which in light mode are dark tones 30 and 40 meant to
     // sit as TEXT on a pastel surface — as a solid dot they read muddy
     // (dark green / maroon / brown). Redirect them to the badge fills.
     //
-    //   success → badge success bg  (green T45 / dark-ramp T60)
-    //   warning → badge warning bg  (yellow T85, same hex both modes)
-    //   error   → badge error bg    (red T58 / dark-ramp T60)
-    //   accent  → badge info bg     (blue T50 / dark-ramp T60) — the
+    //   success → badge success bg  (green light tone 45 / dark tone 60)
+    //   warning → badge warning bg  (yellow tone 85, same hex both modes)
+    //   error   → badge error bg    (red light tone 58 / dark tone 60)
+    //   accent  → badge info bg     (blue light tone 50 / dark tone 60) — the
     //             StatusDot "accent" is the info/attention color, so it
     //             pairs with the info badge rather than --color-accent
     //             (near-black #262626, the darkest offender).
     //
     // `neutral` is intentionally NOT overridden: the neutral badge bg is a
-    // near-invisible light gray (--color-background-gray #e5e5e5 / 10% white
+    // near-invisible light gray (--color-background-gray tone 90 / 10% white
     // wash), fine as a large pill but unreadable as an 8px dot. It keeps the
     // component default's visible mid-gray (--color-icon-secondary), which is
     // not among the "too dark" cases.
     // =========================================================================
-    statusdot: {
-      'variant:success': {backgroundColor: 'light-dark(#198100, #64af4c)'},
-      'variant:warning': {backgroundColor: '#ffce2f'},
-      'variant:error': {backgroundColor: 'light-dark(#c9303a, #ff705d)'},
-      'variant:accent': {backgroundColor: 'light-dark(#0074e2, #6d9cfe)'},
+    'status-dot': {
+      'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
+      'variant:warning': {backgroundColor: FILLED_STATE_COLORS.warning},
+      'variant:error': {backgroundColor: FILLED_STATE_COLORS.error},
+      'variant:accent': {backgroundColor: FILLED_STATE_COLORS.info},
+    },
+
+    // AvatarStatusDot shares the same filled state language as StatusDot.
+    'avatar-status-dot': {
+      'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
+      'variant:error': {backgroundColor: FILLED_STATE_COLORS.error},
     },
 
     // =========================================================================
     // Banner — sits on a hue-tinted surface with colored text/icon:
-    //   Light: pastel T90 bg (pulled from --color-{X}-muted / --color-background-blue)
-    //          + dark T30 colored text (--color-text-{hue}).
-    //   Dark : tinted T20 bg (same tokens, dark slot) + light T80 colored text.
+    //   Light: pastel tone 90 bg (pulled from --color-{X}-muted / --color-background-blue)
+    //          + dark tone 30 colored text (--color-text-{hue}).
+    //   Dark : tinted tone 20 bg (same tokens, dark slot) + light tone 80 colored text.
     //          Per #2150 §5 — large hue-tinted surfaces in dark mode invert
     //          to a deep tinted bg + light text rather than locking the
     //          light-mode pastel.
     //
-    // The inner-header *-muted token carries the tinted background for every
-    // status, info included. A theme override that sets a plain CSS property
-    // instead lands in @layer astryx-theme, which StyleX's @layer priority4
-    // outranks, so `backgroundColor` here would silently do nothing and the
-    // info banner would paint no background at all.
+    // The inner header and its nested text, icon, and action consumers resolve
+    // their colors through semantic tokens. Rebind those public tokens here so
+    // the whole Banner subtree stays synchronized. A direct `backgroundColor`
+    // component override would win through @layer astryx-theme, but it would
+    // update only the targeted element rather than the related consumers.
     //
     // Status overrides reference --color-text-{hue} so text/icon colors
     // stay in sync with the palette anchors automatically.
     banner: {
+      base: {
+        // Secondary actions sit inside a tinted header. The global neutral
+        // wash darkens light surfaces and lightens dark surfaces, which moves
+        // colored Banner text toward the action fill in both modes. Invert
+        // that wash locally so action surfaces add contrast instead.
+        '--color-neutral': lightDark(
+          withAlpha(palette('neutral', 100), '33'),
+          withAlpha(palette('neutral', 0), '33'),
+        ),
+        '--color-overlay-hover': lightDark(
+          withAlpha(palette('neutral', 100), '1A'),
+          withAlpha(palette('neutral', 0), '1A'),
+        ),
+        '--color-overlay-pressed': lightDark(
+          withAlpha(palette('neutral', 100), '33'),
+          withAlpha(palette('neutral', 0), '33'),
+        ),
+      },
       'status:info': {
         '--color-accent-muted': 'var(--color-background-blue)',
         '--color-text-primary': 'var(--color-text-blue)',
@@ -1230,21 +1289,19 @@ export const neutralTheme = defineTheme({
     },
 
     // =========================================================================
-    // TextInput — no per-status overrides needed. The global tokens
-    // --color-{success,error,warning} carry the correct values in both
-    // modes (light=T40 dark colored, dark=T80 light pastel) for both
-    // surfaces the input border/icon touches: the input surface
-    // (white/T15-dark) and the status message bubble (light pastel T90 /
-    // dark T20). Verified all six combinations clear AA non-text 3:1.
+    // TextInput / FieldStatus — no per-status overrides needed. FieldStatus
+    // deliberately uses the same muted background + colored foreground pairs
+    // as Banner for success, warning, and error. The global tokens also carry
+    // the correct values for the input border/icon in both modes (light-mode
+    // tone 40 dark colored, dark-mode tone 80 light pastel). Verified the
+    // message pairs clear
+    // AA text 4.5:1 and the input affordances clear AA non-text 3:1.
     // =========================================================================
 
     // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
+    // Switch — the off-state track is itself the control boundary, so it uses
+    // the globally contrast-safe emphasized border token. ProgressBar is a
+    // different relationship (fill on track) and is configured separately.
     // =========================================================================
     switch: {
       base: {
@@ -1252,33 +1309,35 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    progressbar: {
+    'progress-bar': {
       base: {
-        // Track uses --color-background-muted; override it to
-        // --color-border-emphasized (Neutral T85 #d4d4d4 in light mode) so
-        // the track is clearly darker than the body bg (Neutral T95 #f1f1f1)
-        // and reads as a defined channel rather than blending in. Dark
-        // mode inherits T35 #525252 — same one-step-lighter behavior.
-        '--color-background-muted': 'var(--color-border-emphasized)',
+        '--color-background-muted': PROGRESS_TRACK,
       },
-      // Vivid stops match the filled semantic badge colors (info/success/
-      // warning/error variants in the badge override above). Same hex
-      // values; documented per role with palette provenance.
+      // Vivid stops match the filled semantic badge colors except light-mode
+      // warning, which moves darker so every variant can share one gray track.
       'variant:accent': {
-        // Blue T50 saturated stop (= variant:info badge bg)
-        '--color-accent': '#0074e2',
+        '--color-accent': FILLED_STATE_COLORS.info,
       },
       'variant:success': {
-        // Green T45 saturated stop (= variant:success badge bg)
-        '--color-success': '#198100',
+        '--color-success': FILLED_STATE_COLORS.success,
       },
       'variant:warning': {
-        // Yellow T85 saturated stop (= variant:warning badge bg)
-        '--color-warning': '#ffce2f',
+        '--color-warning': PROGRESS_WARNING_FILL,
       },
       'variant:error': {
-        // Red T58 saturated stop (= variant:error badge bg)
-        '--color-error': '#c9303a',
+        '--color-error': FILLED_STATE_COLORS.error,
+      },
+    },
+    // Keep the live neutral fill aligned with the primary Button without
+    // rebinding disabled progress on the ProgressBar root.
+    'progress-bar-fill': {
+      'variant:neutral': {
+        '--color-text-disabled': 'var(--color-accent)',
+      },
+    },
+    'progress-bar-mark': {
+      'variant:neutral+placement:fill': {
+        '--color-text-primary': 'var(--color-on-accent)',
       },
     },
 
@@ -1288,6 +1347,79 @@ export const neutralTheme = defineTheme({
     card: {
       base: {
         padding: 'var(--spacing-3)',
+      },
+    },
+
+    // SelectableCard's ring is a meaningful selected-state indicator. Use the
+    // lightest same-hue palette tone that clears WCAG 1.4.11 against each Card
+    // surface, rather than the much stronger text/icon stop. Neutral variants
+    // use a balanced gray just above the same threshold.
+    'selectable-card': {
+      base: {
+        '--selectable-card-ring-color': lightDark(
+          palette('neutral', 55),
+          palette('neutral', 40, 'dark'),
+        ),
+      },
+      'variant:red': {
+        '--selectable-card-ring-color': lightDark(
+          palette('red', 50),
+          'var(--color-border-red)',
+        ),
+      },
+      'variant:orange': {
+        '--selectable-card-ring-color': lightDark(
+          palette('orange', 50),
+          'var(--color-border-orange)',
+        ),
+      },
+      'variant:yellow': {
+        '--selectable-card-ring-color': lightDark(
+          palette('yellow', 50),
+          'var(--color-border-yellow)',
+        ),
+      },
+      'variant:green': {
+        '--selectable-card-ring-color': lightDark(
+          palette('green', 45),
+          'var(--color-border-green)',
+        ),
+      },
+      'variant:teal': {
+        '--selectable-card-ring-color': lightDark(
+          palette('teal', 45),
+          'var(--color-border-teal)',
+        ),
+      },
+      'variant:cyan': {
+        '--selectable-card-ring-color': lightDark(
+          palette('cyan', 45),
+          'var(--color-border-cyan)',
+        ),
+      },
+      'variant:blue': {
+        '--selectable-card-ring-color': lightDark(
+          palette('blue', 50),
+          'var(--color-border-blue)',
+        ),
+      },
+      'variant:purple': {
+        '--selectable-card-ring-color': lightDark(
+          palette('purple', 50),
+          'var(--color-border-purple)',
+        ),
+      },
+      'variant:pink': {
+        '--selectable-card-ring-color': lightDark(
+          palette('pink', 50),
+          'var(--color-border-pink)',
+        ),
+      },
+      'variant:gray': {
+        '--selectable-card-ring-color': lightDark(
+          palette('neutral', 50),
+          palette('neutral', 50, 'dark'),
+        ),
       },
     },
 

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -611,11 +611,7 @@ const neutralSyntax = defineSyntaxTheme({
   },
 });
 
-/**
- * Filled semantic colors are shared by Badge and StatusDot. ProgressBar uses
- * the same colors except where its fill-on-track relationship needs a
- * contrast-specific stop (light-mode warning).
- */
+/** Shared filled-state colors for Badge, status dots, and ProgressBar. */
 const FILLED_STATE_COLORS = {
   info: lightDark(palette('blue', 45), palette('blue', 60, 'dark')),
   success: lightDark(palette('green', 45), palette('green', 60, 'dark')),
@@ -628,18 +624,13 @@ const FILLED_STATE_TEXT = {
   onBright: palette('neutral', 10),
 } as const;
 
-/**
- * Progress is a fill-on-track relationship, not a control boundary. Every
- * variant uses the same neutral track so the remaining range has one stable
- * visual treatment.
- */
+/** Shared ProgressBar track. */
 const PROGRESS_TRACK = lightDark(
   palette('neutral', 85),
   palette('neutral', 20, 'dark'),
 );
-// The bright Badge yellow is only 1.01:1 against the light neutral track.
-// Progress therefore uses yellow, light-mode tone 50, the closest darker tone
-// that clears 3:1. Dark mode keeps the brighter semantic yellow.
+// The Badge yellow does not reach 3:1 against the track, so ProgressBar uses a
+// darker light-mode stop.
 const PROGRESS_WARNING_FILL = lightDark(
   palette('yellow', 50),
   palette('yellow', 80, 'dark'),
@@ -1017,12 +1008,7 @@ export const neutralTheme = defineTheme({
       getPaletteStop('neutral', 90, 'dark'),
     ],
 
-    // =========================================================================
-    // Radius — a deliberately non-linear adjustment. The higher-order radius
-    // config cannot produce inner=6px and element=10px while preserving the
-    // default 12px container and 28px page steps, so only the two values that
-    // differ from the defaults are overridden explicitly.
-    // =========================================================================
+    // Only override radii that differ from Core defaults.
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
 
@@ -1064,11 +1050,6 @@ export const neutralTheme = defineTheme({
   },
 
   components: {
-    // =========================================================================
-    // Button — primary/secondary/ghost inherit the semantic global tokens.
-    // Destructive uses the status surface/text pair rather than inventing a
-    // component-local red.
-    // =========================================================================
     button: {
       'variant:destructive': {
         backgroundColor: 'var(--color-error-muted)',
@@ -1076,7 +1057,6 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
     // Badge —
     //   Semantic (info/success/warning/error): filled saturated tone 50 + contrasting
     //     text (white, or dark on yellow). The filled-button rule from #2150
@@ -1097,44 +1077,30 @@ export const neutralTheme = defineTheme({
       //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
       //          and tames the §4 vibration. Same dark-text-on-bright-bg
       //          treatment that warning yellow uses in both modes.
+=======
+    badge: {
+      // Semantic badges use shared fills with contrast-safe label colors.
       'variant:info': {
-        // Blue: light-mode tone 45 / dark-mode tone 60.
         backgroundColor: FILLED_STATE_COLORS.info,
         color: FILLED_STATE_TEXT.standard,
       },
       'variant:neutral': {
-        // Mirrors the gray categorical badge — same neutral chip treatment
-        // (Neutral light-mode tone 90 / semi-transparent white wash in dark
-        // mode) sourced
-        // from the gray hue tokens, so a single change at the token layer
-        // updates both variants.
         backgroundColor: 'var(--color-background-gray)',
         color: 'var(--color-text-gray)',
       },
       'variant:success': {
-        // Green: light-mode tone 45 / dark-mode tone 60.
         backgroundColor: FILLED_STATE_COLORS.success,
         color: FILLED_STATE_TEXT.standard,
       },
       'variant:warning': {
-        // Yellow: light-mode tone 80 / dark-mode tone 75, both with dark text.
         backgroundColor: FILLED_STATE_COLORS.warning,
         color: FILLED_STATE_TEXT.onBright,
       },
       'variant:error': {
-        // Red: light-mode tone 50 / dark-mode tone 60. The light-mode tone is
-        // the brightest red that still clears AA with the badge's white label.
         backgroundColor: FILLED_STATE_COLORS.error,
         color: FILLED_STATE_TEXT.standard,
       },
 
-      // Categorical — bg + text reference the per-hue tokens, so behavior
-      // tracks the categorical palette automatically:
-      //   Light: pastel tones 87-90 bg + dark tone 30 colored text (low-key chip)
-      //   Dark : tinted tone 20 bg + light tone 80 colored text (per #2150 §5,
-      //          inverted from light to avoid the "pastel-in-both-modes"
-      //          anti-pattern that makes locked light pastels glow on a
-      //          dark body)
       'variant:red': {
         backgroundColor: 'var(--color-background-red)',
         color: 'var(--color-text-red)',
@@ -1177,11 +1143,7 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // Token uses the same categorical color language as Badge. Core already
-    // maps red–pink and gray to the shared --color-background-X / --color-text-X
-    // pairs, so those variants stay aligned automatically. Only the default
-    // Token needs a redirect: match Badge neutral to the gray palette pair
-    // instead of using the generic translucent --color-neutral wash.
+    // Match the default Token to the neutral Badge treatment.
     token: {
       'color:default': {
         backgroundColor: 'var(--color-background-gray)',
@@ -1189,30 +1151,8 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
-    // StatusDot — fill uses the SAME vivid stops as the filled semantic Badge
-    // (and ProgressBar), so a dot and its badge read as one status language.
-    //
-    // The default component maps each variant to a raw semantic token
-    // (--color-success / --color-error / --color-warning / --color-icon-
-    // secondary), which in light mode are dark tones 30 and 40 meant to
-    // sit as TEXT on a pastel surface — as a solid dot they read muddy
-    // (dark green / maroon / brown). Redirect them to the badge fills.
-    //
-    //   success → badge success bg  (green light tone 45 / dark tone 60)
-    //   warning → badge warning bg  (yellow tone 85, same hex both modes)
-    //   error   → badge error bg    (red light tone 58 / dark tone 60)
-    //   accent  → badge info bg     (blue light tone 50 / dark tone 60) — the
-    //             StatusDot "accent" is the info/attention color, so it
-    //             pairs with the info badge rather than --color-accent
-    //             (near-black #262626, the darkest offender).
-    //
-    // `neutral` is intentionally NOT overridden: the neutral badge bg is a
-    // near-invisible light gray (--color-background-gray tone 90 / 10% white
-    // wash), fine as a large pill but unreadable as an 8px dot. It keeps the
-    // component default's visible mid-gray (--color-icon-secondary), which is
-    // not among the "too dark" cases.
-    // =========================================================================
+    // Status dots share semantic Badge fills; neutral keeps its visible
+    // mid-gray component default.
     'status-dot': {
       'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
       'variant:warning': {backgroundColor: FILLED_STATE_COLORS.warning},
@@ -1220,35 +1160,16 @@ export const neutralTheme = defineTheme({
       'variant:accent': {backgroundColor: FILLED_STATE_COLORS.info},
     },
 
-    // AvatarStatusDot shares the same filled state language as StatusDot.
     'avatar-status-dot': {
       'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
       'variant:error': {backgroundColor: FILLED_STATE_COLORS.error},
     },
 
-    // =========================================================================
-    // Banner — sits on a hue-tinted surface with colored text/icon:
-    //   Light: pastel tone 90 bg (pulled from --color-{X}-muted / --color-background-blue)
-    //          + dark tone 30 colored text (--color-text-{hue}).
-    //   Dark : tinted tone 20 bg (same tokens, dark slot) + light tone 80 colored text.
-    //          Per #2150 §5 — large hue-tinted surfaces in dark mode invert
-    //          to a deep tinted bg + light text rather than locking the
-    //          light-mode pastel.
-    //
-    // The inner header and its nested text, icon, and action consumers resolve
-    // their colors through semantic tokens. Rebind those public tokens here so
-    // the whole Banner subtree stays synchronized. A direct `backgroundColor`
-    // component override would win through @layer astryx-theme, but it would
-    // update only the targeted element rather than the related consumers.
-    //
-    // Status overrides reference --color-text-{hue} so text/icon colors
-    // stay in sync with the palette anchors automatically.
+    // Rebind Banner's semantic tokens so its surface, text, icons, and actions
+    // remain synchronized.
     banner: {
       base: {
-        // Secondary actions sit inside a tinted header. The global neutral
-        // wash darkens light surfaces and lightens dark surfaces, which moves
-        // colored Banner text toward the action fill in both modes. Invert
-        // that wash locally so action surfaces add contrast instead.
+        // Invert action overlays so they remain visible on tinted headers.
         '--color-neutral': lightDark(
           withAlpha(palette('neutral', 100), '33'),
           withAlpha(palette('neutral', 0), '33'),
@@ -1268,9 +1189,6 @@ export const neutralTheme = defineTheme({
         '--color-text-secondary': 'var(--color-text-blue)',
         '--color-accent': 'var(--color-text-blue)',
       },
-      // success/warning/error banner bgs come from --color-{X}-muted, which
-      // already carries the correct light/dark tinted values. We only need
-      // to redirect the text/icon to the palette colored stop.
       'status:success': {
         '--color-text-primary': 'var(--color-text-green)',
         '--color-text-secondary': 'var(--color-text-green)',
@@ -1288,21 +1206,7 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
-    // TextInput / FieldStatus — no per-status overrides needed. FieldStatus
-    // deliberately uses the same muted background + colored foreground pairs
-    // as Banner for success, warning, and error. The global tokens also carry
-    // the correct values for the input border/icon in both modes (light-mode
-    // tone 40 dark colored, dark-mode tone 80 light pastel). Verified the
-    // message pairs clear
-    // AA text 4.5:1 and the input affordances clear AA non-text 3:1.
-    // =========================================================================
-
-    // =========================================================================
-    // Switch — the off-state track is itself the control boundary, so it uses
-    // the globally contrast-safe emphasized border token. ProgressBar is a
-    // different relationship (fill on track) and is configured separately.
-    // =========================================================================
+    // The off Switch track is the control boundary.
     switch: {
       base: {
         '--color-background-gray': 'var(--color-border-emphasized)',
@@ -1313,8 +1217,7 @@ export const neutralTheme = defineTheme({
       base: {
         '--color-background-muted': PROGRESS_TRACK,
       },
-      // Vivid stops match the filled semantic badge colors except light-mode
-      // warning, which moves darker so every variant can share one gray track.
+      // Warning uses a darker light-mode stop to contrast with the track.
       'variant:accent': {
         '--color-accent': FILLED_STATE_COLORS.info,
       },
@@ -1328,8 +1231,7 @@ export const neutralTheme = defineTheme({
         '--color-error': FILLED_STATE_COLORS.error,
       },
     },
-    // Keep the live neutral fill aligned with the primary Button without
-    // rebinding disabled progress on the ProgressBar root.
+    // Keep the live neutral fill aligned with the primary Button.
     'progress-bar-fill': {
       'variant:neutral': {
         '--color-text-disabled': 'var(--color-accent)',
@@ -1350,10 +1252,7 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // SelectableCard's ring is a meaningful selected-state indicator. Use the
-    // lightest same-hue palette tone that clears WCAG 1.4.11 against each Card
-    // surface, rather than the much stronger text/icon stop. Neutral variants
-    // use a balanced gray just above the same threshold.
+    // Selection rings use the lightest same-hue tone that reaches 3:1.
     'selectable-card': {
       base: {
         '--selectable-card-ring-color': lightDark(

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -613,27 +613,42 @@ const neutralSyntax = defineSyntaxTheme({
 
 /** Shared filled-state colors for Badge, status dots, and ProgressBar. */
 const FILLED_STATE_COLORS = {
-  info: lightDark(palette('blue', 45), palette('blue', 60, 'dark')),
-  success: lightDark(palette('green', 45), palette('green', 60, 'dark')),
-  warning: lightDark(palette('yellow', 80), palette('yellow', 75, 'dark')),
-  error: lightDark(palette('red', 50), palette('red', 60, 'dark')),
+  info: lightDark(
+    getPaletteStop('blue', 45),
+    getPaletteStop('blue', 60, 'dark'),
+  ),
+  success: lightDark(
+    getPaletteStop('green', 45),
+    getPaletteStop('green', 60, 'dark'),
+  ),
+  warning: lightDark(
+    getPaletteStop('yellow', 80),
+    getPaletteStop('yellow', 75, 'dark'),
+  ),
+  error: lightDark(
+    getPaletteStop('red', 50),
+    getPaletteStop('red', 60, 'dark'),
+  ),
 } as const;
 
 const FILLED_STATE_TEXT = {
-  standard: lightDark(palette('neutral', 100), palette('neutral', 10)),
-  onBright: palette('neutral', 10),
+  standard: lightDark(
+    getPaletteStop('neutral', 100),
+    getPaletteStop('neutral', 10),
+  ),
+  onBright: getPaletteStop('neutral', 10),
 } as const;
 
 /** Shared ProgressBar track. */
 const PROGRESS_TRACK = lightDark(
-  palette('neutral', 85),
-  palette('neutral', 20, 'dark'),
+  getPaletteStop('neutral', 85),
+  getPaletteStop('neutral', 20, 'dark'),
 );
 // The Badge yellow does not reach 3:1 against the track, so ProgressBar uses a
 // darker light-mode stop.
 const PROGRESS_WARNING_FILL = lightDark(
-  palette('yellow', 50),
-  palette('yellow', 80, 'dark'),
+  getPaletteStop('yellow', 50),
+  getPaletteStop('yellow', 80, 'dark'),
 );
 
 export const neutralTheme = defineTheme({
@@ -1057,27 +1072,6 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // Badge —
-    //   Semantic (info/success/warning/error): filled saturated tone 50 + contrasting
-    //     text (white, or dark on yellow). The filled-button rule from #2150
-    //     §3 — text contrast locks the bg stop, so this stays at T50 in
-    //     BOTH modes, unlike pastel surfaces which invert by mode.
-    //   Categorical (blue/green/red/orange/etc.): pastel-tinted hue surface +
-    //     colored text — light mode = soft tones 87-90 + dark tone 30 text; dark mode
-    //     = tone 20 tinted + tone 80 light pastel text (sources: --color-background-X
-    //     and --color-text-X tokens).
-    //   Neutral: light gray bg + dark text (or inverted in dark mode).
-    // =========================================================================
-    badge: {
-      // Semantic — filled saturated bg + contrasting text.
-      //   Light: vivid tones 45-55 from the OKLCH palette + white text
-      //          (~4.5-5:1 — Material/Linear/Vercel pop).
-      //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
-      //          +5 stop-lift taper from issue #2150 §4) + DARK text.
-      //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
-      //          and tames the §4 vibration. Same dark-text-on-bright-bg
-      //          treatment that warning yellow uses in both modes.
-=======
     badge: {
       // Semantic badges use shared fills with contrast-safe label colors.
       'variant:info': {
@@ -1171,16 +1165,16 @@ export const neutralTheme = defineTheme({
       base: {
         // Invert action overlays so they remain visible on tinted headers.
         '--color-neutral': lightDark(
-          withAlpha(palette('neutral', 100), '33'),
-          withAlpha(palette('neutral', 0), '33'),
+          withAlpha(getPaletteStop('neutral', 100), '33'),
+          withAlpha(getPaletteStop('neutral', 0), '33'),
         ),
         '--color-overlay-hover': lightDark(
-          withAlpha(palette('neutral', 100), '1A'),
-          withAlpha(palette('neutral', 0), '1A'),
+          withAlpha(getPaletteStop('neutral', 100), '1A'),
+          withAlpha(getPaletteStop('neutral', 0), '1A'),
         ),
         '--color-overlay-pressed': lightDark(
-          withAlpha(palette('neutral', 100), '33'),
-          withAlpha(palette('neutral', 0), '33'),
+          withAlpha(getPaletteStop('neutral', 100), '33'),
+          withAlpha(getPaletteStop('neutral', 0), '33'),
         ),
       },
       'status:info': {
@@ -1252,72 +1246,72 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // Selection rings use the lightest same-hue tone that reaches 3:1.
+    // Selection rings use the lightest same-hue stop that reaches 3:1.
     'selectable-card': {
       base: {
         '--selectable-card-ring-color': lightDark(
-          palette('neutral', 55),
-          palette('neutral', 40, 'dark'),
+          getPaletteStop('neutral', 55),
+          getPaletteStop('neutral', 40, 'dark'),
         ),
       },
       'variant:red': {
         '--selectable-card-ring-color': lightDark(
-          palette('red', 50),
+          getPaletteStop('red', 50),
           'var(--color-border-red)',
         ),
       },
       'variant:orange': {
         '--selectable-card-ring-color': lightDark(
-          palette('orange', 50),
+          getPaletteStop('orange', 50),
           'var(--color-border-orange)',
         ),
       },
       'variant:yellow': {
         '--selectable-card-ring-color': lightDark(
-          palette('yellow', 50),
+          getPaletteStop('yellow', 50),
           'var(--color-border-yellow)',
         ),
       },
       'variant:green': {
         '--selectable-card-ring-color': lightDark(
-          palette('green', 45),
+          getPaletteStop('green', 45),
           'var(--color-border-green)',
         ),
       },
       'variant:teal': {
         '--selectable-card-ring-color': lightDark(
-          palette('teal', 45),
+          getPaletteStop('teal', 45),
           'var(--color-border-teal)',
         ),
       },
       'variant:cyan': {
         '--selectable-card-ring-color': lightDark(
-          palette('cyan', 45),
+          getPaletteStop('cyan', 45),
           'var(--color-border-cyan)',
         ),
       },
       'variant:blue': {
         '--selectable-card-ring-color': lightDark(
-          palette('blue', 50),
+          getPaletteStop('blue', 50),
           'var(--color-border-blue)',
         ),
       },
       'variant:purple': {
         '--selectable-card-ring-color': lightDark(
-          palette('purple', 50),
+          getPaletteStop('purple', 50),
           'var(--color-border-purple)',
         ),
       },
       'variant:pink': {
         '--selectable-card-ring-color': lightDark(
-          palette('pink', 50),
+          getPaletteStop('pink', 50),
           'var(--color-border-pink)',
         ),
       },
       'variant:gray': {
         '--selectable-card-ring-color': lightDark(
-          palette('neutral', 50),
-          palette('neutral', 50, 'dark'),
+          getPaletteStop('neutral', 50),
+          getPaletteStop('neutral', 50, 'dark'),
         ),
       },
     },

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -23,10 +23,9 @@
  * ```
  *
  * Pair the theme rule's `backgroundColor` with `--selectable-card-ring-color`.
- * SelectableCard rings an added variant in that var, defaulting to the accent —
- * no token the component could pick is guaranteed to contrast with a fill it
- * cannot know, so the theme that supplied the fill picks the ring, in the same
- * rule.
+ * SelectableCard reads that variable for built-in and added variants, retaining
+ * the matching border token (or accent) as its fallback. The theme that supplied
+ * the fill can therefore choose a ring that reaches 3:1 against it.
  */
 export interface CardVariantMap {
   default: true;

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -22,10 +22,8 @@
  * }
  * ```
  *
- * Pair the theme rule's `backgroundColor` with `--selectable-card-ring-color`.
- * SelectableCard reads that variable for built-in and added variants, retaining
- * the matching border token (or accent) as its fallback. The theme that supplied
- * the fill can therefore choose a ring that reaches 3:1 against it.
+ * Theme variants may set `--selectable-card-ring-color` when their background
+ * requires a stronger SelectableCard selection indicator.
  */
 export interface CardVariantMap {
   default: true;

--- a/packages/core/src/SelectableCard/SelectableCard.doc.mjs
+++ b/packages/core/src/SelectableCard/SelectableCard.doc.mjs
@@ -38,7 +38,7 @@ export const docs = {
     container: true,
     targets: [{className: 'astryx-selectable-card', visualProps: ['selected', 'variant']}],
     vars: [
-      {name: '--selectable-card-ring-color', description: 'Colour of the selection ring drawn for a variant a theme added. The built-in variants each ring in their own border token and ignore this; a theme that adds a variant sets it in the same rule as that variant\'s `backgroundColor`, because no token the component could pick is guaranteed to contrast with a fill it cannot know.', default: 'var(--color-accent)'},
+      {name: '--selectable-card-ring-color', description: 'Colour of the selected-state ring and matching Card border. A theme can set it for any built-in or added variant when the default ring does not reach 3:1 against the rendered Card background. Built-in variants otherwise fall back to their matching border token; default, transparent, muted, and unknown variants fall back to `--color-accent`.', default: 'Variant border token or var(--color-accent)'},
     ],
   },
   playground: {

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -153,11 +153,7 @@ const styles = stylex.create({
     borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-yellow']})`,
     '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-yellow']})`,
   },
-  // A theme-added variant paints with colours the component cannot know, so no
-  // token is guaranteed to contrast with it. The same public variable can also
-  // strengthen a built-in variant whose default border token is too subtle
-  // against that theme's Card surface. Each style keeps its prior token as the
-  // fallback when the theme does not provide an override.
+  // Theme variants may override the ring while built-in tokens remain fallbacks.
   selectedUnknown: {
     borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-accent']})`,
     '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-accent']})`,

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -55,10 +55,6 @@ import {useMergedRefs} from '../hooks/useMergedRefs';
 
 const styles = stylex.create({
   interactive: {
-    // Declared here, on the element that carries the `astryx-selectable-card`
-    // target, so a theme has something to override — the ring for a variant
-    // only the theme knows about reads it (see selectedUnknown).
-    '--selectable-card-ring-color': colorVars['--color-accent'],
     position: 'relative',
     cursor: {
       default: 'pointer',
@@ -114,56 +110,57 @@ const styles = stylex.create({
   // (rather than box-shadow directly) lets it compose with the card's
   // elevation instead of clobbering it.
   selected: {
-    borderColor: colorVars['--color-accent'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-accent']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-accent']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-accent']})`,
   },
   selectedBlue: {
-    borderColor: colorVars['--color-border-blue'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-blue']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-blue']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-blue']})`,
   },
   selectedCyan: {
-    borderColor: colorVars['--color-border-cyan'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-cyan']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-cyan']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-cyan']})`,
   },
   selectedGray: {
-    borderColor: colorVars['--color-border-gray'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-gray']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-gray']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-gray']})`,
   },
   selectedGreen: {
-    borderColor: colorVars['--color-border-green'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-green']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-green']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-green']})`,
   },
   selectedOrange: {
-    borderColor: colorVars['--color-border-orange'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-orange']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-orange']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-orange']})`,
   },
   selectedPink: {
-    borderColor: colorVars['--color-border-pink'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-pink']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-pink']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-pink']})`,
   },
   selectedPurple: {
-    borderColor: colorVars['--color-border-purple'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-purple']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-purple']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-purple']})`,
   },
   selectedRed: {
-    borderColor: colorVars['--color-border-red'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-red']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-red']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-red']})`,
   },
   selectedTeal: {
-    borderColor: colorVars['--color-border-teal'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-teal']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-teal']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-teal']})`,
   },
   selectedYellow: {
-    borderColor: colorVars['--color-border-yellow'],
-    '--_card-ring': `inset 0 0 0 2px ${colorVars['--color-border-yellow']}`,
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-border-yellow']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-border-yellow']})`,
   },
   // A theme-added variant paints with colours the component cannot know, so no
-  // token is guaranteed to contrast with it — an accent ring disappears against
-  // an accent fill, and an outset one is no better. The theme that supplied the
-  // fill is the only thing that can pick a ring, so it gets a lever beside it;
-  // the var defaults to the accent, keeping every built-in unchanged.
+  // token is guaranteed to contrast with it. The same public variable can also
+  // strengthen a built-in variant whose default border token is too subtle
+  // against that theme's Card surface. Each style keeps its prior token as the
+  // fallback when the theme does not provide an override.
   selectedUnknown: {
-    '--_card-ring': 'inset 0 0 0 2px var(--selectable-card-ring-color)',
+    borderColor: `var(--selectable-card-ring-color, ${colorVars['--color-accent']})`,
+    '--_card-ring': `inset 0 0 0 2px var(--selectable-card-ring-color, ${colorVars['--color-accent']})`,
   },
 });
 

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -611,6 +611,40 @@ const neutralSyntax = defineSyntaxTheme({
   },
 });
 
+/**
+ * Filled semantic colors are shared by Badge and StatusDot. ProgressBar uses
+ * the same colors except where its fill-on-track relationship needs a
+ * contrast-specific stop (light-mode warning).
+ */
+const FILLED_STATE_COLORS = {
+  info: lightDark(palette('blue', 45), palette('blue', 60, 'dark')),
+  success: lightDark(palette('green', 45), palette('green', 60, 'dark')),
+  warning: lightDark(palette('yellow', 80), palette('yellow', 75, 'dark')),
+  error: lightDark(palette('red', 50), palette('red', 60, 'dark')),
+} as const;
+
+const FILLED_STATE_TEXT = {
+  standard: lightDark(palette('neutral', 100), palette('neutral', 10)),
+  onBright: palette('neutral', 10),
+} as const;
+
+/**
+ * Progress is a fill-on-track relationship, not a control boundary. Every
+ * variant uses the same neutral track so the remaining range has one stable
+ * visual treatment.
+ */
+const PROGRESS_TRACK = lightDark(
+  palette('neutral', 85),
+  palette('neutral', 20, 'dark'),
+);
+// The bright Badge yellow is only 1.01:1 against the light neutral track.
+// Progress therefore uses yellow, light-mode tone 50, the closest darker tone
+// that clears 3:1. Dark mode keeps the brighter semantic yellow.
+const PROGRESS_WARNING_FILL = lightDark(
+  palette('yellow', 50),
+  palette('yellow', 80, 'dark'),
+);
+
 export const neutralTheme = defineTheme({
   name: 'neutral',
   palettes: neutralPalettes,
@@ -984,17 +1018,13 @@ export const neutralTheme = defineTheme({
     ],
 
     // =========================================================================
-    // Radius — slightly larger than default (kept as-is)
-    // --radius-none and --radius-full are always fixed and must never be
-    // scaled by a theme (see defineTheme's radius config docs) — 0 and
-    // 9999px respectively, matching @astryxdesign/core's own defaults.
+    // Radius — a deliberately non-linear adjustment. The higher-order radius
+    // config cannot produce inner=6px and element=10px while preserving the
+    // default 12px container and 28px page steps, so only the two values that
+    // differ from the defaults are overridden explicitly.
     // =========================================================================
-    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
-    '--radius-container': '0.75rem',
-    '--radius-page': '1.75rem',
-    '--radius-full': '9999px',
 
     // =========================================================================
     // Shadows
@@ -1035,31 +1065,32 @@ export const neutralTheme = defineTheme({
 
   components: {
     // =========================================================================
-    // Button — primary gets white text, secondary gets a border, destructive
-    // uses the OKLCH red filled treatment.
+    // Button — primary/secondary/ghost inherit the semantic global tokens.
+    // Destructive uses the status surface/text pair rather than inventing a
+    // component-local red.
     // =========================================================================
     button: {
       'variant:destructive': {
-        backgroundColor: 'var(--color-error-muted)', // locked pastel red bg
-        color: 'var(--color-error)', // locked T30 red — matches banner/input error text
+        backgroundColor: 'var(--color-error-muted)',
+        color: 'var(--color-error)',
       },
     },
 
     // =========================================================================
     // Badge —
-    //   Semantic (info/success/warning/error): filled saturated T50 + contrasting
+    //   Semantic (info/success/warning/error): filled saturated tone 50 + contrasting
     //     text (white, or dark on yellow). The filled-button rule from #2150
     //     §3 — text contrast locks the bg stop, so this stays at T50 in
     //     BOTH modes, unlike pastel surfaces which invert by mode.
     //   Categorical (blue/green/red/orange/etc.): pastel-tinted hue surface +
-    //     colored text — light mode = soft T87-T90 + dark T30 text; dark mode
-    //     = T20 tinted + T80 light pastel text (sources: --color-background-X
+    //     colored text — light mode = soft tones 87-90 + dark tone 30 text; dark mode
+    //     = tone 20 tinted + tone 80 light pastel text (sources: --color-background-X
     //     and --color-text-X tokens).
     //   Neutral: light gray bg + dark text (or inverted in dark mode).
     // =========================================================================
     badge: {
       // Semantic — filled saturated bg + contrasting text.
-      //   Light: vivid T45-T55 from the OKLCH palette + white text
+      //   Light: vivid tones 45-55 from the OKLCH palette + white text
       //          (~4.5-5:1 — Material/Linear/Vercel pop).
       //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
       //          +5 stop-lift taper from issue #2150 §4) + DARK text.
@@ -1067,48 +1098,40 @@ export const neutralTheme = defineTheme({
       //          and tames the §4 vibration. Same dark-text-on-bright-bg
       //          treatment that warning yellow uses in both modes.
       'variant:info': {
-        // Light: T50 #0074e2 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #0074e2
-        backgroundColor: 'light-dark(#0074e2, #6d9cfe)',
-        color: 'light-dark(#ffffff, #171717)',
+        // Blue: light-mode tone 45 / dark-mode tone 60.
+        backgroundColor: FILLED_STATE_COLORS.info,
+        color: FILLED_STATE_TEXT.standard,
       },
       'variant:neutral': {
         // Mirrors the gray categorical badge — same neutral chip treatment
-        // (Neutral 200 light / semi-transparent white wash dark) sourced
+        // (Neutral light-mode tone 90 / semi-transparent white wash in dark
+        // mode) sourced
         // from the gray hue tokens, so a single change at the token layer
         // updates both variants.
         backgroundColor: 'var(--color-background-gray)',
         color: 'var(--color-text-gray)',
       },
       'variant:success': {
-        // Light: T45 #198100 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #198100
-        backgroundColor: 'light-dark(#198100, #64af4c)',
-        color: 'light-dark(#ffffff, #171717)',
+        // Green: light-mode tone 45 / dark-mode tone 60.
+        backgroundColor: FILLED_STATE_COLORS.success,
+        color: FILLED_STATE_TEXT.standard,
       },
       'variant:warning': {
-        // Yellow stays at the same hex in both modes — chroma reduction
-        // is barely visible at T85, and dark text on yellow doesn't
-        // suffer from the §4 vibration concern.
-        backgroundColor: '#ffce2f',
-        color: '#171717',
+        // Yellow: light-mode tone 80 / dark-mode tone 75, both with dark text.
+        backgroundColor: FILLED_STATE_COLORS.warning,
+        color: FILLED_STATE_TEXT.onBright,
       },
       'variant:error': {
-        // Light: T58 #c9303a. The T55 stop #e33f4a pairs with white at only
-        //        4.14:1 — the label is 12px/500, so AA wants 4.5, not the 3:1
-        //        large-text allowance. One tonal step down holds the hue
-        //        (OKLCH H 21.9 -> 22.8, C 0.200 -> 0.189) and reaches 5.29:1.
-        // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
-        //        source #dc2626 (kept on H=27 alarm-red rather than coral).
-        //        Dark text on it is 6.60:1 and unchanged.
-        backgroundColor: 'light-dark(#c9303a, #ff705d)',
-        color: 'light-dark(#ffffff, #171717)',
+        // Red: light-mode tone 50 / dark-mode tone 60. The light-mode tone is
+        // the brightest red that still clears AA with the badge's white label.
+        backgroundColor: FILLED_STATE_COLORS.error,
+        color: FILLED_STATE_TEXT.standard,
       },
 
       // Categorical — bg + text reference the per-hue tokens, so behavior
       // tracks the categorical palette automatically:
-      //   Light: pastel T87-T90 bg + dark T30 colored text (low-key chip)
-      //   Dark : tinted T20 bg + light T80 colored text (per #2150 §5,
+      //   Light: pastel tones 87-90 bg + dark tone 30 colored text (low-key chip)
+      //   Dark : tinted tone 20 bg + light tone 80 colored text (per #2150 §5,
       //          inverted from light to avoid the "pastel-in-both-modes"
       //          anti-pattern that makes locked light pastels glow on a
       //          dark body)
@@ -1154,55 +1177,91 @@ export const neutralTheme = defineTheme({
       },
     },
 
+    // Token uses the same categorical color language as Badge. Core already
+    // maps red–pink and gray to the shared --color-background-X / --color-text-X
+    // pairs, so those variants stay aligned automatically. Only the default
+    // Token needs a redirect: match Badge neutral to the gray palette pair
+    // instead of using the generic translucent --color-neutral wash.
+    token: {
+      'color:default': {
+        backgroundColor: 'var(--color-background-gray)',
+        color: 'var(--color-text-gray)',
+      },
+    },
+
     // =========================================================================
     // StatusDot — fill uses the SAME vivid stops as the filled semantic Badge
     // (and ProgressBar), so a dot and its badge read as one status language.
     //
     // The default component maps each variant to a raw semantic token
     // (--color-success / --color-error / --color-warning / --color-icon-
-    // secondary), which in light mode are the dark T30/T40 stops meant to
+    // secondary), which in light mode are dark tones 30 and 40 meant to
     // sit as TEXT on a pastel surface — as a solid dot they read muddy
     // (dark green / maroon / brown). Redirect them to the badge fills.
     //
-    //   success → badge success bg  (green T45 / dark-ramp T60)
-    //   warning → badge warning bg  (yellow T85, same hex both modes)
-    //   error   → badge error bg    (red T58 / dark-ramp T60)
-    //   accent  → badge info bg     (blue T50 / dark-ramp T60) — the
+    //   success → badge success bg  (green light tone 45 / dark tone 60)
+    //   warning → badge warning bg  (yellow tone 85, same hex both modes)
+    //   error   → badge error bg    (red light tone 58 / dark tone 60)
+    //   accent  → badge info bg     (blue light tone 50 / dark tone 60) — the
     //             StatusDot "accent" is the info/attention color, so it
     //             pairs with the info badge rather than --color-accent
     //             (near-black #262626, the darkest offender).
     //
     // `neutral` is intentionally NOT overridden: the neutral badge bg is a
-    // near-invisible light gray (--color-background-gray #e5e5e5 / 10% white
+    // near-invisible light gray (--color-background-gray tone 90 / 10% white
     // wash), fine as a large pill but unreadable as an 8px dot. It keeps the
     // component default's visible mid-gray (--color-icon-secondary), which is
     // not among the "too dark" cases.
     // =========================================================================
-    statusdot: {
-      'variant:success': {backgroundColor: 'light-dark(#198100, #64af4c)'},
-      'variant:warning': {backgroundColor: '#ffce2f'},
-      'variant:error': {backgroundColor: 'light-dark(#c9303a, #ff705d)'},
-      'variant:accent': {backgroundColor: 'light-dark(#0074e2, #6d9cfe)'},
+    'status-dot': {
+      'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
+      'variant:warning': {backgroundColor: FILLED_STATE_COLORS.warning},
+      'variant:error': {backgroundColor: FILLED_STATE_COLORS.error},
+      'variant:accent': {backgroundColor: FILLED_STATE_COLORS.info},
+    },
+
+    // AvatarStatusDot shares the same filled state language as StatusDot.
+    'avatar-status-dot': {
+      'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
+      'variant:error': {backgroundColor: FILLED_STATE_COLORS.error},
     },
 
     // =========================================================================
     // Banner — sits on a hue-tinted surface with colored text/icon:
-    //   Light: pastel T90 bg (pulled from --color-{X}-muted / --color-background-blue)
-    //          + dark T30 colored text (--color-text-{hue}).
-    //   Dark : tinted T20 bg (same tokens, dark slot) + light T80 colored text.
+    //   Light: pastel tone 90 bg (pulled from --color-{X}-muted / --color-background-blue)
+    //          + dark tone 30 colored text (--color-text-{hue}).
+    //   Dark : tinted tone 20 bg (same tokens, dark slot) + light tone 80 colored text.
     //          Per #2150 §5 — large hue-tinted surfaces in dark mode invert
     //          to a deep tinted bg + light text rather than locking the
     //          light-mode pastel.
     //
-    // The inner-header *-muted token carries the tinted background for every
-    // status, info included. A theme override that sets a plain CSS property
-    // instead lands in @layer astryx-theme, which StyleX's @layer priority4
-    // outranks, so `backgroundColor` here would silently do nothing and the
-    // info banner would paint no background at all.
+    // The inner header and its nested text, icon, and action consumers resolve
+    // their colors through semantic tokens. Rebind those public tokens here so
+    // the whole Banner subtree stays synchronized. A direct `backgroundColor`
+    // component override would win through @layer astryx-theme, but it would
+    // update only the targeted element rather than the related consumers.
     //
     // Status overrides reference --color-text-{hue} so text/icon colors
     // stay in sync with the palette anchors automatically.
     banner: {
+      base: {
+        // Secondary actions sit inside a tinted header. The global neutral
+        // wash darkens light surfaces and lightens dark surfaces, which moves
+        // colored Banner text toward the action fill in both modes. Invert
+        // that wash locally so action surfaces add contrast instead.
+        '--color-neutral': lightDark(
+          withAlpha(palette('neutral', 100), '33'),
+          withAlpha(palette('neutral', 0), '33'),
+        ),
+        '--color-overlay-hover': lightDark(
+          withAlpha(palette('neutral', 100), '1A'),
+          withAlpha(palette('neutral', 0), '1A'),
+        ),
+        '--color-overlay-pressed': lightDark(
+          withAlpha(palette('neutral', 100), '33'),
+          withAlpha(palette('neutral', 0), '33'),
+        ),
+      },
       'status:info': {
         '--color-accent-muted': 'var(--color-background-blue)',
         '--color-text-primary': 'var(--color-text-blue)',
@@ -1230,21 +1289,19 @@ export const neutralTheme = defineTheme({
     },
 
     // =========================================================================
-    // TextInput — no per-status overrides needed. The global tokens
-    // --color-{success,error,warning} carry the correct values in both
-    // modes (light=T40 dark colored, dark=T80 light pastel) for both
-    // surfaces the input border/icon touches: the input surface
-    // (white/T15-dark) and the status message bubble (light pastel T90 /
-    // dark T20). Verified all six combinations clear AA non-text 3:1.
+    // TextInput / FieldStatus — no per-status overrides needed. FieldStatus
+    // deliberately uses the same muted background + colored foreground pairs
+    // as Banner for success, warning, and error. The global tokens also carry
+    // the correct values for the input border/icon in both modes (light-mode
+    // tone 40 dark colored, dark-mode tone 80 light pastel). Verified the
+    // message pairs clear
+    // AA text 4.5:1 and the input affordances clear AA non-text 3:1.
     // =========================================================================
 
     // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
+    // Switch — the off-state track is itself the control boundary, so it uses
+    // the globally contrast-safe emphasized border token. ProgressBar is a
+    // different relationship (fill on track) and is configured separately.
     // =========================================================================
     switch: {
       base: {
@@ -1252,33 +1309,35 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    progressbar: {
+    'progress-bar': {
       base: {
-        // Track uses --color-background-muted; override it to
-        // --color-border-emphasized (Neutral T85 #d4d4d4 in light mode) so
-        // the track is clearly darker than the body bg (Neutral T95 #f1f1f1)
-        // and reads as a defined channel rather than blending in. Dark
-        // mode inherits T35 #525252 — same one-step-lighter behavior.
-        '--color-background-muted': 'var(--color-border-emphasized)',
+        '--color-background-muted': PROGRESS_TRACK,
       },
-      // Vivid stops match the filled semantic badge colors (info/success/
-      // warning/error variants in the badge override above). Same hex
-      // values; documented per role with palette provenance.
+      // Vivid stops match the filled semantic badge colors except light-mode
+      // warning, which moves darker so every variant can share one gray track.
       'variant:accent': {
-        // Blue T50 saturated stop (= variant:info badge bg)
-        '--color-accent': '#0074e2',
+        '--color-accent': FILLED_STATE_COLORS.info,
       },
       'variant:success': {
-        // Green T45 saturated stop (= variant:success badge bg)
-        '--color-success': '#198100',
+        '--color-success': FILLED_STATE_COLORS.success,
       },
       'variant:warning': {
-        // Yellow T85 saturated stop (= variant:warning badge bg)
-        '--color-warning': '#ffce2f',
+        '--color-warning': PROGRESS_WARNING_FILL,
       },
       'variant:error': {
-        // Red T58 saturated stop (= variant:error badge bg)
-        '--color-error': '#c9303a',
+        '--color-error': FILLED_STATE_COLORS.error,
+      },
+    },
+    // Keep the live neutral fill aligned with the primary Button without
+    // rebinding disabled progress on the ProgressBar root.
+    'progress-bar-fill': {
+      'variant:neutral': {
+        '--color-text-disabled': 'var(--color-accent)',
+      },
+    },
+    'progress-bar-mark': {
+      'variant:neutral+placement:fill': {
+        '--color-text-primary': 'var(--color-on-accent)',
       },
     },
 
@@ -1288,6 +1347,79 @@ export const neutralTheme = defineTheme({
     card: {
       base: {
         padding: 'var(--spacing-3)',
+      },
+    },
+
+    // SelectableCard's ring is a meaningful selected-state indicator. Use the
+    // lightest same-hue palette tone that clears WCAG 1.4.11 against each Card
+    // surface, rather than the much stronger text/icon stop. Neutral variants
+    // use a balanced gray just above the same threshold.
+    'selectable-card': {
+      base: {
+        '--selectable-card-ring-color': lightDark(
+          palette('neutral', 55),
+          palette('neutral', 40, 'dark'),
+        ),
+      },
+      'variant:red': {
+        '--selectable-card-ring-color': lightDark(
+          palette('red', 50),
+          'var(--color-border-red)',
+        ),
+      },
+      'variant:orange': {
+        '--selectable-card-ring-color': lightDark(
+          palette('orange', 50),
+          'var(--color-border-orange)',
+        ),
+      },
+      'variant:yellow': {
+        '--selectable-card-ring-color': lightDark(
+          palette('yellow', 50),
+          'var(--color-border-yellow)',
+        ),
+      },
+      'variant:green': {
+        '--selectable-card-ring-color': lightDark(
+          palette('green', 45),
+          'var(--color-border-green)',
+        ),
+      },
+      'variant:teal': {
+        '--selectable-card-ring-color': lightDark(
+          palette('teal', 45),
+          'var(--color-border-teal)',
+        ),
+      },
+      'variant:cyan': {
+        '--selectable-card-ring-color': lightDark(
+          palette('cyan', 45),
+          'var(--color-border-cyan)',
+        ),
+      },
+      'variant:blue': {
+        '--selectable-card-ring-color': lightDark(
+          palette('blue', 50),
+          'var(--color-border-blue)',
+        ),
+      },
+      'variant:purple': {
+        '--selectable-card-ring-color': lightDark(
+          palette('purple', 50),
+          'var(--color-border-purple)',
+        ),
+      },
+      'variant:pink': {
+        '--selectable-card-ring-color': lightDark(
+          palette('pink', 50),
+          'var(--color-border-pink)',
+        ),
+      },
+      'variant:gray': {
+        '--selectable-card-ring-color': lightDark(
+          palette('neutral', 50),
+          palette('neutral', 50, 'dark'),
+        ),
       },
     },
 

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -611,11 +611,7 @@ const neutralSyntax = defineSyntaxTheme({
   },
 });
 
-/**
- * Filled semantic colors are shared by Badge and StatusDot. ProgressBar uses
- * the same colors except where its fill-on-track relationship needs a
- * contrast-specific stop (light-mode warning).
- */
+/** Shared filled-state colors for Badge, status dots, and ProgressBar. */
 const FILLED_STATE_COLORS = {
   info: lightDark(palette('blue', 45), palette('blue', 60, 'dark')),
   success: lightDark(palette('green', 45), palette('green', 60, 'dark')),
@@ -628,18 +624,13 @@ const FILLED_STATE_TEXT = {
   onBright: palette('neutral', 10),
 } as const;
 
-/**
- * Progress is a fill-on-track relationship, not a control boundary. Every
- * variant uses the same neutral track so the remaining range has one stable
- * visual treatment.
- */
+/** Shared ProgressBar track. */
 const PROGRESS_TRACK = lightDark(
   palette('neutral', 85),
   palette('neutral', 20, 'dark'),
 );
-// The bright Badge yellow is only 1.01:1 against the light neutral track.
-// Progress therefore uses yellow, light-mode tone 50, the closest darker tone
-// that clears 3:1. Dark mode keeps the brighter semantic yellow.
+// The Badge yellow does not reach 3:1 against the track, so ProgressBar uses a
+// darker light-mode stop.
 const PROGRESS_WARNING_FILL = lightDark(
   palette('yellow', 50),
   palette('yellow', 80, 'dark'),
@@ -1017,12 +1008,7 @@ export const neutralTheme = defineTheme({
       getPaletteStop('neutral', 90, 'dark'),
     ],
 
-    // =========================================================================
-    // Radius — a deliberately non-linear adjustment. The higher-order radius
-    // config cannot produce inner=6px and element=10px while preserving the
-    // default 12px container and 28px page steps, so only the two values that
-    // differ from the defaults are overridden explicitly.
-    // =========================================================================
+    // Only override radii that differ from Core defaults.
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
 
@@ -1064,11 +1050,6 @@ export const neutralTheme = defineTheme({
   },
 
   components: {
-    // =========================================================================
-    // Button — primary/secondary/ghost inherit the semantic global tokens.
-    // Destructive uses the status surface/text pair rather than inventing a
-    // component-local red.
-    // =========================================================================
     button: {
       'variant:destructive': {
         backgroundColor: 'var(--color-error-muted)',
@@ -1076,7 +1057,6 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
     // Badge —
     //   Semantic (info/success/warning/error): filled saturated tone 50 + contrasting
     //     text (white, or dark on yellow). The filled-button rule from #2150
@@ -1097,44 +1077,30 @@ export const neutralTheme = defineTheme({
       //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
       //          and tames the §4 vibration. Same dark-text-on-bright-bg
       //          treatment that warning yellow uses in both modes.
+=======
+    badge: {
+      // Semantic badges use shared fills with contrast-safe label colors.
       'variant:info': {
-        // Blue: light-mode tone 45 / dark-mode tone 60.
         backgroundColor: FILLED_STATE_COLORS.info,
         color: FILLED_STATE_TEXT.standard,
       },
       'variant:neutral': {
-        // Mirrors the gray categorical badge — same neutral chip treatment
-        // (Neutral light-mode tone 90 / semi-transparent white wash in dark
-        // mode) sourced
-        // from the gray hue tokens, so a single change at the token layer
-        // updates both variants.
         backgroundColor: 'var(--color-background-gray)',
         color: 'var(--color-text-gray)',
       },
       'variant:success': {
-        // Green: light-mode tone 45 / dark-mode tone 60.
         backgroundColor: FILLED_STATE_COLORS.success,
         color: FILLED_STATE_TEXT.standard,
       },
       'variant:warning': {
-        // Yellow: light-mode tone 80 / dark-mode tone 75, both with dark text.
         backgroundColor: FILLED_STATE_COLORS.warning,
         color: FILLED_STATE_TEXT.onBright,
       },
       'variant:error': {
-        // Red: light-mode tone 50 / dark-mode tone 60. The light-mode tone is
-        // the brightest red that still clears AA with the badge's white label.
         backgroundColor: FILLED_STATE_COLORS.error,
         color: FILLED_STATE_TEXT.standard,
       },
 
-      // Categorical — bg + text reference the per-hue tokens, so behavior
-      // tracks the categorical palette automatically:
-      //   Light: pastel tones 87-90 bg + dark tone 30 colored text (low-key chip)
-      //   Dark : tinted tone 20 bg + light tone 80 colored text (per #2150 §5,
-      //          inverted from light to avoid the "pastel-in-both-modes"
-      //          anti-pattern that makes locked light pastels glow on a
-      //          dark body)
       'variant:red': {
         backgroundColor: 'var(--color-background-red)',
         color: 'var(--color-text-red)',
@@ -1177,11 +1143,7 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // Token uses the same categorical color language as Badge. Core already
-    // maps red–pink and gray to the shared --color-background-X / --color-text-X
-    // pairs, so those variants stay aligned automatically. Only the default
-    // Token needs a redirect: match Badge neutral to the gray palette pair
-    // instead of using the generic translucent --color-neutral wash.
+    // Match the default Token to the neutral Badge treatment.
     token: {
       'color:default': {
         backgroundColor: 'var(--color-background-gray)',
@@ -1189,30 +1151,8 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
-    // StatusDot — fill uses the SAME vivid stops as the filled semantic Badge
-    // (and ProgressBar), so a dot and its badge read as one status language.
-    //
-    // The default component maps each variant to a raw semantic token
-    // (--color-success / --color-error / --color-warning / --color-icon-
-    // secondary), which in light mode are dark tones 30 and 40 meant to
-    // sit as TEXT on a pastel surface — as a solid dot they read muddy
-    // (dark green / maroon / brown). Redirect them to the badge fills.
-    //
-    //   success → badge success bg  (green light tone 45 / dark tone 60)
-    //   warning → badge warning bg  (yellow tone 85, same hex both modes)
-    //   error   → badge error bg    (red light tone 58 / dark tone 60)
-    //   accent  → badge info bg     (blue light tone 50 / dark tone 60) — the
-    //             StatusDot "accent" is the info/attention color, so it
-    //             pairs with the info badge rather than --color-accent
-    //             (near-black #262626, the darkest offender).
-    //
-    // `neutral` is intentionally NOT overridden: the neutral badge bg is a
-    // near-invisible light gray (--color-background-gray tone 90 / 10% white
-    // wash), fine as a large pill but unreadable as an 8px dot. It keeps the
-    // component default's visible mid-gray (--color-icon-secondary), which is
-    // not among the "too dark" cases.
-    // =========================================================================
+    // Status dots share semantic Badge fills; neutral keeps its visible
+    // mid-gray component default.
     'status-dot': {
       'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
       'variant:warning': {backgroundColor: FILLED_STATE_COLORS.warning},
@@ -1220,35 +1160,16 @@ export const neutralTheme = defineTheme({
       'variant:accent': {backgroundColor: FILLED_STATE_COLORS.info},
     },
 
-    // AvatarStatusDot shares the same filled state language as StatusDot.
     'avatar-status-dot': {
       'variant:success': {backgroundColor: FILLED_STATE_COLORS.success},
       'variant:error': {backgroundColor: FILLED_STATE_COLORS.error},
     },
 
-    // =========================================================================
-    // Banner — sits on a hue-tinted surface with colored text/icon:
-    //   Light: pastel tone 90 bg (pulled from --color-{X}-muted / --color-background-blue)
-    //          + dark tone 30 colored text (--color-text-{hue}).
-    //   Dark : tinted tone 20 bg (same tokens, dark slot) + light tone 80 colored text.
-    //          Per #2150 §5 — large hue-tinted surfaces in dark mode invert
-    //          to a deep tinted bg + light text rather than locking the
-    //          light-mode pastel.
-    //
-    // The inner header and its nested text, icon, and action consumers resolve
-    // their colors through semantic tokens. Rebind those public tokens here so
-    // the whole Banner subtree stays synchronized. A direct `backgroundColor`
-    // component override would win through @layer astryx-theme, but it would
-    // update only the targeted element rather than the related consumers.
-    //
-    // Status overrides reference --color-text-{hue} so text/icon colors
-    // stay in sync with the palette anchors automatically.
+    // Rebind Banner's semantic tokens so its surface, text, icons, and actions
+    // remain synchronized.
     banner: {
       base: {
-        // Secondary actions sit inside a tinted header. The global neutral
-        // wash darkens light surfaces and lightens dark surfaces, which moves
-        // colored Banner text toward the action fill in both modes. Invert
-        // that wash locally so action surfaces add contrast instead.
+        // Invert action overlays so they remain visible on tinted headers.
         '--color-neutral': lightDark(
           withAlpha(palette('neutral', 100), '33'),
           withAlpha(palette('neutral', 0), '33'),
@@ -1268,9 +1189,6 @@ export const neutralTheme = defineTheme({
         '--color-text-secondary': 'var(--color-text-blue)',
         '--color-accent': 'var(--color-text-blue)',
       },
-      // success/warning/error banner bgs come from --color-{X}-muted, which
-      // already carries the correct light/dark tinted values. We only need
-      // to redirect the text/icon to the palette colored stop.
       'status:success': {
         '--color-text-primary': 'var(--color-text-green)',
         '--color-text-secondary': 'var(--color-text-green)',
@@ -1288,21 +1206,7 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
-    // TextInput / FieldStatus — no per-status overrides needed. FieldStatus
-    // deliberately uses the same muted background + colored foreground pairs
-    // as Banner for success, warning, and error. The global tokens also carry
-    // the correct values for the input border/icon in both modes (light-mode
-    // tone 40 dark colored, dark-mode tone 80 light pastel). Verified the
-    // message pairs clear
-    // AA text 4.5:1 and the input affordances clear AA non-text 3:1.
-    // =========================================================================
-
-    // =========================================================================
-    // Switch — the off-state track is itself the control boundary, so it uses
-    // the globally contrast-safe emphasized border token. ProgressBar is a
-    // different relationship (fill on track) and is configured separately.
-    // =========================================================================
+    // The off Switch track is the control boundary.
     switch: {
       base: {
         '--color-background-gray': 'var(--color-border-emphasized)',
@@ -1313,8 +1217,7 @@ export const neutralTheme = defineTheme({
       base: {
         '--color-background-muted': PROGRESS_TRACK,
       },
-      // Vivid stops match the filled semantic badge colors except light-mode
-      // warning, which moves darker so every variant can share one gray track.
+      // Warning uses a darker light-mode stop to contrast with the track.
       'variant:accent': {
         '--color-accent': FILLED_STATE_COLORS.info,
       },
@@ -1328,8 +1231,7 @@ export const neutralTheme = defineTheme({
         '--color-error': FILLED_STATE_COLORS.error,
       },
     },
-    // Keep the live neutral fill aligned with the primary Button without
-    // rebinding disabled progress on the ProgressBar root.
+    // Keep the live neutral fill aligned with the primary Button.
     'progress-bar-fill': {
       'variant:neutral': {
         '--color-text-disabled': 'var(--color-accent)',
@@ -1350,10 +1252,7 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // SelectableCard's ring is a meaningful selected-state indicator. Use the
-    // lightest same-hue palette tone that clears WCAG 1.4.11 against each Card
-    // surface, rather than the much stronger text/icon stop. Neutral variants
-    // use a balanced gray just above the same threshold.
+    // Selection rings use the lightest same-hue tone that reaches 3:1.
     'selectable-card': {
       base: {
         '--selectable-card-ring-color': lightDark(

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -613,27 +613,42 @@ const neutralSyntax = defineSyntaxTheme({
 
 /** Shared filled-state colors for Badge, status dots, and ProgressBar. */
 const FILLED_STATE_COLORS = {
-  info: lightDark(palette('blue', 45), palette('blue', 60, 'dark')),
-  success: lightDark(palette('green', 45), palette('green', 60, 'dark')),
-  warning: lightDark(palette('yellow', 80), palette('yellow', 75, 'dark')),
-  error: lightDark(palette('red', 50), palette('red', 60, 'dark')),
+  info: lightDark(
+    getPaletteStop('blue', 45),
+    getPaletteStop('blue', 60, 'dark'),
+  ),
+  success: lightDark(
+    getPaletteStop('green', 45),
+    getPaletteStop('green', 60, 'dark'),
+  ),
+  warning: lightDark(
+    getPaletteStop('yellow', 80),
+    getPaletteStop('yellow', 75, 'dark'),
+  ),
+  error: lightDark(
+    getPaletteStop('red', 50),
+    getPaletteStop('red', 60, 'dark'),
+  ),
 } as const;
 
 const FILLED_STATE_TEXT = {
-  standard: lightDark(palette('neutral', 100), palette('neutral', 10)),
-  onBright: palette('neutral', 10),
+  standard: lightDark(
+    getPaletteStop('neutral', 100),
+    getPaletteStop('neutral', 10),
+  ),
+  onBright: getPaletteStop('neutral', 10),
 } as const;
 
 /** Shared ProgressBar track. */
 const PROGRESS_TRACK = lightDark(
-  palette('neutral', 85),
-  palette('neutral', 20, 'dark'),
+  getPaletteStop('neutral', 85),
+  getPaletteStop('neutral', 20, 'dark'),
 );
 // The Badge yellow does not reach 3:1 against the track, so ProgressBar uses a
 // darker light-mode stop.
 const PROGRESS_WARNING_FILL = lightDark(
-  palette('yellow', 50),
-  palette('yellow', 80, 'dark'),
+  getPaletteStop('yellow', 50),
+  getPaletteStop('yellow', 80, 'dark'),
 );
 
 export const neutralTheme = defineTheme({
@@ -1057,27 +1072,6 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // Badge —
-    //   Semantic (info/success/warning/error): filled saturated tone 50 + contrasting
-    //     text (white, or dark on yellow). The filled-button rule from #2150
-    //     §3 — text contrast locks the bg stop, so this stays at T50 in
-    //     BOTH modes, unlike pastel surfaces which invert by mode.
-    //   Categorical (blue/green/red/orange/etc.): pastel-tinted hue surface +
-    //     colored text — light mode = soft tones 87-90 + dark tone 30 text; dark mode
-    //     = tone 20 tinted + tone 80 light pastel text (sources: --color-background-X
-    //     and --color-text-X tokens).
-    //   Neutral: light gray bg + dark text (or inverted in dark mode).
-    // =========================================================================
-    badge: {
-      // Semantic — filled saturated bg + contrasting text.
-      //   Light: vivid tones 45-55 from the OKLCH palette + white text
-      //          (~4.5-5:1 — Material/Linear/Vercel pop).
-      //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
-      //          +5 stop-lift taper from issue #2150 §4) + DARK text.
-      //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
-      //          and tames the §4 vibration. Same dark-text-on-bright-bg
-      //          treatment that warning yellow uses in both modes.
-=======
     badge: {
       // Semantic badges use shared fills with contrast-safe label colors.
       'variant:info': {
@@ -1171,16 +1165,16 @@ export const neutralTheme = defineTheme({
       base: {
         // Invert action overlays so they remain visible on tinted headers.
         '--color-neutral': lightDark(
-          withAlpha(palette('neutral', 100), '33'),
-          withAlpha(palette('neutral', 0), '33'),
+          withAlpha(getPaletteStop('neutral', 100), '33'),
+          withAlpha(getPaletteStop('neutral', 0), '33'),
         ),
         '--color-overlay-hover': lightDark(
-          withAlpha(palette('neutral', 100), '1A'),
-          withAlpha(palette('neutral', 0), '1A'),
+          withAlpha(getPaletteStop('neutral', 100), '1A'),
+          withAlpha(getPaletteStop('neutral', 0), '1A'),
         ),
         '--color-overlay-pressed': lightDark(
-          withAlpha(palette('neutral', 100), '33'),
-          withAlpha(palette('neutral', 0), '33'),
+          withAlpha(getPaletteStop('neutral', 100), '33'),
+          withAlpha(getPaletteStop('neutral', 0), '33'),
         ),
       },
       'status:info': {
@@ -1252,72 +1246,72 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // Selection rings use the lightest same-hue tone that reaches 3:1.
+    // Selection rings use the lightest same-hue stop that reaches 3:1.
     'selectable-card': {
       base: {
         '--selectable-card-ring-color': lightDark(
-          palette('neutral', 55),
-          palette('neutral', 40, 'dark'),
+          getPaletteStop('neutral', 55),
+          getPaletteStop('neutral', 40, 'dark'),
         ),
       },
       'variant:red': {
         '--selectable-card-ring-color': lightDark(
-          palette('red', 50),
+          getPaletteStop('red', 50),
           'var(--color-border-red)',
         ),
       },
       'variant:orange': {
         '--selectable-card-ring-color': lightDark(
-          palette('orange', 50),
+          getPaletteStop('orange', 50),
           'var(--color-border-orange)',
         ),
       },
       'variant:yellow': {
         '--selectable-card-ring-color': lightDark(
-          palette('yellow', 50),
+          getPaletteStop('yellow', 50),
           'var(--color-border-yellow)',
         ),
       },
       'variant:green': {
         '--selectable-card-ring-color': lightDark(
-          palette('green', 45),
+          getPaletteStop('green', 45),
           'var(--color-border-green)',
         ),
       },
       'variant:teal': {
         '--selectable-card-ring-color': lightDark(
-          palette('teal', 45),
+          getPaletteStop('teal', 45),
           'var(--color-border-teal)',
         ),
       },
       'variant:cyan': {
         '--selectable-card-ring-color': lightDark(
-          palette('cyan', 45),
+          getPaletteStop('cyan', 45),
           'var(--color-border-cyan)',
         ),
       },
       'variant:blue': {
         '--selectable-card-ring-color': lightDark(
-          palette('blue', 50),
+          getPaletteStop('blue', 50),
           'var(--color-border-blue)',
         ),
       },
       'variant:purple': {
         '--selectable-card-ring-color': lightDark(
-          palette('purple', 50),
+          getPaletteStop('purple', 50),
           'var(--color-border-purple)',
         ),
       },
       'variant:pink': {
         '--selectable-card-ring-color': lightDark(
-          palette('pink', 50),
+          getPaletteStop('pink', 50),
           'var(--color-border-pink)',
         ),
       },
       'variant:gray': {
         '--selectable-card-ring-color': lightDark(
-          palette('neutral', 50),
-          palette('neutral', 50, 'dark'),
+          getPaletteStop('neutral', 50),
+          getPaletteStop('neutral', 50, 'dark'),
         ),
       },
     },

--- a/scripts/check-neutral-theme-contrast.test.mjs
+++ b/scripts/check-neutral-theme-contrast.test.mjs
@@ -1,0 +1,870 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Neutral theme component-pair contrast guard.
+ * @input The maintained neutral theme's control-boundary, Switch, and
+ *   ProgressBar theme overrides.
+ * @output Fails when a meaningful non-text pair falls below WCAG 2.2 AA 3:1
+ *   in either color scheme, or when the theme returns to deprecated targets.
+ * @position Repo-level theme guard, sibling of the other scripts/check-*.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {neutralTheme} from '../packages/themes/neutral/src/neutralTheme.ts';
+import {contrastRatio} from '../packages/core/src/theme/contrast.ts';
+
+const MODES = [
+  {name: 'light', index: 0},
+  {name: 'dark', index: 1},
+];
+const AA_NON_TEXT = 3;
+const AA_TEXT = 4.5;
+
+/** Split `a, b` at the top level, ignoring commas nested in parentheses. */
+function splitArgs(input) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+  for (const char of input) {
+    if (char === '(') depth++;
+    if (char === ')') depth--;
+    if (char === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current.trim());
+  return parts;
+}
+
+/** Resolve `light-dark()` and component-local/global `var()` references. */
+function resolve(value, modeIndex, local = {}, seen = new Set()) {
+  if (typeof value !== 'string') {
+    throw new Error(`expected a color string, got ${String(value)}`);
+  }
+  const expression = value.trim();
+  if (expression.startsWith('light-dark(')) {
+    const choices = splitArgs(expression.slice('light-dark('.length, -1));
+    return resolve(choices[modeIndex], modeIndex, local, seen);
+  }
+  if (expression.startsWith('var(')) {
+    const [name, fallback] = splitArgs(expression.slice('var('.length, -1));
+    if (seen.has(name)) throw new Error(`token cycle at ${name}`);
+    const next = local[name] ?? neutralTheme.tokens?.[name] ?? fallback;
+    if (next == null) throw new Error(`could not resolve ${name}`);
+    return resolve(next, modeIndex, local, new Set([...seen, name]));
+  }
+  return expression;
+}
+
+function expectPairToPass(foreground, background, modeIndex, local = {}) {
+  const fg = resolve(foreground, modeIndex, local);
+  const bg = resolve(background, modeIndex, local);
+  expect(
+    contrastRatio(fg, bg),
+    `${fg} on ${bg} should meet ${AA_NON_TEXT}:1`,
+  ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+}
+
+function parseHex(color) {
+  if (color === 'black') return {rgb: [0, 0, 0], alpha: 1};
+  if (color === 'white') return {rgb: [255, 255, 255], alpha: 1};
+  const hex = color.replace('#', '');
+  return {
+    rgb: [0, 2, 4].map(index =>
+      Number.parseInt(hex.slice(index, index + 2), 16),
+    ),
+    alpha: hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) / 255 : 1,
+  };
+}
+
+function composite(foreground, background) {
+  const fg = parseHex(foreground);
+  const bg = parseHex(background);
+  return `#${fg.rgb
+    .map((channel, index) =>
+      Math.round(channel * fg.alpha + bg.rgb[index] * (1 - fg.alpha))
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')}`;
+}
+
+function mix(base, tint, tintWeight) {
+  const baseColor = parseHex(base);
+  const tintColor = parseHex(tint);
+  return `#${baseColor.rgb
+    .map((channel, index) =>
+      Math.round(channel * (1 - tintWeight) + tintColor.rgb[index] * tintWeight)
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')}`;
+}
+
+describe('neutral theme component-pair contrast', () => {
+  it('uses canonical component target names', () => {
+    expect(neutralTheme.components['status-dot']).toBeDefined();
+    expect(neutralTheme.components['progress-bar']).toBeDefined();
+    expect(neutralTheme.components.statusdot).toBeUndefined();
+    expect(neutralTheme.components.progressbar).toBeUndefined();
+  });
+
+  it.each(MODES)(
+    'keeps Card content readable across every background in $name mode',
+    ({index}) => {
+      const body = resolve('var(--color-background-body)', index);
+      const foreground = resolve('var(--color-text-primary)', index);
+      const backgrounds = {
+        default: 'var(--color-background-card)',
+        transparent: null,
+        muted: 'var(--color-background-muted)',
+        blue: 'var(--color-background-blue)',
+        cyan: 'var(--color-background-cyan)',
+        gray: 'var(--color-background-gray)',
+        green: 'var(--color-background-green)',
+        orange: 'var(--color-background-orange)',
+        pink: 'var(--color-background-pink)',
+        purple: 'var(--color-background-purple)',
+        red: 'var(--color-background-red)',
+        teal: 'var(--color-background-teal)',
+        yellow: 'var(--color-background-yellow)',
+      };
+
+      for (const [variant, token] of Object.entries(backgrounds)) {
+        const background = token
+          ? composite(resolve(token, index), body)
+          : body;
+        expect(
+          contrastRatio(foreground, background),
+          `${variant} Card text should contrast with ${background}`,
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps every SelectableCard ring distinct from its background in $name mode',
+    ({index}) => {
+      const body = resolve('var(--color-background-body)', index);
+      const selectableCard = neutralTheme.components['selectable-card'];
+      const variants = {
+        default: {
+          background: 'var(--color-background-card)',
+          fallback: 'var(--color-accent)',
+        },
+        transparent: {background: null, fallback: 'var(--color-accent)'},
+        muted: {
+          background: 'var(--color-background-muted)',
+          fallback: 'var(--color-accent)',
+        },
+        blue: {
+          background: 'var(--color-background-blue)',
+          fallback: 'var(--color-border-blue)',
+        },
+        cyan: {
+          background: 'var(--color-background-cyan)',
+          fallback: 'var(--color-border-cyan)',
+        },
+        gray: {
+          background: 'var(--color-background-gray)',
+          fallback: 'var(--color-border-gray)',
+        },
+        green: {
+          background: 'var(--color-background-green)',
+          fallback: 'var(--color-border-green)',
+        },
+        orange: {
+          background: 'var(--color-background-orange)',
+          fallback: 'var(--color-border-orange)',
+        },
+        pink: {
+          background: 'var(--color-background-pink)',
+          fallback: 'var(--color-border-pink)',
+        },
+        purple: {
+          background: 'var(--color-background-purple)',
+          fallback: 'var(--color-border-purple)',
+        },
+        red: {
+          background: 'var(--color-background-red)',
+          fallback: 'var(--color-border-red)',
+        },
+        teal: {
+          background: 'var(--color-background-teal)',
+          fallback: 'var(--color-border-teal)',
+        },
+        yellow: {
+          background: 'var(--color-background-yellow)',
+          fallback: 'var(--color-border-yellow)',
+        },
+      };
+
+      for (const [variant, pair] of Object.entries(variants)) {
+        const background = pair.background
+          ? composite(resolve(pair.background, index), body)
+          : body;
+        const override =
+          selectableCard?.[`variant:${variant}`]?.[
+            '--selectable-card-ring-color'
+          ];
+        const ring = resolve(override ?? pair.fallback, index);
+        expect(
+          contrastRatio(ring, background),
+          `${variant} SelectableCard ring should contrast with ${background}`,
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps every ProgressBar fill distinct from its track in $name mode',
+    ({index}) => {
+      const progress = neutralTheme.components['progress-bar'];
+      const progressFill = neutralTheme.components['progress-bar-fill'];
+      const fillTokens = {
+        accent: '--color-accent',
+        success: '--color-success',
+        warning: '--color-warning',
+        error: '--color-error',
+        neutral: '--color-text-disabled',
+      };
+
+      for (const [variant, fillToken] of Object.entries(fillTokens)) {
+        const local = {
+          ...progress.base,
+          ...progress[`variant:${variant}`],
+          ...progressFill?.[`variant:${variant}`],
+        };
+        expectPairToPass(
+          progressFill?.[`variant:${variant}`]?.backgroundColor ??
+            `var(${fillToken})`,
+          'var(--color-background-muted)',
+          index,
+          local,
+        );
+      }
+    },
+  );
+
+  it('maps live neutral ProgressBar fill and labels to the primary Button pair', () => {
+    expect(
+      neutralTheme.components['progress-bar-fill']['variant:neutral'][
+        '--color-text-disabled'
+      ],
+    ).toBe('var(--color-accent)');
+    expect(
+      neutralTheme.components['progress-bar-mark'][
+        'variant:neutral+placement:fill'
+      ]['--color-text-primary'],
+    ).toBe('var(--color-on-accent)');
+  });
+
+  it('uses one ProgressBar track and a contrast-specific warning fill', () => {
+    const progress = neutralTheme.components['progress-bar'];
+    expect(progress.base['--color-background-muted']).toBe(
+      'light-dark(#d4d4d4, #3b3b3b)',
+    );
+    expect(
+      progress['variant:warning']['--color-background-muted'],
+    ).toBeUndefined();
+    expect(progress['variant:warning']['--color-warning']).toBe(
+      'light-dark(#927300, #f4d170)',
+    );
+  });
+
+  it.each(MODES)(
+    'keeps every Button variant readable through rest, hover, and pressed states in $name mode',
+    ({index}) => {
+      const backgrounds = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+      ];
+      const hover = resolve('var(--color-overlay-hover)', index);
+      const pressed = resolve('var(--color-overlay-pressed)', index);
+      const destructive = neutralTheme.components.button['variant:destructive'];
+      const variants = [
+        {
+          name: 'primary',
+          foreground: resolve('var(--color-on-accent)', index),
+          background: () => resolve('var(--color-accent)', index),
+        },
+        {
+          name: 'secondary',
+          foreground: resolve('var(--color-text-primary)', index),
+          background: parent =>
+            composite(resolve('var(--color-neutral)', index), parent),
+        },
+        {
+          name: 'ghost',
+          foreground: resolve('var(--color-text-primary)', index),
+          background: parent => parent,
+        },
+        {
+          name: 'destructive',
+          foreground: resolve(destructive.color, index),
+          background: parent =>
+            composite(resolve(destructive.backgroundColor, index), parent),
+        },
+      ];
+
+      for (const variant of variants) {
+        for (const parent of backgrounds) {
+          const rest = variant.background(parent);
+          for (const [state, background] of [
+            ['rest', rest],
+            ['hover', composite(hover, rest)],
+            ['pressed', composite(pressed, rest)],
+          ]) {
+            expect(
+              contrastRatio(variant.foreground, background),
+              `${variant.name} ${state}: ${variant.foreground} on ${background}`,
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+          }
+        }
+      }
+    },
+  );
+
+  it('maps the default Token to the same pair as the neutral Badge', () => {
+    expect(neutralTheme.components.token['color:default']).toEqual(
+      neutralTheme.components.badge['variant:neutral'],
+    );
+  });
+
+  it.each(MODES)(
+    'keeps every Token color readable through rest, hover, and pressed states in $name mode',
+    ({index}) => {
+      const backgrounds = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+        resolve('var(--color-background-card)', index),
+      ];
+      const hover = resolve('var(--color-overlay-hover)', index);
+      const pressed = resolve('var(--color-overlay-pressed)', index);
+      const tokenPairs = {
+        default: neutralTheme.components.token['color:default'],
+        red: {
+          backgroundColor: 'var(--color-background-red)',
+          color: 'var(--color-text-red)',
+        },
+        orange: {
+          backgroundColor: 'var(--color-background-orange)',
+          color: 'var(--color-text-orange)',
+        },
+        yellow: {
+          backgroundColor: 'var(--color-background-yellow)',
+          color: 'var(--color-text-yellow)',
+        },
+        green: {
+          backgroundColor: 'var(--color-background-green)',
+          color: 'var(--color-text-green)',
+        },
+        teal: {
+          backgroundColor: 'var(--color-background-teal)',
+          color: 'var(--color-text-teal)',
+        },
+        cyan: {
+          backgroundColor: 'var(--color-background-cyan)',
+          color: 'var(--color-text-cyan)',
+        },
+        blue: {
+          backgroundColor: 'var(--color-background-blue)',
+          color: 'var(--color-text-blue)',
+        },
+        purple: {
+          backgroundColor: 'var(--color-background-purple)',
+          color: 'var(--color-text-purple)',
+        },
+        pink: {
+          backgroundColor: 'var(--color-background-pink)',
+          color: 'var(--color-text-pink)',
+        },
+        gray: {
+          backgroundColor: 'var(--color-background-gray)',
+          color: 'var(--color-text-gray)',
+        },
+      };
+
+      for (const [name, pair] of Object.entries(tokenPairs)) {
+        const foreground = resolve(pair.color, index);
+        const tokenBackground = resolve(pair.backgroundColor, index);
+        for (const parent of backgrounds) {
+          const rest = composite(tokenBackground, parent);
+          for (const [state, background] of [
+            ['rest', rest],
+            ['hover', composite(hover, rest)],
+            ['pressed', composite(pressed, rest)],
+          ]) {
+            expect(
+              contrastRatio(foreground, background),
+              `${name} Token ${state}: ${foreground} on ${background}`,
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+          }
+        }
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps Banner text, icons, controls, and actions readable in $name mode',
+    ({index}) => {
+      const parents = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+        resolve('var(--color-background-card)', index),
+      ];
+      const statuses = {
+        info: {
+          background: 'var(--color-accent-muted)',
+          icon: 'var(--color-accent)',
+        },
+        success: {
+          background: 'var(--color-success-muted)',
+          icon: 'var(--color-success)',
+        },
+        warning: {
+          background: 'var(--color-warning-muted)',
+          icon: 'var(--color-warning)',
+        },
+        error: {
+          background: 'var(--color-error-muted)',
+          icon: 'var(--color-error)',
+        },
+      };
+
+      for (const [status, defaults] of Object.entries(statuses)) {
+        const local = {
+          ...neutralTheme.components.banner.base,
+          ...neutralTheme.components.banner[`status:${status}`],
+        };
+        const bannerFill = resolve(defaults.background, index, local);
+        const title = resolve('var(--color-text-primary)', index, local);
+        const description = resolve(
+          'var(--color-text-secondary)',
+          index,
+          local,
+        );
+        const statusIcon = resolve(defaults.icon, index, local);
+        const focus = resolve('var(--color-accent)', index, local);
+        const actionFill = resolve('var(--color-neutral)', index, local);
+        const hover = resolve('var(--color-overlay-hover)', index, local);
+        const pressed = resolve('var(--color-overlay-pressed)', index, local);
+
+        for (const parent of parents) {
+          const header = composite(bannerFill, parent);
+          for (const [name, foreground, minimum] of [
+            ['title', title, AA_TEXT],
+            ['description', description, AA_TEXT],
+            ['status icon', statusIcon, AA_NON_TEXT],
+          ]) {
+            expect(
+              contrastRatio(foreground, header),
+              `${status} Banner ${name}: ${foreground} on ${header}`,
+            ).toBeGreaterThanOrEqual(minimum);
+          }
+
+          for (const [state, background] of [
+            ['rest', header],
+            ['hover', composite(hover, header)],
+            ['pressed', composite(pressed, header)],
+          ]) {
+            expect(
+              contrastRatio(title, background),
+              `${status} Banner ghost action ${state}: ${title} on ${background}`,
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+          }
+
+          expect(
+            contrastRatio(focus, header),
+            `${status} Banner action focus: ${focus} on ${header}`,
+          ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+
+          const actionRest = composite(actionFill, header);
+          for (const [state, background] of [
+            ['rest', actionRest],
+            ['hover', composite(hover, actionRest)],
+            ['pressed', composite(pressed, actionRest)],
+          ]) {
+            expect(
+              contrastRatio(title, background),
+              `${status} Banner action ${state}: ${title} on ${background}`,
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+          }
+        }
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps FieldStatus aligned with Banner semantic pairs in $name mode',
+    ({index}) => {
+      const parents = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+        resolve('var(--color-background-card)', index),
+      ];
+      const pairs = {
+        success: {
+          background: 'var(--color-success-muted)',
+          foreground: 'var(--color-text-green)',
+        },
+        warning: {
+          background: 'var(--color-warning-muted)',
+          foreground: 'var(--color-text-yellow)',
+        },
+        error: {
+          background: 'var(--color-error-muted)',
+          foreground: 'var(--color-text-red)',
+        },
+      };
+
+      for (const [status, pair] of Object.entries(pairs)) {
+        const bannerLocal = {
+          ...neutralTheme.components.banner.base,
+          ...neutralTheme.components.banner[`status:${status}`],
+        };
+        const fieldForeground = resolve(pair.foreground, index);
+        const fieldBackground = resolve(pair.background, index);
+        const bannerForeground = resolve(
+          'var(--color-text-primary)',
+          index,
+          bannerLocal,
+        );
+        const bannerBackground = resolve(pair.background, index, bannerLocal);
+
+        expect(fieldForeground).toBe(bannerForeground);
+        expect(fieldBackground).toBe(bannerBackground);
+
+        for (const parent of parents) {
+          const background = composite(fieldBackground, parent);
+          expect(
+            contrastRatio(fieldForeground, background),
+            `${status} FieldStatus: ${fieldForeground} on ${background}`,
+          ).toBeGreaterThanOrEqual(AA_TEXT);
+        }
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps active TextInput content, icons, and status affordances readable in $name mode',
+    ({index}) => {
+      const parents = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+        resolve('var(--color-background-card)', index),
+      ];
+      const inputBackground = resolve('var(--color-background-surface)', index);
+
+      for (const [name, token] of [
+        ['value', 'var(--color-text-primary)'],
+        ['placeholder', 'var(--color-text-secondary)'],
+      ]) {
+        const foreground = resolve(token, index);
+        expect(
+          contrastRatio(foreground, inputBackground),
+          `TextInput ${name}: ${foreground} on ${inputBackground}`,
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+      }
+
+      const label = resolve('var(--color-text-secondary)', index);
+      for (const parent of parents) {
+        expect(
+          contrastRatio(label, parent),
+          `TextInput label: ${label} on ${parent}`,
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+      }
+
+      for (const [name, token] of [
+        ['focus border', 'var(--color-accent)'],
+        ['start / clear icon', 'var(--color-icon-secondary)'],
+        ['loading spinner arc', 'var(--color-accent)'],
+        ['success border / icon', 'var(--color-success)'],
+        ['warning border / icon', 'var(--color-warning)'],
+        ['error border / icon', 'var(--color-error)'],
+      ]) {
+        const foreground = resolve(token, index);
+        expect(
+          contrastRatio(foreground, inputBackground),
+          `TextInput ${name}: ${foreground} on ${inputBackground}`,
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps Checkbox, Radio, and Switch selected states perceivable in $name mode',
+    ({index}) => {
+      const parents = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+        resolve('var(--color-background-card)', index),
+      ];
+      const surface = resolve('var(--color-background-surface)', index);
+      const primary = resolve('var(--color-text-primary)', index);
+      const secondary = resolve('var(--color-text-secondary)', index);
+      const accent = resolve('var(--color-accent)', index);
+      const onAccent = resolve('var(--color-on-accent)', index);
+      const tint = resolve('var(--color-tint-hover)', index);
+      const focus = accent;
+      const checkedHoverFill = mix(accent, tint, 0.15);
+      const againstParents = foreground =>
+        Math.min(...parents.map(parent => contrastRatio(foreground, parent)));
+      const expectNonText = (name, foreground, background) => {
+        expect(
+          contrastRatio(foreground, background),
+          `${name}: ${foreground} on ${background}`,
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+      };
+
+      for (const [name, foreground] of [
+        ['checkbox / switch label', secondary],
+        ['radio label', primary],
+        ['radio description', secondary],
+      ]) {
+        for (const parent of parents) {
+          expect(
+            contrastRatio(foreground, parent),
+            `${name}: ${foreground} on ${parent}`,
+          ).toBeGreaterThanOrEqual(AA_TEXT);
+        }
+      }
+
+      for (const parent of parents) {
+        expectNonText('selected control fill', accent, parent);
+        expectNonText('selected hover fill', checkedHoverFill, parent);
+        expectNonText('focus indicator', focus, parent);
+      }
+
+      expectNonText('selected check / dot', onAccent, accent);
+      expectNonText('selected hover check / dot', onAccent, checkedHoverFill);
+      expectNonText('Switch on thumb', surface, accent);
+      expectNonText('Switch on hover thumb', surface, checkedHoverFill);
+      expectNonText('unchecked Checkbox spinner', accent, surface);
+      expectNonText('checked Checkbox spinner', onAccent, accent);
+      expectNonText('Switch spinner', accent, surface);
+      expect(againstParents(focus)).toBeGreaterThanOrEqual(AA_NON_TEXT);
+    },
+  );
+
+  it.each(MODES)(
+    'keeps standalone Spinner arcs and labels readable in $name mode',
+    ({index}) => {
+      const parents = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+        resolve('var(--color-background-card)', index),
+      ];
+      const accent = resolve('var(--color-accent)', index);
+      const secondary = resolve('var(--color-text-secondary)', index);
+      const primary = resolve('var(--color-text-primary)', index);
+      const onDark = resolve('var(--color-on-dark)', index);
+      const media = resolve('var(--color-on-light)', index);
+      const onAccent = resolve('var(--color-on-accent)', index);
+
+      for (const parent of parents) {
+        expect(
+          contrastRatio(accent, parent),
+          `default Spinner arc: ${accent} on ${parent}`,
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+        expect(
+          contrastRatio(secondary, parent),
+          `subtle Spinner arc: ${secondary} on ${parent}`,
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+        expect(
+          contrastRatio(primary, parent),
+          `Spinner label: ${primary} on ${parent}`,
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+      }
+
+      expect(contrastRatio(onDark, media)).toBeGreaterThanOrEqual(AA_NON_TEXT);
+      expect(contrastRatio(onAccent, accent)).toBeGreaterThanOrEqual(
+        AA_NON_TEXT,
+      );
+    },
+  );
+
+  it.each(MODES)(
+    'keeps ProgressBar labels and target marks readable in $name mode',
+    ({index}) => {
+      const parents = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+        resolve('var(--color-background-card)', index),
+      ];
+      const primary = resolve('var(--color-text-primary)', index);
+      const secondary = resolve('var(--color-text-secondary)', index);
+      const progress = neutralTheme.components['progress-bar'];
+      const progressFill = neutralTheme.components['progress-bar-fill'];
+      const progressMark = neutralTheme.components['progress-bar-mark'];
+      const variants = {
+        accent: ['var(--color-accent)', 'var(--color-on-accent)'],
+        success: ['var(--color-success)', 'var(--color-on-success)'],
+        warning: ['var(--color-warning)', 'var(--color-on-warning)'],
+        error: ['var(--color-error)', 'var(--color-on-error)'],
+        neutral: ['var(--color-text-disabled)', 'var(--color-text-primary)'],
+      };
+
+      for (const parent of parents) {
+        expect(contrastRatio(primary, parent)).toBeGreaterThanOrEqual(AA_TEXT);
+        expect(contrastRatio(secondary, parent)).toBeGreaterThanOrEqual(
+          AA_TEXT,
+        );
+      }
+
+      for (const [variant, [fillToken, markToken]] of Object.entries(
+        variants,
+      )) {
+        const local = {
+          ...progress.base,
+          ...progress[`variant:${variant}`],
+        };
+        const fillLocal = {
+          ...local,
+          ...progressFill?.[`variant:${variant}`],
+        };
+        const markLocal = {
+          ...fillLocal,
+          ...progressMark?.[`variant:${variant}`],
+          ...progressMark?.[`variant:${variant}+placement:fill`],
+        };
+        const fill = resolve(
+          progressFill?.[`variant:${variant}`]?.backgroundColor ?? fillToken,
+          index,
+          fillLocal,
+        );
+        const track = resolve('var(--color-background-muted)', index, local);
+        const markOnFill = resolve(
+          progressMark?.[`variant:${variant}+placement:fill`]
+            ?.backgroundColor ??
+            progressMark?.[`variant:${variant}`]?.backgroundColor ??
+            markToken,
+          index,
+          markLocal,
+        );
+        const markOnTrack = resolve('var(--color-text-primary)', index, local);
+        expect(
+          contrastRatio(markOnFill, fill),
+          `${variant} ProgressBar mark on fill`,
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+        expect(
+          contrastRatio(markOnTrack, track),
+          `${variant} ProgressBar mark on track`,
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+      }
+    },
+  );
+
+  it.todo('makes the ProgressBar track visible against every parent surface');
+  it.todo('keeps ProgressBar mark focus visible on both fill and track');
+
+  it.each(MODES)(
+    'keeps every Button loading spinner distinct from its background in $name mode',
+    ({index}) => {
+      const backgrounds = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+      ];
+      const destructive = neutralTheme.components.button['variant:destructive'];
+      const variants = [
+        {
+          name: 'primary',
+          foreground: resolve('var(--color-on-accent)', index),
+          background: () => resolve('var(--color-accent)', index),
+        },
+        {
+          name: 'secondary',
+          foreground: resolve('var(--color-text-primary)', index),
+          background: parent =>
+            composite(resolve('var(--color-neutral)', index), parent),
+        },
+        {
+          name: 'ghost',
+          foreground: resolve('var(--color-text-primary)', index),
+          background: parent => parent,
+        },
+        {
+          name: 'destructive',
+          foreground: resolve(destructive.color, index),
+          background: parent =>
+            composite(resolve(destructive.backgroundColor, index), parent),
+        },
+      ];
+
+      for (const variant of variants) {
+        for (const parent of backgrounds) {
+          const background = variant.background(parent);
+          expect(
+            contrastRatio(variant.foreground, background),
+            `${variant.name} spinner arc should contrast with ${background}`,
+          ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+        }
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps common Button end-content badges readable in $name mode',
+    ({index}) => {
+      const backgrounds = [
+        resolve('var(--color-background-body)', index),
+        resolve('var(--color-background-surface)', index),
+      ];
+      const destructive = neutralTheme.components.button['variant:destructive'];
+      const combinations = [
+        {
+          name: 'primary + info',
+          buttonBackground: () => resolve('var(--color-accent)', index),
+          badge: neutralTheme.components.badge['variant:info'],
+        },
+        {
+          name: 'secondary + neutral',
+          buttonBackground: parent =>
+            composite(resolve('var(--color-neutral)', index), parent),
+          badge: neutralTheme.components.badge['variant:neutral'],
+        },
+        {
+          name: 'ghost + info',
+          buttonBackground: parent => parent,
+          badge: neutralTheme.components.badge['variant:info'],
+        },
+        {
+          name: 'destructive + error',
+          buttonBackground: parent =>
+            composite(resolve(destructive.backgroundColor, index), parent),
+          badge: neutralTheme.components.badge['variant:error'],
+        },
+      ];
+
+      for (const combination of combinations) {
+        const foreground = resolve(combination.badge.color, index);
+        const background = resolve(combination.badge.backgroundColor, index);
+        for (const parent of backgrounds) {
+          const buttonBackground = combination.buttonBackground(parent);
+          const badgeBackground = composite(background, buttonBackground);
+          expect(
+            contrastRatio(foreground, badgeBackground),
+            `${combination.name}: ${foreground} on ${badgeBackground}`,
+          ).toBeGreaterThanOrEqual(AA_TEXT);
+        }
+      }
+    },
+  );
+
+  it.each(MODES)(
+    'keeps Button focus indicators distinct from adjacent surfaces in $name mode',
+    ({index}) => {
+      const backgrounds = [
+        'var(--color-background-body)',
+        'var(--color-background-surface)',
+      ];
+      for (const background of backgrounds) {
+        expectPairToPass('var(--color-accent)', background, index);
+        expectPairToPass('var(--color-error)', background, index);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Apply the remapped Neutral palette to component-specific Button, Badge, status indicator, Token, Banner, and ProgressBar treatments.
- Add an explicit SelectableCard selection-ring theme hook without changing card backgrounds.
- Remove redundant radius overrides that match Core defaults.
- Keep the ProgressBar endpoint unchanged and remove the invalid no-op endpoint theme target.
- Add focused component-pair contrast coverage.

## Why

PR #5628 now contains only the palette definition and semantic/categorical token remapping. This stacked PR isolates the component-specific decisions so they can be reviewed visually and technically on their own.

## Stack

#5627 → #5668 → #5628 → this PR → #5649 → #5667

## Verification

- 56 focused tests pass, with 2 existing todos.
- Neutral theme build passes with no unknown component-target warning.
- Repository checks and source/CLI template parity pass.

@rubyycheung