### PR TITLE
test(rtl): cover AppShell side placement

### DIFF
--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -1,5 +1,16 @@
 [
   {
+    "component": "AppShell",
+    "storyId": "core-appshell--top-nav-with-side-nav",
+    "dims": [
+      "D4"
+    ],
+    "selectors": {
+      "overlay": ".astryx-app-shell-sidenav",
+      "overlayRoot": ".astryx-app-shell"
+    }
+  },
+  {
     "component": "ButtonGroup",
     "storyId": "core-buttongroup--horizontal",
     "dims": [


### PR DESCRIPTION
## Why

The PR-scoped RTL audit for #5873 found no applicable automatic dimension for AppShell, so it reported an unexplained coverage gap. AppShell is not direction-neutral: its inline side navigation must move from the start side in LTR to the start side in RTL.

## What

Add a focused D4 geometry target for the `TopNavWithSideNav` story. It compares the side navigation's position within the AppShell root across LTR and RTL.

## Risk

Test-only. Runtime behavior is unchanged.

## Testing

- Focused AppShell RTL audit: `CUR RTL-ready core/appshell {"D4":"pass"}`
- Coverage: `1 measured / 0 verified N-A / 0 gap / 0 stale`
- Pre-commit repository checks
