### PR TITLE
fix(AppShell): clip root overflow in both height modes

### DIFF
--- a/.changeset/appshell-root-overflow-boundary.md
+++ b/.changeset/appshell-root-overflow-boundary.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AppShell: the root now clips overflow in both height modes, so a margin-collapsing child (auto) or an absolutely-positioned child (fill) can no longer escape the shell's intended height boundary and scroll the page past it.
+
+@HelloOjasMutreja

--- a/packages/core/src/AppShell/AppShell.test.tsx
+++ b/packages/core/src/AppShell/AppShell.test.tsx
@@ -555,6 +555,27 @@ describe('AppShell', () => {
     expect(screen.getByText('Nav')).toBeInTheDocument();
   });
 
+  it('clips overflow on the root so a descendant cannot escape the height boundary (#5775, #5815)', () => {
+    // Both height modes need overflow other than visible on the root:
+    // - fill: a fixed height with no clip lets an absolutely-positioned
+    //   descendant paint past it (#5815).
+    // - auto: a bare minHeight with no clip lets a child's margin-top
+    //   collapse straight through the root (#5775).
+    const {rerender} = render(
+      <AppShell height="fill" data-testid="shell">
+        <div>Content</div>
+      </AppShell>,
+    );
+    expect(getComputedStyle(screen.getByTestId('shell')).overflow).toBe('clip');
+
+    rerender(
+      <AppShell height="auto" data-testid="shell">
+        <div>Content</div>
+      </AppShell>,
+    );
+    expect(getComputedStyle(screen.getByTestId('shell')).overflow).toBe('clip');
+  });
+
   // ===========================================================================
   // Sticky navigation in auto mode
   // ===========================================================================

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -284,9 +284,20 @@ const styles = stylex.create({
   },
   rootFill: {
     height: '100dvh',
+    // Without a clip boundary, a descendant that escapes normal flow (an
+    // absolutely-positioned child extending past the box, a negative-margin
+    // trick) paints outside the fixed height and the page scrolls past what
+    // "fill the viewport" promises (#5815).
+    overflow: 'clip',
   },
   rootAuto: {
     minHeight: '100dvh',
+    // `overflow` other than visible also opens a block formatting context,
+    // which stops a child's margin-top from collapsing through the root and
+    // escaping the intended boundary (#5775). `minHeight` (not `height`)
+    // means this never clips legitimately taller content — the box still
+    // grows to fit it, same as before.
+    overflow: 'clip',
   },
   skipLink: {
     // Visually hidden by default, visible on focus (keyboard navigation)


### PR DESCRIPTION
Fixes #5775.
Fixes #5815.

## Problem

Both height modes set a size on the root but neither sets `overflow`:

- `rootFill`: `height: 100dvh`
- `rootAuto`: `minHeight: 100dvh`

Without `overflow` other than `visible`, nothing stops a descendant from escaping that boundary:

- **fill mode (#5815):** an absolutely-positioned descendant (root has `position: relative`, so it's the containing block) that extends past the fixed height simply paints outside it, and the page scrolls further than "fill the viewport" should allow.
- **auto mode (#5775):** `overflow: visible` does not open a block formatting context, so a child's `margin-top` collapses straight through the root instead of pushing the root's own box down — the classic margin-collapse-escapes-the-parent case.

## Fix

`overflow: 'clip'` on both. For `auto` mode this is safe specifically because the root uses `minHeight`, not `height` — the box still grows to fit content taller than the viewport, `overflow: clip` only stops content from escaping via margin collapse or absolute positioning, not from growing the box itself.

## Testing

- Fail-first verified: reverted just the source change and confirmed the new test fails, asserting `overflow: clip` on the root in both modes, before re-applying the fix.
- `npx vitest run packages/core/src/AppShell` — 49/49 pass, including the existing sticky-header/sticky-sideNav tests for auto mode (auto mode's `position: sticky` behavior is unaffected — it relies on the page/viewport scroll, not an ancestor scroll container, and `overflow: clip` doesn't create one).
- Typecheck and lint clean.

No visual change in the common case — this only affects the specific escape-hatch shapes in the two linked issues.