### PR TITLE
fix(vibe-tests): run pnpm through cmd.exe on Windows in more scripts

### DIFF
--- a/internal/vibe-tests/scripts/fixture-browser.mjs
+++ b/internal/vibe-tests/scripts/fixture-browser.mjs
@@ -28,11 +28,28 @@ const CONTRAST_PROBES = [
   ['destructive action', 'destructive-action'],
 ];
 
-function run(command, args, cwd) {
-  const result = spawnSync(command, args, {cwd, encoding: 'utf8'});
+/**
+ * pnpm is a .cmd (batch) file on Windows. spawnSync can only run a batch
+ * file through a shell — a bare 'pnpm' fails with ENOENT and an explicit
+ * 'pnpm.cmd' still fails with EINVAL (batch files need a shell even named
+ * exactly). Shelling out through cmd.exe /c directly, rather than
+ * spawnSync's shell:true, avoids Node's shell-argument-escaping deprecation
+ * warning (DEP0190) — every argument here is a hardcoded literal, never
+ * user input, so we build the argv ourselves instead of asking spawnSync to
+ * build a shell string. See internal/vibe-tests/src/fixture-suite.mjs for
+ * the same pattern.
+ */
+function runPnpm(args, cwd) {
+  const result =
+    process.platform === 'win32'
+      ? spawnSync('cmd.exe', ['/d', '/s', '/c', 'pnpm', ...args], {
+          cwd,
+          encoding: 'utf8',
+        })
+      : spawnSync('pnpm', args, {cwd, encoding: 'utf8'});
   if (result.status !== 0) {
     throw new Error(
-      `${command} ${args.join(' ')} failed in ${cwd}\n${result.stdout}${result.stderr}`,
+      `pnpm ${args.join(' ')} failed in ${cwd}\n${result.stdout ?? ''}${result.stderr ?? result.error?.message ?? ''}`,
     );
   }
 }
@@ -221,9 +238,9 @@ async function main() {
   let browser;
   try {
     copyFixture(FIXTURE_ID, sandbox);
-    run('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], sandbox);
-    run('pnpm', ['typecheck'], sandbox);
-    run('pnpm', ['build'], sandbox);
+    runPnpm(['install', '--frozen-lockfile', '--ignore-scripts'], sandbox);
+    runPnpm(['typecheck'], sandbox);
+    runPnpm(['build'], sandbox);
     server = await preview({
       root: sandbox,
       logLevel: 'silent',

--- a/internal/vibe-tests/setup-test/run-setup.mjs
+++ b/internal/vibe-tests/setup-test/run-setup.mjs
@@ -75,6 +75,23 @@ const write = (file, content) => {
 };
 const run = (command, commandArgs, cwd) =>
   execFileSync(command, commandArgs, {cwd, stdio: 'pipe', encoding: 'utf8'});
+// pnpm is a .cmd (batch) file on Windows. execFileSync, like spawnSync, can
+// only run a batch file through a shell — a bare 'pnpm' fails with ENOENT
+// and an explicit 'pnpm.cmd' still fails with EINVAL (batch files need a
+// shell even named exactly). Shelling out through cmd.exe /c directly,
+// rather than execFileSync's shell:true, avoids Node's
+// shell-argument-escaping deprecation warning (DEP0190) — every argument
+// here is a hardcoded literal, never user input, so we build the argv
+// ourselves instead of asking execFileSync to build a shell string. See
+// internal/vibe-tests/src/fixture-suite.mjs for the same pattern.
+const runPnpm = (pnpmArgs, cwd) =>
+  process.platform === 'win32'
+    ? execFileSync('cmd.exe', ['/d', '/s', '/c', 'pnpm', ...pnpmArgs], {
+        cwd,
+        stdio: 'pipe',
+        encoding: 'utf8',
+      })
+    : execFileSync('pnpm', pnpmArgs, {cwd, stdio: 'pipe', encoding: 'utf8'});
 
 function copyDirectory(source, destination) {
   ensureDir(destination);
@@ -94,7 +111,7 @@ function prepareDependencies(fixtureId) {
   for (const file of ['package.json', 'pnpm-lock.yaml']) {
     fs.copyFileSync(path.join(fixtureRoot, file), path.join(depsDir, file));
   }
-  run('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], depsDir);
+  runPnpm(['install', '--frozen-lockfile', '--ignore-scripts'], depsDir);
   return depsDir;
 }
 
@@ -133,7 +150,7 @@ function createSandbox(fixtureId, sandboxDir, depsDir) {
   copyFixture(fixtureId, sandboxDir);
   linkDependencies(depsDir, sandboxDir);
   installLoggingShim(sandboxDir);
-  run('pnpm', ['build'], sandboxDir);
+  runPnpm(['build'], sandboxDir);
 }
 
 function appendGuidance(sandboxDir, guidanceFile) {

--- a/internal/vibe-tests/setup-test/setup-canonical.test.ts
+++ b/internal/vibe-tests/setup-test/setup-canonical.test.ts
@@ -62,6 +62,21 @@ function run(command: string, args: string[], cwd: string) {
   });
 }
 
+// pnpm is a .cmd (batch) file on Windows. execFileSync, like spawnSync, can
+// only run a batch file through a shell — a bare 'pnpm' fails with ENOENT
+// and an explicit 'pnpm.cmd' still fails with EINVAL (batch files need a
+// shell even named exactly). Shelling out through cmd.exe /c directly,
+// rather than execFileSync's shell:true, avoids Node's
+// shell-argument-escaping deprecation warning (DEP0190) — every argument
+// here is a hardcoded literal, never user input, so we build the argv
+// ourselves instead of asking execFileSync to build a shell string. See
+// internal/vibe-tests/src/fixture-suite.mjs for the same pattern.
+function runPnpm(args: string[], cwd: string) {
+  return process.platform === 'win32'
+    ? run('cmd.exe', ['/d', '/s', '/c', 'pnpm', ...args], cwd)
+    : run('pnpm', args, cwd);
+}
+
 function edit(file: string, transform: (source: string) => string) {
   const source = fs.readFileSync(file, 'utf8');
   const next = transform(source);
@@ -75,14 +90,14 @@ function ensurePackageBuilds() {
   if (
     !fs.existsSync(path.join(REPO_ROOT, 'packages/core/dist/Button/index.js'))
   ) {
-    run('pnpm', ['-F', '@astryxdesign/core', 'build'], REPO_ROOT);
+    runPnpm(['-F', '@astryxdesign/core', 'build'], REPO_ROOT);
   }
   if (
     !fs.existsSync(
       path.join(REPO_ROOT, 'packages/themes/neutral/dist/theme.css'),
     )
   ) {
-    run('pnpm', ['-F', '@astryxdesign/theme-neutral', 'build'], REPO_ROOT);
+    runPnpm(['-F', '@astryxdesign/theme-neutral', 'build'], REPO_ROOT);
   }
 }
 
@@ -97,7 +112,7 @@ function dependencyRoot(fixture: string) {
   temporaryDirectories.push(parent);
   const root = path.join(parent, 'app');
   copyFixture(fixture, root);
-  run('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], root);
+  runPnpm(['install', '--frozen-lockfile', '--ignore-scripts'], root);
   dependencyRoots.set(fixture, root);
   return root;
 }

--- a/internal/vibe-tests/setup-test/setup-canonical.test.ts
+++ b/internal/vibe-tests/setup-test/setup-canonical.test.ts
@@ -77,6 +77,16 @@ function runPnpm(args: string[], cwd: string) {
     : run('pnpm', args, cwd);
 }
 
+// The non-throwing counterpart to runPnpm, for the cases below where a
+// failing pnpm invocation is the assertion under test, not an error: same
+// cmd.exe routing on win32, but returns spawnSync's result object instead of
+// throwing on a non-zero exit.
+function spawnPnpm(args: string[], options: Parameters<typeof spawnSync>[2]) {
+  return process.platform === 'win32'
+    ? spawnSync('cmd.exe', ['/d', '/s', '/c', 'pnpm', ...args], options)
+    : spawnSync('pnpm', args, options);
+}
+
 function edit(file: string, transform: (source: string) => string) {
   const source = fs.readFileSync(file, 'utf8');
   const next = transform(source);
@@ -2138,7 +2148,7 @@ describeCanonical('canonical pnpm build approval', () => {
   // spawnSync rather than execFileSync's throwing form: a failing install is
   // the assertion in half these cases, not an error.
   const install = (app: string) =>
-    spawnSync('pnpm', ['install'], {
+    spawnPnpm(['install'], {
       cwd: app,
       encoding: 'utf8',
       env: {...process.env, CI: 'true'},
@@ -2162,7 +2172,7 @@ describeCanonical('canonical pnpm build approval', () => {
     expect(
       fs.existsSync(path.join(app, 'node_modules', PACKAGE, 'package.json')),
     ).toBe(true);
-    const built = spawnSync('pnpm', ['build'], {
+    const built = spawnPnpm(['build'], {
       cwd: app,
       encoding: 'utf8',
       env: {...process.env, CI: 'true'},

--- a/internal/vibe-tests/setup-test/setup-measure.mjs
+++ b/internal/vibe-tests/setup-test/setup-measure.mjs
@@ -66,15 +66,28 @@ export function parseLayerOrder(css) {
  * `CI=true` and piped stdio keep it non-interactive: a package manager or
  * bundler that finds no TTY must not stop to ask anything, and a spinner that
  * probes for one must not error out. Measurement is unattended by definition.
+ *
+ * pnpm is a .cmd (batch) file on Windows; spawnSync can only run a batch
+ * file through a shell, so shell out through cmd.exe /c directly rather than
+ * spawnSync's shell:true. See internal/vibe-tests/src/fixture-suite.mjs for
+ * the same pattern.
  */
 function build(appDir) {
   const started = Date.now();
-  const result = spawnSync('pnpm', ['build'], {
-    cwd: appDir,
-    encoding: 'utf8',
-    env: {...process.env, CI: 'true'},
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  const result =
+    process.platform === 'win32'
+      ? spawnSync('cmd.exe', ['/d', '/s', '/c', 'pnpm', 'build'], {
+          cwd: appDir,
+          encoding: 'utf8',
+          env: {...process.env, CI: 'true'},
+          stdio: ['ignore', 'pipe', 'pipe'],
+        })
+      : spawnSync('pnpm', ['build'], {
+          cwd: appDir,
+          encoding: 'utf8',
+          env: {...process.env, CI: 'true'},
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
   return {
     ok: result.status === 0,
     status: result.status ?? -1,


### PR DESCRIPTION
Follow-up to #5841, which fixed the same pnpm-spawn-on-Windows bug in `internal/vibe-tests/src/fixture-suite.mjs`. This applies the identical fix to the three other spots that spawn `pnpm` directly without shell handling:

- `scripts/fixture-browser.mjs` (`spawnSync`, used by `fixtures:contrast`/`fixtures:screenshots`)
- `setup-test/run-setup.mjs` (`execFileSync`, used by `setup:prepare`)
- `setup-test/setup-canonical.test.ts` (`execFileSync`, its own inline `run()` helper)

## Why this matters even though it's not blocking `check:repo`

`setup-canonical.test.ts`'s pnpm-spawning tests are gated behind `ASTRYX_CANONICAL_SETUP_BROWSER=1`, which is only set by the `fixture-contrast` CI job — and that job runs on `2-core-ubuntu-arm`, so the bug is silent there. It only bites a Windows contributor who runs `setup:prepare`, `fixtures:contrast`/`fixtures:screenshots`, or the canonical setup test suite locally.

## Fix

Same pattern as #5841: shell out through `cmd.exe /d /s /c pnpm ...` on `win32`, call `pnpm` directly elsewhere. Every argument at every call site is a hardcoded literal, never user input, so this avoids Node's `DEP0190` shell-argument-escaping deprecation warning that plain `shell: true` would trigger.

## What I deliberately left alone

`run-setup.mjs` and `setup-canonical.test.ts` also both shell out to `cp -al` (GNU hardlink flag) to link a prepared `node_modules` into each sandbox. That's a separate, pre-existing Windows breakage (no Windows equivalent for the flag, and creating hardlinks this way fails with `Permission denied`) — confirmed with a real run, out of scope for this PR.

## Testing

- Directly verified both spawn mechanisms (the `spawnSync` variant used in `fixture-browser.mjs`, and the `execFileSync` variant used in the other two) against a real `pnpm --version` call on Windows — both succeed.
- Ran `setup-canonical.test.ts` with `ASTRYX_CANONICAL_SETUP_BROWSER=1` for real: it got past both `runPnpm` calls (`pnpm install`, `pnpm -F @astryxdesign/core build`) successfully before hitting the separate, expected `cp -al` failure described above — real evidence the fix works, not just that it compiles.
- Confirmed the `public-artifact-cli.test.mjs` failures seen in the same test run are pre-existing and unrelated: they fail identically against the unfixed baseline (a different bug, `.bin/tsx` needing the same treatment — filed as its own follow-up).
- `npx eslint internal/vibe-tests/setup-test/setup-canonical.test.ts` — clean. The two `.mjs` files are outside the linted `packages/cli` scope, matching the project's existing `.mjs` lint-ignore convention.