### PR TITLE
test(Toast): measure logical placement under RTL

### DIFF
--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -111,5 +111,19 @@
       "prev": ".astryx-token",
       "next": ".astryx-input-clear-button"
     }
+  },
+  {
+    "component": "Toast",
+    "storyId": "core-toast--logical-placement",
+    "dims": [
+      "D4"
+    ],
+    "setup": {
+      "click": "button:has-text(\"Show toast\")"
+    },
+    "selectors": {
+      "overlay": "[data-toast-id]",
+      "overlayRoot": "body"
+    }
   }
 ]

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -1024,3 +1024,49 @@ export const CustomContent: StoryObj = {
     },
   },
 };
+
+// =============================================================================
+// Logical placement
+// =============================================================================
+
+/**
+ * The viewport is rendered IN THE STORY TREE, not through the provider-less
+ * fallback the other stories use, and `isTopLayer` keeps its default.
+ *
+ * Both details are load-bearing for the RTL audit:
+ *
+ * - the fallback container is appended to `<body>`, outside the decorator that
+ *   sets `dir`, so a toast raised there can never flip and reads as a false
+ *   not-RTL;
+ * - `isTopLayer={false}` drops the `popover` attribute, and with it the UA
+ *   `width: fit-content` this placement has to survive — a story without the
+ *   popover would pass whether or not the viewport can span the inline axis.
+ */
+export const LogicalPlacement: StoryObj = {
+  name: 'Logical placement follows direction',
+  render: function LogicalPlacementStory() {
+    return (
+      <ToastViewport position="bottomEnd" maxVisible={1}>
+        <LogicalPlacementTrigger />
+      </ToastViewport>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`bottomEnd` is a logical placement: the toast sits on the inline END edge, which is the right in LTR and the left in RTL. The viewport spans the inline axis and aligns the card within itself, so the card follows the document direction with no per-direction styling.',
+      },
+    },
+  },
+};
+
+function LogicalPlacementTrigger() {
+  const toast = useToast();
+  return (
+    <Button
+      label="Show toast"
+      onClick={() => toast({body: 'Placement follows the document direction.'})}
+    />
+  );
+}


### PR DESCRIPTION
Stacks on #5822 — base is `fix/toast-viewport-popover-width`, so review that one first.

## Why

Toast is an unexplained **coverage gap** in the RTL audit: every dimension returns N-A with no recorded reason, which the audit counts as *unmeasured*, not fine. And it is not fine — `bottomEnd` is a logical placement, so the card belongs on the right in LTR and the left in RTL, and nothing checked that.

A `verified-not-applicable` entry would be the wrong fix here. Toast placement is direction-sensitive by design; the honest answer is to measure it.

## Why a new story was needed

None of the existing Toast stories can be measured, for harness reasons rather than component ones:

- **`Default` and siblings** call `useToast()` with no provider, so the toast is raised through the body-appended fallback container — **outside** the decorator that sets `dir`. It cannot flip, and scoring it would report Toast as `not-RTL` for a Storybook reason. (I tried this first; it produced exactly that false red.)
- **`MobileRtlSafeAreaPlacement`** hardcodes `isRtl`, so it is RTL in *both* runs of an LTR-vs-RTL comparison.

`LogicalPlacement` renders `ToastViewport` in the story tree and leaves `isTopLayer` at its default. Both details are load-bearing — `isTopLayer={false}` would drop the `popover` attribute along with the UA `width: fit-content` this placement has to survive, so a story without the popover would pass whether or not the viewport can span the inline axis.

## The check

D4 (overlay-side): the card's center as a fraction of root width, LTR against RTL, asserted to mirror. The auto dimensions cannot see this — D1 finds no directional icons, D5 no logical-anchor + physical-transform pair, D6 no decorations.

## Testing

Chromium, built Storybook:

| | LTR | RTL | |
|---|---|---|---|
| with #5822's popover-width reset | 0.80 | 0.20 | `flipped=true` → **pass** |
| with that reset removed | 0.20 | 0.20 | `flipped=false` → **fail** |

The second row is the negative control, and it is the bug this stacks on — so this is a regression test, not a rubber stamp. Toast's coverage goes `0 measured / 1 gap` → `1 measured / 0 gap`.

Gates: 8941 tests / 316 files pass, `core typecheck`, `check:repo`, `lint:strict` all clean.

## Note on the wider gate

`pr-rtl` is currently red on most open PRs. That is not this change: #5365 landed the coverage gate with `verified-not-applicable.json` empty, and a full-library run reports **229 gaps across 246 components**. Seeding that registry is a real per-component judgement — `core/table` reading as RTL-N/A would be wrong — so it wants its own diff and its own reviewer, not a rubber stamp across 229 entries. Happy to take it if you want it.
