### PR TITLE
ci: protect DESIGNOWNER self-merge for design records

### DIFF
--- a/.github/DESIGNOWNERS
+++ b/.github/DESIGNOWNERS
@@ -1,13 +1,18 @@
 # Design owners for the Astryx repository
-# Design-team members. This list has two responsibilities:
+# Design-team members. This list has three responsibilities:
 #
 # - Current design specs and normative design assets may receive exact-head
 #   approval from any DESIGNOWNER, cixzhang, or imdreamrunner.
+# - A DESIGNOWNER author may attest an exact PR head by marking the PR ready for
+#   review. That evidence satisfies the design-approval group even in a mixed PR;
+#   every other applicable code or spec-owner group remains required. The
+#   existing gate may enable squash auto-merge only when every changed path is a
+#   recognized spec record and every required group and branch check passes.
 # - Review tooling may use the list to frame design-authored changes.
 #
-# This does not grant general merge rights or exempt an author from engineering
-# review. Mixed PRs still need cixzhang or imdreamrunner for every non-design
-# current record.
+# This is not general merge permission. A design attestation alone never
+# authorizes non-design records or mixed code/spec changes, and any code path
+# prevents the spec-only auto-merge path.
 #
 # Uses the same @handle format as CODEOWNERS. Keep this list current.
 

--- a/.github/REVIEW_GATE.md
+++ b/.github/REVIEW_GATE.md
@@ -33,6 +33,17 @@ with their read-only token, so an approver uses an issue comment containing
 `/approve-spec <full-head-sha>` instead; that command runs from the trusted
 default branch and a new commit invalidates it.
 
+When a DESIGNOWNER authors a PR, marking it ready for review attests that exact
+head for the design-approval group. That evidence also counts when the PR
+contains non-design current records, but every other applicable code or
+spec-owner group remains separately required.
+
+The attestation does not grant auto-merge by itself. The existing gate may enable
+squash auto-merge only when every changed path is a recognized spec record,
+every required owner group has approved the exact head, and all branch checks
+pass. Normative assets and indexes are outside that scope; adding any code path
+also prevents the spec-only auto-merge path.
+
 A PR changes only spec records when every changed path is one of:
 
 - `docs/specs/<id>/spec.md` or `plan.md`;

--- a/.github/scripts/spec-owner-reconcile.test.mjs
+++ b/.github/scripts/spec-owner-reconcile.test.mjs
@@ -90,15 +90,18 @@ function createHarness({
   timeline = [],
   labels = [],
   autoMerge = null,
+  draft = false,
   onPullGet,
   onEnableAutoMerge,
   changedFile = {
     filename: 'docs/specs/owner-ready/spec.md',
     status: 'added',
   },
+  changedFiles,
   headContent = 'kind: architecture\nauthority: current\n',
   baseContent = '',
 } = {}) {
+  const files = changedFiles ?? [changedFile];
   const state = {
     pullGets: 0,
     statuses: [...statuses],
@@ -117,10 +120,10 @@ function createHarness({
         sha: '2222222222222222222222222222222222222222',
         repo: {full_name: repository},
       },
-      changed_files: 1,
+      changed_files: files.length,
       labels: [],
       auto_merge: autoMerge,
-      draft: false,
+      draft,
     },
   };
 
@@ -136,7 +139,7 @@ function createHarness({
       syncLabels();
       return {data: state.pr};
     },
-    listFiles: async () => ({data: [changedFile]}),
+    listFiles: async () => ({data: files}),
     listReviews: async () => ({data: state.reviews}),
     listComments: async () => ({data: state.comments}),
     listTimeline: async () => ({data: state.timeline}),
@@ -240,6 +243,27 @@ function latestGateStatus(state) {
   );
 }
 
+const designRecord = {
+  filename: 'docs/design/interaction-states.md',
+  status: 'added',
+};
+const currentDesign = 'kind: design\nauthority: current\n';
+
+function createDesignHarness(options = {}) {
+  return createHarness({
+    author: 'ernestt',
+    changedFile: designRecord,
+    headContent: currentDesign,
+    ...options,
+  });
+}
+
+function hasReadyAttestation(state, owner = 'ernestt') {
+  return state.statuses.some(
+    status => status.context === `spec-owner-ready/${owner}`,
+  );
+}
+
 describe('spec owner workflow reconciliation', () => {
   it('treats an eligible owner-author ready event as exact-head approval', async () => {
     const harness = createHarness();
@@ -253,6 +277,105 @@ describe('spec owner workflow reconciliation', () => {
     ).toBe(true);
     expect(latestGateStatus(harness.state).state).toBe('success');
     expect(harness.state.calls).toContain('enable-auto-merge');
+  });
+
+  it('lets a DESIGNOWNER author self-attest an exact design-record-only head', async () => {
+    const harness = createDesignHarness();
+
+    await run(
+      harness,
+      context({runId: 100n, actor: 'ernestt', author: 'ernestt'}),
+    );
+
+    expect(hasReadyAttestation(harness.state)).toBe(true);
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'success',
+      description: expect.stringContaining('Approved by @ernestt'),
+    });
+    expect(harness.state.calls).toContain('enable-auto-merge');
+  });
+
+  it('requires the ready actor to be the PR author', async () => {
+    const harness = createDesignHarness();
+
+    await run(
+      harness,
+      context({runId: 100n, actor: 'rubyycheung', author: 'ernestt'}),
+    );
+
+    expect(hasReadyAttestation(harness.state, 'rubyycheung')).toBe(false);
+    expect(latestGateStatus(harness.state).state).toBe('pending');
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+  });
+
+  it('requires the ready event to identify the exact live head', async () => {
+    const harness = createDesignHarness();
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        actor: 'ernestt',
+        author: 'ernestt',
+        headSha: nextHead,
+      }),
+    );
+
+    expect(hasReadyAttestation(harness.state)).toBe(false);
+    expect(latestGateStatus(harness.state).state).toBe('pending');
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+  });
+
+  it('keeps a DESIGNOWNER ready marker outside the spec-only auto-merge path', async () => {
+    const harness = createDesignHarness({
+      changedFiles: [
+        designRecord,
+        {
+          filename: 'packages/core/src/Button/Button.tsx',
+          status: 'modified',
+        },
+      ],
+    });
+
+    await run(
+      harness,
+      context({runId: 100n, actor: 'ernestt', author: 'ernestt'}),
+    );
+
+    // The exact-head marker is evidence for applicable owner groups, not merge
+    // authority. Mixed code/spec scope must stop before auto-merge enablement.
+    expect(hasReadyAttestation(harness.state)).toBe(true);
+    expect(latestGateStatus(harness.state).state).toBe('success');
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+    expect(harness.state.pr.auto_merge).toBe(null);
+  });
+
+  it('requires a real ready transition and never auto-merges a draft PR', async () => {
+    const readyDraft = createDesignHarness({draft: true});
+
+    await run(
+      readyDraft,
+      context({runId: 100n, actor: 'ernestt', author: 'ernestt'}),
+    );
+
+    expect(hasReadyAttestation(readyDraft.state)).toBe(true);
+    expect(readyDraft.state.calls).not.toContain('enable-auto-merge');
+    expect(readyDraft.state.pr.auto_merge).toBe(null);
+
+    const synchronizedDraft = createDesignHarness({draft: true});
+    await run(
+      synchronizedDraft,
+      context({
+        runId: 101n,
+        action: 'synchronize',
+        actor: 'ernestt',
+        author: 'ernestt',
+      }),
+    );
+
+    expect(hasReadyAttestation(synchronizedDraft.state)).toBe(false);
+    expect(synchronizedDraft.state.calls).not.toContain('enable-auto-merge');
+    expect(synchronizedDraft.state.pr.auto_merge).toBe(null);
   });
 
   it('publishes owner approval and keeps conservative ownership when enablement is rejected', async () => {

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,4 +20,12 @@ and normative asset updates require exact-head approval from `cixzhang`,
 needs `cixzhang` or `imdreamrunner` for non-design current records. The design
 record names its content owners separately from this repository gate.
 
+A DESIGNOWNER author may attest the exact PR head for the design-approval group
+by marking it ready for review. That evidence also counts in a mixed PR, while
+every other applicable code or spec-owner group remains required. The existing
+gate may enable squash auto-merge only when every changed path is a recognized
+spec record, every required group has approved, and all branch checks pass.
+Normative assets and indexes are outside that scope; any code path prevents the
+spec-only auto-merge path.
+
 Use `docs/templates/knowledge/design-spec.md`.


### PR DESCRIPTION
## Why

The exact-head owner gate already lets an eligible owner-author attest through ready-for-review, and recognized spec-record scope already uses the spec-only auto-merge path. That DESIGNOWNER behavior was implicit and lacked boundary-sensitive regression coverage.

## What

- Document that a DESIGNOWNER author ready-for-review attestation counts as exact-head evidence for the design group, including in mixed PRs.
- Document that every other applicable code/spec group remains required and any code path prevents spec-only auto-merge.
- Prove author match, exact event head, mixed-code scope, draft protection, and actual ready-for-review transition boundaries.

## Risk

No production gate logic, owner union, knowledge checker, approval group, workflow, or path classifier changes. Approval ownership semantics are unchanged.

## Testing

- 86 focused owner-gate and scope tests
- Targeted actionlint
- Prettier
- `pnpm check:repo`
- `git diff --check`

No Changeset: policy documentation and CI regression coverage only.

## Integration

Based on current `main` after #5814; duplicate terminal-status and auto-merge failure safety logic/tests remain excluded.