### PR TITLE
fix(ci): accept tall visual regression sheets

### DIFF
--- a/.github/scripts/visual-gate/publish-pr-report.mjs
+++ b/.github/scripts/visual-gate/publish-pr-report.mjs
@@ -48,7 +48,9 @@ const NAME = /^[A-Za-z0-9._-]{1,120}$/;
 const PACKAGE_NAME = /^@[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 const SHA = /^[0-9a-f]{40}$/;
 const MAX_PNG_BYTES = 12 * 1024 * 1024;
-const MAX_EDGE = 5000;
+const MAX_PNG_WIDTH = 5000;
+const MAX_PNG_HEIGHT = 10000;
+const MAX_PNG_PIXELS = 25_000_000;
 const MAX_SHOTS = 5000;
 
 function fail(message) {
@@ -67,6 +69,29 @@ function shaFile(file) {
   return createHash('sha256').update(fs.readFileSync(file)).digest('hex');
 }
 
+function pngDimensions(bytes, label) {
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  if (
+    bytes.length < 24 ||
+    !bytes.subarray(0, 8).equals(signature) ||
+    bytes.toString('ascii', 12, 16) !== 'IHDR'
+  ) {
+    fail(`${label} is not a valid PNG: invalid header`);
+  }
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    width > MAX_PNG_WIDTH ||
+    height > MAX_PNG_HEIGHT ||
+    width * height > MAX_PNG_PIXELS
+  ) {
+    fail(`${label} has invalid dimensions ${width}x${height}`);
+  }
+  return {width, height};
+}
+
 function copyPng(source, target, label) {
   if (!fs.existsSync(source)) fail(`${label} is missing`);
   const stat = fs.lstatSync(source);
@@ -74,19 +99,16 @@ function copyPng(source, target, label) {
     fail(`${label} is not a regular file`);
   if (stat.size <= 0 || stat.size > MAX_PNG_BYTES)
     fail(`${label} has invalid size`);
+  const bytes = fs.readFileSync(source);
+  const dimensions = pngDimensions(bytes, label);
   let image;
   try {
-    image = canonicalizePng(fs.readFileSync(source));
+    image = canonicalizePng(bytes);
   } catch (error) {
     fail(`${label} is not a valid PNG: ${error.message}`);
   }
-  if (
-    image.width <= 0 ||
-    image.height <= 0 ||
-    image.width > MAX_EDGE ||
-    image.height > MAX_EDGE
-  ) {
-    fail(`${label} has invalid dimensions ${image.width}x${image.height}`);
+  if (image.width !== dimensions.width || image.height !== dimensions.height) {
+    fail(`${label} dimensions changed while decoding`);
   }
   fs.mkdirSync(path.dirname(target), {recursive: true});
   fs.writeFileSync(target, image.bytes);

--- a/.github/scripts/visual-gate/publish-pr-report.test.mjs
+++ b/.github/scripts/visual-gate/publish-pr-report.test.mjs
@@ -44,8 +44,8 @@ let output;
 let baseline;
 let scope;
 
-function png(red = 255, green = 0, blue = 0) {
-  const image = new PNG({width: 2, height: 2});
+function pngWithSize(width, height, red = 255, green = 0, blue = 0) {
+  const image = new PNG({width, height});
   for (let i = 0; i < image.data.length; i += 4) {
     image.data[i] = red;
     image.data[i + 1] = green;
@@ -53,6 +53,10 @@ function png(red = 255, green = 0, blue = 0) {
     image.data[i + 3] = 255;
   }
   return PNG.sync.write(image);
+}
+
+function png(red = 255, green = 0, blue = 0) {
+  return pngWithSize(2, 2, red, green, blue);
 }
 
 function writeJSON(file, value) {
@@ -323,7 +327,10 @@ describe('trusted PR visual publisher', () => {
     const other = 'core-card--default__neutral-light';
     writeBaseline({
       [KEY]: {shot: SHOT, bytes: png()},
-      [other]: {shot: {...SHOT, storyId: 'core-card--default', component: 'Card'}, bytes: png()},
+      [other]: {
+        shot: {...SHOT, storyId: 'core-card--default', component: 'Card'},
+        bytes: png(),
+      },
     });
     run();
     const verdict = JSON.parse(
@@ -351,6 +358,27 @@ describe('trusted PR visual publisher', () => {
   it('rejects capture bytes that are not a PNG', () => {
     fs.writeFileSync(path.join(input, 'shots', `${KEY}.png`), 'not png');
     expect(() => run()).toThrow(/not a valid PNG/);
+  });
+
+  it('accepts tall sheets that stay within the existing pixel budget', () => {
+    const tall = pngWithSize(2, 7673, 0, 0, 255);
+    writeCapture({[KEY]: {shot: SHOT, bytes: tall}});
+
+    run();
+
+    const evidence = JSON.parse(
+      fs.readFileSync(path.join(output, 'evidence.json'), 'utf8'),
+    );
+    expect(evidence.deltas[0].shot).toMatchObject({width: 2, height: 7673});
+  });
+
+  it('rejects PNG headers above the pixel budget before decoding', () => {
+    const oversized = Buffer.from(png());
+    oversized.writeUInt32BE(5000, 16);
+    oversized.writeUInt32BE(5001, 20);
+    fs.writeFileSync(path.join(input, 'shots', `${KEY}.png`), oversized);
+
+    expect(() => run()).toThrow(/invalid dimensions 5000x5001/);
   });
 
   it('rejects an empty capture for an unbaselined stable scope', () => {


### PR DESCRIPTION
## Summary
- accept tall visual sheets up to 10,000 px while preserving the existing 25M-pixel safety budget
- reject oversized PNG dimensions from the header before decoding
- add regressions for the 7,673 px sheet that blocked #5671 and for decompression-sized images

## Why
[#5671](https://github.com/facebook/astryx/pull/5671) captured a legitimate 1024×7673 props-table story, but report publication rejected any edge above 5,000 px even though the image was smaller than the previously allowed 5,000×5,000 pixel area.

## Test plan
- `pnpm exec vitest run .github/scripts/visual-gate/publish-pr-report.test.mjs`
- `pnpm exec prettier --check .github/scripts/visual-gate/publish-pr-report.mjs .github/scripts/visual-gate/publish-pr-report.test.mjs`
- `pnpm check:repo`
- `git diff --check`