### PR TITLE
fix(Spinner): keep theme target on status element

### DIFF
--- a/.changeset/spinner-labelled-theme-target.md
+++ b/.changeset/spinner-labelled-theme-target.md
@@ -1,0 +1,15 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep Spinner's documented `spinner` target on the status element that
+paints the ring, including when a visible label adds a structural wrapper. Theme
+size and shade overrides now reach the same visual part in labelled and
+unlabelled states.
+
+The labelled wrapper remains the public root for refs, DOM props, and consumer
+styling. An unregistered private bridge carries root `style`, `className`, and
+`xstyle` variable overrides into the ring, so they keep consumer precedence even
+when an active theme declares the same public variables on the status target.
+
+@cixzhang

--- a/.github/scripts/theme-var-reachability.js
+++ b/.github/scripts/theme-var-reachability.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-
 /**
- * @description Asserts every documented public component var is settable from a theme
+ * @description Asserts documented component vars and the Spinner root cascade in Chromium
  * @input --storybook-dir <path> [--port <n>]
- * @output One line per var; exit 1 if any var cannot be reached from @layer astryx-theme
+ * @output One line per check; exit 1 if a theme or root override cannot reach its painted owner
  *
  * A public var is a promise: set it on the component's theme target and the
  * component changes. Nothing in the unit suite can check that promise. jsdom
@@ -26,8 +25,10 @@
  *   3. the theme rule loses               — an inline write or an unlayered
  *                                           declaration outranks it (#4530)
  *
- * What it does NOT prove is the pixel: it stops at the value arriving on the
- * element. What the component then paints with it is that component's own test.
+ * The generic pass stops at the value arriving on the declared element; it does
+ * not prove the component paints with it. Spinner's focused regression below
+ * continues through computed SVG geometry and stroke paint because its public
+ * root and painted target are different elements.
  */
 
 const {chromium} = require('playwright');
@@ -139,9 +140,7 @@ function reachInPage([name, classNames, sentinel]) {
   const declaring = [...document.querySelectorAll('*')].find(el => {
     if (!getComputedStyle(el).getPropertyValue(name).trim()) return false;
     const parent = el.parentElement;
-    return (
-      !parent || !getComputedStyle(parent).getPropertyValue(name).trim()
-    );
+    return !parent || !getComputedStyle(parent).getPropertyValue(name).trim();
   });
   if (!declaring) return {status: 'undeclared'};
 
@@ -195,6 +194,114 @@ async function probe(context, entry, index) {
   return last;
 }
 
+/**
+ * Spinner's labelled public root and painted theme target are different
+ * elements. This browser fixture proves the private bridge keeps the normal
+ * theme path and all three root styling escape hatches in the promised order.
+ */
+async function probeSpinnerCascade(context, index) {
+  const id = 'core-spinner--theme-cascade-contract';
+  if (!Object.values(index.entries || {}).some(entry => entry.id === id)) {
+    return {status: 'nostory'};
+  }
+
+  const page = await context.newPage();
+  try {
+    await page.goto(
+      `http://localhost:${port}/iframe.html?id=${id}&viewMode=story`,
+      {waitUntil: 'networkidle', timeout: 30000},
+    );
+    await page.waitForSelector('[data-spinner-cascade="root-class"]', {
+      timeout: 20000,
+    });
+    const readings = await page.evaluate(() => {
+      const read = name => {
+        const root = document.querySelector(`[data-spinner-cascade="${name}"]`);
+        const status = root?.matches('[role="status"]')
+          ? root
+          : root?.querySelector('[role="status"]');
+        const circles = status?.querySelectorAll('circle');
+        const svg = status?.querySelector('svg');
+        if (
+          !(root instanceof HTMLElement) ||
+          !(status instanceof HTMLElement) ||
+          !svg ||
+          circles?.length !== 2
+        ) {
+          return {name, error: 'missing root, status, svg, or circles'};
+        }
+        const statusStyle = getComputedStyle(status);
+        const svgStyle = getComputedStyle(svg);
+        const box = status.getBoundingClientRect();
+        return {
+          name,
+          rootHasTarget: root.classList.contains('astryx-spinner'),
+          statusHasTarget: status.classList.contains('astryx-spinner'),
+          publicDiameter: statusStyle
+            .getPropertyValue('--spinner-diameter')
+            .trim(),
+          publicStroke: statusStyle
+            .getPropertyValue('--spinner-stroke-width')
+            .trim(),
+          rootDiameter: statusStyle
+            .getPropertyValue('--_spinner-root-diameter')
+            .trim(),
+          rootStroke: statusStyle
+            .getPropertyValue('--_spinner-root-stroke')
+            .trim(),
+          box: [box.width, box.height],
+          svgBox: [svgStyle.width, svgStyle.height],
+          radius: getComputedStyle(circles[1]).r,
+          strokeWidth: getComputedStyle(circles[1]).strokeWidth,
+          arcPaint: getComputedStyle(circles[1]).stroke,
+          trackPaint: getComputedStyle(circles[0]).stroke,
+        };
+      };
+      return [
+        read('theme-unlabelled'),
+        read('theme-labelled'),
+        read('root-style'),
+        read('root-xstyle'),
+        read('root-class'),
+      ];
+    });
+
+    const expected = {
+      'theme-unlabelled': [74, 30, 7, 'rgb(71, 72, 73)', 'rgb(74, 75, 76)', ''],
+      'theme-labelled': [74, 30, 7, 'rgb(71, 72, 73)', 'rgb(74, 75, 76)', ''],
+      'root-style': [50, 20, 5, 'rgb(1, 2, 3)', 'rgb(4, 5, 6)', '40px'],
+      'root-xstyle': [54, 21, 6, 'rgb(7, 8, 9)', 'rgb(10, 11, 12)', '42px'],
+      'root-class': [60, 22, 8, 'rgb(13, 14, 15)', 'rgb(16, 17, 18)', '44px'],
+    };
+    const near = (value, number) =>
+      Math.abs(Number.parseFloat(String(value)) - number) < 0.05;
+    const failed = readings.find(reading => {
+      const want = expected[reading.name];
+      return (
+        reading.error ||
+        !reading.statusHasTarget ||
+        (reading.name !== 'theme-unlabelled' && reading.rootHasTarget) ||
+        reading.publicDiameter !== '60px' ||
+        reading.publicStroke !== '7px' ||
+        reading.rootDiameter !== want[5] ||
+        !near(reading.box?.[0], want[0]) ||
+        !near(reading.box?.[1], want[0]) ||
+        !near(reading.svgBox?.[0], want[0]) ||
+        !near(reading.svgBox?.[1], want[0]) ||
+        !near(reading.radius, want[1]) ||
+        !near(reading.strokeWidth, want[2]) ||
+        reading.arcPaint !== want[3] ||
+        reading.trackPaint !== want[4]
+      );
+    });
+    return failed == null
+      ? {status: 'reaches', readings}
+      : {status: 'failed', reading: failed};
+  } finally {
+    await page.close();
+  }
+}
+
 async function run() {
   const repoRoot = process.cwd();
   const dir = path.resolve(repoRoot, storybookDir);
@@ -231,7 +338,9 @@ async function run() {
       const r = await probe(context, entry, index);
       const where = `${entry.component} ${entry.name}`;
       if (r.status === 'reaches') {
-        console.log(`✓ ${where} — .${r.target} sets it (${r.before} → ${r.after})`);
+        console.log(
+          `✓ ${where} — .${r.target} sets it (${r.before} → ${r.after})`,
+        );
         continue;
       }
       failures.push(where);
@@ -252,6 +361,18 @@ async function run() {
         );
       }
     }
+
+    const spinnerCascade = await probeSpinnerCascade(context, index);
+    if (spinnerCascade.status === 'reaches') {
+      console.log(
+        '✓ Spinner labelled root overrides — theme, style, xstyle, and className precedence reaches the ring',
+      );
+    } else {
+      failures.push('Spinner labelled root override precedence');
+      console.error(
+        `✗ Spinner labelled root override precedence: ${JSON.stringify(spinnerCascade)}`,
+      );
+    }
   } finally {
     await browser.close();
     server.close();
@@ -259,13 +380,15 @@ async function run() {
 
   if (failures.length > 0) {
     console.error(
-      `\nFailing: ${failures.length} documented public var(s) a theme cannot set — ` +
-        `${failures.join(', ')}. A var an author reads about and cannot use is ` +
-        `worse than no var.`,
+      `\nFailing: ${failures.length} theme reachability check(s) — ` +
+        `${failures.join(', ')}. A documented override that cannot reach its ` +
+        `painted owner is worse than no override.`,
     );
     return 1;
   }
-  console.log(`\nAll ${entries.length} public component vars are settable from a theme.`);
+  console.log(
+    `\nAll ${entries.length} public component vars and the Spinner root override cascade are reachable.`,
+  );
   return 0;
 }
 

--- a/apps/storybook/stories/Spinner.stories.tsx
+++ b/apps/storybook/stories/Spinner.stories.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {CSSProperties} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import type {Meta, StoryObj} from '@storybook/react';
-import {Spinner} from '@astryxdesign/core/Spinner';
+import {Spinner, type SpinnerProps} from '@astryxdesign/core/Spinner';
 import {Text} from '@astryxdesign/core/Text';
 import {HStack, VStack} from '@astryxdesign/core/Layout';
 import {Theme, defineTheme} from '@astryxdesign/core/theme';
@@ -267,5 +268,91 @@ export const NarrowFlexHost: Story = {
         </div>
       </VStack>
     </VStack>
+  ),
+};
+
+const cascadeContractTheme = defineTheme({
+  name: 'spinner-cascade-contract',
+  components: {
+    spinner: {
+      'size:xl': {
+        '--spinner-diameter': '60px',
+        '--spinner-stroke-width': '7px',
+      },
+      'shade:subtle': {
+        '--spinner-color': 'rgb(71, 72, 73)',
+        '--spinner-track-color': 'rgb(74, 75, 76)',
+      },
+    },
+  },
+});
+
+const rootStyleOverride = {
+  '--spinner-diameter': '40px',
+  '--spinner-stroke-width': '5px',
+  '--spinner-color': 'rgb(1, 2, 3)',
+  '--spinner-track-color': 'rgb(4, 5, 6)',
+} as CSSProperties;
+
+const rootXstyleOverride = stylex.create({
+  root: {
+    '--spinner-diameter': '42px',
+    '--spinner-stroke-width': '6px',
+    '--spinner-color': 'rgb(7, 8, 9)',
+    '--spinner-track-color': 'rgb(10, 11, 12)',
+  },
+});
+
+/**
+ * A browser fixture for the labelled root / painted target split. A theme owns
+ * the status target, while consumer styling remains on the public wrapper and
+ * must keep its higher precedence through the private variable bridge.
+ */
+export const ThemeCascadeContract: Story = {
+  render: () => (
+    <Theme theme={cascadeContractTheme} mode="light">
+      <VStack gap={3} hAlign="start">
+        <style>{`
+          .spinner-root-class-override {
+            --spinner-diameter: 44px;
+            --spinner-stroke-width: 8px;
+            --spinner-color: rgb(13, 14, 15);
+            --spinner-track-color: rgb(16, 17, 18);
+          }
+        `}</style>
+        <Spinner
+          size="xl"
+          shade="subtle"
+          data-spinner-cascade="theme-unlabelled"
+        />
+        <Spinner
+          size="xl"
+          shade="subtle"
+          label="Theme only"
+          data-spinner-cascade="theme-labelled"
+        />
+        <Spinner
+          size="xl"
+          shade="subtle"
+          label="Root style override"
+          style={rootStyleOverride}
+          data-spinner-cascade="root-style"
+        />
+        <Spinner
+          size="xl"
+          shade="subtle"
+          label="Root xstyle override"
+          xstyle={rootXstyleOverride.root as unknown as SpinnerProps['xstyle']}
+          data-spinner-cascade="root-xstyle"
+        />
+        <Spinner
+          size="xl"
+          shade="subtle"
+          label="Root class override"
+          className="spinner-root-class-override"
+          data-spinner-cascade="root-class"
+        />
+      </VStack>
+    </Theme>
   ),
 };

--- a/packages/core/src/Spinner/Spinner.test.tsx
+++ b/packages/core/src/Spinner/Spinner.test.tsx
@@ -9,9 +9,11 @@
  * SYNC: When Spinner.tsx changes, update tests to match new behavior
  */
 
+import type {CSSProperties} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {Spinner} from './Spinner';
+import {Spinner, type SpinnerProps} from './Spinner';
 import {defineTheme} from '../theme/defineTheme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
 
@@ -22,6 +24,15 @@ const SIZES = {
   lg: {diameter: 18, border: 3},
   xl: {diameter: 28, border: 4},
 } as const;
+
+const rootVariableOverrides = stylex.create({
+  spinner: {
+    '--spinner-diameter': '42px',
+    '--spinner-stroke-width': '6px',
+    '--spinner-color': 'rgb(7, 8, 9)',
+    '--spinner-track-color': 'rgb(10, 11, 12)',
+  },
+});
 
 const ring = (testId = 'spinner') =>
   screen.getByTestId(testId).querySelector('svg') as SVGSVGElement;
@@ -141,6 +152,117 @@ describe('Spinner', () => {
     render(<Spinner data-testid="spinner" />);
     const spinner = screen.getByTestId('spinner');
     expect(spinner.tagName.toLowerCase()).toBe('span');
+  });
+
+  describe('theme target ownership', () => {
+    const expectSpinnerTarget = (element: HTMLElement) => {
+      expect(element).toHaveClass('astryx-spinner', 'xl', 'subtle');
+      expect(element).toHaveAttribute('data-size', 'xl');
+      expect(element).toHaveAttribute('data-shade', 'subtle');
+    };
+
+    const expectSpinnerVars = (element: HTMLElement) => {
+      const computed = window.getComputedStyle(element);
+      expect(computed.getPropertyValue('--spinner-diameter')).toBe('28px');
+      expect(computed.getPropertyValue('--spinner-stroke-width')).toBe('4px');
+      expect(computed.getPropertyValue('--spinner-color')).not.toBe('');
+      expect(computed.getPropertyValue('--spinner-track-color')).not.toBe('');
+    };
+
+    it('places the target and variant declarations on an unlabelled status span', () => {
+      render(<Spinner size="xl" shade="subtle" data-testid="spinner" />);
+      const root = screen.getByTestId('spinner');
+
+      expect(root).toBe(screen.getByRole('status'));
+      expect(root.tagName).toBe('SPAN');
+      expectSpinnerTarget(root);
+      expectSpinnerVars(root);
+    });
+
+    it('places the labelled target on the status span while its root owns the variant declarations', () => {
+      render(
+        <Spinner
+          size="xl"
+          shade="subtle"
+          label="Loading results"
+          data-testid="spinner"
+        />,
+      );
+      const root = screen.getByTestId('spinner');
+      const status = screen.getByRole('status');
+
+      expect(root.tagName).toBe('DIV');
+      expect(status.tagName).toBe('SPAN');
+      expect(status.parentElement).toBe(root);
+      expectSpinnerTarget(status);
+      expect(root).not.toHaveClass('astryx-spinner', 'xl', 'subtle');
+      expect(root).not.toHaveAttribute('data-size');
+      expect(root).not.toHaveAttribute('data-shade');
+      expectSpinnerVars(status);
+    });
+
+    it('keeps labelled root CSS variable overrides on the ring ancestor without shadowing them', () => {
+      const style = {
+        '--spinner-diameter': '40px',
+        '--spinner-stroke-width': '5px',
+        '--spinner-color': 'rgb(1, 2, 3)',
+        '--spinner-track-color': 'rgb(4, 5, 6)',
+      } as CSSProperties;
+      render(
+        <Spinner
+          size="xl"
+          shade="subtle"
+          label="Loading results"
+          style={style}
+          data-testid="spinner"
+        />,
+      );
+      const root = screen.getByTestId('spinner');
+      const status = screen.getByRole('status');
+
+      const rootStyle = window.getComputedStyle(root);
+      expect(rootStyle.getPropertyValue('--spinner-diameter')).toBe('40px');
+      expect(rootStyle.getPropertyValue('--spinner-stroke-width')).toBe('5px');
+      expect(rootStyle.getPropertyValue('--spinner-color')).toBe(
+        'rgb(1, 2, 3)',
+      );
+      expect(rootStyle.getPropertyValue('--spinner-track-color')).toBe(
+        'rgb(4, 5, 6)',
+      );
+      // jsdom does not resolve inherited custom-property bridges. It can still
+      // pin both ends: the root keeps the consumer values, while the targeted
+      // status owns the component defaults that a theme can override. The real
+      // cascade and painted result are covered in Chromium.
+      expectSpinnerVars(status);
+      expect(status.parentElement).toBe(root);
+      expect(status.querySelectorAll('circle')).toHaveLength(2);
+    });
+
+    it('keeps labelled root xstyle variable overrides on the ring ancestor', () => {
+      render(
+        <Spinner
+          size="xl"
+          shade="subtle"
+          label="Loading results"
+          xstyle={
+            rootVariableOverrides.spinner as unknown as SpinnerProps['xstyle']
+          }
+          data-testid="spinner"
+        />,
+      );
+      const root = screen.getByTestId('spinner');
+      const status = screen.getByRole('status');
+      const rootStyle = window.getComputedStyle(root);
+
+      expect(rootStyle.getPropertyValue('--spinner-diameter')).toBe('42px');
+      expect(rootStyle.getPropertyValue('--spinner-stroke-width')).toBe('6px');
+      expect(rootStyle.getPropertyValue('--spinner-color')).toBe('rgb(7,8,9)');
+      expect(rootStyle.getPropertyValue('--spinner-track-color')).toBe(
+        'rgb(10,11,12)',
+      );
+      expect(status.parentElement).toBe(root);
+      expectSpinnerVars(status);
+    });
   });
 
   // The box has always been sized by an inline width/height written after the

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -75,6 +75,19 @@ const RESOLVED_STROKE = '--_spinner-ring-stroke';
 const RESOLVED_GEOMETRY_VARS = [RESOLVED_DIAMETER, RESOLVED_STROKE];
 
 /**
+ * An unregistered bridge from the labelled public root to the painted status
+ * element. A missing public var makes the bridge invalid, so the status falls
+ * back to its own default or theme declaration. A consumer `style`, `className`,
+ * or `xstyle` declaration on the root makes the bridge concrete; the inherited
+ * value then keeps consumer precedence even when the theme declares that public
+ * var directly on the child target.
+ */
+const ROOT_DIAMETER = '--_spinner-root-diameter';
+const ROOT_STROKE = '--_spinner-root-stroke';
+const ROOT_COLOR = '--_spinner-root-color';
+const ROOT_TRACK_COLOR = '--_spinner-root-track-color';
+
+/**
  * The composed box size: diameter plus a stroke width on each side.
  *
  * It is deliberately NOT registered, unlike the pair above. The element reads
@@ -222,18 +235,20 @@ const styles = stylex.create({
     flexDirection: 'column',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
+    [ROOT_DIAMETER]: 'var(--spinner-diameter)',
+    [ROOT_STROKE]: 'var(--spinner-stroke-width)',
+    [ROOT_COLOR]: 'var(--spinner-color)',
+    [ROOT_TRACK_COLOR]: 'var(--spinner-track-color)',
   },
   spinner: {
     display: 'inline-grid',
     placeItems: 'center',
     verticalAlign: 'middle',
-    // The public geometry vars, resolved into the registered `<length>` pair
-    // the arithmetic below needs. Reading them here rather than in each
-    // `calc()` keeps one place where a themed value enters the component, and
-    // it is the span that reads them whether the theme target is the span or
-    // the wrapper — a custom property inherits either way.
-    [RESOLVED_DIAMETER]: 'var(--spinner-diameter)',
-    [RESOLVED_STROKE]: 'var(--spinner-stroke-width)',
+    // A labelled root may supply a consumer override through the private bridge.
+    // Without one, the invalid first arm falls back to the public value declared
+    // directly on this target by the component default or active theme.
+    [RESOLVED_DIAMETER]: `var(${ROOT_DIAMETER}, var(--spinner-diameter))`,
+    [RESOLVED_STROKE]: `var(${ROOT_STROKE}, var(--spinner-stroke-width))`,
     // The size of the box, composed here and applied as an inline style at the
     // element, so that the box and the drawn ring come from the same two vars
     // and a themed size moves both together — without the sizing moving from
@@ -309,11 +324,9 @@ const styles = stylex.create({
     r: `calc(var(${RESOLVED_DIAMETER}) / 2)`,
     strokeWidth: `var(${RESOLVED_STROKE})`,
   },
-  // The two ring colors ride `stroke` directly, read off the public vars the
-  // shade declares. The paint comes from the cascade, so every notation a
-  // theme can write — `var()`, `color-mix()`, and the `currentColor` the
-  // inherit shade is built on — resolves where it is used, and a color changed
-  // after mount repaints instead of going stale.
+  // The ring colors use the same bridge as geometry. This preserves the public
+  // root's consumer overrides without moving the target away from the element
+  // that paints the ring.
   //
   // The dash pattern is composed from the resolved diameter the same way, so a
   // themed ring keeps the same fraction of arc rather than the same absolute
@@ -323,18 +336,21 @@ const styles = stylex.create({
   // default arc by 0.64% and moves the cap by half a pixel. Composing the
   // lengths keeps the default byte-identical to what it drew before.
   arc: {
-    stroke: 'var(--spinner-color)',
+    stroke: `var(${ROOT_COLOR}, var(--spinner-color))`,
     transform: 'rotate(-90deg)',
     strokeDasharray: `calc(var(${RESOLVED_DIAMETER}) * ${ARC_DASH}) calc(var(${RESOLVED_DIAMETER}) * ${ARC_GAP})`,
   },
-  track: {stroke: 'var(--spinner-track-color)'},
+  track: {stroke: `var(${ROOT_TRACK_COLOR}, var(--spinner-track-color))`},
 });
 
-// What each named `size` and `shade` resolve to. Both groups DECLARE the four
-// public vars, on the element that carries the `spinner` theme target, and
-// everything downstream reads them — so a theme's `@layer astryx-theme` rule
-// against `.astryx-spinner.xl` overrides the default the same way it does for
-// `--tree-list-indent` or `--button-focus-offset`, e.g.
+// What each named `size` and `shade` resolves to. Both groups declare the four
+// public vars on the status element that carries the `spinner` target. A
+// labelled wrapper declares only the private bridges above: they are invalid
+// until a consumer sets the corresponding public var on that root, so normal
+// defaults and theme overrides resolve on the target while a root override keeps
+// the documented consumer precedence. A theme's `@layer astryx-theme` rule
+// against `.astryx-spinner.xl` overrides the target's default the same way it
+// does for `--tree-list-indent` or `--button-focus-offset`, e.g.
 // spinner: { 'size:xl': { '--spinner-diameter': '40px' } }.
 //
 // Declaring is only safe because #5410 moved the compiled StyleX CSS inside
@@ -505,16 +521,11 @@ export function Spinner({
       data-testid={hasLabel ? undefined : testId}
       {...(hasLabel ? {} : restProps)}
       {...mergeProps(
-        hasLabel ? '' : themeProps('spinner', {size, shade}),
+        themeProps('spinner', {size, shade}),
         stylex.props(
           styles.spinner,
-          // The defaults are declared on whichever element carries the theme
-          // target, and only there: when a label moves the target to the
-          // wrapper, this span must inherit the wrapper's value rather than
-          // declare its own, which would shadow a theme's override with the
-          // default it is trying to replace.
-          !hasLabel && sizeStyles[size],
-          !hasLabel && shadeStyles[shade],
+          sizeStyles[size],
+          shadeStyles[shade],
           !hasLabel && xstyle,
         ),
         hasLabel ? undefined : className,
@@ -572,17 +583,7 @@ export function Spinner({
       ref={ref as React.Ref<HTMLDivElement>}
       data-testid={testId}
       {...restProps}
-      {...mergeProps(
-        themeProps('spinner', {size, shade}),
-        stylex.props(
-          styles.wrapper,
-          sizeStyles[size],
-          shadeStyles[shade],
-          xstyle,
-        ),
-        className,
-        style,
-      )}>
+      {...mergeProps(stylex.props(styles.wrapper, xstyle), className, style)}>
       {spinner}
       {typeof label === 'string' ? (
         <Text id={labelId} type="body" weight="bold">


### PR DESCRIPTION
## Why

A labelled Spinner published its stable theme target on a structural layout wrapper instead of the status element that paints the ring. That made direct target properties describe the wrapper rather than the Spinner’s owned visual part.

## What

- Keep the existing `spinner` target and reflected size/shade state on the `role="status"` element in labelled and unlabelled states.
- Keep the wrapper as the public root for refs, rest props, `data-testid`, and consumer styling.
- Add an unregistered private bridge from the labelled root to the ring so root `style`, `className`, and `xstyle` custom-property overrides keep consumer precedence even when the active theme declares the same variables on the child target.
- Add unit coverage plus a committed Chromium story/guard for target ownership and the full root/theme cascade.

## Compatibility

This is a patch fix. The documented target name, props, public root, ref destination, DOM pass-through, and styling APIs are unchanged. The selector now remains on the semantic element that owns and paints the Spinner, as required by the current component-theming contract; the structural wrapper was never documented as a separate target or anatomy part.

## Testing

- Full package build and actual Storybook production build via `pnpm storybook:build`.
- Generated probe-theme reach in Chromium 149: labelled and unlabelled `spinner` targets reached, with no failure or shadowing.
- Focused Chromium matrix: all 32 labelled/unlabelled size × shade states reached the target and public-variable paint path, including `xl`.
- Committed Chromium guard: theme-only labelled/unlabelled fallbacks and labelled root `style`, `xstyle`, and `className` overrides all reached computed SVG geometry and stroke paint. Root overrides still win when the active theme declares the same variables.
- All 10 documented public component variables pass the real-browser theme reachability guard.
- 600 focused unit/theming/probe tests and the repository checks pass.
- `visual:probe-theme:check` currently reports existing unrelated fixture drift: regeneration adds only Selector and MultiSelector `readonly` selectors. No Spinner fixture change remains after rebasing, so those updates are intentionally excluded.
