### PR TITLE
fix(vibe-tests): run tsx through cmd.exe on Windows in public-artifact-cli.test.mjs

### DIFF
--- a/internal/vibe-tests/setup-test/public-artifact-cli.test.mjs
+++ b/internal/vibe-tests/setup-test/public-artifact-cli.test.mjs
@@ -25,10 +25,44 @@ afterEach(() => {
   }
 });
 
+// tsx is a .cmd (batch) shim on Windows; spawnSync can only run a batch file
+// through a shell, so shell out through cmd.exe /c directly rather than
+// spawnSync's shell:true (which triggers Node's shell-argument-escaping
+// deprecation warning DEP0190 even though every argument here is either a
+// hardcoded literal or a test-controlled path). See
+// internal/vibe-tests/src/fixture-suite.mjs for the same pattern applied to
+// pnpm.
+//
+// cmd.exe /c doesn't receive Node's argv array as discrete arguments the way
+// a normal executable does; it reconstructs one command-line string from
+// them and reparses it with its own rules, so an unquoted path containing a
+// space (this suite deliberately uses one, see the "setup report <pid>"
+// tmpdir below) gets split apart before tsx ever sees it. Quoting each
+// argument and joining into a single string fixes that half of it, but
+// spawnSync would then re-quote/escape that already-quoted string as if it
+// were one plain argument (since cmd.exe is, to Node, just another regular
+// executable), corrupting the quotes before cmd.exe ever sees them.
+// windowsVerbatimArguments skips Node's own quoting so our string reaches
+// cmd.exe as-is; the outer quote pair around the whole command line is what
+// makes cmd's /S switch strip it and treat the quoted TSX path inside as the
+// command rather than splitting on its internal spaces (both empirically
+// required together, verified by probing the plainer combinations first).
+function quoteForCmd(arg) {
+  return /[\s"]/.test(arg) ? `"${arg.replace(/"/g, '""')}"` : arg;
+}
+
 function run(script, args) {
-  return spawnSync(TSX, [script, ...args], {
+  if (process.platform !== 'win32') {
+    return spawnSync(TSX, [script, ...args], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+  }
+  const commandLine = [TSX, script, ...args].map(quoteForCmd).join(' ');
+  return spawnSync('cmd.exe', ['/d', '/s', '/c', `"${commandLine}"`], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
+    windowsVerbatimArguments: true,
   });
 }
 


### PR DESCRIPTION
## Problem

`public-artifact-cli.test.mjs` spawns `node_modules/.bin/tsx` directly via `spawnSync(TSX, [script, ...args], {cwd, encoding: 'utf8'})`. pnpm generates `tsx.cmd` on Windows (a batch shim), not a bare `tsx` executable, and `spawnSync` can't run a batch file without a shell. The spawn fails silently: `result.status` comes back `null` instead of a real exit code, `result.stderr` stays empty. Both tests asserting `result.status` to be `0` fail as a result.

Confirmed on a real Windows run before the fix: `npx vitest run internal/vibe-tests/setup-test/public-artifact-cli.test.mjs --project node`, 2 of 10 tests failing with `expected null to be +0`.

## Fix

Shells out through `cmd.exe /c` instead, matching the established pattern for pnpm elsewhere in this package. Needed two things beyond that baseline pattern, both required together (confirmed by testing simpler combinations first and watching them fail differently):

- **Quote each argument, join into one command-line string.** `cmd.exe /c` doesn't receive Node's argv array as discrete arguments; it reconstructs one string from them and reparses it with its own rules. This suite deliberately exercises a path containing a space (a `"setup report <pid>"` tmpdir), which gets split apart before `tsx` ever sees it without this.
- **`windowsVerbatimArguments: true`.** Without it, `spawnSync` re-quotes/escapes that already-quoted command-line string as if it were a single plain argument (since `cmd.exe` is, to Node, just another regular executable), corrupting the quotes before `cmd.exe` ever sees them.

## Testing

- Ran the actual test file, not just the source: both previously-failing tests now pass.
- Ran the full `internal/vibe-tests/setup-test/` suite: 116/124 passing (8 skipped, the unrelated env-gated canonical suite), up from 114 before this fix.
- `eslint` clean (the file matches this package's existing eslint ignore pattern, same as the other `internal/vibe-tests` scripts touched in prior PRs).

Related to the same root-cause bug class already fixed for pnpm in #5841 and #5843.