### PR TITLE
feat(useResizable): minSize/maxSize accept min() and max()

### DIFF
--- a/.changeset/resizable-minmax-bound-expressions.md
+++ b/.changeset/resizable-minmax-bound-expressions.md
@@ -1,0 +1,29 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useResizable: `minSize`/`maxSize` accept `min()` and `max()`
+
+A bound could be proportional or fixed, never both. `max(40%, 333px)` — 40% of the container, but never below 333px — had no spelling: the whole string failed to parse and took the invalid-input fallback. Measured in Chromium before this change, `minSize: 'max(40%, 333px)'` resolved to **50px at every container width from 1200px down to 400px**, and `maxSize: 'min(400px, 10%)'` to `Infinity` at 1200/4000/6000px. Development warned; `devWarn` is a no-op in production, so a shipped build got the wrong geometry silently.
+
+`minSize` and `maxSize` now take `min()`/`max()` over the terms they already took — two terms, one level of nesting. Terms resolve against the same basis as a plain percentage and are compared as resolved pixels, so which arm wins changes with the container, exactly as in CSS. After, same widths:
+
+| container | `minSize: 'max(40%, 333px)'` | `maxSize: 'min(400px, 10%)'` |
+|---|---|---|
+| 1600 / 6000 | **640** | **400** |
+| 1200 | **480** | 120 |
+| 900 | **360** | — |
+| 833 (crossover) | **333** | — |
+| 400 | **333** | — |
+
+Everything the percentage path already guarantees applies unchanged: the bound re-resolves when the container resizes and clamps the selection rather than rescaling it, it holds one frozen basis for the duration of a drag, and state, paint, persistence and `aria-valuemin`/`aria-valuemax` stay one geometry.
+
+Basis-dependency is decided on the parsed expression, not the source text. A percentage at any depth — `max(80px, min(90px, 50%))` — makes the whole bound track its container. An all-pixel expression is static and observes nothing.
+
+`minSize` and `maxSize` are now typed by a Resizable-owned `ResizableSize` instead of the shared `SizeValue`. `'40vw'`, `'20rem'`, `'calc(100% - 3rem)'`, `'clamp(...)'`, `'var(--w)'`, an unbalanced call and over-deep nesting are compile errors rather than runtime fallbacks. The runtime parser is unchanged in authority — a type cannot say "0 through 100" or "finite" — and still repairs anything invalid to the documented 50px / `Infinity` without disturbing a persisted size.
+
+Unchanged: `defaultSize` keeps its released `number | string`, so a computed string still compiles; the released `minSizePx`/`maxSizePx` aliases still work, and one bound can still migrate while the other keeps its alias; and when a resolved minimum exceeds its maximum the maximum still wins under the released `Math.min(max, Math.max(min, size))` order, now covered by a test with an expression floor.
+
+`calc()`, arithmetic, `clamp()`, `var()` and other units stay out of the grammar — an unrecognized function is invalid input, not a passthrough to CSS. AST-010 FR13/DEC-3 record the decision.
+
+@freddymeta

--- a/apps/storybook/stories/useResizable.stories.tsx
+++ b/apps/storybook/stories/useResizable.stories.tsx
@@ -405,3 +405,51 @@ export const ViewportPercentage: Story = {
     );
   },
 };
+
+/**
+ * A bound that is proportional on a wide container and fixed on a narrow one.
+ *
+ * `minSize: 'max(40%, 333px)'` is the CSS spelling and the CSS meaning: the
+ * terms resolve to pixels against the container, and the larger wins. Above a
+ * 832.5px frame that is the 40% arm; below it, the 333px floor holds and the
+ * panel stops shrinking. `maxSize: 'min(400px, 10%)'` is the mirror image — a
+ * 400px cap that tightens to 10% once the frame is under 4000px.
+ *
+ * Narrow the frame and watch the reported minimum change arm. Only the BOUNDS
+ * move; the size you dragged to stays the pixel size you chose.
+ */
+export const ExpressionBounds: Story = {
+  render: () => {
+    const frameRef = useRef<HTMLDivElement>(null);
+    const region = useResizable({
+      defaultSize: '50%',
+      minSize: 'max(40%, 333px)',
+      maxSize: 'min(400px, 10%)',
+      containerRef: frameRef,
+    });
+    return (
+      <div ref={frameRef} {...stylex.props(s.shell)}>
+        <Layout
+          height="fill"
+          start={
+            <>
+              <LayoutPanel width={region.size} hasDivider={false}>
+                <div {...stylex.props(s.card)}>
+                  {Math.round(region.size)}px · min{' '}
+                  {Math.round(region.props._minSizePx)} · max{' '}
+                  {Math.round(region.props._maxSizePx)}
+                </div>
+              </LayoutPanel>
+              <ResizeHandle
+                direction="horizontal"
+                hasDivider
+                resizable={region.props}
+              />
+            </>
+          }
+          content={<LayoutContent>Content</LayoutContent>}
+        />
+      </div>
+    );
+  },
+};

--- a/docs/specs/AST-010/spec.md
+++ b/docs/specs/AST-010/spec.md
@@ -43,7 +43,9 @@ record is updated alongside that implementation.
 - Preserving a percentage ratio after pointer, keyboard, or programmatic resize.
 - Automatically distributing remaining space or requiring independently sized
   regions to total 100%.
-- Supporting arbitrary CSS units such as `rem`, `vw`, or `calc()`.
+- Supporting arbitrary CSS units such as `rem` or `vw`, or arithmetic such as
+  `calc()`, `clamp()`, and `var()`. `min()` and `max()` over the accepted terms
+  are in scope; see DEC-3.
 - Adding percentage snap points or percentage collapse thresholds.
 - Adding controlled size state; current controlled collapse behavior is
   unchanged.
@@ -118,7 +120,8 @@ record is updated alongside that implementation.
   ratio preservation, or a 100% total invariant.
 - **FR12 — Invalid configuration has safe deterministic fallbacks.** Accepted
   configuration is a non-negative finite number, an exact non-negative finite
-  `Npx` string, or an exact `N%` string from 0% through 100%. An invalid,
+  `Npx` string, an exact `N%` string from 0% through 100%, or an exact
+  `min()`/`max()` expression over those terms (FR13). An invalid,
   malformed, negative, or non-finite `defaultSize` MUST use 250px before normal
   bounds clamping; an invalid `minSize` or `minSizePx` MUST use 50px; and an
   invalid `maxSize` or `maxSizePx` MUST use unbounded `Infinity`. Explicit
@@ -127,6 +130,26 @@ record is updated alongside that implementation.
   fallback without warning. After initialization, an invalid raw value MUST NOT
   directly replace a persisted or otherwise legal selected pixel size; a
   fallback-normalized bound may affect that size only through normal clamping.
+- **FR13 — Sizes accept `min()` and `max()` over the accepted terms.** A
+  configured size MAY be an exact `min(a, b)` or `max(a, b)` expression. Each
+  term is a non-negative finite `Npx`, an `N%` from 0% through 100%, or one
+  nested `min()`/`max()` over those. Exactly two terms are required, and nesting
+  is one level deep; an expression breaking either limit is invalid under FR12,
+  as is an unbalanced call, an unsupported unit in any term, or any other CSS
+  function. Terms resolve against the FR1/FR2 basis and are compared as resolved
+  pixel lengths, so `max` selects the largest and `min` the smallest, matching
+  CSS. Which arm wins therefore changes with the basis.
+
+  An expression containing a percentage at ANY depth is a percentage value for
+  every purpose in this spec: it re-resolves when its basis changes (FR4/FR6), it
+  holds one frozen basis for the duration of a gesture (FR7), and it causes the
+  container to be observed. That test MUST be made against the parsed expression,
+  not the source text. An expression whose terms are all pixels is static and
+  observes nothing.
+
+  A percentage `defaultSize` already resolves once (FR1); an expression
+  `defaultSize` resolves once the same way, by the same parser. It gains no
+  crossover behaviour after that first resolution, because no default does.
 
 ### Public API requirements
 
@@ -146,12 +169,21 @@ record is updated alongside that implementation.
 - **API3 — One configuration vocabulary covers both units.** Add `minSize` and
   `maxSize` with the same `number | string` shape as `defaultSize`. Accepted
   numbers are finite and non-negative. Accepted strings match the complete input:
-  a finite non-negative `Npx`, or `N%` from 0% through 100%; partial parses,
+  a finite non-negative `Npx`, `N%` from 0% through 100%, or a `min()`/`max()`
+  expression over those (FR13); partial parses,
   trailing text, other units, negatives, and non-finite values are invalid. The
   deprecated `maxSizePx` alone additionally accepts explicit `Infinity` to
   preserve released usage. Apply FR12's role-specific fallback in development and
   production, warning only in development. Do not add parallel
   `defaultSizePercent`, `minSizePercent`, or `maxSizePercent` props.
+
+  `minSize` and `maxSize` are typed by a Resizable-owned `ResizableSize` rather
+  than the shared `SizeValue`, so an unsupported unit or function is a compile
+  error instead of a runtime fallback. That type encodes the same two-term,
+  one-level limits the parser enforces. It does not replace the parser, which
+  stays authoritative for what a type cannot state — a percentage above 100, a
+  negative, a non-finite. `defaultSize` keeps its released `SizeValue`, because
+  narrowing a shipped prop would reject callers passing a computed string.
 - **API4 — Pixel aliases are exactly mutually exclusive with unified bounds.**
   `minSizePx` and `maxSizePx` remain supported but become deprecated. TypeScript
   MUST encode each old/new pair as an exact union, equivalent to:
@@ -186,12 +218,13 @@ record is updated alongside that implementation.
 
 | Input                                                      | Accepted values                                                                    | Invalid fallback                | Development behavior                                         | Production behavior                |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
-| `defaultSize`                                              | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100 | 250px, then normal bounds clamp | warn and use fallback                                        | use same fallback without warning  |
-| `minSize` / `minSizePx`                                    | non-negative finite number; unified prop also accepts exact `Npx` and 0–100 `N%`   | 50px                            | warn and use fallback                                        | use same fallback without warning  |
-| `maxSize`                                                  | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100 | unbounded `Infinity`            | warn and use fallback                                        | use same fallback without warning  |
+| `defaultSize`                                              | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100; `min()`/`max()` over those, resolved once | 250px, then normal bounds clamp | warn and use fallback                                        | use same fallback without warning  |
+| `minSize` / `minSizePx`                                    | non-negative finite number; unified prop also accepts exact `Npx`, 0–100 `N%`, and `min()`/`max()` over those | 50px                            | warn and use fallback                                        | use same fallback without warning  |
+| `maxSize`                                                  | non-negative finite number; exact non-negative finite `Npx`; exact `N%` from 0–100; `min()`/`max()` over those | unbounded `Infinity`            | warn and use fallback                                        | use same fallback without warning  |
 | `maxSizePx`                                                | non-negative finite number or explicit `Infinity`                                  | unbounded `Infinity`            | warn for invalid values; do not warn for explicit `Infinity` | use same fallback without warning  |
 | old/new bound pair supplied together through untyped input | unified value is authoritative                                                     | ignore deprecated alias         | warn and name the ignored alias                              | unified value wins without warning |
-| resolved minimum above resolved maximum                    | both values are individually valid                                                 | maximum wins                    | warn and use released clamp order                            | use same ordering without warning  |
+| `min()`/`max()` that is not exactly two terms, nests more than one level, is unbalanced, or has an unsupported term | none — the whole expression is invalid | the role's fallback above | warn and use fallback | use same fallback without warning |
+| resolved minimum above resolved maximum, including from an expression | both values are individually valid                                                 | maximum wins                    | warn and use released clamp order                            | use same ordering without warning  |
 
 A fallback repairs configuration; it is not a new user selection. After
 initialization, an invalid raw value never directly replaces persisted or otherwise
@@ -323,6 +356,7 @@ a percentage or relative intent.
 | FR11             | Multi-region and shared-observer tests                        | two regions on one container; another hook observing the same node                                                                | regions use different bases, selected ratios are introduced, or one subscription removes another                                                       |
 | FR12             | Production/development parser and state-preservation tests    | negative/non-finite number; partial/malformed string; wrong unit; invalid rerender; persisted selection; explicit legacy Infinity | fallback differs by build, warning occurs in production, invalid input replaces legal state, or any path produces `NaN`                                |
 | API3, API4, API6 | Type, runtime validation, and development-warning tests       | exact valid strings; old-only aliases; exact-union duplicate rejection; JS/`any`/spread conflicts; `resize('50%')`                | duplicate pairs type-check, deprecated alias overrides unified input, warning omits ignored alias, exact parsing is skipped, or resize accepts strings |
+| FR13             | Expression parser, recursive basis-dependency, and Chromium crossover tests | `max(P%, Npx)` above/below/at crossover; `min(Npx, P%)`; nested; all-pixel expression; percentage nested inside; one term; unsupported term; unbalanced; over-depth; expression vs opposing bound; no-ref; unmeasured container | a crossover picks the wrong arm, an expression stops tracking its basis, an all-pixel expression observes a container, a nested percentage is missed, or an invalid expression replaces legal state |
 | Platform/SSR     | Server render, hydration test, and Chromium evidence          | no ref; ref not measured; hidden/zero container; first positive measurement                                                       | 1200px fallback changes, temporary fallback persists, or correction fires `onSizeChange`                                                               |
 | Compatibility    | Existing Resizable, LayoutPanel, SideNav, and template suites | current pixel-only callsites and no-ref percentage default                                                                        | existing numeric configuration, percentage fallback, output, interaction, or persistence changes                                                       |
 
@@ -343,11 +377,15 @@ This spec moves from `accepted` to `shipped` only when:
   pair is an exact mutually exclusive TypeScript union, and untyped conflicts
   prefer the unified value with a clear ignored-alias warning;
 - exact parsing accepts only non-negative finite numbers, complete `Npx` strings,
-  and 0–100 `N%` strings; invalid values use the documented 250px, 50px, or
+  0–100 `N%` strings, and two-term one-level `min()`/`max()` over those;
+  invalid values use the documented 250px, 50px, or
   `Infinity` fallback in every build without replacing persisted/legal selected
   state, while explicit legacy `maxSizePx: Infinity` remains valid;
+- a value containing a percentage at any depth re-resolves with its basis and
+  observes the container, while an all-pixel expression is static;
 - inverted resolved bounds warn in development, deterministically choose the
-  maximum, and never produce `NaN` or invalid geometry;
+  maximum, and never produce `NaN` or invalid geometry, including when either
+  bound came from an expression;
 - mixed bounds keep effective state, paint, storage, and separator ARIA aligned,
   while controlled-collapse callbacks preserve released intent reporting;
 - single and multi-region subscriptions coexist with every other observer of the
@@ -407,6 +445,59 @@ Astryx template. If a resolved minimum exceeds its maximum, development warns an
 the maximum wins under the released clamp order. These rules keep malformed input,
 conflicts, and inverted bounds from producing `NaN` or replacing persisted/legal
 selected state.
+
+### DEC-3 — Sizes accept `min()` and `max()`, and nothing else from CSS math
+
+**Reference:** `spec:AST-010/DEC-3`
+**Decider:** `cixzhang`, `2026-09-03`
+
+A single scalar cannot express a bound that is relative on a wide container and
+fixed on a narrow one. `max(40%, 333px)` is the ordinary CSS spelling of "40% of
+the container, but never less than 333px", and its inverse `min(400px, 10%)` caps
+a panel at 400px until 10% is the tighter limit. Without them a builder writes
+that constraint in CSS, and CSS clamps paint without clamping hook state — the
+split this spec exists to close (FR5). Measured in Chromium before the change,
+`minSize: 'max(40%, 333px)'` produced a resolved minimum of 50px at every
+container width from 1200px to 400px, because the whole string failed to parse
+and took the invalid-input fallback. In production that fallback is silent.
+
+`min()` and `max()` are therefore accepted over the terms already accepted,
+two terms, one level of nesting (FR13).
+
+Rejected: `calc()` and arithmetic generally, `clamp()`, `var()`, and every other
+unit. Arithmetic needs operator precedence and mixed-unit addition, which is an
+expression language rather than a bounded vocabulary. `clamp(a, b, c)` restates
+the floor-and-ceiling relationship `minSize` and `maxSize` already own, giving a
+second way to write one thing — the ambiguity DEC-2 rejected for percentage
+props. The grammar is closed rather than open: an unrecognized function is
+invalid input under FR12, not a passthrough to CSS.
+
+Rejected: a structured object AST (`{max: [{containerPercent: 40}, {pixels:
+333}]}`). It cannot replace the released `number | string` value, so it would be
+a third spelling beside `333` and `'333px'`, and the `string` member it must
+coexist with re-admits every unvalidated input it was meant to prevent. Compiled
+both ways, the AST caught two error classes (unknown key, non-node element) and
+the narrowed string caught eight (`banana`, `calc()`, `rem`, `vw`, `clamp()`,
+unbalanced, non-finite, over-depth); neither can express numeric range, so both
+still need the runtime parser. The CSS string is also the spelling a builder
+already knows and an assistant already emits.
+
+Rejected: grouping the bounds as `{min, max}`. Every bounded pair in the package
+is flat sibling props — Slider, NumberInput, DateInput, Calendar — and a group
+must be mutually exclusive with both deprecated aliases at once, which would
+forbid migrating one bound while the other keeps its alias.
+
+The two-term, one-level limits are not arbitrary. They are what keeps the public
+`ResizableSize` union small enough for TypeScript to represent: a wider grammar
+raised `TS2590` ("union type that is too complex to represent") where a bound
+meets its deprecated pixel alias. The parser enforces exactly the same limits, so
+the compiler and the runtime accept the same set of strings.
+
+A value is basis-dependent whenever a percentage appears at any depth, and that
+test runs on the parsed expression rather than the source text. A syntactic check
+would classify `max(40%, 333px)` as static and the container would never be
+observed: the bound would resolve once against the initial basis and never track
+the container again — supported-looking and quietly broken.
 
 ## Open questions
 

--- a/packages/core/src/Resizable/useResizable.doc.mjs
+++ b/packages/core/src/Resizable/useResizable.doc.mjs
@@ -25,16 +25,16 @@ export const docs = {
     },
     {
       name: 'minSize',
-      type: 'number | string',
+      type: 'ResizableSize',
       description:
-        'Minimum size, in the same vocabulary as defaultSize. A percentage minimum re-resolves when its basis changes and clamps the current pixel size.',
+        'Minimum size. A number of pixels, an exact "Npx", an exact "N%" from 0% to 100%, or min()/max() over those — for example "max(40%, 333px)", a floor that is 40% of the container but never below 333px. Terms are compared as resolved pixels, so which one wins changes with the container: above a 832.5px container 40% wins, below it the 333px floor does. Anything basis-dependent re-resolves when the container resizes and clamps the current pixel size.',
       default: '50',
     },
     {
       name: 'maxSize',
-      type: 'number | string',
+      type: 'ResizableSize',
       description:
-        'Maximum size, in the same vocabulary as defaultSize. A percentage maximum re-resolves when its basis changes and clamps the current pixel size.',
+        'Maximum size, in the same vocabulary as minSize — for example "min(400px, 10%)", a cap of 400px until 10% of the container is tighter. Re-resolves when its basis changes and clamps the current pixel size.',
       default: 'Infinity',
     },
     {
@@ -146,6 +146,16 @@ export const docs = {
         guidance: true,
         description:
           'Set autoSaveId to persist user-chosen sizes across page reloads.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give a bound that must stay usable on small containers a pixel floor with min()/max(): minSize: "max(40%, 333px)" with containerRef stays proportional while there is room and stops at 333px once there is not. The inverse caps growth: maxSize: "min(400px, 10%)".',
+      },
+      {
+        guidance: false,
+        description:
+          'Write a percentage ceiling in CSS (max-width) instead of maxSize. CSS clamps what is painted but not the hook state, so the handle announces a width the panel does not have.',
       },
       {
         guidance: false,

--- a/packages/core/src/Resizable/useResizable.public.test.ts
+++ b/packages/core/src/Resizable/useResizable.public.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useResizable.public.test.ts
+ * @input Public useResizable configuration types
+ * @output Compile-time assertions on the bound vocabulary
+ * @position Testing; pins the public type surface of AST-010 FR13/API3
+ *
+ * These assertions are about what the COMPILER accepts. The runtime parser is
+ * covered in useResizable.test.ts, and it stays authoritative for anything a
+ * type cannot express — a percentage above 100, a negative, a non-finite.
+ */
+
+import {describe, expectTypeOf, it} from 'vitest';
+import type {
+  ResizableLength,
+  ResizableSize,
+  UseResizableSingleConfig,
+} from './useResizable';
+
+describe('ResizableSize (AST-010 FR13/API3)', () => {
+  it('accepts the released spellings', () => {
+    expectTypeOf<333>().toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'333px'>().toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'40%'>().toMatchTypeOf<ResizableSize>();
+    expectTypeOf<ResizableLength>().toMatchTypeOf<ResizableSize>();
+  });
+
+  it('accepts min() and max() over lengths', () => {
+    expectTypeOf<'max(40%, 333px)'>().toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'min(400px, 10%)'>().toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'max(333px, 40%)'>().toMatchTypeOf<ResizableSize>();
+  });
+
+  it('accepts one level of nesting', () => {
+    expectTypeOf<'max(20%, min(500px, 60%))'>().toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'min(max(100px, 10%), 400px)'>().toMatchTypeOf<ResizableSize>();
+  });
+
+  it('rejects units and functions outside the grammar', () => {
+    expectTypeOf<'banana'>().not.toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'40vw'>().not.toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'20rem'>().not.toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'calc(100% - 3rem)'>().not.toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'clamp(100px, 40%, 500px)'>().not.toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'var(--w)'>().not.toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'max(40%, 20rem)'>().not.toMatchTypeOf<ResizableSize>();
+    // Unclosed, and a bare function with nothing to choose between.
+    expectTypeOf<'max(40%, 333px'>().not.toMatchTypeOf<ResizableSize>();
+    expectTypeOf<'max(40%)'>().not.toMatchTypeOf<ResizableSize>();
+  });
+
+  it('rejects nesting past the documented depth', () => {
+    expectTypeOf<
+      'max(10%, min(20%, max(30%, 40px)))'
+    >().not.toMatchTypeOf<ResizableSize>();
+  });
+});
+
+describe('bound configuration (AST-010 API4)', () => {
+  it('accepts an expression as either bound', () => {
+    const floor: UseResizableSingleConfig = {minSize: 'max(40%, 333px)'};
+    const ceiling: UseResizableSingleConfig = {maxSize: 'min(400px, 10%)'};
+    expectTypeOf(floor).toMatchTypeOf<UseResizableSingleConfig>();
+    expectTypeOf(ceiling).toMatchTypeOf<UseResizableSingleConfig>();
+  });
+
+  it('keeps the released pixel-alias callsites compiling', () => {
+    const released: UseResizableSingleConfig = {
+      defaultSize: 200,
+      minSizePx: 100,
+      maxSizePx: 400,
+    };
+    expectTypeOf(released).toMatchTypeOf<UseResizableSingleConfig>();
+  });
+
+  it('still lets one bound migrate while the other keeps its alias', () => {
+    const mixed: UseResizableSingleConfig = {
+      minSize: 'max(40%, 333px)',
+      maxSizePx: 960,
+    };
+    expectTypeOf(mixed).toMatchTypeOf<UseResizableSingleConfig>();
+  });
+
+  it('still rejects both spellings of one bound', () => {
+    // @ts-expect-error -- minSize and minSizePx are mutually exclusive
+    const conflict: UseResizableSingleConfig = {
+      minSize: 'max(40%, 333px)',
+      minSizePx: 100,
+    };
+    void conflict;
+  });
+
+  it('leaves defaultSize on its released wide type', () => {
+    // `defaultSize` shipped as `number | string` and stays that way, so a
+    // computed string still compiles. It resolves an expression once, exactly
+    // as it already resolves `'50%'` once — same grammar, same one-time
+    // resolution, no special case.
+    const released: UseResizableSingleConfig = {defaultSize: '50%'};
+    const computed: UseResizableSingleConfig = {
+      defaultSize: `${40}%` as string,
+    };
+    expectTypeOf(released).toMatchTypeOf<UseResizableSingleConfig>();
+    expectTypeOf(computed).toMatchTypeOf<UseResizableSingleConfig>();
+  });
+});

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -985,6 +985,235 @@ describe('useResizable percentage configuration (AST-010)', () => {
       expect(result.current.size).toBe(100);
     });
   });
+
+  describe('FR13 — min()/max() bound expressions', () => {
+    // `max(40%, 333px)`: the percentage arm wins on a wide container, the
+    // pixel floor below the 832.5px crossover. This is the canonical example.
+    it.each([
+      [1200, 480],
+      [900, 360],
+      [833, 333],
+      [832, 333],
+      [600, 333],
+      [400, 333],
+    ])('resolves max(40%, 333px) at basis $0 to $1', (basis, expected) => {
+      content = basis;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 200,
+          minSize: 'max(40%, 333px)',
+        }),
+      );
+      expect(result.current.props._minSizePx).toBe(expected);
+    });
+
+    it.each([
+      [1200, 120],
+      [4000, 400],
+      [6000, 400],
+    ])('resolves min(400px, 10%) at basis $0 to $1', (basis, expected) => {
+      content = basis;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 100,
+          maxSize: 'min(400px, 10%)',
+        }),
+      );
+      expect(result.current.props._maxSizePx).toBe(expected);
+    });
+
+    it('re-resolves an expression when the basis changes', () => {
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 200,
+          minSize: 'max(40%, 333px)',
+        }),
+      );
+      // 400px container: the pixel arm wins.
+      expect(result.current.props._minSizePx).toBe(333);
+      act(() => {
+        content = 1200;
+        StubResizeObserver.resizeAll();
+      });
+      // Wide enough for the percentage arm to overtake it.
+      expect(result.current.props._minSizePx).toBe(480);
+    });
+
+    it('resolves one level of nesting', () => {
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 100,
+          maxSize: 'max(20%, min(500px, 60%))',
+        }),
+      );
+      // min(500, 600) = 500; max(200, 500) = 500.
+      expect(result.current.props._maxSizePx).toBe(500);
+    });
+
+    it('treats an all-pixel expression as static, observing nothing', () => {
+      const containerRef = makeContainer();
+      const before = StubResizeObserver.instances.length;
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 100,
+          maxSize: 'min(400px, 900px)',
+        }),
+      );
+      expect(result.current.props._maxSizePx).toBe(400);
+      // No percentage anywhere in the tree, so there is nothing to observe.
+      const observed = StubResizeObserver.instances
+        .slice(before)
+        .flatMap(o => o.targets);
+      expect(observed).toHaveLength(0);
+    });
+
+    it('observes the container for a percentage nested inside an expression', () => {
+      // The dependency test has to recurse. A syntactic check on the raw
+      // string would call this static and the bound would never re-resolve.
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 100,
+          maxSize: 'max(80px, min(90px, 50%))',
+        }),
+      );
+      expect(result.current.props._maxSizePx).toBe(90);
+      act(() => {
+        content = 100;
+        StubResizeObserver.resizeAll();
+      });
+      // 50% of 100 = 50; min(90, 50) = 50; max(80, 50) = 80.
+      expect(result.current.props._maxSizePx).toBe(80);
+    });
+
+    it.each([
+      ['max(40%)', 'a single term'],
+      ['max()', 'no terms'],
+      ['max(10px, 20px, 30px, 40px)', 'more terms than the grammar allows'],
+      ['max(40%, 333px', 'an unclosed call'],
+      ['max(40%, 20rem)', 'an unsupported unit in a term'],
+      ['max(10%, min(20%, max(30%, 40px)))', 'nesting past the depth limit'],
+      ['calc(100% - 3rem)', 'arithmetic'],
+      ['clamp(100px, 40%, 500px)', 'clamp'],
+      ['var(--w)', 'a custom property'],
+      ['banana', 'nonsense'],
+    ])('rejects %s (%s) and falls back', raw => {
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 10_000,
+          maxSize: raw as never,
+        }),
+      );
+      // The maximum's documented fallback is unbounded, so the default stands.
+      expect(result.current.props._maxSizePx).toBe(Infinity);
+      expect(result.current.size).toBe(10_000);
+    });
+
+    it('keeps a legal selection when an expression is invalid', () => {
+      // FR12: a repair is not a new selection.
+      localStorage.setItem(
+        'astryx-resizable:expr-invalid',
+        JSON.stringify({size: 321, isCollapsed: false}),
+      );
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 200,
+          maxSize: 'max(40%, 20rem)' as never,
+          autoSaveId: 'expr-invalid',
+        }),
+      );
+      expect(result.current.size).toBe(321);
+      localStorage.clear();
+    });
+
+    it('freezes an expression bound for the duration of a gesture', () => {
+      content = 1000;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 200,
+          maxSize: 'min(400px, 50%)',
+        }),
+      );
+      expect(result.current.props._maxSizePx).toBe(400);
+      act(() => {
+        result.current.props._onResizeStart();
+      });
+      act(() => {
+        content = 400;
+        StubResizeObserver.resizeAll();
+      });
+      // Held: the bound must not move under the pointer mid-drag (FR7).
+      expect(result.current.props._maxSizePx).toBe(400);
+      act(() => {
+        result.current.props._onResizeEnd();
+      });
+      // min(400, 200) = 200.
+      expect(result.current.props._maxSizePx).toBe(200);
+    });
+
+    it('keeps the maximum winning when an expression floor exceeds it', () => {
+      // The released clamp order is Math.min(max, Math.max(min, size)), so an
+      // inverted pair resolves to the maximum. Unchanged by expressions; this
+      // pins it rather than inventing a new rule (AST-010 FR4).
+      content = 400;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 300,
+          minSize: 'max(40%, 333px)',
+          maxSize: '50%',
+        }),
+      );
+      expect(result.current.props._minSizePx).toBe(333);
+      expect(result.current.props._maxSizePx).toBe(200);
+      expect(result.current.size).toBe(200);
+      expect(Number.isFinite(result.current.size)).toBe(true);
+    });
+
+    it('uses the released viewport basis for an expression with no container', () => {
+      // No containerRef: percentages keep resolving against window.innerWidth
+      // (FR1), inside an expression exactly as on their own.
+      window.innerWidth = 1000;
+      const {result} = renderHook(() =>
+        useResizable({defaultSize: 100, maxSize: 'min(400px, 10%)'}),
+      );
+      expect(result.current.props._maxSizePx).toBe(100);
+    });
+
+    it('resolves an expression against the server basis with no window measurement', () => {
+      // A container that has not been laid out yet holds the documented
+      // temporary 1200px basis rather than resolving against zero.
+      content = 0;
+      const containerRef = makeContainer();
+      const {result} = renderHook(() =>
+        useResizable({
+          containerRef,
+          defaultSize: 100,
+          maxSize: 'min(400px, 10%)',
+        }),
+      );
+      // 10% of the 1200 stand-in is 120; min(400, 120) = 120.
+      expect(result.current.props._maxSizePx).toBe(120);
+    });
+  });
 });
 
 describe('ResizableProps source compatibility (AST-010 API5)', () => {

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -27,17 +27,58 @@ import type {SizeValue} from '../utils/types';
 // =============================================================================
 
 /**
+ * A length a bound may be written as: pixels as a number, an exact `Npx`, or an
+ * exact `N%` of the basis.
+ *
+ * Narrower than the shared `SizeValue` on purpose. `SizeValue` is
+ * `number | string`, so `'40vw'` and `'banana'` type-check and only fail at
+ * runtime; here an unsupported unit is a compile error. The runtime parser
+ * stays authoritative regardless, because a type cannot say "0 through 100" or
+ * "finite".
+ */
+export type ResizableLength = number | `${number}px` | `${number}%`;
+
+/**
+ * A bound: a length, or `min()`/`max()` over lengths — the CSS spelling, with
+ * the CSS meaning. `max(40%, 333px)` is 40% of the container but never less
+ * than 333px; `min(400px, 10%)` caps at 400px until 10% is tighter.
+ *
+ * Two terms, nested one level deep (`max(20%, min(500px, 60%))`). Both limits
+ * are deliberate and the parser enforces exactly the same ones, so a string the
+ * compiler accepts is a string the runtime accepts. They are also what keeps
+ * this union small enough for TypeScript to represent: a wider grammar here
+ * costs a `TS2590` at every call site that combines a bound with its
+ * deprecated pixel alias.
+ *
+ * `calc()`, `clamp()`, arithmetic, `var()` and every other unit are out — an
+ * unrecognized function is invalid input, not something forwarded to CSS
+ * (AST-010 DEC-3).
+ */
+export type ResizableSize = ResizableLength | ResizableSizeFunction;
+
+type ResizableLengthString = `${number}px` | `${number}%`;
+
+/** One level of nesting, so a term may itself be a `min()`/`max()`. */
+type ResizableNestedFunction =
+  `${'min' | 'max'}(${ResizableLengthString}, ${ResizableLengthString})`;
+
+type ResizableSizeTerm = ResizableLengthString | ResizableNestedFunction;
+
+type ResizableSizeFunction =
+  `${'min' | 'max'}(${ResizableSizeTerm}, ${ResizableSizeTerm})`;
+
+/**
  * The minimum, in one of two spellings. Exactly one may be supplied: the union
  * makes passing both a type error, so a migration cannot leave a stale
  * deprecated value shadowing the new one (AST-010 API4).
  */
 export type ResizableMinConfig =
-  | {minSize?: SizeValue; minSizePx?: never}
+  | {minSize?: ResizableSize; minSizePx?: never}
   | {minSize?: never; minSizePx?: number};
 
 /** The maximum, in one of two spellings. See {@link ResizableMinConfig}. */
 export type ResizableMaxConfig =
-  | {maxSize?: SizeValue; maxSizePx?: never}
+  | {maxSize?: ResizableSize; maxSizePx?: never}
   | {maxSize?: never; maxSizePx?: number};
 
 export type ResizableDirection = 'horizontal' | 'vertical';
@@ -314,30 +355,100 @@ const DEFAULT_SIZE_FALLBACK = 250;
  * Parsing is exact and matches the COMPLETE input: `'50 px'`, `'50%%'`,
  * `'50rem'`, `'120%'` and `'-1px'` are all rejected rather than partially
  * parsed into a number that happens to look plausible.
+ *
+ * A bound may also be `min()`/`max()` over those terms (AST-010 FR13), which is
+ * the `fn` node. Nothing else from CSS math is accepted: `calc()`, `clamp()`,
+ * arithmetic and `var()` are non-goals, so an unrecognized function is invalid
+ * input rather than something passed through to CSS.
  */
 type ParsedSize =
-  {kind: 'px'; value: number} | {kind: 'percent'; value: number};
+  | {kind: 'px'; value: number}
+  | {kind: 'percent'; value: number}
+  | {kind: 'fn'; op: 'min' | 'max'; args: ParsedSize[]};
 
 const PX_PATTERN = /^(\d+(?:\.\d+)?)px$/;
 const PERCENT_PATTERN = /^(\d+(?:\.\d+)?)%$/;
+const FN_PATTERN = /^(min|max)\(([\s\S]*)\)$/;
 
-function isPercentage(value: SizeValue | undefined): boolean {
-  return typeof value === 'string' && PERCENT_PATTERN.test(value);
+/**
+ * How deeply `min()`/`max()` may nest, and how many terms each may take. The
+ * public `ResizableSize` type spells out the same two limits, so a string the
+ * compiler accepts is a string this parser accepts.
+ */
+const MAX_EXPRESSION_DEPTH = 2;
+const MAX_EXPRESSION_TERMS = 3;
+
+/**
+ * Split on top-level commas only, so a nested `min()`/`max()` stays one term.
+ * Returns `null` when the parentheses do not balance, which is what makes
+ * `'max(40%, 333px'` invalid rather than silently parsed.
+ */
+function splitTerms(input: string): string[] | null {
+  const terms: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of input) {
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+      if (depth < 0) {
+        return null;
+      }
+    }
+    if (char === ',' && depth === 0) {
+      terms.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  if (depth !== 0) {
+    return null;
+  }
+  terms.push(current);
+  return terms;
 }
 
-function parseSize(value: SizeValue | undefined): ParsedSize | null {
+function parseSize(value: SizeValue | undefined, depth = 0): ParsedSize | null {
   if (value == null) {
     return null;
   }
   if (typeof value === 'number') {
     return Number.isFinite(value) && value >= 0 ? {kind: 'px', value} : null;
   }
-  const px = PX_PATTERN.exec(value);
+  const input = value.trim();
+  const fn = FN_PATTERN.exec(input);
+  if (fn) {
+    if (depth >= MAX_EXPRESSION_DEPTH) {
+      return null;
+    }
+    const terms = splitTerms(fn[2]);
+    // Two terms minimum: a one-term `max()` is a choice between one thing, so
+    // it is a typo rather than a preference. Three maximum, matching the type.
+    if (
+      terms == null ||
+      terms.length < 2 ||
+      terms.length > MAX_EXPRESSION_TERMS
+    ) {
+      return null;
+    }
+    const args: ParsedSize[] = [];
+    for (const term of terms) {
+      const parsed = parseSize(term.trim(), depth + 1);
+      if (parsed == null) {
+        return null;
+      }
+      args.push(parsed);
+    }
+    return {kind: 'fn', op: fn[1] === 'min' ? 'min' : 'max', args};
+  }
+  const px = PX_PATTERN.exec(input);
   if (px) {
     const parsed = Number(px[1]);
     return Number.isFinite(parsed) ? {kind: 'px', value: parsed} : null;
   }
-  const percent = PERCENT_PATTERN.exec(value);
+  const percent = PERCENT_PATTERN.exec(input);
   if (percent) {
     const parsed = Number(percent[1]);
     return Number.isFinite(parsed) && parsed <= 100
@@ -348,13 +459,55 @@ function parseSize(value: SizeValue | undefined): ParsedSize | null {
 }
 
 /**
- * A parsed size in pixels, or `null` when it is a percentage and the basis is
- * not measurable yet. Percentages round, because a fractional pixel basis
- * would otherwise leak into ARIA and persistence.
+ * Whether a parsed value reads the basis anywhere inside it.
+ *
+ * This decides whether the container is observed, and it is a question about
+ * the PARSED tree, not the source text. A regex for `%` on the raw string would
+ * call `max(40%, 333px)` static: the bound would resolve once against whatever
+ * the basis happened to be and then never track the container again — an
+ * expression that looks supported and quietly is not.
+ */
+function dependsOnBasis(parsed: ParsedSize): boolean {
+  if (parsed.kind === 'percent') {
+    return true;
+  }
+  if (parsed.kind === 'fn') {
+    return parsed.args.some(dependsOnBasis);
+  }
+  return false;
+}
+
+function isPercentage(value: SizeValue | undefined): boolean {
+  const parsed = parseSize(value);
+  return parsed != null && dependsOnBasis(parsed);
+}
+
+/**
+ * A parsed size in pixels, or `null` when it reads a basis that is not
+ * measurable yet. Percentages round, because a fractional pixel basis would
+ * otherwise leak into ARIA and persistence.
+ *
+ * `min()`/`max()` resolve every term first and then select, which is what CSS
+ * does: the comparison is between resolved pixel lengths, so which arm wins
+ * changes with the basis. That is the whole point of `max(40%, 333px)` — the
+ * percentage arm above the crossover, the pixel floor below it.
  */
 function toPixels(parsed: ParsedSize, basis: number | null): number | null {
   if (parsed.kind === 'px') {
     return parsed.value;
+  }
+  if (parsed.kind === 'fn') {
+    const resolved: number[] = [];
+    for (const arg of parsed.args) {
+      const px = toPixels(arg, basis);
+      if (px == null) {
+        return null;
+      }
+      resolved.push(px);
+    }
+    return parsed.op === 'max'
+      ? Math.max(...resolved)
+      : Math.min(...resolved);
   }
   if (basis == null) {
     return null;
@@ -389,8 +542,9 @@ function resolveBound(
       devWarn(
         'useResizable',
         `${label}: ${JSON.stringify(raw)} is not a size. Use a non-negative ` +
-          'number of pixels, an exact "Npx" string, or an exact "N%" string ' +
-          `from 0% to 100%. Falling back to ${fallback}.`,
+          'number of pixels, an exact "Npx" string, an exact "N%" string ' +
+          'from 0% to 100%, or min()/max() over those — for example ' +
+          `"max(40%, 333px)". Falling back to ${fallback}.`,
       );
     }
     return fallback;
@@ -465,8 +619,12 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
   // otherwise silently beat the explicit migration target.
   const minConflict = minSize !== undefined && minSizePx !== undefined;
   const maxConflict = maxSize !== undefined && maxSizePx !== undefined;
-  const rawMin = minSize ?? minSizePx;
-  const rawMax = maxSize ?? maxSizePx;
+  // Widened back to `SizeValue` deliberately. `ResizableSize` is a large
+  // template-literal union whose job is done at the call site; combining it
+  // with the alias's `number` here makes a union TypeScript refuses to
+  // represent (TS2590), and the runtime parser validates the value anyway.
+  const rawMin: SizeValue | undefined = minSize ?? minSizePx;
+  const rawMax: SizeValue | undefined = maxSize ?? maxSizePx;
 
   // Whether any percentage is in play at all. A region configured entirely in
   // pixels subscribes to nothing and behaves exactly as it did before.


### PR DESCRIPTION
Stacked on #5783. **Base is `fix/resizable-percentage-sizes`, not `main`** — review that one first; this diff is only the files below.

A bound could be proportional or fixed, never both. `max(40%, 333px)` — 40% of the container, but never below 333px — had no spelling. The string failed to parse whole and took the invalid-input fallback.

## Measured at the parent commit

| config | container | resolved |
|---|---|---|
| `minSize: 'max(40%, 333px)'` | 1200 → 400 | **50px at every width** |
| `maxSize: 'min(400px, 10%)'` | 1200 / 4000 / 6000 | **`Infinity` at every width** |

Development warned. `devWarn` is a no-op in production (`utils/devWarning.ts`), so a shipped build got the wrong geometry with no signal at all.

## After

`minSize` and `maxSize` accept `min()`/`max()` over the terms they already accepted — two terms, one level of nesting. Terms resolve against the same basis as a plain percentage and are compared as resolved pixels, so which arm wins changes with the container, exactly as in CSS.

Chromium 149, container driven at runtime, every row checked against an independent CSS reference evaluation in the harness:

| container | `minSize: 'max(40%, 333px)'` | `maxSize: 'min(400px, 10%)'` |
|---|---|---|
| 1600 | **640** | — |
| 1200 | **480** | **120** |
| 900 | **360** | — |
| 833 (crossover) | **333** | — |
| 832 | **333** | — |
| 400 | **333** | — |
| 2000 / 3999 / 4000 / 6000 | — | 200 / **400** / 400 / 400 |

`aria-valuemin`/`aria-valuemax` carry the same numbers on every row. Nested `max(20%, min(500px, 60%))` measured 600 / 500 / 360 / 120 at 3000 / 1000 / 600 / 200.

## Basis-dependency recurses

A percentage at any depth makes the whole bound track its container; an all-pixel expression is static and observes nothing. The test is on the **parsed tree**, not the source text — a syntactic check would classify `max(40%, 333px)` as static, the container would never be observed, and the bound would resolve once and never move again. Supported-looking and quietly broken. Covered both ways: `max(80px, min(90px, 50%))` re-resolves 90 → 80 when the container shrinks to 100px; `min(400px, 900px)` registers no observer.

## Typing

`minSize`/`maxSize` move from the shared `SizeValue` to a Resizable-owned `ResizableSize`. `'40vw'`, `'20rem'`, `'calc(100% - 3rem)'`, `'clamp(...)'`, `'var(--w)'`, an unbalanced call and over-deep nesting are now **compile errors** rather than runtime fallbacks. Asserted in `useResizable.public.test.ts` with `expectTypeOf`, and I mutation-tested those assertions: claiming `'banana'` is valid, or that the canonical example is not, both fail `tsc`.

The two-term/one-level limits are not arbitrary. They are what keeps the union representable — a wider grammar raised `TS2590` ("union type that is too complex to represent") exactly where a bound meets its deprecated pixel alias. The parser enforces the same two limits, so the compiler and the runtime accept the same set of strings. Compile cost is unchanged: 21.48s vs 21.39s on the parent.

The type does not replace the parser, which stays authoritative for what a type cannot state — a percentage above 100, a negative, a non-finite.

## Compatibility

- `defaultSize` keeps its released `number | string`. Narrowing a shipped prop would reject callers passing a computed string. It resolves an expression once, by the same parser, exactly as it already resolves `'50%'` once.
- `minSizePx`/`maxSizePx` still work, and **one bound can still migrate while the other keeps its alias** — `{minSize: 'max(40%, 333px)', maxSizePx: 960}` type-checks. A grouped `{min, max}` shape would have forbidden that; rejected for it, and because every bounded pair in the package is flat sibling props.
- **Maximum-wins is unchanged and now pinned.** When a resolved minimum exceeds its maximum the released `Math.min(max, Math.max(min, size))` order stands. Verified identical in `main` before touching it, and there is a test with an expression floor: a 400px container with `minSize: 'max(40%, 333px)'` and `maxSize: '50%'` gives min 333 / max 200 / size 200, finite.

## Gates

```
core build        ✅ 598 dist file(s) checked
vitest            Test Files 319 passed · Tests 9134 passed
typecheck         exit 0
typecheck:docs    exit 0
check:repo        exit 0 (incl. check:knowledge — spec validates)
lint:strict       ✖ 85 problems (0 errors, 85 warnings) — identical to the parent
```

Negative control: reverting the implementation and keeping the tests fails **17** runtime tests; reverting the types fails `tsc` on the type-test file.

## Spec

AST-010 gains **FR13** and **DEC-3**, plus rows in the invalid-configuration and verification tables. `calc()`, arithmetic, `clamp()`, `var()` and other units stay non-goals — the grammar is closed, so an unrecognized function is invalid input rather than a passthrough to CSS. DEC-3 records the rejected alternatives, including the structured-AST shape, with the measured catch rates that decided it.
