### PR TITLE
Deduplicate DropdownMenu divider theme metadata

### DIFF
--- a/.changeset/dropdown-divider-theme-target-dedup.md
+++ b/.changeset/dropdown-divider-theme-target-dedup.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Remove the duplicate `dropdown-menu-divider` row from CLI theme target documentation while leaving the runtime theme target unchanged.
+
+@cixzhang

--- a/packages/cli/api/theme/targets/targets.test.mjs
+++ b/packages/cli/api/theme/targets/targets.test.mjs
@@ -39,6 +39,19 @@ describe('themeTargets (api/theme/targets)', () => {
     ]);
   }, 60_000);
 
+  it('lists each target once under its owning component', async () => {
+    const {data} = await themeTargets('dropdown-menu-divider');
+    expect(data.targets).toEqual([
+      {
+        key: 'dropdown-menu-divider',
+        className: 'astryx-dropdown-menu-divider',
+        component: 'DropdownMenu',
+        props: [],
+        states: [],
+      },
+    ]);
+  }, 60_000);
+
   // Half the system's keys contain "button" (chat-send-button, toggle-button,
   // …). A component name has to mean the component, or `theme targets Button`
   // answers a different question than `component Button` and the two views

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -144,7 +144,14 @@ export const docs = {
         'Compound-mode menu content: DropdownMenuItem, DropdownMenuDivider, DropdownMenuSubMenu, and the selectable items. Mutually exclusive with `items`.',
     },
   ],
-  components: [{name: 'DropdownMenuItem'}],
+  components: [
+    {name: 'DropdownMenuItem'},
+    {name: 'DropdownMenuDivider'},
+    {name: 'DropdownMenuCheckboxItem'},
+    {name: 'DropdownMenuRadioGroup'},
+    {name: 'DropdownMenuRadioItem'},
+    {name: 'DropdownMenuSubMenu'},
+  ],
   usage: {
     description:
       'A dropdown menu that displays a list of actionable items in a popup triggered by a button. Use to present action options as a next step in a process, or to offer contextual actions without cluttering the interface.',

--- a/packages/core/src/DropdownMenu/DropdownMenuDivider.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuDivider.doc.mjs
@@ -17,9 +17,6 @@ export const docs = {
         'StyleX styles applied after the menu spacing. Must be a stylex.create() value: not an inline style object like style={{}}.',
     },
   ],
-  theming: {
-    targets: [{className: 'astryx-dropdown-menu-divider'}],
-  },
 };
 
 export const docsDense = {


### PR DESCRIPTION
## Why
`astryx theme targets dropdown-menu-divider` reported the same target twice because both the parent and child docs claimed ownership.

## What
- Keep the divider theme target owned by `DropdownMenu` only.
- Complete the parent component roster with every existing public DropdownMenu child doc.
- Add a CLI regression asserting one divider row owned by `DropdownMenu`.

## Risk
Documentation metadata and tests only; no runtime behavior changes.

## Testing
- Focused DropdownMenu and CLI theme-target tests (138 tests)
- Core, lab, charts, and richtext docs typechecks
- CLI template-docs typecheck
- `pnpm check:repo`