### PR TITLE
fix(core): add overflow clip to AppShell styles

### DIFF
--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -269,6 +269,7 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     position: 'relative',
+    overflow: 'clip',
   },
   variantWash: {
     backgroundColor: colorVars['--color-background-body'],


### PR DESCRIPTION
## Description

Fixes two scrolling boundary issues in AppShell component by adding `overflow: clip` to the styles.

## Issues Fixed

1. #5775
2. #5815

## Problem

When `AppShell` components have children with `margin-top` or descendants with `position: absolute`, scrolling upward causes content to scroll beyond the expected boundary, resulting in a view offset issue.

## Solution

By adding `overflow: clip` to the AppShell styles, we prevent content from overflowing outside the component's boundaries, ensuring that:
1. Children with `margin-top` don't cause scroll overflow when `height="auto"`
2. Absolutely positioned descendants don't cause scroll overflow when `height="fill"`