### PR TITLE
fix(ci): give Pages uploads a full runner

### DIFF
--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -370,6 +370,10 @@ describe('visual acceptance workflow concurrency', () => {
     expect(prComment).toContain('uses: ./.github/workflows/deploy-preview.yml');
     expect(pages).toContain("- 'PR Comment'");
     expect(pages).toContain('workflow_dispatch:');
+    const deployJob = pages.slice(pages.indexOf('  deploy:'));
+    expect(deployJob).toContain('runs-on: ubuntu-latest');
+    expect(deployJob).toContain('timeout-minutes: 60');
+    expect(deployJob).not.toContain('runs-on: ubuntu-slim');
     expect(pages).toContain('group: github-pages-deployment');
     expect(pages).toContain('cancel-in-progress: false');
     expect(pages).toContain('pages: write');

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -59,8 +59,11 @@ jobs:
   deploy:
     needs: source
     if: needs.source.outputs.workflow == 'true'
-    runs-on: ubuntu-slim
-    timeout-minutes: 20
+    # The published branch is several GiB and contains hundreds of thousands of
+    # files. ubuntu-slim has a 15-minute hard job limit, which can interrupt the
+    # archive created by upload-pages-artifact before it reaches the upload step.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Why

The first GitHub Actions Pages rollout could not finish archiving the published `gh-pages` snapshot. The branch is about 5.46 GiB across 221,000 files, and the deploy job's `ubuntu-slim` runner was hard-cancelled at 15 minutes while `upload-pages-artifact` was still creating its tar archive. That leaves new stable and PR-preview publications unable to reach the live site.

## What

Run only the artifact-and-deploy job on `ubuntu-latest` and give it a 60-minute timeout. Keep the lightweight Pages-source probe on `ubuntu-slim`. Lock this requirement in the workflow regression test.

## Risk

Low: publication content and ordering are unchanged. The deploy job receives more time and a full hosted runner; the shared concurrency group still serializes deployments.

## Testing

- `vitest run .github/scripts/visual-gate/workflow-concurrency.test.mjs` — 27 passed
- `actionlint .github/workflows/pages-deploy.yml`
- Prettier check
- Repository pre-commit checks
