### PR TITLE
fix(cli): deduplicate parent and child theme targets

### DIFF
--- a/.changeset/deduplicate-parent-theme-targets.md
+++ b/.changeset/deduplicate-parent-theme-targets.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Deduplicate parent-owned theming targets in CLI discovery while preserving each child component's direct documentation.
+
+@cixzhang

--- a/packages/cli/api/theme/targets/targets.test.mjs
+++ b/packages/cli/api/theme/targets/targets.test.mjs
@@ -39,6 +39,21 @@ describe('themeTargets (api/theme/targets)', () => {
     ]);
   }, 60_000);
 
+  it.each(['table-header', 'table-body', 'table-footer'])(
+    '%s appears once under the Table owner',
+    async target => {
+      const {data} = await themeTargets('Table');
+      const matches = data.targets.filter(entry => entry.key === target);
+      expect(data.componentCount).toBe(1);
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({
+        key: target,
+        component: 'Table',
+      });
+    },
+    60_000,
+  );
+
   // Half the system's keys contain "button" (chat-send-button, toggle-button,
   // …). A component name has to mean the component, or `theme targets Button`
   // answers a different question than `component Button` and the two views

--- a/packages/cli/foundation/discovery/theming-targets.mjs
+++ b/packages/cli/foundation/discovery/theming-targets.mjs
@@ -45,8 +45,10 @@ function targetKey(className) {
 
 /**
  * Every theming target declared under a core `src` directory, sorted by key
- * then component. A key can appear more than once: a shared sub-element (the
- * radio indicator, say) is documented by every component that renders it.
+ * then component. When both a parent doc and one of its `subComponentOf`
+ * children declare the same class, the parent is the canonical discovery owner;
+ * the child keeps its direct docs but does not add a second listing row. Shared
+ * targets declared by unrelated components remain separate rows.
  *
  * Unreadable docs are skipped rather than fatal — a single malformed doc must
  * not take out theme validation or the listing.
@@ -57,7 +59,7 @@ function targetKey(className) {
 export async function collectThemingTargets(coreSrc) {
   if (!coreSrc || !fs.existsSync(coreSrc)) return [];
 
-  /** @type {ThemingTarget[]} */
+  /** @type {Array<ThemingTarget & {parent: string|null}>} */
   const targets = [];
 
   /** @param {string} dir */
@@ -93,6 +95,8 @@ export async function collectThemingTargets(coreSrc) {
           key,
           className,
           component,
+          parent:
+            typeof doc?.subComponentOf === 'string' ? doc.subComponentOf : null,
           props: stringList(target.visualProps),
           states: stringList(target.states),
         });
@@ -102,10 +106,53 @@ export async function collectThemingTargets(coreSrc) {
 
   await scan(coreSrc);
 
-  targets.sort(
+  const canonical = canonicalizeParentTargets(targets);
+  canonical.sort(
     (a, b) => a.key.localeCompare(b.key) || a.component.localeCompare(b.component),
   );
-  return targets;
+  return canonical;
+}
+
+/**
+ * Collapse only an explicit parent/child duplicate. A child target is removed
+ * when its `subComponentOf` parent declares that same class exactly once; its
+ * props and states are merged into the parent's row so no capability is lost.
+ *
+ * Unrelated components sharing a class remain separate. An ambiguous parent
+ * declaration also remains untouched rather than guessing which row is
+ * canonical.
+ *
+ * @param {Array<ThemingTarget & {parent: string|null}>} targets
+ * @returns {ThemingTarget[]}
+ */
+function canonicalizeParentTargets(targets) {
+  /** @type {Map<string, Array<ThemingTarget & {parent: string|null}>>} */
+  const rootsByComponentAndClass = new Map();
+  for (const target of targets) {
+    if (target.parent != null) continue;
+    const identity = `${target.component}\0${target.className}`;
+    const roots = rootsByComponentAndClass.get(identity) ?? [];
+    roots.push(target);
+    rootsByComponentAndClass.set(identity, roots);
+  }
+
+  /** @type {Set<ThemingTarget & {parent: string|null}>} */
+  const duplicates = new Set();
+  for (const target of targets) {
+    if (target.parent == null) continue;
+    const roots =
+      rootsByComponentAndClass.get(`${target.parent}\0${target.className}`) ?? [];
+    if (roots.length !== 1) continue;
+
+    const canonical = roots[0];
+    canonical.props = [...new Set([...canonical.props, ...target.props])];
+    canonical.states = [...new Set([...canonical.states, ...target.states])];
+    duplicates.add(target);
+  }
+
+  return targets
+    .filter(target => !duplicates.has(target))
+    .map(({parent: _parent, ...target}) => target);
 }
 
 /**

--- a/packages/cli/foundation/discovery/theming-targets.test.mjs
+++ b/packages/cli/foundation/discovery/theming-targets.test.mjs
@@ -67,6 +67,34 @@ describe('collectThemingTargets', () => {
     });
   });
 
+  it.each([
+    ['TableHeader', 'table-header'],
+    ['TableBody', 'table-body'],
+    ['TableFooter', 'table-footer'],
+  ])('keeps %s theming metadata available in its direct doc', async (name, key) => {
+    const doc = await loadComponentDoc(
+      path.join(coreSrc, 'Table', `${name}.doc.mjs`),
+    );
+    expect(doc.subComponentOf).toBe('Table');
+    expect(doc.theming.targets).toContainEqual({className: `astryx-${key}`});
+  });
+
+  it.each(['table-header', 'table-body', 'table-footer'])(
+    'enumerates %s once under its canonical Table owner',
+    async key => {
+      const matches = (await enumerated).filter(target => target.key === key);
+      expect(matches).toEqual([
+        {
+          key,
+          className: `astryx-${key}`,
+          component: 'Table',
+          props: [],
+          states: [],
+        },
+      ]);
+    },
+  );
+
   it('is sorted by key, so a diff of two runs is readable', async () => {
     const keys = (await enumerated).map(t => t.key);
     expect(keys).toEqual([...keys].sort((a, b) => a.localeCompare(b)));
@@ -78,9 +106,10 @@ describe('collectThemingTargets', () => {
   it('collapses to the override keys, merging the components that share one', async () => {
     const byKey = targetsByKey(await enumerated);
     expect(byKey['switch']).toEqual(['size', 'checked', 'disabled']);
-    // `radio` is documented by both Indicator and RadioList.
+    // `radio` is documented by two unrelated owners. Parent/child
+    // canonicalization must not collapse a shared target across families.
     const radio = (await enumerated).filter(t => t.key === 'radio');
-    expect(radio.length).toBeGreaterThan(1);
+    expect(radio.map(t => t.component)).toEqual(['Indicator', 'RadioList']);
     for (const t of radio) {
       for (const name of [...t.props, ...t.states]) {
         expect(byKey['radio']).toContain(name);


### PR DESCRIPTION
## Why

Theme authors could see duplicate Table section targets because both the Table parent and its child docs correctly expose the same metadata for different lookup paths.

## What

- Preserve direct theming docs for `TableHeader`, `TableBody`, and `TableFooter`.
- Canonicalize parent/child duplicates in CLI target discovery under the parent owner, while retaining unrelated shared-target rows.
- Add direct-doc and unfiltered-discovery regression coverage for all three Table sections.
- Add a CLI patch Changeset.

## Risk

CLI metadata discovery only; Table runtime behavior is unchanged.

## Testing

- Full CLI suite: 2,880 tests
- Focused Table suite: 130 tests
- CLI strict, authoring, JSON API, template-docs, and core docs typechecks
- `pnpm check:repo`