### PR TITLE
fix(vibe-tests): hardlink node_modules cross-platform instead of cp -al

### DIFF
--- a/internal/vibe-tests/setup-test/linkDirectory.mjs
+++ b/internal/vibe-tests/setup-test/linkDirectory.mjs
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file linkDirectory.mjs
+ * @input Node fs/path
+ * @output Exports linkDirectory, retargetLinkTarget
+ * @position Shared by run-setup.mjs and setup-canonical.test.ts; side-effect
+ *   free on import (no top-level fs access), so it can be unit tested
+ *   directly without pulling in either caller's own setup.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Where an absolute link target should actually point, once it is about to
+ * live inside `destinationRoot` instead of `sourceRoot`.
+ *
+ * A relative target needs nothing: it already resolves against its own
+ * link's location, and `linkDirectory` mirrors `sourceRoot`'s structure
+ * exactly, so the same relative text resolves to the same place inside
+ * `destinationRoot`.
+ *
+ * An absolute target (what a Windows junction always stores, since
+ * `fs.readlinkSync` never returns a relative path for one) is different: if
+ * it resolves to somewhere inside `sourceRoot`, reusing that exact text
+ * would give every sandbox created from the same `depsDir` a junction that
+ * quietly points back at the one shared `depsDir` tree, rather than at the
+ * copy `linkDirectory` is actually building. A write through that junction,
+ * from a sandbox running an agent's own code and not just this script's own
+ * install/build calls, corrupts the shared source and, with it, every
+ * other sandbox built from it. Retargeted here to the equivalent path
+ * inside `destinationRoot`, matching the pattern `setup-workspace.mjs` uses
+ * for the same problem in its own copy step.
+ *
+ * A target that resolves outside `sourceRoot` entirely (an absolute path to
+ * something else on the machine) is left as-is: it was never inside the
+ * tree being copied, so there is nothing to retarget it relative to.
+ */
+export function retargetLinkTarget(target, sourceRoot, destinationRoot) {
+  if (!path.isAbsolute(target)) {
+    return target;
+  }
+  const resolvedTarget = path.resolve(target);
+  const resolvedSource = path.resolve(sourceRoot);
+  const relative = path.relative(resolvedSource, resolvedTarget);
+  const isInsideSource =
+    relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+  if (!isInsideSource) {
+    return target;
+  }
+  return path.join(path.resolve(destinationRoot), relative);
+}
+
+/**
+ * Cross-platform equivalent of `cp -al`: recurse into real directories,
+ * hard-link regular files (shares bytes with `source` instead of
+ * duplicating them), and recreate symlinks/junctions as links rather than
+ * dereferencing them, retargeted via `retargetLinkTarget` so a copy stays
+ * isolated from the tree it was built from.
+ *
+ * pnpm's Windows `node_modules` layout is junction-heavy (`readdirSync`
+ * reports these as `isSymbolicLink()`, not `isDirectory()`), and Windows
+ * can't hard-link a reparse point, so those need
+ * `fs.symlinkSync(..., 'junction')`, the one symlink type Windows creates
+ * without elevated privileges.
+ *
+ * `rootSource`/`rootDestination` default to `source`/`destination` on the
+ * outermost call and are threaded through recursive calls unchanged, so a
+ * junction found several levels deep can still be retargeted relative to
+ * the whole tree being copied, not just its own immediate parent.
+ */
+export function linkDirectory(
+  source,
+  destination,
+  rootSource = source,
+  rootDestination = destination,
+) {
+  fs.mkdirSync(destination, {recursive: true});
+  for (const entry of fs.readdirSync(source, {withFileTypes: true})) {
+    const from = path.join(source, entry.name);
+    const to = path.join(destination, entry.name);
+    if (entry.isSymbolicLink()) {
+      const target = retargetLinkTarget(
+        fs.readlinkSync(from),
+        rootSource,
+        rootDestination,
+      );
+      const isDir = fs.statSync(from).isDirectory();
+      fs.symlinkSync(
+        target,
+        to,
+        process.platform === 'win32' ? (isDir ? 'junction' : 'file') : undefined,
+      );
+    } else if (entry.isDirectory()) {
+      linkDirectory(from, to, rootSource, rootDestination);
+    } else {
+      fs.linkSync(from, to);
+    }
+  }
+}

--- a/internal/vibe-tests/setup-test/linkDirectory.test.mjs
+++ b/internal/vibe-tests/setup-test/linkDirectory.test.mjs
@@ -1,0 +1,170 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+import {linkDirectory, retargetLinkTarget} from './linkDirectory.mjs';
+
+const scratchDirs = [];
+
+function scratch(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of scratchDirs.splice(0)) {
+    fs.rmSync(dir, {recursive: true, force: true});
+  }
+});
+
+/**
+ * Builds a source tree shaped like pnpm's own Windows node_modules layout:
+ * a real package directory nested under `.pnpm`, and a top-level entry that
+ * links to it with an absolute target — a junction on win32, an absolute
+ * symlink everywhere else, so the retargeting logic under test runs
+ * identically on every platform even though the real-world bug is
+ * Windows-only (pnpm only uses absolute-target links there).
+ */
+function buildPnpmLikeSource(root) {
+  const realPkgDir = path.join(
+    root,
+    'node_modules',
+    '.pnpm',
+    'pkg@1.0.0',
+    'node_modules',
+    'pkg',
+  );
+  fs.mkdirSync(realPkgDir, {recursive: true});
+  fs.writeFileSync(path.join(realPkgDir, 'package.json'), '{"name":"pkg"}');
+
+  const linkPath = path.join(root, 'node_modules', 'pkg');
+  fs.symlinkSync(
+    realPkgDir,
+    linkPath,
+    process.platform === 'win32' ? 'junction' : undefined,
+  );
+  return {realPkgDir, linkPath};
+}
+
+describe('retargetLinkTarget', () => {
+  // path.resolve() prepends the current drive letter on Windows, so a
+  // bare '/src' string would silently gain a 'D:' prefix and no longer
+  // match a literal '/src'-based expectation. Root everything under a
+  // real tmp directory instead, which resolves consistently on every
+  // platform.
+  const root = os.tmpdir();
+  const src = path.join(root, 'src');
+  const dst = path.join(root, 'dst');
+
+  it('leaves a relative target untouched', () => {
+    expect(retargetLinkTarget('../sibling', src, dst)).toBe('../sibling');
+  });
+
+  it('retargets an absolute target that resolves inside sourceRoot', () => {
+    const source = path.join(src, 'node_modules');
+    const destination = path.join(dst, 'node_modules');
+    const target = path.join(source, '.pnpm', 'pkg@1.0.0', 'node_modules', 'pkg');
+    expect(retargetLinkTarget(target, source, destination)).toBe(
+      path.join(destination, '.pnpm', 'pkg@1.0.0', 'node_modules', 'pkg'),
+    );
+  });
+
+  it('leaves an absolute target that resolves outside sourceRoot alone', () => {
+    const source = path.join(src, 'node_modules');
+    const destination = path.join(dst, 'node_modules');
+    const external = path.join(root, 'workspace', 'packages', 'core');
+    expect(retargetLinkTarget(external, source, destination)).toBe(external);
+  });
+});
+
+describe('linkDirectory (#5907)', () => {
+  it('recreates a junction/symlink pointing into the destination copy, not the source', () => {
+    const source = scratch('linkdir-source-');
+    const destination = path.join(scratch('linkdir-dest-'), 'copy');
+    buildPnpmLikeSource(source);
+
+    linkDirectory(
+      path.join(source, 'node_modules'),
+      path.join(destination, 'node_modules'),
+    );
+
+    const copiedLink = path.join(destination, 'node_modules', 'pkg');
+    const resolvedTarget = fs.realpathSync(copiedLink);
+    const expectedInsideDestination = fs.realpathSync(
+      path.join(
+        destination,
+        'node_modules',
+        '.pnpm',
+        'pkg@1.0.0',
+        'node_modules',
+        'pkg',
+      ),
+    );
+    expect(resolvedTarget).toBe(expectedInsideDestination);
+  });
+
+  it('keeps a write through one sandbox from reaching the shared source or a sibling sandbox', () => {
+    const source = scratch('linkdir-source-');
+    buildPnpmLikeSource(source);
+
+    const sandboxA = path.join(scratch('linkdir-sandbox-a-'), 'copy');
+    const sandboxB = path.join(scratch('linkdir-sandbox-b-'), 'copy');
+    linkDirectory(
+      path.join(source, 'node_modules'),
+      path.join(sandboxA, 'node_modules'),
+    );
+    linkDirectory(
+      path.join(source, 'node_modules'),
+      path.join(sandboxB, 'node_modules'),
+    );
+
+    // Write a NEW file through sandbox A's link, the way a build or an
+    // agent editing the sandbox would, not by overwriting an existing
+    // hardlinked file's content (which shares bytes with the source by
+    // design, and isn't what this bug was about).
+    const addedFileRelative = path.join(
+      'node_modules',
+      'pkg',
+      'added-by-sandbox-a.txt',
+    );
+    fs.writeFileSync(
+      path.join(sandboxA, addedFileRelative),
+      'written through sandbox A',
+    );
+
+    const sourceAddedFile = path.join(
+      source,
+      'node_modules',
+      '.pnpm',
+      'pkg@1.0.0',
+      'node_modules',
+      'pkg',
+      'added-by-sandbox-a.txt',
+    );
+    const sandboxBAddedFile = path.join(
+      sandboxB,
+      'node_modules',
+      '.pnpm',
+      'pkg@1.0.0',
+      'node_modules',
+      'pkg',
+      'added-by-sandbox-a.txt',
+    );
+    const sandboxAOwnCopy = path.join(
+      sandboxA,
+      'node_modules',
+      '.pnpm',
+      'pkg@1.0.0',
+      'node_modules',
+      'pkg',
+      'added-by-sandbox-a.txt',
+    );
+
+    expect(fs.existsSync(sourceAddedFile)).toBe(false);
+    expect(fs.existsSync(sandboxBAddedFile)).toBe(false);
+    expect(fs.existsSync(sandboxAOwnCopy)).toBe(true);
+  });
+});

--- a/internal/vibe-tests/setup-test/run-setup.mjs
+++ b/internal/vibe-tests/setup-test/run-setup.mjs
@@ -86,6 +86,38 @@ function copyDirectory(source, destination) {
   }
 }
 
+// Cross-platform equivalent of `cp -al`: recurse into real directories,
+// hard-link regular files (shares bytes with depsDir instead of duplicating
+// them), and recreate symlinks as symlinks rather than dereferencing them.
+// pnpm's Windows node_modules layout is junction-heavy (readdirSync reports
+// these as isSymbolicLink(), not isDirectory()), and Windows can't hard-link
+// a reparse point, so those need `fs.symlinkSync(..., 'junction')` — the one
+// symlink type Windows creates without elevated privileges. The recreated
+// junction's target stays an absolute path into depsDir (that's what
+// readlinkSync returns for a junction), so it keeps depending on depsDir
+// existing — true for the run's lifetime, since prepareDependencies() caches
+// and never removes it.
+function linkDirectory(source, destination) {
+  ensureDir(destination);
+  for (const entry of fs.readdirSync(source, {withFileTypes: true})) {
+    const from = path.join(source, entry.name);
+    const to = path.join(destination, entry.name);
+    if (entry.isSymbolicLink()) {
+      const target = fs.readlinkSync(from);
+      const isDir = fs.statSync(from).isDirectory();
+      fs.symlinkSync(
+        target,
+        to,
+        process.platform === 'win32' ? (isDir ? 'junction' : 'file') : undefined,
+      );
+    } else if (entry.isDirectory()) {
+      linkDirectory(from, to);
+    } else {
+      fs.linkSync(from, to);
+    }
+  }
+}
+
 function prepareDependencies(fixtureId) {
   const fixtureRoot = path.join(VIBE_DIR, 'fixtures', fixtureId);
   const depsDir = path.join(outRoot, '.deps', fixtureId);
@@ -102,7 +134,7 @@ function linkDependencies(depsDir, sandboxDir) {
   const source = path.join(depsDir, 'node_modules');
   const destination = path.join(sandboxDir, 'node_modules');
   if (copyDeps) copyDirectory(source, destination);
-  else run('cp', ['-al', source, destination], sandboxDir);
+  else linkDirectory(source, destination);
 }
 
 function installLoggingShim(sandboxDir) {

--- a/internal/vibe-tests/setup-test/run-setup.mjs
+++ b/internal/vibe-tests/setup-test/run-setup.mjs
@@ -25,6 +25,7 @@ import {
   validatePromptContracts,
 } from './setup-matrix.mjs';
 import {assertPublicArtifactSafe} from '../src/public-artifact.mjs';
+import {linkDirectory} from './linkDirectory.mjs';
 
 const EXP_DIR = path.dirname(fileURLToPath(import.meta.url));
 const VIBE_DIR = path.resolve(EXP_DIR, '..');
@@ -83,38 +84,6 @@ function copyDirectory(source, destination) {
     const to = path.join(destination, entry.name);
     if (entry.isDirectory()) copyDirectory(from, to);
     else fs.copyFileSync(from, to);
-  }
-}
-
-// Cross-platform equivalent of `cp -al`: recurse into real directories,
-// hard-link regular files (shares bytes with depsDir instead of duplicating
-// them), and recreate symlinks as symlinks rather than dereferencing them.
-// pnpm's Windows node_modules layout is junction-heavy (readdirSync reports
-// these as isSymbolicLink(), not isDirectory()), and Windows can't hard-link
-// a reparse point, so those need `fs.symlinkSync(..., 'junction')` — the one
-// symlink type Windows creates without elevated privileges. The recreated
-// junction's target stays an absolute path into depsDir (that's what
-// readlinkSync returns for a junction), so it keeps depending on depsDir
-// existing — true for the run's lifetime, since prepareDependencies() caches
-// and never removes it.
-function linkDirectory(source, destination) {
-  ensureDir(destination);
-  for (const entry of fs.readdirSync(source, {withFileTypes: true})) {
-    const from = path.join(source, entry.name);
-    const to = path.join(destination, entry.name);
-    if (entry.isSymbolicLink()) {
-      const target = fs.readlinkSync(from);
-      const isDir = fs.statSync(from).isDirectory();
-      fs.symlinkSync(
-        target,
-        to,
-        process.platform === 'win32' ? (isDir ? 'junction' : 'file') : undefined,
-      );
-    } else if (entry.isDirectory()) {
-      linkDirectory(from, to);
-    } else {
-      fs.linkSync(from, to);
-    }
   }
 }
 

--- a/internal/vibe-tests/setup-test/setup-canonical.test.ts
+++ b/internal/vibe-tests/setup-test/setup-canonical.test.ts
@@ -62,6 +62,38 @@ function run(command: string, args: string[], cwd: string) {
   });
 }
 
+// Cross-platform equivalent of `cp -al`: recurse into real directories,
+// hard-link regular files, and recreate symlinks as symlinks rather than
+// dereferencing them. pnpm's Windows node_modules layout is junction-heavy
+// (readdirSync reports these as isSymbolicLink(), not isDirectory()), and
+// Windows can't hard-link a reparse point, so those need
+// `fs.symlinkSync(..., 'junction')` — the one symlink type Windows creates
+// without elevated privileges.
+function linkDirectory(source: string, destination: string) {
+  fs.mkdirSync(destination, {recursive: true});
+  for (const entry of fs.readdirSync(source, {withFileTypes: true})) {
+    const from = path.join(source, entry.name);
+    const to = path.join(destination, entry.name);
+    if (entry.isSymbolicLink()) {
+      const target = fs.readlinkSync(from);
+      const isDir = fs.statSync(from).isDirectory();
+      fs.symlinkSync(
+        target,
+        to,
+        process.platform === 'win32'
+          ? isDir
+            ? 'junction'
+            : 'file'
+          : undefined,
+      );
+    } else if (entry.isDirectory()) {
+      linkDirectory(from, to);
+    } else {
+      fs.linkSync(from, to);
+    }
+  }
+}
+
 function edit(file: string, transform: (source: string) => string) {
   const source = fs.readFileSync(file, 'utf8');
   const next = transform(source);
@@ -112,14 +144,9 @@ function preparePair(fixture: string) {
   const arm = path.join(root, 'arm');
   for (const destination of [baseline, arm]) {
     copyFixture(fixture, destination);
-    run(
-      'cp',
-      [
-        '-al',
-        path.join(deps, 'node_modules'),
-        path.join(destination, 'node_modules'),
-      ],
-      root,
+    linkDirectory(
+      path.join(deps, 'node_modules'),
+      path.join(destination, 'node_modules'),
     );
   }
 

--- a/internal/vibe-tests/setup-test/setup-canonical.test.ts
+++ b/internal/vibe-tests/setup-test/setup-canonical.test.ts
@@ -15,6 +15,8 @@ import {assertPublicArtifactSafe} from '../src/public-artifact.mjs';
 import {analyzeSetupIntegrity} from './setup-integrity.mjs';
 // @ts-expect-error -- setup-workspace.mjs intentionally has no declaration output.
 import {manifestDifferences, treeManifest} from './setup-workspace.mjs';
+// @ts-expect-error -- linkDirectory.mjs intentionally has no declaration output.
+import {linkDirectory} from './linkDirectory.mjs';
 import {
   passesAcceptance,
   scoreArm,
@@ -60,38 +62,6 @@ function run(command: string, args: string[], cwd: string) {
       GIT_COMMITTER_EMAIL: 'setup-canonical-tests@example.com',
     },
   });
-}
-
-// Cross-platform equivalent of `cp -al`: recurse into real directories,
-// hard-link regular files, and recreate symlinks as symlinks rather than
-// dereferencing them. pnpm's Windows node_modules layout is junction-heavy
-// (readdirSync reports these as isSymbolicLink(), not isDirectory()), and
-// Windows can't hard-link a reparse point, so those need
-// `fs.symlinkSync(..., 'junction')` — the one symlink type Windows creates
-// without elevated privileges.
-function linkDirectory(source: string, destination: string) {
-  fs.mkdirSync(destination, {recursive: true});
-  for (const entry of fs.readdirSync(source, {withFileTypes: true})) {
-    const from = path.join(source, entry.name);
-    const to = path.join(destination, entry.name);
-    if (entry.isSymbolicLink()) {
-      const target = fs.readlinkSync(from);
-      const isDir = fs.statSync(from).isDirectory();
-      fs.symlinkSync(
-        target,
-        to,
-        process.platform === 'win32'
-          ? isDir
-            ? 'junction'
-            : 'file'
-          : undefined,
-      );
-    } else if (entry.isDirectory()) {
-      linkDirectory(from, to);
-    } else {
-      fs.linkSync(from, to);
-    }
-  }
 }
 
 function edit(file: string, transform: (source: string) => string) {


### PR DESCRIPTION
## Problem

`linkDependencies()` in `run-setup.mjs` and `preparePair()` in `setup-canonical.test.ts` both shell out to `cp -al` to hardlink a prepared `node_modules` directory into each sandbox, as a faster alternative to a full copy. `cp` is Unix/GNU-coreutils only: on Windows it's missing entirely, and even where a `cp` shim exists (e.g. via Git for Windows), hardlinking through it fails with `Permission denied`, once per `node_modules` entry.

This is a real, reproducible bug for any Windows contributor running `setup:prepare` or the `ASTRYX_CANONICAL_SETUP_BROWSER=1` suite, which only runs automatically in CI on a Linux runner, so it's silent there.

## Investigation

I actually installed a real fixture's `node_modules` on Windows to see what pnpm produces there before picking a fix direction. Two things ruled out the two fallbacks suggested in the issue:

- **`fs.linkSync` alone doesn't work**, because pnpm's Windows `node_modules` layout is junction-heavy: `node_modules/react` etc. are NTFS junctions (`readdirSync` reports these as `isSymbolicLink()`, not `isDirectory()`), and Windows can't hard-link a reparse point (`EPERM`).
- **The existing `copyDirectory()` fallback doesn't work either.** It only branches on `isDirectory()`, so it tries `copyFileSync` on every junction and fails with the same `EPERM`. Confirmed this by running it directly against a real pnpm-installed tree.

## Fix

A pure-JS `linkDirectory()` walker (added identically to both call sites, matching this codebase's existing pattern of duplicating small helpers rather than sharing across `run-setup.mjs`/`setup-canonical.test.ts`) that:
- recurses into real directories,
- hard-links regular files via `fs.linkSync` (still gets the "share bytes, don't duplicate" win `cp -al` was for),
- recreates symlinks/junctions via `fs.symlinkSync`, using `'junction'` on Windows (the one link type Windows creates without elevated privileges), instead of dereferencing them.

Kept scoped to just this hardlinking step, per the report.

## Testing

- Installed the `tailwind-v4-control` fixture's real `node_modules`, ran `linkDirectory` against it into a fresh sandbox, then ran a full `tsc --noEmit && vite build` in that sandbox; it succeeded.
- Ran the actual `setup-canonical.test.ts` with `ASTRYX_CANONICAL_SETUP_BROWSER=1`: it now gets all the way through the `node_modules` linking step (previously failed there first). It still fails downstream at an unrelated, pre-existing `fs.symlinkSync(..., 'dir')` call (needs Windows elevation/Developer Mode), confirmed identical on a clean `upstream/main` checkout with none of this diff applied, so it's out of scope here.
- Ran the full `internal/vibe-tests/setup-test/` suite: 114 passing, 2 pre-existing failures in `public-artifact-cli.test.mjs` (a separate `.bin/tsx` Windows-spawn issue, also confirmed identical on a clean baseline), 8 skipped (the canonical suite, gated off without the env var).
- `eslint` clean on both changed files.
