### PR TITLE
fix(ci): skip fork spec-owner review reconciliation

### DIFF
--- a/.github/REVIEW_GATE.md
+++ b/.github/REVIEW_GATE.md
@@ -27,9 +27,11 @@ family, design, or system spec waits on `spec-owner-approval` for its exact
 current head. `cixzhang` or `imdreamrunner` can approve every record kind.
 Current design records and normative design assets may also be approved by any
 handle in `.github/DESIGNOWNERS`. Mixed PRs still require `cixzhang` or
-`imdreamrunner` for non-design current records. When an approver is also the
-author, the explicit equivalent is a comment containing
-`/approve-spec <full-head-sha>`; a new commit invalidates it.
+`imdreamrunner` for non-design current records. Same-repository owner reviews
+update the exact-head approval automatically. Fork review events cannot write
+with their read-only token, so an approver uses an issue comment containing
+`/approve-spec <full-head-sha>` instead; that command runs from the trusted
+default branch and a new commit invalidates it.
 
 A PR changes only spec records when every changed path is one of:
 

--- a/.github/scripts/spec-owner-reconcile.cjs
+++ b/.github/scripts/spec-owner-reconcile.cjs
@@ -52,6 +52,18 @@ async function reconcileSpecOwnerGate({
   workspace = process.env.GITHUB_WORKSPACE,
   env = process.env,
 }) {
+  const {owner, repo} = context.repo;
+  const repository = `${owner}/${repo}`;
+  if (
+    context.eventName === 'pull_request_review' &&
+    context.payload.pull_request?.head?.repo?.full_name !== repository
+  ) {
+    core.info(
+      'Skipping fork pull request review; use an exact-head owner command to reconcile.',
+    );
+    return;
+  }
+
   const specOwners = env.SPEC_OWNERS.split(',').map(ownerName =>
     ownerName.toLowerCase(),
   );
@@ -64,8 +76,6 @@ async function reconcileSpecOwnerGate({
     return;
   }
 
-  const {owner, repo} = context.repo;
-  const repository = `${owner}/${repo}`;
   const pullNumber = Number(
     context.payload.pull_request?.number ??
       context.payload.issue?.number ??

--- a/.github/scripts/spec-owner-reconcile.test.mjs
+++ b/.github/scripts/spec-owner-reconcile.test.mjs
@@ -30,6 +30,7 @@ function context({
   actor = 'cixzhang',
   author = 'cixzhang',
   headSha = head,
+  headRepository = repository,
   comment,
   review,
 }) {
@@ -51,7 +52,10 @@ function context({
               number: 17,
               updated_at: '2026-08-30T10:00:00Z',
               user: {login: author},
-              head: {sha: headSha},
+              head: {
+                sha: headSha,
+                repo: {full_name: headRepository},
+              },
             },
     },
   };
@@ -78,6 +82,7 @@ function trustedStatus({
 
 function createHarness({
   author = 'cixzhang',
+  headRepository = repository,
   statuses = [],
   comments = [],
   reviews = [],
@@ -100,7 +105,7 @@ function createHarness({
       number: 17,
       node_id: 'PR_node',
       user: {login: author},
-      head: {sha: head, repo: {full_name: repository}},
+      head: {sha: head, repo: {full_name: headRepository}},
       base: {
         sha: '2222222222222222222222222222222222222222',
         repo: {full_name: repository},
@@ -404,6 +409,92 @@ describe('spec owner workflow reconciliation', () => {
     expect(
       harness.state.calls.some(call => call.includes('yielded to newer run')),
     ).toBe(true);
+  });
+
+  it('skips fork owner reviews before any GitHub API work', async () => {
+    const review = {
+      user: {login: 'cixzhang'},
+      state: 'APPROVED',
+      commit_id: head,
+      submitted_at: '2026-08-30T10:00:00Z',
+    };
+    const messages = [];
+    const github = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('GitHub API accessed');
+        },
+      },
+    );
+
+    await reconcileSpecOwnerGate({
+      github,
+      context: context({
+        runId: 100n,
+        eventName: 'pull_request_review',
+        action: 'submitted',
+        headRepository: 'contributor/astryx',
+        review,
+      }),
+      core: {info: message => messages.push(message)},
+      workspace,
+      env,
+    });
+
+    expect(messages).toEqual([
+      'Skipping fork pull request review; use an exact-head owner command to reconcile.',
+    ]);
+  });
+
+  it('reconciles same-repository owner reviews automatically', async () => {
+    const review = {
+      user: {login: 'cixzhang'},
+      state: 'APPROVED',
+      commit_id: head,
+      submitted_at: '2026-08-30T10:00:00Z',
+    };
+    const harness = createHarness({reviews: [review]});
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        eventName: 'pull_request_review',
+        action: 'submitted',
+        review,
+      }),
+    );
+
+    expect(harness.state.pullGets).toBeGreaterThan(0);
+    expect(latestGateStatus(harness.state).state).toBe('success');
+    expect(harness.state.calls).toContain('enable-auto-merge');
+  });
+
+  it('reconciles an exact-head owner command for a fork current-spec PR', async () => {
+    const comment = {
+      user: {login: 'cixzhang'},
+      body: `/approve-spec ${head}`,
+      created_at: '2026-08-30T10:00:00Z',
+    };
+    const harness = createHarness({
+      headRepository: 'contributor/astryx',
+      comments: [comment],
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        eventName: 'issue_comment',
+        action: 'created',
+        comment,
+      }),
+    );
+
+    expect(harness.state.pullGets).toBeGreaterThan(0);
+    expect(latestGateStatus(harness.state).state).toBe('success');
+    expect(harness.state.calls).toContain('enable-auto-merge');
   });
 
   it('rejects valid-shaped non-owner commands before API work', async () => {

--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -90,6 +90,21 @@ describe('spec-only workflow contract', () => {
       'reconcileSpecOwnerGate({github, context, core})',
     );
     expect(workflow).not.toContain('concurrency:');
+    const reconcileCondition = workflow
+      .slice(
+        workflow.indexOf('    if: >-', workflow.indexOf('  reconcile:')),
+        workflow.indexOf('    runs-on:', workflow.indexOf('  reconcile:')),
+      )
+      .replace(/^    if: >-\s*/, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    expect(reconcileCondition).toBe(
+      "(github.event_name != 'pull_request_review' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'issue_comment' || (github.event.issue.pull_request != null && (startsWith(github.event.comment.body, '/approve-spec ') || startsWith(github.event.comment.body, '/revoke-spec '))))",
+    );
+    expect(workflow).toContain('pull_request_review:');
+    expect(workflow).toContain('issue_comment:');
+    expect(workflow).toContain('permissions: {}');
+    expect(workflow).not.toContain('pull_request_review_target');
     expect(workflow).toContain(
       "startsWith(github.event.comment.body, '/approve-spec ')",
     );

--- a/.github/workflows/spec-owner-gate.yml
+++ b/.github/workflows/spec-owner-gate.yml
@@ -41,12 +41,15 @@ env:
 
 jobs:
   reconcile:
-    # Keep ordinary PR discussion outside the privileged pull_request_target path.
+    # Fork review events have read-only tokens. Same-repo reviews reconcile
+    # automatically; fork approvals use the trusted issue_comment command path.
     if: >-
-      github.event_name != 'issue_comment' ||
-      (github.event.issue.pull_request != null &&
-       (startsWith(github.event.comment.body, '/approve-spec ') ||
-        startsWith(github.event.comment.body, '/revoke-spec ')))
+      (github.event_name != 'pull_request_review' ||
+       github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event_name != 'issue_comment' ||
+       (github.event.issue.pull_request != null &&
+        (startsWith(github.event.comment.body, '/approve-spec ') ||
+         startsWith(github.event.comment.body, '/revoke-spec '))))
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
## Why

Fork pull request review events receive a read-only `GITHUB_TOKEN`. The spec owner gate tried to write a pending commit status immediately, so an owner review on a fork produced a failing workflow even when the pull request did not change specs.

## What

- Skip privileged reconciliation for fork `pull_request_review` events, both at the job boundary and before any API access in the trusted script.
- Preserve automatic exact-head owner review updates for same-repository pull requests and the trusted `/approve-spec <full-head-sha>` issue-comment path for fork pull requests.
- Add mutation-sensitive coverage for all three paths and document the fork approval command.

## Risk

Same-repository review behavior is unchanged. Fork review events now skip cleanly; fork pull requests that change current specs require an authorized exact-head issue comment. No event gains additional permissions.

## Testing

- `pnpm exec vitest run .github/scripts/spec-owner-decision.test.mjs .github/scripts/spec-owner-reconcile.test.mjs .github/scripts/spec-owner-workflow.test.mjs`
- `pnpm check:repo`
- Prettier check on changed files

No Changeset: workflow and contributor documentation only.
