### PR TITLE
fix(ci): install dependencies before spec validation

### DIFF
--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -40,6 +40,34 @@ describe('spec-only workflow contract', () => {
     expect(lint).toContain('node scripts/check-knowledge.mjs');
   });
 
+  it('sets up dependencies before spec validation and skips heavy spec-only work', () => {
+    const ci = read('.github/workflows/ci.yml');
+    const jobStart = ci.indexOf('  docsite-test:');
+    const jobEnd = ci.indexOf('\n  check-components:', jobStart);
+    const docsiteJob = ci.slice(jobStart, jobEnd);
+
+    const checkout = docsiteJob.indexOf('- uses: actions/checkout@v7');
+    const setup = docsiteJob.indexOf('- uses: ./.github/actions/setup');
+    const validate = docsiteJob.indexOf('- name: Validate spec records');
+    const build = docsiteJob.indexOf('- name: Build core package');
+    const generate = docsiteJob.indexOf(
+      '- name: Generate and test docsite data',
+    );
+
+    expect(checkout).toBeGreaterThanOrEqual(0);
+    expect(setup).toBeGreaterThan(checkout);
+    expect(validate).toBeGreaterThan(setup);
+    expect(build).toBeGreaterThan(validate);
+    expect(generate).toBeGreaterThan(build);
+    expect(docsiteJob.slice(setup, validate)).not.toContain('\n        if:');
+    expect(docsiteJob.slice(build, generate)).toContain(
+      "if: needs.check-scope.outputs.spec_only != 'true'",
+    );
+    expect(docsiteJob.slice(generate)).toContain(
+      "if: needs.check-scope.outputs.spec_only != 'true'",
+    );
+  });
+
   it('fails closed when file APIs are truncated or scope classification fails', () => {
     const ci = read('.github/workflows/ci.yml');
     expect(ci).toContain('if: ${{ always() && !cancelled() }}');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,13 @@ jobs:
 
       - uses: actions/checkout@v7
 
+      # Spec validation imports the canonical CLI discovery path, so the
+      # lightweight docs path needs workspace dependencies too.
+      - uses: ./.github/actions/setup
+
       - name: Validate spec records
         if: needs.check-scope.outputs.spec_only == 'true'
         run: node scripts/check-knowledge.mjs
-
-      - uses: ./.github/actions/setup
-        if: needs.check-scope.outputs.spec_only != 'true'
 
       # docsite `generate` runs `astryx theme build`, which imports the compiled
       # @astryxdesign/core/theme entry (dist/theme/index.js). Build core first so that


### PR DESCRIPTION
## Why

The spec-only `docsite-test` path ran `scripts/check-knowledge.mjs` before workspace setup. Delegated-target validation now imports the canonical CLI discovery path, so clean runners fail on undeclared-at-runtime packages such as `jiti` before validating any branch content.

## What

Run the shared setup action immediately after checkout for both docsite paths. Heavy core/docsite generation remains skipped for spec-only changes.

## Risk

Spec-only documentation checks now install workspace dependencies, adding setup time while leaving validation behavior unchanged.

## Testing

- `pnpm exec vitest run .github/scripts/change-scope.test.mjs scripts/check-knowledge.test.mjs packages/cli/foundation/discovery/theming-targets.test.mjs`
- `pnpm exec prettier --check .github/workflows/ci.yml`
- `node scripts/check-knowledge.mjs`
- `pnpm check:repo`