### PR TITLE
docs(datetimeinput): straighten curly apostrophes in prop descriptions

### DIFF
--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -121,14 +121,14 @@ export const docs = {
       name: 'timeIncrement',
       type: '1 | 5 | 10 | 15 | 30',
       description:
-        'Minute step for arrow keys in Astryx’s typed time field. A non-default value keeps the Astryx time field in nativePicker modes because iOS treats native step as validation, not picker cadence. Ignored by the Astryx touch sheet, which uses wheels.',
+        'Minute step for arrow keys in Astryx\'s typed time field. A non-default value keeps the Astryx time field in nativePicker modes because iOS treats native step as validation, not picker cadence. Ignored by the Astryx touch sheet, which uses wheels.',
       default: '1',
     },
     {
       name: 'timeOptionInterval',
       type: '5 | 10 | 15 | 30 | 60',
       description:
-        'Minute cadence for the preset-time combobox on Astryx’s fine-pointer time field. Setting it keeps that Astryx time field even in nativePicker modes because the OS picker has no equivalent preset list. The Astryx touch sheet uses wheels.',
+        'Minute cadence for the preset-time combobox on Astryx\'s fine-pointer time field. Setting it keeps that Astryx time field even in nativePicker modes because the OS picker has no equivalent preset list. The Astryx touch sheet uses wheels.',
     },
     {
       name: 'hasClear',
@@ -309,7 +309,7 @@ export const docs = {
         name: 'Time options popover',
         required: false,
         description:
-          'A list of preset times at the timeOptionInterval cadence. Setting the prop retains Astryx’s text/combobox time field even when nativePicker otherwise selects native controls; the Astryx touch sheet uses wheels instead.',
+          'A list of preset times at the timeOptionInterval cadence. Setting the prop retains Astryx\'s text/combobox time field even when nativePicker otherwise selects native controls; the Astryx touch sheet uses wheels instead.',
       },
       {
         name: 'Clear button',


### PR DESCRIPTION
## What

Three DateTimeInput prop descriptions (`timeIncrement`, `timeOptionInterval`, `timeOptions`) used a curly apostrophe (U+2019) in "Astryx's" rather than a straight ASCII one. This is an AI-slop typographic tell (check 17, A4). Replaced each with an escaped straight apostrophe (`\'`) so the single-quoted JS strings still parse and CLI/Storybook output renders plain ASCII.

No behavior change; prose meaning is unchanged.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes (after core build)
- [x] File parse-checked; CLI `--props` render shows 0 curly apostrophes
- [x] Single file, prose strings only, meaning preserved

---
Night Watch — Doc Reviewer