### PR TITLE
docs(Popover): compact component contract

### DIFF
--- a/packages/core/src/Popover/Popover.spec.md
+++ b/packages/core/src/Popover/Popover.spec.md
@@ -38,235 +38,88 @@ system_specs: []
 
 ## Intent
 
-Popover presents interactive, caller-supplied content in an anchored top-layer
-surface. The component owns the standard trigger-to-surface composition;
-`usePopover` exposes the same semantic lifecycle, focus containment, dismissal,
-and rendering contract for custom compositions.
-
-This contract records the behavior present after
-[PR #5373](https://github.com/facebook/astryx/pull/5373) and the Popover target
-direction settled by Cindy Zhang on 2026-08-31. It does not change runtime
-behavior, public API, emitted classes, or release status. Consumer syntax and
-complete signatures remain owned by `Popover.doc.mjs` and
-`usePopover.doc.mjs`; automatic canonical-target emission and compatibility
-removal require separately reviewed runtime work.
+Popover presents caller-supplied interactive content in an anchored top-layer surface. `<Popover>` owns the standard trigger-to-surface composition; `usePopover` exposes the same lifecycle, focus containment, dismissal, and rendering semantics for custom compositions. Consumer syntax and signatures remain in [`Popover.doc.mjs`](./Popover.doc.mjs) and [`usePopover.doc.mjs`](./usePopover.doc.mjs).
 
 ## Compatibility and migration
 
-- Released default preserved: `yes`
-- Compatibility class: documentation-only target ownership clarification;
-  runtime, DOM, styling, emitted classes, and public API are unchanged
-- Canonical target: `popover` owns the broad painted-surface contract for
-  `<Popover>` and public `usePopover` compositions
-- Deprecated alias: `popover-surface` remains emitted so existing themes keep
-  working during a documented migration window; it is not a second anatomy part
-  or equal durable owner
-- Composed components: component-specific surface targets such as
-  `selector-popup` and `multi-selector-popup` remain authoritative refinements;
-  compatibility output may remain underneath until migration
-- New hook consumers: a direct `usePopover` composition that needs its own theme
-  reachability provides and documents an owned `surfaceTarget`; it does not
-  create a new dependency on `popover-surface`
-- Migration decision: target ownership is settled; automatic `popover` emission
-  for every painted hook surface and eventual alias removal ship only through
-  separately reviewed runtime changes
-
-The implementation migration must preserve `popover-surface` themes until its
-announced removal window. Implementation and removal each update consumer
-migration guidance, target inventory, focused tests, and changelog or release
-documentation; this documentation-only PR does none of those runtime steps.
+- Released default preserved: `yes`.
+- Compatibility class: documentation-only ownership clarification; runtime, DOM, styling, emitted classes, public API, and release status are unchanged.
+- `popover` is the canonical broad target for every painted `<Popover>` and public `usePopover` surface. `popover-surface` remains emitted with `deprecatedFor: 'popover'` as a compatibility alias on that same element until a documented removal window.
+- A composed component may add one authoritative component-specific refinement, such as `selector-popup` or `multi-selector-popup`, through `surfaceTarget`. New direct hook consumers needing distinct reachability document an owned refinement; they do not depend on `popover-surface`.
+- Automatic hook-wide `popover` emission and later alias removal require separate runtime reviews. Each step must preserve existing themes and update migration guidance, target inventory, focused tests, and release documentation.
 
 ## Ownership boundary
 
-**Owns**
+**Owns:** the standard wrapped, render-prop, or referenced trigger composition; one painted surface and caller-content slot; public hook visibility, trigger, renderer, focus, semantics, and notifications; Popover-specific focus destination, viewport fit, safe-area gutters, trigger-width preference, conditional scrolling, open-only measurement; and the hook's optional fallback close control.
 
-- The standard trigger or referenced-anchor composition, the painted Popover
-  surface, the canonical broad `popover` theme target for that surface, and the
-  slot that renders caller-supplied content inside it.
-- The public `usePopover` semantic contract: visibility operations, trigger
-  bindings, surface rendering, dialog semantics, focus containment, and
-  lifecycle notifications.
-- Popover-specific focus destination selection, viewport fitting, safe-area
-  gutters, match-trigger sizing, conditional internal scrolling, and the
-  measurement lifecycle needed to support them.
-- The current fallback close control appended by the hook.
-
-**Does not own / non-goals**
-
-- Trigger presentation and caller content presentation — caller-owned.
-- Component-specific surface refinement targets — owned and documented by the
-  composed component; Popover supplies only the shared baseline target contract.
-- Generic top-layer hosting, native popover lifecycle reconciliation, anchor
-  positioning, portal/context selection, and same-gesture reopen protection —
-  owned by `architecture:layer-runtime`.
-- Shared Escape and platform-close ordering — owned by
-  `family:overlay-dismissal`.
-- The shared focus-trap algorithm outside Popover-specific destination choice —
-  owned by `useFocusTrap`.
-- Hover previews and brief helper text — owned by HoverCard and Tooltip.
-
-## Public surface and package boundary
-
-The installable root package and `@astryxdesign/core/Popover` subpath expose the
-full Popover public surface. The backward-compatible Layer entry point re-exports
-`Popover`, `usePopover`, `UsePopoverOptions`, `UsePopoverReturn`, and
-`PopoverProps`; `PopoverTriggerRenderProps` is exposed through the Popover package
-surface, not the Layer entry point. There is no installable
-`Popover/usePopover` implementation subpath.
-
-The source-level internal hook is a package implementation seam used by Popover
-and related presentation components. Its dismissal guard and wider focus-opening
-controls are not installable consumer API. Source-file exports do not promote
-those concepts into the package contract.
+**Does not own:** caller trigger/content presentation; composed-component refinement targets; HoverCard/Tooltip use cases; generic hosting, portal/context selection, native lifecycle, anchor geometry, or same-gesture reopening ([Layer runtime](../../../../docs/architecture/layer-runtime.md)); shared Escape/platform-close ordering ([overlay dismissal](../../../../docs/families/overlay-dismissal.md)); shared modality classification ([interaction modality](../../../../docs/architecture/interaction-modality.md)); or the shared focus-trap algorithm outside Popover's destination choice ([`useFocusTrap`](../hooks/useFocusTrap.ts)).
 
 ## Public concepts
 
-| Concept                  | Closed values or states                                      | Meaning                                                                                                            | Availability              | Default                                                                      | Owner                                                                               | Stability                                    | Invalid or unsupported behavior                                                                                                                            |
-| ------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Trigger composition      | Wrapped trigger, render-prop trigger, or referenced anchor   | Supplies the anchor and the control that opens or closes the standard component                                    | Popover                   | Wrapped trigger when children are supplied                                   | `component:Popover`                                                                 | Current public behavior                      | A referenced or wrapped anchor without a button or button role warns in development and receives no trigger handler; it does not throw.                    |
-| Visibility ownership     | Uncontrolled or externally controlled                        | Chooses whether Popover stores visibility or synchronizes to caller state                                          | Popover                   | Uncontrolled                                                                 | `component:Popover`                                                                 | Current public behavior                      | Controlled changes are synchronized through show/hide; dismissal requests are reported to the caller rather than redefining the external source of truth.  |
-| Popup semantics          | Dialog or neutral wrapper                                    | Exposes dialog semantics or lets child menu/listbox semantics own the popup                                        | Popover and hook          | Dialog                                                                       | `component:Popover`                                                                 | Current public behavior                      | A dialog without a label warns in development. Neutral mode omits dialog role and modal semantics.                                                         |
-| Focus entry              | Automatic or caller-preserved                                | Moves focus according to the matrix below or leaves current focus unchanged                                        | Popover and hook          | Automatic                                                                    | `component:Popover`                                                                 | Current public behavior                      | A request to skip autofocus affects that opening only.                                                                                                     |
-| Dismissal                | Outside/Escape enabled or disabled within native constraints | Controls light dismiss and explicit Escape participation                                                           | Popover and hook          | Both enabled                                                                 | `component:Popover`; `family:overlay-dismissal` owns Escape/platform-close ordering | Current public behavior                      | Disabling Escape alone cannot override the native Escape behavior of an auto popover; explicit-dismiss behavior requires light dismiss to be disabled too. |
-| Surface treatment        | Default surface or caller-owned treatment                    | Applies the shared painted surface and optional consumer styling                                                   | Popover and hook          | Default surface                                                              | `component:Popover`                                                                 | Current public behavior                      | Custom styling does not change lifecycle, focus, or dismissal semantics.                                                                                   |
-| Surface target ownership | Shared baseline or component-specific refinement             | Assigns `popover` as the broad surface owner and lets a composed component add its own target on that same element | Popover and hook          | `popover` baseline; no component-specific refinement                         | `component:Popover`; the composed component owns its refinement target              | Accepted contract; runtime alignment pending | `popover-surface` is compatibility output, not a new target for consumers or a second anatomy owner.                                                       |
-| Placement and fit        | Logical placement/alignment plus preferred width             | Positions the anchor surface and constrains it to available space                                                  | Popover and hook renderer | Below/start; Popover matches trigger minimum width when no width is supplied | `component:Popover` above `architecture:layer-runtime`                              | Current public behavior                      | Preferred width and trigger matching remain capped by viewport and safe-area availability.                                                                 |
+The root package and `@astryxdesign/core/Popover` expose `Popover`, `usePopover`, their options/return/props types, and `PopoverTriggerRenderProps`. The compatible Layer entry re-exports all except `PopoverTriggerRenderProps`; there is no installable `Popover/usePopover` subpath. Source-only dismissal guards and wider focus-opening controls remain implementation seams under [AST-002](../../../../docs/specs/AST-002/spec.md) and [public component API](../../../../docs/architecture/public-component-api.md).
 
-### Public `usePopover` semantic inputs
+| Concept           | Values / default                                                        | Durable contract                                                                                                                                                                                                        |
+| ----------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Trigger           | wrapped children, render prop, or referenced anchor; wrapped by default | Supplies the anchor and control. A wrapped/referenced element without a button or button role warns in development, receives no handler, and does not throw. Disabled Popover ignores only its own trigger interaction. |
+| Visibility        | uncontrolled (default) or controlled                                    | `show`, `hide`, and `toggle` are one lifecycle. Controlled state remains caller-owned; dismissal requests report through the established callback path.                                                                 |
+| Popup semantics   | labeled modal dialog (default) or neutral wrapper                       | Dialog mode stamps role/modal/name and warns, rather than throws or invents a label, when unnamed. Neutral mode leaves menu/listbox semantics to caller content.                                                        |
+| Focus entry       | automatic (default) or caller-preserved                                 | Focus follows the matrix below once per successful open; a skip request applies only to that opening. Consumers do not choose a public focus target.                                                                    |
+| Dismissal         | outside and Escape enabled by default                                   | Escape joins the shared stack. Disabling Escape is complete only with native light dismiss also disabled.                                                                                                               |
+| Surface           | default paint; optional consumer styling and refinement                 | `xstyle`, class, and inline style merge on the painted surface without changing lifecycle. `hasSurface` may delegate paint; `surfaceTarget` adds one refinement on the same surface.                                    |
+| Placement and fit | below/start; trigger minimum width unless explicit width                | Logical placement/alignment and preferred width remain capped by viewport and safe-area availability; explicit width wins over trigger matching.                                                                        |
+| Hook lifecycle    | optional notifications and fallback close control (`Close popover`)     | Notifications fire only after an actual imperative or reconciled transition. The fallback control is appended per rendered surface when enabled and is not replaced when omitted.                                       |
 
-Consumer syntax, exact names, and types remain in `usePopover.doc.mjs`; this
-table owns their semantic effect.
-
-| Input concept                     | Default                          | Effect and lifetime                                                                                                                                                                                              | Invalid or unsupported behavior                                                                                          |
-| --------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Show and hide notifications       | Absent                           | Fire after the hook updates its visibility for an imperative or reconciled browser transition. They remain active for the mounted hook instance.                                                                 | No callback is fired when no transition occurs. Callers own any focus return they add in a hide notification.            |
-| Surface styling                   | No consumer override             | Merges consumer StyleX, class, and inline styles onto the painted surface for every rendered lifetime.                                                                                                           | Styling cannot move ownership to the positioned outer layer; positioning styles belong to the renderer's layer props.    |
-| Light and Escape dismissal        | Enabled                          | Escape dismissal registers through the focus trap when enabled; outside light dismiss uses native `popover="auto"` and is not shared-stack coordinated.                                                          | Escape disablement is only complete when native light dismiss is also disabled.                                          |
-| Automatic focus                   | Enabled                          | Runs once for each successful open unless that opening requests preservation.                                                                                                                                    | If no genuine content control exists, dialog mode falls back to the surface container.                                   |
-| Fallback close control and label  | Included; “Close popover”        | Appends an end-of-trap close control for each rendered surface.                                                                                                                                                  | When omitted, the hook does not synthesize another close affordance.                                                     |
-| Popup role, label, and modality   | Dialog, modal, no implicit label | Stamps semantics on the painted surface for its rendered lifetime.                                                                                                                                               | Neutral role suppresses dialog and modal semantics. Missing dialog label warns in development rather than throwing.      |
-| Default surface                   | Enabled                          | Applies the shared background, radius, and elevation treatment while rendered.                                                                                                                                   | Turning it off delegates painting to caller content but does not turn `usePopover` into a different lifecycle primitive. |
-| Optional component surface target | No component-specific refinement | Adds a component-owned refinement target beside the canonical `popover` target on the same rendered surface. New direct hook consumers provide and document one only when they need distinct theme reachability. | `surfaceTarget` does not create another surface or owner. Do not pass or depend on deprecated `popover-surface`.         |
-
-### Public `usePopover` semantic outputs
-
-| Output concept        | Meaning and lifetime                                                                                                                                                                                                            |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Trigger binding       | A ref binding establishes the anchor while attached; ARIA trigger state tracks the current role and open state; a stable anchor identifier supports advanced composition. Detaching the trigger removes its anchor association. |
-| Visibility operations | `show`, `hide`, and `toggle` are the canonical operations for the mounted hook instance. Show may preserve current focus for one opening; hide and toggle add no separate caller-owned focus destination.                       |
-| Open state            | Reflects the hook's reconciled visibility. Browser-initiated close is observed on the queued native toggle event, so DOM visibility may lead React state briefly.                                                               |
-| Surface binding       | A content ref identifies the focus-trap surface while mounted.                                                                                                                                                                  |
-| Renderer              | Produces the positioned layer and painted surface around caller content, including focus containment and the optional fallback close control. The renderer must remain in the React tree for the surface to exist.              |
-| Surface identifier    | A stable identifier connects the trigger's control relationship to the rendered surface for the hook instance.                                                                                                                  |
-
-### Side effects and lifetime
-
-- Attaching the trigger ref assigns and removes the CSS anchor name used by the
-  Layer runtime.
-- Successful visibility operations call the browser popover methods when
-  available, update hook state, and invoke the corresponding lifecycle
-  notification. Native close events reconcile back into that same state model.
-- The default context layer keeps its mounted host while closed after initial
-  resolution; open state, not host existence, controls visibility. Lazy mounting
-  remains a Layer-level option rather than a separate Popover contract.
-- Popover component trigger handlers and ARIA state exist only while the trigger
-  is mounted and enabled. Disabling Popover ignores its trigger interaction; it
-  does not disable the caller's trigger element.
+The mounted hook returns a trigger ref that owns the anchor association while attached, a stable anchor identifier, role/open ARIA props, reconciled open state, a content ref binding the focus-trap surface, a stable surface ID, and a renderer that must remain in the React tree. Detaching the trigger removes its association; removing the renderer removes the surface. After initial resolution, the default context host remains mounted while open state controls visibility. Browser-initiated close can hide the DOM before the queued native `toggle` event updates React state.
 
 ## Behavioral and layout contract
 
-| ID  | Invariant                                                                                                                                                                                                                                        | Basis                                                             | Acceptance and implementation state                                                                                        |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| FR1 | Popover and public `usePopover` expose one visibility lifecycle with canonical show, hide, and toggle operations. Options that refine opening remain part of that operation; an internal need does not create a durable parallel toggle concept. | Current public package surface plus owner direction on 2026-08-31 | Direction settled; current internal helper naming remains a verification gap, not a second API decision                    |
-| FR2 | Focus destination is derived from popup role, activation style, content, and autofocus policy. Callers do not choose a public focus target.                                                                                                      | PR #5373, current source, and current tests                       | Settled current component behavior                                                                                         |
-| FR3 | The preferred surface size is capped to logical viewport and safe-area availability before overflow is enabled.                                                                                                                                  | PR #5373, current source, tests, and Storybook fixtures           | Verified in unit/style evidence; real rendered viewport evidence remains a gap                                             |
-| FR4 | Popover enables internal scrolling only after measured overflow exceeds the current tolerance. Fitting content does not become a scroll container.                                                                                               | PR #5373 and current tests                                        | Verified current behavior                                                                                                  |
-| FR5 | Overflow signals while open coalesce into at most one measurement per animation frame, and Popover owns no measurement observers while closed.                                                                                                   | PR #5373 and current tests                                        | Verified current resource behavior                                                                                         |
-| FR6 | Component anatomy contains the caller trigger and content, one painted Popover surface, and the optional fallback close control. Popover owns no Header, Body, or separate shared-hook surface part.                                             | Current source, docs target inventory, and tests                  | Accepted anatomy; stale consumer anatomy corrected by this contract                                                        |
-| FR7 | The painted surface has one broad canonical target, `popover`. `popover-surface` is a deprecated compatibility alias on that same part; composed components may add one authoritative component-specific refinement target.                      | Owner direction on 2026-08-31 plus current target inventory       | Accepted semantic contract; automatic hook-wide emission and compatibility removal remain separately reviewed runtime work |
+- **FR1 — One lifecycle.** `toggle` selects `show` or `hide`; opening options refine `show` rather than create a parallel operation. Popover derives its internal focus destination.
+- **FR2 — Focus.** Destination derives from popup role, activation style, content, and autofocus policy; the fallback close control is never treated as initial content.
+- **FR3 — Fit.** The preferred size is capped to logical viewport and safe-area availability before overflow is evaluated.
+- **FR4 — Conditional scroll.** Internal scrolling and overscroll containment begin only when measured overflow exceeds 1 px; fitting content remains a non-scroll container.
+- **FR5 — Resources.** Resize, mutation, captured load, window resize, and visual-viewport resize observation exists only while open; signals coalesce to one animation-frame measurement, cleanup cancels all work, and state updates only when the overflow boolean changes.
+- **FR6 — Anatomy.** The component has caller trigger and content, one painted Popover surface, and an optional fallback close control—no Header, Body, or shared-hook surface part.
+- **FR7 — Target ownership.** `popover` is the one broad canonical target; `popover-surface` is its deprecated compatibility alias; a composed component may add one owned refinement on the same surface.
 
 ### Allowed variation
 
-- **AV1 — Trigger composition.** Wrapped, render-prop, and referenced-anchor
-  modes may attach the same semantic trigger behavior without changing the
-  surface contract.
-- **AV2 — Popup semantics.** Dialog mode may focus the dialog container;
-  role-neutral popups let their child role and content focus model remain
-  exposed.
-- **AV3 — Surface treatment.** The hook may omit its default paint or add a
-  component-owned refinement target while preserving the canonical `popover`
-  ownership, lifecycle, focus containment, and dismissal model.
-- **AV4 — Placement.** Logical placement, alignment, preferred width, and
-  available viewport size may change geometry without changing the fit and
-  overflow precedence below.
+Trigger composition, dialog versus neutral semantics, default versus caller-owned paint, component refinement, logical placement/alignment, preferred width, and available viewport may vary without changing lifecycle, ownership, focus containment, dismissal, or fit/overflow precedence.
 
 ### Representative focus and dismissal states
 
-| State                                             | Required invariant                                                                                                                                                           | Allowed variation                                                                                        |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| Pointer or touch activation of dialog Popover     | Initial focus moves to the labeled dialog container so an action does not appear preselected.                                                                                | The trigger and content may vary.                                                                        |
-| Keyboard or AT-style activation of dialog Popover | Initial focus moves to the first genuine content control; when none exists, it moves to the dialog container.                                                                | Activation with absent or zero event detail follows this path. Named AT announcement remains unverified. |
-| Read-only dialog                                  | The dialog container receives initial focus; the fallback close control remains reachable by Tab but is not selected as initial content.                                     | Caller content may contain no tabbable control.                                                          |
-| Neutral-role popup                                | The neutral wrapper is not selected as a dialog focus target; automatic entry prefers genuine content focus, or callers may disable autofocus for trigger-retained patterns. | Child menu, listbox, or other semantics own their focus model.                                           |
-| Automatic focus disabled                          | Opening does not move focus.                                                                                                                                                 | May be persistent configuration or a one-opening show preference.                                        |
-| Controlled open                                   | External open state invokes the no-activation opening path: first genuine content control, then dialog-container fallback.                                                   | The caller remains the visibility source of truth.                                                       |
-| Tab from a focused container                      | Focus enters the first tabbable descendant.                                                                                                                                  | If none exists, focus remains inside.                                                                    |
-| Shift+Tab from a focused container                | Focus enters the last tabbable descendant.                                                                                                                                   | If none exists, focus remains inside.                                                                    |
-| Escape                                            | The topmost eligible Popover closes according to shared dismissal policy.                                                                                                    | Explicit-dismiss surfaces may disable both light and Escape dismissal.                                   |
-| Close after focus entered the popup               | Focus returns to the trigger when removal would otherwise strand focus.                                                                                                      | A caller may additionally own focus return through its hide notification.                                |
+| State                                   | Required result                                                                                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pointer/touch dialog open               | Focus the labeled dialog container so no action appears preselected.                                                                                        |
+| Keyboard/AT-style dialog open           | Focus the first genuine content control, then the dialog container if none exists.                                                                          |
+| Controlled or autofocus-suppressed open | Controlled open uses the no-activation path and remains caller-owned; disabling autofocus moves no focus, either persistently or for one `show`.            |
+| Read-only dialog                        | Focus the container; the fallback close control remains reachable by Tab but is not initial focus.                                                          |
+| Neutral popup                           | Do not focus the wrapper as a dialog; prefer genuine content, or preserve trigger focus when autofocus is disabled.                                         |
+| Container focused                       | Tab enters the first tabbable descendant; Shift+Tab enters the last; with none, focus remains contained.                                                    |
+| Dismiss request                         | Shared Escape closes the topmost eligible Popover; native outside dismissal follows the light-dismiss option. Fully explicit-dismiss surfaces disable both. |
+| Close after focus entered               | Focus returns to the trigger when removal would otherwise strand it; a caller may additionally own focus return through its hide notification.              |
 
 ### Transformation and precedence order
 
-- **ORD1 — Visibility operation.** `toggle` selects the existing `show` or `hide`
-  transition; it is not a second lifecycle. Opening preferences refine `show`.
-  Popover derives any internal focus destination before invoking that operation.
-- **ORD2 — Preferred inline size.** An explicit width wins over trigger matching.
-  Without explicit width, Popover prefers trigger minimum width. Either preferred
-  size remains capped by available viewport and safe-area space.
-- **ORD3 — Viewport fit.** Logical placement and alignment select the applicable
-  safe-area gutters; the positioned layer and painted surface are capped before
-  overflow state is evaluated.
-- **ORD4 — Conditional scroll.** Measured overflow greater than 1 px enables
-  internal scrolling and overscroll containment; fitting content leaves both
-  disabled.
-
-### Performance and resources
-
-- **PR1 — Open-only observation.** Resize, mutation, captured resource-load,
-  window-resize, and visual-viewport-resize observation exists only while the
-  Popover component is open; cleanup disconnects listeners and observers and
-  cancels pending work.
-- **PR2 — One measurement per frame.** Repeated signals while a measurement is
-  pending coalesce into one animation-frame callback.
-- **PR3 — Stable state update.** Measurement updates overflow state only when the
-  overflow boolean changes.
+1. Resolve `toggle` to show/hide and derive any opening focus preference.
+2. Prefer explicit width, otherwise trigger minimum width; cap either to available viewport/safe-area space.
+3. Apply logical placement/alignment gutters to the positioned layer and painted surface.
+4. Enable scrolling only after post-cap measurement exceeds the 1 px tolerance.
 
 ## Accessibility contract
 
-- **AR1 — Trigger relationship.** The trigger exposes expanded state, the popup
-  relationship, and a role-appropriate popup type while mounted.
-- **AR2 — Dialog naming.** Dialog mode requires a caller-provided accessible
-  label and places dialog/modal semantics on the painted surface. Missing naming
-  warns in development but does not synthesize a label.
-- **AR3 — Focus containment.** Automatic entry and Tab/Shift+Tab behavior follow
-  the matrix above; a trapped surface with no tabbable descendant does not let
-  focus escape.
-- **AR4 — Focus return.** Dismissal returns focus to the trigger when focus had
-  entered the closing Popover and would otherwise be lost.
-- **AR5 — Evidence boundary.** Current automated tests establish DOM roles, ARIA
-  state, focus movement, and focus return. The Storybook manual-AT story is a
-  fixture, not a recorded result. PR #5373 records no named NVDA + Chrome or
-  VoiceOver + Safari announcement result, so this contract makes no AT
-  announcement claim.
+- The mounted trigger exposes expanded state, control relationship, and the popup type promised by its composition mode.
+- Dialog mode requires a caller-provided accessible label and places dialog/modal semantics on the painted surface; neutral mode omits them.
+- Automatic entry, Tab/Shift+Tab containment, Escape ordering, and focus return follow the states above and [overlay dismissal](../../../../docs/families/overlay-dismissal.md).
+- Automated evidence proves DOM roles/ARIA and focus movement/return, not announcements; no NVDA/VoiceOver result is claimed. [Draft AST-009](https://github.com/facebook/astryx/pull/5786) is non-authoritative proposal context for release evidence, not a policy this current contract adopts before it lands.
 
 ## Design relationships
 
-| Anatomy or state       | Design requirement                                                                                                      | Representation authority       | Hierarchy role | Component contract |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------ | -------------- | ------------------ |
-| Trigger element        | Supplies or references the control and anchor without becoming Popover-owned presentation.                              | Caller content                 | Supporting     | FR6, AR1           |
-| Popover surface        | Paints the component surface, owns the canonical `popover` target, and carries fit, scroll, focus, and dialog behavior. | Current source and owner DEC-2 | Prominent      | FR2–FR7, AR2–AR4   |
-| Popover content        | Renders caller-supplied interaction or information inside the surface.                                                  | Caller content                 | Prominent      | FR2, FR6           |
-| Fallback close control | Provides an end-of-trap close affordance without becoming the initial focus destination.                                | `component:Button`             | Supporting     | FR2, AR3           |
+| Anatomy                | Requirement / owner                                     | Role       |
+| ---------------------- | ------------------------------------------------------- | ---------- |
+| Trigger element        | caller-owned control and anchor; no Popover target      | Supporting |
+| Popover surface        | owns `popover`, fit, scroll, focus, and dialog behavior | Prominent  |
+| Popover content        | caller-owned interaction/information inside the surface | Prominent  |
+| Fallback close control | delegates presentation to `component:Button` / `button` | Supporting |
 
 ### Theming anatomy
 
@@ -291,131 +144,47 @@ table owns their semantic effect.
 }
 ```
 
-### Deprecated compatibility target
-
-`popover-surface` is a deprecated alias for `popover` on the same painted
-surface. It is not anatomy and has no independent conceptual ownership. The
-component doc marks it with `deprecatedFor: 'popover'`, so the anatomy validator
-excludes it from the active target inventory while the runtime keeps emitting
-it for existing themes.
-
-Every public `usePopover` painted surface belongs to the broad `popover` target.
-A composed component may add its own authoritative refinement target, such as
-`selector-popup` or `multi-selector-popup`, on that same element. New direct
-hook consumers that need distinct theme reachability provide and document an
-owned `surfaceTarget`; they do not use `popover-surface`.
-
-Automatic hook-wide `popover` emission and eventual removal of the compatibility
-alias are runtime migration work outside this contract. Existing
-`popover-surface` themes remain supported until that separately reviewed
-migration includes target-inventory and regression-test updates plus changelog
-or release guidance.
+Target qualification, alias treatment, and anatomy mapping belong to [component theming surface](../../../../docs/architecture/component-theming-surface.md). `popover-surface` is compatibility output, not anatomy or an equal owner.
 
 ## Family and system relationships
 
-- `architecture:public-component-api` owns installable reachability and the
-  distinction between public package API and source-level implementation seams.
-- `architecture:layer-runtime` owns the shared host, native popover lifecycle,
-  anchor geometry, portal/context behavior, and same-gesture dismissal guard;
-  Popover owns the component-specific fit, overflow, and focus composition above
-  that runtime.
-- `architecture:interaction-modality` owns shared modality classification and
-  evidence expectations. Popover owns the destination matrix and derives the
-  internal focus choice from activation and role.
-- `architecture:component-theming-surface` owns anatomy qualification and target
-  placement. `popover` is the one broad target on the painted surface;
-  `popover-surface` is only its deprecated compatibility alias. Caller content
-  adds no target, the fallback close control delegates to Button's target, and
-  composed components own any additional surface refinement target.
-- `family:overlay-dismissal` owns topmost Escape and platform-close ordering.
-  Popover participates through the shared layer owner while retaining its local
-  focus, outside-dismiss, and open-state behavior.
+- [Public component API](../../../../docs/architecture/public-component-api.md) and [AST-002](../../../../docs/specs/AST-002/spec.md) own installable reachability, canonical operation shape, and the source/public seam.
+- [Layer runtime](../../../../docs/architecture/layer-runtime.md) owns hosting, native lifecycle reconciliation, anchor geometry, portal/context behavior, and same-gesture guards; Popover owns the focus, fit, and overflow composition above it.
+- [Interaction modality](../../../../docs/architecture/interaction-modality.md) owns shared modality; Popover owns its destination matrix.
+- [Component theming surface](../../../../docs/architecture/component-theming-surface.md) owns target qualification and alias rules; Popover owns its one broad surface target and composed refinements own theirs.
+- [Overlay dismissal](../../../../docs/families/overlay-dismissal.md) owns topmost Escape/platform-close ordering; Popover retains local focus, outside-dismiss, and open-state behavior.
 
 ## Verification map
 
-| Contract                     | Verification                                                                                                                          | Representative states                                                                                              | Mutation or failure expectation                                                                                                                       | Audit section                 |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| Public boundary, FR1         | `Popover.test.tsx` compile-time public-surface assertions plus package/barrel inspection                                              | Public component/hook imports and package-internal seam                                                            | Promoting internal controls or changing public operations fails type assertions or package review.                                                    | `audit:Popover/api`           |
-| FR2, AR2–AR4                 | `Popover.test.tsx` focus/role suites and `useFocusTrap.test.tsx` container-entry suites                                               | Pointer, keyboard/AT-style, read-only, neutral role, no autofocus, controlled, Tab/Shift+Tab, Escape, focus return | Changing a destination, selecting fallback close initially, or allowing focus escape fails focus assertions.                                          | `audit:Popover/accessibility` |
-| FR3, FR4                     | `Popover.test.tsx` sizing/overflow suites; `Popover.stories.tsx` real-viewport scenarios for manual/browser evidence                  | Explicit width, trigger matching, all alignments, fitting and overflowing content                                  | Removing a cap, reversing width precedence, or always enabling scroll fails emitted-style or overflow assertions.                                     | `audit:Popover/layout`        |
-| FR5                          | `Popover.test.tsx` scheduling and observer-lifecycle suites                                                                           | Closed, opened, repeated signals, cleanup                                                                          | Constructing observers while closed or measuring more than once per pending frame fails lifecycle assertions.                                         | `audit:Popover/resources`     |
-| FR6, FR7 and theming anatomy | `Popover.test.tsx`, `Popover.doc.mjs`, `usePopover.doc.mjs`, `astryx theme targets Popover --json`, and `scripts/check-knowledge.mjs` | One real surface with canonical `popover`; deprecated alias on that element; composed-component refinements        | A fake anatomy part, loss of compatibility output, missing deprecation metadata, or an active target without a real owner fails review or validation. | `audit:Popover/theming`       |
-| AR5                          | `Popover.stories.tsx` manual-AT fixture and PR #5373 test record                                                                      | Read-only dialog manual-AT fixture; no recorded NVDA/VoiceOver announcement result                                 | A fixture without recorded AT/browser observations cannot be cited as announcement proof.                                                             | `audit:Popover/at-evidence`   |
+| Contract             | Evidence                                                                                                                                                                  | Boundary / pending proof                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public boundary, FR1 | [`Popover.test.tsx`](./Popover.test.tsx), package/barrel inspection, consumer docs                                                                                        | Type assertions reject internal-control promotion; binding review verifies trigger attach/detach, anchor and role/open ARIA, stable IDs, content ref, and renderer lifetime. |
+| FR2, accessibility   | [`Popover.test.tsx`](./Popover.test.tsx), [`useFocusTrap.test.tsx`](../hooks/useFocusTrap.test.tsx)                                                                       | Covers representative focus, role, Escape, and return states; real AT remains below.                                                                                         |
+| FR3–FR5              | [`Popover.test.tsx`](./Popover.test.tsx), [`Popover.stories.tsx`](../../../../apps/storybook/stories/Popover.stories.tsx)                                                 | Unit/style evidence covers caps, scrolling, and observers; rendered viewport proof remains pending.                                                                          |
+| FR6–FR7              | [`Popover.doc.mjs`](./Popover.doc.mjs), [`usePopover.doc.mjs`](./usePopover.doc.mjs), theming discovery, [`check-knowledge.mjs`](../../../../scripts/check-knowledge.mjs) | Rejects fake anatomy, lost alias metadata/output, or ownerless active targets.                                                                                               |
+| AT evidence gap      | [PR #5373](https://github.com/facebook/astryx/pull/5373); [draft AST-009 proposal](https://github.com/facebook/astryx/pull/5786)                                          | The manual story is a fixture, not an announcement result; the unlanded proposal is context, not authority.                                                                  |
 
 ## Decision log
 
 ### DEC-1 — One canonical visibility operation model
 
-**Reference:** `component:Popover/DEC-1`
-
-**Decider:** Cindy Zhang, 2026-08-31
-
-Showing, hiding, and toggling are one visibility lifecycle. Options may refine the
-opening half of toggle, but a package-internal need for a derived focus destination
-does not establish a durable parallel toggle API. Popover derives focus placement
-from activation, role, content, and autofocus policy; consumers are not asked to
-choose it.
-
-Rejected: preserving a separate `toggleWithOptions` concept or exposing
-`focusTarget` as durable API. Both describe implementation choices within the
-same caller operation, and public focus selection would let callers create
-inconsistent or inaccessible destinations.
+**Reference:** `component:Popover/DEC-1` · **Decider:** Cindy Zhang, 2026-08-31 — Showing, hiding, and toggling are one lifecycle. Opening options may refine that operation, but internal focus derivation does not establish `toggleWithOptions` or public `focusTarget` as a second durable concept. Callers cannot select destinations that create inconsistent or inaccessible focus.
 
 ### DEC-2 — One canonical Popover surface target
 
-**Reference:** `component:Popover/DEC-2`
-
-**Decider:** Cindy Zhang, 2026-08-31
-
-`popover` is the broad canonical theming baseline automatically owned by every
-painted surface created by `<Popover>` or public `usePopover`.
-`popover-surface` is deprecated compatibility output on that same element, not a
-second anatomy part or equal owner. Existing themes using it remain supported
-through a documented migration window.
-
-Composed components keep authoritative refinement targets such as
-`selector-popup` and `multi-selector-popup`. Optional `surfaceTarget` adds that
-owned refinement on the same surface; it does not replace the broad `popover`
-baseline. New direct hook consumers that need distinct reachability provide and
-document an owned target rather than depending on `popover-surface`.
-
-Rejected: treating `popover` and `popover-surface` as two durable sibling targets,
-or inventing a “Shared hook surface” anatomy part to satisfy inventory coverage.
-Both make one painted element look like two design concepts and preserve an
-accidental implementation name as permanent public structure.
+**Reference:** `component:Popover/DEC-2` · **Decider:** Cindy Zhang, 2026-08-31 — `popover` is the broad baseline for every `<Popover>` and public `usePopover` painted surface. `popover-surface` remains a deprecated alias on that element; owned composed refinements may coexist without replacing the baseline. Rejected: durable sibling targets or a fictitious “Shared hook surface” anatomy part.
 
 ## Verification gaps
 
-These implementation and evidence items remain required follow-up, but they do
-not block acceptance of the semantic contract above.
-
-- **VG1 — Internal operation naming.** Current source still names a
-  package-internal wider toggle helper separately. This contract treats it as an
-  implementation seam to reconcile in future runtime work, not as public or
-  durable package API. This documentation-only PR does not rename it.
-- **VG2 — Real browser behavior.** Unit tests assert emitted sizing styles and
-  synthetic dimensions, not rendered viewport layout. Native popover light
-  dismiss, top-layer ordering, anchor geometry, and rendered focus behavior still
-  require real Chromium/WebKit evidence when changed.
-- **VG3 — AT announcement.** The current story provides manual instructions, but
-  named NVDA + Chrome and VoiceOver + Safari results are absent. No announcement
-  outcome is claimed.
-- **VG4 — Target migration.** Current runtime still emits `popover-surface` as
-  the automatic shared class and reaches `popover` through Popover's explicit
-  `surfaceTarget`. A separate implementation must make `popover` automatic for
-  every public hook surface while preserving the alias, then verify direct-hook
-  and composed-component target inventories before any later removal.
+- **VG1 — Internal naming.** Source still names a wider package-internal toggle helper; future runtime work must reconcile it under the canonical operation without making it public.
+- **VG2 — Browser behavior.** Unit tests do not prove rendered viewport layout, native light dismiss/top-layer order, real anchor geometry, or rendered focus; applicable changes require real Chromium and WebKit evidence.
+- **VG3 — AT evidence.** The story has instructions but no named NVDA + Chrome or VoiceOver + Safari receipt. This remains a release-evidence gap for [PR #5373](https://github.com/facebook/astryx/pull/5373). [Draft AST-009](https://github.com/facebook/astryx/pull/5786) proposes a named release gate but is non-authoritative until landed; this contract claims no announcement result.
+- **VG4 — Target migration.** Runtime still emits `popover-surface` automatically and reaches `popover` through `<Popover>`'s explicit refinement. Separate work must make `popover` automatic for every public hook surface, preserve the alias, verify direct-hook/composed inventories, and separately review any later removal.
 
 ## Open questions
 
-None. DEC-1 settles the visibility model and derived focus destination; DEC-2
-settles canonical target ownership and compatibility direction. The remaining
-items are verification or separately reviewed implementation work, not human API
-questions.
+None.
 
 ## Content boundary
 
-This file does not duplicate consumer signatures, prop tables, examples,
-implementation steps, shared layer algorithms, or family dismissal rules. It
-links to their owners and records only Popover-specific semantics, boundaries,
-and invariants.
+This file records only Popover-specific semantics, boundaries, decisions, gaps, and evidence links. Consumer signatures/examples, implementation steps, shared layer algorithms, family dismissal rules, theming policy, and AT policy stay with their owners.


### PR DESCRIPTION
## Status: benchmark blocked

This draft is **not ready for approval**. A two-attempt reviewer benchmark at frozen authority `701fd39b` found that the compact Popover contract reduced contract context by 44.6%, but did not preserve review quality on [#5675](https://github.com/facebook/astryx/pull/5675):

- not every compact attempt recovered the below-400 ineffective-cap blocker;
- objective precision fell from 1.00 under the current contract to 0.83;
- both attempts classified the case as an objective finding instead of the settled/no-reask boundary;
- reviewer output grew from 1,443 to 1,640 estimated tokens.

The compact record remains semantically faithful as documentation, but it fails the stricter question that now matters: whether it helps reviewers identify the right decisions and blockers. Keep this PR draft until the compact structure restores that signal and passes the repeatable benchmark.

## Why

The current Popover contract repeats evidence and shared-system rules, making its durable promises harder to scan and audit. This documentation-only change keeps the settled contract intact while making it substantially smaller.

## What

- preserves the exact metadata, authority, approval, ownership boundaries, public concepts and defaults, normative behavior and accessibility, theming target compatibility and refinement model, relationships, decision rulings, and pending implementation/evidence gaps
- replaces duplicated shared policy with links to canonical owners while keeping the unlanded AST-009 proposal explicitly non-authoritative
- reduces the contract from 421 to 190 lines without changing its semantic scope

## Risk

Documentation-only compaction. No runtime, public API, consumer-facing documentation, target, behavior, migration, or release-status change.

The reviewer benchmark identifies a separate risk: semantic parity does not guarantee equal review-decision quality.

## Testing

- `pnpm exec prettier --check packages/core/src/Popover/Popover.spec.md`
- `pnpm check:knowledge --base origin/main`
- `pnpm exec vitest run packages/core/src/Popover/Popover.test.tsx packages/core/src/hooks/useFocusTrap.test.tsx` (60 tests)
- `pnpm check:repo`
- public-hygiene review: no internal links, identifiers, paths, or hostnames
- private repeatable reviewer benchmark: **failed strict gate** on objective recall, precision, label accuracy, and output-size parity

No Changeset: this compacts an existing contract without changing a published package or consumer-facing promise.
