### PR TITLE
ci: keep spec-only changes out of releases

### DIFF
--- a/.github/REVIEW_GATE.md
+++ b/.github/REVIEW_GATE.md
@@ -38,6 +38,8 @@ A PR changes only spec records when every changed path is one of:
 - a colocated Core/Lab `<Name>.spec.md`.
 
 Draft-only spec records can merge after validation without owner approval.
+Pure spec-record PRs do not add Changesets because they do not release packages;
+CI rejects a PR containing only spec records and `.changeset` entries.
 That classification fails closed on an empty or truncated file list and checks
 both sides of a rename. Pure spec-record PRs run knowledge validation, skip
 runtime/build/visual work with successful required-status acknowledgements, and

--- a/.github/scripts/change-scope.cjs
+++ b/.github/scripts/change-scope.cjs
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 'use strict';
-/* global module, process, require */
+/* global console, module, process, require */
 
 /**
  * Classifies changed paths without reading PR-controlled content.
@@ -17,6 +17,8 @@ const SPEC_RECORD_PATTERNS = [
   /^packages\/(?:core|lab)\/src\/[^/]+\/[^/]+\.spec\.md$/,
 ];
 
+const CHANGESET_PATTERN = /^\.changeset\/(?!README\.md$)[^/]+\.md$/;
+
 const KNOWLEDGE_RECORD_PATTERNS = [
   ...SPEC_RECORD_PATTERNS,
   /^docs\/architecture\/(?!README\.md$)[^/]+\.md$/,
@@ -25,6 +27,22 @@ const KNOWLEDGE_RECORD_PATTERNS = [
 
 function isSpecRecordPath(filePath) {
   return SPEC_RECORD_PATTERNS.some(pattern => pattern.test(filePath));
+}
+
+function isPackageReleasePath(filePath) {
+  if (!filePath.startsWith('packages/') || isSpecRecordPath(filePath)) {
+    return false;
+  }
+  if (
+    /(?:^|\/)(?:test|tests|test-utils|__tests__|__fixtures__|__snapshots__)\//.test(
+      filePath,
+    ) ||
+    /\.test\.[^/]+$/.test(filePath) ||
+    /\.audit\.json$/.test(filePath)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isKnowledgeRecordPath(filePath) {
@@ -51,6 +69,7 @@ function classifyChanges(changes, {expectedCount} = {}) {
       specOnly: false,
       touchesKnowledgeRecords: !complete,
       touchesDesignAssets: false,
+      specChangesetConflict: false,
       docsiteOnly: false,
       complete,
       reason: complete ? 'no changed files' : 'changed-file list is incomplete',
@@ -68,6 +87,13 @@ function classifyChanges(changes, {expectedCount} = {}) {
   const touchesDesignAssets = allPaths.some(filePath =>
     filePath.startsWith('docs/design/assets/'),
   );
+  const hasSpecRecord = allPaths.some(isSpecRecordPath);
+  const hasChangeset = allPaths.some(filePath =>
+    CHANGESET_PATTERN.test(filePath),
+  );
+  const hasPackageReleaseChange = allPaths.some(isPackageReleasePath);
+  const specChangesetConflict =
+    complete && hasSpecRecord && hasChangeset && !hasPackageReleaseChange;
   const specOnly = complete && allPaths.every(isSpecRecordPath);
   const docsiteOnly = allPaths.every(filePath =>
     filePath.startsWith('apps/docsite/'),
@@ -76,6 +102,7 @@ function classifyChanges(changes, {expectedCount} = {}) {
     specOnly,
     touchesKnowledgeRecords,
     touchesDesignAssets,
+    specChangesetConflict,
     docsiteOnly,
     complete,
     reason: !complete
@@ -109,7 +136,12 @@ if (require.main === module) {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const fs = require('node:fs');
   const result = classifyChanges(parseNameStatus(fs.readFileSync(0, 'utf8')));
-  if (process.argv.includes('--github-output')) {
+  if (result.specChangesetConflict) {
+    console.error(
+      'Pure spec-record changes must not add a Changeset; they do not release packages.',
+    );
+    process.exitCode = 1;
+  } else if (process.argv.includes('--github-output')) {
     const outputPath = process.env.GITHUB_OUTPUT;
     if (!outputPath)
       throw new Error('GITHUB_OUTPUT is required with --github-output.');

--- a/.github/scripts/change-scope.test.mjs
+++ b/.github/scripts/change-scope.test.mjs
@@ -36,6 +36,51 @@ describe('spec-only change scope', () => {
     expect(result.specOnly).toBe(false);
   });
 
+  it('rejects Changesets attached only to spec records', () => {
+    const result = classifyChanges([
+      {filename: 'docs/families/input-fields.md'},
+      {filename: '.changeset/input-fields-docs.md'},
+    ]);
+    expect(result.specOnly).toBe(false);
+    expect(result.specChangesetConflict).toBe(true);
+  });
+
+  it('does not let an unrelated file hide a spec-only Changeset', () => {
+    const result = classifyChanges([
+      {filename: 'docs/families/input-fields.md'},
+      {filename: '.changeset/input-fields-docs.md'},
+      {filename: 'docs/README.md'},
+    ]);
+    expect(result.specChangesetConflict).toBe(true);
+  });
+
+  it.each([
+    'packages/core/src/Selector/Selector.test.tsx',
+    'packages/core/src/Selector/Selector.audit.json',
+    'packages/core/test/selector-fixture.ts',
+    'packages/core/src/Selector/__fixtures__/options.ts',
+    'packages/core/src/__tests__/TestIcon.tsx',
+  ])(
+    'does not let non-release package file %s hide a spec-only Changeset',
+    filename => {
+      const result = classifyChanges([
+        {filename: 'docs/families/input-fields.md'},
+        {filename: '.changeset/input-fields-docs.md'},
+        {filename},
+      ]);
+      expect(result.specChangesetConflict).toBe(true);
+    },
+  );
+
+  it('allows a Changeset when a package release surface also changes', () => {
+    const result = classifyChanges([
+      {filename: 'docs/families/input-fields.md'},
+      {filename: 'packages/core/src/Selector/Selector.tsx'},
+      {filename: '.changeset/selector-behavior.md'},
+    ]);
+    expect(result.specChangesetConflict).toBe(false);
+  });
+
   it.each([
     'packages/core/src/Selector/Selector.tsx',
     'packages/core/src/Selector/Selector.audit.json',

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,8 @@ aligned. They are intentionally separate:
   schema change therefore includes an active-record migration. Archived records
   may retain an older schema that remains checked in.
 
-Run `pnpm check:knowledge` to validate templates and records.
+Run `pnpm check:knowledge` to validate templates and records. Pure spec-record
+pull requests do not add Changesets because they do not publish package changes.
 
 ## Visibility
 


### PR DESCRIPTION
## Problem

Pure spec records do not change published packages, so adding a Changeset would create release noise and could publish a package version for documentation-only governance work.

## Change

Reject a PR containing only recognized spec records plus `.changeset` entries. Pure spec PRs remain release-neutral and use their existing lightweight validation path. A mixed runtime/spec PR may still include a legitimate Changeset.

## Testing

- 17 change-scope tests
- CLI-path rejection check
- strict touched-file ESLint
- copyright and diff checks
