### PR TITLE
fix(Button): inherit default icon size

### DIFF
--- a/.changeset/button-icon-default-size.md
+++ b/.changeset/button-icon-default-size.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Size an Astryx Icon without an explicit size to match its Button or
+IconButton: 16px for small and medium controls, and 20px for large controls.
+
+@rubyycheung

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -11,6 +11,17 @@
     }
   },
   {
+    "component": "Button",
+    "storyId": "core-button--icon-with-text",
+    "dims": [
+      "D2"
+    ],
+    "selectors": {
+      "prev": "[data-testid=\"button-leading-icon\"]",
+      "next": "[data-testid=\"button-label\"]"
+    }
+  },
+  {
     "component": "ButtonGroup",
     "storyId": "core-buttongroup--horizontal",
     "dims": [

--- a/apps/storybook/rtl-audit/verified-not-applicable.json
+++ b/apps/storybook/rtl-audit/verified-not-applicable.json
@@ -8,6 +8,14 @@
     "reason": "FieldStatus uses block-flow message layout and logical padding and corner radii. Its status glyphs are non-directional, and it has no side-specific placement, order, scrolling, dragging, overlays, or directional keyboard behavior."
   },
   {
+    "component": "core/Icon",
+    "reason": "Across the Core/Icon stories, Icon renders one centered, non-directional glyph and only owns its size, color, theme target, and accessibility presentation. It has no component-owned order, inline-side placement, scrolling, dragging, overlay, or keyboard behavior; when a caller chooses a directional glyph, that callsite owns the semantic direction and any required mirroring."
+  },
+  {
+    "component": "core/IconButton",
+    "reason": "Across the Core/IconButton stories, IconButton is a square Button containing one centered, non-directional glyph. It has no leading/trailing relationship, inline-side placement, scrolling, dragging, overlay, or direction-dependent keyboard behavior; the caller owns the semantics and mirroring of any directional glyph supplied to its icon slot."
+  },
+  {
     "component": "core/Spinner",
     "reason": "No direction-sensitive visual, layout, or behavior. The ring is a concentric SVG — two <circle> elements sharing one center, sized by diameter and stroke, with no physical inset, offset, or asymmetry to mirror. Its only layout is the optional label wrapper, which is flexDirection: column + alignItems: center, so the label stacks below the ring on both axes' terms rather than beside it. The rotation keyframe (0deg to 360deg) is deliberately absolute: a loading spinner turns the same way in every locale, and mirroring it would be a bug, not RTL support."
   },

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -133,8 +133,14 @@ export const IconWithText: Story = {
       <Button
         label="Settings"
         variant="secondary"
-        icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
-      />
+        icon={
+          <Cog6ToothIcon
+            data-testid="button-leading-icon"
+            style={{width: 16, height: 16}}
+          />
+        }>
+        <span data-testid="button-label">Settings</span>
+      </Button>
       <Button
         label="Delete"
         variant="destructive"

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -157,8 +157,8 @@ export const docs = {
       name: 'icon',
       type: 'ReactNode',
       description:
-        'Icon element rendered before the label text.',
-      slotElements: [{__element: 'Icon', props: {icon: 'check', size: 'sm'}}],
+        'Icon element rendered before the label text. An Astryx Icon with no explicit size defaults to sm for sm/md buttons and md for lg buttons.',
+      slotElements: [{__element: 'Icon', props: {icon: 'check'}}],
     },
     {
       name: 'isIconOnly',
@@ -294,7 +294,7 @@ export const docsZh = {
       description: '禁用按钮。存在工具提示时，使用 aria-disabled 代替原生 disabled 以保持可聚焦。',
       default: 'false',
     },
-    {name: 'icon', type: 'ReactNode', description: '图标元素。仅提供 icon 而不提供 children 时，按钮渲染为正方形的纯图标按钮。'},
+    {name: 'icon', type: 'ReactNode', description: '图标元素。未显式指定尺寸的 Astryx Icon 在 sm/md 按钮中默认为 sm，在 lg 按钮中默认为 md。仅提供 icon 而不提供 children 时，按钮渲染为正方形的纯图标按钮。'},
     {name: 'width', type: 'SizeValue', description: "按钮宽度。数字按像素处理，字符串按原样使用（如 '100%' 表示全宽按钮）。默认按内容自适应宽度。"},
     {name: 'children', type: 'ReactNode', description: '可选的可见内容覆盖；label 仍然是必需的（用于无障碍名称）。大多数情况使用 <Button label="Save" />。'},
     {
@@ -361,7 +361,7 @@ export const docsDense = {
     value: 'HTML value for form submission',
     form: 'associates button with form element by ID',
     isLoading: 'shows spinner+disables interaction; announces via live region',
-    icon: 'icon element rendered before label text',
+    icon: 'icon element rendered before label text; unsized Astryx Icon defaults to sm for sm/md buttons and md for lg',
     isIconOnly: 'when true, renders square icon-only button; label becomes aria-label',
     width: "Width of button. Numbers=pixels, strings=as-is (e.g. '100%' for full-width).",
     children: 'optional visible override; label is still required for a11y. Prefer <Button label="Save" /> over using children',

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -38,6 +38,10 @@ import {
 } from '../theme/tokens.stylex';
 import {Spinner} from '../Spinner';
 import {VisuallyHidden} from '../VisuallyHidden';
+import {
+  IconDefaultSizeProvider,
+  type ContextualIconSize,
+} from '../Icon/IconDefaultSizeContext';
 
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {useSize} from '../SizeContext/SizeContext';
@@ -232,6 +236,12 @@ export type ButtonVariant = keyof ButtonVariantMap;
  * Button size type derived from the sizeStyles StyleX object
  */
 export type ButtonSize = keyof typeof sizeStyles;
+
+const defaultIconSizeByButtonSize: Record<ButtonSize, ContextualIconSize> = {
+  sm: 'sm',
+  md: 'sm',
+  lg: 'md',
+};
 
 export interface ButtonProps extends BaseProps<HTMLButtonElement> {
   /** Ref forwarded to the root element */
@@ -706,7 +716,9 @@ export function Button({
         aria-hidden={isLoadingState || undefined}>
         {icon && (
           <span {...stylex.props(styles.iconWrapper, iconSizeStyles[size])}>
-            {icon}
+            <IconDefaultSizeProvider value={defaultIconSizeByButtonSize[size]}>
+              {icon}
+            </IconDefaultSizeProvider>
           </span>
         )}
         {isIconOnly ? null : (

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -38,10 +38,8 @@ import {
 } from '../theme/tokens.stylex';
 import {Spinner} from '../Spinner';
 import {VisuallyHidden} from '../VisuallyHidden';
-import {
-  IconDefaultSizeProvider,
-  type ContextualIconSize,
-} from '../Icon/IconDefaultSizeContext';
+import {IconDefaultSizeProvider} from '../Icon/IconDefaultSizeContext';
+import {iconBoxSizeStyles, type IconSize} from '../Icon/IconSize.stylex';
 
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {useSize} from '../SizeContext/SizeContext';
@@ -175,17 +173,6 @@ const sizeStyles = stylex.create({
 });
 
 /**
- * Icon size per button size.
- * Matches Icon sizing: sm/md=16px, lg=20px.
- * fontSize is set so emoji and text-based icons scale correctly.
- */
-const iconSizeStyles = stylex.create({
-  sm: {width: 16, height: 16, fontSize: 16},
-  md: {width: 16, height: 16, fontSize: 16},
-  lg: {width: 20, height: 20, fontSize: 20},
-});
-
-/**
  * Resting elevation for floating buttons (e.g. a FAB). `none` is the default
  * flat button; `low`/`med`/`high` map to the shadow token scale. 'none' stays
  * a literal so it never conflicts with a variant's background layering.
@@ -237,11 +224,11 @@ export type ButtonVariant = keyof ButtonVariantMap;
  */
 export type ButtonSize = keyof typeof sizeStyles;
 
-const defaultIconSizeByButtonSize: Record<ButtonSize, ContextualIconSize> = {
+const iconSizeByButtonSize = {
   sm: 'sm',
   md: 'sm',
   lg: 'md',
-};
+} satisfies Record<ButtonSize, IconSize>;
 
 export interface ButtonProps extends BaseProps<HTMLButtonElement> {
   /** Ref forwarded to the root element */
@@ -693,6 +680,8 @@ export function Button({
     style,
   );
 
+  const iconSize = iconSizeByButtonSize[size];
+
   const buttonContent = (
     <>
       {isLoadingState && (
@@ -715,8 +704,9 @@ export function Button({
         )}
         aria-hidden={isLoadingState || undefined}>
         {icon && (
-          <span {...stylex.props(styles.iconWrapper, iconSizeStyles[size])}>
-            <IconDefaultSizeProvider value={defaultIconSizeByButtonSize[size]}>
+          <span
+            {...stylex.props(styles.iconWrapper, iconBoxSizeStyles[iconSize])}>
+            <IconDefaultSizeProvider value={iconSize}>
               {icon}
             </IconDefaultSizeProvider>
           </span>

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -31,6 +31,7 @@ import {getIcon} from './globalIconRegistry';
 import type {IconName, NamespacedIconName} from './globalIconRegistry';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {useIconSize} from './IconDefaultSizeContext';
 
 // =============================================================================
 // Styles
@@ -297,7 +298,7 @@ function getIconA11yProps(
 export function Icon({
   icon,
   color = 'inherit',
-  size = 'md',
+  size: sizeProp,
   label,
   ref,
   className,
@@ -305,6 +306,7 @@ export function Icon({
   xstyle,
   ...props
 }: IconProps) {
+  const size = useIconSize(sizeProp);
   // Derive ARIA from `label`: decorative (aria-hidden) by default, or a
   // meaningful image (role="img" + aria-label) when `label` is non-empty.
   const a11yProps = getIconA11yProps(label);

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -32,6 +32,13 @@ import type {IconName, NamespacedIconName} from './globalIconRegistry';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import {useIconSize} from './IconDefaultSizeContext';
+import {
+  iconBoxSizeStyles,
+  iconSizeStyles,
+  type IconSize,
+} from './IconSize.stylex';
+
+export type {IconSize} from './IconSize.stylex';
 
 // =============================================================================
 // Styles
@@ -111,75 +118,11 @@ const colorStyles = stylex.create({
   },
 });
 
-/**
- * Size styles for direct SVG icon components.
- * Uses width/height only — SVG components handle their own viewBox scaling.
- *
- * Sizes are expressed in `rem` (relative to the root font-size) so icons scale
- * in step with text when the document font-size changes, matching the rest of
- * the design system's rem-based type scale. Values are the px-equivalents at a
- * 16px root: 12px → 0.75rem, 16px → 1rem, 20px → 1.25rem, 24px → 1.5rem.
- */
-const sizeStyles = stylex.create({
-  xsm: {
-    width: '0.75rem',
-    height: '0.75rem',
-  },
-  sm: {
-    width: '1rem',
-    height: '1rem',
-  },
-  md: {
-    width: '1.25rem',
-    height: '1.25rem',
-  },
-  lg: {
-    width: '1.5rem',
-    height: '1.5rem',
-  },
-});
-
-/**
- * Size styles for string-based (registry) icons.
- * Includes fontSize so that 1em-based icons from the registry scale correctly.
- *
- * Expressed in `rem` for the same reason as {@link sizeStyles} — icons track the
- * root font-size instead of being locked to absolute pixels.
- */
-const spanSizeStyles = stylex.create({
-  /* eslint-disable @astryx/no-hardcoded-styles -- fontSize here sizes 1em-based
-     registry SVGs to the icon box; icons use their own 12/16/20/24 scale, not
-     the 14px-anchored textSizeVars type scale. Values are rem so icons track
-     the root font-size. */
-  xsm: {
-    width: '0.75rem',
-    height: '0.75rem',
-    fontSize: '0.75rem',
-  },
-  sm: {
-    width: '1rem',
-    height: '1rem',
-    fontSize: '1rem',
-  },
-  md: {
-    width: '1.25rem',
-    height: '1.25rem',
-    fontSize: '1.25rem',
-  },
-  lg: {
-    width: '1.5rem',
-    height: '1.5rem',
-    fontSize: '1.5rem',
-  },
-  /* eslint-enable @astryx/no-hardcoded-styles */
-});
-
 // =============================================================================
 // Types
 // =============================================================================
 
 export type IconColor = keyof typeof colorStyles;
-export type IconSize = keyof typeof sizeStyles;
 
 /**
  * Type for icon components that can be passed to Icon.
@@ -343,7 +286,12 @@ export function Icon({
       // precedence as escape hatches.
       {...mergeProps(
         themeProps('icon', {size, color}),
-        stylex.props(styles.root, colorStyles[color], sizeStyles[size], xstyle),
+        stylex.props(
+          styles.root,
+          colorStyles[color],
+          iconSizeStyles[size],
+          xstyle,
+        ),
         className ?? undefined,
         style,
       )}
@@ -412,7 +360,7 @@ function IconFromRegistry({
         stylex.props(
           styles.span,
           colorStyles[color],
-          spanSizeStyles[size],
+          iconBoxSizeStyles[size],
           xstyle,
         ),
         className ?? undefined,

--- a/packages/core/src/Icon/IconDefaultSizeContext.ts
+++ b/packages/core/src/Icon/IconDefaultSizeContext.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file IconDefaultSizeContext.ts
+ * @input Uses React context and an optional Icon size prop
+ * @output Supplies a component-owned default size to descendant Icon instances
+ * @position Internal Icon sizing context; consumed by Icon and icon-slot owners
+ */
+
+import {createContext, use} from 'react';
+
+export type ContextualIconSize = 'xsm' | 'sm' | 'md' | 'lg';
+
+const IconDefaultSizeContext = createContext<ContextualIconSize | null>(null);
+IconDefaultSizeContext.displayName = 'IconDefaultSizeContext';
+
+export const IconDefaultSizeProvider = IconDefaultSizeContext.Provider;
+
+export function useIconSize(
+  size: ContextualIconSize | undefined,
+): ContextualIconSize {
+  const contextualSize = use(IconDefaultSizeContext);
+  return size ?? contextualSize ?? 'md';
+}

--- a/packages/core/src/Icon/IconDefaultSizeContext.ts
+++ b/packages/core/src/Icon/IconDefaultSizeContext.ts
@@ -10,17 +10,14 @@
  */
 
 import {createContext, use} from 'react';
+import type {IconSize} from './IconSize.stylex';
 
-export type ContextualIconSize = 'xsm' | 'sm' | 'md' | 'lg';
-
-const IconDefaultSizeContext = createContext<ContextualIconSize | null>(null);
+const IconDefaultSizeContext = createContext<IconSize | null>(null);
 IconDefaultSizeContext.displayName = 'IconDefaultSizeContext';
 
 export const IconDefaultSizeProvider = IconDefaultSizeContext.Provider;
 
-export function useIconSize(
-  size: ContextualIconSize | undefined,
-): ContextualIconSize {
+export function useIconSize(size: IconSize | undefined): IconSize {
   const contextualSize = use(IconDefaultSizeContext);
   return size ?? contextualSize ?? 'md';
 }

--- a/packages/core/src/Icon/IconSize.stylex.ts
+++ b/packages/core/src/Icon/IconSize.stylex.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file IconSize.stylex.ts
+ * @input Defines the Icon size scale
+ * @output Exports shared Icon size types and StyleX styles
+ * @position Internal Icon sizing source; consumed by Icon and icon-slot owners
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Icon sizes are expressed in `rem` so they scale with the root font-size.
+ * Values are the px-equivalents at a 16px root: 12, 16, 20, and 24px.
+ */
+const iconSizeValues = {
+  xsm: '0.75rem',
+  sm: '1rem',
+  md: '1.25rem',
+  lg: '1.5rem',
+} as const;
+
+export type IconSize = keyof typeof iconSizeValues;
+
+/** Size styles for direct SVG icon components. */
+export const iconSizeStyles = stylex.create({
+  xsm: {
+    width: iconSizeValues.xsm,
+    height: iconSizeValues.xsm,
+  },
+  sm: {
+    width: iconSizeValues.sm,
+    height: iconSizeValues.sm,
+  },
+  md: {
+    width: iconSizeValues.md,
+    height: iconSizeValues.md,
+  },
+  lg: {
+    width: iconSizeValues.lg,
+    height: iconSizeValues.lg,
+  },
+});
+
+/**
+ * Size styles for icon boxes and string-based registry icons. `fontSize`
+ * keeps 1em-based icons in step with the box.
+ */
+export const iconBoxSizeStyles = stylex.create({
+  xsm: {
+    width: iconSizeValues.xsm,
+    height: iconSizeValues.xsm,
+    fontSize: iconSizeValues.xsm,
+  },
+  sm: {
+    width: iconSizeValues.sm,
+    height: iconSizeValues.sm,
+    fontSize: iconSizeValues.sm,
+  },
+  md: {
+    width: iconSizeValues.md,
+    height: iconSizeValues.md,
+    fontSize: iconSizeValues.md,
+  },
+  lg: {
+    width: iconSizeValues.lg,
+    height: iconSizeValues.lg,
+    fontSize: iconSizeValues.lg,
+  },
+});

--- a/packages/core/src/IconButton/IconButton.doc.mjs
+++ b/packages/core/src/IconButton/IconButton.doc.mjs
@@ -20,9 +20,9 @@ export const docs = {
     {
       name: 'icon',
       type: 'ReactNode',
-      description: 'Icon element rendered inside the button.',
+      description: 'Icon element rendered inside the button. An Astryx Icon with no explicit size defaults to sm for sm/md buttons and md for lg buttons.',
       required: true,
-      slotElements: [{__element: 'Icon', props: {icon: 'check', size: 'sm'}}],
+      slotElements: [{__element: 'Icon', props: {icon: 'check'}}],
     },
     {
       name: 'variant',
@@ -137,7 +137,7 @@ export const docsDense = {
   },
   propDescriptions: {
     label: 'accessible label; used as aria-label, not rendered as visible text',
-    icon: 'icon element rendered inside button',
+    icon: 'icon element rendered inside button; unsized Astryx Icon defaults to sm for sm/md buttons and md for lg',
     variant: 'visual style variant',
     size: 'size variant',
     elevation: 'resting shadow depth: none|low|med|high; raise for a floating action button (FAB)',

--- a/packages/core/src/IconButton/IconButton.test.tsx
+++ b/packages/core/src/IconButton/IconButton.test.tsx
@@ -12,6 +12,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {Icon} from '../Icon/Icon';
 import {IconButton} from './IconButton';
 
 describe('IconButton', () => {
@@ -44,6 +45,37 @@ describe('IconButton', () => {
   it('forwards size prop', () => {
     render(<IconButton label="Add" icon={<span>+</span>} size="sm" />);
     expect(screen.getByRole('button', {name: 'Add'})).toBeInTheDocument();
+  });
+
+  it.each([
+    ['sm', 'sm'],
+    ['md', 'sm'],
+    ['lg', 'md'],
+  ] as const)(
+    'defaults the Astryx Icon to the %s button icon size',
+    (buttonSize, iconSize) => {
+      render(
+        <IconButton
+          label="Add"
+          icon={<Icon icon="check" data-testid="icon" />}
+          size={buttonSize}
+        />,
+      );
+
+      expect(screen.getByTestId('icon')).toHaveAttribute('data-size', iconSize);
+    },
+  );
+
+  it('preserves an explicit Astryx Icon size', () => {
+    render(
+      <IconButton
+        label="Add"
+        icon={<Icon icon="check" size="lg" data-testid="icon" />}
+        size="sm"
+      />,
+    );
+
+    expect(screen.getByTestId('icon')).toHaveAttribute('data-size', 'lg');
   });
 
   it('handles click events', async () => {

--- a/packages/core/src/IconButton/IconButton.test.tsx
+++ b/packages/core/src/IconButton/IconButton.test.tsx
@@ -48,12 +48,12 @@ describe('IconButton', () => {
   });
 
   it.each([
-    ['sm', 'sm'],
-    ['md', 'sm'],
-    ['lg', 'md'],
+    ['sm', 'sm', '1rem'],
+    ['md', 'sm', '1rem'],
+    ['lg', 'md', '1.25rem'],
   ] as const)(
-    'defaults the Astryx Icon to the %s button icon size',
-    (buttonSize, iconSize) => {
+    'renders the %s button wrapper and inherited Icon at the same size',
+    (buttonSize, iconSize, renderedSize) => {
       render(
         <IconButton
           label="Add"
@@ -62,7 +62,15 @@ describe('IconButton', () => {
         />,
       );
 
-      expect(screen.getByTestId('icon')).toHaveAttribute('data-size', iconSize);
+      const icon = screen.getByTestId('icon');
+      const wrapper = icon.parentElement;
+      expect(wrapper).not.toBeNull();
+
+      expect(icon).toHaveAttribute('data-size', iconSize);
+      expect(getComputedStyle(icon).width).toBe(renderedSize);
+      expect(getComputedStyle(icon).height).toBe(renderedSize);
+      expect(getComputedStyle(wrapper!).width).toBe(renderedSize);
+      expect(getComputedStyle(wrapper!).height).toBe(renderedSize);
     },
   );
 


### PR DESCRIPTION
## Summary

- provide Button-sized defaults to descendant Astryx Icons
- render 16px icons in small and medium buttons and 20px icons in large buttons
- preserve explicit Icon size overrides
- document the behavior and add IconButton regression coverage

## Test plan

- `pnpm vitest run packages/core/src/Icon/Icon.test.tsx packages/core/src/Button/Button.test.tsx packages/core/src/IconButton/IconButton.test.tsx`
- `ASTRYX_STRICT_LINT=1 pnpm exec eslint packages/core/src/Button/Button.tsx packages/core/src/Icon/Icon.tsx packages/core/src/Icon/IconDefaultSizeContext.ts packages/core/src/IconButton/IconButton.test.tsx`
- `pnpm -F @astryxdesign/core build`
- `pnpm check:repo`