### PR TITLE
fix(Table): align the sortable header button with its column

### DIFF
--- a/.changeset/table-sortable-header-align.md
+++ b/.changeset/table-sortable-header-align.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table's sortable header button now follows its column's `align`, so an `align: 'end'` or `align: 'center'` column no longer gets a start-hugging header label sitting above right-aligned figures. Sorting wraps the header in a full-width flex button, which the `textAlign` that `align` sets on the cell cannot position; the alignment is now carried onto the button's main axis with a flow-relative `justify-content`, so it keeps mirroring under RTL.
+
+@ernestt

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
@@ -795,3 +795,75 @@ describe('useTableSortable — i18n', () => {
     ).toBeInTheDocument();
   });
 });
+
+// =============================================================================
+// Header Alignment
+// =============================================================================
+
+describe('useTableSortable — header alignment', () => {
+  // A column's `align` lands as `textAlign` on the <th>, which cannot position
+  // the contents of the full-width flex button the plugin renders inside it.
+  // The plugin has to mirror the alignment onto the button's main axis, or a
+  // numeric column gets a left-hugging header over right-aligned figures.
+  const buttonFor = (name: RegExp) => screen.getByRole('button', {name});
+
+  it('gives an end-aligned column a different button style than a default one', () => {
+    render(
+      <SortableTable
+        columns={[
+          {key: 'name', header: 'Name', sortable: true},
+          {key: 'age', header: 'Age', sortable: true, align: 'end'},
+        ]}
+      />,
+    );
+
+    expect(buttonFor(/sort by age/i).className).not.toBe(
+      buttonFor(/sort by name/i).className,
+    );
+  });
+
+  it('gives a center-aligned column a different button style than a default one', () => {
+    render(
+      <SortableTable
+        columns={[
+          {key: 'name', header: 'Name', sortable: true},
+          {key: 'age', header: 'Age', sortable: true, align: 'center'},
+        ]}
+      />,
+    );
+
+    expect(buttonFor(/sort by age/i).className).not.toBe(
+      buttonFor(/sort by name/i).className,
+    );
+  });
+
+  it('distinguishes end from center', () => {
+    render(
+      <SortableTable
+        columns={[
+          {key: 'name', header: 'Name', sortable: true, align: 'end'},
+          {key: 'age', header: 'Age', sortable: true, align: 'center'},
+        ]}
+      />,
+    );
+
+    expect(buttonFor(/sort by name/i).className).not.toBe(
+      buttonFor(/sort by age/i).className,
+    );
+  });
+
+  it('leaves a start-aligned column styled like an unaligned one', () => {
+    render(
+      <SortableTable
+        columns={[
+          {key: 'name', header: 'Name', sortable: true},
+          {key: 'age', header: 'Age', sortable: true, align: 'start'},
+        ]}
+      />,
+    );
+
+    expect(buttonFor(/sort by age/i).className).toBe(
+      buttonFor(/sort by name/i).className,
+    );
+  });
+});

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -136,6 +136,16 @@ const sortStyles = stylex.create({
     textAlign: 'inherit',
     borderRadius: radiusVars['--radius-inner'],
   },
+  // The button is a full-width flex container, so the `textAlign` a column's
+  // `align` puts on the <th> cannot position its contents. Mirror the column
+  // alignment onto the main axis, or an `align: 'end'` numeric column ends up
+  // with a left-hugging header over right-aligned figures.
+  buttonAlignCenter: {
+    justifyContent: 'center',
+  },
+  buttonAlignEnd: {
+    justifyContent: 'flex-end',
+  },
   iconWrapperUnsorted: {
     display: 'inline-flex',
     opacity: {
@@ -306,7 +316,14 @@ function SortHeaderButton<T extends Record<string, unknown>>({
   return (
     <button
       type="button"
-      {...focusOutlineProps.focusVisible(sortStyles.button)}
+      {...focusOutlineProps.focusVisible(
+        sortStyles.button,
+        column.align === 'end'
+          ? sortStyles.buttonAlignEnd
+          : column.align === 'center'
+            ? sortStyles.buttonAlignCenter
+            : null,
+      )}
       aria-label={ariaLabel}
       onClick={handleClick}>
       <span>{children}</span>


### PR DESCRIPTION
## What

A sortable column with `align: 'end'` rendered its header label hard against the start of the cell, sitting above right-aligned figures. Same for `align: 'center'`.

The cause is that `align` lands as `textAlign` on the `<th>`, and the sortable plugin renders a **full-width flex button** inside that cell. `textAlign` cannot position flex children, so the alignment stopped at the cell boundary and never reached the label.

This mirrors the column's alignment onto the button's main axis via `justify-content`. `flex-end` resolves against the flex direction rather than the physical box, so it keeps mirroring correctly under RTL.

## Why it's split out

Found while building an invoice template ([#5865](https://github.com/facebook/astryx/pull/5865)), where every numeric column is both sortable and end-aligned. Pulled into its own PR so the template stays a pure template change and this can be reviewed as the consumer-visible core fix it is.

## Scope

| File | Change |
|---|---|
| `useTableSortable.tsx` | +19/−2 — two StyleX rules, applied from `column.align` |
| `useTableSortable.test.tsx` | +72 — four tests |
| `.changeset/` | patch |

Only `align: 'end'` and `align: 'center'` are affected. `align: 'start'` and unaligned columns produce byte-identical output, which the fourth test pins.

## Test plan

`useTableSortable.test.tsx` — 44 pass, including four new cases asserting that end and center each produce a button style distinct from the default and from each other, and that `start` stays identical to unaligned.

Non-sortable columns never had the bug: without the plugin there is no button, and `textAlign` reaches the label directly.
