### PR TITLE
docs: project parent-owned member contracts

### DIFF
--- a/.changeset/deduplicate-parent-theme-targets.md
+++ b/.changeset/deduplicate-parent-theme-targets.md
@@ -2,6 +2,6 @@
 '@astryxdesign/cli': patch
 ---
 
-[fix] Deduplicate parent-owned theming targets in CLI discovery while preserving each child component's direct documentation. (#5767)
+[fix] Keep parent-owned theming targets in one source while projecting each member's exact anatomy and target into its direct CLI and docsite documentation. (#5767)
 
 @cixzhang

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -22,6 +22,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
+import {
+  findParentOwnedMemberProjection,
+  projectParentOwnedMemberDoc,
+  stripMemberProjectionMetadata,
+} from '../../../packages/cli/authoring/doctypes/component/member-projection.mjs';
 import {resolveContentRoot} from './resolve-content-root.mjs';
 import {expandWorkspaceDirs} from '../../../scripts/lib/workspace-globs.mjs';
 import {
@@ -367,7 +372,7 @@ async function generateComponentRegistry() {
           const mod = await import(pathToFileURL(dfPath).href);
           const d = mod.docs;
           if (d && (d.components || d.props) && !d.params && !d.subComponentOf) {
-            dirPrimaryDoc = d.name || null;
+            dirPrimaryDoc = d;
             dirPrimaryMeta = {
               name: d.name || null,
               group: d.group || null,
@@ -396,6 +401,17 @@ async function generateComponentRegistry() {
         } catch (err) {
           console.warn(`  warn: failed to import ${docFileName}: ${err.message}`);
           continue;
+        }
+
+        let memberProjection = null;
+        if (doc.subComponentOf && dirPrimaryDoc) {
+          memberProjection = findParentOwnedMemberProjection(
+            dirPrimaryDoc,
+            doc.name,
+          );
+          doc = projectParentOwnedMemberDoc(dirPrimaryDoc, doc);
+        } else {
+          doc = stripMemberProjectionMetadata(doc);
         }
 
         const group = doc.group || null;
@@ -455,7 +471,9 @@ async function generateComponentRegistry() {
                 ? null
                 : doc.theming
                   ? sanitizeForJson(doc.theming)
-                  : parentMeta.theming ?? null,
+                  : memberProjection
+                    ? null
+                    : parentMeta.theming ?? null,
               params: isHookEntry
                 ? Array.isArray(doc.params)
                   ? sanitizeForJson(doc.params)
@@ -611,7 +629,7 @@ async function generateComponentRegistry() {
             description: topDescription,
             keywords,
             hidden,
-            parentDoc: dirPrimaryDoc,
+            parentDoc: dirPrimaryDoc?.name ?? null,
             props: [],
             usage,
             theming: null,

--- a/apps/docsite/src/__tests__/component-detail-wiring.test.ts
+++ b/apps/docsite/src/__tests__/component-detail-wiring.test.ts
@@ -129,6 +129,26 @@ describe('component detail wiring', () => {
       }
     }
   });
+  it('routes projected member anatomy through the existing Anatomy renderer', () => {
+    const entries = Object.values(components).flat();
+    for (const name of [
+      'DropdownMenuDivider',
+      'TableHeader',
+      'TableBody',
+      'TableFooter',
+    ]) {
+      expect(
+        entries.find(entry => entry.name === name)?.usage?.anatomy,
+      ).toHaveLength(1);
+    }
+
+    const source = fs.readFileSync(
+      path.join(DETAIL_DIR, 'ComponentDetailClient.tsx'),
+      'utf8',
+    );
+    expect(source).toContain('<Anatomy elements={comp.usage.anatomy} />');
+  });
+
   it('carries component accessibility requirements into the registry', () => {
     const button = Object.values(components)
       .flat()

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -253,6 +253,75 @@ describe('componentRegistry', () => {
     );
   });
 
+  it('projects exact parent-owned anatomy and targets onto extracted members', () => {
+    const core = components['@astryxdesign/core'];
+    const expected = {
+      DropdownMenuDivider: {
+        anatomy: 'Pointer divider',
+        target: 'astryx-dropdown-menu-divider',
+      },
+      TableHeader: {
+        anatomy: 'Header section',
+        target: 'astryx-table-header',
+      },
+      TableBody: {
+        anatomy: 'Body section',
+        target: 'astryx-table-body',
+      },
+      TableFooter: {
+        anatomy: 'Footer section',
+        target: 'astryx-table-footer',
+      },
+    } as const;
+
+    for (const [name, contract] of Object.entries(expected)) {
+      const member = core.find(component => component.name === name);
+      expect(member, name).toBeDefined();
+      expect(
+        member!.usage?.anatomy?.map(part => part.name),
+        name,
+      ).toEqual([contract.anatomy]);
+      expect(
+        member!.theming?.targets.map(target => target.className),
+        name,
+      ).toEqual([contract.target]);
+    }
+
+    const dropdownDivider = core.find(
+      component => component.name === 'DropdownMenuDivider',
+    );
+    expect(
+      dropdownDivider!.usage?.anatomy?.map(part => part.name),
+    ).not.toContain('Touch divider');
+    const tableHeader = core.find(
+      component => component.name === 'TableHeader',
+    );
+    expect(tableHeader!.usage?.anatomy?.map(part => part.name)).not.toContain(
+      'Body section',
+    );
+  });
+
+  it('keeps aggregate anatomy and targets on projection parents', () => {
+    const core = components['@astryxdesign/core'];
+    const table = core.find(component => component.name === 'Table');
+    expect(table!.usage?.anatomy).toHaveLength(16);
+    expect(table!.theming?.targets.map(target => target.className)).toEqual(
+      expect.arrayContaining([
+        'astryx-table-header',
+        'astryx-table-body',
+        'astryx-table-footer',
+      ]),
+    );
+
+    const menu = core.find(component => component.name === 'DropdownMenu');
+    expect(menu!.usage?.anatomy?.map(part => part.name)).toEqual(
+      expect.arrayContaining(['Pointer divider', 'Touch divider']),
+    );
+    expect(menu!.theming?.targets.map(target => target.className)).toContain(
+      'astryx-dropdown-menu-divider',
+    );
+  });
+
   it('sub-components can override inherited playground defaults', () => {
     const core = components['@astryxdesign/core'];
     const avatarGroupOverflow = core.find(

--- a/packages/cli/api/component/_adapter.mjs
+++ b/packages/cli/api/component/_adapter.mjs
@@ -33,7 +33,9 @@ import {
   resolveImportPath,
 } from '../../foundation/discovery/component-discovery.mjs';
 import {Project} from '../../foundation/config/project.mjs';
-import {loadDocs} from '../../foundation/discovery/component-loader.mjs';
+import {
+  loadResolvedComponentDoc,
+} from '../../foundation/discovery/component-loader.mjs';
 import {searchComponents} from '../../foundation/text/string-utils.mjs';
 import {AstryxError} from '../error.mjs';
 
@@ -337,9 +339,10 @@ export async function resolveUnscopedDoc(dirName, {coreDir, cwd, name}) {
 }
 
 /**
- * Load a `.doc.mjs` through the shared loader, applying the API's doc-load
- * options. Centralizes the `LoadedComponentDoc`/`LoadDocsOpts` casts so leaves
- * get a typed doc without re-casting.
+ * Load a `.doc.mjs` through the resolved loader while preserving the component
+ * API's historical permissive loading for integration docs. Centralizes the
+ * `LoadedComponentDoc`/`LoadDocsOpts` casts so leaves get one resolved view
+ * without widening validation for unprojected consumers.
  * @param {string} docPath
  * @param {{zh?: boolean, dense?: boolean, lang?: string|null}} [opts]
  * @returns {Promise<LoadedComponentDoc>}
@@ -347,7 +350,15 @@ export async function resolveUnscopedDoc(dirName, {coreDir, cwd, name}) {
 export async function loadComponentDoc(docPath, opts = {}) {
   const {zh = false, dense = false, lang = null} = opts;
   return /** @type {LoadedComponentDoc} */ (
-    await loadDocs(docPath, /** @type {LoadDocsOpts} */ ({zh, dense, lang}))
+    await loadResolvedComponentDoc(
+      docPath,
+      /** @type {LoadDocsOpts & {validate: false}} */ ({
+        zh,
+        dense,
+        lang,
+        validate: false,
+      }),
+    )
   );
 }
 

--- a/packages/cli/api/discover/_adapter.mjs
+++ b/packages/cli/api/discover/_adapter.mjs
@@ -20,7 +20,7 @@ import {
   scanAllPackages,
   findComponentInPackages,
 } from './_package-scanner.mjs';
-import {loadDocs} from '../../foundation/discovery/component-loader.mjs';
+import {loadResolvedComponentDoc} from '../../foundation/discovery/component-loader.mjs';
 import {AstryxError} from '../error.mjs';
 import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
 
@@ -136,9 +136,13 @@ export function findComponent(packages, name) {
 export async function loadValidatedDoc(result, {lang, zh}) {
   let docs;
   try {
-    docs = await loadDocs(
+    docs = await loadResolvedComponentDoc(
       result.docPath,
-      /** @type {{zh?: boolean, dense?: boolean, lang?: string}} */ ({zh, lang}),
+      /** @type {{zh?: boolean, dense?: boolean, lang?: string, validate?: boolean}} */ ({
+        zh,
+        lang,
+        validate: false,
+      }),
     );
   } catch (e) {
     throw new AstryxError(

--- a/packages/cli/api/discover/detail/doc/doc.test.mjs
+++ b/packages/cli/api/discover/detail/doc/doc.test.mjs
@@ -29,6 +29,30 @@ beforeAll(() => {
     path.join(docsDir, 'Beta.doc.mjs'),
     `export const docs = {name: 'Beta', usage: {description: 'Beta component'}, props: []};\n`,
   );
+  fs.writeFileSync(
+    path.join(docsDir, 'Parent.doc.mjs'),
+    `export const docs = {
+  name: 'Parent', usage: {description: 'Parent component', anatomy: [
+    {name: 'Child part', required: false, description: 'Projected child part.'},
+  ]}, props: [], theming: {targets: [{className: 'astryx-child-part'}]},
+  components: [{name: 'Child', projection: {anatomy: ['Child part'], targets: ['astryx-child-part']}}],
+};\n`,
+  );
+  fs.writeFileSync(
+    path.join(docsDir, 'Child.doc.mjs'),
+    `export const docs = {name: 'Child', subComponentOf: 'Parent', usage: {description: 'Child component'}, props: []};\n`,
+  );
+  fs.writeFileSync(
+    path.join(docsDir, 'BadProjection.doc.mjs'),
+    `export const docs = {
+  name: 'BadProjection', usage: {description: 'Bad projection parent'}, props: [],
+  components: [{name: 'BadChild', projection: {targetz: ['astryx-missing']}}],
+};\n`,
+  );
+  fs.writeFileSync(
+    path.join(docsDir, 'BadChild.doc.mjs'),
+    `export const docs = {name: 'BadChild', subComponentOf: 'BadProjection', usage: {description: 'Bad child'}, props: []};\n`,
+  );
   pkg = {
     name: '@acme/widgets',
     category: '@acme/widgets',
@@ -36,7 +60,15 @@ beforeAll(() => {
     dir: docsDir,
     astryx: {},
     docsDir,
-    components: ['Alpha', 'AlphaCard', 'Beta'],
+    components: [
+      'Alpha',
+      'AlphaCard',
+      'Beta',
+      'Parent',
+      'Child',
+      'BadProjection',
+      'BadChild',
+    ],
   };
 });
 
@@ -55,6 +87,31 @@ describe('discover.detail.doc leaf', () => {
   it('resolves case-insensitively', async () => {
     const res = await doc([pkg], '@acme/widgets', 'alpha', {});
     expect(res.data.name).toBe('Alpha');
+  });
+
+  it('projects child docs and strips projection metadata from parents', async () => {
+    const child = await doc([pkg], '@acme/widgets', 'Child', {});
+    expect(child.data.usage.anatomy).toEqual([
+      {
+        name: 'Child part',
+        required: false,
+        description: 'Projected child part.',
+      },
+    ]);
+    expect(child.data.theming.targets).toEqual([
+      {className: 'astryx-child-part'},
+    ]);
+
+    const parent = await doc([pkg], '@acme/widgets', 'Parent', {});
+    expect(parent.data.components).toEqual([{name: 'Child'}]);
+  });
+
+  it('rejects unknown projection fields instead of erasing them', async () => {
+    await expect(
+      doc([pkg], '@acme/widgets', 'BadChild', {}),
+    ).rejects.toMatchObject({
+      code: 'ERR_INVALID_DOC',
+    });
   });
 
   it('throws ERR_UNKNOWN_PACKAGE for an unknown scope', async () => {

--- a/packages/cli/api/theme/targets/targets.test.mjs
+++ b/packages/cli/api/theme/targets/targets.test.mjs
@@ -39,16 +39,21 @@ describe('themeTargets (api/theme/targets)', () => {
     ]);
   }, 60_000);
 
-  it.each(['table-header', 'table-body', 'table-footer'])(
-    '%s appears once under the Table owner',
-    async target => {
-      const {data} = await themeTargets('Table');
+  it.each([
+    ['DropdownMenu', 'dropdown-menu-divider'],
+    ['Table', 'table-header'],
+    ['Table', 'table-body'],
+    ['Table', 'table-footer'],
+  ])(
+    '%s target %s appears once under its parent owner',
+    async (component, target) => {
+      const {data} = await themeTargets(component);
       const matches = data.targets.filter(entry => entry.key === target);
       expect(data.componentCount).toBe(1);
       expect(matches).toHaveLength(1);
       expect(matches[0]).toMatchObject({
         key: target,
-        component: 'Table',
+        component,
       });
     },
     60_000,

--- a/packages/cli/authoring/doctypes/component/component.doc.mjs
+++ b/packages/cli/authoring/doctypes/component/component.doc.mjs
@@ -170,7 +170,7 @@ export const doc = {
       name: 'components',
       type: '(ComponentEntry | ComponentRef)[]',
       description:
-        'MultiComponentDoc variant (required there): one entry per public component/hook exported from the directory. Each entry is a full ComponentEntry (inline: name, displayName, description, props | params+returns) or a name-only ComponentRef pointing at a sibling {Name}.doc.mjs.',
+        'MultiComponentDoc variant (required there): one entry per public component/hook exported from the directory. Each entry is a full ComponentEntry (inline: name, displayName, description, props | params+returns) or a ComponentRef cross-link pointing at a sibling {Name}.doc.mjs. A ref may add `projection: {anatomy?: string[], targets?: string[]}` to expose exact parent-owned anatomy names and target class names on that member’s direct docs. Projection selectors must each match exactly once, preserve parent order, and may not be re-authored by the child.',
     },
     {
       name: 'subComponentOf',
@@ -239,7 +239,7 @@ export const docs = {
       style: 'unordered',
       items: [
         'SingleComponentDoc: one primary component; put props directly on the doc via `props`. Use for Switch, Badge, Spinner, TextInput.',
-        'MultiComponentDoc: a directory exporting several components/hooks; list them in `components` (inline ComponentEntry or name-only ComponentRef). Use for Table, Dialog, TabList.',
+        'MultiComponentDoc: a directory exporting several components/hooks; list them in `components` (inline ComponentEntry or ComponentRef cross-link). A ref’s optional projection selects exact parent-owned anatomy names and target class names for the member’s direct read-only docs; stale, duplicate, or child-redeclared selections fail.',
         'SubComponentDoc: a single sub-component in its own {Name}.doc.mjs inside the parent directory; set `subComponentOf` to the parent name. It inherits family fields and may omit `usage`.',
       ],
     },

--- a/packages/cli/authoring/doctypes/component/member-projection.mjs
+++ b/packages/cli/authoring/doctypes/component/member-projection.mjs
@@ -1,0 +1,275 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Pure projection of parent-owned anatomy and theming targets onto a
+ * sibling member's read-only documentation view.
+ */
+
+/**
+ * Find the explicit parent-owned projection for one member.
+ *
+ * @param {any} parentDoc
+ * @param {string} childName
+ * @returns {{anatomy?: string[], targets?: string[]} | null}
+ */
+export function findParentOwnedMemberProjection(parentDoc, childName) {
+  const matches = (parentDoc?.components ?? []).filter(
+    (/** @type {any} */ component) => component?.name === childName,
+  );
+  if (matches.length > 1) {
+    throw projectionError(
+      parentDoc,
+      childName,
+      `the parent lists this member ${matches.length} times`,
+    );
+  }
+  const projection = matches[0]?.projection;
+  if (projection == null) return null;
+  if (typeof projection !== 'object' || Array.isArray(projection)) {
+    throw projectionError(parentDoc, childName, 'projection must be an object');
+  }
+  const unknownKeys = Object.keys(projection).filter(
+    key => key !== 'anatomy' && key !== 'targets',
+  );
+  if (unknownKeys.length > 0) {
+    throw projectionError(
+      parentDoc,
+      childName,
+      `unknown projection field ${JSON.stringify(unknownKeys[0])}`,
+    );
+  }
+  return projection;
+}
+
+/**
+ * Materialize the read-only member view selected by its parent ComponentRef.
+ * Selectors are resolved against canonical docs; optional localized views supply
+ * only the displayed entries. Authored inputs are never mutated.
+ *
+ * @param {any} parentDoc
+ * @param {any} childDoc
+ * @param {{parentView?: any, childView?: any}} [views]
+ * @returns {any}
+ */
+export function projectParentOwnedMemberDoc(
+  parentDoc,
+  childDoc,
+  {parentView = parentDoc, childView = childDoc} = {},
+) {
+  const childName = childDoc?.name;
+  const projection = findParentOwnedMemberProjection(parentDoc, childName);
+  if (projection == null) return childView;
+
+  if (childDoc?.subComponentOf !== parentDoc?.name) {
+    throw projectionError(
+      parentDoc,
+      childName,
+      `child subComponentOf must be ${JSON.stringify(parentDoc?.name)}`,
+    );
+  }
+
+  const projectedAnatomy = selectParentEntries({
+    parentDoc,
+    childName,
+    selectors: projection.anatomy,
+    entries: parentDoc?.usage?.anatomy,
+    selectorLabel: 'anatomy',
+    entryKey: 'name',
+  });
+  const projectedAnatomyView = presentSelectedEntries(
+    projectedAnatomy,
+    parentDoc?.usage?.anatomy,
+    parentView?.usage?.anatomy,
+  );
+  const projectedTargets = selectParentEntries({
+    parentDoc,
+    childName,
+    selectors: projection.targets,
+    entries: parentDoc?.theming?.targets,
+    selectorLabel: 'target',
+    entryKey: 'className',
+  });
+  const projectedTargetsView = presentSelectedEntries(
+    projectedTargets,
+    parentDoc?.theming?.targets,
+    parentView?.theming?.targets,
+  );
+
+  const childAnatomy = childDoc?.usage?.anatomy ?? [];
+  rejectChildDuplicates({
+    parentDoc,
+    childName,
+    childEntries: childAnatomy,
+    projectedEntries: projectedAnatomy,
+    selectorLabel: 'anatomy',
+    entryKey: 'name',
+  });
+  const childTargets = childDoc?.theming?.targets ?? [];
+  rejectChildDuplicates({
+    parentDoc,
+    childName,
+    childEntries: childTargets,
+    projectedEntries: projectedTargets,
+    selectorLabel: 'target',
+    entryKey: 'className',
+  });
+
+  const childAnatomyView = childView?.usage?.anatomy ?? childAnatomy;
+  const childTargetsView = childView?.theming?.targets ?? childTargets;
+  const projected = {...childView};
+  if (projectedAnatomyView.length > 0) {
+    projected.usage = {
+      ...(childView.usage ?? {description: childView.description}),
+      anatomy: [...childAnatomyView, ...projectedAnatomyView],
+    };
+  }
+  if (projectedTargetsView.length > 0) {
+    projected.theming = {
+      ...childView.theming,
+      targets: [...childTargetsView, ...projectedTargetsView],
+    };
+  }
+  return projected;
+}
+
+/**
+ * Remove projection-only authoring metadata from a public parent doc.
+ *
+ * @param {any} parentDoc
+ * @returns {any}
+ */
+export function stripMemberProjectionMetadata(parentDoc) {
+  if (!Array.isArray(parentDoc?.components)) return parentDoc;
+  let changed = false;
+  const components = parentDoc.components.map((/** @type {any} */ component) => {
+    if (component?.projection === undefined) return component;
+    changed = true;
+    const {projection: _projection, ...publicComponent} = component;
+    return publicComponent;
+  });
+  return changed ? {...parentDoc, components} : parentDoc;
+}
+
+/**
+ * Resolve exact selected parent entries while preserving parent order.
+ *
+ * @param {{
+ *   parentDoc: any,
+ *   childName: string,
+ *   selectors: unknown,
+ *   entries: unknown,
+ *   selectorLabel: string,
+ *   entryKey: string,
+ * }} options
+ * @returns {any[]}
+ */
+function selectParentEntries({
+  parentDoc,
+  childName,
+  selectors,
+  entries,
+  selectorLabel,
+  entryKey,
+}) {
+  if (selectors === undefined) return [];
+  if (!Array.isArray(selectors)) {
+    throw projectionError(
+      parentDoc,
+      childName,
+      `${selectorLabel} selectors must be an array`,
+    );
+  }
+  const duplicateSelectors = selectors.filter(
+    (selector, index) => selectors.indexOf(selector) !== index,
+  );
+  if (duplicateSelectors.length > 0) {
+    throw projectionError(
+      parentDoc,
+      childName,
+      `duplicate ${selectorLabel} selector ${JSON.stringify(duplicateSelectors[0])}`,
+    );
+  }
+
+  const sourceEntries = Array.isArray(entries) ? entries : [];
+  for (const selector of selectors) {
+    if (typeof selector !== 'string') {
+      throw projectionError(
+        parentDoc,
+        childName,
+        `${selectorLabel} selectors must be strings`,
+      );
+    }
+    const matches = sourceEntries.filter(entry => entry?.[entryKey] === selector);
+    if (matches.length !== 1) {
+      throw projectionError(
+        parentDoc,
+        childName,
+        `${selectorLabel} selector ${JSON.stringify(selector)} matched ${matches.length} parent entries; expected exactly one`,
+      );
+    }
+  }
+
+  const selected = new Set(selectors);
+  return sourceEntries.filter(entry => selected.has(entry?.[entryKey]));
+}
+
+/**
+ * Return the presentation entry at each selected canonical index.
+ *
+ * @param {any[]} selected
+ * @param {unknown} canonicalEntries
+ * @param {unknown} presentedEntries
+ * @returns {any[]}
+ */
+function presentSelectedEntries(selected, canonicalEntries, presentedEntries) {
+  if (!Array.isArray(presentedEntries)) return selected;
+  const canonical = Array.isArray(canonicalEntries) ? canonicalEntries : [];
+  return selected.map(entry => {
+    const index = canonical.indexOf(entry);
+    return presentedEntries[index] ?? entry;
+  });
+}
+
+/**
+ * Reject a selected entry that remains independently authored by the child.
+ *
+ * @param {{
+ *   parentDoc: any,
+ *   childName: string,
+ *   childEntries: any[],
+ *   projectedEntries: any[],
+ *   selectorLabel: string,
+ *   entryKey: string,
+ * }} options
+ * @returns {void}
+ */
+function rejectChildDuplicates({
+  parentDoc,
+  childName,
+  childEntries,
+  projectedEntries,
+  selectorLabel,
+  entryKey,
+}) {
+  const projectedKeys = new Set(projectedEntries.map(entry => entry?.[entryKey]));
+  const duplicate = childEntries.find(entry => projectedKeys.has(entry?.[entryKey]));
+  if (duplicate) {
+    throw projectionError(
+      parentDoc,
+      childName,
+      `child authors projected ${selectorLabel} ${JSON.stringify(duplicate[entryKey])}; it is owned by the parent`,
+    );
+  }
+}
+
+/**
+ * @param {any} parentDoc
+ * @param {string} childName
+ * @param {string} detail
+ * @returns {Error}
+ */
+function projectionError(parentDoc, childName, detail) {
+  return new Error(
+    `Invalid component projection ${JSON.stringify(parentDoc?.name)} -> ${JSON.stringify(childName)}: ${detail}.`,
+  );
+}

--- a/packages/cli/authoring/doctypes/component/member-projection.test.mjs
+++ b/packages/cli/authoring/doctypes/component/member-projection.test.mjs
@@ -1,0 +1,215 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {
+  findParentOwnedMemberProjection,
+  projectParentOwnedMemberDoc,
+  stripMemberProjectionMetadata,
+} from './member-projection.mjs';
+
+function parent(overrides = {}) {
+  return {
+    name: 'Parent',
+    usage: {
+      description: 'Parent usage.',
+      anatomy: [
+        {name: 'First', required: true, description: 'First part.'},
+        {name: 'Second', required: false, description: 'Second part.'},
+        {name: 'Third', required: false, description: 'Third part.'},
+      ],
+    },
+    theming: {
+      targets: [
+        {className: 'astryx-parent-first', states: ['active']},
+        {className: 'astryx-parent-second', visualProps: ['size']},
+        {className: 'astryx-parent-third'},
+      ],
+    },
+    components: [
+      {
+        name: 'Child',
+        projection: {
+          anatomy: ['Third', 'First'],
+          targets: ['astryx-parent-third', 'astryx-parent-first'],
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function child(overrides = {}) {
+  return {
+    name: 'Child',
+    displayName: 'Child',
+    subComponentOf: 'Parent',
+    description: 'Child description.',
+    props: [{name: 'value', type: 'string', description: 'Value.'}],
+    examples: [{code: '<Child />'}],
+    playground: {defaults: {value: 'example'}},
+    ...overrides,
+  };
+}
+
+describe('projectParentOwnedMemberDoc', () => {
+  it('selects exact entries in parent order and preserves child-owned fields', () => {
+    const parentDoc = parent();
+    const childDoc = child({
+      usage: {
+        description: 'Child usage.',
+        anatomy: [
+          {name: 'Child part', required: false, description: 'Child-owned.'},
+        ],
+      },
+      theming: {
+        vars: [{name: '--child', description: 'Child var.', default: '0'}],
+        targets: [{className: 'astryx-child-local'}],
+      },
+    });
+    const beforeParent = structuredClone(parentDoc);
+    const beforeChild = structuredClone(childDoc);
+
+    const projected = projectParentOwnedMemberDoc(parentDoc, childDoc);
+
+    expect(projected.usage.description).toBe('Child usage.');
+    expect(projected.usage.anatomy.map(entry => entry.name)).toEqual([
+      'Child part',
+      'First',
+      'Third',
+    ]);
+    expect(projected.theming.targets).toEqual([
+      {className: 'astryx-child-local'},
+      {className: 'astryx-parent-first', states: ['active']},
+      {className: 'astryx-parent-third'},
+    ]);
+    expect(projected.theming.vars).toEqual(childDoc.theming.vars);
+    expect(projected.props).toEqual(childDoc.props);
+    expect(projected.examples).toEqual(childDoc.examples);
+    expect(projected.playground).toEqual(childDoc.playground);
+    expect(parentDoc).toEqual(beforeParent);
+    expect(childDoc).toEqual(beforeChild);
+  });
+
+  it('creates child usage from its description when projecting anatomy', () => {
+    const projected = projectParentOwnedMemberDoc(parent(), child());
+    expect(projected.usage).toMatchObject({
+      description: 'Child description.',
+      anatomy: [
+        {name: 'First', required: true, description: 'First part.'},
+        {name: 'Third', required: false, description: 'Third part.'},
+      ],
+    });
+  });
+
+  it('returns an unprojected child unchanged', () => {
+    const childDoc = child();
+    expect(
+      projectParentOwnedMemberDoc(
+        parent({components: [{name: 'Child'}]}),
+        childDoc,
+      ),
+    ).toBe(childDoc);
+  });
+
+  it('finds and strips projection metadata without changing other ref fields', () => {
+    const parentDoc = parent();
+    expect(findParentOwnedMemberProjection(parentDoc, 'Child')).toEqual({
+      anatomy: ['Third', 'First'],
+      targets: ['astryx-parent-third', 'astryx-parent-first'],
+    });
+    expect(stripMemberProjectionMetadata(parentDoc).components).toEqual([
+      {name: 'Child'},
+    ]);
+    expect(parentDoc.components[0]).toHaveProperty('projection');
+  });
+
+  it.each([
+    [
+      'an unknown projection field',
+      {components: [{name: 'Child', projection: {targetz: ['astryx-parent-first']}}]},
+      /unknown projection field "targetz"/,
+    ],
+    [
+      'a stale anatomy selector',
+      {components: [{name: 'Child', projection: {anatomy: ['Missing']}}]},
+      /anatomy selector "Missing" matched 0/,
+    ],
+    [
+      'a stale target selector',
+      {components: [{name: 'Child', projection: {targets: ['astryx-missing']}}]},
+      /target selector "astryx-missing" matched 0/,
+    ],
+    [
+      'a duplicate selector',
+      {
+        components: [
+          {name: 'Child', projection: {anatomy: ['First', 'First']}},
+        ],
+      },
+      /duplicate anatomy selector "First"/,
+    ],
+    [
+      'a duplicate selected parent entry',
+      {
+        usage: {
+          anatomy: [
+            {name: 'First', description: 'One.'},
+            {name: 'First', description: 'Two.'},
+          ],
+        },
+        components: [
+          {name: 'Child', projection: {anatomy: ['First']}},
+        ],
+      },
+      /anatomy selector "First" matched 2/,
+    ],
+  ])('fails closed on %s', (_name, overrides, expected) => {
+    expect(() => projectParentOwnedMemberDoc(parent(overrides), child())).toThrow(
+      expected,
+    );
+  });
+
+  it('rejects duplicate parent references for the same child', () => {
+    expect(() =>
+      findParentOwnedMemberProjection(
+        parent({
+          components: [
+            {name: 'Child', projection: {anatomy: ['First']}},
+            {name: 'Child'},
+          ],
+        }),
+        'Child',
+      ),
+    ).toThrow(/lists this member 2 times/);
+  });
+
+  it.each([
+    [
+      'anatomy',
+      child({
+        usage: {
+          description: 'Child usage.',
+          anatomy: [{name: 'First', description: 'Duplicate.'}],
+        },
+      }),
+      /child authors projected anatomy "First"/,
+    ],
+    [
+      'target',
+      child({
+        theming: {targets: [{className: 'astryx-parent-first'}]},
+      }),
+      /child authors projected target "astryx-parent-first"/,
+    ],
+  ])('rejects a child-authored duplicate %s', (_name, childDoc, expected) => {
+    expect(() => projectParentOwnedMemberDoc(parent(), childDoc)).toThrow(
+      expected,
+    );
+  });
+
+  it('rejects a child that points at a different parent', () => {
+    expect(() =>
+      projectParentOwnedMemberDoc(parent(), child({subComponentOf: 'Other'})),
+    ).toThrow(/subComponentOf must be "Parent"/);
+  });
+});

--- a/packages/cli/authoring/doctypes/component/type.ts
+++ b/packages/cli/authoring/doctypes/component/type.ts
@@ -229,11 +229,23 @@ export interface ComponentGroupDoc {
  * `{Name}.doc.mjs` file (see {@link SubComponentDoc}). The parent's
  * `components` array lists these names so the family stays discoverable;
  * the entry's content is emitted from the sub-component's own file, not here.
+ * A name-only reference is a cross-link, not a standalone component contract.
+ * An optional projection may expose exact parent-owned anatomy and theming
+ * targets on the member's read-only consumer view.
  */
 export interface ComponentRef {
   /** Full export name including Astryx prefix, e.g. `"ChatComposer"`. Must
    *  match the `name` field of the referenced sub-component's own doc. */
   name: string;
+  /** Optional read-only projection of exact parent-owned entries onto the
+   *  referenced member's direct documentation. Selectors match anatomy names
+   *  and target class names exactly; the parent remains their only author. */
+  projection?: {
+    /** Exact `parent.usage.anatomy[].name` values. */
+    anatomy?: string[];
+    /** Exact `parent.theming.targets[].className` values. */
+    targets?: string[];
+  };
 }
 
 /**

--- a/packages/cli/clients/cli/commands/component-resolution.test.mjs
+++ b/packages/cli/clients/cli/commands/component-resolution.test.mjs
@@ -55,6 +55,48 @@ describe('component() sub-component scoping', () => {
     expect(result.data.name).not.toBe('TabList');
   });
 
+  it.each([
+    ['DropdownMenuDivider', 'Pointer divider', 'astryx-dropdown-menu-divider'],
+    ['TableHeader', 'Header section', 'astryx-table-header'],
+    ['TableBody', 'Body section', 'astryx-table-body'],
+    ['TableFooter', 'Footer section', 'astryx-table-footer'],
+  ])(
+    'component("%s") returns its exact parent-owned anatomy and target',
+    async (name, anatomy, target) => {
+      const result = await component(name, CWD);
+      expect(result.data.name).toBe(name);
+      expect(result.data.usage.anatomy.map(part => part.name)).toEqual([
+        anatomy,
+      ]);
+      expect(result.data.theming.targets.map(entry => entry.className)).toEqual([
+        target,
+      ]);
+    },
+  );
+
+  it('parent detail keeps aggregate docs while hiding projection metadata', async () => {
+    const table = await component('Table', CWD);
+    expect(table.data.usage.anatomy).toHaveLength(16);
+    expect(table.data.theming.targets.map(target => target.className)).toEqual(
+      expect.arrayContaining([
+        'astryx-table-header',
+        'astryx-table-body',
+        'astryx-table-footer',
+      ]),
+    );
+    expect(
+      table.data.components.some(component => 'projection' in component),
+    ).toBe(false);
+
+    const menu = await component('DropdownMenu', CWD);
+    expect(menu.data.usage.anatomy.map(part => part.name)).toContain(
+      'Touch divider',
+    );
+    expect(menu.data.theming.targets.map(target => target.className)).toContain(
+      'astryx-dropdown-menu-divider',
+    );
+  });
+
   // Non-regression: asking for the parent still returns the full doc, with its
   // family listed as name-only cross-links (sub-component content now lives in
   // each sub-component's own .doc.mjs file).

--- a/packages/cli/foundation/discovery/component-loader.mjs
+++ b/packages/cli/foundation/discovery/component-loader.mjs
@@ -4,9 +4,15 @@
  * @file Component doc loader — load and merge translations
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {importUserModule} from '../fs/module-loader.mjs';
 import {parseDoc} from '../../authoring/doctypes/parse.mjs';
+import {
+  projectParentOwnedMemberDoc,
+  stripMemberProjectionMetadata,
+} from '../../authoring/doctypes/component/member-projection.mjs';
 
 /**
  * Load a component doc through the shared load/validation boundary.
@@ -54,6 +60,65 @@ export async function loadComponentDoc(
     return overlayComponentDoc(docs, translation);
   }
   return mergeTranslation(docs, translation);
+}
+
+/**
+ * Load a component's public documentation view. Extracted members resolve
+ * selectors against canonical sibling docs before the same locale overlay is
+ * used for displayed entries. Parent ComponentRef projections are authoring
+ * metadata and never escape this boundary.
+ *
+ * `validate: false` preserves the component API's historical permissive loader
+ * for integration docs; projection validation still runs in the pure helper.
+ *
+ * @param {string} docPath absolute path to a component doc
+ * @param {{zh?: boolean, dense?: boolean, lang?: string, validate?: boolean}} [opts]
+ * @returns {Promise<any>}
+ */
+export async function loadResolvedComponentDoc(
+  docPath,
+  {zh = false, dense = false, lang, validate = true} = {},
+) {
+  const load = validate ? loadComponentDoc : loadDocs;
+  const canonicalDoc = await load(docPath);
+  const loadOptions = {zh, dense, lang};
+  const hasLocale = lang != null || dense || zh;
+  const docView = hasLocale ? await load(docPath, loadOptions) : canonicalDoc;
+  if (!canonicalDoc?.subComponentOf) {
+    return stripMemberProjectionMetadata(docView);
+  }
+
+  const parentPath = findSiblingParentDoc(docPath, canonicalDoc.subComponentOf);
+  if (parentPath == null) return stripMemberProjectionMetadata(docView);
+
+  const canonicalParentDoc = await load(parentPath);
+  const parentView = hasLocale
+    ? await load(parentPath, loadOptions)
+    : canonicalParentDoc;
+  return stripMemberProjectionMetadata(
+    projectParentOwnedMemberDoc(canonicalParentDoc, canonicalDoc, {
+      parentView,
+      childView: docView,
+    }),
+  );
+}
+
+/**
+ * @param {string} docPath
+ * @param {string} parentName
+ * @returns {string | null}
+ */
+function findSiblingParentDoc(docPath, parentName) {
+  const directory = path.dirname(docPath);
+  const currentSuffix = path.basename(docPath).match(/(\.doc\.(?:mjs|js|ts))$/)?.[1];
+  const suffixes = [currentSuffix, '.doc.mjs', '.doc.js', '.doc.ts'].filter(
+    (suffix, index, values) => suffix && values.indexOf(suffix) === index,
+  );
+  for (const suffix of suffixes) {
+    const candidate = path.join(directory, `${parentName}${suffix}`);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 /**

--- a/packages/cli/foundation/discovery/component-loader.test.mjs
+++ b/packages/cli/foundation/discovery/component-loader.test.mjs
@@ -8,9 +8,23 @@
  * regression guard for the existing component prop-description merge.
  */
 
-import {describe, it, expect} from 'vitest';
+import {afterEach, describe, it, expect} from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
-import {loadComponentDoc, loadDocs, mergeTranslation} from './component-loader.mjs';
+import {
+  loadComponentDoc,
+  loadDocs,
+  loadResolvedComponentDoc,
+  mergeTranslation,
+} from './component-loader.mjs';
+
+const fixtureDirs = [];
+afterEach(() => {
+  for (const dir of fixtureDirs.splice(0)) {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
 
 /** Minimal HookDoc-shaped fixture with params + returns. */
 function hookDocs() {
@@ -138,5 +152,91 @@ describe('loadComponentDoc — full localized doc overlays', () => {
     expect(direct).toEqual(cli);
     expect(direct.usage.anatomy).not.toEqual(canonical.usage.anatomy);
     expect(direct.usage.anatomy[0].name).toBe('文本区域');
+  });
+});
+
+describe('loadResolvedComponentDoc — parent-owned member projection', () => {
+  function writeProjectionFixture() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-member-loader-'));
+    fixtureDirs.push(dir);
+    fs.writeFileSync(
+      path.join(dir, 'Parent.doc.mjs'),
+      `export const docs = {
+  name: 'Parent', displayName: 'Parent', props: [],
+  usage: {description: 'Parent usage.', anatomy: [
+    {name: 'First', required: true, description: 'English first.'},
+    {name: 'Second', required: false, description: 'English second.'},
+  ]},
+  theming: {targets: [
+    {className: 'astryx-parent-first'},
+    {className: 'astryx-parent-second'},
+  ]},
+  components: [
+    {name: 'Child', projection: {anatomy: ['Second'], targets: ['astryx-parent-second']}},
+    {name: 'Unprojected'},
+  ],
+};
+export const docsDense = {
+  props: [],
+  usage: {description: 'Dense parent.', anatomy: [
+    {name: 'Dense first section', required: true, description: 'Dense first.'},
+    {name: 'Dense second section', required: false, description: 'Dense second.'},
+  ]},
+};\n`,
+    );
+    fs.writeFileSync(
+      path.join(dir, 'Child.doc.mjs'),
+      `export const docs = {
+  name: 'Child', displayName: 'Child', subComponentOf: 'Parent',
+  description: 'English child.', props: [],
+};
+export const docsDense = {description: 'Dense child.'};\n`,
+    );
+    fs.writeFileSync(
+      path.join(dir, 'Unprojected.doc.mjs'),
+      `export const docs = {
+  name: 'Unprojected', displayName: 'Unprojected', subComponentOf: 'Parent',
+  description: 'Unprojected child.', props: [],
+};\n`,
+    );
+    return dir;
+  }
+
+  it('selects canonical entries before applying matching overlays', async () => {
+    const dir = writeProjectionFixture();
+    const resolved = await loadResolvedComponentDoc(
+      path.join(dir, 'Child.doc.mjs'),
+      {dense: true},
+    );
+
+    expect(resolved.description).toBe('Dense child.');
+    expect(resolved.usage).toEqual({
+      description: 'Dense child.',
+      anatomy: [
+        {name: 'Dense second section', required: false, description: 'Dense second.'},
+      ],
+    });
+    expect(resolved.theming.targets).toEqual([
+      {className: 'astryx-parent-second'},
+    ]);
+  });
+
+  it('strips parent projection metadata from public output', async () => {
+    const dir = writeProjectionFixture();
+    const resolved = await loadResolvedComponentDoc(
+      path.join(dir, 'Parent.doc.mjs'),
+    );
+    expect(resolved.components).toEqual([
+      {name: 'Child'},
+      {name: 'Unprojected'},
+    ]);
+  });
+
+  it('leaves an unprojected extracted child unchanged', async () => {
+    const dir = writeProjectionFixture();
+    const childPath = path.join(dir, 'Unprojected.doc.mjs');
+    expect(await loadResolvedComponentDoc(childPath)).toEqual(
+      await loadComponentDoc(childPath),
+    );
   });
 });

--- a/packages/cli/foundation/discovery/theming-targets.mjs
+++ b/packages/cli/foundation/discovery/theming-targets.mjs
@@ -45,10 +45,10 @@ function targetKey(className) {
 
 /**
  * Every theming target declared under a core `src` directory, sorted by key
- * then component. When both a parent doc and one of its `subComponentOf`
- * children declare the same class, the parent is the canonical discovery owner;
- * the child keeps its direct docs but does not add a second listing row. Shared
- * targets declared by unrelated components remain separate rows.
+ * then component. Authored source docs are enumerated directly. If a child and
+ * its explicit `subComponentOf` parent both author the same class, discovery
+ * fails instead of silently choosing an owner. Shared targets declared by
+ * unrelated components remain separate rows.
  *
  * Unreadable docs are skipped rather than fatal — a single malformed doc must
  * not take out theme validation or the listing.
@@ -111,53 +111,35 @@ export async function collectThemingTargets(
 
   await scan(coreSrc);
 
-  const canonical = canonicalizeParentTargets(targets);
-  canonical.sort(
+  assertNoParentChildTargetDuplicates(targets);
+  const authoredTargets = targets.map(({parent: _parent, ...target}) => target);
+  authoredTargets.sort(
     (a, b) => a.key.localeCompare(b.key) || a.component.localeCompare(b.component),
   );
-  return canonical;
+  return authoredTargets;
 }
 
 /**
- * Collapse only an explicit parent/child duplicate. A child target is removed
- * when its `subComponentOf` parent declares that same class exactly once; its
- * props and states are merged into the parent's row so no capability is lost.
- *
- * Unrelated components sharing a class remain separate. An ambiguous parent
- * declaration also remains untouched rather than guessing which row is
- * canonical.
+ * Reject two writable declarations for one explicit parent-owned target.
  *
  * @param {Array<ThemingTarget & {parent: string|null}>} targets
- * @returns {ThemingTarget[]}
  */
-function canonicalizeParentTargets(targets) {
-  /** @type {Map<string, Array<ThemingTarget & {parent: string|null}>>} */
-  const rootsByComponentAndClass = new Map();
+function assertNoParentChildTargetDuplicates(targets) {
+  const parentClasses = new Set(
+    targets
+      .filter(target => target.parent == null)
+      .map(target => `${target.component}\0${target.className}`),
+  );
   for (const target of targets) {
-    if (target.parent != null) continue;
-    const identity = `${target.component}\0${target.className}`;
-    const roots = rootsByComponentAndClass.get(identity) ?? [];
-    roots.push(target);
-    rootsByComponentAndClass.set(identity, roots);
+    if (
+      target.parent != null &&
+      parentClasses.has(`${target.parent}\0${target.className}`)
+    ) {
+      throw new Error(
+        `Duplicate theming target ownership: ${target.component} and its parent ${target.parent} both author ${target.className}.`,
+      );
+    }
   }
-
-  /** @type {Set<ThemingTarget & {parent: string|null}>} */
-  const duplicates = new Set();
-  for (const target of targets) {
-    if (target.parent == null) continue;
-    const roots =
-      rootsByComponentAndClass.get(`${target.parent}\0${target.className}`) ?? [];
-    if (roots.length !== 1) continue;
-
-    const canonical = roots[0];
-    canonical.props = [...new Set([...canonical.props, ...target.props])];
-    canonical.states = [...new Set([...canonical.states, ...target.states])];
-    duplicates.add(target);
-  }
-
-  return targets
-    .filter(target => !duplicates.has(target))
-    .map(({parent: _parent, ...target}) => target);
 }
 
 /**

--- a/packages/cli/foundation/discovery/theming-targets.test.mjs
+++ b/packages/cli/foundation/discovery/theming-targets.test.mjs
@@ -29,7 +29,10 @@ import {
   discoverComponents,
   findComponentReadme,
 } from './component-discovery.mjs';
-import {loadComponentDoc} from './component-loader.mjs';
+import {
+  loadComponentDoc,
+  loadResolvedComponentDoc,
+} from './component-loader.mjs';
 import {
   collectThemingTargets,
   collectThemingVars,
@@ -105,35 +108,67 @@ describe('collectThemingTargets', () => {
   });
 
   it.each([
-    ['TableHeader', 'table-header'],
-    ['TableBody', 'table-body'],
-    ['TableFooter', 'table-footer'],
+    ['DropdownMenu', 'DropdownMenuDivider', 'dropdown-menu-divider'],
+    ['Table', 'TableHeader', 'table-header'],
+    ['Table', 'TableBody', 'table-body'],
+    ['Table', 'TableFooter', 'table-footer'],
   ])(
-    'keeps %s theming metadata available in its direct doc',
-    async (name, key) => {
-      const doc = await loadComponentDoc(
-        path.join(coreSrc, 'Table', `${name}.doc.mjs`),
+    'keeps %s theming metadata available in its resolved direct doc',
+    async (parent, name, key) => {
+      const directory = parent === 'DropdownMenu' ? 'DropdownMenu' : 'Table';
+      const doc = await loadResolvedComponentDoc(
+        path.join(coreSrc, directory, `${name}.doc.mjs`),
       );
-      expect(doc.subComponentOf).toBe('Table');
+      expect(doc.subComponentOf).toBe(parent);
       expect(doc.theming.targets).toContainEqual({className: `astryx-${key}`});
     },
   );
 
-  it.each(['table-header', 'table-body', 'table-footer'])(
-    'enumerates %s once under its canonical Table owner',
-    async key => {
+  it.each([
+    ['DropdownMenu', 'dropdown-menu-divider'],
+    ['Table', 'table-header'],
+    ['Table', 'table-body'],
+    ['Table', 'table-footer'],
+  ])(
+    'enumerates %s target %s once under its canonical owner',
+    async (component, key) => {
       const matches = (await enumerated).filter(target => target.key === key);
       expect(matches).toEqual([
         {
           key,
           className: `astryx-${key}`,
-          component: 'Table',
+          component,
           props: [],
           states: [],
         },
       ]);
     },
   );
+
+  it('rejects a parent/child authored target duplicate instead of choosing an owner', async () => {
+    const fixture = fs.mkdtempSync(
+      path.join(process.env.TMPDIR || '/tmp', 'astryx-target-owner-'),
+    );
+    try {
+      const familyDir = path.join(fixture, 'Family');
+      fs.mkdirSync(familyDir);
+      const usage = `usage: {description: 'Fixture.', anatomy: []}`;
+      fs.writeFileSync(
+        path.join(familyDir, 'Parent.doc.mjs'),
+        `export const docs = {name: 'Parent', displayName: 'Parent', props: [], ${usage}, components: [{name: 'Child'}], theming: {targets: [{className: 'astryx-shared'}]}};\n`,
+      );
+      fs.writeFileSync(
+        path.join(familyDir, 'Child.doc.mjs'),
+        `export const docs = {name: 'Child', displayName: 'Child', subComponentOf: 'Parent', description: 'Child.', props: [], theming: {targets: [{className: 'astryx-shared'}]}};\n`,
+      );
+
+      await expect(collectThemingTargets(fixture)).rejects.toThrow(
+        /Child and its parent Parent both author astryx-shared/,
+      );
+    } finally {
+      fs.rmSync(fixture, {recursive: true, force: true});
+    }
+  });
 
   it('is sorted by key, so a diff of two runs is readable', async () => {
     const keys = (await enumerated).map(t => t.key);

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -246,7 +246,16 @@ export const docs = {
         'Compound-mode menu content: DropdownMenuItem, DropdownMenuDivider, DropdownMenuSubMenu, and the selectable items. Mutually exclusive with `items`.',
     },
   ],
-  components: [{name: 'DropdownMenuItem'}],
+  components: [
+    {name: 'DropdownMenuItem'},
+    {
+      name: 'DropdownMenuDivider',
+      projection: {
+        anatomy: ['Pointer divider'],
+        targets: ['astryx-dropdown-menu-divider'],
+      },
+    },
+  ],
   usage: {
     anatomy,
     description:

--- a/packages/core/src/DropdownMenu/DropdownMenuDivider.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuDivider.doc.mjs
@@ -17,9 +17,6 @@ export const docs = {
         'StyleX styles applied after the menu spacing. Must be a stylex.create() value: not an inline style object like style={{}}.',
     },
   ],
-  theming: {
-    targets: [{className: 'astryx-dropdown-menu-divider'}],
-  },
 };
 
 export const docsDense = {

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -217,9 +217,27 @@ export const docs = {
     },
   ],
   components: [
-    {name: 'TableHeader'},
-    {name: 'TableBody'},
-    {name: 'TableFooter'},
+    {
+      name: 'TableHeader',
+      projection: {
+        anatomy: ['Header section'],
+        targets: ['astryx-table-header'],
+      },
+    },
+    {
+      name: 'TableBody',
+      projection: {
+        anatomy: ['Body section'],
+        targets: ['astryx-table-body'],
+      },
+    },
+    {
+      name: 'TableFooter',
+      projection: {
+        anatomy: ['Footer section'],
+        targets: ['astryx-table-footer'],
+      },
+    },
     {name: 'TableRow'},
     {name: 'TableCell'},
     {name: 'TableHeaderCell'},

--- a/packages/core/src/Table/TableBody.doc.mjs
+++ b/packages/core/src/Table/TableBody.doc.mjs
@@ -23,9 +23,6 @@ export const docs = {
         'StyleX styles for layout customization. Must be a stylex.create() value: not an inline style object like style={{}}.',
     },
   ],
-  theming: {
-    targets: [{className: 'astryx-table-body'}],
-  },
 };
 
 export const docsDense = {

--- a/packages/core/src/Table/TableFooter.doc.mjs
+++ b/packages/core/src/Table/TableFooter.doc.mjs
@@ -23,9 +23,6 @@ export const docs = {
         'StyleX styles for layout customization. Must be a stylex.create() value: not an inline style object like style={{}}.',
     },
   ],
-  theming: {
-    targets: [{className: 'astryx-table-footer'}],
-  },
 };
 
 export const docsDense = {

--- a/packages/core/src/Table/TableHeader.doc.mjs
+++ b/packages/core/src/Table/TableHeader.doc.mjs
@@ -23,9 +23,6 @@ export const docs = {
         'StyleX styles for layout customization. Must be a stylex.create() value: not an inline style object like style={{}}.',
     },
   ],
-  theming: {
-    targets: [{className: 'astryx-table-header'}],
-  },
 };
 
 export const docsDense = {

--- a/scripts/check-knowledge.mjs
+++ b/scripts/check-knowledge.mjs
@@ -7,6 +7,7 @@ import {execFileSync} from 'node:child_process';
 import {createRequire} from 'node:module';
 import {fileURLToPath} from 'node:url';
 import {collectThemingTargets} from '../packages/cli/foundation/discovery/theming-targets.mjs';
+import {findParentOwnedMemberProjection} from '../packages/cli/authoring/doctypes/component/member-projection.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -786,6 +787,7 @@ export function validateDelegations(
 
 function loadComponentContract(root, specPath, componentName) {
   const directory = path.dirname(specPath);
+  const loadedDocs = [];
   for (const docPath of matchingFiles(directory, name =>
     name.endsWith('.doc.mjs'),
   )) {
@@ -798,30 +800,76 @@ function loadComponentContract(root, specPath, componentName) {
       };
     }
     const doc = mod.docs ?? mod.default;
-    if (!doc) continue;
-    const candidates = [doc, ...(doc.components ?? [])];
-    const candidate = candidates.find(
-      entry => entry?.name?.replace(/^XDS/, '') === componentName,
-    );
-    if (!candidate) continue;
-    const anatomy = candidate.usage?.anatomy ?? doc.usage?.anatomy;
-    if (!Array.isArray(anatomy)) {
-      return {
-        problem: `${path.relative(root, docPath)}: ${componentName} has no canonical English usage.anatomy.`,
-      };
-    }
-    const targets = (candidate.theming?.targets ?? doc.theming?.targets ?? [])
-      .filter(target => target.deprecatedFor == null)
-      .map(target => target.className.replace(/^astryx-/, ''));
-    return {
-      contract: {
-        anatomy: anatomy.map(part => part.name),
-        targets,
-      },
-    };
+    if (doc) loadedDocs.push({doc, docPath});
   }
+
+  const normalizeName = name => name?.replace(/^XDS/, '');
+  const exact = loadedDocs.find(
+    ({doc}) => normalizeName(doc.name) === componentName,
+  );
+  if (exact) {
+    if (exact.doc.subComponentOf) {
+      const parent = loadedDocs.find(
+        ({doc}) =>
+          normalizeName(doc.name) === normalizeName(exact.doc.subComponentOf),
+      );
+      if (parent) {
+        let projection;
+        try {
+          projection = findParentOwnedMemberProjection(
+            parent.doc,
+            exact.doc.name,
+          );
+        } catch (error) {
+          return {problem: `${path.relative(root, parent.docPath)}: ${error.message}`};
+        }
+        if (
+          projection &&
+          !Array.isArray(exact.doc?.usage?.anatomy)
+        ) {
+          return {
+            problem:
+              `${path.relative(root, specPath)}: selected anatomy and targets for ` +
+              `${componentName} are owned by ${parent.doc.name} and must be mapped in ` +
+              `${parent.doc.name}.spec.md.`,
+          };
+        }
+      }
+    }
+    return contractFromDoc(root, exact.docPath, componentName, exact.doc);
+  }
+
+  for (const {doc, docPath} of loadedDocs) {
+    const candidate = (doc.components ?? []).find(
+      entry =>
+        normalizeName(entry?.name) === componentName &&
+        isFullConsumerDocEntry(entry),
+    );
+    if (candidate) {
+      return contractFromDoc(root, docPath, componentName, candidate);
+    }
+  }
+
   return {
     problem: `${path.relative(root, specPath)}: no component doc for ${componentName}.`,
+  };
+}
+
+function contractFromDoc(root, docPath, componentName, doc) {
+  const anatomy = doc.usage?.anatomy;
+  if (!Array.isArray(anatomy)) {
+    return {
+      problem: `${path.relative(root, docPath)}: ${componentName} has no canonical English usage.anatomy.`,
+    };
+  }
+  const targets = (doc.theming?.targets ?? [])
+    .filter(target => target.deprecatedFor == null)
+    .map(target => target.className.replace(/^astryx-/, ''));
+  return {
+    contract: {
+      anatomy: anatomy.map(part => part.name),
+      targets,
+    },
   };
 }
 

--- a/scripts/check-knowledge.test.mjs
+++ b/scripts/check-knowledge.test.mjs
@@ -287,6 +287,45 @@ function writeButtonDoc(directory) {
   return content;
 }
 
+function writeParentMemberDocs(
+  directory,
+  {projection = false, includeChild = true} = {},
+) {
+  const ref = projection
+    ? `{name: 'Member', projection: {anatomy: ['Member part'], targets: ['astryx-member']}}`
+    : `{name: 'Member'}`;
+  fs.writeFileSync(
+    path.join(directory, 'Parent.doc.mjs'),
+    `export const docs = {
+  name: 'Parent', displayName: 'Parent', props: [],
+  components: [${ref}],
+  usage: {description: 'Parent.', anatomy: [
+    {name: 'Parent root', required: true, description: 'Root.'},
+    {name: 'Member part', required: false, description: 'Member.'},
+  ]},
+  theming: {targets: [
+    {className: 'astryx-parent'},
+    {className: 'astryx-member'},
+  ]},
+};\n`,
+  );
+  if (includeChild) {
+    const childContract = projection
+      ? ''
+      : `usage: {description: 'Member.', anatomy: [
+    {name: 'Child part', required: true, description: 'Child.'},
+  ]},
+  theming: {targets: [{className: 'astryx-child'}]},`;
+    fs.writeFileSync(
+      path.join(directory, 'Member.doc.mjs'),
+      `export const docs = {
+  name: 'Member', displayName: 'Member', subComponentOf: 'Parent',
+  description: 'Member.', props: [], ${childContract}
+};\n`,
+    );
+  }
+}
+
 afterEach(() => {
   for (const root of roots.splice(0))
     fs.rmSync(root, {recursive: true, force: true});
@@ -488,6 +527,147 @@ describe('component theming anatomy metadata', () => {
     expect(
       fs.readFileSync(path.join(directory, 'Button.doc.mjs'), 'utf8'),
     ).toBe(consumerDoc);
+  });
+
+  it('rejects a projected member spec with the parent owner diagnostic', async () => {
+    const root = fixtureRoot();
+    const directory = path.join(root, 'packages/core/src/Parent');
+    fs.mkdirSync(directory);
+    writeParentMemberDocs(directory, {projection: true});
+    fs.writeFileSync(
+      path.join(directory, 'Member.spec.md'),
+      withAnatomyTheming(
+        componentRecord({id: 'component:Member'}),
+        {"Member part": {target: 'member'}},
+      ),
+    );
+
+    const problems = (await validateKnowledgeRoot(root)).join('\n');
+    expect(problems).toContain(
+      'selected anatomy and targets for Member are owned by Parent and must be mapped in Parent.spec.md',
+    );
+  });
+
+  it('validates child-owned facts independently of parent-owned projections', async () => {
+    const root = fixtureRoot();
+    const directory = path.join(root, 'packages/core/src/Parent');
+    fs.mkdirSync(directory);
+    fs.writeFileSync(
+      path.join(directory, 'Parent.doc.mjs'),
+      `export const docs = {
+  name: 'Parent', displayName: 'Parent', props: [],
+  components: [{name: 'Member', projection: {anatomy: ['Shared part'], targets: ['astryx-shared']}}],
+  usage: {description: 'Parent.', anatomy: [
+    {name: 'Shared part', required: false, description: 'Shared.'},
+  ]},
+  theming: {targets: [{className: 'astryx-shared'}]},
+};\n`,
+    );
+    fs.writeFileSync(
+      path.join(directory, 'Member.doc.mjs'),
+      `export const docs = {
+  name: 'Member', displayName: 'Member', subComponentOf: 'Parent',
+  description: 'Member.', props: [],
+  usage: {description: 'Member.', anatomy: [
+    {name: 'Local part', required: true, description: 'Local.'},
+  ]},
+  theming: {targets: [{className: 'astryx-local'}]},
+};\n`,
+    );
+    fs.writeFileSync(
+      path.join(directory, 'Member.spec.md'),
+      withAnatomyTheming(
+        componentRecord({id: 'component:Member'}),
+        {"Local part": {target: 'local'}},
+      ),
+    );
+
+    expect(await validateKnowledgeRoot(root)).toEqual([]);
+  });
+
+  it('does not validate an extracted child against a name-only ref parent aggregate', async () => {
+    const root = fixtureRoot();
+    const directory = path.join(root, 'packages/core/src/Parent');
+    fs.mkdirSync(directory);
+    writeParentMemberDocs(directory);
+    fs.writeFileSync(
+      path.join(directory, 'Member.spec.md'),
+      withAnatomyTheming(
+        componentRecord({id: 'component:Member'}),
+        {"Parent root": {target: 'parent'}},
+      ),
+    );
+
+    const problems = (await validateKnowledgeRoot(root)).join('\n');
+    expect(problems).toContain('theming anatomy is missing Child part');
+    expect(problems).toContain('theming anatomy has unknown Parent root');
+    expect(problems).toContain('current target "child" has no anatomy entry');
+  });
+
+  it('does not treat a name-only ref without an exact child doc as a contract', async () => {
+    const root = fixtureRoot();
+    const directory = path.join(root, 'packages/core/src/Parent');
+    fs.mkdirSync(directory);
+    writeParentMemberDocs(directory, {includeChild: false});
+    fs.writeFileSync(
+      path.join(directory, 'Member.spec.md'),
+      withAnatomyTheming(
+        componentRecord({id: 'component:Member'}),
+        {"Parent root": {target: 'parent'}},
+      ),
+    );
+
+    expect((await validateKnowledgeRoot(root)).join('\n')).toContain(
+      'no component doc for Member',
+    );
+  });
+
+  it('still validates the parent against its full aggregate contract', async () => {
+    const root = fixtureRoot();
+    const directory = path.join(root, 'packages/core/src/Parent');
+    fs.mkdirSync(directory);
+    writeParentMemberDocs(directory, {projection: true});
+    fs.writeFileSync(
+      path.join(directory, 'Parent.spec.md'),
+      withAnatomyTheming(
+        componentRecord({id: 'component:Parent'}),
+        {
+          "Parent root": {target: 'parent'},
+          "Member part": {target: 'member'},
+        },
+      ),
+    );
+
+    expect(await validateKnowledgeRoot(root)).toEqual([]);
+  });
+
+  it('preserves full inline legacy component contracts', async () => {
+    const root = fixtureRoot();
+    const directory = path.join(root, 'packages/core/src/Family');
+    fs.mkdirSync(directory);
+    fs.writeFileSync(
+      path.join(directory, 'Family.doc.mjs'),
+      `export const docs = {
+  name: 'Family', displayName: 'Family',
+  usage: {description: 'Family.', anatomy: []},
+  components: [{
+    name: 'Inline', displayName: 'Inline', description: 'Inline member.', props: [],
+    usage: {description: 'Inline.', anatomy: [
+      {name: 'Inline root', required: true, description: 'Root.'},
+    ]},
+    theming: {targets: [{className: 'astryx-inline'}]},
+  }],
+};\n`,
+    );
+    fs.writeFileSync(
+      path.join(directory, 'Inline.spec.md'),
+      withAnatomyTheming(
+        componentRecord({id: 'component:Inline'}),
+        {"Inline root": {target: 'inline'}},
+      ),
+    );
+
+    expect(await validateKnowledgeRoot(root)).toEqual([]);
   });
 
   it('keeps the block optional while existing specs migrate', async () => {


### PR DESCRIPTION
## Why

Extracted member pages need their exact parent-owned anatomy and theming target without creating a second writable declaration or inheriting the parent's full aggregate contract.

## What

- Adds an explicit, fail-closed parent-owned projection resolved by both direct CLI lookup and docsite generation.
- Migrates the four proven members and removes their duplicate target declarations while keeping public target discovery unchanged.
- Keeps name-only refs out of knowledge contracts and rejects member theming-anatomy maps owned by the parent.

## Risk

Documentation and tooling only. No React API, runtime DOM, CSS, target name, or import-path changes.

## Testing

- Focused projection, loader, CLI, target, knowledge, and docsite suites
- `pnpm check:repo`
- Generated docsite registry inspection for projected members and aggregate parents
