### PR TITLE
docs: distinguish bug fixes from API changes

### DIFF
--- a/docs/architecture/public-component-api.md
+++ b/docs/architecture/public-component-api.md
@@ -96,9 +96,13 @@ public promises until promotion.
 ## Change coupling
 
 - Adding or changing an exported prop, type, default, package entry point, ref
-  target, or observable behavior triggers public-API review.
-- Consumer docs and representative tests change with the API in the same pull
-  request.
+  target, or intentional observable contract triggers public-API review.
+- A bug fix that restores an existing current contract or standard is
+  `preserves`. It requires regression evidence, but it does not create a new API
+  decision.
+- Consumer docs change when consumer usage or a documented promise changes, or
+  when the existing docs would otherwise become false. Fixing an implementation
+  defect does not by itself require consumer-doc changes.
 - A new prop includes the admission argument from `spec:AST-002/DEC-1`; it does
   not get accepted only because it solves one callsite.
 - A released breaking change includes the compatibility decision and migration

--- a/docs/contributing/api-conventions.md
+++ b/docs/contributing/api-conventions.md
@@ -219,9 +219,13 @@ Before requesting review:
   open or closed.
 - **Protect compatibility.** State defaults and observable behavior. Include a
   migration for a released breaking change.
-- **Ship evidence together.** Update consumer docs, public exports, focused
-  runtime and type tests, and representative integration coverage in the same
-  pull request.
+- **Ship API evidence together.** When consumer usage or a documented promise
+  changes, update consumer docs, public exports, focused runtime and type tests,
+  and representative integration coverage in the same pull request.
+
+A bug fix that restores an existing current contract or standard is not a new
+API proposal. Add regression evidence. Change consumer docs only when usage or a
+documented promise changes, or when existing docs would otherwise become false.
 
 If two or three viable shapes remain after applying current conventions, use the
 [API Arbitration](https://github.com/facebook/astryx/wiki/API-Arbitration)


### PR DESCRIPTION
## Problem

The first expanded review benchmark produced a false block on PR #5666: a fix restoring existing accessibility behavior was treated as a new API change that required consumer-doc updates.

## Change

Clarify that contract-preserving bug fixes are `preserves`. They need regression evidence, but consumer docs change only when usage or a documented promise changes, or existing docs would otherwise become false.

## Testing

- `node scripts/check-knowledge.mjs`
- `git diff --check`
- public-content leak scan
