### PR TITLE
fix(ci): queue GitHub Pages deployments

### DIFF
--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -331,6 +331,66 @@ describe('visual acceptance workflow concurrency', () => {
     expect(releasePublisher).not.toContain('/tmp/gh-pages');
   });
 
+  it('enforces the main-push stable-site chain through the Actions Pages deployer', () => {
+    const stableSite = workflow('deploy.yml');
+    const pages = workflow('pages-deploy.yml');
+    const stableSiteHeader = stableSite.slice(
+      0,
+      stableSite.indexOf('\npermissions:'),
+    );
+
+    expect(stableSiteHeader).toContain('name: Deploy');
+    expect(stableSiteHeader).toContain("branches: ['main']");
+    expect(stableSite).toContain(
+      'node .github/scripts/gh-pages-publisher.mjs stable-site --source staged',
+    );
+    expect(pages).toContain("- 'Deploy'");
+    expect(pages).toContain('ref: gh-pages');
+    expect(pages).toContain('actions/upload-pages-artifact@v5');
+    expect(pages).toContain('actions/deploy-pages@v5');
+  });
+
+  it('deploys the latest gh-pages snapshot without cancelling an active deployment', () => {
+    const pages = workflow('pages-deploy.yml');
+    const reusablePreview = workflow('deploy-preview.yml');
+    const prComment = workflow('pr-comment.yml');
+    const directPublisherNames = fs
+      .readdirSync(WORKFLOWS)
+      .filter(file => file.endsWith('.yml'))
+      .filter(file => file !== 'deploy-preview.yml')
+      .map(file => workflow(file))
+      .filter(value => value.includes('gh-pages-publisher.mjs'))
+      .map(value => value.match(/^name: (.+)$/m)?.[1])
+      .filter(Boolean);
+
+    for (const source of directPublisherNames) {
+      expect(pages).toContain(`- '${source}'`);
+    }
+    expect(reusablePreview).toContain('workflow_call:');
+    expect(prComment).toContain('uses: ./.github/workflows/deploy-preview.yml');
+    expect(pages).toContain("- 'PR Comment'");
+    expect(pages).toContain('workflow_dispatch:');
+    expect(pages).toContain('group: github-pages-deployment');
+    expect(pages).toContain('cancel-in-progress: false');
+    expect(pages).toContain('pages: write');
+    expect(pages).toContain('id-token: write');
+    expect(pages).toContain('actions/configure-pages@v6');
+  });
+
+  it('queues an Actions deployment after the supported manual report publisher', () => {
+    const report = fs.readFileSync(
+      path.join(ROOT, 'internal/vibe-tests/src/deploy-report.ts'),
+      'utf8',
+    );
+    const publish = report.indexOf('gh-pages-publisher.mjs vibe-report');
+    const deploy = report.indexOf(
+      'gh workflow run pages-deploy.yml --repo ${shellQuote(repository)} --ref main',
+    );
+
+    expect(publish).toBeGreaterThan(-1);
+    expect(deploy).toBeGreaterThan(publish);
+  });
+
   it('grants queued gh-pages publishers read access to overlapping workflow runs', () => {
     const deploy = workflow('deploy.yml');
     const deployJob = deploy.slice(

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Deploy the latest serialized gh-pages snapshot after a workflow that can write
+# it settles. The legacy branch-source deployment starts once per queue commit
+# and cancels an in-progress deployment whenever a newer commit arrives. Under
+# normal PR traffic that can leave the public site permanently behind even
+# though every publisher succeeded.
+#
+# This workflow deliberately keeps the active deployment running. GitHub may
+# replace an older pending run with a newer one, but the current deployment
+# finishes and the newest queued run then deploys the latest branch snapshot.
+# Until the repository's Pages source is set to GitHub Actions, the source
+# check exits successfully and the deployment job stays skipped.
+
+name: Deploy GitHub Pages
+
+on:
+  workflow_run:
+    workflows:
+      - 'Deploy'
+      - 'PR Comment'
+      - 'Re-deploy Preview'
+      - 'Cleanup Preview Deployments'
+      - 'Release Gate'
+      - 'Visual Baseline'
+      - 'Visual acceptance'
+      - 'Visual acceptance promotion'
+      - 'Vibe Test Screenshots'
+      - 'Compact GitHub Pages History'
+    types: [completed]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: github-pages-deployment
+  cancel-in-progress: false
+
+jobs:
+  source:
+    runs-on: ubuntu-slim
+    permissions:
+      pages: read
+    outputs:
+      workflow: ${{ steps.source.outputs.workflow }}
+    steps:
+      - name: Check Pages deployment source
+        id: source
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const {data} = await github.rest.repos.getPages(context.repo);
+            const enabled = data.build_type === 'workflow';
+            core.setOutput('workflow', String(enabled));
+            if (!enabled) {
+              core.notice('GitHub Pages still uses the legacy branch source; switch the source to GitHub Actions, then dispatch this workflow.');
+            }
+
+  deploy:
+    needs: source
+    if: needs.source.outputs.workflow == 'true'
+    runs-on: ubuntu-slim
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout latest published site
+        uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload latest published site
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: .
+
+      - name: Deploy latest published site
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/internal/vibe-tests/src/deploy-report.ts
+++ b/internal/vibe-tests/src/deploy-report.ts
@@ -210,6 +210,18 @@ async function main() {
       {cwd: REPO_ROOT},
     );
 
+    const repository = getRepository();
+    if (!repository) {
+      throw new Error(
+        'Report was published to gh-pages, but the repository identity could not be resolved for the Pages deployment.',
+      );
+    }
+    run(
+      `gh workflow run pages-deploy.yml --repo ${shellQuote(repository)} --ref main`,
+      {cwd: REPO_ROOT},
+    );
+    console.log('   ✓ Queued the GitHub Actions Pages deployment');
+
     const repoUrl = getRepoUrl();
     const reportUrl = repoUrl
       ? `${repoUrl}/${deployPath}/`
@@ -315,17 +327,27 @@ function countFiles(dir: string, ext: string): number {
   return count;
 }
 
-function getRepoUrl(): string | null {
+function getRepository(): string | null {
+  const fromEnvironment = process.env.GITHUB_REPOSITORY;
+  if (fromEnvironment && /^[^/]+\/[^/]+$/.test(fromEnvironment)) {
+    return fromEnvironment;
+  }
   try {
     const remote = runSilent('git remote get-url origin', {cwd: REPO_ROOT});
     const match = remote.match(/github\.com[:/]([^/]+)\/([^/.]+)/);
-    if (match) {
-      return `https://${match[1]}.github.io/${match[2]}`;
-    }
+    return match ? `${match[1]}/${match[2]}` : null;
   } catch {
-    // ignore
+    return null;
   }
-  return null;
+}
+
+function getRepoUrl(): string | null {
+  const repository = getRepository();
+  if (!repository) {
+    return null;
+  }
+  const [owner, repo] = repository.split('/');
+  return `https://${owner}.github.io/${repo}`;
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Why

The shared publisher serializes `gh-pages` writers correctly, but its queue bookkeeping also writes to the served branch. During inspection, 23 of the 29 commits after the latest stable-site publish were queue coordination. Legacy Pages starts a deployment for each commit and cancels the active deployment when a newer commit arrives, so the public site can remain stale while every publisher succeeds.

## What

Deploy the latest `gh-pages` snapshot from one GitHub Actions workflow after any top-level publisher settles. Its concurrency keeps the active deployment running and coalesces older pending work behind the newest snapshot.

The stable-site path is explicitly enforced as:

`main` push → **Deploy** → shared publisher `stable-site` → `gh-pages` → **Deploy GitHub Pages** → Actions Pages deployment.

The contract test discovers every workflow that invokes the shared publisher and requires the Pages deployer to listen to its exact workflow name. The reusable preview publisher is proved to run under **PR Comment**. The supported manual vibe-report publisher now dispatches **Deploy GitHub Pages** after writing `gh-pages`.

The workflow checks the current Pages source first and skips cleanly until the repository is switched from **Deploy from a branch** to **GitHub Actions**.

## Risk

The published bytes are unchanged: existing workflows still own and serialize `gh-pages`. This only changes how that branch snapshot reaches the Pages environment. The existing environment policy already allows `main`.

## Testing

- `npx --yes pnpm@11.10.0 exec vitest run .github/scripts/visual-gate/workflow-concurrency.test.mjs`
- `actionlint -ignore 'label "2-core-ubuntu-arm" is unknown' -ignore 'shellcheck reported issue' .github/workflows/pages-deploy.yml`
- `npx --yes pnpm@11.10.0 exec prettier --check .github/workflows/pages-deploy.yml .github/scripts/visual-gate/workflow-concurrency.test.mjs internal/vibe-tests/src/deploy-report.ts`
- `npx --yes pnpm@11.10.0 exec eslint --no-warn-ignored .github/scripts/visual-gate/workflow-concurrency.test.mjs internal/vibe-tests/src/deploy-report.ts`
- `deploy-report.ts` transpilation and argument validation
- Real Chromium: the current landing page, Storybook, Sandbox, and an existing PR preview all returned HTTP 200 with no page errors; the live `latest` marker lagged the published branch during queue churn
- pre-commit repository checks

## One-time rollout after merge

1. In **Settings → Pages**, change **Build and deployment → Source** to **GitHub Actions**.
2. Dispatch **Deploy GitHub Pages** once; later publisher workflows trigger it automatically.
