### PR TITLE
fix(docsite): keep example previews within padded frame

### DIFF
--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -3,6 +3,7 @@
 'use client';
 
 import {useEffect, useState, type ComponentType} from 'react';
+import * as stylex from '@stylexjs/stylex';
 import {Card} from '@astryxdesign/core/Card';
 import {Section} from '@astryxdesign/core/Section';
 import {Center} from '@astryxdesign/core/Center';
@@ -11,13 +12,24 @@ import {CodeExampleBlock} from '../CodeExampleBlock';
 import {TabList, Tab} from '@astryxdesign/core/TabList';
 import {Spinner} from '@astryxdesign/core/Spinner';
 import {Button} from '@astryxdesign/core/Button';
-import {HStack} from '@astryxdesign/core/Layout';
+import {HStack, overlayPaddingReset} from '@astryxdesign/core/Layout';
 import type {ExampleEntry} from '../../generated/exampleRegistry';
 import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {buildPlaygroundHref} from '../playgroundLink';
 import {trackOpenPlayground} from '../../lib/analytics';
 import {MarkdownText} from '../MarkdownText';
 import {preventPreviewNavigation} from './previewNavigation';
+
+const styles = stylex.create({
+  previewContent: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    justifyContent: 'safe center',
+    minWidth: 'fit-content',
+    width: '100%',
+    padding: 'var(--spacing-4)',
+  },
+});
 
 function LivePreview({
   entry,
@@ -67,10 +79,13 @@ function LivePreview({
         minHeight: 200,
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        // Center examples that fit, but keep the leading edge reachable when
+        // an example is wider than the preview frame.
+        justifyContent: 'safe center',
       }}
       {...previewNavigationProps}>
-      <div style={{minWidth: 'fit-content', padding: 'var(--spacing-4)'}}>
+      {/* Stop the Card's inherited padding variables at the preview boundary. */}
+      <div {...stylex.props(styles.previewContent, overlayPaddingReset.reset)}>
         <Component />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- preserve the existing 16px spacing around component examples
- keep oversized examples reachable from their leading edge when they overflow
- stop the surrounding Card's padding variables at the preview boundary so AppShell content is not clipped

## Screenshots

| Before | After |
| --- | --- |
| ![AppShell example before the fix](https://images.bent.build/astryx/example-preview-overflow/2026-09-03/before.png) | ![AppShell example after the fix](https://images.bent.build/astryx/example-preview-overflow/2026-09-03/after.png) |

<details>
<summary>Full-page comparison</summary>

### Before

![Full AppShell documentation page before the fix](https://images.bent.build/astryx/example-preview-overflow/2026-09-03/before-fullpage.png)

### After

![Full AppShell documentation page after the fix](https://images.bent.build/astryx/example-preview-overflow/2026-09-03/after-fullpage.png)

</details>
