### PR TITLE
docs(ChatComposerTokenElement): add playground token fixture (#5886)

### DIFF
--- a/packages/core/src/Chat/ChatComposerTokenElement.doc.mjs
+++ b/packages/core/src/Chat/ChatComposerTokenElement.doc.mjs
@@ -8,6 +8,11 @@ export const docs = {
   displayName: 'Chat Composer Token Element',
   isHiddenFromOverview: true,
   description: 'Renders a single token chip outside the contentEditable input. Wraps a badge config or custom render function in the correct data-astryx-token span so the token serializes properly and stays visually consistent with tokens inside the composer.',
+  playground: {
+    defaults: {
+      token: {value: '@astryx', label: '@astryx', variant: 'blue'},
+    },
+  },
   props: [
     {
       name: 'token',


### PR DESCRIPTION
Closes #5886.

### Problem

On the `ChatComposerTokenElement` Properties tab, the preview renders:

> Interactive preview needs required props that cannot be generated automatically. Missing: token.

The doc has a required `token` prop of type `ChatComposerToken` but no `playground.defaults` entry for it, and the generic preview cannot synthesize that object automatically.

### Fix

Add a minimal badge-style `token` fixture to `playground.defaults`:

```js
playground: {
  defaults: {
    token: {value: '@astryx', label: '@astryx', variant: 'blue'},
  },
},
```

This follows the same pattern as other docs whose required props are objects — e.g. `Citation` (`source`), `NavMenu` (`children`), `Dialog` (`children`). The badge shape (`{value, label, variant?}`) matches `ChatComposerToken` as used elsewhere in the package (e.g. `ChatComposerInput.test.tsx`, which uses `variant: 'blue'`).

### Why it works

In `apps/docsite/src/components/component-detail/interactiveState.ts`, `buildInitialState()` seeds state from `playground.defaults` before computing missing props, and `getMissingRequiredProps()` only reports required props where `state[name] === undefined`. With the default present, `state.token` is defined, so `token` is no longer reported missing and the token chip renders.

Docs-only change (single `.doc.mjs`), no public API or runtime change.
