### PR TITLE
fix(ci): reconcile fork review events safely

### DIFF
--- a/.github/scripts/spec-owner-reconcile.cjs
+++ b/.github/scripts/spec-owner-reconcile.cjs
@@ -49,6 +49,7 @@ async function reconcileSpecOwnerGate({
   github,
   context,
   core,
+  pullNumber: requestedPullNumber,
   workspace = process.env.GITHUB_WORKSPACE,
   env = process.env,
 }) {
@@ -67,7 +68,8 @@ async function reconcileSpecOwnerGate({
   const {owner, repo} = context.repo;
   const repository = `${owner}/${repo}`;
   const pullNumber = Number(
-    context.payload.pull_request?.number ??
+    requestedPullNumber ??
+      context.payload.pull_request?.number ??
       context.payload.issue?.number ??
       context.payload.inputs?.pr,
   );

--- a/.github/scripts/spec-owner-reconcile.test.mjs
+++ b/.github/scripts/spec-owner-reconcile.test.mjs
@@ -221,13 +221,14 @@ function createHarness({
   return {github, core, state};
 }
 
-async function run(harness, runContext) {
+async function run(harness, runContext, options = {}) {
   await reconcileSpecOwnerGate({
     github: harness.github,
     context: runContext,
     core: harness.core,
     workspace,
     env,
+    ...options,
   });
 }
 
@@ -404,6 +405,17 @@ describe('spec owner workflow reconciliation', () => {
     expect(
       harness.state.calls.some(call => call.includes('yielded to newer run')),
     ).toBe(true);
+  });
+
+  it('accepts a pull number resolved by a trusted workflow-run companion', async () => {
+    const harness = createHarness({author: 'contributor'});
+    const relayContext = context({runId: 100n, eventName: 'workflow_run'});
+    delete relayContext.payload.pull_request;
+
+    await run(harness, relayContext, {pullNumber: 17});
+
+    expect(harness.state.pullGets).toBeGreaterThan(0);
+    expect(latestGateStatus(harness.state).state).toBe('pending');
   });
 
   it('rejects valid-shaped non-owner commands before API work', async () => {

--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -96,6 +96,27 @@ describe('spec-only workflow contract', () => {
     expect(workflow).toContain(
       "startsWith(github.event.comment.body, '/revoke-spec ')",
     );
+    expect(workflow).toContain("github.event_name != 'pull_request_review'");
+    expect(workflow).toContain('review-anchor:');
+    expect(workflow).toContain('permissions: {}');
+
+    const reviewWorkflow = read(
+      '.github/workflows/spec-owner-review-reconcile.yml',
+    );
+    expect(reviewWorkflow).toContain("workflows: ['Spec owner gate']");
+    expect(reviewWorkflow).toContain(
+      "github.event.workflow_run.event == 'pull_request_review'",
+    );
+    expect(reviewWorkflow).toContain(
+      "github.event.workflow_run.conclusion == 'success'",
+    );
+    expect(reviewWorkflow).toContain(
+      'ref: ${{ github.event.repository.default_branch }}',
+    );
+    expect(reviewWorkflow).toContain('pull.head.sha === run.head_sha');
+    expect(reviewWorkflow).toContain('pull.head.ref === run.head_branch');
+    expect(reviewWorkflow).toContain('matches.length !== 1');
+    expect(reviewWorkflow).toContain('pullNumber: matches[0].number');
     expect(reconciler).toContain('expectedCount: after.changed_files');
     expect(reconciler).toContain('scope.touchesKnowledgeRecords');
     expect(reconciler).toContain('scope.touchesDesignAssets');

--- a/.github/workflows/spec-owner-gate.yml
+++ b/.github/workflows/spec-owner-gate.yml
@@ -41,12 +41,15 @@ env:
 
 jobs:
   reconcile:
-    # Keep ordinary PR discussion outside the privileged pull_request_target path.
+    # Raw review events on fork PRs always receive a read-only token. Leave
+    # those to the no-permission anchor below and the trusted workflow_run
+    # companion; all other events continue to reconcile here.
     if: >-
-      github.event_name != 'issue_comment' ||
-      (github.event.issue.pull_request != null &&
-       (startsWith(github.event.comment.body, '/approve-spec ') ||
-        startsWith(github.event.comment.body, '/revoke-spec ')))
+      github.event_name != 'pull_request_review' &&
+      (github.event_name != 'issue_comment' ||
+       (github.event.issue.pull_request != null &&
+        (startsWith(github.event.comment.body, '/approve-spec ') ||
+         startsWith(github.event.comment.body, '/revoke-spec '))))
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -71,3 +74,12 @@ jobs:
               '.github/scripts/spec-owner-reconcile.cjs',
             ));
             await reconcileSpecOwnerGate({github, context, core});
+
+  review-anchor:
+    if: github.event_name == 'pull_request_review'
+    name: Queue trusted review reconcile
+    runs-on: ubuntu-slim
+    permissions: {}
+    steps:
+      - name: Record review event
+        run: echo "Review event received; the trusted companion will reconcile it."

--- a/.github/workflows/spec-owner-review-reconcile.yml
+++ b/.github/workflows/spec-owner-review-reconcile.yml
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pull_request_review receives a read-only token for fork PRs, even when this
+# repository requests write permissions. The source workflow records the event
+# without permissions; this trusted default-branch companion resolves the exact
+# open PR and performs the status reconciliation without running PR code.
+name: Spec owner review reconcile
+
+on:
+  workflow_run:
+    workflows: ['Spec owner gate']
+    types: [completed]
+
+permissions: {}
+
+env:
+  SPEC_OWNERS: cixzhang,imdreamrunner
+  REVIEW_LABEL: needs:spec-owner-review
+  AUTO_MERGE_LABEL: spec-auto-merge
+
+jobs:
+  reconcile:
+    if: >-
+      github.event.workflow_run.event == 'pull_request_review' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      statuses: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Reconcile owner gate
+        uses: actions/github-script@v9
+        with:
+          retries: 3
+          script: |
+            const path = require('node:path');
+            const {reconcileSpecOwnerGate} = require(path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/scripts/spec-owner-reconcile.cjs',
+            ));
+            const run = context.payload.workflow_run;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              ...context.repo,
+              state: 'open',
+              base: context.payload.repository.default_branch,
+              per_page: 100,
+            });
+            const matches = pulls.filter(pull =>
+              pull.head.sha === run.head_sha &&
+              pull.head.ref === run.head_branch &&
+              pull.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`
+            );
+            if (matches.length !== 1) {
+              throw new Error(
+                `Expected one open PR for review run ${run.id}; found ${matches.length}.`,
+              );
+            }
+            await reconcileSpecOwnerGate({
+              github,
+              context,
+              core,
+              pullNumber: matches[0].number,
+            });


### PR DESCRIPTION
## Why

Fork `pull_request_review` runs receive a read-only `GITHUB_TOKEN`, so the spec-owner reconciler fails when it writes commit statuses.

## What

Route review events through a no-permission anchor and a trusted `workflow_run` companion. The companion resolves exactly one open PR by head SHA, branch, and base repository before invoking the existing reconciler; ambiguous or stale identities fail closed.

## Risk

No product behavior changes. Privileged code still comes only from the default branch, and approval remains derived from the existing owner rules.

## Testing

- 35 focused spec-owner workflow tests
- `actionlint` on both changed workflows
- repository pre-commit checks
