### PR TITLE
fix(docs): classify factual theming gaps

### DIFF
--- a/packages/core/src/CommandPalette/CommandPalette.spec.md
+++ b/packages/core/src/CommandPalette/CommandPalette.spec.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 1
-template_version: 2
+template_version: 3
 kind: component
 id: component:CommandPalette
 authority: draft
@@ -153,7 +153,7 @@ reachability, not a decision that it must remain unthemeable.
   },
   "Query field": {
     "none": {
-      "reason": "No current public target is applied directly to the native query field"
+      "reason": "unsettled: No current public target is applied directly to the native query field; future exposure still needs an owner decision"
     }
   },
   "Loading spinner": {

--- a/packages/core/src/TreeList/TreeList.spec.md
+++ b/packages/core/src/TreeList/TreeList.spec.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 1
-template_version: 2
+template_version: 3
 kind: component
 id: component:TreeList
 authority: draft
@@ -142,7 +142,7 @@ caller-owned even though TreeList positions their slot wrappers.
   "Tree list": {"target": "tree-list"},
   "Header": {
     "none": {
-      "reason": "TreeList applies no public target to caller-provided Header content"
+      "reason": "intentional: Header is caller-provided content outside TreeList's public theming ownership"
     }
   },
   "Item": {"target": "tree-list-item"},
@@ -153,17 +153,17 @@ caller-owned even though TreeList positions their slot wrappers.
   "Item label": {"target": "tree-list-item-label"},
   "Item description": {
     "none": {
-      "reason": "No current public target is applied to the stable Item description"
+      "reason": "unsettled: No current public target reaches the stable Item description; future exposure still needs an owner decision"
     }
   },
   "Start content": {
     "none": {
-      "reason": "TreeList applies no public target to caller-provided Start content"
+      "reason": "intentional: Start content is caller-provided content outside TreeList's public theming ownership"
     }
   },
   "End content": {
     "none": {
-      "reason": "TreeList applies no public target to caller-provided End content"
+      "reason": "intentional: End content is caller-provided content outside TreeList's public theming ownership"
     }
   },
   "Guide": {"target": "tree-list-guide"}


### PR DESCRIPTION
## Why

#5739 added required factual classifications for `none` theming-anatomy dispositions, but #5748 had already landed five unclassified records. That made current `main` fail `check:knowledge`.

## What

- Classifies CommandPalette's native Query field as `unsettled` because current reachability is absent and future public exposure still needs an owner decision.
- Classifies TreeList's stable Item description as `unsettled` for the same reason.
- Classifies TreeList Header, Start content, and End content as `intentional` current ownership boundaries because they are caller-provided content.
- Advances both records to component template version 3.

## Risk

Documentation-data migration only; no runtime, public API, or generated output change.

## Testing

- `node scripts/check-knowledge.mjs`
- `pnpm exec vitest run scripts/check-knowledge.test.mjs` — 32/32
- repository pre-commit checks
- Prettier check for both records

No Changeset: contract metadata migration only.
