### PR TITLE
fix(ci): preserve approved spec owner status

### DIFF
--- a/.github/scripts/spec-owner-reconcile.cjs
+++ b/.github/scripts/spec-owner-reconcile.cjs
@@ -160,6 +160,13 @@ async function reconcileSpecOwnerGate({
     return newest === null || newest.runId <= runId;
   }
 
+  async function currentPullForRun(headSha) {
+    const current = await getPullRequest();
+    if (current.head.sha !== headSha) return null;
+    if (!(await isCurrentRun(headSha))) return null;
+    return current;
+  }
+
   async function setFinalStatus(headSha, state, description) {
     if (!(await isCurrentRun(headSha))) return false;
     await createStatus({
@@ -431,9 +438,7 @@ async function reconcileSpecOwnerGate({
     throw new Error('No ENGOWNERS or DESIGNOWNERS are configured.');
   }
   const designApprovers = [...new Set([...specOwners, ...designOwners])];
-  const themeApprovers = [
-    ...new Set([...engineeringOwners, ...designOwners]),
-  ];
+  const themeApprovers = [...new Set([...engineeringOwners, ...designOwners])];
   const readyAttestations = parseReadyAttestations(statuses, {
     repository,
     headSha: initialHead,
@@ -455,9 +460,7 @@ async function reconcileSpecOwnerGate({
     ? resolveOwnerDecision({...decisionInput, owners: themeApprovers})
     : {approved: true, owner: null};
   const approved =
-    specDecision.approved &&
-    designDecision.approved &&
-    themeDecision.approved;
+    specDecision.approved && designDecision.approved && themeDecision.approved;
   const approvingOwners = [
     specDecision.owner,
     designDecision.owner,
@@ -520,16 +523,26 @@ async function reconcileSpecOwnerGate({
     return;
   }
 
+  // Owner approval is the gate decision; auto-merge is an optional convenience.
+  // Publish the truthful terminal status first so an integration permission
+  // failure cannot leave an approved head stuck on "Reconciling".
+  if (!(await setFinalStatus(initialHead, 'success', successDescription))) {
+    return;
+  }
+  await removeLabel(env.REVIEW_LABEL);
+
   let enabledAutoMergeByThisRun = false;
   if (!pr.auto_merge) {
-    if (!(await isCurrentRun(initialHead))) return;
+    const beforeEnable = await currentPullForRun(initialHead);
+    if (beforeEnable === null || beforeEnable.auto_merge) return;
     await ensureLabel(
-      pr,
+      beforeEnable,
       env.AUTO_MERGE_LABEL,
       'bfdadc',
       'Auto-merge was enabled by the spec owner gate',
     );
-    if (!(await isCurrentRun(initialHead))) return;
+    const afterLabel = await currentPullForRun(initialHead);
+    if (afterLabel === null || afterLabel.auto_merge) return;
     try {
       await github.graphql(
         `mutation($id: ID!, $oid: GitObjectID!) {
@@ -546,6 +559,11 @@ async function reconcileSpecOwnerGate({
       enabledAutoMergeByThisRun = true;
       core.info(`Enabled squash auto-merge for spec-only PR #${pullNumber}.`);
     } catch (error) {
+      // Leave the conservative ownership marker intact. The failure may be an
+      // ambiguous response after a successful enable, or a newer run for the
+      // same or a newer head may already be using the global marker. A stale
+      // marker with auto-merge off is harmless: later reconciliation observes the real PR
+      // state and can retry or remove it without racing a newer owner.
       core.warning(`Could not enable auto-merge: ${error.message}`);
       return;
     }
@@ -564,10 +582,6 @@ async function reconcileSpecOwnerGate({
       return;
     }
   }
-
-  if (!(await isCurrentRun(initialHead))) return;
-  await removeLabel(env.REVIEW_LABEL);
-  await setFinalStatus(initialHead, 'success', successDescription);
 }
 
 module.exports = {isCommandComment, reconcileSpecOwnerGate};

--- a/.github/scripts/spec-owner-reconcile.test.mjs
+++ b/.github/scripts/spec-owner-reconcile.test.mjs
@@ -3,6 +3,7 @@
 /* global Buffer */
 
 import {createRequire} from 'node:module';
+import fs from 'node:fs';
 import path from 'node:path';
 import {describe, expect, it} from 'vitest';
 
@@ -252,6 +253,133 @@ describe('spec owner workflow reconciliation', () => {
     ).toBe(true);
     expect(latestGateStatus(harness.state).state).toBe('success');
     expect(harness.state.calls).toContain('enable-auto-merge');
+  });
+
+  it('publishes owner approval and keeps conservative ownership when enablement is rejected', async () => {
+    const harness = createHarness({
+      onEnableAutoMerge: () => {
+        const error = new Error('Resource not accessible by integration');
+        error.status = 403;
+        throw error;
+      },
+    });
+
+    await run(harness, context({runId: 100n}));
+
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'success',
+      description: expect.stringContaining('Approved by @cixzhang'),
+    });
+    const terminalStatus = harness.state.calls.indexOf(
+      'status:spec-owner-approval:success',
+    );
+    const warning = harness.state.calls.findIndex(call =>
+      call.includes('Could not enable auto-merge'),
+    );
+    expect(terminalStatus).toBeGreaterThan(-1);
+    expect(warning).toBeGreaterThan(terminalStatus);
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+    expect(harness.state.labels.has('spec-auto-merge')).toBe(true);
+    expect(harness.state.calls).not.toContain('remove-label:spec-auto-merge');
+    expect(harness.state.calls).not.toContain('disable-auto-merge');
+    expect(harness.state.pr.auto_merge).toBe(null);
+  });
+
+  it('preserves the marker when an ambiguous enable error follows a successful mutation', async () => {
+    const harness = createHarness({
+      onEnableAutoMerge: state => {
+        state.pr.auto_merge = {merge_method: 'squash'};
+        state.calls.push('auto-merge-applied-before-error');
+        const error = new Error('The response was lost after the mutation.');
+        error.status = 502;
+        throw error;
+      },
+    });
+
+    await run(harness, context({runId: 100n}));
+
+    expect(latestGateStatus(harness.state).state).toBe('success');
+    expect(harness.state.pr.auto_merge).toEqual({merge_method: 'squash'});
+    expect(harness.state.labels.has('spec-auto-merge')).toBe(true);
+    expect(harness.state.calls).not.toContain('remove-label:spec-auto-merge');
+    expect(harness.state.calls).not.toContain('disable-auto-merge');
+  });
+
+  it('does not let an old failure erase newer same-head auto-merge ownership', async () => {
+    const harness = createHarness({
+      onEnableAutoMerge: state => {
+        // The old run added the marker, then a newer run for the same exact
+        // head enabled auto-merge before the old request returned an error.
+        state.statuses.unshift(
+          trustedStatus({runId: 101n, sha: head, state: 'success'}),
+        );
+        state.pr.auto_merge = {merge_method: 'squash'};
+        state.labels.add('spec-auto-merge');
+        state.pr.labels = [{name: 'spec-auto-merge'}];
+        state.calls.push('newer-run-enabled-auto-merge');
+        const error = new Error('The old enable request was rejected.');
+        error.status = 422;
+        throw error;
+      },
+    });
+
+    await run(harness, context({runId: 100n}));
+
+    expect(
+      harness.state.statuses.some(
+        status =>
+          status.sha === head &&
+          status.context === 'spec-owner-approval' &&
+          status.state === 'success' &&
+          status.target_url === canonicalRunUrl(repository, '100', '1'),
+      ),
+    ).toBe(true);
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'success',
+      target_url: canonicalRunUrl(repository, '101', '1'),
+    });
+    expect(harness.state.pr.head.sha).toBe(head);
+    expect(harness.state.pr.auto_merge).toEqual({merge_method: 'squash'});
+    expect(harness.state.labels.has('spec-auto-merge')).toBe(true);
+    const oldMarker = harness.state.calls.indexOf('add-label:spec-auto-merge');
+    const newerOwner = harness.state.calls.indexOf(
+      'newer-run-enabled-auto-merge',
+    );
+    expect(oldMarker).toBeGreaterThan(-1);
+    expect(newerOwner).toBeGreaterThan(oldMarker);
+    expect(harness.state.calls).not.toContain('remove-label:spec-auto-merge');
+    expect(harness.state.calls).not.toContain('disable-auto-merge');
+  });
+
+  it('keeps terminal approval before a non-destructive enable failure path', () => {
+    const source = fs.readFileSync(
+      path.join(workspace, '.github/scripts/spec-owner-reconcile.cjs'),
+      'utf8',
+    );
+    const specOnlyPath = source.slice(
+      source.indexOf('// Owner approval is the gate decision'),
+    );
+    const terminalStatus = specOnlyPath.indexOf(
+      "setFinalStatus(initialHead, 'success', successDescription)",
+    );
+    const enable = specOnlyPath.indexOf('enablePullRequestAutoMerge');
+    const catchStart = specOnlyPath.indexOf('} catch (error) {', enable);
+    const catchEnd = specOnlyPath.indexOf(
+      '\n    }\n  }\n\n  if (enabledAutoMergeByThisRun)',
+      catchStart,
+    );
+    const catchBlock = specOnlyPath.slice(catchStart, catchEnd);
+
+    expect(terminalStatus).toBeGreaterThan(-1);
+    expect(enable).toBeGreaterThan(terminalStatus);
+    expect(catchStart).toBeGreaterThan(enable);
+    expect(catchEnd).toBeGreaterThan(catchStart);
+    expect(catchBlock).toContain(
+      'Leave the conservative ownership marker intact.',
+    );
+    expect(catchBlock).not.toContain('removeLabel');
+    expect(catchBlock).not.toContain('disableAutoMerge');
+    expect(catchBlock).not.toContain('cleanupFailedAutoMergeEnable');
   });
 
   it('does not attest ready_for_review by a non-owner author', async () => {


### PR DESCRIPTION
## Why

An exact-head spec-owner approval was published only after optional auto-merge enablement. If GitHub rejected that convenience mutation, the workflow exited successfully while the required `spec-owner-approval` context remained pending on “Reconciling exact head.” Destructive failed-enable cleanup could also race a newer same-head run and erase its global ownership marker.

## What

- Publish the truthful terminal owner decision before attempting auto-merge.
- Keep auto-merge best-effort and perform no destructive cleanup when enablement returns an error.
- Preserve the conservative ownership marker after definitive and ambiguous failures; a stale marker with auto-merge off is harmless, while deleting it can race a newer owner.
- Keep exact-head/current-run checks before the enable attempt and existing post-success revoke protection.

## Risk

The approval decision and exact-head checks are unchanged. Later reconciliation observes actual `auto_merge` state and can retry, remove the marker, or disable gate-owned auto-merge through the normal exact-head path.

## Testing

- 50 focused spec-owner workflow/helper tests
- Same-head newer-run takeover and ambiguous-success regressions
- Source contract proving terminal status precedes enablement and the catch path cannot remove the label or disable auto-merge
- actionlint, Prettier, `pnpm check:repo`, and pre-commit repository checks

No Changeset: workflow-only infrastructure change.