### PR TITLE
docs: fix changeset coverage for v0.5.2

### DIFF
--- a/.changeset/improve-translation-lookup-performance.md
+++ b/.changeset/improve-translation-lookup-performance.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[perf] Improve frequent translation lookups by pre-building locale maps (#4696)
+@ngolin

--- a/.changeset/rename-the-data-input-component-category-to-form-cfkv.md
+++ b/.changeset/rename-the-data-input-component-category-to-form-cfkv.md
@@ -3,5 +3,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Rename the Data Input component category to Form Controls
+[fix] Rename the Data Input component category to Form Controls (#5686)
 @rubyycheung


### PR DESCRIPTION
## Summary

- add the missing performance changeset for #4696 and credit @ngolin
- link the existing Form Controls changeset to #5686

## Why

Without this cleanup, the next release would omit the translation lookup performance improvement and generate an unlinked category rename entry.

## Testing

- `pnpm check:changesets`
- pre-commit repository checks