### PR TITLE
fix(ci): only link deployed PR previews

### DIFF
--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -1,22 +1,21 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-
 /**
  * @description Generates and posts PR comment with analysis results
- * @input --analysis <file> --a11y <file> --visual <file> --storybook-url <url> --run-url <url>
+ * @input --analysis <file> --a11y <file> --visual <file> --storybook-url <url> --sandbox-url <url> --preview-state <state> --source-conclusion <conclusion> --run-url <url>
  * @output Formatted markdown comment body to stdout
  */
 
 const fs = require('node:fs');
-const { buildA11ySection } = require('./lib/a11y-format');
-const { buildVisualSection } = require('./lib/visual-format');
+const {buildA11ySection} = require('./lib/a11y-format');
+const {buildVisualSection} = require('./lib/visual-format');
 // Report-file strings render as literal inline text, report numbers as
 // numbers — the comment's structure comes only from this file's literals.
-const { inline, num } = require('./lib/report-text');
+const {inline, num} = require('./lib/report-text');
 
 const args = process.argv.slice(2);
-const getArg = (name) => {
+const getArg = name => {
   const idx = args.indexOf(`--${name}`);
   return idx !== -1 ? args[idx + 1] : null;
 };
@@ -28,10 +27,17 @@ const runUrl = getArg('run-url') || '';
 const prNumber = getArg('pr-number') || '';
 const storybookUrl = getArg('storybook-url') || '';
 const sandboxUrl = getArg('sandbox-url') || '';
+const previewState = getArg('preview-state') || '';
+const sourceConclusion = getArg('source-conclusion') || '';
 
 // Read analysis results
-let analysis = { newComponents: [], modifiedComponents: [], componentStats: {}, totalBundle: {} };
-let a11yReport = { components: {} };
+let analysis = {
+  newComponents: [],
+  modifiedComponents: [],
+  componentStats: {},
+  totalBundle: {},
+};
+let a11yReport = {components: {}};
 try {
   analysis = JSON.parse(fs.readFileSync(analysisFile, 'utf8'));
 } catch (e) {
@@ -55,7 +61,10 @@ function getStorybookLink(storybookBaseUrl, storyTitle) {
   // prefix. Story ids only ever contain [a-z0-9_-]; the title came from a
   // report file, so drop anything outside that alphabet before it lands in
   // the href.
-  const storyPath = title.toLowerCase().replace(/\//g, '-').replace(/[^a-z0-9_-]/g, '');
+  const storyPath = title
+    .toLowerCase()
+    .replace(/\//g, '-')
+    .replace(/[^a-z0-9_-]/g, '');
   return `${storybookBaseUrl}?path=/docs/${storyPath}--docs`;
 }
 
@@ -72,7 +81,9 @@ if (analysis.newComponents && analysis.newComponents.length > 0) {
     const stats = analysis.componentStats[comp] || {};
     const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
     const sbBadge = sbLink ? ` · ${extLink('View in Storybook', sbLink)}` : '';
-    const pkgBadge = stats.package ? ` <sub>(${inline(stats.package)})</sub>` : '';
+    const pkgBadge = stats.package
+      ? ` <sub>(${inline(stats.package)})</sub>`
+      : '';
     componentSection += `<details>\n<summary><strong>${inline(comp)}</strong>${pkgBadge}${sbBadge}</summary>\n\n`;
     componentSection += `| Metric | Value |\n|--------|-------|\n`;
     componentSection += `| Bundle Size (ESM) | ${inline(stats.esmSize) || 'N/A'} |\n`;
@@ -100,18 +111,26 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
     const newExports = analysis.newExports || [];
     const compExports = stats.exports || [];
     const newInComp = compExports.filter(e => newExports.includes(e));
-    const newBadge = newInComp.length > 0 ? ` · 🆕 ${newInComp.map(inline).join(', ')}` : '';
-    const pkgBadge = stats.package ? ` <sub>(${inline(stats.package)})</sub>` : '';
+    const newBadge =
+      newInComp.length > 0 ? ` · 🆕 ${newInComp.map(inline).join(', ')}` : '';
+    const pkgBadge = stats.package
+      ? ` <sub>(${inline(stats.package)})</sub>`
+      : '';
 
     componentSection += `<details>\n<summary><strong>${inline(comp)}</strong>${pkgBadge}${sbBadge}${newBadge}</summary>\n\n`;
     componentSection += `| Metric | Before | After | Delta |\n|--------|--------|-------|-------|\n`;
 
-    const esmDelta = Number.isFinite(Number(stats.esmBytes)) && Number.isFinite(Number(baseStats.esmBytes))
-      ? (Number(stats.esmBytes) - Number(baseStats.esmBytes))
-      : null;
-    const esmDeltaStr = esmDelta !== null
-      ? (esmDelta > 0 ? `+${esmDelta}B` : `${esmDelta}B`)
-      : 'N/A';
+    const esmDelta =
+      Number.isFinite(Number(stats.esmBytes)) &&
+      Number.isFinite(Number(baseStats.esmBytes))
+        ? Number(stats.esmBytes) - Number(baseStats.esmBytes)
+        : null;
+    const esmDeltaStr =
+      esmDelta !== null
+        ? esmDelta > 0
+          ? `+${esmDelta}B`
+          : `${esmDelta}B`
+        : 'N/A';
 
     componentSection += `| Bundle Size (ESM) | ${inline(baseStats.esmSize) || 'N/A'} | ${inline(stats.esmSize) || 'N/A'} | ${esmDeltaStr} |\n`;
     componentSection += `| Lines of Code | ${inline(baseStats.linesOfCode) || 'N/A'} | ${inline(stats.linesOfCode) || 'N/A'} | - |\n`;
@@ -147,7 +166,7 @@ const bundlePackages =
   analysis.bundlePackages && analysis.bundlePackages.length > 0
     ? analysis.bundlePackages
     : analysis.totalBundle
-      ? [{ package: '@astryxdesign/core', ...analysis.totalBundle }]
+      ? [{package: '@astryxdesign/core', ...analysis.totalBundle}]
       : [];
 
 if (bundlePackages.length > 0) {
@@ -163,7 +182,8 @@ if (bundlePackages.length > 0) {
 
 if (analysis.bundleDelta) {
   const delta = num(analysis.bundleDelta);
-  const direction = delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'unchanged';
+  const direction =
+    delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'unchanged';
   bundleSection += `**Bundle size ${direction}:** ${delta > 0 ? '+' : ''}${delta} bytes\n\n`;
 }
 
@@ -189,12 +209,29 @@ _GitHub Pages may take up to a minute to hydrate after deploy._
 `;
 }
 
+// Explain each independently unavailable target. The reconciler only passes this
+// state after validating the publisher's exact PR/head/source-run result.
+let previewAvailabilitySection = '';
+if (previewState) {
+  const missing = [];
+  if (!storybookUrl) missing.push('Storybook');
+  if (!sandboxUrl) missing.push('Sandbox');
+  if (missing.length > 0) {
+    const reason =
+      sourceConclusion === 'success'
+        ? `${missing.join(' and ')} ${missing.length === 1 ? 'was' : 'were'} not published for this CI run.`
+        : 'CI did not succeed, so no preview was published.';
+    previewAvailabilitySection = `> **Preview availability:** ${reason}\n\n`;
+  }
+}
+
 // Build footer with links
 let footerLinks = [];
 if (storybookUrl) footerLinks.push(extLink('Storybook', storybookUrl));
 if (sandboxUrl) footerLinks.push(extLink('Sandbox', sandboxUrl));
 if (runUrl) footerLinks.push(extLink('View full report', runUrl));
-const footerLinksStr = footerLinks.length > 0 ? ` | ${footerLinks.join(' | ')}` : '';
+const footerLinksStr =
+  footerLinks.length > 0 ? ` | ${footerLinks.join(' | ')}` : '';
 
 // A one-line caveat shown when the analysis fell back to the approximate
 // two-dot diff. The file list may include base-only churn and, worse, may
@@ -207,8 +244,9 @@ const diffModeCaveat =
 
 // Build the full comment
 const body = `## PR Analysis Report
+<!-- astryx-pr-analysis -->
 
-${diffModeCaveat}${storybookSection}${sandboxSection}${componentSection || '_No new or modified components detected._\n\n'}
+${diffModeCaveat}${previewAvailabilitySection}${storybookSection}${sandboxSection}${componentSection || '_No new or modified components detected._\n\n'}
 ${bundleSection}
 ${a11ySection}
 ${visualSection}---

--- a/.github/scripts/generate-pr-comment.test.mjs
+++ b/.github/scripts/generate-pr-comment.test.mjs
@@ -20,15 +20,19 @@ const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.join(SCRIPTS_DIR, 'generate-pr-comment.js');
 
 /** Run the comment generator with the given analysis.json; return stdout. */
-function runComment(analysis) {
+function runComment(analysis, extraArgs = []) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-comment-'));
   try {
     const analysisFile = path.join(dir, 'analysis.json');
     fs.writeFileSync(analysisFile, JSON.stringify(analysis));
-    return execFileSync(process.execPath, [SCRIPT, '--analysis', analysisFile], {
-      cwd: dir,
-      encoding: 'utf8',
-    });
+    return execFileSync(
+      process.execPath,
+      [SCRIPT, '--analysis', analysisFile, ...extraArgs],
+      {
+        cwd: dir,
+        encoding: 'utf8',
+      },
+    );
   } finally {
     fs.rmSync(dir, {recursive: true, force: true});
   }
@@ -59,5 +63,65 @@ describe('generate-pr-comment diffMode caveat', () => {
     // Back-compat: analyses written before diffMode existed must render clean.
     const stdout = runComment(baseAnalysis);
     expect(stdout).not.toContain('Approximate analysis');
+  });
+});
+
+describe('generate-pr-comment preview availability', () => {
+  it.each([
+    ['none', [], false, false],
+    [
+      'storybook',
+      ['--storybook-url', 'https://example.test/pr/1/'],
+      true,
+      false,
+    ],
+    [
+      'sandbox',
+      ['--sandbox-url', 'https://example.test/pr/1/sandbox/'],
+      false,
+      true,
+    ],
+    [
+      'both',
+      [
+        '--storybook-url',
+        'https://example.test/pr/1/',
+        '--sandbox-url',
+        'https://example.test/pr/1/sandbox/',
+      ],
+      true,
+      true,
+    ],
+  ])(
+    'renders independent %s availability',
+    (state, urls, storybook, sandbox) => {
+      const stdout = runComment(baseAnalysis, [
+        ...urls,
+        '--preview-state',
+        state,
+        '--source-conclusion',
+        'success',
+      ]);
+
+      expect(stdout.includes('View Storybook for this PR')).toBe(storybook);
+      expect(stdout.includes('View Sandbox for this PR')).toBe(sandbox);
+      expect(stdout.includes('> **Preview availability:**')).toBe(
+        !storybook || !sandbox,
+      );
+      expect(stdout).toContain('<!-- astryx-pr-analysis -->');
+    },
+  );
+
+  it('explains that failed CI published no previews', () => {
+    const stdout = runComment(baseAnalysis, [
+      '--preview-state',
+      'none',
+      '--source-conclusion',
+      'failure',
+    ]);
+
+    expect(stdout).toContain('CI did not succeed');
+    expect(stdout).not.toContain('View Storybook for this PR');
+    expect(stdout).not.toContain('View Sandbox for this PR');
   });
 });

--- a/.github/scripts/lib/gh-pages-publisher.mjs
+++ b/.github/scripts/lib/gh-pages-publisher.mjs
@@ -2,10 +2,17 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {spawnSync} from 'node:child_process';
+import {createHash} from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+
+import {
+  createPreviewPublicationManifest,
+  createPublishedDeploymentResult,
+  writeDeploymentResult,
+} from './pr-preview.mjs';
 
 const PAGES_BRANCH = 'gh-pages';
 const QUEUE_REL = path.join('.astryx-gh-pages', 'publication-queue');
@@ -1541,11 +1548,41 @@ export async function publishManualVisualBaseline({
   refuse(`could not push the updated baseline after ${maxAttempts} attempts`);
 }
 
-function replacePreviewContents(destination) {
+const PREVIEW_MANIFEST = '.astryx-preview.json';
+const PREVIEW_RESERVED_ROOTS = new Set([PREVIEW_MANIFEST, 'sandbox', 'visual']);
+
+function previewDirectory(value, name, {storybook = false} = {}) {
+  if (!value) return null;
+  const directory = path.resolve(value);
+  if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+    refuse(`${name} must be a directory`);
+  }
+  const index = path.join(directory, 'index.html');
+  if (!fs.existsSync(index) || !fs.statSync(index).isFile()) {
+    refuse(`${name} must contain index.html`);
+  }
+  if (storybook) {
+    for (const reserved of PREVIEW_RESERVED_ROOTS) {
+      if (fs.existsSync(path.join(directory, reserved))) {
+        refuse(`${name} contains reserved path ${reserved}`);
+      }
+    }
+  }
+  return directory;
+}
+
+function sha256(file) {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function clearPreviewContents(destination) {
   fs.mkdirSync(destination, {recursive: true});
-  for (const entry of fs.readdirSync(destination)) {
-    if (entry === 'visual') continue;
-    fs.rmSync(path.join(destination, entry), {recursive: true, force: true});
+  for (const entry of fs.readdirSync(destination, {withFileTypes: true})) {
+    if (entry.name === 'visual') continue;
+    fs.rmSync(path.join(destination, entry.name), {
+      recursive: true,
+      force: true,
+    });
   }
 }
 
@@ -1555,8 +1592,17 @@ export async function publishPrPreview({
   tempRoot,
   remoteURL,
   pr,
+  head,
+  headRepo,
+  headRepoId,
+  headRef,
+  baseRepo,
+  sourceRunId,
+  sourceRunAttempt,
+  sourceConclusion,
   storybook,
   sandbox,
+  resultFile,
   maxAttempts = 5,
   beforePush,
 }) {
@@ -1564,19 +1610,37 @@ export async function publishPrPreview({
   if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
     refuse('PR number is invalid');
   }
-  const storybookDir = path.resolve(storybook);
-  const sandboxDir = path.resolve(sandbox);
-  for (const [name, dir] of [
-    ['--storybook', storybookDir],
-    ['--sandbox', sandboxDir],
-  ]) {
-    if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
-      refuse(`${name} must be a directory`);
-    }
+  if (baseRepo !== repository) {
+    refuse('preview base repository does not match publisher repository');
   }
-  if (fs.existsSync(path.join(storybookDir, 'visual'))) {
-    refuse('the Storybook artifact contains the reserved visual path');
+  const storybookDir = previewDirectory(storybook, '--storybook', {
+    storybook: true,
+  });
+  const sandboxDir = previewDirectory(sandbox, '--sandbox');
+  if (sourceConclusion !== 'success' && (storybookDir || sandboxDir)) {
+    refuse('failed source CI cannot publish preview targets');
   }
+  const identity = {
+    prNumber,
+    headSha: head,
+    headRepository: headRepo,
+    headRepositoryId: headRepoId,
+    headRef,
+    baseRepository: baseRepo,
+    sourceRunId,
+    sourceRunAttempt,
+    sourceConclusion,
+  };
+  const storybookIndexSha256 = storybookDir
+    ? sha256(path.join(storybookDir, 'index.html'))
+    : null;
+  const sandboxIndexSha256 = sandboxDir
+    ? sha256(path.join(sandboxDir, 'index.html'))
+    : null;
+  const manifest = createPreviewPublicationManifest(identity, {
+    storybookIndexSha256,
+    sandboxIndexSha256,
+  });
   const destinationRel = `pr/${prNumber}`;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const checkout = checkoutPages({
@@ -1589,45 +1653,72 @@ export async function publishPrPreview({
     });
     try {
       const destination = path.join(checkout, destinationRel);
-      replacePreviewContents(destination);
-      copyContents(storybookDir, destination);
-      fs.mkdirSync(path.join(destination, 'sandbox'), {recursive: true});
-      for (const entry of fs.readdirSync(sandboxDir, {withFileTypes: true})) {
-        if (entry.name === 'template-assets') continue;
-        fs.cpSync(
-          path.join(sandboxDir, entry.name),
-          path.join(destination, 'sandbox', entry.name),
-          {recursive: true, force: true},
-        );
+      clearPreviewContents(destination);
+      if (storybookDir) copyContents(storybookDir, destination);
+      if (sandboxDir) {
+        const sandboxDestination = path.join(destination, 'sandbox');
+        fs.mkdirSync(sandboxDestination, {recursive: true});
+        for (const entry of fs.readdirSync(sandboxDir, {withFileTypes: true})) {
+          if (entry.name === 'template-assets') continue;
+          fs.cpSync(
+            path.join(sandboxDir, entry.name),
+            path.join(sandboxDestination, entry.name),
+            {recursive: true, force: true},
+          );
+        }
       }
-      const commit = commitIfNeeded(
-        checkout,
-        `Deploy PR #${prNumber} preview`,
-        ['-A', destinationRel],
+      if (
+        storybookDir &&
+        sha256(path.join(destination, 'index.html')) !== storybookIndexSha256
+      ) {
+        refuse('published Storybook index does not match its source artifact');
+      }
+      if (
+        sandboxDir &&
+        sha256(path.join(destination, 'sandbox', 'index.html')) !==
+          sandboxIndexSha256
+      ) {
+        refuse('published Sandbox index does not match its source artifact');
+      }
+      fs.writeFileSync(
+        path.join(destination, PREVIEW_MANIFEST),
+        `${JSON.stringify(manifest, null, 2)}\n`,
       );
-      if (commit === null) {
-        process.stdout.write('Nothing to publish.\n');
-        return {published: false};
-      }
-      await beforePush?.({attempt, checkout, commit});
-      const pushed = tryRun('git', [
-        '-C',
-        checkout,
-        'push',
-        'origin',
-        PAGES_BRANCH,
+      let commit = commitIfNeeded(checkout, `Deploy PR #${prNumber} preview`, [
+        '-A',
+        destinationRel,
       ]);
-      if (pushOrRetry(pushed)) {
-        process.stdout.write(`Deployed PR #${prNumber} preview.\n`);
-        return {published: true, commit};
+      if (commit !== null) {
+        await beforePush?.({attempt, checkout, commit});
+        const pushed = tryRun('git', [
+          '-C',
+          checkout,
+          'push',
+          'origin',
+          PAGES_BRANCH,
+        ]);
+        if (!pushOrRetry(pushed)) {
+          process.stdout.write(
+            `Push rejected; retrying PR preview publish (${attempt}/${maxAttempts}).\n`,
+          );
+          await sleep(attempt * 2000);
+          continue;
+        }
+      } else {
+        commit = git(checkout, 'rev-parse', 'HEAD');
       }
+
+      const result = createPublishedDeploymentResult(identity, {
+        storybookIndexSha256,
+        sandboxIndexSha256,
+        pagesCommit: commit,
+      });
+      if (resultFile) writeDeploymentResult(resultFile, result);
+      process.stdout.write(`Reconciled PR #${prNumber} preview.\n`);
+      return result;
     } finally {
       fs.rmSync(checkout, {recursive: true, force: true});
     }
-    process.stdout.write(
-      `Push rejected; retrying PR preview publish (${attempt}/${maxAttempts}).\n`,
-    );
-    await sleep(attempt * 2000);
   }
   refuse(
     `could not publish PR #${prNumber} preview after ${maxAttempts} attempts`,
@@ -2520,8 +2611,17 @@ export async function main(argv = process.argv.slice(2)) {
         publishPrPreview({
           ...context,
           pr,
+          head: flag(argv, '--head'),
+          headRepo: flag(argv, '--head-repo'),
+          headRepoId: flag(argv, '--head-repo-id'),
+          headRef: flag(argv, '--head-ref'),
+          baseRepo: flag(argv, '--base-repo'),
+          sourceRunId: flag(argv, '--source-run-id'),
+          sourceRunAttempt: flag(argv, '--source-run-attempt'),
+          sourceConclusion: flag(argv, '--source-conclusion'),
           storybook: flag(argv, '--storybook'),
           sandbox: flag(argv, '--sandbox'),
+          resultFile: flag(argv, '--result'),
         }),
     });
   } else if (command === 'cleanup-previews') {

--- a/.github/scripts/lib/gh-pages-publisher.test.mjs
+++ b/.github/scripts/lib/gh-pages-publisher.test.mjs
@@ -146,7 +146,7 @@ function fixture() {
   writeFile(path.join(seed, 'pr', '123', 'index.html'), 'preview');
   writeFile(
     path.join(seed, 'pr', '123', 'visual', 'evidence.json'),
-    'visual evidence',
+    'same-PR visual evidence',
   );
   writeFile(path.join(seed, 'pr', '124', 'index.html'), 'closed preview');
   writeFile(
@@ -365,6 +365,21 @@ function context({root, remote, bin}, runId, scope) {
     tempRoot: root,
     remoteURL: `file://${remote}`,
     envPath: `${bin}:${process.env.PATH}`,
+  };
+}
+
+function previewIdentity(overrides = {}) {
+  return {
+    pr: 123,
+    head: HEAD,
+    headRepo: 'cixzhang/astryx',
+    headRepoId: '321',
+    headRef: 'preview-fix',
+    baseRepo: REPO,
+    sourceRunId: 333,
+    sourceRunAttempt: 1,
+    sourceConclusion: 'success',
+    ...overrides,
   };
 }
 
@@ -1062,10 +1077,10 @@ describe('gh-pages publisher', () => {
       'shared asset copy',
     );
 
-    await queuedPublish(fx, 940, 'pr-preview/123', () =>
+    const result = await queuedPublish(fx, 940, 'pr-preview/123', () =>
       publishPrPreview({
         ...context(fx, 940, 'pr-preview/123'),
-        pr: 123,
+        ...previewIdentity(),
         storybook,
         sandbox,
       }),
@@ -1091,7 +1106,30 @@ describe('gh-pages publisher', () => {
         path.join(final, 'pr', '123', 'visual', 'evidence.json'),
         'utf8',
       ),
-    ).toBe('visual evidence');
+    ).toBe('same-PR visual evidence');
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(final, 'pr', '123', '.astryx-preview.json'),
+        'utf8',
+      ),
+    );
+    expect(manifest).toMatchObject({
+      repository: REPO,
+      pullRequest: {number: 123, headSha: HEAD},
+      sourceRun: {id: 333, attempt: 1},
+      targets: {
+        storybook: {available: true, path: 'pr/123/'},
+        sandbox: {available: true, path: 'pr/123/sandbox/'},
+      },
+    });
+    expect(result).toMatchObject({
+      status: 'published',
+      pagesCommit: expect.stringMatching(/^[0-9a-f]{40}$/),
+      targets: {
+        storybook: {available: true},
+        sandbox: {available: true},
+      },
+    });
     expect(
       fs.readFileSync(
         path.join(final, 'reports', 'vibe', 'index.html'),
@@ -1131,15 +1169,15 @@ describe('gh-pages publisher', () => {
     writeFile(path.join(sandbox, 'index.html'), 'new sandbox');
 
     await expect(
-      queuedPublish(fx, 940, 'pr-preview/123', () =>
+      queuedPublish(fx, 944, 'pr-preview/123', () =>
         publishPrPreview({
-          ...context(fx, 940, 'pr-preview/123'),
-          pr: 123,
+          ...context(fx, 944, 'pr-preview/123'),
+          ...previewIdentity(),
           storybook,
           sandbox,
         }),
       ),
-    ).rejects.toThrow(/reserved visual path/);
+    ).rejects.toThrow(/reserved path visual/);
 
     const final = cloneRemote(fx.remote, fx.root);
     expect(
@@ -1147,7 +1185,99 @@ describe('gh-pages publisher', () => {
         path.join(final, 'pr', '123', 'visual', 'evidence.json'),
         'utf8',
       ),
-    ).toBe('visual evidence');
+    ).toBe('same-PR visual evidence');
+  });
+
+  it.each([
+    ['no deployment', false, false],
+    ['Storybook only', true, false],
+    ['Sandbox only', false, true],
+    ['both previews', true, true],
+  ])(
+    'publishes independent target state: %s',
+    async (_label, hasStorybook, hasSandbox) => {
+      const fx = fixture();
+      const storybook = hasStorybook
+        ? path.join(fx.root, 'matrix-storybook')
+        : undefined;
+      const sandbox = hasSandbox
+        ? path.join(fx.root, 'matrix-sandbox')
+        : undefined;
+      if (storybook) writeFile(path.join(storybook, 'index.html'), 'storybook');
+      if (sandbox) writeFile(path.join(sandbox, 'index.html'), 'sandbox');
+      const resultFile = path.join(fx.root, 'preview-deployment.json');
+
+      await queuedPublish(fx, 945, 'pr-preview/123', () =>
+        publishPrPreview({
+          ...context(fx, 945, 'pr-preview/123'),
+          ...previewIdentity(),
+          storybook,
+          sandbox,
+          resultFile,
+        }),
+      );
+
+      const final = cloneRemote(fx.remote, fx.root);
+      expect(fs.existsSync(path.join(final, 'pr', '123', 'index.html'))).toBe(
+        hasStorybook,
+      );
+      expect(
+        fs.existsSync(path.join(final, 'pr', '123', 'sandbox', 'index.html')),
+      ).toBe(hasSandbox);
+      expect(
+        fs.readFileSync(
+          path.join(final, 'pr', '123', 'visual', 'evidence.json'),
+          'utf8',
+        ),
+      ).toBe('same-PR visual evidence');
+      expect(fs.existsSync(path.join(final, 'pr', '124', 'index.html'))).toBe(
+        true,
+      );
+      const result = JSON.parse(fs.readFileSync(resultFile, 'utf8'));
+      expect(result.targets.storybook.available).toBe(hasStorybook);
+      expect(result.targets.sandbox.available).toBe(hasSandbox);
+    },
+  );
+
+  it('refuses to mark a target available without its entry point', async () => {
+    const fx = fixture();
+    const storybook = path.join(fx.root, 'missing-index-storybook');
+    writeFile(path.join(storybook, 'assets', 'bundle.js'), 'bundle');
+
+    await expect(
+      publishPrPreview({
+        ...context(fx, 946, 'pr-preview/123'),
+        ...previewIdentity(),
+        storybook,
+      }),
+    ).rejects.toThrow('--storybook must contain index.html');
+  });
+
+  it('does not claim deployment when the gh-pages push fails', async () => {
+    const fx = fixture();
+    const storybook = path.join(fx.root, 'failed-storybook');
+    writeFile(path.join(storybook, 'index.html'), 'new preview');
+    const resultFile = path.join(fx.root, 'preview-deployment.json');
+
+    await expect(
+      queuedPublish(fx, 946, 'pr-preview/123', () =>
+        publishPrPreview({
+          ...context(fx, 946, 'pr-preview/123'),
+          ...previewIdentity(),
+          storybook,
+          resultFile,
+          beforePush: () => {
+            throw new Error('simulated publisher failure');
+          },
+        }),
+      ),
+    ).rejects.toThrow('simulated publisher failure');
+
+    const final = cloneRemote(fx.remote, fx.root);
+    expect(
+      fs.readFileSync(path.join(final, 'pr', '123', 'index.html'), 'utf8'),
+    ).toBe('preview');
+    expect(fs.existsSync(resultFile)).toBe(false);
   });
 
   it('cleans stale previews without deleting visual evidence or live previews', async () => {

--- a/.github/scripts/lib/pr-preview.mjs
+++ b/.github/scripts/lib/pr-preview.mjs
@@ -1,0 +1,596 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+
+export const PR_ANALYSIS_MARKER = '<!-- astryx-pr-analysis -->';
+export const PREVIEW_RESULT_VERSION = 1;
+
+const FULL_SHA = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const GENERATOR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'generate-pr-comment.js',
+);
+
+function refuse(message) {
+  throw new Error(`PR preview refused: ${message}`);
+}
+
+function positiveInteger(value, name) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    refuse(`${name} must be a positive integer`);
+  }
+  return number;
+}
+
+function fullSha(value, name) {
+  const sha = String(value ?? '');
+  if (!FULL_SHA.test(sha)) refuse(`${name} must be a full lowercase SHA`);
+  return sha;
+}
+
+function repository(value, name) {
+  const repo = String(value ?? '');
+  if (!REPOSITORY.test(repo)) refuse(`${name} is invalid`);
+  return repo;
+}
+
+function nonempty(value, name) {
+  const string = String(value ?? '');
+  if (!string) refuse(`${name} is missing`);
+  return string;
+}
+
+function runRepository(run) {
+  return repository(run?.head_repository?.full_name, 'source head repository');
+}
+
+function runRepositoryId(run) {
+  return nonempty(run?.head_repository?.id, 'source head repository id');
+}
+
+function identityFromPullAndRun({pull, run, baseRepository}) {
+  if (run?.event !== 'pull_request') {
+    refuse('source run is not backed by a pull request');
+  }
+  if (run?.name && run.name !== 'CI') {
+    refuse(`source workflow is ${run.name}, not CI`);
+  }
+
+  const expectedBase = repository(baseRepository, 'base repository');
+  const sourceRunId = positiveInteger(run.id, 'source run id');
+  const sourceRunAttempt = positiveInteger(
+    run.run_attempt,
+    'source run attempt',
+  );
+  const headSha = fullSha(run.head_sha, 'source head');
+  const headRef = nonempty(run.head_branch, 'source head branch');
+  const headRepository = runRepository(run);
+  const headRepositoryId = runRepositoryId(run);
+
+  if (pull?.state !== 'open') refuse('pull request is not open');
+  if (pull?.head?.sha !== headSha)
+    refuse('pull request head does not match source run');
+  if (pull?.head?.ref !== headRef)
+    refuse('pull request branch does not match source run');
+  if (pull?.head?.repo?.full_name !== headRepository) {
+    refuse('pull request repository does not match source run');
+  }
+  if (String(pull?.head?.repo?.id ?? '') !== headRepositoryId) {
+    refuse('pull request repository id does not match source run');
+  }
+  if (pull?.base?.repo?.full_name !== expectedBase) {
+    refuse('pull request targets another repository');
+  }
+
+  return {
+    prNumber: positiveInteger(pull.number, 'pull request number'),
+    headSha,
+    headRef,
+    headRepository,
+    headRepositoryId,
+    baseRepository: expectedBase,
+    baseSha: fullSha(pull.base.sha, 'pull request base'),
+    sourceRunId,
+    sourceRunAttempt,
+    sourceConclusion: String(run.conclusion ?? ''),
+    draft: pull.draft === true,
+  };
+}
+
+function sameIdentity(actual, expected) {
+  for (const key of [
+    'prNumber',
+    'headSha',
+    'headRef',
+    'headRepository',
+    'headRepositoryId',
+    'baseRepository',
+    'sourceRunId',
+    'sourceRunAttempt',
+    'sourceConclusion',
+  ]) {
+    if (String(actual[key]) !== String(expected[key])) {
+      refuse(`${key} does not match the trusted source identity`);
+    }
+  }
+}
+
+export function validatePullRequestSourceRun({pull, run, baseRepository}) {
+  return identityFromPullAndRun({pull, run, baseRepository});
+}
+
+export async function resolveWorkflowRunPullRequest({
+  github,
+  owner,
+  repo,
+  run,
+}) {
+  const baseRepository = `${owner}/${repo}`;
+  let candidates;
+  const directNumbers = [
+    ...new Set(
+      (run?.pull_requests ?? [])
+        .map(pull => Number(pull?.number))
+        .filter(number => Number.isSafeInteger(number) && number > 0),
+    ),
+  ];
+
+  if (directNumbers.length > 0) {
+    candidates = await Promise.all(
+      directNumbers.map(async pullNumber => {
+        const {data} = await github.rest.pulls.get({
+          owner,
+          repo,
+          pull_number: pullNumber,
+        });
+        return data;
+      }),
+    );
+  } else {
+    const headOwner = nonempty(
+      run?.head_repository?.owner?.login,
+      'source head repository owner',
+    );
+    const headRef = nonempty(run?.head_branch, 'source head branch');
+    const {data} = await github.rest.pulls.list({
+      owner,
+      repo,
+      state: 'open',
+      head: `${headOwner}:${headRef}`,
+      per_page: 100,
+    });
+    candidates = data;
+  }
+
+  const matches = [];
+  const seen = new Set();
+  for (const pull of candidates) {
+    if (seen.has(pull?.number)) continue;
+    seen.add(pull?.number);
+    try {
+      matches.push(identityFromPullAndRun({pull, run, baseRepository}));
+    } catch {
+      // A candidate is not authority. Only the exact run/PR/repository identity
+      // accepted above may reach a privileged mutation.
+    }
+  }
+  if (matches.length !== 1) {
+    refuse(
+      `expected exactly one current pull request for source run ${run?.id}; found ${matches.length}`,
+    );
+  }
+  return matches[0];
+}
+
+export async function confirmSourceRunIdentity({
+  github,
+  owner,
+  repo,
+  expected,
+}) {
+  const sourceRunId = positiveInteger(expected.sourceRunId, 'source run id');
+  const prNumber = positiveInteger(expected.prNumber, 'pull request number');
+  const [{data: run}, {data: pull}] = await Promise.all([
+    github.rest.actions.getWorkflowRun({owner, repo, run_id: sourceRunId}),
+    github.rest.pulls.get({owner, repo, pull_number: prNumber}),
+  ]);
+  const actual = identityFromPullAndRun({
+    pull,
+    run,
+    baseRepository: `${owner}/${repo}`,
+  });
+  sameIdentity(actual, expected);
+  return actual;
+}
+
+function targetPaths(prNumber) {
+  return {
+    storybook: `pr/${prNumber}/`,
+    sandbox: `pr/${prNumber}/sandbox/`,
+  };
+}
+
+function resultIdentity(identity) {
+  return {
+    repository: repository(identity.baseRepository, 'base repository'),
+    pullRequest: {
+      number: positiveInteger(identity.prNumber, 'pull request number'),
+      headSha: fullSha(identity.headSha, 'pull request head'),
+      headRef: nonempty(identity.headRef, 'pull request branch'),
+      headRepository: repository(
+        identity.headRepository,
+        'pull request head repository',
+      ),
+      headRepositoryId: nonempty(
+        identity.headRepositoryId,
+        'pull request head repository id',
+      ),
+    },
+    sourceRun: {
+      id: positiveInteger(identity.sourceRunId, 'source run id'),
+      attempt: positiveInteger(identity.sourceRunAttempt, 'source run attempt'),
+      conclusion: String(identity.sourceConclusion ?? ''),
+    },
+  };
+}
+
+export function createUnavailableDeploymentResult(identity, reason) {
+  const normalized = resultIdentity(identity);
+  const paths = targetPaths(normalized.pullRequest.number);
+  return {
+    version: PREVIEW_RESULT_VERSION,
+    status: 'unavailable',
+    reason: nonempty(reason, 'unavailable reason'),
+    ...normalized,
+    pagesCommit: null,
+    targets: {
+      storybook: {
+        available: false,
+        path: paths.storybook,
+        indexSha256: null,
+      },
+      sandbox: {
+        available: false,
+        path: paths.sandbox,
+        indexSha256: null,
+      },
+    },
+  };
+}
+
+export function createPreviewPublicationManifest(
+  identity,
+  {storybookIndexSha256 = null, sandboxIndexSha256 = null} = {},
+) {
+  const normalized = resultIdentity(identity);
+  const paths = targetPaths(normalized.pullRequest.number);
+  const target = (targetPath, digest) => {
+    if (digest !== null && !SHA256.test(String(digest))) {
+      refuse('preview index digest is invalid');
+    }
+    return {
+      available: digest !== null,
+      path: targetPath,
+      indexSha256: digest,
+    };
+  };
+  return {
+    version: PREVIEW_RESULT_VERSION,
+    ...normalized,
+    targets: {
+      storybook: target(paths.storybook, storybookIndexSha256),
+      sandbox: target(paths.sandbox, sandboxIndexSha256),
+    },
+  };
+}
+
+export function createPublishedDeploymentResult(
+  identity,
+  {storybookIndexSha256 = null, sandboxIndexSha256 = null, pagesCommit},
+) {
+  return {
+    ...createPreviewPublicationManifest(identity, {
+      storybookIndexSha256,
+      sandboxIndexSha256,
+    }),
+    status: 'published',
+    reason: null,
+    pagesCommit: fullSha(pagesCommit, 'gh-pages commit'),
+  };
+}
+
+export function writeDeploymentResult(file, value) {
+  fs.mkdirSync(path.dirname(path.resolve(file)), {recursive: true});
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function validateDeploymentResult(value, expected) {
+  const identity = resultIdentity(expected);
+  if (value?.version !== PREVIEW_RESULT_VERSION) {
+    refuse('deployment result version is invalid');
+  }
+  if (!['published', 'unavailable'].includes(value.status)) {
+    refuse('deployment result status is invalid');
+  }
+  if (value.repository !== identity.repository) {
+    refuse('deployment base repository does not match');
+  }
+  for (const [key, expectedValue] of Object.entries(identity.pullRequest)) {
+    if (String(value.pullRequest?.[key]) !== String(expectedValue)) {
+      refuse(`deployment pull request ${key} does not match`);
+    }
+  }
+  for (const [key, expectedValue] of Object.entries(identity.sourceRun)) {
+    if (String(value.sourceRun?.[key]) !== String(expectedValue)) {
+      refuse(`deployment source run ${key} does not match`);
+    }
+  }
+
+  const paths = targetPaths(identity.pullRequest.number);
+  for (const name of ['storybook', 'sandbox']) {
+    const target = value.targets?.[name];
+    if (target?.path !== paths[name] || typeof target.available !== 'boolean') {
+      refuse(`deployment ${name} target is invalid`);
+    }
+    if (target.available) {
+      if (
+        value.status !== 'published' ||
+        !SHA256.test(target.indexSha256 ?? '')
+      ) {
+        refuse(`deployment ${name} proof is invalid`);
+      }
+      if (identity.sourceRun.conclusion !== 'success') {
+        refuse(`deployment ${name} cannot be available for failed source CI`);
+      }
+    } else if (target.indexSha256 !== null) {
+      refuse(`deployment ${name} has a digest without availability`);
+    }
+  }
+  if (value.status === 'published') {
+    fullSha(value.pagesCommit, 'deployment gh-pages commit');
+  } else {
+    if (value.pagesCommit !== null)
+      refuse('unavailable deployment has a commit');
+    if (value.targets.storybook.available || value.targets.sandbox.available) {
+      refuse('unavailable deployment advertises a target');
+    }
+  }
+  return value;
+}
+
+export function validateAnalysisMetadata(metadata, identity) {
+  if (String(metadata?.prNumber) !== String(identity.prNumber)) {
+    refuse('analysis pull request does not match');
+  }
+  if (
+    metadata?.headSha !== undefined &&
+    metadata.headSha !== identity.headSha
+  ) {
+    refuse('analysis head does not match');
+  }
+  if (
+    metadata?.headRepository !== undefined &&
+    metadata.headRepository !== identity.headRepository
+  ) {
+    refuse('analysis head repository does not match');
+  }
+  if (
+    metadata?.baseRepository !== undefined &&
+    metadata.baseRepository !== identity.baseRepository
+  ) {
+    refuse('analysis base repository does not match');
+  }
+  if (String(metadata?.runId) !== String(identity.sourceRunId)) {
+    refuse('analysis source run does not match');
+  }
+  if (
+    metadata?.runAttempt !== undefined &&
+    String(metadata.runAttempt) !== String(identity.sourceRunAttempt)
+  ) {
+    refuse('analysis source run attempt does not match');
+  }
+  if (
+    !/^[0-9a-f]{7,40}$/.test(String(metadata?.shortHash ?? '')) ||
+    !identity.headSha.startsWith(metadata.shortHash)
+  ) {
+    refuse('analysis short hash does not match');
+  }
+  return metadata;
+}
+
+function previewState(storybook, sandbox) {
+  if (storybook && sandbox) return 'both';
+  if (storybook) return 'storybook';
+  if (sandbox) return 'sandbox';
+  return 'none';
+}
+
+function pagesURL(identity, targetPath) {
+  const [owner, repo] = identity.baseRepository.split('/');
+  return `https://${owner}.github.io/${repo}/${targetPath}`;
+}
+
+function safeCurrentBody({identity, runUrl, message: overrideMessage}) {
+  const conclusion = identity.sourceConclusion;
+  const message =
+    overrideMessage ??
+    (conclusion === 'success'
+      ? 'The current CI run completed, but its trusted analysis is unavailable. Preview links are not shown.'
+      : `The current CI run concluded ${conclusion || 'without a result'}. Current analysis and preview links are unavailable.`);
+  return `## PR Analysis Report\n${PR_ANALYSIS_MARKER}\n\n> **Current run:** ${message}\n\n---\n\n<sub>Generated by PR Enrichment workflow | <a href="${runUrl}" target="_blank" rel="noopener noreferrer">View current CI run</a></sub>\n`;
+}
+
+function readJSON(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function trustedAnalysis({analysisPath, metadataPath, identity, core}) {
+  try {
+    if (!fs.existsSync(analysisPath) || !fs.existsSync(metadataPath))
+      return false;
+    validateAnalysisMetadata(readJSON(metadataPath), identity);
+    readJSON(analysisPath);
+    return true;
+  } catch (error) {
+    core.warning(`Ignoring untrusted or stale analysis: ${error.message}`);
+    return false;
+  }
+}
+
+function trustedDeployment({deploymentResultPath, identity, core}) {
+  try {
+    if (!fs.existsSync(deploymentResultPath)) return null;
+    return validateDeploymentResult(readJSON(deploymentResultPath), identity);
+  } catch (error) {
+    core.warning(
+      `Ignoring untrusted or stale preview result: ${error.message}`,
+    );
+    return null;
+  }
+}
+
+async function allComments(github, owner, repo, prNumber) {
+  return github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+}
+
+export async function reconcilePrComment({
+  github,
+  core,
+  context,
+  expectedIdentity,
+  analysisPath = 'pr-analysis/analysis.json',
+  metadataPath = 'pr-analysis/pr-meta.json',
+  a11yPath = 'a11y/a11y-report.json',
+  deploymentResultPath = 'preview-deployment/preview-deployment.json',
+  visualPath = 'trusted-visual/verdict.json',
+  visualPublished = false,
+  visualReportPath = '',
+  createIfMissing = true,
+  fallbackMessage,
+  generator = GENERATOR,
+  execute = execFileSync,
+}) {
+  const {owner, repo} = context.repo;
+  const identity = await confirmSourceRunIdentity({
+    github,
+    owner,
+    repo,
+    expected: expectedIdentity,
+  });
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${identity.sourceRunId}`;
+  const analysisReady = trustedAnalysis({
+    analysisPath,
+    metadataPath,
+    identity,
+    core,
+  });
+  const deployment = trustedDeployment({
+    deploymentResultPath,
+    identity,
+    core,
+  });
+  const storybook = deployment?.targets.storybook.available === true;
+  const sandbox = deployment?.targets.sandbox.available === true;
+  const comments = await allComments(github, owner, repo, identity.prNumber);
+  const botComments = comments.filter(comment => comment.user?.type === 'Bot');
+  const botComment =
+    botComments.find(comment => comment.body?.includes(PR_ANALYSIS_MARKER)) ??
+    botComments.find(comment => comment.body?.includes('PR Analysis Report'));
+  if (!botComment && !createIfMissing) {
+    core.info(
+      `No existing PR Analysis Report to reconcile on #${identity.prNumber}.`,
+    );
+    return {action: 'none', body: null, identity, deployment};
+  }
+
+  let body;
+  if (analysisReady) {
+    let resolvedA11yPath = a11yPath;
+    if (!fs.existsSync(resolvedA11yPath)) {
+      resolvedA11yPath = path.resolve('a11y-empty.json');
+      fs.writeFileSync(
+        resolvedA11yPath,
+        '{"components":{},"summary":{"componentsAudited":0,"totalViolations":0}}',
+      );
+    }
+    const args = [
+      generator,
+      '--analysis',
+      analysisPath,
+      '--a11y',
+      resolvedA11yPath,
+      ...(fs.existsSync(visualPath)
+        ? [
+            '--visual',
+            visualPath,
+            ...(visualPublished && visualReportPath
+              ? [
+                  '--visual-report-url',
+                  `https://${owner}.github.io/${repo}/${visualReportPath}/`,
+                  '--visual-image-url',
+                  `https://raw.githubusercontent.com/${owner}/${repo}/gh-pages/${visualReportPath}/`,
+                ]
+              : []),
+          ]
+        : []),
+      ...(storybook
+        ? [
+            '--storybook-url',
+            pagesURL(identity, deployment.targets.storybook.path),
+          ]
+        : []),
+      ...(sandbox
+        ? ['--sandbox-url', pagesURL(identity, deployment.targets.sandbox.path)]
+        : []),
+      '--preview-state',
+      previewState(storybook, sandbox),
+      '--source-conclusion',
+      identity.sourceConclusion,
+      '--run-url',
+      runUrl,
+      '--pr-number',
+      String(identity.prNumber),
+    ];
+    try {
+      body = execute(process.execPath, args, {encoding: 'utf8'});
+    } catch (error) {
+      core.warning(`Could not render current analysis: ${error.message}`);
+      body = safeCurrentBody({identity, runUrl, message: fallbackMessage});
+    }
+  } else {
+    body = safeCurrentBody({identity, runUrl, message: fallbackMessage});
+  }
+
+  if (botComment) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: botComment.id,
+      body,
+    });
+    core.info(`Updated PR Analysis Report on #${identity.prNumber}.`);
+    return {action: 'updated', body, identity, deployment};
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: identity.prNumber,
+    body,
+  });
+  core.info(`Posted PR Analysis Report on #${identity.prNumber}.`);
+  return {action: 'created', body, identity, deployment};
+}

--- a/.github/scripts/lib/pr-preview.test.mjs
+++ b/.github/scripts/lib/pr-preview.test.mjs
@@ -1,0 +1,541 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  PR_ANALYSIS_MARKER,
+  createPublishedDeploymentResult,
+  createUnavailableDeploymentResult,
+  reconcilePrComment,
+  resolveWorkflowRunPullRequest,
+  writeDeploymentResult,
+} from './pr-preview.mjs';
+
+const HEAD = 'a'.repeat(40);
+const BASE = 'b'.repeat(40);
+const PAGES = 'c'.repeat(40);
+const INDEX = 'd'.repeat(64);
+const roots = [];
+
+function identity(overrides = {}) {
+  return {
+    prNumber: 5697,
+    headSha: HEAD,
+    headRef: 'fix-failed-ci-preview-links',
+    headRepository: 'cixzhang/astryx',
+    headRepositoryId: '321',
+    baseRepository: 'facebook/astryx',
+    baseSha: BASE,
+    sourceRunId: 33321033727,
+    sourceRunAttempt: 1,
+    sourceConclusion: 'success',
+    draft: false,
+    ...overrides,
+  };
+}
+
+function sourceRun(value = identity()) {
+  return {
+    id: value.sourceRunId,
+    run_attempt: value.sourceRunAttempt,
+    name: 'CI',
+    event: 'pull_request',
+    conclusion: value.sourceConclusion,
+    head_sha: value.headSha,
+    head_branch: value.headRef,
+    head_repository: {
+      id: Number(value.headRepositoryId),
+      full_name: value.headRepository,
+      owner: {login: value.headRepository.split('/')[0]},
+    },
+    pull_requests: [],
+  };
+}
+
+function pull(value = identity()) {
+  return {
+    number: value.prNumber,
+    state: 'open',
+    draft: value.draft,
+    head: {
+      sha: value.headSha,
+      ref: value.headRef,
+      repo: {
+        id: Number(value.headRepositoryId),
+        full_name: value.headRepository,
+      },
+    },
+    base: {
+      sha: value.baseSha,
+      repo: {full_name: value.baseRepository},
+    },
+  };
+}
+
+function githubFixture({value = identity(), comments = []} = {}) {
+  const state = {
+    comments: comments.map(comment => ({...comment})),
+    created: [],
+    updated: [],
+    listedIssues: [],
+  };
+  const github = {
+    rest: {
+      actions: {
+        getWorkflowRun: vi.fn(async () => ({data: sourceRun(value)})),
+      },
+      pulls: {
+        get: vi.fn(async () => ({data: pull(value)})),
+        list: vi.fn(async () => ({data: [pull(value)]})),
+      },
+      issues: {
+        listComments: vi.fn(async ({issue_number}) => {
+          state.listedIssues.push(issue_number);
+          return {data: state.comments};
+        }),
+        updateComment: vi.fn(async request => {
+          state.updated.push(request);
+          const comment = state.comments.find(
+            item => item.id === request.comment_id,
+          );
+          if (comment) comment.body = request.body;
+          return {data: comment};
+        }),
+        createComment: vi.fn(async request => {
+          state.created.push(request);
+          const comment = {
+            id: 9000 + state.created.length,
+            user: {type: 'Bot'},
+            body: request.body,
+          };
+          state.comments.push(comment);
+          return {data: comment};
+        }),
+      },
+    },
+    paginate: vi.fn(async (method, request) => (await method(request)).data),
+  };
+  return {github, state};
+}
+
+function fixture(value = identity(), {analysis = true, deployment} = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pr-preview-'));
+  roots.push(root);
+  const paths = {
+    analysis: path.join(root, 'analysis.json'),
+    metadata: path.join(root, 'pr-meta.json'),
+    a11y: path.join(root, 'a11y.json'),
+    deployment: path.join(root, 'preview-deployment.json'),
+    visual: path.join(root, 'missing-visual.json'),
+  };
+  if (analysis) {
+    fs.writeFileSync(
+      paths.analysis,
+      JSON.stringify({
+        newComponents: [],
+        modifiedComponents: ['Card'],
+        componentStats: {Card: {package: '@astryxdesign/core'}},
+        bundlePackages: [],
+        totalBundle: null,
+      }),
+    );
+    fs.writeFileSync(
+      paths.metadata,
+      JSON.stringify({
+        prNumber: value.prNumber,
+        shortHash: value.headSha.slice(0, 7),
+        headSha: value.headSha,
+        headRepository: value.headRepository,
+        baseRepository: value.baseRepository,
+        runId: value.sourceRunId,
+        runAttempt: value.sourceRunAttempt,
+      }),
+    );
+  }
+  fs.writeFileSync(
+    paths.a11y,
+    '{"components":{},"summary":{"componentsAudited":0,"totalViolations":0}}',
+  );
+  if (deployment) writeDeploymentResult(paths.deployment, deployment);
+  return paths;
+}
+
+function published(value, available = ['storybook', 'sandbox']) {
+  return createPublishedDeploymentResult(value, {
+    storybookIndexSha256: available.includes('storybook') ? INDEX : null,
+    sandboxIndexSha256: available.includes('sandbox') ? INDEX : null,
+    pagesCommit: PAGES,
+  });
+}
+
+async function reconcile({
+  value = identity(),
+  deployment,
+  analysis = true,
+  comments = [],
+  githubFixtureValue = value,
+  createIfMissing,
+  fallbackMessage,
+  execute,
+} = {}) {
+  const paths = fixture(value, {analysis, deployment});
+  const {github, state} = githubFixture({
+    value: githubFixtureValue,
+    comments,
+  });
+  const core = {info: vi.fn(), warning: vi.fn()};
+  const result = await reconcilePrComment({
+    github,
+    core,
+    context: {
+      repo: {owner: 'facebook', repo: 'astryx'},
+      serverUrl: 'https://github.com',
+    },
+    expectedIdentity: value,
+    analysisPath: paths.analysis,
+    metadataPath: paths.metadata,
+    a11yPath: paths.a11y,
+    deploymentResultPath: paths.deployment,
+    visualPath: paths.visual,
+    createIfMissing,
+    fallbackMessage,
+    execute,
+  });
+  return {result, state, core, github, paths};
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, {recursive: true, force: true});
+  }
+});
+
+describe('trusted PR preview identity', () => {
+  it('resolves a fork run through the trusted owner and branch fallback', async () => {
+    const value = identity();
+    const {github} = githubFixture({value});
+    const run = sourceRun(value);
+
+    const resolved = await resolveWorkflowRunPullRequest({
+      github,
+      owner: 'facebook',
+      repo: 'astryx',
+      run,
+    });
+
+    expect(resolved).toMatchObject(value);
+    expect(github.rest.pulls.list).toHaveBeenCalledWith({
+      owner: 'facebook',
+      repo: 'astryx',
+      state: 'open',
+      head: 'cixzhang:fix-failed-ci-preview-links',
+      per_page: 100,
+    });
+  });
+
+  it.each([
+    ['wrong head', {headSha: 'e'.repeat(40)}],
+    ['wrong head repository', {headRepository: 'someone/astryx'}],
+    ['wrong base repository', {baseRepository: 'someone/astryx'}],
+  ])('rejects a candidate with the %s', async (_label, overrides) => {
+    const trusted = identity();
+    const candidate = identity(overrides);
+    const {github} = githubFixture({value: candidate});
+
+    await expect(
+      resolveWorkflowRunPullRequest({
+        github,
+        owner: 'facebook',
+        repo: 'astryx',
+        run: sourceRun(trusted),
+      }),
+    ).rejects.toThrow(/expected exactly one current pull request/);
+  });
+
+  it('rejects workflow dispatch without a PR-backed CI run', async () => {
+    const value = identity();
+    const {github} = githubFixture({value});
+    const run = {...sourceRun(value), event: 'workflow_dispatch'};
+
+    await expect(
+      resolveWorkflowRunPullRequest({
+        github,
+        owner: 'facebook',
+        repo: 'astryx',
+        run,
+      }),
+    ).rejects.toThrow(/expected exactly one current pull request/);
+  });
+});
+
+describe('PR comment preview reconciliation', () => {
+  it.each([
+    ['no deployment', undefined, false, false],
+    ['Storybook only', published(identity(), ['storybook']), true, false],
+    ['Sandbox only', published(identity(), ['sandbox']), false, true],
+    [
+      'both previews',
+      published(identity(), ['storybook', 'sandbox']),
+      true,
+      true,
+    ],
+    [
+      'deployment failure',
+      createUnavailableDeploymentResult(identity(), 'publisher-failed'),
+      false,
+      false,
+    ],
+  ])(
+    'renders the behavioral availability matrix: %s',
+    async (_label, deployment, hasStorybook, hasSandbox) => {
+      const {result} = await reconcile({deployment});
+
+      expect(result.body.includes('View Storybook for this PR')).toBe(
+        hasStorybook,
+      );
+      expect(result.body.includes('View Sandbox for this PR')).toBe(hasSandbox);
+      expect(result.body.includes('> **Preview availability:**')).toBe(
+        !hasStorybook || !hasSandbox,
+      );
+    },
+  );
+
+  it('keeps current trustworthy analysis when source CI fails', async () => {
+    const value = identity({sourceConclusion: 'failure'});
+    const deployment = createUnavailableDeploymentResult(
+      value,
+      'source-failed',
+    );
+
+    const {result} = await reconcile({value, deployment});
+
+    expect(result.body).toContain('Modified Components');
+    expect(result.body).toContain('Card');
+    expect(result.body).toContain('CI did not succeed');
+    expect(result.body).not.toContain('View Storybook for this PR');
+    expect(result.body).not.toContain('View Sandbox for this PR');
+  });
+
+  it('replaces a stale linked comment when failed CI has no analysis artifact', async () => {
+    const value = identity({sourceConclusion: 'failure'});
+    const stale = {
+      id: 77,
+      user: {type: 'Bot'},
+      body: `## PR Analysis Report\n\n### 📚 Storybook Preview\nhttps://facebook.github.io/astryx/pr/5697/\n\n### 🧪 Sandbox Preview\nhttps://facebook.github.io/astryx/pr/5697/sandbox/`,
+    };
+
+    const {result, state} = await reconcile({
+      value,
+      analysis: false,
+      comments: [stale],
+    });
+
+    expect(result.action).toBe('updated');
+    expect(state.created).toHaveLength(0);
+    expect(state.updated).toHaveLength(1);
+    expect(result.body).toContain(PR_ANALYSIS_MARKER);
+    expect(result.body).toContain('concluded failure');
+    expect(result.body).not.toContain('/pr/5697/');
+  });
+
+  it('reconciles an existing spec-only report without creating a new one', async () => {
+    const message =
+      'The current change only updates durable specifications. Preview links are not shown.';
+    const withoutPrior = await reconcile({
+      analysis: false,
+      createIfMissing: false,
+      fallbackMessage: message,
+    });
+    expect(withoutPrior.result.action).toBe('none');
+    expect(withoutPrior.state.created).toHaveLength(0);
+    expect(withoutPrior.state.updated).toHaveLength(0);
+
+    const stale = {
+      id: 79,
+      user: {type: 'Bot'},
+      body: '## PR Analysis Report\nhttps://facebook.github.io/astryx/pr/5697/',
+    };
+    const withPrior = await reconcile({
+      analysis: false,
+      comments: [stale],
+      createIfMissing: false,
+      fallbackMessage: message,
+    });
+    expect(withPrior.result.action).toBe('updated');
+    expect(withPrior.result.body).toContain(message);
+    expect(withPrior.result.body).not.toContain('/pr/5697/');
+    expect(withPrior.state.created).toHaveLength(0);
+    expect(withPrior.state.updated).toHaveLength(1);
+  });
+
+  it('falls back to a safe current message when analysis rendering fails', async () => {
+    const stale = {
+      id: 78,
+      user: {type: 'Bot'},
+      body: '## PR Analysis Report\nhttps://facebook.github.io/astryx/pr/5697/',
+    };
+
+    const {result, core} = await reconcile({
+      deployment: published(identity()),
+      comments: [stale],
+      execute: () => {
+        throw new Error('malformed analysis');
+      },
+    });
+
+    expect(result.body).toContain('trusted analysis is unavailable');
+    expect(result.body).not.toContain('/pr/5697/');
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Could not render current analysis'),
+    );
+  });
+
+  it('updates one same-PR comment across repeated source attempts', async () => {
+    const first = identity();
+    const harness = githubFixture({value: first});
+    const firstPaths = fixture(first, {deployment: published(first)});
+    const core = {info: vi.fn(), warning: vi.fn()};
+    const common = {
+      github: harness.github,
+      core,
+      context: {
+        repo: {owner: 'facebook', repo: 'astryx'},
+        serverUrl: 'https://github.com',
+      },
+      visualPath: firstPaths.visual,
+    };
+
+    await reconcilePrComment({
+      ...common,
+      expectedIdentity: first,
+      analysisPath: firstPaths.analysis,
+      metadataPath: firstPaths.metadata,
+      a11yPath: firstPaths.a11y,
+      deploymentResultPath: firstPaths.deployment,
+    });
+
+    const second = identity({sourceRunAttempt: 2});
+    harness.github.rest.actions.getWorkflowRun.mockResolvedValue({
+      data: sourceRun(second),
+    });
+    harness.github.rest.pulls.get.mockResolvedValue({data: pull(second)});
+    const secondPaths = fixture(second, {
+      deployment: published(second, ['storybook']),
+    });
+    await reconcilePrComment({
+      ...common,
+      expectedIdentity: second,
+      analysisPath: secondPaths.analysis,
+      metadataPath: secondPaths.metadata,
+      a11yPath: secondPaths.a11y,
+      deploymentResultPath: secondPaths.deployment,
+      visualPath: secondPaths.visual,
+    });
+
+    expect(harness.state.created).toHaveLength(1);
+    expect(harness.state.updated).toHaveLength(1);
+    expect(harness.state.comments).toHaveLength(1);
+    expect(harness.state.comments[0].body).toContain(
+      'View Storybook for this PR',
+    );
+    expect(harness.state.comments[0].body).not.toContain(
+      'View Sandbox for this PR',
+    );
+    expect(harness.state.listedIssues).toEqual([5697, 5697]);
+  });
+
+  it.each([
+    ['wrong PR', {prNumber: 9999}],
+    ['wrong head', {headSha: 'e'.repeat(40)}],
+    ['wrong repository', {headRepository: 'someone/astryx'}],
+  ])(
+    'fails closed for a deployment result with the %s',
+    async (_label, overrides) => {
+      const deployment = published(identity(overrides));
+
+      const {result, core} = await reconcile({deployment});
+
+      expect(result.body).not.toContain('View Storybook for this PR');
+      expect(result.body).not.toContain('View Sandbox for this PR');
+      expect(core.warning).toHaveBeenCalledWith(
+        expect.stringContaining('Ignoring untrusted or stale preview result'),
+      );
+    },
+  );
+
+  it('does not mutate any PR after the source identity becomes stale', async () => {
+    const expected = identity();
+    const current = identity({headSha: 'f'.repeat(40)});
+    const paths = fixture(expected, {deployment: published(expected)});
+    const {github, state} = githubFixture({value: current});
+
+    await expect(
+      reconcilePrComment({
+        github,
+        core: {info: vi.fn(), warning: vi.fn()},
+        context: {
+          repo: {owner: 'facebook', repo: 'astryx'},
+          serverUrl: 'https://github.com',
+        },
+        expectedIdentity: expected,
+        analysisPath: paths.analysis,
+        metadataPath: paths.metadata,
+        a11yPath: paths.a11y,
+        deploymentResultPath: paths.deployment,
+        visualPath: paths.visual,
+      }),
+    ).rejects.toThrow(/headSha does not match/);
+    expect(state.created).toHaveLength(0);
+    expect(state.updated).toHaveLength(0);
+    expect(state.listedIssues).toHaveLength(0);
+  });
+
+  it('does not emit links for dispatch without a PR-backed source run', async () => {
+    const value = identity();
+    const paths = fixture(value, {deployment: published(value)});
+    const {github, state} = githubFixture({value});
+    github.rest.actions.getWorkflowRun.mockResolvedValue({
+      data: {...sourceRun(value), event: 'workflow_dispatch'},
+    });
+
+    await expect(
+      reconcilePrComment({
+        github,
+        core: {info: vi.fn(), warning: vi.fn()},
+        context: {
+          repo: {owner: 'facebook', repo: 'astryx'},
+          serverUrl: 'https://github.com',
+        },
+        expectedIdentity: value,
+        analysisPath: paths.analysis,
+        metadataPath: paths.metadata,
+        a11yPath: paths.a11y,
+        deploymentResultPath: paths.deployment,
+        visualPath: paths.visual,
+      }),
+    ).rejects.toThrow(/not backed by a pull request/);
+    expect(state.created).toHaveLength(0);
+    expect(state.updated).toHaveLength(0);
+  });
+
+  it('renders the current successful path from exact publisher proof', async () => {
+    const value = identity();
+    const {result, state} = await reconcile({
+      value,
+      deployment: published(value),
+    });
+
+    expect(result.action).toBe('created');
+    expect(result.body).toContain(PR_ANALYSIS_MARKER);
+    expect(result.body).toContain('https://facebook.github.io/astryx/pr/5697/');
+    expect(result.body).toContain(
+      'https://facebook.github.io/astryx/pr/5697/sandbox/',
+    );
+    expect(state.created[0].issue_number).toBe(5697);
+    expect(state.listedIssues).toEqual([5697]);
+  });
+});

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -43,22 +43,38 @@ describe('visual acceptance workflow concurrency', () => {
     );
   });
 
-  it('only advertises previews when the source CI run can deploy them', () => {
+  it('orders trusted preview publication before comment reconciliation', () => {
+    const publisher = workflow('deploy-preview.yml');
+    const comment = workflow('pr-comment.yml');
+
+    expect(publisher).toContain('workflow_call:');
+    expect(publisher).toContain('source_run_attempt:');
+    expect(publisher).toContain('--result preview-deployment.json');
+    expect(comment).toContain('uses: ./.github/workflows/deploy-preview.yml');
+    expect(comment).toContain('needs: [resolve, deploy-preview]');
+    expect(comment).toContain(
+      "if: always() && steps.identity.outputs.valid == 'true'",
+    );
+    expect(comment).toContain('reconcilePrComment');
+    expect(comment).not.toContain('const previewAvailable');
+  });
+
+  it('keeps spec-only checks lightweight while removing stale links', () => {
     const value = workflow('pr-comment.yml');
-    const comment = value.slice(
-      value.indexOf('      - name: Generate and post PR comment'),
-      value.indexOf('      - name: Evaluate visual acceptance state'),
+    const reconcile = value.slice(
+      value.indexOf('  spec-only-reconcile:'),
+      value.indexOf('  deploy-preview:'),
+    );
+    const deploy = value.slice(
+      value.indexOf('  deploy-preview:'),
+      value.indexOf('  comment:'),
     );
 
-    expect(comment).toContain(
-      'SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}',
-    );
-    expect(comment).toContain(
-      "const previewAvailable = process.env.SOURCE_CONCLUSION === 'success';",
-    );
-    expect(comment).toContain('...(previewAvailable');
-    expect(comment).toContain("'--storybook-url'");
-    expect(comment).toContain("'--sandbox-url'");
+    expect(value).toContain("needs.resolve.outputs.spec_only == 'true'");
+    expect(reconcile).toContain('reconcilePrComment');
+    expect(reconcile).toContain('createIfMissing: false');
+    expect(reconcile).not.toContain('Setup Node and pnpm');
+    expect(deploy).toContain("needs.resolve.outputs.spec_only != 'true'");
   });
 
   it('keeps comment authorization read-only until the shared lock is held', () => {
@@ -324,9 +340,13 @@ describe('visual acceptance workflow concurrency', () => {
 
   it('grants visual publisher jobs read access to overlapping workflow runs', () => {
     const comment = workflow('pr-comment.yml');
+    const commentStart = comment.indexOf('  comment:');
     const commentJob = comment.slice(
-      comment.indexOf('  comment:'),
-      comment.indexOf('      - name: Checkout trusted default-branch code'),
+      commentStart,
+      comment.indexOf(
+        '      - name: Checkout trusted default-branch code',
+        commentStart,
+      ),
     );
     const acceptance = workflow('visual-acceptance.yml');
     const acceptJob = acceptance.slice(
@@ -357,45 +377,51 @@ describe('visual acceptance workflow concurrency', () => {
     expect(promoteJob).toContain('contents: write');
   });
 
-  it('resolves automatic previews from trusted API state before checking artifacts', () => {
+  it('verifies exact source identity before checking preview artifacts', () => {
     const value = workflow('deploy-preview.yml');
-    const resolve = value.indexOf('Resolve trusted preview target');
-    const metadata = value.indexOf('Download PR metadata from the CI run');
+    const resolve = value.indexOf(
+      'Confirm trusted source and preview identity',
+    );
+    const metadata = value.indexOf(
+      'Download PR metadata from the exact CI run',
+    );
     const crossCheck = value.indexOf('Cross-check artifact identity');
 
-    expect(value).toContain("run.conclusion !== 'success'");
-    expect(value).toContain('pr.draft');
-    expect(value).toContain('listPullRequestsAssociatedWithCommit');
-    expect(value).toContain('pr.head?.sha === run.head_sha');
-    expect(value).toContain('pr.head?.repo?.id');
-    expect(value).not.toContain('PR_NUMBER="$(jq');
+    expect(value).toContain('workflow_call:');
+    expect(value).toContain('confirmSourceRunIdentity');
+    expect(value).toContain('head_repository_id:');
+    expect(value).toContain('base_repository:');
+    expect(value).toContain('source_run_attempt:');
+    expect(value).not.toContain('listPullRequestsAssociatedWithCommit');
     expect(resolve).toBeGreaterThan(-1);
     expect(resolve).toBeLessThan(metadata);
     expect(metadata).toBeLessThan(crossCheck);
-    expect(value).toContain('artifact PR number does not match trusted PR');
-    expect(value).toContain('artifact head does not match trusted PR head');
-    expect(value).toContain('steps.preview.outputs.ready');
+    expect(value).toContain('validateAnalysisMetadata');
     expect(value).toContain('steps.artifact.outputs.ready');
   });
 
-  it('rechecks trusted preview readiness immediately before publishing', () => {
+  it('rechecks independent target readiness immediately before publishing', () => {
     const value = workflow('deploy-preview.yml');
-    const verify = value.indexOf('Verify preview artifacts are present');
-    const final = value.indexOf('Confirm preview target before publish');
-    const publish = value.indexOf('Deploy PR preview to GitHub Pages');
+    const detect = value.indexOf(
+      'Detect independently available preview targets',
+    );
+    const final = value.indexOf(
+      'Confirm preview target immediately before publication',
+    );
+    const publish = value.indexOf('Publish trusted preview result');
     const finalBlock = value.slice(final, publish);
     const publishBlock = value.slice(publish);
 
-    expect(final).toBeGreaterThan(verify);
+    expect(final).toBeGreaterThan(detect);
     expect(final).toBeLessThan(publish);
-    expect(finalBlock).toContain("pr.state !== 'open'");
-    expect(finalBlock).toContain('pr.draft');
-    expect(finalBlock).toContain('pr.head.sha !== process.env.HEAD_SHA');
-    expect(finalBlock).toContain('pr.head.ref !== process.env.HEAD_REF');
-    expect(finalBlock).toContain('pr.head.repo?.id');
+    expect(finalBlock).toContain('confirmSourceRunIdentity');
+    expect(finalBlock).toContain('identity.draft');
+    expect(finalBlock).toContain("'storybook',");
+    expect(finalBlock).toContain("'sandbox',");
     expect(publishBlock).toContain(
-      "if: steps.final-preview.outputs.ready == 'true'",
+      "if: always() && steps.final.outputs.ready == 'true'",
     );
+    expect(publishBlock).toContain('--result preview-deployment.json');
   });
 
   it('keeps every remaining gh-pages writer behind the shared publisher', () => {
@@ -439,12 +465,18 @@ describe('visual acceptance workflow concurrency', () => {
     const compact = workflow('compact-gh-pages.yml');
     const vibe = workflow('vibe-screenshots.yml');
 
-    expect(deployPreview).toContain('gh-pages-publisher.mjs pr-preview');
-    expect(redeployPreview).toContain('gh-pages-publisher.mjs pr-preview');
-    expect(redeployPreview).toContain('uses: actions/checkout@v7');
+    expect(deployPreview).toContain(
+      'node .github/scripts/gh-pages-publisher.mjs "${args[@]}"',
+    );
+    expect(deployPreview).toContain('--result preview-deployment.json');
+    expect(redeployPreview).toContain(
+      'node .github/scripts/gh-pages-publisher.mjs "${args[@]}"',
+    );
+    expect(redeployPreview).toContain('--result preview-deployment.json');
+    expect(redeployPreview).toContain('Checkout trusted publisher');
     expect(redeployPreview).toContain('ref: main');
-    expect(redeployPreview.indexOf('uses: actions/checkout@v7')).toBeLessThan(
-      redeployPreview.indexOf('gh-pages-publisher.mjs pr-preview'),
+    expect(redeployPreview.indexOf('Checkout trusted publisher')).toBeLessThan(
+      redeployPreview.indexOf('--result preview-deployment.json'),
     );
     expect(cleanup).toContain('gh-pages-publisher.mjs cleanup-previews');
     expect(compact).toContain('gh-pages-publisher.mjs compact');

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -43,6 +43,24 @@ describe('visual acceptance workflow concurrency', () => {
     );
   });
 
+  it('only advertises previews when the source CI run can deploy them', () => {
+    const value = workflow('pr-comment.yml');
+    const comment = value.slice(
+      value.indexOf('      - name: Generate and post PR comment'),
+      value.indexOf('      - name: Evaluate visual acceptance state'),
+    );
+
+    expect(comment).toContain(
+      'SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}',
+    );
+    expect(comment).toContain(
+      "const previewAvailable = process.env.SOURCE_CONCLUSION === 'success';",
+    );
+    expect(comment).toContain('...(previewAvailable');
+    expect(comment).toContain("'--storybook-url'");
+    expect(comment).toContain("'--sandbox-url'");
+  });
+
   it('keeps comment authorization read-only until the shared lock is held', () => {
     const value = workflow('visual-acceptance.yml');
     const authorize = value.slice(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,9 +361,11 @@ jobs:
           {
             "prNumber": "${{ steps.urls.outputs.pr_number }}",
             "shortHash": "${{ steps.urls.outputs.short_hash }}",
-            "storybookUrl": "${{ steps.urls.outputs.storybook_url }}",
-            "sandboxUrl": "${{ steps.urls.outputs.sandbox_url }}",
+            "headSha": "${{ github.event.pull_request.head.sha }}",
+            "headRepository": "${{ github.event.pull_request.head.repo.full_name }}",
+            "baseRepository": "${{ github.event.pull_request.base.repo.full_name }}",
             "runId": "${{ github.run_id }}",
+            "runAttempt": "${{ github.run_attempt }}",
             "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }
           EOF

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,217 +1,286 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-# Deploy PR Preview — publishes the Storybook + Sandbox preview for ALL PRs.
-#
-# Runs on workflow_run after CI completes, NOT on pull_request. That matters:
-# a pull_request workflow triggered by a fork gets a READ-ONLY token and can't
-# push to gh-pages, which is why fork PRs never got a preview. workflow_run runs
-# from the base repo with the repo's own write token, so it can deploy previews
-# for fork PRs too — one code path for every PR, no drift between a fork path
-# and a same-repo path (mirrors pr-comment.yml).
-#
-# Safety: this NEVER checks out or runs PR-controlled code. It only downloads
-# the pre-built static artifacts (storybook-<hash>, sandbox-<hash>) that CI
-# already produced and copies them into gh-pages. Do not add checkout of the PR
-# head or execution of PR code here.
+# Trusted preview publisher used by pr-comment.yml after an exact pull-request CI
+# run completes. The caller resolves the source identity; this workflow verifies
+# it again, downloads only that run's static artifacts, and records the published
+# targets in a result produced by the shared gh-pages publisher.
 
 name: Deploy PR Preview
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    types: [completed]
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+      head_sha:
+        required: true
+        type: string
+      head_repository:
+        required: true
+        type: string
+      head_repository_id:
+        required: true
+        type: string
+      head_ref:
+        required: true
+        type: string
+      base_repository:
+        required: true
+        type: string
+      source_run_id:
+        required: true
+        type: string
+      source_run_attempt:
+        required: true
+        type: string
+      source_conclusion:
+        required: true
+        type: string
 
 permissions: {}
 
-# Serialize preview deploys per source branch (≈ per PR). Two pushes to the same
-# PR shouldn't race each other's gh-pages push; cross-PR and main-deploy conflicts
-# are handled by the retry loop below. head_branch is the only PR-stable key
-# available in workflow_run context (the PR number isn't known until we parse the
-# artifact). Not cancel-in-progress: let an in-flight deploy finish its push.
-concurrency:
-  group: 'pr-preview-${{ github.event.workflow_run.head_branch }}'
-  cancel-in-progress: false
-
 jobs:
   deploy-preview:
-    # Only for CI runs triggered by a pull request.
-    if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: write
       pull-requests: read
     steps:
-      - name: Checkout publisher
+      - name: Checkout trusted publisher
         uses: actions/checkout@v7
         with:
           ref: main
 
-      - name: Resolve trusted preview target
-        id: preview
+      - name: Confirm trusted source and preview identity
+        id: identity
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_REPOSITORY: ${{ inputs.head_repository }}
+          HEAD_REPOSITORY_ID: ${{ inputs.head_repository_id }}
+          HEAD_REF: ${{ inputs.head_ref }}
+          BASE_REPOSITORY: ${{ inputs.base_repository }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
+          SOURCE_CONCLUSION: ${{ inputs.source_conclusion }}
         with:
           retries: 3
           script: |
-            const run = context.payload.workflow_run;
-            const {owner, repo} = context.repo;
-            if (run.conclusion !== 'success') {
-              core.info(`CI run ${run.id} concluded ${run.conclusion}; preview deploy is not ready.`);
-              core.setOutput('ready', 'false');
-              return;
-            }
-            const pullByNumber = async number =>
-              (await github.rest.pulls.get({owner, repo, pull_number: number})).data;
-            let candidates = [];
-            for (const pr of run.pull_requests ?? []) {
-              if (pr.number) candidates.push(await pullByNumber(pr.number));
-            }
-            if (candidates.length === 0) {
-              candidates = await github.paginate(
-                github.rest.repos.listPullRequestsAssociatedWithCommit,
-                {owner, repo, commit_sha: run.head_sha, per_page: 100},
-              );
-            }
-            const matches = candidates.filter(pr =>
-              pr.state === 'open' &&
-              pr.head?.sha === run.head_sha &&
-              pr.head?.ref === run.head_branch &&
-              String(pr.head?.repo?.id ?? '') === String(run.head_repository?.id ?? ''),
+            const {pathToFileURL} = require('node:url');
+            const preview = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
             );
-            if (matches.length !== 1) {
-              core.setFailed(`Could not resolve one open PR for CI run ${run.id} at ${run.head_sha}.`);
-              return;
-            }
-            const pr = matches[0];
-            if (pr.draft) {
-              core.info(`PR #${pr.number} is draft; preview deploy is not ready.`);
-              core.setOutput('ready', 'false');
-              return;
-            }
-            core.setOutput('ready', 'true');
-            core.setOutput('pr_number', String(pr.number));
-            core.setOutput('head_sha', pr.head.sha);
-            core.setOutput('head_repo_id', String(pr.head.repo.id));
-            core.setOutput('head_ref', pr.head.ref);
-            core.setOutput('short_hash', pr.head.sha.slice(0, 7));
+            const expected = {
+              prNumber: Number(process.env.PR_NUMBER),
+              headSha: process.env.HEAD_SHA,
+              headRepository: process.env.HEAD_REPOSITORY,
+              headRepositoryId: process.env.HEAD_REPOSITORY_ID,
+              headRef: process.env.HEAD_REF,
+              baseRepository: process.env.BASE_REPOSITORY,
+              sourceRunId: Number(process.env.SOURCE_RUN_ID),
+              sourceRunAttempt: Number(process.env.SOURCE_RUN_ATTEMPT),
+              sourceConclusion: process.env.SOURCE_CONCLUSION,
+            };
+            const identity = await preview.confirmSourceRunIdentity({
+              github,
+              ...context.repo,
+              expected,
+            });
+            const reason =
+              identity.sourceConclusion === 'success'
+                ? identity.draft ? 'draft-pull-request' : 'publication-pending'
+                : `source-${identity.sourceConclusion || 'unknown'}`;
+            preview.writeDeploymentResult(
+              'preview-deployment.json',
+              preview.createUnavailableDeploymentResult(identity, reason),
+            );
+            core.setOutput('valid', 'true');
+            core.setOutput(
+              'eligible',
+              String(identity.sourceConclusion === 'success' && !identity.draft),
+            );
+            core.setOutput('short_hash', identity.headSha.slice(0, 7));
 
-      - name: Download PR metadata from the CI run
-        if: steps.preview.outputs.ready == 'true'
-        id: meta
+      - name: Download PR metadata from the exact CI run
+        if: steps.identity.outputs.eligible == 'true'
         uses: actions/download-artifact@v8
         with:
           name: pr-analysis
           path: pr-analysis
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.source_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Cross-check artifact identity
         id: artifact
-        if: steps.preview.outputs.ready == 'true'
-        env:
-          EXPECTED_PR: ${{ steps.preview.outputs.pr_number }}
-          EXPECTED_HEAD: ${{ steps.preview.outputs.head_sha }}
-          EXPECTED_RUN: ${{ github.event.workflow_run.id }}
-        run: |
-          if [ ! -f pr-analysis/pr-meta.json ]; then
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No pr-meta.json — docsite-only or skipped PR, nothing to deploy."
-            exit 0
-          fi
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const meta = JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8'));
-          const fail = message => { console.error(`::error::${message}`); process.exit(1); };
-          if (String(meta.prNumber) !== process.env.EXPECTED_PR) fail('artifact PR number does not match trusted PR');
-          const shortHash = String(meta.shortHash ?? '');
-          if (!/^[0-9a-f]{7,40}$/.test(shortHash)) fail('artifact head is not a valid hash');
-          if (!process.env.EXPECTED_HEAD.startsWith(shortHash)) fail('artifact head does not match trusted PR head');
-          if (String(meta.runId) !== process.env.EXPECTED_RUN) fail('artifact run id does not match workflow_run');
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, 'ready=true\n');
-          NODE
-
-      - name: Download Storybook artifact
-        id: dl-storybook
-        if: steps.preview.outputs.ready == 'true' && steps.artifact.outputs.ready == 'true'
-        uses: actions/download-artifact@v8
-        with:
-          name: storybook-${{ steps.preview.outputs.short_hash }}
-          path: storybook-dist
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        # Don't red-X the run if the artifact is gone (expired past retention, or
-        # a run that never produced it). The verify step below turns a missing
-        # artifact into a clean skip, not a failure — a preview is best-effort.
-        continue-on-error: true
-
-      - name: Download Sandbox artifact
-        id: dl-sandbox
-        if: steps.preview.outputs.ready == 'true' && steps.artifact.outputs.ready == 'true'
-        uses: actions/download-artifact@v8
-        with:
-          name: sandbox-${{ steps.preview.outputs.short_hash }}
-          path: sandbox-dist
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Verify preview artifacts are present
-        id: verify
-        if: steps.preview.outputs.ready == 'true' && steps.artifact.outputs.ready == 'true'
-        run: |
-          # A missing/expired artifact is not an error — deploy is best-effort.
-          # Skip cleanly (green) with a warning rather than failing CI for every
-          # contributor. Both dirs must exist AND be non-empty to deploy.
-          if [ -d storybook-dist ] && [ -n "$(ls -A storybook-dist 2>/dev/null)" ] && \
-             [ -d sandbox-dist ] && [ -n "$(ls -A sandbox-dist 2>/dev/null)" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Preview artifacts missing or empty (likely expired past retention) — skipping preview deploy for this run."
-          fi
-
-      - name: Confirm preview target before publish
-        id: final-preview
-        if: >-
-          steps.preview.outputs.ready == 'true' &&
-          steps.artifact.outputs.ready == 'true' &&
-          steps.verify.outputs.ready == 'true'
+        if: steps.identity.outputs.eligible == 'true'
         uses: actions/github-script@v9
         env:
-          PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
-          HEAD_SHA: ${{ steps.preview.outputs.head_sha }}
-          HEAD_REF: ${{ steps.preview.outputs.head_ref }}
-          HEAD_REPO_ID: ${{ steps.preview.outputs.head_repo_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_REPOSITORY: ${{ inputs.head_repository }}
+          BASE_REPOSITORY: ${{ inputs.base_repository }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
         with:
-          retries: 3
           script: |
-            const {owner, repo} = context.repo;
-            const pr = (await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: Number(process.env.PR_NUMBER),
-            })).data;
-            if (
-              pr.state !== 'open' ||
-              pr.draft ||
-              pr.head.sha !== process.env.HEAD_SHA ||
-              pr.head.ref !== process.env.HEAD_REF ||
-              String(pr.head.repo?.id ?? '') !== process.env.HEAD_REPO_ID
-            ) {
-              core.info(`PR #${process.env.PR_NUMBER} is no longer the trusted preview target.`);
+            const fs = require('node:fs');
+            const {pathToFileURL} = require('node:url');
+            if (!fs.existsSync('pr-analysis/pr-meta.json')) {
+              core.warning('No current pr-meta.json; preview targets are unavailable.');
               core.setOutput('ready', 'false');
               return;
             }
-            core.setOutput('ready', 'true');
+            const preview = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            try {
+              preview.validateAnalysisMetadata(
+                JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8')),
+                {
+                  prNumber: Number(process.env.PR_NUMBER),
+                  headSha: process.env.HEAD_SHA,
+                  headRepository: process.env.HEAD_REPOSITORY,
+                  baseRepository: process.env.BASE_REPOSITORY,
+                  sourceRunId: Number(process.env.SOURCE_RUN_ID),
+                  sourceRunAttempt: Number(process.env.SOURCE_RUN_ATTEMPT),
+                },
+              );
+              core.setOutput('ready', 'true');
+            } catch (error) {
+              core.warning(`Ignoring invalid preview metadata: ${error.message}`);
+              core.setOutput('ready', 'false');
+            }
 
-      - name: Deploy PR preview to GitHub Pages
-        if: steps.final-preview.outputs.ready == 'true'
+      - name: Download Storybook artifact
+        if: steps.artifact.outputs.ready == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: storybook-${{ steps.identity.outputs.short_hash }}
+          path: storybook-dist
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Download Sandbox artifact
+        if: steps.artifact.outputs.ready == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: sandbox-${{ steps.identity.outputs.short_hash }}
+          path: sandbox-dist
+          run-id: ${{ inputs.source_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Detect independently available preview targets
+        id: targets
+        if: always() && steps.identity.outputs.valid == 'true'
+        run: |
+          if [ "${{ steps.artifact.outputs.ready }}" = 'true' ] && [ -f storybook-dist/index.html ]; then
+            echo "storybook=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "storybook=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ steps.artifact.outputs.ready }}" = 'true' ] && [ -f sandbox-dist/index.html ]; then
+            echo "sandbox=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sandbox=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Confirm preview target immediately before publication
+        id: final
+        if: always() && steps.identity.outputs.valid == 'true'
+        uses: actions/github-script@v9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.preview.outputs.pr_number }}
-        run: >
-          node .github/scripts/gh-pages-publisher.mjs pr-preview
-          --pr "$PR_NUMBER"
-          --storybook storybook-dist
-          --sandbox sandbox-dist
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_REPOSITORY: ${{ inputs.head_repository }}
+          HEAD_REPOSITORY_ID: ${{ inputs.head_repository_id }}
+          HEAD_REF: ${{ inputs.head_ref }}
+          BASE_REPOSITORY: ${{ inputs.base_repository }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
+          SOURCE_CONCLUSION: ${{ inputs.source_conclusion }}
+          STORYBOOK_CANDIDATE: ${{ steps.targets.outputs.storybook }}
+          SANDBOX_CANDIDATE: ${{ steps.targets.outputs.sandbox }}
+        with:
+          retries: 3
+          script: |
+            const {pathToFileURL} = require('node:url');
+            const preview = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            const identity = await preview.confirmSourceRunIdentity({
+              github,
+              ...context.repo,
+              expected: {
+                prNumber: Number(process.env.PR_NUMBER),
+                headSha: process.env.HEAD_SHA,
+                headRepository: process.env.HEAD_REPOSITORY,
+                headRepositoryId: process.env.HEAD_REPOSITORY_ID,
+                headRef: process.env.HEAD_REF,
+                baseRepository: process.env.BASE_REPOSITORY,
+                sourceRunId: Number(process.env.SOURCE_RUN_ID),
+                sourceRunAttempt: Number(process.env.SOURCE_RUN_ATTEMPT),
+                sourceConclusion: process.env.SOURCE_CONCLUSION,
+              },
+            });
+            const mayPublish = identity.sourceConclusion === 'success' && !identity.draft;
+            core.setOutput('ready', 'true');
+            core.setOutput(
+              'storybook',
+              String(mayPublish && process.env.STORYBOOK_CANDIDATE === 'true'),
+            );
+            core.setOutput(
+              'sandbox',
+              String(mayPublish && process.env.SANDBOX_CANDIDATE === 'true'),
+            );
+
+      - name: Publish trusted preview result
+        if: always() && steps.final.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_REPOSITORY: ${{ inputs.head_repository }}
+          HEAD_REPOSITORY_ID: ${{ inputs.head_repository_id }}
+          HEAD_REF: ${{ inputs.head_ref }}
+          BASE_REPOSITORY: ${{ inputs.base_repository }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt }}
+          SOURCE_CONCLUSION: ${{ inputs.source_conclusion }}
+          STORYBOOK_AVAILABLE: ${{ steps.final.outputs.storybook }}
+          SANDBOX_AVAILABLE: ${{ steps.final.outputs.sandbox }}
+        run: |
+          args=(
+            pr-preview
+            --pr "$PR_NUMBER"
+            --head "$HEAD_SHA"
+            --head-repo "$HEAD_REPOSITORY"
+            --head-repo-id "$HEAD_REPOSITORY_ID"
+            --head-ref "$HEAD_REF"
+            --base-repo "$BASE_REPOSITORY"
+            --source-run-id "$SOURCE_RUN_ID"
+            --source-run-attempt "$SOURCE_RUN_ATTEMPT"
+            --source-conclusion "$SOURCE_CONCLUSION"
+            --result preview-deployment.json
+          )
+          if [ "$STORYBOOK_AVAILABLE" = 'true' ]; then
+            args+=(--storybook storybook-dist)
+          fi
+          if [ "$SANDBOX_AVAILABLE" = 'true' ]; then
+            args+=(--sandbox sandbox-dist)
+          fi
+          node .github/scripts/gh-pages-publisher.mjs "${args[@]}"
+
+      - name: Upload trusted preview result
+        if: always() && hashFiles('preview-deployment.json') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-deployment-${{ inputs.source_run_id }}-${{ inputs.source_run_attempt }}
+          path: preview-deployment.json
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -465,6 +465,7 @@ jobs:
           PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
           HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
           RUN_ID: ${{ steps.identity.outputs.run_id }}
+          SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           VISUAL_PUBLISHED: ${{ steps.publish.outputs.published }}
           VISUAL_PATH: ${{ steps.visual.outputs.path }}
         with:
@@ -499,6 +500,7 @@ jobs:
               a11yPath = 'a11y-empty.json';
             }
 
+            const previewAvailable = process.env.SOURCE_CONCLUSION === 'success';
             const args = [
               '.github/scripts/generate-pr-comment.js',
               '--analysis', 'pr-analysis/analysis.json',
@@ -516,8 +518,12 @@ jobs:
                       : []),
                   ]
                 : []),
-              '--storybook-url', `https://facebook.github.io/astryx/pr/${prNumber}/`,
-              '--sandbox-url', `https://facebook.github.io/astryx/pr/${prNumber}/sandbox/`,
+              ...(previewAvailable
+                ? [
+                    '--storybook-url', `https://facebook.github.io/astryx/pr/${prNumber}/`,
+                    '--sandbox-url', `https://facebook.github.io/astryx/pr/${prNumber}/sandbox/`,
+                  ]
+                : []),
               '--run-url', `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`,
               '--pr-number', String(prNumber),
             ];

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -9,11 +9,10 @@
 # write), so it can comment on fork PRs too — one code path for every PR, no
 # drift between a fork path and a same-repo path.
 #
-# Safety: resolves scope and PR identity from the GitHub API. Default-branch
-# code builds the capture plan, serves the PR's static Storybook to an isolated
-# browser with off-origin requests blocked, derives the comparison, re-encodes
-# PNGs, and generates the report. PR code is never checked out, imported into
-# Node, or given credentials; PR-produced HTML/JS is never published.
+# Safety: resolves scope and PR identity from the GitHub API. Privileged jobs
+# check out only trusted default-branch code. PR-built static artifacts are
+# published only after exact run/PR/repository checks; report fields remain
+# untrusted data and are rendered by default-branch code.
 
 name: PR Comment
 
@@ -45,9 +44,17 @@ jobs:
       valid: ${{ steps.identity.outputs.valid }}
       pr_number: ${{ steps.identity.outputs.pr_number }}
       head_sha: ${{ steps.identity.outputs.head_sha }}
+      head_repo: ${{ steps.identity.outputs.head_repo }}
+      head_repo_id: ${{ steps.identity.outputs.head_repo_id }}
+      head_ref: ${{ steps.identity.outputs.head_ref }}
+      base_repo: ${{ steps.identity.outputs.base_repo }}
+      base_sha: ${{ steps.identity.outputs.base_sha }}
+      run_id: ${{ steps.identity.outputs.run_id }}
+      run_attempt: ${{ steps.identity.outputs.run_attempt }}
+      source_conclusion: ${{ steps.identity.outputs.source_conclusion }}
       spec_only: ${{ steps.identity.outputs.spec_only }}
     steps:
-      - name: Checkout trusted classifier
+      - name: Checkout trusted default-branch code
         uses: actions/checkout@v7
         with:
           ref: main
@@ -56,47 +63,46 @@ jobs:
         id: identity
         uses: actions/github-script@v9
         with:
+          retries: 3
           script: |
-            const run = context.payload.workflow_run;
-            const {owner, repo} = context.repo;
-            let numbers = (run.pull_requests || []).map((pr) => pr.number);
-            if (numbers.length === 0) {
-              // commits/{sha}/pulls only indexes base-repo branches, so a fork
-              // head returns [] (and run.pull_requests is empty on forks too).
-              // Resolve by the run's own head repo + branch instead; the
-              // exact-SHA check below keeps it pinned to this run.
-              const {data: byHead} = await github.rest.pulls.list({
-                owner, repo, state: 'open',
-                head: `${run.head_repository.owner.login}:${run.head_branch}`,
-                per_page: 100,
-              });
-              numbers = byHead.map((pr) => pr.number);
-            }
-            numbers = [...new Set(numbers)];
-            if (numbers.length !== 1) {
-              core.setFailed(`Expected exactly one open PR for run ${run.id}; found ${numbers.join(',') || 'none'}`);
-              return;
-            }
-            const {data: pr} = await github.rest.pulls.get({owner, repo, pull_number: numbers[0]});
-            if (pr.head.sha !== run.head_sha) {
-              core.setFailed(`Run head ${run.head_sha} is stale; PR head is ${pr.head.sha}`);
-              return;
-            }
+            const {pathToFileURL} = require('node:url');
+            const {resolveWorkflowRunPullRequest} = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            const identity = await resolveWorkflowRunPullRequest({
+              github,
+              ...context.repo,
+              run: context.payload.workflow_run,
+            });
             const path = require('node:path');
             const {classifyChanges} = require(path.join(
               process.env.GITHUB_WORKSPACE,
               '.github/scripts/change-scope.cjs',
             ));
+            const {data: pull} = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: identity.prNumber,
+            });
             const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner, repo, pull_number: pr.number, per_page: 100,
+              ...context.repo,
+              pull_number: identity.prNumber,
+              per_page: 100,
+            });
+            const changeScope = classifyChanges(files, {
+              expectedCount: pull.changed_files,
             });
             core.setOutput('valid', 'true');
-            core.setOutput('pr_number', String(pr.number));
-            core.setOutput('head_sha', pr.head.sha);
-            core.setOutput(
-              'spec_only',
-              String(classifyChanges(files, {expectedCount: pr.changed_files}).specOnly),
-            );
+            core.setOutput('pr_number', String(identity.prNumber));
+            core.setOutput('head_sha', identity.headSha);
+            core.setOutput('head_repo', identity.headRepository);
+            core.setOutput('head_repo_id', identity.headRepositoryId);
+            core.setOutput('head_ref', identity.headRef);
+            core.setOutput('base_repo', identity.baseRepository);
+            core.setOutput('base_sha', identity.baseSha);
+            core.setOutput('run_id', String(identity.sourceRunId));
+            core.setOutput('run_attempt', String(identity.sourceRunAttempt));
+            core.setOutput('source_conclusion', identity.sourceConclusion);
+            core.setOutput('spec_only', String(changeScope.specOnly));
 
   invalidate:
     needs: resolve
@@ -158,10 +164,93 @@ jobs:
               description: 'Spec-only change — no visual scope.',
             });
 
-  comment:
+  spec-only-reconcile:
     needs: resolve
-    # Only for completed CI runs whose PR identity was resolved above.
     if: >-
+      github.event.action == 'completed' &&
+      needs.resolve.outputs.valid == 'true' &&
+      needs.resolve.outputs.spec_only == 'true'
+    runs-on: ubuntu-slim
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout trusted default-branch code
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Remove stale preview links from an existing report
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          HEAD_REPOSITORY: ${{ needs.resolve.outputs.head_repo }}
+          HEAD_REPOSITORY_ID: ${{ needs.resolve.outputs.head_repo_id }}
+          HEAD_REF: ${{ needs.resolve.outputs.head_ref }}
+          BASE_REPOSITORY: ${{ needs.resolve.outputs.base_repo }}
+          BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
+          RUN_ID: ${{ needs.resolve.outputs.run_id }}
+          RUN_ATTEMPT: ${{ needs.resolve.outputs.run_attempt }}
+          SOURCE_CONCLUSION: ${{ needs.resolve.outputs.source_conclusion }}
+        with:
+          retries: 3
+          script: |
+            const {pathToFileURL} = require('node:url');
+            const {reconcilePrComment} = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            await reconcilePrComment({
+              github,
+              core,
+              context,
+              expectedIdentity: {
+                prNumber: Number(process.env.PR_NUMBER),
+                headSha: process.env.HEAD_SHA,
+                headRepository: process.env.HEAD_REPOSITORY,
+                headRepositoryId: process.env.HEAD_REPOSITORY_ID,
+                headRef: process.env.HEAD_REF,
+                baseRepository: process.env.BASE_REPOSITORY,
+                baseSha: process.env.BASE_SHA,
+                sourceRunId: Number(process.env.RUN_ID),
+                sourceRunAttempt: Number(process.env.RUN_ATTEMPT),
+                sourceConclusion: process.env.SOURCE_CONCLUSION,
+              },
+              createIfMissing: false,
+              fallbackMessage:
+                'The current change only updates durable specifications. Preview links are not shown.',
+            });
+
+  deploy-preview:
+    needs: resolve
+    if: >-
+      github.event.action == 'completed' &&
+      needs.resolve.outputs.valid == 'true' &&
+      needs.resolve.outputs.spec_only != 'true'
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: read
+    uses: ./.github/workflows/deploy-preview.yml
+    with:
+      pr_number: ${{ needs.resolve.outputs.pr_number }}
+      head_sha: ${{ needs.resolve.outputs.head_sha }}
+      head_repository: ${{ needs.resolve.outputs.head_repo }}
+      head_repository_id: ${{ needs.resolve.outputs.head_repo_id }}
+      head_ref: ${{ needs.resolve.outputs.head_ref }}
+      base_repository: ${{ needs.resolve.outputs.base_repo }}
+      source_run_id: ${{ needs.resolve.outputs.run_id }}
+      source_run_attempt: ${{ needs.resolve.outputs.run_attempt }}
+      source_conclusion: ${{ needs.resolve.outputs.source_conclusion }}
+    secrets: inherit
+
+  comment:
+    needs: [resolve, deploy-preview]
+    # Reconcile after the trusted publisher settles. A failed publisher still
+    # runs this job so stale links are removed rather than retained.
+    if: >-
+      always() &&
       github.event.action == 'completed' &&
       needs.resolve.outputs.valid == 'true' &&
       needs.resolve.outputs.spec_only != 'true'
@@ -172,63 +261,62 @@ jobs:
       actions: read
       contents: write # immutable validated visual evidence on gh-pages
     steps:
-      - name: Checkout base repo (scripts only)
+      - name: Checkout trusted default-branch code
         uses: actions/checkout@v7
+        with:
+          ref: main
 
       - name: Setup Node and pnpm
         uses: ./.github/actions/setup
 
-      # Never trust the PR number inside a PR-produced artifact. Resolve the PR
-      # from the workflow_run through the GitHub API, then require its current
-      # head to be the run's head. A fork cannot redirect this privileged job
-      # at another PR by editing pr-meta.json.
-      - name: Resolve trusted PR identity
+      # Recheck the exact source run and current PR immediately before any
+      # privileged report or status mutation.
+      - name: Reconfirm trusted PR identity
         id: identity
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          HEAD_REPOSITORY: ${{ needs.resolve.outputs.head_repo }}
+          HEAD_REPOSITORY_ID: ${{ needs.resolve.outputs.head_repo_id }}
+          HEAD_REF: ${{ needs.resolve.outputs.head_ref }}
+          BASE_REPOSITORY: ${{ needs.resolve.outputs.base_repo }}
+          SOURCE_RUN_ID: ${{ needs.resolve.outputs.run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.resolve.outputs.run_attempt }}
+          SOURCE_CONCLUSION: ${{ needs.resolve.outputs.source_conclusion }}
         with:
+          retries: 3
           script: |
-            const run = context.payload.workflow_run;
-            const {owner, repo} = context.repo;
-            let numbers = (run.pull_requests || []).map((pr) => pr.number);
-            if (numbers.length === 0) {
-              // Fork heads are invisible to commits/{sha}/pulls and to
-              // run.pull_requests — resolve by head repo + branch (see the
-              // resolve job above); the SHA and repo checks below still pin
-              // the result to this exact run.
-              const {data: byHead} = await github.rest.pulls.list({
-                owner, repo, state: 'open',
-                head: `${run.head_repository.owner.login}:${run.head_branch}`,
-                per_page: 100,
-              });
-              numbers = byHead.map((pr) => pr.number);
-            }
-            numbers = [...new Set(numbers)];
-            if (numbers.length !== 1) {
-              core.setFailed(`Expected exactly one PR for run ${run.id}; found ${numbers.join(',') || 'none'}`);
-              return;
-            }
-            const {data: pr} = await github.rest.pulls.get({
-              owner, repo, pull_number: numbers[0],
+            const {pathToFileURL} = require('node:url');
+            const {confirmSourceRunIdentity} = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            const identity = await confirmSourceRunIdentity({
+              github,
+              ...context.repo,
+              expected: {
+                prNumber: Number(process.env.PR_NUMBER),
+                headSha: process.env.HEAD_SHA,
+                headRepository: process.env.HEAD_REPOSITORY,
+                headRepositoryId: process.env.HEAD_REPOSITORY_ID,
+                headRef: process.env.HEAD_REF,
+                baseRepository: process.env.BASE_REPOSITORY,
+                sourceRunId: Number(process.env.SOURCE_RUN_ID),
+                sourceRunAttempt: Number(process.env.SOURCE_RUN_ATTEMPT),
+                sourceConclusion: process.env.SOURCE_CONCLUSION,
+              },
             });
-            if (pr.head.sha !== run.head_sha) {
-              core.setFailed(`Run head ${run.head_sha} is stale; PR head is ${pr.head.sha}`);
-              return;
-            }
-            if (pr.head.repo.full_name !== run.head_repository.full_name) {
-              core.setFailed(`Run repository ${run.head_repository.full_name} does not match PR head ${pr.head.repo.full_name}`);
-              return;
-            }
-            if (pr.base.repo.full_name !== `${owner}/${repo}`) {
-              core.setFailed(`PR #${pr.number} targets another repository`);
-              return;
-            }
             core.setOutput('valid', 'true');
-            core.setOutput('pr_number', String(pr.number));
-            core.setOutput('head_sha', pr.head.sha);
-            core.setOutput('head_repo', pr.head.repo.full_name);
-            core.setOutput('base_sha', pr.base.sha);
-            core.setOutput('run_id', String(run.id));
-            core.setOutput('run_attempt', String(run.run_attempt));
+            core.setOutput('pr_number', String(identity.prNumber));
+            core.setOutput('head_sha', identity.headSha);
+            core.setOutput('head_repo', identity.headRepository);
+            core.setOutput('head_repo_id', identity.headRepositoryId);
+            core.setOutput('head_ref', identity.headRef);
+            core.setOutput('base_repo', identity.baseRepository);
+            core.setOutput('base_sha', identity.baseSha);
+            core.setOutput('run_id', String(identity.sourceRunId));
+            core.setOutput('run_attempt', String(identity.sourceRunAttempt));
+            core.setOutput('source_conclusion', identity.sourceConclusion);
 
       - name: Derive trusted stable visual scope
         id: scope
@@ -306,6 +394,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
+      - name: Download trusted preview deployment result
+        if: steps.identity.outputs.valid == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: preview-deployment-${{ steps.identity.outputs.run_id }}-${{ steps.identity.outputs.run_attempt }}
+          path: preview-deployment
+        continue-on-error: true
+
       - name: Download Storybook for trusted visual capture
         if: >-
           steps.identity.outputs.valid == 'true' &&
@@ -324,17 +420,24 @@ jobs:
         env:
           EXPECTED_PR: ${{ steps.identity.outputs.pr_number }}
           EXPECTED_HEAD: ${{ steps.identity.outputs.head_sha }}
+          EXPECTED_HEAD_REPO: ${{ steps.identity.outputs.head_repo }}
+          EXPECTED_BASE_REPO: ${{ steps.identity.outputs.base_repo }}
           EXPECTED_RUN: ${{ steps.identity.outputs.run_id }}
+          EXPECTED_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
         run: |
           node - <<'NODE'
           const fs = require('node:fs');
           const meta = JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8'));
           const fail = (message) => { console.error(`::error::${message}`); process.exit(1); };
           if (String(meta.prNumber) !== process.env.EXPECTED_PR) fail('artifact PR number does not match trusted PR');
+          if (meta.headSha !== process.env.EXPECTED_HEAD) fail('artifact head does not match trusted PR head');
+          if (meta.headRepository !== process.env.EXPECTED_HEAD_REPO) fail('artifact head repository does not match trusted PR');
+          if (meta.baseRepository !== process.env.EXPECTED_BASE_REPO) fail('artifact base repository does not match trusted PR');
+          if (String(meta.runId) !== process.env.EXPECTED_RUN) fail('artifact run id does not match workflow_run');
+          if (String(meta.runAttempt) !== process.env.EXPECTED_ATTEMPT) fail('artifact run attempt does not match workflow_run');
           const shortHash = String(meta.shortHash ?? '');
           if (!/^[0-9a-f]{7,40}$/.test(shortHash)) fail('artifact head is not a valid hash');
-          if (!process.env.EXPECTED_HEAD.startsWith(shortHash)) fail('artifact head does not match trusted PR head');
-          if (String(meta.runId) !== process.env.EXPECTED_RUN) fail('artifact run id does not match workflow_run');
+          if (!process.env.EXPECTED_HEAD.startsWith(shortHash)) fail('artifact short hash does not match trusted PR head');
           NODE
 
       - name: Fetch the trusted visual baseline
@@ -459,97 +562,47 @@ jobs:
           "pr/${PR_NUMBER}/visual/${HEAD_SHA}"
 
       - name: Generate and post PR comment
-        if: steps.identity.outputs.valid == 'true'
+        if: always() && steps.identity.outputs.valid == 'true'
         uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.identity.outputs.pr_number }}
           HEAD_SHA: ${{ steps.identity.outputs.head_sha }}
+          HEAD_REPOSITORY: ${{ steps.identity.outputs.head_repo }}
+          HEAD_REPOSITORY_ID: ${{ steps.identity.outputs.head_repo_id }}
+          HEAD_REF: ${{ steps.identity.outputs.head_ref }}
+          BASE_REPOSITORY: ${{ steps.identity.outputs.base_repo }}
+          BASE_SHA: ${{ steps.identity.outputs.base_sha }}
           RUN_ID: ${{ steps.identity.outputs.run_id }}
-          SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
+          SOURCE_CONCLUSION: ${{ steps.identity.outputs.source_conclusion }}
           VISUAL_PUBLISHED: ${{ steps.publish.outputs.published }}
           VISUAL_PATH: ${{ steps.visual.outputs.path }}
         with:
+          retries: 3
           script: |
-            const fs = require('node:fs');
-            const { execFileSync } = require('node:child_process');
-
-            // The analysis artifact is only produced for non-docsite-only PRs.
-            // If it's absent, there's nothing to report — exit quietly.
-            if (!fs.existsSync('pr-analysis/analysis.json') ||
-                !fs.existsSync('pr-analysis/pr-meta.json')) {
-              core.info('No analysis artifact — nothing to comment (docsite-only or skipped).');
-              return;
-            }
-
-            const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            const headSha = process.env.HEAD_SHA;
-            const runId = process.env.RUN_ID;
-            if (!prNumber || !headSha || !runId) {
-              core.setFailed('Trusted PR identity outputs are missing.');
-              return;
-            }
-
-            // a11y is optional (the pr-a11y job is skipped when no components
-            // changed). Fall back to an empty report so the comment still posts;
-            // generate-pr-comment.js renders the a11y section from whatever it
-            // gets.
-            let a11yPath = 'a11y/a11y-report.json';
-            if (!fs.existsSync(a11yPath)) {
-              fs.writeFileSync('a11y-empty.json',
-                '{"components":{},"summary":{"componentsAudited":0,"totalViolations":0}}');
-              a11yPath = 'a11y-empty.json';
-            }
-
-            const previewAvailable = process.env.SOURCE_CONCLUSION === 'success';
-            const args = [
-              '.github/scripts/generate-pr-comment.js',
-              '--analysis', 'pr-analysis/analysis.json',
-              '--a11y', a11yPath,
-              ...(fs.existsSync('trusted-visual/verdict.json')
-                ? [
-                    '--visual', 'trusted-visual/verdict.json',
-                    ...(process.env.VISUAL_PUBLISHED === 'true'
-                      ? [
-                          '--visual-report-url',
-                          `https://facebook.github.io/astryx/${process.env.VISUAL_PATH}/`,
-                          '--visual-image-url',
-                          `https://raw.githubusercontent.com/facebook/astryx/gh-pages/${process.env.VISUAL_PATH}/`,
-                        ]
-                      : []),
-                  ]
-                : []),
-              ...(previewAvailable
-                ? [
-                    '--storybook-url', `https://facebook.github.io/astryx/pr/${prNumber}/`,
-                    '--sandbox-url', `https://facebook.github.io/astryx/pr/${prNumber}/sandbox/`,
-                  ]
-                : []),
-              '--run-url', `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`,
-              '--pr-number', String(prNumber),
-            ];
-
-            // Argument vector, no shell — report inputs are data, not command text.
-            const body = execFileSync('node', args, { encoding: 'utf8' });
-            fs.writeFileSync('pr-comment.md', body);
-
-            const { owner, repo } = context.repo;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number: prNumber, per_page: 100,
+            const {pathToFileURL} = require('node:url');
+            const {reconcilePrComment} = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            await reconcilePrComment({
+              github,
+              core,
+              context,
+              expectedIdentity: {
+                prNumber: Number(process.env.PR_NUMBER),
+                headSha: process.env.HEAD_SHA,
+                headRepository: process.env.HEAD_REPOSITORY,
+                headRepositoryId: process.env.HEAD_REPOSITORY_ID,
+                headRef: process.env.HEAD_REF,
+                baseRepository: process.env.BASE_REPOSITORY,
+                baseSha: process.env.BASE_SHA,
+                sourceRunId: Number(process.env.RUN_ID),
+                sourceRunAttempt: Number(process.env.RUN_ATTEMPT),
+                sourceConclusion: process.env.SOURCE_CONCLUSION,
+              },
+              visualPublished: process.env.VISUAL_PUBLISHED === 'true',
+              visualReportPath: process.env.VISUAL_PATH,
             });
-            const botComment = comments.find((c) =>
-              c.user.type === 'Bot' && c.body.includes('PR Analysis Report'));
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner, repo, comment_id: botComment.id, body,
-              });
-              core.info(`Updated PR Analysis Report on #${prNumber}.`);
-            } else {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: prNumber, body,
-              });
-              core.info(`Posted PR Analysis Report on #${prNumber}.`);
-            }
 
       - name: Evaluate visual acceptance state
         if: always() && steps.identity.outputs.valid == 'true'

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -1,19 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-# Re-deploy Preview
-#
-# Manually re-deploys a PR's preview (Storybook + Sandbox) to GitHub Pages by
-# re-publishing the static artifacts its CI run already built — the same
-# artifacts deploy-preview.yml publishes automatically. Uses a retry-based git
-# push instead of peaceiris/actions-gh-pages to avoid concurrency conflicts
-# with the main deploy workflow.
-#
-# Safety: this NEVER checks out or runs PR-controlled code (mirroring
-# deploy-preview.yml and pr-comment.yml). It locates the PR's latest CI run for
-# its current head commit, downloads the pre-built storybook-<hash> /
-# sandbox-<hash> artifacts, and copies them into gh-pages. If the artifacts
-# have expired past retention, the fix is to re-run CI on the PR (which also
-# re-deploys the preview via deploy-preview.yml) — not to rebuild here.
+# Re-publishes whatever independent preview artifacts remain for a PR's latest
+# successful CI run. It never checks out or executes the PR head.
 
 name: Re-deploy Preview
 
@@ -35,83 +23,235 @@ jobs:
   redeploy-preview:
     runs-on: ubuntu-slim
     permissions:
+      actions: read
       contents: write
       pull-requests: read
-      actions: read
-
-    env:
-      PR_NUMBER: ${{ github.event.inputs.pr_number }}
 
     steps:
-      - name: Checkout publisher
+      - name: Checkout trusted publisher
         uses: actions/checkout@v7
         with:
           ref: main
 
-      - name: Locate the PR's CI run
-        id: pr-info
+      - name: Locate the PR's exact successful CI run
+        id: source
+        uses: actions/github-script@v9
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # The PR number is an operator-typed input — require digits before it
-          # names a gh-pages path.
-          if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
-            echo "::error::PR number must be numeric, got: $PR_NUMBER"
-            exit 1
-          fi
+          REQUESTED_PR: ${{ github.event.inputs.pr_number }}
+        with:
+          retries: 3
+          script: |
+            const {pathToFileURL} = require('node:url');
+            const preview = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            if (!/^[1-9][0-9]*$/.test(process.env.REQUESTED_PR)) {
+              core.setFailed('PR number must be a positive integer.');
+              return;
+            }
+            const {owner, repo} = context.repo;
+            const prNumber = Number(process.env.REQUESTED_PR);
+            const {data: pull} = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              {
+                owner,
+                repo,
+                event: 'pull_request',
+                head_sha: pull.head.sha,
+                per_page: 100,
+              },
+            );
+            const identities = [];
+            for (const run of runs) {
+              if (run.path !== '.github/workflows/ci.yml' || run.conclusion !== 'success') {
+                continue;
+              }
+              try {
+                identities.push(
+                  preview.validatePullRequestSourceRun({
+                    pull,
+                    run,
+                    baseRepository: `${owner}/${repo}`,
+                  }),
+                );
+              } catch {
+                // A run for another branch/repository is not a candidate.
+              }
+            }
+            identities.sort(
+              (a, b) =>
+                b.sourceRunId - a.sourceRunId ||
+                b.sourceRunAttempt - a.sourceRunAttempt,
+            );
+            const identity = identities[0];
+            if (!identity) {
+              core.setFailed(`No successful PR-backed CI run matches PR #${prNumber}.`);
+              return;
+            }
+            if (identity.draft) {
+              core.setFailed(`PR #${prNumber} is still a draft.`);
+              return;
+            }
+            core.setOutput('valid', 'true');
+            core.setOutput('pr_number', String(identity.prNumber));
+            core.setOutput('head_sha', identity.headSha);
+            core.setOutput('head_repo', identity.headRepository);
+            core.setOutput('head_repo_id', identity.headRepositoryId);
+            core.setOutput('head_ref', identity.headRef);
+            core.setOutput('base_repo', identity.baseRepository);
+            core.setOutput('run_id', String(identity.sourceRunId));
+            core.setOutput('run_attempt', String(identity.sourceRunAttempt));
+            core.setOutput('short_hash', identity.headSha.slice(0, 7));
 
-          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json headRefOid --jq '.headRefOid')
-          SHORT_HASH="${HEAD_SHA:0:7}"
+      - name: Download PR metadata
+        if: steps.source.outputs.valid == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-analysis
+          path: pr-analysis
+          run-id: ${{ steps.source.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-          # Latest CI run for the PR's current head commit — its artifacts are
-          # what deploy-preview.yml published (or would have published).
-          RUN_ID=$(gh api "repos/${{ github.repository }}/actions/runs?head_sha=${HEAD_SHA}&event=pull_request&per_page=50" \
-            --jq '[.workflow_runs[] | select(.path == ".github/workflows/ci.yml")][0].id // empty')
-          if [ -z "$RUN_ID" ]; then
-            echo "::error::No CI run found for PR #${PR_NUMBER} head ${HEAD_SHA} — re-run CI on the PR instead."
-            exit 1
-          fi
-
-          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-          echo "short_hash=$SHORT_HASH" >> "$GITHUB_OUTPUT"
-          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+      - name: Cross-check artifact identity
+        if: steps.source.outputs.valid == 'true'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+          HEAD_REPOSITORY: ${{ steps.source.outputs.head_repo }}
+          BASE_REPOSITORY: ${{ steps.source.outputs.base_repo }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.source.outputs.run_attempt }}
+        with:
+          script: |
+            const fs = require('node:fs');
+            const {pathToFileURL} = require('node:url');
+            const {validateAnalysisMetadata} = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            validateAnalysisMetadata(
+              JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8')),
+              {
+                prNumber: Number(process.env.PR_NUMBER),
+                headSha: process.env.HEAD_SHA,
+                headRepository: process.env.HEAD_REPOSITORY,
+                baseRepository: process.env.BASE_REPOSITORY,
+                sourceRunId: Number(process.env.SOURCE_RUN_ID),
+                sourceRunAttempt: Number(process.env.SOURCE_RUN_ATTEMPT),
+              },
+            );
 
       - name: Download Storybook artifact
         uses: actions/download-artifact@v8
         with:
-          name: storybook-${{ steps.pr-info.outputs.short_hash }}
+          name: storybook-${{ steps.source.outputs.short_hash }}
           path: storybook-dist
-          run-id: ${{ steps.pr-info.outputs.run_id }}
+          run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
       - name: Download Sandbox artifact
         uses: actions/download-artifact@v8
         with:
-          name: sandbox-${{ steps.pr-info.outputs.short_hash }}
+          name: sandbox-${{ steps.source.outputs.short_hash }}
           path: sandbox-dist
-          run-id: ${{ steps.pr-info.outputs.run_id }}
+          run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
-      - name: Verify preview artifacts are present
+      - name: Detect independently available preview targets
+        id: targets
         run: |
-          # Unlike deploy-preview.yml (best-effort on every CI completion), a
-          # manual re-deploy that can't find its artifacts should fail loudly
-          # with the actionable fix.
-          if [ -d storybook-dist ] && [ -n "$(ls -A storybook-dist 2>/dev/null)" ] && \
-             [ -d sandbox-dist ] && [ -n "$(ls -A sandbox-dist 2>/dev/null)" ]; then
-            exit 0
+          storybook=false
+          sandbox=false
+          if [ -f storybook-dist/index.html ]; then storybook=true; fi
+          if [ -f sandbox-dist/index.html ]; then sandbox=true; fi
+          echo "storybook=$storybook" >> "$GITHUB_OUTPUT"
+          echo "sandbox=$sandbox" >> "$GITHUB_OUTPUT"
+          if [ "$storybook" != 'true' ] && [ "$sandbox" != 'true' ]; then
+            echo "::error::No preview artifact remains for source run ${{ steps.source.outputs.run_id }}. Re-run CI on the PR."
+            exit 1
           fi
-          echo "::error::Preview artifacts for run ${{ steps.pr-info.outputs.run_id }} are missing or expired — re-run CI on PR #${PR_NUMBER}; deploy-preview will publish the fresh preview automatically."
-          exit 1
 
-      - name: Deploy to GitHub Pages
+      - name: Reconfirm source identity immediately before publication
+        uses: actions/github-script@v9
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
-        run: >
-          node .github/scripts/gh-pages-publisher.mjs pr-preview
-          --pr "$PR_NUMBER"
-          --storybook storybook-dist
-          --sandbox sandbox-dist
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+          HEAD_REPOSITORY: ${{ steps.source.outputs.head_repo }}
+          HEAD_REPOSITORY_ID: ${{ steps.source.outputs.head_repo_id }}
+          HEAD_REF: ${{ steps.source.outputs.head_ref }}
+          BASE_REPOSITORY: ${{ steps.source.outputs.base_repo }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.source.outputs.run_attempt }}
+        with:
+          retries: 3
+          script: |
+            const {pathToFileURL} = require('node:url');
+            const {confirmSourceRunIdentity} = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/lib/pr-preview.mjs`).href
+            );
+            const identity = await confirmSourceRunIdentity({
+              github,
+              ...context.repo,
+              expected: {
+                prNumber: Number(process.env.PR_NUMBER),
+                headSha: process.env.HEAD_SHA,
+                headRepository: process.env.HEAD_REPOSITORY,
+                headRepositoryId: process.env.HEAD_REPOSITORY_ID,
+                headRef: process.env.HEAD_REF,
+                baseRepository: process.env.BASE_REPOSITORY,
+                sourceRunId: Number(process.env.SOURCE_RUN_ID),
+                sourceRunAttempt: Number(process.env.SOURCE_RUN_ATTEMPT),
+                sourceConclusion: 'success',
+              },
+            });
+            if (identity.draft) core.setFailed(`PR #${identity.prNumber} is still a draft.`);
+
+      - name: Deploy available targets to GitHub Pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.source.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.source.outputs.head_sha }}
+          HEAD_REPOSITORY: ${{ steps.source.outputs.head_repo }}
+          HEAD_REPOSITORY_ID: ${{ steps.source.outputs.head_repo_id }}
+          HEAD_REF: ${{ steps.source.outputs.head_ref }}
+          BASE_REPOSITORY: ${{ steps.source.outputs.base_repo }}
+          SOURCE_RUN_ID: ${{ steps.source.outputs.run_id }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.source.outputs.run_attempt }}
+          STORYBOOK_AVAILABLE: ${{ steps.targets.outputs.storybook }}
+          SANDBOX_AVAILABLE: ${{ steps.targets.outputs.sandbox }}
+        run: |
+          args=(
+            pr-preview
+            --pr "$PR_NUMBER"
+            --head "$HEAD_SHA"
+            --head-repo "$HEAD_REPOSITORY"
+            --head-repo-id "$HEAD_REPOSITORY_ID"
+            --head-ref "$HEAD_REF"
+            --base-repo "$BASE_REPOSITORY"
+            --source-run-id "$SOURCE_RUN_ID"
+            --source-run-attempt "$SOURCE_RUN_ATTEMPT"
+            --source-conclusion success
+            --result preview-deployment.json
+          )
+          if [ "$STORYBOOK_AVAILABLE" = 'true' ]; then
+            args+=(--storybook storybook-dist)
+          fi
+          if [ "$SANDBOX_AVAILABLE" = 'true' ]; then
+            args+=(--sandbox sandbox-dist)
+          fi
+          node .github/scripts/gh-pages-publisher.mjs "${args[@]}"
+
+      - name: Upload deployment result
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-deployment-${{ steps.source.outputs.run_id }}-${{ steps.source.outputs.run_attempt }}
+          path: preview-deployment.json
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## Summary
- include Storybook and Sandbox preview links only when the source CI run succeeded and was eligible for preview deployment
- retain the full analysis, accessibility, and visual report for failed CI runs without advertising 404 preview URLs

## Why
A live audit found [#5684](https://github.com/facebook/astryx/pull/5684) correctly skipped preview deployment after its CI failure, while its PR Analysis comment still linked to nonexistent Storybook and Sandbox pages.

## Test plan
- `pnpm exec vitest run .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `pnpm exec actionlint -ignore 'label "2-core-ubuntu-arm" is unknown' .github/workflows/pr-comment.yml`
- `pnpm exec prettier --check .github/workflows/pr-comment.yml .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `pnpm check:repo`
- `git diff --check`