### PR TITLE
docs: prototype a closed-world spec-writing workflow

### DIFF
--- a/.claude/skills/writing-knowledge-records.md
+++ b/.claude/skills/writing-knowledge-records.md
@@ -1,0 +1,109 @@
+# Writing knowledge records
+
+Use this skill before creating or materially editing any component, module,
+family, design, architecture, system, or theme knowledge record.
+
+## Purpose and defining constraint
+
+One record is one authoritative decision boundary, not a review dossier. Every claim
+traces to authority; improve first-read clarity without changing meaning. Follow
+[the templates and co-location rules](../../docs/README.md).
+
+## Step 0 — Preflight metadata and shape
+
+List every schema-required frontmatter key and checker/schema-required H2. Other
+template headings are prompts; preserve all required shape. Resolve each value from
+current authority. If unavailable, stop and report blocked;
+never publish or guess. Use an empty array only after verifying no completed or
+linked value exists. `verified_by` lists only completed, present evidence; future
+requirements go in Verification. Requiring axe, Chromium, or AT does not prove they
+ran.
+
+## Step 1 — Build a source-fact ledger in scratch
+
+Keep this ledger in uncommitted scratch space; never publish it.
+
+| ID  | Classification                                              | Exact fact | Source link/path | Modality/cardinality/predicate         | Canonical owner | Destination    |
+| --- | ----------------------------------------------------------- | ---------- | ---------------- | -------------------------------------- | --------------- | -------------- |
+| F1  | `<supplied / derived-checkable / source-stated-unresolved>` | `<fact>`   | `<source>`       | `<may/must; one/many; if/when/unless>` | `<owner>`       | `<section/ID>` |
+
+Include every frontmatter, authority, default, release, compatibility, ownership,
+evidence, decider, behavior, variation, and open-decision fact. Absence is not a
+fact; never turn it into a default, decision, owner, or rule. Classify each fact as:
+
+- **Supplied fact:** stated directly by an authoritative input.
+- **Derived checkable fact:** mechanically verifiable from its source or check.
+- **Source-stated unresolved question:** explicitly left open by authority.
+
+## Step 2 — Draft for a human first read
+
+Open the intent/purpose with who is affected, their state, and the outcome or
+defining guarantee. Follow with an **At a glance** table of exactly six rows. Each
+gives an exact answer and exactly one H2/ID for user impact; public concepts and
+explicit default status; critical state/interaction behavior;
+compatibility/variation; canonical owners; and open decisions plus
+required/completed evidence.
+
+Preserve every predicate and signal word; never replace an exact answer with
+“conditional.” “Repeated count changes are polite and deduplicated” does not mean
+all count announcements. Use `not supplied` for default status only after verifying
+no public default is supplied.
+
+Use plain sentences and one stable term per concept. Component/module behavior uses
+FR, accessibility uses AR, and decisions use DEC; design normative representations
+use DR and decisions use DEC. Component Design relationships cite DR only from
+linked design; theming stays descriptive or FR-linked unless linked design supplies
+DR. Other kinds follow their template and source.
+
+Co-locate critical behavior. Components put every interacting state needed for
+review (busy/disabled/announcement and Escape predicates) in Behavioral and layout
+contract; Accessibility cites those FRs and adds only accessibility semantics.
+Design puts active presentation, predicates, fixed-open lifecycle, focus
+entry/return, dismissal, viewport/safe-area, and fallback behavior in Responsive
+and input behavior or one chosen H2; Design principles points to that DR. Use lists or tables for branches. Link shared owners and inspectable source/evidence;
+delete optional placeholders, comments, and absence-only body sections.
+
+## Step 3 — Run a closed-world fidelity audit
+
+Map every frontmatter value, normative sentence/table cell, default, owner,
+evidence status/scope, decision, and open question to the ledger. Preserve `if`,
+`when`, `unless`, `only`, `may`, `must`, `never`, `always`, cardinality, defaults,
+inheritance, and predicate order.
+
+- “May use A or B, never both” does not mean “exactly one.”
+- A positive predicate defines no negative branch. Record only source-stated
+  branches; `compact AND coarse → sheet` does not imply `otherwise → popover`.
+- “New” or “additive” does not mean “not released” or “default preserved.”
+- Preserve the exact owner identifier. Add `component:`, `family:`, or
+  `architecture:` only when current authority resolves that record kind.
+
+Delete unsupported claims. Never infer authority, release/default state, decider,
+ownership, review state, evidence scope, or formal open decisions. Use `not
+supplied` only for required metadata or verified absence of a public default;
+`unresolved` requires an authority-stated product or design question.
+
+## Step 4 — Compress by removing duplication
+
+Keep each meaning once, then cite its ID. Remove review history, implementation
+narration, copied audit evidence, exhaustive tests, source caches, and repeated
+rationale/rules. Keep domain names, signals, predicates, compatibility boundaries,
+and cross-owner links. Roughly 100–150 lines guides an ordinary component/module;
+it is not a gate. Keep one coherent matrix together when splitting harms clarity.
+
+## Completion gate
+
+Finish only when every required key/heading and ledger fact is present, every claim
+maps to the ledger, and unsupported claims and contradictions are zero. Delete
+non-required headings with no authoritative content.
+
+Run the six-question retrieval audit. Each summary row must answer directly,
+preserve predicates/signals, and route to exactly one H2/ID; the reader uses the
+opening plus at most that section.
+
+## Validation
+
+1. Run `pnpm check:knowledge`.
+2. Open every changed link and confirm its source or evidence.
+3. Review the diff for duplicated meaning, missing signals, and invented claims.
+4. When possible, ask an independent reviewer to compare the record with the
+   scratch ledger for fidelity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ Meta-only context.
   applicable design spec under `docs/design/`, and current architecture under
   `docs/architecture/`.
 - Consequential shared-system changes: use a record under `docs/specs/`.
+- Before creating or materially editing a knowledge record, read
+  `.claude/skills/writing-knowledge-records.md`; it owns required-metadata
+  preflight, the scratch source-ledger, closed-world fidelity, first-read routing,
+  and compression.
 
 ## Authority
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,13 +64,39 @@ Every knowledge record declares `authority: draft | current | archived`.
 ## Record lifecycle and concision
 
 A durable record is the smallest coherent decision boundary, not a review dossier.
-Create one only for an independent semantic surface with one owner, review triggers,
-and evidence; otherwise amend the nearest owner.
+Before creating or materially amending one, follow
+[Writing knowledge records](../.claude/skills/writing-knowledge-records.md) and
+`architecture:knowledge-contracts/DEC-3`. Create a record only for an independent
+semantic surface with one owner, review triggers, and evidence; otherwise amend
+the nearest owner. Write for a first read: lead with user impact and the defining
+constraint, use plain direct sentences, and keep one stable term per concept. In
+the existing opening intent or purpose section, add an **At a glance** table with
+six concise rows. Each row gives a direct answer and canonical ID for user impact,
+public concepts and explicit default status, critical state/interaction behavior,
+compatibility/allowed variation, canonical owners, and open decisions plus
+required/completed evidence. A reader should answer those questions from the
+opening and at most one linked section.
 
-- Keep intent, ownership, normative contract, decisions, compatibility,
-  relationships, and links to evidence. Leave review history, implementation
-  narration, exhaustive test matrices, and copied audit evidence in their transient
-  owners.
+- Before drafting, enumerate every schema-required frontmatter key. Preserve the
+  body headings the checker/schema requires; other template headings are prompts
+  and should be deleted when they have no authoritative content. Missing required
+  metadata blocks publication; do not guess. Empty arrays require verified absence
+  of a completed or linked value.
+- `verified_by` lists only completed evidence already present. Put required future
+  checks in Verification; requiring axe, Chromium, or assistive-technology evidence
+  does not prove those checks ran.
+- Keep each owned concept's normative rule, allowed variation, and caveats in one
+  canonical section. Other sections refer to its FR, AR, DR, or DEC id instead of
+  restating it.
+- Put state, variant, viewport, and input branches in a table or list. A draft is
+  complete when every authoritative input has a canonical statement and every
+  source-stated branch is explicit. Preserve source modality, cardinality, and
+  branch predicates; omit unsupported claims, and use `unresolved` only for a
+  source-stated open question.
+- Source files and evidence remain authoritative for inspectable syntax,
+  implementation shape, current measurements, and exhaustive test inventories.
+  Link them here. The record remains authoritative for intent, ownership,
+  normative constraints, decisions, compatibility, and relationships.
 - Treat roughly 100–150 lines as guidance for an ordinary component or module
   record, not a gate. A longer record should contain one coherent behavior matrix
   that would become harder to reason about if split.

--- a/docs/templates/knowledge/component-spec.md
+++ b/docs/templates/knowledge/component-spec.md
@@ -22,17 +22,15 @@ system_specs: [spec:AST-000/DEC-0]
 # <Name> component contract
 
 <!--
-Follow architecture:knowledge-contracts/DEC-3. Create this record only for an
-independently owned component surface; otherwise amend the nearest owner. Keep
-ordinary records near 100–150 lines as guidance, never a gate. Delete unused
-optional placeholders and comments. Link shared rules and evidence. Keep one
-coherent behavior matrix together and remove review or implementation narration
-instead of splitting it.
+When creating or materially amending this record, follow
+`.claude/skills/writing-knowledge-records.md` and
+`architecture:knowledge-contracts/DEC-3`. Keep one independently owned semantic
+boundary. Roughly 100–150 lines is guidance, not a gate.
 -->
 
 ## Intent
 
-<!-- Why this component exists and the system-level job it owns. Consumer usage belongs in <Name>.doc.mjs. -->
+<!-- Start with who is affected, in which state, and the component's defining guarantee. Then add the six-row At a glance table defined by the writing skill, with direct answers and canonical IDs. Details remain canonical below; consumer usage belongs in <Name>.doc.mjs. -->
 
 ## Compatibility and migration
 

--- a/docs/templates/knowledge/design-spec.md
+++ b/docs/templates/knowledge/design-spec.md
@@ -20,14 +20,15 @@ deciding_specs: [spec:AST-000/DEC-0]
 # <Surface> design specification
 
 <!--
-Follow architecture:knowledge-contracts/DEC-3. Keep one human-owned design
-boundary and its normative representations. Link component contracts and visual
-evidence; omit review history, implementation narration, and copied audit results.
+When creating or materially amending this record, follow
+`.claude/skills/writing-knowledge-records.md` and
+`architecture:knowledge-contracts/DEC-3`. Keep one human-owned visual and
+interaction boundary.
 -->
 
 ## User intent
 
-<!-- Who is affected, in which state, and what they should understand or do. -->
+<!-- Start with who is affected, in which state, and the outcome they should understand or achieve. Then add the six-row At a glance table defined by the writing skill, with direct answers and canonical IDs. Details remain canonical below. -->
 
 ## Design principles
 


### PR DESCRIPTION
## Status

**Experimental; not ready to land.** This draft is stacked on [#5871](https://github.com/facebook/astryx/pull/5871), which owns the concise knowledge-record lifecycle policy.

## Prototype

This change adds a public writing workflow for new or materially edited knowledge records:

- preflight every required metadata field and stop instead of guessing;
- build a scratch-only source-fact ledger;
- draft a six-row first-read summary with exact canonical routing;
- audit every published claim against the ledger; and
- compress duplication only after fidelity passes.

`AGENTS.md` routes authors to the skill. Component and design templates retain only concise, record-local pointers, and `docs/README.md` links the workflow.

## Evidence and limits

Seven controlled rounds measured substantial token reduction but did **not** pass both the zero-invention and first-read gates.

In Round 7, both component samples preserved 92/92 facts. The design samples preserved 87/87 and 86/87 facts. Median estimated tokens fell 42.8% for component records and 19.7% for design records.

The remaining failures are material:

- one design sample dropped `only` from “title prominent only in sheet”;
- the same sample invented `component:Popover` and `component:BottomSheet` instead of preserving the supplied owner identifiers `Popover` and `BottomSheet`;
- first-read retrieval scored 4/6, 4/6, 5/6, and 5/6 because summary rows were incomplete or routed to a section without the full answer; and
- zero of four samples passed every mandatory gate.

The skill therefore remains a prototype. It must not be treated as demonstrated reliable generation guidance until another controlled evaluation clears both fidelity and retrieval.

## Schema and migration

This stacked change adds no schema, required template shape, template-version change, or active-record migration.

## Test plan

- Prettier on changed files
- `pnpm check:knowledge`
- `pnpm exec vitest run --project node scripts/check-knowledge.test.mjs`
- `pnpm check:repo`
- Public repository hygiene and changed-file review

No Changeset: documentation and contributor workflow only.
