### PR TITLE
chore(i18n): translations update from Crowdin

### DIFF
--- a/packages/core/locales/fr-FR.json
+++ b/packages/core/locales/fr-FR.json
@@ -1,4 +1,8 @@
 {
+  "@astryx.pagination.label": {
+    "defaultMessage": "Pagination",
+    "description": "Aria label for the pagination navigation region."
+  },
   "@astryx.pagination.previous": {
     "defaultMessage": "Aller à la page précédente",
     "description": "Aria label for the previous-page button."
@@ -598,6 +602,10 @@
   "@astryx.dateInput.clear": {
     "defaultMessage": "Effacer {label}",
     "description": "Aria label for the clear-value button in DateInput / DateRangeInput / DateTimeInput. `{label}` is the field's own label so screen readers announce e.g. 'Clear Start date'."
+  },
+  "@astryx.dateInput.invalidDate": {
+    "defaultMessage": "Date non valide",
+    "description": "Screen-reader-only live-region alert in DateInput / DateTimeInput when the typed date cannot be parsed. The field silently reverts on blur, so this is the only rejection feedback a screen-reader user gets."
   },
   "@astryx.dateTimeInput.timeSuffix": {
     "defaultMessage": "Heure de {label}",


### PR DESCRIPTION
Automated translations pulled from Crowdin.

Source: https://crowdin.com/project/astryx

Locale JSON has been normalized with `prettier`. Review the diff
for any strings that shifted meaning or formatting, then merge
when ready.