### PR TITLE
Add Table row status theming target

### DIFF
--- a/.changeset/table-row-status-theming-target.md
+++ b/.changeset/table-row-status-theming-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add a theming target for Table row status indicators.
+
+@rubyycheung

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -129,6 +129,7 @@ export const docs = {
       {className: 'astryx-table-body'},
       {className: 'astryx-table-footer'},
       {className: 'astryx-table-row'},
+      {className: 'astryx-table-row-status', visualProps: ['color', 'presentation']},
       {className: 'astryx-table-cell', visualProps: ['density']},
       {className: 'astryx-table-header-cell', visualProps: ['density']},
       // Still emitted beside the names above, so themes written against

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -68,6 +68,12 @@ const anatomy = [
       'TableCell containing one value or caller-provided content in a standard body or footer row.',
   },
   {
+    name: 'Row status indicator',
+    required: false,
+    description:
+      'Labeled icon or dot rendered by the row-status plugin for one row.',
+  },
+  {
     name: 'Default empty state',
     required: false,
     description:

--- a/packages/core/src/Table/Table.spec.md
+++ b/packages/core/src/Table/Table.spec.md
@@ -16,6 +16,7 @@ verified_by:
     packages/core/src/Table/plugins/selection/useTableSelection.test.tsx,
     packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx,
     packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx,
+    packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx,
     packages/cli/foundation/discovery/theming-targets.test.mjs,
     packages/cli/api/theme/targets/targets.test.mjs,
     packages/core/src/theme/themingTargets.test.ts,
@@ -40,14 +41,15 @@ system_specs: []
 
 Table presents consistently structured data in semantic rows and columns. This
 draft records its current aggregate anatomy, parent-owned target inventory, and
-stable sorting, selection, expansion, and empty-state parts without changing
-runtime behavior, DOM, styling, targets, aliases, or public API.
+stable sorting, selection, expansion, row-status, and empty-state parts. It adds
+one parent-owned target for the existing row-status indicator wrapper without
+changing its caller-controlled status semantics.
 
 ## Compatibility and migration
 
 - Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, aliases, and public API remain unchanged
+- Compatibility class: additive theming surface; existing runtime behavior,
+  DOM roles, status semantics, aliases, and caller API remain unchanged
 - Controlled/uncontrolled behavior: unchanged
 - Migration decision: none
 
@@ -58,13 +60,15 @@ Consumer migration instructions belong in consumer docs and release notes.
 **Owns**
 
 - The Table and Scroll region, the aggregate Header section, Body section,
-  conditional Footer section, Row, Column header cell, and Cell anatomy, and the
-  eight current `table*` targets mapped below.
+  conditional Footer section, Row, Column header cell, Cell, and Row status
+  indicator anatomy, and the nine current `table*` targets mapped below.
 - The stable Sort control and Sort priority rendered by useTableSortable.
 - The stable Expansion control and Expanded detail panel rendered by
   useTableRowExpansion.
 - Placement of selection-plugin CheckboxInput controls in generated header and
   body cells.
+- Placement and theming ownership of the row-status indicator wrapper rendered
+  by useTableRowStatus.
 
 **Does not own / non-goals**
 
@@ -74,28 +78,30 @@ Consumer migration instructions belong in consumer docs and release notes.
   expanded detail content supplied by the caller.
 - Pagination, filtering, column-management, tree, grouping, sticky-column, or
   context-menu anatomy beyond the stable parts explicitly recorded here.
-- New targets for current untargeted plugin parts, or correction of current
-  target-reachability gaps.
+- New targets for other currently untargeted plugin parts, or correction of
+  current target-reachability gaps.
 - New runtime behavior, DOM, API, target, alias, or plugin contract.
 
 ## Public concepts
 
-No new public concept is introduced. Consumer data, columns, props, composition,
-plugins, defaults, and usage remain documented in `Table.doc.mjs` and the member
-and hook docs.
+The additive `table-row-status` theming target exposes the existing row-status
+indicator wrapper to maintained themes. Consumer data, columns, props,
+composition, plugins, defaults, and usage remain documented in `Table.doc.mjs`
+and the member and hook docs.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                                                                                                                                                      | Basis                             | Draft review state                                                        |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------- |
-| FR1 | Styled Table renders one keyboard-focusable Scroll region around one semantic Table.                                                                                                                                                                                                                     | Current source, docs, and tests   | Verified current behavior; no new behavior decided                        |
-| FR2 | Data-driven mode renders a Body section and a Header section with Column header cells when columns are present. Each data item renders a standard Row and Cells; an empty data array instead renders the configured empty-state row when enabled. It never creates a Footer section.                     | Current source, docs, and tests   | Verified current behavior; no new behavior decided                        |
-| FR3 | Children mode passes caller composition through to the Table. TableHeader, TableBody, and TableFooter provide the respective sections, and TableRow, TableHeaderCell, and TableCell provide standard rows and cells.                                                                                     | Current source, docs, and tests   | Verified current composition; no new API or DOM rule                      |
-| FR4 | `Table.doc.mjs` is the canonical aggregate consumer owner for the eight current targets: `table`, `table-scroll-wrapper`, `table-header`, `table-body`, `table-footer`, `table-row`, `table-cell`, and `table-header-cell`. Member docs retain direct lookup metadata through `subComponentOf: 'Table'`. | Current docs and CLI target tests | Verified parent ownership; focused placement coverage is partial          |
-| FR5 | For a sortable column, useTableSortable renders a Sort control around the column label, an Icon-owned Sort indicator glyph, and a numeric Sort priority only while multi-sort has more than one active entry.                                                                                            | Current source, docs, and tests   | Control and priority are tested; glyph presence is source-inspected only  |
-| FR6 | useTableSelection renders CheckboxInput-owned Selection controls in the generated selection Column header cell and each selectable body Cell; selection remains row state rather than separate anatomy.                                                                                                  | Current source, docs, and tests   | Verified stable delegated controls; no target or state change             |
-| FR7 | For an expandable row, useTableRowExpansion renders an Expansion control with an Icon-owned Expansion glyph and conditionally appends an Expanded detail panel whose cell spans the column count captured by that plugin's `transformColumns` step.                                                      | Current source, docs, and tests   | Verified stable plugin parts; current target gaps remain                  |
-| FR8 | Empty data renders the default compact EmptyState unless the caller supplies replacement content or disables it.                                                                                                                                                                                         | Current source, docs, and tests   | Verified conditional delegation; caller content remains outside ownership |
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                                         | Basis                             | Draft review state                                                           |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------- |
+| FR1 | Styled Table renders one keyboard-focusable Scroll region around one semantic Table.                                                                                                                                                                                                                                        | Current source, docs, and tests   | Verified current behavior; no new behavior decided                           |
+| FR2 | Data-driven mode renders a Body section and a Header section with Column header cells when columns are present. Each data item renders a standard Row and Cells; an empty data array instead renders the configured empty-state row when enabled. It never creates a Footer section.                                        | Current source, docs, and tests   | Verified current behavior; no new behavior decided                           |
+| FR3 | Children mode passes caller composition through to the Table. TableHeader, TableBody, and TableFooter provide the respective sections, and TableRow, TableHeaderCell, and TableCell provide standard rows and cells.                                                                                                        | Current source, docs, and tests   | Verified current composition; no new API or DOM rule                         |
+| FR4 | `Table.doc.mjs` is the canonical aggregate consumer owner for the nine current targets: `table`, `table-scroll-wrapper`, `table-header`, `table-body`, `table-footer`, `table-row`, `table-cell`, `table-header-cell`, and `table-row-status`. Member docs retain direct lookup metadata through `subComponentOf: 'Table'`. | Current docs and CLI target tests | Verified parent ownership; focused placement coverage is partial             |
+| FR5 | For a sortable column, useTableSortable renders a Sort control around the column label, an Icon-owned Sort indicator glyph, and a numeric Sort priority only while multi-sort has more than one active entry.                                                                                                               | Current source, docs, and tests   | Control and priority are tested; glyph presence is source-inspected only     |
+| FR6 | useTableSelection renders CheckboxInput-owned Selection controls in the generated selection Column header cell and each selectable body Cell; selection remains row state rather than separate anatomy.                                                                                                                     | Current source, docs, and tests   | Verified stable delegated controls; no target or state change                |
+| FR7 | For an expandable row, useTableRowExpansion renders an Expansion control with an Icon-owned Expansion glyph and conditionally appends an Expanded detail panel whose cell spans the column count captured by that plugin's `transformColumns` step.                                                                         | Current source, docs, and tests   | Verified stable plugin parts; current target gaps remain                     |
+| FR8 | Empty data renders the default compact EmptyState unless the caller supplies replacement content or disables it.                                                                                                                                                                                                            | Current source, docs, and tests   | Verified conditional delegation; caller content remains outside ownership    |
+| FR9 | useTableRowStatus renders one Row status indicator wrapper for each returned status. The wrapper exposes `color` and `presentation` to themes while the caller retains status label, semantic color, and optional icon control. Semantic outcome colors keep their current themed default icons.                            | Current source, docs, and tests   | Verified additive theming target; existing status semantics remain unchanged |
 
 ### Current evidence and gaps
 
@@ -117,6 +123,9 @@ and hook docs.
   columns and leave the span stale. The current full-span test covers only the case
   where expansion captures the final column set. This draft records both gaps and
   does not correct them.
+- Row-status tests assert the wrapper target, color and presentation metadata,
+  semantic default icons, caller icon overrides, dot fallback, and accessible
+  label.
 
 ### Allowed variation
 
@@ -126,21 +135,23 @@ and hook docs.
 - **AV2 - Repetition and content.** Column, Row, and Cell counts and caller-owned
   content may vary without creating new anatomy parts.
 - **AV3 - Optional parts.** Header section, Footer section, default EmptyState,
-  Sort, Selection, and Expansion parts may be absent according to columns,
-  rendering mode, plugin configuration, data, and row eligibility.
+  Sort, Selection, Expansion, and Row status indicator parts may be absent
+  according to columns, rendering mode, plugin configuration, data, and row
+  eligibility.
 - **AV4 - Delegated rendering.** CheckboxInput, Icon, and EmptyState may change
   internal element shape while preserving their own public contracts.
 
 ### Representative states
 
-| State            | Required invariant                                                                                                                              | Allowed variation                                                          |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| Data-driven rows | Scroll region contains Table, Header section when columns exist, Body section, and one standard Row with Cells per data item.                   | Counts, values, density, dividers, and cell content.                       |
-| Empty data       | Body section contains default EmptyState unless replaced or disabled.                                                                           | Caller replacement content or no empty state.                              |
-| Children mode    | Caller-supplied sections are passed directly to Table.                                                                                          | Header, Body, and Footer section presence and content.                     |
-| Sortable column  | Column header cell contains Sort control and Sort indicator glyph.                                                                              | Direction and conditional multi-sort priority.                             |
-| Selectable rows  | Selection controls occupy generated header and body cells.                                                                                      | Checked, indeterminate, disabled, or absent per row.                       |
-| Expandable row   | Expansion control occupies a generated Cell; open state adds the detail panel after its row using the expansion plugin's captured column count. | Expanded state, caller detail content, and later plugin column transforms. |
+| State            | Required invariant                                                                                                                                     | Allowed variation                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| Data-driven rows | Scroll region contains Table, Header section when columns exist, Body section, and one standard Row with Cells per data item.                          | Counts, values, density, dividers, and cell content.                                                    |
+| Empty data       | Body section contains default EmptyState unless replaced or disabled.                                                                                  | Caller replacement content or no empty state.                                                           |
+| Children mode    | Caller-supplied sections are passed directly to Table.                                                                                                 | Header, Body, and Footer section presence and content.                                                  |
+| Sortable column  | Column header cell contains Sort control and Sort indicator glyph.                                                                                     | Direction and conditional multi-sort priority.                                                          |
+| Selectable rows  | Selection controls occupy generated header and body cells.                                                                                             | Checked, indeterminate, disabled, or absent per row.                                                    |
+| Expandable row   | Expansion control occupies a generated Cell; open state adds the detail panel after its row using the expansion plugin's captured column count.        | Expanded state, caller detail content, and later plugin column transforms.                              |
+| Row status       | A returned status renders one labeled indicator using an icon or dot presentation and exposes its semantic color and presentation to the active theme. | Status color, caller icon override, semantic default icon, raw CSS escape hatch, or no returned status. |
 
 ### Transformation and precedence order
 
@@ -156,7 +167,8 @@ and hook docs.
 
 This draft does not change or extend the current native table semantics,
 focusable Scroll region, column-header scope, sort `aria-sort`, selection
-`aria-selected`, CheckboxInput labels, or expansion `aria-expanded` behavior.
+`aria-selected`, CheckboxInput labels, expansion `aria-expanded`, or required
+row-status accessible-label behavior.
 
 ## Design relationships
 
@@ -173,6 +185,7 @@ focusable Scroll region, column-header scope, sort `aria-sort`, selection
 | Body section          | Groups data, empty-state, and expanded-detail rows.                               | Current source and public docs | Supporting     | FR2-FR4, FR7, FR8  |
 | Row                   | Groups standard header, body, or footer cells.                                    | Current source and public docs | Supporting     | FR2-FR4, FR6       |
 | Cell                  | Contains one value or caller-provided content in a standard body or footer row.   | Current source and public docs | Prominent      | FR2-FR4, FR6, FR7  |
+| Row status indicator  | Communicates one caller-provided row status through a labeled themed icon or dot. | Current source and public docs | Supporting     | FR9                |
 | Default empty state   | Communicates that the current data array has no rows through EmptyState.          | `component:EmptyState`         | Prominent      | FR8                |
 | Expansion control     | Expands or collapses one eligible row.                                            | Current source and public docs | Prominent      | FR7                |
 | Expansion glyph       | Shows the current expansion direction through Icon.                               | `component:Icon`               | Supporting     | FR7                |
@@ -207,6 +220,7 @@ focusable Scroll region, column-header scope, sort `aria-sort`, selection
   "Body section": {"target": "table-body"},
   "Row": {"target": "table-row"},
   "Cell": {"target": "table-cell"},
+  "Row status indicator": {"target": "table-row-status"},
   "Default empty state": {
     "delegatesTo": {"owner": "component:EmptyState", "target": "empty-state"}
   },
@@ -227,7 +241,7 @@ focusable Scroll region, column-header scope, sort `aria-sort`, selection
 }
 ```
 
-The exact map records all eight current non-deprecated Table targets once. The
+The exact map records all nine current non-deprecated Table targets once. The
 legacy `base-table` alias is compatibility, not anatomy. TableHeader, TableBody,
 TableFooter, TableRow, TableCell, and TableHeaderCell retain direct docs linked by
 `subComponentOf: 'Table'`; they do not need independent component specs for this
@@ -249,15 +263,16 @@ aggregate ownership.
 
 ## Verification map
 
-| Contract            | Verification                                                                                         | Representative states                                  | Mutation or failure expectation                                                                                                                                                                                                                                           | Audit section         |
-| ------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| FR1-FR3             | `Table.test.tsx` render, structure, children-mode, section, and target assertions                    | Data-driven rows, empty data, and children composition | Removing Table, Scroll region, or configured structure fails existing role, structure, class, or prop-forwarding assertions; Row and Cell are conditional on rendered data or caller composition.                                                                         | `audit:Table/anatomy` |
-| FR4                 | CLI discovery and API target tests plus source inspection                                            | Direct member docs and unfiltered/scoped target output | Duplicating a parent/member target or changing the canonical owner fails parent-aware discovery assertions; section target placement remains source-inspected.                                                                                                            | `audit:Table/theming` |
-| FR5                 | `plugins/sortable/useTableSortable.test.tsx` plus source inspection                                  | Unsorted, ascending, descending, and multi-sort        | Removing the Sort control, conditional priority, or ARIA state fails existing assertions. Removing the Sort indicator glyph does not currently fail a focused test; glyph presence and delegated Icon target placement remain source-inspected.                           | `audit:Table/anatomy` |
-| FR6                 | `plugins/selection/useTableSelection.test.tsx`                                                       | Select all, individual, disabled, and non-selectable   | Removing header/body Selection controls or row selection state fails existing structure, label, interaction, and ARIA assertions; delegated CheckboxInput target placement remains source-inspected.                                                                      | `audit:Table/anatomy` |
-| FR7                 | `plugins/rowExpansion/useTableRowExpansion.test.tsx` plus source inspection                          | Collapsed, expanded, and non-expandable rows           | Removing the Expansion control, conditional detail panel, captured-count `colSpan`, or ARIA state fails existing assertions in the covered plugin order; later column transforms, delegated Icon target placement, and untargeted panel wrappers remain source-inspected. | `audit:Table/anatomy` |
-| FR8                 | `Table.test.tsx` empty-state suite plus EmptyState public target metadata                            | Default, custom, disabled, and non-empty               | Removing conditional empty behavior fails existing assertions; default EmptyState delegation remains source-inspected.                                                                                                                                                    | `audit:Table/anatomy` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`, `themingTargets.test.ts`, and CLI parent-aware target discovery tests | Canonical anatomy, eight current targets, legacy alias | Missing, extra, duplicated, prefixed, stale, alias-backed, or independently owned member mappings fail repository validation or discovery coverage.                                                                                                                       | `audit:Table/theming` |
+| Contract            | Verification                                                                                         | Representative states                                              | Mutation or failure expectation                                                                                                                                                                                                                                           | Audit section         |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| FR1-FR3             | `Table.test.tsx` render, structure, children-mode, section, and target assertions                    | Data-driven rows, empty data, and children composition             | Removing Table, Scroll region, or configured structure fails existing role, structure, class, or prop-forwarding assertions; Row and Cell are conditional on rendered data or caller composition.                                                                         | `audit:Table/anatomy` |
+| FR4                 | CLI discovery and API target tests plus source inspection                                            | Direct member docs and unfiltered/scoped target output             | Duplicating a parent/member target or changing the canonical owner fails parent-aware discovery assertions; section target placement remains source-inspected.                                                                                                            | `audit:Table/theming` |
+| FR5                 | `plugins/sortable/useTableSortable.test.tsx` plus source inspection                                  | Unsorted, ascending, descending, and multi-sort                    | Removing the Sort control, conditional priority, or ARIA state fails existing assertions. Removing the Sort indicator glyph does not currently fail a focused test; glyph presence and delegated Icon target placement remain source-inspected.                           | `audit:Table/anatomy` |
+| FR6                 | `plugins/selection/useTableSelection.test.tsx`                                                       | Select all, individual, disabled, and non-selectable               | Removing header/body Selection controls or row selection state fails existing structure, label, interaction, and ARIA assertions; delegated CheckboxInput target placement remains source-inspected.                                                                      | `audit:Table/anatomy` |
+| FR7                 | `plugins/rowExpansion/useTableRowExpansion.test.tsx` plus source inspection                          | Collapsed, expanded, and non-expandable rows                       | Removing the Expansion control, conditional detail panel, captured-count `colSpan`, or ARIA state fails existing assertions in the covered plugin order; later column transforms, delegated Icon target placement, and untargeted panel wrappers remain source-inspected. | `audit:Table/anatomy` |
+| FR8                 | `Table.test.tsx` empty-state suite plus EmptyState public target metadata                            | Default, custom, disabled, and non-empty                           | Removing conditional empty behavior fails existing assertions; default EmptyState delegation remains source-inspected.                                                                                                                                                    | `audit:Table/anatomy` |
+| FR9                 | `plugins/rowStatus/useTableRowStatus.test.tsx`                                                       | Semantic default icon, caller icon, palette/raw dot, absent status | Removing the target, metadata, accessible name, existing default-icon behavior, or dot fallback fails focused assertions.                                                                                                                                                 | `audit:Table/theming` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`, `themingTargets.test.ts`, and CLI parent-aware target discovery tests | Canonical anatomy, nine current targets, legacy alias              | Missing, extra, duplicated, prefixed, stale, alias-backed, or independently owned member mappings fail repository validation or discovery coverage.                                                                                                                       | `audit:Table/theming` |
 
 ## Decision log
 

--- a/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx
+++ b/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.test.tsx
@@ -78,6 +78,14 @@ describe('useTableRowStatus', () => {
     expect(screen.getByRole('img', {name: 'Error'})).toContainElement(
       screen.getByTestId('themed-error'),
     );
+    expect(screen.getByRole('img', {name: 'Error'})).toHaveAttribute(
+      'data-color',
+      'error',
+    );
+    expect(screen.getByRole('img', {name: 'Error'})).toHaveAttribute(
+      'data-presentation',
+      'icon',
+    );
     expect(screen.getByRole('img', {name: 'Warning'})).toContainElement(
       screen.getByTestId('themed-warning'),
     );
@@ -93,6 +101,9 @@ describe('useTableRowStatus', () => {
     );
     const indicator = screen.getByRole('img', {name: 'Red'});
     expect(indicator.querySelector('svg')).toBeNull();
+    expect(indicator).toHaveClass('astryx-table-row-status');
+    expect(indicator).toHaveAttribute('data-color', 'red');
+    expect(indicator).toHaveAttribute('data-presentation', 'dot');
     expect(indicator.querySelector('span')?.getAttribute('style')).toContain(
       '--color-icon-red',
     );
@@ -133,6 +144,9 @@ describe('useTableRowStatus', () => {
     // Icon-mode still exposes the accessible label via role=img.
     const indicator = screen.getByRole('img', {name: 'Error'});
     expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveClass('astryx-table-row-status');
+    expect(indicator).toHaveAttribute('data-color', 'red');
+    expect(indicator).toHaveAttribute('data-presentation', 'icon');
     // An SVG icon is rendered inside the indicator (dot mode has no svg).
     expect(indicator.querySelector('svg')).not.toBeNull();
   });

--- a/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx
+++ b/packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx
@@ -14,10 +14,12 @@
 
 import {useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {Icon, type IconColor, type IconName} from '../../../Icon';
+import {Icon, type IconName} from '../../../Icon';
 import {Tooltip} from '../../../Tooltip';
 import {useTranslator} from '../../../i18n';
 import {VisuallyHidden} from '../../../VisuallyHidden';
+import {mergeProps} from '../../../utils';
+import {themeProps} from '../../../utils/themeProps';
 import type {TableColumn, TablePlugin} from '../../types';
 
 /**
@@ -49,18 +51,17 @@ const SEMANTIC_COLORS: Record<TableRowStatusColor, string> = {
   gray: 'var(--color-icon-gray)',
 };
 
-/** Icon colors that map cleanly from a semantic status color. */
-const ICON_COLOR_BY_STATUS: Record<TableRowStatusColor, IconColor> = {
-  accent: 'accent',
-  success: 'success',
-  error: 'error',
-  warning: 'warning',
-  red: 'red',
-  orange: 'warning',
-  green: 'green',
-  yellow: 'warning',
-  blue: 'blue',
-  gray: 'gray',
+const THEMEABLE_ICON_COLORS: Record<TableRowStatusColor, string> = {
+  accent: 'var(--color-accent)',
+  success: 'var(--color-success)',
+  error: 'var(--color-error)',
+  warning: 'var(--color-warning)',
+  red: 'var(--color-icon-red)',
+  orange: 'var(--color-warning)',
+  green: 'var(--color-icon-green)',
+  yellow: 'var(--color-warning)',
+  blue: 'var(--color-icon-blue)',
+  gray: 'var(--color-icon-gray)',
 };
 
 /**
@@ -124,6 +125,17 @@ function resolveColor(color: string): string {
   return (SEMANTIC_COLORS as Record<string, string>)[color] ?? color;
 }
 
+function resolveIconColor(color: string): string {
+  return (
+    (THEMEABLE_ICON_COLORS as Record<string, string>)[color] ??
+    'var(--color-icon-primary)'
+  );
+}
+
+function isTableRowStatusColor(color: string): color is TableRowStatusColor {
+  return color in SEMANTIC_COLORS;
+}
+
 const styles = stylex.create({
   // Centers the dot or icon within the narrow status column.
   wrap: {
@@ -131,6 +143,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  icon: (color: string) => ({color}),
   dot: (color: string) => ({
     width: '8px',
     height: '8px',
@@ -184,22 +197,28 @@ export function useTableRowStatus<T extends Record<string, unknown>>(
             const icon =
               status.icon ??
               DEFAULT_ICON_BY_STATUS[status.color as TableRowStatusColor];
+            const presentation = icon ? 'icon' : 'dot';
+            const themeColor = isTableRowStatusColor(status.color)
+              ? status.color
+              : undefined;
             const signifier = icon ? (
-              <Icon
-                icon={icon}
-                size="xsm"
-                color={
-                  ICON_COLOR_BY_STATUS[status.color as TableRowStatusColor] ??
-                  'primary'
-                }
-              />
+              <Icon icon={icon} size="xsm" color="inherit" />
             ) : (
               <span {...stylex.props(styles.dot(resolveColor(status.color)))} />
             );
             return (
               <Tooltip content={status.label}>
                 <span
-                  {...stylex.props(styles.wrap)}
+                  {...mergeProps(
+                    themeProps('table-row-status', {
+                      color: themeColor,
+                      presentation,
+                    }),
+                    stylex.props(
+                      styles.wrap,
+                      icon && styles.icon(resolveIconColor(status.color)),
+                    ),
+                  )}
                   role="img"
                   aria-label={status.label}>
                   {signifier}

--- a/packages/core/src/Table/useTableRowStatus.doc.mjs
+++ b/packages/core/src/Table/useTableRowStatus.doc.mjs
@@ -8,6 +8,14 @@ export const docs = {
   displayName: 'useTableRowStatus',
   description:
     'Hook that returns a TablePlugin which prepends a narrow column signaling per-row status. Semantic status colors (success, warning, error) use the matching themed semantic icon by default; palette colors and raw CSS values use a colored dot because they do not establish an outcome glyph. getStatus may override either default with an explicit icon and must provide an accessible label (shown in a tooltip on hover and announced to assistive technology, so status is never color-only); return null for no indicator. The column header is visually blank but carries a screen-reader-only localized name ("Row status", i18n key @astryx.table.rowStatus.columnHeader). Memoize getStatus with useCallback for a stable plugin identity.',
+  theming: {
+    targets: [
+      {
+        className: 'astryx-table-row-status',
+        visualProps: ['color', 'presentation'],
+      },
+    ],
+  },
   props: [
     {
       name: 'getStatus',


### PR DESCRIPTION
## Summary

- add an `astryx-table-row-status` theming target with `color` and `presentation` visual props
- preserve the current behavior where success, warning, and error use their themed semantic icons by default
- keep palette and raw CSS colors as dots unless the caller supplies an icon
- allow themes to style dot and icon presentations without changing caller-controlled status semantics
- record the new target in Table's canonical anatomy/specification

## Scope

This is the standalone `main`-based replacement for #5754. It no longer waits behind the tonal-palette metadata stack.

## Validation

- focused row-status tests: 8 passed
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm check:sync`
- `pnpm check:knowledge`
- `pnpm check:changesets`
- `pnpm check:package-boundaries`

The rebase preserves newer default semantic-icon behavior that landed on `main` after the original stacked PR was created.
