### PR TITLE
fix(AppShell): keep auto section header solid

### DIFF
--- a/.changeset/appshell-auto-header-background.md
+++ b/.changeset/appshell-auto-header-background.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep AppShell's section top bar solid in auto-height mode while content scrolls beneath it.
+
+@cixzhang

--- a/packages/core/src/AppShell/AppShell.test.tsx
+++ b/packages/core/src/AppShell/AppShell.test.tsx
@@ -579,6 +579,27 @@ describe('AppShell', () => {
     ).toBeDefined();
   });
 
+  it('renders an opaque section header only in auto mode', () => {
+    const {rerender} = render(
+      <AppShell height="auto" variant="section" topNav={<div>Nav</div>}>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    expect(
+      getComputedStyle(screen.getByRole('banner')).backgroundColor,
+    ).not.toBe('rgba(0, 0, 0, 0)');
+
+    rerender(
+      <AppShell height="fill" variant="section" topNav={<div>Nav</div>}>
+        <div>Content</div>
+      </AppShell>,
+    );
+    expect(getComputedStyle(screen.getByRole('banner')).backgroundColor).toBe(
+      'rgba(0, 0, 0, 0)',
+    );
+  });
+
   it('does not apply sticky wrapper in fill mode', () => {
     render(
       <AppShell

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -554,6 +554,11 @@ export function AppShell({
       : variant === 'surface'
         ? styles.navAreaSurface
         : undefined;
+  // Section normally inherits the shell's surface background. Its auto-height
+  // header needs to paint that surface itself while content scrolls beneath it.
+  const headerAreaStyle =
+    navAreaStyle ??
+    (isAuto && variant === 'section' ? styles.navAreaSurface : undefined);
   const contentAreaStyle =
     variant === 'wash'
       ? styles.contentBgWash
@@ -684,7 +689,7 @@ export function AppShell({
       role="banner"
       {...mergeProps(
         themeProps('app-shell-header', {variant}),
-        stylex.props(navAreaStyle, isAuto && styles.headerSticky),
+        stylex.props(headerAreaStyle, isAuto && styles.headerSticky),
       )}>
       {headerInner}
     </div>
@@ -773,7 +778,7 @@ export function AppShell({
         role={headerContent == null ? 'banner' : undefined}
         {...mergeProps(
           themeProps('app-shell-header', {variant}),
-          stylex.props(navAreaStyle, isAuto && styles.headerSticky),
+          stylex.props(headerAreaStyle, isAuto && styles.headerSticky),
         )}>
         <LayoutHeader padding={0} hasDivider={navHasDividers}>
           <div


### PR DESCRIPTION
## Why

On mobile, `AppShell` with `height="auto"` and `variant="section"` renders a sticky top bar. The header inherited its background from the shell, so content scrolling underneath showed through it.

This regressed in #2464 when the explicit auto-height fallback paint was replaced by the normal nav-area style. `section` intentionally has no normal nav-area paint.

## What

- Restore an explicit surface background only for the `section + auto` header path.
- Add a normal AppShell unit test that asserts the rendered computed background is opaque in auto mode and remains inherited in fill mode.

## Risk

Low. Other variants and fill-height mode keep their existing styling.

## Testing

- `pnpm vitest run packages/core/src/AppShell/AppShell.test.tsx --project ui`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm check:changesets`
- pre-commit repo checks
