### PR TITLE
fix(core): add playground wrapper and defaults for LayoutHeader docsite preview

### DIFF
--- a/.changeset/layout-header-playground-wrapper.md
+++ b/.changeset/layout-header-playground-wrapper.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] LayoutHeader: add playground wrapper and default children for docsite preview
+
+Prevents the properties-tab preview on the docsite from rendering an empty stage by wrapping LayoutHeader inside a Layout scaffold with representative header text.
+
+@Geervan

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -311,6 +311,18 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('LayoutHeader declares a playground wrapper and default content so preview is not empty', () => {
+    const core = components['@astryxdesign/core'];
+    const layoutHeader = core.find(c => c.name === 'LayoutHeader');
+    expect(layoutHeader).toBeDefined();
+    expect(layoutHeader!.playground?.defaults).toMatchObject({
+      children: expect.any(String),
+    });
+    expect(layoutHeader!.playground?.wrapper).toMatchObject({
+      component: 'Layout',
+    });
+  });
+
   it('Lightbox declares an overlay playground with a closed initial state (#3657)', () => {
     const core = components['@astryxdesign/core'];
     const lightbox = core.find(c => c.name === 'Lightbox');

--- a/packages/core/src/Layout/LayoutHeader.doc.mjs
+++ b/packages/core/src/Layout/LayoutHeader.doc.mjs
@@ -8,6 +8,15 @@ export const docs = {
   displayName: 'Layout Header',
   isHiddenFromOverview: true,
   description: 'Top bar for page titles, app bars, and toolbars.',
+  playground: {
+    defaults: {
+      children: 'Page Title',
+      hasDivider: true,
+    },
+    wrapper: {
+      component: 'Layout',
+    },
+  },
   props: [
     {
       name: 'children',


### PR DESCRIPTION
## Summary
Fixes #5896

Adds default `children` and a `Layout` playground wrapper to `LayoutHeader.doc.mjs` so the component renders a visible header preview on the docsite **Properties** tab.

### Problem
Navigating to the **Properties** tab for `LayoutHeader` on the docsite displayed an empty preview stage because `LayoutHeader` had no default child text and no parent `Layout` scaffold declared in its `.doc.mjs` metadata.

### Solution
- Configured `playground.defaults` with `children: 'Page Title'` and `hasDivider: true` in `packages/core/src/Layout/LayoutHeader.doc.mjs`.
- Configured `playground.wrapper` with `{ component: 'Layout' }`.
- Added unit test assertion in `apps/docsite/src/__tests__/data-extraction.test.ts`.
- Included patch changeset file `.changeset/layout-header-playground-wrapper.md`.

## Acceptance Criteria Verification

- [x] Add representative header content and a minimal Layout playground wrapper.
- [x] The preview renders a visible header on first load.
- [x] A relevant header control such as divider or height produces an observable update.
- [x] Add focused preview/data-extraction coverage.
