### PR TITLE
feat(TextArea, TextInput): forward the native autoComplete attribute

### DIFF
--- a/.changeset/textarea-textinput-autocomplete.md
+++ b/.changeset/textarea-textinput-autocomplete.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] TextArea and TextInput now accept a native `autoComplete` prop, forwarded unchanged to the underlying element, so consumers no longer need a ref-mutation workaround to set browser/form autofill behavior. (#5638)
+
+@HelloOjasMutreja

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -256,6 +256,12 @@ export const docs = {
       description: 'Callback fired when the textarea loses focus.',
     },
     {
+      name: 'autoComplete',
+      type: 'string',
+      description:
+        "The native autocomplete attribute, forwarded unchanged to the <textarea>. Browser/form autofill behavior, not a styling escape hatch; unset leaves the browser's default.",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -505,6 +511,12 @@ export const docsZh = {
       name: 'onBlur',
       type: '(e: FocusEvent<HTMLTextAreaElement>) => void',
       description: '文本域失去焦点时触发的回调。',
+    },
+    {
+      name: 'autoComplete',
+      type: 'string',
+      description:
+        '原生 autocomplete 属性，原样转发给 <textarea>。这是浏览器/表单自动填充行为，不是样式逃生舱；不设置则使用浏览器默认值。',
     },
     {
       name: 'xstyle',

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -745,6 +745,28 @@ describe('TextArea', () => {
     });
   });
 
+  describe('autoComplete prop (#5638)', () => {
+    it('forwards autoComplete to the underlying textarea', () => {
+      render(
+        <TextArea
+          label="Bio"
+          value=""
+          onChange={() => {}}
+          autoComplete="off"
+        />,
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'autocomplete',
+        'off',
+      );
+    });
+
+    it('does not set autocomplete when autoComplete is not provided', () => {
+      render(<TextArea label="Bio" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('autocomplete');
+    });
+  });
+
   describe('form participation', () => {
     it('submits the value under htmlName', () => {
       const {container} = render(

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -16,6 +16,7 @@
  * - /packages/cli/assets/templates/blocks/components/TextArea/ (showcase blocks)
  */
 
+import type React from 'react';
 import {
   useId,
   useOptimistic,
@@ -349,6 +350,12 @@ export interface TextAreaProps extends Omit<
    * Callback fired when the textarea loses focus.
    */
   onBlur?: (e: FocusEvent<HTMLTextAreaElement>) => void;
+  /**
+   * The native `autocomplete` attribute, forwarded unchanged to the
+   * `<textarea>`. Browser/form autofill behavior, not a styling escape
+   * hatch — unset leaves the browser's default.
+   */
+  autoComplete?: React.TextareaHTMLAttributes<HTMLTextAreaElement>['autoComplete'];
 }
 
 /**
@@ -387,6 +394,7 @@ export function TextArea({
   htmlName,
   onFocus,
   onBlur,
+  autoComplete,
   width,
   xstyle,
   className,
@@ -597,6 +605,7 @@ export function TextArea({
           onBlur={onBlur}
           placeholder={placeholder}
           rows={rows}
+          autoComplete={autoComplete}
           // With a disabledMessage the textarea keeps focusability via
           // aria-disabled so the reason is focus-discoverable; readOnly + the
           // handleChange guard keep the value from changing.

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -163,6 +163,12 @@ export const docs = {
       description:
         'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
     },
+    {
+      name: 'autoComplete',
+      type: 'string',
+      description:
+        "The native autocomplete attribute, forwarded unchanged to the <input>. Browser/form autofill behavior, not a styling escape hatch; unset leaves the browser's default.",
+    },
   ],
   theming: {
     targets: [
@@ -335,6 +341,12 @@ export const docsZh = {
       type: 'string',
       description:
         '输入框的 HTML name 属性，用于表单提交。',
+    },
+    {
+      name: 'autoComplete',
+      type: 'string',
+      description:
+        '原生 autocomplete 属性，原样转发给 <input>。这是浏览器/表单自动填充行为，不是样式逃生舱；不设置则使用浏览器默认值。',
     },
   ],
   theming: {

--- a/packages/core/src/TextInput/TextInput.test.tsx
+++ b/packages/core/src/TextInput/TextInput.test.tsx
@@ -371,6 +371,28 @@ describe('TextInput', () => {
     });
   });
 
+  describe('autoComplete prop (#5638)', () => {
+    it('forwards autoComplete to the underlying input', () => {
+      render(
+        <TextInput
+          label="Name"
+          value=""
+          onChange={() => {}}
+          autoComplete="name"
+        />,
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'autocomplete',
+        'name',
+      );
+    });
+
+    it('does not set autocomplete when autoComplete is not provided', () => {
+      render(<TextInput label="Name" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('autocomplete');
+    });
+  });
+
   describe('form participation', () => {
     it('submits the value under htmlName', () => {
       const {container} = render(

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -16,6 +16,7 @@
  * - /packages/cli/assets/templates/blocks/components/TextInput/ (showcase blocks)
  */
 
+import type React from 'react';
 import {
   useId,
   useOptimistic,
@@ -259,6 +260,12 @@ export interface TextInputProps extends Omit<
    * Callback fired on keydown events on the input.
    */
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  /**
+   * The native `autocomplete` attribute, forwarded unchanged to the
+   * `<input>`. Browser/form autofill behavior, not a styling escape hatch —
+   * unset leaves the browser's default.
+   */
+  autoComplete?: React.InputHTMLAttributes<HTMLInputElement>['autoComplete'];
 }
 
 /**
@@ -295,6 +302,7 @@ export function TextInput({
   htmlName,
   onEnter,
   onKeyDown,
+  autoComplete,
   width,
   xstyle,
   className,
@@ -439,6 +447,7 @@ export function TextInput({
             : undefined
         }
         placeholder={placeholder}
+        autoComplete={autoComplete}
         // With a disabledMessage the input keeps focusability via aria-disabled
         // so the reason is focus-discoverable; readOnly + the handleChange guard
         // keep the value from changing.


### PR DESCRIPTION
## Problem

Neither `TextArea` nor `TextInput` exposes the native `autocomplete` attribute: both `TextAreaProps` and `TextInputProps` extend `BaseProps` only, not the corresponding native HTML attributes type, so there's no typed way to set it, and consumers were left with a ref-mutation workaround.

## Fix

Coordinated addition, per the discussion on #5638:

- `TextArea`: `autoComplete?: React.TextareaHTMLAttributes<HTMLTextAreaElement>['autoComplete']`, forwarded unchanged to the `<textarea>`.
- `TextInput`: `autoComplete?: React.InputHTMLAttributes<HTMLInputElement>['autoComplete']`, forwarded unchanged to the `<input>`.

Both follow the same explicit-prop passthrough pattern already used for `placeholder`/`htmlName`, keeping `BaseProps`' narrow surface intact rather than widening either component to the full native attributes type.

## Testing

- One forwarding test and one "omitted stays unset" test per component, matching the existing `htmlName prop` describe blocks' structure.
- Full `TextArea.test.tsx` + `TextInput.test.tsx` suites: 161/161 passing.
- `tsc --noEmit` and `eslint` clean on the changed files.
- Doc entries (English + Chinese) added to both `.doc.mjs` files.

Fixes #5638