### PR TITLE
fix(ci): resolve package for new PR stories

### DIFF
--- a/.github/scripts/visual-gate/lib/plan.mjs
+++ b/.github/scripts/visual-gate/lib/plan.mjs
@@ -102,22 +102,30 @@ function titlePackage(title, catalog, candidates = null) {
 
 function storyPackageNames(entry, storybookDir, repoRoot, catalog) {
   const fromComponent = packageFromComponentPath(entry.componentPath);
+  const titleOwner = titlePackage(entry.title, catalog);
   let names = fromComponent ? [fromComponent] : [];
   if (!fromComponent) {
     const relative = entry.importPath?.replace(/^\.\//, '');
     const source = relative && path.resolve(path.dirname(storybookDir), relative);
-    if (!source || !fs.existsSync(source)) {
+    if (source && fs.existsSync(source)) {
+      const text = fs.readFileSync(source, 'utf8');
+      names = [...new Set([...text.matchAll(/(?:from\s+|import\s*)['"](@astryxdesign\/[^/'"]+)/g)].map(match => match[1]))].sort();
+    } else if (titleOwner) {
+      // Trusted workflow_run jobs inspect PR-built Storybook artifacts from a
+      // default-branch checkout. A new PR-only story has no local source yet,
+      // so use its package-scoped Storybook title when that title names one
+      // known workspace package.
+      names = [titleOwner];
+    } else {
       throw new Error(`Story ${entry.id} has no resolvable package metadata.`);
     }
-    const text = fs.readFileSync(source, 'utf8');
-    names = [...new Set([...text.matchAll(/(?:from\s+|import\s*)['"](@astryxdesign\/[^/'"]+)/g)].map(match => match[1]))].sort();
   }
-  const titleOwner = titlePackage(entry.title, catalog, names);
-  const themeOwner = titlePackage(entry.title, catalog);
+  const scopedTitleOwner = titlePackage(entry.title, catalog, names);
+  const themeOwner = titleOwner?.startsWith('@astryxdesign/theme-') ? titleOwner : null;
   const owner =
     fromComponent ??
-    (themeOwner?.startsWith('@astryxdesign/theme-') ? themeOwner : null) ??
-    titleOwner ??
+    themeOwner ??
+    scopedTitleOwner ??
     (names.length === 1 ? names[0] : null);
   if (!owner) throw new Error(`Story ${entry.id} has ambiguous package ownership: ${names.join(', ')}.`);
   for (const name of new Set([...names, owner])) {

--- a/.github/scripts/visual-gate/lib/plan.test.mjs
+++ b/.github/scripts/visual-gate/lib/plan.test.mjs
@@ -198,6 +198,7 @@ describe('readStoryIndex package metadata', () => {
       lab: {type: 'story', id: 'lab-thing--default', title: 'Lab/Thing', name: 'Default', importPath: './stories/Lab.stories.tsx'},
       mixed: {type: 'story', id: 'core-layer--default', title: 'Core/Layer', name: 'Default', importPath: './stories/CoreMixed.stories.tsx'},
       probe: {type: 'story', id: 'core-probe--default', title: 'Core/Themes/Probe Theme', name: 'Default', importPath: './stories/Probe.stories.tsx'},
+      prOnly: {type: 'story', id: 'core-new--default', title: 'Core/New', name: 'Default', importPath: './stories/NewPrOnly.stories.tsx'},
       skipped: {type: 'story', id: 'core-skip--default', title: 'Core/Skip', name: 'Default', tags: ['no-visual']},
     }}));
     return {root, dist};
@@ -213,6 +214,7 @@ describe('readStoryIndex package metadata', () => {
       expect(indexed.find(value => value.id === 'lab-thing--default')).toMatchObject({packageName: '@astryxdesign/lab', stableVisual: false});
       expect(indexed.find(value => value.id === 'core-layer--default')).toMatchObject({packageName: '@astryxdesign/core', stableVisual: true});
       expect(indexed.find(value => value.id === 'core-probe--default')).toMatchObject({packageName: '@astryxdesign/theme-probe', stableVisual: false});
+      expect(indexed.find(value => value.id === 'core-new--default')).toMatchObject({packageName: '@astryxdesign/core', packageNames: ['@astryxdesign/core'], stableVisual: true});
       expect(indexed.some(value => value.id === 'core-skip--default')).toBe(false);
     } finally {
       fs.rmSync(root, {recursive: true, force: true});


### PR DESCRIPTION
## Why

Trusted `workflow_run` jobs inspect PR-built Storybook artifacts from a default-branch checkout. When a PR adds a new story without component metadata, its source file is not present on `main`, so package resolution failed and made the PR Comment workflow red even though CI had built the story successfully.

## What

Use an unambiguous package-scoped Storybook title as the fallback when the story source is unavailable, while continuing to reject titles that do not map to a known workspace package.

## Risk

Low. Existing component-path and import-based ownership remain preferred. The fallback only accepts package names already present in the trusted workspace catalog.

## Testing

- `npx --yes pnpm@11.10.0 exec vitest run .github/scripts/visual-gate/lib/plan.test.mjs`
- Re-ran `readStoryIndex` against the exact failed `storybook-fc8c184` artifact in a trusted-main checkout layout: all 1,865 stories resolved, including the PR-only Spinner story as `@astryxdesign/core`
