### PR TITLE
fix(lab): smooth CircularProgress indeterminate animation

### DIFF
--- a/apps/storybook/rtl-audit/verified-not-applicable.json
+++ b/apps/storybook/rtl-audit/verified-not-applicable.json
@@ -22,5 +22,9 @@
   {
     "component": "core/Timestamp",
     "reason": "Timestamp renders locale-formatted text and a direction-neutral hover card; it has no directional icons, contextual decorations, side-specific layout, order, scroll, drag, or directional keyboard behavior."
+  },
+  {
+    "component": "lab/CircularProgress",
+    "reason": "No direction-sensitive visual, layout, or behavior. The track and fill are concentric SVG circles sharing one center; size, stroke, dash, and clockwise rotation are intentionally identical in LTR and RTL. The optional label is vertically stacked and centered, with no inline positioning or directional glyph."
   }
 ]

--- a/packages/lab/src/CircularProgress/CircularProgress.tsx
+++ b/packages/lab/src/CircularProgress/CircularProgress.tsx
@@ -143,18 +143,20 @@ const indeterminateRotation = stylex.keyframes({
   '100%': {transform: 'rotate(360deg)'},
 });
 
+// SVG dash percentages scale with the square viewport. A 300% gap exceeds every
+// ring circumference; shifting the 2% + 300% pattern by 302% closes the loop.
 const indeterminateDash = stylex.keyframes({
   '0%': {
-    strokeDasharray: '1, 150',
-    strokeDashoffset: '0',
+    strokeDasharray: '2%, 300%',
+    strokeDashoffset: '0%',
   },
   '50%': {
-    strokeDasharray: '90, 150',
-    strokeDashoffset: '-35',
+    strokeDasharray: '175%, 300%',
+    strokeDashoffset: '-68%',
   },
   '100%': {
-    strokeDasharray: '90, 150',
-    strokeDashoffset: '-124',
+    strokeDasharray: '2%, 300%',
+    strokeDashoffset: '-302%',
   },
 });
 


### PR DESCRIPTION
## Summary

- scale the indeterminate dash with SVG viewport percentages so every size uses the same proportional animation without `pathLength` rescaling
- make the final keyframe match the initial dash geometry and shift exactly one full dash period, removing the loop snap
- record CircularProgress as direction-neutral for the RTL audit

## Root cause

The old fixed-unit animation had two discontinuities:

- the 64px ring's path is about 185 units, but the initial `1, 150` dash pattern totals 151, so SVG repeated it and briefly painted a second dash
- the final keyframe kept a 90-unit dash through 100%, then reset it to 1 unit in one frame

The new `2%, 300%` pattern scales with the square SVG viewport. Its 300% gap exceeds every ring circumference, and the `-302%` endpoint shifts one complete pattern, so the next iteration begins at equivalent geometry.

Related to #4133.

## Visual proof

Frozen at the first animation frame, before (left) and after (right):

![CircularProgress before and after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5916/pr-assets/pr-5916-circular-progress-before-after.png)

The extra dash near the top of the 64px ring is the flash seen at normal speed.

Chromium boundary samples for the shrinking dash: `16.1272% → 5.41198% → 2.53244% → 2.05847% → 2.00058% → 2%`. The loop no longer has a one-frame size collapse.

## Test plan

- `pnpm lint:strict`
- GitHub CI `test` job on exact head `8a0931b` — passed
- `pnpm exec vitest run packages/lab/src/CircularProgress/CircularProgress.test.tsx` — 32 passed
- `pnpm build`
- `pnpm -F @astryxdesign/lab typecheck`
- `pnpm -F @astryxdesign/storybook build`
- `pnpm -F @astryxdesign/storybook rtl-audit -- --filter CircularProgress` — verified N/A, zero gaps
- `node internal/stylex-capabilities/scan.mjs` — 83/92 supported
- Chromium: sampled eight points across the animation for all three sizes; the dash gap cannot repeat, the dash shrinks monotonically into the loop boundary, and no `pathLength` scaling is present

No changeset: `@astryxdesign/lab` is private/canary-only, and the repository changeset check passes without one.

— Puck, on behalf of Freddy
