### PR TITLE
fix(field): separate tooltip status presentation

### DIFF
--- a/.changeset/field-status-tooltip-boundary.md
+++ b/.changeset/field-status-tooltip-boundary.md
@@ -1,0 +1,10 @@
+---
+'@astryxdesign/core': minor
+---
+
+[breaking] FieldStatus now limits its direct `variant` prop to the presentations it renders: `attached` and `detached`. The Field family still supports `statusVariant="tooltip"` through the new `FieldStatusPresentation` type. (#5738)
+@cixzhang
+
+If you imported `FieldStatusVariant` from `@astryxdesign/core/Field` to type a Field-family `statusVariant`, rename it to `FieldStatusPresentation`. Direct `<FieldStatus variant="tooltip">` usage must move to `attached` or `detached`, or use a Field-family control whose `statusVariant="tooltip"` surfaces the message from its on-field affordance.
+
+**Codemod:** `npx astryx upgrade --codemod rename-field-status-presentation-type --apply` retargets imports only when every use is directly on a known Field-family component's `statusVariant` prop. Standalone annotations, root imports, re-exports, mixed direct `FieldStatus` usage, and other ambiguous cases require manual review.

--- a/packages/cli/assets/codemods/transforms/next/__tests__/rename-field-status-presentation-type.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/rename-field-status-presentation-type.test.mjs
@@ -1,0 +1,116 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} =
+    await import('../rename-field-status-presentation-type.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j = jscodeshift.withParser('tsx');
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('rename-field-status-presentation-type', () => {
+  it('retargets a cast directly on a Field-family statusVariant prop', async () => {
+    const input = `import {Field, type FieldStatusVariant} from '@astryxdesign/core/Field';
+const field = (
+  <Field label="Email" inputID="email" statusVariant={'tooltip' as FieldStatusVariant}>
+    <input id="email" />
+  </Field>
+);`;
+
+    const output = await applyTransform(input);
+
+    expect(output).toContain(`FieldStatusPresentation as FieldStatusVariant`);
+    expect(output).toContain(`statusVariant={'tooltip' as FieldStatusVariant}`);
+  });
+
+  it('recognizes aliased Field-family components and type imports', async () => {
+    const input = `import {TextInput as Input} from '@astryxdesign/core/TextInput';
+import type {FieldStatusVariant as Presentation} from '@astryxdesign/core/Field';
+const field = <Input label="Email" value="" onChange={() => {}} statusVariant={'tooltip' as Presentation} />;`;
+
+    const output = await applyTransform(input);
+
+    expect(output).toContain(`FieldStatusPresentation as Presentation`);
+    expect(output).toContain(`'tooltip' as Presentation`);
+  });
+
+  it('leaves a standalone type annotation unchanged because its use is ambiguous', async () => {
+    const input = `import type {FieldStatusVariant} from '@astryxdesign/core/Field';
+const presentation: FieldStatusVariant = 'tooltip';`;
+
+    expect(await applyTransform(input)).toBe(input);
+  });
+
+  it('leaves mixed Field-family and direct FieldStatus usage unchanged', async () => {
+    const input = `import {Field, FieldStatus, type FieldStatusVariant} from '@astryxdesign/core/Field';
+const content = (
+  <>
+    <Field label="Email" inputID="email" statusVariant={'tooltip' as FieldStatusVariant}>
+      <input id="email" />
+    </Field>
+    <FieldStatus type="error" message="Invalid" variant={'attached' as FieldStatusVariant} />
+  </>
+);`;
+
+    expect(await applyTransform(input)).toBe(input);
+  });
+
+  it('does not collide with an existing FieldStatusPresentation import', async () => {
+    const input = `import {Field, type FieldStatusVariant, type FieldStatusPresentation} from '@astryxdesign/core/Field';
+const field = <Field label="Email" inputID="email" statusVariant={'tooltip' as FieldStatusVariant}><input id="email" /></Field>;
+const other: FieldStatusPresentation = 'attached';`;
+
+    const output = await applyTransform(input);
+
+    expect(output).toContain(
+      `FieldStatusPresentation as FieldStatusVariant, type FieldStatusPresentation`,
+    );
+    expect(output).toContain(`const other: FieldStatusPresentation`);
+  });
+
+  it('leaves a parameter shadowing an imported Field-family component unchanged', async () => {
+    const input = `import {Field, type FieldStatusVariant} from '@astryxdesign/core/Field';
+function Example(Field: React.ComponentType<any>) {
+  return <Field statusVariant={'tooltip' as FieldStatusVariant} />;
+}`;
+
+    expect(await applyTransform(input)).toBe(input);
+  });
+
+  it('leaves a local binding shadowing an imported Field-family component unchanged', async () => {
+    const input = `import {TextInput, type FieldStatusVariant} from '@astryxdesign/core/Field';
+function Example() {
+  const TextInput = CustomInput;
+  return <TextInput statusVariant={'tooltip' as FieldStatusVariant} />;
+}`;
+
+    expect(await applyTransform(input)).toBe(input);
+  });
+
+  it('is idempotent', async () => {
+    const input = `import {Field, type FieldStatusVariant} from '@astryxdesign/core/Field';
+const field = <Field label="Email" inputID="email" statusVariant={'tooltip' as FieldStatusVariant}><input id="email" /></Field>;`;
+
+    const once = await applyTransform(input);
+    expect(await applyTransform(once)).toBe(once);
+  });
+
+  it('leaves re-exports for manual migration', async () => {
+    const input = `export type {FieldStatusVariant} from '@astryxdesign/core/Field';`;
+
+    expect(await applyTransform(input)).toBe(input);
+  });
+
+  it('leaves ambiguous root and direct-component imports unchanged', async () => {
+    const rootImport = `import type {FieldStatusVariant} from '@astryxdesign/core';`;
+    const directImport = `import type {FieldStatusVariant} from '@astryxdesign/core/FieldStatus';`;
+
+    expect(await applyTransform(rootImport)).toBe(rootImport);
+    expect(await applyTransform(directImport)).toBe(directImport);
+  });
+});

--- a/packages/cli/assets/codemods/transforms/next/index.mjs
+++ b/packages/cli/assets/codemods/transforms/next/index.mjs
@@ -7,4 +7,14 @@
  * this file into the resolved version folder.
  */
 
-export default [];
+import renameFieldStatusPresentationType, {
+  meta as renameFieldStatusPresentationTypeMeta,
+} from './rename-field-status-presentation-type.mjs';
+
+export default [
+  {
+    name: 'rename-field-status-presentation-type',
+    transform: renameFieldStatusPresentationType,
+    meta: renameFieldStatusPresentationTypeMeta,
+  },
+];

--- a/packages/cli/assets/codemods/transforms/next/rename-field-status-presentation-type.mjs
+++ b/packages/cli/assets/codemods/transforms/next/rename-field-status-presentation-type.mjs
@@ -1,0 +1,206 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: Retarget provably Field-family FieldStatusVariant imports
+ *
+ * FieldStatusVariant now describes only variants rendered by FieldStatus.
+ * Field-family statusVariant props use FieldStatusPresentation, which also
+ * includes the tooltip sentinel consumed before FieldStatus renders.
+ *
+ * The Field subpath exports both Field and FieldStatus, so an import alone does
+ * not reveal which contract the type describes. This transform changes an
+ * import only when every reference to that binding is a cast written directly
+ * on a known Field-family component's `statusVariant` JSX prop. All other uses
+ * remain unchanged for manual review.
+ */
+
+export const meta = {
+  title: 'Retarget Field status presentation type imports',
+  description:
+    'Retargets FieldStatusVariant imports only when every use is directly on ' +
+    'a known Field-family statusVariant prop. Ambiguous and mixed direct-' +
+    'FieldStatus uses remain unchanged for manual review.',
+  pr: '#5738',
+};
+
+const FIELD_IMPORT_SOURCES = new Set([
+  '@astryxdesign/core/Field',
+  '@xds/core/Field',
+]);
+
+const FIELD_FAMILY_COMPONENTS = new Set([
+  'ComplexSelector',
+  'DateInput',
+  'DateRangeInput',
+  'Field',
+  'FileInput',
+  'MultiSelector',
+  'NumberInput',
+  'PowerSearch',
+  'RichTextEditor',
+  'Selector',
+  'TextArea',
+  'TextInput',
+  'TimeInput',
+  'Tokenizer',
+  'TransferList',
+  'Typeahead',
+]);
+
+const FIELD_FAMILY_IMPORT_PREFIXES = [
+  '@astryxdesign/core',
+  '@astryxdesign/lab',
+  '@astryxdesign/richtext',
+  '@xds/core',
+];
+
+/** @param {string} source */
+function isFieldFamilyImportSource(source) {
+  return FIELD_FAMILY_IMPORT_PREFIXES.some(
+    prefix => source === prefix || source.startsWith(`${prefix}/`),
+  );
+}
+
+/** @param {any} node */
+function jsxIdentifierName(node) {
+  return node?.type === 'JSXIdentifier' ? node.name : null;
+}
+
+/** @param {any} identifierPath */
+function isInsideImport(identifierPath) {
+  for (let path = identifierPath; path != null; path = path.parentPath) {
+    if (path.node?.type === 'ImportDeclaration') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @param {any} identifierPath
+ * @param {Map<string, any>} fieldFamilyBindings
+ */
+function isSafeStatusVariantTypeReference(identifierPath, fieldFamilyBindings) {
+  let expressionPath = null;
+  for (let path = identifierPath; path != null; path = path.parentPath) {
+    if (
+      path.node?.type === 'TSAsExpression' ||
+      path.node?.type === 'TSTypeAssertion'
+    ) {
+      expressionPath = path;
+      break;
+    }
+    if (path.node?.type === 'ImportDeclaration') {
+      return false;
+    }
+  }
+  if (expressionPath == null) {
+    return false;
+  }
+
+  const containerPath = expressionPath.parentPath;
+  const attributePath = containerPath?.parentPath;
+  const openingPath = attributePath?.parentPath;
+  if (
+    containerPath?.node?.type !== 'JSXExpressionContainer' ||
+    attributePath?.node?.type !== 'JSXAttribute' ||
+    jsxIdentifierName(attributePath.node.name) !== 'statusVariant' ||
+    openingPath?.node?.type !== 'JSXOpeningElement'
+  ) {
+    return false;
+  }
+
+  const componentName = jsxIdentifierName(openingPath.node.name);
+  if (componentName == null) {
+    return false;
+  }
+  const importScope = fieldFamilyBindings.get(componentName);
+  return (
+    importScope != null &&
+    openingPath.get('name').scope.lookup(componentName) === importScope
+  );
+}
+
+/**
+ * @param {import('../../../../authoring/codemod/type').AstryxCodemodFile} file
+ * @param {import('../../../../authoring/codemod/type').CodemodTransformApi} api
+ * @returns {string | null | undefined}
+ */
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  /** @type {Map<string, any>} */
+  const fieldFamilyBindings = new Map();
+  let hasChanges = false;
+
+  root.find(j.ImportDeclaration).forEach((/** @type {any} */ path) => {
+    const source = path.node.source.value;
+    if (!isFieldFamilyImportSource(source)) {
+      return;
+    }
+    for (const specifier of path.node.specifiers ?? []) {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        FIELD_FAMILY_COMPONENTS.has(specifier.imported.name)
+      ) {
+        fieldFamilyBindings.set(
+          specifier.local?.name ?? specifier.imported.name,
+          path.scope,
+        );
+      }
+    }
+  });
+
+  root.find(j.ImportDeclaration).forEach((/** @type {any} */ path) => {
+    if (!FIELD_IMPORT_SOURCES.has(path.node.source.value)) {
+      return;
+    }
+
+    for (const [index, specifier] of (path.node.specifiers ?? []).entries()) {
+      if (
+        specifier.type !== 'ImportSpecifier' ||
+        specifier.imported.name !== 'FieldStatusVariant'
+      ) {
+        continue;
+      }
+
+      const localName = specifier.local?.name ?? specifier.imported.name;
+      const importScope = path.scope;
+      /** @type {any[]} */
+      const references = [];
+      root
+        .find(j.Identifier, {name: localName})
+        .forEach((/** @type {any} */ identifierPath) => {
+          if (
+            !isInsideImport(identifierPath) &&
+            identifierPath.scope.lookup(localName) === importScope
+          ) {
+            references.push(identifierPath);
+          }
+        });
+
+      if (
+        references.length === 0 ||
+        !references.every((/** @type {any} */ identifierPath) =>
+          isSafeStatusVariantTypeReference(identifierPath, fieldFamilyBindings),
+        )
+      ) {
+        continue;
+      }
+
+      // Preserve the local binding so no consumer references need rewriting.
+      const replacement = j.importSpecifier(
+        j.identifier('FieldStatusPresentation'),
+        j.identifier(localName),
+      );
+      replacement.importKind = specifier.importKind;
+      path.node.specifiers[index] = replacement;
+      hasChanges = true;
+    }
+  });
+
+  if (!hasChanges) {
+    return undefined;
+  }
+  return root.toSource({quote: 'single'});
+}

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -28,7 +28,11 @@ import React, {
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
-import {Field, inputWrapperStyles, type FieldStatusVariant} from '../Field';
+import {
+  Field,
+  inputWrapperStyles,
+  type FieldStatusPresentation,
+} from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Spinner} from '../Spinner';
 import {useTranslator} from '../i18n';
@@ -260,7 +264,7 @@ export interface ComplexSelectorProps<Value> extends Omit<
   /** Validation status. */
   status?: ComplexSelectorStatus;
   /** Status placement. */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /** Tooltip text displayed next to the label. */
   labelTooltip?: string;
   /** Trigger and field size. */

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -41,7 +41,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Icon} from '../Icon';
 import {VisuallyHidden} from '../VisuallyHidden';
@@ -308,7 +308,7 @@ export interface DateInputProps extends Omit<
    * - 'tooltip': no message box; the status icon becomes a focusable info-tip button that reveals the message on hover, keyboard focus, or tap
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
 
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -43,7 +43,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
@@ -408,7 +408,7 @@ export interface DateRangeInputProps extends Omit<
    * - 'tooltip': no message box; the status icon becomes a focusable info-tip button that reveals the message on hover, keyboard focus, or tap
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
 
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is

--- a/packages/core/src/Field/Field.tsx
+++ b/packages/core/src/Field/Field.tsx
@@ -65,6 +65,12 @@ export type {SizeValue} from '../utils/types';
 
 export type FieldStatusType = 'warning' | 'error' | 'success';
 
+/**
+ * Status presentation used by Field-family components. `tooltip` is a sentinel
+ * consumed by the field composition before it renders FieldStatus.
+ */
+export type FieldStatusPresentation = FieldStatusVariant | 'tooltip';
+
 export interface FieldStatusInput {
   /**
    * The type of status to display.
@@ -160,7 +166,7 @@ export interface FieldProps extends Omit<
    * - 'tooltip': No message box; the input surfaces status through a tooltip on its on-field icon
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is
    * (e.g. `'100%'`). Sizes the whole field — label, control, and status — so

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -15,6 +15,7 @@ export {Field} from './Field';
 export type {
   FieldProps,
   FieldStatusInput,
+  FieldStatusPresentation,
   FieldStatusType,
 } from './Field';
 export {FieldLabel} from './FieldLabel';

--- a/packages/core/src/FieldStatus/FieldStatus.test.tsx
+++ b/packages/core/src/FieldStatus/FieldStatus.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen, waitFor} from '@testing-library/react';
 import * as stylex from '@stylexjs/stylex';
 import {FieldStatus} from './FieldStatus';
+import type {FieldStatusVariant} from './FieldStatus';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
 const testStyles = stylex.create({
@@ -32,6 +33,12 @@ afterEach(() => {
 
 describe('FieldStatus', () => {
   it('renders the message text', () => {
+    const directVariants: FieldStatusVariant[] = ['attached', 'detached'];
+    // @ts-expect-error tooltip is a Field-family sentinel, not a FieldStatus variant
+    const tooltip: FieldStatusVariant = 'tooltip';
+    expect(directVariants).toEqual(['attached', 'detached']);
+    expect(tooltip).toBe('tooltip');
+
     render(<FieldStatus type="error" message="This field is required" />);
     expect(screen.getByText('This field is required')).toBeInTheDocument();
   });

--- a/packages/core/src/FieldStatus/FieldStatus.tsx
+++ b/packages/core/src/FieldStatus/FieldStatus.tsx
@@ -129,9 +129,7 @@ export interface FieldStatusProps extends BaseProps<HTMLDivElement> {
  * decorative for assistive tech (`aria-hidden`): the message text already names
  * the status in words and is announced through the live region. The `attached`
  * variant keeps its status affordance on the bordered input, so it renders no
- * icon here to avoid a duplicate. The `tooltip` variant renders no message box
- * at all — the input surfaces the status through a tooltip on its on-field
- * icon — so callers skip rendering FieldStatus for it.
+ * icon here to avoid a duplicate.
  *
  * Screen-reader announcements go through the persistent `useAnnounce` live
  * regions (assertive for errors, polite otherwise) rather than `role`/

--- a/packages/core/src/FieldStatus/index.ts
+++ b/packages/core/src/FieldStatus/index.ts
@@ -25,7 +25,6 @@
 export interface FieldStatusVariantMap {
   attached: true;
   detached: true;
-  tooltip: true;
 }
 
 export {FieldStatus} from './FieldStatus';

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -40,7 +40,7 @@ import {
   Field,
   InputClearButton,
   type InputStatus,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
@@ -374,7 +374,7 @@ export interface FileInputProps extends Omit<
    * - 'tooltip': no message box; the status icon becomes a focusable info-tip button that reveals the message on hover, keyboard focus, or tap
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * Description text displayed below the label.
    */

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -36,7 +36,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputWrapperStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {useKeepLayerOpenProps} from '../Layer/useLayer';
 import {InternalInputClearButton} from '../Field/InputClearButton';
@@ -557,7 +557,7 @@ export interface MultiSelectorProps<
    * - 'tooltip': message is exposed from the on-field status icon
    * @default 'attached' for input selectors; 'detached' for ghost selectors
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
 
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -45,7 +45,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {VisuallyHidden} from '../VisuallyHidden';
@@ -301,7 +301,7 @@ interface NumberInputPropsBase extends Omit<
    * - 'tooltip': no message box; the status icon becomes a focusable info-tip button that reveals the message on hover, keyboard focus, or tap
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * The size of the input.
    * - 'sm': Compact size (28px height)

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -37,7 +37,7 @@ import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {Icon} from '../Icon';
 import type {IconType} from '../Icon';
 import type {IconName} from '../Icon/globalIconRegistry';
-import type {InputStatus, FieldStatusVariant} from '../Field';
+import type {InputStatus, FieldStatusPresentation} from '../Field';
 import {usePopover} from '../Popover/usePopover';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {
@@ -409,7 +409,7 @@ export interface PowerSearchProps extends Omit<
    * - 'detached': message floats below as a separate element with spacing
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /** Max width for dropdown menu. */
   menuWidth?: number;
   /** Max display length for filter token values. @default 40 */

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -39,7 +39,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputWrapperStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Divider} from '../Divider';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
@@ -577,7 +577,7 @@ interface SelectorPropsBase<
    * - 'tooltip': message is exposed from the on-field status icon
    * @default 'attached' for input selectors; 'detached' for ghost selectors
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
 
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -41,7 +41,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Spinner} from '../Spinner';
@@ -290,7 +290,7 @@ export interface TextAreaProps extends Omit<
    * - 'tooltip': no message box; the status icon becomes a focusable info-tip button that reveals the message on hover, keyboard focus, or tap
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is
    * (e.g. `'100%'`). Sizes the whole field (label, control, and status) so they

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -41,7 +41,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {renderIconSlot, type IconType} from '../Icon';
 import {Spinner} from '../Spinner';
@@ -198,7 +198,7 @@ export interface TextInputProps extends Omit<
    * - 'tooltip': no message box; the status icon becomes a focusable info-tip button that reveals the message on hover, keyboard focus, or tap
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * The size of the input.
    * - 'sm': Compact size (18px height)

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -43,7 +43,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
@@ -289,7 +289,7 @@ export interface TimeInputProps extends Omit<
    * - 'tooltip': no message box; the status icon becomes a focusable info-tip button that reveals the message on hover, keyboard focus, or tap
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
 
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -37,7 +37,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Token} from '../Token';
 import {renderIconSlot, type IconType} from '../Icon';
@@ -118,7 +118,7 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
    * - 'detached': message floats below as a separate element with spacing
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * Icon to display at the start of the input.
    * Accepts a ReactNode (e.g. `<Icon icon={SearchIcon} />`) or an SVG icon component directly.

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -36,7 +36,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '../Field';
 import {Token} from '../Token';
 import {useTooltip} from '../Tooltip';
@@ -83,7 +83,7 @@ export interface TypeaheadProps<T extends SearchableItem> extends Omit<
    * - 'detached': message floats below as a separate element with spacing
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * Icon to display at the start of the input.
    * Accepts a ReactNode (e.g. `<Icon icon={SearchIcon} />`) or an SVG icon component directly.

--- a/packages/core/src/hooks/useInputStatusIcon.test.tsx
+++ b/packages/core/src/hooks/useInputStatusIcon.test.tsx
@@ -10,7 +10,7 @@ import {DateInput} from '../DateInput/DateInput';
 import {DateRangeInput} from '../DateRangeInput/DateRangeInput';
 import {TimeInput} from '../TimeInput/TimeInput';
 import {FileInput} from '../FileInput/FileInput';
-import type {FieldStatusVariant} from '../FieldStatus/FieldStatus';
+import type {FieldStatusPresentation} from '../Field/Field';
 
 // Every id referenced by an aria-describedby must resolve to an element in the
 // document (WCAG 1.3.1) — a described-by pointing at a non-rendered node is a
@@ -28,9 +28,9 @@ function expectNoDanglingDescribedBy(root: HTMLElement) {
   }
 }
 
-const VARIANTS: FieldStatusVariant[] = ['attached', 'detached', 'tooltip'];
+const VARIANTS: FieldStatusPresentation[] = ['attached', 'detached', 'tooltip'];
 
-const INPUTS: [string, (variant: FieldStatusVariant) => ReactElement][] = [
+const INPUTS: [string, (variant: FieldStatusPresentation) => ReactElement][] = [
   [
     'TextInput',
     v => (

--- a/packages/core/src/hooks/useInputStatusIcon.tsx
+++ b/packages/core/src/hooks/useInputStatusIcon.tsx
@@ -36,7 +36,7 @@ import {useCallback, useEffect, useState} from 'react';
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Icon, type IconName, type IconSize} from '../Icon';
-import type {FieldStatusVariant} from '../FieldStatus/FieldStatus';
+import type {FieldStatusPresentation} from '../Field/Field';
 import type {InputStatus, InputStatusType} from '../Field/types';
 import {useTooltip} from '../Tooltip';
 import {useTranslator} from '../i18n';
@@ -103,7 +103,7 @@ export interface UseInputStatusIconOptions {
   /** The input's status, or undefined when there is none. */
   status?: InputStatus;
   /** How the status is presented relative to the input. */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /** Whether the input is inside an InputGroup (which owns status rendering). */
   isInGroup?: boolean;
   /** Size of the on-field icon. @default 'md' */

--- a/packages/lab/src/TransferList/TransferList.doc.mjs
+++ b/packages/lab/src/TransferList/TransferList.doc.mjs
@@ -224,7 +224,7 @@ export const docs = {
     },
     {
       name: 'statusVariant',
-      type: 'FieldStatusVariant',
+      type: 'FieldStatusPresentation',
       description: 'Placement treatment for the status message.',
     },
     {

--- a/packages/richtext/src/RichTextEditor.tsx
+++ b/packages/richtext/src/RichTextEditor.tsx
@@ -50,7 +50,7 @@ import {
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputStatusFocusWithinStyles,
-  type FieldStatusVariant,
+  type FieldStatusPresentation,
 } from '@astryxdesign/core/Field';
 import type {BaseProps} from '@astryxdesign/core';
 import {useInputStatusIcon} from '@astryxdesign/core/hooks';
@@ -348,7 +348,7 @@ export interface RichTextEditorProps extends Omit<
    *   info-tip button that reveals the message
    * @default 'attached'
    */
-  statusVariant?: FieldStatusVariant;
+  statusVariant?: FieldStatusPresentation;
   /**
    * Width of the field. Numbers are treated as pixels, strings are used as-is
    * (e.g. `'100%'`).


### PR DESCRIPTION
## Why

Direct `FieldStatus` renders only attached and detached message presentations. The `tooltip` value belongs to the Field family, where composing controls consume it before rendering `FieldStatus` and surface the message from an on-field affordance.

This implements the boundary approved in #5736.

## What

- narrow `FieldStatusVariant` to `attached` and `detached`
- add `FieldStatusPresentation` for Field-family `statusVariant` props, including the `tooltip` sentinel
- add a conservative migration codemod only for casts directly on known Field-family `statusVariant` props
- add a breaking Changeset with manual guidance for ambiguous root imports and direct JSX

No runtime rendering, DOM, styling, or ARIA behavior changes.

## Compatibility

This is a TypeScript breaking change for direct `FieldStatus variant=\"tooltip\"` usage and for Field-family code that explicitly annotated values as `FieldStatusVariant`. Existing Field-family `statusVariant=\"tooltip\"` behavior remains unchanged; those annotations move to `FieldStatusPresentation`.

## Testing

- `pnpm test --run packages/core/src/FieldStatus/FieldStatus.test.tsx packages/core/src/Field/Field.test.tsx packages/core/src/hooks/useInputStatusIcon.test.tsx` (95 passed)
- migration codemod tests (10 passed, including parameter/local shadowing and idempotence)
- Core, Lab, RichText, and strict CLI typechecks
- `pnpm check:repo`