### PR TITLE
feat(Table): expose row selection to theming

### DIFF
--- a/.changeset/table-expose-row-selection-to-theming-5425-hgdx.md
+++ b/.changeset/table-expose-row-selection-to-theming-5425-hgdx.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Table: expose row selection to theming (#5425)
+@Cypher-Aura-19

--- a/apps/storybook/stories/TableSelection.stories.tsx
+++ b/apps/storybook/stories/TableSelection.stories.tsx
@@ -8,6 +8,7 @@ import {
   useTableSelectionState,
 } from '@astryxdesign/core/Table';
 import type {TableColumn} from '@astryxdesign/core/Table';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 
 // =============================================================================
 // Sample Data
@@ -289,6 +290,58 @@ export const WithStripedRows: Story = {
           plugins={{selection: selectionPlugin}}
         />
       </div>
+    );
+  },
+};
+
+/**
+ * Recolour the checked-row wash from a theme, via `defineTheme`.
+ *
+ * Checked rows publish their state on the `astryx-table-row` target
+ * (`selected` class + `data-selected`), and the wash resolves through
+ * `--table-row-selected-background` — so a theme retints the selection by
+ * setting that var under the `selected` key instead of turning
+ * `hasRowHighlight` off. The same var is republished as the row overlay, so
+ * pinned cells replay the themed colour too.
+ *
+ * Defaults are unchanged; this story only demonstrates the override channel.
+ */
+const themedWashTheme = defineTheme({
+  name: 'table-selection-wash-demo',
+  components: {
+    'table-row': {
+      selected: {
+        '--table-row-selected-background': 'var(--color-success-muted)',
+      },
+    },
+  },
+});
+
+export const ThemedSelectionWash: Story = {
+  render: () => {
+    const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
+      new Set(['1', '3']),
+    );
+
+    const {selectionConfig} = useTableSelectionState<User>({
+      data: users,
+      idKey: 'id',
+      selectedKeys,
+      setSelectedKeys,
+    });
+    const selectionPlugin = useTableSelection<User>(selectionConfig);
+
+    return (
+      <Theme theme={themedWashTheme} mode="light">
+        <div style={{maxWidth: 600}}>
+          <Table
+            data={users}
+            columns={columns}
+            idKey="id"
+            plugins={{selection: selectionPlugin}}
+          />
+        </div>
+      </Theme>
     );
   },
 };

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -29,12 +29,21 @@ export const docs = {
       {className: 'astryx-table-header'},
       {className: 'astryx-table-body'},
       {className: 'astryx-table-footer'},
-      {className: 'astryx-table-row'},
+      // `selected` is set by useTableSelection on checked rows.
+      {className: 'astryx-table-row', states: ['selected']},
       {className: 'astryx-table-cell', visualProps: ['density']},
       {className: 'astryx-table-header-cell', visualProps: ['density']},
       // Still emitted beside the names above, so themes written against
       // them keep working. Drop in the next major.
       {className: 'astryx-base-table', deprecatedFor: 'table'},
+    ],
+    vars: [
+      {
+        name: '--table-row-selected-background',
+        description:
+          'Colour of the wash useTableSelection paints on checked rows. Republished as the row overlay, so pinned cells replay the same colour. Set it on the table-row selected target to retint the selection; hasRowHighlight: false removes the wash entirely.',
+        default: 'var(--color-accent-muted)',
+      },
     ],
   },
   description: 'Styled, data-driven table with density, dividers, hover highlight, striped rows, and named plugin support. T must extend Record<string, unknown>.',

--- a/packages/core/src/Table/plugins/selection/useTableSelection.test.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelection.test.tsx
@@ -14,6 +14,8 @@ import userEvent from '@testing-library/user-event';
 import {Table} from '../../Table';
 import {useTableSelection} from './useTableSelection';
 import {colorVars} from '../../../theme/tokens.stylex';
+import {defineTheme} from '../../../theme/defineTheme';
+import {generateThemeCSS} from '../../../theme/generateThemeRules';
 import type {BodyRowRenderProps, TableColumn} from '../../types';
 
 // =============================================================================
@@ -91,6 +93,60 @@ function SelectionTable({
       idKey="id"
       plugins={{selection: selectionPlugin}}
     />
+  );
+}
+
+/**
+ * Selection table whose row data can change for reasons unrelated to
+ * selection. Renaming keeps the item's `id`, so the row keeps its React key
+ * and the same `<tr>` element re-renders — the situation where React re-owns
+ * the row's `className` while the plugin's imperative theming state has to
+ * survive on it.
+ */
+function RenamingSelectionTable() {
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [items, setItems] = useState<SelectableUser[]>(selectableUsers);
+
+  const selectionPlugin = useTableSelection<SelectableUser>({
+    getIsItemSelected: item => selectedKeys.has(item.id),
+    onSelectItem: ({item, isSelected}) => {
+      const next = new Set(selectedKeys);
+      if (isSelected) {
+        next.add(item.id);
+      } else {
+        next.delete(item.id);
+      }
+      setSelectedKeys(next);
+    },
+    onSelectAll: ({isAllSelected}) => {
+      setSelectedKeys(
+        isAllSelected ? new Set(items.map(u => u.id)) : new Set(),
+      );
+    },
+    getIsAllSelected: () =>
+      items.length > 0 && items.every(u => selectedKeys.has(u.id)),
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          setItems(prev =>
+            prev.map(item =>
+              item.id === '1' ? {...item, name: 'Alicia'} : item,
+            ),
+          )
+        }>
+        Rename Alice
+      </button>
+      <Table
+        data={items}
+        columns={selectableColumns}
+        idKey="id"
+        plugins={{selection: selectionPlugin}}
+      />
+    </div>
   );
 }
 
@@ -216,7 +272,9 @@ describe('useTableSelection', () => {
   });
 
   describe('hasRowHighlight', () => {
-    const selectedBgColor = colorVars['--color-accent-muted'];
+    // The wash resolves through the themeable lever (see the
+    // 'selected-row theming' block below) rather than a fixed colour.
+    const selectedBgColor = `var(--table-row-selected-background, ${colorVars['--color-accent-muted']})`;
 
     it('paints a checked row with the accent wash by default', async () => {
       const user = userEvent.setup();
@@ -346,6 +404,164 @@ describe('useTableSelection', () => {
 
         expect(readOverlay(screen.getAllByRole('row')[2])).toBe('');
       });
+    });
+  });
+
+  // The selected state has to reach the theming system through the same
+  // surface every component uses (the `astryx-table-row` target), and the
+  // wash has to resolve through a value a theme can actually set — otherwise
+  // a theme can only turn the highlight off, never restyle it (#5425).
+  describe('selected-row theming', () => {
+    const selectedWashColor = `var(--table-row-selected-background, ${colorVars['--color-accent-muted']})`;
+
+    it('publishes the selected state on the table-row target', async () => {
+      const user = userEvent.setup();
+      render(<SelectionTable />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+
+      const [selectedRow, unselectedRow] = [
+        screen.getAllByRole('row')[1],
+        screen.getAllByRole('row')[2],
+      ];
+      expect(selectedRow).toHaveClass('astryx-table-row');
+      expect(selectedRow).toHaveClass('selected');
+      expect(selectedRow).toHaveAttribute('data-selected', 'selected');
+      expect(unselectedRow).toHaveClass('astryx-table-row');
+      expect(unselectedRow).not.toHaveClass('selected');
+      expect(unselectedRow).not.toHaveAttribute('data-selected');
+    });
+
+    it('matches the selectors a theme generates for the selected state', async () => {
+      const user = userEvent.setup();
+      render(<SelectionTable />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+
+      // The rule `defineTheme({components: {'table-row': {selected: …}}})`
+      // emits is `.astryx-table-row.selected`; the data-attribute form is the
+      // raw-CSS escape hatch. Both must distinguish selected from unselected.
+      const [selectedRow, unselectedRow] = [
+        screen.getAllByRole('row')[1],
+        screen.getAllByRole('row')[2],
+      ];
+      expect(selectedRow.matches('.astryx-table-row.selected')).toBe(true);
+      expect(selectedRow.matches('[data-selected="selected"]')).toBe(true);
+      expect(unselectedRow.matches('.astryx-table-row.selected')).toBe(false);
+      expect(unselectedRow.matches('[data-selected="selected"]')).toBe(false);
+    });
+
+    it('keeps the published state across a rerender that does not change selection', async () => {
+      const user = userEvent.setup();
+      render(<RenamingSelectionTable />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+
+      const rowBefore = screen.getAllByRole('row')[1];
+      expect(rowBefore).toHaveClass('astryx-table-row');
+      expect(rowBefore).toHaveClass('selected');
+      expect(rowBefore).toHaveAttribute('data-selected', 'selected');
+      expect(rowBefore).toHaveAttribute('aria-selected', 'true');
+
+      // Rerender the selected row itself for a reason unrelated to selection:
+      // same item id, so the same <tr> element re-renders under React.
+      await user.click(screen.getByRole('button', {name: 'Rename Alice'}));
+
+      // The rerender really happened, on the same element...
+      expect(screen.getByText('Alicia')).toBeInTheDocument();
+      const rowAfter = screen.getAllByRole('row')[1];
+      expect(rowAfter).toBe(rowBefore);
+      // ...and the imperatively-published theming state survived it.
+      expect(rowAfter).toHaveClass('astryx-table-row');
+      expect(rowAfter).toHaveClass('selected');
+      expect(rowAfter).toHaveAttribute('data-selected', 'selected');
+      expect(rowAfter).toHaveAttribute('aria-selected', 'true');
+      // The paint contract survived it too.
+      expect(rowAfter.style.backgroundColor).toBe(selectedWashColor);
+      expect(rowAfter.style.getPropertyValue('--table-row-overlay')).toBe(
+        selectedWashColor,
+      );
+    });
+
+    it('clears the published state when a row is unchecked', async () => {
+      const user = userEvent.setup();
+      render(<SelectionTable />);
+
+      const checkbox = screen.getAllByLabelText('Select row')[0];
+      await user.click(checkbox);
+      await user.click(checkbox);
+
+      const row = screen.getAllByRole('row')[1];
+      expect(row).not.toHaveClass('selected');
+      expect(row).not.toHaveAttribute('data-selected');
+      expect(row).not.toHaveAttribute('aria-selected');
+    });
+
+    it('publishes the state even when the wash is opted out', async () => {
+      const user = userEvent.setup();
+      render(<SelectionTable hasRowHighlight={false} />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+
+      // hasRowHighlight drops only the paint. The state a theme keys off —
+      // and the semantics — stay, so a theme can supply its own selected
+      // treatment on a table that turned the built-in wash off.
+      const row = screen.getAllByRole('row')[1];
+      expect(row).toHaveClass('selected');
+      expect(row).toHaveAttribute('data-selected', 'selected');
+      expect(row).toHaveAttribute('aria-selected', 'true');
+      expect(row.style.backgroundColor).toBe('');
+    });
+
+    it('paints the wash through a value a theme can set', async () => {
+      const user = userEvent.setup();
+      render(<SelectionTable />);
+
+      await user.click(screen.getAllByLabelText('Select row')[0]);
+
+      // Not a fixed colour: the inline wash reads --table-row-selected-background,
+      // so a theme that sets it retints every checked row without touching the
+      // plugin config.
+      const row = screen.getAllByRole('row')[1];
+      expect(row.style.backgroundColor).toBe(
+        `var(--table-row-selected-background, ${colorVars['--color-accent-muted']})`,
+      );
+      // The same lever is what pinned cells replay, so a themed wash runs
+      // under the freeze line instead of stopping at it.
+      expect(row.style.getPropertyValue('--table-row-overlay')).toBe(
+        `var(--table-row-selected-background, ${colorVars['--color-accent-muted']})`,
+      );
+    });
+
+    it('emits the themed wash on the selected target the row matches', () => {
+      // The full chain, end to end: a theme recolours the wash through the
+      // selected state key, the generated rule lands on
+      // `.astryx-table-row.selected`, and that selector matches exactly the
+      // rows the plugin marks.
+      const {component} = generateThemeCSS(
+        defineTheme({
+          name: 'selection-theme-test',
+          components: {
+            'table-row': {
+              selected: {
+                '--table-row-selected-background': 'var(--color-success-muted)',
+              },
+            },
+          },
+        }),
+      );
+
+      expect(component).toContain('.astryx-table-row.selected');
+      expect(component).toContain(
+        '--table-row-selected-background: var(--color-success-muted)',
+      );
+
+      const selected = document.createElement('tr');
+      selected.className = 'astryx-table-row selected';
+      const unselected = document.createElement('tr');
+      unselected.className = 'astryx-table-row';
+      expect(selected.matches('.astryx-table-row.selected')).toBe(true);
+      expect(unselected.matches('.astryx-table-row.selected')).toBe(false);
     });
   });
 

--- a/packages/core/src/Table/plugins/selection/useTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelection.tsx
@@ -26,10 +26,14 @@
  * DOM elements and no central element tracking. Each subscription
  * self-cleans when the row disconnects.
  *
- * Because the background is an inline style, it outranks anything
- * userland can layer on with StyleX. `hasRowHighlight: false` is the
- * supported way to reclaim the row background; `aria-selected` is
- * unaffected by it.
+ * The selected state is published on the `astryx-table-row` theming target
+ * (state class + data attribute, derived from themeProps) on the same
+ * imperative path, so a theme can key off it. The wash itself resolves
+ * through the `--table-row-selected-background` var, so a theme can
+ * retint it. Because the background is an inline style it still outranks
+ * anything userland can layer on with StyleX — `hasRowHighlight: false`
+ * remains the way to reclaim the row background entirely; `aria-selected`
+ * is unaffected by it.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/useTableSelection.doc.mjs (config prop table)
@@ -50,7 +54,7 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../../../theme/tokens.stylex';
 import {CheckboxInput} from '../../../CheckboxInput';
-import {mergeRefs} from '../../../utils';
+import {mergeRefs, themeProps} from '../../../utils';
 import type {TablePlugin, TableColumn, BodyRowRenderProps} from '../../types';
 import {pixel} from '../../columnUtils';
 import {useTranslator} from '../../../i18n';
@@ -91,7 +95,10 @@ export interface UseTableSelectionConfig<T extends Record<string, unknown>> {
    * Paint checked rows with the accent wash. Set false when the surrounding
    * UI already uses row background to mean something else — a row that is
    * open in a detail panel, for instance. The wash is an inline style, so
-   * it cannot be overridden from userland; this flag is the way off it.
+   * it cannot be overridden from userland; this flag is the way off it. A
+   * theme that only wants a different colour can retint the wash in place
+   * by setting `--table-row-selected-background` on the `table-row`
+   * selected target, without turning it off.
    *
    * Only the background is dropped. `aria-selected` is still set on checked
    * rows either way, so the selection stays legible to screen readers.
@@ -145,7 +152,10 @@ function createSelectionStore<T extends Record<string, unknown>>(
  * Apply or remove selection styling on a <tr> element.
  *
  * `aria-selected` tracks selection on its own: it is the semantic half of
- * the state and stays correct whether or not the row is painted.
+ * the state and stays correct whether or not the row is painted. The
+ * `selected` class and `data-selected` attribute are the theming half —
+ * same imperative path, same conditions — so a theme can key off a checked
+ * row (`table-row` + `selected`) whether or not it is painted.
  */
 function applyRowSelectionStyle(
   el: HTMLTableRowElement,
@@ -156,6 +166,18 @@ function applyRowSelectionStyle(
     el.setAttribute('aria-selected', 'true');
   } else {
     el.removeAttribute('aria-selected');
+  }
+  // The theming surface comes from themeProps so it stays in step with how
+  // every other component publishes state (class token + data attribute),
+  // never a hand-authored one. Toggling imperatively keeps the fine-grained
+  // path: no row re-renders to carry it.
+  for (const className of selectedRowStateClasses) {
+    el.classList.toggle(className, isSelected);
+  }
+  if (isSelected && selectedRowDataAttribute != null) {
+    el.setAttribute('data-selected', selectedRowDataAttribute);
+  } else {
+    el.removeAttribute('data-selected');
   }
   // Written on every pass, not just when painting: the flag can flip while a
   // row is already selected, and the wash has to come back off.
@@ -320,7 +342,34 @@ function SelectionCellContentInner<T extends Record<string, unknown>>({
 // Styles
 // =============================================================================
 
-const selectedBgColor = colorVars['--color-accent-muted'];
+/**
+ * The wash painted on checked rows. Resolves through a themeable var — the
+ * same contract as `--table-sticky-background` in useTableStickyColumns — so
+ * a theme can retint the selection (`table-row` + `selected` sets
+ * `--table-row-selected-background`) instead of only opting out of it. The
+ * same value publishes as the row overlay, so a themed wash runs under
+ * pinned columns too. Defaults to the accent token.
+ */
+const selectedBgColor = `var(--table-row-selected-background, ${colorVars['--color-accent-muted']})`;
+
+/**
+ * The selected state as published on the row's theming target. Selection is
+ * runtime state, so it rides the one `astryx-table-row` target (class token
+ * + data attribute from themeProps, like `calendar-day`'s selected) rather
+ * than a separate `-selected` element or a hand-authored attribute. Derived
+ * once here; the per-row ref writes the delta on top of the stable base.
+ */
+const SELECTED_ROW_STATE = 'selected';
+const tableRowBaseClassName = themeProps('table-row').className;
+const selectedRowStateProps = themeProps('table-row', {
+  selected: SELECTED_ROW_STATE,
+});
+/** The state classes `selected` adds on top of the stable base class. */
+const selectedRowStateClasses = selectedRowStateProps.className
+  .split(' ')
+  .filter(className => className !== tableRowBaseClassName);
+/** The `data-selected` value themeProps reflects for the selected state. */
+const selectedRowDataAttribute = selectedRowStateProps['data-selected'];
 
 /**
  * The row's current fill, republished for pinned cells to read. Declared as a

--- a/packages/core/src/Table/useTableSelection.doc.mjs
+++ b/packages/core/src/Table/useTableSelection.doc.mjs
@@ -65,7 +65,7 @@ export const docs = {
       name: 'hasRowHighlight',
       type: 'boolean',
       description:
-        'Paints checked rows with the accent wash. Set false when the surrounding UI already uses row background to mean something else (a row open in a detail panel, say). The wash is an inline style, so it cannot be overridden from userland. Only the background is dropped: aria-selected is still set on checked rows either way.',
+        'Paints checked rows with the accent wash. Set false when the surrounding UI already uses row background to mean something else (a row open in a detail panel, say). The wash is an inline style, so it cannot be overridden from userland; a theme that only wants a different colour sets --table-row-selected-background on the table-row selected target instead of turning it off. Only the background is dropped: aria-selected (and the selected state a theme can key off) is still set on checked rows either way.',
       default: 'true',
     },
   ],
@@ -103,6 +103,25 @@ const selectionPlugin = useTableSelection({
   onSelectAll: ({isAllSelected}) => selectAll(isAllSelected),
   getIsAllSelected: () => selectedIds.size === users.length,
   hasRowHighlight: false,
+});
+`,
+    },
+    {
+      label: 'Recolour the checked-row wash from a theme',
+      code: `
+// A theme retints the wash by setting --table-row-selected-background on
+// the table-row selected target. Checked rows publish the selected state
+// (.astryx-table-row.selected / [data-selected="selected"]), so any other
+// property can be themed on them too.
+const theme = defineTheme({
+  name: 'my-brand',
+  components: {
+    'table-row': {
+      selected: {
+        '--table-row-selected-background': 'var(--color-success-muted)',
+      },
+    },
+  },
 });
 `,
     },
@@ -168,7 +187,7 @@ export const docsZh = {
       name: 'hasRowHighlight',
       type: 'boolean',
       description:
-        '为选中的行绘制强调色背景。当周围的界面已用行背景表达其他含义（例如该行已在详情面板中打开）时设为 false —— 该背景是内联样式，无法从业务代码覆盖。仅去掉背景：无论如何选中的行仍会设置 aria-selected。',
+        '为选中的行绘制强调色背景。当周围的界面已用行背景表达其他含义（例如该行已在详情面板中打开）时设为 false —— 该背景是内联样式，无法从业务代码覆盖；只需换色的主题可改为在 table-row 的 selected 目标上设置 --table-row-selected-background。仅去掉背景：无论如何选中的行仍会设置 aria-selected（以及主题可依据的 selected 状态）。',
       default: 'true',
     },
   ],
@@ -194,6 +213,6 @@ export const docsDense = {
     getRowLabel:
       'Derives row identity for the checkbox\'s hidden label: `Select ${getRowLabel(item)}`. Falls back to "Select row" when omitted.',
     hasRowHighlight:
-      'false => skip the accent wash on checked rows (inline style, not overridable from userland). aria-selected is unaffected. Defaults to true.',
+      'false => skip the accent wash on checked rows (inline style, not overridable from userland); a theme wanting a different colour sets --table-row-selected-background on the table-row selected target. aria-selected and the published selected state are unaffected. Defaults to true.',
   },
 };


### PR DESCRIPTION
## Summary

- expose selected Table rows through the `table-row` theming target
- make the checked-row wash retintable with `--table-row-selected-background`
- preserve the existing fine-grained selection-store update path and pinned-column overlay behavior
- add regression coverage for selection transitions, theme targeting, opt-out behavior, and React rerenders

Selected rows now publish the `selected` state without routing selection through React row state, so themes can target the row without changing the existing render-performance model.

## Testing

- selection plugin tests
- Table theming target/derived-var guards
- core typecheck
- strict ESLint
- changeset validation
- core build
- verified the theme build accepts the `table-row.selected` target

Fixes #5425
