### PR TITLE
Correct PowerSearch theme target ownership

### DIFF
--- a/.changeset/power-search-target-ownership.md
+++ b/.changeset/power-search-target-ownership.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': minor
+---
+
+[breaking] Remove the non-visual PowerSearch wrapper's `astryx-power-search` theme target.
+
+@cixzhang
+
+Themes that target `power-search` should migrate those styles to the existing Tokenizer `tokenizer` target. PowerSearch does not publish a replacement root target until touch-surface ownership is defined.

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -230,7 +230,7 @@ export const docs = {
     ],
   },
   theming: {
-    targets: [{className: 'astryx-power-search'}],
+    targets: [],
   },
 };
 

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -9,7 +9,7 @@
  * SYNC: When PowerSearch.tsx changes, update tests to match
  */
 
-import {useState} from 'react';
+import {createRef, useState} from 'react';
 import {describe, it, expect, vi, beforeAll, afterAll, afterEach} from 'vitest';
 import {
   render,
@@ -129,19 +129,24 @@ function PowerSearchWrapper(props: {config: PowerSearchConfig}) {
 
 describe('PowerSearch', () => {
   it('forwards ref to the root element', () => {
-    let root: HTMLDivElement | null = null;
-    render(
+    const root = createRef<HTMLDivElement>();
+    const {container} = render(
       <PowerSearch
-        ref={el => {
-          root = el;
-        }}
+        ref={root}
         config={config}
         filters={[]}
         onChange={() => {}}
       />,
     );
-    expect(root).toBeInstanceOf(HTMLDivElement);
-    expect(root).toHaveClass('astryx-power-search');
+    expect(root.current).toBeInstanceOf(HTMLDivElement);
+    const tokenizerTarget =
+      container.querySelector<HTMLElement>('.astryx-tokenizer');
+    const tokenizerRoot = tokenizerTarget?.closest('.astryx-field');
+    expect(tokenizerTarget).toBeInstanceOf(HTMLDivElement);
+    expect(tokenizerTarget).not.toBe(root.current);
+    expect(root.current?.firstElementChild).toBe(tokenizerRoot);
+    expect(tokenizerRoot).toContainElement(tokenizerTarget ?? null);
+    expect(root.current).not.toHaveClass('astryx-power-search');
   });
 
   it('exposes typeahead focus through handleRef', () => {

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -55,7 +55,6 @@ import {
 } from './formatFilterValue';
 import {PowerSearchEditPopover} from './PowerSearchEditPopover';
 import {resolveOperatorLabel} from './resolveOperatorLabel';
-import {themeProps} from '../utils/themeProps';
 import {truncateCharacters} from '../utils/characters';
 import {useTranslator} from '../i18n';
 import {useLocale} from '../i18n/useLocale';
@@ -1056,8 +1055,7 @@ export function PowerSearch({
         ref={useMergedRefs(
           ref,
           popover.triggerRef as React.Ref<HTMLDivElement>,
-        )}
-        {...themeProps('power-search')}>
+        )}>
         <Tokenizer
           handleRef={tokenizerRef}
           label={label}

--- a/packages/themes/probe/src/probeTheme.ts
+++ b/packages/themes/probe/src/probeTheme.ts
@@ -6,7 +6,7 @@
 // test fixture. Regenerate with: pnpm visual:probe-theme
 //
 // defineTheme takes six things and this covers all six:
-//   components  274 targets, 883 selectors (generated from the docs)
+//   components  273 targets, 884 selectors (generated from the docs)
 //   tokens      custom properties, read back off the themed element
 //   icons       every registry entry swapped for a marked glyph
 //   indicators  check / radio / checkbox swapped — the swap that reaches furthest
@@ -3047,6 +3047,12 @@ export const probeTheme = defineTheme({
         borderColor: 'hsl(40.4 92% 25%)',
         outlineColor: 'hsl(177.8 82% 25%)',
       },
+      readonly: {
+        backgroundColor: 'hsl(291.7 88% 52%)',
+        color: 'hsl(213.7 89% 12%)',
+        borderColor: 'hsl(50.2 86% 25%)',
+        outlineColor: 'hsl(214.5 74% 25%)',
+      },
     },
     'multi-selector-clear-icon': {
       base: {
@@ -3461,14 +3467,6 @@ export const probeTheme = defineTheme({
         color: 'hsl(120.8 82% 12%)',
         borderColor: 'hsl(94.4 91% 25%)',
         outlineColor: 'hsl(42.1 87% 25%)',
-      },
-    },
-    'power-search': {
-      base: {
-        backgroundColor: 'hsl(123.6 94% 47%)',
-        color: 'hsl(136.0 85% 12%)',
-        borderColor: 'hsl(103.5 73% 25%)',
-        outlineColor: 'hsl(203.1 71% 25%)',
       },
     },
     'progress-bar': {
@@ -4135,6 +4133,12 @@ export const probeTheme = defineTheme({
         color: 'hsl(54.2 73% 12%)',
         borderColor: 'hsl(298.2 93% 25%)',
         outlineColor: 'hsl(59.6 86% 25%)',
+      },
+      readonly: {
+        backgroundColor: 'hsl(149.0 90% 62%)',
+        color: 'hsl(226.6 78% 12%)',
+        borderColor: 'hsl(25.9 71% 25%)',
+        outlineColor: 'hsl(86.5 79% 25%)',
       },
     },
     'selector-check': {


### PR DESCRIPTION
## Why

PowerSearch's pointer wrapper only forwards refs and anchors the edit popover; it does not paint the control. Publishing that wrapper as `astryx-power-search` gives theme authors a target on the wrong ownership layer while the visible surface is already owned by Tokenizer.

## Dependency

Depends on #5623. Do not land this PR until #5623 is settled and this branch is rebased; that work overlaps PowerSearch target ownership.

## What

- Keep the wrapper, forwarded ref, popover anchor, Tokenizer, and DOM shape unchanged while removing the wrapper's theme class.
- Remove the pointer-owned target metadata and regenerate the canonical probe theme.
- Keep the focused ref contract and assert that the wrapper directly owns a distinct Tokenizer target. Add a breaking changeset that directs themes to `tokenizer`.

## Risk

This removes the documented `.astryx-power-search` selector from the pointer path. Defer this PR and land it only with the next minor release unless the owner explicitly chooses patch compatibility treatment.

## Testing

- `pnpm vitest run packages/core/src/PowerSearch`
- `pnpm vitest run packages/core/src/theme/themingTargets.test.ts`
- `pnpm visual:probe-theme:check`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/theme-probe build`
- `pnpm lint` (includes `pnpm check:repo`)
