### PR TITLE
ci: let record owners satisfy the spec gate

### DIFF
--- a/.github/REVIEW_GATE.md
+++ b/.github/REVIEW_GATE.md
@@ -24,14 +24,31 @@ neutral yellow "waiting" signal, not a red failure).
 
 Any PR that creates, changes, or archives a `current` architecture, component,
 family, design, or system spec waits on `spec-owner-approval` for its exact
-current head. `cixzhang` or `imdreamrunner` can approve every record kind.
-Current design records and normative design assets may also be approved by any
-handle in `.github/DESIGNOWNERS`. Mixed PRs still require `cixzhang` or
-`imdreamrunner` for non-design current records. Same-repository owner reviews
-update the exact-head approval automatically. Fork review events cannot write
-with their read-only token, so an approver uses an issue comment containing
-`/approve-spec <full-head-sha>` instead; that command runs from the trusted
-default branch and a new commit invalidates it.
+current head. When the PR author is named in every changed record's valid
+`owners` list on both the trusted base and proposed head, the exact current head
+passes automatically. Deleted records use the trusted base list. A rename must
+preserve the record identity and ownership. Missing, malformed, or ambiguous
+metadata fails closed. Normative design assets and renames into any recognized
+but non-authorizable knowledge path are never eligible for this record-owner
+path because their applicable owner-group approval must remain explicit.
+
+The workflow evaluates one stable base/head snapshot and records success as an
+attestation for that exact head, matching the temporal model of an exact-head
+review or command. A base change during reconciliation aborts the run. A later
+base-owner change does not retroactively revoke an already published exact-head
+attestation; use the existing exact-head revoke path when immediate revocation
+is required.
+
+A newly added record never self-authorizes from its proposed `owners` list. It
+uses the existing exact-head approval path, so an arbitrary contributor cannot
+become trusted by naming themselves. `cixzhang` or `imdreamrunner` can approve
+every record kind. Current design records and normative design assets may also
+be approved by any handle in `.github/DESIGNOWNERS`. Mixed PRs still require
+`cixzhang` or `imdreamrunner` for non-design current records. Same-repository
+owner reviews update the exact-head approval automatically. Fork review events
+cannot write with their read-only token, so an approver uses an issue comment
+containing `/approve-spec <full-head-sha>` instead; that command runs from the
+trusted default branch and a new commit invalidates it.
 
 When a DESIGNOWNER authors a PR, marking it ready for review attests that exact
 head for the design-approval group. That evidence also counts when the PR

--- a/.github/scripts/change-scope.cjs
+++ b/.github/scripts/change-scope.cjs
@@ -27,11 +27,14 @@ const THEME_DOC_CANDIDATE = /^docs\/themes\/(?!README\.md$)[^/]+\.md$/;
 const THEME_PACKAGE_CANDIDATE =
   /^packages\/themes\/[^/]+\/(?:.*\/)?[^/]+\.spec\.md$/;
 
+const ARCHITECTURE_RECORD_PATTERN =
+  /^docs\/architecture\/(?!README\.md$)[^/]+\.md$/;
+
 const KNOWLEDGE_RECORD_PATTERNS = [
   ...SPEC_RECORD_PATTERNS,
   THEME_DOC_CANDIDATE,
   THEME_PACKAGE_CANDIDATE,
-  /^docs\/architecture\/(?!README\.md$)[^/]+\.md$/,
+  ARCHITECTURE_RECORD_PATTERN,
   /^docs\/design\/assets\//,
 ];
 
@@ -39,6 +42,12 @@ function isSpecRecordPath(filePath) {
   return (
     isComponentSpecRecordPath(filePath) ||
     SPEC_RECORD_PATTERNS.some(pattern => pattern.test(filePath))
+  );
+}
+
+function isOwnerAuthorizableRecordPath(filePath) {
+  return (
+    isSpecRecordPath(filePath) || ARCHITECTURE_RECORD_PATTERN.test(filePath)
   );
 }
 
@@ -173,6 +182,7 @@ if (require.main === module) {
 module.exports = {
   classifyChanges,
   isKnowledgeRecordPath,
+  isOwnerAuthorizableRecordPath,
   isSpecRecordPath,
   parseNameStatus,
 };

--- a/.github/scripts/knowledge-frontmatter.cjs
+++ b/.github/scripts/knowledge-frontmatter.cjs
@@ -37,4 +37,104 @@ function parseOwnerFile(content) {
   ];
 }
 
-module.exports = {parseAuthority, parseKind, parseOwnerFile, parseSingleField};
+const GITHUB_LOGIN_PATTERN =
+  /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?(?:\[bot\])?$/i;
+
+function normalizeGitHubLogin(value) {
+  if (typeof value !== 'string') return null;
+  const login = value.trim();
+  if (!GITHUB_LOGIN_PATTERN.test(login) || login.includes('--')) return null;
+  return login.toLowerCase();
+}
+
+function parseQuotedScalar(raw, field, filePath) {
+  const value = raw.trim();
+  const startsQuoted = value.startsWith("'") || value.startsWith('"');
+  const endsQuoted = value.endsWith("'") || value.endsWith('"');
+  if (startsQuoted !== endsQuoted) {
+    throw new Error(`${filePath}: ${field} has unmatched quotes.`);
+  }
+  if (startsQuoted && value[0] !== value.at(-1)) {
+    throw new Error(`${filePath}: ${field} has mismatched quotes.`);
+  }
+  return startsQuoted ? value.slice(1, -1) : value;
+}
+
+function parseRecordOwnership(content, filePath = '<knowledge record>') {
+  if (content == null) return null;
+  const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontmatter) {
+    throw new Error(`${filePath}: missing frontmatter.`);
+  }
+
+  const fields = new Map();
+  const lines = frontmatter[1].split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^\s/.test(line) || line.trim() === '' || line.startsWith('#')) {
+      continue;
+    }
+    const match = line.match(/^([a-z][a-z0-9_]*):\s*(.*)$/);
+    if (!match || !['id', 'owners'].includes(match[1])) continue;
+    if (fields.has(match[1])) {
+      throw new Error(`${filePath}: duplicate frontmatter field ${match[1]}.`);
+    }
+
+    let raw = match[2].trim();
+    if (raw === '') {
+      const block = [];
+      while (index + 1 < lines.length && /^\s/.test(lines[index + 1])) {
+        block.push(lines[index + 1].trim());
+        index += 1;
+      }
+      if (block.length === 1 && /^\[.*\]$/.test(block[0])) {
+        raw = block[0];
+      } else if (block[0] === '[' && block.at(-1) === ']') {
+        raw = `[${block.slice(1, -1).join('')}]`;
+      } else if (
+        block.length > 0 &&
+        block.every(item => item.startsWith('- '))
+      ) {
+        raw = `[${block.map(item => item.slice(2)).join(',')}]`;
+      }
+    }
+    fields.set(match[1], raw);
+  }
+
+  const id = parseQuotedScalar(fields.get('id') ?? '', 'id', filePath);
+  if (!/^[A-Za-z0-9][A-Za-z0-9:._/-]*$/.test(id)) {
+    throw new Error(`${filePath}: id is missing or ambiguous.`);
+  }
+
+  const ownersRaw = fields.get('owners') ?? '';
+  const ownersMatch = ownersRaw.match(/^\[([\s\S]*)\]$/);
+  if (!ownersMatch) {
+    throw new Error(`${filePath}: owners must be a non-empty list.`);
+  }
+  const ownerValues = ownersMatch[1]
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+  const owners = ownerValues.map(value => {
+    const parsed = parseQuotedScalar(value, 'owners', filePath);
+    const normalized = normalizeGitHubLogin(parsed);
+    if (!normalized) {
+      throw new Error(`${filePath}: owners contains an invalid GitHub login.`);
+    }
+    return normalized;
+  });
+  if (owners.length === 0 || new Set(owners).size !== owners.length) {
+    throw new Error(`${filePath}: owners must be non-empty and unambiguous.`);
+  }
+
+  return {id, owners};
+}
+
+module.exports = {
+  normalizeGitHubLogin,
+  parseAuthority,
+  parseKind,
+  parseOwnerFile,
+  parseRecordOwnership,
+  parseSingleField,
+};

--- a/.github/scripts/spec-owner-decision.cjs
+++ b/.github/scripts/spec-owner-decision.cjs
@@ -5,9 +5,11 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 const {
+  normalizeGitHubLogin,
   parseAuthority,
   parseKind,
   parseOwnerFile,
+  parseRecordOwnership,
 } = require('./knowledge-frontmatter.cjs');
 /* eslint-enable @typescript-eslint/no-require-imports */
 
@@ -239,9 +241,84 @@ function requiresOwnerApproval(records, options = {}) {
   return groups.spec || groups.design || groups.theme;
 }
 
+function authorOwnsAllChangedRecords(records, author) {
+  const normalizedAuthor = normalizeGitHubLogin(author);
+  const rejected = reason => ({
+    approved: false,
+    author: normalizedAuthor,
+    reason,
+    recordIds: [],
+  });
+
+  if (!normalizedAuthor)
+    return rejected('missing or invalid pull request author');
+  if (!Array.isArray(records) || records.length === 0) {
+    return rejected('no changed knowledge records');
+  }
+
+  const recordIds = new Set();
+  const orderedRecords = [...records].sort((left, right) =>
+    (left.path ?? '').localeCompare(right.path ?? ''),
+  );
+  for (const record of orderedRecords) {
+    const basePath = record.previousPath ?? record.path;
+    if (!record.baseIsAuthorizableRecord || record.baseContent == null) {
+      return rejected(`${record.path}: no trusted base record`);
+    }
+
+    let baseOwnership;
+    try {
+      baseOwnership = parseRecordOwnership(record.baseContent, basePath);
+    } catch (error) {
+      return rejected(error.message);
+    }
+    if (!baseOwnership.owners.includes(normalizedAuthor)) {
+      return rejected(`${basePath}: author is not a base owner`);
+    }
+
+    let recordId = baseOwnership.id;
+    if (record.headIsKnowledgeRecord && !record.headIsAuthorizableRecord) {
+      return rejected(`${record.path}: head path is not author-authorizable`);
+    }
+    if (record.headIsAuthorizableRecord) {
+      if (record.headContent == null) {
+        return rejected(`${record.path}: head record could not be read`);
+      }
+      let headOwnership;
+      try {
+        headOwnership = parseRecordOwnership(record.headContent, record.path);
+      } catch (error) {
+        return rejected(error.message);
+      }
+      if (headOwnership.id !== baseOwnership.id) {
+        return rejected(`${record.path}: record identity changed`);
+      }
+      if (!headOwnership.owners.includes(normalizedAuthor)) {
+        return rejected(`${record.path}: author is not a head owner`);
+      }
+      recordId = headOwnership.id;
+    }
+
+    if (recordIds.has(recordId)) {
+      return rejected(
+        `${record.path}: duplicate changed record id ${recordId}`,
+      );
+    }
+    recordIds.add(recordId);
+  }
+
+  return {
+    approved: true,
+    author: normalizedAuthor,
+    reason: null,
+    recordIds: [...recordIds].sort(),
+  };
+}
+
 module.exports = {
   GATE_STATUS_CONTEXT,
   READY_STATUS_PREFIX,
+  authorOwnsAllChangedRecords,
   canonicalRunUrl,
   newestGateRun,
   parseAuthority,

--- a/.github/scripts/spec-owner-decision.test.mjs
+++ b/.github/scripts/spec-owner-decision.test.mjs
@@ -5,6 +5,7 @@ import {describe, expect, it} from 'vitest';
 
 const require = createRequire(import.meta.url);
 const {
+  authorOwnsAllChangedRecords,
   canonicalRunUrl,
   newestGateRun,
   parseCanonicalRunId,
@@ -489,5 +490,173 @@ describe('spec owner decision', () => {
       9007199254740993n,
     );
     expect(newestGateRun(statuses, repository)?.runId).toBe(9007199254740993n);
+  });
+});
+
+function recordContent(id, owners) {
+  return `---\nid: ${id}\nowners: ${owners}\n---\n`;
+}
+
+function changedRecord({
+  id = 'component:Button',
+  baseOwners = '[cixzhang]',
+  headId = id,
+  headOwners = baseOwners,
+  path = 'packages/core/src/Button/Button.spec.md',
+  previousPath = path,
+  baseIsAuthorizableRecord = true,
+  headIsAuthorizableRecord = true,
+  baseIsKnowledgeRecord = baseIsAuthorizableRecord,
+  headIsKnowledgeRecord = headIsAuthorizableRecord,
+} = {}) {
+  return {
+    path,
+    previousPath,
+    baseIsKnowledgeRecord,
+    headIsKnowledgeRecord,
+    baseIsAuthorizableRecord,
+    headIsAuthorizableRecord,
+    baseContent: baseIsAuthorizableRecord
+      ? recordContent(id, baseOwners)
+      : null,
+    headContent: headIsAuthorizableRecord
+      ? recordContent(headId, headOwners)
+      : null,
+  };
+}
+
+describe('record owner author decision', () => {
+  it('accepts one existing record owner case-insensitively', () => {
+    expect(
+      authorOwnsAllChangedRecords(
+        [changedRecord({baseOwners: '[CiXzHaNg]'})],
+        'CIXZHANG',
+      ),
+    ).toEqual({
+      approved: true,
+      author: 'cixzhang',
+      reason: null,
+      recordIds: ['component:Button'],
+    });
+  });
+
+  it('accepts validator-supported multiline owner arrays', () => {
+    const multilineOwners = '\n  [\n    cixzhang,\n  ]';
+    expect(
+      authorOwnsAllChangedRecords(
+        [
+          changedRecord({
+            baseOwners: multilineOwners,
+            headOwners: multilineOwners,
+          }),
+        ],
+        'cixzhang',
+      ).approved,
+    ).toBe(true);
+  });
+
+  it('requires the author to own every changed record and sorts record ids', () => {
+    const records = [
+      changedRecord({
+        id: 'family:inputs',
+        path: 'docs/families/inputs.md',
+      }),
+      changedRecord({
+        id: 'architecture:buttons',
+        path: 'docs/architecture/buttons.md',
+      }),
+    ];
+    expect(authorOwnsAllChangedRecords(records, 'cixzhang')).toMatchObject({
+      approved: true,
+      recordIds: ['architecture:buttons', 'family:inputs'],
+    });
+
+    records[1] = changedRecord({
+      id: 'architecture:buttons',
+      baseOwners: '[imdreamrunner]',
+      headOwners: '[imdreamrunner]',
+      path: 'docs/architecture/buttons.md',
+    });
+    expect(authorOwnsAllChangedRecords(records, 'cixzhang')).toMatchObject({
+      approved: false,
+      reason: expect.stringContaining('author is not a base owner'),
+    });
+  });
+
+  it('does not let a new record self-admit its author', () => {
+    const record = changedRecord({baseIsAuthorizableRecord: false});
+    expect(authorOwnsAllChangedRecords([record], 'cixzhang')).toMatchObject({
+      approved: false,
+      reason: expect.stringContaining('no trusted base record'),
+    });
+  });
+
+  it('handles preserving renames and owner-authored deletions', () => {
+    const renamed = changedRecord({
+      path: 'docs/architecture/new-name.md',
+      previousPath: 'docs/architecture/old-name.md',
+    });
+    const deleted = changedRecord({headIsAuthorizableRecord: false});
+
+    expect(authorOwnsAllChangedRecords([renamed], 'cixzhang').approved).toBe(
+      true,
+    );
+    expect(authorOwnsAllChangedRecords([deleted], 'cixzhang').approved).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    {
+      name: 'unsafe knowledge-path rename',
+      record: changedRecord({
+        path: 'docs/design/assets/button.md',
+        previousPath: 'docs/design/button.md',
+        headIsKnowledgeRecord: true,
+        headIsAuthorizableRecord: false,
+      }),
+      reason: 'head path is not author-authorizable',
+    },
+    {
+      name: 'changed identity',
+      record: changedRecord({headId: 'component:OtherButton'}),
+      reason: 'record identity changed',
+    },
+    {
+      name: 'missing owners',
+      record: changedRecord({headOwners: '[]'}),
+      reason: 'owners must be non-empty',
+    },
+    {
+      name: 'duplicate owners',
+      record: changedRecord({headOwners: '[cixzhang, CIXZHANG]'}),
+      reason: 'owners must be non-empty and unambiguous',
+    },
+    {
+      name: 'invalid owner login',
+      record: changedRecord({headOwners: '[not a login]'}),
+      reason: 'invalid GitHub login',
+    },
+  ])('fails closed for $name', ({record, reason}) => {
+    expect(authorOwnsAllChangedRecords([record], 'cixzhang')).toMatchObject({
+      approved: false,
+      reason: expect.stringContaining(reason),
+    });
+  });
+
+  it('accepts a bot only when the trusted record names its exact identity', () => {
+    const botOwned = changedRecord({
+      baseOwners: '[dependabot[bot]]',
+      headOwners: '[dependabot[bot]]',
+    });
+    expect(
+      authorOwnsAllChangedRecords([botOwned], 'dependabot[bot]').approved,
+    ).toBe(true);
+    expect(
+      authorOwnsAllChangedRecords([botOwned], 'app/dependabot'),
+    ).toMatchObject({
+      approved: false,
+      reason: 'missing or invalid pull request author',
+    });
   });
 });

--- a/.github/scripts/spec-owner-reconcile.cjs
+++ b/.github/scripts/spec-owner-reconcile.cjs
@@ -6,10 +6,15 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require('node:fs');
 const path = require('node:path');
-const {classifyChanges} = require('./change-scope.cjs');
+const {
+  classifyChanges,
+  isKnowledgeRecordPath,
+  isOwnerAuthorizableRecordPath,
+} = require('./change-scope.cjs');
 const {
   GATE_STATUS_CONTEXT,
   READY_STATUS_PREFIX,
+  authorOwnsAllChangedRecords,
   canonicalRunUrl,
   newestGateRun,
   parseOwnerCommand,
@@ -43,6 +48,12 @@ function isAuthorizedEvent(eventName, payload, owners) {
 
 function labelNames(pr) {
   return new Set(pr.labels.map(label => label.name));
+}
+
+function authorOwnershipDescription(ownership, prefix = '') {
+  const full = `${prefix}Author @${ownership.author} owns all changed records: ${ownership.recordIds.join(', ')}.`;
+  if (full.length <= 140) return full;
+  return `${prefix}Author @${ownership.author} owns all ${ownership.recordIds.length} changed records; record IDs are in the workflow log.`;
 }
 
 async function reconcileSpecOwnerGate({
@@ -160,9 +171,10 @@ async function reconcileSpecOwnerGate({
     return newest === null || newest.runId <= runId;
   }
 
-  async function currentPullForRun(headSha) {
+  async function currentPullForRun(headSha, baseSha) {
     const current = await getPullRequest();
-    if (current.head.sha !== headSha) return null;
+    if (current.head.sha !== headSha || current.base.sha !== baseSha)
+      return null;
     if (!(await isCurrentRun(headSha))) return null;
     return current;
   }
@@ -259,6 +271,7 @@ async function reconcileSpecOwnerGate({
   async function fetchSnapshot() {
     const before = await getPullRequest();
     const headSha = before.head.sha;
+    const baseSha = before.base.sha;
     const [files, reviews, comments, timeline, statuses] = await Promise.all([
       github.paginate(github.rest.pulls.listFiles, {
         owner,
@@ -287,7 +300,7 @@ async function reconcileSpecOwnerGate({
       listStatuses(headSha),
     ]);
     const after = await getPullRequest();
-    if (after.head.sha !== headSha) return null;
+    if (after.head.sha !== headSha || after.base.sha !== baseSha) return null;
 
     const scope = classifyChanges(files, {expectedCount: after.changed_files});
     const knowledgeChanges = files.filter(
@@ -301,32 +314,44 @@ async function reconcileSpecOwnerGate({
     const records = await Promise.all(
       knowledgeChanges.map(async file => {
         const previousPath = file.previous_filename || file.filename;
-        const baseIsTextRecord = previousPath.endsWith('.md');
-        const headIsTextRecord = file.filename.endsWith('.md');
+        const baseIsKnowledgeRecord =
+          file.status !== 'added' && isKnowledgeRecordPath(previousPath);
+        const headIsKnowledgeRecord =
+          file.status !== 'removed' && isKnowledgeRecordPath(file.filename);
+        const baseIsAuthorizableRecord =
+          baseIsKnowledgeRecord && isOwnerAuthorizableRecordPath(previousPath);
+        const headIsAuthorizableRecord =
+          headIsKnowledgeRecord && isOwnerAuthorizableRecordPath(file.filename);
+        const baseIsTextRecord =
+          baseIsKnowledgeRecord && previousPath.endsWith('.md');
+        const headIsTextRecord =
+          headIsKnowledgeRecord && file.filename.endsWith('.md');
         return {
           path: file.filename,
           previousPath,
-          baseContent:
-            !baseIsTextRecord || file.status === 'added'
-              ? null
-              : await readText(
-                  after.base.repo.full_name,
-                  after.base.sha,
-                  previousPath,
-                ),
-          headContent:
-            !headIsTextRecord || file.status === 'removed'
-              ? null
-              : await readText(
-                  after.head.repo.full_name,
-                  after.head.sha,
-                  file.filename,
-                ),
+          baseIsKnowledgeRecord,
+          headIsKnowledgeRecord,
+          baseIsAuthorizableRecord,
+          headIsAuthorizableRecord,
+          baseContent: !baseIsTextRecord
+            ? null
+            : await readText(
+                after.base.repo.full_name,
+                after.base.sha,
+                previousPath,
+              ),
+          headContent: !headIsTextRecord
+            ? null
+            : await readText(
+                after.head.repo.full_name,
+                after.head.sha,
+                file.filename,
+              ),
         };
       }),
     );
     const latest = await getPullRequest();
-    if (latest.head.sha !== headSha) return null;
+    if (latest.head.sha !== headSha || latest.base.sha !== baseSha) return null;
     return {
       pr: latest,
       files,
@@ -341,6 +366,7 @@ async function reconcileSpecOwnerGate({
 
   const initialPr = await getPullRequest();
   const initialHead = initialPr.head.sha;
+  const initialBase = initialPr.base.sha;
   await createStatus({
     sha: initialHead,
     context: GATE_STATUS_CONTEXT,
@@ -389,9 +415,13 @@ async function reconcileSpecOwnerGate({
   }
 
   const snapshot = await fetchSnapshot();
-  if (snapshot === null || snapshot.pr.head.sha !== initialHead) {
+  if (
+    snapshot === null ||
+    snapshot.pr.head.sha !== initialHead ||
+    snapshot.pr.base.sha !== initialBase
+  ) {
     core.info(
-      'The pull request head changed while this run was reading state.',
+      'The pull request head or base changed while this run was reading state.',
     );
     return;
   }
@@ -439,6 +469,9 @@ async function reconcileSpecOwnerGate({
   }
   const designApprovers = [...new Set([...specOwners, ...designOwners])];
   const themeApprovers = [...new Set([...engineeringOwners, ...designOwners])];
+  const authorOwnership = ownerApprovalRequired
+    ? authorOwnsAllChangedRecords(records, pr.user?.login)
+    : {approved: false, author: null, recordIds: []};
   const readyAttestations = parseReadyAttestations(statuses, {
     repository,
     headSha: initialHead,
@@ -459,8 +492,25 @@ async function reconcileSpecOwnerGate({
   const themeDecision = requiredGroups.theme
     ? resolveOwnerDecision({...decisionInput, owners: themeApprovers})
     : {approved: true, owner: null};
+  const groupDecisions = [specDecision, designDecision, themeDecision];
+  const exactHeadObjection = groupDecisions.some(
+    decision => decision.approved === false && decision.owner !== null,
+  );
+  const authorOwnershipApproved =
+    authorOwnership.approved && !exactHeadObjection;
+  if (authorOwnership.approved) {
+    const detail = authorOwnershipDescription(authorOwnership);
+    core.info(
+      exactHeadObjection
+        ? `${detail} An exact-head owner objection keeps the gate pending.`
+        : `${detail} Trusted base ${initialBase}; attesting exact head ${initialHead}.`,
+    );
+  }
   const approved =
-    specDecision.approved && designDecision.approved && themeDecision.approved;
+    authorOwnershipApproved ||
+    (specDecision.approved &&
+      designDecision.approved &&
+      themeDecision.approved);
   const approvingOwners = [
     specDecision.owner,
     designDecision.owner,
@@ -479,6 +529,14 @@ async function reconcileSpecOwnerGate({
   ]
     .filter(Boolean)
     .join(' and ');
+
+  if (
+    authorOwnershipApproved &&
+    (await currentPullForRun(initialHead, initialBase)) === null
+  ) {
+    core.info('The owner-author snapshot changed before final status.');
+    return;
+  }
 
   if (ownerApprovalRequired && !approved) {
     await disableAutoMerge(pr);
@@ -504,16 +562,20 @@ async function reconcileSpecOwnerGate({
     await setFinalStatus(
       initialHead,
       'success',
-      'Draft PR; owner gate is not blocking.',
+      authorOwnershipApproved
+        ? authorOwnershipDescription(authorOwnership, 'Draft PR; ')
+        : 'Draft PR; owner gate is not blocking.',
     );
     return;
   }
 
-  const successDescription = ownerApprovalRequired
-    ? `Approved by ${approvingOwners
-        .map(name => `@${name}`)
-        .join(' and ')} for ${initialHead.slice(0, 7)}.`
-    : 'Draft-only knowledge change; owner approval is not required.';
+  const successDescription = authorOwnershipApproved
+    ? authorOwnershipDescription(authorOwnership)
+    : ownerApprovalRequired
+      ? `Approved by ${approvingOwners
+          .map(name => `@${name}`)
+          .join(' and ')} for ${initialHead.slice(0, 7)}.`
+      : 'Draft-only knowledge change; owner approval is not required.';
 
   if (!scope.specOnly) {
     await disableAutoMerge(pr);
@@ -533,7 +595,7 @@ async function reconcileSpecOwnerGate({
 
   let enabledAutoMergeByThisRun = false;
   if (!pr.auto_merge) {
-    const beforeEnable = await currentPullForRun(initialHead);
+    const beforeEnable = await currentPullForRun(initialHead, initialBase);
     if (beforeEnable === null || beforeEnable.auto_merge) return;
     await ensureLabel(
       beforeEnable,
@@ -541,7 +603,7 @@ async function reconcileSpecOwnerGate({
       'bfdadc',
       'Auto-merge was enabled by the spec owner gate',
     );
-    const afterLabel = await currentPullForRun(initialHead);
+    const afterLabel = await currentPullForRun(initialHead, initialBase);
     if (afterLabel === null || afterLabel.auto_merge) return;
     try {
       await github.graphql(

--- a/.github/scripts/spec-owner-reconcile.test.mjs
+++ b/.github/scripts/spec-owner-reconcile.test.mjs
@@ -100,6 +100,8 @@ function createHarness({
   changedFiles,
   headContent = 'kind: architecture\nauthority: current\n',
   baseContent = '',
+  headContents,
+  baseContents,
 } = {}) {
   const files = changedFiles ?? [changedFile];
   const state = {
@@ -199,13 +201,19 @@ function createHarness({
           state.calls.push(`status:${input.context}:${input.state}`);
           return {data: status};
         },
-        getContent: async ({ref}) => ({
-          data: {
-            content: Buffer.from(
-              ref === state.pr.head.sha ? headContent : baseContent,
-            ).toString('base64'),
-          },
-        }),
+        getContent: async ({ref, path: filePath}) => {
+          const contents =
+            ref === state.pr.head.sha ? headContents : baseContents;
+          const fallback =
+            ref === state.pr.head.sha ? headContent : baseContent;
+          const content = contents?.[filePath] ?? fallback;
+          if (content == null) {
+            const error = new Error('Not found');
+            error.status = 404;
+            throw error;
+          }
+          return {data: {content: Buffer.from(content).toString('base64')}};
+        },
       },
     },
     graphql: async query => {
@@ -264,6 +272,10 @@ function hasReadyAttestation(state, owner = 'ernestt') {
   );
 }
 
+function currentRecord(id, owners, kind = 'architecture') {
+  return `---\nkind: ${kind}\nid: ${id}\nauthority: current\nowners: [${owners.join(', ')}]\n---\n`;
+}
+
 describe('spec owner workflow reconciliation', () => {
   it('treats an eligible owner-author ready event as exact-head approval', async () => {
     const harness = createHarness();
@@ -277,6 +289,201 @@ describe('spec owner workflow reconciliation', () => {
     ).toBe(true);
     expect(latestGateStatus(harness.state).state).toBe('success');
     expect(harness.state.calls).toContain('enable-auto-merge');
+  });
+
+  it('auto-approves a fork head when the PR author owns its existing record', async () => {
+    const content = currentRecord('architecture:owned', ['record-owner']);
+    const harness = createHarness({
+      author: 'Record-Owner',
+      headRepository: 'record-owner/astryx',
+      changedFile: {
+        filename: 'docs/architecture/owned.md',
+        status: 'modified',
+      },
+      baseContent: content,
+      headContent: content,
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        actor: 'github-actions[bot]',
+        author: 'Record-Owner',
+        headRepository: 'record-owner/astryx',
+      }),
+    );
+
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'success',
+      description:
+        'Author @record-owner owns all changed records: architecture:owned.',
+    });
+    expect(
+      harness.state.calls.some(call =>
+        call.includes(
+          'Author @record-owner owns all changed records: architecture:owned.',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      harness.state.statuses.some(status =>
+        status.context.startsWith('spec-owner-ready/'),
+      ),
+    ).toBe(false);
+  });
+
+  it('auto-approves only when the author owns every changed record', async () => {
+    const firstPath = 'docs/architecture/first.md';
+    const secondPath = 'docs/architecture/second.md';
+    const changedFiles = [
+      {filename: firstPath, status: 'modified'},
+      {filename: secondPath, status: 'modified'},
+    ];
+    const allOwned = createHarness({
+      author: 'record-owner',
+      changedFiles,
+      baseContents: {
+        [firstPath]: currentRecord('architecture:first', ['record-owner']),
+        [secondPath]: currentRecord('architecture:second', ['record-owner']),
+      },
+      headContents: {
+        [firstPath]: currentRecord('architecture:first', ['record-owner']),
+        [secondPath]: currentRecord('architecture:second', ['record-owner']),
+      },
+    });
+
+    await run(
+      allOwned,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        actor: 'automation',
+        author: 'record-owner',
+      }),
+    );
+    expect(latestGateStatus(allOwned.state)).toMatchObject({
+      state: 'success',
+      description:
+        'Author @record-owner owns all changed records: architecture:first, architecture:second.',
+    });
+
+    const mixed = createHarness({
+      author: 'record-owner',
+      changedFiles,
+      baseContents: {
+        [firstPath]: currentRecord('architecture:first', ['record-owner']),
+        [secondPath]: currentRecord('architecture:second', ['another-owner']),
+      },
+      headContents: {
+        [firstPath]: currentRecord('architecture:first', ['record-owner']),
+        [secondPath]: currentRecord('architecture:second', ['another-owner']),
+      },
+    });
+    await run(
+      mixed,
+      context({
+        runId: 101n,
+        action: 'synchronize',
+        author: 'record-owner',
+      }),
+    );
+    expect(latestGateStatus(mixed.state).state).toBe('pending');
+  });
+
+  it('keeps a new record self-listing on the existing approval path', async () => {
+    const harness = createHarness({
+      author: 'contributor',
+      changedFile: {
+        filename: 'docs/architecture/new-record.md',
+        status: 'added',
+      },
+      headContent: currentRecord('architecture:new-record', ['contributor']),
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        actor: 'contributor',
+        author: 'contributor',
+      }),
+    );
+
+    expect(latestGateStatus(harness.state).state).toBe('pending');
+  });
+
+  it('keeps stale approval stale unless the current author-owner path applies', async () => {
+    const staleReview = {
+      user: {login: 'cixzhang'},
+      state: 'APPROVED',
+      commit_id: nextHead,
+      submitted_at: '2026-08-30T10:00:00Z',
+    };
+    const content = currentRecord('architecture:owned', ['record-owner']);
+    const baseOptions = {
+      changedFile: {
+        filename: 'docs/architecture/owned.md',
+        status: 'modified',
+      },
+      baseContent: content,
+      headContent: content,
+      reviews: [staleReview],
+    };
+    const nonOwner = createHarness({...baseOptions, author: 'contributor'});
+    await run(
+      nonOwner,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        author: 'contributor',
+      }),
+    );
+    expect(latestGateStatus(nonOwner.state).state).toBe('pending');
+
+    const ownerAuthor = createHarness({...baseOptions, author: 'record-owner'});
+    await run(
+      ownerAuthor,
+      context({
+        runId: 101n,
+        action: 'synchronize',
+        author: 'record-owner',
+      }),
+    );
+    expect(latestGateStatus(ownerAuthor.state).state).toBe('success');
+  });
+
+  it('keeps an exact-head owner objection blocking an owner-author', async () => {
+    const content = currentRecord('architecture:owned', ['record-owner']);
+    const objection = {
+      user: {login: 'cixzhang'},
+      state: 'CHANGES_REQUESTED',
+      commit_id: head,
+      submitted_at: '2026-08-30T10:00:00Z',
+    };
+    const harness = createHarness({
+      author: 'record-owner',
+      changedFile: {
+        filename: 'docs/architecture/owned.md',
+        status: 'modified',
+      },
+      baseContent: content,
+      headContent: content,
+      reviews: [objection],
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        author: 'record-owner',
+      }),
+    );
+
+    expect(latestGateStatus(harness.state).state).toBe('pending');
   });
 
   it('lets a DESIGNOWNER author self-attest an exact design-record-only head', async () => {
@@ -369,6 +576,74 @@ describe('spec owner workflow reconciliation', () => {
     });
     expect(harness.state.calls).not.toContain('enable-auto-merge');
   });
+
+  it('does not let record-shaped design assets use the author-owner path', async () => {
+    const content = currentRecord('design:palette', ['asset-owner'], 'design');
+    const harness = createHarness({
+      author: 'asset-owner',
+      changedFile: {
+        filename: 'docs/design/assets/palette.md',
+        status: 'modified',
+      },
+      baseContent: content,
+      headContent: content,
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        author: 'asset-owner',
+      }),
+    );
+
+    expect(latestGateStatus(harness.state).state).toBe('pending');
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+  });
+
+  it.each([
+    {
+      name: 'a normative design asset',
+      filename: 'docs/design/assets/palette.md',
+      previousFilename: 'docs/design/palette.md',
+      baseContent: currentRecord('design:palette', ['record-owner'], 'design'),
+      headContent: currentRecord('design:palette', ['record-owner'], 'design'),
+    },
+    {
+      name: 'a misplaced theme candidate',
+      filename: 'docs/themes/neutral.md',
+      previousFilename: 'docs/architecture/neutral.md',
+      baseContent: currentRecord('architecture:neutral', ['record-owner']),
+      headContent: currentRecord('theme:neutral', ['record-owner'], 'theme'),
+    },
+  ])(
+    'keeps an owner-authored rename into $name on the explicit approval path',
+    async ({filename, previousFilename, baseContent, headContent}) => {
+      const harness = createHarness({
+        author: 'record-owner',
+        changedFile: {
+          filename,
+          previous_filename: previousFilename,
+          status: 'renamed',
+        },
+        baseContent,
+        headContent,
+      });
+
+      await run(
+        harness,
+        context({
+          runId: 100n,
+          action: 'synchronize',
+          author: 'record-owner',
+        }),
+      );
+
+      expect(latestGateStatus(harness.state).state).toBe('pending');
+      expect(harness.state.calls).not.toContain('enable-auto-merge');
+    },
+  );
 
   it('requires a real ready transition and never auto-merges a draft PR', async () => {
     const readyDraft = createDesignHarness({draft: true});
@@ -721,6 +996,39 @@ describe('spec owner workflow reconciliation', () => {
     ).toHaveLength(1);
   });
 
+  it('abandons an ownership snapshot when the live base changes', async () => {
+    const content = currentRecord('architecture:owned', ['record-owner']);
+    const harness = createHarness({
+      author: 'record-owner',
+      changedFile: {
+        filename: 'docs/architecture/owned.md',
+        status: 'modified',
+      },
+      baseContent: content,
+      headContent: content,
+      onPullGet: (count, state) => {
+        if (count === 3) state.pr.base.sha = nextHead;
+      },
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        author: 'record-owner',
+      }),
+    );
+
+    expect(latestGateStatus(harness.state).state).toBe('pending');
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+    expect(
+      harness.state.calls.some(call =>
+        call.includes('head or base changed while this run was reading state'),
+      ),
+    ).toBe(true);
+  });
+
   it('disables gate-owned auto-merge before reconciling a later revoke', async () => {
     const harness = createHarness();
     await run(harness, context({runId: 100n}));
@@ -876,14 +1184,14 @@ describe('spec owner workflow reconciliation', () => {
     ]);
   });
 
-  it('reconciles same-repository owner reviews automatically', async () => {
+  it('accepts an exact-head owner review for a non-owner author', async () => {
     const review = {
       user: {login: 'cixzhang'},
       state: 'APPROVED',
       commit_id: head,
       submitted_at: '2026-08-30T10:00:00Z',
     };
-    const harness = createHarness({reviews: [review]});
+    const harness = createHarness({author: 'contributor', reviews: [review]});
 
     await run(
       harness,
@@ -891,6 +1199,8 @@ describe('spec owner workflow reconciliation', () => {
         runId: 100n,
         eventName: 'pull_request_review',
         action: 'submitted',
+        actor: 'cixzhang',
+        author: 'contributor',
         review,
       }),
     );

--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -175,6 +175,7 @@ describe('spec-only workflow contract', () => {
     expect(reconciler).toContain('expectedCount: after.changed_files');
     expect(reconciler).toContain('scope.touchesKnowledgeRecords');
     expect(reconciler).toContain('scope.touchesDesignAssets');
+    expect(reconciler).toContain('isOwnerAuthorizableRecordPath');
     expect(reconciler).toContain('requiredApprovalGroups(records');
     expect(reconciler).toContain("'.github/DESIGNOWNERS'");
     expect(reconciler).toContain("'.github/ENGOWNERS'");

--- a/.github/workflows/spec-owner-gate.yml
+++ b/.github/workflows/spec-owner-gate.yml
@@ -1,7 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 # Current knowledge records are consequential to future reviewers. Creating,
-# changing, or archiving one waits for owner approval. Current design records
+# changing, or archiving one waits for owner approval. An author already named
+# by every changed record on both one stable trusted-base/proposed-head snapshot
+# satisfies that gate automatically; new records and normative design assets
+# cannot self-authorize. Current design records
 # and normative design assets also accept DESIGNOWNERS; current theme records
 # accept the committed union of ENGOWNERS and DESIGNOWNERS. Mixed PRs keep every applicable owner-group
 # requirement. Pure spec-record PRs

--- a/docs/architecture/knowledge-contracts.md
+++ b/docs/architecture/knowledge-contracts.md
@@ -227,8 +227,11 @@ Before any component, module, family, design, theme, or architecture record beco
    - If the direction is rejected, the rejected implementation is removed or
      changed. Record the rejected alternative only when the boundary is
      consequential and likely to come up again.
-5. The final commits invalidate prior approval. The owner approves the exact
-   heads after the record and implementation agree.
+5. A final commit invalidates prior comment and review approval. For the exact
+   current head, the gate re-evaluates whether the pull-request author is already
+   named by every changed record on both the trusted base and proposed head. New
+   records cannot grant this author path; otherwise an owner approves the exact
+   head after the record and implementation agree.
 
 If no implementation direction is accepted, close the contributor pull request.
 The maintainer-owned spec pull request remains only when the ruling is useful
@@ -292,9 +295,17 @@ this flow passes the historical review benchmark and is enforced on pull request
   metadata.
 - `.github/scripts/change-scope.cjs` identifies pure spec-record changes.
 - `.github/workflows/spec-owner-gate.yml` binds approval to the exact pull
-  request head. Theme approval derives from the committed union of
-  `.github/ENGOWNERS` and `.github/DESIGNOWNERS`; record metadata never
-  self-authorizes. The workflow enables auto-merge only for pure spec changes.
+  request head. An author-owner path derives only from a valid record already on
+  the trusted base and requires the author in the valid `owners` lists on both
+  base and head; added records, identity changes, normative design assets,
+  cross-boundary knowledge-path renames, and missing or ambiguous owner metadata
+  never self-authorize. The workflow aborts
+  if either snapshot changes while it is reading. A successful run is an
+  attestation for that exact head, like an exact-head review or command; later
+  base-owner changes do not retroactively revoke it. Theme approval otherwise
+  derives from the committed union of `.github/ENGOWNERS` and
+  `.github/DESIGNOWNERS`. The workflow enables auto-merge only for pure spec
+  changes.
 
 ## Deciding specs
 
@@ -331,9 +342,9 @@ work.
 
 ## Verification
 
-| Invariant                         | Evidence                                       | Failure signal                                                                                                                                      |
-| --------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| INV1, INV6                        | `scripts/check-knowledge.test.mjs`             | An unapproved current record or unmigrated active record passes                                                                                     |
-| INV5, INV7                        | `.github/scripts/change-scope.test.mjs`        | A template, schema, guidance, architecture, code change, unsafe rename, or truncated list qualifies as spec-only                                    |
-| Approval follows the current head | `.github/scripts/spec-owner-decision.test.mjs` | An approval for another commit clears the gate, a self-declared owner becomes an approver, or the wrong owner group approves a current theme record |
-| INV3, INV4                        | Blinded historical review benchmark            | Reviewer re-asks a settled decision or invents a new one                                                                                            |
+| Invariant                         | Evidence                                       | Failure signal                                                                                                                                                                                                         |
+| --------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| INV1, INV6                        | `scripts/check-knowledge.test.mjs`             | An unapproved current record or unmigrated active record passes                                                                                                                                                        |
+| INV5, INV7                        | `.github/scripts/change-scope.test.mjs`        | A template, schema, guidance, architecture, code change, unsafe rename, or truncated list qualifies as spec-only                                                                                                       |
+| Approval follows the current head | `.github/scripts/spec-owner-decision.test.mjs` | An approval for another commit clears the gate, a new record self-authorizes, an author missing from either trusted-base or proposed-head owners auto-passes, or the wrong owner group approves a current theme record |
+| INV3, INV4                        | Blinded historical review benchmark            | Reviewer re-asks a settled decision or invents a new one                                                                                                                                                               |


### PR DESCRIPTION
## Why

Knowledge-record owners currently have to restate approval when editing records they already own. This adds manual review work without adding another decision-maker.

## What

- Let the exact GitHub PR author satisfy `spec-owner-approval` when every changed knowledge record already exists on one stable trusted-base/proposed-head snapshot, keeps the same record ID, and names that author in valid `owners` lists on both sides.
- Keep new records, normative design assets, cross-boundary knowledge-path renames, mixed ownership, identity changes, and missing or ambiguous owner metadata on the existing exact-head owner approval path.
- Preserve current review, revoke, fork, draft, auto-merge, and non-knowledge behavior, and report the owned record IDs when the author path succeeds.

## Compatibility and security

The trusted base is the admission boundary: a new record cannot authorize its author by listing them. Existing exact-head objections still block, comment and review approvals still invalidate on a new head, and the author path does not expand spec-only auto-merge scope.

The workflow aborts if the head or base changes while it reads or before it publishes the author attestation. As with an exact-head review or command, a later base-owner change does not retroactively revoke an already published attestation for an unchanged head; the existing exact-head revoke path remains available.

## Testing

- 120 focused change-scope, spec-owner decision, reconciliation, and workflow tests
- `pnpm check:knowledge`
- `pnpm check:repo`
- touched-file ESLint
- `actionlint .github/workflows/spec-owner-gate.yml`
- public hygiene and `git diff --check`
- independent exact-head security review

No Changeset: repository workflow policy only.
