### PR TITLE
Fix detail template layout spacing inheritance

### DIFF
--- a/.changeset/themeable-layout-padding.md
+++ b/.changeset/themeable-layout-padding.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] Allow themes to control default Layout padding and let the detail page template inherit layout region spacing defaults.
+
+@rubyycheung

--- a/packages/cli/assets/templates/pages/detail-page/page.tsx
+++ b/packages/cli/assets/templates/pages/detail-page/page.tsx
@@ -52,7 +52,7 @@ import type {CSSProperties} from 'react';
 // meets the header divider. No edge-dock prop on TabList (#2622).
 const tabsRow: CSSProperties = {
   marginInline: -12,
-  marginBottom: -16,
+  marginBottom: 'calc(-1 * var(--container-padding-block-end))',
   marginTop: 12,
 };
 // Pull the list items' inner padding back so their content optically aligns
@@ -176,7 +176,7 @@ function PageHeader({
   isNarrow: boolean;
 }) {
   return (
-    <LayoutHeader hasDivider padding={4}>
+    <LayoutHeader hasDivider>
       <VStack gap={3}>
         <HStack gap={4} vAlign="start">
           <StackItem size="fill">
@@ -557,7 +557,7 @@ function PanelContent() {
 // Desktop: fixed-width side panel in the layout's `end` slot.
 function RightPanel() {
   return (
-    <LayoutPanel width={320} padding={4} role="complementary">
+    <LayoutPanel width={320} role="complementary">
       <PanelContent />
     </LayoutPanel>
   );
@@ -620,7 +620,7 @@ export default function DetailPage2Template() {
             />
           }
           content={
-            <LayoutContent padding={4}>
+            <LayoutContent>
               <PanelContent />
             </LayoutContent>
           }

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -41,12 +41,46 @@ export const docs = {
   displayName: 'Layout',
   group: 'Layout',
   category: 'Layout',
-  keywords: ["layout","container","content","flex","box","wrapper","page","regions"],
+  keywords: [
+    'layout',
+    'container',
+    'content',
+    'flex',
+    'box',
+    'wrapper',
+    'page',
+    'regions',
+  ],
   playground: {
     defaults: {
-      header: {__element: 'LayoutHeader', props: {}, children: {__element: 'Heading', props: {level: 3}, children: 'Page Title'}},
-      content: {__element: 'LayoutContent', props: {}, children: {__element: 'Text', props: {type: 'body', color: 'secondary'}, children: 'Main content area. This is the scrollable center section of the layout.'}},
-      footer: {__element: 'LayoutFooter', props: {}, children: {__element: 'Text', props: {type: 'supporting', color: 'secondary'}, children: 'Footer: status bar or actions'}},
+      header: {
+        __element: 'LayoutHeader',
+        props: {},
+        children: {
+          __element: 'Heading',
+          props: {level: 3},
+          children: 'Page Title',
+        },
+      },
+      content: {
+        __element: 'LayoutContent',
+        props: {},
+        children: {
+          __element: 'Text',
+          props: {type: 'body', color: 'secondary'},
+          children:
+            'Main content area. This is the scrollable center section of the layout.',
+        },
+      },
+      footer: {
+        __element: 'LayoutFooter',
+        props: {},
+        children: {
+          __element: 'Text',
+          props: {type: 'supporting', color: 'secondary'},
+          children: 'Footer: status bar or actions',
+        },
+      },
     },
   },
   theming: {
@@ -57,8 +91,47 @@ export const docs = {
       {className: 'astryx-layout-header'},
       {className: 'astryx-layout-panel'},
     ],
+    vars: [
+      {
+        name: '--astryx-layout-padding',
+        description:
+          'Default padding for LayoutHeader, LayoutContent, LayoutFooter, and LayoutPanel when their padding prop is omitted.',
+        default: 'var(--spacing-4)',
+      },
+      {
+        name: '--astryx-layout-padding-inline',
+        description: 'Default horizontal layout-region padding.',
+        default: 'var(--astryx-layout-padding)',
+      },
+      {
+        name: '--astryx-layout-padding-inline-start',
+        description: 'Default inline-start layout-region padding.',
+        default: 'var(--astryx-layout-padding-inline)',
+      },
+      {
+        name: '--astryx-layout-padding-inline-end',
+        description: 'Default inline-end layout-region padding.',
+        default: 'var(--astryx-layout-padding-inline)',
+      },
+      {
+        name: '--astryx-layout-padding-block',
+        description: 'Default vertical layout-region padding.',
+        default: 'var(--astryx-layout-padding)',
+      },
+      {
+        name: '--astryx-layout-padding-block-start',
+        description: 'Default block-start layout-region padding.',
+        default: 'var(--astryx-layout-padding-block)',
+      },
+      {
+        name: '--astryx-layout-padding-block-end',
+        description: 'Default block-end layout-region padding.',
+        default: 'var(--astryx-layout-padding-block)',
+      },
+    ],
   },
-  description: 'General five-slot layout primitive for arranging header, start, content, end, and footer regions.',
+  description:
+    'General five-slot layout primitive for arranging header, start, content, end, and footer regions.',
   props: [
     {
       name: 'content',
@@ -162,10 +235,26 @@ export const docs = {
     description:
       'Layout is a general five-slot primitive for arranging header, start, content, end, and footer regions within a page or bounded container. AppShell owns the page shell and app-wide navigation behavior; use HStack or VStack for simple directional stacking.',
     bestPractices: [
-      { guidance: true, description: 'Use Layout when content needs named header, start, content, end, or footer regions.' },
-      { guidance: true, description: 'Use HStack and VStack for simple directional stacking within a content area.' },
-      { guidance: false, description: 'Use Layout for simple stacking layouts; use HStack or VStack instead.' },
-      { guidance: false, description: 'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.' },
+      {
+        guidance: true,
+        description:
+          'Use Layout when content needs named header, start, content, end, or footer regions.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use HStack and VStack for simple directional stacking within a content area.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout for simple stacking layouts; use HStack or VStack instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.',
+      },
     ],
     anatomy,
   },
@@ -177,10 +266,26 @@ export const docsZh = {
     description:
       'Layout is a general five-slot primitive for arranging header, start, content, end, and footer regions within a page or bounded container. AppShell owns the page shell and app-wide navigation behavior; use HStack or VStack for simple directional stacking.',
     bestPractices: [
-      { guidance: true, description: 'Use Layout when content needs named header, start, content, end, or footer regions.' },
-      { guidance: true, description: 'Use HStack and VStack for simple directional stacking within a content area.' },
-      { guidance: false, description: 'Use Layout for simple stacking layouts; use HStack or VStack instead.' },
-      { guidance: false, description: 'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.' },
+      {
+        guidance: true,
+        description:
+          'Use Layout when content needs named header, start, content, end, or footer regions.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use HStack and VStack for simple directional stacking within a content area.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout for simple stacking layouts; use HStack or VStack instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.',
+      },
     ],
   },
 };
@@ -193,10 +298,26 @@ export const docsDense = {
     description:
       'Layout is a general five-slot primitive for arranging header, start, content, end, and footer regions within a page or bounded container. AppShell owns the page shell and app-wide navigation behavior; use HStack or VStack for simple directional stacking.',
     bestPractices: [
-      { guidance: true, description: 'Use Layout when content needs named header, start, content, end, or footer regions.' },
-      { guidance: true, description: 'Use HStack and VStack for simple directional stacking within a content area.' },
-      { guidance: false, description: 'Use Layout for simple stacking layouts; use HStack or VStack instead.' },
-      { guidance: false, description: 'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.' },
+      {
+        guidance: true,
+        description:
+          'Use Layout when content needs named header, start, content, end, or footer regions.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use HStack and VStack for simple directional stacking within a content area.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout for simple stacking layouts; use HStack or VStack instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.',
+      },
     ],
     anatomy,
   },

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -28,10 +28,20 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {spacingVars} from '../theme/tokens.stylex';
 import {
   layoutPaddingOuterXVarStyles,
   layoutPaddingOuterYVarStyles,
+  layoutPaddingVarStyles,
 } from './padding.stylex';
+
+const layoutPadding = `var(--astryx-layout-padding, ${spacingVars['--spacing-4']})`;
+const layoutPaddingInline = `var(--astryx-layout-padding-inline, ${layoutPadding})`;
+const layoutPaddingBlock = `var(--astryx-layout-padding-block, ${layoutPadding})`;
+const layoutPaddingInlineStart = `var(--astryx-layout-padding-inline-start, ${layoutPaddingInline})`;
+const layoutPaddingInlineEnd = `var(--astryx-layout-padding-inline-end, ${layoutPaddingInline})`;
+const layoutPaddingBlockStart = `var(--astryx-layout-padding-block-start, ${layoutPaddingBlock})`;
+const layoutPaddingBlockEnd = `var(--astryx-layout-padding-block-end, ${layoutPaddingBlock})`;
 
 /**
  * Height behavior for the layout.
@@ -54,6 +64,14 @@ const styles = stylex.create({
     '--container-padding-inline-end': '0px',
     '--container-padding-block-start': '0px',
     '--container-padding-block-end': '0px',
+    '--layout-padding-outer-x': layoutPaddingInline,
+    '--layout-padding-inner-x': layoutPaddingInline,
+    '--layout-padding-outer-y': layoutPaddingBlock,
+    '--layout-padding-inner-y': layoutPaddingBlock,
+    '--layout-padding-inline-start': layoutPaddingInlineStart,
+    '--layout-padding-inline-end': layoutPaddingInlineEnd,
+    '--layout-padding-block-start': layoutPaddingBlockStart,
+    '--layout-padding-block-end': layoutPaddingBlockEnd,
   },
   fill: {
     // Add 2x container block padding to compensate for negative block margins
@@ -72,6 +90,10 @@ const styles = stylex.create({
   fullBleed: {
     '--layout-padding-outer-x': '0px',
     '--layout-padding-outer-y': '0px',
+    '--layout-padding-inline-start': '0px',
+    '--layout-padding-inline-end': '0px',
+    '--layout-padding-block-start': '0px',
+    '--layout-padding-block-end': '0px',
   },
 });
 
@@ -281,6 +303,7 @@ export function Layout({
             padding === 0 && styles.fullBleed,
             padding != null && layoutPaddingOuterXVarStyles[padding],
             padding != null && layoutPaddingOuterYVarStyles[padding],
+            padding != null && layoutPaddingVarStyles[padding],
             contentWidth != null && dynamicStyles.contentWidthVar(contentWidth),
           )}>
           <AreaProvider area="header">{header}</AreaProvider>

--- a/packages/core/src/Layout/LayoutContent.tsx
+++ b/packages/core/src/Layout/LayoutContent.tsx
@@ -31,6 +31,11 @@ import {
   containerPaddingBlockEndVarStyles,
 } from './padding.stylex';
 
+const layoutPaddingInlineStart = `var(--layout-padding-inline-start, var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingInlineEnd = `var(--layout-padding-inline-end, var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockStart = `var(--layout-padding-block-start, var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockEnd = `var(--layout-padding-block-end, var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`;
+
 const styles = stylex.create({
   content: {
     boxSizing: 'border-box',
@@ -39,47 +44,47 @@ const styles = stylex.create({
     minHeight: 0,
     overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
-    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
-    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineStart: layoutPaddingInlineStart,
+    paddingInlineEnd: layoutPaddingInlineEnd,
     paddingBlockStart: {
-      default: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+      default: layoutPaddingBlockStart,
       // When header has no divider, collapse top padding for seamless visual flow
       [stylex.when.ancestor(
         ':has(> .astryx-layout-header:not([data-divider]))',
       )]: 0,
     },
     paddingBlockEnd: {
-      default: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+      default: layoutPaddingBlockEnd,
       // When footer has no divider, collapse bottom padding for seamless visual flow
       [stylex.when.ancestor(
         ':has(> .astryx-layout-footer:not([data-divider]))',
       )]: 0,
     },
     // Publish container padding vars for bleed children (Table, Divider, etc.)
-    '--container-padding-inline-start': `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-end': `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-inline-start': layoutPaddingInlineStart,
+    '--container-padding-inline-end': layoutPaddingInlineEnd,
+    '--container-padding-block-start': layoutPaddingBlockStart,
+    '--container-padding-block-end': layoutPaddingBlockEnd,
   },
   // When no start panel: outer-x on left edge
   noStart: {
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-start': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-end': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineStart: layoutPaddingInlineStart,
+    '--container-padding-inline-start': layoutPaddingInlineStart,
+    '--container-padding-inline-end': layoutPaddingInlineStart,
   },
   // When no end panel: outer-x on right edge
   noEnd: {
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineEnd: layoutPaddingInlineEnd,
   },
   // When no header: outer-y on top
   noHeader: {
-    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-start': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockStart: layoutPaddingBlockStart,
+    '--container-padding-block-start': layoutPaddingBlockStart,
   },
   // When no footer: outer-y on bottom
   noFooter: {
-    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-end': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockEnd: layoutPaddingBlockEnd,
+    '--container-padding-block-end': layoutPaddingBlockEnd,
   },
   scrollable: {
     overflow: 'auto',

--- a/packages/core/src/Layout/LayoutFooter.tsx
+++ b/packages/core/src/Layout/LayoutFooter.tsx
@@ -31,6 +31,11 @@ import {
   containerPaddingBlockEndVarStyles,
 } from './padding.stylex';
 
+const layoutPaddingInlineStart = `var(--layout-padding-inline-start, var(--layout-padding-outer-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingInlineEnd = `var(--layout-padding-inline-end, var(--layout-padding-outer-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockStart = `var(--layout-padding-block-start, var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockEnd = `var(--layout-padding-block-end, var(--layout-padding-outer-y, ${spacingVars['--spacing-4']}))`;
+
 const styles = stylex.create({
   // Outer shell: owns border/divider and sizing. No padding — that lives on inner.
   footer: {
@@ -43,14 +48,14 @@ const styles = stylex.create({
     maxWidth: 'var(--layout-content-width, none)',
     marginInline: 'auto',
     // Default: outer padding on edges that touch container, inner on interior edges
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
-    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-start': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-end': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-end': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    paddingInlineStart: layoutPaddingInlineStart,
+    paddingInlineEnd: layoutPaddingInlineEnd,
+    paddingBlockStart: layoutPaddingBlockStart,
+    paddingBlockEnd: layoutPaddingBlockEnd,
+    '--container-padding-inline-start': layoutPaddingInlineStart,
+    '--container-padding-inline-end': layoutPaddingInlineEnd,
+    '--container-padding-block-start': layoutPaddingBlockStart,
+    '--container-padding-block-end': layoutPaddingBlockEnd,
   },
   fullBleed: {
     paddingInlineStart: 0,

--- a/packages/core/src/Layout/LayoutHeader.tsx
+++ b/packages/core/src/Layout/LayoutHeader.tsx
@@ -31,6 +31,11 @@ import {
   containerPaddingBlockEndVarStyles,
 } from './padding.stylex';
 
+const layoutPaddingInlineStart = `var(--layout-padding-inline-start, var(--layout-padding-outer-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingInlineEnd = `var(--layout-padding-inline-end, var(--layout-padding-outer-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockStart = `var(--layout-padding-block-start, var(--layout-padding-outer-y, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockEnd = `var(--layout-padding-block-end, var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`;
+
 const styles = stylex.create({
   // Outer shell: owns border/divider and sizing. No padding — that lives on inner.
   header: {
@@ -43,14 +48,14 @@ const styles = stylex.create({
     maxWidth: 'var(--layout-content-width, none)',
     marginInline: 'auto',
     // Default: outer padding on edges that touch container, inner on interior edges
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
-    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-start': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-end': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-start': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    paddingInlineStart: layoutPaddingInlineStart,
+    paddingInlineEnd: layoutPaddingInlineEnd,
+    paddingBlockStart: layoutPaddingBlockStart,
+    paddingBlockEnd: layoutPaddingBlockEnd,
+    '--container-padding-inline-start': layoutPaddingInlineStart,
+    '--container-padding-inline-end': layoutPaddingInlineEnd,
+    '--container-padding-block-start': layoutPaddingBlockStart,
+    '--container-padding-block-end': layoutPaddingBlockEnd,
   },
   fullBleed: {
     paddingInlineStart: 0,

--- a/packages/core/src/Layout/LayoutPanel.tsx
+++ b/packages/core/src/Layout/LayoutPanel.tsx
@@ -33,36 +33,41 @@ import {
   containerPaddingBlockEndVarStyles,
 } from './padding.stylex';
 
+const layoutPaddingInlineStart = `var(--layout-padding-inline-start, var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingInlineEnd = `var(--layout-padding-inline-end, var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockStart = `var(--layout-padding-block-start, var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`;
+const layoutPaddingBlockEnd = `var(--layout-padding-block-end, var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`;
+
 const styles = stylex.create({
   panel: {
     boxSizing: 'border-box',
     flexShrink: 0,
     overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
-    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
-    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
-    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
-    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-start': `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-inline-end': `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
-    '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    paddingInlineStart: layoutPaddingInlineStart,
+    paddingInlineEnd: layoutPaddingInlineEnd,
+    paddingBlockStart: layoutPaddingBlockStart,
+    paddingBlockEnd: layoutPaddingBlockEnd,
+    '--container-padding-inline-start': layoutPaddingInlineStart,
+    '--container-padding-inline-end': layoutPaddingInlineEnd,
+    '--container-padding-block-start': layoutPaddingBlockStart,
+    '--container-padding-block-end': layoutPaddingBlockEnd,
   },
   // Start panel: outer-x on left edge
   startPanel: {
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineStart: layoutPaddingInlineStart,
   },
   // End panel: outer-x on right edge
   endPanel: {
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineEnd: layoutPaddingInlineEnd,
   },
   // When no header: outer-y on top
   noHeader: {
-    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockStart: layoutPaddingBlockStart,
   },
   // When no footer: outer-y on bottom
   noFooter: {
-    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockEnd: layoutPaddingBlockEnd,
   },
   fullBleed: {
     paddingInlineStart: 0,
@@ -93,10 +98,10 @@ const styles = stylex.create({
   // Start panel: collapse end (right in LTR) to merge with content
   // End panel: collapse start (left in LTR) to merge with content
   collapseStart: {
-    marginInlineStart: `calc(-1 * var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`,
+    marginInlineStart: `calc(-1 * ${layoutPaddingInlineStart})`,
   },
   collapseEnd: {
-    marginInlineEnd: `calc(-1 * var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`,
+    marginInlineEnd: `calc(-1 * ${layoutPaddingInlineEnd})`,
   },
 });
 

--- a/packages/core/src/Layout/overlayPaddingReset.test.tsx
+++ b/packages/core/src/Layout/overlayPaddingReset.test.tsx
@@ -84,6 +84,10 @@ const CLEARED = [
   '--layout-padding-outer-y',
   '--layout-padding-inner-x',
   '--layout-padding-inner-y',
+  '--layout-padding-inline-start',
+  '--layout-padding-inline-end',
+  '--layout-padding-block-start',
+  '--layout-padding-block-end',
   '--_section-padding-propagated',
 ];
 

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -221,6 +221,80 @@ export const layoutPaddingOuterYVarStyles = stylex.create({
 });
 
 /**
+ * Layout directional padding CSS variable styles.
+ * Mirrors the legacy x/y variables so an explicit Layout padding prop continues
+ * to override theme-provided layout padding defaults on every edge.
+ */
+export const layoutPaddingVarStyles = stylex.create({
+  0: {
+    '--layout-padding-inline-start': spacingVars['--spacing-0'],
+    '--layout-padding-inline-end': spacingVars['--spacing-0'],
+    '--layout-padding-block-start': spacingVars['--spacing-0'],
+    '--layout-padding-block-end': spacingVars['--spacing-0'],
+  },
+  0.5: {
+    '--layout-padding-inline-start': spacingVars['--spacing-0-5'],
+    '--layout-padding-inline-end': spacingVars['--spacing-0-5'],
+    '--layout-padding-block-start': spacingVars['--spacing-0-5'],
+    '--layout-padding-block-end': spacingVars['--spacing-0-5'],
+  },
+  1: {
+    '--layout-padding-inline-start': spacingVars['--spacing-1'],
+    '--layout-padding-inline-end': spacingVars['--spacing-1'],
+    '--layout-padding-block-start': spacingVars['--spacing-1'],
+    '--layout-padding-block-end': spacingVars['--spacing-1'],
+  },
+  1.5: {
+    '--layout-padding-inline-start': spacingVars['--spacing-1-5'],
+    '--layout-padding-inline-end': spacingVars['--spacing-1-5'],
+    '--layout-padding-block-start': spacingVars['--spacing-1-5'],
+    '--layout-padding-block-end': spacingVars['--spacing-1-5'],
+  },
+  2: {
+    '--layout-padding-inline-start': spacingVars['--spacing-2'],
+    '--layout-padding-inline-end': spacingVars['--spacing-2'],
+    '--layout-padding-block-start': spacingVars['--spacing-2'],
+    '--layout-padding-block-end': spacingVars['--spacing-2'],
+  },
+  3: {
+    '--layout-padding-inline-start': spacingVars['--spacing-3'],
+    '--layout-padding-inline-end': spacingVars['--spacing-3'],
+    '--layout-padding-block-start': spacingVars['--spacing-3'],
+    '--layout-padding-block-end': spacingVars['--spacing-3'],
+  },
+  4: {
+    '--layout-padding-inline-start': spacingVars['--spacing-4'],
+    '--layout-padding-inline-end': spacingVars['--spacing-4'],
+    '--layout-padding-block-start': spacingVars['--spacing-4'],
+    '--layout-padding-block-end': spacingVars['--spacing-4'],
+  },
+  5: {
+    '--layout-padding-inline-start': spacingVars['--spacing-5'],
+    '--layout-padding-inline-end': spacingVars['--spacing-5'],
+    '--layout-padding-block-start': spacingVars['--spacing-5'],
+    '--layout-padding-block-end': spacingVars['--spacing-5'],
+  },
+  6: {
+    '--layout-padding-inline-start': spacingVars['--spacing-6'],
+    '--layout-padding-inline-end': spacingVars['--spacing-6'],
+    '--layout-padding-block-start': spacingVars['--spacing-6'],
+    '--layout-padding-block-end': spacingVars['--spacing-6'],
+  },
+  8: {
+    '--layout-padding-inline-start': spacingVars['--spacing-8'],
+    '--layout-padding-inline-end': spacingVars['--spacing-8'],
+    '--layout-padding-block-start': spacingVars['--spacing-8'],
+    '--layout-padding-block-end': spacingVars['--spacing-8'],
+  },
+  10: {
+    '--layout-padding-inline-start': spacingVars['--spacing-10'],
+    '--layout-padding-inline-end': spacingVars['--spacing-10'],
+    '--layout-padding-block-start': spacingVars['--spacing-10'],
+    '--layout-padding-block-end': spacingVars['--spacing-10'],
+  },
+});
+
+/**
  * Inline-only padding styles.
  * Use when a component needs to set inline (horizontal) padding independently
  * of block padding — e.g. the `paddingX` prop on Stack.
@@ -521,6 +595,10 @@ export const overlayPaddingReset = stylex.create({
     '--layout-padding-outer-y': 'initial',
     '--layout-padding-inner-x': 'initial',
     '--layout-padding-inner-y': 'initial',
+    '--layout-padding-inline-start': 'initial',
+    '--layout-padding-inline-end': 'initial',
+    '--layout-padding-block-start': 'initial',
+    '--layout-padding-block-end': 'initial',
     '--_section-padding-propagated': 'initial',
   },
 });

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -927,6 +927,23 @@ describe('container padding mapping', () => {
     expect(css).not.toContain('--astryx-button-padding');
   });
 
+  it('preserves layout padding as a raw CSS property for compatibility', () => {
+    const theme = defineTheme({
+      name: 'test',
+      components: {
+        layout: {
+          base: {
+            padding: '20px',
+            '--astryx-layout-padding': '12px',
+          },
+        },
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('padding: 20px');
+    expect(css).toContain('--astryx-layout-padding: 12px');
+  });
+
   it('preserves non-padding properties alongside padding mapping', () => {
     const theme = defineTheme({
       name: 'test',

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -313,6 +313,16 @@ const VARS_WITHOUT_DERIVED_MAPPING = new Set([
   '--spinner-stroke-width',
   '--spinner-color',
   '--spinner-track-color',
+  // Preserve the existing meaning of `components.layout.base.padding` as raw
+  // CSS on `.astryx-layout`; themes set these semantic layout defaults
+  // directly when they want Layout regions to inherit different spacing.
+  '--astryx-layout-padding',
+  '--astryx-layout-padding-inline',
+  '--astryx-layout-padding-inline-start',
+  '--astryx-layout-padding-inline-end',
+  '--astryx-layout-padding-block',
+  '--astryx-layout-padding-block-start',
+  '--astryx-layout-padding-block-end',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -522,6 +522,25 @@ describe('derived var expansion', () => {
     expect(rule).toContain('--astryx-card-padding: 20px');
   });
 
+  it('preserves layout padding as raw CSS for compatibility', () => {
+    const theme = defineTheme({
+      name: 'test-layout-container',
+      components: {
+        layout: {
+          base: {
+            padding: '20px',
+            '--astryx-layout-padding': '12px',
+          },
+        },
+      },
+    });
+    const rules = generateThemeRules(theme);
+    const rule = rules.find(r => r.includes('.astryx-layout'));
+    expect(rule).toBeDefined();
+    expect(rule).toContain('padding: 20px');
+    expect(rule).toContain('--astryx-layout-padding: 12px');
+  });
+
   it('handles variant-specific derived vars', () => {
     const theme = defineTheme({
       name: 'test-variant-derived',


### PR DESCRIPTION
## Summary
- add semantic `--astryx-layout-padding*` variables for Layout region defaults without changing the existing meaning of `components.layout.base.padding`
- wire LayoutHeader, LayoutContent, LayoutFooter, and LayoutPanel to that semantic layout padding variable chain when their padding prop is omitted
- remove hardcoded default layout padding from the Order Detail template so header/content/panel inherit layout region defaults together

## Compatibility
- Existing themes that set `components.layout.base.padding` still emit raw `padding` on `.astryx-layout`, matching the previous behavior.
- Themes that want responsive/default Layout region spacing can opt into the new semantic variables directly, e.g. `components.layout.base['--astryx-layout-padding']`.
- Existing explicit `padding` props on LayoutHeader, LayoutContent, LayoutFooter, and LayoutPanel continue to win over the semantic default.

## Validation
- pnpm exec vitest run packages/core/src/theme/defineTheme.test.ts packages/core/src/theme/generateThemeRules.test.ts packages/core/src/theme/derivedVarRegistry.test.ts packages/core/src/Layout/Layout.test.tsx packages/core/src/Layout/overlayPaddingReset.test.tsx
- pnpm -F @astryxdesign/core typecheck
- pnpm check:sync && pnpm check:knowledge && pnpm check:changesets
- pnpm exec eslint packages/cli/assets/templates/pages/detail-page/page.tsx packages/core/src/Layout/Layout.tsx packages/core/src/Layout/LayoutHeader.tsx packages/core/src/Layout/LayoutContent.tsx packages/core/src/Layout/LayoutFooter.tsx packages/core/src/Layout/LayoutPanel.tsx packages/core/src/Layout/padding.stylex.ts packages/core/src/Layout/Layout.doc.mjs packages/core/src/Layout/overlayPaddingReset.test.tsx packages/core/src/theme/derivedVarRegistry.ts packages/core/src/theme/derivedVarRegistry.test.ts packages/core/src/theme/defineTheme.test.ts packages/core/src/theme/generateThemeRules.test.ts
