### PR TITLE
Align direct localized doc loading

### DIFF
--- a/.changeset/direct-loader-anatomy-fallback.md
+++ b/.changeset/direct-loader-anatomy-fallback.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Preserve anatomy when loading localized component docs directly
+
+The validated component-doc loader now applies the same full-overlay fallback as the CLI loader, so omitted localized anatomy inherits the canonical structure while explicit localized anatomy still wins.
+
+@cixzhang

--- a/packages/cli/foundation/discovery/component-loader.mjs
+++ b/packages/cli/foundation/discovery/component-loader.mjs
@@ -51,7 +51,7 @@ export async function loadComponentDoc(
   /** @type {any} */
   const translation = mod[translationKey];
   if (translation.props || translation.components?.some((/** @type {any} */ c) => c.props)) {
-    return translation;
+    return overlayComponentDoc(docs, translation);
   }
   return mergeTranslation(docs, translation);
 }

--- a/packages/cli/foundation/discovery/component-loader.test.mjs
+++ b/packages/cli/foundation/discovery/component-loader.test.mjs
@@ -9,7 +9,8 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {mergeTranslation} from './component-loader.mjs';
+import * as path from 'node:path';
+import {loadComponentDoc, loadDocs, mergeTranslation} from './component-loader.mjs';
 
 /** Minimal HookDoc-shaped fixture with params + returns. */
 function hookDocs() {
@@ -103,5 +104,39 @@ describe('mergeTranslation — component prop descriptions (regression)', () => 
     expect(merged.usage.description).toBe('Dense.');
     expect(merged.props.find(p => p.name === 'variant').description).toBe('Vrnt.');
     expect(merged.props.find(p => p.name === 'disabled').description).toBe('Disabled state.');
+  });
+});
+
+describe('loadComponentDoc — full localized doc overlays', () => {
+  it('inherits canonical anatomy when docsZh omits it and matches loadDocs', async () => {
+    const docPath = path.join(
+      import.meta.dirname,
+      '__fixtures__',
+      'component-accessibility-overlay.doc.mjs',
+    );
+
+    const direct = await loadComponentDoc(docPath, {zh: true});
+    const cli = await loadDocs(docPath, {zh: true});
+
+    expect(direct).toEqual(cli);
+    expect(direct.usage.description).toBe('Translated full-doc description.');
+    expect(direct.usage.anatomy).toEqual((await loadComponentDoc(docPath)).usage.anatomy);
+    expect(direct.usage.bestPractices).toBeUndefined();
+  });
+
+  it('keeps explicit localized anatomy and matches loadDocs', async () => {
+    const docPath = path.join(
+      import.meta.dirname,
+      '__fixtures__',
+      'component-anatomy-override.doc.mjs',
+    );
+
+    const direct = await loadComponentDoc(docPath, {zh: true});
+    const cli = await loadDocs(docPath, {zh: true});
+    const canonical = await loadComponentDoc(docPath);
+
+    expect(direct).toEqual(cli);
+    expect(direct.usage.anatomy).not.toEqual(canonical.usage.anatomy);
+    expect(direct.usage.anatomy[0].name).toBe('文本区域');
   });
 });


### PR DESCRIPTION
## Why

The validated `loadComponentDoc` path returned legacy full localized docs wholesale, while the CLI `loadDocs` path merged them over the canonical doc. Direct consumers could therefore lose canonical `usage.anatomy` and other base-only fields.

## What

- Route full localized docs loaded through `loadComponentDoc` through the shared full-overlay merge.
- Verify omitted anatomy inherits canonical structure, explicit localized anatomy wins, and `loadComponentDoc` matches `loadDocs` in both cases.
- Add a patch Changeset for the corrected CLI behavior.

## Risk

Low. The direct loader now uses the already-shipped overlay behavior from the CLI loader instead of maintaining a replacement-only branch.

## Testing

- `vitest run packages/cli` (210 files, 2,873 tests)
- Focused component loader/overlay suites (206 tests)
- CLI authoring, template-doc, JSON API, and strict typechecks
- Strict lint on changed source/test files
- `pnpm check:repo`
