### PR TITLE
fix(docsite): supply Selector preview defaults

### DIFF
--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -298,6 +298,21 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('Selector satisfies its required props via playground defaults', () => {
+    const selector = components['@astryxdesign/core'].find(
+      c => c.name === 'Selector',
+    );
+    expect(selector).toBeDefined();
+    expect(selector!.playground?.defaults).toMatchObject({
+      label: 'Fruit',
+      options: [
+        {value: 'apple', label: 'Apple'},
+        {value: 'banana', label: 'Banana'},
+        {value: 'orange', label: 'Orange'},
+      ],
+    });
+  });
+
   it('MetadataListItem declares a playground wrapper for realistic preview structure', () => {
     const core = components['@astryxdesign/core'];
     const metadataListItem = core.find(c => c.name === 'MetadataListItem');

--- a/apps/storybook/rtl-audit/verified-not-applicable.json
+++ b/apps/storybook/rtl-audit/verified-not-applicable.json
@@ -26,5 +26,9 @@
   {
     "component": "lab/CircularProgress",
     "reason": "No direction-sensitive visual, layout, or behavior. The track and fill are concentric SVG circles sharing one center; size, stroke, dash, and clockwise rotation are intentionally identical in LTR and RTL. The optional label is vertically stacked and centered, with no inline positioning or directional glyph."
+  },
+  {
+    "component": "core/Selector",
+    "reason": "Selector uses block-flow field content and an inline list of text options without directional icons, physical positioning, order-dependent layout, scrolling, dragging, or directional keyboard behavior. Its label, value text, status text, and option labels follow the document direction without component-specific mirroring."
   }
 ]

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -167,6 +167,16 @@ export const docs = {
     ],
   },
   description: 'Dropdown selector for choosing from a list of options.',
+  playground: {
+    defaults: {
+      label: 'Fruit',
+      options: [
+        {value: 'apple', label: 'Apple'},
+        {value: 'banana', label: 'Banana'},
+        {value: 'orange', label: 'Orange'},
+      ],
+    },
+  },
   props: [
     {
       name: 'label',


### PR DESCRIPTION
## Summary
- add representative label and options defaults for the Selector properties preview
- cover the extracted defaults so the required preview data cannot regress

Fixes #5904.

## Validation
- direct Selector documentation module check passed

The full docsite test suite was not run locally because dependencies are not installed in this checkout.