### PR TITLE
fix(docsite): seed PowerSearch properties preview

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -209,6 +209,75 @@ describe('component detail preview state', () => {
     expect(getMissingRequiredProps(knobs, state)).toEqual([]);
   });
 
+  it('gives PowerSearch a renderable controlled filter fixture', () => {
+    const knobs = pickPrimaryProps('PowerSearch', [
+      prop({name: 'config', type: 'PowerSearchConfig', required: true}),
+      prop({
+        name: 'filters',
+        type: 'ReadonlyArray<PowerSearchFilter>',
+        required: true,
+      }),
+      prop({
+        name: 'onChange',
+        type: "(filters: ReadonlyArray<PowerSearchFilter>, changeType: 'add' | 'edit' | 'remove', index: number) => void",
+        required: true,
+      }),
+    ]);
+    const initialFilters = [
+      {
+        field: 'status',
+        operator: 'is',
+        value: {type: 'enum', value: 'open'},
+      },
+    ];
+    const state = buildInitialState(knobs, {
+      defaults: {
+        config: {
+          name: 'IssueSearch',
+          fields: [
+            {
+              key: 'status',
+              label: 'Status',
+              defaultOperator: 'is',
+              operators: [
+                {
+                  key: 'is',
+                  label: 'is',
+                  value: {
+                    type: 'enum',
+                    values: [
+                      {value: 'open', label: 'Open'},
+                      {value: 'closed', label: 'Closed'},
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        filters: initialFilters,
+      },
+    });
+
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+    expect(state.filters).toEqual(initialFilters);
+
+    const onPropChange = vi.fn();
+    const runtimeState = buildRuntimePreviewState(state, onPropChange, {
+      knobs,
+    });
+    const changedFilters = [
+      ...initialFilters,
+      {
+        field: 'status',
+        operator: 'is',
+        value: {type: 'enum', value: 'closed'},
+      },
+    ];
+    (runtimeState.onChange as (filters: unknown) => void)(changedFilters);
+    expect(onPropChange).toHaveBeenCalledWith('filters', changedFilters);
+  });
+
   it('gives Timestamp a valid date value via playground defaults', () => {
     const knobs = pickPrimaryProps('Timestamp', [
       prop({name: 'value', type: 'string | number', required: true}),

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -298,6 +298,42 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('PowerSearch supplies representative config and filters playground defaults', () => {
+    const core = components['@astryxdesign/core'];
+    const powerSearch = core.find(c => c.name === 'PowerSearch');
+    expect(powerSearch).toBeDefined();
+    expect(powerSearch!.playground?.defaults).toMatchObject({
+      config: {
+        name: 'IssueSearch',
+        fields: [
+          {
+            key: 'status',
+            operators: [
+              {
+                key: 'is',
+                value: {
+                  type: 'enum',
+                  values: [
+                    {value: 'open', label: 'Open'},
+                    {value: 'closed', label: 'Closed'},
+                  ],
+                },
+              },
+            ],
+          },
+          {key: 'title'},
+        ],
+      },
+      filters: [
+        {
+          field: 'status',
+          operator: 'is',
+          value: {type: 'enum', value: 'open'},
+        },
+      ],
+    });
+  });
+
   it('MetadataListItem declares a playground wrapper for realistic preview structure', () => {
     const core = components['@astryxdesign/core'];
     const metadataListItem = core.find(c => c.name === 'MetadataListItem');

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -203,6 +203,51 @@ export const docs = {
         'StyleX styles for layout customization. Must be a stylex.create() value.',
     },
   ],
+  // `config` and `filters` are custom values the docsite preview cannot
+  // generate automatically. Keep this small, but include an initial token so
+  // the Properties tab demonstrates a realistic controlled PowerSearch.
+  playground: {
+    defaults: {
+      config: {
+        name: 'IssueSearch',
+        fields: [
+          {
+            key: 'status',
+            label: 'Status',
+            defaultOperator: 'is',
+            operators: [
+              {
+                key: 'is',
+                label: 'is',
+                value: {
+                  type: 'enum',
+                  values: [
+                    {value: 'open', label: 'Open'},
+                    {value: 'closed', label: 'Closed'},
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            key: 'title',
+            label: 'Title',
+            defaultOperator: 'contains',
+            operators: [
+              {key: 'contains', label: 'contains', value: {type: 'string'}},
+            ],
+          },
+        ],
+      },
+      filters: [
+        {
+          field: 'status',
+          operator: 'is',
+          value: {type: 'enum', value: 'open'},
+        },
+      ],
+    },
+  },
   usage: {
     description:
       'PowerSearch is a structured filter bar where each token represents a field, operator, and value. Use it for complex multi-dimensional filtering when users need to combine multiple search criteria. For simple single-field search, use a text input instead.',


### PR DESCRIPTION
## Related Issue

https://github.com/facebook/astryx/issues/5902

## Summary

Fixes the PowerSearch Properties preview, which previously showed a missing-required-props placeholder because it could not generate the required config and filters values.

The preview now opens with a small, representative field configuration and an initial Status = Open filter.

## Changes

- Add serializable playground defaults for PowerSearch config and filters.
- Provide Status and Title fields with valid operators and values.
- Seed the preview with a Status = Open filter token.
- Reuse the existing controlled onChange(filters, ...) preview bridge so filter interactions update rendered state.
- Add focused regression coverage for preview state and generated docsite data.

## Tests

Added coverage for:

- Required config and filters defaults preventing the missing-props placeholder.
- Initial filter fixture rendering state.
- Controlled filter change propagation through onChange.
- Generated component registry extraction of the PowerSearch fixture.

Validated locally:

- PowerSearch doc fixture module import.
- Knowledge-record validation.
- Whitespace diff validation.

### Screenshots

<img width="1341" height="801" alt="스크린샷 2026-09-03 오후 9 13 43" src="https://github.com/user-attachments/assets/d4b5c060-b97c-4d9e-8928-e5675b20b841" />
