### PR TITLE
feat(knowledge): reserve system spec IDs

### DIFF
--- a/.github/scripts/spec-id-collision.cjs
+++ b/.github/scripts/spec-id-collision.cjs
@@ -1,0 +1,95 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use strict';
+/* global module, require */
+
+const {
+  listLandedSpecIds,
+  loadOpenPullRequests,
+  reservedSpecIds,
+} = require('../../scripts/lib/spec-id.cjs');
+
+function checkSpecIdCollisions({
+  openPulls,
+  currentPullNumber,
+  expectedHeadOid,
+  landedIds,
+}) {
+  const current = openPulls.find(pull => pull.number === currentPullNumber);
+  if (!current) {
+    throw new Error(
+      `PR #${currentPullNumber} is not in the open-PR inventory.`,
+    );
+  }
+  if (current.headRefOid !== expectedHeadOid) {
+    throw new Error(
+      `PR #${currentPullNumber} moved from ${expectedHeadOid} to ${current.headRefOid}; rerun on the latest head.`,
+    );
+  }
+
+  const candidateIds = reservedSpecIds(current.files, landedIds);
+  const conflicts = [];
+  for (const id of candidateIds) {
+    const pulls = openPulls.filter(
+      pull =>
+        pull.number !== currentPullNumber &&
+        reservedSpecIds(pull.files, landedIds).includes(id),
+    );
+    if (pulls.length > 0) conflicts.push({id, pulls});
+  }
+  return {candidateIds, conflicts};
+}
+
+function formatConflictMessage(conflicts) {
+  const lines = ['System-spec ID reservation collision:'];
+  for (const {id, pulls} of conflicts) {
+    for (const pull of pulls) {
+      lines.push(
+        `- ${id} is also reserved by #${pull.number}: ${pull.title} (${pull.url})`,
+      );
+    }
+  }
+  lines.push(
+    '',
+    'Run `pnpm spec:id` again, move the new spec to the suggested path, update its frontmatter ID, and push.',
+  );
+  return lines.join('\n');
+}
+
+async function runSpecIdCollisionGate({github, context, core, root}) {
+  const eventPull = context.payload.pull_request;
+  if (!eventPull) throw new Error('This check requires a pull_request event.');
+  const {owner, repo} = context.repo;
+  if (eventPull.base?.repo?.full_name !== `${owner}/${repo}`) {
+    throw new Error(
+      'The event repository does not match the checked repository.',
+    );
+  }
+
+  const openPulls = await loadOpenPullRequests({
+    owner,
+    repo,
+    graphql: (query, variables) => github.graphql(query, variables),
+  });
+  const result = checkSpecIdCollisions({
+    openPulls,
+    currentPullNumber: eventPull.number,
+    expectedHeadOid: eventPull.head.sha,
+    landedIds: listLandedSpecIds(root),
+  });
+
+  if (result.conflicts.length > 0) {
+    core.setFailed(formatConflictMessage(result.conflicts));
+  } else if (result.candidateIds.length > 0) {
+    core.info(`Reserved by this PR: ${result.candidateIds.join(', ')}`);
+  } else {
+    core.info('This PR does not reserve a new system-spec ID.');
+  }
+  return result;
+}
+
+module.exports = {
+  checkSpecIdCollisions,
+  formatConflictMessage,
+  runSpecIdCollisionGate,
+};

--- a/.github/scripts/spec-id-collision.test.mjs
+++ b/.github/scripts/spec-id-collision.test.mjs
@@ -1,0 +1,117 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {createRequire} from 'node:module';
+import {describe, expect, it} from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  checkSpecIdCollisions,
+  formatConflictMessage,
+} = require('./spec-id-collision.cjs');
+
+const root = path.resolve(import.meta.dirname, '../..');
+
+function pull(number, files, headRefOid = `head-${number}`) {
+  return {
+    number,
+    title: `PR ${number}`,
+    url: `https://github.com/facebook/astryx/pull/${number}`,
+    headRefOid,
+    changedFiles: files.length,
+    files,
+  };
+}
+
+function added(id) {
+  return {path: `docs/specs/${id}/spec.md`, changeType: 'ADDED'};
+}
+
+describe('spec ID collision gate', () => {
+  it('reports two open additions of the same new ID', () => {
+    const result = checkSpecIdCollisions({
+      openPulls: [pull(10, [added('AST-013')]), pull(20, [added('AST-013')])],
+      currentPullNumber: 10,
+      expectedHeadOid: 'head-10',
+      landedIds: ['AST-001'],
+    });
+
+    expect(result.conflicts).toEqual([
+      {id: 'AST-013', pulls: [expect.objectContaining({number: 20})]},
+    ]);
+    expect(formatConflictMessage(result.conflicts)).toContain(
+      'AST-013 is also reserved by #20',
+    );
+    expect(formatConflictMessage(result.conflicts)).toContain('pnpm spec:id');
+  });
+
+  it('allows a modification to an already-landed ID', () => {
+    const result = checkSpecIdCollisions({
+      openPulls: [
+        pull(10, [
+          {path: 'docs/specs/AST-002/spec.md', changeType: 'MODIFIED'},
+        ]),
+        pull(20, [added('AST-002')]),
+      ],
+      currentPullNumber: 10,
+      expectedHeadOid: 'head-10',
+      landedIds: ['AST-002'],
+    });
+    expect(result).toEqual({candidateIds: [], conflicts: []});
+  });
+
+  it('detects a rename into an ID reserved by another PR', () => {
+    const result = checkSpecIdCollisions({
+      openPulls: [
+        pull(10, [
+          {
+            path: 'docs/specs/AST-013/spec.md',
+            changeType: 'RENAMED',
+          },
+        ]),
+        pull(20, [added('AST-013')]),
+      ],
+      currentPullNumber: 10,
+      expectedHeadOid: 'head-10',
+      landedIds: ['AST-001'],
+    });
+    expect(result.conflicts).toHaveLength(1);
+  });
+
+  it('excludes the current PR from its collision set', () => {
+    const result = checkSpecIdCollisions({
+      openPulls: [pull(10, [added('AST-013')])],
+      currentPullNumber: 10,
+      expectedHeadOid: 'head-10',
+      landedIds: ['AST-001'],
+    });
+    expect(result).toEqual({candidateIds: ['AST-013'], conflicts: []});
+  });
+
+  it('fails when the queried head no longer matches the event head', () => {
+    expect(() =>
+      checkSpecIdCollisions({
+        openPulls: [pull(10, [added('AST-013')], 'new-head')],
+        currentPullNumber: 10,
+        expectedHeadOid: 'event-head',
+        landedIds: [],
+      }),
+    ).toThrow('moved from event-head to new-head');
+  });
+
+  it('keeps the workflow trusted and read-only', () => {
+    const workflow = fs.readFileSync(
+      path.join(root, '.github/workflows/spec-id-reservation.yml'),
+      'utf8',
+    );
+    expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain(
+      'ref: ${{ github.event.repository.default_branch }}',
+    );
+    expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).toContain('pull-requests: read');
+    expect(workflow).not.toContain('pull-requests: write');
+    expect(workflow).not.toContain('github.event.pull_request.head.sha }}');
+  });
+});

--- a/.github/workflows/spec-id-reservation.yml
+++ b/.github/workflows/spec-id-reservation.yml
@@ -1,0 +1,54 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# A spec ID is reserved by an open PR that adds or renames a new
+# docs/specs/AST-NNN/spec.md path. This trusted, read-only workflow compares the
+# exact current PR head with complete file inventories for every open PR.
+name: Spec ID reservation
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+concurrency:
+  group: spec-id-reservation
+  cancel-in-progress: false
+
+jobs:
+  collision:
+    name: Spec ID collision
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      # pull_request_target is privileged context, so execute only helpers from
+      # the trusted default branch. Never check out or run the PR head here.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Check open spec ID reservations
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const path = require('node:path');
+            const {runSpecIdCollisionGate} = require(path.join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/scripts/spec-id-collision.cjs',
+            ));
+            try {
+              await runSpecIdCollisionGate({
+                github,
+                context,
+                core,
+                root: process.env.GITHUB_WORKSPACE,
+              });
+            } catch (error) {
+              core.setFailed(
+                `Spec ID collision check could not complete safely: ${error.message}`,
+              );
+            }

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,7 +1,7 @@
 # System specs
 
 This directory contains records for consequential shared-system changes. Each
-spec lives under `docs/specs/<id>-<slug>/spec.md`; an optional sibling `plan.md`
+spec lives under `docs/specs/AST-NNN/spec.md`; an optional sibling `plan.md`
 is used only for multi-step implementation.
 
 Templates live separately under `docs/templates/knowledge/`. Existing records
@@ -17,3 +17,18 @@ Only records with `authority: current` are authoritative. Draft records may
 carry unresolved evidence or owner decisions; they do not govern review.
 Archived records state why they no longer govern and link a replacement when
 one exists. Initial promotion to `current` requires explicit owner approval.
+
+## Reserve an ID
+
+Run `pnpm spec:id` before starting a system spec. The read-only default checks
+landed specs and complete file inventories for every open pull request, then
+prints the lowest available ID at or above the next landed number. Run
+`pnpm spec:id -- --write` to scaffold that proposal from the system-spec
+template.
+
+An ID is reserved only after a pull request adds or renames its exact
+`docs/specs/AST-NNN/spec.md` path. Re-run the helper immediately before opening
+the pull request. The **Spec ID collision** check rejects duplicate open
+reservations; when that happens, re-run the helper and move the spec to its new
+suggested path. Changes to an ID that already exists on `main` are not new
+reservations.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "dev:sandbox": "pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/sandbox dev",
     "dev:sandbox:source": "ASTRYX_SOURCE=1 pnpm -F @astryxdesign/sandbox dev",
     "npm:prune-canaries": "node scripts/npm/prune-canaries.mjs",
-    "check:knowledge": "node scripts/check-knowledge.mjs"
+    "check:knowledge": "node scripts/check-knowledge.mjs",
+    "spec:id": "node scripts/spec-id.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/scripts/check-knowledge.mjs
+++ b/scripts/check-knowledge.mjs
@@ -201,6 +201,27 @@ export function discoverKnowledgeRecords(root = DEFAULT_ROOT) {
   return records.sort();
 }
 
+export function validateSystemSpecIdentity(root, absolutePath, document) {
+  const filePath = path.relative(root, absolutePath).split(path.sep).join('/');
+  const match = filePath.match(/^docs\/specs\/([^/]+)\/spec\.md$/);
+  if (!match) return [];
+
+  const directoryId = match[1];
+  if (!/^AST-[0-9]{3}$/.test(directoryId)) {
+    return [
+      `${filePath}: system specs must be placed at docs/specs/AST-NNN/spec.md.`,
+    ];
+  }
+
+  const expectedId = `spec:${directoryId}`;
+  const actualId = document.frontmatter.get('id');
+  return actualId === expectedId
+    ? []
+    : [
+        `${filePath}: frontmatter id must be ${expectedId} to match its directory; received ${JSON.stringify(actualId)}.`,
+      ];
+}
+
 export function parseAnatomyThemingBlock(
   content,
   filePath = '<component spec>',
@@ -896,6 +917,7 @@ export async function validateKnowledgeRoot(root = DEFAULT_ROOT) {
     const filePath = path.relative(root, absolutePath);
     const content = fs.readFileSync(absolutePath, 'utf8');
     const document = parseKnowledgeDocument(content, filePath);
+    problems.push(...validateSystemSpecIdentity(root, absolutePath, document));
     const recordVersion = document.frontmatter.get('schema_version');
     const versionedSchema = schemas.get(recordVersion);
     if (!versionedSchema) {

--- a/scripts/check-knowledge.test.mjs
+++ b/scripts/check-knowledge.test.mjs
@@ -251,6 +251,35 @@ afterEach(() => {
     fs.rmSync(root, {recursive: true, force: true});
 });
 
+describe('system-spec identity', () => {
+  it('accepts matching AST-NNN directory and frontmatter IDs', async () => {
+    const root = fixtureRoot();
+    writeSystemSpec(root, 'AST-900', systemSpecRecord());
+
+    expect(await validateKnowledgeRoot(root)).not.toContainEqual(
+      expect.stringContaining('to match its directory'),
+    );
+  });
+
+  it('rejects a frontmatter ID that differs from the directory ID', async () => {
+    const root = fixtureRoot();
+    writeSystemSpec(root, 'AST-901', systemSpecRecord());
+
+    expect((await validateKnowledgeRoot(root)).join('\n')).toContain(
+      'frontmatter id must be spec:AST-901 to match its directory; received "spec:AST-900".',
+    );
+  });
+
+  it('rejects a system-spec directory outside the AST-NNN format', async () => {
+    const root = fixtureRoot();
+    writeSystemSpec(root, 'AST-90', systemSpecRecord({id: 'spec:AST-90'}));
+
+    expect((await validateKnowledgeRoot(root)).join('\n')).toContain(
+      'system specs must be placed at docs/specs/AST-NNN/spec.md.',
+    );
+  });
+});
+
 describe('schema evolution', () => {
   it('tracks latest schema versions per kind', () => {
     const raw = new Map([

--- a/scripts/lib/spec-id.cjs
+++ b/scripts/lib/spec-id.cjs
@@ -1,0 +1,257 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SPEC_ID_PATTERN = /^AST-([0-9]{3})$/;
+const SPEC_PATH_PATTERN = /^docs\/specs\/(AST-[0-9]{3})\/spec\.md$/;
+
+const OPEN_PULLS_QUERY = `
+  query SpecIdOpenPulls(
+    $owner: String!
+    $name: String!
+    $cursor: String
+  ) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(
+        states: OPEN
+        first: 50
+        after: $cursor
+        orderBy: {field: UPDATED_AT, direction: DESC}
+      ) {
+        totalCount
+        nodes {
+          number
+          title
+          url
+          headRefOid
+          changedFiles
+          files(first: 100) {
+            nodes {
+              path
+              changeType
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+const PULL_FILES_QUERY = `
+  query SpecIdPullFiles(
+    $owner: String!
+    $name: String!
+    $number: Int!
+    $cursor: String!
+  ) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        number
+        headRefOid
+        changedFiles
+        files(first: 100, after: $cursor) {
+          nodes {
+            path
+            changeType
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;
+
+function compareSpecIds(left, right) {
+  return Number(left.slice(4)) - Number(right.slice(4));
+}
+
+function parseSpecId(value) {
+  const match = String(value).match(SPEC_ID_PATTERN);
+  return match ? {id: match[0], number: Number(match[1])} : null;
+}
+
+function specIdFromPath(filePath) {
+  return String(filePath).match(SPEC_PATH_PATTERN)?.[1] ?? null;
+}
+
+function normalizeChangeType(file) {
+  return String(file.changeType ?? file.status ?? '').toUpperCase();
+}
+
+function reservedSpecIds(files, landedIds) {
+  const landed = new Set(landedIds);
+  const reserved = new Set();
+
+  for (const file of files) {
+    const changeType = normalizeChangeType(file);
+    if (changeType === 'DELETED' || changeType === 'REMOVED') continue;
+    const id = specIdFromPath(file.path ?? file.filename ?? '');
+    if (id && !landed.has(id)) reserved.add(id);
+  }
+
+  return [...reserved].sort(compareSpecIds);
+}
+
+function nextAvailableSpecId(landedIds, openReservedIds) {
+  const landedNumbers = landedIds.map(id => {
+    const parsed = parseSpecId(id);
+    if (!parsed) throw new Error(`Invalid landed spec ID: ${id}`);
+    return parsed.number;
+  });
+  const reserved = new Set(openReservedIds);
+  let candidate = Math.max(0, ...landedNumbers) + 1;
+
+  while (candidate <= 999) {
+    const id = `AST-${String(candidate).padStart(3, '0')}`;
+    if (!reserved.has(id)) return id;
+    candidate += 1;
+  }
+
+  throw new Error('The AST-NNN ID range is exhausted.');
+}
+
+function listLandedSpecIds(root) {
+  const directory = path.join(root, 'docs/specs');
+  if (!fs.existsSync(directory)) return [];
+  return fs
+    .readdirSync(directory, {withFileTypes: true})
+    .filter(
+      entry =>
+        entry.isDirectory() &&
+        SPEC_ID_PATTERN.test(entry.name) &&
+        fs.existsSync(path.join(directory, entry.name, 'spec.md')),
+    )
+    .map(entry => entry.name)
+    .sort(compareSpecIds);
+}
+
+function requirePageInfo(pageInfo, description) {
+  if (
+    pageInfo == null ||
+    typeof pageInfo.hasNextPage !== 'boolean' ||
+    (pageInfo.hasNextPage && !pageInfo.endCursor)
+  ) {
+    throw new Error(`${description} returned incomplete pagination metadata.`);
+  }
+}
+
+async function completePullFiles({graphql, owner, repo, pull}) {
+  if (!Number.isInteger(pull.changedFiles) || pull.changedFiles < 0) {
+    throw new Error(`PR #${pull.number} did not report a changed-file count.`);
+  }
+
+  const files = [...(pull.files?.nodes ?? [])];
+  let pageInfo = pull.files?.pageInfo;
+  requirePageInfo(pageInfo, `PR #${pull.number} files`);
+  const seenCursors = new Set();
+
+  while (pageInfo.hasNextPage) {
+    if (seenCursors.has(pageInfo.endCursor)) {
+      throw new Error(`PR #${pull.number} file pagination repeated a cursor.`);
+    }
+    seenCursors.add(pageInfo.endCursor);
+    const result = await graphql(PULL_FILES_QUERY, {
+      owner,
+      name: repo,
+      number: pull.number,
+      cursor: pageInfo.endCursor,
+    });
+    const current = result?.repository?.pullRequest;
+    if (!current) throw new Error(`PR #${pull.number} could not be reloaded.`);
+    if (
+      current.headRefOid !== pull.headRefOid ||
+      current.changedFiles !== pull.changedFiles
+    ) {
+      throw new Error(
+        `PR #${pull.number} changed while its files were being read; rerun the check.`,
+      );
+    }
+    files.push(...(current.files?.nodes ?? []));
+    pageInfo = current.files?.pageInfo;
+    requirePageInfo(pageInfo, `PR #${pull.number} files`);
+  }
+
+  if (files.length !== pull.changedFiles) {
+    throw new Error(
+      `PR #${pull.number} file inventory is incomplete: expected ${pull.changedFiles}, received ${files.length}.`,
+    );
+  }
+  return files;
+}
+
+async function loadOpenPullRequests({graphql, owner, repo}) {
+  const pulls = [];
+  const seenNumbers = new Set();
+  const seenCursors = new Set();
+  let cursor = null;
+  let expectedTotal = null;
+
+  do {
+    const result = await graphql(OPEN_PULLS_QUERY, {owner, name: repo, cursor});
+    const connection = result?.repository?.pullRequests;
+    if (!connection) throw new Error('Open pull requests could not be loaded.');
+    if (!Number.isInteger(connection.totalCount)) {
+      throw new Error('Open pull request count is missing.');
+    }
+    if (expectedTotal == null) expectedTotal = connection.totalCount;
+    else if (expectedTotal !== connection.totalCount) {
+      throw new Error(
+        'Open pull requests changed while they were being read; rerun the check.',
+      );
+    }
+
+    for (const pull of connection.nodes ?? []) {
+      if (seenNumbers.has(pull.number)) {
+        throw new Error(`PR #${pull.number} appeared more than once.`);
+      }
+      seenNumbers.add(pull.number);
+      pulls.push({
+        number: pull.number,
+        title: pull.title,
+        url: pull.url,
+        headRefOid: pull.headRefOid,
+        changedFiles: pull.changedFiles,
+        files: await completePullFiles({graphql, owner, repo, pull}),
+      });
+    }
+
+    requirePageInfo(connection.pageInfo, 'Open pull requests');
+    if (!connection.pageInfo.hasNextPage) break;
+    cursor = connection.pageInfo.endCursor;
+    if (seenCursors.has(cursor)) {
+      throw new Error('Open pull request pagination repeated a cursor.');
+    }
+    seenCursors.add(cursor);
+  } while (true);
+
+  if (pulls.length !== expectedTotal) {
+    throw new Error(
+      `Open pull request inventory is incomplete: expected ${expectedTotal}, received ${pulls.length}.`,
+    );
+  }
+  return pulls;
+}
+
+module.exports = {
+  SPEC_ID_PATTERN,
+  compareSpecIds,
+  listLandedSpecIds,
+  loadOpenPullRequests,
+  nextAvailableSpecId,
+  reservedSpecIds,
+  specIdFromPath,
+};

--- a/scripts/lib/spec-id.test.mjs
+++ b/scripts/lib/spec-id.test.mjs
@@ -1,0 +1,160 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {createRequire} from 'node:module';
+import {describe, expect, it, vi} from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  loadOpenPullRequests,
+  nextAvailableSpecId,
+  reservedSpecIds,
+} = require('./spec-id.cjs');
+
+function file(path, changeType = 'ADDED') {
+  return {path, changeType};
+}
+
+function pull({
+  number,
+  headRefOid = `head-${number}`,
+  files = [],
+  changedFiles = files.length,
+}) {
+  return {
+    number,
+    title: `PR ${number}`,
+    url: `https://github.com/facebook/astryx/pull/${number}`,
+    headRefOid,
+    changedFiles,
+    files: {
+      nodes: files,
+      pageInfo: {hasNextPage: false, endCursor: null},
+    },
+  };
+}
+
+function openPullPage(nodes, options = {}) {
+  return {
+    repository: {
+      pullRequests: {
+        totalCount: options.totalCount ?? nodes.length,
+        nodes,
+        pageInfo: {
+          hasNextPage: options.hasNextPage ?? false,
+          endCursor: options.endCursor ?? null,
+        },
+      },
+    },
+  };
+}
+
+describe('spec ID allocation', () => {
+  it('skips current open reservations AST-006 through AST-012', () => {
+    const landed = ['AST-001', 'AST-002', 'AST-003', 'AST-004', 'AST-005'];
+    const open = [
+      'AST-006',
+      'AST-007',
+      'AST-008',
+      'AST-009',
+      'AST-010',
+      'AST-011',
+      'AST-012',
+    ];
+    expect(nextAvailableSpecId(landed, open)).toBe('AST-013');
+  });
+
+  it('does not reserve a modification to an already-landed spec', () => {
+    expect(
+      reservedSpecIds(
+        [file('docs/specs/AST-002/spec.md', 'MODIFIED')],
+        ['AST-002'],
+      ),
+    ).toEqual([]);
+  });
+
+  it('treats a rename to a new exact spec path as a reservation', () => {
+    expect(
+      reservedSpecIds(
+        [file('docs/specs/AST-013/spec.md', 'RENAMED')],
+        ['AST-001'],
+      ),
+    ).toEqual(['AST-013']);
+  });
+});
+
+describe('open PR inventory', () => {
+  it('paginates both pull requests and changed files', async () => {
+    const firstHundred = Array.from({length: 100}, (_, index) =>
+      file(`packages/core/src/F${index}.ts`),
+    );
+    const firstPull = pull({
+      number: 1,
+      files: firstHundred,
+      changedFiles: 101,
+    });
+    firstPull.files.pageInfo = {hasNextPage: true, endCursor: 'files-1'};
+    const secondPull = pull({number: 2, files: [file('README.md')]});
+
+    const graphql = vi.fn(async (_query, variables) => {
+      if (variables.number === 1) {
+        return {
+          repository: {
+            pullRequest: {
+              number: 1,
+              headRefOid: 'head-1',
+              changedFiles: 101,
+              files: {
+                nodes: [file('docs/specs/AST-013/spec.md')],
+                pageInfo: {hasNextPage: false, endCursor: null},
+              },
+            },
+          },
+        };
+      }
+      if (variables.cursor === 'pulls-1') {
+        return openPullPage([secondPull], {totalCount: 2});
+      }
+      return openPullPage([firstPull], {
+        totalCount: 2,
+        hasNextPage: true,
+        endCursor: 'pulls-1',
+      });
+    });
+
+    const pulls = await loadOpenPullRequests({
+      graphql,
+      owner: 'facebook',
+      repo: 'astryx',
+    });
+    expect(pulls).toHaveLength(2);
+    expect(pulls[0].files).toHaveLength(101);
+    expect(graphql).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed when a file inventory is incomplete', async () => {
+    const graphql = vi.fn(async () =>
+      openPullPage([
+        pull({
+          number: 1,
+          files: [file('docs/specs/AST-013/spec.md')],
+          changedFiles: 2,
+        }),
+      ]),
+    );
+
+    await expect(
+      loadOpenPullRequests({graphql, owner: 'facebook', repo: 'astryx'}),
+    ).rejects.toThrow(
+      'PR #1 file inventory is incomplete: expected 2, received 1.',
+    );
+  });
+
+  it('fails closed when the GitHub API fails', async () => {
+    const graphql = vi.fn(async () => {
+      throw new Error('rate limited');
+    });
+    await expect(
+      loadOpenPullRequests({graphql, owner: 'facebook', repo: 'astryx'}),
+    ).rejects.toThrow('rate limited');
+  });
+});

--- a/scripts/spec-id.mjs
+++ b/scripts/spec-id.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file spec-id.mjs
+ * @input Reads landed spec directories and open pull-request file inventories
+ *   from GitHub through the authenticated `gh` CLI
+ * @output Prints the next collision-free AST-NNN reservation and optionally
+ *   scaffolds docs/specs/AST-NNN/spec.md from the system-spec template
+ * @position Contributor helper for reserving system-spec IDs without a central
+ *   registry; opening the pull request is what reserves the proposed path
+ */
+
+/* global console, process */
+import fs from 'node:fs';
+import path from 'node:path';
+import {execFileSync} from 'node:child_process';
+import {createRequire} from 'node:module';
+import {fileURLToPath} from 'node:url';
+
+const require = createRequire(import.meta.url);
+const {
+  loadOpenPullRequests,
+  nextAvailableSpecId,
+  reservedSpecIds,
+} = require('./lib/spec-id.cjs');
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_REPOSITORY = 'facebook/astryx';
+const DEFAULT_REF = 'main';
+
+function usage() {
+  return `Usage: node scripts/spec-id.mjs [options]
+
+Find the next system-spec ID that is absent from both landed specs and open PRs.
+The default is read-only. Opening a PR that adds the proposed spec.md reserves it.
+
+Options:
+  --write          Scaffold docs/specs/AST-NNN/spec.md
+  --repo OWNER/REPO  GitHub repository (default: ${DEFAULT_REPOSITORY})
+  --ref REF         Landed base ref (default: ${DEFAULT_REF})
+  --help            Show this help
+`;
+}
+
+function parseArguments(argv) {
+  const options = {
+    write: false,
+    repository: DEFAULT_REPOSITORY,
+    ref: DEFAULT_REF,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--write') options.write = true;
+    else if (argument === '--help' || argument === '-h') options.help = true;
+    else if (argument === '--repo' || argument === '--ref') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${argument} requires a value.`);
+      }
+      index += 1;
+      if (argument === '--repo') options.repository = value;
+      else options.ref = value;
+    } else if (argument.startsWith('--repo=')) {
+      options.repository = argument.slice('--repo='.length);
+    } else if (argument.startsWith('--ref=')) {
+      options.ref = argument.slice('--ref='.length);
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!/^[^/\s]+\/[^/\s]+$/.test(options.repository)) {
+    throw new Error('--repo must use OWNER/REPO format.');
+  }
+  if (!options.ref) throw new Error('--ref must not be empty.');
+  return options;
+}
+
+function runGhJson(args) {
+  try {
+    return JSON.parse(
+      execFileSync('gh', args, {
+        cwd: ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+    );
+  } catch (error) {
+    const detail = error.stderr?.trim() || error.message;
+    throw new Error(`GitHub query failed: ${detail}`);
+  }
+}
+
+function loadLandedIds({repository, ref}) {
+  const entries = runGhJson([
+    'api',
+    '--method',
+    'GET',
+    `repos/${repository}/contents/docs/specs`,
+    '-f',
+    `ref=${ref}`,
+  ]);
+  if (!Array.isArray(entries)) {
+    throw new Error('GitHub returned an invalid docs/specs directory listing.');
+  }
+  if (entries.length >= 1000) {
+    throw new Error(
+      'GitHub may have truncated docs/specs at 1,000 entries; no ID was allocated.',
+    );
+  }
+  return entries
+    .filter(entry => entry.type === 'dir' && /^AST-[0-9]{3}$/.test(entry.name))
+    .map(entry => entry.name);
+}
+
+async function loadOpenPulls(repository) {
+  const [owner, repo] = repository.split('/');
+  return loadOpenPullRequests({
+    owner,
+    repo,
+    graphql: async (query, variables) => {
+      const args = ['api', 'graphql', '-f', `query=${query}`];
+      for (const [name, value] of Object.entries(variables)) {
+        if (value == null) continue;
+        args.push(typeof value === 'number' ? '-F' : '-f', `${name}=${value}`);
+      }
+      const result = runGhJson(args);
+      if (!result?.data)
+        throw new Error('GitHub GraphQL response has no data.');
+      return result.data;
+    },
+  });
+}
+
+function scaffoldSpec(id) {
+  const target = path.join(ROOT, 'docs/specs', id, 'spec.md');
+  if (fs.existsSync(target)) {
+    throw new Error(`${path.relative(ROOT, target)} already exists.`);
+  }
+  const template = fs.readFileSync(
+    path.join(ROOT, 'docs/templates/knowledge/system-spec.md'),
+    'utf8',
+  );
+  fs.mkdirSync(path.dirname(target), {recursive: false});
+  fs.writeFileSync(target, template.replaceAll('AST-000', id));
+  return path.relative(ROOT, target);
+}
+
+export async function allocateSpecId(options) {
+  const landedIds = loadLandedIds(options);
+  const pulls = await loadOpenPulls(options.repository);
+  const openIds = new Set();
+  const reservations = new Map();
+
+  for (const pull of pulls) {
+    for (const id of reservedSpecIds(pull.files, landedIds)) {
+      openIds.add(id);
+      const current = reservations.get(id) ?? [];
+      current.push(pull);
+      reservations.set(id, current);
+    }
+  }
+
+  const id = nextAvailableSpecId(landedIds, [...openIds]);
+  return {id, landedIds, reservations};
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(usage());
+    return;
+  }
+
+  const {id, landedIds, reservations} = await allocateSpecId(options);
+  const target = `docs/specs/${id}/spec.md`;
+  console.log(`Next available system-spec ID: ${id}`);
+  console.log(`Proposed path: ${target}`);
+  console.log(
+    `Checked ${landedIds.length} landed IDs and ${reservations.size} IDs reserved by open PRs.`,
+  );
+
+  if (options.write) {
+    console.log(`Scaffolded ${scaffoldSpec(id)}.`);
+  } else {
+    console.log('Dry run only; no files were changed.');
+    console.log('Run `pnpm spec:id -- --write` to scaffold this proposal.');
+  }
+  console.log(
+    'Opening a PR that adds this exact path reserves the ID. Re-run this helper immediately before opening the PR.',
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    console.error(`Could not allocate a system-spec ID: ${error.message}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Why

Concurrent system-spec proposals can choose the same AST-NNN ID before either pull request lands.

## What

Adds a read-only allocator that considers landed specs and complete open-PR file inventories, a trusted exact-head collision check, and local path/frontmatter validation.

## Risk

No package runtime behavior changes. GitHub availability is required only for allocation and the remote collision gate; normal check:knowledge stays offline.

## Testing

- pnpm exec vitest run --project node scripts/lib/spec-id.test.mjs .github/scripts/spec-id-collision.test.mjs scripts/check-knowledge.test.mjs
- pnpm spec:id
- pnpm check:repo
- actionlint .github/workflows/spec-id-reservation.yml
- pnpm exec prettier --check on changed files