### PR TITLE
fix(ci): preserve visual reports during preview deploy

### DIFF
--- a/.github/scripts/lib/gh-pages-publisher.mjs
+++ b/.github/scripts/lib/gh-pages-publisher.mjs
@@ -1541,9 +1541,12 @@ export async function publishManualVisualBaseline({
   refuse(`could not push the updated baseline after ${maxAttempts} attempts`);
 }
 
-function removeContents(destination) {
-  fs.rmSync(destination, {recursive: true, force: true});
+function replacePreviewContents(destination) {
   fs.mkdirSync(destination, {recursive: true});
+  for (const entry of fs.readdirSync(destination)) {
+    if (entry === 'visual') continue;
+    fs.rmSync(path.join(destination, entry), {recursive: true, force: true});
+  }
 }
 
 export async function publishPrPreview({
@@ -1571,6 +1574,9 @@ export async function publishPrPreview({
       refuse(`${name} must be a directory`);
     }
   }
+  if (fs.existsSync(path.join(storybookDir, 'visual'))) {
+    refuse('the Storybook artifact contains the reserved visual path');
+  }
   const destinationRel = `pr/${prNumber}`;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const checkout = checkoutPages({
@@ -1583,7 +1589,7 @@ export async function publishPrPreview({
     });
     try {
       const destination = path.join(checkout, destinationRel);
-      removeContents(destination);
+      replacePreviewContents(destination);
       copyContents(storybookDir, destination);
       fs.mkdirSync(path.join(destination, 'sandbox'), {recursive: true});
       for (const entry of fs.readdirSync(sandboxDir, {withFileTypes: true})) {

--- a/.github/scripts/lib/gh-pages-publisher.test.mjs
+++ b/.github/scripts/lib/gh-pages-publisher.test.mjs
@@ -144,6 +144,10 @@ function fixture() {
   writeFile(path.join(seed, 'sandbox', 'old.html'), 'old sandbox');
   writeFile(path.join(seed, 'assets', 'old.css'), 'old asset');
   writeFile(path.join(seed, 'pr', '123', 'index.html'), 'preview');
+  writeFile(
+    path.join(seed, 'pr', '123', 'visual', 'evidence.json'),
+    'visual evidence',
+  );
   writeFile(path.join(seed, 'pr', '124', 'index.html'), 'closed preview');
   writeFile(
     path.join(seed, 'pr', '123', 'sandbox', 'template-assets', 'old.txt'),
@@ -1084,6 +1088,12 @@ describe('gh-pages publisher', () => {
     ).toBe(false);
     expect(
       fs.readFileSync(
+        path.join(final, 'pr', '123', 'visual', 'evidence.json'),
+        'utf8',
+      ),
+    ).toBe('visual evidence');
+    expect(
+      fs.readFileSync(
         path.join(final, 'reports', 'vibe', 'index.html'),
         'utf8',
       ),
@@ -1107,6 +1117,37 @@ describe('gh-pages publisher', () => {
         ),
       ),
     ).toBe(true);
+  });
+
+  it('rejects Storybook artifacts that collide with trusted visual evidence', async () => {
+    const fx = fixture();
+    const storybook = path.join(fx.root, 'colliding-storybook');
+    const sandbox = path.join(fx.root, 'colliding-sandbox');
+    writeFile(path.join(storybook, 'index.html'), 'new preview');
+    writeFile(
+      path.join(storybook, 'visual', 'evidence.json'),
+      'untrusted evidence',
+    );
+    writeFile(path.join(sandbox, 'index.html'), 'new sandbox');
+
+    await expect(
+      queuedPublish(fx, 940, 'pr-preview/123', () =>
+        publishPrPreview({
+          ...context(fx, 940, 'pr-preview/123'),
+          pr: 123,
+          storybook,
+          sandbox,
+        }),
+      ),
+    ).rejects.toThrow(/reserved visual path/);
+
+    const final = cloneRemote(fx.remote, fx.root);
+    expect(
+      fs.readFileSync(
+        path.join(final, 'pr', '123', 'visual', 'evidence.json'),
+        'utf8',
+      ),
+    ).toBe('visual evidence');
   });
 
   it('cleans stale previews without deleting visual evidence or live previews', async () => {


### PR DESCRIPTION
## Summary
- preserve `pr/<number>/visual/` when replacing a PR's Storybook and Sandbox preview
- add a same-PR regression so preview deployment cannot silently delete published visual evidence

## Why
A live audit found [#5682](https://github.com/facebook/astryx/pull/5682) had a successful `visual-acceptance` status pointing to a 404. Its later preview deployment replaced all of `pr/5682/`, including the sibling `visual/` tree.

## Test plan
- `pnpm exec vitest run .github/scripts/lib/gh-pages-publisher.test.mjs`
- `pnpm exec prettier --check .github/scripts/lib/gh-pages-publisher.mjs .github/scripts/lib/gh-pages-publisher.test.mjs`
- `pnpm check:repo`
- `git diff --check`