### PR TITLE
docs(Center): add playground children fixture (#5891)

### DIFF
--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -9,6 +9,13 @@ export const docs = {
   category: 'Layout',
   isHiddenFromOverview: true,
   keywords: ["center","centered","centering","align","alignment","justify","flexbox","middle"],
+  playground: {
+    defaults: {
+      width: 240,
+      height: 120,
+      children: {__element: 'Text', props: {type: 'body'}, children: 'Centered content'},
+    },
+  },
   props: [
     {
       name: 'axis',


### PR DESCRIPTION
Closes #5891.

### Problem
The `Center` Properties preview renders empty because the doc has no `playground.defaults` — the generic preview has no child content to center, so there is nothing visible.

### Fix
Add a minimal `playground.defaults` with centered sample content and preview dimensions, using the `{__element}` descriptor pattern already used by other docs (e.g. `Dialog`):

```js
playground: {
  defaults: {
    width: 240,
    height: 120,
    children: {__element: 'Text', props: {type: 'body'}, children: 'Centered content'},
  },
},
```

### Result
The preview now demonstrates centering on first load, and the width/height/padding/axis controls produce an observable change. Docs-only change (single `.doc.mjs`); verified to parse and expose the expected `playground.defaults` keys.
