### PR TITLE
fix(ci): checkout publisher for preview recovery

### DIFF
--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -423,6 +423,11 @@ describe('visual acceptance workflow concurrency', () => {
 
     expect(deployPreview).toContain('gh-pages-publisher.mjs pr-preview');
     expect(redeployPreview).toContain('gh-pages-publisher.mjs pr-preview');
+    expect(redeployPreview).toContain('uses: actions/checkout@v7');
+    expect(redeployPreview).toContain('ref: main');
+    expect(redeployPreview.indexOf('uses: actions/checkout@v7')).toBeLessThan(
+      redeployPreview.indexOf('gh-pages-publisher.mjs pr-preview'),
+    );
     expect(cleanup).toContain('gh-pages-publisher.mjs cleanup-previews');
     expect(compact).toContain('gh-pages-publisher.mjs compact');
     expect(vibe).toContain('gh-pages-publisher.mjs vibe-screenshots');

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -43,6 +43,11 @@ jobs:
       PR_NUMBER: ${{ github.event.inputs.pr_number }}
 
     steps:
+      - name: Checkout publisher
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
       - name: Locate the PR's CI run
         id: pr-info
         env:


### PR DESCRIPTION
## Summary
- check out trusted `main` before the manual preview recovery workflow invokes the shared publisher
- enforce checkout ordering in the workflow contract test

## Why
A live recovery attempt for four recent PR previews failed because `redeploy-preview.yml` downloaded the static artifacts but never checked out `.github/scripts/gh-pages-publisher.mjs`.

## Test plan
- `pnpm exec vitest run .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `pnpm exec actionlint -ignore 'SC2129' .github/workflows/redeploy-preview.yml`
- `pnpm exec prettier --check .github/workflows/redeploy-preview.yml .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `pnpm check:repo`
- `git diff --check`