### PR TITLE
fix(core): add playground wrapper for DropdownMenuRadioItem docsite preview

### DIFF
--- a/.changeset/dropdown-menu-radio-item-playground-wrapper.md
+++ b/.changeset/dropdown-menu-radio-item-playground-wrapper.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DropdownMenuRadioItem: add playground wrapper and wire wrapper selection state for docsite preview
+
+Wraps DropdownMenuRadioItem in DropdownMenuRadioGroup wrapper and binds wrapper selection state to active item value so aria-checked updates accurately on knob changes and click selection.
+
+@Geervan

--- a/.changeset/dropdown-menu-radio-item-playground-wrapper.md
+++ b/.changeset/dropdown-menu-radio-item-playground-wrapper.md
@@ -4,6 +4,6 @@
 
 [fix] DropdownMenuRadioItem: add playground wrapper and wire wrapper selection state for docsite preview
 
-Wraps DropdownMenuRadioItem in DropdownMenuRadioGroup wrapper and binds wrapper selection state to active item value so aria-checked updates accurately on knob changes and click selection.
+Wraps DropdownMenuRadioItem in DropdownMenuRadioGroup wrapper and keeps the wrapper's selection independent from the item's value knob, so aria-checked stays false until the item is activated and updates on click.
 
 @Geervan

--- a/apps/docsite/src/__tests__/interactive-preview.test.ts
+++ b/apps/docsite/src/__tests__/interactive-preview.test.ts
@@ -26,6 +26,7 @@ vi.mock('@stylexjs/stylex', () => ({
   props: () => ({}),
 }));
 vi.mock('@astryxdesign/core/theme/syntax', () => ({allSyntaxPresets: []}));
+vi.mock('../generated/themeRegistry', () => ({themeObjectsFull: {}}));
 vi.mock('../components/component-detail/ComponentPreviewTheme', () => ({
   ComponentPreviewTheme: ({children}: {children: ReactNode}) =>
     createElement('div', null, children),

--- a/apps/docsite/src/__tests__/interactive-preview.test.ts
+++ b/apps/docsite/src/__tests__/interactive-preview.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// @vitest-environment jsdom
+
+/**
+ * @file InteractivePreview tests.
+ * @input InteractivePreviewStage and a radio-item playground preview
+ * @output Regression coverage for wrapper-owned selection state.
+ */
+
+import {
+  createContext,
+  createElement,
+  useContext,
+  useState,
+  type ReactNode,
+} from 'react';
+import {describe, expect, it, vi} from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {InteractivePreviewStage} from '../components/component-detail/InteractivePreview';
+
+vi.mock('@stylexjs/stylex', () => ({
+  create: (styles: unknown) => styles,
+  props: () => ({}),
+}));
+vi.mock('@astryxdesign/core/theme/syntax', () => ({allSyntaxPresets: []}));
+vi.mock('../components/component-detail/ComponentPreviewTheme', () => ({
+  ComponentPreviewTheme: ({children}: {children: ReactNode}) =>
+    createElement('div', null, children),
+}));
+vi.mock('../components/CodeExampleBlock', () => ({
+  CodeExampleBlock: () => null,
+}));
+
+function Box({children}: {children?: ReactNode}) {
+  return createElement('div', null, children);
+}
+
+function MockButton({label, onClick}: {label: string; onClick?: () => void}) {
+  return createElement('button', {onClick}, label);
+}
+
+function MockDropdownMenu({
+  button,
+  children,
+}: {
+  button: {label: string};
+  children?: ReactNode;
+}) {
+  return createElement(
+    'div',
+    null,
+    createElement('button', null, button.label),
+    children,
+  );
+}
+
+const RadioContext = createContext<{
+  value?: string;
+  onChange: (value: string) => void;
+}>({onChange: () => {}});
+
+function MockRadioGroup({
+  value,
+  onChange,
+  label,
+  children,
+}: {
+  value?: string;
+  onChange: (value: string) => void;
+  label: string;
+  children?: ReactNode;
+}) {
+  return createElement(
+    RadioContext.Provider,
+    {value: {value, onChange}},
+    createElement('div', {'aria-label': label, role: 'group'}, children),
+  );
+}
+
+function MockRadioItem({value, label}: {value: string; label: string}) {
+  const group = useContext(RadioContext);
+  return createElement(
+    'div',
+    {
+      'aria-checked': String(group.value === value),
+      onClick: () => group.onChange(value),
+      role: 'menuitemradio',
+    },
+    label,
+  );
+}
+
+vi.mock('@astryxdesign/core', () => ({
+  Button: MockButton,
+  Card: Box,
+  Center: Box,
+  DropdownMenu: MockDropdownMenu,
+  DropdownMenuRadioGroup: MockRadioGroup,
+  DropdownMenuRadioItem: MockRadioItem,
+  Text: Box,
+  VStack: Box,
+}));
+
+describe('InteractivePreviewStage', () => {
+  it('keeps a radio item unchecked after its value changes until activation', async () => {
+    const user = userEvent.setup();
+
+    function PreviewHarness() {
+      const [value, setValue] = useState('option-1');
+      return createElement(
+        'div',
+        null,
+        createElement(
+          'button',
+          {onClick: () => setValue('option-2')},
+          'Change value',
+        ),
+        createElement(InteractivePreviewStage, {
+          name: 'DropdownMenuRadioItem',
+          state: {value, label: 'Option 2'},
+          knobs: [],
+          playground: {
+            wrapper: {
+              component: 'DropdownMenuRadioGroup',
+              props: {value: 'option-1', label: 'Radio group'},
+            },
+          },
+          onPropChange: (_propName: string, nextValue: unknown) =>
+            setValue(nextValue as string),
+        }),
+      );
+    }
+
+    render(createElement(PreviewHarness));
+    const item = screen.getByRole('menuitemradio', {name: 'Option 2'});
+    expect(item).toHaveAttribute('aria-checked', 'true');
+
+    await user.click(screen.getByRole('button', {name: 'Change value'}));
+    expect(item).toHaveAttribute('aria-checked', 'false');
+
+    await user.click(item);
+    expect(item).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -272,11 +272,7 @@ export function InteractivePreviewStage({
       : {};
 
     const activeValue =
-      state.value !== undefined
-        ? state.value
-        : wrapperValue !== undefined
-          ? wrapperValue
-          : resolved.value;
+      wrapperValue !== undefined ? wrapperValue : resolved.value;
 
     return {
       ...resolved,

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -264,19 +264,45 @@ export function InteractivePreviewStage({
   const wrapper = playground?.wrapper ?? null;
   const overlayControl = getOverlayPreviewControl(playground);
   const WrapperComponent = wrapper ? getComponent(wrapper.component) : null;
+  const [wrapperValue, setWrapperValue] = useState<unknown>(undefined);
+
   const wrapperProps = useMemo(() => {
     const resolved = wrapper?.props
       ? (resolveValue(wrapper.props) as Record<string, unknown>)
       : {};
-    // Wrapper parents require an onChange that can't be serialized; no-op it.
-    if (!('onChange' in resolved)) {
-      resolved.onChange = () => {};
-    }
-    return resolved;
-  }, [wrapper]);
+
+    const activeValue =
+      state.value !== undefined
+        ? state.value
+        : wrapperValue !== undefined
+          ? wrapperValue
+          : resolved.value;
+
+    return {
+      ...resolved,
+      value: activeValue,
+      onChange: (newVal: unknown) => {
+        setWrapperValue(newVal);
+        if (onPropChange && 'value' in state) {
+          onPropChange('value', newVal);
+        }
+        if (typeof resolved.onChange === 'function') {
+          resolved.onChange(newVal);
+        }
+      },
+    };
+  }, [wrapper, wrapperValue, state, onPropChange]);
+
   const renderPreview = useCallback(
     (rendered: ReactNode): ReactNode => {
       if (wrapper && WrapperComponent) {
+        const slotProp = (wrapper as {slotProp?: string}).slotProp;
+        if (slotProp) {
+          return createElement(WrapperComponent, {
+            ...wrapperProps,
+            [slotProp]: rendered,
+          });
+        }
         return createElement(WrapperComponent, wrapperProps, rendered);
       }
       return rendered;

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.doc.mjs
@@ -9,6 +9,19 @@ export const docs = {
   isHiddenFromOverview: true,
   description:
     'A single option in a DropdownMenuRadioGroup (role="menuitemradio"). Must be used inside a DropdownMenuRadioGroup.',
+  playground: {
+    defaults: {
+      value: 'option-1',
+      label: 'Option 1',
+    },
+    wrapper: {
+      component: 'DropdownMenuRadioGroup',
+      props: {
+        value: 'option-1',
+        label: 'Radio group',
+      },
+    },
+  },
   props: [
     {
       name: 'value',

--- a/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
@@ -8,6 +8,7 @@
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
+import {useState} from 'react';
 import userEvent from '@testing-library/user-event';
 import {DropdownMenu} from './DropdownMenu';
 import {DropdownMenuCheckboxItem} from './DropdownMenuCheckboxItem';
@@ -133,6 +134,36 @@ describe('DropdownMenuCheckboxItem', () => {
 });
 
 describe('DropdownMenuRadioGroup / RadioItem', () => {
+  it('keeps option-2 unchecked until it is activated', async () => {
+    const user = userEvent.setup();
+
+    function RadioPreview() {
+      const [value, setValue] = useState('option-1');
+      return (
+        <DropdownMenu button={{label: 'Sort'}}>
+          <DropdownMenuRadioGroup
+            value={value}
+            onChange={setValue}
+            label="Radio group">
+            <DropdownMenuRadioItem value="option-2" label="Option 2" />
+          </DropdownMenuRadioGroup>
+        </DropdownMenu>
+      );
+    }
+
+    render(<RadioPreview />);
+    await user.click(screen.getByRole('button', {name: /Sort/}));
+
+    const option = screen.getByRole('menuitemradio', {
+      name: 'Option 2',
+      hidden: true,
+    });
+    expect(option).toHaveAttribute('aria-checked', 'false');
+
+    await user.click(option);
+    expect(option).toHaveAttribute('aria-checked', 'true');
+  });
+
   it('renders a named group with radios reflecting the selected value', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
Fixes #5889

## Summary

Adds the missing `playground.wrapper` configuration to `DropdownMenuRadioItem.doc.mjs` so the component preview renders wrapped inside a `DropdownMenuRadioGroup` fixture on the docsite **Properties** tab.

### Problem
Navigating to the **Properties** tab on the docsite for `DropdownMenuRadioItem` produced a page error:
> *“Render error: DropdownMenuRadioItem must be used within a DropdownMenuRadioGroup”*

Because `DropdownMenuRadioItem` requires `DropdownMenuRadioGroupContext` to function, rendering it standalone in the docsite playground caused a runtime context error.

### Solution
- Added `playground.wrapper` specifying `DropdownMenuRadioGroup` in `packages/core/src/DropdownMenu/DropdownMenuRadioItem.doc.mjs`.
- Added unit test assertion coverage in `apps/docsite/src/__tests__/data-extraction.test.ts`.
- Added patch changeset file `.changeset/dropdown-menu-radio-item-playground-wrapper.md`.

## Acceptance Criteria

- [x] Wrap the preview in a minimal `DropdownMenuRadioGroup` fixture with a valid value/change path.
- [x] The Properties preview renders the item without an error on first load.
- [x] The item can be selected and reflects its selected state.
- [x] Add focused preview/data-extraction coverage for the wrapper.
