### PR TITLE
feat(theme-neutral): map semantic status colors

### DIFF
--- a/.changeset/neutral-theme-local-status-mappings.md
+++ b/.changeset/neutral-theme-local-status-mappings.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/cli': patch
+---
+
+[new] Reuse Neutral-owned local tokens for semantic status fills across badges, status dots, step indicators, and progress bars.
+
+@rubyycheung

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -30,7 +30,11 @@
  * Only overrides tokens that differ from the defaults.
  */
 
-import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
+import {
+  defineTheme,
+  defineSyntaxTheme,
+  type TokenValue,
+} from '@astryxdesign/core/theme';
 import {neutralIconRegistry} from './icons';
 
 /**
@@ -59,8 +63,32 @@ const neutralSyntax = defineSyntaxTheme({
   },
 });
 
+const neutralLocalTokens: Record<string, TokenValue> = {
+  '--astryx-theme-neutral-color-status-fill-accent': ['#0074e2', '#6d9cfe'],
+  '--astryx-theme-neutral-color-status-fill-success': ['#198100', '#64af4c'],
+  '--astryx-theme-neutral-color-status-fill-warning': '#ffce2f',
+  '--astryx-theme-neutral-color-status-fill-error': ['#c9303a', '#ff705d'],
+  '--astryx-theme-neutral-color-on-tint-neutral': ['#0a0a0a4D', '#fafafa4D'],
+  '--astryx-theme-neutral-color-on-tint-overlay-hover': [
+    '#0a0a0a1A',
+    '#fafafa1A',
+  ],
+  '--astryx-theme-neutral-color-on-tint-overlay-pressed': [
+    '#0a0a0a33',
+    '#fafafa33',
+  ],
+};
+
+const statusFill = {
+  accent: 'var(--astryx-theme-neutral-color-status-fill-accent)',
+  success: 'var(--astryx-theme-neutral-color-status-fill-success)',
+  warning: 'var(--astryx-theme-neutral-color-status-fill-warning)',
+  error: 'var(--astryx-theme-neutral-color-status-fill-error)',
+} as const;
+
 export const neutralTheme = defineTheme({
   name: 'neutral',
+  localTokens: neutralLocalTokens,
 
   // Typography: Figtree across body, heading, and display sizes (display
   // size tokens inherit from heading.family). Monospace stays as the
@@ -410,8 +438,8 @@ export const neutralTheme = defineTheme({
       'variant:info': {
         // Light: T50 #0074e2 (palette saturated stop)
         // Dark : T60 stop from dark-mode tonal palette of source #0074e2
-        backgroundColor: 'light-dark(#0074e2, #6d9cfe)',
-        color: 'light-dark(#ffffff, #171717)',
+        backgroundColor: statusFill.accent,
+        color: 'var(--color-on-accent)',
       },
       'variant:neutral': {
         // Mirrors the gray categorical badge — same neutral chip treatment
@@ -424,15 +452,15 @@ export const neutralTheme = defineTheme({
       'variant:success': {
         // Light: T45 #198100 (palette saturated stop)
         // Dark : T60 stop from dark-mode tonal palette of source #198100
-        backgroundColor: 'light-dark(#198100, #64af4c)',
-        color: 'light-dark(#ffffff, #171717)',
+        backgroundColor: statusFill.success,
+        color: 'var(--color-on-success)',
       },
       'variant:warning': {
         // Yellow stays at the same hex in both modes — chroma reduction
         // is barely visible at T85, and dark text on yellow doesn't
         // suffer from the §4 vibration concern.
-        backgroundColor: '#ffce2f',
-        color: '#171717',
+        backgroundColor: statusFill.warning,
+        color: 'var(--color-on-warning)',
       },
       'variant:error': {
         // Light: T58 #c9303a. The T55 stop #e33f4a pairs with white at only
@@ -442,8 +470,8 @@ export const neutralTheme = defineTheme({
         // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
         //        source #dc2626 (kept on H=27 alarm-red rather than coral).
         //        Dark text on it is 6.60:1 and unchanged.
-        backgroundColor: 'light-dark(#c9303a, #ff705d)',
-        color: 'light-dark(#ffffff, #171717)',
+        backgroundColor: statusFill.error,
+        color: 'var(--color-on-error)',
       },
 
       // Categorical — bg + text reference the per-hue tokens, so behavior
@@ -520,10 +548,15 @@ export const neutralTheme = defineTheme({
     // not among the "too dark" cases.
     // =========================================================================
     statusdot: {
-      'variant:success': {backgroundColor: 'light-dark(#198100, #64af4c)'},
-      'variant:warning': {backgroundColor: '#ffce2f'},
-      'variant:error': {backgroundColor: 'light-dark(#c9303a, #ff705d)'},
-      'variant:accent': {backgroundColor: 'light-dark(#0074e2, #6d9cfe)'},
+      'variant:success': {backgroundColor: statusFill.success},
+      'variant:warning': {backgroundColor: statusFill.warning},
+      'variant:error': {backgroundColor: statusFill.error},
+      'variant:accent': {backgroundColor: statusFill.accent},
+    },
+
+    'avatar-status-dot': {
+      'variant:success': {backgroundColor: statusFill.success},
+      'variant:error': {backgroundColor: statusFill.error},
     },
 
     // =========================================================================
@@ -544,6 +577,13 @@ export const neutralTheme = defineTheme({
     // Status overrides reference --color-text-{hue} so text/icon colors
     // stay in sync with the palette anchors automatically.
     banner: {
+      base: {
+        '--color-neutral': 'var(--astryx-theme-neutral-color-on-tint-neutral)',
+        '--color-overlay-hover':
+          'var(--astryx-theme-neutral-color-on-tint-overlay-hover)',
+        '--color-overlay-pressed':
+          'var(--astryx-theme-neutral-color-on-tint-overlay-pressed)',
+      },
       'status:info': {
         '--color-accent-muted': 'var(--color-background-blue)',
         '--color-text-primary': 'var(--color-text-blue)',
@@ -564,10 +604,18 @@ export const neutralTheme = defineTheme({
         '--color-warning': 'var(--color-text-yellow)',
       },
       'status:error': {
+        '--color-error-muted': 'var(--color-background-red)',
         '--color-text-primary': 'var(--color-text-red)',
         '--color-text-secondary': 'var(--color-text-red)',
         '--color-error': 'var(--color-text-red)',
       },
+    },
+
+    'step-indicator': {
+      'status:accent': {'--color-accent': statusFill.accent},
+      'status:success': {'--color-success': statusFill.success},
+      'status:warning': {'--color-warning': statusFill.warning},
+      'status:error': {'--color-error': statusFill.error},
     },
 
     // =========================================================================
@@ -607,19 +655,19 @@ export const neutralTheme = defineTheme({
       // values; documented per role with palette provenance.
       'variant:accent': {
         // Blue T50 saturated stop (= variant:info badge bg)
-        '--color-accent': '#0074e2',
+        '--color-accent': statusFill.accent,
       },
       'variant:success': {
         // Green T45 saturated stop (= variant:success badge bg)
-        '--color-success': '#198100',
+        '--color-success': statusFill.success,
       },
       'variant:warning': {
         // Yellow T85 saturated stop (= variant:warning badge bg)
-        '--color-warning': '#ffce2f',
+        '--color-warning': statusFill.warning,
       },
       'variant:error': {
         // Red T58 saturated stop (= variant:error badge bg)
-        '--color-error': '#c9303a',
+        '--color-error': statusFill.error,
       },
     },
 

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -403,84 +403,35 @@ export const neutralTheme = defineTheme({
   },
 
   components: {
-    // =========================================================================
-    // Button — primary gets white text, secondary gets a border, destructive
-    // uses the OKLCH red filled treatment.
-    // =========================================================================
     button: {
       'variant:destructive': {
-        backgroundColor: 'var(--color-error-muted)', // locked pastel red bg
-        color: 'var(--color-error)', // locked T30 red — matches banner/input error text
+        backgroundColor: 'var(--color-error-muted)',
+        color: 'var(--color-error)',
       },
     },
 
-    // =========================================================================
-    // Badge —
-    //   Semantic (info/success/warning/error): filled saturated T50 + contrasting
-    //     text (white, or dark on yellow). The filled-button rule from #2150
-    //     §3 — text contrast locks the bg tone, so this stays at T50 in
-    //     BOTH modes, unlike pastel surfaces which invert by mode.
-    //   Categorical (blue/green/red/orange/etc.): pastel-tinted hue surface +
-    //     colored text — light mode = soft T87-T90 + dark T30 text; dark mode
-    //     = T20 tinted + T80 light pastel text (sources: --color-background-X
-    //     and --color-text-X tokens).
-    //   Neutral: light gray bg + dark text (or inverted in dark mode).
-    // =========================================================================
     badge: {
-      // Semantic — filled saturated bg + contrasting text.
-      //   Light: vivid T45-T55 from the OKLCH palette + white text
-      //          (~4.5-5:1 — Material/Linear/Vercel pop).
-      //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
-      //          +5 tone-lift taper from issue #2150 §4) + DARK text.
-      //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
-      //          and tames the §4 vibration. Same dark-text-on-bright-bg
-      //          treatment that warning yellow uses in both modes.
       'variant:info': {
-        // Light: T50 #0074e2 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #0074e2
         backgroundColor: statusFill.accent,
         color: 'var(--color-on-accent)',
       },
       'variant:neutral': {
-        // Mirrors the gray categorical badge — same neutral chip treatment
-        // (Neutral 200 light / semi-transparent white wash dark) sourced
-        // from the gray hue tokens, so a single change at the token layer
-        // updates both variants.
         backgroundColor: 'var(--color-background-gray)',
         color: 'var(--color-text-gray)',
       },
       'variant:success': {
-        // Light: T45 #198100 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #198100
         backgroundColor: statusFill.success,
         color: 'var(--color-on-success)',
       },
       'variant:warning': {
-        // Yellow stays at the same hex in both modes — chroma reduction
-        // is barely visible at T85, and dark text on yellow doesn't
-        // suffer from the §4 vibration concern.
         backgroundColor: statusFill.warning,
         color: 'var(--color-on-warning)',
       },
       'variant:error': {
-        // Light: T58 #c9303a. The T55 stop #e33f4a pairs with white at only
-        //        4.14:1 — the label is 12px/500, so AA wants 4.5, not the 3:1
-        //        large-text allowance. One tonal step down holds the hue
-        //        (OKLCH H 21.9 -> 22.8, C 0.200 -> 0.189) and reaches 5.29:1.
-        // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
-        //        source #dc2626 (kept on H=27 alarm-red rather than coral).
-        //        Dark text on it is 6.60:1 and unchanged.
         backgroundColor: statusFill.error,
         color: 'var(--color-on-error)',
       },
 
-      // Categorical — bg + text reference the per-hue tokens, so behavior
-      // tracks the categorical palette automatically:
-      //   Light: pastel T87-T90 bg + dark T30 colored text (low-key chip)
-      //   Dark : tinted T20 bg + light T80 colored text (per #2150 §5,
-      //          inverted from light to avoid the "pastel-in-both-modes"
-      //          anti-pattern that makes locked light pastels glow on a
-      //          dark body)
       'variant:red': {
         backgroundColor: 'var(--color-background-red)',
         color: 'var(--color-text-red)',
@@ -523,30 +474,6 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
-    // StatusDot — fill uses the SAME vivid stops as the filled semantic Badge
-    // (and ProgressBar), so a dot and its badge read as one status language.
-    //
-    // The default component maps each variant to a raw semantic token
-    // (--color-success / --color-error / --color-warning / --color-icon-
-    // secondary), which in light mode are the dark T30/T40 stops meant to
-    // sit as TEXT on a pastel surface — as a solid dot they read muddy
-    // (dark green / maroon / brown). Redirect them to the badge fills.
-    //
-    //   success → badge success bg  (green T45 / dark-ramp T60)
-    //   warning → badge warning bg  (yellow T85, same hex both modes)
-    //   error   → badge error bg    (red T58 / dark-ramp T60)
-    //   accent  → badge info bg     (blue T50 / dark-ramp T60) — the
-    //             StatusDot "accent" is the info/attention color, so it
-    //             pairs with the info badge rather than --color-accent
-    //             (near-black #262626, the darkest offender).
-    //
-    // `neutral` is intentionally NOT overridden: the neutral badge bg is a
-    // near-invisible light gray (--color-background-gray #e5e5e5 / 10% white
-    // wash), fine as a large pill but unreadable as an 8px dot. It keeps the
-    // component default's visible mid-gray (--color-icon-secondary), which is
-    // not among the "too dark" cases.
-    // =========================================================================
     statusdot: {
       'variant:success': {backgroundColor: statusFill.success},
       'variant:warning': {backgroundColor: statusFill.warning},
@@ -559,23 +486,6 @@ export const neutralTheme = defineTheme({
       'variant:error': {backgroundColor: statusFill.error},
     },
 
-    // =========================================================================
-    // Banner — sits on a hue-tinted surface with colored text/icon:
-    //   Light: pastel T90 bg (pulled from --color-{X}-muted / --color-background-blue)
-    //          + dark T30 colored text (--color-text-{hue}).
-    //   Dark : tinted T20 bg (same tokens, dark slot) + light T80 colored text.
-    //          Per #2150 §5 — large hue-tinted surfaces in dark mode invert
-    //          to a deep tinted bg + light text rather than locking the
-    //          light-mode pastel.
-    //
-    // The inner-header *-muted token carries the tinted background for every
-    // status, info included. A theme override that sets a plain CSS property
-    // instead lands in @layer astryx-theme, which StyleX's @layer priority4
-    // outranks, so `backgroundColor` here would silently do nothing and the
-    // info banner would paint no background at all.
-    //
-    // Status overrides reference --color-text-{hue} so text/icon colors
-    // stay in sync with the palette anchors automatically.
     banner: {
       base: {
         '--color-neutral': 'var(--astryx-theme-neutral-color-on-tint-neutral)',
@@ -590,9 +500,6 @@ export const neutralTheme = defineTheme({
         '--color-text-secondary': 'var(--color-text-blue)',
         '--color-accent': 'var(--color-text-blue)',
       },
-      // success/warning/error banner bgs come from --color-{X}-muted, which
-      // already carries the correct light/dark tinted values. We only need
-      // to redirect the text/icon to the palette colored stop.
       'status:success': {
         '--color-text-primary': 'var(--color-text-green)',
         '--color-text-secondary': 'var(--color-text-green)',
@@ -618,23 +525,6 @@ export const neutralTheme = defineTheme({
       'status:error': {'--color-error': statusFill.error},
     },
 
-    // =========================================================================
-    // TextInput — no per-status overrides needed. The global tokens
-    // --color-{success,error,warning} carry the correct values in both
-    // modes (light=T40 dark colored, dark=T80 light pastel) for both
-    // surfaces the input border/icon touches: the input surface
-    // (white/T15-dark) and the status message bubble (light pastel T90 /
-    // dark T20). Verified all six combinations clear AA non-text 3:1.
-    // =========================================================================
-
-    // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
-    // =========================================================================
     switch: {
       base: {
         '--color-background-gray': 'var(--color-border-emphasized)',
@@ -643,46 +533,28 @@ export const neutralTheme = defineTheme({
 
     progressbar: {
       base: {
-        // Track uses --color-background-muted; override it to
-        // --color-border-emphasized (Neutral T85 #d4d4d4 in light mode) so
-        // the track is clearly darker than the body bg (Neutral T95 #f1f1f1)
-        // and reads as a defined channel rather than blending in. Dark
-        // mode inherits T35 #525252 — same one-step-lighter behavior.
         '--color-background-muted': 'var(--color-border-emphasized)',
       },
-      // Vivid stops match the filled semantic badge colors (info/success/
-      // warning/error variants in the badge override above). Same hex
-      // values; documented per role with palette provenance.
       'variant:accent': {
-        // Blue T50 saturated stop (= variant:info badge bg)
         '--color-accent': statusFill.accent,
       },
       'variant:success': {
-        // Green T45 saturated stop (= variant:success badge bg)
         '--color-success': statusFill.success,
       },
       'variant:warning': {
-        // Yellow T85 saturated stop (= variant:warning badge bg)
         '--color-warning': statusFill.warning,
       },
       'variant:error': {
-        // Red T58 saturated stop (= variant:error badge bg)
         '--color-error': statusFill.error,
       },
     },
 
-    // =========================================================================
-    // Card — tighter padding via public card padding token
-    // =========================================================================
     card: {
       base: {
         padding: 'var(--spacing-3)',
       },
     },
 
-    // =========================================================================
-    // Section — tighter padding via public section padding token
-    // =========================================================================
     section: {
       base: {
         padding: 'var(--spacing-3)',

--- a/packages/themes/neutral/neutral.spec.md
+++ b/packages/themes/neutral/neutral.spec.md
@@ -51,15 +51,22 @@ vocabulary remains owned by `architecture:theme-tokens`.
 
 ## Theme-local role definitions
 
-Neutral owns this local role for future implementation:
+Neutral's candidate implementation owns the approved accent role and proposes
+the related roles below for exact-head review:
 
-| Approved exact name                               | Approved Neutral-only meaning                                                     | Proposed value           |
-| ------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------ |
-| `--astryx-theme-neutral-color-status-fill-accent` | Filled accent status in contexts whose actual semantic role is accent status fill | `['#0074e2', '#6d9cfe']` |
+| Exact name                                             | Neutral-only meaning                                | Proposed value               | Status   |
+| ------------------------------------------------------ | --------------------------------------------------- | ---------------------------- | -------- |
+| `--astryx-theme-neutral-color-status-fill-accent`      | Filled accent status                                | `['#0074e2', '#6d9cfe']`     | Approved |
+| `--astryx-theme-neutral-color-status-fill-success`     | Filled success status                               | `['#198100', '#64af4c']`     | Proposed |
+| `--astryx-theme-neutral-color-status-fill-warning`     | Filled warning status                               | `'#ffce2f'`                  | Proposed |
+| `--astryx-theme-neutral-color-status-fill-error`       | Filled error status                                 | `['#c9303a', '#ff705d']`     | Proposed |
+| `--astryx-theme-neutral-color-on-tint-neutral`         | Neutral content placed on a semantic tinted surface | `['#0a0a0a4D', '#fafafa4D']` | Proposed |
+| `--astryx-theme-neutral-color-on-tint-overlay-hover`   | Hover overlay placed on a semantic tinted surface   | `['#0a0a0a1A', '#fafafa1A']` | Proposed |
+| `--astryx-theme-neutral-color-on-tint-overlay-pressed` | Pressed overlay placed on a semantic tinted surface | `['#0a0a0a33', '#fafafa33']` | Proposed |
 
-AST-006 is current and accepted, but its implementation is not shipped. Once that
-implementation exists, Neutral would author and consume the exact name without an
-alias:
+AST-006 is current and accepted, and its implementation is proposed separately
+in the parent local-token PR. This stacked candidate authors and consumes exact
+names without aliases:
 
 ```ts
 localTokens: {
@@ -98,14 +105,15 @@ separate draft system spec.
 
 ## Component and state mappings
 
-Current source remains the implementation baseline. The exact
-`var(--astryx-theme-neutral-color-status-fill-accent)` reference may be adopted
-only where an existing Neutral component state genuinely means filled accent
-status. Badge `variant:info` is the first proposed mapping. Every added mapping is
-a theme-spec compatibility review: it must demonstrate the same semantic context
-and provide rendered evidence for its actual light/dark and relevant interaction
-states. Shared color alone is not enough. This record does not add component
-states or authorize implementation before that evidence is complete.
+The candidate maps the shared status-fill roles across Badge, StatusDot,
+AvatarStatusDot, Stepper indicators, and ProgressBar wherever the existing state
+already has the same semantic meaning. Banner uses the proposed tint-content and
+interaction roles. Every mapping remains subject to exact-head theme review and
+rendered light/dark evidence; shared color alone is not enough.
+
+This work does not add component states. It intentionally excludes
+`table-row-status`, which has no approved theming target, and SegmentedControl
+geometry/shadow changes, which are reviewed independently.
 
 ## Compatibility and migration
 
@@ -115,13 +123,13 @@ Neutral stays unenrolled until it explicitly supplies `localTokens`; merely
 emitting or referencing the same prefix today does not activate validation or
 create the public contract.
 
-Implementation requires AST-006 implementation to ship first, followed by
-complete rendered evidence for the proposed value and mappings. When Neutral
-then ships the definition, its exact name and approved semantic meaning become a
-public compatibility contract of the Neutral family. A local-token name,
-enrolled theme name, or semantic meaning change must preserve descendants and
-consumers through an explicit reviewed migration or alias. Compiled CSS does not
-broaden the role beyond the contexts approved here.
+Implementation requires the parent AST-006 implementation to ship first,
+followed by complete rendered evidence and exact-head approval for every
+proposed value and mapping. When Neutral ships a definition, its exact name and
+approved semantic meaning become a public compatibility contract of the Neutral
+family. A local-token name, enrolled theme name, or semantic meaning change must
+preserve descendants and consumers through an explicit reviewed migration or
+alias. Compiled CSS does not broaden a role beyond its approved contexts.
 
 ## Accessibility and contrast evidence
 
@@ -193,6 +201,10 @@ or applying it merely because two contexts currently share a color.
   (`checkable`) Neutral promotion and implementation remain blocked until the
   actual pairings meet the applicable current contrast methodology, each mapped
   context is visibly verified, and `rubyycheung` ratifies that exact record head.
+- **OQ2 — Do the proposed success, warning, error, and tint roles have stable
+  meanings across every listed component mapping?** (`checkable`) The additional
+  names remain proposals until reviewers confirm each mapping represents the
+  same semantic role rather than merely sharing a current color value.
 
 ## Content boundary
 

--- a/packages/themes/neutral/src/neutralTheme.test.ts
+++ b/packages/themes/neutral/src/neutralTheme.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {neutralTheme} from './neutralTheme';
+
+const statusFill = {
+  accent: 'var(--astryx-theme-neutral-color-status-fill-accent)',
+  success: 'var(--astryx-theme-neutral-color-status-fill-success)',
+  warning: 'var(--astryx-theme-neutral-color-status-fill-warning)',
+  error: 'var(--astryx-theme-neutral-color-status-fill-error)',
+} as const;
+
+describe('neutral theme-local status mappings', () => {
+  it('owns reusable status fills through exact Neutral-local token names', () => {
+    expect(neutralTheme.localTokens).toMatchObject({
+      '--astryx-theme-neutral-color-status-fill-accent':
+        'light-dark(#0074e2, #6d9cfe)',
+      '--astryx-theme-neutral-color-status-fill-success':
+        'light-dark(#198100, #64af4c)',
+      '--astryx-theme-neutral-color-status-fill-warning': '#ffce2f',
+      '--astryx-theme-neutral-color-status-fill-error':
+        'light-dark(#c9303a, #ff705d)',
+    });
+    expect(neutralTheme.tokens).not.toHaveProperty(
+      '--astryx-theme-neutral-color-status-fill-accent',
+    );
+  });
+
+  it('shares each status fill across the components with the same role', () => {
+    expect(neutralTheme.components?.badge?.['variant:info']).toMatchObject({
+      backgroundColor: statusFill.accent,
+    });
+    expect(neutralTheme.components?.statusdot?.['variant:success']).toEqual({
+      backgroundColor: statusFill.success,
+    });
+    expect(
+      neutralTheme.components?.['avatar-status-dot']?.['variant:error'],
+    ).toEqual({backgroundColor: statusFill.error});
+    expect(
+      neutralTheme.components?.['step-indicator']?.['status:warning'],
+    ).toEqual({'--color-warning': statusFill.warning});
+    expect(neutralTheme.components?.progressbar?.['variant:accent']).toEqual({
+      '--color-accent': statusFill.accent,
+    });
+  });
+
+  it('does not adopt the unapproved table row-status target', () => {
+    expect(neutralTheme.components).not.toHaveProperty('table-row-status');
+  });
+});

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -30,7 +30,11 @@
  * Only overrides tokens that differ from the defaults.
  */
 
-import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
+import {
+  defineTheme,
+  defineSyntaxTheme,
+  type TokenValue,
+} from '@astryxdesign/core/theme';
 import {neutralIconRegistry} from './icons';
 
 /**
@@ -59,8 +63,32 @@ const neutralSyntax = defineSyntaxTheme({
   },
 });
 
+const neutralLocalTokens: Record<string, TokenValue> = {
+  '--astryx-theme-neutral-color-status-fill-accent': ['#0074e2', '#6d9cfe'],
+  '--astryx-theme-neutral-color-status-fill-success': ['#198100', '#64af4c'],
+  '--astryx-theme-neutral-color-status-fill-warning': '#ffce2f',
+  '--astryx-theme-neutral-color-status-fill-error': ['#c9303a', '#ff705d'],
+  '--astryx-theme-neutral-color-on-tint-neutral': ['#0a0a0a4D', '#fafafa4D'],
+  '--astryx-theme-neutral-color-on-tint-overlay-hover': [
+    '#0a0a0a1A',
+    '#fafafa1A',
+  ],
+  '--astryx-theme-neutral-color-on-tint-overlay-pressed': [
+    '#0a0a0a33',
+    '#fafafa33',
+  ],
+};
+
+const statusFill = {
+  accent: 'var(--astryx-theme-neutral-color-status-fill-accent)',
+  success: 'var(--astryx-theme-neutral-color-status-fill-success)',
+  warning: 'var(--astryx-theme-neutral-color-status-fill-warning)',
+  error: 'var(--astryx-theme-neutral-color-status-fill-error)',
+} as const;
+
 export const neutralTheme = defineTheme({
   name: 'neutral',
+  localTokens: neutralLocalTokens,
 
   // Typography: Figtree across body, heading, and display sizes (display
   // size tokens inherit from heading.family). Monospace stays as the
@@ -410,8 +438,8 @@ export const neutralTheme = defineTheme({
       'variant:info': {
         // Light: T50 #0074e2 (palette saturated stop)
         // Dark : T60 stop from dark-mode tonal palette of source #0074e2
-        backgroundColor: 'light-dark(#0074e2, #6d9cfe)',
-        color: 'light-dark(#ffffff, #171717)',
+        backgroundColor: statusFill.accent,
+        color: 'var(--color-on-accent)',
       },
       'variant:neutral': {
         // Mirrors the gray categorical badge — same neutral chip treatment
@@ -424,15 +452,15 @@ export const neutralTheme = defineTheme({
       'variant:success': {
         // Light: T45 #198100 (palette saturated stop)
         // Dark : T60 stop from dark-mode tonal palette of source #198100
-        backgroundColor: 'light-dark(#198100, #64af4c)',
-        color: 'light-dark(#ffffff, #171717)',
+        backgroundColor: statusFill.success,
+        color: 'var(--color-on-success)',
       },
       'variant:warning': {
         // Yellow stays at the same hex in both modes — chroma reduction
         // is barely visible at T85, and dark text on yellow doesn't
         // suffer from the §4 vibration concern.
-        backgroundColor: '#ffce2f',
-        color: '#171717',
+        backgroundColor: statusFill.warning,
+        color: 'var(--color-on-warning)',
       },
       'variant:error': {
         // Light: T58 #c9303a. The T55 stop #e33f4a pairs with white at only
@@ -442,8 +470,8 @@ export const neutralTheme = defineTheme({
         // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
         //        source #dc2626 (kept on H=27 alarm-red rather than coral).
         //        Dark text on it is 6.60:1 and unchanged.
-        backgroundColor: 'light-dark(#c9303a, #ff705d)',
-        color: 'light-dark(#ffffff, #171717)',
+        backgroundColor: statusFill.error,
+        color: 'var(--color-on-error)',
       },
 
       // Categorical — bg + text reference the per-hue tokens, so behavior
@@ -520,10 +548,15 @@ export const neutralTheme = defineTheme({
     // not among the "too dark" cases.
     // =========================================================================
     statusdot: {
-      'variant:success': {backgroundColor: 'light-dark(#198100, #64af4c)'},
-      'variant:warning': {backgroundColor: '#ffce2f'},
-      'variant:error': {backgroundColor: 'light-dark(#c9303a, #ff705d)'},
-      'variant:accent': {backgroundColor: 'light-dark(#0074e2, #6d9cfe)'},
+      'variant:success': {backgroundColor: statusFill.success},
+      'variant:warning': {backgroundColor: statusFill.warning},
+      'variant:error': {backgroundColor: statusFill.error},
+      'variant:accent': {backgroundColor: statusFill.accent},
+    },
+
+    'avatar-status-dot': {
+      'variant:success': {backgroundColor: statusFill.success},
+      'variant:error': {backgroundColor: statusFill.error},
     },
 
     // =========================================================================
@@ -544,6 +577,13 @@ export const neutralTheme = defineTheme({
     // Status overrides reference --color-text-{hue} so text/icon colors
     // stay in sync with the palette anchors automatically.
     banner: {
+      base: {
+        '--color-neutral': 'var(--astryx-theme-neutral-color-on-tint-neutral)',
+        '--color-overlay-hover':
+          'var(--astryx-theme-neutral-color-on-tint-overlay-hover)',
+        '--color-overlay-pressed':
+          'var(--astryx-theme-neutral-color-on-tint-overlay-pressed)',
+      },
       'status:info': {
         '--color-accent-muted': 'var(--color-background-blue)',
         '--color-text-primary': 'var(--color-text-blue)',
@@ -564,10 +604,18 @@ export const neutralTheme = defineTheme({
         '--color-warning': 'var(--color-text-yellow)',
       },
       'status:error': {
+        '--color-error-muted': 'var(--color-background-red)',
         '--color-text-primary': 'var(--color-text-red)',
         '--color-text-secondary': 'var(--color-text-red)',
         '--color-error': 'var(--color-text-red)',
       },
+    },
+
+    'step-indicator': {
+      'status:accent': {'--color-accent': statusFill.accent},
+      'status:success': {'--color-success': statusFill.success},
+      'status:warning': {'--color-warning': statusFill.warning},
+      'status:error': {'--color-error': statusFill.error},
     },
 
     // =========================================================================
@@ -607,19 +655,19 @@ export const neutralTheme = defineTheme({
       // values; documented per role with palette provenance.
       'variant:accent': {
         // Blue T50 saturated stop (= variant:info badge bg)
-        '--color-accent': '#0074e2',
+        '--color-accent': statusFill.accent,
       },
       'variant:success': {
         // Green T45 saturated stop (= variant:success badge bg)
-        '--color-success': '#198100',
+        '--color-success': statusFill.success,
       },
       'variant:warning': {
         // Yellow T85 saturated stop (= variant:warning badge bg)
-        '--color-warning': '#ffce2f',
+        '--color-warning': statusFill.warning,
       },
       'variant:error': {
         // Red T58 saturated stop (= variant:error badge bg)
-        '--color-error': '#c9303a',
+        '--color-error': statusFill.error,
       },
     },
 

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -403,84 +403,35 @@ export const neutralTheme = defineTheme({
   },
 
   components: {
-    // =========================================================================
-    // Button — primary gets white text, secondary gets a border, destructive
-    // uses the OKLCH red filled treatment.
-    // =========================================================================
     button: {
       'variant:destructive': {
-        backgroundColor: 'var(--color-error-muted)', // locked pastel red bg
-        color: 'var(--color-error)', // locked T30 red — matches banner/input error text
+        backgroundColor: 'var(--color-error-muted)',
+        color: 'var(--color-error)',
       },
     },
 
-    // =========================================================================
-    // Badge —
-    //   Semantic (info/success/warning/error): filled saturated T50 + contrasting
-    //     text (white, or dark on yellow). The filled-button rule from #2150
-    //     §3 — text contrast locks the bg tone, so this stays at T50 in
-    //     BOTH modes, unlike pastel surfaces which invert by mode.
-    //   Categorical (blue/green/red/orange/etc.): pastel-tinted hue surface +
-    //     colored text — light mode = soft T87-T90 + dark T30 text; dark mode
-    //     = T20 tinted + T80 light pastel text (sources: --color-background-X
-    //     and --color-text-X tokens).
-    //   Neutral: light gray bg + dark text (or inverted in dark mode).
-    // =========================================================================
     badge: {
-      // Semantic — filled saturated bg + contrasting text.
-      //   Light: vivid T45-T55 from the OKLCH palette + white text
-      //          (~4.5-5:1 — Material/Linear/Vercel pop).
-      //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
-      //          +5 tone-lift taper from issue #2150 §4) + DARK text.
-      //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
-      //          and tames the §4 vibration. Same dark-text-on-bright-bg
-      //          treatment that warning yellow uses in both modes.
       'variant:info': {
-        // Light: T50 #0074e2 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #0074e2
         backgroundColor: statusFill.accent,
         color: 'var(--color-on-accent)',
       },
       'variant:neutral': {
-        // Mirrors the gray categorical badge — same neutral chip treatment
-        // (Neutral 200 light / semi-transparent white wash dark) sourced
-        // from the gray hue tokens, so a single change at the token layer
-        // updates both variants.
         backgroundColor: 'var(--color-background-gray)',
         color: 'var(--color-text-gray)',
       },
       'variant:success': {
-        // Light: T45 #198100 (palette saturated stop)
-        // Dark : T60 stop from dark-mode tonal palette of source #198100
         backgroundColor: statusFill.success,
         color: 'var(--color-on-success)',
       },
       'variant:warning': {
-        // Yellow stays at the same hex in both modes — chroma reduction
-        // is barely visible at T85, and dark text on yellow doesn't
-        // suffer from the §4 vibration concern.
         backgroundColor: statusFill.warning,
         color: 'var(--color-on-warning)',
       },
       'variant:error': {
-        // Light: T58 #c9303a. The T55 stop #e33f4a pairs with white at only
-        //        4.14:1 — the label is 12px/500, so AA wants 4.5, not the 3:1
-        //        large-text allowance. One tonal step down holds the hue
-        //        (OKLCH H 21.9 -> 22.8, C 0.200 -> 0.189) and reaches 5.29:1.
-        // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
-        //        source #dc2626 (kept on H=27 alarm-red rather than coral).
-        //        Dark text on it is 6.60:1 and unchanged.
         backgroundColor: statusFill.error,
         color: 'var(--color-on-error)',
       },
 
-      // Categorical — bg + text reference the per-hue tokens, so behavior
-      // tracks the categorical palette automatically:
-      //   Light: pastel T87-T90 bg + dark T30 colored text (low-key chip)
-      //   Dark : tinted T20 bg + light T80 colored text (per #2150 §5,
-      //          inverted from light to avoid the "pastel-in-both-modes"
-      //          anti-pattern that makes locked light pastels glow on a
-      //          dark body)
       'variant:red': {
         backgroundColor: 'var(--color-background-red)',
         color: 'var(--color-text-red)',
@@ -523,30 +474,6 @@ export const neutralTheme = defineTheme({
       },
     },
 
-    // =========================================================================
-    // StatusDot — fill uses the SAME vivid stops as the filled semantic Badge
-    // (and ProgressBar), so a dot and its badge read as one status language.
-    //
-    // The default component maps each variant to a raw semantic token
-    // (--color-success / --color-error / --color-warning / --color-icon-
-    // secondary), which in light mode are the dark T30/T40 stops meant to
-    // sit as TEXT on a pastel surface — as a solid dot they read muddy
-    // (dark green / maroon / brown). Redirect them to the badge fills.
-    //
-    //   success → badge success bg  (green T45 / dark-ramp T60)
-    //   warning → badge warning bg  (yellow T85, same hex both modes)
-    //   error   → badge error bg    (red T58 / dark-ramp T60)
-    //   accent  → badge info bg     (blue T50 / dark-ramp T60) — the
-    //             StatusDot "accent" is the info/attention color, so it
-    //             pairs with the info badge rather than --color-accent
-    //             (near-black #262626, the darkest offender).
-    //
-    // `neutral` is intentionally NOT overridden: the neutral badge bg is a
-    // near-invisible light gray (--color-background-gray #e5e5e5 / 10% white
-    // wash), fine as a large pill but unreadable as an 8px dot. It keeps the
-    // component default's visible mid-gray (--color-icon-secondary), which is
-    // not among the "too dark" cases.
-    // =========================================================================
     statusdot: {
       'variant:success': {backgroundColor: statusFill.success},
       'variant:warning': {backgroundColor: statusFill.warning},
@@ -559,23 +486,6 @@ export const neutralTheme = defineTheme({
       'variant:error': {backgroundColor: statusFill.error},
     },
 
-    // =========================================================================
-    // Banner — sits on a hue-tinted surface with colored text/icon:
-    //   Light: pastel T90 bg (pulled from --color-{X}-muted / --color-background-blue)
-    //          + dark T30 colored text (--color-text-{hue}).
-    //   Dark : tinted T20 bg (same tokens, dark slot) + light T80 colored text.
-    //          Per #2150 §5 — large hue-tinted surfaces in dark mode invert
-    //          to a deep tinted bg + light text rather than locking the
-    //          light-mode pastel.
-    //
-    // The inner-header *-muted token carries the tinted background for every
-    // status, info included. A theme override that sets a plain CSS property
-    // instead lands in @layer astryx-theme, which StyleX's @layer priority4
-    // outranks, so `backgroundColor` here would silently do nothing and the
-    // info banner would paint no background at all.
-    //
-    // Status overrides reference --color-text-{hue} so text/icon colors
-    // stay in sync with the palette anchors automatically.
     banner: {
       base: {
         '--color-neutral': 'var(--astryx-theme-neutral-color-on-tint-neutral)',
@@ -590,9 +500,6 @@ export const neutralTheme = defineTheme({
         '--color-text-secondary': 'var(--color-text-blue)',
         '--color-accent': 'var(--color-text-blue)',
       },
-      // success/warning/error banner bgs come from --color-{X}-muted, which
-      // already carries the correct light/dark tinted values. We only need
-      // to redirect the text/icon to the palette colored stop.
       'status:success': {
         '--color-text-primary': 'var(--color-text-green)',
         '--color-text-secondary': 'var(--color-text-green)',
@@ -618,23 +525,6 @@ export const neutralTheme = defineTheme({
       'status:error': {'--color-error': statusFill.error},
     },
 
-    // =========================================================================
-    // TextInput — no per-status overrides needed. The global tokens
-    // --color-{success,error,warning} carry the correct values in both
-    // modes (light=T40 dark colored, dark=T80 light pastel) for both
-    // surfaces the input border/icon touches: the input surface
-    // (white/T15-dark) and the status message bubble (light pastel T90 /
-    // dark T20). Verified all six combinations clear AA non-text 3:1.
-    // =========================================================================
-
-    // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
-    // =========================================================================
     switch: {
       base: {
         '--color-background-gray': 'var(--color-border-emphasized)',
@@ -643,46 +533,28 @@ export const neutralTheme = defineTheme({
 
     progressbar: {
       base: {
-        // Track uses --color-background-muted; override it to
-        // --color-border-emphasized (Neutral T85 #d4d4d4 in light mode) so
-        // the track is clearly darker than the body bg (Neutral T95 #f1f1f1)
-        // and reads as a defined channel rather than blending in. Dark
-        // mode inherits T35 #525252 — same one-step-lighter behavior.
         '--color-background-muted': 'var(--color-border-emphasized)',
       },
-      // Vivid stops match the filled semantic badge colors (info/success/
-      // warning/error variants in the badge override above). Same hex
-      // values; documented per role with palette provenance.
       'variant:accent': {
-        // Blue T50 saturated stop (= variant:info badge bg)
         '--color-accent': statusFill.accent,
       },
       'variant:success': {
-        // Green T45 saturated stop (= variant:success badge bg)
         '--color-success': statusFill.success,
       },
       'variant:warning': {
-        // Yellow T85 saturated stop (= variant:warning badge bg)
         '--color-warning': statusFill.warning,
       },
       'variant:error': {
-        // Red T58 saturated stop (= variant:error badge bg)
         '--color-error': statusFill.error,
       },
     },
 
-    // =========================================================================
-    // Card — tighter padding via public card padding token
-    // =========================================================================
     card: {
       base: {
         padding: 'var(--spacing-3)',
       },
     },
 
-    // =========================================================================
-    // Section — tighter padding via public section padding token
-    // =========================================================================
     section: {
       base: {
         padding: 'var(--spacing-3)',

--- a/scripts/check-badge-contrast.test.mjs
+++ b/scripts/check-badge-contrast.test.mjs
@@ -82,7 +82,7 @@ function resolve(value, theme, modeIndex, seen = new Set()) {
     const args = splitArgs(v.slice('var('.length, -1));
     const [name, fallback] = args;
     if (seen.has(name)) return null; // cycle guard
-    const next = theme.tokens?.[name];
+    const next = theme.localTokens?.[name] ?? theme.tokens?.[name];
     if (next == null) {
       return fallback ? resolve(fallback, theme, modeIndex, seen) : null;
     }


### PR DESCRIPTION
## Summary

Restores the Neutral theme mapping work that was previously bundled into #5752, now isolated from the local-token API and unrelated component styling.

- defines Neutral-owned local roles for semantic status fills and tinted-surface interactions
- reuses the fill roles across Badge, StatusDot, AvatarStatusDot, Stepper, and ProgressBar
- keeps the bundled CLI Neutral template in sync
- teaches the badge contrast guard to resolve theme-local tokens
- updates the draft Neutral record with the proposed roles and mapping review scope

## Stack

- **Base:** #5844 (`localTokens` API)
- **Follow-up to:** #5668 for final palette-backed values and evidence

## Deliberate exclusions

- no SegmentedControl geometry or shadow changes (#5851)
- no syntax-theme identifier changes (#5847)
- no `table-row-status` mapping; that target remains unapproved under #5830

## Verification

- `pnpm -F @astryxdesign/core build`
- `pnpm -F @astryxdesign/theme-neutral build`
- focused Neutral mapping, badge contrast, CLI bundle, and template tests
- knowledge, sync, package-boundary, changeset, and repository pre-commit checks

This remains a draft until the exact-head Neutral record and rendered light/dark evidence are reviewed.