### PR TITLE
feat(useResizable): support CSS min()/max() constraints

### DIFF
--- a/.changeset/resizable-css-math-constraints.md
+++ b/.changeset/resizable-css-math-constraints.md
@@ -2,10 +2,12 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] useResizable: compose minSize and maxSize with CSS min()/max()
+[feat] useResizable: compose defaultSize, minSize, and maxSize with CSS min()/max()
 
-`minSize` and `maxSize` now accept recursive CSS `min()` and `max()` expressions over pixel and percentage leaves, including `max(40%, 333px)` and `min(400px, 10%)`. Percentage leaves follow the configured basis at any nesting depth. Other CSS functions, arithmetic, variables, and units remain invalid; malformed values keep the existing deterministic fallbacks and development warnings. If resolved bounds conflict, the maximum wins.
+`defaultSize`, `minSize`, and `maxSize` now accept recursive CSS `min()` and `max()` expressions over pixel and percentage leaves, including `max(40%, 333px)` and `min(400px, 10%)`. A composed `defaultSize` resolves once against the initial measurable basis and becomes a pixel choice; composed bounds continue following percentage leaves and re-clamp that choice when their basis changes.
 
-The new `ResizableConstraintValue` type documents this Resizable-only input without widening shared `SizeValue`. Released `defaultSize` typing and behavior, and the deprecated `minSizePx` / `maxSizePx` aliases, remain compatible.
+Other CSS functions, arithmetic, variables, and units remain invalid. Malformed values keep the existing role-specific deterministic fallbacks and development warnings. If resolved bounds conflict, the maximum still wins.
+
+The Resizable-specific `ResizableConstraintValue` narrows the new bound props without widening shared `SizeValue`. Released `defaultSize: number | string` typing, pixel-only `resize()`, and deprecated `minSizePx` / `maxSizePx` aliases remain compatible; runtime validation is authoritative for default strings.
 
 @freddymeta

--- a/.changeset/resizable-css-math-constraints.md
+++ b/.changeset/resizable-css-math-constraints.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] useResizable: compose minSize and maxSize with CSS min()/max()
+
+`minSize` and `maxSize` now accept recursive CSS `min()` and `max()` expressions over pixel and percentage leaves, including `max(40%, 333px)` and `min(400px, 10%)`. Percentage leaves follow the configured basis at any nesting depth. Other CSS functions, arithmetic, variables, and units remain invalid; malformed values keep the existing deterministic fallbacks and development warnings. If resolved bounds conflict, the maximum wins.
+
+The new `ResizableConstraintValue` type documents this Resizable-only input without widening shared `SizeValue`. Released `defaultSize` typing and behavior, and the deprecated `minSizePx` / `maxSizePx` aliases, remain compatible.
+
+@freddymeta

--- a/apps/storybook/stories/useResizable.stories.tsx
+++ b/apps/storybook/stories/useResizable.stories.tsx
@@ -30,10 +30,69 @@ const s = stylex.create({
     borderRadius: radiusVars['--radius-container'],
     margin: spacingVars['--spacing-2'],
   },
+  constraintStack: {
+    display: 'grid',
+    gap: spacingVars['--spacing-4'],
+  },
+  constraintFrame: {height: 120},
 });
 
 function HookDemo({children}: {children: React.ReactNode}) {
   return <div>{children}</div>;
+}
+
+function CssMathConstraintProbe({kind}: {kind: 'minimum' | 'maximum'}) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const isMinimum = kind === 'minimum';
+  const expression = isMinimum ? 'max(40%, 333px)' : 'min(400px, 10%)';
+  const region = useResizable(
+    isMinimum
+      ? {
+          defaultSize: 0,
+          minSize: 'max(40%, 333px)',
+          containerRef: frameRef,
+        }
+      : {
+          defaultSize: 500,
+          maxSize: 'min(400px, 10%)',
+          containerRef: frameRef,
+        },
+  );
+  const resolvedBound = isMinimum
+    ? region.props._minSizePx
+    : region.props._maxSizePx;
+  const testId = `css-math-${kind}`;
+
+  return (
+    <div
+      ref={frameRef}
+      data-testid={`${testId}-frame`}
+      data-expression={expression}
+      data-resolved-bound={resolvedBound}
+      data-size={region.size}
+      {...stylex.props(s.shell, s.constraintFrame)}>
+      <Layout
+        height="fill"
+        start={
+          <>
+            <LayoutPanel
+              width={region.size}
+              hasDivider={false}
+              data-testid={`${testId}-panel`}>
+              {Math.round(region.size)}px
+            </LayoutPanel>
+            <ResizeHandle
+              direction="horizontal"
+              hasDivider
+              label={`Resize ${kind} constraint example`}
+              resizable={region.props}
+            />
+          </>
+        }
+        content={<LayoutContent>{expression}</LayoutContent>}
+      />
+    </div>
+  );
 }
 
 const meta: Meta<typeof HookDemo> = {
@@ -370,6 +429,24 @@ export const PercentageSizing: Story = {
       </div>
     );
   },
+};
+
+/**
+ * Recursive CSS min()/max() constraints against a live container basis.
+ *
+ * The two rows intentionally keep the canonical expressions separate: combining
+ * this minimum and maximum would invert the bounds, in which case the maximum
+ * wins. Resize either frame to see percentage leaves recompute recursively.
+ */
+export const CssMathConstraints: Story = {
+  render: () => (
+    <div
+      data-testid="css-math-constraints"
+      {...stylex.props(s.constraintStack)}>
+      <CssMathConstraintProbe kind="minimum" />
+      <CssMathConstraintProbe kind="maximum" />
+    </div>
+  ),
 };
 
 /**

--- a/apps/storybook/stories/useResizable.stories.tsx
+++ b/apps/storybook/stories/useResizable.stories.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -91,6 +91,92 @@ function CssMathConstraintProbe({kind}: {kind: 'minimum' | 'maximum'}) {
         }
         content={<LayoutContent>{expression}</LayoutContent>}
       />
+    </div>
+  );
+}
+
+function CssMathDefaultProbe({
+  initialWidth,
+  label,
+}: {
+  initialWidth: number;
+  label: 'wide' | 'narrow';
+}) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const expression = 'max(40%, 333px)';
+  const storageKey = `storybook-css-math-default-${label}`;
+  const region = useResizable({
+    defaultSize: expression,
+    containerRef: frameRef,
+    autoSaveId: storageKey,
+  });
+
+  return (
+    <div
+      ref={frameRef}
+      data-testid={`css-math-default-${label}-frame`}
+      data-expression={expression}
+      data-initial-width={initialWidth}
+      data-size={region.size}
+      data-storage-key={`astryx-resizable:${storageKey}`}
+      {...stylex.props(s.shell, s.constraintFrame)}
+      style={{width: initialWidth}}>
+      <Layout
+        height="fill"
+        start={
+          <>
+            <LayoutPanel
+              width={region.size}
+              hasDivider={false}
+              data-testid={`css-math-default-${label}-panel`}>
+              <div {...stylex.props(s.card)}>
+                <strong>
+                  {label === 'wide' ? 'Wide' : 'Narrow'} initial basis ·{' '}
+                  {initialWidth}px outer / {initialWidth - 2}px content
+                </strong>
+                <div>
+                  <code>defaultSize: &apos;{expression}&apos;</code>
+                </div>
+                <div>{Math.round(region.size)}px initial pixel choice</div>
+              </div>
+            </LayoutPanel>
+            <ResizeHandle
+              direction="horizontal"
+              hasDivider
+              label={`Resize ${label} default expression example`}
+              resizable={region.props}
+            />
+          </>
+        }
+        content={
+          <LayoutContent>
+            Later container resizes do not rescale this initial choice.
+          </LayoutContent>
+        }
+      />
+    </div>
+  );
+}
+
+function CssMathDefaultsStory() {
+  const [storageReady, setStorageReady] = useState(false);
+
+  useEffect(() => {
+    localStorage.removeItem('astryx-resizable:storybook-css-math-default-wide');
+    localStorage.removeItem(
+      'astryx-resizable:storybook-css-math-default-narrow',
+    );
+    setStorageReady(true);
+  }, []);
+
+  if (!storageReady) {
+    return null;
+  }
+
+  return (
+    <div data-testid="css-math-defaults" {...stylex.props(s.constraintStack)}>
+      <CssMathDefaultProbe initialWidth={1000} label="wide" />
+      <CssMathDefaultProbe initialWidth={500} label="narrow" />
     </div>
   );
 }
@@ -429,6 +515,19 @@ export const PercentageSizing: Story = {
       </div>
     );
   },
+};
+
+/**
+ * A CSS math default chooses one initial pixel size, then stops following its basis.
+ *
+ * Both rows use `defaultSize: 'max(40%, 333px)'`. Their different initial
+ * containing blocks select different arms: 399px from the wide 998px content box,
+ * and 333px from the narrow 498px content box. Changing either containing block
+ * later does not rescale the selected size. Use `minSize: 'max(40%, 333px)'`
+ * instead when the expression should remain a persistent responsive floor.
+ */
+export const CssMathDefaults: Story = {
+  render: () => <CssMathDefaultsStory />,
 };
 
 /**

--- a/docs/specs/AST-010/spec.md
+++ b/docs/specs/AST-010/spec.md
@@ -21,11 +21,12 @@ affects_consumer_docs: [Resizable]
 ## Intent
 
 A person resizing a panel should get the same panel size that the handle presents
-and assistive technology announces. Builders may configure an initial size in
-pixels or as a percentage. Bounds additionally accept recursive CSS `min()` and
-`max()` expressions over pixel and percentage leaves, so common fluid floors and
-ceilings do not require CSS-only clamping. Every user-selected size remains pixels
-so pointer, keyboard, persistence, and programmatic behavior stay predictable.
+and assistive technology announces. Builders may configure an initial size or
+bounds with pixels, percentages, and recursive CSS `min()` / `max()` over those
+leaves. A `defaultSize` expression chooses one initial pixel size; a bound
+expression remains live and re-clamps that pixel selection when its basis changes.
+Every user-selected size remains pixels so pointer, keyboard, persistence, and
+programmatic behavior stay predictable.
 
 This spec preserves the released meaning of `defaultSize: 'N%'` when no
 `containerRef` is supplied: resolve once against `window.innerWidth` (or the
@@ -60,34 +61,35 @@ record is updated alongside that implementation.
 
 ## Requirements
 
-- **FR1 — Percentage configuration uses an explicit basis.** Without
-  `containerRef`, a percentage `defaultSize` MUST resolve once against
-  `window.innerWidth`, or 1200px when `window` is unavailable, preserving the
-  released fallback. With `containerRef`, it MUST resolve once against that
-  container's measured content-box active axis. After either resolution, the
-  selected size is pixels and MUST NOT scale when the viewport or container
-  changes.
+- **FR1 — Basis-dependent defaults use an explicit basis once.** Without
+  `containerRef`, a percentage leaf anywhere in `defaultSize` MUST resolve once
+  against `window.innerWidth`, or 1200px when `window` is unavailable, preserving
+  the released fallback. With `containerRef`, it MUST resolve once against that
+  container's first positive measured content-box active axis. A pure-pixel
+  expression needs no basis measurement. After resolution, the selected size is
+  pixels and MUST NOT scale when the viewport or container changes.
 - **FR2 — Direction selects the container basis.** With `containerRef`,
   horizontal resizing MUST use the container's content-box inline size and
   vertical resizing MUST use its content-box block size. RTL may reverse pointer
   delta, but MUST NOT change the percentage basis. Without `containerRef`, the
   compatibility basis remains `window.innerWidth` regardless of direction.
 - **FR3 — Interactions remain pixel-based.** Numeric defaults and every result of
-  a percentage default resolve to pixels. Pointer, keyboard, snap, collapse,
-  expand, persistence, callback, and programmatic resize paths MUST continue to
-  read and write pixel selections exactly as the released API does. No
-  interaction may create or preserve a percentage-selected mode.
-- **FR4 — Mixed and composed bounds remain valid.** Builders MAY combine pixel
-  and percentage values across `defaultSize`, `minSize`, and `maxSize`. Unified
-  bounds MAY recursively compose those leaves with CSS `min()` and `max()` up to
-  eight function levels. Numeric and `Npx` leaves remain pixels. Every percentage
-  leaf resolves against the same viewport or container basis as FR1; basis
-  dependency is recursive, so a percentage nested anywhere in an expression makes
-  that bound re-resolve whenever the basis changes. Re-resolved bounds clamp the
-  existing pixel selection; they MUST NOT scale it proportionally. If the resolved
-  minimum exceeds the resolved maximum, development MUST warn and the maximum MUST
-  win, preserving the released `Math.min(max, Math.max(min, size))` ordering and
-  guaranteeing finite, non-`NaN` geometry.
+  a percentage or CSS math default resolve to pixels. Pointer, keyboard, snap,
+  collapse, expand, persistence, callback, and programmatic resize paths MUST
+  continue to read and write pixel selections exactly as the released API does.
+  No interaction may create or preserve a relative selected mode.
+- **FR4 — Mixed and composed sizes remain valid.** Builders MAY combine pixel and
+  percentage values across `defaultSize`, `minSize`, and `maxSize`. `defaultSize`
+  and unified bounds MAY recursively compose those leaves with CSS `min()` and
+  `max()` up to eight function levels. Numeric and `Npx` leaves remain pixels.
+  Every percentage leaf resolves against the same viewport or container basis as
+  FR1; basis dependency is recursive. A composed default uses that dependency only
+  to obtain its initial pixel choice. A composed bound re-resolves whenever the
+  basis changes and clamps the existing pixel selection; it MUST NOT scale it
+  proportionally. If the resolved minimum exceeds the resolved maximum,
+  development MUST warn and the maximum MUST win, preserving the released
+  `Math.min(max, Math.max(min, size))` ordering and guaranteeing finite,
+  non-`NaN` geometry.
 - **FR5 — Effective geometry stays synchronized.** The effective selected pixel
   size, LayoutPanel or caller-rendered size, persisted expanded value, and
   ResizeHandle's `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` MUST describe
@@ -96,11 +98,11 @@ record is updated alongside that implementation.
   explicit exception: they report a rejected collapse or expand intent without
   claiming that the controlled owner changed the rendered size.
 - **FR6 — Basis changes update only percentage-dependent constraints.** Once a
-  percentage default has initialized the selected pixel size, a viewport or
-  container resize MUST NOT re-resolve that default. Bounds with a percentage leaf
-  at any nesting depth MUST re-resolve and clamp the selected pixel size. A
-  basis-only layout change MUST NOT fire an interaction callback or otherwise claim
-  that a person selected a new size.
+  percentage or CSS math default has initialized the selected pixel size, a
+  viewport or container resize MUST NOT re-resolve that default. Bounds with a
+  percentage leaf at any nesting depth MUST re-resolve and clamp the selected
+  pixel size. A basis-only layout change MUST NOT fire an interaction callback or
+  otherwise claim that a person selected a new size.
 - **FR7 — Pointer gestures preserve released behavior.** Pointer deltas continue
   from the selected pixel size. Percentage-dependent bounds MUST use one stable
   basis during a gesture; a basis change during the gesture takes effect after the
@@ -123,21 +125,23 @@ record is updated alongside that implementation.
   multi-region call MUST use one optional container and axis for all regions.
   Regions remain independently pixel-selected; this change MUST NOT add balancing,
   ratio preservation, or a 100% total invariant.
-- **FR12 — Invalid configuration has safe deterministic fallbacks.** The released
-  `defaultSize` input remains a non-negative finite number, an exact non-negative
-  finite `Npx` string, or an exact `N%` string from 0% through 100%. Unified
-  `minSize` and `maxSize` accept those same leaves plus full-match recursive CSS
-  `min()` and `max()` expressions, bounded to eight function levels. Empty
-  functions, malformed separators or parentheses, trailing input, other units,
-  `calc()`, `clamp()`, arithmetic, `var()`, negatives, out-of-range percentages,
-  and non-finite values are invalid. An invalid `defaultSize` MUST use 250px before
-  normal bounds clamping; an invalid `minSize` or `minSizePx` MUST use 50px; and an
-  invalid `maxSize` or `maxSizePx` MUST use unbounded `Infinity`. Explicit
-  `maxSizePx: Infinity` remains valid for compatibility because a shipped template
-  uses it. Development MUST warn for every fallback; production MUST use the same
-  fallback without warning. After initialization, an invalid raw value MUST NOT
-  directly replace a persisted or otherwise legal selected pixel size; a
-  fallback-normalized bound may affect that size only through normal clamping.
+- **FR12 — Invalid configuration has safe deterministic fallbacks.** Unified
+  runtime configuration accepts a non-negative finite number, an exact
+  non-negative finite `Npx` string, an exact `N%` string from 0% through 100%, or
+  full-match recursive CSS `min()` / `max()` expressions over those leaves,
+  bounded to eight function levels. `defaultSize` keeps its released
+  `number | string` public type, so runtime validation remains authoritative.
+  Empty functions, malformed separators or parentheses, trailing input, other
+  units, `calc()`, `clamp()`, arithmetic, `var()`, negatives, out-of-range
+  percentages, and non-finite values are invalid. An invalid `defaultSize` MUST
+  use 250px before normal bounds clamping; an invalid `minSize` or `minSizePx`
+  MUST use 50px; and an invalid `maxSize` or `maxSizePx` MUST use unbounded
+  `Infinity`. Explicit `maxSizePx: Infinity` remains valid for compatibility
+  because a shipped template uses it. Development MUST warn for every fallback;
+  production MUST use the same fallback without warning. After initialization,
+  an invalid raw value MUST NOT directly replace a persisted or otherwise legal
+  selected pixel size; a fallback-normalized bound may affect that size only
+  through normal clamping.
 
 ### Public API requirements
 
@@ -154,24 +158,28 @@ record is updated alongside that implementation.
   axis. ResizeHandle direction and hook direction MUST agree; the implementation
   MUST make a mismatch detectable in development. Direction affects the
   container basis only when `containerRef` is present.
-- **API3 — Bounds use one restricted Resizable vocabulary.** Add the public
-  `ResizableConstraintValue` type and use it for flat `minSize` and `maxSize`:
+- **API3 — One restricted runtime vocabulary, compatibility-preserving public
+  types.** `defaultSize`, flat `minSize`, and flat `maxSize` accept the same
+  runtime values: a non-negative finite number, exact `Npx`, exact `N%` from
+  0–100, or recursive lowercase CSS `min()` / `max()` over those leaves. Functions
+  accept one or more comma-separated expressions and recurse up to eight function
+  levels. Partial parses, trailing text, malformed separators or parentheses,
+  other units, negatives, non-finite values, `calc()`, `clamp()`, arithmetic,
+  `var()`, and every other function are invalid.
+
+  Add the public `ResizableConstraintValue` type for `minSize` and `maxSize`:
 
   ```ts
   type ResizableConstraintValue =
     number | `${number}px` | `${number}%` | `min(${string})` | `max(${string})`;
   ```
 
-  Runtime parsing remains authoritative for expression interiors and MUST match
-  the complete input. Functions are lowercase CSS `min()` or `max()` only, accept
-  one or more comma-separated expressions, recurse up to eight function levels,
-  and may contain only non-negative finite `Npx` or 0–100 `N%` leaves. Partial
-  parses, trailing text, malformed separators or parentheses, other units,
-  negatives, non-finite values, `calc()`, `clamp()`, arithmetic, `var()`, and
-  every other function are invalid. Keep the released `defaultSize?: SizeValue`
-  type and its existing number / exact `Npx` / exact `N%` runtime behavior; CSS
-  math is constraint-only. Do not add parallel `defaultSizePercent`,
-  `minSizePercent`, or `maxSizePercent` props.
+  Keep `defaultSize?: SizeValue` (`number | string`) exactly as released so
+  computed strings remain source-compatible. The wider type does not widen the
+  runtime grammar: parsing is authoritative for every value the type cannot
+  prove, and invalid strings take FR12's existing 250px fallback and development
+  warning. Do not add parallel `defaultSizePercent`, `minSizePercent`, or
+  `maxSizePercent` props.
 
 - **API4 — Pixel aliases are exactly mutually exclusive with unified bounds.**
   `minSizePx` and `maxSizePx` remain supported but become deprecated. TypeScript
@@ -205,15 +213,15 @@ record is updated alongside that implementation.
 
 ### Invalid configuration behavior
 
-| Input                                                      | Accepted values                                                                                  | Invalid fallback                | Development behavior                                         | Production behavior                |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
-| `defaultSize`                                              | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100               | 250px, then normal bounds clamp | warn and use fallback                                        | use same fallback without warning  |
-| `minSize`                                                  | `ResizableConstraintValue`; full-match runtime grammar from API3                                 | 50px                            | warn and use fallback                                        | use same fallback without warning  |
-| `minSizePx`                                                | non-negative finite number                                                                       | 50px                            | warn and use fallback                                        | use same fallback without warning  |
-| `maxSize`                                                  | `ResizableConstraintValue`; full-match runtime grammar from API3                                 | unbounded `Infinity`            | warn and use fallback                                        | use same fallback without warning  |
-| `maxSizePx`                                                | non-negative finite number or explicit `Infinity`                                                | unbounded `Infinity`            | warn for invalid values; do not warn for explicit `Infinity` | use same fallback without warning  |
-| old/new bound pair supplied together through untyped input | unified value is authoritative                                                                   | ignore deprecated alias         | warn and name the ignored alias                              | unified value wins without warning |
-| resolved minimum above resolved maximum                    | both values are individually valid, including after recursive CSS math and percentage resolution | maximum wins                    | warn and use released clamp order                            | use same ordering without warning  |
+| Input                                                      | Accepted values                                                                                                                                     | Invalid fallback                | Development behavior                                         | Production behavior                |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
+| `defaultSize`                                              | released `SizeValue` type; runtime accepts non-negative finite number, exact `Npx`, exact 0–100 `N%`, or recursive `min()` / `max()`; resolves once | 250px, then normal bounds clamp | warn and use fallback                                        | use same fallback without warning  |
+| `minSize`                                                  | `ResizableConstraintValue`; full-match runtime grammar from API3                                                                                    | 50px                            | warn and use fallback                                        | use same fallback without warning  |
+| `minSizePx`                                                | non-negative finite number                                                                                                                          | 50px                            | warn and use fallback                                        | use same fallback without warning  |
+| `maxSize`                                                  | `ResizableConstraintValue`; full-match runtime grammar from API3                                                                                    | unbounded `Infinity`            | warn and use fallback                                        | use same fallback without warning  |
+| `maxSizePx`                                                | non-negative finite number or explicit `Infinity`                                                                                                   | unbounded `Infinity`            | warn for invalid values; do not warn for explicit `Infinity` | use same fallback without warning  |
+| old/new bound pair supplied together through untyped input | unified value is authoritative                                                                                                                      | ignore deprecated alias         | warn and name the ignored alias                              | unified value wins without warning |
+| resolved minimum above resolved maximum                    | both values are individually valid, including after recursive CSS math and percentage resolution                                                    | maximum wins                    | warn and use released clamp order                            | use same ordering without warning  |
 
 A fallback repairs configuration; it is not a new user selection. After
 initialization, an invalid raw value never directly replaces persisted or otherwise
@@ -225,21 +233,24 @@ through normal clamping.
 - Supported feature/engine floor: every browser supported by Astryx Core with
   `ResizeObserver`; the shared observer remains the one runtime owner for a
   supplied container.
-- Before a supplied container has a positive measurement, percentage configuration
-  MAY use the released deterministic 1200px basis as a temporary fallback. The
-  first valid measurement resolves the percentage default to its final initial
-  pixel size and resolves percentage bounds without persisting or announcing the
-  temporary fallback.
+- Before a supplied container has a positive measurement, basis-dependent
+  configuration MAY use the released deterministic 1200px basis as a temporary
+  fallback. The first valid measurement resolves a basis-dependent default to its
+  final initial pixel size and resolves percentage-dependent bounds without
+  persisting or announcing the temporary fallback. When no live bound still needs
+  the basis, the default-only observation MUST be removed after that initial
+  selection.
 - Browser evidence: real Chromium MUST verify nested containers, horizontal and
   vertical axes, pointer and keyboard resizing, live basis changes, both canonical
   expressions (`max(40%, 333px)` and `min(400px, 10%)`) across wide and narrow
   containers, and the unchanged viewport-compatibility and pixel paths. jsdom
   geometry stubs alone are not sufficient.
-- SSR: without `containerRef`, percentage defaults preserve the released 1200px
-  server basis and client viewport initialization behavior. With `containerRef`,
-  the server uses the same temporary 1200px basis until the first client
-  measurement. Hydration MAY make one documented correction, but MUST NOT write the
-  temporary fallback to storage or fire `onSizeChange` for that correction.
+- SSR: without `containerRef`, percentage leaves in atomic or composed defaults
+  preserve the released 1200px server basis and client initialization behavior.
+  With `containerRef`, the server uses the same temporary 1200px basis until the
+  first client measurement. Hydration MAY make one documented correction, but
+  MUST NOT write the temporary fallback to storage or fire `onSizeChange` for
+  that correction.
 
 ## Current-state impact
 
@@ -293,31 +304,35 @@ interface PersistedResizableState {
 }
 ```
 
-A percentage default becomes a pixel selection before it is persisted. A
-persisted pixel selection wins over `defaultSize` on restore and is clamped by the
-currently resolved bounds. A legacy plain `0` remains a collapse marker with no
-expanded size, so expand falls back to the configured default; when collapse is
-disabled it supplies no usable saved size. Pointer, keyboard, collapse, expand, and
-numeric programmatic resize continue to persist pixels. Basis changes never write
-a percentage or relative intent.
+A basis-dependent default becomes a pixel selection before it is persisted. A
+persisted pixel selection wins over `defaultSize` on restore, so an unused default
+expression does not require a basis measurement, and the restored size is clamped
+only by the currently resolved bounds. A legacy plain `0` remains a collapse
+marker with no expanded size, so expand falls back to the configured default; when
+collapse is disabled it supplies no usable saved size. Pointer, keyboard, collapse,
+expand, and numeric programmatic resize continue to persist pixels. Basis changes
+never write an expression, percentage, or relative intent.
 
 ### Implementation requirements
 
-1. Preserve the current no-ref resolver for valid percentage defaults:
+1. Preserve the current no-ref resolver for every percentage leaf in a default:
    `window.innerWidth` on the client and 1200px when `window` is unavailable.
-2. Parse the complete value. Keep `defaultSize` on its released atomic grammar;
-   parse unified bounds with the bounded recursive API3 grammar; validate deprecated
-   aliases as pixel numbers only. Apply FR12's 250px/50px/`Infinity` fallbacks
-   before clamping and warn only in development. Preserve explicit
-   `maxSizePx: Infinity` as valid legacy input.
+2. Parse every unified value with the bounded recursive API3 grammar; validate
+   deprecated aliases as pixel numbers only. Keep `defaultSize`'s released wide
+   public type while applying the same runtime grammar. Apply FR12's
+   250px/50px/`Infinity` fallbacks before clamping and warn only in development.
+   Preserve explicit `maxSizePx: Infinity` as valid legacy input.
 3. Encode each unified/deprecated bound pair as the exact API4 union. At runtime,
    prefer a unified bound over a simultaneously supplied alias and warn in
    development with the ignored alias's name.
 4. When `containerRef` is supplied, measure its content box on the configured axis
    and observe it through Astryx's shared ResizeObserver.
-5. Resolve a percentage default once into selected pixel state. Re-resolve only
+5. Resolve a basis-dependent default once into selected pixel state. Observe a
+   supplied container only until that initial selection has a positive basis, then
+   unsubscribe unless a percentage-dependent bound still needs live updates. A
+   persisted pixel selection skips the unused default measurement. Re-resolve only
    bounds with a percentage dependency anywhere in their parsed expression when
-   the viewport or container basis changes, then clamp the selected pixel state so
+   the viewport or container basis changes, then clamp selected pixel state so
    paint, persistence, and ARIA stay synchronized.
 6. Preserve the released maximum-wins clamp order when a resolved minimum exceeds
    its maximum, warn in development, and never emit `NaN` or invalid geometry.
@@ -337,30 +352,32 @@ a percentage or relative intent.
 
 ## Verification
 
-| Contract         | Verification                                                          | Representative states                                                                                              | Mutation or failure expectation                                                                                                                          |
-| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| FR1, API1        | Focused hook tests plus Chromium geometry                             | no ref at 1200px viewport; nested container; first positive measurement                                            | no-ref default changes semantics, or supplied ref measures viewport/panel/handle ancestor                                                                |
-| FR2, API2        | Axis tests and Chromium interaction                                   | horizontal/vertical; LTR/RTL; reversed handle; no-ref vertical compatibility                                       | vertical container sizing reads width, or compatibility stops using `innerWidth`                                                                         |
-| FR3, FR6-FR8     | Interaction and basis-change tests                                    | percentage default before/after drag; viewport/container resize; Arrow, Shift+Arrow, Home, End; collapse/expand    | selected size preserves a ratio, basis change scales it, or existing pixel interactions change                                                           |
-| FR4              | Mixed-bound, nested-expression, basis-change, and invalid-order tests | canonical `max(40%, 333px)` / `min(400px, 10%)`; variadic nesting; recursive percentage dependency; min above max  | parser drops nested basis dependency, bounds use different bases, selection scales instead of clamps, maximum does not win, or geometry becomes invalid  |
-| FR5              | Hook, LayoutPanel, persistence, and ResizeHandle assertions           | below/at/above max; basis shrink; controlled collapse intent                                                       | effective paint, state, storage, and ARIA diverge, or controlled rejection changes owned state                                                           |
-| FR9              | Persistence compatibility tests                                       | positive number; legacy zero; legacy object; percentage default; corrupt entry                                     | stored shape changes, a percentage is persisted, or old state changes meaning                                                                            |
-| FR10, API5       | Callback tests                                                        | initialization; hydration correction; basis-only re-clamp; pointer/keyboard/programmatic change                    | callback receives a percentage or reports a non-interaction layout correction                                                                            |
-| FR11             | Multi-region and shared-observer tests                                | two regions on one container; another hook observing the same node                                                 | regions use different bases, selected ratios are introduced, or one subscription removes another                                                         |
-| FR12             | Production/development parser and state-preservation tests            | malformed functions; unsupported functions/units/arithmetic; depth 8/9; invalid rerender; explicit legacy Infinity | fallback differs by build, warning occurs in production, invalid input replaces legal state, unbounded recursion, or any path produces `NaN`             |
-| API3, API4, API6 | Type, runtime validation, and development-warning tests               | restricted constraint type; recursive grammar; old-only aliases; exact-union conflicts; `resize('50%')`            | unsupported top-level strings type-check, duplicate pairs type-check, alias overrides unified input, exact parsing is skipped, or resize accepts strings |
-| Platform/SSR     | Server render, hydration test, and Chromium evidence                  | no ref; ref not measured; hidden/zero container; first positive measurement                                        | 1200px fallback changes, temporary fallback persists, or correction fires `onSizeChange`                                                                 |
-| Compatibility    | Existing Resizable, LayoutPanel, SideNav, and template suites         | current pixel-only callsites and no-ref percentage default                                                         | existing numeric configuration, percentage fallback, output, interaction, or persistence changes                                                         |
+| Contract         | Verification                                                          | Representative states                                                                                                             | Mutation or failure expectation                                                                                                                         |
+| ---------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR1, API1        | Focused hook tests plus Chromium geometry                             | atomic/composed default; wide/narrow initial container; no ref at 1200px viewport; first positive measurement; later basis resize | default expression uses the wrong initial basis, rescales after initialization, or supplied ref measures viewport/panel/handle ancestor                 |
+| FR2, API2        | Axis tests and Chromium interaction                                   | horizontal/vertical; LTR/RTL; reversed handle; no-ref vertical compatibility                                                      | vertical container sizing reads width, or compatibility stops using `innerWidth`                                                                        |
+| FR3, FR6-FR8     | Interaction and basis-change tests                                    | atomic/composed default before/after initialization; viewport/container resize; Arrow, Shift+Arrow, Home, End; collapse/expand    | selected default preserves a ratio, basis change rescales it, or existing pixel interactions change                                                     |
+| FR4              | Mixed-bound, nested-expression, basis-change, and invalid-order tests | canonical `max(40%, 333px)` / `min(400px, 10%)`; variadic nesting; recursive percentage dependency; min above max                 | parser drops nested basis dependency, bounds use different bases, selection scales instead of clamps, maximum does not win, or geometry becomes invalid |
+| FR5              | Hook, LayoutPanel, persistence, and ResizeHandle assertions           | below/at/above max; basis shrink; controlled collapse intent                                                                      | effective paint, state, storage, and ARIA diverge, or controlled rejection changes owned state                                                          |
+| FR9              | Persistence compatibility tests                                       | positive number; legacy zero; legacy object; composed default; corrupt entry; unmeasured container                                | stored shape changes, an expression is persisted, an unused persisted default measures a basis, or old state changes meaning                            |
+| FR10, API5       | Callback tests                                                        | initialization; hydration correction; basis-only re-clamp; pointer/keyboard/programmatic change                                   | callback receives a percentage or reports a non-interaction layout correction                                                                           |
+| FR11             | Multi-region and shared-observer tests                                | two regions on one container; another hook observing the same node                                                                | regions use different bases, selected ratios are introduced, or one subscription removes another                                                        |
+| FR12             | Production/development parser and state-preservation tests            | default/bound malformed functions; unsupported functions/units/arithmetic; depth 8/9; invalid rerender; explicit legacy Infinity  | fallback differs by role/build, warning occurs in production, invalid input replaces legal state, unbounded recursion, or any path produces `NaN`       |
+| API3, API4, API6 | Type, runtime validation, and development-warning tests               | wide compatible default type; restricted bound type; recursive grammar; aliases/conflicts; `resize('50%')`                        | default type narrows, unsupported bound strings type-check, alias overrides unified input, exact parsing is skipped, or resize accepts strings          |
+| Platform/SSR     | Server render, hydration test, and Chromium evidence                  | no ref; ref not measured; hidden/zero container; first positive measurement                                                       | 1200px fallback changes, temporary fallback persists, or correction fires `onSizeChange`                                                                |
+| Compatibility    | Existing Resizable, LayoutPanel, SideNav, and template suites         | current pixel-only callsites; no-ref atomic percentage default; computed `string` default                                         | existing numeric/percentage defaults, wide default type, output, interaction, or persistence changes                                                    |
 
 ### Completion criteria
 
 This spec moves from `accepted` to `shipped` only when:
 
-- no-ref percentage defaults preserve one-time `window.innerWidth` resolution and
-  the 1200px SSR fallback without tracking viewport resize;
-- supplied-container percentage defaults resolve once against the content-box
-  active axis, then remain pixel selections through basis changes and every
-  interaction path;
+- no-ref basis-dependent defaults preserve one-time `window.innerWidth` resolution
+  and the 1200px SSR fallback without subscribing to later viewport resize;
+- supplied-container basis-dependent defaults resolve once against the first
+  positive content-box active axis, remove default-only observation after that
+  choice, and remain pixel selections through later basis changes and every
+  interaction path; pure-pixel default expressions add no observer or render cost
+  beyond an atomic pixel default; persisted pixels skip unused default measurement;
 - bounds with percentage leaves at any nesting depth re-resolve in both basis modes
   and clamp existing pixel state without proportionally scaling it; pure-pixel
   expressions do not subscribe to basis changes;
@@ -369,13 +386,14 @@ This spec moves from `accepted` to `shipped` only when:
 - old-only `minSizePx` and `maxSizePx` callers remain unchanged, each old/new
   pair is an exact mutually exclusive TypeScript union, and untyped conflicts
   prefer the unified value with a clear ignored-alias warning;
-- exact parsing preserves `defaultSize`'s released atomic grammar and accepts
-  unified bounds only as `ResizableConstraintValue`: non-negative finite numbers,
-  complete `Npx` / 0–100 `N%` strings, or recursive lowercase `min()` / `max()`
-  expressions up to eight levels; every other function, unit, arithmetic form,
-  malformed input, and deeper expression uses the documented 50px or `Infinity`
-  fallback without replacing persisted/legal selected state, while explicit legacy
-  `maxSizePx: Infinity` remains valid;
+- exact runtime parsing accepts all three unified values as non-negative finite
+  numbers, complete `Npx` / 0–100 `N%` strings, or recursive lowercase `min()` /
+  `max()` expressions up to eight levels. `defaultSize` keeps the released
+  `number | string` type while `minSize` / `maxSize` use
+  `ResizableConstraintValue`; every unsupported function, unit, arithmetic form,
+  malformed input, and deeper expression uses the role's documented 250px, 50px,
+  or `Infinity` fallback without replacing persisted/legal selected state, while
+  explicit legacy `maxSizePx: Infinity` remains valid;
 - inverted resolved bounds warn in development, deterministically choose the
   maximum, and never produce `NaN` or invalid geometry;
 - mixed bounds keep effective state, paint, storage, and separator ARIA aligned,
@@ -383,8 +401,10 @@ This spec moves from `accepted` to `shipped` only when:
 - single and multi-region subscriptions coexist with every other observer of the
   same element;
 - focused tests fail against the old implementation and pass against the new one;
-- real Chromium proves both container-basis behavior and unchanged compatibility
-  and pixel paths; and
+- real Chromium proves composed defaults at wide and narrow initial bases remain
+  fixed after later resize, while composed bounds continue to follow the basis;
+  state, panel geometry, persistence, ARIA, and unchanged compatibility/pixel paths
+  all agree; and
 - `component:Resizable` and consumer docs describe the shipped contract in the
   same pull request as the implementation.
 
@@ -419,8 +439,9 @@ caller did not request.
 Add flat `minSize` and `maxSize` alongside `defaultSize`. Numbers remain static
 pixels; atomic strings accept finite non-negative `Npx` or `N%`; and mixing units
 across the initial size and bounds is valid. This gives builders one predictable
-set of flat size props without parallel percentage props. DEC-3 amends only the
-accepted bound-string grammar; `defaultSize` remains unchanged.
+set of flat size props without parallel percentage props. DEC-3 extends the
+accepted runtime string grammar without changing `defaultSize`'s released type or
+one-time-selection semantics.
 
 Preserve `minSizePx` and `maxSizePx` as deprecated compatibility aliases so
 old-only callers behave unchanged. TypeScript encodes each old/new pair as an exact
@@ -439,23 +460,32 @@ the maximum wins under the released clamp order. These rules keep malformed inpu
 conflicts, and inverted bounds from producing `NaN` or replacing persisted/legal
 selected state.
 
-### DEC-3 — Bounds accept bounded CSS min/max composition
+### DEC-3 — Unified sizes accept bounded CSS min/max composition
 
 **Reference:** `spec:AST-010/DEC-3`
 **Amendment author:** `freddymeta`, `2026-09-03`
 **Approval:** exact-head spec-owner approval required before merge
 
-Keep released `defaultSize` typing and runtime behavior unchanged. Restrict flat
-`minSize` and `maxSize` to the Resizable-specific `ResizableConstraintValue`:
-numbers remain static pixels; atomic strings accept finite non-negative `Npx` or
-0–100 `N%`; and bounds additionally accept lowercase, full-match, recursive CSS
+Keep `defaultSize`'s released `number | string` type, but validate it at runtime
+with the same restricted grammar as `minSize` and `maxSize`: non-negative finite
+pixels, exact `Npx`, exact 0–100 `N%`, or lowercase, full-match, recursive CSS
 `min()` / `max()` expressions up to eight function levels. No `calc()`, `clamp()`,
-arithmetic, `var()`, other function, or other unit is accepted.
+arithmetic, `var()`, other function, or other unit is accepted. Runtime validation
+is authoritative for the wide compatibility type; unsupported strings keep the
+existing 250px fallback and development warning.
 
-The template-literal type rejects unrelated top-level strings while the runtime
-parser remains authoritative for non-negativity, finiteness, and recursive
-function interiors. This keeps shared `SizeValue` unchanged and adds only the two
-CSS comparisons needed for fluid constraints.
+The same expression has deliberately different lifecycle meaning by prop:
+`defaultSize: 'max(40%, 333px)'` chooses one initial pixel size from the first
+measurable basis, then stops following that basis. `minSize: 'max(40%, 333px)'`
+is a persistent floor whose percentage leaves continue to re-resolve and re-clamp.
+A default-only container observation ends after the initial choice; a persisted
+pixel choice skips that unused measurement. Pure-pixel default expressions observe
+nothing.
+
+The template-literal bound type rejects unrelated top-level strings while the
+runtime parser remains authoritative for non-negativity, finiteness, recursive
+function interiors, and every `defaultSize`. This keeps shared `SizeValue`
+unchanged and adds only the two CSS comparisons needed for fluid sizing.
 
 ## Open questions
 

--- a/docs/specs/AST-010/spec.md
+++ b/docs/specs/AST-010/spec.md
@@ -16,14 +16,16 @@ affects_contributing: []
 affects_consumer_docs: [Resizable]
 ---
 
-# Percentage-based useResizable configuration system spec
+# Percentage and CSS math useResizable configuration system spec
 
 ## Intent
 
 A person resizing a panel should get the same panel size that the handle presents
-and assistive technology announces. Builders may configure an initial size or
-bounds as percentages, but every user-selected size remains pixels so pointer,
-keyboard, persistence, and programmatic behavior stay predictable.
+and assistive technology announces. Builders may configure an initial size in
+pixels or as a percentage. Bounds additionally accept recursive CSS `min()` and
+`max()` expressions over pixel and percentage leaves, so common fluid floors and
+ceilings do not require CSS-only clamping. Every user-selected size remains pixels
+so pointer, keyboard, persistence, and programmatic behavior stay predictable.
 
 This spec preserves the released meaning of `defaultSize: 'N%'` when no
 `containerRef` is supplied: resolve once against `window.innerWidth` (or the
@@ -39,11 +41,12 @@ record is updated alongside that implementation.
 
 ## Non-goals
 
-- Implementing runtime behavior in this specification pull request.
 - Preserving a percentage ratio after pointer, keyboard, or programmatic resize.
 - Automatically distributing remaining space or requiring independently sized
   regions to total 100%.
-- Supporting arbitrary CSS units such as `rem`, `vw`, or `calc()`.
+- Supporting CSS constraint syntax beyond non-negative pixel and percentage leaves
+  composed with `min()` and `max()`: no other units, `calc()`, `clamp()`,
+  arithmetic, `var()`, or other functions.
 - Adding percentage snap points or percentage collapse thresholds.
 - Adding controlled size state; current controlled collapse behavior is
   unchanged.
@@ -74,14 +77,17 @@ record is updated alongside that implementation.
   expand, persistence, callback, and programmatic resize paths MUST continue to
   read and write pixel selections exactly as the released API does. No
   interaction may create or preserve a percentage-selected mode.
-- **FR4 — Mixed bounds remain valid.** Builders MAY combine pixel and percentage
-  values across `defaultSize`, `minSize`, and `maxSize`. Numeric bounds remain
-  pixels. Percentage bounds resolve against the same viewport or container basis
-  as FR1 and MUST re-resolve whenever that basis changes. Re-resolved bounds clamp
-  the existing pixel selection; they MUST NOT scale it proportionally. If the
-  resolved minimum exceeds the resolved maximum, development MUST warn and the
-  maximum MUST win, preserving the released `Math.min(max, Math.max(min, size))`
-  ordering and guaranteeing finite, non-`NaN` geometry.
+- **FR4 — Mixed and composed bounds remain valid.** Builders MAY combine pixel
+  and percentage values across `defaultSize`, `minSize`, and `maxSize`. Unified
+  bounds MAY recursively compose those leaves with CSS `min()` and `max()` up to
+  eight function levels. Numeric and `Npx` leaves remain pixels. Every percentage
+  leaf resolves against the same viewport or container basis as FR1; basis
+  dependency is recursive, so a percentage nested anywhere in an expression makes
+  that bound re-resolve whenever the basis changes. Re-resolved bounds clamp the
+  existing pixel selection; they MUST NOT scale it proportionally. If the resolved
+  minimum exceeds the resolved maximum, development MUST warn and the maximum MUST
+  win, preserving the released `Math.min(max, Math.max(min, size))` ordering and
+  guaranteeing finite, non-`NaN` geometry.
 - **FR5 — Effective geometry stays synchronized.** The effective selected pixel
   size, LayoutPanel or caller-rendered size, persisted expanded value, and
   ResizeHandle's `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` MUST describe
@@ -89,15 +95,16 @@ record is updated alongside that implementation.
   painted bounds is prohibited. Existing controlled-collapse callbacks remain an
   explicit exception: they report a rejected collapse or expand intent without
   claiming that the controlled owner changed the rendered size.
-- **FR6 — Basis changes update only percentage constraints.** Once a percentage
-  default has initialized the selected pixel size, a viewport or container resize
-  MUST NOT re-resolve that default. Percentage bounds MUST re-resolve and clamp the
-  selected pixel size. A basis-only layout change MUST NOT fire an interaction
-  callback or otherwise claim that a person selected a new size.
+- **FR6 — Basis changes update only percentage-dependent constraints.** Once a
+  percentage default has initialized the selected pixel size, a viewport or
+  container resize MUST NOT re-resolve that default. Bounds with a percentage leaf
+  at any nesting depth MUST re-resolve and clamp the selected pixel size. A
+  basis-only layout change MUST NOT fire an interaction callback or otherwise claim
+  that a person selected a new size.
 - **FR7 — Pointer gestures preserve released behavior.** Pointer deltas continue
-  from the selected pixel size. Percentage bounds MUST use one stable basis during
-  a gesture; a basis change during the gesture takes effect after the gesture ends
-  so the handle does not move away from the pointer.
+  from the selected pixel size. Percentage-dependent bounds MUST use one stable
+  basis during a gesture; a basis change during the gesture takes effect after the
+  gesture ends so the handle does not move away from the pointer.
 - **FR8 — Keyboard, snap, and collapse semantics continue.** Arrow-key steps,
   Shift+Arrow steps, Home, End, collapse thresholds, and snap points remain
   pixel-based. Collapse retains the expanded pixel size, and expand restores that
@@ -116,11 +123,15 @@ record is updated alongside that implementation.
   multi-region call MUST use one optional container and axis for all regions.
   Regions remain independently pixel-selected; this change MUST NOT add balancing,
   ratio preservation, or a 100% total invariant.
-- **FR12 — Invalid configuration has safe deterministic fallbacks.** Accepted
-  configuration is a non-negative finite number, an exact non-negative finite
-  `Npx` string, or an exact `N%` string from 0% through 100%. An invalid,
-  malformed, negative, or non-finite `defaultSize` MUST use 250px before normal
-  bounds clamping; an invalid `minSize` or `minSizePx` MUST use 50px; and an
+- **FR12 — Invalid configuration has safe deterministic fallbacks.** The released
+  `defaultSize` input remains a non-negative finite number, an exact non-negative
+  finite `Npx` string, or an exact `N%` string from 0% through 100%. Unified
+  `minSize` and `maxSize` accept those same leaves plus full-match recursive CSS
+  `min()` and `max()` expressions, bounded to eight function levels. Empty
+  functions, malformed separators or parentheses, trailing input, other units,
+  `calc()`, `clamp()`, arithmetic, `var()`, negatives, out-of-range percentages,
+  and non-finite values are invalid. An invalid `defaultSize` MUST use 250px before
+  normal bounds clamping; an invalid `minSize` or `minSizePx` MUST use 50px; and an
   invalid `maxSize` or `maxSizePx` MUST use unbounded `Infinity`. Explicit
   `maxSizePx: Infinity` remains valid for compatibility because a shipped template
   uses it. Development MUST warn for every fallback; production MUST use the same
@@ -143,25 +154,35 @@ record is updated alongside that implementation.
   axis. ResizeHandle direction and hook direction MUST agree; the implementation
   MUST make a mismatch detectable in development. Direction affects the
   container basis only when `containerRef` is present.
-- **API3 — One configuration vocabulary covers both units.** Add `minSize` and
-  `maxSize` with the same `number | string` shape as `defaultSize`. Accepted
-  numbers are finite and non-negative. Accepted strings match the complete input:
-  a finite non-negative `Npx`, or `N%` from 0% through 100%; partial parses,
-  trailing text, other units, negatives, and non-finite values are invalid. The
-  deprecated `maxSizePx` alone additionally accepts explicit `Infinity` to
-  preserve released usage. Apply FR12's role-specific fallback in development and
-  production, warning only in development. Do not add parallel
-  `defaultSizePercent`, `minSizePercent`, or `maxSizePercent` props.
+- **API3 — Bounds use one restricted Resizable vocabulary.** Add the public
+  `ResizableConstraintValue` type and use it for flat `minSize` and `maxSize`:
+
+  ```ts
+  type ResizableConstraintValue =
+    number | `${number}px` | `${number}%` | `min(${string})` | `max(${string})`;
+  ```
+
+  Runtime parsing remains authoritative for expression interiors and MUST match
+  the complete input. Functions are lowercase CSS `min()` or `max()` only, accept
+  one or more comma-separated expressions, recurse up to eight function levels,
+  and may contain only non-negative finite `Npx` or 0–100 `N%` leaves. Partial
+  parses, trailing text, malformed separators or parentheses, other units,
+  negatives, non-finite values, `calc()`, `clamp()`, arithmetic, `var()`, and
+  every other function are invalid. Keep the released `defaultSize?: SizeValue`
+  type and its existing number / exact `Npx` / exact `N%` runtime behavior; CSS
+  math is constraint-only. Do not add parallel `defaultSizePercent`,
+  `minSizePercent`, or `maxSizePercent` props.
+
 - **API4 — Pixel aliases are exactly mutually exclusive with unified bounds.**
   `minSizePx` and `maxSizePx` remain supported but become deprecated. TypeScript
   MUST encode each old/new pair as an exact union, equivalent to:
 
   ```ts
   type MinSizeConfig =
-    | {minSize?: SizeValue; minSizePx?: never}
+    | {minSize?: ResizableConstraintValue; minSizePx?: never}
     | {minSize?: never; minSizePx?: number};
   type MaxSizeConfig =
-    | {maxSize?: SizeValue; maxSizePx?: never}
+    | {maxSize?: ResizableConstraintValue; maxSizePx?: never}
     | {maxSize?: never; maxSizePx?: number};
   ```
 
@@ -184,14 +205,15 @@ record is updated alongside that implementation.
 
 ### Invalid configuration behavior
 
-| Input                                                      | Accepted values                                                                    | Invalid fallback                | Development behavior                                         | Production behavior                |
-| ---------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
-| `defaultSize`                                              | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100 | 250px, then normal bounds clamp | warn and use fallback                                        | use same fallback without warning  |
-| `minSize` / `minSizePx`                                    | non-negative finite number; unified prop also accepts exact `Npx` and 0–100 `N%`   | 50px                            | warn and use fallback                                        | use same fallback without warning  |
-| `maxSize`                                                  | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100 | unbounded `Infinity`            | warn and use fallback                                        | use same fallback without warning  |
-| `maxSizePx`                                                | non-negative finite number or explicit `Infinity`                                  | unbounded `Infinity`            | warn for invalid values; do not warn for explicit `Infinity` | use same fallback without warning  |
-| old/new bound pair supplied together through untyped input | unified value is authoritative                                                     | ignore deprecated alias         | warn and name the ignored alias                              | unified value wins without warning |
-| resolved minimum above resolved maximum                    | both values are individually valid                                                 | maximum wins                    | warn and use released clamp order                            | use same ordering without warning  |
+| Input                                                      | Accepted values                                                                                  | Invalid fallback                | Development behavior                                         | Production behavior                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
+| `defaultSize`                                              | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100               | 250px, then normal bounds clamp | warn and use fallback                                        | use same fallback without warning  |
+| `minSize`                                                  | `ResizableConstraintValue`; full-match runtime grammar from API3                                 | 50px                            | warn and use fallback                                        | use same fallback without warning  |
+| `minSizePx`                                                | non-negative finite number                                                                       | 50px                            | warn and use fallback                                        | use same fallback without warning  |
+| `maxSize`                                                  | `ResizableConstraintValue`; full-match runtime grammar from API3                                 | unbounded `Infinity`            | warn and use fallback                                        | use same fallback without warning  |
+| `maxSizePx`                                                | non-negative finite number or explicit `Infinity`                                                | unbounded `Infinity`            | warn for invalid values; do not warn for explicit `Infinity` | use same fallback without warning  |
+| old/new bound pair supplied together through untyped input | unified value is authoritative                                                                   | ignore deprecated alias         | warn and name the ignored alias                              | unified value wins without warning |
+| resolved minimum above resolved maximum                    | both values are individually valid, including after recursive CSS math and percentage resolution | maximum wins                    | warn and use released clamp order                            | use same ordering without warning  |
 
 A fallback repairs configuration; it is not a new user selection. After
 initialization, an invalid raw value never directly replaces persisted or otherwise
@@ -209,9 +231,10 @@ through normal clamping.
   pixel size and resolves percentage bounds without persisting or announcing the
   temporary fallback.
 - Browser evidence: real Chromium MUST verify nested containers, horizontal and
-  vertical axes, pointer and keyboard resizing, live basis changes, and the
-  unchanged viewport-compatibility and pixel paths. jsdom geometry stubs alone are
-  not sufficient.
+  vertical axes, pointer and keyboard resizing, live basis changes, both canonical
+  expressions (`max(40%, 333px)` and `min(400px, 10%)`) across wide and narrow
+  containers, and the unchanged viewport-compatibility and pixel paths. jsdom
+  geometry stubs alone are not sufficient.
 - SSR: without `containerRef`, percentage defaults preserve the released 1200px
   server basis and client viewport initialization behavior. With `containerRef`,
   the server uses the same temporary 1200px basis until the first client
@@ -282,8 +305,10 @@ a percentage or relative intent.
 
 1. Preserve the current no-ref resolver for valid percentage defaults:
    `window.innerWidth` on the client and 1200px when `window` is unavailable.
-2. Parse the complete configuration value, apply FR12's 250px/50px/`Infinity`
-   fallbacks before clamping, and warn only in development. Preserve explicit
+2. Parse the complete value. Keep `defaultSize` on its released atomic grammar;
+   parse unified bounds with the bounded recursive API3 grammar; validate deprecated
+   aliases as pixel numbers only. Apply FR12's 250px/50px/`Infinity` fallbacks
+   before clamping and warn only in development. Preserve explicit
    `maxSizePx: Infinity` as valid legacy input.
 3. Encode each unified/deprecated bound pair as the exact API4 union. At runtime,
    prefer a unified bound over a simultaneously supplied alias and warn in
@@ -291,8 +316,9 @@ a percentage or relative intent.
 4. When `containerRef` is supplied, measure its content box on the configured axis
    and observe it through Astryx's shared ResizeObserver.
 5. Resolve a percentage default once into selected pixel state. Re-resolve only
-   percentage bounds when their viewport or container basis changes, then clamp
-   the selected pixel state so paint, persistence, and ARIA stay synchronized.
+   bounds with a percentage dependency anywhere in their parsed expression when
+   the viewport or container basis changes, then clamp the selected pixel state so
+   paint, persistence, and ARIA stay synchronized.
 6. Preserve the released maximum-wins clamp order when a resolved minimum exceeds
    its maximum, warn in development, and never emit `NaN` or invalid geometry.
 7. Keep pointer, keyboard, snap, collapse, expand, callback, persistence, and
@@ -311,20 +337,20 @@ a percentage or relative intent.
 
 ## Verification
 
-| Contract         | Verification                                                  | Representative states                                                                                                             | Mutation or failure expectation                                                                                                                        |
-| ---------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| FR1, API1        | Focused hook tests plus Chromium geometry                     | no ref at 1200px viewport; nested container; first positive measurement                                                           | no-ref default changes semantics, or supplied ref measures viewport/panel/handle ancestor                                                              |
-| FR2, API2        | Axis tests and Chromium interaction                           | horizontal/vertical; LTR/RTL; reversed handle; no-ref vertical compatibility                                                      | vertical container sizing reads width, or compatibility stops using `innerWidth`                                                                       |
-| FR3, FR6-FR8     | Interaction and basis-change tests                            | percentage default before/after drag; viewport/container resize; Arrow, Shift+Arrow, Home, End; collapse/expand                   | selected size preserves a ratio, basis change scales it, or existing pixel interactions change                                                         |
-| FR4              | Mixed-bound and invalid-order tests                           | percent default + pixel minimum; pixel default + percent maximum; percentage min + pixel max; min above max                       | bounds use different bases, selection scales instead of clamps, maximum does not win, warning is absent, or geometry becomes invalid                   |
-| FR5              | Hook, LayoutPanel, persistence, and ResizeHandle assertions   | below/at/above max; basis shrink; controlled collapse intent                                                                      | effective paint, state, storage, and ARIA diverge, or controlled rejection changes owned state                                                         |
-| FR9              | Persistence compatibility tests                               | positive number; legacy zero; legacy object; percentage default; corrupt entry                                                    | stored shape changes, a percentage is persisted, or old state changes meaning                                                                          |
-| FR10, API5       | Callback tests                                                | initialization; hydration correction; basis-only re-clamp; pointer/keyboard/programmatic change                                   | callback receives a percentage or reports a non-interaction layout correction                                                                          |
-| FR11             | Multi-region and shared-observer tests                        | two regions on one container; another hook observing the same node                                                                | regions use different bases, selected ratios are introduced, or one subscription removes another                                                       |
-| FR12             | Production/development parser and state-preservation tests    | negative/non-finite number; partial/malformed string; wrong unit; invalid rerender; persisted selection; explicit legacy Infinity | fallback differs by build, warning occurs in production, invalid input replaces legal state, or any path produces `NaN`                                |
-| API3, API4, API6 | Type, runtime validation, and development-warning tests       | exact valid strings; old-only aliases; exact-union duplicate rejection; JS/`any`/spread conflicts; `resize('50%')`                | duplicate pairs type-check, deprecated alias overrides unified input, warning omits ignored alias, exact parsing is skipped, or resize accepts strings |
-| Platform/SSR     | Server render, hydration test, and Chromium evidence          | no ref; ref not measured; hidden/zero container; first positive measurement                                                       | 1200px fallback changes, temporary fallback persists, or correction fires `onSizeChange`                                                               |
-| Compatibility    | Existing Resizable, LayoutPanel, SideNav, and template suites | current pixel-only callsites and no-ref percentage default                                                                        | existing numeric configuration, percentage fallback, output, interaction, or persistence changes                                                       |
+| Contract         | Verification                                                          | Representative states                                                                                              | Mutation or failure expectation                                                                                                                          |
+| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR1, API1        | Focused hook tests plus Chromium geometry                             | no ref at 1200px viewport; nested container; first positive measurement                                            | no-ref default changes semantics, or supplied ref measures viewport/panel/handle ancestor                                                                |
+| FR2, API2        | Axis tests and Chromium interaction                                   | horizontal/vertical; LTR/RTL; reversed handle; no-ref vertical compatibility                                       | vertical container sizing reads width, or compatibility stops using `innerWidth`                                                                         |
+| FR3, FR6-FR8     | Interaction and basis-change tests                                    | percentage default before/after drag; viewport/container resize; Arrow, Shift+Arrow, Home, End; collapse/expand    | selected size preserves a ratio, basis change scales it, or existing pixel interactions change                                                           |
+| FR4              | Mixed-bound, nested-expression, basis-change, and invalid-order tests | canonical `max(40%, 333px)` / `min(400px, 10%)`; variadic nesting; recursive percentage dependency; min above max  | parser drops nested basis dependency, bounds use different bases, selection scales instead of clamps, maximum does not win, or geometry becomes invalid  |
+| FR5              | Hook, LayoutPanel, persistence, and ResizeHandle assertions           | below/at/above max; basis shrink; controlled collapse intent                                                       | effective paint, state, storage, and ARIA diverge, or controlled rejection changes owned state                                                           |
+| FR9              | Persistence compatibility tests                                       | positive number; legacy zero; legacy object; percentage default; corrupt entry                                     | stored shape changes, a percentage is persisted, or old state changes meaning                                                                            |
+| FR10, API5       | Callback tests                                                        | initialization; hydration correction; basis-only re-clamp; pointer/keyboard/programmatic change                    | callback receives a percentage or reports a non-interaction layout correction                                                                            |
+| FR11             | Multi-region and shared-observer tests                                | two regions on one container; another hook observing the same node                                                 | regions use different bases, selected ratios are introduced, or one subscription removes another                                                         |
+| FR12             | Production/development parser and state-preservation tests            | malformed functions; unsupported functions/units/arithmetic; depth 8/9; invalid rerender; explicit legacy Infinity | fallback differs by build, warning occurs in production, invalid input replaces legal state, unbounded recursion, or any path produces `NaN`             |
+| API3, API4, API6 | Type, runtime validation, and development-warning tests               | restricted constraint type; recursive grammar; old-only aliases; exact-union conflicts; `resize('50%')`            | unsupported top-level strings type-check, duplicate pairs type-check, alias overrides unified input, exact parsing is skipped, or resize accepts strings |
+| Platform/SSR     | Server render, hydration test, and Chromium evidence                  | no ref; ref not measured; hidden/zero container; first positive measurement                                        | 1200px fallback changes, temporary fallback persists, or correction fires `onSizeChange`                                                                 |
+| Compatibility    | Existing Resizable, LayoutPanel, SideNav, and template suites         | current pixel-only callsites and no-ref percentage default                                                         | existing numeric configuration, percentage fallback, output, interaction, or persistence changes                                                         |
 
 ### Completion criteria
 
@@ -335,17 +361,21 @@ This spec moves from `accepted` to `shipped` only when:
 - supplied-container percentage defaults resolve once against the content-box
   active axis, then remain pixel selections through basis changes and every
   interaction path;
-- percentage bounds in both basis modes re-resolve and clamp existing pixel state
-  without proportionally scaling it;
+- bounds with percentage leaves at any nesting depth re-resolve in both basis modes
+  and clamp existing pixel state without proportionally scaling it; pure-pixel
+  expressions do not subscribe to basis changes;
 - pointer, keyboard, snap, collapse, expand, persistence, callbacks, and
   `resize(number)` preserve released pixel semantics;
 - old-only `minSizePx` and `maxSizePx` callers remain unchanged, each old/new
   pair is an exact mutually exclusive TypeScript union, and untyped conflicts
   prefer the unified value with a clear ignored-alias warning;
-- exact parsing accepts only non-negative finite numbers, complete `Npx` strings,
-  and 0–100 `N%` strings; invalid values use the documented 250px, 50px, or
-  `Infinity` fallback in every build without replacing persisted/legal selected
-  state, while explicit legacy `maxSizePx: Infinity` remains valid;
+- exact parsing preserves `defaultSize`'s released atomic grammar and accepts
+  unified bounds only as `ResizableConstraintValue`: non-negative finite numbers,
+  complete `Npx` / 0–100 `N%` strings, or recursive lowercase `min()` / `max()`
+  expressions up to eight levels; every other function, unit, arithmetic form,
+  malformed input, and deeper expression uses the documented 50px or `Infinity`
+  fallback without replacing persisted/legal selected state, while explicit legacy
+  `maxSizePx: Infinity` remains valid;
 - inverted resolved bounds warn in development, deterministically choose the
   maximum, and never produce `NaN` or invalid geometry;
 - mixed bounds keep effective state, paint, storage, and separator ARIA aligned,
@@ -381,15 +411,16 @@ accept percentage strings. Both would change released pixel-based interaction an
 add unit-aware state, persistence, callback, and restoration semantics that the
 caller did not request.
 
-### DEC-2 — Initial size and bounds share one configuration vocabulary
+### DEC-2 — Initial size and bounds share one flat configuration vocabulary
 
 **Reference:** `spec:AST-010/DEC-2`
 **Decider:** `cixzhang`, `2026-08-31`
 
-Add `minSize` and `maxSize` with the same accepted vocabulary as `defaultSize`.
-Numbers remain static pixels; strings accept finite non-negative `Npx` or `N%`;
-and mixing units across the initial size and bounds is valid. This gives builders
-one predictable size vocabulary without parallel percentage props.
+Add flat `minSize` and `maxSize` alongside `defaultSize`. Numbers remain static
+pixels; atomic strings accept finite non-negative `Npx` or `N%`; and mixing units
+across the initial size and bounds is valid. This gives builders one predictable
+set of flat size props without parallel percentage props. DEC-3 amends only the
+accepted bound-string grammar; `defaultSize` remains unchanged.
 
 Preserve `minSizePx` and `maxSizePx` as deprecated compatibility aliases so
 old-only callers behave unchanged. TypeScript encodes each old/new pair as an exact
@@ -407,6 +438,24 @@ Astryx template. If a resolved minimum exceeds its maximum, development warns an
 the maximum wins under the released clamp order. These rules keep malformed input,
 conflicts, and inverted bounds from producing `NaN` or replacing persisted/legal
 selected state.
+
+### DEC-3 — Bounds accept bounded CSS min/max composition
+
+**Reference:** `spec:AST-010/DEC-3`
+**Amendment author:** `freddymeta`, `2026-09-03`
+**Approval:** exact-head spec-owner approval required before merge
+
+Keep released `defaultSize` typing and runtime behavior unchanged. Restrict flat
+`minSize` and `maxSize` to the Resizable-specific `ResizableConstraintValue`:
+numbers remain static pixels; atomic strings accept finite non-negative `Npx` or
+0–100 `N%`; and bounds additionally accept lowercase, full-match, recursive CSS
+`min()` / `max()` expressions up to eight function levels. No `calc()`, `clamp()`,
+arithmetic, `var()`, other function, or other unit is accepted.
+
+The template-literal type rejects unrelated top-level strings while the runtime
+parser remains authoritative for non-negativity, finiteness, and recursive
+function interiors. This keeps shared `SizeValue` unchanged and adds only the two
+CSS comparisons needed for fluid constraints.
 
 ## Open questions
 

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -85,7 +85,7 @@ export const docs = {
           name: 'defaultSize',
           type: 'number | string',
           description:
-            'Released initial size: a pixel number, exact "Npx", or exact "N%" from 0% to 100%. Unsupported strings use the documented fallback.',
+            'Released public type remains number | string. Runtime accepts a non-negative pixel number, exact "Npx", exact "N%" from 0% to 100%, or recursive CSS min()/max(). A basis-dependent value resolves once into the initial pixel choice; unsupported strings use the existing 250px fallback and development warning.',
           default: '250',
         },
         {
@@ -144,7 +144,16 @@ export const docs = {
       ],
       examples: [
         {
-          label: 'Container-relative minimum',
+          label: 'One-time initial choice',
+          code: `const containerRef = useRef<HTMLDivElement>(null);
+const region = useResizable({
+  defaultSize: 'max(40%, 333px)',
+  containerRef,
+});
+// Resolves once from the initial basis, then remains pixels.`,
+        },
+        {
+          label: 'Persistent container-relative minimum',
           code: `const containerRef = useRef<HTMLDivElement>(null);
 const region = useResizable({
   defaultSize: 360,
@@ -275,7 +284,8 @@ export const docsDense = {
       description:
         'Hook managing resize state for one or more panel regions. Returns size, isCollapsed, collapse/expand/resize methods, + props to pass to handles.',
       propDescriptions: {
-        defaultSize: 'initial size: px number, "Npx", or "N%" of the basis',
+        defaultSize:
+          'initial px number/string; runtime accepts px, %, min()/max(); resolves once',
         minSize: 'minimum: px number, "Npx", "N%", or nested CSS min()/max()',
         maxSize: 'maximum: px number, "Npx", "N%", or nested CSS min()/max()',
         collapsible: 'region can collapse to size 0?',

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -85,20 +85,33 @@ export const docs = {
           name: 'defaultSize',
           type: 'number | string',
           description:
-            'Initial size in pixels or percentage string (e.g. "20%").',
+            'Released initial size: a pixel number, exact "Npx", or exact "N%" from 0% to 100%. Unsupported strings use the documented fallback.',
           default: '250',
+        },
+        {
+          name: 'minSize',
+          type: 'ResizableConstraintValue',
+          description:
+            'Minimum size: a pixel number, "Npx", "N%", or recursive CSS min()/max() expression.',
+          default: '50',
+        },
+        {
+          name: 'maxSize',
+          type: 'ResizableConstraintValue',
+          description:
+            'Maximum size: a pixel number, "Npx", "N%", or recursive CSS min()/max() expression. The maximum wins if resolved bounds conflict.',
+          default: 'Infinity',
         },
         {
           name: 'minSizePx',
           type: 'number',
-          description: 'Minimum size in pixels.',
-          default: '50',
+          description: 'Deprecated pixel-only alias for minSize.',
         },
         {
           name: 'maxSizePx',
           type: 'number',
-          description: 'Maximum size in pixels.',
-          default: 'Infinity',
+          description:
+            'Deprecated pixel-only alias for maxSize. Explicit Infinity remains valid.',
         },
         {
           name: 'collapsible',
@@ -127,6 +140,26 @@ export const docs = {
           type: 'string',
           description:
             'Key for persisting sizes and collapse state to localStorage.',
+        },
+      ],
+      examples: [
+        {
+          label: 'Container-relative minimum',
+          code: `const containerRef = useRef<HTMLDivElement>(null);
+const region = useResizable({
+  defaultSize: 360,
+  minSize: 'max(40%, 333px)',
+  containerRef,
+});`,
+        },
+        {
+          label: 'Container-relative maximum',
+          code: `const containerRef = useRef<HTMLDivElement>(null);
+const region = useResizable({
+  defaultSize: 360,
+  maxSize: 'min(400px, 10%)',
+  containerRef,
+});`,
         },
       ],
     },
@@ -243,8 +276,8 @@ export const docsDense = {
         'Hook managing resize state for one or more panel regions. Returns size, isCollapsed, collapse/expand/resize methods, + props to pass to handles.',
       propDescriptions: {
         defaultSize: 'initial size: px number, "Npx", or "N%" of the basis',
-        minSize: 'minimum size: px number, "Npx", or "N%" of the basis',
-        maxSize: 'maximum size: px number, "Npx", or "N%" of the basis',
+        minSize: 'minimum: px number, "Npx", "N%", or nested CSS min()/max()',
+        maxSize: 'maximum: px number, "Npx", "N%", or nested CSS min()/max()',
         collapsible: 'region can collapse to size 0?',
         collapsedSize: 'px threshold triggering collapse during drag',
         snaps: 'px values to snap to during resize',

--- a/packages/core/src/Resizable/Resizable.spec.md
+++ b/packages/core/src/Resizable/Resizable.spec.md
@@ -27,7 +27,7 @@ architecture:
     architecture:public-component-api,
   ]
 contributing: []
-system_specs: []
+system_specs: [spec:AST-010]
 ---
 
 # Resizable component contract
@@ -36,17 +36,21 @@ system_specs: []
 
 Resizable combines the useResizable state and behavior hook with a focusable
 ResizeHandle. The handle presents a default Grip pill over an enlarged invisible
-Grab zone. This draft records current consumer anatomy and theming ownership
-without changing resize semantics, runtime behavior, styling, targets, or public
-API.
+Grab zone. This draft records consumer anatomy and theming ownership plus the
+AST-010 sizing contract: configuration may express container- or viewport-based
+percentage constraints, including bounded recursive CSS `min()` / `max()`, while
+selected state, rendered geometry, persistence, callbacks, and ARIA remain pixels.
 
 ## Compatibility and migration
 
-- Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, aliases, and public API remain unchanged
+- Released default preserved: `yes`; `defaultSize` retains its released type,
+  one-time percentage resolution, and 250px invalid fallback
+- Compatibility class: additive `minSize` / `maxSize` and
+  `ResizableConstraintValue`; deprecated `minSizePx` / `maxSizePx`, pixel output,
+  controlled behavior, DOM, styling, and theming targets remain compatible
 - Controlled/uncontrolled behavior: unchanged
-- Migration decision: none
+- Migration decision: aliases remain supported; use unified constraints for new
+  code
 
 Consumer migration instructions belong in consumer docs and release notes.
 
@@ -67,21 +71,26 @@ Consumer migration instructions belong in consumer docs and release notes.
 - Layout-region topology, inset, divider, or scrolling rules.
 - A public target for the Grab zone; none exists on current `main`.
 - Fixing the missing runtime reflection for the documented Handle `direction`
-  theming state in this documentation-only change.
+  theming state in this constraint change.
 
 ## Public concepts
 
-No new public concept is introduced. Consumer props, hook outputs, and usage
-remain documented in `Resizable.doc.mjs` and `useResizable.doc.mjs`.
+`minSize` and `maxSize` are flat unified constraints typed as
+`ResizableConstraintValue`: a non-negative pixel number, exact `Npx`, exact
+0–100 `N%`, or a lowercase recursive CSS `min()` / `max()` expression over those
+string leaves, nested at most eight function levels. `defaultSize` keeps its
+released `SizeValue` surface and atomic runtime grammar. Consumer props, outputs,
+and examples are documented in `Resizable.doc.mjs` and `useResizable.doc.mjs`.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                                             | Basis                           | Draft review state                                            |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
-| FR1 | ResizeHandle renders one focusable Handle and one enlarged Grab zone; the default render also contains a Grip pill, while caller-provided children replace that pill.                           | Current source, docs, and tests | Verified current behavior; no new behavior decided            |
-| FR2 | Handle carries `resize-handle`, Grip pill carries `resize-handle-pill`, and Grab zone carries no public target.                                                                                 | Current source and public docs  | Verified current target inventory; no target change           |
-| FR3 | Pointer, keyboard, collapse, snap, persistence, reversal, and size behavior remain owned by ResizeHandle and useResizable rather than layout-regions collaborators.                             | Current source, docs, and tests | Verified current ownership; resize semantics remain unchanged |
-| FR4 | Resizable metadata advertises `direction` as a Handle visual state, but current runtime calls `themeProps('resize-handle')` without reflecting that value, so direction selectors cannot match. | Current source and public docs  | Verified audit gap; deliberately not fixed in this change     |
+| ID  | Candidate invariant                                                                                                                                                                                                                                                  | Basis                            | Draft review state                                                        |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------- |
+| FR1 | ResizeHandle renders one focusable Handle and one enlarged Grab zone; the default render also contains a Grip pill, while caller-provided children replace that pill.                                                                                                | Current source, docs, and tests  | Verified current behavior; no new behavior decided                        |
+| FR2 | Handle carries `resize-handle`, Grip pill carries `resize-handle-pill`, and Grab zone carries no public target.                                                                                                                                                      | Current source and public docs   | Verified current target inventory; no target change                       |
+| FR3 | Pointer, keyboard, collapse, snap, persistence, reversal, and size behavior remain owned by ResizeHandle and useResizable rather than layout-regions collaborators.                                                                                                  | Current source, docs, and tests  | Verified current ownership; resize semantics remain unchanged             |
+| FR4 | Resizable metadata advertises `direction` as a Handle visual state, but current runtime calls `themeProps('resize-handle')` without reflecting that value, so direction selectors cannot match.                                                                      | Current source and public docs   | Verified audit gap; deliberately not fixed in this change                 |
+| FR5 | Percentage leaves in `minSize` / `maxSize`, including inside recursive CSS `min()` / `max()`, resolve against the AST-010 basis and re-clamp pixel state when it changes. Invalid expressions use deterministic fallbacks; if minimum exceeds maximum, maximum wins. | AST-010, source, tests, Chromium | New additive constraint contract; defaults and interactions remain pixels |
 
 ### Allowed variation
 
@@ -106,12 +115,20 @@ remain documented in `Resizable.doc.mjs` and `useResizable.doc.mjs`.
 
 ### Transformation and precedence order
 
-- No new clamp, snap, collapse, persistence, reversal, pointer, or keyboard order
-  is introduced.
+- Parse each bound fully, rejecting unsupported syntax before evaluation.
+- Resolve pixel leaves directly and percentage leaves against one active basis;
+  evaluate nested `min()` / `max()` from the leaves outward.
+- Clamp with `Math.min(max, Math.max(min, size))`; maximum wins when bounds
+  conflict.
+- Pointer, keyboard, snap, collapse, persistence, and callbacks then continue on
+  resolved pixel state.
 
 ### Performance and resources
 
-- No new listener, storage, observer, or render requirement is introduced.
+- Parsing is linear in the authored value and recursion is bounded to eight
+  function levels.
+- Percentage-dependent constraints reuse the one shared ResizeObserver subscription
+  required by AST-010; pure-pixel values and expressions subscribe to no basis.
 
 ## Accessibility contract
 
@@ -153,8 +170,11 @@ not emit the documented target state.
 
 - `architecture:component-theming-surface` owns anatomy qualification, target
   mapping, and target-state reflection requirements.
-- `architecture:interaction-modality` and `architecture:public-component-api`
-  own shared modality and API boundaries; this draft changes neither.
+- `architecture:interaction-modality` continues to own shared modality behavior;
+  `architecture:public-component-api` owns the additive constraint type and
+  compatibility boundary.
+- `spec:AST-010` owns basis resolution, parsing, clamping, persistence, and the
+  maximum-wins conflict rule.
 - `family:layout-regions` lists useResizable and ResizeHandle as collaborators
   that may drive a LayoutPanel's size. Resizable is not a layout-regions member,
   and that family does not own or redefine resize state, snapping, persistence,
@@ -162,13 +182,14 @@ not emit the documented target state.
 
 ## Verification map
 
-| Contract            | Verification                                       | Representative states                           | Mutation or failure expectation                                                                                 | Audit section              |
-| ------------------- | -------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| FR1                 | `ResizeHandle.test.tsx` plus source inspection     | Default, custom, collapsed, disabled, both axes | Handle and Grab zone regressions fail focused tests; custom Grip replacement currently relies on source review. | `audit:Resizable/anatomy`  |
-| FR2                 | Source inspection and `themingTargets.test.ts`     | Handle, Grip pill, and Grab zone                | Removing a target or documenting an unshipped Grab zone target fails evidence or inventory.                     | `audit:Resizable/theming`  |
-| FR3                 | `ResizeHandle.test.tsx` and `useResizable.test.ts` | Pointer, keyboard, snap, collapse, persistence  | Moving resize ownership or changing current transformations fails focused behavior coverage.                    | `audit:Resizable/behavior` |
-| FR4                 | Source and public metadata comparison              | Horizontal and vertical Handle                  | No current test detects that documented `direction` is absent from runtime target-state reflection.             | `audit:Resizable/theming`  |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                      | Canonical anatomy and two current targets       | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                      | `audit:Resizable/theming`  |
+| Contract            | Verification                                       | Representative states                                                        | Mutation or failure expectation                                                                                                         | Audit section              |
+| ------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| FR1                 | `ResizeHandle.test.tsx` plus source inspection     | Default, custom, collapsed, disabled, both axes                              | Handle and Grab zone regressions fail focused tests; custom Grip replacement currently relies on source review.                         | `audit:Resizable/anatomy`  |
+| FR2                 | Source inspection and `themingTargets.test.ts`     | Handle, Grip pill, and Grab zone                                             | Removing a target or documenting an unshipped Grab zone target fails evidence or inventory.                                             | `audit:Resizable/theming`  |
+| FR3                 | `ResizeHandle.test.tsx` and `useResizable.test.ts` | Pointer, keyboard, snap, collapse, persistence                               | Moving resize ownership or changing current transformations fails focused behavior coverage.                                            | `audit:Resizable/behavior` |
+| FR4                 | Source and public metadata comparison              | Horizontal and vertical Handle                                               | No current test detects that documented `direction` is absent from runtime target-state reflection.                                     | `audit:Resizable/theming`  |
+| FR5                 | `useResizable.test.ts`, typecheck, and Chromium    | Atomic/nested/invalid values; wide/narrow basis; inverted bounds; SSR/no-ref | Parser or dependency regressions fail focused tests; canonical browser measurements must match resolved ARIA bounds and panel geometry. | `audit:Resizable/behavior` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                      | Canonical anatomy and two current targets                                    | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                              | `audit:Resizable/theming`  |
 
 Current tests exercise Handle and Grab zone structure and behavior but do not
 render `children` to prove that custom content replaces Grip pill. That branch is
@@ -178,8 +199,9 @@ cover its missing runtime reflection; that mismatch is currently unguarded.
 
 ## Decision log
 
-None. This draft records current facts and introduces no component-local design,
-API, resize, layout-family, or theming decision.
+Resizable sizing decisions are delegated to `spec:AST-010`, including
+constraint vocabulary, basis dependency, deterministic fallbacks, and
+maximum-wins conflict handling. This component record adds no second policy.
 
 ## Open questions
 

--- a/packages/core/src/Resizable/Resizable.spec.md
+++ b/packages/core/src/Resizable/Resizable.spec.md
@@ -38,13 +38,16 @@ Resizable combines the useResizable state and behavior hook with a focusable
 ResizeHandle. The handle presents a default Grip pill over an enlarged invisible
 Grab zone. This draft records consumer anatomy and theming ownership plus the
 AST-010 sizing contract: configuration may express container- or viewport-based
-percentage constraints, including bounded recursive CSS `min()` / `max()`, while
-selected state, rendered geometry, persistence, callbacks, and ARIA remain pixels.
+percentage values, including bounded recursive CSS `min()` / `max()`. A composed
+`defaultSize` chooses one initial pixel size; percentage-dependent bounds remain
+live. Selected state, rendered geometry, persistence, callbacks, and ARIA remain
+pixels.
 
 ## Compatibility and migration
 
-- Released default preserved: `yes`; `defaultSize` retains its released type,
-  one-time percentage resolution, and 250px invalid fallback
+- Released default preserved: `yes`; `defaultSize` retains its released
+  `number | string` type, one-time basis resolution, and 250px invalid fallback,
+  while accepting the same restricted runtime CSS math grammar as bounds
 - Compatibility class: additive `minSize` / `maxSize` and
   `ResizableConstraintValue`; deprecated `minSizePx` / `maxSizePx`, pixel output,
   controlled behavior, DOM, styling, and theming targets remain compatible
@@ -78,19 +81,20 @@ Consumer migration instructions belong in consumer docs and release notes.
 `minSize` and `maxSize` are flat unified constraints typed as
 `ResizableConstraintValue`: a non-negative pixel number, exact `Npx`, exact
 0–100 `N%`, or a lowercase recursive CSS `min()` / `max()` expression over those
-string leaves, nested at most eight function levels. `defaultSize` keeps its
-released `SizeValue` surface and atomic runtime grammar. Consumer props, outputs,
-and examples are documented in `Resizable.doc.mjs` and `useResizable.doc.mjs`.
+string leaves, nested at most eight function levels. `defaultSize` accepts that
+same runtime grammar but keeps its released wide `SizeValue` (`number | string`)
+public type, with runtime validation authoritative. Consumer props, outputs, and
+examples are documented in `Resizable.doc.mjs` and `useResizable.doc.mjs`.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                                                                                                                  | Basis                            | Draft review state                                                        |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------- |
-| FR1 | ResizeHandle renders one focusable Handle and one enlarged Grab zone; the default render also contains a Grip pill, while caller-provided children replace that pill.                                                                                                | Current source, docs, and tests  | Verified current behavior; no new behavior decided                        |
-| FR2 | Handle carries `resize-handle`, Grip pill carries `resize-handle-pill`, and Grab zone carries no public target.                                                                                                                                                      | Current source and public docs   | Verified current target inventory; no target change                       |
-| FR3 | Pointer, keyboard, collapse, snap, persistence, reversal, and size behavior remain owned by ResizeHandle and useResizable rather than layout-regions collaborators.                                                                                                  | Current source, docs, and tests  | Verified current ownership; resize semantics remain unchanged             |
-| FR4 | Resizable metadata advertises `direction` as a Handle visual state, but current runtime calls `themeProps('resize-handle')` without reflecting that value, so direction selectors cannot match.                                                                      | Current source and public docs   | Verified audit gap; deliberately not fixed in this change                 |
-| FR5 | Percentage leaves in `minSize` / `maxSize`, including inside recursive CSS `min()` / `max()`, resolve against the AST-010 basis and re-clamp pixel state when it changes. Invalid expressions use deterministic fallbacks; if minimum exceeds maximum, maximum wins. | AST-010, source, tests, Chromium | New additive constraint contract; defaults and interactions remain pixels |
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                         | Basis                            | Draft review state                                                                                    |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| FR1 | ResizeHandle renders one focusable Handle and one enlarged Grab zone; the default render also contains a Grip pill, while caller-provided children replace that pill.                                                                                                                                       | Current source, docs, and tests  | Verified current behavior; no new behavior decided                                                    |
+| FR2 | Handle carries `resize-handle`, Grip pill carries `resize-handle-pill`, and Grab zone carries no public target.                                                                                                                                                                                             | Current source and public docs   | Verified current target inventory; no target change                                                   |
+| FR3 | Pointer, keyboard, collapse, snap, persistence, reversal, and size behavior remain owned by ResizeHandle and useResizable rather than layout-regions collaborators.                                                                                                                                         | Current source, docs, and tests  | Verified current ownership; resize semantics remain unchanged                                         |
+| FR4 | Resizable metadata advertises `direction` as a Handle visual state, but current runtime calls `themeProps('resize-handle')` without reflecting that value, so direction selectors cannot match.                                                                                                             | Current source and public docs   | Verified audit gap; deliberately not fixed in this change                                             |
+| FR5 | A composed `defaultSize` resolves against the first measurable AST-010 basis and becomes one pixel choice; percentage leaves nested in `minSize` / `maxSize` remain live and re-clamp that choice. Invalid expressions use role-specific deterministic fallbacks; if minimum exceeds maximum, maximum wins. | AST-010, source, tests, Chromium | Additive composed sizing contract; released defaults, public type, and interactions remain compatible |
 
 ### Allowed variation
 
@@ -115,9 +119,12 @@ and examples are documented in `Resizable.doc.mjs` and `useResizable.doc.mjs`.
 
 ### Transformation and precedence order
 
-- Parse each bound fully, rejecting unsupported syntax before evaluation.
+- Parse each configured value fully, rejecting unsupported syntax before
+  evaluation.
 - Resolve pixel leaves directly and percentage leaves against one active basis;
   evaluate nested `min()` / `max()` from the leaves outward.
+- Commit `defaultSize` as one initial pixel choice; keep only
+  percentage-dependent bounds live.
 - Clamp with `Math.min(max, Math.max(min, size))`; maximum wins when bounds
   conflict.
 - Pointer, keyboard, snap, collapse, persistence, and callbacks then continue on
@@ -127,8 +134,10 @@ and examples are documented in `Resizable.doc.mjs` and `useResizable.doc.mjs`.
 
 - Parsing is linear in the authored value and recursion is bounded to eight
   function levels.
-- Percentage-dependent constraints reuse the one shared ResizeObserver subscription
-  required by AST-010; pure-pixel values and expressions subscribe to no basis.
+- Percentage-dependent bounds reuse the one shared ResizeObserver subscription
+  required by AST-010. A basis-dependent default observes only until its initial
+  choice is final; pure-pixel expressions and persisted default choices observe no
+  basis.
 
 ## Accessibility contract
 
@@ -182,14 +191,14 @@ not emit the documented target state.
 
 ## Verification map
 
-| Contract            | Verification                                       | Representative states                                                        | Mutation or failure expectation                                                                                                         | Audit section              |
-| ------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| FR1                 | `ResizeHandle.test.tsx` plus source inspection     | Default, custom, collapsed, disabled, both axes                              | Handle and Grab zone regressions fail focused tests; custom Grip replacement currently relies on source review.                         | `audit:Resizable/anatomy`  |
-| FR2                 | Source inspection and `themingTargets.test.ts`     | Handle, Grip pill, and Grab zone                                             | Removing a target or documenting an unshipped Grab zone target fails evidence or inventory.                                             | `audit:Resizable/theming`  |
-| FR3                 | `ResizeHandle.test.tsx` and `useResizable.test.ts` | Pointer, keyboard, snap, collapse, persistence                               | Moving resize ownership or changing current transformations fails focused behavior coverage.                                            | `audit:Resizable/behavior` |
-| FR4                 | Source and public metadata comparison              | Horizontal and vertical Handle                                               | No current test detects that documented `direction` is absent from runtime target-state reflection.                                     | `audit:Resizable/theming`  |
-| FR5                 | `useResizable.test.ts`, typecheck, and Chromium    | Atomic/nested/invalid values; wide/narrow basis; inverted bounds; SSR/no-ref | Parser or dependency regressions fail focused tests; canonical browser measurements must match resolved ARIA bounds and panel geometry. | `audit:Resizable/behavior` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                      | Canonical anatomy and two current targets                                    | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                              | `audit:Resizable/theming`  |
+| Contract            | Verification                                       | Representative states                                                                                                  | Mutation or failure expectation                                                                                                             | Audit section              |
+| ------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| FR1                 | `ResizeHandle.test.tsx` plus source inspection     | Default, custom, collapsed, disabled, both axes                                                                        | Handle and Grab zone regressions fail focused tests; custom Grip replacement currently relies on source review.                             | `audit:Resizable/anatomy`  |
+| FR2                 | Source inspection and `themingTargets.test.ts`     | Handle, Grip pill, and Grab zone                                                                                       | Removing a target or documenting an unshipped Grab zone target fails evidence or inventory.                                                 | `audit:Resizable/theming`  |
+| FR3                 | `ResizeHandle.test.tsx` and `useResizable.test.ts` | Pointer, keyboard, snap, collapse, persistence                                                                         | Moving resize ownership or changing current transformations fails focused behavior coverage.                                                | `audit:Resizable/behavior` |
+| FR4                 | Source and public metadata comparison              | Horizontal and vertical Handle                                                                                         | No current test detects that documented `direction` is absent from runtime target-state reflection.                                         | `audit:Resizable/theming`  |
+| FR5                 | `useResizable.test.ts`, typecheck, and Chromium    | Default expression at wide/narrow initial basis then resize; atomic/nested/invalid values; inverted bounds; SSR/no-ref | Parser/lifecycle regressions fail focused tests; canonical browser measurements must keep state, storage, ARIA, and panel geometry aligned. | `audit:Resizable/behavior` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                      | Canonical anatomy and two current targets                                                                              | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                                  | `audit:Resizable/theming`  |
 
 Current tests exercise Handle and Grab zone structure and behavior but do not
 render `children` to prove that custom content replaces Grip pill. That branch is

--- a/packages/core/src/Resizable/index.ts
+++ b/packages/core/src/Resizable/index.ts
@@ -13,6 +13,7 @@ export {useResizable} from './useResizable';
 export type {
   ResizableRegion,
   ResizableRegionConfig,
+  ResizableConstraintValue,
   ResizableProps,
   ResizableConfig,
   UseResizableSingleConfig,

--- a/packages/core/src/Resizable/useResizable.doc.mjs
+++ b/packages/core/src/Resizable/useResizable.doc.mjs
@@ -20,7 +20,7 @@ export const docs = {
       name: 'defaultSize',
       type: 'number | string',
       description:
-        'Initial size: a number of pixels, an exact "Npx" string, or an exact "N%" string from 0% to 100%. A percentage resolves ONCE into pixels — against the container when containerRef is supplied, against the viewport otherwise — and does not track its basis afterwards.',
+        'Initial size. Runtime accepts a non-negative pixel number, exact "Npx", exact "N%" from 0% to 100%, or the same recursive CSS min()/max() grammar as the bounds. For example, defaultSize: "max(40%, 333px)" chooses 40% of the initial basis with a 333px floor, resolves ONCE into pixels against containerRef or the viewport, and does not follow later basis changes. The public type remains the released number | string for compatibility; runtime validation is authoritative, and unsupported strings keep the 250px fallback plus a development warning.',
       default: '250',
     },
     {
@@ -145,7 +145,12 @@ export const docs = {
       {
         guidance: true,
         description:
-          "Use minSize: 'max(40%, 333px)' for a fluid floor, or maxSize: 'min(400px, 10%)' for a fluid ceiling. Percentage leaves use containerRef when supplied.",
+          "Use defaultSize: 'max(40%, 333px)' to choose an initial pixel size from the first measurable basis. It does not rescale when the basis later changes.",
+      },
+      {
+        guidance: true,
+        description:
+          "Use minSize: 'max(40%, 333px)' for a persistent fluid floor, or maxSize: 'min(400px, 10%)' for a persistent fluid ceiling. Percentage leaves in bounds re-resolve when their basis changes.",
       },
       {
         guidance: true,
@@ -175,7 +180,8 @@ export const docsDense = {
   description:
     'Adds drag-to-resize behavior to layout regions. Supports single-/multi-region configs w/ snap points, collapsible panels, localStorage persistence, cascade resize ordering.',
   paramDescriptions: {
-    defaultSize: 'initial size: px number, "Npx", or "N%" of the basis.',
+    defaultSize:
+      'initial px number, "Npx", "N%", or nested CSS min()/max(); resolves once.',
     minSize:
       'min constraint: px number, "Npx", "N%", or nested CSS min()/max().',
     maxSize:
@@ -209,6 +215,11 @@ export const docsDense = {
         guidance: true,
         description:
           'Use w/ Layout / AppShell sidebar for resizable navigation panels.',
+      },
+      {
+        guidance: true,
+        description:
+          "Use defaultSize: 'max(40%, 333px)' for a one-time initial choice; use minSize with the same expression for a persistent floor.",
       },
       {
         guidance: true,

--- a/packages/core/src/Resizable/useResizable.doc.mjs
+++ b/packages/core/src/Resizable/useResizable.doc.mjs
@@ -25,16 +25,16 @@ export const docs = {
     },
     {
       name: 'minSize',
-      type: 'number | string',
+      type: 'ResizableConstraintValue',
       description:
-        'Minimum size, in the same vocabulary as defaultSize. A percentage minimum re-resolves when its basis changes and clamps the current pixel size.',
+        'Minimum size: a non-negative pixel number, exact "Npx", exact "N%" from 0% to 100%, or a recursive CSS min()/max() expression nested up to eight levels. Percentage leaves re-resolve when their basis changes and clamp the current pixel size. Other CSS functions, arithmetic, variables, and units are invalid.',
       default: '50',
     },
     {
       name: 'maxSize',
-      type: 'number | string',
+      type: 'ResizableConstraintValue',
       description:
-        'Maximum size, in the same vocabulary as defaultSize. A percentage maximum re-resolves when its basis changes and clamps the current pixel size.',
+        'Maximum size: a non-negative pixel number, exact "Npx", exact "N%" from 0% to 100%, or a recursive CSS min()/max() expression nested up to eight levels. Percentage leaves re-resolve when their basis changes and clamp the current pixel size. Other CSS functions, arithmetic, variables, and units are invalid.',
       default: 'Infinity',
     },
     {
@@ -54,13 +54,13 @@ export const docs = {
       name: 'minSizePx',
       type: 'number',
       description:
-        'Deprecated. Use minSize, which also accepts a percentage. Supplying both is a type error; if untyped code supplies both, minSize wins.',
+        'Deprecated. Use minSize, which also accepts percentage and CSS min()/max() constraints. Supplying both is a type error; if untyped code supplies both, minSize wins.',
     },
     {
       name: 'maxSizePx',
       type: 'number',
       description:
-        'Deprecated. Use maxSize, which also accepts a percentage. Explicit Infinity remains valid.',
+        'Deprecated. Use maxSize, which also accepts percentage and CSS min()/max() constraints. Explicit Infinity remains valid.',
     },
     {
       name: 'collapsible',
@@ -145,7 +145,17 @@ export const docs = {
       {
         guidance: true,
         description:
+          "Use minSize: 'max(40%, 333px)' for a fluid floor, or maxSize: 'min(400px, 10%)' for a fluid ceiling. Percentage leaves use containerRef when supplied.",
+      },
+      {
+        guidance: true,
+        description:
           'Set autoSaveId to persist user-chosen sizes across page reloads.',
+      },
+      {
+        guidance: false,
+        description:
+          'Configure a minimum that can resolve above its maximum. If they conflict, the maximum wins deterministically.',
       },
       {
         guidance: false,
@@ -166,8 +176,10 @@ export const docsDense = {
     'Adds drag-to-resize behavior to layout regions. Supports single-/multi-region configs w/ snap points, collapsible panels, localStorage persistence, cascade resize ordering.',
   paramDescriptions: {
     defaultSize: 'initial size: px number, "Npx", or "N%" of the basis.',
-    minSize: 'min size: px number, "Npx", or "N%" of the basis.',
-    maxSize: 'max size: px number, "Npx", or "N%" of the basis.',
+    minSize:
+      'min constraint: px number, "Npx", "N%", or nested CSS min()/max().',
+    maxSize:
+      'max constraint: px number, "Npx", "N%", or nested CSS min()/max().',
     containerRef: 'the element a percentage is a share of.',
     direction: 'which axis to resize along.',
     collapsible:
@@ -201,7 +213,17 @@ export const docsDense = {
       {
         guidance: true,
         description:
+          "Use minSize: 'max(40%, 333px)' for a fluid floor, or maxSize: 'min(400px, 10%)' for a fluid ceiling.",
+      },
+      {
+        guidance: true,
+        description:
           'Set autoSaveId to persist user-chosen sizes across page reloads.',
+      },
+      {
+        guidance: false,
+        description:
+          'Configure min > max. Maximum wins deterministically when resolved bounds conflict.',
       },
       {
         guidance: false,

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -11,11 +11,16 @@
  * SYNC: When useResizable changes, update tests to match new behavior
  */
 
-import {useLayoutEffect} from 'react';
+import {createElement, useLayoutEffect} from 'react';
+import {renderToString} from 'react-dom/server';
 import {describe, it, expect, beforeEach, vi} from 'vitest';
 import {renderHook, act} from '@testing-library/react';
 import {useResizable} from './useResizable';
-import type {ResizableProps} from './useResizable';
+import type {
+  ResizableConstraintValue,
+  ResizableProps,
+  UseResizableSingleConfig,
+} from './useResizable';
 
 const AUTO_SAVE_ID = 'test-panel';
 const KEY = `astryx-resizable:${AUTO_SAVE_ID}`;
@@ -646,6 +651,188 @@ describe('useResizable percentage configuration (AST-010)', () => {
     });
   });
 
+  describe('CSS min()/max() constraints — AST-010 amendment', () => {
+    it('resolves the canonical minimum against the container basis', () => {
+      content = 500;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 0,
+          minSize: 'max(40%, 333px)',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.props._minSizePx).toBe(333);
+      expect(result.current.size).toBe(333);
+
+      act(() => {
+        content = 1000;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.props._minSizePx).toBe(400);
+      expect(result.current.size).toBe(400);
+    });
+
+    it('resolves the canonical maximum and re-clamps when the basis narrows', () => {
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 500,
+          maxSize: 'min(400px, 10%)',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.props._maxSizePx).toBe(100);
+      expect(result.current.size).toBe(100);
+
+      act(() => {
+        content = 500;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.props._maxSizePx).toBe(50);
+      expect(result.current.size).toBe(50);
+    });
+
+    it('evaluates nested and variadic expressions', () => {
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 0,
+          minSize: 'min(900px, 80%, max(40%, 333px))',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.props._minSizePx).toBe(400);
+      expect(result.current.size).toBe(400);
+    });
+
+    it('detects a nested percentage dependency and follows the viewport basis', () => {
+      window.innerWidth = 1000;
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 500,
+          maxSize: 'min(400px, max(5%, 10%))',
+        }),
+      );
+      expect(result.current.props._maxSizePx).toBe(100);
+      expect(result.current.size).toBe(100);
+
+      act(() => {
+        window.innerWidth = 500;
+        window.dispatchEvent(new Event('resize'));
+      });
+      expect(result.current.props._maxSizePx).toBe(50);
+      expect(result.current.size).toBe(50);
+    });
+
+    it('does not observe a container for a pure-pixel expression', () => {
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 0,
+          minSize: 'max(40px, 333px)',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.props._minSizePx).toBe(333);
+      expect(
+        StubResizeObserver.instances.flatMap(observer => observer.targets),
+      ).not.toContain(containerRef.current);
+    });
+
+    it('keeps maximum-wins ordering when resolved constraints conflict', () => {
+      content = 1000;
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 500,
+          minSize: 'max(40%, 333px)',
+          maxSize: 'min(400px, 10%)',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.props._minSizePx).toBe(400);
+      expect(result.current.props._maxSizePx).toBe(100);
+      expect(result.current.size).toBe(100);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('The maximum wins'),
+      );
+      warn.mockRestore();
+    });
+
+    it.each([
+      'calc(100% - 20px)',
+      'clamp(100px, 20%, 400px)',
+      'var(--panel-width)',
+      'min(100px + 20px, 50%)',
+      'min(10rem, 50%)',
+      'min()',
+      'min(100px,)',
+      'min(100px 50%)',
+      'min(100px, 50%))trailing',
+      'MIN(100px, 50%)',
+      'max(-1px, 50%)',
+      'min(120%, 100px)',
+    ])('rejects unsupported or malformed syntax: %s', invalid => {
+      const {result} = renderHook(() =>
+        useResizable({defaultSize: 10, minSize: invalid as never}),
+      );
+      expect(result.current.props._minSizePx).toBe(50);
+      expect(result.current.size).toBe(50);
+    });
+
+    it('bounds expression nesting at eight functions', () => {
+      const nest = (depth: number) => {
+        let value = '1px';
+        for (let i = 0; i < depth; i += 1) {
+          value = `max(1px, ${value})`;
+        }
+        return value;
+      };
+
+      const accepted = renderHook(() =>
+        useResizable({defaultSize: 0, minSize: nest(8) as never}),
+      );
+      expect(accepted.result.current.props._minSizePx).toBe(1);
+
+      const rejected = renderHook(() =>
+        useResizable({defaultSize: 0, minSize: nest(9) as never}),
+      );
+      expect(rejected.result.current.props._minSizePx).toBe(50);
+    });
+
+    it('uses the 1200px server basis with no container ref', () => {
+      const originalWindow = globalThis.window;
+      vi.stubGlobal('window', undefined);
+      try {
+        const html = renderToString(
+          createElement(() => {
+            const region = useResizable({
+              defaultSize: 500,
+              maxSize: 'min(400px, 10%)',
+            });
+            return createElement(
+              'output',
+              null,
+              `${region.size}/${region.props._maxSizePx}`,
+            );
+          }),
+        );
+        expect(html).toContain('120/120');
+      } finally {
+        vi.stubGlobal('window', originalWindow);
+      }
+    });
+  });
+
   describe('FR5 — state, ARIA and paint describe one geometry', () => {
     it('publishes the clamped size and the resolved bounds', () => {
       const containerRef = makeContainer();
@@ -716,6 +903,27 @@ describe('useResizable percentage configuration (AST-010)', () => {
         useResizable({defaultSize: 10_000, maxSize: 'nope' as never}),
       );
       expect(result.current.size).toBe(10_000);
+    });
+
+    it('keeps CSS math out of released defaultSize', () => {
+      const {result} = renderHook(() =>
+        useResizable({defaultSize: 'min(400px, 10%)'}),
+      );
+      expect(result.current.size).toBe(250);
+    });
+
+    it('keeps deprecated aliases pixel-only at runtime', () => {
+      const min = renderHook(() =>
+        useResizable({defaultSize: 10, minSizePx: '25%' as never}),
+      );
+      expect(min.result.current.props._minSizePx).toBe(50);
+      expect(min.result.current.size).toBe(50);
+
+      const max = renderHook(() =>
+        useResizable({defaultSize: 10_000, maxSizePx: '25%' as never}),
+      );
+      expect(max.result.current.props._maxSizePx).toBe(Infinity);
+      expect(max.result.current.size).toBe(10_000);
     });
 
     it('accepts an exact px string', () => {
@@ -1006,5 +1214,59 @@ describe('ResizableProps source compatibility (AST-010 API5)', () => {
     };
     expect(prePr._direction).toBeUndefined();
     expect(prePr._onResizeCancel).toBeUndefined();
+  });
+});
+
+describe('Resizable constraint types', () => {
+  it('accepts numbers, px, percentages, and CSS min()/max()', () => {
+    const accepted = [
+      240,
+      '240px',
+      '40%',
+      'max(40%, 333px)',
+      'min(400px, max(5%, 10%))',
+    ] satisfies ResizableConstraintValue[];
+
+    expect(accepted).toHaveLength(5);
+  });
+
+  it('rejects unsupported top-level string forms', () => {
+    // @ts-expect-error only px, %, min(), and max() string forms are public
+    const rem: ResizableConstraintValue = '10rem';
+    // @ts-expect-error arithmetic is outside the constraint grammar
+    const calc: ResizableConstraintValue = 'calc(100% - 20px)';
+    // @ts-expect-error clamp() is outside the constraint grammar
+    const clamp: ResizableConstraintValue = 'clamp(100px, 20%, 400px)';
+    // @ts-expect-error custom properties are outside the constraint grammar
+    const variable: ResizableConstraintValue = 'var(--panel-width)';
+
+    expect([rem, calc, clamp, variable]).toHaveLength(4);
+  });
+
+  it('preserves defaultSize and the legacy aliases while excluding conflicts', () => {
+    const releasedDefault: UseResizableSingleConfig = {
+      defaultSize: 'runtime-validated-string',
+    };
+    const legacyBounds: UseResizableSingleConfig = {
+      minSizePx: 100,
+      maxSizePx: Infinity,
+    };
+    // @ts-expect-error unified and legacy minimums are mutually exclusive
+    const conflictingMin: UseResizableSingleConfig = {
+      minSize: 'max(40%, 333px)',
+      minSizePx: 100,
+    };
+    // @ts-expect-error unified and legacy maximums are mutually exclusive
+    const conflictingMax: UseResizableSingleConfig = {
+      maxSize: 'min(400px, 10%)',
+      maxSizePx: 400,
+    };
+
+    expect([
+      releasedDefault,
+      legacyBounds,
+      conflictingMin,
+      conflictingMax,
+    ]).toHaveLength(4);
   });
 });

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -11,10 +11,11 @@
  * SYNC: When useResizable changes, update tests to match new behavior
  */
 
-import {createElement, useLayoutEffect} from 'react';
+import {createElement, useLayoutEffect, useRef} from 'react';
+import {hydrateRoot} from 'react-dom/client';
 import {renderToString} from 'react-dom/server';
 import {describe, it, expect, beforeEach, vi} from 'vitest';
-import {renderHook, act} from '@testing-library/react';
+import {renderHook, act, waitFor} from '@testing-library/react';
 import {useResizable} from './useResizable';
 import type {
   ResizableConstraintValue,
@@ -495,6 +496,7 @@ describe('useResizable percentage configuration (AST-010)', () => {
   beforeEach(() => {
     content = 400;
     contentBlock = 300;
+    StubResizeObserver.instances = [];
     vi.stubGlobal('ResizeObserver', StubResizeObserver);
     vi.spyOn(window, 'getComputedStyle').mockReturnValue({
       paddingTop: '0px',
@@ -648,6 +650,416 @@ describe('useResizable percentage configuration (AST-010)', () => {
       // Inverted on purpose: the maximum wins, as the released clamp order has
       // always done.
       expect(result.current.size).toBe(80);
+    });
+  });
+
+  describe('CSS min()/max() defaults — one initial pixel choice', () => {
+    const observedTargets = () =>
+      StubResizeObserver.instances.flatMap(observer => observer.targets);
+
+    it('resolves against the initial container basis and does not rescale later', () => {
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 'max(40%, 333px)',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.size).toBe(400);
+      expect(result.current.props._size).toBe(400);
+      expect(observedTargets()).not.toContain(containerRef.current);
+
+      act(() => {
+        content = 500;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.size).toBe(400);
+      expect(result.current.props._size).toBe(400);
+    });
+
+    it('resolves a narrow initial container independently, then stays pixels', () => {
+      content = 500;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 'max(40%, 333px)',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.size).toBe(333);
+      act(() => {
+        content = 1000;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.size).toBe(333);
+    });
+
+    it('uses the same recursive and variadic grammar as bounds', () => {
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 'min(900px, 80%, max(40%, 333px))',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.size).toBe(400);
+    });
+
+    it('uses the initial viewport with no ref and does not follow window resize', () => {
+      window.innerWidth = 1000;
+      const addEventListener = vi.spyOn(window, 'addEventListener');
+      const {result} = renderHook(() =>
+        useResizable({defaultSize: 'max(40%, 333px)'}),
+      );
+
+      expect(result.current.size).toBe(400);
+      expect(
+        addEventListener.mock.calls.some(([type]) => type === 'resize'),
+      ).toBe(false);
+      act(() => {
+        window.innerWidth = 500;
+        window.dispatchEvent(new Event('resize'));
+      });
+      expect(result.current.size).toBe(400);
+    });
+
+    it('uses the deterministic 1200px server basis', () => {
+      const originalWindow = globalThis.window;
+      vi.stubGlobal('window', undefined);
+      try {
+        const html = renderToString(
+          createElement(() => {
+            const region = useResizable({
+              defaultSize: 'max(40%, 333px)',
+            });
+            return createElement('output', null, String(region.size));
+          }),
+        );
+        expect(html).toContain('480');
+      } finally {
+        vi.stubGlobal('window', originalWindow);
+      }
+    });
+
+    it('hydrates the 1200px server choice without a mismatch', async () => {
+      window.innerWidth = 1000;
+      function Probe() {
+        const region = useResizable({
+          defaultSize: 'max(40%, 333px)',
+        });
+        return createElement('output', {'data-size': region.size}, region.size);
+      }
+
+      const serverHTML = renderToString(createElement(Probe));
+      expect(serverHTML).toContain('data-size="480"');
+      const container = document.createElement('div');
+      container.innerHTML = serverHTML;
+      document.body.appendChild(container);
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const recoverableErrors: unknown[] = [];
+      let root: ReturnType<typeof hydrateRoot>;
+
+      await act(async () => {
+        root = hydrateRoot(container, createElement(Probe), {
+          onRecoverableError: error => recoverableErrors.push(error),
+        });
+      });
+
+      expect(recoverableErrors).toEqual([]);
+      expect(
+        consoleError.mock.calls.filter(call =>
+          String(call[0] ?? '')
+            .toLowerCase()
+            .includes('hydrat'),
+        ),
+      ).toEqual([]);
+      expect(container.querySelector('output')).toHaveAttribute(
+        'data-size',
+        '480',
+      );
+      await act(async () => root.unmount());
+      consoleError.mockRestore();
+      container.remove();
+    });
+
+    it('hydrates a container default from the temporary server basis without persisting it', async () => {
+      content = 500;
+      const clientWidth = vi
+        .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+        .mockImplementation(() => content);
+      const clientHeight = vi
+        .spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+        .mockImplementation(() => contentBlock);
+      const setItem = vi.spyOn(Storage.prototype, 'setItem');
+      const onSizeChange = vi.fn();
+
+      function Probe() {
+        const containerRef = useRef<HTMLDivElement>(null);
+        const region = useResizable({
+          defaultSize: 'max(40%, 333px)',
+          containerRef,
+          autoSaveId: 'default-expression-hydration',
+          onSizeChange,
+        });
+        return createElement(
+          'div',
+          {ref: containerRef},
+          createElement('output', {'data-size': region.size}, region.size),
+        );
+      }
+
+      const serverHTML = renderToString(createElement(Probe));
+      expect(serverHTML).toContain('data-size="480"');
+      const container = document.createElement('div');
+      container.innerHTML = serverHTML;
+      document.body.appendChild(container);
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const recoverableErrors: unknown[] = [];
+      let root: ReturnType<typeof hydrateRoot>;
+
+      await act(async () => {
+        root = hydrateRoot(container, createElement(Probe), {
+          onRecoverableError: error => recoverableErrors.push(error),
+        });
+      });
+      await waitFor(() =>
+        expect(container.querySelector('output')).toHaveAttribute(
+          'data-size',
+          '333',
+        ),
+      );
+
+      expect(recoverableErrors).toEqual([]);
+      expect(
+        consoleError.mock.calls.filter(call =>
+          String(call[0] ?? '')
+            .toLowerCase()
+            .includes('hydrat'),
+        ),
+      ).toEqual([]);
+      expect(onSizeChange).not.toHaveBeenCalled();
+      expect(
+        setItem.mock.calls.some(([, value]) => value.includes('"size":480')),
+      ).toBe(false);
+      expect(
+        localStorage.getItem('astryx-resizable:default-expression-hydration'),
+      ).toBe(JSON.stringify({size: 333, isCollapsed: false}));
+
+      await act(async () => root.unmount());
+      consoleError.mockRestore();
+      setItem.mockRestore();
+      clientWidth.mockRestore();
+      clientHeight.mockRestore();
+      container.remove();
+    });
+
+    it('holds the temporary basis without persisting until a zero container lays out', () => {
+      content = 0;
+      const containerRef = makeContainer();
+      const onSizeChange = vi.fn();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 'max(40%, 333px)',
+          containerRef,
+          autoSaveId: 'default-expression-zero',
+          onSizeChange,
+        }),
+      );
+
+      expect(result.current.size).toBe(480);
+      expect(
+        localStorage.getItem('astryx-resizable:default-expression-zero'),
+      ).toBeNull();
+      expect(observedTargets()).toContain(containerRef.current);
+
+      act(() => {
+        content = 500;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.size).toBe(333);
+      expect(
+        localStorage.getItem('astryx-resizable:default-expression-zero'),
+      ).toBe(JSON.stringify({size: 333, isCollapsed: false}));
+      expect(onSizeChange).not.toHaveBeenCalled();
+      expect(observedTargets()).not.toContain(containerRef.current);
+    });
+
+    it('removes the default observer after resize selects pixels before layout', () => {
+      content = 0;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 'max(40%, 333px)',
+          containerRef,
+        }),
+      );
+
+      expect(observedTargets()).toContain(containerRef.current);
+      act(() => result.current.resize(275));
+      expect(result.current.size).toBe(275);
+
+      act(() => {
+        content = 500;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.size).toBe(275);
+      expect(observedTargets()).not.toContain(containerRef.current);
+    });
+
+    it('lets a persisted pixel choice win without measuring the unused default', () => {
+      localStorage.setItem(
+        'astryx-resizable:default-expression-persisted',
+        JSON.stringify({size: 321, isCollapsed: false}),
+      );
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 'max(40%, 333px)',
+          containerRef,
+          autoSaveId: 'default-expression-persisted',
+        }),
+      );
+
+      expect(result.current.size).toBe(321);
+      expect(observedTargets()).not.toContain(containerRef.current);
+      act(() => {
+        content = 500;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.size).toBe(321);
+      expect(
+        localStorage.getItem('astryx-resizable:default-expression-persisted'),
+      ).toBe(JSON.stringify({size: 321, isCollapsed: false}));
+    });
+
+    it('measures the current basis before a newly added bound can clamp', () => {
+      content = 500;
+      const containerRef = makeContainer();
+      const initialProps: {maxSize?: ResizableConstraintValue} = {};
+      const {result, rerender} = renderHook(
+        ({maxSize}: {maxSize?: ResizableConstraintValue}) =>
+          useResizable({
+            defaultSize: 'max(40%, 333px)',
+            maxSize,
+            containerRef,
+          }),
+        {initialProps},
+      );
+
+      expect(result.current.size).toBe(333);
+      expect(observedTargets()).not.toContain(containerRef.current);
+      act(() => result.current.resize(450));
+      expect(result.current.size).toBe(450);
+
+      content = 1000;
+      rerender({maxSize: '50%'});
+
+      expect(result.current.props._maxSizePx).toBe(500);
+      expect(result.current.size).toBe(450);
+      expect(observedTargets()).toContain(containerRef.current);
+    });
+
+    it('keeps bounds responsive after the default becomes pixels', () => {
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          defaultSize: 'max(40%, 333px)',
+          maxSize: '50%',
+          containerRef,
+        }),
+      );
+
+      expect(result.current.size).toBe(400);
+      expect(result.current.props._maxSizePx).toBe(500);
+      expect(observedTargets()).toContain(containerRef.current);
+      act(() => {
+        content = 600;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.props._maxSizePx).toBe(300);
+      expect(result.current.size).toBe(300);
+      act(() => {
+        content = 1000;
+        StubResizeObserver.resizeAll();
+      });
+      expect(result.current.size).toBe(300);
+    });
+
+    it('gives a pure-pixel default expression no observer or render penalty', () => {
+      const containerRef = makeContainer();
+      let atomicPasses = 0;
+      const atomic = renderHook(() => {
+        atomicPasses += 1;
+        return useResizable({defaultSize: 333, containerRef});
+      });
+      const atomicRenders = atomicPasses;
+      atomic.unmount();
+
+      let expressionPasses = 0;
+      const expression = renderHook(() => {
+        expressionPasses += 1;
+        return useResizable({
+          defaultSize: 'max(40px, 333px)',
+          containerRef,
+        });
+      });
+
+      expect(expression.result.current.size).toBe(333);
+      expect(expressionPasses).toBe(atomicRenders);
+      expect(observedTargets()).not.toContain(containerRef.current);
+    });
+
+    it('matches a plain percentage default render count and drops both subscriptions', () => {
+      content = 1000;
+      const plainRef = makeContainer();
+      let plainPasses = 0;
+      const plain = renderHook(() => {
+        plainPasses += 1;
+        return useResizable({defaultSize: '40%', containerRef: plainRef});
+      });
+      expect(plain.result.current.size).toBe(400);
+      expect(observedTargets()).not.toContain(plainRef.current);
+      plain.unmount();
+
+      const expressionRef = makeContainer();
+      let expressionPasses = 0;
+      const expression = renderHook(() => {
+        expressionPasses += 1;
+        return useResizable({
+          defaultSize: 'max(40%, 333px)',
+          containerRef: expressionRef,
+        });
+      });
+      expect(expression.result.current.size).toBe(400);
+      expect(expressionPasses).toBe(plainPasses);
+      expect(observedTargets()).not.toContain(expressionRef.current);
+    });
+
+    it('keeps unsupported strings on the existing fallback and warning path', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const {result} = renderHook(() =>
+        useResizable({defaultSize: 'calc(100% - 20px)'}),
+      );
+
+      expect(result.current.size).toBe(250);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('useResizable: defaultSize:'),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Falling back to 250'),
+      );
+      warn.mockRestore();
     });
   });
 
@@ -905,11 +1317,14 @@ describe('useResizable percentage configuration (AST-010)', () => {
       expect(result.current.size).toBe(10_000);
     });
 
-    it('keeps CSS math out of released defaultSize', () => {
-      const {result} = renderHook(() =>
-        useResizable({defaultSize: 'min(400px, 10%)'}),
-      );
-      expect(result.current.size).toBe(250);
+    it('accepts CSS math in defaultSize while preserving its wide public type', () => {
+      const cssMathDefault: UseResizableSingleConfig = {
+        defaultSize: 'max(40%, 333px)',
+      };
+      const computedDefault: UseResizableSingleConfig = {
+        defaultSize: 'runtime-validated-string',
+      };
+      expect([cssMathDefault, computedDefault]).toHaveLength(2);
     });
 
     it('keeps deprecated aliases pixel-only at runtime', () => {

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -4,8 +4,9 @@
 
 /**
  * @file useResizable.ts
- * @input Resize configuration (defaultSize, minSizePx, maxSizePx, snaps) and
- *   collapse configuration (collapsible, defaultIsCollapsed, isCollapsed)
+ * @input Resize configuration (defaultSize, minSize, maxSize, legacy pixel
+ *   aliases, snaps) and collapse configuration (collapsible,
+ *   defaultIsCollapsed, isCollapsed)
  * @output Hook return: size, isCollapsed, collapse/expand/resize methods, props for handle
  * @position Public hook; consumed by layout components via `resizable` prop
  */
@@ -27,17 +28,27 @@ import type {SizeValue} from '../utils/types';
 // =============================================================================
 
 /**
+ * A Resizable bound: pixels, a percentage of its basis, or bounded recursive CSS
+ * `min()` / `max()` over those string leaves. Runtime parsing validates the full
+ * expression. Template literals reject unrelated top-level strings; runtime
+ * parsing remains normative for non-negativity, finiteness, and function
+ * interiors.
+ */
+export type ResizableConstraintValue =
+  number | `${number}px` | `${number}%` | `min(${string})` | `max(${string})`;
+
+/**
  * The minimum, in one of two spellings. Exactly one may be supplied: the union
  * makes passing both a type error, so a migration cannot leave a stale
  * deprecated value shadowing the new one (AST-010 API4).
  */
 export type ResizableMinConfig =
-  | {minSize?: SizeValue; minSizePx?: never}
+  | {minSize?: ResizableConstraintValue; minSizePx?: never}
   | {minSize?: never; minSizePx?: number};
 
 /** The maximum, in one of two spellings. See {@link ResizableMinConfig}. */
 export type ResizableMaxConfig =
-  | {maxSize?: SizeValue; maxSizePx?: never}
+  | {maxSize?: ResizableConstraintValue; maxSizePx?: never}
   | {maxSize?: never; maxSizePx?: number};
 
 export type ResizableDirection = 'horizontal' | 'vertical';
@@ -46,7 +57,9 @@ export interface ResizableRegionSizing {
   /**
    * Initial size. A number is pixels, `'Npx'` is pixels, and `'N%'` (0–100) is
    * a share of the basis: the container when `containerRef` is supplied, the
-   * viewport otherwise.
+   * viewport otherwise. This released input intentionally remains broader than
+   * {@link ResizableConstraintValue}; unsupported strings take the documented
+   * fallback at runtime.
    *
    * A percentage is resolved ONCE into a pixel size. It configures the initial
    * selection; it does not make the region track its basis afterwards.
@@ -304,34 +317,40 @@ function persistState(key: string, state: PersistedResizableState): void {
 /** The released compatibility basis when there is no window to measure. */
 const SERVER_BASIS = 1200;
 const DEFAULT_SIZE_FALLBACK = 250;
+const MAX_CSS_MATH_DEPTH = 8;
+const ATOMIC_SIZE_GUIDANCE =
+  'Use a non-negative number of pixels, an exact "Npx" string, or an exact ' +
+  '"N%" string from 0% to 100%.';
+const CONSTRAINT_SIZE_GUIDANCE =
+  'Use a non-negative number of pixels, an exact "Npx" string, an exact ' +
+  `"N%" string from 0% to 100%, or a recursive CSS min()/max() expression ` +
+  `nested at most ${MAX_CSS_MATH_DEPTH} levels.`;
+const LEGACY_PIXEL_GUIDANCE = 'Use a non-negative number of pixels.';
+const LEGACY_MAX_PIXEL_GUIDANCE =
+  'Use a non-negative number of pixels or explicit Infinity.';
 
-/**
- * A configured size, parsed. `null` means the input was not accepted — the
- * caller applies its own role-specific fallback, because an invalid default
- * (250px), minimum (50px) and maximum (Infinity) each repair to something
- * different (AST-010 FR12).
- *
- * Parsing is exact and matches the COMPLETE input: `'50 px'`, `'50%%'`,
- * `'50rem'`, `'120%'` and `'-1px'` are all rejected rather than partially
- * parsed into a number that happens to look plausible.
- */
+/** Parsed, validated input. */
 type ParsedSize =
-  {kind: 'px'; value: number} | {kind: 'percent'; value: number};
+  | {kind: 'px'; value: number}
+  | {kind: 'percent'; value: number}
+  | {kind: 'min' | 'max'; values: ParsedSize[]};
 
 const PX_PATTERN = /^(\d+(?:\.\d+)?)px$/;
 const PERCENT_PATTERN = /^(\d+(?:\.\d+)?)%$/;
+const SIZE_TOKEN_PATTERN = /^(\d+(?:\.\d+)?)(px|%)/;
+const CSS_WHITESPACE_PATTERN = /^[\t\n\f\r ]$/;
 
-function isPercentage(value: SizeValue | undefined): boolean {
-  return typeof value === 'string' && PERCENT_PATTERN.test(value);
-}
-
-function parseSize(value: SizeValue | undefined): ParsedSize | null {
-  if (value == null) {
-    return null;
-  }
-  if (typeof value === 'number') {
-    return Number.isFinite(value) && value >= 0 ? {kind: 'px', value} : null;
-  }
+/**
+ * Parses the complete string. Constraint values additionally accept recursive,
+ * comma-separated CSS `min()` and `max()` expressions. Nesting is bounded so a
+ * configuration value cannot recurse without limit.
+ */
+function parseSizeString(
+  value: string,
+  allowCssMath: boolean,
+): ParsedSize | null {
+  // Preserve the released atomic fast path exactly. CSS math is additive, so a
+  // plain px/% value should not pay for recursive parsing on every render.
   const px = PX_PATTERN.exec(value);
   if (px) {
     const parsed = Number(px[1]);
@@ -344,59 +363,161 @@ function parseSize(value: SizeValue | undefined): ParsedSize | null {
       ? {kind: 'percent', value: parsed}
       : null;
   }
+  if (!allowCssMath || value.trim() !== value) {
+    return null;
+  }
+
+  let offset = 0;
+  const skipWhitespace = () => {
+    while (CSS_WHITESPACE_PATTERN.test(value[offset] ?? '')) {
+      offset += 1;
+    }
+  };
+
+  const parseExpression = (depth: number): ParsedSize | null => {
+    skipWhitespace();
+
+    const kind = value.startsWith('min(', offset)
+      ? 'min'
+      : value.startsWith('max(', offset)
+        ? 'max'
+        : null;
+    if (kind != null) {
+      if (!allowCssMath || depth >= MAX_CSS_MATH_DEPTH) {
+        return null;
+      }
+      offset += 4;
+      const values: ParsedSize[] = [];
+      while (true) {
+        const child = parseExpression(depth + 1);
+        if (child == null) {
+          return null;
+        }
+        values.push(child);
+        skipWhitespace();
+        if (value[offset] === ')') {
+          offset += 1;
+          return {kind, values};
+        }
+        if (value[offset] !== ',') {
+          return null;
+        }
+        offset += 1;
+      }
+    }
+
+    const token = SIZE_TOKEN_PATTERN.exec(value.slice(offset));
+    if (token == null) {
+      return null;
+    }
+    offset += token[0].length;
+    const parsed = Number(token[1]);
+    if (!Number.isFinite(parsed)) {
+      return null;
+    }
+    return token[2] === '%'
+      ? parsed <= 100
+        ? {kind: 'percent', value: parsed}
+        : null
+      : {kind: 'px', value: parsed};
+  };
+
+  const parsed = parseExpression(0);
+  skipWhitespace();
+  return parsed != null && offset === value.length ? parsed : null;
+}
+
+function parseSize(value: unknown, allowCssMath = false): ParsedSize | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value >= 0 ? {kind: 'px', value} : null;
+  }
+  return typeof value === 'string'
+    ? parseSizeString(value, allowCssMath)
+    : null;
+}
+
+function parseLegacyPixel(
+  value: unknown,
+  allowInfinity: boolean,
+): ParsedSize | null {
+  if (typeof value !== 'number' || value < 0) {
+    return null;
+  }
+  if (Number.isFinite(value) || (allowInfinity && value === Infinity)) {
+    return {kind: 'px', value};
+  }
   return null;
 }
 
+/** Whether this parsed value must be recomputed when its basis changes. */
+function dependsOnBasis(parsed: ParsedSize | null): boolean {
+  if (parsed == null || parsed.kind === 'px') {
+    return false;
+  }
+  if (parsed.kind === 'percent') {
+    return true;
+  }
+  return parsed.values.some(dependsOnBasis);
+}
+
 /**
- * A parsed size in pixels, or `null` when it is a percentage and the basis is
- * not measurable yet. Percentages round, because a fractional pixel basis
- * would otherwise leak into ARIA and persistence.
+ * A parsed size in pixels, or `null` when it depends on a basis that is not
+ * measurable yet. Percentage leaves round before CSS math is evaluated so
+ * fractional geometry does not leak into ARIA or persistence.
  */
 function toPixels(parsed: ParsedSize, basis: number | null): number | null {
   if (parsed.kind === 'px') {
     return parsed.value;
   }
-  if (basis == null) {
-    return null;
+  if (parsed.kind === 'percent') {
+    return basis == null ? null : Math.round((parsed.value / 100) * basis);
   }
-  return Math.round((parsed.value / 100) * basis);
+
+  let aggregate: number | null = null;
+  for (const child of parsed.values) {
+    const resolved = toPixels(child, basis);
+    if (resolved == null) {
+      return null;
+    }
+    aggregate =
+      aggregate == null
+        ? resolved
+        : parsed.kind === 'min'
+          ? Math.min(aggregate, resolved)
+          : Math.max(aggregate, resolved);
+  }
+  return aggregate;
 }
 
 /**
- * Resolve one configured bound, applying its role's fallback when the input is
- * not accepted. Warns once per invalid input in development only: production
- * takes the identical fallback silently, so behaviour never differs by build.
+ * Resolves one configured value, applying its role's fallback when the input is
+ * not accepted. The warning remains development-only through `devWarn`; every
+ * build takes the same deterministic fallback.
  */
 function resolveBound(
-  raw: SizeValue | undefined,
+  raw: unknown,
+  parsed: ParsedSize | null,
   basis: number | null,
   fallback: number,
   label: string,
+  accepted: string,
   didWarnRef: {current: boolean},
 ): number {
   if (raw === undefined) {
     return fallback;
   }
-  // Explicit `Infinity` is legal for `maxSizePx` alone — a shipped template
-  // uses it — and reaches here already normalized to the same fallback.
-  if (raw === Infinity && fallback === Infinity) {
-    return Infinity;
-  }
-  const parsed = parseSize(raw);
   if (parsed == null) {
     if (!didWarnRef.current) {
       didWarnRef.current = true;
       devWarn(
         'useResizable',
-        `${label}: ${JSON.stringify(raw)} is not a size. Use a non-negative ` +
-          'number of pixels, an exact "Npx" string, or an exact "N%" string ' +
-          `from 0% to 100%. Falling back to ${fallback}.`,
+        `${label}: ${JSON.stringify(raw)} is not a size. ${accepted} ` +
+          `Falling back to ${fallback}.`,
       );
     }
     return fallback;
   }
-  const px = toPixels(parsed, basis);
-  return px ?? fallback;
+  return toPixels(parsed, basis) ?? fallback;
 }
 
 /**
@@ -463,15 +584,28 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   // both an error, so reaching here means untyped JavaScript, an `any`, or a
   // spread — exactly the case where a stale alias hidden in an object would
   // otherwise silently beat the explicit migration target.
-  const minConflict = minSize !== undefined && minSizePx !== undefined;
-  const maxConflict = maxSize !== undefined && maxSizePx !== undefined;
-  const rawMin = minSize ?? minSizePx;
-  const rawMax = maxSize ?? maxSizePx;
+  const hasUnifiedMin = minSize !== undefined;
+  const hasUnifiedMax = maxSize !== undefined;
+  const minConflict = hasUnifiedMin && minSizePx !== undefined;
+  const maxConflict = hasUnifiedMax && maxSizePx !== undefined;
+  const rawMin = hasUnifiedMin ? minSize : minSizePx;
+  const rawMax = hasUnifiedMax ? maxSize : maxSizePx;
 
-  // Whether any percentage is in play at all. A region configured entirely in
-  // pixels subscribes to nothing and behaves exactly as it did before.
-  const usesPercentage =
-    isPercentage(defaultSize) || isPercentage(rawMin) || isPercentage(rawMax);
+  const parsedDefault = parseSize(defaultSize);
+  const parsedMin = hasUnifiedMin
+    ? parseSize(minSize, true)
+    : parseLegacyPixel(minSizePx, false);
+  const parsedMax = hasUnifiedMax
+    ? parseSize(maxSize, true)
+    : parseLegacyPixel(maxSizePx, true);
+
+  // A pure-pixel expression subscribes to nothing. Percentage dependency must
+  // be recursive: `min(400px, max(5%, 10%))` follows the basis even though the
+  // outer function itself carries no percentage token.
+  const usesBasis =
+    dependsOnBasis(parsedDefault) ||
+    dependsOnBasis(parsedMin) ||
+    dependsOnBasis(parsedMax);
   const hasContainer = containerRef != null;
 
   // The container basis, read through the shared observer. `useSyncExternalStore`
@@ -509,7 +643,7 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
 
   const subscribeToContainer = useCallback(
     (onStoreChange: () => void) => {
-      if (!usesPercentage || containerElement == null) {
+      if (!usesBasis || containerElement == null) {
         return () => {};
       }
       // Unsubscribe by callback: several regions share one container, and any
@@ -523,10 +657,10 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
         onStoreChange();
       });
     },
-    [containerElement, usesPercentage, direction],
+    [containerElement, usesBasis, direction],
   );
   const readContainerBasis = useCallback(() => {
-    if (!usesPercentage || containerElement == null) {
+    if (!usesBasis || containerElement == null) {
       return null;
     }
     // Cached in a ref so the snapshot is referentially stable between resizes;
@@ -538,7 +672,7 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
       );
     }
     return containerBasisRef.current;
-  }, [containerElement, usesPercentage, direction]);
+  }, [containerElement, usesBasis, direction]);
   const containerBasis = useSyncExternalStore(
     subscribeToContainer,
     readContainerBasis,
@@ -550,13 +684,13 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   // latched once below.
   const subscribeToViewport = useCallback(
     (onStoreChange: () => void) => {
-      if (hasContainer || !usesPercentage || typeof window === 'undefined') {
+      if (hasContainer || !usesBasis || typeof window === 'undefined') {
         return () => {};
       }
       window.addEventListener('resize', onStoreChange);
       return () => window.removeEventListener('resize', onStoreChange);
     },
-    [hasContainer, usesPercentage],
+    [hasContainer, usesBasis],
   );
   const viewportBasis = useSyncExternalStore(
     subscribeToViewport,
@@ -574,7 +708,7 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   // the panel collapsed and, with `autoSaveId`, that 0 was written over a
   // perfectly good saved width. Treating 0 as unmeasured keeps the temporary
   // basis until the container is actually laid out (AST-010 Platform support).
-  const needsContainerBasis = hasContainer && usesPercentage;
+  const needsContainerBasis = hasContainer && usesBasis;
   const hasPositiveMeasurement = containerBasis != null && containerBasis > 0;
   const liveBasis = hasContainer
     ? hasPositiveMeasurement
@@ -603,16 +737,20 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   // point of a percentage bound — and clamp the pixel selection below.
   const resolvedMin = resolveBound(
     rawMin,
+    parsedMin,
     basis,
     DEFAULT_MIN,
-    'minSize',
+    hasUnifiedMin ? 'minSize' : 'minSizePx',
+    hasUnifiedMin ? CONSTRAINT_SIZE_GUIDANCE : LEGACY_PIXEL_GUIDANCE,
     didWarnMinRef,
   );
   const resolvedMax = resolveBound(
     rawMax,
+    parsedMax,
     basis,
     Infinity,
-    'maxSize',
+    hasUnifiedMax ? 'maxSize' : 'maxSizePx',
+    hasUnifiedMax ? CONSTRAINT_SIZE_GUIDANCE : LEGACY_MAX_PIXEL_GUIDANCE,
     didWarnMaxRef,
   );
 
@@ -632,9 +770,11 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
     initialDefaultRef.current = {
       px: resolveBound(
         defaultSize,
+        parsedDefault,
         basis,
         DEFAULT_SIZE_FALLBACK,
         'defaultSize',
+        ATOMIC_SIZE_GUIDANCE,
         didWarnDefaultRef,
       ),
       isFinal: isBasisMeasured,

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -55,14 +55,17 @@ export type ResizableDirection = 'horizontal' | 'vertical';
 
 export interface ResizableRegionSizing {
   /**
-   * Initial size. A number is pixels, `'Npx'` is pixels, and `'N%'` (0–100) is
-   * a share of the basis: the container when `containerRef` is supplied, the
-   * viewport otherwise. This released input intentionally remains broader than
-   * {@link ResizableConstraintValue}; unsupported strings take the documented
-   * fallback at runtime.
+   * Initial size. At runtime, accepts a non-negative pixel number, exact `Npx`,
+   * exact `N%` from 0–100, or the same bounded recursive CSS `min()` / `max()`
+   * grammar as {@link ResizableConstraintValue}. The public type remains the
+   * released {@link SizeValue} (`number | string`) for compatibility, so runtime
+   * validation is authoritative and unsupported strings use the documented
+   * fallback and development warning.
    *
-   * A percentage is resolved ONCE into a pixel size. It configures the initial
-   * selection; it does not make the region track its basis afterwards.
+   * A basis-dependent value resolves ONCE into a pixel size — against the
+   * container when `containerRef` is supplied, against the viewport otherwise.
+   * It configures the initial selection; it does not make the region track its
+   * basis afterwards.
    */
   defaultSize?: SizeValue;
   /** Whether this region can collapse to 0. @default false */
@@ -318,10 +321,7 @@ function persistState(key: string, state: PersistedResizableState): void {
 const SERVER_BASIS = 1200;
 const DEFAULT_SIZE_FALLBACK = 250;
 const MAX_CSS_MATH_DEPTH = 8;
-const ATOMIC_SIZE_GUIDANCE =
-  'Use a non-negative number of pixels, an exact "Npx" string, or an exact ' +
-  '"N%" string from 0% to 100%.';
-const CONSTRAINT_SIZE_GUIDANCE =
+const UNIFIED_SIZE_GUIDANCE =
   'Use a non-negative number of pixels, an exact "Npx" string, an exact ' +
   `"N%" string from 0% to 100%, or a recursive CSS min()/max() expression ` +
   `nested at most ${MAX_CSS_MATH_DEPTH} levels.`;
@@ -341,7 +341,7 @@ const SIZE_TOKEN_PATTERN = /^(\d+(?:\.\d+)?)(px|%)/;
 const CSS_WHITESPACE_PATTERN = /^[\t\n\f\r ]$/;
 
 /**
- * Parses the complete string. Constraint values additionally accept recursive,
+ * Parses the complete string. Unified values additionally accept recursive,
  * comma-separated CSS `min()` and `max()` expressions. Nesting is bounded so a
  * configuration value cannot recurse without limit.
  */
@@ -591,22 +591,32 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   const rawMin = hasUnifiedMin ? minSize : minSizePx;
   const rawMax = hasUnifiedMax ? maxSize : maxSizePx;
 
-  const parsedDefault = parseSize(defaultSize);
+  const parsedDefault = parseSize(defaultSize, true);
   const parsedMin = hasUnifiedMin
     ? parseSize(minSize, true)
     : parseLegacyPixel(minSizePx, false);
   const parsedMax = hasUnifiedMax
     ? parseSize(maxSize, true)
     : parseLegacyPixel(maxSizePx, true);
-
-  // A pure-pixel expression subscribes to nothing. Percentage dependency must
-  // be recursive: `min(400px, max(5%, 10%))` follows the basis even though the
-  // outer function itself carries no percentage token.
-  const usesBasis =
-    dependsOnBasis(parsedDefault) ||
-    dependsOnBasis(parsedMin) ||
-    dependsOnBasis(parsedMax);
   const hasContainer = containerRef != null;
+  const persisted = autoSaveId ? loadPersistedState(autoSaveId) : null;
+  const initialDefaultRef = useRef<{px: number; isFinal: boolean} | null>(null);
+  const [, setDefaultBasisCleanupTick] = useState(0);
+
+  const defaultDependsOnBasis = dependsOnBasis(parsedDefault);
+  const boundsDependOnBasis =
+    dependsOnBasis(parsedMin) || dependsOnBasis(parsedMax);
+  // A default needs a live container only until its initial pixel choice is
+  // final. A persisted pixel choice wins without measuring the unused default.
+  // Bounds are different: percentage leaves at any depth keep following the
+  // basis so they can re-clamp the selected pixel size.
+  const defaultNeedsInitialBasis =
+    persisted?.size == null &&
+    defaultDependsOnBasis &&
+    initialDefaultRef.current?.isFinal !== true;
+  const observeContainerBasis =
+    hasContainer && (boundsDependOnBasis || defaultNeedsInitialBasis);
+  const observeViewportBasis = !hasContainer && boundsDependOnBasis;
 
   // The container basis, read through the shared observer. `useSyncExternalStore`
   // rather than an effect: the store IS the measurement, so there is no render
@@ -643,7 +653,7 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
 
   const subscribeToContainer = useCallback(
     (onStoreChange: () => void) => {
-      if (!usesBasis || containerElement == null) {
+      if (!observeContainerBasis || containerElement == null) {
         return () => {};
       }
       // Unsubscribe by callback: several regions share one container, and any
@@ -657,10 +667,15 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
         onStoreChange();
       });
     },
-    [containerElement, usesBasis, direction],
+    [containerElement, observeContainerBasis, direction],
   );
   const readContainerBasis = useCallback(() => {
-    if (!usesBasis || containerElement == null) {
+    if (!observeContainerBasis || containerElement == null) {
+      // An inactive subscription owns no current measurement. Clearing this is
+      // important when a percentage bound is added later: the first active
+      // render must measure the container as it is now, not clamp against the
+      // last basis seen by a default-only subscription.
+      containerBasisRef.current = null;
       return null;
     }
     // Cached in a ref so the snapshot is referentially stable between resizes;
@@ -672,25 +687,29 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
       );
     }
     return containerBasisRef.current;
-  }, [containerElement, usesBasis, direction]);
+  }, [containerElement, observeContainerBasis, direction]);
   const containerBasis = useSyncExternalStore(
     subscribeToContainer,
     readContainerBasis,
     () => null,
   );
 
-  // The viewport basis, for the no-container compatibility path. Percentage
-  // BOUNDS follow it (FR6); the percentage default does not, because it is
-  // latched once below.
+  // The viewport basis is always readable synchronously. Percentage-dependent
+  // BOUNDS subscribe to later resizes (FR6); a default reads the initial
+  // snapshot only, because it becomes a pixel choice immediately.
   const subscribeToViewport = useCallback(
     (onStoreChange: () => void) => {
-      if (hasContainer || !usesBasis || typeof window === 'undefined') {
+      if (
+        hasContainer ||
+        !observeViewportBasis ||
+        typeof window === 'undefined'
+      ) {
         return () => {};
       }
       window.addEventListener('resize', onStoreChange);
       return () => window.removeEventListener('resize', onStoreChange);
     },
-    [hasContainer, usesBasis],
+    [hasContainer, observeViewportBasis],
   );
   const viewportBasis = useSyncExternalStore(
     subscribeToViewport,
@@ -708,7 +727,7 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   // the panel collapsed and, with `autoSaveId`, that 0 was written over a
   // perfectly good saved width. Treating 0 as unmeasured keeps the temporary
   // basis until the container is actually laid out (AST-010 Platform support).
-  const needsContainerBasis = hasContainer && usesBasis;
+  const needsContainerBasis = observeContainerBasis;
   const hasPositiveMeasurement = containerBasis != null && containerBasis > 0;
   const liveBasis = hasContainer
     ? hasPositiveMeasurement
@@ -741,7 +760,7 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
     basis,
     DEFAULT_MIN,
     hasUnifiedMin ? 'minSize' : 'minSizePx',
-    hasUnifiedMin ? CONSTRAINT_SIZE_GUIDANCE : LEGACY_PIXEL_GUIDANCE,
+    hasUnifiedMin ? UNIFIED_SIZE_GUIDANCE : LEGACY_PIXEL_GUIDANCE,
     didWarnMinRef,
   );
   const resolvedMax = resolveBound(
@@ -750,22 +769,20 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
     basis,
     Infinity,
     hasUnifiedMax ? 'maxSize' : 'maxSizePx',
-    hasUnifiedMax ? CONSTRAINT_SIZE_GUIDANCE : LEGACY_MAX_PIXEL_GUIDANCE,
+    hasUnifiedMax ? UNIFIED_SIZE_GUIDANCE : LEGACY_MAX_PIXEL_GUIDANCE,
     didWarnMaxRef,
   );
 
-  const persisted = autoSaveId ? loadPersistedState(autoSaveId) : null;
-
-  // The percentage default is resolved ONCE into a pixel size. Latched in a ref
-  // (React's sanctioned lazy-init shape) rather than recomputed, because a
+  // A basis-dependent default is resolved ONCE into a pixel size. Latched in a
+  // ref (React's sanctioned lazy-init shape) rather than recomputed, because a
   // default that kept tracking its basis would be a second, responsive sizing
   // mode — the thing this API deliberately does not have.
   //
   // Not final while a supplied container is still unmeasured: that render used
   // the temporary 1200px stand-in, and the first real measurement replaces it.
-  // That correction is not a user interaction, so it neither persists nor
-  // fires `onSizeChange`.
-  const initialDefaultRef = useRef<{px: number; isFinal: boolean} | null>(null);
+  // Once final, a default-only subscription is removed. The correction is not a
+  // user interaction, so it neither persists the placeholder nor fires
+  // `onSizeChange`.
   if (initialDefaultRef.current == null || !initialDefaultRef.current.isFinal) {
     initialDefaultRef.current = {
       px: resolveBound(
@@ -774,7 +791,7 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
         basis,
         DEFAULT_SIZE_FALLBACK,
         'defaultSize',
-        ATOMIC_SIZE_GUIDANCE,
+        UNIFIED_SIZE_GUIDANCE,
         didWarnDefaultRef,
       ),
       isFinal: isBasisMeasured,
@@ -803,6 +820,19 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
       ? clampSize(initialDefaultPx, resolvedMin, resolvedMax, snaps)
       : null;
   });
+
+  if (
+    hasContainer &&
+    !boundsDependOnBasis &&
+    isBasisMeasured &&
+    defaultNeedsInitialBasis &&
+    chosenSize != null
+  ) {
+    // A programmatic resize may have selected pixels while the container was
+    // still unmeasured, so chosenSize can already be non-null here. Force the
+    // render that re-evaluates and removes the now-finished default subscription.
+    setDefaultBasisCleanupTick(tick => tick + 1);
+  }
 
   if (isBasisMeasured && chosenSize == null) {
     // The supplied container has now been measured, so the selection latched


### PR DESCRIPTION
## Summary

- add the Resizable-specific `ResizableConstraintValue` for flat `minSize` / `maxSize`
- accept non-negative numbers, exact `px` / `%` leaves, and recursive CSS `min()` / `max()` expressions (maximum depth 8)
- reject `calc()`, `clamp()`, arithmetic, `var()`, other units, malformed input, and deeper nesting through the existing deterministic fallback + development-warning path
- detect percentage dependency recursively so bounds re-resolve and re-clamp on container or viewport basis changes
- preserve released `defaultSize`, pixel-only `resize()`, and deprecated `minSizePx` / `maxSizePx` compatibility
- document and test the existing maximum-wins rule when resolved minimum exceeds maximum
- amend AST-010, update Resizable docs and Storybook, and add a core changeset

## Stack

Depends on #5783. This PR intentionally targets `fix/resizable-percentage-sizes`; its parent at implementation and latest push time is `57f6e816b743610e218279fe0749d5cc1f5b900a`.

Astryx's PR workflows intentionally filter on base `main`: CI and Lint use `pull_request.branches: [main]`; the review and spec-owner workflows use `pull_request_target.branches: [main]`. Therefore this feature-branch-based draft has no GitHub Actions runs while stacked. Do not interpret their absence as a green CI result. The current external checks are Meta CLA plus Vercel.

## Browser evidence

Built Storybook from `a67d677def7a8b6dabb6573acd57487bf62efbd0` and measured `Core/Hooks/useResizable / Css Math Constraints` in Chromium. The requested 1000px / 500px bordered frames produced 998px / 498px content-box bases.

| constraint | 998px content box | 498px content box |
| --- | --- | --- |
| `minSize: 'max(40%, 333px)'` | bound 399px; selected / panel / ARIA 399px | bound 333px; selected / panel / ARIA 333px |
| `maxSize: 'min(400px, 10%)'` | bound 100px; selected / panel / ARIA 100px | bound 50px; selected / panel / ARIA 50px |

No browser console errors or page errors.

## Verification

- `pnpm lint:strict` — pass, 0 errors (85 repository warnings)
- `pnpm exec vitest run packages/core/src/Resizable/useResizable.test.ts` — 95 passed
- `pnpm -F @astryxdesign/core build` — pass
- `pnpm -F @astryxdesign/core typecheck` — pass
- `pnpm -F @astryxdesign/core typecheck:docs` — pass
- `pnpm -F @astryxdesign/storybook typecheck` — pass
- `pnpm check:knowledge` — pass
- `node scripts/check-changesets.mjs` — pass
- `pnpm build` — pass
- `pnpm -F @astryxdesign/storybook build` — pass
- `pnpm test` — 13,950 passed, 8 skipped, 5 failed outside this diff. Three `ContextMenu` timing failures passed on immediate exact-head single-file rerun (48/48); the same file also passed on the exact parent head (48/48). Two story-tree assertions name only three titles already present at the exact parent head: `Foundations/Internationalization/Date consistency`, `Core/Icon/Size Theming`, and `Core/SideNav/Collapse Ownership`.

## Diff-only review follow-up

- removed variadic `Math.min(...values)` / `Math.max(...values)` evaluation so a valid wide expression cannot hit the JavaScript argument-count limit
- added a guard that pure-pixel `min()` / `max()` expressions do not subscribe to the container basis
- kept AST-010's 2026-08-31 decision attribution intact and recorded CSS math separately as DEC-3, pending exact-head spec-owner approval
- verified the public type intentionally narrows top-level string forms; runtime parsing remains authoritative for non-negativity, finiteness, and recursive function interiors
- restored the parent's exact atomic px/% parser fast path after a production microbenchmark found a 1.96× common-path delta; final median is 1.10× (+8.24ns), with exact parent/child render and observer counts


