### PR TITLE
test(ci): probe PR-only Storybook ownership

### DIFF
--- a/apps/storybook/stories/CIProbePrOnly.stories.tsx
+++ b/apps/storybook/stories/CIProbePrOnly.stories.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {Button} from '@astryxdesign/core/Button';
+
+const meta: Meta = {
+  title: 'Core/CI Probe',
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const PackageOwnership: Story = {
+  render: () => <Button label="PR-only Story" />,
+};

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -2,6 +2,8 @@
 
 'use client';
 
+// CI probe only: touching a shipped component activates the trusted visual planner.
+
 /**
  * @file Button.tsx
  * @input Uses React, ButtonHTMLAttributes, ReactNode, i18n (useTranslator)


### PR DESCRIPTION
## Purpose

Temporary CI probe for the merged PR-only Storybook package-ownership fix.

This adds a new Storybook story file whose source does not exist on `main`. A temporary no-op comment in Button activates the trusted stable-visual planner, so default-branch code must resolve the PR-only story’s package from its built Storybook title before the preview can complete.

Do not merge. This PR will be closed after the live preview is verified.
