### PR TITLE
fix(Selector): align selected item after layer flips

### DIFF
--- a/.changeset/fix-selector-flipped-overlay.md
+++ b/.changeset/fix-selector-flipped-overlay.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep Selector's selected-item overlay aligned when anchor positioning flips the menu, and expose the signed `translateY` correction from `useSelectedItemOffset` while preserving its existing `offset`. (#5835)
+
+@cixzhang

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -91,6 +91,20 @@
     }
   },
   {
+    "component": "Selector",
+    "storyId": "core-selector--default",
+    "dims": [
+      "D2"
+    ],
+    "setup": {
+      "click": "[role=\"combobox\"]"
+    },
+    "selectors": {
+      "prev": ".astryx-selector-option-row:first-of-type > span:first-child",
+      "next": ".astryx-selector-option-row:first-of-type > span:last-child"
+    }
+  },
+  {
     "component": "TabList",
     "storyId": "core-tablist--overflow",
     "dims": [

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -914,6 +914,42 @@ export const PlacementAbove: Story = {
   },
 };
 
+export const SelectedItemOverlayNearViewportBottom: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => {
+    const [value, setValue] = useState('Gamma');
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'center',
+          boxSizing: 'border-box',
+          paddingBottom: 52,
+        }}>
+        <div style={{width: 250}}>
+          <Selector
+            label="Selected item overlay near viewport bottom"
+            options={['Alpha', 'Beta', 'Gamma', 'Delta']}
+            value={value}
+            onChange={setValue}
+          />
+        </div>
+      </div>
+    );
+  },
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector('[role="combobox"]');
+    if (trigger instanceof HTMLElement) {
+      trigger.click();
+    }
+  },
+};
+
 export const Placements: Story = {
   render: () => {
     const [below, setBelow] = useState('Banana');

--- a/packages/core/src/Selector/Selector.spec.md
+++ b/packages/core/src/Selector/Selector.spec.md
@@ -7,7 +7,7 @@ authority: current
 archive_reason: null
 superseded_by: null
 approved_by: cixzhang
-approved_at: 2026-08-30
+approved_at: 2026-09-02
 owners: [cixzhang, imdreamrunner]
 review_triggers: [public-api, behavior, layout, theming, accessibility]
 verified_by:
@@ -88,6 +88,25 @@ and examples remain in `Selector.doc.mjs`.
 | popup semantics        | `listbox`; modal dialog containing one | Semantics follow the active presentation                 | Popover; bottom sheet                     | `listbox` | Selector | released  | No separate role prop is public |
 | option-row state       | `selected`, `disabled`                 | Stable theming state on each option row                  | Every rendered option                     | neither   | Selector | released  | Unknown states are not emitted  |
 | read-only state        | `false`, `true`                        | Preserves and submits value without selection affordance | Closed trigger                            | `false`   | Caller   | additive  | Boolean normalization           |
+
+### Public hook contract
+
+`useSelectedItemOffset` exposes the selected-row alignment calculation for
+consumers building on Selector's positioning foundation. It accepts the open
+state, selected-item index, listbox id/ref, and outer anchor ref. After the open
+popover's existing hidden layout pass, it returns:
+
+- `offset`: the released non-negative distance from the below-anchor origin;
+  consumers using the original composition apply it as a negative block-start
+  margin;
+- `translateY`: an additive signed correction from the browser-resolved layer top
+  to the viewport-clamped target; consumers apply it with CSS `translate` so a
+  `position-try-fallbacks` choice remains stable; and
+- `isPositioned`: whether the measurement pass is complete and the surface may be
+  revealed.
+
+`translateY` is additive. `offset` retains its released name, sign, and meaning so
+existing hook consumers do not need to migrate.
 
 ## Behavioral and layout contract
 

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -14,6 +14,7 @@ import {readFileSync} from 'node:fs';
 import {
   act,
   render,
+  renderHook,
   screen,
   fireEvent,
   waitFor,
@@ -24,6 +25,7 @@ import * as stylex from '@stylexjs/stylex';
 import {useState} from 'react';
 import type {ReactNode} from 'react';
 import {Selector} from './Selector';
+import {useSelectedItemOffset} from './hooks';
 import {SelectorOption} from './SelectorOption';
 import {Item} from '../Item';
 import type {SelectorOptionData} from './types';
@@ -157,6 +159,7 @@ function mockSelectorRects({
   listboxLayoutHeight = listbox.height,
   selectedItemLayoutTop = selectedItem.top - listbox.top,
   selectedItemLayoutHeight = selectedItem.height,
+  popoverLayoutTop = anchor.bottom,
   viewportHeight = 200,
 }: {
   anchor?: DOMRect;
@@ -166,6 +169,7 @@ function mockSelectorRects({
   listboxLayoutHeight?: number;
   selectedItemLayoutTop?: number;
   selectedItemLayoutHeight?: number;
+  popoverLayoutTop?: number;
   viewportHeight?: number;
 } = {}) {
   const originalGetBoundingClientRect =
@@ -205,6 +209,9 @@ function mockSelectorRects({
   Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
     configurable: true,
     get() {
+      if (this.hasAttribute('popover')) {
+        return popoverLayoutTop;
+      }
       if (this.getAttribute('role') === 'listbox') {
         return 0;
       }
@@ -253,6 +260,43 @@ function mockSelectorRects({
 }
 
 describe('Selector', () => {
+  it('preserves public offset semantics while adding signed translation', async () => {
+    const restoreRects = mockSelectorRects();
+    const anchor = document.createElement('div');
+    anchor.className = 'astryx-selector';
+    const listbox = document.createElement('div');
+    listbox.id = 'public-offset-listbox';
+    listbox.setAttribute('role', 'listbox');
+    const selectedItem = document.createElement('div');
+    selectedItem.id = 'public-offset-listbox-item-1';
+    listbox.appendChild(selectedItem);
+    document.body.append(anchor, listbox);
+
+    try {
+      const {result} = renderHook(() =>
+        useSelectedItemOffset({
+          isOpen: true,
+          selectedItemIndex: 1,
+          listboxId: listbox.id,
+          listboxRef: {current: listbox},
+          anchorRef: {current: anchor},
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current).toEqual({
+          offset: 110,
+          translateY: -110,
+          isPositioned: true,
+        });
+      });
+    } finally {
+      anchor.remove();
+      listbox.remove();
+      restoreRects();
+    }
+  });
+
   it('uses a bottom sheet and closes after a selection when requested', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
@@ -538,9 +582,46 @@ describe('Selector', () => {
         .getByRole('listbox', {hidden: true})
         .closest('[popover]');
       await waitFor(() => {
-        expect(popover?.getAttribute('style')).toContain(
-          'margin-block-start: -110px',
-        );
+        expect(popover?.getAttribute('style')).toContain('translate: 0 -110px');
+      });
+    } finally {
+      restoreRects();
+    }
+  });
+
+  it("uses the layer's resolved layout top during the existing measurement pass (#5835)", async () => {
+    const restoreRects = mockSelectorRects({
+      anchor: rect({top: 648, bottom: 668, height: 20}),
+      trigger: rect({top: 648, bottom: 668, height: 20}),
+      listbox: rect({top: 512, bottom: 648, height: 136}),
+      selectedItem: rect({top: 544, bottom: 576, height: 32}),
+      listboxLayoutHeight: 136,
+      selectedItemLayoutTop: 32,
+      selectedItemLayoutHeight: 32,
+      popoverLayoutTop: 512,
+      viewportHeight: 720,
+    });
+    const user = userEvent.setup();
+
+    try {
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={() => {}}
+        />,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      const popover = screen
+        .getByRole('listbox', {hidden: true})
+        .closest('[popover]');
+      await waitFor(() => {
+        // CSS placed the 136px menu above the 648px anchor (top 512). The
+        // viewport clamp wants top 584, so the same pre-paint pass moves it
+        // down 72px without changing CSS's chosen fallback.
+        expect(popover?.getAttribute('style')).toContain('translate: 0 72px');
       });
     } finally {
       restoreRects();
@@ -581,9 +662,7 @@ describe('Selector', () => {
         .closest('[popover]');
       await waitFor(() => {
         // 68px geometric alignment plus the 1px optical correction.
-        expect(popover?.getAttribute('style')).toContain(
-          'margin-block-start: -69px',
-        );
+        expect(popover?.getAttribute('style')).toContain('translate: 0 -69px');
       });
     } finally {
       restoreRects();
@@ -641,9 +720,7 @@ describe('Selector', () => {
         .getByRole('listbox', {hidden: true})
         .closest('[popover]');
       await waitFor(() => {
-        expect(popover?.getAttribute('style')).not.toContain(
-          'margin-block-start',
-        );
+        expect(popover?.getAttribute('style')).not.toContain('translate:');
       });
     } finally {
       restoreRects();
@@ -722,7 +799,7 @@ describe('Selector', () => {
           .closest('[popover]') as HTMLElement;
         await waitFor(() => {
           expect(popover.getAttribute('style')).toContain(
-            'margin-block-start: -110px',
+            'translate: 0 -110px',
           );
         });
         expect(popover.style.getPropertyValue('--x-marginBlockStart')).toBe('');

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1105,7 +1105,7 @@ export function Selector<T extends SelectorOptionType>(
   // placement opts out of the selector-specific overlay behavior and uses the
   // standard layer positioning API instead.
   const shouldOverlaySelectedItem = placement == null && !hasSearch;
-  const {offset: rawOffset, isPositioned: rawIsPositioned} =
+  const {translateY: rawTranslateY, isPositioned: rawIsPositioned} =
     useSelectedItemOffset({
       isOpen: popover.isOpen && shouldOverlaySelectedItem,
       selectedItemIndex,
@@ -1114,12 +1114,14 @@ export function Selector<T extends SelectorOptionType>(
       anchorRef,
     });
 
-  const selectedItemOffset = shouldOverlaySelectedItem ? rawOffset : 0;
+  const selectedItemTranslateY = shouldOverlaySelectedItem ? rawTranslateY : 0;
   const isPositioned = shouldOverlaySelectedItem ? rawIsPositioned : true;
   const popoverPlacement = placement ?? 'below';
+  // Individual translate composes with the layer's transform animation and,
+  // unlike margin, cannot make position-try-fallbacks choose a different side.
   const popoverOffsetStyle: React.CSSProperties | undefined =
-    selectedItemOffset > 0
-      ? {marginBlockStart: `-${selectedItemOffset}px`}
+    selectedItemTranslateY !== 0
+      ? {translate: `0 ${selectedItemTranslateY}px`}
       : undefined;
 
   // Clear the current value. Shared by the clear button and the keyboard
@@ -1686,8 +1688,8 @@ export function Selector<T extends SelectorOptionType>(
       placement: popoverPlacement,
       alignment: 'start',
       // The system's standard menu clearance, except in overlay mode:
-      // there the measured negative margin owns the block geometry and
-      // the menu is meant to sit on the trigger, not clear it.
+      // there the measured translation owns the block geometry and the
+      // menu is meant to sit on the trigger, not clear it.
       offset: shouldOverlaySelectedItem
         ? undefined
         : spacingVars['--spacing-1'],

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -4,10 +4,15 @@
 
 /**
  * @file hooks.ts
- * @input Uses untransformed DOM layout geometry from the Selector's outer
- *   anchor, listbox, and selected option
+ * @input Uses resolved Layer placement plus untransformed DOM layout geometry
+ *   from the Selector's outer anchor, listbox, and selected option
  * @output Hooks for Selector
- * @position Internal hooks; used by Selector.tsx
+ * @position Internal module; exports public Selector hooks through index.ts
+ *
+ * SYNC: When modifying useSelectedItemOffset, update:
+ * - /packages/core/src/Selector/useSelectedItemOffset.doc.mjs
+ * - /packages/core/src/Selector/Selector.spec.md
+ * - /packages/core/src/Selector/Selector.test.tsx
  */
 
 import {useCallback, useState} from 'react';
@@ -47,19 +52,36 @@ interface UseSelectedItemOffsetOptions {
 }
 
 interface UseSelectedItemOffsetResult {
+  /**
+   * Legacy positive distance from the below-anchor origin. Apply as a negative
+   * block-start margin when composing the original positioning behavior.
+   */
   offset: number;
+  /**
+   * Signed correction from the browser-resolved layer top to the clamped target.
+   * Apply with CSS `translate` so anchor fallback selection remains stable.
+   */
+  translateY: number;
   isPositioned: boolean;
 }
 
 /**
- * Calculates the offset needed to position the dropdown so that the selected
- * item appears centered over the outer selector control (macOS-style selector).
+ * Calculates the translation needed to position the dropdown so that the
+ * selected item appears centered over the outer selector control (macOS-style
+ * selector).
  *
  * The desired dropdown top is calculated directly from the anchor center and
  * selected-item center, then clamped to the viewport. This preserves the
  * default "selected item over trigger" behavior while letting the menu slide
  * upward near the bottom edge or downward near the top edge instead of being
  * clipped off-screen.
+ *
+ * CSS anchor positioning may place the layer above or below before this layout
+ * effect runs. The popover's `offsetTop` is that resolved, untransformed layout
+ * position, so translating from it to the viewport-clamped target reuses the
+ * existing hidden measurement pass without parsing CSS or adding another pass.
+ * `translate` does not participate in `position-try-fallbacks`, so applying the
+ * correction cannot make the browser choose a different fallback.
  */
 export function useSelectedItemOffset({
   isOpen,
@@ -69,12 +91,15 @@ export function useSelectedItemOffset({
   anchorRef,
 }: UseSelectedItemOffsetOptions): UseSelectedItemOffsetResult {
   const [offset, setOffset] = useState(0);
+  const [translateY, setTranslateY] = useState(0);
   const [isPositioned, setIsPositioned] = useState(false);
 
   const commitPosition = useCallback(
-    (nextOffset: number, nextIsPositioned: boolean) => {
+    (nextOffset: number, nextTranslateY: number, nextIsPositioned: boolean) => {
       // eslint-disable-next-line @eslint-react/set-state-in-effect -- selector popover position is derived from DOM layout
       setOffset(nextOffset);
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- selector popover position is derived from DOM layout
+      setTranslateY(nextTranslateY);
       // eslint-disable-next-line @eslint-react/set-state-in-effect -- selector popover position is derived from DOM layout
       setIsPositioned(nextIsPositioned);
     },
@@ -83,13 +108,13 @@ export function useSelectedItemOffset({
 
   useIsomorphicLayoutEffect(() => {
     if (!isOpen) {
-      // Reset offset when closed
-      commitPosition(0, false);
+      // Reset translation when closed.
+      commitPosition(0, 0, false);
       return;
     }
 
     if (!listboxRef.current || !anchorRef.current) {
-      commitPosition(0, true);
+      commitPosition(0, 0, true);
       return;
     }
 
@@ -100,7 +125,7 @@ export function useSelectedItemOffset({
     const targetItem = document.getElementById(targetItemId);
 
     if (!targetItem) {
-      commitPosition(0, true);
+      commitPosition(0, 0, true);
       return;
     }
 
@@ -110,7 +135,7 @@ export function useSelectedItemOffset({
     // offset* metrics intentionally exclude the popover's entry transform.
     const listboxHeight = listbox.offsetHeight;
     if (listboxHeight <= 0) {
-      commitPosition(0, true);
+      commitPosition(0, 0, true);
       return;
     }
 
@@ -127,16 +152,18 @@ export function useSelectedItemOffset({
     // Desired top aligns the selected item's center with the anchor center.
     const desiredTop =
       anchorCenter - itemCenterInListbox - SELECTED_ITEM_OPTICAL_OFFSET;
-    const viewportHeight = window.innerHeight;
-    const maxTop = Math.max(0, viewportHeight - listboxHeight);
+    const view = listbox.ownerDocument.defaultView ?? window;
+    const maxTop = Math.max(0, view.innerHeight - listboxHeight);
     const clampedTop = Math.min(Math.max(desiredTop, 0), maxTop);
 
-    // useLayer positions the popover below the outer anchor. Apply a negative
-    // block-start margin to the layer container so the listbox top moves from
-    // anchorRect.bottom to clampedTop.
-    const clampedOffset = Math.max(0, anchorRect.bottom - clampedTop);
+    // The top-layer popover's offsetTop is its resolved layout top in the
+    // viewport. Unlike getBoundingClientRect(), it excludes the entry transform;
+    // unlike position-area, it needs no knowledge of which fallback won.
+    const popover = listbox.closest<HTMLElement>('[popover]');
+    const anchoredTop = popover?.offsetTop ?? anchorRect.bottom;
+    const offset = Math.max(0, anchorRect.bottom - clampedTop);
 
-    commitPosition(clampedOffset, true);
+    commitPosition(offset, clampedTop - anchoredTop, true);
   }, [
     isOpen,
     selectedItemIndex,
@@ -146,7 +173,7 @@ export function useSelectedItemOffset({
     commitPosition,
   ]);
 
-  return {offset, isPositioned};
+  return {offset, translateY, isPositioned};
 }
 
 // =============================================================================

--- a/packages/core/src/Selector/useSelectedItemOffset.doc.mjs
+++ b/packages/core/src/Selector/useSelectedItemOffset.doc.mjs
@@ -1,0 +1,150 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').HookDoc} */
+export const docs = {
+  name: 'useSelectedItemOffset',
+  displayName: 'useSelectedItemOffset',
+  group: 'Selector',
+  category: 'layout',
+  keywords: [
+    'selector',
+    'selected item',
+    'popover',
+    'anchor positioning',
+    'dropdown alignment',
+    'viewport clamp',
+    'position fallback',
+  ],
+  params: [
+    {
+      name: 'isOpen',
+      type: 'boolean',
+      description:
+        'Whether the selection surface is open and should be measured. Closing resets the result.',
+      required: true,
+    },
+    {
+      name: 'selectedItemIndex',
+      type: 'number',
+      description:
+        'Flat index of the selected option. A negative index aligns the first option.',
+      required: true,
+    },
+    {
+      name: 'listboxId',
+      type: 'string',
+      description:
+        'DOM id of the listbox. Option ids must follow `${listboxId}-item-${index}`.',
+      required: true,
+    },
+    {
+      name: 'listboxRef',
+      type: 'RefObject<HTMLDivElement | null>',
+      description:
+        'Ref for the rendered listbox whose height and selected row are measured.',
+      required: true,
+    },
+    {
+      name: 'anchorRef',
+      type: 'RefObject<HTMLElement | null>',
+      description:
+        'Ref for the outer control that the selected row should align over.',
+      required: true,
+    },
+  ],
+  returns: [
+    {
+      name: 'offset',
+      type: 'number',
+      description:
+        'Released non-negative distance from the below-anchor origin. Apply it as a negative block-start margin when using the original composition.',
+    },
+    {
+      name: 'translateY',
+      type: 'number',
+      description:
+        'Signed correction from the browser-resolved layer top to the viewport-clamped target. Apply it with CSS translate so position-try fallback selection stays stable.',
+    },
+    {
+      name: 'isPositioned',
+      type: 'boolean',
+      description:
+        'Whether the open-surface measurement is complete and the surface can be revealed.',
+    },
+  ],
+  usage: {
+    description:
+      'Headless selected-row alignment for Selector-like anchored surfaces. It measures during the open surface’s existing hidden layout pass, aligns the selected option over the outer control, and clamps the result to the viewport. Use offset for compatibility with the original negative-margin composition or translateY for anchor-positioned layers that may flip.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use translateY with CSS translate when the layer uses position-try-fallbacks, so applying the correction cannot trigger a different fallback.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep the surface hidden until isPositioned is true so the measurement does not create a visible intermediate position.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use offset only when maintaining the original below-anchor negative-margin composition.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use for ordinary popovers that do not align a selected row over their trigger: use Layer placement and offset instead.',
+      },
+    ],
+  },
+  relatedComponents: ['Selector', 'Popover'],
+  relatedHooks: ['useLayer'],
+  importPath: '@astryxdesign/core/Selector',
+};
+
+/** @type {import('@astryxdesign/cli/authoring').HookTranslationDoc} */
+export const docsDense = {
+  description:
+    'Aligns a selected option over an outer control and clamps it to the viewport during the existing hidden open-surface measurement pass.',
+  paramDescriptions: {
+    isOpen: 'surface open and ready to measure?',
+    selectedItemIndex:
+      'flat selected-option index; negative uses first option.',
+    listboxId: 'listbox id; option ids follow `${listboxId}-item-${index}`.',
+    listboxRef: 'rendered listbox ref.',
+    anchorRef: 'outer alignment-control ref.',
+  },
+  returnDescriptions: {
+    offset:
+      'non-negative distance from below-anchor origin; negate for legacy block-start margin composition.',
+    translateY:
+      'signed correction from resolved layer top; apply with CSS translate for flip-stable composition.',
+    isPositioned: 'measurement complete; surface may be revealed.',
+  },
+  usage: {
+    description:
+      'Headless selected-row overlay alignment. Use translateY for anchor-positioned layers that may flip; offset preserves the original negative-margin composition.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use translateY + CSS translate with position-try-fallbacks so correction does not change fallback selection.',
+      },
+      {
+        guidance: true,
+        description: 'Hide surface until isPositioned is true.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use offset only for original below-anchor margin composition.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use for ordinary popovers without selected-row overlay; use Layer placement/offset.',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Why

Selector's selected-item overlay correction assumed CSS anchor positioning had placed the menu below its trigger. When `position-try-fallbacks` flipped the menu above, the negative margin moved an already-flipped menu again and could pin or clip it at the viewport edge.

## What

Reuse the existing hidden layout measurement to read the popover's resolved, untransformed `offsetTop`, then translate from that actual position to the viewport-clamped selected-item alignment. `translate` stays outside anchor fallback fit calculations, so applying the correction cannot make the browser choose a different side.

`useSelectedItemOffset()` remains the one public composable foundation. It preserves the released non-negative `offset` and `isPositioned`, and additively returns signed `translateY` for flip-stable CSS-translate composition. The hook now has consumer-facing CLI docs and an explicit current contract.

Adds a regression for the flipped geometry, an open Storybook example with the trigger near the viewport bottom, and RTL coverage for Selector's logical option/indicator order.

## Risk

Scoped to the default non-search selected-item overlay. Existing hook consumers keep the released `offset` name, sign, and meaning. Search menus and explicit `placement` continue through normal Layer positioning unchanged.

## Testing

- `pnpm exec vitest run packages/core/src/Selector/Selector.test.tsx` (194 tests)
- targeted ESLint with zero warnings
- `pnpm -F @astryxdesign/core typecheck`
- knowledge, SYNC, and Changeset checks
- `astryx hook useSelectedItemOffset --dense` resolves the public hook and all three return fields
- Chromium at 800×720: resolved layout top 500 translated to viewport-safe 567–703; the selected row center matched the trigger center within the existing 1px optical offset
- Chromium unchanged path: below placement translated from layout top 398 to 297–433 with the same 1px optical alignment
- RTL audit: Selector option/indicator order flips correctly with no coverage gap

Fixes #5835
