### PR TITLE
feat(templates): five table templates — tree, comparison, inbox, plus rebuilt searchable and grouped

### DIFF
--- a/apps/docsite/src/components/templateComponents.ts
+++ b/apps/docsite/src/components/templateComponents.ts
@@ -154,6 +154,10 @@ export const TEMPLATE_COMPONENTS: Record<
   table: lazy(
     () => import('../../../../packages/cli/assets/templates/pages/table/page'),
   ),
+  'table-comparison': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/table-comparison/page'),
+  ),
   'table-filter': lazy(
     () =>
       import('../../../../packages/cli/assets/templates/pages/table-filter/page'),
@@ -162,9 +166,17 @@ export const TEMPLATE_COMPONENTS: Record<
     () =>
       import('../../../../packages/cli/assets/templates/pages/table-grouped/page'),
   ),
+  'table-inbox': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/table-inbox/page'),
+  ),
   'table-page': lazy(
     () =>
       import('../../../../packages/cli/assets/templates/pages/table-page/page'),
+  ),
+  'table-tree': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/table-tree/page'),
   ),
 };
 

--- a/packages/cli/assets/templates/pages/table-comparison/page.tsx
+++ b/packages/cli/assets/templates/pages/table-comparison/page.tsx
@@ -1,0 +1,524 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * A comparison matrix: candidates across the top, criteria down the side, and a
+ * label column that stays put while the candidates scroll past it.
+ *
+ * This is the transpose of every other table in the set. Elsewhere a row is a
+ * record and a column is a field; here a *column* is the record — one compute
+ * instance — and a row is a single attribute measured across all of them. That
+ * flip is what makes the layout work: comparison is a vertical scan, and a
+ * vertical scan only works if the thing being compared shares a column.
+ *
+ * It is also the shape that makes `useTableGroupedRows` correct, where
+ * `table-grouped` made it wrong. Every group here — capacity, throughput,
+ * pricing, efficiency — is measured against the same eight instances, so one
+ * header row is true of every section beneath it. Groups are a way to chunk a
+ * long criteria list, not a sign that the records differ.
+ *
+ * ## Extending this template
+ *
+ * **The matrix is derived, not authored.** Eight instances times twelve
+ * criteria is ninety-six cells, and hand-writing them guarantees a typo nobody
+ * finds. Instead `INSTANCES` holds each machine's real specs once, `SPEC_ROWS`
+ * declares each criterion as a `get(instance)` accessor, and the table is the
+ * product of the two. Memory-per-vCPU and both cost-efficiency rows are pure
+ * functions of the columns above them, so they cannot drift. Add an instance
+ * and every row gains a cell; add a criterion and every instance gains a value.
+ *
+ * **Columns are generated, which is the point.** `columns` is built by mapping
+ * over `INSTANCES`, so the candidate set is data. A comparison table with
+ * hardcoded columns is a comparison table that nobody will extend — the moment
+ * the list comes from an API you are rewriting it. Note the cost: because the
+ * columns are dynamic, their widths must be `pixel()` for the sticky plugin to
+ * compute offsets, so the table scrolls rather than compresses.
+ *
+ * **The label column is pinned because the row labels are the axis.** Scrolled
+ * horizontally, an unpinned matrix becomes a grid of anonymous numbers.
+ * `useTableStickyColumns({startKeys: ['spec']})` keeps the criterion visible;
+ * `endKeys` does the same for a trailing run if you want a fixed reference
+ * column on the right. The plugin needs pixel widths to compute its offsets,
+ * which is the real constraint behind the previous point.
+ *
+ * **Best-in-row is computed, and only where "best" means something.** A
+ * criterion declares `better: 'higher' | 'lower'`, and rows that declare
+ * neither — a processor name, a yes/no — get no winner at all. This is the part
+ * teams get wrong: marking a winner on a row where the values are merely
+ * different, not better or worse, quietly tells the reader a preference that
+ * the data does not support. Winners render semibold, so a column that is
+ * strong overall reads as a vertical run of bold rather than as a colour.
+ *
+ * **Ties are winners too.** `isBest` compares against the extreme value rather
+ * than picking one index, so identical values are all marked. Choosing an
+ * arbitrary winner among equals is a bug that survives review because it looks
+ * decisive.
+ */
+
+import {useMemo, useState} from 'react';
+
+import {
+  HStack,
+  Layout,
+  LayoutContent,
+  LayoutHeader,
+  StackItem,
+  VStack,
+} from '@astryxdesign/core/Layout';
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Button} from '@astryxdesign/core/Button';
+import {Icon} from '@astryxdesign/core/Icon';
+import {
+  Table,
+  pixel,
+  useTableGroupedRows,
+  useTableStickyColumns,
+} from '@astryxdesign/core/Table';
+import type {TableColumn} from '@astryxdesign/core/Table';
+import {ArrowDownTrayIcon} from '@heroicons/react/24/outline';
+
+// ============= CANDIDATES =============
+
+/** One machine's specs, stated once. Every cell in the table derives from here. */
+interface Instance {
+  id: string;
+  name: string;
+  family: string;
+  vcpu: number;
+  memoryGib: number;
+  /** Attached NVMe in GB; 0 means EBS-only. */
+  nvmeGb: number;
+  networkGbps: number;
+  ebsGbps: number;
+  ebsIops: number;
+  /** Dollars per hour. */
+  onDemand: number;
+  reserved: number;
+  spot: number;
+  isShortlisted?: boolean;
+}
+
+const INSTANCES: Instance[] = [
+  {
+    id: 'm6i-large',
+    name: 'm6i.large',
+    family: 'General purpose',
+    vcpu: 2,
+    memoryGib: 8,
+    nvmeGb: 0,
+    networkGbps: 5,
+    ebsGbps: 4.75,
+    ebsIops: 20_000,
+    onDemand: 0.096,
+    reserved: 0.06,
+    spot: 0.037,
+  },
+  {
+    id: 'm6i-xlarge',
+    name: 'm6i.xlarge',
+    family: 'General purpose',
+    vcpu: 4,
+    memoryGib: 16,
+    nvmeGb: 0,
+    networkGbps: 8,
+    ebsGbps: 6.5,
+    ebsIops: 26_700,
+    onDemand: 0.192,
+    reserved: 0.121,
+    spot: 0.074,
+  },
+  {
+    id: 'm6i-2xlarge',
+    name: 'm6i.2xlarge',
+    family: 'General purpose',
+    vcpu: 8,
+    memoryGib: 32,
+    nvmeGb: 0,
+    networkGbps: 12.5,
+    ebsGbps: 10,
+    ebsIops: 40_000,
+    onDemand: 0.384,
+    reserved: 0.242,
+    spot: 0.148,
+    isShortlisted: true,
+  },
+  {
+    id: 'c6i-2xlarge',
+    name: 'c6i.2xlarge',
+    family: 'Compute optimized',
+    vcpu: 8,
+    memoryGib: 16,
+    nvmeGb: 0,
+    networkGbps: 12.5,
+    ebsGbps: 10,
+    ebsIops: 40_000,
+    onDemand: 0.34,
+    reserved: 0.214,
+    spot: 0.131,
+  },
+  {
+    id: 'c6i-4xlarge',
+    name: 'c6i.4xlarge',
+    family: 'Compute optimized',
+    vcpu: 16,
+    memoryGib: 32,
+    nvmeGb: 0,
+    networkGbps: 20,
+    ebsGbps: 16,
+    ebsIops: 60_000,
+    onDemand: 0.68,
+    reserved: 0.428,
+    spot: 0.262,
+  },
+  {
+    id: 'r6i-2xlarge',
+    name: 'r6i.2xlarge',
+    family: 'Memory optimized',
+    vcpu: 8,
+    memoryGib: 64,
+    nvmeGb: 0,
+    networkGbps: 12.5,
+    ebsGbps: 10,
+    ebsIops: 40_000,
+    onDemand: 0.504,
+    reserved: 0.317,
+    spot: 0.194,
+  },
+  {
+    id: 'r6id-2xlarge',
+    name: 'r6id.2xlarge',
+    family: 'Memory optimized',
+    vcpu: 8,
+    memoryGib: 64,
+    nvmeGb: 474,
+    networkGbps: 12.5,
+    ebsGbps: 10,
+    ebsIops: 40_000,
+    onDemand: 0.605,
+    reserved: 0.381,
+    spot: 0.233,
+  },
+  {
+    id: 'r6i-4xlarge',
+    name: 'r6i.4xlarge',
+    family: 'Memory optimized',
+    vcpu: 16,
+    memoryGib: 128,
+    nvmeGb: 0,
+    networkGbps: 20,
+    ebsGbps: 16,
+    ebsIops: 60_000,
+    onDemand: 1.008,
+    reserved: 0.635,
+    spot: 0.388,
+  },
+];
+
+// ============= FORMATTING =============
+
+// Pinned locale keeps the rendered output identical in every environment.
+const decimal = new Intl.NumberFormat('en-US', {maximumFractionDigits: 2});
+const rate = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 3,
+  maximumFractionDigits: 3,
+});
+const fineRate = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 4,
+  maximumFractionDigits: 4,
+});
+
+// ============= CRITERIA =============
+
+type GroupKey = 'Capacity' | 'Throughput' | 'Pricing' | 'Efficiency';
+
+const GROUP_ORDER: GroupKey[] = [
+  'Capacity',
+  'Throughput',
+  'Pricing',
+  'Efficiency',
+];
+
+interface SpecRow extends Record<string, unknown> {
+  id: string;
+  group: GroupKey;
+  label: string;
+  /** Suffix shown under the label, never repeated in every cell. */
+  unit?: string;
+  /** Omitted when the values differ without one being better. */
+  better?: 'higher' | 'lower';
+  get: (instance: Instance) => number;
+  format: (value: number) => string;
+}
+
+const SPEC_ROWS: SpecRow[] = [
+  {
+    id: 'vcpu',
+    group: 'Capacity',
+    label: 'vCPUs',
+    better: 'higher',
+    get: i => i.vcpu,
+    format: v => decimal.format(v),
+  },
+  {
+    id: 'memory',
+    group: 'Capacity',
+    label: 'Memory',
+    unit: 'GiB',
+    better: 'higher',
+    get: i => i.memoryGib,
+    format: v => decimal.format(v),
+  },
+  {
+    id: 'mem-per-vcpu',
+    group: 'Capacity',
+    label: 'Memory per vCPU',
+    unit: 'GiB',
+    better: 'higher',
+    get: i => i.memoryGib / i.vcpu,
+    format: v => decimal.format(v),
+  },
+  {
+    id: 'nvme',
+    group: 'Capacity',
+    label: 'Local NVMe',
+    unit: 'GB',
+    better: 'higher',
+    get: i => i.nvmeGb,
+    format: v => (v === 0 ? 'EBS only' : decimal.format(v)),
+  },
+  {
+    id: 'network',
+    group: 'Throughput',
+    label: 'Network bandwidth',
+    unit: 'Gbps',
+    better: 'higher',
+    get: i => i.networkGbps,
+    format: v => decimal.format(v),
+  },
+  {
+    id: 'ebs',
+    group: 'Throughput',
+    label: 'EBS bandwidth',
+    unit: 'Gbps',
+    better: 'higher',
+    get: i => i.ebsGbps,
+    format: v => decimal.format(v),
+  },
+  {
+    id: 'iops',
+    group: 'Throughput',
+    label: 'Max EBS IOPS',
+    better: 'higher',
+    get: i => i.ebsIops,
+    format: v => decimal.format(v),
+  },
+  {
+    id: 'on-demand',
+    group: 'Pricing',
+    label: 'On-demand',
+    unit: 'per hour',
+    better: 'lower',
+    get: i => i.onDemand,
+    format: v => rate.format(v),
+  },
+  {
+    id: 'reserved',
+    group: 'Pricing',
+    label: '1-year reserved',
+    unit: 'per hour',
+    better: 'lower',
+    get: i => i.reserved,
+    format: v => rate.format(v),
+  },
+  {
+    id: 'spot',
+    group: 'Pricing',
+    label: 'Spot average',
+    unit: 'per hour',
+    better: 'lower',
+    get: i => i.spot,
+    format: v => rate.format(v),
+  },
+  {
+    id: 'per-vcpu',
+    group: 'Efficiency',
+    label: 'Cost per vCPU-hour',
+    better: 'lower',
+    get: i => i.onDemand / i.vcpu,
+    format: v => fineRate.format(v),
+  },
+  {
+    id: 'per-gib',
+    group: 'Efficiency',
+    label: 'Cost per GiB-hour',
+    better: 'lower',
+    get: i => i.onDemand / i.memoryGib,
+    format: v => fineRate.format(v),
+  },
+];
+
+/**
+ * The extreme value for a row, or null when the row declares no direction.
+ * Comparing against the extreme rather than picking an index means ties are all
+ * marked instead of one being chosen arbitrarily.
+ */
+function bestValue(row: SpecRow): number | null {
+  if (!row.better) {
+    return null;
+  }
+  const values = INSTANCES.map(row.get);
+  return row.better === 'higher' ? Math.max(...values) : Math.min(...values);
+}
+
+const BEST_BY_ROW = new Map(SPEC_ROWS.map(row => [row.id, bestValue(row)]));
+
+// ============= COLUMNS =============
+
+const SPEC_COLUMN_WIDTH = 220;
+const INSTANCE_COLUMN_WIDTH = 168;
+
+// Widths are pixel-valued because useTableStickyColumns resolves its offsets
+// from them; a proportional column would fall back to its min width and the
+// pinned cells would sit in the wrong place.
+const columns: TableColumn<SpecRow>[] = [
+  {
+    key: 'spec',
+    header: 'Criterion',
+    width: pixel(SPEC_COLUMN_WIDTH),
+    renderCell: row => (
+      <VStack gap={0}>
+        <Text>{row.label}</Text>
+        {row.unit != null && <Text type="supporting">{row.unit}</Text>}
+      </VStack>
+    ),
+  },
+  ...INSTANCES.map<TableColumn<SpecRow>>(instance => ({
+    key: instance.id,
+    width: pixel(INSTANCE_COLUMN_WIDTH),
+    align: 'end',
+    header: (
+      <VStack gap={0.5} hAlign="end">
+        <Text weight="semibold">{instance.name}</Text>
+        {instance.isShortlisted ? (
+          <Badge variant="info" label="Shortlisted" />
+        ) : (
+          <Text type="supporting">{instance.family}</Text>
+        )}
+      </VStack>
+    ),
+    renderCell: row => {
+      const value = row.get(instance);
+      const best = BEST_BY_ROW.get(row.id);
+      const isBest = best != null && value === best;
+      return (
+        <Text hasTabularNumbers weight={isBest ? 'semibold' : 'normal'}>
+          {row.format(value)}
+        </Text>
+      );
+    },
+  })),
+];
+
+// ============= PAGE =============
+
+export default function InstanceComparisonTemplate() {
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const toggleGroup = (groupKey: string) => {
+    setCollapsedGroups(previous => {
+      const next = new Set(previous);
+      if (next.has(groupKey)) {
+        next.delete(groupKey);
+      } else {
+        next.add(groupKey);
+      }
+      return next;
+    });
+  };
+
+  const grouped = useTableGroupedRows<SpecRow>({
+    data: SPEC_ROWS,
+    groupBy: row => row.group,
+    groupOrder: GROUP_ORDER,
+    collapsedGroups,
+    onToggleGroup: toggleGroup,
+    getRowKey: row => row.id,
+    // A group header is one cell spanning every column, so the sticky-columns
+    // plugin has nothing to pin it to and the label scrolls off with the rest
+    // of the row — leaving a blank band. Sticking the label itself to the
+    // scrollport edge keeps each section named at any scroll position.
+    renderGroupHeader: (groupKey, count) => (
+      <HStack
+        gap={2}
+        vAlign="center"
+        style={{position: 'sticky', insetInlineStart: 0, width: 'fit-content'}}>
+        <Text weight="semibold">{groupKey}</Text>
+        <Text type="supporting">
+          {count} {count === 1 ? 'criterion' : 'criteria'}
+        </Text>
+      </HStack>
+    ),
+  });
+
+  // T cannot be inferred from the config alone, so it is named explicitly.
+  const sticky = useTableStickyColumns<SpecRow>({startKeys: ['spec']});
+
+  const shortlisted = useMemo(
+    () => INSTANCES.find(instance => instance.isShortlisted),
+    [],
+  );
+
+  return (
+    <Layout
+      height="fill"
+      header={
+        <LayoutHeader hasDivider padding={4}>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            <StackItem size="fill">
+              <VStack gap={0.5}>
+                <Heading level={1}>Instance comparison</Heading>
+                <Text type="supporting">
+                  {INSTANCES.length} candidates across {SPEC_ROWS.length}{' '}
+                  criteria
+                  {shortlisted != null &&
+                    ` · ${shortlisted.name} shortlisted for the API tier`}
+                </Text>
+              </VStack>
+            </StackItem>
+            <Button
+              label="Export comparison"
+              variant="secondary"
+              icon={<Icon icon={ArrowDownTrayIcon} size="sm" />}
+            />
+          </HStack>
+        </LayoutHeader>
+      }
+      content={
+        <LayoutContent padding={4}>
+          <VStack gap={3}>
+            <Table<SpecRow>
+              data={grouped.data}
+              columns={columns}
+              idKey={grouped.idKey}
+              density="compact"
+              dividers="grid"
+              plugins={{grouped: grouped.plugin, sticky}}
+            />
+            <Text type="supporting">
+              Bold marks the best value in a row. Rows without a better
+              direction are left unmarked.
+            </Text>
+          </VStack>
+        </LayoutContent>
+      }
+    />
+  );
+}

--- a/packages/cli/assets/templates/pages/table-comparison/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-comparison/template.doc.mjs
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'page',
+  name: 'Comparison Table',
+  displayName: 'Comparison Table',
+  description:
+    'Transposed matrix that puts candidates in the columns and criteria in grouped rows, with a pinned label column that survives horizontal scroll and computed best-in-row marks. Comparison, matrix, spec sheet, feature grid, pricing table, frozen column, or side-by-side.',
+  isReady: true,
+  category: 'Table - Frozen Column',
+};

--- a/packages/cli/assets/templates/pages/table-grouped/page.tsx
+++ b/packages/cli/assets/templates/pages/table-grouped/page.tsx
@@ -2,1217 +2,765 @@
 
 'use client';
 
-import React, {useState, useMemo} from 'react';
-import {useResizable, ResizeHandle} from '@astryxdesign/core/Resizable';
-import type {ResizableProps} from '@astryxdesign/core/Resizable';
+/**
+ * Four kinds of financial account on one page, each in a collapsible Card with
+ * a table of its own — because a credit card and a checking account do not
+ * share a column grid.
+ *
+ * This is the grouping shape for heterogeneous records. `useTableGroupedRows`
+ * is the right tool when every group is the same kind of thing and grouping is
+ * just a sort you can collapse: issues by status, orders by month, rows by
+ * owner. One table, one header, section rows in between. It is the wrong tool
+ * the moment the groups stop agreeing on what the columns mean. Utilization is
+ * a credit-card idea, next payout is a processor idea, and cost basis is an
+ * investment idea; forcing all three into one grid produces a table that is
+ * mostly em-dashes, with a header row that is true of no row beneath it.
+ *
+ * So each group owns a table. The Card supplies the boundary the shared header
+ * row used to supply, and the Collapsible trigger carries the group's name,
+ * count, and running total, so a collapsed group still answers the question
+ * most people came for.
+ *
+ * ## Extending this template
+ *
+ * **The test for splitting is column divergence, not group count.** Two groups
+ * with different columns belong in separate tables; twelve groups with
+ * identical columns belong in one table with the plugin. If you find yourself
+ * adding a column that only applies to some groups and writing a fallback dash
+ * for the rest, that is the signal to split. Conversely, if these four tables
+ * ever converge on the same columns, collapse them back — this layout costs a
+ * Card and a header per group, and that is only worth paying for real
+ * structural difference.
+ *
+ * **Each table is data-driven, and that is the payoff.** Because the groups are
+ * separate tables, every one of them can use `data` + `columns` with
+ * `renderCell`, which is the RSC-friendly path and the one that gets headers,
+ * widths, and plugins for free. The single-table version of this page has to
+ * drop to children mode to emit section rows, and loses all of that.
+ *
+ * **The trigger is a button, so it holds no buttons.** Group name, count, and
+ * total are text and icons only. Per-account actions live in the rows, and
+ * anything that acts on a whole group belongs in the page header rather than
+ * inside the trigger — nesting a control inside the trigger makes the click
+ * target ambiguous and is invalid HTML besides.
+ *
+ * **Open state is controlled, not `defaultIsOpen`.** The page owns a Set of
+ * open group ids, which is what lets Expand all / Collapse all work and what
+ * you would persist per user. Uncontrolled Collapsibles are fine for a static
+ * FAQ; they cannot participate in a page-level control.
+ *
+ * **Money is stored in cents.** Every amount is an integer and only the display
+ * step formats, so group totals and the header's net position stay exact. Net
+ * position deliberately subtracts card balances — it is a derived figure, never
+ * a stored one, so adding an account updates it with no other edit.
+ *
+ * **Sync state is the one piece of shared vocabulary.** All four record types
+ * carry the same `syncState`, rendered by the same StatusDot, because "is this
+ * connection healthy" is the one question that means the same thing across
+ * every group. Where groups genuinely agree, share the component.
+ */
+
+import {useMemo, useState} from 'react';
+
 import {
+  HStack,
   Layout,
   LayoutContent,
-  LayoutFooter,
   LayoutHeader,
-  LayoutPanel,
-  VStack,
-  HStack,
   StackItem,
+  VStack,
 } from '@astryxdesign/core/Layout';
-import {Text, Heading} from '@astryxdesign/core/Text';
-import {TextInput} from '@astryxdesign/core/TextInput';
-import {Button} from '@astryxdesign/core/Button';
+import {Heading, Text} from '@astryxdesign/core/Text';
 import {Badge} from '@astryxdesign/core/Badge';
-import {Avatar} from '@astryxdesign/core/Avatar';
-import {Selector} from '@astryxdesign/core/Selector';
-import {PowerSearch} from '@astryxdesign/core/PowerSearch';
-import type {
-  PowerSearchConfig,
-  PowerSearchFilter,
-} from '@astryxdesign/core/PowerSearch';
-import {Dialog, DialogHeader} from '@astryxdesign/core/Dialog';
-import {Popover} from '@astryxdesign/core/Popover';
-import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
-import {DropdownMenu} from '@astryxdesign/core/DropdownMenu';
-import {Center} from '@astryxdesign/core/Center';
+import {Button} from '@astryxdesign/core/Button';
+import {Card} from '@astryxdesign/core/Card';
+import {Collapsible} from '@astryxdesign/core/Collapsible';
 import {Icon} from '@astryxdesign/core/Icon';
+import {ProgressBar} from '@astryxdesign/core/ProgressBar';
 import {StatusDot} from '@astryxdesign/core/StatusDot';
-import {Divider} from '@astryxdesign/core/Divider';
-import {MetadataList, MetadataListItem} from '@astryxdesign/core/MetadataList';
-import {
-  Table,
-  TableBody,
-  TableRow,
-  TableCell,
-  proportional,
-  pixel,
-  resolveColumnWidths,
-} from '@astryxdesign/core/Table';
+import {Token} from '@astryxdesign/core/Token';
+import {Table, pixel, proportional} from '@astryxdesign/core/Table';
 import type {TableColumn} from '@astryxdesign/core/Table';
 import {
-  ChevronRightIcon,
-  ChevronDownIcon,
-  PencilIcon,
-  DocumentDuplicateIcon,
-  ArrowRightIcon,
-  TagIcon,
-  UserIcon,
-  TrashIcon,
-  EllipsisHorizontalIcon,
+  ArrowPathIcon,
+  ArrowsRightLeftIcon,
+  BuildingLibraryIcon,
+  CreditCardIcon,
+  PlusIcon,
+  PresentationChartLineIcon,
 } from '@heroicons/react/24/outline';
-import {XMarkIcon} from '@heroicons/react/24/outline';
-import {ChartBarIcon} from '@heroicons/react/24/solid';
 
-// Plain inline styles using Astryx design-token CSS variables (declared at
-// :root by `@astryxdesign/core/astryx.css`). No StyleX compiler required.
-// The group-header background + cursor live on the colSpan TableCell (which
-// reliably forwards `style`) so they fill the full row width.
-const groupHeaderCell: React.CSSProperties = {
-  cursor: 'pointer',
-  backgroundColor: 'var(--color-background-muted)',
-  padding: 'var(--spacing-3) var(--spacing-4)',
+// ============= SHARED VOCABULARY =============
+
+/** The one attribute every account type genuinely shares. */
+type SyncState = 'connected' | 'syncing' | 'reconnect';
+
+const SYNC_VARIANT: Record<SyncState, 'success' | 'accent' | 'warning'> = {
+  connected: 'success',
+  syncing: 'accent',
+  reconnect: 'warning',
 };
 
-// Types
-type TaskStatus = 'in_progress' | 'todo' | 'backlog' | 'done';
-type TaskPriority = 'urgent' | 'high' | 'medium' | 'low' | 'none';
+const SYNC_LABEL: Record<SyncState, string> = {
+  connected: 'Connected',
+  syncing: 'Syncing',
+  reconnect: 'Action needed',
+};
 
-interface TaskRow extends Record<string, unknown> {
-  id: string;
-  taskId: string;
-  title: string;
-  subtitle: string;
-  status: TaskStatus;
-  priority: TaskPriority;
-  project: string;
-  tags: string[];
-  created: string;
-  createdISO: string;
-  updated: string;
-  updatedISO: string;
-  assignee: string;
+// Pinned locale keeps the rendered output identical in every environment.
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+function money(cents: number): string {
+  return currency.format(cents / 100);
 }
 
-const STATUS_DOT_VARIANT: Record<
-  TaskStatus,
-  'success' | 'accent' | 'neutral' | 'warning'
-> = {
-  in_progress: 'accent',
-  todo: 'warning',
-  backlog: 'neutral',
-  done: 'success',
-};
-
-const PRIORITY_COLOR: Record<
-  TaskPriority,
-  'primary' | 'secondary' | 'disabled'
-> = {
-  urgent: 'primary',
-  high: 'primary',
-  medium: 'secondary',
-  low: 'disabled',
-  none: 'disabled',
-};
-
-// Mock data matching a task tracker
-const allTasks: TaskRow[] = [
-  {
-    id: '1',
-    taskId: 'T235040469',
-    title: 'Update user interface',
-    subtitle: 'Update payment gateway integration',
-    status: 'in_progress',
-    priority: 'medium',
-    project: 'Payment gateway integration 2.0',
-    tags: [],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Olivia Martin',
-  },
-  {
-    id: '2',
-    taskId: 'T235040470',
-    title: 'Use Projects to organize work for features or releases',
-    subtitle: '',
-    status: 'in_progress',
-    priority: 'medium',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Jackson Lee',
-  },
-  {
-    id: '3',
-    taskId: 'T235040471',
-    title: 'Use Cycles to focus work over n-weeks',
-    subtitle: '',
-    status: 'in_progress',
-    priority: 'medium',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Isabella Nguyen',
-  },
-  {
-    id: '4',
-    taskId: 'T235040472',
-    title: 'Testing code',
-    subtitle: 'Update payment gateway integration',
-    status: 'todo',
-    priority: 'medium',
-    project: 'Payment gateway integration 2.0',
-    tags: [],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'William Kim',
-  },
-  {
-    id: '5',
-    taskId: 'T235040473',
-    title: 'Update backend code',
-    subtitle: 'Update payment gateway integration',
-    status: 'todo',
-    priority: 'medium',
-    project: 'Payment gateway integration 2.0',
-    tags: [],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Sofia Davis',
-  },
-  {
-    id: '6',
-    taskId: 'T235040474',
-    title: 'Update front end code',
-    subtitle: 'Update payment gateway integration',
-    status: 'todo',
-    priority: 'medium',
-    project: 'Payment gateway integration 2.0',
-    tags: [],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Mia Wilson',
-  },
-  {
-    id: '7',
-    taskId: 'T235040475',
-    title: 'Update payment gateway integration',
-    subtitle: '',
-    status: 'todo',
-    priority: 'high',
-    project: 'Payment gateway integration 2.0',
-    tags: ['Improvement', '3rd Party'],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Lucas Brown',
-  },
-  {
-    id: '8',
-    taskId: 'T235040476',
-    title: 'Update payment gateway backend code',
-    subtitle: '',
-    status: 'todo',
-    priority: 'medium',
-    project: '',
-    tags: [],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Ethan Jones',
-  },
-  {
-    id: '9',
-    taskId: 'T235040477',
-    title: 'Invite your teammates',
-    subtitle: '',
-    status: 'todo',
-    priority: 'low',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 1',
-    updatedISO: '2025-07-01',
-    assignee: 'Ava Taylor',
-  },
-  {
-    id: '10',
-    taskId: 'T235040478',
-    title: 'Next steps',
-    subtitle: '',
-    status: 'todo',
-    priority: 'none',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Noah Garcia',
-  },
-  {
-    id: '11',
-    taskId: 'T235040479',
-    title: 'Welcome to Linear',
-    subtitle: '',
-    status: 'backlog',
-    priority: 'none',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Olivia Martin',
-  },
-  {
-    id: '12',
-    taskId: 'T235040480',
-    title: 'Connect GitHub or GitLab',
-    subtitle: '',
-    status: 'backlog',
-    priority: 'none',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Jackson Lee',
-  },
-  {
-    id: '13',
-    taskId: 'T235040481',
-    title: 'Customize settings',
-    subtitle: '',
-    status: 'backlog',
-    priority: 'none',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Isabella Nguyen',
-  },
-  {
-    id: '14',
-    taskId: 'T235040482',
-    title: 'Try 3 ways to navigate: Command menu, keyboard or mouse',
-    subtitle: '',
-    status: 'done',
-    priority: 'none',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'William Kim',
-  },
-  {
-    id: '15',
-    taskId: 'T235040483',
-    title: 'Connect to Slack',
-    subtitle: '',
-    status: 'done',
-    priority: 'none',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Sofia Davis',
-  },
-  {
-    id: '16',
-    taskId: 'T235040484',
-    title: 'Migrate database schema to v2',
-    subtitle: 'Payment gateway integration',
-    status: 'in_progress',
-    priority: 'high',
-    project: 'Payment gateway integration 2.0',
-    tags: [],
-    created: 'Jul 4',
-    createdISO: '2025-07-04',
-    updated: 'Jul 5',
-    updatedISO: '2025-07-05',
-    assignee: 'Lucas Brown',
-  },
-  {
-    id: '17',
-    taskId: 'T235040485',
-    title: 'Write integration tests for checkout flow',
-    subtitle: '',
-    status: 'in_progress',
-    priority: 'medium',
-    project: 'Payment gateway integration 2.0',
-    tags: [],
-    created: 'Jul 4',
-    createdISO: '2025-07-04',
-    updated: 'Jul 5',
-    updatedISO: '2025-07-05',
-    assignee: 'Ethan Jones',
-  },
-  {
-    id: '18',
-    taskId: 'T235040486',
-    title: 'Set up CI/CD pipeline for staging',
-    subtitle: '',
-    status: 'in_progress',
-    priority: 'high',
-    project: '',
-    tags: [],
-    created: 'Jul 2',
-    createdISO: '2025-07-02',
-    updated: 'Jul 5',
-    updatedISO: '2025-07-05',
-    assignee: 'Ava Taylor',
-  },
-  {
-    id: '19',
-    taskId: 'T235040487',
-    title: 'Add rate limiting to public API endpoints',
-    subtitle: '',
-    status: 'todo',
-    priority: 'urgent',
-    project: '',
-    tags: [],
-    created: 'Jul 5',
-    createdISO: '2025-07-05',
-    updated: 'Jul 5',
-    updatedISO: '2025-07-05',
-    assignee: 'Noah Garcia',
-  },
-  {
-    id: '20',
-    taskId: 'T235040488',
-    title: 'Refactor auth middleware to support OAuth2',
-    subtitle: '',
-    status: 'todo',
-    priority: 'high',
-    project: '',
-    tags: [],
-    created: 'Jul 4',
-    createdISO: '2025-07-04',
-    updated: 'Jul 5',
-    updatedISO: '2025-07-05',
-    assignee: 'Olivia Martin',
-  },
-  {
-    id: '21',
-    taskId: 'T235040489',
-    title: 'Design error pages for 404 and 500',
-    subtitle: '',
-    status: 'todo',
-    priority: 'low',
-    project: '',
-    tags: [],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 4',
-    updatedISO: '2025-07-04',
-    assignee: 'Mia Wilson',
-  },
-  {
-    id: '22',
-    taskId: 'T235040490',
-    title: 'Audit third-party dependencies for vulnerabilities',
-    subtitle: '',
-    status: 'todo',
-    priority: 'medium',
-    project: '',
-    tags: [],
-    created: 'Jul 5',
-    createdISO: '2025-07-05',
-    updated: 'Jul 5',
-    updatedISO: '2025-07-05',
-    assignee: 'Jackson Lee',
-  },
-  {
-    id: '23',
-    taskId: 'T235040491',
-    title: 'Implement webhook retry logic with exponential backoff',
-    subtitle: 'Payment gateway integration',
-    status: 'todo',
-    priority: 'medium',
-    project: 'Payment gateway integration 2.0',
-    tags: [],
-    created: 'Jul 4',
-    createdISO: '2025-07-04',
-    updated: 'Jul 5',
-    updatedISO: '2025-07-05',
-    assignee: 'William Kim',
-  },
-  {
-    id: '24',
-    taskId: 'T235040492',
-    title: 'Add dark mode support to dashboard',
-    subtitle: '',
-    status: 'backlog',
-    priority: 'low',
-    project: '',
-    tags: [],
-    created: 'Jul 2',
-    createdISO: '2025-07-02',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Sofia Davis',
-  },
-  {
-    id: '25',
-    taskId: 'T235040493',
-    title: 'Create onboarding flow for new team members',
-    subtitle: '',
-    status: 'backlog',
-    priority: 'none',
-    project: '',
-    tags: [],
-    created: 'Jul 1',
-    createdISO: '2025-07-01',
-    updated: 'Jul 2',
-    updatedISO: '2025-07-02',
-    assignee: 'Isabella Nguyen',
-  },
-  {
-    id: '26',
-    taskId: 'T235040494',
-    title: 'Set up error tracking with Sentry',
-    subtitle: '',
-    status: 'backlog',
-    priority: 'medium',
-    project: '',
-    tags: [],
-    created: 'Jul 3',
-    createdISO: '2025-07-03',
-    updated: 'Jul 4',
-    updatedISO: '2025-07-04',
-    assignee: 'Ethan Jones',
-  },
-  {
-    id: '27',
-    taskId: 'T235040495',
-    title: 'Improve search performance with indexing',
-    subtitle: '',
-    status: 'backlog',
-    priority: 'low',
-    project: '',
-    tags: [],
-    created: 'Jul 2',
-    createdISO: '2025-07-02',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Ava Taylor',
-  },
-  {
-    id: '28',
-    taskId: 'T235040496',
-    title: 'Write API documentation for v2 endpoints',
-    subtitle: '',
-    status: 'done',
-    priority: 'medium',
-    project: '',
-    tags: [],
-    created: 'Jun 28',
-    createdISO: '2025-06-28',
-    updated: 'Jul 3',
-    updatedISO: '2025-07-03',
-    assignee: 'Noah Garcia',
-  },
-  {
-    id: '29',
-    taskId: 'T235040497',
-    title: 'Set up staging environment',
-    subtitle: '',
-    status: 'done',
-    priority: 'high',
-    project: '',
-    tags: [],
-    created: 'Jun 25',
-    createdISO: '2025-06-25',
-    updated: 'Jul 1',
-    updatedISO: '2025-07-01',
-    assignee: 'Lucas Brown',
-  },
-  {
-    id: '30',
-    taskId: 'T235040498',
-    title: 'Fix flaky end-to-end tests in CI',
-    subtitle: '',
-    status: 'done',
-    priority: 'medium',
-    project: '',
-    tags: [],
-    created: 'Jun 30',
-    createdISO: '2025-06-30',
-    updated: 'Jul 2',
-    updatedISO: '2025-07-02',
-    assignee: 'Mia Wilson',
-  },
-];
-
-const STATUS_LABEL: Record<TaskStatus, string> = {
-  in_progress: 'In Progress',
-  todo: 'Todo',
-  backlog: 'Backlog',
-  done: 'Done',
-};
-
-const GROUP_ORDER: TaskStatus[] = ['in_progress', 'todo', 'backlog', 'done'];
-
-type GroupByField = 'status' | 'priority' | 'project' | 'assignee' | 'none';
-
-const GROUP_BY_OPTIONS: {value: GroupByField; label: string}[] = [
-  {value: 'none', label: 'None'},
-  {value: 'status', label: 'Status'},
-  {value: 'priority', label: 'Priority'},
-  {value: 'project', label: 'Project'},
-  {value: 'assignee', label: 'Assignee'},
-];
-
-function groupTasks(
-  tasks: TaskRow[],
-  groupBy: GroupByField,
-): Map<string, TaskRow[]> {
-  if (groupBy === 'none') {
-    return new Map([['All', tasks]]);
-  }
-  const map = new Map<string, TaskRow[]>();
-  for (const task of tasks) {
-    const key = String(task[groupBy]) || '—';
-    let group = map.get(key);
-    if (!group) {
-      group = [];
-      map.set(key, group);
-    }
-    group.push(task);
-  }
-  return map;
+function sum<T>(rows: T[], pick: (row: T) => number): number {
+  return rows.reduce((total, row) => total + pick(row), 0);
 }
 
-function getGroupLabel(groupBy: GroupByField, key: string): string {
-  if (groupBy === 'status') {
-    return STATUS_LABEL[key as TaskStatus] ?? key;
-  }
-  if (groupBy === 'priority') {
-    const labels: Record<string, string> = {
-      urgent: 'Urgent',
-      high: 'High',
-      medium: 'Medium',
-      low: 'Low',
-      none: 'No priority',
-    };
-    return labels[key] ?? key;
-  }
-  return key;
-}
-
-const columns: TableColumn<TaskRow>[] = [
-  {
-    key: 'status',
-    header: '',
-    width: pixel(44),
-  },
-  {
-    key: 'title',
-    header: 'Issue',
-    width: proportional(1),
-  },
-  {
-    key: 'project',
-    header: 'Project',
-    width: pixel(180),
-  },
-  {
-    key: 'created',
-    header: 'Created',
-    width: pixel(72),
-  },
-  {
-    key: 'updated',
-    header: 'Updated',
-    width: pixel(72),
-  },
-  {
-    key: 'assignee',
-    header: 'Assignee',
-    width: pixel(52),
-  },
-  {
-    key: 'actions',
-    header: '',
-    width: pixel(56),
-  },
-];
-
-const powerSearchConfig: PowerSearchConfig = {
-  name: 'IssueSearch',
-  fields: [
-    {
-      key: 'status',
-      label: 'Status',
-      operators: [
-        {
-          key: 'is',
-          label: 'is',
-          value: {
-            type: 'enum',
-            values: [
-              {value: 'in_progress', label: 'In Progress'},
-              {value: 'todo', label: 'Todo'},
-              {value: 'backlog', label: 'Backlog'},
-              {value: 'done', label: 'Done'},
-            ],
-          },
-        },
-      ],
-    },
-    {
-      key: 'priority',
-      label: 'Priority',
-      operators: [
-        {
-          key: 'is',
-          label: 'is',
-          value: {
-            type: 'enum',
-            values: [
-              {value: 'urgent', label: 'Urgent'},
-              {value: 'high', label: 'High'},
-              {value: 'medium', label: 'Medium'},
-              {value: 'low', label: 'Low'},
-              {value: 'none', label: 'None'},
-            ],
-          },
-        },
-      ],
-    },
-    {
-      key: 'title',
-      label: 'Title',
-      operators: [
-        {key: 'contains', label: 'contains', value: {type: 'string'}},
-      ],
-    },
-    {
-      key: 'assignee',
-      label: 'Assignee',
-      operators: [
-        {key: 'contains', label: 'contains', value: {type: 'string'}},
-      ],
-    },
-    {
-      key: 'project',
-      label: 'Project',
-      operators: [
-        {key: 'contains', label: 'contains', value: {type: 'string'}},
-      ],
-    },
-  ],
-};
-
-const PRIORITY_LABEL: Record<TaskPriority, string> = {
-  urgent: 'Urgent',
-  high: 'High',
-  medium: 'Medium',
-  low: 'Low',
-  none: 'None',
-};
-
-function TaskDetailPanel({
-  task,
-  onClose,
-  resizable,
-}: {
-  task: TaskRow | null;
-  onClose: () => void;
-  resizable: ResizableProps;
-}) {
-  if (!task) {
-    return null;
-  }
+/** Right-aligned tabular figure — every numeric cell on the page uses this. */
+function Figure({children}: {children: string}) {
   return (
-    // Panel owns the separator (its full-height left border). The adjacent
-    // ResizeHandle is kept divider-less + isAlwaysVisible={false} so its
-    // always-on pill doesn't float above the panel as a stray stub.
-    <LayoutPanel
-      hasDivider
-      resizable={resizable}
-      padding={4}
-      role="complementary"
-      label="Task details">
-      <VStack gap={4}>
-        <HStack gap={2} vAlign="center">
-          <StackItem size="fill">
-            <Text type="supporting" color="secondary">
-              {task.taskId}
-            </Text>
-          </StackItem>
-          <Button
-            label="Close panel"
-            variant="ghost"
+    <Text display="block" justify="end" hasTabularNumbers>
+      {children}
+    </Text>
+  );
+}
+
+// StatusDot's label is for assistive tech only, so the visible wording is a
+// sibling Text rather than a second label on the dot.
+function SyncCell({state}: {state: SyncState}) {
+  return (
+    <HStack gap={2} vAlign="center">
+      <StatusDot variant={SYNC_VARIANT[state]} label={SYNC_LABEL[state]} />
+      <Text color="secondary">{SYNC_LABEL[state]}</Text>
+    </HStack>
+  );
+}
+
+/** Secondary right-aligned figure — used for the de-emphasised comparison
+ * column that sits beside each group's headline number. */
+function MutedFigure({children}: {children: string}) {
+  return (
+    <Text display="block" justify="end" hasTabularNumbers color="secondary">
+      {children}
+    </Text>
+  );
+}
+
+// ============= GROUP 1 — BANK ACCOUNTS =============
+
+interface BankAccount extends Record<string, unknown> {
+  id: string;
+  name: string;
+  institution: string;
+  mask: string;
+  kind: 'Checking' | 'Savings' | 'Money market';
+  availableCents: number;
+  lastSynced: string;
+  syncState: SyncState;
+}
+
+const BANK_ACCOUNTS: BankAccount[] = [
+  {
+    id: 'bank-1',
+    name: 'Operating',
+    institution: 'First Meridian Bank',
+    mask: '••4417',
+    kind: 'Checking',
+    availableCents: 84_215_600,
+    lastSynced: 'Today, 6:02 AM',
+    syncState: 'connected',
+  },
+  {
+    id: 'bank-2',
+    name: 'Payroll',
+    institution: 'First Meridian Bank',
+    mask: '••8830',
+    kind: 'Checking',
+    availableCents: 21_940_800,
+    lastSynced: 'Today, 6:02 AM',
+    syncState: 'connected',
+  },
+  {
+    id: 'bank-3',
+    name: 'Tax reserve',
+    institution: 'Harborline Credit Union',
+    mask: '••1265',
+    kind: 'Savings',
+    availableCents: 47_500_000,
+    lastSynced: 'Today, 5:48 AM',
+    syncState: 'connected',
+  },
+  {
+    id: 'bank-4',
+    name: 'Treasury sweep',
+    institution: 'Northgate Financial',
+    mask: '••7702',
+    kind: 'Money market',
+    availableCents: 132_800_000,
+    lastSynced: 'Mar 28, 9:14 PM',
+    syncState: 'reconnect',
+  },
+];
+
+const bankColumns: TableColumn<BankAccount>[] = [
+  {
+    key: 'name',
+    header: 'Account',
+    width: proportional(2),
+    renderCell: account => (
+      <VStack gap={0}>
+        <Text>{account.name}</Text>
+        <Text type="supporting">
+          {account.institution} · {account.mask}
+        </Text>
+      </VStack>
+    ),
+  },
+  {
+    key: 'kind',
+    header: 'Type',
+    width: pixel(140),
+    renderCell: account => <Text color="secondary">{account.kind}</Text>,
+  },
+  {
+    key: 'available',
+    header: 'Available',
+    width: pixel(150),
+    renderCell: account => <Figure>{money(account.availableCents)}</Figure>,
+  },
+  {
+    key: 'lastSynced',
+    header: 'Last synced',
+    width: pixel(160),
+    renderCell: account => <Text color="secondary">{account.lastSynced}</Text>,
+  },
+  {
+    key: 'syncState',
+    header: 'Status',
+    width: pixel(180),
+    renderCell: account => <SyncCell state={account.syncState} />,
+  },
+];
+
+// ============= GROUP 2 — CREDIT CARDS =============
+
+interface CreditCardAccount extends Record<string, unknown> {
+  id: string;
+  name: string;
+  issuer: string;
+  mask: string;
+  balanceCents: number;
+  limitCents: number;
+  statementDue: string;
+  syncState: SyncState;
+}
+
+const CREDIT_CARDS: CreditCardAccount[] = [
+  {
+    id: 'card-1',
+    name: 'Corporate — Engineering',
+    issuer: 'Meridian Business Card',
+    mask: '••2041',
+    balanceCents: 4_182_300,
+    limitCents: 15_000_000,
+    statementDue: 'Apr 12',
+    syncState: 'connected',
+  },
+  {
+    id: 'card-2',
+    name: 'Corporate — Travel',
+    issuer: 'Meridian Business Card',
+    mask: '••6688',
+    balanceCents: 9_640_500,
+    limitCents: 12_000_000,
+    statementDue: 'Apr 12',
+    syncState: 'connected',
+  },
+  {
+    id: 'card-3',
+    name: 'Vendor payments',
+    issuer: 'Northgate Commercial',
+    mask: '••3319',
+    balanceCents: 1_205_000,
+    limitCents: 25_000_000,
+    statementDue: 'Apr 20',
+    syncState: 'syncing',
+  },
+];
+
+/** Credit utilization reads inversely: a full bar is the bad outcome. */
+function utilizationVariant(pct: number): 'success' | 'warning' | 'error' {
+  if (pct >= 70) {
+    return 'error';
+  }
+  if (pct >= 30) {
+    return 'warning';
+  }
+  return 'success';
+}
+
+const creditCardColumns: TableColumn<CreditCardAccount>[] = [
+  {
+    key: 'name',
+    header: 'Card',
+    width: proportional(2),
+    renderCell: card => (
+      <VStack gap={0}>
+        <Text>{card.name}</Text>
+        <Text type="supporting">
+          {card.issuer} · {card.mask}
+        </Text>
+      </VStack>
+    ),
+  },
+  {
+    key: 'balance',
+    header: 'Balance',
+    width: pixel(140),
+    renderCell: card => <Figure>{money(card.balanceCents)}</Figure>,
+  },
+  {
+    key: 'limit',
+    header: 'Limit',
+    width: pixel(140),
+    renderCell: card => <MutedFigure>{money(card.limitCents)}</MutedFigure>,
+  },
+  {
+    key: 'utilization',
+    header: 'Utilization',
+    width: pixel(190),
+    renderCell: card => {
+      const pct = Math.round((card.balanceCents / card.limitCents) * 100);
+      return (
+        <ProgressBar
+          label={`${card.name} utilization`}
+          isLabelHidden
+          hasValueLabel
+          value={pct}
+          variant={utilizationVariant(pct)}
+        />
+      );
+    },
+  },
+  {
+    key: 'statementDue',
+    header: 'Statement due',
+    width: pixel(140),
+    renderCell: card => <Text color="secondary">{card.statementDue}</Text>,
+  },
+  {
+    key: 'syncState',
+    header: 'Status',
+    width: pixel(150),
+    renderCell: card => <SyncCell state={card.syncState} />,
+  },
+];
+
+// ============= GROUP 3 — PAYMENT PROCESSORS =============
+
+interface ProcessorAccount extends Record<string, unknown> {
+  id: string;
+  name: string;
+  merchantId: string;
+  pendingPayoutCents: number;
+  feesMtdCents: number;
+  nextPayout: string;
+  syncState: SyncState;
+}
+
+const PROCESSORS: ProcessorAccount[] = [
+  {
+    id: 'proc-1',
+    name: 'Stripe',
+    merchantId: 'acct_1Qf82LmR',
+    pendingPayoutCents: 18_442_900,
+    feesMtdCents: 612_400,
+    nextPayout: 'Apr 2',
+    syncState: 'connected',
+  },
+  {
+    id: 'proc-2',
+    name: 'PayPal Commerce',
+    merchantId: 'MRC-88214-XT',
+    pendingPayoutCents: 3_218_650,
+    feesMtdCents: 148_900,
+    nextPayout: 'Apr 3',
+    syncState: 'connected',
+  },
+  {
+    id: 'proc-3',
+    name: 'Adyen',
+    merchantId: 'AD-NORTHWIND-01',
+    pendingPayoutCents: 7_905_100,
+    feesMtdCents: 233_050,
+    nextPayout: 'Apr 5',
+    syncState: 'syncing',
+  },
+];
+
+const processorColumns: TableColumn<ProcessorAccount>[] = [
+  {
+    key: 'name',
+    header: 'Processor',
+    width: proportional(2),
+    renderCell: processor => (
+      <VStack gap={0}>
+        <Text>{processor.name}</Text>
+        <Text type="supporting">{processor.merchantId}</Text>
+      </VStack>
+    ),
+  },
+  {
+    key: 'pendingPayout',
+    header: 'Pending payout',
+    width: pixel(160),
+    renderCell: processor => (
+      <Figure>{money(processor.pendingPayoutCents)}</Figure>
+    ),
+  },
+  {
+    key: 'feesMtd',
+    header: 'Fees (MTD)',
+    width: pixel(150),
+    renderCell: processor => (
+      <MutedFigure>{money(processor.feesMtdCents)}</MutedFigure>
+    ),
+  },
+  {
+    key: 'nextPayout',
+    header: 'Next payout',
+    width: pixel(140),
+    renderCell: processor => (
+      <Text color="secondary">{processor.nextPayout}</Text>
+    ),
+  },
+  {
+    key: 'syncState',
+    header: 'Status',
+    width: pixel(150),
+    renderCell: processor => <SyncCell state={processor.syncState} />,
+  },
+];
+
+// ============= GROUP 4 — INVESTMENT ACCOUNTS =============
+
+interface InvestmentAccount extends Record<string, unknown> {
+  id: string;
+  name: string;
+  custodian: string;
+  marketValueCents: number;
+  costBasisCents: number;
+  dayChangeCents: number;
+  syncState: SyncState;
+}
+
+const INVESTMENTS: InvestmentAccount[] = [
+  {
+    id: 'inv-1',
+    name: 'Short-duration treasuries',
+    custodian: 'Northgate Asset Management',
+    marketValueCents: 245_180_000,
+    costBasisCents: 240_000_000,
+    dayChangeCents: 184_200,
+    syncState: 'connected',
+  },
+  {
+    id: 'inv-2',
+    name: 'Corporate bond ladder',
+    custodian: 'Northgate Asset Management',
+    marketValueCents: 98_420_000,
+    costBasisCents: 100_000_000,
+    dayChangeCents: -62_800,
+    syncState: 'connected',
+  },
+  {
+    id: 'inv-3',
+    name: 'Money market fund',
+    custodian: 'Harborline Capital',
+    marketValueCents: 61_050_000,
+    costBasisCents: 61_000_000,
+    dayChangeCents: 8_400,
+    syncState: 'connected',
+  },
+];
+
+const investmentColumns: TableColumn<InvestmentAccount>[] = [
+  {
+    key: 'name',
+    header: 'Account',
+    width: proportional(2),
+    renderCell: account => (
+      <VStack gap={0}>
+        <Text>{account.name}</Text>
+        <Text type="supporting">{account.custodian}</Text>
+      </VStack>
+    ),
+  },
+  {
+    key: 'marketValue',
+    header: 'Market value',
+    width: pixel(160),
+    renderCell: account => <Figure>{money(account.marketValueCents)}</Figure>,
+  },
+  {
+    key: 'costBasis',
+    header: 'Cost basis',
+    width: pixel(150),
+    renderCell: account => (
+      <MutedFigure>{money(account.costBasisCents)}</MutedFigure>
+    ),
+  },
+  {
+    key: 'dayChange',
+    header: 'Day change',
+    width: pixel(150),
+    renderCell: account => {
+      const isUp = account.dayChangeCents >= 0;
+      return (
+        <HStack hAlign="end">
+          <Token
             size="sm"
-            icon={<Icon icon={XMarkIcon} size="sm" />}
-            isIconOnly
-            onClick={onClose}
+            color={isUp ? 'green' : 'red'}
+            label={`${isUp ? '+' : '−'}${money(Math.abs(account.dayChangeCents))}`}
           />
         </HStack>
+      );
+    },
+  },
+  {
+    key: 'syncState',
+    header: 'Status',
+    width: pixel(150),
+    renderCell: account => <SyncCell state={account.syncState} />,
+  },
+];
 
-        <VStack gap={1}>
-          <Heading level={3}>{task.title}</Heading>
-          {task.subtitle && (
-            <Text type="body" color="secondary">
-              {task.subtitle}
+// ============= GROUP SHELL =============
+
+const GROUP_IDS = ['bank', 'cards', 'processors', 'investments'] as const;
+type GroupId = (typeof GROUP_IDS)[number];
+
+function AccountGroup({
+  icon,
+  title,
+  count,
+  summaryLabel,
+  summaryValue,
+  isOpen,
+  onOpenChange,
+  children,
+}: {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  title: string;
+  count: number;
+  summaryLabel: string;
+  summaryValue: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card padding={0}>
+      <Collapsible
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        // Collapsible wraps trigger content in a shrink-to-fit span, so a flex
+        // spacer cannot push the summary to the right edge. Fixed widths on the
+        // title and label blocks line the four group totals up as a column
+        // instead, which is the part that matters when every group is closed.
+        trigger={
+          <HStack gap={4} vAlign="center">
+            <HStack gap={2} vAlign="center" width={240}>
+              <Icon icon={icon} size="sm" color="secondary" />
+              <Text weight="semibold">{title}</Text>
+              <Badge variant="neutral" label={String(count)} />
+            </HStack>
+            <HStack width={128}>
+              <Text type="supporting">{summaryLabel}</Text>
+            </HStack>
+            <Text weight="semibold" hasTabularNumbers>
+              {summaryValue}
             </Text>
-          )}
-        </VStack>
-
-        <MetadataList label={{position: 'start'}}>
-          <MetadataListItem label="Status">
-            <HStack gap={2} vAlign="center">
-              <StatusDot
-                variant={STATUS_DOT_VARIANT[task.status]}
-                label={STATUS_LABEL[task.status]}
-              />
-              <Text type="body">{STATUS_LABEL[task.status]}</Text>
-            </HStack>
-          </MetadataListItem>
-          <MetadataListItem label="Priority">
-            <HStack gap={2} vAlign="center">
-              <Icon
-                icon={ChartBarIcon}
-                size="sm"
-                color={PRIORITY_COLOR[task.priority]}
-              />
-              <Text type="body">{PRIORITY_LABEL[task.priority]}</Text>
-            </HStack>
-          </MetadataListItem>
-          <MetadataListItem label="Assignee">
-            <HStack gap={2} vAlign="center">
-              <Avatar name={task.assignee} size="sm" />
-              <Text type="body">{task.assignee}</Text>
-            </HStack>
-          </MetadataListItem>
-          <MetadataListItem label="Project">
-            {task.project || '\u2014'}
-          </MetadataListItem>
-          <MetadataListItem label="Created">{task.created}</MetadataListItem>
-          <MetadataListItem label="Updated">{task.updated}</MetadataListItem>
-        </MetadataList>
-
-        {task.tags.length > 0 && (
-          <>
-            <Divider />
-            <VStack gap={2}>
-              <Text type="label">Labels</Text>
-              <HStack gap={2}>
-                {task.tags.map(tag => (
-                  <Badge key={tag} variant="neutral" label={tag} />
-                ))}
-              </HStack>
-            </VStack>
-          </>
-        )}
-      </VStack>
-    </LayoutPanel>
+          </HStack>
+        }>
+        {children}
+      </Collapsible>
+    </Card>
   );
 }
 
-export default function DataTableTemplate() {
-  const [search, _setSearch] = useState('');
-  const [priorityFilter, _setPriorityFilter] = useState('all');
-  const [dialogOpen, setDialogOpen] = useState(false);
-  const [selectedTask, setSelectedTask] = useState<TaskRow | null>(null);
-  const [powerSearchFilters, setPowerSearchFilters] = useState<
-    ReadonlyArray<PowerSearchFilter>
-  >([]);
-  const [groupBy, setGroupBy] = useState<GroupByField>('status');
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
-    () => new Set(GROUP_ORDER as string[]),
+// ============= PAGE =============
+
+export default function ConnectedAccountsTemplate() {
+  const [openGroups, setOpenGroups] = useState<Set<GroupId>>(
+    () => new Set(GROUP_IDS),
   );
 
-  const filtered = useMemo(() => {
-    let data = allTasks;
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      data = data.filter(
-        t =>
-          t.title.toLowerCase().includes(q) ||
-          t.taskId.toLowerCase().includes(q) ||
-          t.subtitle.toLowerCase().includes(q),
-      );
-    }
-    if (priorityFilter !== 'all') {
-      data = data.filter(t => t.priority === priorityFilter);
-    }
-    return data;
-  }, [search, priorityFilter]);
-
-  const grouped = useMemo(
-    () => groupTasks(filtered, groupBy),
-    [filtered, groupBy],
-  );
-
-  const groupKeys = useMemo(() => Array.from(grouped.keys()), [grouped]);
-
-  React.useEffect(() => {
-    setExpandedGroups(new Set(groupKeys));
-  }, [groupKeys]);
-
-  const toggleGroup = (key: string) => {
-    setExpandedGroups(prev => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
+  const toggleGroup = (id: GroupId) => (open: boolean) => {
+    setOpenGroups(previous => {
+      const next = new Set(previous);
+      if (open) {
+        next.add(id);
       } else {
-        next.add(key);
+        next.delete(id);
       }
       return next;
     });
   };
 
-  const detailPanel = useResizable({
-    defaultSize: 360,
-    minSizePx: 280,
-    maxSizePx: 500,
-  });
+  const totals = useMemo(() => {
+    const banks = sum(BANK_ACCOUNTS, account => account.availableCents);
+    const cards = sum(CREDIT_CARDS, card => card.balanceCents);
+    const pending = sum(PROCESSORS, p => p.pendingPayoutCents);
+    const investments = sum(INVESTMENTS, i => i.marketValueCents);
+    return {
+      banks,
+      cards,
+      pending,
+      investments,
+      // Outstanding card balances are a liability, so they come off the top.
+      net: banks + pending + investments - cards,
+    };
+  }, []);
 
-  const COL_COUNT = columns.length;
-  const resolvedWidths = resolveColumnWidths(columns);
+  const needsAttention = [
+    ...BANK_ACCOUNTS,
+    ...CREDIT_CARDS,
+    ...PROCESSORS,
+    ...INVESTMENTS,
+  ].filter(account => account.syncState === 'reconnect').length;
+
+  const areAllOpen = openGroups.size === GROUP_IDS.length;
 
   return (
-    <>
-      <Layout
-        height="fill"
-        header={
-          <LayoutHeader hasDivider padding={4}>
-            <VStack gap={4}>
-              <HStack gap={3} vAlign="center">
-                <StackItem size="fill">
-                  <Heading level={1}>All Issues</Heading>
-                </StackItem>
-                <Button
-                  label="Create issue"
-                  variant="primary"
-                  size="lg"
-                  onClick={() => setDialogOpen(true)}
-                />
-              </HStack>
-              <HStack gap={2} vAlign="center">
-                <StackItem size="fill">
-                  <PowerSearch
-                    config={powerSearchConfig}
-                    filters={powerSearchFilters}
-                    onChange={newFilters => setPowerSearchFilters(newFilters)}
-                    placeholder="Filter issues..."
-                    resultCount={`${filtered.length} issue${filtered.length !== 1 ? 's' : ''}`}
-                  />
-                </StackItem>
-                <Popover
-                  placement="below"
-                  alignment="end"
-                  width={320}
-                  label="Grouping options"
-                  content={
-                    <VStack gap={4}>
-                      <RadioList
-                        label="Group by"
-                        value={groupBy}
-                        onChange={v => setGroupBy(v as GroupByField)}>
-                        {GROUP_BY_OPTIONS.map(opt => (
-                          <RadioListItem
-                            key={opt.value}
-                            value={opt.value}
-                            label={opt.label}
-                          />
-                        ))}
-                      </RadioList>
-                    </VStack>
-                  }>
-                  <Button label="View Options" variant="secondary" size="md" />
-                </Popover>
-              </HStack>
-            </VStack>
-          </LayoutHeader>
-        }
-        content={
-          <LayoutContent role="main" padding={0}>
-            <Table
-              columns={columns}
-              density="balanced"
-              dividers="rows"
-              textOverflow="truncate"
-              hasHover>
-              <colgroup>
-                {columns.map(col => (
-                  <col
-                    key={col.key}
-                    style={resolvedWidths.columns.get(col.key)?.style}
-                  />
-                ))}
-              </colgroup>
-              <TableBody>
-                {groupKeys.map(key => {
-                  const tasks = grouped.get(key);
-                  if (!tasks || tasks.length === 0) {
-                    return null;
-                  }
-                  const isExpanded = expandedGroups.has(key);
-
-                  return (
-                    <React.Fragment key={key}>
-                      {groupBy !== 'none' && (
-                        <TableRow
-                          role="button"
-                          tabIndex={0}
-                          onClick={() => toggleGroup(key)}
-                          onKeyDown={e => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                              e.preventDefault();
-                              toggleGroup(key);
-                            }
-                          }}>
-                          <TableCell
-                            colSpan={COL_COUNT}
-                            style={groupHeaderCell}>
-                            <HStack gap={2} vAlign="center">
-                              <Icon
-                                icon={
-                                  isExpanded
-                                    ? ChevronDownIcon
-                                    : ChevronRightIcon
-                                }
-                                size="sm"
-                                color="secondary"
-                              />
-                              <Text type="body" weight="bold">
-                                {getGroupLabel(groupBy, key)}
-                              </Text>
-                              <Badge
-                                variant="neutral"
-                                label={String(tasks.length)}
-                              />
-                            </HStack>
-                          </TableCell>
-                        </TableRow>
-                      )}
-                      {(groupBy === 'none' || isExpanded) &&
-                        tasks.map(task => (
-                          <TableRow
-                            key={task.id}
-                            onClick={() => setSelectedTask(task)}>
-                            <TableCell>
-                              <Center axis="horizontal">
-                                <StatusDot
-                                  variant={STATUS_DOT_VARIANT[task.status]}
-                                  label={STATUS_LABEL[task.status]}
-                                />
-                              </Center>
-                            </TableCell>
-                            <TableCell>
-                              <HStack gap={3} vAlign="center">
-                                <Icon
-                                  icon={ChartBarIcon}
-                                  size="sm"
-                                  color={PRIORITY_COLOR[task.priority]}
-                                />
-                                <Text type="supporting" color="secondary">
-                                  {task.taskId}
-                                </Text>
-                                <Text type="body" maxLines={1}>
-                                  {task.title}
-                                </Text>
-                                {task.subtitle && (
-                                  <Text
-                                    type="body"
-                                    color="secondary"
-                                    maxLines={1}>
-                                    › {task.subtitle}
-                                  </Text>
-                                )}
-                              </HStack>
-                            </TableCell>
-                            <TableCell>
-                              {task.project ? (
-                                <Text type="body" maxLines={1}>
-                                  {task.project}
-                                </Text>
-                              ) : (
-                                <Text type="supporting" color="secondary">
-                                  —
-                                </Text>
-                              )}
-                            </TableCell>
-                            <TableCell>
-                              <Text type="supporting" color="secondary">
-                                {task.created}
-                              </Text>
-                            </TableCell>
-                            <TableCell>
-                              <Text type="supporting" color="secondary">
-                                {task.updated}
-                              </Text>
-                            </TableCell>
-                            <TableCell>
-                              <Avatar name={task.assignee} size="sm" />
-                            </TableCell>
-                            <TableCell>
-                              <DropdownMenu
-                                button={{
-                                  label: 'Actions',
-                                  variant: 'ghost',
-                                  size: 'sm',
-                                  icon: (
-                                    <Icon
-                                      icon={EllipsisHorizontalIcon}
-                                      size="sm"
-                                    />
-                                  ),
-                                  isIconOnly: true,
-                                }}
-                                hasChevron={false}
-                                items={[
-                                  {
-                                    label: 'Edit issue',
-                                    icon: PencilIcon,
-                                    onClick: () => {},
-                                  },
-                                  {
-                                    label: 'Assign to...',
-                                    icon: UserIcon,
-                                    onClick: () => {},
-                                  },
-                                  {
-                                    label: 'Add label',
-                                    icon: TagIcon,
-                                    onClick: () => {},
-                                  },
-                                  {
-                                    label: 'Duplicate',
-                                    icon: DocumentDuplicateIcon,
-                                    onClick: () => {},
-                                  },
-                                  {
-                                    label: 'Move to project',
-                                    icon: ArrowRightIcon,
-                                    onClick: () => {},
-                                  },
-                                  {type: 'divider' as const},
-                                  {
-                                    label: 'Delete issue',
-                                    icon: TrashIcon,
-                                    onClick: () => {},
-                                  },
-                                ]}
-                              />
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                    </React.Fragment>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </LayoutContent>
-        }
-        end={
-          selectedTask && (
-            <>
-              <ResizeHandle
-                resizable={detailPanel.props}
-                isReversed
-                isAlwaysVisible={false}
-              />
-              <TaskDetailPanel
-                task={selectedTask}
-                onClose={() => setSelectedTask(null)}
-                resizable={detailPanel.props}
-              />
-            </>
-          )
-        }
-      />
-      <Dialog isOpen={dialogOpen} onOpenChange={open => setDialogOpen(open)}>
-        <Layout
-          header={
-            <DialogHeader
-              title="Create Issue"
-              onOpenChange={open => setDialogOpen(open)}
-            />
-          }
-          content={
-            <LayoutContent padding={4}>
-              <VStack gap={4}>
-                <TextInput
-                  label="Title"
-                  placeholder="Issue title"
-                  value=""
-                  onChange={() => {}}
-                />
-                <Selector
-                  label="Status"
-                  value="todo"
-                  options={[
-                    {value: 'in_progress', label: 'In Progress'},
-                    {value: 'todo', label: 'Todo'},
-                    {value: 'backlog', label: 'Backlog'},
-                  ]}
-                  onChange={() => {}}
-                />
-                <Selector
-                  label="Priority"
-                  value="none"
-                  options={[
-                    {value: 'urgent', label: 'Urgent'},
-                    {value: 'high', label: 'High'},
-                    {value: 'medium', label: 'Medium'},
-                    {value: 'low', label: 'Low'},
-                    {value: 'none', label: 'No priority'},
-                  ]}
-                  onChange={() => {}}
-                />
-                <TextInput
-                  label="Project"
-                  placeholder="Project name"
-                  value=""
-                  onChange={() => {}}
-                />
+    <Layout
+      height="fill"
+      contentWidth={1200}
+      header={
+        <LayoutHeader hasDivider padding={4}>
+          <HStack gap={3} vAlign="center" wrap="wrap">
+            <StackItem size="fill">
+              <VStack gap={0.5}>
+                <Heading level={1}>Connected accounts</Heading>
+                <HStack gap={2} vAlign="center">
+                  <Text type="supporting">
+                    Net position {money(totals.net)} across 13 accounts
+                  </Text>
+                  {needsAttention > 0 && (
+                    <StatusDot
+                      variant="warning"
+                      label={`${needsAttention} account needs reconnecting`}
+                    />
+                  )}
+                </HStack>
               </VStack>
-            </LayoutContent>
-          }
-          footer={
-            <LayoutFooter hasDivider>
-              <HStack gap={2} hAlign="end">
-                <Button
-                  label="Cancel"
-                  variant="secondary"
-                  size="md"
-                  onClick={() => setDialogOpen(false)}
-                />
-                <Button
-                  label="Create"
-                  variant="primary"
-                  size="md"
-                  onClick={() => setDialogOpen(false)}
-                />
-              </HStack>
-            </LayoutFooter>
-          }
-        />
-      </Dialog>
-    </>
+            </StackItem>
+            <Button
+              label={areAllOpen ? 'Collapse all' : 'Expand all'}
+              variant="ghost"
+              onClick={() =>
+                setOpenGroups(areAllOpen ? new Set() : new Set(GROUP_IDS))
+              }
+            />
+            <Button
+              label="Sync now"
+              variant="secondary"
+              icon={<Icon icon={ArrowPathIcon} size="sm" />}
+            />
+            <Button
+              label="Connect account"
+              variant="primary"
+              icon={<Icon icon={PlusIcon} size="sm" />}
+            />
+          </HStack>
+        </LayoutHeader>
+      }
+      content={
+        <LayoutContent padding={4}>
+          <VStack gap={4}>
+            <AccountGroup
+              icon={BuildingLibraryIcon}
+              title="Bank accounts"
+              count={BANK_ACCOUNTS.length}
+              summaryLabel="Available"
+              summaryValue={money(totals.banks)}
+              isOpen={openGroups.has('bank')}
+              onOpenChange={toggleGroup('bank')}>
+              <Table<BankAccount>
+                data={BANK_ACCOUNTS}
+                columns={bankColumns}
+                idKey="id"
+                density="compact"
+                dividers="rows"
+                textOverflow="truncate"
+                hasHover
+              />
+            </AccountGroup>
+
+            <AccountGroup
+              icon={CreditCardIcon}
+              title="Credit cards"
+              count={CREDIT_CARDS.length}
+              summaryLabel="Outstanding"
+              summaryValue={money(totals.cards)}
+              isOpen={openGroups.has('cards')}
+              onOpenChange={toggleGroup('cards')}>
+              <Table<CreditCardAccount>
+                data={CREDIT_CARDS}
+                columns={creditCardColumns}
+                idKey="id"
+                density="compact"
+                dividers="rows"
+                textOverflow="truncate"
+                hasHover
+              />
+            </AccountGroup>
+
+            <AccountGroup
+              icon={ArrowsRightLeftIcon}
+              title="Payment processors"
+              count={PROCESSORS.length}
+              summaryLabel="Pending payout"
+              summaryValue={money(totals.pending)}
+              isOpen={openGroups.has('processors')}
+              onOpenChange={toggleGroup('processors')}>
+              <Table<ProcessorAccount>
+                data={PROCESSORS}
+                columns={processorColumns}
+                idKey="id"
+                density="compact"
+                dividers="rows"
+                textOverflow="truncate"
+                hasHover
+              />
+            </AccountGroup>
+
+            <AccountGroup
+              icon={PresentationChartLineIcon}
+              title="Investment accounts"
+              count={INVESTMENTS.length}
+              summaryLabel="Market value"
+              summaryValue={money(totals.investments)}
+              isOpen={openGroups.has('investments')}
+              onOpenChange={toggleGroup('investments')}>
+              <Table<InvestmentAccount>
+                data={INVESTMENTS}
+                columns={investmentColumns}
+                idKey="id"
+                density="compact"
+                dividers="rows"
+                textOverflow="truncate"
+                hasHover
+              />
+            </AccountGroup>
+          </VStack>
+        </LayoutContent>
+      }
+    />
   );
 }

--- a/packages/cli/assets/templates/pages/table-grouped/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-grouped/template.doc.mjs
@@ -5,7 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Grouped Table',
   displayName: 'Grouped Table',
-  description: 'Row collection bundled into collapsible sections with per-group counts, so a long list reads as a handful of blocks that expand and collapse. Query filtering and a resizable inspector for the selected row. Table, list, rows, records, grid, or grouped dataset.',
+  description:
+    'Heterogeneous records split across collapsible cards, each holding its own table and its own column set, with per-group totals in the card header. The shape for groups that do not share a schema, where one grouped table would force empty columns. Accounts, integrations, connections, sections, grouped dataset, or collapsible tables.',
   isReady: true,
   category: 'Table - Grouped',
 };

--- a/packages/cli/assets/templates/pages/table-inbox/page.tsx
+++ b/packages/cli/assets/templates/pages/table-inbox/page.tsx
@@ -1,0 +1,521 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * A triage queue that reads as a list and behaves as a table: no header row, no
+ * dividers, every row a doorway into a conversation.
+ *
+ * An inbox is the case where the table's chrome works against it. A header row
+ * labels columns you never compare across rows — nobody scans an inbox by
+ * sender, they scan it for the one thread that matters — and row dividers chop
+ * a continuous queue into a grid. What is left is a table's real value: a fixed
+ * column grid so sender, subject, tags, and time land in the same place on
+ * every row, which is what makes the list scannable at all. Strip the chrome,
+ * keep the grid.
+ *
+ * ## Extending this template
+ *
+ * **Headerless means children mode, and children mode has a real cost.** In
+ * data-driven mode `BaseTable` renders `{hasColumns && <TableHeader>}` — there
+ * is no way to suppress it while keeping columns. Passing `children` replaces
+ * the entire header-and-body render, which is what makes a headerless table
+ * possible and, in the same stroke, means render plugins never run. Your rows
+ * go straight to the `<table>`, so `useTableSelection` cannot inject its
+ * checkbox column and `useTableRowStatus` cannot inject its status gutter.
+ *
+ * **The headless state hooks still work, and that is the way through.**
+ * `useTableSelectionState` is pure state: it owns the selected set, computes
+ * select-all and indeterminate across the *visible* rows, and correctly freezes
+ * rows you mark unselectable. This template drives its own checkbox cells from
+ * that state. You lose the plugin's rendering, not its logic — so do not
+ * hand-roll the selection maths, which is where the bugs are (select-all over a
+ * filtered list, indeterminate, locked rows surviving a deselect-all).
+ *
+ * **The column grid is a `colgroup`, not a header.** `resolveColumnWidths`
+ * turns the same column definitions the data path would use into `<col>`
+ * styles, so alignment survives without a `<thead>`. Keep the definitions even
+ * though nothing renders their `header` — they are the contract that every row
+ * agrees to, and the place to change a width.
+ *
+ * **Unread is weight, not colour.** Unread rows render their sender and subject
+ * semibold and show an accent dot; read rows go quiet. Encoding it as colour
+ * alone would fail anyone who cannot distinguish it, and the dot carries a text
+ * label for assistive tech. The preview text stays secondary in both states so
+ * the subject keeps the emphasis.
+ *
+ * **The toolbar swaps rather than grows.** With nothing selected it holds the
+ * scope filters; with a selection it becomes bulk actions and a count. Showing
+ * both at once is the common version and it is worse — the actions are dead
+ * controls most of the time, and the row of filters competes with them exactly
+ * when the user has committed to an action. Swapping keeps one job on screen.
+ *
+ * **Rows are activatable, so they are buttons.** Each row wires `onClick` plus
+ * Enter and Space through `onKeyDown` and carries `tabIndex={0}`, because a
+ * `<tr>` has no built-in activation. Do not put the checkbox click inside that
+ * handler — the cell stops propagation so selecting never opens the thread.
+ */
+
+import {useMemo, useState} from 'react';
+
+import {
+  HStack,
+  Layout,
+  LayoutContent,
+  LayoutHeader,
+  StackItem,
+  VStack,
+} from '@astryxdesign/core/Layout';
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {Avatar} from '@astryxdesign/core/Avatar';
+import {Button} from '@astryxdesign/core/Button';
+import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
+import {EmptyState} from '@astryxdesign/core/EmptyState';
+import {Icon} from '@astryxdesign/core/Icon';
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@astryxdesign/core/SegmentedControl';
+import {StatusDot} from '@astryxdesign/core/StatusDot';
+import {Token} from '@astryxdesign/core/Token';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  pixel,
+  proportional,
+  resolveColumnWidths,
+  useTableSelectionState,
+} from '@astryxdesign/core/Table';
+import type {TableColumn} from '@astryxdesign/core/Table';
+import {
+  ArchiveBoxIcon,
+  ArrowPathIcon,
+  CheckIcon,
+  UserPlusIcon,
+} from '@heroicons/react/24/outline';
+
+// ============= DATA =============
+
+type Priority = 'urgent' | 'high' | 'normal';
+
+interface Conversation extends Record<string, unknown> {
+  id: string;
+  sender: string;
+  subject: string;
+  preview: string;
+  tags: string[];
+  receivedAt: string;
+  isUnread: boolean;
+  priority: Priority;
+  assignee: string | null;
+  /** Locked threads are mid-escalation and cannot be bulk-actioned. */
+  isLocked?: boolean;
+}
+
+const PRIORITY_VARIANT: Record<Priority, 'error' | 'warning' | 'neutral'> = {
+  urgent: 'error',
+  high: 'warning',
+  normal: 'neutral',
+};
+
+const PRIORITY_LABEL: Record<Priority, string> = {
+  urgent: 'Urgent',
+  high: 'High priority',
+  normal: 'Normal priority',
+};
+
+const CONVERSATIONS: Conversation[] = [
+  {
+    id: 'c-01',
+    sender: 'Priya Raman',
+    subject: 'Checkout returns 502 for EU customers',
+    preview:
+      'Started around 09:40 UTC. Roughly one in five card payments fails at the confirm step…',
+    tags: ['Billing', 'Escalated'],
+    receivedAt: '9:52 AM',
+    isUnread: true,
+    priority: 'urgent',
+    assignee: null,
+    isLocked: true,
+  },
+  {
+    id: 'c-02',
+    sender: 'Marcus Feld',
+    subject: 'SSO metadata rotation — need new certificate',
+    preview:
+      'Our IdP certificate expires Friday. Can you confirm the fingerprint before we cut over?',
+    tags: ['Identity'],
+    receivedAt: '9:31 AM',
+    isUnread: true,
+    priority: 'high',
+    assignee: null,
+  },
+  {
+    id: 'c-03',
+    sender: 'Dana Osei',
+    subject: 'Re: Bulk export finished but the file is empty',
+    preview:
+      'Thanks — re-running with the date filter cleared did produce rows this time.',
+    tags: ['Exports'],
+    receivedAt: '8:58 AM',
+    isUnread: true,
+    priority: 'normal',
+    assignee: 'You',
+  },
+  {
+    id: 'c-04',
+    sender: 'Tomás Ibarra',
+    subject: 'Webhook retries stopped after the 3rd attempt',
+    preview:
+      'We expected five retries with backoff. Logs show three and then nothing for order 88214.',
+    tags: ['Webhooks', 'Bug'],
+    receivedAt: '8:14 AM',
+    isUnread: false,
+    priority: 'high',
+    assignee: 'You',
+  },
+  {
+    id: 'c-05',
+    sender: 'Hannah Lindqvist',
+    subject: 'Requesting a sandbox with production-shaped data',
+    preview:
+      'Happy to sign whatever is needed. We mostly need realistic invoice volumes.',
+    tags: ['Sales'],
+    receivedAt: 'Yesterday',
+    isUnread: false,
+    priority: 'normal',
+    assignee: null,
+  },
+  {
+    id: 'c-06',
+    sender: 'Owen Baptiste',
+    subject: 'Seat count says 145 but we only provisioned 120',
+    preview:
+      'Finance flagged the discrepancy on the March invoice. Can we reconcile before the 30th?',
+    tags: ['Billing'],
+    receivedAt: 'Yesterday',
+    isUnread: false,
+    priority: 'high',
+    assignee: 'You',
+  },
+  {
+    id: 'c-07',
+    sender: 'Aiko Tanaka',
+    subject: 'Docs: the rate-limit page contradicts the API response header',
+    preview:
+      'Page says 600/min, header reports 300/min on our plan. One of them is wrong.',
+    tags: ['Docs'],
+    receivedAt: 'Yesterday',
+    isUnread: false,
+    priority: 'normal',
+    assignee: null,
+  },
+  {
+    id: 'c-08',
+    sender: 'Reuben Cole',
+    subject: 'Re: Scheduled maintenance window confirmation',
+    preview: 'Confirmed for Sunday 02:00–04:00 UTC. Nothing further needed.',
+    tags: ['Ops'],
+    receivedAt: 'Mon',
+    isUnread: false,
+    priority: 'normal',
+    assignee: 'You',
+  },
+  {
+    id: 'c-09',
+    sender: 'Sofia Marchetti',
+    subject: 'Feature request: per-workspace retention policy',
+    preview:
+      'Our legal team needs 30-day retention on one workspace and 400 on another.',
+    tags: ['Feature request'],
+    receivedAt: 'Mon',
+    isUnread: false,
+    priority: 'normal',
+    assignee: null,
+  },
+];
+
+type Scope = 'all' | 'unread' | 'mine';
+
+const SCOPES: {value: Scope; label: string}[] = [
+  {value: 'all', label: 'All'},
+  {value: 'unread', label: 'Unread'},
+  {value: 'mine', label: 'Assigned to me'},
+];
+
+// ============= COLUMN GRID =============
+
+// The same column definitions the data-driven path would take. Nothing renders
+// their `header` — they exist to produce the colgroup below, which is what
+// holds every row on the same grid without a <thead>.
+const columns: TableColumn<Conversation>[] = [
+  {key: 'select', width: pixel(44)},
+  // Wide enough for the dot plus both cell paddings. Any narrower and the
+  // dot overflows, which makes `textOverflow="truncate"` paint an ellipsis
+  // next to it even though the cell holds no text.
+  {key: 'status', width: pixel(44)},
+  {key: 'sender', width: pixel(200)},
+  {key: 'subject', width: proportional(3)},
+  {key: 'tags', width: pixel(210)},
+  {key: 'received', width: pixel(96)},
+];
+
+const COLUMN_WIDTHS = resolveColumnWidths(columns);
+
+// ============= PAGE =============
+
+export default function SupportInboxTemplate() {
+  const [scope, setScope] = useState<Scope>('all');
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  const visible = useMemo(() => {
+    if (scope === 'unread') {
+      return CONVERSATIONS.filter(item => item.isUnread);
+    }
+    if (scope === 'mine') {
+      return CONVERSATIONS.filter(item => item.assignee === 'You');
+    }
+    return CONVERSATIONS;
+  }, [scope]);
+
+  // Headless: this hook is pure selection state, so it works in children mode
+  // where the selection *plugin* would not. It scopes select-all to the rows
+  // passed in, which is why `visible` goes in rather than the full list.
+  const {selectionConfig} = useTableSelectionState<Conversation>({
+    data: visible,
+    idKey: 'id',
+    selectedKeys,
+    setSelectedKeys,
+    getIsItemEnabled: item => !item.isLocked,
+  });
+
+  const selectedCount = selectedKeys.size;
+  const hasSelection = selectedCount > 0;
+  const unreadCount = CONVERSATIONS.filter(item => item.isUnread).length;
+
+  const clearSelection = () => setSelectedKeys(new Set());
+
+  return (
+    <Layout
+      height="fill"
+      header={
+        <LayoutHeader hasDivider padding={4}>
+          <VStack gap={4}>
+            <HStack gap={3} vAlign="center" wrap="wrap">
+              <StackItem size="fill">
+                <VStack gap={0.5}>
+                  <Heading level={1}>Inbox</Heading>
+                  <Text type="supporting">
+                    {unreadCount} unread of {CONVERSATIONS.length} conversations
+                  </Text>
+                </VStack>
+              </StackItem>
+              <Button
+                label="Refresh"
+                variant="ghost"
+                icon={<Icon icon={ArrowPathIcon} size="sm" />}
+              />
+            </HStack>
+
+            {/* One job on screen: scope filters, or bulk actions — never both.
+                Select-all sits outside the swap because a headerless table has
+                no header cell to host it, and it has to stay reachable before
+                the first row is picked. */}
+            <HStack gap={3} vAlign="center" wrap="wrap">
+              <CheckboxInput
+                label="Select all conversations"
+                isLabelHidden
+                value={
+                  selectionConfig.getIsIndeterminate?.() === true
+                    ? 'indeterminate'
+                    : selectionConfig.getIsAllSelected()
+                }
+                onChange={checked =>
+                  selectionConfig.onSelectAll({isAllSelected: checked})
+                }
+              />
+              {hasSelection ? (
+                <HStack gap={2} vAlign="center" wrap="wrap">
+                  <Text weight="semibold">{selectedCount} selected</Text>
+                  <Button
+                    label="Archive"
+                    variant="secondary"
+                    icon={<Icon icon={ArchiveBoxIcon} size="sm" />}
+                  />
+                  <Button
+                    label="Mark read"
+                    variant="secondary"
+                    icon={<Icon icon={CheckIcon} size="sm" />}
+                  />
+                  <Button
+                    label="Assign"
+                    variant="secondary"
+                    icon={<Icon icon={UserPlusIcon} size="sm" />}
+                  />
+                  <Button
+                    label="Clear selection"
+                    variant="ghost"
+                    onClick={clearSelection}
+                  />
+                </HStack>
+              ) : (
+                <SegmentedControl
+                  label="Filter conversations"
+                  value={scope}
+                  onChange={value => setScope(value as Scope)}>
+                  {SCOPES.map(option => (
+                    <SegmentedControlItem
+                      key={option.value}
+                      value={option.value}
+                      label={option.label}
+                    />
+                  ))}
+                </SegmentedControl>
+              )}
+            </HStack>
+          </VStack>
+        </LayoutHeader>
+      }
+      content={
+        <LayoutContent padding={0} isScrollable>
+          {visible.length === 0 ? (
+            <VStack padding={6}>
+              <EmptyState
+                title="Nothing here"
+                description="No conversation matches this filter."
+                actions={
+                  <Button
+                    label="Show all"
+                    variant="secondary"
+                    onClick={() => setScope('all')}
+                  />
+                }
+              />
+            </VStack>
+          ) : (
+            <Table
+              density="balanced"
+              dividers="none"
+              hasHover
+              textOverflow="truncate">
+              <colgroup>
+                {columns.map(column => (
+                  <col
+                    key={column.key}
+                    style={COLUMN_WIDTHS.columns.get(column.key)?.style}
+                  />
+                ))}
+              </colgroup>
+              {/* No TableHeader. Children mode is the only way to omit it. */}
+              <TableBody>
+                {visible.map(item => {
+                  const isSelected = selectionConfig.getIsItemSelected(item);
+                  return (
+                    <TableRow
+                      key={item.id}
+                      tabIndex={0}
+                      aria-selected={isSelected}
+                      onClick={() => {
+                        // Open the thread. A row is not a button element, so
+                        // activation is wired by hand — see onKeyDown.
+                      }}
+                      onKeyDown={event => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                        }
+                      }}>
+                      {/* Selecting must never open the thread, so the cell
+                          swallows the click before it reaches the row. */}
+                      <TableCell onClick={event => event.stopPropagation()}>
+                        <CheckboxInput
+                          label={`Select conversation from ${item.sender}`}
+                          isLabelHidden
+                          value={isSelected}
+                          isDisabled={item.isLocked === true}
+                          disabledMessage="This thread is mid-escalation"
+                          onChange={checked =>
+                            selectionConfig.onSelectItem({
+                              item,
+                              isSelected: checked,
+                            })
+                          }
+                        />
+                      </TableCell>
+
+                      <TableCell>
+                        {item.priority === 'normal' ? null : (
+                          <StatusDot
+                            variant={PRIORITY_VARIANT[item.priority]}
+                            label={PRIORITY_LABEL[item.priority]}
+                          />
+                        )}
+                      </TableCell>
+
+                      <TableCell>
+                        <HStack gap={2} vAlign="center">
+                          <Avatar
+                            name={item.sender}
+                            size="sm"
+                            tooltip={false}
+                          />
+                          <Text
+                            maxLines={1}
+                            weight={item.isUnread ? 'semibold' : 'normal'}>
+                            {item.sender}
+                          </Text>
+                        </HStack>
+                      </TableCell>
+
+                      <TableCell>
+                        <HStack gap={2} vAlign="center">
+                          {item.isUnread && (
+                            <StatusDot variant="accent" label="Unread" />
+                          )}
+                          <Text
+                            maxLines={1}
+                            weight={item.isUnread ? 'semibold' : 'normal'}>
+                            {item.subject}
+                          </Text>
+                          {/* The preview absorbs the leftover width and
+                              truncates, so the subject keeps its natural size
+                              instead of both shrinking in step. */}
+                          <StackItem size="fill">
+                            <Text maxLines={1} color="secondary">
+                              — {item.preview}
+                            </Text>
+                          </StackItem>
+                        </HStack>
+                      </TableCell>
+
+                      <TableCell>
+                        <HStack gap={1.5} vAlign="center">
+                          {item.tags.map(tag => (
+                            <Token key={tag} size="sm" label={tag} />
+                          ))}
+                        </HStack>
+                      </TableCell>
+
+                      <TableCell>
+                        <Text
+                          display="block"
+                          justify="end"
+                          color="secondary"
+                          weight={item.isUnread ? 'semibold' : 'normal'}>
+                          {item.receivedAt}
+                        </Text>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </LayoutContent>
+      }
+    />
+  );
+}

--- a/packages/cli/assets/templates/pages/table-inbox/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-inbox/template.doc.mjs
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'page',
+  name: 'Inbox Table',
+  displayName: 'Inbox Table',
+  description:
+    'Headerless, divider-free triage queue that still holds a real table column grid, with unread weight, per-row priority, and headless selection state that swaps the toolbar filters for bulk actions. Inbox, mail, messages, conversations, triage, queue, notifications, or bulk actions.',
+  isReady: true,
+  category: 'Table - Bulk Actions',
+};

--- a/packages/cli/assets/templates/pages/table-page/page.tsx
+++ b/packages/cli/assets/templates/pages/table-page/page.tsx
@@ -2,435 +2,892 @@
 
 'use client';
 
-import {useState, useMemo} from 'react';
+/**
+ * An invoice you can interrogate: the document's own facts up top, a sortable
+ * and filterable table of line items, and totals that stay glued to the
+ * columns above them.
+ *
+ * The reader here does two things — find a line, and check what it cost. Sorting
+ * by amount answers "what is driving this bill?" and the column filters answer
+ * "show me only the design work", without either question needing a new screen.
+ * `table-grouped` is the version for heterogeneous records and `table-inbox` the
+ * version for triage; this is the one for a single uniform list.
+ *
+ * ## Extending this template
+ *
+ * **Plugins mean data mode, and data mode has no footer.** `BaseTable` renders
+ * `children ? children : (header + body)`, so composing rows by hand — the only
+ * way to reach `TableFooter` — bypasses the plugin pipeline entirely. Sorting
+ * and column filters are render plugins, so they need `data` + `columns`. The
+ * totals therefore live in a **second table** that shares the same `columns`,
+ * and so the same `colgroup`, which is what keeps the figures in the same
+ * vertical line as the Amount column above. It costs one extra `<table>` in the
+ * accessibility tree, which is why the pair is wrapped in a labelled group.
+ *
+ * This alignment holds only because every column declares an explicit width.
+ * `useTableFiltering` rewrites a column to `proportional(1)` when it has a
+ * filter *and no width* — leave one width off and the two tables drift apart.
+ *
+ * **Sort keys default to the column key, so derived columns need comparators.**
+ * `unitPrice` and `amount` are not fields on the row — the money lives in
+ * `unitPriceCents` and `amountCents` — and the hook's fallback stringifies the
+ * value it finds, which for a missing key means sorting a column of
+ * `undefined`. Every numeric column here passes an explicit comparator, and
+ * they subtract integers rather than comparing formatted strings, so `$1,240.00`
+ * never sorts below `$980.00`.
+ *
+ * **Two filtering surfaces, one predicate.** PowerSearch owns the free-form
+ * query and `useTableFiltering` owns the per-column popovers, but both produce
+ * `PowerSearchFilter`s against the same `SEARCH_FIELDS`, so they are
+ * concatenated and run through a single `applyFilters`. `toSearchFilters` is
+ * the adapter that turns column filter state into that shape. Filtering the
+ * data twice — once per surface — is the version that eventually disagrees with
+ * itself.
+ *
+ * The popover variant is deliberate. `inline` puts a control row under every
+ * header, which on a five-column invoice competes with the PowerSearch directly
+ * above it; the popover keeps the filter available and the header quiet. Switch
+ * to `inline` when the table is the only thing on the page.
+ *
+ * **A plugin is just an object of transforms.** `useFlushEdges` below is a
+ * complete plugin in a dozen lines — no factory, no registration. It exists
+ * because cancelling the container bleed only gets the *stripe* to the content
+ * line: cell padding resolves to `max(var(--container-padding-inline-start),
+ * spacing-2)`, so zeroing the variable still floors at 8px and the text sits
+ * indented. In children mode an inline `style` on the outer cells fixes that;
+ * in data mode a `transformBodyCell` is the equivalent. Reach for this whenever
+ * you need per-cell chrome that columns cannot express.
+ *
+ * **Zebra striping replaces the row hairline, rather than joining it.** The
+ * table runs `dividers="none"` with `isStriped`, so the eye tracks a row by its
+ * background rather than by the line under it. Both at once double-encodes the
+ * same boundary, which is the usual reason a plain table starts to read as
+ * busy. The cost is that a striped table can never be visually quiet — on a
+ * page where the table is one widget among several, invert this: keep
+ * `dividers="rows"` and drop the stripe.
+ *
+ * The stripe's corners are square and cannot be rounded from here. The band is
+ * painted on the `<tr>`, and `BaseTable` sets `border-collapse: collapse`,
+ * under which browsers ignore `border-radius` on rows and cells alike.
+ *
+ * **The one rule on the page sits above the total.** With `dividers="none"`
+ * there is no hairline anywhere, which is what makes a single `borderBlockStart`
+ * read as punctuation rather than as one more line in a grid. Add a second rule
+ * elsewhere and this one stops meaning anything.
+ *
+ * **Document facts belong above the table, not inside it.** Client, project,
+ * and terms are true of the whole invoice, so they render as a `MetadataList`
+ * rather than as columns repeating the same value nineteen times. The test is
+ * whether the value varies per row; if it does not, it is a header fact.
+ *
+ * **Width is capped on the Layout, not on the table.** `contentWidth` bounds
+ * every slot and leaves dividers full-bleed, so the header rule still spans the
+ * window while the invoice sits in a readable column. Wrapping the table in a
+ * centered box instead would pull the header rule in with it.
+ *
+ * **The totals are derived from the rows on screen.** `visible` feeds the body,
+ * the count caption, and every figure below it, so filtering to Design really
+ * does retotal the invoice. The failure mode this avoids is a hardcoded total
+ * that silently disagrees with the rows above it.
+ *
+ * **Money is stored in cents and formatted once.** Only the display step goes
+ * through `Intl.NumberFormat`, at a pinned locale. Float dollars accumulate
+ * rounding drift across nineteen lines and the total is exactly where it shows
+ * up. Swap the formatter for the viewer's locale in a real app; keep the
+ * integers.
+ */
+
+import {useEffect, useMemo, useRef, useState} from 'react';
+
 import {
-  VStack,
   HStack,
-  StackItem,
   Layout,
   LayoutContent,
   LayoutHeader,
+  StackItem,
+  VStack,
 } from '@astryxdesign/core/Layout';
-import {Text, Heading} from '@astryxdesign/core/Text';
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {Banner} from '@astryxdesign/core/Banner';
 import {Button} from '@astryxdesign/core/Button';
-import {IconButton} from '@astryxdesign/core/IconButton';
+import {EmptyState} from '@astryxdesign/core/EmptyState';
+import {useHoverCard} from '@astryxdesign/core/HoverCard';
 import {Icon} from '@astryxdesign/core/Icon';
-import {Avatar} from '@astryxdesign/core/Avatar';
+import {MetadataList, MetadataListItem} from '@astryxdesign/core/MetadataList';
 import {
   PowerSearch,
   usePowerSearchConfig,
 } from '@astryxdesign/core/PowerSearch';
 import type {PowerSearchFilter} from '@astryxdesign/core/PowerSearch';
-import {Table, proportional, pixel} from '@astryxdesign/core/Table';
-import type {TableColumn} from '@astryxdesign/core/Table';
 import {
-  FunnelIcon,
-  ArrowDownTrayIcon,
-  PlusIcon,
-} from '@heroicons/react/24/outline';
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@astryxdesign/core/SegmentedControl';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+  pixel,
+  proportional,
+  resolveColumnWidths,
+  toSearchFilters,
+  useTableFilterState,
+  useTableFiltering,
+  useTableSortable,
+  useTableSortableState,
+} from '@astryxdesign/core/Table';
+import type {
+  TableColumn,
+  TablePlugin,
+  TableSortComparator,
+} from '@astryxdesign/core/Table';
+import {ArrowDownTrayIcon} from '@heroicons/react/24/outline';
 
-interface DogRow extends Record<string, unknown> {
+// ============= DATA =============
+
+type LineCategory = 'design' | 'development' | 'content' | 'project';
+
+/**
+ * How the line is priced. Hourly lines vary with the time booked against them
+ * and are the ones a client queries; fixed-fee lines were agreed up front.
+ */
+type BillingBasis = 'hourly' | 'fixed';
+
+interface LineItem extends Record<string, unknown> {
   id: string;
-  name: string;
-  breed: string;
-  biography: string;
-  age: number;
+  description: string;
+  category: LineCategory;
+  basis: BillingBasis;
+  /** Hours booked on an hourly line, or units delivered on a fixed-fee one. */
+  quantity: number;
+  /** Integer cents. Dollars are a formatting concern, never a stored one. */
+  unitPriceCents: number;
 }
 
-const allDogs: DogRow[] = [
+/** A line with its extended amount precomputed, so `amount` is sortable. */
+interface InvoiceRow extends LineItem {
+  amountCents: number;
+}
+
+const CATEGORY_LABEL: Record<LineCategory, string> = {
+  design: 'Design',
+  development: 'Development',
+  content: 'Content',
+  project: 'Project management',
+};
+
+const LINE_ITEMS: LineItem[] = [
   {
-    id: '1',
-    name: 'Adam',
-    breed: 'Labrador',
-    biography:
-      'I love relaxing in the park and hate skateboards — you might wonder how well those things mix and the answer is "not that well."',
-    age: 17,
+    id: 'li-01',
+    description: 'Discovery workshop',
+    category: 'design',
+    basis: 'fixed',
+    quantity: 1,
+    unitPriceCents: 240_000,
   },
   {
-    id: '2',
-    name: 'Al Chihuahua',
-    breed: 'Chihuahua',
-    biography: 'This is a Chihuahua generated by meta.ai',
-    age: 2,
+    id: 'li-02',
+    description: 'Stakeholder interviews',
+    category: 'design',
+    basis: 'hourly',
+    quantity: 12,
+    unitPriceCents: 14_500,
   },
   {
-    id: '3',
-    name: 'Archer',
-    breed: 'Doberman',
-    biography:
-      "I'm an 8 year old Greater Swiss Mountain Dog and I live in Mountain View with my mom and dad.",
-    age: 9,
+    id: 'li-03',
+    description: 'User research synthesis',
+    category: 'design',
+    basis: 'hourly',
+    quantity: 18,
+    unitPriceCents: 14_500,
   },
   {
-    id: '4',
-    name: 'Archie',
-    breed: 'Australian Shepherd',
-    biography: 'Border collie at heart, shepherd by trade.',
-    age: 5,
+    id: 'li-04',
+    description: 'Wireframes — key templates',
+    category: 'design',
+    basis: 'hourly',
+    quantity: 34,
+    unitPriceCents: 14_500,
   },
   {
-    id: '5',
-    name: 'Argos',
-    breed: 'Labrador',
-    biography: 'Faithful hunting dog who never gives up the trail.',
-    age: 23,
+    id: 'li-05',
+    description: 'Visual design system',
+    category: 'design',
+    basis: 'fixed',
+    quantity: 1,
+    unitPriceCents: 680_000,
   },
   {
-    id: '6',
-    name: 'Banjo',
-    breed: 'Poodle',
-    biography:
-      "Banjo was a rescue from Underdog Rescue in Concord, CA. He's a loving poodle mix that loves to run on the beach.",
-    age: 9,
+    id: 'li-06',
+    description: 'Page designs — 14 templates',
+    category: 'design',
+    basis: 'hourly',
+    quantity: 62,
+    unitPriceCents: 14_500,
   },
   {
-    id: '7',
-    name: 'Barley',
-    breed: 'Maltese',
-    biography: 'Teacup-sized with a full-sized personality.',
-    age: 4,
+    id: 'li-07',
+    description: 'Prototype & usability testing',
+    category: 'design',
+    basis: 'hourly',
+    quantity: 22,
+    unitPriceCents: 14_500,
   },
   {
-    id: '8',
-    name: 'Beast',
-    breed: 'Bulldog',
-    biography: 'Summers in Palo Alto, winters on the couch.',
-    age: 14,
+    id: 'li-08',
+    description: 'Frontend build — component library',
+    category: 'development',
+    basis: 'hourly',
+    quantity: 88,
+    unitPriceCents: 16_500,
   },
   {
-    id: '9',
-    name: 'Belki',
-    breed: 'Pomsky',
-    biography: 'Belki is actually three squirrels in an overcoat.',
-    age: 6,
+    id: 'li-09',
+    description: 'Frontend build — page templates',
+    category: 'development',
+    basis: 'hourly',
+    quantity: 104,
+    unitPriceCents: 16_500,
   },
   {
-    id: '10',
-    name: 'Bella',
-    breed: 'Doberman',
-    biography: 'Guard dog by day, cuddle bug by night.',
-    age: 10,
+    id: 'li-10',
+    description: 'CMS setup & content modelling',
+    category: 'development',
+    basis: 'hourly',
+    quantity: 40,
+    unitPriceCents: 16_500,
   },
   {
-    id: '11',
-    name: 'Brienne',
-    breed: 'Dachshund',
-    biography: 'Brienne of Bark, the cream mini dachshund.',
-    age: 7,
+    id: 'li-11',
+    description: 'Search & filtering integration',
+    category: 'development',
+    basis: 'hourly',
+    quantity: 26,
+    unitPriceCents: 16_500,
   },
   {
-    id: '12',
-    name: 'Bruno',
-    breed: 'Poodle',
-    biography:
-      "Bruno is a shih tzu. He's a smart doggo — I never needed more than a day to teach him a trick.",
-    age: 5,
+    id: 'li-12',
+    description: 'Analytics & tag manager setup',
+    category: 'development',
+    basis: 'hourly',
+    quantity: 10,
+    unitPriceCents: 16_500,
   },
   {
-    id: '13',
-    name: 'Cabo',
-    breed: 'Poodle',
-    biography:
-      'Cabo is a mix of Terrier, Poodle, and unknown. Fat and grumpy but lovable.',
-    age: 9,
+    id: 'li-13',
+    description: 'Accessibility audit & remediation',
+    category: 'development',
+    basis: 'fixed',
+    quantity: 1,
+    unitPriceCents: 320_000,
   },
   {
-    id: '14',
-    name: 'Chai',
-    breed: 'Shiba Inu',
-    biography: 'Sunshine and hiking are the only two things that matter.',
-    age: 1,
+    id: 'li-14',
+    description: 'Cross-browser QA',
+    category: 'development',
+    basis: 'hourly',
+    quantity: 24,
+    unitPriceCents: 13_500,
   },
   {
-    id: '15',
-    name: 'Charlie',
-    breed: 'Golden Retriever',
-    biography: 'The goodest boy in the whole wide world.',
-    age: 3,
+    id: 'li-15',
+    description: 'Copywriting — 14 pages',
+    category: 'content',
+    basis: 'hourly',
+    quantity: 36,
+    unitPriceCents: 12_500,
   },
   {
-    id: '16',
-    name: 'Coco',
-    breed: 'French Bulldog',
-    biography: 'Loves naps and belly rubs more than anything.',
-    age: 6,
+    id: 'li-16',
+    description: 'Content migration',
+    category: 'content',
+    basis: 'hourly',
+    quantity: 28,
+    unitPriceCents: 9_500,
   },
   {
-    id: '17',
-    name: 'Daisy',
-    breed: 'Beagle',
-    biography: 'Will follow any scent trail anywhere, anytime.',
-    age: 8,
+    id: 'li-17',
+    description: 'Stock photography licences',
+    category: 'content',
+    basis: 'fixed',
+    quantity: 24,
+    unitPriceCents: 1_800,
   },
   {
-    id: '18',
-    name: 'Duke',
-    breed: 'German Shepherd',
-    biography: 'Guard dog by day, couch potato by night.',
-    age: 11,
+    id: 'li-18',
+    description: 'Project management — 12 weeks',
+    category: 'project',
+    basis: 'fixed',
+    quantity: 12,
+    unitPriceCents: 85_000,
   },
   {
-    id: '19',
-    name: 'Ella',
-    breed: 'Corgi',
-    biography: 'Short legs, big personality, endless zoomies.',
-    age: 4,
-  },
-  {
-    id: '20',
-    name: 'Finn',
-    breed: 'Husky',
-    biography: 'Loves snow and howling at the moon.',
-    age: 7,
-  },
-  {
-    id: '21',
-    name: 'Ginger',
-    breed: 'Irish Setter',
-    biography: 'Red and rambunctious with boundless energy.',
-    age: 5,
-  },
-  {
-    id: '22',
-    name: 'Hank',
-    breed: 'Basset Hound',
-    biography: 'Ears for days and a nose that never quits.',
-    age: 9,
-  },
-  {
-    id: '23',
-    name: 'Izzy',
-    breed: 'Border Collie',
-    biography: 'Smarter than most people I know.',
-    age: 3,
-  },
-  {
-    id: '24',
-    name: 'Jax',
-    breed: 'Pit Bull',
-    biography: 'Gentle giant who loves kids and belly scratches.',
-    age: 6,
-  },
-  {
-    id: '25',
-    name: 'Koda',
-    breed: 'Akita',
-    biography: 'Loyal, fluffy, and fiercely protective.',
-    age: 8,
-  },
-  {
-    id: '26',
-    name: 'Luna',
-    breed: 'Samoyed',
-    biography: 'A cloud on four legs with a permanent smile.',
-    age: 2,
-  },
-  {
-    id: '27',
-    name: 'Max',
-    breed: 'Rottweiler',
-    biography: 'Looks tough, but melts for ear scratches.',
-    age: 10,
-  },
-  {
-    id: '28',
-    name: 'Nala',
-    breed: 'Labradoodle',
-    biography: 'Hypoallergenic and proud of it.',
-    age: 4,
-  },
-  {
-    id: '29',
-    name: 'Oscar',
-    breed: 'Dachshund',
-    biography: 'Long boy with short legs and big dreams.',
-    age: 12,
-  },
-  {
-    id: '30',
-    name: 'Penny',
-    breed: 'Cavalier King Charles',
-    biography: 'Lap dog extraordinaire and treat connoisseur.',
-    age: 7,
-  },
-  {
-    id: '31',
-    name: 'Rex',
-    breed: 'Doberman',
-    biography: 'Fast, fearless, and first to the food bowl.',
-    age: 5,
-  },
-  {
-    id: '32',
-    name: 'Sadie',
-    breed: 'Australian Shepherd',
-    biography: 'Herds everything, including the cat.',
-    age: 3,
-  },
-  {
-    id: '33',
-    name: 'Tucker',
-    breed: 'Golden Retriever',
-    biography: 'Tennis ball enthusiast and professional fetcher.',
-    age: 6,
-  },
-  {
-    id: '34',
-    name: 'Willow',
-    breed: 'Greyhound',
-    biography: 'Retired racer, full-time lounger.',
-    age: 8,
-  },
-  {
-    id: '35',
-    name: 'Zeus',
-    breed: 'Great Dane',
-    biography: 'Thinks he is a lap dog despite weighing 150 lbs.',
-    age: 4,
-  },
-  {
-    id: '36',
-    name: 'Rosie',
-    breed: 'Maltipoo',
-    biography: 'Tiny but mighty with a bark bigger than her bite.',
-    age: 2,
-  },
-  {
-    id: '37',
-    name: 'Scout',
-    breed: 'Labrador',
-    biography: 'Adventure buddy who never says no to a hike.',
-    age: 5,
-  },
-  {
-    id: '38',
-    name: 'Teddy',
-    breed: 'Bernese Mountain Dog',
-    biography: 'Gentle giant of the mountains.',
-    age: 7,
+    id: 'li-19',
+    description: 'Training & handover session',
+    category: 'project',
+    basis: 'fixed',
+    quantity: 2,
+    unitPriceCents: 120_000,
   },
 ];
 
-const breedValues = [
-  {value: 'Labrador', label: 'Labrador'},
-  {value: 'Chihuahua', label: 'Chihuahua'},
-  {value: 'Doberman', label: 'Doberman'},
-  {value: 'Australian Shepherd', label: 'Australian Shepherd'},
-  {value: 'Poodle', label: 'Poodle'},
-  {value: 'Maltese', label: 'Maltese'},
-  {value: 'Bulldog', label: 'Bulldog'},
-  {value: 'Pomsky', label: 'Pomsky'},
-  {value: 'Dachshund', label: 'Dachshund'},
-  {value: 'Shiba Inu', label: 'Shiba Inu'},
-  {value: 'Golden Retriever', label: 'Golden Retriever'},
-  {value: 'French Bulldog', label: 'French Bulldog'},
-  {value: 'Beagle', label: 'Beagle'},
-  {value: 'German Shepherd', label: 'German Shepherd'},
-  {value: 'Corgi', label: 'Corgi'},
-  {value: 'Husky', label: 'Husky'},
-  {value: 'Irish Setter', label: 'Irish Setter'},
-  {value: 'Basset Hound', label: 'Basset Hound'},
-  {value: 'Border Collie', label: 'Border Collie'},
-  {value: 'Pit Bull', label: 'Pit Bull'},
-  {value: 'Akita', label: 'Akita'},
-  {value: 'Samoyed', label: 'Samoyed'},
-  {value: 'Rottweiler', label: 'Rottweiler'},
-  {value: 'Labradoodle', label: 'Labradoodle'},
-  {value: 'Cavalier King Charles', label: 'Cavalier King Charles'},
-  {value: 'Great Dane', label: 'Great Dane'},
-  {value: 'Maltipoo', label: 'Maltipoo'},
-  {value: 'Greyhound', label: 'Greyhound'},
-  {value: 'Bernese Mountain Dog', label: 'Bernese Mountain Dog'},
+/** Extended amounts are precomputed so the Amount column has a value to sort. */
+const ROWS: InvoiceRow[] = LINE_ITEMS.map(item => ({
+  ...item,
+  amountCents: item.quantity * item.unitPriceCents,
+}));
+
+/** Invoice-wide, so a line's share does not move when the view is filtered. */
+const INVOICE_SUBTOTAL_CENTS = ROWS.reduce(
+  (sum, item) => sum + item.amountCents,
+  0,
+);
+
+/**
+ * The segmented control answers one question — "which lines are time-based?" —
+ * and leaves every other cut to the search and the column filters. Two segments
+ * is the ceiling for a control that sits in front of a query builder.
+ */
+const BASIS_FILTERS: {value: BillingBasis | 'all'; label: string}[] = [
+  {value: 'all', label: 'All lines'},
+  {value: 'hourly', label: 'Hourly'},
 ];
 
-const fieldDefs = [
-  {key: 'name', type: 'string', label: 'Name'},
-  {key: 'breed', type: 'enum', label: 'Breed', enumValues: breedValues},
-  {key: 'biography', type: 'string', label: 'Biography'},
+/**
+ * One set of field definitions feeds both filtering surfaces: PowerSearch
+ * renders its query builder from them, and the column filter popovers resolve
+ * their controls through the same config.
+ */
+const SEARCH_FIELDS = [
+  {key: 'description', type: 'string', label: 'Description'},
+  {
+    key: 'category',
+    type: 'enum',
+    label: 'Category',
+    enumValues: [
+      {value: 'design', label: 'Design'},
+      {value: 'development', label: 'Development'},
+      {value: 'content', label: 'Content'},
+      {value: 'project', label: 'Project management'},
+    ],
+  },
+  {key: 'quantity', type: 'number', label: 'Quantity'},
 ] as const;
 
-const columns: TableColumn<DogRow>[] = [
+const TAX_RATE = 0.0875;
+
+/** Static invoice facts. Rendered as a MetadataList, not as table columns —
+ * they describe the whole document, so repeating them per row would be noise. */
+const INVOICE_DETAILS: {label: string; value: string}[] = [
+  {label: 'Billed to', value: 'Brightwater Coffee Co.'},
+  {label: 'Project', value: 'Website redesign'},
+  {label: 'Issue date', value: 'Mar 31, 2026'},
+  {label: 'Due date', value: 'Apr 30, 2026'},
+  {label: 'Payment terms', value: 'Net 30'},
+  {label: 'Purchase order', value: 'PO-4471'},
+];
+
+// ============= FORMATTING =============
+
+// Pinned locale so the rendered output is identical in every environment.
+// A real app resolves this from the viewer instead.
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+const decimal = new Intl.NumberFormat('en-US');
+
+function formatCents(cents: number): string {
+  return currency.format(cents / 100);
+}
+
+/** Right-aligned tabular figure. The column's `align` handles the cell; this
+ * keeps the digits themselves on a grid so decimal points line up. */
+function Figure({
+  children,
+  weight,
+}: {
+  children: string;
+  weight?: 'normal' | 'semibold';
+}) {
+  return (
+    <Text hasTabularNumbers weight={weight}>
+      {children}
+    </Text>
+  );
+}
+
+// ============= ROW DETAIL =============
+
+/**
+ * One hover card per row, triggered by the whole row.
+ *
+ * Three constraints shape this. The `<HoverCard>` wrapper is unusable: it wraps
+ * its trigger in a `display: contents` span, and a span between `<tr>` and
+ * `<td>` is invalid markup. A column's `renderCell` is a plain function, so the
+ * hook has to live in a per-row component like this one. And `Table` has no
+ * `rowComponent` escape hatch, so there is no way to hand the row itself a hook.
+ *
+ * The way through is to let the hook keep its own uncontrolled hover/focus
+ * handling and simply point it at the enclosing `<tr>`. Driving `isOpen` from
+ * row-level mouse handlers instead — the obvious alternative — produces a card
+ * that closes the moment the pointer leaves the row, which makes anything
+ * interactive inside it unreachable. Uncontrolled, the hook keeps the card open
+ * while the pointer is moving onto it, so the Dispute button is clickable.
+ *
+ * `tabIndex` and `aria-describedby` are set on the row in the same effect,
+ * because the node is already in hand and neither can be expressed through a
+ * column definition. That also makes the detail reachable without a pointer.
+ */
+function DescriptionCell({item}: {item: InvoiceRow}) {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const hoverCard = useHoverCard({
+    placement: 'below',
+    alignment: 'start',
+    label: `${item.description} details`,
+  });
+
+  const attach = hoverCard.ref;
+  const cardId = hoverCard.id;
+  useEffect(() => {
+    const row = anchorRef.current?.closest('tr');
+    if (row == null) {
+      return;
+    }
+    attach(row);
+    row.tabIndex = 0;
+    row.setAttribute('aria-describedby', cardId);
+    return () => {
+      attach(null);
+      row.removeAttribute('aria-describedby');
+    };
+  }, [attach, cardId]);
+
+  const share = (item.amountCents / INVOICE_SUBTOTAL_CENTS) * 100;
+
+  return (
+    <>
+      <Text maxLines={1}>
+        <span ref={anchorRef}>{item.description}</span>
+      </Text>
+      {hoverCard.renderHoverCard(
+        // No padding here — useHoverCard's content wrapper already applies
+        // spacing-3 on all four sides. Adding it again doubles it to 24px.
+        <VStack gap={3} width={280}>
+          <Text weight="semibold">{item.description}</Text>
+          <MetadataList label={{position: 'start'}}>
+            <MetadataListItem label="Category">
+              {CATEGORY_LABEL[item.category]}
+            </MetadataListItem>
+            <MetadataListItem label="Billing">
+              {item.basis === 'hourly' ? 'Hourly' : 'Fixed fee'}
+            </MetadataListItem>
+            <MetadataListItem label="Calculation">
+              {`${decimal.format(item.quantity)} \u00d7 ${formatCents(item.unitPriceCents)}`}
+            </MetadataListItem>
+            <MetadataListItem label="Amount">
+              {formatCents(item.amountCents)}
+            </MetadataListItem>
+            <MetadataListItem label="Share of invoice">
+              {`${share.toFixed(1)}%`}
+            </MetadataListItem>
+          </MetadataList>
+          <Button label="Dispute this line" variant="secondary" width="100%" />
+        </VStack>,
+      )}
+    </>
+  );
+}
+
+// ============= COLUMNS =============
+
+const columns: TableColumn<InvoiceRow>[] = [
   {
-    key: 'name',
-    header: 'Name',
-    width: proportional(2),
-    renderCell: (item: DogRow) => (
-      <HStack gap={3} vAlign="center">
-        <Avatar name={item.name} size="md" />
-        <VStack gap={0}>
-          <Text type="body">{item.name}</Text>
-          <Text type="supporting" color="secondary">
-            {item.breed}
-          </Text>
-        </VStack>
-      </HStack>
+    key: 'description',
+    header: 'Description',
+    width: proportional(3),
+    sortable: true,
+    filter: 'description',
+    renderCell: item => <DescriptionCell item={item} />,
+  },
+  {
+    key: 'category',
+    header: 'Category',
+    width: pixel(160),
+    sortable: true,
+    filter: 'category',
+    renderCell: item => (
+      <Text color="secondary" maxLines={1}>
+        {CATEGORY_LABEL[item.category]}
+      </Text>
     ),
   },
   {
-    key: 'biography',
-    header: 'Biography',
-    width: proportional(5),
-    renderCell: (item: DogRow) => <Text type="body">{item.biography}</Text>,
+    key: 'quantity',
+    header: 'Qty',
+    width: pixel(80),
+    align: 'end',
+    sortable: true,
+    filter: 'quantity',
+    renderCell: item => <Figure>{decimal.format(item.quantity)}</Figure>,
   },
   {
-    key: 'age',
-    header: 'Age',
-    width: pixel(80),
-    renderCell: (item: DogRow) => <Text type="body">{item.age}</Text>,
+    key: 'unitPrice',
+    header: 'Rate',
+    width: pixel(120),
+    align: 'end',
+    sortable: true,
+    renderCell: item => <Figure>{formatCents(item.unitPriceCents)}</Figure>,
+  },
+  {
+    key: 'amount',
+    header: 'Amount',
+    width: pixel(132),
+    align: 'end',
+    sortable: true,
+    renderCell: item => <Figure>{formatCents(item.amountCents)}</Figure>,
   },
 ];
 
-export default function TablePageTemplate() {
-  const [filters, setFilters] = useState<PowerSearchFilter[]>([]);
-  const {config, applyFilters} = usePowerSearchConfig(fieldDefs, 'Dogs');
+const COLUMN_WIDTHS = resolveColumnWidths(columns);
 
-  const filtered = useMemo(() => {
-    return applyFilters(filters, allDogs);
-  }, [filters, applyFilters]);
+/**
+ * Sort keys default to the column key. `unitPrice` and `amount` are display
+ * names with no matching field, and the built-in fallback stringifies whatever
+ * it finds — so every numeric column subtracts integers here instead.
+ */
+const COMPARATORS: Partial<Record<string, TableSortComparator<InvoiceRow>>> = {
+  description: (a, b) => a.description.localeCompare(b.description),
+  category: (a, b) =>
+    CATEGORY_LABEL[a.category].localeCompare(CATEGORY_LABEL[b.category]),
+  quantity: (a, b) => a.quantity - b.quantity,
+  unitPrice: (a, b) => a.unitPriceCents - b.unitPriceCents,
+  amount: (a, b) => a.amountCents - b.amountCents,
+};
+
+// ============= EDGE ALIGNMENT =============
+
+/**
+ * Table bleeds past its container by default: the scroll wrapper applies
+ * negative inline margins equal to the container's padding, and the outer cells
+ * add that padding back so text still lines up. That is right for a table that
+ * owns its surface. Here the table shares a column with a MetadataList, so it
+ * has to respect the same content line. Zeroing these cancels the bleed.
+ */
+type StyleWithVars = React.CSSProperties & Record<`--${string}`, string>;
+
+const FLUSH_WRAPPER: StyleWithVars = {
+  '--container-padding-inline-start': '0px',
+  '--container-padding-inline-end': '0px',
+};
+const FLUSH_START: React.CSSProperties = {paddingInlineStart: 0};
+const FLUSH_END: React.CSSProperties = {paddingInlineEnd: 0};
+
+/** Inline padding override for a cell at either end of the row. */
+function edgeStyle(
+  index: number,
+  total: number,
+): React.CSSProperties | undefined {
+  if (index === 0) {
+    return FLUSH_START;
+  }
+  if (index === total - 1) {
+    return FLUSH_END;
+  }
+  return undefined;
+}
+
+/**
+ * Cancelling the bleed only moves the stripe; cell padding still resolves to
+ * `max(var(--container-padding-inline-start), spacing-2)`, so the text keeps an
+ * 8px indent. Children mode would fix that with an inline `style` on the outer
+ * cells — this is the data-mode equivalent, and a demonstration that a plugin
+ * is nothing more than an object of transforms.
+ */
+function useFlushEdges(): TablePlugin<InvoiceRow> {
+  return useMemo(
+    () => ({
+      transformHeaderCell: (props, _column, columnIndex, cols) => {
+        const style = edgeStyle(columnIndex, cols.length);
+        return style == null
+          ? props
+          : {
+              ...props,
+              htmlProps: {
+                ...props.htmlProps,
+                style: {...props.htmlProps.style, ...style},
+              },
+            };
+      },
+      transformBodyCell: (props, _column, _item, columnIndex, cols) => {
+        const style = edgeStyle(columnIndex, cols.length);
+        return style == null
+          ? props
+          : {
+              ...props,
+              htmlProps: {
+                ...props.htmlProps,
+                style: {...props.htmlProps.style, ...style},
+              },
+            };
+      },
+    }),
+    [],
+  );
+}
+
+// Drawn per-cell because `dividers="none"` turns the divider system off. Three
+// rules bracket the totals: one opening the block, one closing the arithmetic
+// before the total, one under the amount owed. They are the only rules on the
+// page, which is what lets them read as punctuation rather than as a grid.
+const HAIRLINE = '1px solid var(--color-border, rgba(5, 54, 89, 0.1))';
+const RULE_ABOVE: React.CSSProperties = {borderBlockStart: HAIRLINE};
+const RULE_BOTH: React.CSSProperties = {
+  borderBlockStart: HAIRLINE,
+  borderBlockEnd: HAIRLINE,
+};
+
+// ============= PAGE =============
+
+export default function InvoiceLineItemsTemplate() {
+  const [queryFilters, setQueryFilters] = useState<PowerSearchFilter[]>([]);
+  const [basis, setBasis] = useState<BillingBasis | 'all'>('all');
+
+  // One config drives the query builder, the column popovers, and the predicate.
+  const {config, applyFilters} = usePowerSearchConfig(SEARCH_FIELDS, 'Lines');
+  const {
+    filters: columnFilters,
+    onFilterChange,
+    clearAll,
+  } = useTableFilterState();
+
+  const filterPlugin = useTableFiltering<InvoiceRow>({
+    filters: columnFilters,
+    onFilterChange,
+    searchConfig: config,
+    variant: 'popover',
+  });
+
+  // Both surfaces produce PowerSearchFilters, so they concatenate into a single
+  // pass. Filtering twice is what eventually disagrees with itself.
+  const visible = useMemo(() => {
+    const combined: PowerSearchFilter[] = [
+      ...queryFilters,
+      ...(toSearchFilters(
+        columnFilters,
+        columns,
+        config,
+      ) as PowerSearchFilter[]),
+    ];
+    const matched = applyFilters(combined, ROWS);
+    return basis === 'all'
+      ? matched
+      : matched.filter(item => item.basis === basis);
+  }, [applyFilters, queryFilters, columnFilters, config, basis]);
+
+  const {sortedData, sortConfig} = useTableSortableState<InvoiceRow>({
+    data: visible,
+    comparators: COMPARATORS,
+  });
+  const sortPlugin = useTableSortable<InvoiceRow>(sortConfig);
+  const flushPlugin = useFlushEdges();
+
+  // Every figure below reads the same array the body does, so a filter retotals
+  // the invoice instead of leaving a stale number under a shortened list.
+  const subtotalCents = useMemo(
+    () => visible.reduce((sum, item) => sum + item.amountCents, 0),
+    [visible],
+  );
+  const taxCents = Math.round(subtotalCents * TAX_RATE);
+  const totalCents = subtotalCents + taxCents;
+
+  // Filter *presence*, not row count: a filter that happens to match every line
+  // still means these totals are a view of the invoice rather than the invoice.
+  const activeFilterCount =
+    queryFilters.length +
+    Object.keys(columnFilters).length +
+    (basis === 'all' ? 0 : 1);
+
+  const clearEverything = () => {
+    setQueryFilters([]);
+    setBasis('all');
+    clearAll();
+  };
 
   return (
     <Layout
       height="fill"
+      contentWidth={960}
       header={
-        <LayoutHeader hasDivider>
-          <HStack gap={2} vAlign="center">
+        <LayoutHeader padding={4}>
+          <HStack gap={3} vAlign="center" wrap="wrap">
             <StackItem size="fill">
-              <Heading level={1}>Dogs</Heading>
+              <Heading level={1}>Invoice INV-2043</Heading>
             </StackItem>
-            <IconButton
-              label="Filter"
-              icon={<Icon icon={FunnelIcon} size="sm" />}
-              variant="ghost"
-            />
-            <IconButton
-              label="Download"
+            <Button
+              label="Download PDF"
+              variant="secondary"
               icon={<Icon icon={ArrowDownTrayIcon} size="sm" />}
-              variant="ghost"
             />
-            <Button label="Add" icon={<Icon icon={PlusIcon} size="sm" />} />
           </HStack>
         </LayoutHeader>
       }
       content={
-        <LayoutContent padding={3}>
-          <VStack gap={4}>
-            <PowerSearch
-              config={config}
-              filters={filters}
-              onChange={newFilters => {
-                setFilters([...newFilters]);
-              }}
-              placeholder="Search dogs..."
-              resultCount={filtered.length}
-            />
-            <Table<DogRow>
-              data={filtered}
-              columns={columns}
-              idKey="id"
-              density="balanced"
-              dividers="rows"
-              hasHover
-            />
+        <LayoutContent padding={4}>
+          <VStack gap={8}>
+            {/* Extra block padding sets the document facts apart from the
+                controls and the table without needing a rule to do it. */}
+            <VStack paddingBlock={4}>
+              <MetadataList columns="multi" label={{position: 'top'}}>
+                {INVOICE_DETAILS.map(detail => (
+                  <MetadataListItem key={detail.label} label={detail.label}>
+                    {detail.value}
+                  </MetadataListItem>
+                ))}
+              </MetadataList>
+            </VStack>
+
+            {/* Scope first, then query: the segments narrow what PowerSearch
+                is searching over, which is the order the sentence reads in.
+                The VStack is what makes PowerSearch fill its 300px and sit
+                flush right — as a bare flex child it shrinks to content. */}
+            <HStack gap={3} vAlign="center" hAlign="between" wrap="wrap">
+              <SegmentedControl
+                label="Filter by billing basis"
+                value={basis}
+                onChange={value => setBasis(value as BillingBasis | 'all')}>
+                {BASIS_FILTERS.map(filter => (
+                  <SegmentedControlItem
+                    key={filter.value}
+                    value={filter.value}
+                    label={filter.label}
+                  />
+                ))}
+              </SegmentedControl>
+              <VStack width={300}>
+                <PowerSearch
+                  config={config}
+                  filters={queryFilters}
+                  onChange={next => setQueryFilters([...next])}
+                  placeholder="Filter…"
+                />
+              </VStack>
+            </HStack>
+
+            <VStack gap={6}>
+              {visible.length === 0 ? (
+                <EmptyState
+                  title="No matching line items"
+                  description="No line on this invoice matches the current filters."
+                  actions={
+                    <Button
+                      label="Clear filters"
+                      variant="secondary"
+                      onClick={clearEverything}
+                    />
+                  }
+                />
+              ) : (
+                // The two tables are one thing to a reader, so they are one
+                // thing to assistive tech as well.
+                <div
+                  style={FLUSH_WRAPPER}
+                  role="group"
+                  aria-label="Invoice line items and totals">
+                  <Table<InvoiceRow>
+                    data={sortedData}
+                    columns={columns}
+                    idKey="id"
+                    density="balanced"
+                    dividers="none"
+                    hasHover
+                    textOverflow="truncate"
+                    plugins={{
+                      sort: sortPlugin,
+                      filter: filterPlugin,
+                      flush: flushPlugin,
+                    }}
+                  />
+
+                  {/* Same columns, so the same colgroup — which is the only
+                      reason these figures line up with the Amount column. */}
+                  <Table density="balanced" dividers="none">
+                    <colgroup>
+                      {columns.map(column => (
+                        <col
+                          key={column.key}
+                          style={COLUMN_WIDTHS.columns.get(column.key)?.style}
+                        />
+                      ))}
+                    </colgroup>
+                    <TableBody>
+                      <TableRow isHeaderRow>
+                        <TableCell
+                          colSpan={4}
+                          style={{...FLUSH_START, ...RULE_ABOVE}}>
+                          <Text justify="end" display="block">
+                            Subtotal
+                          </Text>
+                        </TableCell>
+                        <TableCell style={{...FLUSH_END, ...RULE_ABOVE}}>
+                          <Text justify="end" display="block" hasTabularNumbers>
+                            {formatCents(subtotalCents)}
+                          </Text>
+                        </TableCell>
+                      </TableRow>
+                      <TableRow isHeaderRow>
+                        <TableCell colSpan={4} style={FLUSH_START}>
+                          <Text justify="end" display="block" color="secondary">
+                            Tax (8.75%)
+                          </Text>
+                        </TableCell>
+                        <TableCell style={FLUSH_END}>
+                          <Text justify="end" display="block" hasTabularNumbers>
+                            {formatCents(taxCents)}
+                          </Text>
+                        </TableCell>
+                      </TableRow>
+                      <TableRow isHeaderRow>
+                        <TableCell
+                          colSpan={4}
+                          style={{...FLUSH_START, ...RULE_BOTH}}>
+                          <Text justify="end" display="block" weight="semibold">
+                            Total due
+                          </Text>
+                        </TableCell>
+                        <TableCell style={{...FLUSH_END, ...RULE_BOTH}}>
+                          <Text
+                            justify="end"
+                            display="block"
+                            hasTabularNumbers
+                            weight="semibold">
+                            {formatCents(totalCents)}
+                          </Text>
+                        </TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+
+              {/* Mounted on a filter change rather than at first paint, so the
+                  warning role actually announces. */}
+              {visible.length > 0 && activeFilterCount > 0 && (
+                <Banner
+                  status="warning"
+                  title="Filtered view — these totals are partial"
+                  description={`Showing ${visible.length} of ${ROWS.length} lines. The subtotal, tax, and total due above cover only the lines currently visible.`}
+                  endContent={
+                    <Button
+                      label="Clear all filters"
+                      variant="secondary"
+                      onClick={clearEverything}
+                    />
+                  }
+                />
+              )}
+            </VStack>
           </VStack>
         </LayoutContent>
       }

--- a/packages/cli/assets/templates/pages/table-page/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-page/template.doc.mjs
@@ -5,7 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Searchable Table',
   displayName: 'Searchable Table',
-  description: 'Flat row collection with query search and an action toolbar above sortable rows, running full width with no detail pane. Sits between the bare table and the filtered one. Table, list, rows, records, grid, search, or admin index.',
+  description:
+    'Capped-width single-document table: billing metadata above a scope toggle and PowerSearch, sortable and filterable line items with per-row hover detail, and a derived totals block that warns when a filter leaves it partial. Invoice, bill, statement, receipt, line items, table, search, or totals.',
   isReady: true,
   category: 'Table - Basic',
 };

--- a/packages/cli/assets/templates/pages/table-tree/page.tsx
+++ b/packages/cli/assets/templates/pages/table-tree/page.tsx
@@ -1,0 +1,700 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * A cloud bill you can drill into: account, then service, then resource, in one
+ * table whose parent rows carry the sum of everything beneath them.
+ *
+ * A tree table earns its complexity when the parents are *arithmetic* on the
+ * children. A folder listing does not qualify — a folder has no size of its
+ * own, so a tree view is enough. Spend does: "us-east-1 costs $48k" and
+ * "us-east-1's database service costs $19k of it" are the same question asked
+ * at two zoom levels, and the value of the table is that you can move between
+ * them without losing the columns. If your parent rows would be mostly empty
+ * cells, you want a tree view or a grouped table, not this.
+ *
+ * ## Extending this template
+ *
+ * **Two hooks, and neither one is the tree.** `useTableTreeState` owns the
+ * expanded set and flattens the nested data into the visible rows;
+ * `useTableTreeData` is the render plugin that draws the per-level indent and
+ * the chevron in the tree column. You pass the first one's `treeConfig`
+ * straight into the second. Hand-rolling this — a Set of open ids plus a
+ * recursive flatten on every render — is the usual way tree tables get built,
+ * and it costs you the ARIA (`aria-level`, `aria-expanded`), the expand-all
+ * control, and the guarantee that every level shares one column grid.
+ *
+ * **Sorting composes with the hierarchy instead of flattening it.**
+ * `useTableSortableState` returns an `applySort` that is handed to the tree's
+ * `sortSiblings`, so a sort reorders each sibling group in place and children
+ * stay under their parent. Sorting by spend descending gives you the most
+ * expensive account first, and within it the most expensive service — which is
+ * the actual question. Feeding `sortedData` to the table directly instead would
+ * dissolve the tree into a flat list.
+ *
+ * **Totals are computed from the leaves, never stored.** `withRollups` walks the
+ * fixture once and derives every parent's spend and prior-month figure by
+ * summing its descendants, so a parent can never disagree with its children.
+ * Hardcoding a parent total is the bug this shape exists to prevent — the
+ * numbers drift the first time someone edits a leaf. Real data usually arrives
+ * pre-aggregated from the warehouse; keep the derivation anyway as a check.
+ *
+ * **Search prunes the tree and takes the chevrons with it.** A query keeps any
+ * branch with a match anywhere beneath it and force-expands what survives, so
+ * results are never hidden behind a collapsed parent. While a query is active
+ * the expanded set is derived rather than stored, and manual toggling is
+ * suspended; clearing the box restores exactly the expansion state the user had
+ * before searching. The alternative — letting people collapse a branch that
+ * only exists because it matched — reads as the search being broken.
+ *
+ * **A pruned tree has to be re-totalled.** `withRollups` runs again on the
+ * pruned result, because removing children changes what every ancestor
+ * contains. Skipping that second pass is the subtle bug in most filtered tree
+ * tables: the rows are correct, the parents are stale, and a branch quietly
+ * claims more than the children beneath it add up to. If you add a filter of
+ * any kind, re-roll after it.
+ *
+ * **The tree column wraps and does not truncate.** That is a documented
+ * limitation of `useTableTreeData`: `textOverflow="truncate"` does not reach
+ * inside the tree column, because the indent and expander need the cell to be a
+ * flex row. Long resource names wrap to a second line. Keep the tree column
+ * `proportional()` and everything else `pixel()` so only that column absorbs
+ * the slack.
+ */
+
+import {useMemo, useState} from 'react';
+
+import {
+  HStack,
+  Layout,
+  LayoutContent,
+  LayoutHeader,
+  StackItem,
+  VStack,
+} from '@astryxdesign/core/Layout';
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {Button} from '@astryxdesign/core/Button';
+import {EmptyState} from '@astryxdesign/core/EmptyState';
+import {Icon} from '@astryxdesign/core/Icon';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {Token} from '@astryxdesign/core/Token';
+import {
+  Table,
+  pixel,
+  proportional,
+  useTableSortable,
+  useTableSortableState,
+  useTableTreeData,
+  useTableTreeState,
+} from '@astryxdesign/core/Table';
+import type {TableColumn} from '@astryxdesign/core/Table';
+import {
+  ArrowDownTrayIcon,
+  CloudIcon,
+  CubeIcon,
+  MagnifyingGlassIcon,
+  Squares2X2Icon,
+} from '@heroicons/react/24/outline';
+
+// ============= DATA =============
+
+type NodeKind = 'account' | 'service' | 'resource';
+
+interface CostNode extends Record<string, unknown> {
+  id: string;
+  name: string;
+  kind: NodeKind;
+  owner: string;
+  /** Month-to-date spend in cents. Zero on branches — `withRollups` fills it. */
+  spendCents: number;
+  /** Prior-month spend in cents, same rollup treatment. */
+  priorCents: number;
+  children?: CostNode[];
+}
+
+const KIND_ICON: Record<
+  NodeKind,
+  React.ComponentType<React.SVGProps<SVGSVGElement>>
+> = {
+  account: CloudIcon,
+  service: Squares2X2Icon,
+  resource: CubeIcon,
+};
+
+function leaf(
+  id: string,
+  name: string,
+  owner: string,
+  spend: number,
+  prior: number,
+): CostNode {
+  return {
+    id,
+    name,
+    kind: 'resource',
+    owner,
+    spendCents: spend,
+    priorCents: prior,
+  };
+}
+
+function service(id: string, name: string, children: CostNode[]): CostNode {
+  return {
+    id,
+    name,
+    kind: 'service',
+    owner: '—',
+    spendCents: 0,
+    priorCents: 0,
+    children,
+  };
+}
+
+const COST_TREE: CostNode[] = [
+  {
+    id: 'prod-us',
+    name: 'Production — us-east-1',
+    kind: 'account',
+    owner: 'Platform',
+    spendCents: 0,
+    priorCents: 0,
+    children: [
+      service('prod-us/compute', 'Compute', [
+        leaf(
+          'prod-us/compute/web',
+          'EKS node group — prod-web',
+          'Web',
+          1_842_000,
+          1_710_500,
+        ),
+        leaf(
+          'prod-us/compute/api',
+          'EKS node group — prod-api',
+          'API',
+          2_318_400,
+          2_402_000,
+        ),
+        leaf(
+          'prod-us/compute/batch',
+          'Batch worker fleet',
+          'Platform',
+          684_200,
+          902_600,
+        ),
+      ]),
+      service('prod-us/storage', 'Storage', [
+        leaf(
+          'prod-us/storage/media',
+          'S3 — media assets',
+          'Web',
+          1_120_800,
+          1_048_200,
+        ),
+        leaf(
+          'prod-us/storage/logs',
+          'S3 — log archive',
+          'SRE',
+          412_600,
+          386_400,
+        ),
+        leaf(
+          'prod-us/storage/ebs',
+          'EBS volumes',
+          'Platform',
+          596_300,
+          601_100,
+        ),
+      ]),
+      service('prod-us/database', 'Database', [
+        leaf(
+          'prod-us/database/primary',
+          'Aurora PostgreSQL — primary',
+          'API',
+          2_940_000,
+          2_880_000,
+        ),
+        leaf(
+          'prod-us/database/replica',
+          'Aurora read replicas ×3',
+          'API',
+          1_764_000,
+          1_176_000,
+        ),
+        leaf(
+          'prod-us/database/cache',
+          'ElastiCache cluster',
+          'API',
+          486_500,
+          470_200,
+        ),
+      ]),
+      service('prod-us/network', 'Networking', [
+        leaf(
+          'prod-us/network/cdn',
+          'CloudFront distribution',
+          'Web',
+          918_400,
+          1_064_900,
+        ),
+        leaf('prod-us/network/nat', 'NAT gateways ×4', 'SRE', 241_600, 238_800),
+        leaf(
+          'prod-us/network/transfer',
+          'Inter-AZ data transfer',
+          'SRE',
+          372_900,
+          318_500,
+        ),
+      ]),
+    ],
+  },
+  {
+    id: 'prod-eu',
+    name: 'Production — eu-west-1',
+    kind: 'account',
+    owner: 'Platform',
+    spendCents: 0,
+    priorCents: 0,
+    children: [
+      service('prod-eu/compute', 'Compute', [
+        leaf(
+          'prod-eu/compute/web',
+          'EKS node group — eu-web',
+          'Web',
+          1_204_500,
+          1_188_000,
+        ),
+        leaf(
+          'prod-eu/compute/batch',
+          'Batch worker fleet',
+          'Platform',
+          318_700,
+          402_400,
+        ),
+      ]),
+      service('prod-eu/storage', 'Storage', [
+        leaf(
+          'prod-eu/storage/media',
+          'S3 — media assets',
+          'Web',
+          642_300,
+          598_700,
+        ),
+        leaf(
+          'prod-eu/storage/ebs',
+          'EBS volumes',
+          'Platform',
+          288_400,
+          291_000,
+        ),
+      ]),
+      service('prod-eu/database', 'Database', [
+        leaf(
+          'prod-eu/database/primary',
+          'Aurora PostgreSQL — eu primary',
+          'API',
+          1_486_000,
+          1_452_000,
+        ),
+      ]),
+      service('prod-eu/network', 'Networking', [
+        leaf(
+          'prod-eu/network/cdn',
+          'CloudFront distribution',
+          'Web',
+          508_200,
+          544_100,
+        ),
+        leaf(
+          'prod-eu/network/transfer',
+          'Cross-region transfer',
+          'SRE',
+          196_400,
+          142_800,
+        ),
+      ]),
+    ],
+  },
+  {
+    id: 'data',
+    name: 'Data platform',
+    kind: 'account',
+    owner: 'Data',
+    spendCents: 0,
+    priorCents: 0,
+    children: [
+      service('data/compute', 'Compute', [
+        leaf(
+          'data/compute/spark',
+          'Spark clusters — nightly ETL',
+          'Data',
+          2_106_800,
+          1_642_300,
+        ),
+        leaf(
+          'data/compute/airflow',
+          'Airflow scheduler + workers',
+          'Data',
+          384_900,
+          372_100,
+        ),
+      ]),
+      service('data/storage', 'Storage', [
+        leaf(
+          'data/storage/lake',
+          'S3 — data lake',
+          'Data',
+          1_498_200,
+          1_312_400,
+        ),
+        leaf(
+          'data/storage/glacier',
+          'Glacier deep archive',
+          'Data',
+          164_700,
+          158_900,
+        ),
+      ]),
+      service('data/warehouse', 'Warehouse', [
+        leaf(
+          'data/warehouse/redshift',
+          'Redshift cluster',
+          'Data',
+          2_640_000,
+          2_640_000,
+        ),
+      ]),
+    ],
+  },
+  {
+    id: 'staging',
+    name: 'Staging',
+    kind: 'account',
+    owner: 'SRE',
+    spendCents: 0,
+    priorCents: 0,
+    children: [
+      service('staging/compute', 'Compute', [
+        leaf(
+          'staging/compute/eks',
+          'EKS node group — staging',
+          'Platform',
+          462_800,
+          618_200,
+        ),
+      ]),
+      service('staging/storage', 'Storage', [
+        leaf(
+          'staging/storage/artifacts',
+          'S3 — build artifacts',
+          'Platform',
+          148_300,
+          139_600,
+        ),
+      ]),
+      service('staging/database', 'Database', [
+        leaf(
+          'staging/database/primary',
+          'Aurora PostgreSQL — staging',
+          'API',
+          386_400,
+          402_000,
+        ),
+      ]),
+    ],
+  },
+];
+
+/**
+ * Replace every branch's spend and prior figures with the sum of its
+ * descendants, so no parent row can contradict the rows beneath it.
+ */
+function withRollups(nodes: CostNode[]): CostNode[] {
+  return nodes.map(node => {
+    if (!node.children || node.children.length === 0) {
+      return node;
+    }
+    const children = withRollups(node.children);
+    return {
+      ...node,
+      children,
+      spendCents: children.reduce(
+        (total, child) => total + child.spendCents,
+        0,
+      ),
+      priorCents: children.reduce(
+        (total, child) => total + child.priorCents,
+        0,
+      ),
+    };
+  });
+}
+
+const ROLLED_UP = withRollups(COST_TREE);
+
+const GRAND_TOTAL_CENTS = ROLLED_UP.reduce(
+  (total, account) => total + account.spendCents,
+  0,
+);
+
+const DEFAULT_EXPANDED = ['prod-us'];
+
+// ============= SEARCH =============
+
+/** Keep any branch with a match at or beneath it; drop everything else. */
+function pruneTree(nodes: CostNode[], needle: string): CostNode[] {
+  const kept: CostNode[] = [];
+  for (const node of nodes) {
+    const isSelfMatch =
+      node.name.toLowerCase().includes(needle) ||
+      node.owner.toLowerCase().includes(needle);
+    const children = node.children ? pruneTree(node.children, needle) : [];
+    if (isSelfMatch || children.length > 0) {
+      kept.push(
+        node.children
+          ? {
+              ...node,
+              children:
+                isSelfMatch && children.length === 0 ? node.children : children,
+            }
+          : node,
+      );
+    }
+  }
+  return kept;
+}
+
+function collectIds(nodes: CostNode[], into: Set<string>): Set<string> {
+  for (const node of nodes) {
+    if (node.children && node.children.length > 0) {
+      into.add(node.id);
+      collectIds(node.children, into);
+    }
+  }
+  return into;
+}
+
+// ============= FORMATTING =============
+
+// Pinned locale keeps the rendered output identical in every environment.
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
+const percent = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  maximumFractionDigits: 1,
+});
+
+function money(cents: number): string {
+  return currency.format(cents / 100);
+}
+
+// ============= COLUMNS =============
+
+const columns: TableColumn<CostNode>[] = [
+  {
+    key: 'name',
+    header: 'Account / service / resource',
+    width: proportional(3),
+    sortable: true,
+    renderCell: node => (
+      <HStack gap={2} vAlign="center">
+        <Icon icon={KIND_ICON[node.kind]} size="sm" color="secondary" />
+        <Text weight={node.kind === 'account' ? 'semibold' : 'normal'}>
+          {node.name}
+        </Text>
+      </HStack>
+    ),
+  },
+  {
+    key: 'owner',
+    header: 'Owner',
+    width: pixel(120),
+    renderCell: node => <Text color="secondary">{node.owner}</Text>,
+  },
+  {
+    key: 'spend',
+    header: 'Spend (MTD)',
+    width: pixel(150),
+    align: 'end',
+    sortable: true,
+    renderCell: node => (
+      <Text
+        hasTabularNumbers
+        weight={node.kind === 'account' ? 'semibold' : 'normal'}>
+        {money(node.spendCents)}
+      </Text>
+    ),
+  },
+  {
+    key: 'share',
+    header: 'Share',
+    width: pixel(100),
+    align: 'end',
+    renderCell: node => (
+      <Text hasTabularNumbers color="secondary">
+        {percent.format(node.spendCents / GRAND_TOTAL_CENTS)}
+      </Text>
+    ),
+  },
+  {
+    key: 'change',
+    header: 'vs last month',
+    width: pixel(150),
+    align: 'end',
+    sortable: true,
+    renderCell: node => {
+      const delta = node.spendCents - node.priorCents;
+      if (delta === 0) {
+        return <Text color="secondary">—</Text>;
+      }
+      const isUp = delta > 0;
+      return (
+        <Token
+          size="sm"
+          // Rising cloud spend is the bad direction, so up reads red.
+          color={isUp ? 'red' : 'green'}
+          label={`${isUp ? '+' : '−'}${money(Math.abs(delta))}`}
+        />
+      );
+    },
+  },
+];
+
+// ============= PAGE =============
+
+export default function CloudCostTreeTemplate() {
+  const [query, setQuery] = useState('');
+  const [manualExpandedIds, setManualExpandedIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set(DEFAULT_EXPANDED));
+
+  const needle = query.trim().toLowerCase();
+  const isSearching = needle.length > 0;
+
+  // Pruning changes what a parent contains, so the totals have to be recomputed
+  // from the survivors. Reusing the unpruned rollups would leave a parent row
+  // claiming more spend than the children visible underneath it add up to.
+  const data = useMemo(
+    () => (isSearching ? withRollups(pruneTree(ROLLED_UP, needle)) : ROLLED_UP),
+    [isSearching, needle],
+  );
+
+  // While searching, expansion is derived from the pruned tree so no match can
+  // hide behind a collapsed parent; manual state is parked, not overwritten.
+  const searchExpandedIds = useMemo(
+    () => (isSearching ? collectIds(data, new Set<string>()) : null),
+    [isSearching, data],
+  );
+
+  const sortable = useTableSortableState<CostNode>({
+    data,
+    comparators: {
+      name: (a, b) => a.name.localeCompare(b.name),
+      spend: (a, b) => a.spendCents - b.spendCents,
+      change: (a, b) =>
+        a.spendCents - a.priorCents - (b.spendCents - b.priorCents),
+    },
+  });
+
+  const {visibleData, treeConfig, expandAll, collapseAll, isAllExpanded} =
+    useTableTreeState<CostNode>({
+      data,
+      idKey: 'id',
+      expandedIds: searchExpandedIds ?? manualExpandedIds,
+      onExpandedIdsChange: isSearching ? () => {} : setManualExpandedIds,
+      // Reorders each sibling group in place, so children never leave their
+      // parent — this is what keeps sorting and hierarchy compatible.
+      sortSiblings: sortable.applySort,
+    });
+
+  const tree = useTableTreeData({...treeConfig, hasExpandAllControl: true});
+  const sort = useTableSortable<CostNode>(sortable.sortConfig);
+
+  const visibleTotal = data.reduce(
+    (total, account) => total + account.spendCents,
+    0,
+  );
+
+  return (
+    <Layout
+      height="fill"
+      header={
+        <LayoutHeader hasDivider padding={4}>
+          <VStack gap={4}>
+            <HStack gap={3} vAlign="center" wrap="wrap">
+              <StackItem size="fill">
+                <VStack gap={0.5}>
+                  <Heading level={1}>Cloud spend</Heading>
+                  <Text type="supporting">
+                    March 2026 · {money(GRAND_TOTAL_CENTS)} across 4 accounts
+                  </Text>
+                </VStack>
+              </StackItem>
+              <Button
+                label={isAllExpanded === true ? 'Collapse all' : 'Expand all'}
+                variant="ghost"
+                isDisabled={isSearching}
+                onClick={() =>
+                  isAllExpanded === true ? collapseAll() : expandAll()
+                }
+              />
+              <Button
+                label="Export CSV"
+                variant="secondary"
+                icon={<Icon icon={ArrowDownTrayIcon} size="sm" />}
+              />
+            </HStack>
+            <HStack gap={3} vAlign="center">
+              <StackItem size="fill">
+                <TextInput
+                  label="Search accounts, services, and resources"
+                  isLabelHidden
+                  placeholder="Search resources or owners…"
+                  startIcon={MagnifyingGlassIcon}
+                  value={query}
+                  onChange={setQuery}
+                  hasClear
+                />
+              </StackItem>
+              {isSearching && data.length > 0 && (
+                <Text type="supporting">
+                  {money(visibleTotal)} in matching spend
+                </Text>
+              )}
+            </HStack>
+          </VStack>
+        </LayoutHeader>
+      }
+      content={
+        <LayoutContent padding={4}>
+          {data.length === 0 ? (
+            <EmptyState
+              title="No matching resources"
+              description="No account, service, resource, or owner matches your search."
+              actions={
+                <Button
+                  label="Clear search"
+                  variant="secondary"
+                  onClick={() => setQuery('')}
+                />
+              }
+            />
+          ) : (
+            <Table<CostNode>
+              data={visibleData}
+              columns={columns}
+              idKey="id"
+              density="compact"
+              dividers="rows"
+              hasHover
+              plugins={{tree, sort}}
+            />
+          )}
+        </LayoutContent>
+      }
+    />
+  );
+}

--- a/packages/cli/assets/templates/pages/table-tree/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/table-tree/template.doc.mjs
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'page',
+  name: 'Tree Table',
+  displayName: 'Tree Table',
+  description:
+    'Hierarchical table where every parent row is arithmetic over its children: expandable account, service, and resource levels with rolled-up totals, sibling-scoped sorting, and search that prunes the tree and recomputes the rollups. Tree, hierarchy, nested rows, drilldown, expandable rows, cost explorer, or rolled-up totals.',
+  isReady: true,
+  category: 'Table - Tree/Hierarchical List',
+};

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -136,6 +136,16 @@ const sortStyles = stylex.create({
     textAlign: 'inherit',
     borderRadius: radiusVars['--radius-inner'],
   },
+  // The button is a full-width flex container, so the `textAlign` a column's
+  // `align` puts on the <th> cannot position its contents. Mirror the column
+  // alignment onto the main axis, or an `align: 'end'` numeric column ends up
+  // with a left-hugging header over right-aligned figures.
+  buttonAlignCenter: {
+    justifyContent: 'center',
+  },
+  buttonAlignEnd: {
+    justifyContent: 'flex-end',
+  },
   iconWrapperUnsorted: {
     display: 'inline-flex',
     opacity: {
@@ -306,7 +316,14 @@ function SortHeaderButton<T extends Record<string, unknown>>({
   return (
     <button
       type="button"
-      {...focusOutlineProps.focusVisible(sortStyles.button)}
+      {...focusOutlineProps.focusVisible(
+        sortStyles.button,
+        column.align === 'end'
+          ? sortStyles.buttonAlignEnd
+          : column.align === 'center'
+            ? sortStyles.buttonAlignCenter
+            : null,
+      )}
       aria-label={ariaLabel}
       onClick={handleClick}>
       <span>{children}</span>


### PR DESCRIPTION
Five table templates: three new shapes, two rebuilt. Everything composes existing Astryx components — the only core change is a one-property alignment fix to the sortable plugin.

## New templates

- **Tree Table** (`table-tree`) — a hierarchy where every parent row is arithmetic over its children. Expandable account → service → resource levels with rolled-up totals, sibling-scoped sorting, and search that prunes the tree *and recomputes the rollups*, so a filtered parent never contradicts the children under it.
- **Comparison Table** (`table-comparison`) — a transposed matrix: candidates become columns, criteria become grouped rows. A pinned label column survives horizontal scroll, and best-in-row marks are computed from the data rather than hardcoded.
- **Inbox Table** (`table-inbox`) — a headerless, divider-free triage queue that still holds a real table column grid, driven by a `<colgroup>` rather than a `<thead>`. Selection swaps the toolbar's scope filters for bulk actions.

## Rebuilt templates

- **Searchable Table** (`table-page`) — now a capped-width invoice. Runs in data mode so the sort and filter plugins apply, which puts totals out of reach of `TableFooter` (children-mode only), so the totals render as a sibling table sharing the same `colgroup`, wrapped in a labelled group for screen readers. A banner appears whenever a filter leaves those totals partial.
- **Grouped Table** (`table-grouped`) — one grouped table becomes a collapsible card per group, each with its own columns. That is precisely the case `useTableGroupedRows` cannot serve: the groups don't share a schema, so a single table would force empty columns on every row.

## Core change

`useTableSortable` — a column's `align` sets `textAlign` on the `<th>`, but the plugin wraps header content in a full-width flex button whose main-axis alignment ignores it. An `align: 'end'` numeric column rendered a left-hugging header over right-aligned figures. The button now mirrors the column's alignment onto `justifyContent`.

## Validation

- `typecheck:strict` (compiles emitted template sources against built core types) — pass
- `eslint` on all five templates — clean, no warnings
- Rendered every template in a real browser at 1440px light, 1440px dark, and 768px, plus one interaction state each (see screenshots below)
- Confirmed the set is self-contained: all five render byte-identically against `origin/main`'s core, with no dependency on unmerged work

## Template grades

Graded against [Template Grading Rubric v1.3](https://github.com/facebook/astryx/wiki/Contributing-Templates#template-grading-rubric). Mechanical counts (raw HTML tags, custom CSS declarations, icons) are AST-exact with comments stripped; the browser pass covers light/dark/responsive. **Self-assessed and not published to the ledger** — an independent audit should confirm before recording.

| Template | CP /30 | Icon /15 | CSS /15 | Layout /15 | Doc /10 | Img /5 | Code /10 | Total | Grade |
|---|---|---|---|---|---|---|---|---|---|
| Tree (`table-tree`) | 30 | 15 | 15 | 15 | 10 | 5 | 10 | **100** | **A** |
| Grouped (`table-grouped`) | 30 | 15 | 15 | 15 | 10 | 5 | 10 | **100** | **A** |
| Comparison (`table-comparison`) | 30 | 15 | 12 | 15 | 10 | 5 | 10 | **97** | **A** |
| Inbox (`table-inbox`) | 25 | 15 | 12 | 15 | 10 | 5 | 10 | **92** | **A** |
| Searchable (`table-page`) | 15 | 15 | 5 | 15 | 9 | 5 | 10 | **74** | **C** |

Average: 92.6 (A). Four of five are A; **`table-page` is a C and below the "B or above" gallery bar.** That is a real finding, and the cause is a core gap rather than template sloppiness — details below.

### Why `table-page` scores a C

The template needs its table to share a content line with the `MetadataList` above it. `Table` makes that impossible without raw CSS:

- `Table` applies `scrollWrapperStyles.containerBleed` unconditionally (`packages/core/src/Table/Table.tsx:169`) — there is no prop to opt out. Cancelling it requires zeroing `--container-padding-inline-start/end` on a wrapper element, which costs a raw `<div>` and 2 CSS declarations.
- Outer cell padding is floored: `max(var(--container-padding-inline-start, …), spacing-2)` (`packages/core/src/Table/table.stylex.ts:77,81`). Even with the vars at `0`, the first and last cells keep 8px, so a template can never make cell text flush with sibling content. Overriding it costs 2 more declarations.

That accounts for 1 of the 4 raw tags and 4 of the 7 CSS declarations. The remaining 3 declarations draw the three hairlines around the totals block (`dividers="none"` turns the divider system off), and the other raw tags are a `<colgroup>`/`<col>` pair (no Astryx equivalent) and a `<span>` anchoring the row hover card.

The two other deductions are structural: `Doc Metadata` loses its 1 naming point because the slug `table-page` carries a `-page` stopword suffix, and the rubric explicitly treats renaming as a breaking change since resolution is exact-match on the directory name.

### Top 3 fixes

1. **Give `Table` a way to opt out of container bleed** (core). A `hasContainerBleed={false}` prop that drops both the negative margins and the outer-cell compensation would remove the raw `<div>` and 4 of the 7 CSS declarations, taking `table-page` from C to B/A — and would serve any template placing a table beside other content. Filed as follow-up rather than bundled here, since it needs its own design and tests.
2. **Pin group-header labels when sticky columns are active** (core). `useTableGroupedRows` renders its header as one `<td>` spanning every column, so with `useTableStickyColumns` the label scrolls out of view. `table-comparison` works around it with the 3 inline declarations that cost it 3 points (`table-comparison/page.tsx:462`).
3. **Let the row hover card anchor without a `<span>`** (template). If `Text` forwarded a ref, `table-page` could drop the anchor span it currently uses to reach `closest('tr')`.

## Screenshots

Captured from the template viewer at 1440×1200 (2× DPR) unless noted. Dark shots use `prefers-color-scheme: dark` against the default `mode="system"` theme.

### Searchable Table — `table-page`

![Invoice, light](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/invoice-light.png)

<details><summary>Dark, 768px, row hover card, and filtered state</summary>

**Dark**
![Invoice, dark](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/invoice-dark.png)

**768px**
![Invoice, narrow](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/invoice-narrow.png)

**Row hover card** — the whole row is the trigger, and the card stays open when the pointer moves onto it, so the dispute action is clickable.
![Invoice, hover card](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/invoice-hover.png)

**Filtered** — the banner appears whenever a filter leaves the totals partial.
![Invoice, filtered](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/invoice-filtered.png)

</details>

### Grouped Table — `table-grouped`

![Grouped, light](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/grouped-light.png)

<details><summary>Dark, 768px, and a collapsed group</summary>

**Dark**
![Grouped, dark](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/grouped-dark.png)

**768px**
![Grouped, narrow](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/grouped-narrow.png)

**Collapsed** — the group total stays in the card header.
![Grouped, collapsed](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/grouped-collapsed.png)

</details>

### Tree Table — `table-tree`

![Tree, light](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/tree-light.png)

<details><summary>Dark, 768px, and pruned search</summary>

**Dark**
![Tree, dark](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/tree-dark.png)

**768px**
![Tree, narrow](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/tree-narrow.png)

**Search prunes and re-rolls** — searching `storage` keeps only matching branches, and every parent total is recomputed so it still equals the visible children beneath it.
![Tree, search](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/tree-search.png)

</details>

### Comparison Table — `table-comparison`

![Comparison, light](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/comparison-light.png)

<details><summary>Dark, 768px, and scrolled sideways</summary>

**Dark**
![Comparison, dark](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/comparison-dark.png)

**768px**
![Comparison, narrow](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/comparison-narrow.png)

**Scrolled** — the criterion column and the group-header labels both stay pinned.
![Comparison, scrolled](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/comparison-scrolled.png)

</details>

### Inbox Table — `table-inbox`

![Inbox, light](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/inbox-light.png)

<details><summary>Dark, 768px, and bulk selection</summary>

**Dark**
![Inbox, dark](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/inbox-dark.png)

**768px**
![Inbox, narrow](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/inbox-narrow.png)

**Selection** — picking rows swaps the scope filters for bulk actions; one thread is deliberately locked mid-escalation and refuses selection.
![Inbox, selected](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/table-suite/inbox-selected.png)

</details>

