### PR TITLE
fix(theme-neutral): correct Banner tint modes

### DIFF
--- a/.changeset/neutral-banner-tint-modes.md
+++ b/.changeset/neutral-banner-tint-modes.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] Correct Neutral Banner interaction tints so light mode uses translucent light overlays and dark mode uses translucent dark overlays.
+
+@rubyycheung

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -68,14 +68,14 @@ const neutralLocalTokens: Record<string, TokenValue> = {
   '--astryx-theme-neutral-color-status-fill-success': ['#198100', '#64af4c'],
   '--astryx-theme-neutral-color-status-fill-warning': '#ffce2f',
   '--astryx-theme-neutral-color-status-fill-error': ['#c9303a', '#ff705d'],
-  '--astryx-theme-neutral-color-on-tint-neutral': ['#0a0a0a4D', '#fafafa4D'],
+  '--astryx-theme-neutral-color-on-tint-neutral': ['#fafafa4D', '#0a0a0a4D'],
   '--astryx-theme-neutral-color-on-tint-overlay-hover': [
-    '#0a0a0a1A',
     '#fafafa1A',
+    '#0a0a0a1A',
   ],
   '--astryx-theme-neutral-color-on-tint-overlay-pressed': [
-    '#0a0a0a33',
     '#fafafa33',
+    '#0a0a0a33',
   ],
 };
 

--- a/packages/themes/neutral/neutral.spec.md
+++ b/packages/themes/neutral/neutral.spec.md
@@ -60,9 +60,9 @@ the related roles below for exact-head review:
 | `--astryx-theme-neutral-color-status-fill-success`     | Filled success status                               | `['#198100', '#64af4c']`     | Proposed |
 | `--astryx-theme-neutral-color-status-fill-warning`     | Filled warning status                               | `'#ffce2f'`                  | Proposed |
 | `--astryx-theme-neutral-color-status-fill-error`       | Filled error status                                 | `['#c9303a', '#ff705d']`     | Proposed |
-| `--astryx-theme-neutral-color-on-tint-neutral`         | Neutral content placed on a semantic tinted surface | `['#0a0a0a4D', '#fafafa4D']` | Proposed |
-| `--astryx-theme-neutral-color-on-tint-overlay-hover`   | Hover overlay placed on a semantic tinted surface   | `['#0a0a0a1A', '#fafafa1A']` | Proposed |
-| `--astryx-theme-neutral-color-on-tint-overlay-pressed` | Pressed overlay placed on a semantic tinted surface | `['#0a0a0a33', '#fafafa33']` | Proposed |
+| `--astryx-theme-neutral-color-on-tint-neutral`         | Neutral content placed on a semantic tinted surface | `['#fafafa4D', '#0a0a0a4D']` | Proposed |
+| `--astryx-theme-neutral-color-on-tint-overlay-hover`   | Hover overlay placed on a semantic tinted surface   | `['#fafafa1A', '#0a0a0a1A']` | Proposed |
+| `--astryx-theme-neutral-color-on-tint-overlay-pressed` | Pressed overlay placed on a semantic tinted surface | `['#fafafa33', '#0a0a0a33']` | Proposed |
 
 AST-006 is current and accepted, and its implementation is proposed separately
 in the parent local-token PR. This stacked candidate authors and consumes exact

--- a/packages/themes/neutral/src/neutralTheme.test.ts
+++ b/packages/themes/neutral/src/neutralTheme.test.ts
@@ -48,3 +48,23 @@ describe('neutral theme-local status mappings', () => {
     expect(neutralTheme.components).not.toHaveProperty('table-row-status');
   });
 });
+
+describe('neutral Banner tint mappings', () => {
+  it('uses light overlays in light mode and dark overlays in dark mode', () => {
+    expect(neutralTheme.localTokens).toMatchObject({
+      '--astryx-theme-neutral-color-on-tint-neutral':
+        'light-dark(#fafafa4D, #0a0a0a4D)',
+      '--astryx-theme-neutral-color-on-tint-overlay-hover':
+        'light-dark(#fafafa1A, #0a0a0a1A)',
+      '--astryx-theme-neutral-color-on-tint-overlay-pressed':
+        'light-dark(#fafafa33, #0a0a0a33)',
+    });
+    expect(neutralTheme.components?.banner?.base).toMatchObject({
+      '--color-neutral': 'var(--astryx-theme-neutral-color-on-tint-neutral)',
+      '--color-overlay-hover':
+        'var(--astryx-theme-neutral-color-on-tint-overlay-hover)',
+      '--color-overlay-pressed':
+        'var(--astryx-theme-neutral-color-on-tint-overlay-pressed)',
+    });
+  });
+});

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -68,14 +68,14 @@ const neutralLocalTokens: Record<string, TokenValue> = {
   '--astryx-theme-neutral-color-status-fill-success': ['#198100', '#64af4c'],
   '--astryx-theme-neutral-color-status-fill-warning': '#ffce2f',
   '--astryx-theme-neutral-color-status-fill-error': ['#c9303a', '#ff705d'],
-  '--astryx-theme-neutral-color-on-tint-neutral': ['#0a0a0a4D', '#fafafa4D'],
+  '--astryx-theme-neutral-color-on-tint-neutral': ['#fafafa4D', '#0a0a0a4D'],
   '--astryx-theme-neutral-color-on-tint-overlay-hover': [
-    '#0a0a0a1A',
     '#fafafa1A',
+    '#0a0a0a1A',
   ],
   '--astryx-theme-neutral-color-on-tint-overlay-pressed': [
-    '#0a0a0a33',
     '#fafafa33',
+    '#0a0a0a33',
   ],
 };
 


### PR DESCRIPTION
## Summary

- correct the Neutral Banner on-tint values so light mode uses translucent light colors and dark mode uses translucent dark colors
- keep the maintained theme source, CLI template, and Neutral theme specification aligned
- add regression coverage for the tint tuple order and Banner token mappings

## Testing

- `pnpm exec vitest run packages/themes/neutral/src/neutralTheme.test.ts`
- `pnpm -F @astryxdesign/theme-neutral build`
- `pnpm exec eslint packages/themes/neutral/src/neutralTheme.ts packages/themes/neutral/src/neutralTheme.test.ts`
- `pnpm check:sync`
- `pnpm check:knowledge`
- `pnpm check:changesets`
- repository pre-commit validation suite