### PR TITLE
Rename built-in syntax theme identifiers

### DIFF
--- a/.changeset/neutral-syntax-theme-name.md
+++ b/.changeset/neutral-syntax-theme-name.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/theme-butter': patch
+'@astryxdesign/theme-chocolate': patch
+'@astryxdesign/theme-gothic': patch
+'@astryxdesign/theme-matcha': patch
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/theme-stone': patch
+'@astryxdesign/theme-y2k': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] Rename built-in syntax theme identifiers.
+
+@rubyycheung

--- a/packages/cli/assets/templates/themes/butter/butterTheme.ts
+++ b/packages/cli/assets/templates/themes/butter/butterTheme.ts
@@ -24,7 +24,7 @@ import {butterIconRegistry} from './icons';
 
 /** Butter syntax palette — T25 / T80 of each color's ramp. */
 const butterSyntax = defineSyntaxTheme({
-  name: 'xds-butter',
+  name: 'astryx-butter',
   tokens: {
     keyword: ['#52237b', '#ddb9f6'], // Purple
     string: ['#004800', '#a5d29d'], // Green

--- a/packages/cli/assets/templates/themes/chocolate/chocolateTheme.ts
+++ b/packages/cli/assets/templates/themes/chocolate/chocolateTheme.ts
@@ -13,7 +13,7 @@ import {chocolateIconRegistry} from './icons';
 
 /** Chocolate syntax palette — warm browns and amber tones. */
 const chocolateSyntax = defineSyntaxTheme({
-  name: 'xds-chocolate',
+  name: 'astryx-chocolate',
   tokens: {
     keyword: ['#8C5927', '#d4a06a'],
     string: ['#2e6b4a', '#7bc49e'],

--- a/packages/cli/assets/templates/themes/gothic/gothicTheme.ts
+++ b/packages/cli/assets/templates/themes/gothic/gothicTheme.ts
@@ -24,7 +24,7 @@ import {gothicIconRegistry} from './icons';
  * Single values (no tuples) since this is a dark-only theme.
  */
 const gothicSyntax = defineSyntaxTheme({
-  name: 'xds-gothic',
+  name: 'astryx-gothic',
   tokens: {
     keyword: '#c39adb', // Cathedral plum
     string: '#a3c987', // Forest moss

--- a/packages/cli/assets/templates/themes/matcha/matchaTheme.ts
+++ b/packages/cli/assets/templates/themes/matcha/matchaTheme.ts
@@ -13,7 +13,7 @@ import {matchaIconRegistry} from './icons';
 
 /** Matcha syntax palette — earthy greens and warm tones. */
 const matchaSyntax = defineSyntaxTheme({
-  name: 'xds-matcha',
+  name: 'astryx-matcha',
   tokens: {
     keyword: ['#5a6b2a', '#a8bf6a'],
     string: ['#2e6b4a', '#7bc49e'],

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -562,7 +562,7 @@ function withAlpha(
 }
 
 const neutralSyntax = defineSyntaxTheme({
-  name: 'xds-neutral',
+  name: 'astryx-neutral',
   tokens: {
     keyword: [
       getPaletteStop('purple', 30),

--- a/packages/cli/assets/templates/themes/stone/stoneTheme.ts
+++ b/packages/cli/assets/templates/themes/stone/stoneTheme.ts
@@ -40,7 +40,7 @@ const INPUT_STATUS_VARS = {
  * the stone neutral palette doesn't carry a distinct green stop.
  */
 const stoneSyntax = defineSyntaxTheme({
-  name: 'xds-stone',
+  name: 'astryx-stone',
   tokens: {
     keyword: ['#645a72', '#b2a7c1'], // Purple T40 / T70
     string: ['#4e6357', '#9bb19a'], // Teal T40 / Green T70

--- a/packages/cli/assets/templates/themes/y2k/y2kTheme.ts
+++ b/packages/cli/assets/templates/themes/y2k/y2kTheme.ts
@@ -13,7 +13,7 @@ import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
 import {y2kIconRegistry} from './icons';
 
 const y2kSyntax = defineSyntaxTheme({
-  name: 'xds-y2k',
+  name: 'astryx-y2k',
   tokens: {
     keyword: ['#615a7a', '#aea6ca'],
     string: ['#586242', '#a5af8b'],

--- a/packages/themes/butter/src/butterTheme.ts
+++ b/packages/themes/butter/src/butterTheme.ts
@@ -24,7 +24,7 @@ import {butterIconRegistry} from './icons';
 
 /** Butter syntax palette — T25 / T80 of each color's ramp. */
 const butterSyntax = defineSyntaxTheme({
-  name: 'xds-butter',
+  name: 'astryx-butter',
   tokens: {
     keyword: ['#52237b', '#ddb9f6'], // Purple
     string: ['#004800', '#a5d29d'], // Green

--- a/packages/themes/chocolate/src/chocolateTheme.ts
+++ b/packages/themes/chocolate/src/chocolateTheme.ts
@@ -13,7 +13,7 @@ import {chocolateIconRegistry} from './icons';
 
 /** Chocolate syntax palette — warm browns and amber tones. */
 const chocolateSyntax = defineSyntaxTheme({
-  name: 'xds-chocolate',
+  name: 'astryx-chocolate',
   tokens: {
     keyword: ['#8C5927', '#d4a06a'],
     string: ['#2e6b4a', '#7bc49e'],

--- a/packages/themes/gothic/src/gothicTheme.ts
+++ b/packages/themes/gothic/src/gothicTheme.ts
@@ -24,7 +24,7 @@ import {gothicIconRegistry} from './icons';
  * Single values (no tuples) since this is a dark-only theme.
  */
 const gothicSyntax = defineSyntaxTheme({
-  name: 'xds-gothic',
+  name: 'astryx-gothic',
   tokens: {
     keyword: '#c39adb', // Cathedral plum
     string: '#a3c987', // Forest moss

--- a/packages/themes/matcha/src/matchaTheme.ts
+++ b/packages/themes/matcha/src/matchaTheme.ts
@@ -13,7 +13,7 @@ import {matchaIconRegistry} from './icons';
 
 /** Matcha syntax palette — earthy greens and warm tones. */
 const matchaSyntax = defineSyntaxTheme({
-  name: 'xds-matcha',
+  name: 'astryx-matcha',
   tokens: {
     keyword: ['#5a6b2a', '#a8bf6a'],
     string: ['#2e6b4a', '#7bc49e'],

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -562,7 +562,7 @@ function withAlpha(
 }
 
 const neutralSyntax = defineSyntaxTheme({
-  name: 'xds-neutral',
+  name: 'astryx-neutral',
   tokens: {
     keyword: [
       getPaletteStop('purple', 30),

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -40,7 +40,7 @@ const INPUT_STATUS_VARS = {
  * the stone neutral palette doesn't carry a distinct green stop.
  */
 const stoneSyntax = defineSyntaxTheme({
-  name: 'xds-stone',
+  name: 'astryx-stone',
   tokens: {
     keyword: ['#645a72', '#b2a7c1'], // Purple T40 / T70
     string: ['#4e6357', '#9bb19a'], // Teal T40 / Green T70

--- a/packages/themes/y2k/src/y2kTheme.ts
+++ b/packages/themes/y2k/src/y2kTheme.ts
@@ -13,7 +13,7 @@ import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
 import {y2kIconRegistry} from './icons';
 
 const y2kSyntax = defineSyntaxTheme({
-  name: 'xds-y2k',
+  name: 'astryx-y2k',
   tokens: {
     keyword: ['#615a7a', '#aea6ca'],
     string: ['#586242', '#a5af8b'],


### PR DESCRIPTION
## Summary
- renames the Neutral syntax theme id from `xds-neutral` to `astryx-neutral`
- updates the generated CLI Neutral theme template to match

## Notes
- This does not rename the main Neutral theme; it only changes the syntax-theme identifier used for code highlighting.

## Validation
- pnpm -F @astryxdesign/theme-neutral build
- pre-commit checks from commit hook