### PR TITLE
feat(core): prototype BottomSheetStack

### DIFF
--- a/.changeset/stacked-bottom-sheets.md
+++ b/.changeset/stacked-bottom-sheets.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[feat] Add BottomSheetStack for controlled, layered bottom-sheet navigation.
+
+@imdreamrunner

--- a/apps/storybook/stories/BottomSheetStack.stories.tsx
+++ b/apps/storybook/stories/BottomSheetStack.stories.tsx
@@ -1,0 +1,121 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {BottomSheet, BottomSheetStack} from '@astryxdesign/core/BottomSheet';
+import {Button} from '@astryxdesign/core/Button';
+import {Divider} from '@astryxdesign/core/Divider';
+import {Heading} from '@astryxdesign/core/Heading';
+import {Section} from '@astryxdesign/core/Section';
+import {HStack, VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+
+const meta: Meta<typeof BottomSheetStack> = {
+  title: 'Core/BottomSheetStack',
+  component: BottomSheetStack,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      story: {inline: false, height: '560px'},
+    },
+  },
+  decorators: [
+    Story => (
+      <div style={{minHeight: 480, padding: 32}}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomSheetStack>;
+
+function StackExample() {
+  const [openSheetIds, setOpenSheetIds] = useState<ReadonlyArray<string>>([]);
+  const push = (sheetId: string) =>
+    setOpenSheetIds(current => [...current, sheetId]);
+  const pop = () =>
+    setOpenSheetIds(current => current.slice(0, current.length - 1));
+
+  return (
+    <>
+      <Button label="Open inbox" onClick={() => setOpenSheetIds(['inbox'])} />
+      <BottomSheetStack
+        openSheetIds={openSheetIds}
+        onOpenSheetIdsChange={setOpenSheetIds}>
+        <BottomSheet sheetId="inbox" label="Inbox" height="capped">
+          <Section padding={4}>
+            <VStack gap={4}>
+              <VStack gap={1}>
+                <Heading level={3}>Inbox</Heading>
+                <Text type="supporting" color="secondary">
+                  Select a message to inspect it without losing the list.
+                </Text>
+              </VStack>
+              <Divider />
+              <Button
+                label="Review release request"
+                variant="secondary"
+                onClick={() => push('message')}
+              />
+              <Button
+                label="Close"
+                variant="ghost"
+                onClick={() => setOpenSheetIds([])}
+              />
+            </VStack>
+          </Section>
+        </BottomSheet>
+
+        <BottomSheet sheetId="message" label="Release request" height="capped">
+          <Section padding={4}>
+            <VStack gap={4}>
+              <VStack gap={1}>
+                <Heading level={3}>Release request</Heading>
+                <Text type="supporting" color="secondary">
+                  The Inbox remains mounted and visible beneath this sheet.
+                </Text>
+              </VStack>
+              <Divider />
+              <Text>
+                Version 3.4 is ready for review. Inspect the available actions
+                before deciding what to do next.
+              </Text>
+              <HStack gap={2} hAlign="end">
+                <Button label="Back" variant="secondary" onClick={pop} />
+                <Button label="View actions" onClick={() => push('actions')} />
+              </HStack>
+            </VStack>
+          </Section>
+        </BottomSheet>
+
+        <BottomSheet sheetId="actions" label="Release actions" height="hug">
+          <Section padding={4}>
+            <VStack gap={4}>
+              <VStack gap={1}>
+                <Heading level={3}>Release actions</Heading>
+                <Text type="supporting" color="secondary">
+                  Three logical levels are open; only this sheet is interactive.
+                </Text>
+              </VStack>
+              <Divider />
+              <HStack gap={2} hAlign="end">
+                <Button label="Back" variant="secondary" onClick={pop} />
+                <Button
+                  label="Approve and close"
+                  onClick={() => setOpenSheetIds([])}
+                />
+              </HStack>
+            </VStack>
+          </Section>
+        </BottomSheet>
+      </BottomSheetStack>
+    </>
+  );
+}
+
+export const Default: Story = {
+  render: () => <StackExample />,
+};

--- a/docs/families/overlay-dismissal.md
+++ b/docs/families/overlay-dismissal.md
@@ -16,6 +16,7 @@ verified_by:
     packages/core/src/Layer/layerDismissalInvariants.test.tsx,
     packages/core/src/Layer/layerDismissalFamilies.test.tsx,
     packages/core/src/hooks/useFocusTrap.test.tsx,
+    packages/core/src/BottomSheet/BottomSheetStack.test.tsx,
   ]
 members:
   [
@@ -31,6 +32,7 @@ members:
     component:MobileNav,
     component:BottomSheet,
     component:BottomSheetSwitcher,
+    component:BottomSheetStack,
     component:CommandPalette,
     component:ContextMenu,
     component:PowerSearchEditPopover,
@@ -88,7 +90,7 @@ this record's current membership snapshot must be updated with it.
 
 - **Current members:** Dialog, AlertDialog, Popover, DropdownMenu,
   DropdownMenuSubMenu, MoreMenu, Tooltip, HoverCard, Lightbox, MobileNav,
-  BottomSheet, BottomSheetSwitcher, CommandPalette, ContextMenu,
+  BottomSheet, BottomSheetSwitcher, BottomSheetStack, CommandPalette, ContextMenu,
   PowerSearchEditPopover, Lab Drawer, and the component-owned popup surfaces
   listed below.
 - **Component-owned input popups:** ChatComposerInput, ComplexSelector,
@@ -192,6 +194,7 @@ this record's current membership snapshot must be updated with it.
 | Tooltip, HoverCard                                                                                                                                                                                                                                                                                 | shared owner with DOM presence reporting                      | Neither provides nesting depth to descendant layers                                                                                                                                                                                    |
 | Focus traps with `onEscape`                                                                                                                                                                                                                                                                        | shared owner through `useFocusTrap`                           | They provide DOM containment, not descendant depth                                                                                                                                                                                     |
 | BreadcrumbItem, ChatComposerInput, ComplexSelector, DateInput, DateRangeInput, DateTimeInput, Selector, MultiSelector, PowerSearch, BaseTypeahead, Typeahead, Tokenizer, SideNavHeading, SideNavItem, TabMenu, TopNavHeading, TopNavMenu, TopNavMegaMenu, Table, Lab TourStep, Lab ChatEmojiPicker | shared owner through `usePopover` or a composed Popover owner | Adaptive BottomSheet paths inherit BottomSheet's adoption gap; Table filtering owns controlled Popover state and discards its draft on close; TourStep routes Popover close to the Tour; ChatEmojiPicker owns controlled Popover state |
+| BottomSheetStack                                                                                                                                                                                                                                                                                   | shared owner                                                  | none                                                                                                                                                                                                                                   |
 | BottomSheetSwitcher                                                                                                                                                                                                                                                                                | partial                                                       | Modal mode registers through `useFocusTrap`; non-modal mode retains local Escape handling                                                                                                                                              |
 | BottomSheet, CommandPalette, ContextMenu, DropdownMenuSubMenu, PowerSearchEditPopover, Lab Drawer                                                                                                                                                                                                  | local only                                                    | Must migrate from component-specific listeners or registries to the shared owner                                                                                                                                                       |
 

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetStackShowcase.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetStackShowcase.doc.mjs
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'BottomSheetStack',
+  name: 'Bottom Sheet Stack',
+  displayName: 'Bottom Sheet Stack',
+  description:
+    'A drill-down flow that keeps the previous sheet mounted and visibly scaled beneath the active sheet.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 3 / 4,
+  componentsUsed: [
+    'BottomSheet',
+    'BottomSheetStack',
+    'Button',
+    'Divider',
+    'Heading',
+    'Section',
+    'Stack',
+    'Text',
+  ],
+};

--- a/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetStackShowcase.tsx
+++ b/packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetStackShowcase.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {BottomSheet, BottomSheetStack} from '@astryxdesign/core/BottomSheet';
+import {Button} from '@astryxdesign/core/Button';
+import {Divider} from '@astryxdesign/core/Divider';
+import {Heading} from '@astryxdesign/core/Heading';
+import {Section} from '@astryxdesign/core/Section';
+import {HStack, VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+
+export default function BottomSheetStackShowcase() {
+  const [openSheetIds, setOpenSheetIds] = useState<ReadonlyArray<string>>([]);
+  const push = (sheetId: string) =>
+    setOpenSheetIds(current => [...current, sheetId]);
+  const pop = () =>
+    setOpenSheetIds(current => current.slice(0, current.length - 1));
+
+  return (
+    <>
+      <Button label="Open inbox" onClick={() => setOpenSheetIds(['inbox'])} />
+      <BottomSheetStack
+        openSheetIds={openSheetIds}
+        onOpenSheetIdsChange={setOpenSheetIds}>
+        <BottomSheet sheetId="inbox" label="Inbox" height="capped">
+          <Section padding={4}>
+            <VStack gap={4}>
+              <VStack gap={1}>
+                <Heading level={3}>Inbox</Heading>
+                <Text type="supporting" color="secondary">
+                  Select a message to preserve this list beneath its details.
+                </Text>
+              </VStack>
+              <Divider />
+              <Button
+                label="Review release request"
+                variant="secondary"
+                onClick={() => push('message')}
+              />
+              <Button
+                label="Close"
+                variant="ghost"
+                onClick={() => setOpenSheetIds([])}
+              />
+            </VStack>
+          </Section>
+        </BottomSheet>
+
+        <BottomSheet sheetId="message" label="Release request" height="capped">
+          <Section padding={4}>
+            <VStack gap={4}>
+              <VStack gap={1}>
+                <Heading level={3}>Release request</Heading>
+                <Text type="supporting" color="secondary">
+                  The Inbox stays mounted, inert, and visible beneath this
+                  sheet.
+                </Text>
+              </VStack>
+              <Divider />
+              <Text>Version 3.4 is ready for review.</Text>
+              <HStack gap={2} hAlign="end">
+                <Button label="Back" variant="secondary" onClick={pop} />
+                <Button label="Approve" onClick={() => setOpenSheetIds([])} />
+              </HStack>
+            </VStack>
+          </Section>
+        </BottomSheet>
+      </BottomSheetStack>
+    </>
+  );
+}

--- a/packages/core/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/core/src/BottomSheet/BottomSheet.doc.mjs
@@ -86,38 +86,38 @@ export const docs = {
     targets: [{className: 'astryx-bottom-sheet', visualProps: []}],
   },
   description:
-    "A mobile touch sheet that rises from the bottom edge, with animated entrance and exit, a grab handle, optional drag-to-resize snap points, and purpose-controlled dismissal. A standalone sheet owns a native <dialog>; inside BottomSheetSwitcher it renders a panel in the switcher's shared dialog. In both modes, ref and shared DOM props target the visual panel <div>.",
+    "A mobile touch sheet that rises from the bottom edge, with animated entrance and exit, a grab handle, optional drag-to-resize snap points, and purpose-controlled dismissal. A standalone sheet owns a native <dialog>; inside BottomSheetSwitcher or BottomSheetStack it renders a panel in the controller's shared dialog. In all modes, ref and shared DOM props target the visual panel <div>.",
   props: [
     {
       name: 'isOpen',
       type: 'boolean',
       description:
-        'Whether a standalone sheet is open. Fully controlled; pair with onOpenChange. Omit inside BottomSheetSwitcher.',
+        'Whether a standalone sheet is open. Fully controlled; pair with onOpenChange. Omit inside BottomSheetSwitcher or BottomSheetStack.',
     },
     {
       name: 'onOpenChange',
       type: '(isOpen: boolean) => void',
       description:
-        'For a standalone sheet, called when it requests an open-state change. Automatic calls follow purpose: info dismisses on Escape, scrim click, or swipe; form dismisses on Escape only; required never dismisses implicitly. Omit inside BottomSheetSwitcher.',
+        'For a standalone sheet, called when it requests an open-state change. Automatic calls follow purpose: info dismisses on Escape, scrim click, or swipe; form dismisses on Escape only; required never dismisses implicitly. Omit inside BottomSheetSwitcher or BottomSheetStack.',
     },
     {
       name: 'finalFocusRef',
       type: 'RefObject<HTMLElement | null>',
       description:
-        'Optional explicit focus-return target for a standalone sheet. Use when the opener can remount or the active element is not a reliable trigger, such as an adaptive presentation switch. Omit inside BottomSheetSwitcher.',
+        'Optional explicit focus-return target for a standalone sheet. Use when the opener can remount or the active element is not a reliable trigger, such as an adaptive presentation switch. Omit inside BottomSheetSwitcher or BottomSheetStack.',
     },
     {
       name: 'purpose',
       type: "'required' | 'form' | 'info'",
       description:
-        "Controls implicit dismissal behavior, matching Dialog. info allows Escape, scrim click, and swipe-to-dismiss. form protects entered data by blocking scrim click and swipe while allowing Escape. required blocks every implicit dismissal path and uses role='alertdialog'. Explicit controls may still update the controlled state. Works for standalone and BottomSheetSwitcher-managed sheets.",
+        "Controls implicit dismissal behavior, matching Dialog. info allows Escape, scrim click, and swipe-to-dismiss. form protects entered data by blocking scrim click and swipe while allowing Escape. required blocks every implicit dismissal path and uses role='alertdialog'. Explicit controls may still update the controlled state. Works for standalone, BottomSheetSwitcher-managed, and BottomSheetStack-managed sheets.",
       default: "'info'",
     },
     {
       name: 'sheetId',
       type: 'string',
       description:
-        'Unique ID for this sheet inside BottomSheetSwitcher. The switcher opens it when activeSheet matches. Omit isOpen and onOpenChange when sheetId is used.',
+        'Unique ID for this sheet inside BottomSheetSwitcher or BottomSheetStack. A switcher opens it when activeSheet matches; a stack presents it at its position in openSheetIds. Omit isOpen and onOpenChange when sheetId is used.',
     },
     {
       name: 'label',
@@ -150,14 +150,14 @@ export const docs = {
       name: 'hasScrim',
       type: 'boolean',
       description:
-        "For a standalone BottomSheet, whether to render a scrim, the semi-transparent overlay that covers and blocks the background. true (default) uses showModal(): top layer, focus trap, ::backdrop scrim, body scroll lock, and tap-scrim-to-dismiss when purpose='info', with the background inert. false uses show() with no scrim, leaving the page behind interactive and scrollable. For a multi-step flow, configure hasScrim on BottomSheetSwitcher instead; it owns one shared dialog across every child.",
+        "For a standalone BottomSheet, whether to render a scrim, the semi-transparent overlay that covers and blocks the background. true (default) uses showModal(): top layer, focus trap, ::backdrop scrim, body scroll lock, and tap-scrim-to-dismiss when purpose='info', with the background inert. false uses show() with no scrim, leaving the page behind interactive and scrollable. For a controlled flow, configure hasScrim on BottomSheetSwitcher or BottomSheetStack instead; the controller owns one shared dialog across every child.",
       default: 'true',
     },
   ],
   usage: {
     anatomy,
     description:
-      'A mobile touch surface for filters, actions, forms, and detail views that should rise from the bottom of the viewport; use BottomSheetSwitcher for multi-step flows.',
+      'A mobile touch surface for filters, actions, forms, and detail views that should rise from the bottom of the viewport; use BottomSheetSwitcher for replacing steps and BottomSheetStack for visible drill-down layers.',
     bestPractices: [
       {
         guidance: true,
@@ -177,7 +177,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          "Don't make the sheet content overly long. Consider breaking it into steps and using Bottom Sheet Switcher.",
+          "Don't make the sheet content overly long. Use Bottom Sheet Switcher when steps replace one another, or Bottom Sheet Stack when a detail sheet should preserve visible context beneath it.",
       },
     ],
   },
@@ -309,7 +309,7 @@ export const docsDense = {
   usage: {
     anatomy,
     description:
-      'Mobile touch surface for filters, actions, forms, and detail views that should rise from the bottom of the viewport; use BottomSheetSwitcher for multi-step flows.',
+      'Mobile touch surface for filters, actions, forms, and detail views that should rise from the bottom of the viewport; use BottomSheetSwitcher for replacing steps and BottomSheetStack for visible drill-down layers.',
     bestPractices: [
       {
         guidance: true,
@@ -329,7 +329,7 @@ export const docsDense = {
       {
         guidance: false,
         description:
-          "Don't make the sheet content overly long. Consider breaking it into steps and using Bottom Sheet Switcher.",
+          "Don't make the sheet content overly long. Use Bottom Sheet Switcher when steps replace one another, or Bottom Sheet Stack when a detail sheet should preserve visible context beneath it.",
       },
     ],
   },

--- a/packages/core/src/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/BottomSheet/BottomSheet.tsx
@@ -4,21 +4,23 @@
 
 /**
  * @file BottomSheet.tsx
- * @input Uses React, StyleX, core hooks/utils, BottomSheetPanel, BottomSheetSwitcherContext
+ * @input Uses React, StyleX, core hooks/utils, BottomSheetPanel, switcher/stack contexts
  * @output Exports BottomSheet component and BottomSheetProps
- * @position Public BottomSheet router plus private standalone/switcher hosts
+ * @position Public BottomSheet router plus private standalone/controller hosts
  *
- * BottomSheet selects one of two focused hosts. A standalone host owns its
- * native dialog lifecycle; a switcher item participates in the parent's shared
- * dialog and transition state machine. Both render the same BottomSheetPanel,
- * which owns sheet presentation, gestures, mobile-keyboard accommodation, and
- * motion completion.
+ * BottomSheet selects one of three focused hosts. A standalone host owns its
+ * native dialog lifecycle; switcher and stack items participate in their
+ * parent's shared dialog and transition state machine. Every host renders the
+ * same BottomSheetPanel, which owns sheet presentation, gestures,
+ * mobile-keyboard accommodation, and motion completion.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/BottomSheet/BottomSheetPanel.tsx
  * - /packages/core/src/BottomSheet/BottomSheetEdgeTint.tsx
  * - /packages/core/src/BottomSheet/BottomSheet.doc.mjs
  * - /packages/core/src/BottomSheet/BottomSheet.test.tsx
+ * - /packages/core/src/BottomSheet/BottomSheetStack.tsx
+ * - /packages/core/src/BottomSheet/BottomSheetStack.test.tsx
  * - /packages/core/src/BottomSheet/BottomSheetSwitcher.tsx
  * - /packages/core/src/BottomSheet/BottomSheetSwitcher.test.tsx
  * - /apps/storybook/stories/BottomSheet.stories.tsx
@@ -38,7 +40,12 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import type {DialogPurpose} from '../Dialog';
-import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  durationVars,
+  easeVars,
+  spacingVars,
+} from '../theme/tokens.stylex';
 import {isImeKeyEvent, useDevWarning, useScrollLock} from '../hooks';
 import {
   BottomSheetPanel,
@@ -47,6 +54,11 @@ import {
 } from './BottomSheetPanel';
 import {BottomSheetEdgeTint} from './BottomSheetEdgeTint';
 import {
+  BottomSheetStackContext,
+  type BottomSheetStackContextValue,
+  type BottomSheetStackPhase,
+} from './BottomSheetStackContext';
+import {
   BottomSheetSwitcherContext,
   type BottomSheetSwitcherContextValue,
   type BottomSheetSwitcherPhase,
@@ -54,6 +66,18 @@ import {
 
 export type {BottomSheetHeight, BottomSheetSnapPoint} from './BottomSheetPanel';
 import type {BottomSheetHeight, BottomSheetSnapPoint} from './BottomSheetPanel';
+
+const STACK_VISUAL_DEPTH_LIMIT = 2;
+const STACK_SCALE_STEP = 0.04;
+
+function transformForStackDepth(depth: number): string {
+  const visualDepth = Math.min(STACK_VISUAL_DEPTH_LIMIT, Math.max(0, depth));
+  if (visualDepth === 0) {
+    return 'translateY(0) scale(1)';
+  }
+  const scale = (1 - visualDepth * STACK_SCALE_STEP).toFixed(2);
+  return `translateY(calc(${spacingVars['--spacing-2']} * -${visualDepth})) scale(${scale})`;
+}
 
 const styles = stylex.create({
   dialog: {
@@ -124,6 +148,22 @@ const styles = stylex.create({
   positionerTop: {
     zIndex: 1,
   },
+  positionerStackMotion: {
+    transformOrigin: '50% 0',
+    transitionProperty: 'transform',
+    transitionDuration: durationVars['--duration-medium'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    willChange: 'transform',
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.01s',
+    },
+  },
+  positionerStackTransform: (transform: string) => ({
+    transform,
+  }),
+  positionerStackLayer: (zIndex: number) => ({
+    zIndex,
+  }),
 });
 
 interface BottomSheetSharedProps extends BaseProps<HTMLDivElement> {
@@ -191,6 +231,23 @@ function panelStateForSwitcherPhase(
     case 'aligning':
     case 'fading':
       return {kind: 'retained', motion: phase, alignmentOffset};
+    case 'exiting':
+      return {kind: 'exiting'};
+    case 'hidden':
+      return {kind: 'hidden'};
+  }
+}
+
+function panelStateForStackPhase(
+  phase: BottomSheetStackPhase,
+): BottomSheetPanelState {
+  switch (phase) {
+    case 'active':
+      return {kind: 'open', entering: false};
+    case 'entering':
+      return {kind: 'open', entering: true};
+    case 'covered':
+      return {kind: 'retained', motion: 'covered', alignmentOffset: 0};
     case 'exiting':
       return {kind: 'exiting'};
     case 'hidden':
@@ -556,30 +613,207 @@ function SwitcherBottomSheetItem({
   );
 }
 
+interface StackBottomSheetItemProps extends SwitcherBottomSheetProps {
+  stack: BottomSheetStackContextValue;
+}
+
+function StackBottomSheetItem({
+  stack,
+  ref,
+  sheetId,
+  label,
+  children,
+  height = 'capped',
+  snapPoints,
+  purpose = 'info',
+  xstyle,
+  ...props
+}: StackBottomSheetItemProps) {
+  const {
+    openSheetIds,
+    topSheet,
+    hasScrim,
+    requestTopDismiss,
+    getSheetPhase,
+    getSheetDepth,
+    getSheetLayer,
+    registerSheetElement,
+    registerSheetLabel,
+    registerSheetPurpose,
+    onSheetTransitionComplete,
+    onSheetScrimOpacityChange,
+  } = stack;
+  const hasValidSheetId = typeof sheetId === 'string' && sheetId.length > 0;
+  const phase = hasValidSheetId ? getSheetPhase(sheetId) : 'hidden';
+  const depth = hasValidSheetId ? getSheetDepth(sheetId) : 0;
+  const layer = hasValidSheetId ? getSheetLayer(sheetId) : 0;
+  const panelState = panelStateForStackPhase(phase);
+  const isInteractive = phase === 'active' || phase === 'entering';
+  const isInactive = phase === 'covered' || phase === 'exiting';
+  const isPresented = phase !== 'hidden';
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const previousPhaseRef = useRef(phase);
+  const previousPhase = previousPhaseRef.current;
+
+  useLayoutEffect(() => {
+    const wasInteractive =
+      previousPhase === 'active' || previousPhase === 'entering';
+    if (wasInteractive && phase === 'covered') {
+      const activeElement = document.activeElement as HTMLElement | null;
+      if (activeElement != null && panelRef.current?.contains(activeElement)) {
+        returnFocusRef.current = activeElement;
+      }
+    } else if (phase === 'hidden') {
+      returnFocusRef.current = null;
+    }
+    previousPhaseRef.current = phase;
+  }, [phase, previousPhase]);
+
+  const dismissOnSwipe = useCallback(() => {
+    if (purpose === 'info' && hasValidSheetId && topSheet === sheetId) {
+      requestTopDismiss();
+    }
+  }, [hasValidSheetId, purpose, requestTopDismiss, sheetId, topSheet]);
+  const handlePanelElementChange = useCallback(
+    (element: HTMLDivElement | null) => {
+      panelRef.current = element;
+      if (hasValidSheetId) {
+        registerSheetElement(sheetId, element);
+      }
+    },
+    [hasValidSheetId, registerSheetElement, sheetId],
+  );
+  const handleMotionComplete = useCallback(
+    (motion: BottomSheetPanelMotion) => {
+      if (hasValidSheetId && (motion === 'entering' || motion === 'exiting')) {
+        onSheetTransitionComplete({sheetId, phase: motion});
+      }
+    },
+    [hasValidSheetId, onSheetTransitionComplete, sheetId],
+  );
+  const handleScrimOpacity = useCallback(
+    (opacity: number) => {
+      if (hasValidSheetId) {
+        onSheetScrimOpacityChange(sheetId, opacity);
+      }
+    },
+    [hasValidSheetId, onSheetScrimOpacityChange, sheetId],
+  );
+
+  useLayoutEffect(() => {
+    if (!hasValidSheetId) {
+      return;
+    }
+    registerSheetLabel(sheetId, label);
+    return () => registerSheetLabel(sheetId, null);
+  }, [hasValidSheetId, label, registerSheetLabel, sheetId]);
+
+  useLayoutEffect(() => {
+    if (!hasValidSheetId) {
+      return;
+    }
+    registerSheetPurpose(sheetId, purpose);
+    return () => registerSheetPurpose(sheetId, null);
+  }, [hasValidSheetId, purpose, registerSheetPurpose, sheetId]);
+
+  useEffect(() => {
+    const wasInteractive =
+      previousPhase === 'active' || previousPhase === 'entering';
+    if (!isInteractive || wasInteractive) {
+      return;
+    }
+    const returnTarget = returnFocusRef.current;
+    if (
+      returnTarget != null &&
+      returnTarget.isConnected &&
+      panelRef.current?.contains(returnTarget)
+    ) {
+      returnTarget.focus({preventScroll: true});
+    } else {
+      focusPanel(
+        panelRef.current,
+        hasScrim || previousPhase === 'covered' || openSheetIds.length > 1,
+      );
+    }
+  }, [hasScrim, isInteractive, openSheetIds.length, previousPhase]);
+
+  useDevWarning(
+    'BottomSheet',
+    'requires a non-empty `label` for an accessible name; the open sheet ' +
+      'has no built-in heading to derive one from.',
+    isInteractive && !label,
+  );
+
+  return (
+    <div
+      {...stylex.props(
+        styles.positioner,
+        styles.positionerStackMotion,
+        styles.positionerStackTransform(transformForStackDepth(depth)),
+        styles.positionerStackLayer(layer),
+        !isPresented && styles.positionerHidden,
+      )}
+      hidden={!isPresented}
+      aria-hidden={isInactive ? 'true' : undefined}
+      inert={isInactive ? true : undefined}>
+      <BottomSheetPanel
+        {...props}
+        ref={ref}
+        state={panelState}
+        height={height}
+        snapPoints={snapPoints}
+        isSwipeDismissAllowed={purpose === 'info' && isInteractive}
+        isPageScrollLocked={hasScrim}
+        xstyle={xstyle}
+        onDismiss={dismissOnSwipe}
+        onScrimOpacity={handleScrimOpacity}
+        onElementChange={handlePanelElementChange}
+        onMotionComplete={handleMotionComplete}>
+        {/* A stack item consumes its parent controller. Nested BottomSheets are
+            standalone unless their content establishes a new controller. */}
+        <BottomSheetStackContext value={null}>
+          {children}
+        </BottomSheetStackContext>
+      </BottomSheetPanel>
+    </div>
+  );
+}
+
 /**
  * A mobile touch sheet that either owns a native dialog or participates in a
- * BottomSheetSwitcher shared dialog when given a sheetId inside that context.
+ * BottomSheetSwitcher / BottomSheetStack shared dialog when given a sheetId.
  */
 export function BottomSheet(props: BottomSheetProps) {
+  const stack = use(BottomSheetStackContext);
   const switcher = use(BottomSheetSwitcherContext);
+  const controller = stack ?? switcher;
   const runtimeSheetId = (props as {sheetId?: string}).sheetId;
   const hasValidSheetId =
     typeof runtimeSheetId === 'string' && runtimeSheetId.length > 0;
 
   useDevWarning(
     'BottomSheet',
-    'requires a non-empty `sheetId` when nested in ' +
+    'requires a non-empty `sheetId` when nested in BottomSheetStack or ' +
       'BottomSheetSwitcher; standalone `isOpen` / `onOpenChange` props are ' +
       'ignored there.',
-    switcher != null && !hasValidSheetId,
+    controller != null && !hasValidSheetId,
   );
   useDevWarning(
     'BottomSheet',
-    '`sheetId` only works inside BottomSheetSwitcher. Use `isOpen` and ' +
-      '`onOpenChange` for a standalone sheet.',
-    switcher == null && runtimeSheetId != null,
+    '`sheetId` only works inside BottomSheetStack or BottomSheetSwitcher. Use ' +
+      '`isOpen` and `onOpenChange` for a standalone sheet.',
+    controller == null && runtimeSheetId != null,
   );
 
+  if (stack != null) {
+    return (
+      <StackBottomSheetItem
+        {...(props as SwitcherBottomSheetProps)}
+        stack={stack}
+      />
+    );
+  }
   if (switcher != null) {
     return (
       <SwitcherBottomSheetItem

--- a/packages/core/src/BottomSheet/BottomSheetStack.doc.mjs
+++ b/packages/core/src/BottomSheet/BottomSheetStack.doc.mjs
@@ -1,0 +1,188 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
+
+export const docs = {
+  name: 'BottomSheetStack',
+  displayName: 'Bottom Sheet Stack',
+  group: 'BottomSheet',
+  category: 'Overlay',
+  keywords: [
+    'bottom sheet',
+    'stack',
+    'stacked sheet',
+    'drill down',
+    'detail',
+    'navigation',
+  ],
+  playground: {
+    overlay: true,
+    overlayControl: {
+      stateProp: 'openSheetIds',
+      openValue: ['filters'],
+    },
+    defaults: {
+      openSheetIds: [],
+      children: [
+        {
+          __element: 'BottomSheet',
+          props: {
+            sheetId: 'filters',
+            label: 'Filters',
+            height: 'hug',
+          },
+          children: {
+            __element: 'Section',
+            props: {padding: 4},
+            children: {
+              __element: 'VStack',
+              props: {gap: 2},
+              children: [
+                {
+                  __element: 'Heading',
+                  props: {level: 3},
+                  children: 'Filters',
+                },
+                {
+                  __element: 'Text',
+                  props: {type: 'body'},
+                  children:
+                    'Choose a filter, then open a detail sheet without replacing this context.',
+                },
+              ],
+            },
+          },
+        },
+        {
+          __element: 'BottomSheet',
+          props: {
+            sheetId: 'details',
+            label: 'Filter details',
+            height: 'hug',
+          },
+          children: {
+            __element: 'Section',
+            props: {padding: 4},
+            children: {
+              __element: 'VStack',
+              props: {gap: 2},
+              children: [
+                {
+                  __element: 'Heading',
+                  props: {level: 3},
+                  children: 'Filter details',
+                },
+                {
+                  __element: 'Text',
+                  props: {type: 'body'},
+                  children: 'Configure the selected filter.',
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  },
+  description:
+    'Coordinates multiple BottomSheets as one ordered visual stack. openSheetIds lists open sheets bottom-to-top; the last sheet is interactive while covered sheets remain mounted, inert, and slightly scaled and translated beneath it. Pushing appends an ID, Back removes the last ID, and an empty array closes the stack. Escape, scrim click, and swipe request dismissal of only the top sheet. The stack owns one native <dialog>, scrim, focus boundary, and scroll lock across the complete flow.',
+  props: [
+    {
+      name: 'openSheetIds',
+      type: 'ReadonlyArray<string>',
+      description:
+        'Open BottomSheet IDs ordered bottom-to-top. IDs must be unique and match nested BottomSheet sheetId values. Append one ID to push, remove the final ID to pop, and pass [] to close the stack.',
+      required: true,
+    },
+    {
+      name: 'onOpenSheetIdsChange',
+      type: '(openSheetIds: ReadonlyArray<string>) => void',
+      description:
+        'Called with the top ID removed when the top sheet requests dismissal according to its purpose. Flow controls may use the same state setter to append an ID, pop, or close with [].',
+      required: true,
+    },
+    {
+      name: 'hasScrim',
+      type: 'boolean',
+      description:
+        "Whether the shared dialog is modal. true uses showModal() for one native ::backdrop, focus trap, scroll lock, and click-to-dismiss when the top BottomSheet has purpose='info'. false uses show() and leaves the page interactive.",
+      default: 'true',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'BottomSheets identified by unique sheetId values.',
+      required: true,
+    },
+  ],
+  usage: {
+    description:
+      'Use for drill-down interactions where a new sheet should preserve visible context beneath it. Keep the ordered array as the single source of truth; do not model stack order with independent child booleans.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Append one sheet ID for forward navigation and remove the last ID for Back so motion and focus return follow the visible stack.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep sheet IDs unique. Covered sheets stay mounted, so local form and scroll state are preserved while a detail sheet is above them.',
+      },
+      {
+        guidance: false,
+        description:
+          "Don't use BottomSheetStack for mutually exclusive wizard steps that replace one another; use BottomSheetSwitcher instead.",
+      },
+    ],
+  },
+  examples: [
+    {
+      label: 'Stacked detail flow',
+      code: `const [openSheetIds, setOpenSheetIds] =
+  useState<ReadonlyArray<string>>([]);
+
+const push = (sheetId: string) =>
+  setOpenSheetIds(current => [...current, sheetId]);
+const pop = () =>
+  setOpenSheetIds(current => current.slice(0, -1));
+
+<>
+  <Button label="Open filters" onClick={() => push('filters')} />
+  <BottomSheetStack
+    openSheetIds={openSheetIds}
+    onOpenSheetIdsChange={setOpenSheetIds}>
+    <BottomSheet sheetId="filters" label="Filters">
+      <Filters />
+      <Button label="Show details" onClick={() => push('details')} />
+    </BottomSheet>
+    <BottomSheet sheetId="details" label="Filter details">
+      <FilterDetails />
+      <Button label="Back" onClick={pop} />
+    </BottomSheet>
+  </BottomSheetStack>
+</>`,
+    },
+  ],
+};
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
+export const docsDense = {
+  description:
+    'controlled BottomSheet stack; IDs are ordered bottom-to-top and only the final sheet is interactive',
+  usage: {
+    description:
+      'Use for drill-down interactions where each pushed sheet preserves visible context beneath it.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Append one ID to push and remove the final ID to pop; [] closes the stack.',
+      },
+      {
+        guidance: false,
+        description:
+          "Don't use for mutually exclusive wizard steps; use BottomSheetSwitcher.",
+      },
+    ],
+  },
+};

--- a/packages/core/src/BottomSheet/BottomSheetStack.test.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetStack.test.tsx
@@ -1,0 +1,235 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file BottomSheetStack.test.tsx
+ * @input Uses vitest, Testing Library, BottomSheet, BottomSheetStack
+ * @output Tests ordered stacking, top-only dismissal, focus return, and shared dialog ownership
+ * @position Core tests for BottomSheetStack
+ */
+
+import {fireEvent, render, screen} from '@testing-library/react';
+import {useState} from 'react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {BottomSheet} from './BottomSheet';
+import {BottomSheetStack} from './BottomSheetStack';
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+  window.scrollTo = vi.fn();
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function getSharedDialog(): HTMLDialogElement {
+  const dialog = document.querySelector<HTMLDialogElement>('dialog');
+  if (dialog == null) {
+    throw new Error('shared dialog not found');
+  }
+  return dialog;
+}
+
+function getSheetLayer(testId: string): HTMLElement {
+  const panel = screen.getByTestId(testId);
+  const layer = panel.parentElement;
+  if (layer == null) {
+    throw new Error('sheet layer not found');
+  }
+  return layer;
+}
+
+function finishSheetTransition(element: HTMLElement) {
+  fireEvent.transitionEnd(element, {propertyName: 'transform'});
+}
+
+function StackFlow() {
+  const [openSheetIds, setOpenSheetIds] = useState<ReadonlyArray<string>>([]);
+  return (
+    <>
+      <button type="button" onClick={() => setOpenSheetIds(['filters'])}>
+        Open filters
+      </button>
+      <BottomSheetStack
+        openSheetIds={openSheetIds}
+        onOpenSheetIdsChange={setOpenSheetIds}>
+        <BottomSheet
+          sheetId="filters"
+          label="Filters"
+          data-testid="filters-sheet">
+          <button
+            type="button"
+            onClick={() => setOpenSheetIds(current => [...current, 'details'])}>
+            Show details
+          </button>
+        </BottomSheet>
+        <BottomSheet
+          sheetId="details"
+          label="Details"
+          data-testid="details-sheet">
+          <button
+            type="button"
+            onClick={() => setOpenSheetIds(current => current.slice(0, -1))}>
+            Back
+          </button>
+        </BottomSheet>
+      </BottomSheetStack>
+    </>
+  );
+}
+
+describe('BottomSheetStack', () => {
+  it('keeps covered sheets mounted and makes only the top sheet interactive', () => {
+    render(<StackFlow />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open filters'}));
+    const filtersLayer = getSheetLayer('filters-sheet');
+    const detailsLayer = getSheetLayer('details-sheet');
+    const showDetails = screen.getByRole('button', {name: 'Show details'});
+    showDetails.focus();
+    fireEvent.click(showDetails);
+
+    expect(filtersLayer).not.toHaveAttribute('hidden');
+    expect(filtersLayer).toHaveAttribute('aria-hidden', 'true');
+    expect(filtersLayer).toHaveAttribute('inert');
+    expect(filtersLayer.style.getPropertyValue('--x-transform')).toContain(
+      'scale(0.96)',
+    );
+    expect(detailsLayer).not.toHaveAttribute('hidden');
+    expect(detailsLayer).not.toHaveAttribute('aria-hidden');
+    expect(detailsLayer).not.toHaveAttribute('inert');
+    expect(detailsLayer.style.getPropertyValue('--x-transform')).toContain(
+      'scale(1)',
+    );
+    expect(getSharedDialog()).toHaveAccessibleName('Details');
+    expect(document.querySelectorAll('dialog[open]')).toHaveLength(1);
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses only the top sheet from the shared scrim and restores covered focus', () => {
+    render(<StackFlow />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open filters'}));
+    const showDetails = screen.getByRole('button', {name: 'Show details'});
+    showDetails.focus();
+    fireEvent.click(showDetails);
+
+    const details = screen.getByTestId('details-sheet');
+    fireEvent.click(getSharedDialog());
+
+    expect(getSheetLayer('filters-sheet')).not.toHaveAttribute('inert');
+    expect(getSheetLayer('details-sheet')).toHaveAttribute('inert');
+    expect(getSharedDialog()).toHaveAccessibleName('Filters');
+    expect(showDetails).toHaveFocus();
+
+    finishSheetTransition(details);
+    expect(getSheetLayer('details-sheet')).toHaveAttribute('hidden');
+    expect(getSharedDialog()).toHaveAttribute('open');
+  });
+
+  it('keeps the shared dialog until the root exit finishes, then restores the opener', () => {
+    render(<StackFlow />);
+
+    const opener = screen.getByRole('button', {name: 'Open filters'});
+    opener.focus();
+    fireEvent.click(opener);
+    const filters = screen.getByTestId('filters-sheet');
+
+    fireEvent.click(getSharedDialog());
+    expect(getSharedDialog()).toHaveAttribute('open');
+    expect(getSheetLayer('filters-sheet')).toHaveAttribute('inert');
+
+    finishSheetTransition(filters);
+    expect(document.querySelector('dialog[open]')).toBeNull();
+    expect(opener).toHaveFocus();
+  });
+
+  it('requests a suffix pop for Escape', () => {
+    const onOpenSheetIdsChange = vi.fn();
+    render(
+      <BottomSheetStack
+        openSheetIds={['filters', 'details']}
+        onOpenSheetIdsChange={onOpenSheetIdsChange}>
+        <BottomSheet sheetId="filters" label="Filters">
+          Filters
+        </BottomSheet>
+        <BottomSheet sheetId="details" label="Details">
+          Details
+        </BottomSheet>
+      </BottomSheetStack>,
+    );
+
+    fireEvent.keyDown(document, {key: 'Escape'});
+
+    expect(onOpenSheetIdsChange).toHaveBeenCalledTimes(1);
+    expect(onOpenSheetIdsChange).toHaveBeenCalledWith(['filters']);
+  });
+
+  it('uses the top sheet purpose for implicit dismissal', () => {
+    const onOpenSheetIdsChange = vi.fn();
+    render(
+      <BottomSheetStack
+        openSheetIds={['filters', 'required']}
+        onOpenSheetIdsChange={onOpenSheetIdsChange}>
+        <BottomSheet sheetId="filters" label="Filters">
+          Filters
+        </BottomSheet>
+        <BottomSheet sheetId="required" label="Required" purpose="required">
+          Required
+        </BottomSheet>
+      </BottomSheetStack>,
+    );
+
+    expect(getSharedDialog()).toHaveAttribute('role', 'alertdialog');
+    fireEvent.keyDown(document, {key: 'Escape'});
+    fireEvent.click(getSharedDialog());
+    expect(onOpenSheetIdsChange).not.toHaveBeenCalled();
+  });
+
+  it('uses one non-modal shell and still routes Escape to the top sheet', () => {
+    const onOpenSheetIdsChange = vi.fn();
+    render(
+      <BottomSheetStack
+        openSheetIds={['filters', 'details']}
+        onOpenSheetIdsChange={onOpenSheetIdsChange}
+        hasScrim={false}>
+        <BottomSheet sheetId="filters" label="Filters">
+          Filters
+        </BottomSheet>
+        <BottomSheet sheetId="details" label="Details">
+          Details
+        </BottomSheet>
+      </BottomSheetStack>,
+    );
+
+    expect(HTMLDialogElement.prototype.show).toHaveBeenCalledTimes(1);
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+    expect(getSharedDialog()).not.toHaveAttribute('aria-modal');
+
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(onOpenSheetIdsChange).toHaveBeenCalledWith(['filters']);
+  });
+});

--- a/packages/core/src/BottomSheet/BottomSheetStack.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetStack.tsx
@@ -1,0 +1,557 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file BottomSheetStack.tsx
+ * @input Uses React context, StyleX, focus/scroll-lock/layer hooks, BottomSheetStackContext
+ * @output Exports BottomSheetStack and BottomSheetStackProps
+ * @position Core controller for visibly stacked BottomSheet flows
+ *
+ * BottomSheetStack turns declaratively nested BottomSheets into one controlled
+ * ordered stack. `openSheetIds` is ordered bottom-to-top. The last sheet is the
+ * only interactive and dismissible sheet; covered sheets stay mounted, visible,
+ * inert, and progressively transformed by their depth.
+ *
+ * All sheets render inside one stack-owned native <dialog>. This keeps one modal
+ * boundary, one scrim, one focus trap, and one scroll lock across push and pop
+ * transitions. Logical state follows the controlled array immediately while a
+ * removed top sheet may remain mounted long enough to finish its exit motion.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/BottomSheet/BottomSheet.tsx
+ * - /packages/core/src/BottomSheet/BottomSheetEdgeTint.tsx
+ * - /packages/core/src/BottomSheet/BottomSheetStackContext.ts
+ * - /packages/core/src/BottomSheet/BottomSheetStack.doc.mjs
+ * - /packages/core/src/BottomSheet/BottomSheetStack.test.tsx
+ * - /packages/core/src/BottomSheet/index.ts
+ * - /apps/storybook/stories/BottomSheetStack.stories.tsx
+ * - /packages/cli/assets/templates/blocks/components/BottomSheet/BottomSheetStackShowcase.tsx
+ * - /docs/families/overlay-dismissal.md
+ */
+
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  type SyntheticEvent,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {BaseProps} from '../BaseProps';
+import type {DialogPurpose} from '../Dialog';
+import {
+  useDevWarning,
+  useFocusTrap,
+  useMergedRefs,
+  useScrollLock,
+} from '../hooks';
+import {LayerDepthProvider} from '../Layer/LayerDepthContext';
+import {useLayerDismissal} from '../Layer/useLayerDismissal';
+import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
+import {composeEventHandlers, mergeProps} from '../utils';
+import {BottomSheetEdgeTint} from './BottomSheetEdgeTint';
+import {
+  BottomSheetStackContext,
+  type BottomSheetStackContextValue,
+  type BottomSheetStackPhase,
+  type BottomSheetStackTransitionEvent,
+} from './BottomSheetStackContext';
+import {BottomSheetSwitcherContext} from './BottomSheetSwitcherContext';
+
+const styles = stylex.create({
+  dialog: {
+    position: 'fixed',
+    inset: 0,
+    width: '100dvw',
+    height: '100dvh',
+    maxWidth: 'none',
+    maxHeight: 'none',
+    margin: 0,
+    padding: 0,
+    border: 'none',
+    backgroundColor: 'transparent',
+    overflow: 'visible',
+    display: 'none',
+    outline: 'none',
+  },
+  dialogOpen: {
+    display: 'block',
+  },
+  dialogNonModal: {
+    pointerEvents: 'none',
+    zIndex: 1000,
+    width: '100%',
+    height: '100%',
+  },
+  scrim: {
+    '::backdrop': {
+      backgroundColor: colorVars['--color-overlay'],
+      opacity: {
+        default: 'var(--_sheet-scrim-opacity, 1)',
+        '@starting-style': 0,
+      },
+      transitionProperty: 'opacity, display',
+      transitionDuration: durationVars['--duration-medium'],
+      transitionTimingFunction: easeVars['--ease-standard'],
+      transitionBehavior: 'allow-discrete',
+      '@media (prefers-reduced-motion: reduce)': {
+        transitionDuration: '0.01s',
+      },
+    },
+  },
+});
+
+interface StackTransitionState {
+  enteringSheet: string | null;
+  exitingSheet: string | null;
+}
+
+const IDLE_TRANSITION: StackTransitionState = {
+  enteringSheet: null,
+  exitingSheet: null,
+};
+
+function stacksEqual(
+  first: ReadonlyArray<string>,
+  second: ReadonlyArray<string>,
+): boolean {
+  return (
+    first.length === second.length &&
+    first.every((sheetId, index) => sheetId === second[index])
+  );
+}
+
+function isPrefix(
+  prefix: ReadonlyArray<string>,
+  sheets: ReadonlyArray<string>,
+): boolean {
+  return prefix.every((sheetId, index) => sheetId === sheets[index]);
+}
+
+function transitionForOpenSheetIdsChange(
+  previousSheets: ReadonlyArray<string>,
+  nextSheets: ReadonlyArray<string>,
+): StackTransitionState {
+  if (
+    nextSheets.length === previousSheets.length + 1 &&
+    isPrefix(previousSheets, nextSheets)
+  ) {
+    return {
+      enteringSheet: nextSheets[nextSheets.length - 1] ?? null,
+      exitingSheet: null,
+    };
+  }
+  if (
+    previousSheets.length === nextSheets.length + 1 &&
+    isPrefix(nextSheets, previousSheets)
+  ) {
+    return {
+      enteringSheet: null,
+      exitingSheet: previousSheets[previousSheets.length - 1] ?? null,
+    };
+  }
+  return IDLE_TRANSITION;
+}
+
+export interface BottomSheetStackProps extends BaseProps<HTMLDialogElement> {
+  /** Ref forwarded to the shared native dialog. */
+  ref?: React.Ref<HTMLDialogElement>;
+
+  /** Called when the shared native dialog receives a cancel event. */
+  onCancel?: (event: SyntheticEvent<HTMLDialogElement>) => void;
+
+  /**
+   * Open BottomSheet IDs ordered bottom-to-top. IDs must be unique and match
+   * nested BottomSheet `sheetId` values. An empty array closes the stack.
+   */
+  openSheetIds: ReadonlyArray<string>;
+
+  /** Called with the next stack when the top sheet requests dismissal. */
+  onOpenSheetIdsChange: (openSheetIds: ReadonlyArray<string>) => void;
+
+  /**
+   * Whether to open the shared dialog modally with its native ::backdrop.
+   * Disable for a viewport-anchored, non-modal stack over an interactive page.
+   * @default true
+   */
+  hasScrim?: boolean;
+
+  /** BottomSheets identified by unique `sheetId` values. */
+  children: ReactNode;
+}
+
+/**
+ * Coordinates BottomSheets as an ordered visual stack inside one shared native
+ * dialog. Only the last openSheetIds entry is interactive and dismissible.
+ */
+export function BottomSheetStack({
+  openSheetIds,
+  onOpenSheetIdsChange,
+  hasScrim = true,
+  children,
+  ref,
+  xstyle,
+  className,
+  style,
+  onCancel,
+  onClick,
+  ...props
+}: BottomSheetStackProps) {
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const dialogModeRef = useRef<'modal' | 'non-modal' | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const sheetElementsRef = useRef(new Map<string, HTMLElement>());
+  const committedOpenSheetIdsRef = useRef<ReadonlyArray<string>>([
+    ...openSheetIds,
+  ]);
+  const [sheetLabels, setSheetLabels] = useState<ReadonlyMap<string, string>>(
+    () => new Map(),
+  );
+  const [sheetPurposes, setSheetPurposes] = useState<
+    ReadonlyMap<string, DialogPurpose>
+  >(() => new Map());
+  const [transition, setTransition] =
+    useState<StackTransitionState>(IDLE_TRANSITION);
+
+  const openSheetIdsChanged = !stacksEqual(
+    committedOpenSheetIdsRef.current,
+    openSheetIds,
+  );
+  const visibleTransition = openSheetIdsChanged
+    ? transitionForOpenSheetIdsChange(
+        committedOpenSheetIdsRef.current,
+        openSheetIds,
+      )
+    : transition;
+  const topSheet = openSheetIds[openSheetIds.length - 1] ?? null;
+  const isStackVisible =
+    topSheet != null || visibleTransition.exitingSheet != null;
+  const isModal = hasScrim && isStackVisible;
+  const topSheetPurpose =
+    (topSheet == null
+      ? visibleTransition.exitingSheet == null
+        ? null
+        : sheetPurposes.get(visibleTransition.exitingSheet)
+      : sheetPurposes.get(topSheet)) ?? 'info';
+  const allowsEscapeDismiss = topSheetPurpose !== 'required';
+  const allowsLightDismiss = topSheetPurpose === 'info';
+
+  useDevWarning(
+    'BottomSheetStack',
+    '`openSheetIds` must contain unique BottomSheet IDs ordered bottom-to-top.',
+    new Set(openSheetIds).size !== openSheetIds.length,
+  );
+
+  useLayoutEffect(() => {
+    const previousSheets = committedOpenSheetIdsRef.current;
+    if (stacksEqual(previousSheets, openSheetIds)) {
+      return;
+    }
+    committedOpenSheetIdsRef.current = [...openSheetIds];
+    const nextTransition = transitionForOpenSheetIdsChange(
+      previousSheets,
+      openSheetIds,
+    );
+    setTransition(
+      nextTransition.exitingSheet != null &&
+        !sheetElementsRef.current.has(nextTransition.exitingSheet)
+        ? IDLE_TRANSITION
+        : nextTransition,
+    );
+  }, [openSheetIds]);
+
+  const requestTopDismiss = useCallback(() => {
+    if (topSheet != null) {
+      onOpenSheetIdsChange(openSheetIds.slice(0, -1));
+    }
+  }, [onOpenSheetIdsChange, openSheetIds, topSheet]);
+  const dismissOnEscape = useCallback(() => {
+    if (allowsEscapeDismiss) {
+      requestTopDismiss();
+    }
+  }, [allowsEscapeDismiss, requestTopDismiss]);
+  const dismissOnLightInteraction = useCallback(() => {
+    if (allowsLightDismiss) {
+      requestTopDismiss();
+    }
+  }, [allowsLightDismiss, requestTopDismiss]);
+
+  const {containerRef} = useFocusTrap<HTMLDialogElement>({
+    isActive: isModal,
+  });
+  const {shouldDismissOnCloseRequest} = useLayerDismissal({
+    isActive: isStackVisible,
+    escapeBehavior: allowsEscapeDismiss ? 'close' : 'block',
+    onDismiss: dismissOnEscape,
+    getContainer: () => dialogRef.current,
+    isPresent: () => dialogRef.current?.open ?? false,
+  });
+  useScrollLock(isModal);
+
+  useLayoutEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog == null) {
+      return;
+    }
+
+    if (isStackVisible) {
+      const nextMode = hasScrim ? 'modal' : 'non-modal';
+      if (dialog.open && dialogModeRef.current !== nextMode) {
+        dialog.close();
+      }
+      if (!dialog.open) {
+        if (hasScrim && triggerRef.current == null) {
+          triggerRef.current = document.activeElement as HTMLElement | null;
+        }
+        if (hasScrim) {
+          dialog.showModal();
+        } else {
+          dialog.show();
+        }
+      }
+      dialogModeRef.current = nextMode;
+      return;
+    }
+
+    if (dialog.open) {
+      dialog.close();
+    }
+    if (dialogModeRef.current === 'modal') {
+      triggerRef.current?.focus();
+    }
+    triggerRef.current = null;
+    dialogModeRef.current = null;
+  }, [hasScrim, isStackVisible]);
+
+  const getSheetPhase = useCallback(
+    (sheetId: string): BottomSheetStackPhase => {
+      if (sheetId === visibleTransition.exitingSheet) {
+        return 'exiting';
+      }
+      const sheetIndex = openSheetIds.lastIndexOf(sheetId);
+      if (sheetIndex < 0) {
+        return 'hidden';
+      }
+      if (sheetIndex === openSheetIds.length - 1) {
+        return sheetId === visibleTransition.enteringSheet
+          ? 'entering'
+          : 'active';
+      }
+      return 'covered';
+    },
+    [openSheetIds, visibleTransition],
+  );
+
+  const getSheetDepth = useCallback(
+    (sheetId: string) => {
+      const sheetIndex = openSheetIds.lastIndexOf(sheetId);
+      return sheetIndex < 0 ? 0 : openSheetIds.length - 1 - sheetIndex;
+    },
+    [openSheetIds],
+  );
+
+  const getSheetLayer = useCallback(
+    (sheetId: string) => {
+      if (sheetId === visibleTransition.exitingSheet) {
+        return openSheetIds.length + 1;
+      }
+      const sheetIndex = openSheetIds.lastIndexOf(sheetId);
+      return sheetIndex < 0 ? 0 : sheetIndex + 1;
+    },
+    [openSheetIds, visibleTransition.exitingSheet],
+  );
+
+  const registerSheetElement = useCallback(
+    (sheetId: string, element: HTMLElement | null) => {
+      if (element == null) {
+        sheetElementsRef.current.delete(sheetId);
+        setTransition(current =>
+          current.enteringSheet === sheetId || current.exitingSheet === sheetId
+            ? IDLE_TRANSITION
+            : current,
+        );
+      } else {
+        sheetElementsRef.current.set(sheetId, element);
+      }
+    },
+    [],
+  );
+
+  const registerSheetLabel = useCallback(
+    (sheetId: string, label: string | null) => {
+      setSheetLabels(current => {
+        if (label == null) {
+          if (!current.has(sheetId)) {
+            return current;
+          }
+          const next = new Map(current);
+          next.delete(sheetId);
+          return next;
+        }
+        if (current.get(sheetId) === label) {
+          return current;
+        }
+        const next = new Map(current);
+        next.set(sheetId, label);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const registerSheetPurpose = useCallback(
+    (sheetId: string, purpose: DialogPurpose | null) => {
+      setSheetPurposes(current => {
+        if (purpose == null) {
+          if (!current.has(sheetId)) {
+            return current;
+          }
+          const next = new Map(current);
+          next.delete(sheetId);
+          return next;
+        }
+        if (current.get(sheetId) === purpose) {
+          return current;
+        }
+        const next = new Map(current);
+        next.set(sheetId, purpose);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const onSheetTransitionComplete = useCallback(
+    ({sheetId, phase}: BottomSheetStackTransitionEvent) => {
+      setTransition(current => {
+        if (phase === 'entering' && current.enteringSheet === sheetId) {
+          return {...current, enteringSheet: null};
+        }
+        if (phase === 'exiting' && current.exitingSheet === sheetId) {
+          return {...current, exitingSheet: null};
+        }
+        return current;
+      });
+    },
+    [],
+  );
+
+  const setScrimOpacity = useCallback((opacity: number) => {
+    dialogRef.current?.style.setProperty(
+      '--_sheet-scrim-opacity',
+      String(opacity),
+    );
+  }, []);
+  const onSheetScrimOpacityChange = useCallback(
+    (sheetId: string, opacity: number) => {
+      const committedSheets = committedOpenSheetIdsRef.current;
+      if (sheetId !== committedSheets[committedSheets.length - 1]) {
+        return;
+      }
+      setScrimOpacity(opacity);
+    },
+    [setScrimOpacity],
+  );
+
+  useLayoutEffect(() => {
+    setScrimOpacity(topSheet == null ? 0 : 1);
+  }, [setScrimOpacity, topSheet]);
+
+  const contextValue = useMemo<BottomSheetStackContextValue>(
+    () => ({
+      openSheetIds,
+      topSheet,
+      hasScrim,
+      requestTopDismiss,
+      getSheetPhase,
+      getSheetDepth,
+      getSheetLayer,
+      registerSheetElement,
+      registerSheetLabel,
+      registerSheetPurpose,
+      onSheetTransitionComplete,
+      onSheetScrimOpacityChange,
+    }),
+    [
+      getSheetDepth,
+      getSheetLayer,
+      getSheetPhase,
+      hasScrim,
+      onSheetScrimOpacityChange,
+      onSheetTransitionComplete,
+      openSheetIds,
+      registerSheetElement,
+      registerSheetLabel,
+      registerSheetPurpose,
+      requestTopDismiss,
+      topSheet,
+    ],
+  );
+
+  const activeLabel =
+    (topSheet == null ? null : sheetLabels.get(topSheet)) ??
+    (visibleTransition.exitingSheet == null
+      ? undefined
+      : sheetLabels.get(visibleTransition.exitingSheet));
+
+  const handleCancel = useCallback(
+    (event: SyntheticEvent<HTMLDialogElement>) => {
+      event.preventDefault();
+      if (shouldDismissOnCloseRequest()) {
+        dismissOnEscape();
+      }
+    },
+    [dismissOnEscape, shouldDismissOnCloseRequest],
+  );
+  const handleClick = useCallback(
+    (event: ReactMouseEvent<HTMLDialogElement>) => {
+      if (hasScrim && event.target === event.currentTarget) {
+        dismissOnLightInteraction();
+      }
+    },
+    [dismissOnLightInteraction, hasScrim],
+  );
+
+  const dialogStyleProps = stylex.props(
+    styles.dialog,
+    isStackVisible && styles.dialogOpen,
+    hasScrim && styles.scrim,
+    !hasScrim && styles.dialogNonModal,
+    xstyle,
+  );
+  const dialogPresentationProps = mergeProps(
+    dialogStyleProps,
+    className,
+    style,
+  );
+  const ariaLabel =
+    props['aria-label'] ??
+    (props['aria-labelledby'] == null ? activeLabel : undefined);
+
+  return (
+    <BottomSheetSwitcherContext value={null}>
+      <BottomSheetStackContext value={contextValue}>
+        <dialog
+          {...props}
+          {...dialogPresentationProps}
+          ref={useMergedRefs(ref, dialogRef, containerRef)}
+          aria-label={ariaLabel}
+          aria-modal={isModal ? 'true' : undefined}
+          onCancel={composeEventHandlers(onCancel, handleCancel)}
+          onClick={composeEventHandlers(onClick, handleClick)}
+          {...(topSheetPurpose === 'required'
+            ? {role: 'alertdialog'}
+            : undefined)}>
+          <LayerDepthProvider>{children}</LayerDepthProvider>
+          <BottomSheetEdgeTint />
+        </dialog>
+      </BottomSheetStackContext>
+    </BottomSheetSwitcherContext>
+  );
+}
+
+BottomSheetStack.displayName = 'BottomSheetStack';

--- a/packages/core/src/BottomSheet/BottomSheetStackContext.ts
+++ b/packages/core/src/BottomSheet/BottomSheetStackContext.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file BottomSheetStackContext.ts
+ * @input Uses React context
+ * @output Internal stack phase and lifecycle context shared by BottomSheetStack and BottomSheet
+ * @position Private coordination layer for visibly stacked BottomSheets
+ */
+
+import {createContext} from 'react';
+import type {DialogPurpose} from '../Dialog';
+
+export type BottomSheetStackPhase =
+  'entering' | 'active' | 'covered' | 'exiting' | 'hidden';
+
+export interface BottomSheetStackTransitionEvent {
+  sheetId: string;
+  phase: 'entering' | 'exiting';
+}
+
+export interface BottomSheetStackContextValue {
+  openSheetIds: ReadonlyArray<string>;
+  topSheet: string | null;
+  hasScrim: boolean;
+  requestTopDismiss: () => void;
+  getSheetPhase: (sheetId: string) => BottomSheetStackPhase;
+  getSheetDepth: (sheetId: string) => number;
+  getSheetLayer: (sheetId: string) => number;
+  registerSheetElement: (sheetId: string, element: HTMLElement | null) => void;
+  registerSheetLabel: (sheetId: string, label: string | null) => void;
+  registerSheetPurpose: (
+    sheetId: string,
+    purpose: DialogPurpose | null,
+  ) => void;
+  onSheetTransitionComplete: (event: BottomSheetStackTransitionEvent) => void;
+  onSheetScrimOpacityChange: (sheetId: string, opacity: number) => void;
+}
+
+export const BottomSheetStackContext =
+  createContext<BottomSheetStackContextValue | null>(null);
+
+BottomSheetStackContext.displayName = 'BottomSheetStackContext';

--- a/packages/core/src/BottomSheet/BottomSheetSwitcher.tsx
+++ b/packages/core/src/BottomSheet/BottomSheetSwitcher.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file BottomSheetSwitcher.tsx
- * @input Uses React context, StyleX, theme tokens, focus/scroll-lock hooks, BottomSheetSwitcherContext
+ * @input Uses React context, StyleX, theme tokens, focus/scroll-lock hooks, sheet controller contexts
  * @output Exports BottomSheetSwitcher and BottomSheetSwitcherProps
  * @position Core switcher for mutually exclusive BottomSheet flows
  *
@@ -22,6 +22,7 @@
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/BottomSheet/BottomSheet.tsx
+ * - /packages/core/src/BottomSheet/BottomSheetStackContext.ts
  * - /packages/core/src/BottomSheet/BottomSheetEdgeTint.tsx
  * - /packages/core/src/BottomSheet/BottomSheetSwitcher.doc.mjs
  * - /packages/core/src/BottomSheet/BottomSheetSwitcher.test.tsx
@@ -53,6 +54,7 @@ import {
 } from '../hooks';
 import {composeEventHandlers, mergeProps} from '../utils';
 import {BottomSheetEdgeTint} from './BottomSheetEdgeTint';
+import {BottomSheetStackContext} from './BottomSheetStackContext';
 import {
   BottomSheetSwitcherContext,
   type BottomSheetSwitcherContextValue,
@@ -618,23 +620,25 @@ export function BottomSheetSwitcher({
     (props['aria-labelledby'] == null ? activeLabel : undefined);
 
   return (
-    <BottomSheetSwitcherContext value={contextValue}>
-      <dialog
-        {...props}
-        {...dialogPresentationProps}
-        ref={useMergedRefs(ref, dialogRef, containerRef)}
-        aria-label={ariaLabel}
-        aria-modal={isModal ? 'true' : undefined}
-        onCancel={composeEventHandlers(onCancel, handleCancel)}
-        onClick={composeEventHandlers(onClick, handleClick)}
-        onKeyDown={composeEventHandlers(onKeyDown, handleKeyDown)}
-        {...(activeSheetPurpose === 'required'
-          ? {role: 'alertdialog'}
-          : undefined)}>
-        {children}
-        <BottomSheetEdgeTint />
-      </dialog>
-    </BottomSheetSwitcherContext>
+    <BottomSheetStackContext value={null}>
+      <BottomSheetSwitcherContext value={contextValue}>
+        <dialog
+          {...props}
+          {...dialogPresentationProps}
+          ref={useMergedRefs(ref, dialogRef, containerRef)}
+          aria-label={ariaLabel}
+          aria-modal={isModal ? 'true' : undefined}
+          onCancel={composeEventHandlers(onCancel, handleCancel)}
+          onClick={composeEventHandlers(onClick, handleClick)}
+          onKeyDown={composeEventHandlers(onKeyDown, handleKeyDown)}
+          {...(activeSheetPurpose === 'required'
+            ? {role: 'alertdialog'}
+            : undefined)}>
+          {children}
+          <BottomSheetEdgeTint />
+        </dialog>
+      </BottomSheetSwitcherContext>
+    </BottomSheetStackContext>
   );
 }
 

--- a/packages/core/src/BottomSheet/index.ts
+++ b/packages/core/src/BottomSheet/index.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file index.ts
- * @input BottomSheet.tsx, BottomSheetSwitcher.tsx
+ * @input BottomSheet.tsx, BottomSheetStack.tsx, BottomSheetSwitcher.tsx
  * @output Re-exports the BottomSheet public API
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  */
@@ -15,5 +15,7 @@ export type {
   BottomSheetProps,
   BottomSheetSnapPoint,
 } from './BottomSheet';
+export {BottomSheetStack} from './BottomSheetStack';
+export type {BottomSheetStackProps} from './BottomSheetStack';
 export {BottomSheetSwitcher} from './BottomSheetSwitcher';
 export type {BottomSheetSwitcherProps} from './BottomSheetSwitcher';


### PR DESCRIPTION
## Summary

This is a working prototype for API review of `BottomSheetStack`.

- adds a controlled ordered-stack API beside `BottomSheetSwitcher`
- keeps one shared native dialog, scrim, focus boundary, dismissal owner, and scroll lock
- keeps covered sheets mounted but inert and accessibility-hidden
- scales/translates the nearest two covered sheets while the top sheet enters or exits
- dismisses only the top sheet on Escape, scrim click, or swipe
- preserves focus within a covered sheet and restores it when that sheet becomes active again

## Proposed API

```tsx
const [openSheetIds, setOpenSheetIds] =
  useState<ReadonlyArray<string>>([]);

const push = (sheetId: string) =>
  setOpenSheetIds(current => [...current, sheetId]);
const pop = () =>
  setOpenSheetIds(current => current.slice(0, -1));

<BottomSheetStack
  openSheetIds={openSheetIds}
  onOpenSheetIdsChange={setOpenSheetIds}>
  <BottomSheet sheetId="filters" label="Filters">
    <Filters />
    <Button label="Show details" onClick={() => push('details')} />
  </BottomSheet>
  <BottomSheet sheetId="details" label="Filter details">
    <FilterDetails />
    <Button label="Back" onClick={pop} />
  </BottomSheet>
</BottomSheetStack>
```

`openSheetIds` is ordered bottom-to-top. An empty array closes the stack. `BottomSheetSwitcher` remains the mutually-exclusive replacement-step API; it is not widened to accept arrays.

## Design choices

- The ordered controlled array is the source of truth; no imperative `push()` / `pop()` API and no hidden ordering inferred from independent child booleans.
- `BottomSheet` keeps its existing `sheetId`, content, height, snap-point, and purpose props.
- Stacking motion is opinionated in the first API rather than exposing Silk-style arbitrary `stackingAnimation` functions.
- Append and single suffix-pop receive the full transition. Other controlled array changes converge to the requested state without promising bespoke motion.

## Validation

- `pnpm lint:strict`
- `pnpm build`
- `pnpm check:repo`
- Core, Core docs, CLI strict/template docs, and Storybook typechecks
- BottomSheet suite: 211 tests passed
- Storybook production build
- Real Chromium check at 390×844: two levels measured `0.96 / -8px`; three levels measured `0.92 / -16px`, `0.96 / -8px`, `1 / 0px`; only the top layer was interactive
- Full `pnpm test` was also run. Its six failures reproduce on current `main`: two ContextMenu BottomSheet tests, two known story-tree failures, and two discovery timeouts that pass in isolation.
