### PR TITLE
Add Table row status theming target

### DIFF
--- a/.changeset/table-row-status-theming-target.md
+++ b/.changeset/table-row-status-theming-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add a theming target for Table row status indicators.
+
+@rubyycheung

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -30,6 +30,7 @@ export const docs = {
       {className: 'astryx-table-body'},
       {className: 'astryx-table-footer'},
       {className: 'astryx-table-row'},
+      {className: 'astryx-table-row-status', visualProps: ['color', 'presentation']},
       {className: 'astryx-table-cell', visualProps: ['density']},
       {className: 'astryx-table-header-cell', visualProps: ['density']},
       // Still emitted beside the names above, so themes written against

--- a/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx
+++ b/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx
@@ -69,6 +69,9 @@ describe('useTableRowStatus', () => {
     // Default (no icon) renders a plain colored dot: no svg in the indicator.
     const dot = screen.getByRole('img', {name: 'Error'});
     expect(dot.querySelector('svg')).toBeNull();
+    expect(dot).toHaveClass('astryx-table-row-status');
+    expect(dot).toHaveAttribute('data-color', 'red');
+    expect(dot).toHaveAttribute('data-presentation', 'dot');
   });
 
   it('renders no indicator for rows returning null', () => {
@@ -115,6 +118,9 @@ describe('useTableRowStatus', () => {
     // Icon-mode still exposes the accessible label via role=img.
     const indicator = screen.getByRole('img', {name: 'Error'});
     expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveClass('astryx-table-row-status');
+    expect(indicator).toHaveAttribute('data-color', 'red');
+    expect(indicator).toHaveAttribute('data-presentation', 'icon');
     // An SVG icon is rendered inside the indicator (dot mode has no svg).
     expect(indicator.querySelector('svg')).not.toBeNull();
   });

--- a/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx
+++ b/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx
@@ -14,10 +14,12 @@
 
 import {useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {Icon, type IconColor, type IconName} from '../../../Icon';
+import {Icon, type IconName} from '../../../Icon';
 import {Tooltip} from '../../../Tooltip';
 import {useTranslator} from '../../../i18n';
 import {VisuallyHidden} from '../../../VisuallyHidden';
+import {mergeProps} from '../../../utils';
+import {themeProps} from '../../../utils/themeProps';
 import type {TableColumn, TablePlugin} from '../../types';
 
 /**
@@ -49,18 +51,17 @@ const SEMANTIC_COLORS: Record<TableRowStatusColor, string> = {
   gray: 'var(--color-icon-gray)',
 };
 
-/** Icon colors that map cleanly from a semantic status color. */
-const ICON_COLOR_BY_STATUS: Record<TableRowStatusColor, IconColor> = {
-  accent: 'accent',
-  success: 'success',
-  error: 'error',
-  warning: 'warning',
-  red: 'red',
-  orange: 'warning',
-  green: 'green',
-  yellow: 'warning',
-  blue: 'blue',
-  gray: 'gray',
+const SEMANTIC_ICON_COLORS: Record<TableRowStatusColor, string> = {
+  accent: 'var(--color-accent)',
+  success: 'var(--color-success)',
+  error: 'var(--color-error)',
+  warning: 'var(--color-warning)',
+  red: 'var(--color-icon-red)',
+  orange: 'var(--color-warning)',
+  green: 'var(--color-icon-green)',
+  yellow: 'var(--color-warning)',
+  blue: 'var(--color-icon-blue)',
+  gray: 'var(--color-icon-gray)',
 };
 
 /**
@@ -109,6 +110,17 @@ function resolveColor(color: string): string {
   return (SEMANTIC_COLORS as Record<string, string>)[color] ?? color;
 }
 
+function resolveIconColor(color: string): string {
+  return (
+    (SEMANTIC_ICON_COLORS as Record<string, string>)[color] ??
+    'var(--color-icon-primary)'
+  );
+}
+
+function isTableRowStatusColor(color: string): color is TableRowStatusColor {
+  return color in SEMANTIC_COLORS;
+}
+
 const styles = stylex.create({
   // Centers the dot or icon within the narrow status column.
   wrap: {
@@ -116,6 +128,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  icon: (color: string) => ({color}),
   dot: (color: string) => ({
     width: '8px',
     height: '8px',
@@ -166,22 +179,29 @@ export function useTableRowStatus<T extends Record<string, unknown>>(
             if (!status) {
               return null;
             }
+            const presentation = status.icon ? 'icon' : 'dot';
+            const themeColor = isTableRowStatusColor(status.color)
+              ? status.color
+              : undefined;
             const signifier = status.icon ? (
-              <Icon
-                icon={status.icon}
-                size="xsm"
-                color={
-                  ICON_COLOR_BY_STATUS[status.color as TableRowStatusColor] ??
-                  'primary'
-                }
-              />
+              <Icon icon={status.icon} size="xsm" color="inherit" />
             ) : (
               <span {...stylex.props(styles.dot(resolveColor(status.color)))} />
             );
             return (
               <Tooltip content={status.label}>
                 <span
-                  {...stylex.props(styles.wrap)}
+                  {...mergeProps(
+                    themeProps('table-row-status', {
+                      color: themeColor,
+                      presentation,
+                    }),
+                    stylex.props(
+                      styles.wrap,
+                      status.icon &&
+                        styles.icon(resolveIconColor(status.color)),
+                    ),
+                  )}
                   role="img"
                   aria-label={status.label}>
                   {signifier}

--- a/packages/core/src/Table/useTableRowStatus.doc.mjs
+++ b/packages/core/src/Table/useTableRowStatus.doc.mjs
@@ -8,6 +8,14 @@ export const docs = {
   displayName: 'useTableRowStatus',
   description:
     'Hook that returns a TablePlugin which prepends a narrow column signaling per-row status: a colored status dot by default, or an icon when provided (shape + color is more accessible than color alone). getStatus maps a row to a semantic color (mapped to a theme token) or raw CSS color, an optional icon, and a required accessible label (shown in a tooltip on hover and announced to assistive technology, so status is never color-only); return null for no indicator. The column header is visually blank but carries a screen-reader-only localized name ("Row status", i18n key @astryx.table.rowStatus.columnHeader). Memoize getStatus with useCallback for a stable plugin identity.',
+  theming: {
+    targets: [
+      {
+        className: 'astryx-table-row-status',
+        visualProps: ['color', 'presentation'],
+      },
+    ],
+  },
   props: [
     {
       name: 'getStatus',


### PR DESCRIPTION
## Summary
- adds an `astryx-table-row-status` theming target with `color` and `presentation` visual props
- keeps dot/icon behavior caller-controlled while exposing the wrapper for scoped theme overrides
- documents the new target for Table and useTableRowStatus

## Stack
- Base: #5668 palette/theme infra
- Consumer: #5752 Neutral theme color roles

## Validation
- pnpm vitest run packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx
- pre-commit checks from commit hook