### PR TITLE
fix(vibe-tests): run pnpm through cmd.exe on Windows in fixture-suite

### DIFF
--- a/internal/vibe-tests/src/fixture-suite.mjs
+++ b/internal/vibe-tests/src/fixture-suite.mjs
@@ -13,6 +13,22 @@ import {
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(HERE, '..', '..', '..');
+
+/**
+ * pnpm is a .cmd (batch) file on Windows. spawnSync can only run a batch
+ * file through a shell — a bare 'pnpm' fails with ENOENT (never resolved
+ * through PATHEXT) and an explicit 'pnpm.cmd' fails with EINVAL (batch files
+ * still require a shell even named exactly). Shelling out through cmd.exe
+ * /c directly, rather than spawnSync's shell:true, avoids Node's
+ * shell-argument-escaping deprecation warning (DEP0190) — every argument
+ * passed through here is a hardcoded literal, never user input, so we build
+ * the argv ourselves instead of asking spawnSync to build a shell string.
+ */
+function spawnPnpmSync(args, options) {
+  return process.platform === 'win32'
+    ? spawnSync('cmd.exe', ['/d', '/s', '/c', 'pnpm', ...args], options)
+    : spawnSync('pnpm', args, options);
+}
 export const FIXTURES_ROOT = path.join(
   REPO_ROOT,
   'internal',
@@ -447,8 +463,7 @@ function gitFixtureFiles(fixtureId, repoRoot = REPO_ROOT) {
 }
 
 function workspacePackagePaths(repoRoot = REPO_ROOT) {
-  const result = spawnSync(
-    'pnpm',
+  const result = spawnPnpmSync(
     ['list', '--recursive', '--depth', '-1', '--json'],
     {
       cwd: repoRoot,
@@ -456,7 +471,9 @@ function workspacePackagePaths(repoRoot = REPO_ROOT) {
     },
   );
   if (result.status !== 0)
-    fail(`pnpm workspace discovery failed: ${result.stderr.trim()}`);
+    fail(
+      `pnpm workspace discovery failed: ${(result.stderr ?? result.error?.message ?? '').trim()}`,
+    );
   return JSON.parse(result.stdout).map(entry => entry.path);
 }
 
@@ -618,15 +635,15 @@ export function refreshManifest(
   fs.writeFileSync(file, `${JSON.stringify(recipe, null, 2)}\n`);
 }
 
-function run(command, args, cwd) {
-  const result = spawnSync(command, args, {
+function runPnpm(args, cwd) {
+  const result = spawnPnpmSync(args, {
     cwd,
     encoding: 'utf8',
     stdio: 'pipe',
   });
   if (result.status !== 0) {
     fail(
-      `${command} ${args.join(' ')} failed in ${cwd}\n${result.stdout}${result.stderr}`,
+      `pnpm ${args.join(' ')} failed in ${cwd}\n${result.stdout ?? ''}${result.stderr ?? result.error?.message ?? ''}`,
     );
   }
   return `${result.stdout}${result.stderr}`.trim();
@@ -639,13 +656,12 @@ export function buildFixture(fixtureId) {
   const sandbox = path.join(sandboxParent, fixtureId);
   try {
     copyFixture(fixtureId, sandbox);
-    const installOutput = run(
-      'pnpm',
+    const installOutput = runPnpm(
       ['install', '--frozen-lockfile', '--ignore-scripts'],
       sandbox,
     );
-    const typecheckOutput = run('pnpm', ['typecheck'], sandbox);
-    const buildOutput = run('pnpm', ['build'], sandbox);
+    const typecheckOutput = runPnpm(['typecheck'], sandbox);
+    const buildOutput = runPnpm(['build'], sandbox);
     return {fixtureId, installOutput, typecheckOutput, buildOutput};
   } finally {
     fs.rmSync(sandboxParent, {recursive: true, force: true});


### PR DESCRIPTION
## Problem

`internal/vibe-tests/src/fixture-suite.mjs` calls `spawnSync('pnpm', ...)` in two places (`workspacePackagePaths`, and the `pnpm install/typecheck/build` calls in `buildFixture`). On Windows, `pnpm` is a `.cmd` batch file, and `spawnSync` can only execute a batch file through a shell:

- A bare `'pnpm'` fails with `ENOENT` — Node never resolves it through `PATHEXT` without a shell.
- An explicit `'pnpm.cmd'` still fails, with `EINVAL` — batch files need a shell even called by their exact name.

Since a failed spawn (`status: null`, `error: ENOENT`) leaves `result.stderr` as `undefined` rather than a string, the actual failure was masked by a confusing second crash: `TypeError: Cannot read properties of undefined (reading 'trim')`.

This blocks `check:fixtures` (recently added to `check:repo`, which runs on every `pnpm check:repo` and in the pre-commit hook via `lint-staged`/husky) on Windows entirely — every commit fails at this step regardless of what it touches.

## Fix

Added a `spawnPnpmSync(args, options)` helper: shells through `cmd.exe /d /s /c pnpm ...` on `win32`, calls `pnpm` directly elsewhere. Every call site here passes hardcoded argument literals, never user input, so this avoids Node's `DEP0190` shell-argument-escaping deprecation warning that plain `spawnSync(..., {shell: true})` would otherwise emit on every run.

Also hardened the error-message fallback (`result.stderr ?? result.error?.message ?? ''`) so a genuine future spawn failure reports the real error instead of crashing on `.trim()`.

## Testing

- `node internal/vibe-tests/scripts/fixture-suite.mjs verify` — passes cleanly (previously crashed) with no deprecation warnings.
- Fail-first verified: `internal/vibe-tests/src/fixture-suite.test.mjs`'s existing `validates provenance, manifests, hashes, package pins, and isolation` test (which calls `validateCanonicalSuite()`, exercising the crashing path) fails against the unfixed source with the exact reported symptom, and passes with the fix — no new test needed, this one already covers it.
- `npx vitest run internal/vibe-tests/src/fixture-suite.test.mjs` — 21/21 pass.

This file is excluded from the main eslint config (`.mjs` outside `packages/cli`), so no lint step applies.

Found while investigating an unrelated PR — noticed the same unguarded `spawnSync('pnpm', ...)` pattern also exists in `fixture-browser.mjs` and `setup-test/run-setup.mjs`; flagging that separately rather than expanding this PR's scope.