### PR TITLE
docs: add playground defaults for Selector, MultiSelector, ChatToolCalls (#5904, #5903, #5887)

### DIFF
--- a/packages/core/src/Chat/ChatToolCalls.doc.mjs
+++ b/packages/core/src/Chat/ChatToolCalls.doc.mjs
@@ -33,6 +33,15 @@ export const docs = {
     ],
   },
 
+  playground: {
+    defaults: {
+      calls: [
+        {name: 'read_file', status: 'complete', target: 'Button.tsx', duration: '120ms'},
+        {name: 'run_tests', status: 'complete', target: 'yarn test', duration: '1.2s', additions: 12, deletions: 3},
+      ],
+    },
+  },
+
   props: [
     {
       name: 'calls',

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -129,6 +129,17 @@ export const docs = {
     'filter',
     'select',
   ],
+  playground: {
+    defaults: {
+      label: 'Fruit',
+      options: [
+        {value: 'apple', label: 'Apple'},
+        {value: 'orange', label: 'Orange'},
+        {value: 'banana', label: 'Banana'},
+      ],
+      value: [],
+    },
+  },
   theming: {
     targets: [
       {

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -167,6 +167,16 @@ export const docs = {
     ],
   },
   description: 'Dropdown selector for choosing from a list of options.',
+  playground: {
+    defaults: {
+      label: 'Fruit',
+      options: [
+        {value: 'apple', label: 'Apple'},
+        {value: 'orange', label: 'Orange'},
+        {value: 'banana', label: 'Banana'},
+      ],
+    },
+  },
   props: [
     {
       name: 'label',


### PR DESCRIPTION
Closes #5904, closes #5903, closes #5887.

### Problem

Three component Properties previews render the placeholder *"Interactive preview needs required props that cannot be generated automatically"* because a required object/array prop has no `playground.defaults` fixture and the generic preview cannot synthesize it:

| Component | Issue | Missing required prop |
| --- | --- | --- |
| `Selector` | #5904 | `options: SelectorOption[]` |
| `MultiSelector` | #5903 | `options` (and `value`) |
| `ChatToolCalls` | #5887 | `calls: ChatToolCallItem[]` |

### Fix

Add a minimal representative `playground.defaults` fixture to each doc, matching each prop's documented shape:

- `Selector` / `MultiSelector` — `options` as `{value, label}` objects (the shape used in the components' own tests); MultiSelector also gets `value: []`.
- `ChatToolCalls` — `calls` as `ChatToolCallItem` objects (`name` is the only required field; `status: 'complete'` etc. included for a representative row).

This follows the established pattern in other docs (`Citation`, `NavMenu`, `ButtonGroup`). Placement matches each doc's structure — top-level `docs.playground` for the multi-component `MultiSelector` (as in `ButtonGroup`).

### Why it works

In `apps/docsite/src/components/component-detail/interactiveState.ts`, `buildInitialState()` seeds state from `playground.defaults` before `getMissingRequiredProps()` runs; that function only reports required props where `state[name] === undefined`. With the fixtures present, the previously-missing props are defined, so the missing-props placeholder is replaced by the real component.

Docs-only change (three `.doc.mjs` files); no public API or runtime change. Each fixture validated to parse and expose the expected `playground.defaults` keys.
