### PR TITLE
fix(Selector): add interruptible open and close motion

### DIFF
--- a/.changeset/selector-interruptible-motion.md
+++ b/.changeset/selector-interruptible-motion.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Give pointer-opened Selector popovers interruptible open and close transitions while keeping keyboard disclosure instant and reduced motion gentle.
+
+@mrabdussalam

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -350,7 +350,7 @@ export const docs = {
   components: [{name: 'SelectorOption'}],
   usage: {
     description:
-      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options. Keyboard typeahead matches a native select: typing on the focused closed trigger selects the matching option directly, repeated presses cycle through options sharing a first letter, and spaces count as match characters ("new y" reaches "New York"). With the menu open, typing moves the highlight and Enter commits. With hasSearch, typing on the closed trigger opens the popup and seeds the search input.',
+      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options. Keyboard typeahead matches a native select: typing on the focused closed trigger selects the matching option directly, repeated presses cycle through options sharing a first letter, and spaces count as match characters ("new y" reaches "New York"). With the menu open, typing moves the highlight and Enter commits. With hasSearch, typing on the closed trigger opens the popup and seeds the search input. Pointer-opened popovers use short, interruptible open and close transitions; keyboard disclosure remains instant.',
     bestPractices: [
       {
         guidance: true,
@@ -426,7 +426,7 @@ export const docs = {
 export const docsZh = {
   usage: {
     description:
-      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options. Keyboard typeahead matches a native select: typing on the focused closed trigger selects the matching option directly, repeated presses cycle through options sharing a first letter, and spaces count as match characters ("new y" reaches "New York"). With the menu open, typing moves the highlight and Enter commits. With hasSearch, typing on the closed trigger opens the popup and seeds the search input.',
+      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options. Keyboard typeahead matches a native select: typing on the focused closed trigger selects the matching option directly, repeated presses cycle through options sharing a first letter, and spaces count as match characters ("new y" reaches "New York"). With the menu open, typing moves the highlight and Enter commits. With hasSearch, typing on the closed trigger opens the popup and seeds the search input. Pointer-opened popovers use short, interruptible open and close transitions; keyboard disclosure remains instant.',
     bestPractices: [
       {
         guidance: true,
@@ -487,7 +487,7 @@ export const docsZh = {
 export const docsDense = {
   usage: {
     description:
-      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options. Keyboard typeahead matches a native select: typing on the focused closed trigger selects the matching option directly, repeated presses cycle through options sharing a first letter, and spaces count as match characters ("new y" reaches "New York"). With the menu open, typing moves the highlight and Enter commits. With hasSearch, typing on the closed trigger opens the popup and seeds the search input.',
+      'A dropdown selector for choosing a single value from a list of options. Supports labels, validation, descriptions, and required/optional states. Use it in forms and settings when presenting a moderate number of options. Keyboard typeahead matches a native select: typing on the focused closed trigger selects the matching option directly, repeated presses cycle through options sharing a first letter, and spaces count as match characters ("new y" reaches "New York"). With the menu open, typing moves the highlight and Enter commits. With hasSearch, typing on the closed trigger opens the popup and seeds the search input. Pointer-opened popovers use short, interruptible open and close transitions; keyboard disclosure remains instant.',
     bestPractices: [
       {
         guidance: true,

--- a/packages/core/src/Selector/Selector.source-build.test.mjs
+++ b/packages/core/src/Selector/Selector.source-build.test.mjs
@@ -2,8 +2,9 @@
 
 /**
  * @file Selector.source-build.test.mjs
- * @input Uses Babel, next/babel, the StyleX compiler, and Selector source
- * @output Verifies raw Selector source survives a consumer's Babel pipeline
+ * @input Uses Babel, next/babel, the StyleX compiler, Selector source, and
+ *   Selector motion source
+ * @output Verifies raw Selector and motion source survive a consumer's Babel pipeline
  * @position Regression test for Selector source-build compatibility
  */
 
@@ -17,6 +18,7 @@ import {describe, expect, it} from 'vitest';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '../../../..');
 const SELECTOR_SOURCE = path.join(__dirname, 'Selector.tsx');
+const SELECTOR_MOTION_SOURCE = path.join(__dirname, 'selectorMotion.stylex.ts');
 
 const EXPECTED_PADDING_DECLARATIONS = [
   'padding-block:calc((var(--size-element-sm) - var(--spacing-5) - 2 * var(--border-width)) / 2)',
@@ -61,5 +63,48 @@ describe('Selector source-build compatibility (#5464)', () => {
       .filter(declaration => declaration?.startsWith('padding-block:calc'));
 
     expect(declarations).toEqual(EXPECTED_PADDING_DECLARATIONS);
+  });
+
+  it('emits interruptible open/close and reduced-motion rules', async () => {
+    const source = await fs.readFile(SELECTOR_MOTION_SOURCE, 'utf8');
+    const result = await transformAsync(source, {
+      babelrc: false,
+      caller: {
+        name: 'selector-motion-source-build-test',
+        isDev: false,
+        isServer: false,
+        supportsStaticESM: false,
+      },
+      configFile: false,
+      envName: 'production',
+      filename: SELECTOR_MOTION_SOURCE,
+      presets: ['next/babel'],
+      plugins: [
+        [
+          stylexBabelPlugin,
+          {
+            dev: false,
+            runtimeInjection: false,
+            genConditionalClasses: true,
+            treeshakeCompensation: true,
+            unstable_moduleResolution: {
+              type: 'commonJS',
+              rootDir: ROOT,
+            },
+          },
+        ],
+      ],
+    });
+
+    const rules = (result?.metadata?.stylex ?? []).map(([, rule]) => rule.ltr);
+    expect(rules.some(rule => rule.includes('@starting-style'))).toBe(true);
+    expect(
+      rules.some(rule => rule.includes('transition-behavior:allow-discrete')),
+    ).toBe(true);
+    expect(
+      rules.some(rule =>
+        rule.includes('@media (prefers-reduced-motion: reduce)'),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/core/src/Selector/Selector.spec.md
+++ b/packages/core/src/Selector/Selector.spec.md
@@ -95,6 +95,7 @@ These requirements describe shipped behavior on current `main`.
 | FR3 | Every option row reserves one selection-mark column at `indicatorPosition`, even when the default unchecked indicator draws nothing. The column has a minimum width and can grow for a larger themed replacement. | `itemMarkColumn`, indicator-position tests, and theme tests |
 | FR4 | `popover` uses an anchored Popover. `bottom-sheet` uses a modal BottomSheet. `adaptive` resolves to the modal bottom sheet on compact coarse-pointer screens and Popover otherwise.                               | Presentation controller and adaptive-presentation tests     |
 | FR5 | While `isLoading` is true, the trigger exposes busy state and the listbox suppresses empty and no-results output.                                                                                                 | Loading, empty-state, and announcement tests                |
+| FR6 | Pointer-opened popovers transition in and out with interruptible opacity/transform transitions. Keyboard disclosure is instant; reduced motion removes the transform and keeps a brief fade.                      | Motion source-build, modality, and real-browser tests       |
 
 ### Allowed variation
 
@@ -109,16 +110,16 @@ These requirements describe shipped behavior on current `main`.
 
 ### Representative states
 
-| State                    | Required invariant                                                                   | Allowed variation                                      |
-| ------------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------ |
-| closed with no value     | Label and placeholder identify the field                                             | Consumer placeholder text                              |
-| closed with a value      | Selected option is represented in the trigger                                        | Custom `renderValue` content                           |
-| pointer / popover        | Anchored surface exposes the listbox without modal-dialog semantics                  | Default or explicit placement                          |
-| compact coarse pointer   | BottomSheet exposes a modal dialog containing the listbox                            | Explicit `bottom-sheet` or resolved `adaptive`         |
-| searching                | Visible options, keyboard navigation, and announced result count use one filter      | Consumer search and empty text                         |
-| loading                  | Trigger is busy; empty and no-results output is suppressed                           | Consumer loading duration                              |
-| disabled with reason     | Trigger remains focusable enough to expose the reason while activation stays blocked | Consumer reason text                                   |
-| selected/unselected rows | Row semantics and theming state are correct; both reserve the indicator column       | Start/end position and themed indicator representation |
+| State                    | Required invariant                                                                                                           | Allowed variation                                      |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| closed with no value     | Label and placeholder identify the field                                                                                     | Consumer placeholder text                              |
+| closed with a value      | Selected option is represented in the trigger                                                                                | Custom `renderValue` content                           |
+| pointer / popover        | Anchored surface exposes the listbox without modal-dialog semantics; pointer disclosure uses interruptible open/close motion | Default or explicit placement                          |
+| compact coarse pointer   | BottomSheet exposes a modal dialog containing the listbox                                                                    | Explicit `bottom-sheet` or resolved `adaptive`         |
+| searching                | Visible options, keyboard navigation, and announced result count use one filter                                              | Consumer search and empty text                         |
+| loading                  | Trigger is busy; empty and no-results output is suppressed                                                                   | Consumer loading duration                              |
+| disabled with reason     | Trigger remains focusable enough to expose the reason while activation stays blocked                                         | Consumer reason text                                   |
+| selected/unselected rows | Row semantics and theming state are correct; both reserve the indicator column                                               | Start/end position and themed indicator representation |
 
 ### Transformation and precedence order
 
@@ -260,6 +261,7 @@ in `spec:AST-004` as current runtime behavior.
 | FR3, AV1              | `itemMarkColumn` source inspection plus indicator-position and replacement-indicator tests | start/end, selected/unselected, check/radio        | Removing the wrapper fails row-structure tests; changing its reserved width requires source/layout review      | `audit:Selector/design-rendered` |
 | FR4, AR1, AR2         | presentation tests plus `aria-haspopup` source review                                      | pointer, compact coarse pointer, search/non-search | Wrong Popover/dialog roles or focus destinations fail tests; `aria-haspopup` values require source/a11y review | `audit:Selector/accessibility`   |
 | FR5                   | loading, empty-state, and live-region tests                                                | empty options, unmatched search, loading           | Empty/no-results output appears or is announced while loading                                                  | `audit:Selector/behavior`        |
+| FR6                   | motion source-build, modality unit tests, and real-browser frame capture                   | pointer/keyboard, open/close, reduced motion       | Keyboard disclosure animates, exit disappears immediately, or reduced motion still translates/scales           | `audit:Selector/design-rendered` |
 | source-build contract | `Selector.source-build.test.mjs`                                                           | package source compiled by consumer Babel          | Moving evaluated StyleX values outside the supported source form fails compilation                             | `audit:Selector/code-health`     |
 
 ## Decision log

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -38,6 +38,7 @@ import {Theme} from '../theme/Theme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
 import {spacingVars} from '../theme/tokens.stylex';
 import {selectorPresentationStyles} from './selectorPresentation.stylex';
+import {SELECTOR_MOTION_DURATION} from './selectorMotion.stylex';
 
 function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
@@ -253,6 +254,43 @@ function mockSelectorRects({
 }
 
 describe('Selector', () => {
+  it('keeps keyboard-triggered popover disclosure instant', () => {
+    render(<Selector label="Fruit" options={OPTIONS} onChange={() => {}} />);
+    const trigger = screen.getByRole('combobox');
+    const popover = screen.getByRole('listbox', h).closest('[popover]');
+    if (!(popover instanceof HTMLElement)) {
+      throw new Error('selector popover not found');
+    }
+
+    act(() => trigger.focus());
+    fireEvent.keyDown(trigger, {key: 'Enter'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(popover.style.getPropertyValue(SELECTOR_MOTION_DURATION)).toBe('0s');
+
+    fireEvent.keyDown(trigger, {key: 'Escape'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(popover.style.getPropertyValue(SELECTOR_MOTION_DURATION)).toBe('0s');
+  });
+
+  it('leaves pointer-triggered popover disclosure on the themed durations', () => {
+    render(<Selector label="Fruit" options={OPTIONS} onChange={() => {}} />);
+    const trigger = screen.getByRole('combobox');
+    const popover = screen.getByRole('listbox', h).closest('[popover]');
+    if (!(popover instanceof HTMLElement)) {
+      throw new Error('selector popover not found');
+    }
+
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(popover.style.getPropertyValue(SELECTOR_MOTION_DURATION)).toBe('');
+
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(popover.style.getPropertyValue(SELECTOR_MOTION_DURATION)).toBe('');
+  });
+
   it('uses a bottom sheet and closes after a selection when requested', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -5,7 +5,7 @@
 /**
  * @file Selector.tsx
  * @input Uses React, StyleX, usePopover, useTooltip, Icon, InputGroupContext,
- *   and Selector positioning hooks
+ *   interaction modality, and Selector positioning/motion hooks
  * @output Exports Selector component
  * @position Core implementation; consumed by index.ts
  *
@@ -29,6 +29,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {useTooltip} from '../Tooltip';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {useIndicator} from '../Indicator';
@@ -42,7 +43,6 @@ import {
   type FieldStatusVariant,
 } from '../Field';
 import {Divider} from '../Divider';
-import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {useKeepLayerOpenProps, type LayerPlacement} from '../Layer/useLayer';
 import {InternalInputClearButton} from '../Field/InputClearButton';
 import {Spinner} from '../Spinner';
@@ -89,6 +89,14 @@ import type {AdaptivePresentation} from '../hooks/useAdaptivePresentation';
 import {SelectorBottomSheet} from './SelectorBottomSheet';
 import {useSelectorPresentation} from './useSelectorPresentation';
 import {selectorPresentationStyles} from './selectorPresentation.stylex';
+import {
+  SELECTOR_MOTION_DURATION,
+  selectorMotionStyles,
+} from './selectorMotion.stylex';
+import {
+  getInteractionModality,
+  trackInteractionModality,
+} from '../utils/interactionModality';
 
 const styles = stylex.create({
   // Trigger container — the enhanced click target wrapping the combobox button and clear button as siblings
@@ -210,12 +218,22 @@ const styles = stylex.create({
   // picks these up and needs no transition opt-out.
   triggerIconRotation: {
     transitionProperty: 'transform',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
     transformOrigin: 'center',
   },
   triggerIconOpen: {
     transform: 'rotate(180deg)',
+    transitionDuration: {
+      default: durationVars['--duration-fast-max'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
+  },
+  triggerIconInstant: {
+    transitionDuration: '0s',
   },
   triggerGhost: {
     width: 'auto',
@@ -986,11 +1004,60 @@ export function Selector<T extends SelectorOptionType>(
   });
   const {popover} = surface;
   const keepOpenProps = useKeepLayerOpenProps(popover.id, popover.isOpen);
+  const motionResetFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    trackInteractionModality();
+    return () => {
+      if (motionResetFrameRef.current != null) {
+        cancelAnimationFrame(motionResetFrameRef.current);
+      }
+    };
+  }, []);
+
+  // The pointer surface uses a short spatial transition. Keyboard disclosure is
+  // intentionally instant: set the private duration override before the native
+  // popover state changes, then clear it after one painted frame so a later
+  // pointer dismissal still receives the normal exit transition.
+  const preparePopoverMotion = useCallback(() => {
+    if (surface.activePresentation !== 'popover') {
+      return;
+    }
+    const element = document.getElementById(popover.id);
+    if (!element) {
+      return;
+    }
+    if (motionResetFrameRef.current != null) {
+      cancelAnimationFrame(motionResetFrameRef.current);
+      motionResetFrameRef.current = null;
+    }
+    if (getInteractionModality() === 'pointer') {
+      element.style.removeProperty(SELECTOR_MOTION_DURATION);
+      return;
+    }
+    element.style.setProperty(SELECTOR_MOTION_DURATION, '0s');
+    motionResetFrameRef.current = requestAnimationFrame(() => {
+      motionResetFrameRef.current = requestAnimationFrame(() => {
+        element.style.removeProperty(SELECTOR_MOTION_DURATION);
+        motionResetFrameRef.current = null;
+      });
+    });
+  }, [popover.id, surface.activePresentation]);
+
+  const showSurface = useCallback(() => {
+    preparePopoverMotion();
+    surface.show();
+  }, [preparePopoverMotion, surface]);
+
+  const hideSurface = useCallback(() => {
+    preparePopoverMotion();
+    surface.hide();
+  }, [preparePopoverMotion, surface]);
 
   // Open dropdown on mount when isDefaultOpen is true
   useEffect(() => {
     if (isDefaultOpen) {
-      surface.show();
+      showSurface();
     }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only: isDefaultOpen is not reactive
   }, []);
@@ -1149,7 +1216,7 @@ export function Selector<T extends SelectorOptionType>(
     isOpen: surface.isOpen,
     hasSearch,
     onOpen: useCallback(() => {
-      surface.show();
+      showSurface();
       if (hasSearch) {
         requestAnimationFrame(() => {
           const input = searchRef.current;
@@ -1161,8 +1228,8 @@ export function Selector<T extends SelectorOptionType>(
           }
         });
       }
-    }, [surface, hasSearch]),
-    onClose: surface.hide,
+    }, [showSurface, hasSearch]),
+    onClose: hideSurface,
     onSelect: commitValue,
     onClear: hasClear ? clearValue : undefined,
     onSearchSeed: appendSearchQuery,
@@ -1554,6 +1621,7 @@ export function Selector<T extends SelectorOptionType>(
   // it. Outside a group the caller's own row decides, and the trigger's
   // padding sizes it to whatever that draws.
   const rowLayout = inputGroup ? 'inline' : 'stacked';
+  const hasPointerMotion = getInteractionModality() === 'pointer';
 
   // What the closed trigger shows for the current selection: the option's icon
   // and label. `startIcon` wins over the option's own icon so a caller who
@@ -1648,7 +1716,10 @@ export function Selector<T extends SelectorOptionType>(
         offset: shouldOverlaySelectedItem
           ? undefined
           : spacingVars['--spacing-1'],
-        xstyle: [styles.popover, layerAnimations[popoverPlacement]],
+        xstyle: [
+          styles.popover,
+          selectorMotionStyles[popoverPlacement] as unknown as StyleXStyles,
+        ],
         style: popoverOffsetStyle,
       })
     );
@@ -1809,6 +1880,7 @@ export function Selector<T extends SelectorOptionType>(
             xstyle={[
               styles.triggerIcon,
               styles.triggerIconRotation,
+              !hasPointerMotion && styles.triggerIconInstant,
               surface.isOpen && styles.triggerIconOpen,
             ]}
             // Stable theme target on the chevron glyph itself, so a theme can

--- a/packages/core/src/Selector/selectorMotion.stylex.ts
+++ b/packages/core/src/Selector/selectorMotion.stylex.ts
@@ -1,0 +1,138 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file selectorMotion.stylex.ts
+ * @input Uses StyleX plus shared motion and spacing tokens
+ * @output Exports pointer-popover open and close transitions for Selector
+ * @position Selector-owned motion policy; consumed by Selector.tsx
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
+
+/**
+ * Selector keeps keyboard-triggered disclosure instant by setting this private
+ * duration override to `0s` for that interaction. Pointer disclosure falls back
+ * to the shared motion tokens below.
+ */
+export const SELECTOR_MOTION_DURATION = '--_selector-motion-duration';
+
+const transitionDuration = {
+  default: `var(${SELECTOR_MOTION_DURATION}, ${durationVars['--duration-fast']})`,
+  ':popover-open': `var(${SELECTOR_MOTION_DURATION}, ${durationVars['--duration-fast-max']})`,
+  '@media (prefers-reduced-motion: reduce)': `var(${SELECTOR_MOTION_DURATION}, ${durationVars['--duration-fast-min']})`,
+} as const;
+
+const transitionBase = {
+  opacity: {
+    default: 0,
+    ':popover-open': 1,
+    '@starting-style': {
+      ':popover-open': 0,
+    },
+  },
+  transitionBehavior: 'allow-discrete' as const,
+  transitionDuration,
+  transitionProperty: 'opacity, transform, display, overlay',
+  transitionTimingFunction: easeVars['--ease-standard'],
+};
+
+const belowTransform = `translateY(calc(-1 * ${spacingVars['--spacing-2']})) scale(0.97)`;
+const aboveTransform = `translateY(${spacingVars['--spacing-2']}) scale(0.97)`;
+const endTransform = `translateX(calc(-1 * ${spacingVars['--spacing-2']})) scale(0.97)`;
+const startTransform = `translateX(${spacingVars['--spacing-2']}) scale(0.97)`;
+
+export const selectorMotionStyles = stylex.create({
+  below: {
+    ...transitionBase,
+    transform: {
+      default: belowTransform,
+      ':popover-open': 'translateY(0) scale(1)',
+      '@starting-style': {
+        ':popover-open': belowTransform,
+      },
+      '@media (prefers-reduced-motion: reduce)': {
+        default: 'none',
+        ':popover-open': 'none',
+        '@starting-style': {
+          ':popover-open': 'none',
+        },
+      },
+    },
+    transformOrigin: {
+      default: 'top left',
+      ':is([dir="rtl"] *)': 'top right',
+    },
+  },
+  above: {
+    ...transitionBase,
+    transform: {
+      default: aboveTransform,
+      ':popover-open': 'translateY(0) scale(1)',
+      '@starting-style': {
+        ':popover-open': aboveTransform,
+      },
+      '@media (prefers-reduced-motion: reduce)': {
+        default: 'none',
+        ':popover-open': 'none',
+        '@starting-style': {
+          ':popover-open': 'none',
+        },
+      },
+    },
+    transformOrigin: {
+      default: 'bottom left',
+      ':is([dir="rtl"] *)': 'bottom right',
+    },
+  },
+  end: {
+    ...transitionBase,
+    transform: {
+      default: endTransform,
+      ':popover-open': 'translateX(0) scale(1)',
+      ':is([dir="rtl"] *)': startTransform,
+      '@starting-style': {
+        ':popover-open': endTransform,
+        ':is([dir="rtl"] *)': startTransform,
+      },
+      '@media (prefers-reduced-motion: reduce)': {
+        default: 'none',
+        ':popover-open': 'none',
+        ':is([dir="rtl"] *)': 'none',
+        '@starting-style': {
+          ':popover-open': 'none',
+          ':is([dir="rtl"] *)': 'none',
+        },
+      },
+    },
+    transformOrigin: {
+      default: 'center left',
+      ':is([dir="rtl"] *)': 'center right',
+    },
+  },
+  start: {
+    ...transitionBase,
+    transform: {
+      default: startTransform,
+      ':popover-open': 'translateX(0) scale(1)',
+      ':is([dir="rtl"] *)': endTransform,
+      '@starting-style': {
+        ':popover-open': startTransform,
+        ':is([dir="rtl"] *)': endTransform,
+      },
+      '@media (prefers-reduced-motion: reduce)': {
+        default: 'none',
+        ':popover-open': 'none',
+        ':is([dir="rtl"] *)': 'none',
+        '@starting-style': {
+          ':popover-open': 'none',
+          ':is([dir="rtl"] *)': 'none',
+        },
+      },
+    },
+    transformOrigin: {
+      default: 'center right',
+      ':is([dir="rtl"] *)': 'center left',
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- replace Selector’s one-way entry keyframe with interruptible CSS transitions for pointer-opened popovers
- add a symmetric exit path for trigger, selection, and native light-dismiss closes
- keep keyboard disclosure instant and use a fade-only reduced-motion treatment
- align the chevron’s timing with the surface and document the behavior contract

## Verification

- `pnpm -F @astryxdesign/core build`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/core lint` (0 errors; existing warnings only)
- `pnpm vitest run packages/core/src/Selector/Selector.test.tsx packages/core/src/Selector/Selector.source-build.test.mjs` (169 passed)
- `pnpm check:repo`
- Chromium runtime matrix: pointer open, trigger close, selection close, outside close, keyboard open/Escape/Tab, and reduced motion
- frame-by-frame comparison against published `@astryxdesign/core@0.5.2`
