### PR TITLE
docs(stepper): recast em-dash aside in progress bar anatomy description

### DIFF
--- a/.changeset/stepper-progress-bar-anatomy-prose.md
+++ b/.changeset/stepper-progress-bar-anatomy-prose.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] The Stepper progress bar anatomy description now sets its nested aside in parentheses instead of paired em dashes, so the sentence about multi-segment spans reads plainly in the CLI and doc site. Meaning unchanged. (#5691)
+
+@josephfarina

--- a/packages/core/src/Stepper/Stepper.doc.mjs
+++ b/packages/core/src/Stepper/Stepper.doc.mjs
@@ -57,7 +57,7 @@ export const docs = {
         name: 'Progress bar',
         required: true,
         description:
-          'A 4px segmented bar per step. Filled for completed and active steps. Advancing one step grows the fill along the track it just covered, so the movement reads as progress rather than a bar changing color. Every other change applies at once: going back, jumping forward by more than one step, mounting mid-flow, and any change at all under prefers-reduced-motion. Where a span is drawn by more than one segment — the on-track layouts split it between two steps, three when a content slot sits between them — the segments run in track order at one constant speed, so the fill reads as a single line growing rather than pieces lighting in turn.',
+          'A 4px segmented bar per step. Filled for completed and active steps. Advancing one step grows the fill along the track it just covered, so the movement reads as progress rather than a bar changing color. Every other change applies at once: going back, jumping forward by more than one step, mounting mid-flow, and any change at all under prefers-reduced-motion. Where a span is drawn by more than one segment (the on-track layouts split it between two steps, three when a content slot sits between them), the segments run in track order at one constant speed, so the fill reads as a single line growing rather than pieces lighting in turn.',
       },
       {
         name: 'Indicator',


### PR DESCRIPTION
## What

The Stepper `progressBar` anatomy description in `packages/core/src/Stepper/Stepper.doc.mjs` used a paired em-dash to set off a nested aside. Recast the aside with parentheses so the prose reads plainly. The wording and meaning are unchanged; only the punctuation changed.

Before:
> Where a span is drawn by more than one segment — the on-track layouts split it between two steps, three when a content slot sits between them — the segments run in track order...

After:
> Where a span is drawn by more than one segment (the on-track layouts split it between two steps, three when a content slot sits between them), the segments run in track order...

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `astryx component Stepper --lang dense` renders cleanly, no em-dash
- [x] Prose-only change, one file, meaning preserved

Night Watch — Doc Reviewer