### PR TITLE
chore(changesets): add remaining PR references

### DIFF
--- a/.changeset/rtl-contextual-separators.md
+++ b/.changeset/rtl-contextual-separators.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Breadcrumbs mirrors its built-in slash separator in right-to-left layouts
+[fix] Breadcrumbs mirrors its built-in slash separator in right-to-left layouts (#5365)
 
 Fixes #5364.
 

--- a/.changeset/theming-targets-guard-nested.md
+++ b/.changeset/theming-targets-guard-nested.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] `themingTargets.test.ts` now discovers component sources at any depth under `src`, not only in a top-level directory. Sources nested a level down — `Table/plugins/<name>/` — were silently exempt from the guard, which is the same drift #3741 was filed to prevent. Nothing was failing (no nested source rendered a `themeProps()` class before this release), so this closes the hole rather than fixing a live break: the guard goes from 294 to 302 assertions.
+[fix] `themingTargets.test.ts` now discovers component sources at any depth under `src`, not only in a top-level directory. (#5784) Sources nested a level down — `Table/plugins/<name>/` — were silently exempt from the guard, which is the same drift #3741 was filed to prevent. Nothing was failing (no nested source rendered a `themeProps()` class before this release), so this closes the hole rather than fixing a live break: the guard goes from 294 to 302 assertions.
 @freddymeta


### PR DESCRIPTION
## Why

Two pending v0.5.3 changesets retain their GitHub issue references but still lack the pull request that introduced the change.

## What

- add PR #5365 to the Breadcrumbs RTL summary while retaining `Fixes #5364`
- add PR #5784 to the nested theming-target guard summary while retaining issue #3741

No other text or attribution changes.

## Validation

- verified both mappings against the introducing merge commits and GitHub metadata
- `pnpm check:changesets`
- Prettier on both files
- repository pre-commit checks
- public-content scrub