### PR TITLE
docs: backfill changesets for two merged doc-prose PRs

### DIFF
--- a/.changeset/icons-sidenavitem-doc-prose.md
+++ b/.changeset/icons-sidenavitem-doc-prose.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[docs] The namespaced-icon rationale and the add-a-semantic-icon intro in the icons guide, and the `SideNavItem` `actions` prop description, now use a comma and a colon in place of prose em dashes. Meaning unchanged. (#5647)
+
+@josephfarina

--- a/.changeset/template-description-em-dashes.md
+++ b/.changeset/template-description-em-dashes.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] The description prose of 12 page templates now uses parentheses, commas, and colons in place of em dashes. These strings feed the CLI template list and the doc site, so plain punctuation reads better there. Meaning unchanged. (#5679)
+
+@josephfarina


### PR DESCRIPTION
## Summary

[#5679](https://github.com/facebook/astryx/pull/5679) and [#5647](https://github.com/facebook/astryx/pull/5647) merged without changesets, so their copy changes would be omitted from the package changelog. Both ship to builders through the published CLI and core docs, so they meet the same bar applied in review on [#5691](https://github.com/facebook/astryx/pull/5691).

This adds the two missing `[docs]` changesets. No source changes.

- `template-description-em-dashes.md` — `@astryxdesign/cli`, covering #5679
- `icons-sidenavitem-doc-prose.md` — `@astryxdesign/cli` + `@astryxdesign/core`, covering #5647

## Test plan

- [x] `node scripts/check-changesets.mjs` passes (26 changesets valid)
- [ ] CI green

Made with [Cursor](https://cursor.com)