### PR TITLE
feat(Stepper): theme targets for the step label and description

### DIFF
--- a/.changeset/stepper-label-description-targets.md
+++ b/.changeset/stepper-label-description-targets.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Stepper: add `astryx-step-label` and `astryx-step-description` theme targets.
+
+Both text parts declare their own typography and color, so themes cannot reach them through the `step` target by inheritance. The new targets apply in both indicator positions and reflect `progress` and `status`.
+
+`step-label` also reflects `disabled`, because the label owns Stepper's disabled text paint. `step-description` does not. The new targets change no default style.
+
+@freddymeta

--- a/packages/core/src/Stepper/Step.tsx
+++ b/packages/core/src/Stepper/Step.tsx
@@ -5,7 +5,8 @@
 /**
  * @file Step.tsx
  * @input Uses React, stylex, theme tokens (including the motion duration token
- *   the connector fill animates on), StepperContext
+ *   the connector fill animates on), StepperContext, and per-step theme selector
+ *   state
  * @output Exports Step component and StepProps
  * @position Individual step item; used inside Stepper
  *
@@ -1247,11 +1248,33 @@ export function Step({
         ? styles.labelInProgress
         : undefined;
 
+  // Both text parts carry {progress, status}, the phase vocabulary of
+  // `step-indicator` above. The label additionally owns Stepper's disabled
+  // paint, so it alone carries disabled below.
+  const labelThemeProps = themeProps('step-label', {
+    progress,
+    status: status ?? undefined,
+    // The label owns Stepper's disabled paint (`styles.labelDisabled` above),
+    // so it owns the selector too. The description does not change under
+    // disabled and deliberately keeps the smaller {progress, status} surface.
+    disabled: isDisabled ? 'disabled' : null,
+  });
+  const descriptionThemeProps = themeProps('step-description', {
+    progress,
+    status: status ?? undefined,
+  });
+
   // Indicator + Label row
   const iconLabelNode = (
     <div {...stylex.props(styles.iconLabelRow)}>
       {indicatorNode}
-      <span {...stylex.props(styles.label, labelColorStyle)}>{label}</span>
+      <span
+        {...mergeProps(
+          labelThemeProps,
+          stylex.props(styles.label, labelColorStyle),
+        )}>
+        {label}
+      </span>
       {statusTextNode}
       {isOptional && (
         <>
@@ -1272,7 +1295,13 @@ export function Step({
           ? styles.descriptionRowWithIndicator
           : styles.descriptionRow,
       )}>
-      <span {...stylex.props(styles.description)}>{description}</span>
+      <span
+        {...mergeProps(
+          descriptionThemeProps,
+          stylex.props(styles.description),
+        )}>
+        {description}
+      </span>
     </div>
   ) : null;
 
@@ -1354,7 +1383,13 @@ export function Step({
         {...stylex.props(
           isVertical ? styles.otLabelRowStart : styles.otLabelRowCenter,
         )}>
-        <span {...stylex.props(styles.label, labelColorStyle)}>{label}</span>
+        <span
+          {...mergeProps(
+            labelThemeProps,
+            stylex.props(styles.label, labelColorStyle),
+          )}>
+          {label}
+        </span>
         {statusTextNode}
         {isOptional && (
           <>
@@ -1369,7 +1404,13 @@ export function Step({
     );
 
     const otDescriptionNode = isRenderable(description) ? (
-      <span {...stylex.props(styles.description)}>{description}</span>
+      <span
+        {...mergeProps(
+          descriptionThemeProps,
+          stylex.props(styles.description),
+        )}>
+        {description}
+      </span>
     ) : null;
 
     const otContentNode = !isRenderable(children) ? null : isVertical ? (

--- a/packages/core/src/Stepper/Stepper.doc.mjs
+++ b/packages/core/src/Stepper/Stepper.doc.mjs
@@ -103,6 +103,14 @@ export const docs = {
       },
       {className: 'astryx-step', visualProps: ['progress', 'status']},
       {className: 'astryx-step-indicator', visualProps: ['progress', 'status']},
+      {
+        className: 'astryx-step-label',
+        visualProps: ['progress', 'status', 'disabled'],
+      },
+      {
+        className: 'astryx-step-description',
+        visualProps: ['progress', 'status'],
+      },
       {className: 'astryx-step-bar'},
       {className: 'astryx-step-connector'},
     ],
@@ -283,6 +291,14 @@ export const docsZh = {
       },
       {className: 'astryx-step', visualProps: ['progress', 'status']},
       {className: 'astryx-step-indicator', visualProps: ['progress', 'status']},
+      {
+        className: 'astryx-step-label',
+        visualProps: ['progress', 'status', 'disabled'],
+      },
+      {
+        className: 'astryx-step-description',
+        visualProps: ['progress', 'status'],
+      },
       {className: 'astryx-step-bar'},
       {className: 'astryx-step-connector'},
     ],

--- a/packages/core/src/Stepper/Stepper.spec.md
+++ b/packages/core/src/Stepper/Stepper.spec.md
@@ -26,16 +26,16 @@ system_specs: [spec:AST-002/DEC-1]
 ## Intent
 
 Stepper presents an ordered flow of steps and the progress made through it. This
-contract records the anatomy-to-target map for the existing targets and owns the
-one public semantic custom property the component exposes,
-`--step-connector-gap`.
+contract records its anatomy-to-target map, owns the public semantic custom
+property `--step-connector-gap`, and records Label and Description ownership.
 
 ## Compatibility and migration
 
 - Released default preserved: `yes` — `--step-connector-gap` defaults to `0px`,
   which renders the shipped track unchanged
-- Compatibility class: additive; one new public custom property, no change to
-  existing targets, DOM, props, or default pixels
+- Compatibility class: additive. The connector variable is unchanged. This
+  amendment adds targets and state attributes to the existing Label and
+  Description spans; it adds no element, prop, export, or default style
 - Controlled/uncontrolled behavior: not applicable
 - Migration decision: none
 
@@ -45,12 +45,13 @@ Consumer migration instructions belong in consumer docs and release notes.
 
 **Owns**
 
-- The `stepper`, `step`, `step-bar`, `step-connector`, and `step-indicator`
-  targets.
+- The `stepper`, `step`, `step-bar`, `step-connector`, `step-indicator`,
+  `step-label`, and `step-description` targets.
 - The two paint layers of a connector — the unfilled track (the element's own
   background) and the accent fill (an absolutely placed `::before`) — and the
   single clip that holds both off the indicator.
 - Which pieces an on-track connector is drawn from, and how many.
+- Label and Description paint and the target ownership defined by FR9–FR11.
 
 **Does not own / non-goals**
 
@@ -58,6 +59,7 @@ Consumer migration instructions belong in consumer docs and release notes.
 - The step content slot and any `endContent` — owned by the caller.
 - Whether a step is complete: derived from `activeStep`, not from a caller-owned
   per-step lifecycle.
+- The unpainted clickable inner column.
 
 ## Public concepts
 
@@ -69,16 +71,22 @@ Consumer syntax and description remain in `Stepper.doc.mjs` `theming.vars`.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                            | Basis                            | Draft review state |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------ |
-| FR1 | The default for `--step-connector-gap` is declared once, on the `stepper` root, so a theme's `stepper` override is inherited by every connector.               | Reviewed defect (PR #5495)       | Settled            |
-| FR2 | The gap is applied to the ONE edge each segment faces the indicator from, mirrored per axis, so the pair leaves a hole centred on the node.                    | Current source and browser probe | Settled            |
-| FR3 | One declaration covers both connector paint layers. A clip on the segment clips its `::before` with it, against one reference box, so the two cannot disagree. | Current source and browser probe | Settled            |
-| FR4 | The resolved value is clamped to `max(0px, min(value, --spacing-2))` before use.                                                                               | Reviewed defect (PR #5495)       | Settled            |
-| FR5 | A step rendering no indicator (`indicator="none"`) applies no clip, leaving its track continuous.                                                              | Current source and browser probe | Settled            |
-| FR6 | No accepted value changes the Stepper's outer size, in either orientation. A clip cannot affect layout.                                                        | Current source and browser probe | Settled            |
-| FR7 | The horizontal clip mirrors under `dir="rtl"`, so the hole stays at the indicator rather than moving to the join between steps.                                | Reviewed defect (PR #5495)       | Settled            |
-| FR8 | The pieces an on-track connector is drawn from are not public: no `data-segment`, and no bare `lead`/`rail`/`content` class is emitted.                        | `component:Stepper/DEC-1`        | Settled            |
+| ID   | Candidate invariant                                                                                                                                                                          | Basis                             | Draft review state |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------ |
+| FR1  | The default for `--step-connector-gap` is declared once, on the `stepper` root, so a theme's `stepper` override is inherited by every connector.                                             | Reviewed defect (PR #5495)        | Settled            |
+| FR2  | The gap is applied to the ONE edge each segment faces the indicator from, mirrored per axis, so the pair leaves a hole centred on the node.                                                  | Current source and browser probe  | Settled            |
+| FR3  | One declaration covers both connector paint layers. A clip on the segment clips its `::before` with it, against one reference box, so the two cannot disagree.                               | Current source and browser probe  | Settled            |
+| FR4  | The resolved value is clamped to `max(0px, min(value, --spacing-2))` before use.                                                                                                             | Reviewed defect (PR #5495)        | Settled            |
+| FR5  | A step rendering no indicator (`indicator="none"`) applies no clip, leaving its track continuous.                                                                                            | Current source and browser probe  | Settled            |
+| FR6  | No accepted value changes the Stepper's outer size, in either orientation. A clip cannot affect layout.                                                                                      | Current source and browser probe  | Settled            |
+| FR7  | The horizontal clip mirrors under `dir="rtl"`, so the hole stays at the indicator rather than moving to the join between steps.                                                              | Reviewed defect (PR #5495)        | Settled            |
+| FR8  | The pieces an on-track connector is drawn from are not public: no `data-segment`, and no bare `lead`/`rail`/`content` class is emitted.                                                      | `component:Stepper/DEC-1`         | Settled            |
+| FR9  | In both indicator positions, each rendered Label and Description carries its own target and reflects `progress` and `status`.                                                                | Current source, docs, and tests   | Settled            |
+| FR10 | Label alone reflects `disabled`, because only Label owns disabled paint. Description and the other targets do not gain the selector for symmetry.                                            | Current source, docs, and tests   | Settled            |
+| FR11 | Label and Description each declare `font-size`, `line-height`, and `color`. Those declarations outrank values inherited from `step`, so only direct targets can expose that paint to themes. | Current source and Chromium probe | Settled            |
+
+`status` on Label and Description is a selector seam. It does not claim that
+Astryx paints either text part by status.
 
 ### Allowed variation
 
@@ -91,13 +99,14 @@ Consumer syntax and description remain in `Stepper.doc.mjs` `theming.vars`.
 
 ### Representative states
 
-| State                            | Required invariant | Allowed variation |
-| -------------------------------- | ------------------ | ----------------- |
-| vertical, on-track, indicator    | FR2, FR3, FR6      | AV1, AV2          |
-| horizontal, on-track, indicator  | FR2, FR3, FR6, FR7 | AV1, AV2          |
-| `dir="rtl"`, horizontal          | FR7                | AV1               |
-| `indicator="none"`               | FR5                | —                 |
-| value below `0` or above the cap | FR4, FR6           | —                 |
+| State                                                          | Required invariant | Allowed variation |
+| -------------------------------------------------------------- | ------------------ | ----------------- |
+| vertical, on-track, indicator                                  | FR2, FR3, FR6      | AV1, AV2          |
+| horizontal, on-track, indicator                                | FR2, FR3, FR6, FR7 | AV1, AV2          |
+| `dir="rtl"`, horizontal                                        | FR7                | AV1               |
+| `indicator="none"`                                             | FR5                | —                 |
+| value below `0` or above the cap                               | FR4, FR6           | —                 |
+| both indicator positions; each progress/status; disabled Label | FR9–FR11           | —                 |
 
 ### Transformation and precedence order
 
@@ -117,7 +126,7 @@ Consumer syntax and description remain in `Stepper.doc.mjs` `theming.vars`.
 
 This contract does not change Stepper's existing roles, `aria-current` handling,
 or reduced-motion behavior. The connector is `aria-hidden`, so the gap is a
-purely visual change.
+purely visual change. Label and Description targets add no ARIA semantics.
 
 ## Design relationships
 
@@ -128,6 +137,8 @@ purely visual change.
 | Progress bar     | Presents progress as a segmented bar per step.                         | Current source and public docs | Prominent      | —                  |
 | Connector        | Presents the track between indicators, and the progress made along it. | Current source and public docs | Prominent      | FR2–FR7            |
 | Indicator        | Presents the step's position or completion.                            | Current source and public docs | Prominent      | FR5                |
+| Label            | Identifies the step.                                                   | Current source and public docs | Prominent      | FR9–FR11           |
+| Description      | Gives supporting context below the Label.                              | Current source and public docs | Supporting     | FR9–FR11           |
 
 ### Theming anatomy
 
@@ -140,8 +151,8 @@ purely visual change.
   "Progress bar": {"target": "step-bar"},
   "Connector": {"target": "step-connector"},
   "Indicator": {"target": "step-indicator"},
-  "Label": {"inherits": "step"},
-  "Description": {"inherits": "step"}
+  "Label": {"target": "step-label"},
+  "Description": {"target": "step-description"}
 }
 ```
 
@@ -149,6 +160,10 @@ Connector is one anatomy part with one target, even though the on-track layouts
 draw it from up to three elements. Those pieces are layout implementation, not
 semantic parts, so they get no targets of their own — see `DEC-1`, which is also
 why the caller-owned gap is a custom property rather than a per-piece vocabulary.
+
+Label and Description are local spans styled by Stepper, not delegated `Text`
+parts. Their own typography and color declarations make `inherits: step` false;
+`DEC-2` records why they own direct targets instead.
 
 ## Family and system relationships
 
@@ -160,15 +175,17 @@ why the caller-owned gap is a custom property rather than a per-piece vocabulary
 
 ## Verification map
 
-| Contract            | Verification                                | Representative states                          | Mutation or failure expectation                                                          | Audit section           |
-| ------------------- | ------------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------- |
-| FR1                 | `Stepper.test.tsx` root-ownership assertion | vertical on-track                              | Moving the declaration back onto the connector makes a `stepper` theme override a no-op. | `audit:Stepper/theming` |
-| FR2, FR3            | `Stepper.test.tsx` clip assertions          | vertical and horizontal on-track               | Clipping the wrong edge, or per-layer copies of the value, fails the suite.              | `audit:Stepper/theming` |
-| FR4, FR6            | `Stepper.test.tsx` clamp assertion          | values below `0` and above the cap             | Removing the floor lets a negative inset through; removing the cap unbounds the hole.    | `audit:Stepper/theming` |
-| FR5                 | `Stepper.test.tsx` no-indicator assertion   | `indicator="none"`                             | Applying the clip unconditionally puts holes in a track with no node in them.            | `audit:Stepper/theming` |
-| FR7                 | `Stepper.test.tsx` RTL assertion            | `dir="rtl"`, horizontal                        | Dropping the mirror moves the hole to the join between steps; caught by the assertion.   | `audit:Stepper/theming` |
-| FR8                 | `Stepper.test.tsx` vocabulary guard         | vertical on-track                              | Re-adding `data-segment` or a bare role class fails the guard.                           | `audit:Stepper/theming` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`               | Canonical anatomy and the five current targets | A target with no anatomy owner, or a stale/extra part, fails repository validation.      | `audit:Stepper/theming` |
+| Contract            | Verification                                             | Representative states                                    | Mutation or failure expectation                                                          | Audit section           |
+| ------------------- | -------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------- |
+| FR1                 | `Stepper.test.tsx` root-ownership assertion              | vertical on-track                                        | Moving the declaration back onto the connector makes a `stepper` theme override a no-op. | `audit:Stepper/theming` |
+| FR2, FR3            | `Stepper.test.tsx` clip assertions                       | vertical and horizontal on-track                         | Clipping the wrong edge, or per-layer copies of the value, fails the suite.              | `audit:Stepper/theming` |
+| FR4, FR6            | `Stepper.test.tsx` clamp assertion                       | values below `0` and above the cap                       | Removing the floor lets a negative inset through; removing the cap unbounds the hole.    | `audit:Stepper/theming` |
+| FR5                 | `Stepper.test.tsx` no-indicator assertion                | `indicator="none"`                                       | Applying the clip unconditionally puts holes in a track with no node in them.            | `audit:Stepper/theming` |
+| FR7                 | `Stepper.test.tsx` RTL assertion                         | `dir="rtl"`, horizontal                                  | Dropping the mirror moves the hole to the join between steps; caught by the assertion.   | `audit:Stepper/theming` |
+| FR8                 | `Stepper.test.tsx` vocabulary guard                      | vertical on-track                                        | Re-adding `data-segment` or a bare role class fails the guard.                           | `audit:Stepper/theming` |
+| FR9, FR10           | `Stepper.test.tsx` target and generated-theme assertions | Both indicator positions; progress, status, and disabled | Removing a target or state, or moving it off the painted span, fails focused tests.      | `audit:Stepper/theming` |
+| FR11                | Exact-head Chromium probe                                | Themed `step`, Label, and Description                    | If inheritance reaches the text, the Step target's probe color appears there.            | `audit:Stepper/theming` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                            | Canonical anatomy and the seven current targets          | A target with no anatomy owner, or a stale/extra part, fails repository validation.      | `audit:Stepper/theming` |
 
 ## Decision log
 
@@ -207,6 +224,16 @@ Rejected: exposing `lead` / `rail` / `content` as a public segment vocabulary
 emitted bare `lead` / `content` classes a consumer stylesheet can collide with,
 and `lead` denotes different geometry per orientation, so a theme selecting it
 could not know what it would get.
+
+### DEC-2 — Label and Description own direct targets
+
+**Reference:** `component:Stepper/DEC-2`
+**Decider:** `cixzhang`, `2026-09-02`
+
+FR9–FR11 define the admitted targets, state selectors, and inheritance
+evidence. Rejected alternatives: `inherits: step` fails FR11;
+`delegatesTo: component:Text` describes a composition Stepper does not render;
+and `step-row` would expose an unpainted wrapper for speculative styling.
 
 ## Open questions
 

--- a/packages/core/src/Stepper/Stepper.test.tsx
+++ b/packages/core/src/Stepper/Stepper.test.tsx
@@ -1224,3 +1224,116 @@ describe('Stepper', () => {
     });
   });
 });
+
+describe('step-label and step-description theme targets', () => {
+  // A step's two text parts each declare their own typography, so a theme
+  // cannot reach them by styling the step and letting the cascade do the rest
+  // — an inherited value never beats a value the element declares itself.
+  // These targets are the seam; the assertions below pin what a theme selects
+  // and, in the last case, why the cheaper route does not work.
+
+  const withText = (props = {}) => (
+    <Stepper activeStep={1}>
+      <Step step={0} label="Account" description="Your email" {...props} />
+      <Step step={1} label="Payment" description="Card details" />
+      <Step step={2} label="Review" description="Check and submit" />
+    </Stepper>
+  );
+
+  it('puts the target on the element that paints the text', () => {
+    const {container} = render(withText());
+    const label = container.querySelector('.astryx-step-label') as HTMLElement;
+    const description = container.querySelector(
+      '.astryx-step-description',
+    ) as HTMLElement;
+    // The text is the element's own content, not a descendant's: the target
+    // sits where the paint is rather than on a wrapper around it.
+    expect(label.textContent).toBe('Account');
+    expect(description.textContent).toBe('Your email');
+  });
+
+  it('reflects progress and status, the vocabulary step-indicator uses', () => {
+    // Same shape as the sibling target in this file, so a theme states a
+    // step's phase identically wherever it reaches in. Without it a theme
+    // could not say "the label of a completed step": the compiler emits a
+    // compound selector on one element, never a descendant of `.astryx-step`.
+    const {container} = render(
+      <Stepper activeStep={1}>
+        <Step step={0} label="Done" description="d" />
+        <Step step={1} label="Now" description="d" />
+        <Step step={2} label="Later" description="d" status="error" />
+      </Stepper>,
+    );
+    const labels = [
+      ...container.querySelectorAll<HTMLElement>('.astryx-step-label'),
+    ];
+    expect(labels.map(el => el.dataset.progress)).toEqual([
+      'completed',
+      'in-progress',
+      'not-started',
+    ]);
+    expect(labels[2].dataset.status).toBe('error');
+
+    const descriptions = [
+      ...container.querySelectorAll<HTMLElement>('.astryx-step-description'),
+    ];
+    expect(descriptions.map(el => el.dataset.progress)).toEqual([
+      'completed',
+      'in-progress',
+      'not-started',
+    ]);
+    expect(descriptions[2].dataset.status).toBe('error');
+  });
+
+  it('reflects disabled on the label target and emits its theme selector', () => {
+    // The label owns disabled paint (`styles.labelDisabled`); the description
+    // does not. The selector follows that ownership instead of being copied to
+    // every text target for vocabulary symmetry.
+    const {container} = render(
+      <Stepper activeStep={0}>
+        <Step
+          step={0}
+          label="Unavailable"
+          description="Try again later"
+          isDisabled
+        />
+      </Stepper>,
+    );
+    const label = container.querySelector('.astryx-step-label');
+    const description = container.querySelector('.astryx-step-description');
+    expect(label).toHaveAttribute('data-disabled', 'disabled');
+    expect(label).toHaveClass('disabled');
+    expect(description).not.toHaveAttribute('data-disabled');
+    expect(description).not.toHaveClass('disabled');
+
+    // A DOM attribute alone would not prove the public defineTheme path accepts
+    // and emits the state. Hold both halves of the contract.
+    const theme = defineTheme({
+      name: 'step-label-disabled-state-test',
+      components: {
+        'step-label': {
+          'disabled:disabled': {opacity: '0.4'},
+        },
+      },
+    });
+    const {component: css} = generateThemeCSS(theme);
+    expect(css).toContain('.astryx-step-label.disabled');
+    expect(css).toContain('opacity: 0.4');
+  });
+
+  it('carries them on the on-track layout too', () => {
+    // The indicator-on-the-connector layout renders its own label and
+    // description nodes; a target that only covered the default layout would
+    // leave a theme reaching for structural selectors in exactly one mode.
+    const {container} = render(
+      <Stepper activeStep={0} indicatorPosition="on-track">
+        <Step step={0} label="Account" description="Your email" />
+        <Step step={1} label="Payment" description="Card details" />
+      </Stepper>,
+    );
+    expect(container.querySelectorAll('.astryx-step-label')).toHaveLength(2);
+    expect(container.querySelectorAll('.astryx-step-description')).toHaveLength(
+      2,
+    );
+  });
+});

--- a/packages/themes/probe/src/probeTheme.ts
+++ b/packages/themes/probe/src/probeTheme.ts
@@ -6,7 +6,7 @@
 // test fixture. Regenerate with: pnpm visual:probe-theme
 //
 // defineTheme takes six things and this covers all six:
-//   components  272 targets, 881 selectors (generated from the docs)
+//   components  274 targets, 883 selectors (generated from the docs)
 //   tokens      custom properties, read back off the themed element
 //   icons       every registry entry swapped for a marked glyph
 //   indicators  check / radio / checkbox swapped — the swap that reaches furthest
@@ -4541,12 +4541,28 @@ export const probeTheme = defineTheme({
         outlineColor: 'hsl(142.0 87% 25%)',
       },
     },
+    'step-description': {
+      base: {
+        backgroundColor: 'hsl(28.6 77% 50%)',
+        color: 'hsl(226.0 70% 12%)',
+        borderColor: 'hsl(354.8 93% 25%)',
+        outlineColor: 'hsl(33.0 90% 25%)',
+      },
+    },
     'step-indicator': {
       base: {
         backgroundColor: 'hsl(326.1 89% 62%)',
         color: 'hsl(66.4 77% 12%)',
         borderColor: 'hsl(109.9 93% 25%)',
         outlineColor: 'hsl(179.2 75% 25%)',
+      },
+    },
+    'step-label': {
+      base: {
+        backgroundColor: 'hsl(25.1 77% 47%)',
+        color: 'hsl(323.4 90% 12%)',
+        borderColor: 'hsl(185.0 92% 25%)',
+        outlineColor: 'hsl(186.3 83% 25%)',
       },
     },
     stepper: {


### PR DESCRIPTION
## Why

A Step label and description declare their own typography and color, so themes cannot reach them through the existing `step` target by inheritance. Stable targets replace brittle structural selectors on the existing painted spans.

[#5495](https://github.com/facebook/astryx/pull/5495) has now merged the current Stepper contract, Connector anatomy, `--step-connector-gap`, and DEC-1. This PR is rebased on that authority and no longer carries a competing full Stepper record.

## What

- Adds `step-label` and `step-description` in both indicator positions.
- Both targets reflect `progress` and `status`; `step-label` alone reflects `disabled`, because only the label owns disabled text paint.
- Amends the current spec with FR9–FR11 and DEC-2. Connector semantics are unchanged, and the merged DEC-1 text is byte-for-byte preserved; there are no new open questions.
- Drops the duplicate RTL target already supplied by #5495 and keeps the generated probe diff scoped to the two Stepper targets.

The spec is 218 → 245 lines (+27 net). The existing record already exceeded the soft 200-line target; shrinking it further would rewrite settled #5495 authority rather than make this amendment smaller.

## Dependency

[#5953](https://github.com/facebook/astryx/pull/5953) separately owns two pre-existing generated `readonly` selectors from #5805. After it lands, this PR needs one final main rebase and probe regeneration; its generated diff will remain Stepper-only while the standard probe check becomes clean.

## Compatibility

Additive. Existing label and description spans gain stable classes and state attributes. No element, prop, export, default style, or Connector behavior changes.

## Validation

- Focused Vitest: 2 files, 471 tests passed (61 Stepper + 410 theming-target tests)
- `@astryxdesign/core` typecheck and build passed
- Storybook production build passed
- `check:knowledge`, `check:repo`, and `git diff --check` passed
- Chromium + generated probe theme passed in separated and on-track layouts: Step `rgb(5, 56, 29)`, Label `rgb(58, 3, 37)`, Description `rgb(9, 19, 52)`; removing the two text target classes restored their own component colors rather than inheriting Step
- Chromium confirmed `disabled` only on Label and `status` on both text targets
- Full probe generation produced 274 targets / 885 selectors. The committed Stepper-only delta is +2 targets / +2 selectors; #5953 carries the unrelated +2 selector drift from `main`
