### PR TITLE
docs(knowledge): specify theme-local tokens

### DIFF
--- a/docs/specs/AST-006/spec.md
+++ b/docs/specs/AST-006/spec.md
@@ -1,0 +1,409 @@
+---
+schema_version: 1
+template_version: 1
+kind: system-spec
+id: spec:AST-006
+authority: current
+archive_reason: null
+superseded_by: null
+approved_by: cixzhang
+approved_at: 2026-08-31
+phase: accepted
+owners: [cixzhang, rubyycheung, imdreamrunner]
+affects_architecture:
+  [
+    architecture:theme-authoring-contract,
+    architecture:theme-tokens,
+    architecture:theme-compilation,
+  ]
+affects_families: []
+affects_contributing: []
+affects_consumer_docs: []
+---
+
+# Theme-local tokens system spec
+
+## Intent
+
+Let a maintained theme reuse one of its own semantic decisions across component
+overrides without adding that decision to Astryx's portable token vocabulary.
+Theme authors get one explicit, checked path for theme-family-local reuse;
+component and application authors keep the same portable token contract they have
+today.
+
+The accepted API is one optional `DefineThemeInput.localTokens` field. Supplying
+it explicitly enrolls a theme in the new contract; omitting it preserves existing
+behavior, even when legacy component overrides already mention
+`--astryx-theme-*`. A local token is declared with its complete CSS
+custom-property name and referenced by that same name in the defining theme's
+component overrides. Descendants inherit enrollment and may replace exact names
+only through an enrolled exact `extends` lineage. Mere emitted CSS creates no
+contract, but a shipped enrolled definition recorded by its owning theme spec
+does: its exact name and semantic meaning are public within that theme family,
+not portable across themes or intended for Core component source.
+
+This current record accepts the cross-theme API and invariants independently of
+whether any particular theme has completed its own adoption evidence. Theme-local
+names, meanings, values, mappings, and rendered evidence remain owned by each
+adopting theme's colocated record.
+
+## Non-goals
+
+- Changing the type, accepted inputs, runtime or build behavior, permissive
+  spread behavior, names, precedence, inheritance, output, or resolution of the
+  existing `DefineThemeInput.tokens` path.
+- Adding a `defineLocalTokens` helper, a second authoring operation, a shorter
+  role identifier, a reference alias, or a parallel local-token API.
+- Adding theme-local names to `TokenName`, `tokenVar`, `tokenVars`,
+  `resolveThemeToken`, generated portable token documentation, or Core component
+  source.
+- Creating an application-consumer token extension mechanism. A compiled custom
+  property is an implementation output of its maintained theme family, not
+  authorization for application code to depend on it.
+- Defining any adopting theme's role meaning, value, component mappings, or
+  evidence. Those belong to that theme's colocated record.
+- Implementing runtime, build, package, theme, or component changes in this
+  specification-only pull request.
+
+## Requirements
+
+The requirements below are the accepted cross-theme contract.
+
+- **FR1 — Local tokens are purely additive, optional, and explicitly enrolled.**
+  `DefineThemeInput` MUST gain at most one new authoring surface: optional
+  `localTokens`. Supplying `localTokens` explicitly enrolls that theme in the new
+  contract. A descendant inherits enrollment only by extending an enrolled exact
+  base. A theme that neither supplies the field nor extends an enrolled exact
+  base remains unenrolled and MUST produce byte-equivalent `DefinedTheme` data,
+  runtime behavior, static output, package output, and resolution behavior.
+- **FR2 — Existing token behavior is frozen and local values reuse its value
+  contract.** This contract MUST NOT change `tokens` typing, accepted inputs,
+  runtime handling, static handling, permissive unknown-key or broad-spread
+  behavior, names, precedence, inheritance, output, or resolution. Existing
+  casts, spreads, external CSS variables, and legacy token references MUST NOT
+  receive new warnings, failures, reinterpretation, or migration requirements.
+  Inside the opt-in `localTokens` field, each value MUST accept the complete
+  existing `TokenValue` contract: a CSS string or `[light, dark]` tuple. Runtime
+  and static build MUST apply the same value normalization semantics existing
+  `tokens` use, without changing that existing path or normalizing theme names.
+- **FR3 — One exact name survives every stage.** A local token declaration MUST
+  use its complete CSS custom-property name as the `localTokens` key. The same
+  exact string MUST be used in `var(...)` references, `DefinedTheme` data,
+  runtime CSS, static CSS, inherited replacement, and generated theme-specific
+  types or metadata. No transform may create a second identifier.
+- **FR4 — Enrollment requires an exact stable theme name.** A theme supplying
+  `localTokens` MUST already have a `DefineThemeInput.name` that is a valid,
+  stable, lower-kebab theme identifier. No hidden normalization or rewritten
+  namespace is allowed. Every newly declared name MUST follow
+  `--astryx-theme-${name}-<purpose-led Astryx token grammar>`, using the input
+  `name` byte-for-byte. The suffix MUST be purpose-led and lowercase kebab-case.
+  Generic semantic domains such as `color`, `spacing`, `radius`, or `motion` are
+  valid inside the theme namespace. Existing themes with other name shapes
+  remain valid while unenrolled.
+- **FR5 — Local use stays inside the maintained theme family.** A local name MAY
+  be referenced by the maintained enrolled theme that defines it and by
+  descendants enrolled through its exact `extends` lineage. It MUST NOT become a
+  portable cross-theme token or a dependency in Core component source. Mere CSS
+  emission from an unenrolled legacy path creates no contract. Once an enrolled
+  theme ships a local token documented in its colocated theme-level spec, the
+  exact name and semantic meaning ARE a public compatibility contract of that
+  theme family.
+- **FR6 — Extension is exact-name, enrollment, and lineage-aware.** A descendant
+  inherits enrollment and declarations only from an enrolled exact `extends`
+  base. It MAY replace an inherited local token only by restating that inherited
+  complete name. A new local role declared by the descendant MUST use the
+  descendant's exact stable `name`. Arbitrary legacy names, matching prefixes,
+  matching suffixes, or coincidental values MUST NOT be retroactively claimed as
+  lineage. A child MUST NOT forge another theme's namespace.
+- **FR7 — Validation is atomic for enrolled themes only.** Runtime and static
+  build MUST share one recursive validator. For a theme enrolled directly or
+  through an enrolled exact base, it MUST validate the enrolled lineage's exact
+  namespaces, declarations, and every `var(--astryx-theme-...)` reference
+  reachable through local-token values, component overrides, nested pseudo
+  rules, and media-surface component overrides. It MUST reject malformed local
+  names, undeclared enrolled references, cyclic local references, exact-name or
+  lineage mismatch, and foreign local declarations before producing partial
+  output.
+- **FR8 — Unenrolled legacy behavior is grandfathered unchanged.** When
+  `localTokens` is absent and the exact base is not enrolled, runtime and static
+  build MUST NOT scan, reject, warn about, reserve, or reinterpret
+  `--astryx-theme-*` strings that already appear in token values or component
+  overrides. Existing same-prefix custom properties continue unchanged. A
+  maintainer may leave that legacy behavior unenrolled, or explicitly migrate by
+  supplying `localTokens` and declaring every reserved local name used by the
+  enrolled theme. Variables outside the reserved namespace and every existing
+  portable-token path remain untouched in either state.
+- **FR9 — Source and built themes preserve one enrollment lineage.**
+  Source-defined and built themes MUST retain equivalent exact local-token maps,
+  enrollment state, and lineage metadata so descendants accept, inherit,
+  replace, reject, and emit the same names without requiring a base stylesheet.
+- **FR10 — Released names and meanings are compatibility obligations.** Once an
+  enrolled local token ships, its exact name and documented semantic meaning are
+  public contracts of the owning theme family. Renaming the local token or its
+  enrolled theme, or changing that meaning, MUST use an explicit reviewed
+  migration or alias that preserves the prior exact-name, meaning, and lineage
+  contract for its compatibility window. Silent key replacement, semantic
+  broadening, theme-name rewriting, namespace rewriting, and inferred descendant
+  migration are prohibited.
+- **FR11 — The colocated theme spec owns definitions and mappings.** Each
+  theme-local token definition MUST live in the owning theme's colocated
+  theme-level spec, including its exact name, semantic meaning, value, mappings,
+  compatibility, and rendered evidence. A long generated name is acceptable when
+  it accurately names the meaning shared by every context where it is applied.
+  Adding a mapping is a theme-spec compatibility review: the context MUST
+  genuinely match the documented meaning and MUST provide rendered evidence for
+  its actual light/dark and relevant interaction states.
+
+### Accepted authoring shape
+
+`defineTheme` remains the only authoring operation. Opt-in requires the existing
+`name` to already be the exact lower-kebab identifier used in every local token.
+The same complete local name is declared, referenced, preserved in
+`DefinedTheme`, inherited, and emitted:
+
+```ts
+const exampleTheme = defineTheme({
+  name: 'example',
+  localTokens: {
+    '--astryx-theme-example-color-status-fill-accent': ['#0074e2', '#6d9cfe'],
+  },
+  components: {
+    badge: {
+      'variant:info': {
+        backgroundColor: 'var(--astryx-theme-example-color-status-fill-accent)',
+      },
+    },
+  },
+});
+```
+
+The declaration key and the name inside `var(...)` are identical. The tuple uses
+the complete existing `TokenValue` contract and normalizes exactly as an existing
+`tokens` light/dark tuple does. Runtime and static compilation emit
+`--astryx-theme-example-color-status-fill-accent` without shortening or
+renaming it. An adopting `theme:*` record owns its concrete role, value, and
+component mapping.
+
+### Platform support
+
+- Supported feature/engine floor: the same CSS custom-property,
+  `light-dark()`, theme scope, and browser support as existing web themes.
+- Unsupported behavior: a platform compiler that cannot preserve a local role
+  and its lineage MUST reject that enrolled input clearly rather than silently
+  omit it or expose the CSS spelling as shared cross-platform API.
+- Browser evidence: each adopting theme verifies its actual component mappings
+  and color modes in real Chromium. Name, validation, inheritance, and
+  runtime/static parity are structural and testable without visual evidence.
+
+## Current-state impact
+
+Current `main` has a closed portable core/domain token vocabulary and no
+first-class local-token field. Unknown keys that reach permissive existing paths
+can serialize, and broad object spreads can therefore resemble intentional local
+authoring without ownership, reference closure, or lineage validation.
+
+If implemented:
+
+- `architecture:theme-authoring-contract` adds only the optional `localTokens`
+  input, its exact-name map, explicit enrollment state, flattened inheritance,
+  and lineage metadata;
+- `architecture:theme-compilation` emits that exact map through the shared
+  runtime/static compiler and applies one recursive validator only to themes
+  enrolled directly or through an enrolled exact base; and
+- `architecture:theme-tokens` continues to own the unchanged portable
+  vocabulary and explicitly excludes theme-local names from its public helpers
+  and documentation.
+
+The current architecture records remain authoritative for shipped behavior until
+AST-006 is implemented. This accepted spec decides future implementation; their
+`deciding_specs` relationships update with the implementation that changes those
+surfaces. A draft theme record may reference this current spec while keeping its
+own value, mapping, and evidence decisions unresolved.
+
+### Compatibility and adoption
+
+- Adoption is per maintained theme family and optional. Existing themes are not
+  migrated merely because the field exists.
+- A theme that omits `localTokens` and does not extend an enrolled exact base
+  remains byte-equivalent across `DefinedTheme`, runtime, static, and package
+  outputs. Existing component overrides that mention `--astryx-theme-*` receive
+  no new scan, rejection, warning, reservation, or interpretation.
+- An existing same-prefix custom property may continue unchanged while the theme
+  remains unenrolled. To migrate, the maintainer explicitly supplies
+  `localTokens`, declares every reserved local name used by that theme, and uses
+  a valid stable lower-kebab `name` whose bytes match the namespace.
+- Existing `tokens` and external-variable behavior remains byte-equivalent,
+  including permissive broad spreads and runtime inputs.
+- Local names and documented meanings become public theme-family compatibility
+  obligations after release; they never become portable cross-theme or global
+  Core token promises. Mere custom-property emission from an unenrolled legacy
+  path does not create that contract.
+- Each local definition and mapping lives in the owning package's colocated theme
+  spec. Every new mapping reviews whether its context genuinely matches the
+  documented meaning and supplies rendered evidence before adoption.
+- Descendant compatibility follows explicit enrollment and exact lineage. A
+  released enrolled theme or token rename, or semantic meaning change, requires
+  an explicit migration or alias before descendants move.
+- This specification-only change has no Changeset. A later implementation or
+  theme output change carries its own release note.
+
+## Verification
+
+| Contract      | Verification                                                                   | Representative states                                                                                                                        | Mutation or failure expectation                                                                                             |
+| ------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| FR1, FR2, FR8 | Legacy type, runtime, build, resolution, and byte-output fixtures              | omitted field; legacy `--astryx-theme-*` component reference; direct tokens; broad spread; cast; external variable; portable reference       | Adding a reserved-namespace scan to the omitted-field path makes the legacy same-prefix mutation fixture fail.              |
+| FR2           | Local `TokenValue` parity fixtures                                             | CSS string; `[light, dark]` tuple; reference value; runtime/static normalization; existing-token control                                     | Local values reject an existing form, normalize differently across paths, or alter the existing `tokens` control.           |
+| FR3, FR4      | Exact-name authoring, type, and output fixtures                                | valid lower-kebab exact name; invalid input name; declaration key; `var(...)` reference; `DefinedTheme`; runtime CSS; static CSS             | Any stage rewrites `name`, accepts a mismatched namespace, or changes existing name acceptance while unenrolled.            |
+| FR5, FR6, FR9 | Source- and built-base enrollment/lineage fixtures                             | root opt-in; child inherits enrolled exact base; child exact replacement; child new role; unenrolled base; unrelated/legacy matching prefix  | A child gains lineage from an unenrolled or unrelated name, or source/built enrollment differs.                             |
+| FR7, FR8      | Shared recursive validator fixtures for runtime and static build               | enrolled nested references; component/pseudo/media rules; undeclared name; cycle; foreign namespace; unenrolled same-prefix legacy reference | Enrolled errors emit partial output, paths disagree, or the same scan runs on an unenrolled theme.                          |
+| FR8           | Explicit legacy-enrollment migration fixture                                   | same-prefix var omitted and accepted; then declared in `localTokens` and validated                                                           | Omitted legacy behavior changes, or explicit enrollment fails to bring the declaration/reference into the checked contract. |
+| FR10, FR11    | Theme-package compatibility fixtures, colocated theme spec, and release review | exact name; documented meaning; enrolled theme rename; local-token rename; meaning change; alias window; descendant built from old/new base  | A released name or meaning changes silently, a definition lacks an owner, or a descendant loses its inherited contract.     |
+| FR11          | Per-mapping theme-spec review plus focused rendered evidence                   | exact role meaning; mapped components/states; light/dark; relevant interaction states                                                        | A mapping uses the token outside its documented meaning or ships without contextual rendered evidence.                      |
+
+### Completion criteria
+
+AST-006 moves from `accepted` to `shipped` only when:
+
+- optional `DefineThemeInput.localTokens` is the only new local-token authoring
+  surface and its presence is the root enrollment trigger;
+- a theme with no `localTokens` and no enrolled exact base is proven
+  byte-equivalent, including a mutation fixture whose legacy component override
+  mentions `--astryx-theme-*` without any new scan, rejection, or warning;
+- local values accept both existing `TokenValue` forms—a CSS string and
+  `[light, dark]` tuple—and runtime/static normalization matches the existing
+  `tokens` value path without changing it;
+- opt-in requires the existing input `name` to already be a stable lower-kebab
+  identifier, and one exact local name preserves those bytes through declaration,
+  `var(...)` use, `DefinedTheme`, source/built inheritance, and emitted output;
+- descendants inherit enrollment only from an enrolled exact base; arbitrary
+  legacy names are never retroactively claimed;
+- namespace, exact-lineage, undeclared-reference, malformed-name, and cycle
+  failures are atomic and equal across runtime and static paths for enrolled
+  themes only;
+- built themes retain enrollment and exact lineage metadata sufficient for
+  descendants without a base stylesheet;
+- every shipped local definition is owned by its colocated theme-level spec, and
+  its exact name and semantic meaning are treated as public compatibility
+  contracts within that theme family;
+- every added mapping passes theme-spec compatibility review and rendered
+  light/dark and relevant interaction-state evidence showing that its context
+  genuinely matches the documented meaning;
+- public portable token types, helpers, docs, and Core component source do not
+  expose local names as cross-theme API; and
+- each adopter's colocated `theme:*` record owns its names, meanings, values,
+  mappings, migration, and rendered evidence.
+
+## Decision log
+
+The decisions below were approved by `cixzhang` as part of this current accepted
+specification.
+
+### DEC-1 — Add one optional local-token field without changing tokens
+
+**Reference:** `spec:AST-006/DEC-1`
+**Decider:** `cixzhang`, `2026-08-31`
+
+Use a purely additive optional `DefineThemeInput.localTokens` field. Supplying
+it explicitly enrolls a theme; an exact descendant may inherit that enrollment
+from an enrolled base. Keep `defineTheme` as the only authoring operation and
+preserve every existing `tokens` type, input, runtime, build, spread, precedence,
+inheritance, output, and resolution behavior. A theme with no `localTokens` and
+no enrolled exact base remains byte-equivalent even when existing component
+overrides mention `--astryx-theme-*`.
+
+Rejected: a `defineLocalTokens` helper, parallel API, implicit enrollment from a
+matching prefix, module augmentation of the portable token vocabulary, or
+stricter validation on existing token paths.
+
+### DEC-2 — Use one exact theme-owned name through definition and use
+
+**Reference:** `spec:AST-006/DEC-2`
+**Decider:** `cixzhang`, `2026-08-31`
+
+To enroll, the existing `DefineThemeInput.name` must already be a stable
+lower-kebab identifier. A new local name uses
+`--astryx-theme-${name}-<purpose-led Astryx token grammar>`, copying that name
+byte-for-byte with no hidden normalization. The declaration key is the CSS
+variable, and component overrides use that same name in `var(...)`. Generic
+domains such as `color` and `spacing` remain valid inside the owning theme
+namespace. Existing themes with other name forms remain valid while unenrolled.
+
+Rejected: normalizing or rewriting the input name, shorter role ids, generated
+names, reference aliases, and treating a generic domain word as a collision with
+portable tokens.
+
+### DEC-3 — Bind replacement to exact extension lineage
+
+**Reference:** `spec:AST-006/DEC-3`
+**Decider:** `cixzhang`, `2026-08-31`
+
+A descendant inherits enrollment only from an enrolled exact `extends` base and
+may replace an inherited exact name only when that name arrived through that
+lineage. Every new descendant role uses the child's exact stable input `name`.
+Source and built themes retain equivalent enrollment and lineage metadata.
+Arbitrary legacy names are never retroactively claimed. Released enrolled theme
+or token renames require an explicit migration or alias.
+
+Rejected: foreign namespace declarations, suffix- or prefix-based enrollment,
+value-based lineage inference, and silent theme-name or namespace rewriting
+during extension.
+
+### DEC-4 — Validate only the new reserved local namespace
+
+**Reference:** `spec:AST-006/DEC-4`
+**Decider:** `cixzhang`, `2026-08-31`
+
+Runtime and static build share one exact validator. It recursively rejects
+malformed local declarations, undeclared or cyclic reserved local references,
+and namespace or lineage errors only after a theme is enrolled directly through
+`localTokens` or through an enrolled exact base. An unenrolled theme receives no
+reserved-prefix scan, rejection, or warning, even when legacy component
+overrides mention `--astryx-theme-*`. Existing portable tokens, permissive
+spreads, casts, unknown-key behavior, and external variables remain untouched.
+A legacy same-prefix variable either continues unchanged while omitted or enters
+the checked contract through explicit declaration in `localTokens`.
+
+Rejected: a global reserved-prefix scan, a broad CSS-variable validator, or
+using the new field to close legacy runtime permissiveness.
+
+### DEC-5 — The owning theme spec defines a public theme-family contract
+
+**Reference:** `spec:AST-006/DEC-5`
+**Decider:** `cixzhang`, `2026-08-31`
+
+Theme-local token definitions belong in the owning package's colocated
+theme-level spec. Once shipped, the exact token name and semantic meaning are a
+public compatibility contract within that maintained theme family, even though
+the token is not portable across themes and is not intended for Core component
+source. Mere output from an unenrolled legacy path is not enough; explicit
+enrollment, shipment, and the theme spec establish the contract.
+
+A long generated name is acceptable when it accurately describes every context
+where the theme applies it. Adding any mapping is therefore a theme-spec
+compatibility review: the context must genuinely mean the documented role and
+must carry rendered evidence for its actual light/dark and relevant interaction
+states.
+
+Rejected: treating local names as either global portable tokens or disposable
+implementation details, defining them outside the owning theme spec, and reusing
+a name in contexts that only happen to share a value.
+
+### DEC-6 — Reuse the complete existing `TokenValue` contract
+
+**Reference:** `spec:AST-006/DEC-6`
+**Decider:** `cixzhang`, `2026-08-31`
+
+`localTokens` accepts the complete existing `TokenValue` contract: a CSS string
+or `[light, dark]` tuple. Inside the new opt-in field, both runtime and static
+build apply the same value normalization semantics existing `tokens` use. This
+reuses one established light/dark authoring model without changing the existing
+`tokens` path or introducing another value shape.
+
+Rejected: limiting local values to CSS strings only or defining local-specific
+mode syntax and normalization.
+
+## Open questions
+
+None at the cross-theme API level. Adopting theme specs may retain checkable
+rendered-evidence gates; their ownership, exact names, and semantic meanings are
+not re-opened by those gates.

--- a/packages/themes/neutral/neutral.spec.md
+++ b/packages/themes/neutral/neutral.spec.md
@@ -17,14 +17,17 @@ references:
     architecture:theme-tokens,
     architecture:theme-compilation,
     architecture:component-theming-surface,
+    spec:AST-006,
   ]
 ---
 
 # Neutral theme specification
 
 This draft is a theme-record example and a factual inventory. It does not decide
-local-token, palette-generation, compiler, or artifact APIs; separate system
-specifications own those proposals.
+cross-theme local-token, palette-generation, compiler, or artifact APIs;
+current `spec:AST-006` owns the accepted local-token contract. This record keeps
+Neutral's package adoption separate: no value, mapping, rendered evidence, or
+implementation is approved while this record remains draft.
 
 ## Intent and audience
 
@@ -48,11 +51,42 @@ vocabulary remains owned by `architecture:theme-tokens`.
 
 ## Theme-local role definitions
 
-Current source has no accepted first-class theme-local-role API. Candidate
-Neutral-only repeated meanings from unlanded work include filled accent, success,
-warning, and error status colors and content/interaction colors used on tinted
-surfaces. Their names, authoring API, namespace, inheritance, and validation are
-not decided here; a separate draft system spec must be accepted first.
+Neutral owns this local role for future implementation:
+
+| Approved exact name                               | Approved Neutral-only meaning                                                     | Proposed value           |
+| ------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------ |
+| `--astryx-theme-neutral-color-status-fill-accent` | Filled accent status in contexts whose actual semantic role is accent status fill | `['#0074e2', '#6d9cfe']` |
+
+AST-006 is current and accepted, but its implementation is not shipped. Once that
+implementation exists, Neutral would author and consume the exact name without an
+alias:
+
+```ts
+localTokens: {
+  '--astryx-theme-neutral-color-status-fill-accent': ['#0074e2', '#6d9cfe'],
+},
+components: {
+  badge: {
+    'variant:info': {
+      backgroundColor:
+        'var(--astryx-theme-neutral-color-status-fill-accent)',
+    },
+  },
+},
+```
+
+The `localTokens` key, component `var(...)` reference, `DefinedTheme` map, and
+emitted custom property use the same complete name. The proposed value prefers
+the approved `[light, dark]` `TokenValue` tuple, which normalizes exactly as the
+same tuple does under existing `tokens`. Opt-in uses Neutral's existing
+`name: 'neutral'` byte-for-byte; it is already a valid stable lower-kebab
+identifier, so no name normalization occurs.
+
+Once shipped, the exact name and filled-accent-status meaning are a public
+Neutral-family compatibility contract. The role is not portable to other themes
+and is not intended for Core component source. Its length is acceptable because
+it accurately names the context in which it may be applied; output alone does
+not authorize a broader meaning.
 
 ## Tonal palette definitions
 
@@ -64,18 +98,30 @@ separate draft system spec.
 
 ## Component and state mappings
 
-Current source is the implementation baseline. Candidate mappings under review
-share filled status color across Badge, compact status indicators, Stepper, Table
-row status, and ProgressBar, and preserve legibility of Banner content on tinted
-surfaces. This record does not change which component states exist or authorize
-unlanded mappings.
+Current source remains the implementation baseline. The exact
+`var(--astryx-theme-neutral-color-status-fill-accent)` reference may be adopted
+only where an existing Neutral component state genuinely means filled accent
+status. Badge `variant:info` is the first proposed mapping. Every added mapping is
+a theme-spec compatibility review: it must demonstrate the same semantic context
+and provide rendered evidence for its actual light/dark and relevant interaction
+states. Shared color alone is not enough. This record does not add component
+states or authorize implementation before that evidence is complete.
 
 ## Compatibility and migration
 
 This knowledge-only record changes no package output. Existing Neutral authoring,
 portable token overrides, runtime behavior, and package exports remain unchanged.
-Any future API adoption is optional and requires its own accepted system spec,
-implementation evidence, compatibility plan, and release note.
+Neutral stays unenrolled until it explicitly supplies `localTokens`; merely
+emitting or referencing the same prefix today does not activate validation or
+create the public contract.
+
+Implementation requires AST-006 implementation to ship first, followed by
+complete rendered evidence for the proposed value and mappings. When Neutral
+then ships the definition, its exact name and approved semantic meaning become a
+public compatibility contract of the Neutral family. A local-token name,
+enrolled theme name, or semantic meaning change must preserve descendants and
+consumers through an explicit reviewed migration or alias. Compiled CSS does not
+broaden the role beyond the contexts approved here.
 
 ## Accessibility and contrast evidence
 
@@ -84,11 +130,16 @@ so this draft does not select or restate a methodology. The future record is an
 unresolved dependency and therefore is not listed in frontmatter.
 
 Current Neutral-specific receipts include the Badge contrast check and pairings
-documented beside Neutral source. Candidate mappings still need receipts for the
-actual light/dark and interaction states they affect. This record will own those
-pairings, exceptions, measurements, and known gaps after the shared methodology
-is current; it will not copy the methodology or shared measurement-tool
-implementation.
+documented beside Neutral source. The candidate accent fill uses `#0074e2` in
+light mode and `#6d9cfe` in dark mode, but those values are not an accessibility
+claim by themselves. Adoption requires the actual Badge informational foreground
+and background pairing to meet its threshold in rendered light and dark states;
+every later mapping needs receipts for its foreground, graphical-object,
+interaction, and disabled states. No palette tone is accessible by itself, and
+color cannot replace another signal required by the component contract. This
+record will own those pairings, exceptions, measurements, and known gaps after
+the shared methodology is current; it will not copy the methodology or shared
+measurement-tool implementation.
 
 ## Build and artifact contract
 
@@ -98,32 +149,59 @@ palette or local-token artifacts.
 
 ## Verification map
 
-| Theme contract            | Evidence                                   | Representative states                      | Failure signal                                                  |
-| ------------------------- | ------------------------------------------ | ------------------------------------------ | --------------------------------------------------------------- |
-| Current value inventory   | Neutral source and theme tests             | light/dark token families                  | Source and record disagree about a theme-owned meaning.         |
-| Component mappings        | Theme tests and rendered evidence          | status and interaction states              | A mapped state loses its intended distinction.                  |
-| Contrast                  | Badge check plus rendered component matrix | light/dark and interactive states          | A required pairing falls below its threshold.                   |
-| Existing package contract | Theme build, package, and resolution tests | runtime, CSS, declarations, public exports | This record implies an artifact that the package does not ship. |
+| Theme contract            | Evidence                                            | Representative states                                          | Failure signal                                                                                                 |
+| ------------------------- | --------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Current value inventory   | Neutral source and theme tests                      | light/dark token families                                      | Source and record disagree about a theme-owned meaning.                                                        |
+| Local role contract       | Planned AST-006 implementation and Neutral fixtures | exact declaration/use/output name; public meaning; rename      | The shipped name or meaning changes without reviewed compatibility handling, or leaks into portable/Core APIs. |
+| Component mappings        | Theme-spec review and rendered evidence             | Badge info; each future mapping; light/dark; interaction state | A mapping does not genuinely mean filled accent status or lands without contextual evidence.                   |
+| Contrast                  | Badge check plus rendered component matrix          | light/dark and interactive states                              | A required pairing falls below its threshold.                                                                  |
+| Existing package contract | Theme build, package, and resolution tests          | runtime, CSS, declarations, public exports                     | This record implies an artifact that the package does not ship.                                                |
 
 ## Decision log
 
-No theme decision is accepted while this record has `authority: draft`.
+The decision below records settled cross-theme ownership input from `cixzhang`.
+The final Neutral value, mappings, and rendered-evidence ratification belong to
+`rubyycheung`. This record remains `authority: draft`, `approved_by: null`, and
+`approved_at: null` until OQ1 passes and Ruby gives exact-head approval.
+
+### DEC-1 — Own one exact Neutral filled-accent-status role
+
+**Reference:** `theme:neutral/DEC-1`
+**System-boundary decider:** `cixzhang`, `2026-08-31`
+**Final Neutral adoption decider:** `rubyycheung`, after OQ1 passes and exact-head review
+
+Neutral owns theme-local definitions in this colocated theme spec. It may adopt
+`--astryx-theme-neutral-color-status-fill-accent` for filled accent status using
+its exact stable `name: 'neutral'`. The exact name and semantic meaning become a
+public Neutral-family compatibility contract when shipped, despite not being
+portable across themes or intended for Core component source. The long name is
+acceptable because it precisely states the role.
+
+The token may be applied only where the mapped context genuinely means filled
+accent status. Each added mapping is a theme-spec compatibility review and needs
+rendered evidence for its actual light/dark and relevant interaction states.
+Neither the proposed value nor any mapping is authorized until OQ1 passes and
+`rubyycheung` ratifies the exact record head.
+
+Rejected: treating the role as global, treating it as disposable private output,
+or applying it merely because two contexts currently share a color.
 
 ## Open questions
 
-- Which candidate Neutral values and component mappings should become current
-  after their cross-theme enabling APIs, if any, are settled separately?
-- What current design record should own the cross-theme contrast methodology
-  before Neutral can rely on it through `references`?
-- Which rendered pairings and interaction states still need theme-specific
-  measured receipts?
+- **OQ1 — Is rendered light/dark evidence complete for the proposed tuple and
+  Badge mapping, and for every later mapping's relevant interaction states?**
+  (`checkable`) Neutral promotion and implementation remain blocked until the
+  actual pairings meet the applicable current contrast methodology, each mapped
+  context is visibly verified, and `rubyycheung` ratifies that exact record head.
 
 ## Content boundary
 
-This record owns Neutral's intent, factual value inventory, selected mappings,
-required pairings/states, theme-specific exceptions, measured receipts, known
-gaps, compatibility, and package facts. A future current design record owns the
-cross-theme contrast methodology; shared measurement implementation belongs to
+This record owns Neutral's intent, factual value inventory, approved local-token
+name and meaning, proposed value, selected mappings, required pairings/states,
+theme-specific exceptions, measured receipts, known gaps, compatibility, and
+package facts. A future current design record owns the cross-theme contrast
+methodology; shared measurement implementation belongs to
 architecture/tooling. This record does not define cross-theme local-token or
-palette APIs. Component/family records own observable behavior, and consumer
-docs own supported syntax and examples.
+palette APIs. `spec:AST-006` owns the cross-theme local-token API, namespace,
+validation, lineage, and compiler invariants. Component/family records own
+observable behavior, and consumer docs own supported syntax and examples.


### PR DESCRIPTION
## Why

Theme maintainers need to reuse theme-owned semantic roles across their own component overrides without expanding Astryx's portable token vocabulary or changing existing permissive behavior.

## Current cross-theme contract

AST-006 is independently approved by `cixzhang` as `authority: current`, `phase: accepted`.

Supplying optional `DefineThemeInput.localTokens` explicitly enrolls a theme. The existing `name` must already be stable lower-kebab, and names use its exact bytes: `--astryx-theme-${name}-...`. `localTokens` accepts the full existing `TokenValue` contract—CSS strings or `[light, dark]` tuples—with identical value normalization to existing `tokens` inside the opt-in field.

A theme with no `localTokens` and no enrolled exact base remains byte-equivalent. Runtime and static build perform no reserved-prefix scan, rejection, or warning for legacy `--astryx-theme-*` references. Descendants inherit enrollment only through an enrolled exact base. Existing `tokens`, permissive spreads, external variables, public token helpers, Core component APIs, precedence, inheritance, output, and resolution do not change.

Once shipped, an exact local-token name and semantic meaning are public compatibility contracts within the owning theme family, while remaining non-portable across themes and unavailable to Core component source. Definitions and mappings belong in the package's colocated theme spec; renames or meaning changes require explicit migration or aliases.

## Separate draft Neutral adoption

`theme:neutral` remains `authority: draft`, with no approval or implementation authorization. Cindy settled the ownership, naming, and filled-accent-status semantic boundary. The proposed tuple, Badge mapping, and every later mapping still require real rendered light/dark/context/contrast receipts.

`rubyycheung` is the explicit final Neutral adoption decider. Promotion waits for OQ1 to pass and Ruby's exact-head approval; no evidence is claimed by this PR.

## Scope

- Adds current/accepted AST-006 for the cross-theme API.
- Updates only the package-local draft Neutral record with the separate ownership, proposed adoption, evidence gate, and Ruby ratification boundary.
- No runtime implementation, package output, Changeset, schema, workflow, guidance, or palette/generator work.

## Validation

- `npx --yes pnpm@11.10.0 exec prettier --write docs/specs/AST-006/spec.md packages/themes/neutral/neutral.spec.md`
- `npx --yes pnpm@11.10.0 check:knowledge -- --base origin/main`
- `npx --yes pnpm@11.10.0 vitest run scripts/check-knowledge.test.mjs` (60 tests)
- `npx --yes pnpm@11.10.0 check:repo`
