### PR TITLE
docs(core): record factual anatomy batch 11

### DIFF
--- a/packages/core/src/Markdown/Markdown.doc.mjs
+++ b/packages/core/src/Markdown/Markdown.doc.mjs
@@ -1,5 +1,62 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Document',
+    required: true,
+    description:
+      'Root container for block or inline Markdown content.',
+  },
+  {
+    name: 'Heading',
+    required: false,
+    description:
+      'Rendered heading block; a custom heading renderer replaces the default part.',
+  },
+  {
+    name: 'Paragraph',
+    required: false,
+    description:
+      'Rendered paragraph block; a custom paragraph renderer replaces the default part.',
+  },
+  {
+    name: 'List',
+    required: false,
+    description:
+      'Ordered, unordered, or task-list block rendered from Markdown items.',
+  },
+  {
+    name: 'Code block',
+    required: false,
+    description:
+      'Fenced code block; a custom code renderer replaces the default part.',
+  },
+  {
+    name: 'Blockquote',
+    required: false,
+    description:
+      'Quoted block; a custom blockquote renderer replaces the default part.',
+  },
+  {
+    name: 'Table',
+    required: false,
+    description: 'Scrollable table block rendered from Markdown rows and columns.',
+  },
+  {
+    name: 'Divider',
+    required: false,
+    description:
+      'Horizontal rule block; a custom hr renderer replaces the default part.',
+  },
+  {
+    name: 'Image',
+    required: false,
+    description:
+      'Block image or unsafe-URL fallback; a custom image renderer replaces a safe default image.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -168,6 +225,7 @@ export const docs = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'Renders a markdown string as Astryx-styled components. Use Markdown for user-generated content, AI responses, and documentation; it handles headings, lists, tables, code blocks, and citations with consistent styling.',
     bestPractices: [
@@ -381,6 +439,7 @@ export const docsZh = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'Renders a markdown string as Astryx-styled components. Use Markdown for user-generated content, AI responses, and documentation; it handles headings, lists, tables, code blocks, and citations with consistent styling.',
     bestPractices: [
@@ -397,6 +456,7 @@ export const docsDense = {
   description:
     'Renders markdown string as Astryx-styled components. Use for user-generated content, AI responses, docs. Headings, lists, tables, code, citations w/ consistent styling.',
   usage: {
+    anatomy,
     description:
       'Renders a markdown string as Astryx-styled components. Use Markdown for user-generated content, AI responses, and documentation; it handles headings, lists, tables, code blocks, and citations with consistent styling.',
     bestPractices: [

--- a/packages/core/src/Markdown/Markdown.spec.md
+++ b/packages/core/src/Markdown/Markdown.spec.md
@@ -1,0 +1,200 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:Markdown
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [
+    packages/core/src/Markdown/Markdown.test.tsx,
+    packages/core/src/theme/themingTargets.test.ts,
+    scripts/check-knowledge.mjs,
+  ]
+families: []
+design_specs: []
+architecture: [architecture:component-theming-surface]
+contributing: []
+system_specs: []
+---
+
+# Markdown component contract
+
+## Intent
+
+Markdown renders parsed content in a Document with stable default block parts.
+This draft records the nine current Markdown targets and the custom-renderer
+boundary without changing parsing, runtime behavior, styling, targets, or public
+API.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, aliases, and public API remain unchanged
+- Controlled/uncontrolled behavior: not applicable
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The Document and its current `markdown` target in block and inline display.
+- Default Heading, Paragraph, List, Code block, Blockquote, Table, Divider, and
+  Image block presentation and the eight current block targets documented below.
+- Applying block spacing and reflected density (plus Heading level) to those
+  targets on the default render path.
+
+**Does not own / non-goals**
+
+- Output supplied by custom `heading`, `paragraph`, `code`, `blockquote`, `hr`,
+  or `image` renderers; the custom component owns that replacement's structure
+  and styling.
+- Inline emphasis, link, inline-code, citation, or plugin output as additional
+  block anatomy.
+- Nested anatomy or targets owned by CodeBlock, Blockquote, List, CheckboxList,
+  or Table.
+- New block types, custom-renderer behavior, target names, public API, or runtime
+  behavior.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props, renderer hooks, defaults,
+and usage remain documented in `Markdown.doc.mjs`.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                                                                                                                                                            | Basis                                                  | Draft review state                                     |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------ |
+| FR1 | Block and inline displays render one Document root carrying the current `markdown` target. Inline display renders no block anatomy.                                                                                                            | Current source, docs, and tests                        | Verified current behavior; no new behavior decided     |
+| FR2 | On the default block render path, Heading, Paragraph, List, Code block, Blockquote, Table, Divider, and Image carry the eight current local block targets documented below.                                                                    | Current source, docs, tests, and history               | Verified current inventory and placement               |
+| FR3 | A supplied `heading`, `paragraph`, `code`, `blockquote`, `hr`, or safe-URL `image` renderer replaces the corresponding default part, so Markdown does not impose that part's local target on the replacement.                                  | Current source, docs, and history                      | Verified behavior; focused absence coverage is partial |
+| FR4 | The released Code block target is spelled `markdown-codeblock`. Although this runs together a compound name and predates the current naming rule, it is a frozen public target and this factual backfill neither renames it nor adds an alias. | Current source, docs, tests, history, and architecture | Verified compatibility constraint; no target change    |
+| FR5 | Density and Heading level remain reflected capabilities on their owning targets. Display mode, density, Heading level, streaming state, list kind, and custom-renderer selection do not become separate anatomy entries.                       | Current source, docs, tests, and architecture          | Verified current model; no new anatomy or state target |
+
+### Allowed variation
+
+- **AV1 — Parsed content.** The number and ordering of block parts may vary with
+  the Markdown source without changing their ownership.
+- **AV2 — Lists.** Ordered, unordered, and task lists share the List anatomy and
+  current `markdown-list` target.
+- **AV3 — Custom renderers.** Supported custom block renderers may replace their
+  default part and own its styling without receiving a Markdown block target.
+- **AV4 — Nested primitives.** Astryx primitives used inside default blocks may
+  change internal element shape while preserving their own public contracts and
+  Markdown's outer block targets.
+
+### Representative states
+
+| State                  | Required invariant                                                                                                  | Allowed variation                                          |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Default block content  | Every parsed block uses its corresponding current Markdown target.                                                  | Block count, order, density, content width, and alignment. |
+| Custom block renderers | The replaced Heading, Paragraph, Code block, Blockquote, Divider, or Image lacks the corresponding Markdown target. | Replacement structure and styling.                         |
+| Ordered/unordered list | List carries `markdown-list`.                                                                                       | Marker kind, start value, item count, and nested content.  |
+| Task list              | The outer List part carries `markdown-list`.                                                                        | Checked values and item content.                           |
+| Safe block image       | Default Image carries `markdown-image`, or a custom image renderer replaces it.                                     | Source and alternative text.                               |
+| Unsafe block image URL | Markdown renders its fallback Image part with `markdown-image`; no custom image renderer receives the rejected URL. | Alternative text shown by the fallback.                    |
+| Inline display         | Document carries `markdown`; no block target renders.                                                               | Inline text, links, code, citations, and plugin output.    |
+
+### Transformation and precedence order
+
+- No new parsing, sanitization, heading-level, renderer-selection, spacing, or
+  styling precedence rule is introduced.
+
+### Performance and resources
+
+- No new parsing, streaming, render, or resource requirement is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend Markdown's existing document semantics,
+heading IDs, paragraph role, list semantics, scrollable Table wrapper, image
+alternative text, or custom-renderer responsibilities.
+
+## Design relationships
+
+| Anatomy or state | Design requirement                                                               | Representation authority       | Hierarchy role | Component contract |
+| ---------------- | -------------------------------------------------------------------------------- | ------------------------------ | -------------- | ------------------ |
+| Document         | Contains block or inline rendered Markdown content.                              | Current source and public docs | Supporting     | FR1, FR5           |
+| Heading          | Presents one parsed heading with its resolved level and optional generated ID.   | Current source and public docs | Prominent      | FR2, FR3, FR5      |
+| Paragraph        | Presents one prose block using the default composition-safe paragraph structure. | Current source and public docs | Prominent      | FR2, FR3           |
+| List             | Presents ordered, unordered, or task-list items as one block.                    | Current source and public docs | Prominent      | FR2, FR5           |
+| Code block       | Presents fenced code and owns the outer spacing target on the default path.      | Current source and public docs | Prominent      | FR2, FR3, FR4      |
+| Blockquote       | Presents quoted block content on the default path.                               | Current source and public docs | Prominent      | FR2, FR3           |
+| Table            | Presents parsed rows and columns in a keyboard-scrollable block wrapper.         | Current source and public docs | Prominent      | FR2                |
+| Divider          | Presents a horizontal separation between blocks.                                 | Current source and public docs | Supporting     | FR2, FR3           |
+| Image            | Presents a safe block image or the fallback for a rejected image URL.            | Current source and public docs | Prominent      | FR2, FR3           |
+
+Custom renderers replace six default parts rather than becoming nested Markdown
+anatomy. Lists and Tables have no corresponding custom block renderer. The
+Document remains Markdown-owned in every display mode.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Document": {"target": "markdown"},
+  "Heading": {"target": "markdown-heading"},
+  "Paragraph": {"target": "markdown-paragraph"},
+  "List": {"target": "markdown-list"},
+  "Code block": {"target": "markdown-codeblock"},
+  "Blockquote": {"target": "markdown-blockquote"},
+  "Table": {"target": "markdown-table"},
+  "Divider": {"target": "markdown-hr"},
+  "Image": {"target": "markdown-image"}
+}
+```
+
+The map records all nine current targets on Markdown's default render paths. For
+Heading, Paragraph, Code block, Blockquote, Divider, and safe Image, a custom
+renderer replaces the default part and therefore replaces its local target. The
+`markdown-codeblock` spelling is a released compatibility anomaly: the current
+naming rule would produce `markdown-code-block`, but shipped targets are frozen
+and this change preserves the existing spelling exactly.
+
+## Family and system relationships
+
+- `architecture:component-theming-surface` owns anatomy qualification, target
+  mapping, target-capability state, composition boundaries, and compatibility for
+  frozen targets.
+- Nested Astryx primitives retain ownership of their own anatomy and targets;
+  Markdown owns the outer block targets listed here.
+
+## Verification map
+
+| Contract            | Verification                                                                                           | Representative states                                        | Mutation or failure expectation                                                                                       | Audit section            |
+| ------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| FR1                 | `Markdown.test.tsx` root-class, block-root, inline-root, and base-prop suites                          | Block and inline Document                                    | Removing or moving the root target fails focused root assertions or the global inventory.                             | `audit:Markdown/anatomy` |
+| FR2, FR4, FR5       | `Markdown.test.tsx` block-spacing-target, density, Heading-level, task-list, and render suites         | All eight default block types, both densities, Heading level | Removing, renaming, or moving a block target fails focused class or reflected-property assertions.                    | `audit:Markdown/theming` |
+| FR3                 | `Markdown.test.tsx` custom Heading and custom Image suites plus source and target-introduction history | Six replaceable default block parts                          | Imposing a target on a custom replacement violates the owner boundary; only Heading absence is directly pinned today. | `audit:Markdown/theming` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                          | Canonical anatomy and all nine current targets               | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                            | `audit:Markdown/theming` |
+
+Focused tests pin all nine current target names and default block placement. They
+pin target absence only for a custom Heading; custom Paragraph, Code block,
+Blockquote, Divider, and Image replacement paths currently rely on source and
+history for the same ownership rule.
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design,
+API, behavior, or theming decision.
+
+## Open questions
+
+- **OQ1 — Which focused tests should pin target absence for the five remaining
+  custom block replacement paths?** (`checkable`)
+
+## Content boundary
+
+This file does not duplicate consumer prop tables/examples, parser mechanics,
+streaming implementation, nested primitive contracts, current audit results, or
+system theming rules. It links to their owners.

--- a/packages/core/src/Pagination/Pagination.doc.mjs
+++ b/packages/core/src/Pagination/Pagination.doc.mjs
@@ -1,5 +1,76 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Pagination',
+    required: true,
+    description:
+      'Navigation landmark containing the current paging controls and optional page-size selector.',
+  },
+  {
+    name: 'Page-size selector',
+    required: false,
+    description: 'Optional Selector for choosing how many items appear per page.',
+  },
+  {
+    name: 'First/last buttons',
+    required: false,
+    description:
+      'Optional Button controls that jump to the first or last known page.',
+  },
+  {
+    name: 'Previous/next buttons',
+    required: true,
+    description:
+      'Button controls that move backward or forward through the pages.',
+  },
+  {
+    name: 'Page number button',
+    required: false,
+    description:
+      'Button for one directly selectable page in the numbered presentation.',
+  },
+  {
+    name: 'Ellipsis',
+    required: false,
+    description:
+      'Visual omission marker between non-adjacent page-number buttons.',
+  },
+  {
+    name: 'Count readout',
+    required: false,
+    description:
+      'Text showing the current item range and total item count.',
+  },
+  {
+    name: 'Compact readout',
+    required: false,
+    description: 'Text showing the current page and total page count.',
+  },
+  {
+    name: 'Dot',
+    required: false,
+    description:
+      'Page indicator control that reflects and changes the active page.',
+  },
+  {
+    name: 'Page input label',
+    required: false,
+    description: 'Leading visible label for the editable page-number field.',
+  },
+  {
+    name: 'Page input',
+    required: false,
+    description: 'NumberInput used to enter a page directly.',
+  },
+  {
+    name: 'Page input total',
+    required: false,
+    description: 'Trailing text showing the known total page count.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -138,6 +209,7 @@ export const docs = {
     },
   },
   usage: {
+    anatomy,
     description:
       'Pagination lets users step through pages of content. Place it below a table, list, or card grid so users can move forward and backward through results. Pick a variant to match the context: numbered pages for data tables, a count for large lists, compact for tight spaces, or dots for carousels.',
     bestPractices: [
@@ -280,6 +352,7 @@ export const docsZh = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'Pagination lets users step through pages of content. Place it below a table, list, or card grid so users can move forward and backward through results. Pick a variant to match the context: numbered pages for data tables, a count for large lists, compact for tight spaces, or dots for carousels.',
     bestPractices: [
@@ -300,6 +373,7 @@ export const docsDense = {
   description:
     'Standalone pagination controls for navigating content pages. Supports multiple display variants + works w/ known totals or cursor-based pagination.',
   usage: {
+    anatomy,
     description:
       'Pagination lets users step through pages of content. Place it below a table, list, or card grid so users can move forward and backward through results. Pick a variant to match the context: numbered pages for data tables, a count for large lists, compact for tight spaces, or dots for carousels.',
     bestPractices: [

--- a/packages/core/src/Pagination/Pagination.spec.md
+++ b/packages/core/src/Pagination/Pagination.spec.md
@@ -1,0 +1,225 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:Pagination
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [
+    packages/core/src/Pagination/Pagination.test.tsx,
+    packages/core/src/Button/Button.test.tsx,
+    packages/core/src/Text/Text.test.tsx,
+    packages/core/src/NumberInput/NumberInput.test.tsx,
+    packages/core/src/Selector/Selector.test.tsx,
+    packages/core/src/theme/themingTargets.test.ts,
+    scripts/check-knowledge.mjs,
+  ]
+families: []
+design_specs: []
+architecture: [architecture:component-theming-surface]
+contributing: []
+system_specs: []
+---
+
+# Pagination component contract
+
+## Intent
+
+Pagination presents controls for moving through pages and may let people choose a
+page size or enter a page directly. This draft records its current consumer
+anatomy, four local theming targets, delegated control ownership, and current
+unreached Ellipsis without changing runtime behavior, styling, targets, or public
+API.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, aliases, and public API remain unchanged
+- Controlled/uncontrolled behavior: unchanged
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The Pagination navigation landmark and its current `pagination` target.
+- The Dot, Page input label, and Page input total parts and their current
+  `pagination-dot`, `pagination-input-label`, and `pagination-input-total`
+  targets.
+- Choosing which stable controls and readouts render for the current paging
+  configuration.
+
+**Does not own / non-goals**
+
+- Button, Text, NumberInput, or Selector presentation and targets; those remain
+  owned by their respective components.
+- Button icon artwork or other internals of delegated controls.
+- A public target for Ellipsis; none exists on current `main`.
+- New paging behavior, variants, state, public API, or theming targets.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props, presentations, defaults,
+and usage remain documented in `Pagination.doc.mjs`.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                | Basis                                  | Draft review state                                                        |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------- |
+| FR1 | The current render contains one Pagination landmark and Previous/next buttons. Page-size selector, First/last buttons, Page number buttons, Ellipsis, Count readout, Compact readout, Dots, Page input label, Page input, and Page input total appear only when their existing conditions are met. | Current source, docs, and tests        | Verified current behavior; no new behavior decided                        |
+| FR2 | Pagination, Dot, Page input label, and Page input total carry the four current local targets `pagination`, `pagination-dot`, `pagination-input-label`, and `pagination-input-total`.                                                                                                               | Current source, docs, and history      | Verified current inventory; focused placement coverage is absent          |
+| FR3 | Page-size selector delegates to Selector; First/last, Previous/next, and Page number buttons delegate to Button; Count and Compact readouts delegate to Text; Page input delegates to NumberInput.                                                                                                 | Current source and owner evidence      | Verified current ownership; no target change                              |
+| FR4 | Ellipsis is stable visible Pagination-rendered content in a numbered presentation and currently carries no public target.                                                                                                                                                                          | Current source, tests, and target docs | Verified current reachability; long-term theming intent remains unsettled |
+
+### Allowed variation
+
+- **AV1 — Paging data.** Current page, total pages, total items, page size, and
+  stride may vary without changing anatomy ownership.
+- **AV2 — Presentation.** Existing presentation selection changes which optional
+  stable parts are present; presentation names and runtime states are not anatomy.
+- **AV3 — Delegated rendering.** Button, Text, NumberInput, and Selector may
+  change internal element shape while preserving their own public contracts.
+
+### Representative states
+
+| State                         | Required invariant                                                                | Allowed variation                                  |
+| ----------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Numbered, known page count    | Page number buttons render; Ellipsis appears only where pages are omitted.        | Page count, sibling range, and active page.        |
+| Count with known item total   | Count readout renders between Previous/next buttons.                              | Range and total text.                              |
+| Compact with known page count | Compact readout renders between Previous/next buttons.                            | Current and total page text.                       |
+| Dots with known page count    | One Dot renders for each page and active state stays on the Dot target.           | Dot count and active Dot.                          |
+| Input with known page count   | Page input label, Page input, and Page input total render; First/last may render. | Label text and first/last opt-out.                 |
+| Input with unknown page count | Page input label and disabled Page input remain; total and First/last are absent. | Cursor-backed current page.                        |
+| None                          | Previous/next buttons remain without a presentation-specific part between them.   | Enabled state follows current paging availability. |
+
+The optional Page-size selector may precede the paging controls in any current
+presentation when page-size options are provided.
+
+### Transformation and precedence order
+
+- No new page calculation, range generation, optimistic update, or styling
+  precedence rule is introduced.
+
+### Performance and resources
+
+- No new performance or resource rule is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend Pagination's existing navigation landmark,
+button naming, current-page semantics, roving Dot focus, live announcements, or
+input bounds.
+
+## Design relationships
+
+| Anatomy or state      | Design requirement                                                 | Representation authority       | Hierarchy role | Component contract |
+| --------------------- | ------------------------------------------------------------------ | ------------------------------ | -------------- | ------------------ |
+| Pagination            | Groups the page-size and paging controls in a navigation landmark. | Current source and public docs | Supporting     | FR1, FR2           |
+| Page-size selector    | Lets people choose the number of items shown per page.             | `component:Selector`           | Supporting     | FR1, FR3           |
+| First/last buttons    | Jump directly to the first or last known page.                     | `component:Button`             | Supporting     | FR1, FR3           |
+| Previous/next buttons | Move backward or forward through pages.                            | `component:Button`             | Prominent      | FR1, FR3           |
+| Page number button    | Selects one page directly in the numbered presentation.            | `component:Button`             | Prominent      | FR1, FR3           |
+| Ellipsis              | Indicates an omitted span of page numbers.                         | Current source and public docs | Supporting     | FR1, FR4           |
+| Count readout         | Presents the visible item range and total.                         | `component:Text`               | Prominent      | FR1, FR3           |
+| Compact readout       | Presents the current and total page counts.                        | `component:Text`               | Prominent      | FR1, FR3           |
+| Dot                   | Presents and selects one page in the dot presentation.             | Current source and public docs | Prominent      | FR1, FR2           |
+| Page input label      | Names the editable page field visually.                            | Current source and public docs | Supporting     | FR1, FR2           |
+| Page input            | Accepts a direct page-number entry.                                | `component:NumberInput`        | Prominent      | FR1, FR3           |
+| Page input total      | Presents the known total after the editable page field.            | Current source and public docs | Supporting     | FR1, FR2           |
+
+The three Button rows are separate stable controls with different conditions and
+jobs; they do not create Pagination-owned Button targets. Presentation values,
+size, disabled state, and active state remain capabilities on owning targets,
+not anatomy entries.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Pagination": {"target": "pagination"},
+  "Page-size selector": {
+    "delegatesTo": {"owner": "component:Selector", "target": "selector"}
+  },
+  "First/last buttons": {
+    "delegatesTo": {"owner": "component:Button", "target": "button"}
+  },
+  "Previous/next buttons": {
+    "delegatesTo": {"owner": "component:Button", "target": "button"}
+  },
+  "Page number button": {
+    "delegatesTo": {"owner": "component:Button", "target": "button"}
+  },
+  "Ellipsis": {
+    "none": {
+      "reason": "unsettled: no current public target is applied to the Pagination-rendered ellipsis"
+    }
+  },
+  "Count readout": {
+    "delegatesTo": {"owner": "component:Text", "target": "text"}
+  },
+  "Compact readout": {
+    "delegatesTo": {"owner": "component:Text", "target": "text"}
+  },
+  "Dot": {"target": "pagination-dot"},
+  "Page input label": {"target": "pagination-input-label"},
+  "Page input": {
+    "delegatesTo": {"owner": "component:NumberInput", "target": "number-input"}
+  },
+  "Page input total": {"target": "pagination-input-total"}
+}
+```
+
+The four local targets are current public seams. Delegated controls retain their
+component owners. Ellipsis has no current target; that factual `none` disposition
+does not decide whether it should remain unreachable.
+
+## Family and system relationships
+
+- `architecture:component-theming-surface` owns anatomy qualification, local
+  target mapping, delegation, state placement, and factual `none` dispositions.
+- Button, Text, NumberInput, and Selector retain ownership of their delegated
+  targets and presentation.
+
+## Verification map
+
+| Contract            | Verification                                                                                         | Representative states                                      | Mutation or failure expectation                                                                    | Audit section              |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------- |
+| FR1                 | `Pagination.test.tsx` presentation, page-size, input, and navigation suites                          | Numbered, count, compact, dots, input, none, known/unknown | Removing or misplacing a stable control fails existing role, text, or interaction assertions.      | `audit:Pagination/anatomy` |
+| FR2                 | Source inspection, public target metadata, target-introduction history, and `themingTargets.test.ts` | Four local targets and their current capabilities          | Removing a current target fails the global inventory; focused placement is not currently pinned.   | `audit:Pagination/theming` |
+| FR3                 | Pagination composition tests plus Button, Text, NumberInput, and Selector target tests and metadata  | All delegated controls and readouts                        | A composed owner losing its target fails owner coverage; replacing it requires this map to change. | `audit:Pagination/theming` |
+| FR4                 | `generatePageRange` tests, render-source inspection, and current target metadata                     | Left, right, and two-sided omission                        | Adding or documenting an Ellipsis target requires an explicit map and target-inventory update.     | `audit:Pagination/theming` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                        | Canonical anatomy and four current local targets           | Missing, extra, prefixed, stale, or multiply assigned local mappings fail repository validation.   | `audit:Pagination/theming` |
+
+Pagination has broad behavior coverage but no focused assertions for placement
+of its four local target classes. Delegated owner tests pin the owner targets;
+Pagination tests pin that the corresponding controls render, not their target
+class composition.
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design,
+API, behavior, or theming decision.
+
+## Open questions
+
+- **OQ1 — Which focused tests should pin placement and reflected properties for
+  the four local Pagination targets?** (`checkable`)
+- **OQ2 — Should Ellipsis gain a stable public theming target?** (`human-api`)
+  Its current lack of reachability is an audit gap, not settled intent.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables/examples, paging algorithms,
+implementation steps, owner-component internals, or system theming rules. It
+links to their owners.


### PR DESCRIPTION
## Why

Theme authors need factual, canonical anatomy records that distinguish owned targets from delegated controls and current reachability gaps.

## What

- records Pagination anatomy with its four live targets, Button/Text/NumberInput/Selector ownership, and the untargeted ellipsis
- records Markdown's nine stable block targets, custom-renderer replacement boundary, and the frozen `markdown-codeblock` spelling
- adds template-v2 draft contracts and machine-checked anatomy maps; changes no runtime, public API, or target

## Risk

Documentation only. No runtime, API, styling, or theming-target behavior changes.

## Testing

- `pnpm check:knowledge`
- focused Pagination, Markdown, and theming Vitest suites (709 tests)
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/cli typecheck:authoring`
- Prettier on the new component specs
- `pnpm check:repo`

No Changeset: documentation-only.
