### PR TITLE
chore: add josephfarina as a code owner across the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,20 +2,20 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #
 # Matching is LAST-RULE-WINS, not cumulative: a file matched by a later, more
-# specific rule takes ONLY that rule's owners. So an owner of everything has to
-# appear on every line, not just on `*` — which is why @josephfarina is repeated
-# below rather than left to the default.
+# specific rule takes ONLY that rule's owners. Repository-wide stewards must
+# therefore appear on every line, not just on `*`; specialized owners stay on
+# their scoped rules alongside the stewards.
 
 * @cixzhang @imdreamrunner @josephfarina
 
-/packages/cli/ @josephfarina
+/packages/cli/ @cixzhang @imdreamrunner @josephfarina
 
-/packages/richtext/ @potatowagon @josephfarina
+/packages/richtext/ @cixzhang @imdreamrunner @josephfarina @potatowagon
 
-/packages/core/src/Table/ @humbertovirtudes @josephfarina
+/packages/core/src/Table/ @cixzhang @imdreamrunner @josephfarina @humbertovirtudes
 
-# The core README is the front door for component/CLI discovery — often the
+# The core README is the front door for component/CLI discovery, often the
 # first (and only) doc a consumer or agent reads. Scope it to a small set of
 # discovery owners so changes get focused review rather than a silent
 # "it's just docs" merge.
-/packages/core/README.md @cixzhang @josephfarina
+/packages/core/README.md @cixzhang @imdreamrunner @josephfarina

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,18 @@
 # Default reviewers for the Astryx repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Matching is LAST-RULE-WINS, not cumulative: a file matched by a later, more
+# specific rule takes ONLY that rule's owners. So an owner of everything has to
+# appear on every line, not just on `*` — which is why @josephfarina is repeated
+# below rather than left to the default.
 
-* @cixzhang @imdreamrunner
+* @cixzhang @imdreamrunner @josephfarina
 
 /packages/cli/ @josephfarina
 
-/packages/richtext/ @potatowagon
+/packages/richtext/ @potatowagon @josephfarina
 
-/packages/core/src/Table/ @humbertovirtudes
+/packages/core/src/Table/ @humbertovirtudes @josephfarina
 
 # The core README is the front door for component/CLI discovery — often the
 # first (and only) doc a consumer or agent reads. Scope it to a small set of


### PR DESCRIPTION
@cixzhang — I'd like to be a code owner across the repo rather than just on `/packages/cli/`, so I see changes as they go out instead of after. Flagging you since you're the default owner today.

## The one non-obvious bit

CODEOWNERS matching is **last-rule-wins, not cumulative**. A file matched by a later, more specific rule takes *only* that rule's owners. So adding me to `*` alone would not have made me an owner of everything — these two would still have excluded me:

```
/packages/richtext/            @potatowagon
/packages/core/src/Table/      @humbertovirtudes
```

I'm therefore added to each rule rather than just the default, and I left a comment in the file saying why, so the next person adding a scoped rule doesn't silently drop an owner.

Verified all five rules now list me, and no existing owner was removed:

| rule | before | after |
|---|---|---|
| `*` | cixzhang, imdreamrunner | + josephfarina |
| `/packages/cli/` | josephfarina | unchanged |
| `/packages/richtext/` | potatowagon | + josephfarina |
| `/packages/core/src/Table/` | humbertovirtudes | + josephfarina |
| `/packages/core/README.md` | cixzhang, josephfarina | unchanged |

## Blast radius

None on merges: `require_code_owner_reviews` is **false** on `main` and `required_approving_review_count` is **0**. This changes who gets *auto-requested*, not what is *required* — so it costs you nothing and doesn't gate anyone.

Happy to scope it back to `*` only if you'd rather the specific-path owners stay exclusive.