### PR TITLE
docs(core): record factual anatomy for four components

### DIFF
--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -1,5 +1,19 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Container',
+    required: true,
+    description: 'Circular painted container for the supplied icon.',
+  },
+  {
+    name: 'Icon',
+    required: true,
+    description: 'Caller-supplied visual content rendered inside the container.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -29,6 +43,7 @@ export const docs = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'NavIcon is a circular icon container with an accent-colored background. Use it in navigation headers such as TopNavHeading and PageNavHeader to visually identify a section or application.',
     bestPractices: [
@@ -61,6 +76,7 @@ export const docsZh = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'NavIcon is a circular icon container with an accent-colored background. Use it in navigation headers such as TopNavHeading and PageNavHeader to visually identify a section or application.',
     bestPractices: [
@@ -76,6 +92,7 @@ export const docsDense = {
   description:
     'Circular icon container w/ accent background for navigation headers.',
   usage: {
+    anatomy,
     description:
       'NavIcon is a circular icon container with an accent-colored background. Use it in navigation headers such as TopNavHeading and PageNavHeader to visually identify a section or application.',
     bestPractices: [

--- a/packages/core/src/NavIcon/NavIcon.spec.md
+++ b/packages/core/src/NavIcon/NavIcon.spec.md
@@ -1,0 +1,133 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:NavIcon
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [packages/core/src/NavIcon/NavIcon.test.tsx, scripts/check-knowledge.mjs]
+families: []
+design_specs: []
+architecture:
+  [architecture:component-theming-surface, architecture:public-component-api]
+contributing: []
+system_specs: []
+---
+
+# NavIcon component contract
+
+## Intent
+
+NavIcon renders caller-supplied icon content inside a circular navigation
+container. This draft records the current consumer anatomy and theming ownership
+without changing runtime behavior or target compatibility.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, aliases, and public API remain unchanged
+- Controlled/uncontrolled behavior: not applicable
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The circular container and its current `nav-icon` theming target.
+
+**Does not own / non-goals**
+
+- The artwork or component supplied through `icon` — owned by the caller.
+- Interaction semantics — NavIcon remains a display-only container.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props and usage remain documented
+in `NavIcon.doc.mjs`.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                              | Basis                           | Draft review state                                 |
+| --- | ------------------------------------------------------------------------------------------------ | ------------------------------- | -------------------------------------------------- |
+| FR1 | The current render contains a circular container and the caller-supplied icon content.           | Current source, docs, and tests | Verified current behavior; no new behavior decided |
+| FR2 | The container carries `nav-icon`; the deprecated `navicon` alias remains compatibility metadata. | Current source, docs, and tests | Verified current behavior; no target change        |
+
+### Allowed variation
+
+- Caller-supplied icon artwork and implementation may vary without becoming
+  NavIcon-owned anatomy.
+
+### Representative states
+
+- The documented anatomy is the same for every caller-supplied icon.
+
+### Transformation and precedence order
+
+- No new ordering rule is introduced.
+
+### Performance and resources
+
+- No new performance or resource rule is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend NavIcon's existing accessibility behavior.
+
+## Design relationships
+
+| Anatomy or state | Design requirement                             | Representation authority       | Hierarchy role    | Component contract |
+| ---------------- | ---------------------------------------------- | ------------------------------ | ----------------- | ------------------ |
+| Container        | Presents the current circular painted surface. | Current source and public docs | Supporting        | FR1, FR2           |
+| Icon             | Presents caller-supplied visual content.       | Caller-supplied content        | Context-dependent | FR1                |
+
+The deprecated `navicon` alias is compatibility metadata, not a separate anatomy
+part or current target.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Container": {"target": "nav-icon"},
+  "Icon": {"inherits": "nav-icon"}
+}
+```
+
+## Family and system relationships
+
+This draft references the current shared owners without restating their rules:
+`architecture:component-theming-surface` and
+`architecture:public-component-api`. The deprecated `navicon` alias remains
+compatibility metadata rather than separate anatomy.
+
+## Verification map
+
+| Contract            | Verification                         | Representative states                 | Mutation or failure expectation                                                       | Audit section           |
+| ------------------- | ------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------- | ----------------------- |
+| FR1                 | `NavIcon.test.tsx` content suite     | Caller-supplied icon                  | Removing the container or supplied content fails existing render and ref assertions.  | `audit:NavIcon/anatomy` |
+| FR2                 | `NavIcon.test.tsx` target-name suite | Current and deprecated target classes | Removing either emitted compatibility class fails the existing target assertion.      | `audit:NavIcon/theming` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`        | Canonical anatomy and current target  | Missing, extra, prefixed, stale, or alias-backed mappings fail repository validation. | `audit:NavIcon/theming` |
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design
+decision.
+
+## Open questions
+
+None.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables, examples, implementation
+steps, or system rules. It links to their owners.

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -1,5 +1,19 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Section container',
+    required: true,
+    description: 'Painted container that groups a page region.',
+  },
+  {
+    name: 'Consumer content',
+    required: false,
+    description: 'Caller-provided content rendered inside the section container.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -99,6 +113,7 @@ export const docs = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'Section is the correct way to create page regions and group related content on a page. Use it for settings groups, form sections, sidebar areas, or any time you need visual separation between parts of a page. If you are tempted to use a Card for a page section, use Section instead.',
     bestPractices: [
@@ -206,6 +221,7 @@ export const docsZh = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'Section is the correct way to create page regions and group related content on a page. Use it for settings groups, form sections, sidebar areas, or any time you need visual separation between parts of a page. If you are tempted to use a Card for a page section, use Section instead.',
     bestPractices: [
@@ -223,6 +239,7 @@ export const docsDense = {
   description:
     'Page-level container for grouping content into regions. Use INSTEAD of Card for settings panels, form groups, and page sections.',
   usage: {
+    anatomy,
     description:
       'Section creates page regions. Use for settings groups, form sections, sidebar areas. If you want to visually separate a part of a page, use Section, not Card. Cards are for discrete items (one profile, one notification).',
     bestPractices: [

--- a/packages/core/src/Section/Section.spec.md
+++ b/packages/core/src/Section/Section.spec.md
@@ -1,0 +1,138 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:Section
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [packages/core/src/Section/Section.test.tsx, scripts/check-knowledge.mjs]
+families: [family:layout-regions]
+design_specs: []
+architecture:
+  [
+    architecture:component-theming-surface,
+    architecture:container-padding,
+    architecture:public-component-api,
+  ]
+contributing: []
+system_specs: []
+---
+
+# Section component contract
+
+## Intent
+
+Section renders a painted container for a page region and places caller-provided
+content inside it. This draft records current consumer anatomy and theming
+ownership without changing layout, styling, targets, or public API.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, and public API remain unchanged
+- Controlled/uncontrolled behavior: not applicable
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The painted section container and its existing `section` theming target.
+
+**Does not own / non-goals**
+
+- The caller-provided content rendered inside the section.
+- The outer layout wrapper as a consumer-facing anatomy part or theming target.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props and usage remain documented
+in `Section.doc.mjs`.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                         | Basis                           | Draft review state                                 |
+| --- | ----------------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| FR1 | The current render places caller-provided content inside the inner container carrying the `section` target. | Current source, docs, and tests | Verified current behavior; no new behavior decided |
+
+### Allowed variation
+
+- Caller-provided content may vary without becoming Section-owned anatomy.
+
+### Representative states
+
+- The anatomy and target ownership are unchanged across the documented section
+  variants, sizes, dividers, and padding inputs.
+
+### Transformation and precedence order
+
+- No new layout or style precedence rule is introduced.
+
+### Performance and resources
+
+- No new performance or resource rule is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend Section's existing accessibility behavior.
+
+## Design relationships
+
+| Anatomy or state  | Design requirement                                          | Representation authority       | Hierarchy role    | Component contract |
+| ----------------- | ----------------------------------------------------------- | ------------------------------ | ----------------- | ------------------ |
+| Section container | Presents the current painted page-region container.         | Current source and public docs | Supporting        | FR1                |
+| Consumer content  | Presents content supplied by the caller inside the section. | Caller-supplied content        | Context-dependent | FR1                |
+
+The outer layout wrapper remains implementation structure and is not listed as
+consumer anatomy.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Section container": {"target": "section"},
+  "Consumer content": {
+    "none": {
+      "reason": "unsettled: No Section theming target reaches caller-provided content."
+    }
+  }
+}
+```
+
+## Family and system relationships
+
+This draft references the current shared owners without restating their rules:
+`family:layout-regions`, `architecture:component-theming-surface`,
+`architecture:container-padding`, and `architecture:public-component-api`.
+
+## Verification map
+
+| Contract            | Verification                               | Representative states                | Mutation or failure expectation                                                         | Audit section           |
+| ------------------- | ------------------------------------------ | ------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------- |
+| FR1                 | `Section.test.tsx` structure/target suites | Inner container and consumer content | Moving or removing the target or content fails existing structure and class assertions. | `audit:Section/anatomy` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`              | Canonical anatomy and current target | Missing, extra, prefixed, or stale mappings fail repository validation.                 | `audit:Section/theming` |
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design
+decision.
+
+## Open questions
+
+None.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables, examples, implementation
+steps, or system rules. It links to their owners.

--- a/packages/core/src/Skeleton/Skeleton.doc.mjs
+++ b/packages/core/src/Skeleton/Skeleton.doc.mjs
@@ -1,5 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Placeholder',
+    required: true,
+    description: 'Painted shape that stands in for content while it loads.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -49,6 +58,7 @@ export const docs = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'An animated shimmer placeholder that previews the shape of content while it loads. Use it to build loading screens that match the layout of the real content. For content with unknown dimensions, use Spinner instead.',
     bestPractices: [
@@ -98,6 +108,7 @@ export const docsZh = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'An animated shimmer placeholder that previews the shape of content while it loads. Use it to build loading screens that match the layout of the real content. For content with unknown dimensions, use Spinner instead.',
     bestPractices: [
@@ -113,6 +124,7 @@ export const docsZh = {
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   usage: {
+    anatomy,
     description:
       'An animated shimmer placeholder that previews the shape of content while it loads. Use it to build loading screens that match the layout of the real content. For content with unknown dimensions, use Spinner instead.',
     bestPractices: [

--- a/packages/core/src/Skeleton/Skeleton.spec.md
+++ b/packages/core/src/Skeleton/Skeleton.spec.md
@@ -1,0 +1,126 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:Skeleton
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [packages/core/src/Skeleton/Skeleton.test.tsx, scripts/check-knowledge.mjs]
+families: []
+design_specs: []
+architecture:
+  [architecture:component-theming-surface, architecture:public-component-api]
+contributing: []
+system_specs: []
+---
+
+# Skeleton component contract
+
+## Intent
+
+Skeleton renders a placeholder shape while surrounding content loads. This draft
+records the component's current consumer anatomy and theming ownership without
+changing its runtime contract.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, and public API remain unchanged
+- Controlled/uncontrolled behavior: not applicable
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The rendered placeholder shape and its existing `skeleton` theming target.
+
+**Does not own / non-goals**
+
+- The surrounding content's loading state, layout, or replacement timing — owned
+  by the product callsite.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props and usage remain documented
+in `Skeleton.doc.mjs`.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                 | Basis                           | Draft review state                                 |
+| --- | ----------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| FR1 | The current render contains one painted placeholder carrying the `skeleton` target. | Current source, docs, and tests | Verified current behavior; no new behavior decided |
+
+### Allowed variation
+
+- This documentation does not constrain behavior beyond the factual anatomy and
+  target relationship recorded here.
+
+### Representative states
+
+- The anatomy and target relationship is the same for the documented size,
+  radius, and animation inputs.
+
+### Transformation and precedence order
+
+- No new ordering rule is introduced.
+
+### Performance and resources
+
+- No new performance or resource rule is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend Skeleton's existing accessibility behavior.
+
+## Design relationships
+
+| Anatomy or state | Design requirement                         | Representation authority       | Hierarchy role | Component contract |
+| ---------------- | ------------------------------------------ | ------------------------------ | -------------- | ------------------ |
+| Placeholder      | Represents the current painted loading UI. | Current source and public docs | Supporting     | FR1                |
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Placeholder": {"target": "skeleton"}
+}
+```
+
+## Family and system relationships
+
+This draft references the current shared owners without restating their rules:
+`architecture:component-theming-surface` and
+`architecture:public-component-api`.
+
+## Verification map
+
+| Contract            | Verification                     | Representative states                | Mutation or failure expectation                                         | Audit section            |
+| ------------------- | -------------------------------- | ------------------------------------ | ----------------------------------------------------------------------- | ------------------------ |
+| FR1                 | `Skeleton.test.tsx` render suite | A rendered placeholder               | Removing the placeholder fails the existing render assertion.           | `audit:Skeleton/anatomy` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`    | Canonical anatomy and current target | Missing, extra, prefixed, or stale mappings fail repository validation. | `audit:Skeleton/theming` |
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design
+decision.
+
+## Open questions
+
+None.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables, examples, implementation
+steps, or system rules. It links to their owners.

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -1,5 +1,19 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Tooltip surface',
+    required: true,
+    description: 'Painted overlay surface that presents the tooltip.',
+  },
+  {
+    name: 'Tooltip text',
+    required: true,
+    description: 'Tooltip content rendered within the surface.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -110,6 +124,7 @@ export const docs = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'A short text hint that appears on hover or focus, anchored to a trigger element. Use it to describe icon-only buttons, show the full text of truncated labels, or provide supplementary context without cluttering the UI.',
     bestPractices: [
@@ -217,6 +232,7 @@ export const docsZh = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'A short text hint that appears on hover or focus, anchored to a trigger element. Use it to describe icon-only buttons, show the full text of truncated labels, or provide supplementary context without cluttering the UI.',
     bestPractices: [
@@ -233,6 +249,7 @@ export const docsZh = {
 export const docsDense = {
   description: 'Hover/focus triggered tooltip for displaying short, non-interactive text anchored to trigger element.',
   usage: {
+    anatomy,
     description:
       'A short text hint that appears on hover or focus, anchored to a trigger element. Use it to describe icon-only buttons, show the full text of truncated labels, or provide supplementary context without cluttering the UI.',
     bestPractices: [

--- a/packages/core/src/Tooltip/Tooltip.spec.md
+++ b/packages/core/src/Tooltip/Tooltip.spec.md
@@ -1,0 +1,141 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:Tooltip
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [packages/core/src/Tooltip/Tooltip.test.tsx, scripts/check-knowledge.mjs]
+families: [family:overlay-dismissal]
+design_specs: []
+architecture:
+  [
+    architecture:component-theming-surface,
+    architecture:interaction-modality,
+    architecture:layer-runtime,
+    architecture:public-component-api,
+  ]
+contributing: []
+system_specs: []
+---
+
+# Tooltip component contract
+
+## Intent
+
+Tooltip renders supplied tooltip content on an owned overlay surface associated
+with a caller-owned trigger. This draft records current consumer anatomy and
+theming ownership without deciding layer behavior, positioning, or new visual
+parts.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, and public API remain unchanged
+- Controlled/uncontrolled behavior: unchanged
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The rendered tooltip surface and content inside that surface.
+
+**Does not own / non-goals**
+
+- The trigger element — supplied by the caller or referenced externally and
+  outside Tooltip's owned anatomy.
+- An arrow element — the current implementation renders none.
+- Layer lifecycle, light dismissal, and anchor-positioning policy — outside this
+  factual anatomy backfill.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props and usage remain documented
+in `Tooltip.doc.mjs` and `useTooltip.doc.mjs`.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                  | Basis                           | Draft review state                                 |
+| --- | ---------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| FR1 | The current rendered tooltip contains one owned surface with the supplied tooltip content inside it. | Current source, docs, and tests | Verified current behavior; no new behavior decided |
+| FR2 | The surface carries the current `tooltip` target; its content has no separate target.                | Current source and public docs  | Verified current behavior; no target change        |
+
+### Allowed variation
+
+- Supplied content may vary without adding a Tooltip-owned child target.
+
+### Representative states
+
+- The owned anatomy is unchanged across wrapped-trigger and external-anchor
+  modes; the trigger remains outside it.
+
+### Transformation and precedence order
+
+- No new ordering or positioning rule is introduced.
+
+### Performance and resources
+
+- No new performance or resource rule is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend Tooltip's existing accessibility behavior.
+
+## Design relationships
+
+| Anatomy or state | Design requirement                                  | Representation authority       | Hierarchy role | Component contract |
+| ---------------- | --------------------------------------------------- | ------------------------------ | -------------- | ------------------ |
+| Tooltip surface  | Presents the current painted overlay surface.       | Current source and public docs | Supporting     | FR1, FR2           |
+| Tooltip text     | Presents supplied content within the owned surface. | Current source and public docs | Prominent      | FR1, FR2           |
+
+The trigger is caller-owned and outside this anatomy. The current implementation
+has no arrow element.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Tooltip surface": {"target": "tooltip"},
+  "Tooltip text": {"inherits": "tooltip"}
+}
+```
+
+## Family and system relationships
+
+This draft references the current shared owners without restating their rules:
+`architecture:component-theming-surface`, `family:overlay-dismissal`,
+`architecture:interaction-modality`, `architecture:layer-runtime`, and
+`architecture:public-component-api`.
+
+## Verification map
+
+| Contract            | Verification                          | Representative states                 | Mutation or failure expectation                                                  | Audit section           |
+| ------------------- | ------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------- | ----------------------- |
+| FR1                 | `Tooltip.test.tsx` role/content suite | Rendered surface and supplied content | Removing the surface or content fails existing tooltip role and text assertions. | `audit:Tooltip/anatomy` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`         | Canonical anatomy and current target  | Missing, extra, prefixed, or stale mappings fail repository validation.          | `audit:Tooltip/theming` |
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design
+or layer-system decision.
+
+## Open questions
+
+None.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables, examples, layer-system rules,
+implementation steps, or system rules. It links to their owners.


### PR DESCRIPTION
## Why

Theme authors need the consumer-visible parts of Skeleton, NavIcon, Tooltip, and Section mapped to their existing theming surfaces without adding targets or exposing implementation structure.

## What

- Adds shared consumer anatomy arrays to the English, Chinese, and dense doc variants.
- Adds draft component contracts with factual anatomy maps: Skeleton placeholder → `skeleton`; NavIcon container → `nav-icon` and caller-supplied icon → inherits `nav-icon`; Tooltip surface → `tooltip` and tooltip text → inherits `tooltip`; Section container → `section` and caller content → no Section target.
- Keeps NavIcon's deprecated `navicon` alias out of current anatomy, Tooltip's trigger outside owned anatomy, and records that Tooltip currently renders no arrow.

## Risk

Documentation only. No runtime, public API, DOM, styling, target, alias, or behavior change.

## Testing

- `pnpm check:knowledge`
- `vitest run scripts/check-knowledge.test.mjs packages/core/src/Skeleton/Skeleton.test.tsx packages/core/src/NavIcon/NavIcon.test.tsx packages/core/src/Tooltip/Tooltip.test.tsx packages/core/src/Section/Section.test.tsx packages/core/src/theme/themingTargets.test.ts` (503 tests)
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/cli typecheck:authoring`
- Prettier on new specs and changed doc ranges
- `pnpm check:repo`

Stacked on #5744 while the shared layout records are held. Component contracts use template v3 factual-none classification.


