### PR TITLE
fix(TreeList): let a consumer onKeyDown cancel built-in navigation

### DIFF
--- a/.changeset/treelist-onkeydown-precedence.md
+++ b/.changeset/treelist-onkeydown-precedence.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TreeList's `onKeyDown` prop now runs before the built-in arrow-key/expand-collapse handling, so calling `event.preventDefault()` reliably cancels the built-in behavior for that key instead of running too late to matter. (#5584)
+
+@HelloOjasMutreja

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -125,6 +125,12 @@ export const docs = {
           slotElements: [{__element: 'Text', props: {type: 'body'}, children: 'Header'}],
         },
         {
+          name: 'onKeyDown',
+          type: '(e: KeyboardEvent) => void',
+          description:
+            "Runs before TreeList's own arrow-key navigation and expand/collapse handling. Call event.preventDefault() to cancel the built-in behavior for that key; focus and the roving tab stop are left untouched. A handler that doesn't call preventDefault() still lets the built-in keyboard model run afterward.",
+        },
+        {
           name: 'xstyle',
           type: 'StyleXStyles',
           description:
@@ -203,6 +209,12 @@ export const docsZh = {
           type: 'ReactNode',
           description:
             '标题内容，通过 aria-labelledby 与树关联。',
+        },
+        {
+          name: 'onKeyDown',
+          type: '(e: KeyboardEvent) => void',
+          description:
+            '在 TreeList 自身的方向键导航和展开/折叠处理之前运行。调用 event.preventDefault() 可取消该按键的内置行为，焦点和 roving tab stop 保持不变。若处理函数未调用 preventDefault()，内置的键盘模型仍会随后运行。',
         },
         {
           name: 'xstyle',

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -1050,6 +1050,21 @@ describe('TreeList', () => {
     expect(treeitems[1]).toHaveFocus();
   });
 
+  it('still delivers keydowns from the header slot to the consumer onKeyDown (#5853)', () => {
+    const handleKeyDown = vi.fn();
+    render(
+      <TreeList
+        items={flatItems}
+        header={<input data-testid="header-input" />}
+        onKeyDown={handleKeyDown}
+      />,
+    );
+    fireEvent.keyDown(screen.getByTestId('header-input'), {key: 'Escape'});
+
+    expect(handleKeyDown).toHaveBeenCalledTimes(1);
+    expect(handleKeyDown.mock.calls[0][0]).toMatchObject({key: 'Escape'});
+  });
+
   // ===========================================================================
   // APG keyboard navigation
   // ===========================================================================

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -1025,6 +1025,31 @@ describe('TreeList', () => {
     expect(tabbable[0]).toBe(screen.getByText('Banana').closest('li'));
   });
 
+  it('lets a consumer prevent built-in TreeList keyboard navigation (#5584)', () => {
+    render(
+      <TreeList
+        items={flatItems}
+        onKeyDown={event => event.preventDefault()}
+      />,
+    );
+    const treeitems = screen.getAllByRole('treeitem');
+    treeitems[0].focus();
+    fireEvent.keyDown(treeitems[0], {key: 'ArrowDown'});
+
+    expect(treeitems[0]).toHaveFocus();
+    expect(treeitems[0]).toHaveAttribute('tabindex', '0');
+    expect(treeitems[1]).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('still runs built-in navigation when the consumer handler does not cancel', () => {
+    render(<TreeList items={flatItems} onKeyDown={() => {}} />);
+    const treeitems = screen.getAllByRole('treeitem');
+    treeitems[0].focus();
+    fireEvent.keyDown(treeitems[0], {key: 'ArrowDown'});
+
+    expect(treeitems[1]).toHaveFocus();
+  });
+
   // ===========================================================================
   // APG keyboard navigation
   // ===========================================================================

--- a/packages/core/src/TreeList/TreeList.tsx
+++ b/packages/core/src/TreeList/TreeList.tsx
@@ -271,24 +271,23 @@ export function TreeList({
     hasRovingTabIndex: true,
   });
 
-  // Run the consumer's handler first so `event.preventDefault()` reliably
-  // cancels the built-in arrow-key/expand-collapse behavior. Attached
-  // directly to the `<ul>` rather than left on the outer `<div>` (where
-  // `restProps` lands): the native keydown event starts at the focused
-  // treeitem and bubbles outward, so a handler left on the ancestor `<div>`
-  // would always run after `handleKeyDown` already moved focus. The event's
-  // `currentTarget` type differs from the declared `HTMLDivElement` here,
-  // but every property a consumer handler actually reads off it (key,
-  // preventDefault, etc.) is identical.
+  // The consumer's own onKeyDown stays on the root `<div>` (below, via
+  // onKeyDownCapture) rather than moving to the `<ul>`: the root is also
+  // where the `header` slot mounts, as a sibling of the `<ul>`, so a handler
+  // living only on the `<ul>` would never see keydowns from inside `header`.
+  // Capture phase (top-down) is what lets it still run before the built-in
+  // handler below, which stays in its original bubble-phase spot on the
+  // `<ul>` — capture on an ancestor always precedes bubble on a descendant,
+  // regardless of listener registration order. `handleTreeKeyDown` just
+  // bails once the consumer has already called `preventDefault()`.
   const handleTreeKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLUListElement>) => {
-      consumerOnKeyDown?.(e as unknown as React.KeyboardEvent<HTMLDivElement>);
       if (e.defaultPrevented) {
         return;
       }
       handleKeyDown(e);
     },
-    [consumerOnKeyDown, handleKeyDown],
+    [handleKeyDown],
   );
 
   const hasExpandableItems = items.some(
@@ -371,6 +370,7 @@ export function TreeList({
         className,
         style,
       )}
+      onKeyDownCapture={consumerOnKeyDown}
       {...restProps}>
       {header != null && (
         <div id={headerId} {...stylex.props(styles.header)}>

--- a/packages/core/src/TreeList/TreeList.tsx
+++ b/packages/core/src/TreeList/TreeList.tsx
@@ -71,6 +71,16 @@ export interface TreeListProps extends BaseProps<HTMLDivElement> {
   header?: ReactNode;
 
   /**
+   * Callback fired on keydown, before TreeList's own arrow-key navigation
+   * and expand/collapse handling run. Call `event.preventDefault()` to
+   * cancel the built-in behavior for that key entirely — focus and the
+   * roving tab stop are left untouched. A handler that doesn't call
+   * `preventDefault()` still lets the APG tree keyboard model run
+   * afterward.
+   */
+  onKeyDown?: BaseProps<HTMLDivElement>['onKeyDown'];
+
+  /**
    * Test ID for testing frameworks.
    */
   'data-testid'?: string;
@@ -190,6 +200,7 @@ export function TreeList({
   'data-testid': testId,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
+  onKeyDown: consumerOnKeyDown,
   ref,
   ...restProps
 }: TreeListProps) {
@@ -259,6 +270,26 @@ export function TreeList({
     onActivate: activateItem,
     hasRovingTabIndex: true,
   });
+
+  // Run the consumer's handler first so `event.preventDefault()` reliably
+  // cancels the built-in arrow-key/expand-collapse behavior. Attached
+  // directly to the `<ul>` rather than left on the outer `<div>` (where
+  // `restProps` lands): the native keydown event starts at the focused
+  // treeitem and bubbles outward, so a handler left on the ancestor `<div>`
+  // would always run after `handleKeyDown` already moved focus. The event's
+  // `currentTarget` type differs from the declared `HTMLDivElement` here,
+  // but every property a consumer handler actually reads off it (key,
+  // preventDefault, etc.) is identical.
+  const handleTreeKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLUListElement>) => {
+      consumerOnKeyDown?.(e as unknown as React.KeyboardEvent<HTMLDivElement>);
+      if (e.defaultPrevented) {
+        return;
+      }
+      handleKeyDown(e);
+    },
+    [consumerOnKeyDown, handleKeyDown],
+  );
 
   const hasExpandableItems = items.some(
     item => item.children != null && item.children.length > 0,
@@ -351,7 +382,7 @@ export function TreeList({
         role="tree"
         aria-label={header != null ? undefined : ariaLabel}
         aria-labelledby={header != null ? headerId : ariaLabelledby}
-        onKeyDown={handleKeyDown}
+        onKeyDown={handleTreeKeyDown}
         onFocus={handleFocus}
         {...stylex.props(styles.list)}>
         {renderItems(items, 0, [])}


### PR DESCRIPTION
## Problem

A consumer-supplied `onKeyDown` reaches TreeList through `...restProps` on the outer `<div>`, while the built-in arrow-key/expand-collapse handler (`useTreeFocus`) runs on the inner `<ul role="tree">`. The native keydown event starts at the focused treeitem and bubbles outward, hitting the closer `<ul>` ancestor first. So the built-in handler always ran, and moved focus, before the consumer's handler (on the further `<div>`) ever saw the event, let alone had a chance to call `preventDefault()` in time.

## Fix

`onKeyDown` is now composed on the same element (`<ul>`): the consumer's handler runs first, and the built-in navigation only proceeds if `event.defaultPrevented` is still false afterward. A non-canceling handler still lets the APG tree keyboard model run exactly as before.

## Testing

- Added the exact regression test from the issue: focus the first treeitem, fire `ArrowDown` with a `preventDefault()`-calling `onKeyDown`, assert focus and the roving tab stop are unchanged.
- Added a companion test confirming a non-canceling handler still lets navigation proceed.
- Full `TreeList.test.tsx` suite: 83/83 passing.
- `tsc --noEmit` and `eslint` clean on the changed files.
- Added `onKeyDown` to both English and Chinese `.doc.mjs` prop tables (it existed implicitly via `BaseProps` before, undocumented).

Fixes #5584