### PR TITLE
fix(ci): accept trusted legacy PR metadata

### DIFF
--- a/.github/scripts/lib/pr-preview.test.mjs
+++ b/.github/scripts/lib/pr-preview.test.mjs
@@ -12,6 +12,7 @@ import {
   createUnavailableDeploymentResult,
   reconcilePrComment,
   resolveWorkflowRunPullRequest,
+  validateAnalysisMetadata,
   writeDeploymentResult,
 } from './pr-preview.mjs';
 
@@ -269,6 +270,59 @@ describe('trusted PR preview identity', () => {
         run,
       }),
     ).rejects.toThrow(/expected exactly one current pull request/);
+  });
+});
+
+describe('analysis metadata compatibility', () => {
+  it('accepts legacy metadata only when trusted run, PR, and head prefix match', () => {
+    const value = identity();
+    expect(
+      validateAnalysisMetadata(
+        {
+          prNumber: String(value.prNumber),
+          shortHash: value.headSha.slice(0, 7),
+          runId: String(value.sourceRunId),
+        },
+        value,
+      ),
+    ).toBeDefined();
+  });
+
+  it.each([
+    ['prNumber', '9999', /pull request/],
+    ['shortHash', '1234567', /short hash/],
+    ['runId', '9999', /source run/],
+  ])('rejects mismatched legacy %s', (field, mismatch, error) => {
+    const value = identity();
+    expect(() =>
+      validateAnalysisMetadata(
+        {
+          prNumber: String(value.prNumber),
+          shortHash: value.headSha.slice(0, 7),
+          runId: String(value.sourceRunId),
+          [field]: mismatch,
+        },
+        value,
+      ),
+    ).toThrow(error);
+  });
+
+  it('does not ignore mismatched exact identity fields when they are present', () => {
+    const value = identity();
+    expect(() =>
+      validateAnalysisMetadata(
+        {
+          prNumber: value.prNumber,
+          shortHash: value.headSha.slice(0, 7),
+          headSha: 'f'.repeat(40),
+          headRepository: value.headRepository,
+          baseRepository: value.baseRepository,
+          runId: value.sourceRunId,
+          runAttempt: value.sourceRunAttempt,
+        },
+        value,
+      ),
+    ).toThrow(/analysis head does not match/);
   });
 });
 

--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -43,6 +43,18 @@ describe('visual acceptance workflow concurrency', () => {
     );
   });
 
+  it('uses the shared metadata validator for exact and legacy PR artifacts', () => {
+    const value = workflow('pr-comment.yml');
+    const crossCheck = value.slice(
+      value.indexOf('      - name: Cross-check artifact identity'),
+      value.indexOf('      - name: Fetch the trusted visual baseline'),
+    );
+
+    expect(crossCheck).toContain('import {validateAnalysisMetadata}');
+    expect(crossCheck).toContain('validateAnalysisMetadata(metadata, {');
+    expect(crossCheck).not.toContain('meta.headSha !==');
+  });
+
   it('orders trusted preview publication before comment reconciliation', () => {
     const publisher = workflow('deploy-preview.yml');
     const comment = workflow('pr-comment.yml');

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -425,19 +425,18 @@ jobs:
           EXPECTED_RUN: ${{ steps.identity.outputs.run_id }}
           EXPECTED_ATTEMPT: ${{ steps.identity.outputs.run_attempt }}
         run: |
-          node - <<'NODE'
-          const fs = require('node:fs');
-          const meta = JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8'));
-          const fail = (message) => { console.error(`::error::${message}`); process.exit(1); };
-          if (String(meta.prNumber) !== process.env.EXPECTED_PR) fail('artifact PR number does not match trusted PR');
-          if (meta.headSha !== process.env.EXPECTED_HEAD) fail('artifact head does not match trusted PR head');
-          if (meta.headRepository !== process.env.EXPECTED_HEAD_REPO) fail('artifact head repository does not match trusted PR');
-          if (meta.baseRepository !== process.env.EXPECTED_BASE_REPO) fail('artifact base repository does not match trusted PR');
-          if (String(meta.runId) !== process.env.EXPECTED_RUN) fail('artifact run id does not match workflow_run');
-          if (String(meta.runAttempt) !== process.env.EXPECTED_ATTEMPT) fail('artifact run attempt does not match workflow_run');
-          const shortHash = String(meta.shortHash ?? '');
-          if (!/^[0-9a-f]{7,40}$/.test(shortHash)) fail('artifact head is not a valid hash');
-          if (!process.env.EXPECTED_HEAD.startsWith(shortHash)) fail('artifact short hash does not match trusted PR head');
+          node --input-type=module - <<'NODE'
+          import fs from 'node:fs';
+          import {validateAnalysisMetadata} from './.github/scripts/lib/pr-preview.mjs';
+          const metadata = JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8'));
+          validateAnalysisMetadata(metadata, {
+            prNumber: process.env.EXPECTED_PR,
+            headSha: process.env.EXPECTED_HEAD,
+            headRepository: process.env.EXPECTED_HEAD_REPO,
+            baseRepository: process.env.EXPECTED_BASE_REPO,
+            sourceRunId: process.env.EXPECTED_RUN,
+            sourceRunAttempt: process.env.EXPECTED_ATTEMPT,
+          });
           NODE
 
       - name: Fetch the trusted visual baseline


### PR DESCRIPTION
## Summary
- validate PR analysis metadata through the shared trusted validator instead of requiring fields older open PRs never emitted
- retain exact PR number, source run ID, and head-prefix checks for legacy artifacts
- continue enforcing every exact identity field whenever it is present

## Why
A live recovery for [#5671](https://github.com/facebook/astryx/pull/5671) used a fresh trusted CI run, but its older branch emits the pre-proof `pr-meta.json` shape. Current default-branch publication rejected it before reaching the now-fixed tall screenshot.

## Test plan
- `pnpm exec vitest run .github/scripts/lib/pr-preview.test.mjs .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `pnpm exec actionlint -ignore 'label "2-core-ubuntu-arm" is unknown' .github/workflows/pr-comment.yml`
- `pnpm check:repo`
- `git diff --check`