### PR TITLE
fix(SideNavItem): keep a consumer aria-label in collapsed mode

### DIFF
--- a/.changeset/sidenavitem-collapsed-aria-label.md
+++ b/.changeset/sidenavitem-collapsed-aria-label.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNavItem no longer overwrites a consumer-supplied `aria-label` with the visible `label` text in collapsed mode (icon-only link/button and popover-trigger paths), so attention/context conveyed only through `aria-label` survives collapse. (#5641)
+
+@HelloOjasMutreja

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -1138,6 +1138,36 @@ describe('SideNavItem (collapsed)', () => {
     expect(trigger).toHaveAttribute('aria-label', 'Settings');
   });
 
+  it('keeps a consumer aria-label on the collapsed link, not the label text (#5641)', () => {
+    renderCollapsed(
+      <SideNavItem
+        label="Home"
+        icon={StubIcon}
+        href="/home"
+        aria-label="Open Home, 3 items need attention"
+      />,
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'aria-label',
+      'Open Home, 3 items need attention',
+    );
+  });
+
+  it('keeps a consumer aria-label on the collapsed popover trigger, not the label text (#5641)', () => {
+    renderCollapsed(
+      <SideNavItem
+        label="Settings"
+        icon={StubIcon}
+        data-testid="parent"
+        aria-label="Settings, 2 unread">
+        <SideNavItem label="General" />
+      </SideNavItem>,
+    );
+    const trigger = screen.getByTestId('parent');
+    expect(trigger).toHaveAttribute('aria-label', 'Settings, 2 unread');
+  });
+
   it('opens popover on click showing children in expanded form', async () => {
     const user = userEvent.setup();
     renderCollapsed(

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -580,7 +580,7 @@ export function SideNavItem({
             type="button"
             {...rest}
             {...hoverTriggerProps}
-            aria-label={label}
+            aria-label={rest['aria-label'] ?? label}
             data-testid={testId}
             {...popover.triggerProps}
             {...collapsedItemStyles}>
@@ -607,7 +607,7 @@ export function SideNavItem({
     const collapsedAriaProps = {
       'aria-current': isSelected ? ('page' as const) : undefined,
       'aria-disabled': isDisabled || undefined,
-      'aria-label': label,
+      'aria-label': rest['aria-label'] ?? label,
       'data-testid': testId,
     };
 


### PR DESCRIPTION
## Problem

`SideNavItem` forwards a consumer `aria-label` through `...rest`, but both collapsed-mode paths (icon-only link/button, and the popover trigger for items with children) spread a hard-coded `aria-label: label` after `...rest`, so it always won over a caller-supplied value.

That drops accessible context exactly where the visible label is absent — icon-only collapsed navigation.

## Fix

Both paths now use `rest['aria-label'] ?? label`, so an explicit `aria-label` wins in every render mode, and the label text stays the fallback when no consumer value is given.

## Testing

- Added two regression tests under the existing `SideNavItem (collapsed)` describe block: one for the plain collapsed link/button path, one for the popover-trigger (items-with-children) path. Both fail against the pre-fix code and pass after.
- Full `SideNav.test.tsx` suite: 196/196 passing.
- `tsc --noEmit` and `eslint` clean on the changed files.

Fixes #5641