### PR TITLE
fix: add playground fixture for properties preview

### DIFF
--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -17,6 +17,54 @@ export const docs = {
     'structured',
     'omnibar',
   ],
+  playground: {
+    defaults: {
+      config: {
+        name: 'ExampleSearch',
+        fields: [
+          {
+            key: 'title',
+            label: 'Title',
+            defaultOperator: 'contains',
+            operators: [
+              {
+                key: 'contains',
+                label: 'contains',
+                value: {type: 'string'},
+              },
+            ],
+          },
+          {
+            key: 'status',
+            label: 'Status',
+            defaultOperator: 'is',
+            operators: [
+              {
+                key: 'is',
+                label: 'is',
+                value: {
+                  type: 'enum',
+                  values: [
+                    {value: 'open', label: 'Open'},
+                    {value: 'closed', label: 'Closed'},
+                    {value: 'pending', label: 'Pending'},
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      filters: [
+        {
+          field: 'status',
+          operator: 'is',
+          value: {type: 'enum', value: 'open'},
+        },
+      ],
+      onChange: () => {},
+    },
+  },
   props: [
     {
       name: 'config',

--- a/packages/core/src/SideNav/SideNavCollapseButton.doc.mjs
+++ b/packages/core/src/SideNav/SideNavCollapseButton.doc.mjs
@@ -8,6 +8,14 @@ export const docs = {
   displayName: 'Side Nav Collapse Button',
   isHiddenFromOverview: true,
   description: 'Toggle button for sidenav collapse. Place inside SideNav (reads context automatically) or outside it (hand the same controlled collapsible config to both). Renders as an icon-only ghost button by default.',
+  playground: {
+    defaults: {
+      collapsible: {
+        isCollapsed: false,
+        onCollapsedChange: undefined,
+      },
+    },
+  },
   props: [
     {
       name: 'collapsible',


### PR DESCRIPTION
## Issue
The Properties tab for PowerSearch component shows an error instead of a preview:
"Interactive preview needs required props that cannot be generated automatically. Missing: config, filters."

## Root Cause
The required custom `config` and `filters` values have no playground defaults; the generic preview cannot synthesize them.

## Solution
Add a minimal representative PowerSearch config and initial filters fixture to the playground defaults in PowerSearch.doc.mjs.

## Changes
- Added `playground.defaults` with:
  - **config**: PowerSearchConfig with 2 representative fields:
    - `title` field with string operator (for content search)
    - `status` field with enum operator (Open, Closed, Pending values)
  - **filters**: One example filter showing status = "open"
  - **onChange**: Required handler stub

## Testing
- [ ] Preview renders on first load instead of missing-props placeholder
- [ ] Basic filter interaction updates rendered state without errors
- [ ] Can add, edit, and remove filters in the preview

Fixes #2008
