### PR TITLE
fix(theme-neutral): refine SegmentedControl inset

### DIFF
--- a/.changeset/neutral-segmented-control-inset.md
+++ b/.changeset/neutral-segmented-control-inset.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] Give Neutral segmented controls a roomier inset while preserving their outside height.
+
+@rubyycheung

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -486,6 +486,28 @@ export const neutralTheme = defineTheme({
       'variant:error': {backgroundColor: statusFill.error},
     },
 
+    // Give the Neutral segmented control a roomier inset without changing its
+    // outside height. The selected item stays flat against the tinted track.
+    'segmented-control': {
+      base: {
+        padding: 'var(--spacing-1)',
+      },
+    },
+    'segmented-control-item': {
+      'size:sm': {
+        height: 'calc(var(--size-element-sm) - 8px)',
+      },
+      'size:md': {
+        height: 'calc(var(--size-element-md) - 8px)',
+      },
+      'size:lg': {
+        height: 'calc(var(--size-element-lg) - 8px)',
+      },
+      selected: {
+        boxShadow: 'none',
+      },
+    },
+
     banner: {
       base: {
         '--color-neutral': 'var(--astryx-theme-neutral-color-on-tint-neutral)',

--- a/packages/themes/neutral/src/neutralTheme.test.ts
+++ b/packages/themes/neutral/src/neutralTheme.test.ts
@@ -68,3 +68,17 @@ describe('neutral Banner tint mappings', () => {
     });
   });
 });
+
+describe('neutral theme component overrides', () => {
+  it('keeps the roomier segmented-control inset height-neutral', () => {
+    expect(neutralTheme.components?.['segmented-control']).toEqual({
+      base: {padding: 'var(--spacing-1)'},
+    });
+    expect(neutralTheme.components?.['segmented-control-item']).toEqual({
+      'size:sm': {height: 'calc(var(--size-element-sm) - 8px)'},
+      'size:md': {height: 'calc(var(--size-element-md) - 8px)'},
+      'size:lg': {height: 'calc(var(--size-element-lg) - 8px)'},
+      selected: {boxShadow: 'none'},
+    });
+  });
+});

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -486,6 +486,28 @@ export const neutralTheme = defineTheme({
       'variant:error': {backgroundColor: statusFill.error},
     },
 
+    // Give the Neutral segmented control a roomier inset without changing its
+    // outside height. The selected item stays flat against the tinted track.
+    'segmented-control': {
+      base: {
+        padding: 'var(--spacing-1)',
+      },
+    },
+    'segmented-control-item': {
+      'size:sm': {
+        height: 'calc(var(--size-element-sm) - 8px)',
+      },
+      'size:md': {
+        height: 'calc(var(--size-element-md) - 8px)',
+      },
+      'size:lg': {
+        height: 'calc(var(--size-element-lg) - 8px)',
+      },
+      selected: {
+        boxShadow: 'none',
+      },
+    },
+
     banner: {
       base: {
         '--color-neutral': 'var(--astryx-theme-neutral-color-on-tint-neutral)',


### PR DESCRIPTION
## Summary

- increase the Neutral SegmentedControl inset to `var(--spacing-1)`
- reduce each item height by the matching 8px so the control's outside height remains unchanged
- remove the selected-item shadow for a flatter Neutral treatment
- keep the bundled CLI Neutral template synchronized and add a focused contract test

## Scope

This is the standalone `main`-based SegmentedControl styling extracted from #5752. It contains no local-token API work, status-color changes, or Table row-status theming.

## Validation

- focused Neutral test: 1 passed
- `pnpm -F @astryxdesign/core build`
- `pnpm -F @astryxdesign/theme-neutral build`
- `pnpm -F @astryxdesign/cli typecheck:template-docs`
- `pnpm check:sync`
- `pnpm check:changesets`

## Before merge

- capture and approve exact-head light/dark SegmentedControl visuals
