### PR TITLE
Define a concise lifecycle for knowledge records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,28 @@ Every knowledge record declares `authority: draft | current | archived`.
 - `archived` documents declare `archive_reason` (`superseded`, `withdrawn`, or
   `historical`) and link `superseded_by` when a replacement exists.
 
+## Record lifecycle and concision
+
+A durable record is the smallest coherent decision boundary, not a review dossier.
+Create one only for an independent semantic surface with one owner, review triggers,
+and evidence; otherwise amend the nearest owner.
+
+- Keep intent, ownership, normative contract, decisions, compatibility,
+  relationships, and links to evidence. Leave review history, implementation
+  narration, exhaustive test matrices, and copied audit evidence in their transient
+  owners.
+- Treat roughly 100–150 lines as guidance for an ordinary component or module
+  record, not a gate. A longer record should contain one coherent behavior matrix
+  that would become harder to reason about if split.
+- Move repeated shared rules to their family, design, architecture, or system owner.
+  Replace lower copies with links. When a change modifies a current contract,
+  update its owner in the same pull request; a `preserves` result requires no spec
+  edit. When a concept is removed or superseded, archive its record and migrate
+  inbound references there too.
+- Drafts are review context. Age is a reason to review them, never an automatic
+  deletion rule. Indexes route to canonical records and never restate their
+  contracts.
+
 ## Templates and schemas
 
 Templates create documents; schemas keep existing documents structurally

--- a/docs/architecture/knowledge-contracts.md
+++ b/docs/architecture/knowledge-contracts.md
@@ -7,7 +7,7 @@ authority: current
 archive_reason: null
 superseded_by: null
 approved_by: cixzhang
-approved_at: 2026-08-30
+approved_at: 2026-09-01
 owners: [cixzhang]
 applies_to: [AGENTS.md, docs/, packages/core/src/, packages/lab/src/]
 verified_by:
@@ -111,6 +111,30 @@ Every record is either:
   private release or automation systems.
 - **INV9 — Current records have no implicit precedence.** A newer, narrower, or
   more local current record does not silently override another current record.
+- **INV10 — Admission follows a decision boundary.** Create a record only for an
+  independent semantic surface with one owner, review triggers, and evidence.
+  Otherwise amend the nearest current owner; a pull request, component, or
+  investigation is not a record boundary by itself.
+- **INV11 — Durable authoring is concise and normative.** New records and
+  materially amended boundaries keep intent, ownership, normative contract,
+  decisions, compatibility, relationships, and evidence links. They exclude review
+  history, implementation narration, exhaustive test matrices, repeated shared
+  rules, and copied audit evidence. Roughly 100–150 lines is useful guidance for an
+  ordinary component or module record, never a validation gate. Extra length must
+  serve one coherent behavior matrix that would lose meaning if split, not
+  review-dossier prose. Existing current records remain authoritative until their
+  boundary is amended; concision is a review signal, not retroactive invalidation.
+- **INV12 — Consolidation moves shared facts upward.** When a rule repeats, move it
+  to the canonical family, design, architecture, or system owner and replace lower
+  copies with links in the same pull request.
+- **INV13 — Freshness and retirement are graph changes.** A change that modifies a
+  current contract updates its canonical record in the same pull request; a
+  `preserves` result requires no spec edit. Removing or superseding a concept
+  archives its record and migrates every inbound reference in that same pull
+  request.
+- **INV14 — Drafts and indexes are non-authoritative aids.** Drafts are review
+  context; age prompts review but never automatic deletion. Indexes route to
+  canonical records and never duplicate contract text.
 
 ### When current records disagree
 
@@ -266,6 +290,24 @@ Rejected: requiring the owner to open a second pull request for every ruling,
 because it separates the answer from the change and adds unnecessary review
 work.
 
+### DEC-3 — Records follow one durable decision boundary through their lifecycle
+
+**Reference:** `architecture:knowledge-contracts/DEC-3`
+**Decider:** `cixzhang`, `2026-09-01`
+
+Admit a record only when one independent semantic surface can name its owner,
+triggers, and evidence. During exploration, drafts and open questions may carry
+review context. Once settled, fold the durable answer into the canonical current
+owner, archive or supersede transient material, and migrate inbound references.
+Repeated shared rules move upward; lower records and indexes link instead of copy.
+A change that modifies the durable contract updates its canonical current owner in
+the same pull request; a change classified `preserves` requires no spec edit.
+
+Rejected: record-per-pull-request or record-per-artifact filing, deleting drafts by
+age, duplicating contract text in indexes, and splitting one coherent behavior
+matrix merely to satisfy a line target. Those choices trade navigation and review
+clarity for dossier churn.
+
 ## Verification
 
 | Invariant                         | Evidence                                       | Failure signal                                                                                                                                      |
@@ -274,3 +316,4 @@ work.
 | INV5, INV7                        | `.github/scripts/change-scope.test.mjs`        | A template, schema, guidance, architecture, code change, unsafe rename, or truncated list qualifies as spec-only                                    |
 | Approval follows the current head | `.github/scripts/spec-owner-decision.test.mjs` | An approval for another commit clears the gate, a self-declared owner becomes an approver, or the wrong owner group approves a current theme record |
 | INV3, INV4                        | Blinded historical review benchmark            | Reviewer re-asks a settled decision or invents a new one                                                                                            |
+| INV10–INV14                       | Owner review                                   | A new or amended record has no independent owner/triggers/evidence, copies another owner, carries dossier prose, or leaves stale references         |

--- a/docs/templates/knowledge/architecture.md
+++ b/docs/templates/knowledge/architecture.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 1
-template_version: 1
+template_version: 2
 kind: architecture
 id: architecture:<surface>
 authority: draft
@@ -15,6 +15,12 @@ deciding_specs: [spec:AST-000/DEC-0]
 ---
 
 # <Surface> architecture
+
+<!--
+Follow architecture:knowledge-contracts/DEC-3. Keep one durable system boundary:
+model, owners, invariants, decisions, and evidence links. Omit review history,
+implementation narration, repeated lower-level rules, and copied audit evidence.
+-->
 
 ## Purpose
 

--- a/docs/templates/knowledge/component-spec.md
+++ b/docs/templates/knowledge/component-spec.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 3
-template_version: 4
+template_version: 5
 kind: component
 id: component:<Name>
 authority: draft
@@ -20,6 +20,15 @@ system_specs: [spec:AST-000/DEC-0]
 ---
 
 # <Name> component contract
+
+<!--
+Follow architecture:knowledge-contracts/DEC-3. Create this record only for an
+independently owned component surface; otherwise amend the nearest owner. Keep
+ordinary records near 100–150 lines as guidance, never a gate. Delete unused
+optional placeholders and comments. Link shared rules and evidence. Keep one
+coherent behavior matrix together and remove review or implementation narration
+instead of splitting it.
+-->
 
 ## Intent
 

--- a/docs/templates/knowledge/design-spec.md
+++ b/docs/templates/knowledge/design-spec.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 1
-template_version: 1
+template_version: 2
 kind: design
 id: design:<surface>
 authority: draft
@@ -18,6 +18,12 @@ deciding_specs: [spec:AST-000/DEC-0]
 ---
 
 # <Surface> design specification
+
+<!--
+Follow architecture:knowledge-contracts/DEC-3. Keep one human-owned design
+boundary and its normative representations. Link component contracts and visual
+evidence; omit review history, implementation narration, and copied audit results.
+-->
 
 ## User intent
 

--- a/docs/templates/knowledge/family-contract.md
+++ b/docs/templates/knowledge/family-contract.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 1
-template_version: 1
+template_version: 2
 kind: family
 id: family:<family-name>
 authority: draft
@@ -18,6 +18,12 @@ deciding_specs: [spec:AST-000/DEC-0]
 ---
 
 # <Family name> contract
+
+<!--
+Follow architecture:knowledge-contracts/DEC-3. Keep only rules shared by this
+family and one representative matrix. Members link here instead of copying the
+rules; omit component-local detail, review history, and exhaustive evidence prose.
+-->
 
 ## Intent
 

--- a/docs/templates/knowledge/module-spec.md
+++ b/docs/templates/knowledge/module-spec.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 3
-template_version: 1
+template_version: 2
 kind: module
 id: module:<ParentComponent>/<PublicName>
 authority: draft
@@ -16,6 +16,15 @@ references: [architecture:<surface>, design:<surface>, spec:AST-000/DEC-0]
 ---
 
 # <PublicName> module contract
+
+<!--
+Follow architecture:knowledge-contracts/DEC-3. Create this record only for an
+independently owned public semantic module; otherwise amend its parent. Keep
+ordinary records near 100–150 lines as guidance, never a gate. Delete unused
+optional placeholders and comments. Link parent/shared rules and evidence. Keep one
+coherent behavior matrix together and remove review or implementation narration
+instead of splitting it.
+-->
 
 ## Intent
 

--- a/docs/templates/knowledge/system-spec.md
+++ b/docs/templates/knowledge/system-spec.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 1
-template_version: 1
+template_version: 2
 kind: system-spec
 id: spec:AST-000
 authority: draft
@@ -17,6 +17,13 @@ affects_consumer_docs: [<doc-id>]
 ---
 
 # <Change> system spec
+
+<!--
+Follow architecture:knowledge-contracts/DEC-3. Keep one consequential system
+boundary: intent, normative requirements, compatibility, decisions, relationships,
+and evidence links. Extra length must serve one coherent behavior matrix, not a
+review dossier or implementation plan.
+-->
 
 ## Intent
 

--- a/docs/templates/knowledge/theme-spec.md
+++ b/docs/templates/knowledge/theme-spec.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 2
-template_version: 1
+template_version: 2
 kind: theme
 id: theme:<package-theme-name>
 authority: draft
@@ -14,6 +14,13 @@ references: [architecture:<surface>, design:<contrast-methodology>]
 ---
 
 # <Theme name> theme specification
+
+<!--
+Follow architecture:knowledge-contracts/DEC-3. Keep one theme-owned contract:
+intent, mappings, exceptions, compatibility, decisions, and evidence links. Link
+shared methodology and tooling instead of copying them; omit review narration and
+raw audit evidence.
+-->
 
 ## Intent and audience
 

--- a/docs/templates/knowledge/versions.json
+++ b/docs/templates/knowledge/versions.json
@@ -1,10 +1,10 @@
 {
-  "architecture": 1,
-  "component": 4,
-  "design": 1,
-  "family": 1,
+  "architecture": 2,
+  "component": 5,
+  "design": 2,
+  "family": 2,
   "implementation-plan": 1,
-  "module": 1,
-  "system-spec": 1,
-  "theme": 1
+  "module": 2,
+  "system-spec": 2,
+  "theme": 2
 }

--- a/scripts/check-knowledge.test.mjs
+++ b/scripts/check-knowledge.test.mjs
@@ -1485,10 +1485,10 @@ describe('knowledge validation', () => {
     fs.mkdirSync(directory);
     fs.writeFileSync(
       path.join(directory, 'Button.spec.md'),
-      componentRecord({template_version: '5'}),
+      componentRecord({template_version: '6'}),
     );
     expect((await validateKnowledgeRoot(root)).join('\n')).toMatch(
-      /template_version 5 is newer than 4/,
+      /template_version 6 is newer than 5/,
     );
   });
 


### PR DESCRIPTION
## Why

Knowledge records are becoming review dossiers instead of durable contracts. This policy makes one independently owned semantic decision boundary the unit of admission, consolidation, freshness, and retirement.

## Durable and transient boundary

Durable records keep intent, ownership, normative contract, decisions, compatibility, relationships, and evidence links. Review history, implementation narration, exhaustive test matrices, repeated shared rules, and copied audit evidence remain transient or move to their canonical owner.

The authoring templates carry concise hidden guidance without removing required fields or sections. Existing current records remain authoritative until their boundary is materially amended; concision is a review signal, not retroactive invalidation.

## Lifecycle policy

- Create a record only for an independent semantic surface with one owner, review triggers, and evidence; otherwise amend the nearest owner.
- Move repeated shared rules to their family, design, architecture, or system owner and replace lower copies with links.
- Update a modified current contract in the same pull request; a `preserves` result requires no spec edit.
- Archive removed or superseded concepts and migrate inbound references in the same pull request.
- Keep drafts as review context without automatic age-based deletion. Indexes route and never duplicate contract text.
- Treat roughly 100–150 lines as guidance for ordinary component or module records, never a hard gate; longer records justify one coherent behavior matrix.

## Schema and migration

This is guidance-only. It adds no schema or required template shape and migrates no active records. Editorial template-version increments identify the revised authoring guidance.

No claim about automated generation reliability is part of this policy PR. The experimental writing workflow is isolated in a separate stacked draft.

## Test plan

- Prettier on changed files
- `pnpm check:knowledge`
- `pnpm exec vitest run --project node scripts/check-knowledge.test.mjs`
- `pnpm check:repo`
- Public repository hygiene and changed-file review

No Changeset: documentation and repository tooling only.
