### PR TITLE
docs(core): record factual menu anatomy

### DIFF
--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -1,4 +1,50 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Trigger area',
+    required: true,
+    description:
+      'Caller-provided region that accepts right-click, keyboard context-menu, and long-press input.',
+  },
+  {
+    name: 'Pointer menu surface',
+    required: false,
+    description:
+      'Cursor-positioned menu panel used by the pointer presentation.',
+  },
+  {
+    name: 'Pointer action row',
+    required: false,
+    description:
+      'DropdownMenu-owned action, selectable option, or submenu row in the pointer presentation.',
+  },
+  {
+    name: 'Touch sheet frame',
+    required: false,
+    description:
+      'BottomSheet panel, content area, handle, and optional scrim that host touch actions.',
+  },
+  {
+    name: 'Touch menu surface',
+    required: false,
+    description:
+      'ContextMenu-owned content panel rendered inside the touch sheet frame.',
+  },
+  {
+    name: 'Touch action list',
+    required: false,
+    description: 'Spacious List that groups data-driven touch actions.',
+  },
+  {
+    name: 'Touch action row',
+    required: false,
+    description:
+      'ListItem button used for a data-driven action or drill-in entry in the touch presentation.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -80,6 +126,7 @@ export const docs = {
     {name: 'ContextMenuItem'},
   ],
   usage: {
+    anatomy,
     description: 'A right-click context menu that appears at the cursor position. Use to provide contextual actions for specific elements or regions without cluttering the UI with visible buttons.',
     bestPractices: [
       { guidance: true, description: 'Keep menu items concise and action-oriented; users expect quick access to contextual actions.' },
@@ -128,6 +175,7 @@ export const docsZh = {
 export const docsDense = {
   description: 'right-click context menu at cursor position',
   usage: {
+    anatomy,
     description: 'A right-click context menu that appears at the cursor position. Use to provide contextual actions for specific elements or regions.',
     bestPractices: [
       { guidance: true, description: 'Keep items concise and action-oriented.' },

--- a/packages/core/src/ContextMenu/ContextMenu.spec.md
+++ b/packages/core/src/ContextMenu/ContextMenu.spec.md
@@ -1,0 +1,206 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:ContextMenu
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [
+    packages/core/src/ContextMenu/ContextMenu.test.tsx,
+    packages/core/src/DropdownMenu/DropdownMenu.test.tsx,
+    packages/core/src/BottomSheet/BottomSheet.test.tsx,
+    packages/core/src/List/List.test.tsx,
+    scripts/check-knowledge.mjs,
+  ]
+families: [family:overlay-dismissal]
+design_specs: []
+architecture:
+  [
+    architecture:component-theming-surface,
+    architecture:interaction-modality,
+    architecture:layer-runtime,
+  ]
+contributing: []
+system_specs: []
+---
+
+# ContextMenu component contract
+
+## Intent
+
+ContextMenu presents actions for a caller-provided region in either a
+cursor-positioned pointer menu or a BottomSheet-hosted touch action list. This
+draft records current consumer anatomy, presentation-specific ownership, and
+theming reachability without changing runtime behavior, styling, targets, or
+public API.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, and public API remain unchanged
+- Controlled/uncontrolled behavior: unchanged
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The Trigger area's context-menu invocation wiring.
+- The alternative Pointer menu surface and Touch menu surface and their shared
+  current `context-menu` target.
+- Cursor-anchor placement and current open-state coordination across the two
+  presentation paths.
+
+**Does not own / non-goals**
+
+- Caller-provided Trigger area content.
+- Pointer action-row presentation — delegated to `component:DropdownMenu`.
+- The Touch sheet frame — delegated to `component:BottomSheet`.
+- Data-driven Touch action-list and row presentation — delegated to
+  `component:List`.
+- Shared layer lifecycle or dismissal policy.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props, content modes, and
+presentation policy remain documented in `ContextMenu.doc.mjs`.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                     | Basis                           | Draft review state                                 |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| FR1 | Every render contains a caller-provided Trigger area. Pointer presentation opens a Pointer menu surface at the current local cursor anchor; touch presentation opens a Touch sheet frame containing a Touch menu surface and, for data mode, a Touch action list and Touch action rows. | Current source, docs, and tests | Verified current behavior; no new behavior decided |
+| FR2 | The current `context-menu` target remains on the painted Pointer menu surface and alternative Touch menu surface, not on the Trigger area or cursor anchor.                                                                                                                             | Current source, docs, and tests | Verified current inventory; no target change       |
+| FR3 | Pointer action rows retain DropdownMenu ownership. The touch frame retains BottomSheet ownership, while data-driven touch lists and rows retain List ownership.                                                                                                                         | Current source and owner docs   | Verified current delegation; no ownership change   |
+| FR4 | Compound `menuContent` remains a caller-supplied pointer-menu interior and may also render inside the touch frame; the data-driven touch path instead converts the same item data to List and ListItem presentation.                                                                    | Current source and tests        | Verified current branches; no behavior change      |
+
+### Allowed variation
+
+- **AV1 — Invocation.** Right-click, keyboard context-menu invocation, and
+  long-press may open the current resolved presentation without changing
+  anatomy ownership.
+- **AV2 — Presentation.** `popover`, `bottom-sheet`, and resolved `adaptive`
+  presentation may select the current pointer or touch anatomy.
+- **AV3 — Content mode.** Data-driven pointer content renders through
+  DropdownMenu helpers; compound content remains caller-composed. Data-driven
+  touch content renders through List.
+
+### Representative states
+
+| State                 | Required invariant                                                                                  | Allowed variation                                                  |
+| --------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Pointer data menu     | Trigger area opens Pointer menu surface with DropdownMenu-owned rows.                               | Cursor position, row content, width, and nested flyouts may vary.  |
+| Pointer compound menu | Trigger area opens the same surface around caller-supplied menu content.                            | Caller chooses supported DropdownMenu interior components.         |
+| Touch data menu       | Trigger area opens Touch sheet frame and Touch menu surface containing List-owned actions.          | Heading, sections, dividers, icons, and drill-in depth may vary.   |
+| Touch compound menu   | Trigger area opens Touch sheet frame around the ContextMenu surface and caller-supplied interior.   | Caller-supplied content remains responsible for its own structure. |
+| Disabled trigger      | Trigger area remains rendered and the native browser context menu is not suppressed by ContextMenu. | Caller-provided content remains unchanged.                         |
+
+### Transformation and precedence order
+
+- No new presentation-resolution, cursor-position, long-press, item-rendering,
+  or styling precedence rule is introduced.
+
+### Performance and resources
+
+- No new loading, listener, measurement, or render constraint is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend ContextMenu's existing menu and dialog
+naming, keyboard invocation, long-press path, focus movement, item semantics, or
+dismissal behavior.
+
+## Design relationships
+
+| Anatomy or state     | Design requirement                                                                | Representation authority       | Hierarchy role    | Component contract |
+| -------------------- | --------------------------------------------------------------------------------- | ------------------------------ | ----------------- | ------------------ |
+| Trigger area         | Defines the caller-owned region that accepts context-menu input.                  | Caller-supplied content        | Context-dependent | FR1, FR2           |
+| Pointer menu surface | Paints the menu at the current cursor anchor.                                     | Current source and public docs | Prominent         | FR1, FR2           |
+| Pointer action row   | Presents an action, selectable option, or nested-menu entry through DropdownMenu. | `component:DropdownMenu`       | Prominent         | FR1, FR3, FR4      |
+| Touch sheet frame    | Supplies the touch panel, scrolling area, handle, and optional scrim.             | `component:BottomSheet`        | Prominent         | FR1, FR3           |
+| Touch menu surface   | Arranges ContextMenu-owned heading and content inside the sheet.                  | Current source and public docs | Prominent         | FR1, FR2           |
+| Touch action list    | Groups data-driven touch actions using the spacious List presentation.            | `component:List`               | Prominent         | FR1, FR3, FR4      |
+| Touch action row     | Presents one data-driven touch action or drill-in entry using ListItem.           | `component:List`               | Prominent         | FR1, FR3, FR4      |
+
+The `context-menu` target intentionally appears on both alternative painted
+menu surfaces. Trigger area content stays caller-owned and the zero-size cursor
+anchor is positioning infrastructure rather than consumer anatomy.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Trigger area": {
+    "none": {
+      "reason": "intentional: Caller-provided trigger content remains caller-owned and the ContextMenu wrapper has no public target."
+    }
+  },
+  "Pointer menu surface": {"target": "context-menu"},
+  "Pointer action row": {
+    "delegatesTo": {
+      "owner": "component:DropdownMenu",
+      "target": "dropdown-menu-item"
+    }
+  },
+  "Touch sheet frame": {
+    "delegatesTo": {"owner": "component:BottomSheet", "target": "bottom-sheet"}
+  },
+  "Touch menu surface": {"target": "context-menu"},
+  "Touch action list": {
+    "delegatesTo": {"owner": "component:List", "target": "list"}
+  },
+  "Touch action row": {
+    "delegatesTo": {"owner": "component:List", "target": "list-item"}
+  }
+}
+```
+
+## Family and system relationships
+
+- `architecture:component-theming-surface` owns anatomy qualification, local
+  target mapping, presentation-specific rows, and delegation rules.
+- `architecture:interaction-modality` owns the shared right-click, keyboard,
+  long-press, pointer, touch, and adaptive-presentation boundaries; this draft
+  changes none of them.
+- `architecture:layer-runtime` owns the current context-mode `useLayer` host and
+  cursor-anchor positioning. ContextMenu currently retains local outside-click
+  and Escape listeners; touch hosting delegates to BottomSheet.
+- `family:overlay-dismissal` owns shared Escape and platform-close ordering and
+  records ContextMenu and BottomSheet as current local-only adoption gaps. This
+  anatomy backfill does not migrate either path.
+
+## Verification map
+
+| Contract            | Verification                                                                                      | Representative states                         | Mutation or failure expectation                                                                    | Audit section                |
+| ------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------- |
+| FR1, FR4            | `ContextMenu.test.tsx` pointer, long-press, bottom-sheet, adaptive, compound, and drill-in suites | Pointer data/compound and touch data/compound | Collapsing presentation-specific parts or content owners fails structure, role, or behavior tests. | `audit:ContextMenu/anatomy`  |
+| FR2                 | ContextMenu target tests, source inspection, and theming target inventories                       | Pointer and touch menu surfaces               | Moving `context-menu` to the trigger or removing it from a painted branch fails evidence.          | `audit:ContextMenu/theming`  |
+| FR3                 | ContextMenu, DropdownMenu, BottomSheet, and List owner tests                                      | Pointer rows, touch frame, touch list/rows    | A composed part loses its owner target or is documented as a new ContextMenu target.               | `audit:ContextMenu/theming`  |
+| Layer relationships | `ContextMenu.test.tsx` and current layer/dismissal architecture records                           | Outside click, Escape, context anchor, sheet  | Documentation claims shared dismissal where current source retains local behavior.                 | `audit:ContextMenu/behavior` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                     | Canonical anatomy and current target          | Missing, extra, prefixed, stale, or unclassified mappings fail repository validation.              | `audit:ContextMenu/theming`  |
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design,
+API, theming, modality, or layer-system decision.
+
+## Open questions
+
+None.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables, menu examples, cursor and
+long-press algorithms, implementation steps, or shared modality, layer,
+dismissal, and theming rules. It links to their owners.

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -1,5 +1,107 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Trigger button',
+    required: true,
+    description: 'Button that opens and closes the selected menu presentation.',
+  },
+  {
+    name: 'Trigger indicator icon',
+    required: false,
+    description:
+      'Optional trailing chevron shown by a labeled trigger when hasChevron is enabled.',
+  },
+  {
+    name: 'Pointer menu surface',
+    required: false,
+    description:
+      'Anchored top-level or nested menu panel used by the pointer presentation.',
+  },
+  {
+    name: 'Pointer action row',
+    required: false,
+    description:
+      'Action, selectable option, or submenu trigger row in an anchored menu.',
+  },
+  {
+    name: 'Icon-rendered item icon',
+    required: false,
+    description:
+      'Optional semantic or component icon rendered through Icon at the start of an action row.',
+  },
+  {
+    name: 'Caller-rendered item start content',
+    required: false,
+    description:
+      'Optional arbitrary React content rendered directly at the start of an action row.',
+  },
+  {
+    name: 'Checkbox indicator',
+    required: false,
+    description:
+      'Decorative shared checkbox indicator for a checkbox action row.',
+  },
+  {
+    name: 'Radio indicator',
+    required: false,
+    description:
+      'Decorative shared radio indicator with an additional menu-owned target.',
+  },
+  {
+    name: 'Pointer section heading',
+    required: false,
+    description:
+      'Heading that labels a data-driven section in an anchored menu.',
+  },
+  {
+    name: 'Pointer divider',
+    required: false,
+    description: 'Divider between groups in an anchored menu.',
+  },
+  {
+    name: 'Pointer submenu indicator icon',
+    required: false,
+    description:
+      'Trailing chevron that identifies an action row as a nested flyout trigger.',
+  },
+  {
+    name: 'Touch sheet frame',
+    required: false,
+    description:
+      'BottomSheet panel, content area, handle, and optional scrim that host touch actions.',
+  },
+  {
+    name: 'Touch menu surface',
+    required: false,
+    description:
+      'Menu-owned content panel rendered inside the touch sheet frame.',
+  },
+  {
+    name: 'Touch heading',
+    required: false,
+    description:
+      'Current action-sheet title, updated when a nested action view is opened.',
+  },
+  {
+    name: 'Touch action list',
+    required: false,
+    description: 'Spacious List that groups actions in the touch presentation.',
+  },
+  {
+    name: 'Touch action row',
+    required: false,
+    description:
+      'ListItem button used for an action or drill-in entry in the touch presentation.',
+  },
+  {
+    name: 'Touch divider',
+    required: false,
+    description: 'Divider between action groups in the touch presentation.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -146,6 +248,7 @@ export const docs = {
   ],
   components: [{name: 'DropdownMenuItem'}],
   usage: {
+    anatomy,
     description:
       'A dropdown menu that displays a list of actionable items in a popup triggered by a button. Use to present action options as a next step in a process, or to offer contextual actions without cluttering the interface.',
     bestPractices: [
@@ -257,6 +360,7 @@ export const docsZh = {
 export const docsDense = {
   description: 'dropdown menu for actionable items in popup',
   usage: {
+    anatomy,
     description:
       'A dropdown menu that displays a list of actionable items in a popup triggered by a button. Use to present action options as a next step in a process, or to offer contextual actions without cluttering the interface.',
     bestPractices: [

--- a/packages/core/src/DropdownMenu/DropdownMenu.spec.md
+++ b/packages/core/src/DropdownMenu/DropdownMenu.spec.md
@@ -1,0 +1,245 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:DropdownMenu
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [
+    packages/core/src/DropdownMenu/DropdownMenu.test.tsx,
+    packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx,
+    packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx,
+    packages/core/src/BottomSheet/BottomSheet.test.tsx,
+    packages/core/src/List/List.test.tsx,
+    packages/core/src/Indicator/Indicator.test.tsx,
+    packages/core/src/Icon/Icon.test.tsx,
+    scripts/check-knowledge.mjs,
+  ]
+families: [family:overlay-dismissal]
+design_specs: []
+architecture:
+  [
+    architecture:component-theming-surface,
+    architecture:interaction-modality,
+    architecture:layer-runtime,
+  ]
+contributing: []
+system_specs: []
+---
+
+# DropdownMenu component contract
+
+## Intent
+
+DropdownMenu presents actions from a visible Button trigger in either an
+anchored pointer menu or a BottomSheet-hosted touch action list. This draft
+records current consumer anatomy, presentation-specific ownership, and theming
+reachability without changing runtime behavior, styling, targets, or public API.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, and public API remain unchanged
+- Controlled/uncontrolled behavior: unchanged
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The Pointer menu surface and Touch menu surface and their shared current
+  `dropdown-menu` target.
+- Pointer action rows, pointer-only section headings and dividers, radio marker
+  specialization, and submenu indicator presentation through the other five
+  current DropdownMenu targets.
+- Selecting between the current pointer and touch render paths after presentation
+  policy resolves.
+
+**Does not own / non-goals**
+
+- Trigger-button presentation — delegated to `component:Button`.
+- The Touch sheet frame — delegated to `component:BottomSheet`.
+- Touch action-list and row presentation — delegated to `component:List`.
+- Shared checkbox-indicator and ordinary icon presentation — delegated to
+  `component:Indicator` and `component:Icon`.
+- Shared layer lifecycle or dismissal policy.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props, item shapes,
+subcomponents, and presentation policy remain documented in
+`DropdownMenu.doc.mjs` and the subcomponent docs.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                                                           | Basis                           | Draft review state                                 |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
+| FR1 | Every current render contains a Trigger button. Pointer presentation renders a Pointer menu surface with pointer-owned rows and optional pointer headings, dividers, indicators, and nested flyouts. Touch presentation renders a Touch sheet frame containing a Touch menu surface, Touch heading, Touch action list, and Touch action rows. | Current source, docs, and tests | Verified current behavior; no new behavior decided |
+| FR2 | The six current local targets are `dropdown-menu`, `dropdown-menu-item`, `dropdown-menu-radio`, `dropdown-menu-section-heading`, `dropdown-menu-divider`, and `dropdown-menu-indicator-icon`; every target remains on its current painted element.                                                                                            | Current source, docs, and tests | Verified current inventory; no target change       |
+| FR3 | Button owns the Trigger button, BottomSheet owns the Touch sheet frame, List owns the Touch action list and Touch action rows, Indicator owns checkbox chrome, and Icon owns ordinary rendered icons.                                                                                                                                         | Current source and owner docs   | Verified current delegation; no ownership change   |
+| FR4 | The same `dropdown-menu` target reaches the alternative Pointer menu surface and Touch menu surface. Pointer action rows retain `dropdown-menu-item`; touch action rows instead use List's `list-item` target.                                                                                                                                | Current source and tests        | Verified modality split; no target change          |
+
+### Allowed variation
+
+- **AV1 — Presentation.** `popover`, `bottom-sheet`, and resolved `adaptive`
+  presentation may select the current pointer or touch anatomy without changing
+  the ownership of either branch.
+- **AV2 — Content mode.** Data-driven and compound pointer menus may vary their
+  rows while preserving the current target owners. Touch presentation remains
+  data-driven.
+- **AV3 — Optional content.** Icons, selectable indicators, headings, dividers,
+  and nested actions render only when the supplied menu content requires them.
+
+### Representative states
+
+| State                       | Required invariant                                                                                 | Allowed variation                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Anchored root menu          | Trigger button and Pointer menu surface render with pointer-owned rows.                            | Width, placement, alignment, and optional item content vary.   |
+| Anchored nested flyout      | Pointer action row opens another Pointer menu surface and may show the submenu indicator icon.     | Loading may replace the indicator with the current Spinner.    |
+| Bottom-sheet root actions   | Trigger button opens Touch sheet frame, Touch menu surface, heading, action list, and action rows. | Icons, sections, dividers, and action descriptions may vary.   |
+| Bottom-sheet nested actions | The same frame and list owners remain while heading and rows change to the selected action level.  | Back control and drill-in indicator follow current navigation. |
+| Selectable pointer action   | Pointer action row may contain shared checkbox or radio chrome.                                    | Checked and disabled state follow the current item contracts.  |
+
+### Transformation and precedence order
+
+- No new presentation-resolution, open-state, item-rendering, positioning, or
+  styling precedence rule is introduced.
+
+### Performance and resources
+
+- No new loading, listener, measurement, or render constraint is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend DropdownMenu's existing trigger naming,
+menu and dialog roles, focus movement, keyboard navigation, item semantics, or
+dismissal behavior.
+
+## Design relationships
+
+| Anatomy or state                   | Design requirement                                                            | Representation authority       | Hierarchy role    | Component contract |
+| ---------------------------------- | ----------------------------------------------------------------------------- | ------------------------------ | ----------------- | ------------------ |
+| Trigger button                     | Provides the visible control that opens and closes the selected presentation. | `component:Button`             | Supporting        | FR1, FR3           |
+| Trigger indicator icon             | Communicates disclosure on labeled triggers when enabled.                     | `component:Icon`               | Supporting        | FR1, FR3           |
+| Pointer menu surface               | Paints the anchored root or nested pointer menu panel.                        | Current source and public docs | Prominent         | FR1, FR2, FR4      |
+| Pointer action row                 | Presents one action, selectable option, or nested-menu entry.                 | Current source and public docs | Prominent         | FR1, FR2, FR4      |
+| Icon-rendered item icon            | Adds an optional semantic or component icon to an action row through Icon.    | `component:Icon`               | Supporting        | FR1, FR3           |
+| Caller-rendered item start content | Presents arbitrary React content directly in an action-row start slot.        | Caller-supplied content        | Context-dependent | FR1, FR3           |
+| Checkbox indicator                 | Draws the decorative checkbox state for a checkbox action row.                | `component:Indicator`          | Supporting        | FR1, FR3           |
+| Radio indicator                    | Draws shared radio chrome with the current menu-specific radio target.        | Current source and Indicator   | Supporting        | FR1, FR2, FR3      |
+| Pointer section heading            | Labels a grouped set of pointer action rows.                                  | Current source and public docs | Supporting        | FR1, FR2           |
+| Pointer divider                    | Separates groups of pointer action rows.                                      | Current source and public docs | Supporting        | FR1, FR2           |
+| Pointer submenu indicator icon     | Identifies a pointer action row that opens a nested flyout.                   | Current source and public docs | Supporting        | FR1, FR2           |
+| Touch sheet frame                  | Supplies the touch panel, scrolling area, handle, and optional scrim.         | `component:BottomSheet`        | Prominent         | FR1, FR3           |
+| Touch menu surface                 | Arranges menu-owned heading and action content inside the sheet.              | Current source and public docs | Prominent         | FR1, FR2, FR4      |
+| Touch heading                      | Names the current root or drill-in action view.                               | Current source and tests       | Supporting        | FR1                |
+| Touch action list                  | Groups touch actions using the spacious List presentation.                    | `component:List`               | Prominent         | FR1, FR3           |
+| Touch action row                   | Presents one touch action or drill-in entry using ListItem.                   | `component:List`               | Prominent         | FR1, FR3, FR4      |
+| Touch divider                      | Separates groups in the touch action list.                                    | `component:Divider`            | Supporting        | FR1, FR3           |
+
+The `dropdown-menu` target intentionally appears on both alternative menu
+surfaces. The radio element also carries Indicator's shared radio target, and
+the pointer divider also carries Divider's target; their local targets remain
+valid distinct contracts. Touch headings retain the shared `heading` target documented by Text rather
+than adding a DropdownMenu-owned heading target.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Trigger button": {
+    "delegatesTo": {"owner": "component:Button", "target": "button"}
+  },
+  "Trigger indicator icon": {
+    "delegatesTo": {"owner": "component:Icon", "target": "icon"}
+  },
+  "Pointer menu surface": {"target": "dropdown-menu"},
+  "Pointer action row": {"target": "dropdown-menu-item"},
+  "Icon-rendered item icon": {
+    "delegatesTo": {"owner": "component:Icon", "target": "icon"}
+  },
+  "Caller-rendered item start content": {
+    "none": {
+      "reason": "intentional: Arbitrary ReactNode item content is caller-owned and receives no DropdownMenu target."
+    }
+  },
+  "Checkbox indicator": {
+    "delegatesTo": {
+      "owner": "component:Indicator",
+      "target": "checkbox-indicator"
+    }
+  },
+  "Radio indicator": {"target": "dropdown-menu-radio"},
+  "Pointer section heading": {"target": "dropdown-menu-section-heading"},
+  "Pointer divider": {"target": "dropdown-menu-divider"},
+  "Pointer submenu indicator icon": {
+    "target": "dropdown-menu-indicator-icon"
+  },
+  "Touch sheet frame": {
+    "delegatesTo": {"owner": "component:BottomSheet", "target": "bottom-sheet"}
+  },
+  "Touch menu surface": {"target": "dropdown-menu"},
+  "Touch heading": {
+    "delegatesTo": {"owner": "component:Text", "target": "heading"}
+  },
+  "Touch action list": {
+    "delegatesTo": {"owner": "component:List", "target": "list"}
+  },
+  "Touch action row": {
+    "delegatesTo": {"owner": "component:List", "target": "list-item"}
+  },
+  "Touch divider": {
+    "delegatesTo": {"owner": "component:Divider", "target": "divider"}
+  }
+}
+```
+
+## Family and system relationships
+
+- `architecture:component-theming-surface` owns anatomy qualification, local
+  target mapping, presentation-specific rows, and delegation rules.
+- `architecture:interaction-modality` owns the shared pointer, touch, keyboard,
+  and adaptive-presentation boundaries; this draft changes none of them.
+- `architecture:layer-runtime` owns the current `usePopover` host, native
+  light-dismiss reconciliation, anchor positioning, and nested `useLayer`
+  flyouts. Touch presentation delegates hosting to BottomSheet.
+- `family:overlay-dismissal` owns shared Escape and platform-close ordering.
+  DropdownMenu root participates through its Popover focus trap; the composed
+  BottomSheet and DropdownMenuSubMenu retain their recorded local-only adoption
+  gaps.
+
+## Verification map
+
+| Contract            | Verification                                                                                              | Representative states                              | Mutation or failure expectation                                                                  | Audit section                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------- |
+| FR1, FR4            | `DropdownMenu.test.tsx` pointer, bottom-sheet, adaptive, section, divider, and drill-in suites            | Root pointer, nested pointer, root touch, drill-in | Collapsing presentation-specific parts or owners fails structure, target, or role assertions.    | `audit:DropdownMenu/anatomy`  |
+| FR2                 | DropdownMenu target suites, source inspection, and theming target inventories                             | All six local targets                              | Removing, renaming, or assigning a current target to the wrong part fails evidence or inventory. | `audit:DropdownMenu/theming`  |
+| FR3                 | `DropdownMenuSelectable.test.tsx` plus BottomSheet, List, Indicator, Icon, and Divider owner tests        | Trigger, touch actions, icons, checkbox, radio     | A composed part loses its owner target or is documented as a new local target.                   | `audit:DropdownMenu/theming`  |
+| Layer relationships | `DropdownMenu.test.tsx`, `DropdownMenuSubMenu.test.tsx`, and current layer/dismissal architecture records | Light dismiss, nested flyout, sheet dismissal      | Documentation claims a shared owner where current source retains local behavior, or the reverse. | `audit:DropdownMenu/behavior` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                             | Canonical anatomy and current target inventory     | Missing, extra, prefixed, stale, or unclassified mappings fail repository validation.            | `audit:DropdownMenu/theming`  |
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design,
+API, theming, modality, or layer-system decision.
+
+## Open questions
+
+None.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables, item examples, focus and
+positioning algorithms, implementation steps, or shared modality, layer,
+dismissal, and theming rules. It links to their owners.

--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -1,5 +1,45 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/** @type {import('@astryxdesign/cli/authoring').ComponentAnatomyElement[]} */
+const anatomy = [
+  {
+    name: 'Trigger button',
+    required: true,
+    description:
+      'Icon-only Button that provides the visible overflow-menu entry point.',
+  },
+  {
+    name: 'Icon-resolved trigger icon',
+    required: false,
+    description:
+      'Default semantic three-dot artwork resolved from the active Icon registry.',
+  },
+  {
+    name: 'Caller-rendered trigger content',
+    required: false,
+    description:
+      'Arbitrary React content supplied directly as the trigger icon override.',
+  },
+  {
+    name: 'Menu surface',
+    required: true,
+    description:
+      'DropdownMenu panel that also carries MoreMenu’s current public target.',
+  },
+  {
+    name: 'Pointer action row',
+    required: false,
+    description:
+      'Action or nested-action trigger row rendered by DropdownMenu in the anchored presentation.',
+  },
+  {
+    name: 'Touch action row',
+    required: false,
+    description:
+      'ListItem button rendered by DropdownMenu in the BottomSheet presentation.',
+  },
+];
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -94,6 +134,7 @@ export const docs = {
     ],
   },
   usage: {
+    anatomy,
     description:
       'MoreMenu is a three-dot button that opens a list of actions. Use it for secondary actions that don\'t need to be always visible, like in table rows, card headers, or toolbars.',
     bestPractices: [
@@ -195,6 +236,7 @@ export const docsDense = {
   description:
     'Overflow menu w/ three-dot icon trigger. Convenience wrapper composing icon-only Button w/ dropdown menu, eliminating boilerplate for state management, positioning, accessibility.',
   usage: {
+    anatomy,
     description:
       'MoreMenu is a three-dot button that opens a list of actions. Use it for secondary actions that don\'t need to be always visible, like in table rows, card headers, or toolbars.',
     bestPractices: [

--- a/packages/core/src/MoreMenu/MoreMenu.spec.md
+++ b/packages/core/src/MoreMenu/MoreMenu.spec.md
@@ -1,0 +1,221 @@
+---
+schema_version: 1
+template_version: 3
+kind: component
+id: component:MoreMenu
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [theming]
+verified_by:
+  [
+    packages/core/src/MoreMenu/MoreMenu.test.tsx,
+    packages/core/src/DropdownMenu/DropdownMenu.test.tsx,
+    packages/core/src/Button/Button.test.tsx,
+    packages/core/src/Icon/Icon.test.tsx,
+    packages/core/src/List/List.test.tsx,
+    scripts/check-knowledge.mjs,
+  ]
+families: [family:overlay-dismissal]
+design_specs: []
+architecture:
+  [
+    architecture:component-theming-surface,
+    architecture:icon-resolution-and-component-slots,
+    architecture:interaction-modality,
+    architecture:layer-runtime,
+  ]
+contributing: []
+system_specs: []
+---
+
+# MoreMenu component contract
+
+## Intent
+
+MoreMenu provides a visible icon-only overflow trigger and delegates its action
+presentation to DropdownMenu. This draft records current consumer anatomy and
+theming ownership without changing runtime behavior, styling, targets, or public
+API.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive documentation only; runtime, DOM, styling,
+  targets, and public API remain unchanged
+- Controlled/uncontrolled behavior: unchanged
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The overflow-menu composition and its visible icon-only trigger defaults.
+- The Menu surface's current `more-menu` target, which is a second class on the
+  composed DropdownMenu panel.
+
+**Does not own / non-goals**
+
+- Trigger-button presentation — delegated to `component:Button`.
+- Default semantic trigger artwork resolution — delegated to the Icon registry;
+  the current artwork renders directly inside Button and does not carry Icon's
+  `icon` target. Arbitrary caller-rendered trigger content remains caller-owned.
+- Menu-panel lifecycle and presentation switching — delegated to
+  `component:DropdownMenu`.
+- Anchored action rows, sections, dividers, selectable indicators, and nested
+  flyouts — delegated to `component:DropdownMenu`.
+- BottomSheet action rows and lists — delegated through DropdownMenu to
+  `component:List`; the touch frame remains owned by `component:BottomSheet`.
+- Shared layer lifecycle or dismissal policy.
+
+## Public concepts
+
+No new public concept is introduced. Consumer props and usage remain documented
+in `MoreMenu.doc.mjs`; its action data and presentation values remain those of
+DropdownMenu.
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                                           | Basis                           | Draft review state                                  |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------------------------- |
+| FR1 | Every current render contains one icon-only Trigger button and one DropdownMenu-owned Menu surface. Anchored presentation uses Pointer action rows; BottomSheet presentation uses Touch action rows. The default trigger icon resolves through the Icon registry, while a caller may replace it with arbitrary React content. | Current source, docs, and tests | Verified current behavior; no new behavior decided  |
+| FR2 | The current `more-menu` target is applied to the composed DropdownMenu panel as an additional class. It is not applied to the Trigger button.                                                                                                                                                                                 | Current source, docs, and tests | Verified current target placement; no target change |
+| FR3 | Button owns the Trigger button and the Icon registry owns default semantic trigger artwork resolution. DropdownMenu owns Pointer action rows; List owns Touch action rows rendered through DropdownMenu's BottomSheet path.                                                                                                   | Current source and owner docs   | Verified current delegation; no ownership change    |
+| FR4 | MoreMenu forwards the current open state, placement, alignment, and pointer/touch presentation policy to DropdownMenu without adding a parallel menu runtime.                                                                                                                                                                 | Current source and tests        | Verified composition; no behavior change            |
+
+### Allowed variation
+
+- **AV1 — Trigger icon.** The default semantic three-dot icon may be replaced by
+  an icon component or arbitrary React content without moving the MoreMenu target
+  onto the trigger.
+- **AV2 — Presentation.** DropdownMenu may resolve the current anchored or
+  BottomSheet presentation while MoreMenu keeps the same trigger and Menu-surface
+  ownership.
+- **AV3 — Interior.** Action rows, sections, dividers, icons, selectable
+  indicators, and nested actions may vary according to DropdownMenu's current
+  data contract.
+
+### Representative states
+
+| State                  | Required invariant                                                                        | Allowed variation                                    |
+| ---------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Default overflow menu  | Trigger button uses the default Icon-resolved glyph and Menu surface carries `more-menu`. | Button size, variant, placement, and alignment vary. |
+| Arbitrary icon content | Trigger button remains Button-owned while caller content bypasses Icon ownership.         | Caller owns the rendered content.                    |
+| Pointer presentation   | DropdownMenu owns the anchored Menu interior and Pointer action rows.                     | Rows, sections, dividers, and nested flyouts vary.   |
+| Touch presentation     | DropdownMenu owns the BottomSheet-backed Menu interior; List owns Touch action rows.      | Touch rows and drill-in depth vary.                  |
+
+### Transformation and precedence order
+
+- No new icon-resolution, presentation-resolution, open-state, positioning, or
+  styling precedence rule is introduced.
+
+### Performance and resources
+
+- No new loading, listener, measurement, or render constraint is introduced.
+
+## Accessibility contract
+
+This draft does not change or extend MoreMenu's existing accessible label,
+tooltip, icon-only Button semantics, focus behavior, keyboard operation, or
+dismissal behavior.
+
+## Design relationships
+
+| Anatomy or state                | Design requirement                                                               | Representation authority       | Hierarchy role    | Component contract |
+| ------------------------------- | -------------------------------------------------------------------------------- | ------------------------------ | ----------------- | ------------------ |
+| Trigger button                  | Provides the visible and discoverable entry point for secondary actions.         | `component:Button`             | Supporting        | FR1, FR3           |
+| Icon-resolved trigger icon      | Draws semantic three-dot artwork from the active Icon registry.                  | Icon registry                  | Supporting        | FR1, FR3           |
+| Caller-rendered trigger content | Presents arbitrary caller content supplied through the icon override.            | Caller-supplied content        | Context-dependent | FR1, FR3           |
+| Menu surface                    | Adds MoreMenu's target to the composed DropdownMenu panel, not the trigger.      | Current source and public docs | Prominent         | FR1, FR2           |
+| Pointer action row              | Presents an action or nested flyout trigger in the anchored presentation.        | `component:DropdownMenu`       | Prominent         | FR1, FR3, FR4      |
+| Touch action row                | Presents an action or drill-in entry through ListItem in the touch presentation. | `component:List`               | Prominent         | FR1, FR3, FR4      |
+
+The Menu surface is the DropdownMenu panel itself. It carries both
+`astryx-more-menu` and DropdownMenu's own panel target; the local class is not a
+wrapper and does not retarget the trigger. DropdownMenu remains the owner of the
+presentation runtime and anchored interior. Its touch path delegates action rows
+to List rather than extending the pointer-row target into the BottomSheet
+presentation.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Trigger button": {
+    "delegatesTo": {"owner": "component:Button", "target": "button"}
+  },
+  "Icon-resolved trigger icon": {
+    "none": {
+      "reason": "unsettled: The current useIcon artwork renders directly inside Button; whether it should carry Icon's icon target needs an owner decision."
+    }
+  },
+  "Caller-rendered trigger content": {
+    "none": {
+      "reason": "intentional: Arbitrary React icon content is caller-owned and receives no MoreMenu target."
+    }
+  },
+  "Menu surface": {"target": "more-menu"},
+  "Pointer action row": {
+    "delegatesTo": {
+      "owner": "component:DropdownMenu",
+      "target": "dropdown-menu-item"
+    }
+  },
+  "Touch action row": {
+    "delegatesTo": {"owner": "component:List", "target": "list-item"}
+  }
+}
+```
+
+## Family and system relationships
+
+- `architecture:component-theming-surface` owns anatomy qualification, the local
+  Menu-surface target, and composition delegation rules.
+- `architecture:icon-resolution-and-component-slots` owns active-theme icon
+  resolution. MoreMenu's default artwork uses that registry but currently
+  bypasses Icon's painted `icon` target.
+- `architecture:interaction-modality` owns the shared pointer, touch, keyboard,
+  and adaptive-presentation boundaries inherited through DropdownMenu; this
+  draft changes none of them.
+- `architecture:layer-runtime` owns the current DropdownMenu Popover host, native
+  light-dismiss reconciliation, and BottomSheet host distinction. MoreMenu adds
+  no parallel layer runtime.
+- `family:overlay-dismissal` owns shared Escape and platform-close ordering and
+  records MoreMenu as a shared owner through its composed DropdownMenu root;
+  BottomSheet presentation retains BottomSheet's recorded local-only adoption
+  gap.
+
+## Verification map
+
+| Contract            | Verification                                                                        | Representative states                            | Mutation or failure expectation                                                                   | Audit section             |
+| ------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------- | ------------------------- |
+| FR1, FR4            | `MoreMenu.test.tsx` render, pointer, bottom-sheet, placement, and controlled suites | Default, custom icon, pointer, touch             | Replacing the composition or changing forwarded behavior fails existing render/interaction tests. | `audit:MoreMenu/anatomy`  |
+| FR2                 | MoreMenu target test, source inspection, and theming target inventories             | Closed trigger and composed menu panel           | Moving `more-menu` onto the trigger or removing it from the panel fails target evidence.          | `audit:MoreMenu/theming`  |
+| FR3                 | MoreMenu, DropdownMenu, Button, Icon, and List source/owner tests                   | Trigger, icon branches, pointer rows, touch rows | A composed part loses its owner target or is documented as a new MoreMenu-owned descendant.       | `audit:MoreMenu/theming`  |
+| Layer relationships | `MoreMenu.test.tsx`, `DropdownMenu.test.tsx`, and current layer/dismissal records   | Light dismiss, Escape, pointer, touch            | Documentation gives MoreMenu a parallel runtime or misstates the current dismissal owner.         | `audit:MoreMenu/behavior` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                       | Canonical anatomy and current target             | Missing, extra, prefixed, stale, or unclassified mappings fail repository validation.             | `audit:MoreMenu/theming`  |
+
+## Decision log
+
+None. This draft records current facts and introduces no component-local design,
+API, theming, modality, or layer-system decision.
+
+## Open questions
+
+- **OQ1 — Should the default trigger artwork render through Icon's public
+  target?** (`human-api`) The current registry lookup preserves semantic artwork
+  replacement but leaves the painted glyph outside the `icon` target; this
+  draft does not change that reachability.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables, DropdownMenu item examples,
+icon-resolution rules, implementation steps, or shared modality, layer,
+dismissal, and theming rules. It links to their owners.


### PR DESCRIPTION
## Why

Theme authors need factual anatomy and ownership for the menu composition family before bidirectional theming validation can become mandatory. Pointer and touch presentations paint through different component owners.

## What

- records consumer anatomy for DropdownMenu, ContextMenu, and MoreMenu
- adds template-v3 component contracts with current target, delegation, and classified no-target dispositions
- links the current layer-runtime and overlay-dismissal ownership without changing either system

## Risk

Documentation only. No runtime, DOM, API, or theming-target behavior changes.

## Testing

- `pnpm build`
- 414 focused Core tests across the menu family and delegated owners
- 110 focused docsite anatomy/data-extraction tests
- `pnpm check:repo`

No Changeset: documentation-only contract backfill.
