### PR TITLE
docs: define public API operation verb roles

### DIFF
--- a/docs/contributing/api-conventions.md
+++ b/docs/contributing/api-conventions.md
@@ -100,6 +100,55 @@ valid only when its name, type, and behavior across every combination form an
 explicit coherent contract, with invalid or conflicting states prevented under
 [FR15](../specs/AST-002/spec.md#requirements).
 
+## Name public module and utility functions by their result
+
+Choose a function's verb from its primary caller-observable result and side
+effects. Distinguish construction, inspection, lookup, conversion, registration,
+and guaranteed state. Do not name the public function after one internal step.
+Keep one callable role per public capability.
+
+This section covers exported standalone functions that form module or utility
+APIs. It does not reinterpret component names, callback `on<Verb>` names, or
+transition Action names. CLI command verbs and their programmatic command twins
+have separate ownership in the
+[CLI surface architecture](../architecture/cli-surface.md) and CLI conventions.
+
+The repository-wide export audit supports these roles:
+
+| Verb                  | Public module or utility role                                                                      | Boundary                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `define*`             | Construct or normalize and return a durable typed value used by a supported consumer.              | Validation may be a precondition; inspection or unchanged identity alone is not definition.       |
+| `validate*`, `check*` | Inspect input and return structured results.                                                       | State which failures are returned and which conditions throw.                                     |
+| `create*`             | Construct or initialize a caller-used runtime value, state object, source, configuration, or view. | The result may be normalized; inspection alone is not creation.                                   |
+| `build*`              | Assemble a composite configuration or artifact from parts.                                         | This row covers module utilities, not CLI command naming.                                         |
+| `generate*`           | Derive a new aggregate or serialized output from supplied input.                                   | Name the generated result; do not hide unrelated mutation.                                        |
+| `resolve*`            | Choose and return a concrete value from inputs, options, context, or a registry.                   | Document fallback and missing-value behavior.                                                     |
+| `parse*`              | Convert an external or string representation into a typed or structured representation.            | The public contract states whether invalid input returns `null`, returns a result, or throws.     |
+| `format*`             | Serialize a value or produce display text without changing the source value.                       | Include locale, mode, or fallback behavior when it affects output.                                |
+| `get*`                | Read or project a requested value without mutating its source.                                     | Current APIs include both registry lookup and deterministic projection; do not imply persistence. |
+| `is*`, `has*`         | Return a boolean predicate or type guard.                                                          | Use a structured check when callers need reasons, warnings, or multiple findings.                 |
+| `register*`           | Add or replace shared registry state.                                                              | Registration is an explicit side effect.                                                          |
+| `ensure*`             | Idempotently establish required state when it is absent.                                           | The name must disclose the state or resource the function may create or mutate.                   |
+| `use*`                | Expose a React hook that may read context/state and own React lifecycle or effects.                | Follow the Rules of Hooks; a non-hook utility must not use `use*`.                                |
+| `reset*`              | Clear or restore shared state to its documented baseline.                                          | The affected state and intended consumer scope must be explicit.                                  |
+| `expand*`             | Convert a compact configuration or representation into its fuller derived form.                    | Expansion does not imply persistence.                                                             |
+| `merge*`              | Combine compatible inputs into one returned value or composed behavior.                            | State precedence and conflict behavior.                                                           |
+
+If construction, validation, registration, or another capability is public,
+expose each capability through its own callable function. A constructor may reuse
+the same internal validation primitive, but it still returns the constructed
+value and does not absorb a separately public role.
+
+These are roles supported by current repository evidence, not permission to pick
+a familiar verb first and make the implementation fit later. Check the exported
+signature, implementation, tests, consumer docs, supported callsites, and release
+history. Scope a documented exception to the owning module instead of weakening a
+verb across the repository.
+
+Do not silently rename a released mismatch. Preserve compatibility through an
+explicit deprecation and migration, then remove or change the old contract only at
+the approved compatibility boundary.
+
 ## Callbacks and Actions
 
 A callback reports an event synchronously. An Action starts transition-aware

--- a/docs/specs/AST-002/spec.md
+++ b/docs/specs/AST-002/spec.md
@@ -124,6 +124,23 @@ A public API proposal is admitted only when it passes both gates:
   naming the input after one mechanism. Parallel inputs do not create hidden
   conditional precedence: an override is valid only when its name, type, and
   behavior across every combination form an explicit coherent contract.
+- **FR17 — Public module and utility function names disclose one atomic role.**
+  Choose a verb from the function's primary caller-observable result and side
+  effects, not from an internal implementation step. Distinguish construction,
+  inspection, lookup, conversion, registration, and guaranteed state. `define*`
+  constructs or normalizes and returns a durable typed value used by a supported
+  consumer. It may reuse validation as a precondition, but a function that only
+  inspects input or returns the same input unchanged is not `define*`. `validate*`
+  and `check*` inspect input and return structured results; their contracts state
+  which failures are returned and which conditions throw. If construction,
+  validation, registration, or another capability is public, expose it as its own
+  callable function rather than hiding two public roles behind one name. A released
+  mismatch is deprecated and migrated under the compatibility contract, not
+  silently renamed. Other verbs receive rules only when shipped repository
+  evidence supports them. Component prop and event naming remains separate. CLI
+  command verbs and their programmatic command twins belong to the
+  [CLI surface architecture](../../architecture/cli-surface.md) and CLI
+  conventions; this requirement does not define their command semantics.
 
 ### Platform support
 
@@ -152,6 +169,11 @@ A public API proposal is admitted only when it passes both gates:
   remains the consumer syntax and reference authority.
 - Component specs inherit current family contracts and record only local public
   concepts, additions, and explicit exceptions; they do not copy shared rules.
+- Public module and utility function review compares the verb with the function's
+  returned value, validation contract, side effects, and supported consumers.
+  Component prop/event naming and CLI command semantics keep their separate owners.
+  Existing released mismatches remain compatible while an explicit deprecation and
+  migration is designed; this rule does not silently rename or change them.
 
 ### Staged contract coverage
 
@@ -210,19 +232,20 @@ rejected now even when its canonical component owner is draft or missing.
 
 ## Verification
 
-| Contract   | Verification                                                                       | Representative states                                                      | Mutation or failure expectation                                                                                                       |
-| ---------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| FR1, FR5   | Blinded historical API review benchmark                                            | recent utility, mid-range, and composition API additions                   | Reviewer accepts a prop without identifying caller-owned semantic variation                                                           |
-| FR2, FR3   | Component tests and real-browser layout evidence                                   | content, container, viewport, parent context, and platform variation       | Public API exposes a value the component can derive reliably                                                                          |
-| FR4, FR6   | API surface review for utility, mid-range, and composition components              | existing slot, theme, style, layout, and behavior seams                    | High-level component accumulates one-off tuning props instead of using its owning layer                                               |
-| FR7, FR8   | Consumer examples and behavior tests                                               | default, each public value, composed use, and unsupported use              | Meaning depends on implementation knowledge or tests assert only classes/data attributes                                              |
-| FR9, FR10  | Component ownership and accessibility review                                       | owned content, external sibling content, missing or incorrect context      | A state is correct only when the caller fulfills a promise the component cannot verify                                                |
-| FR11       | Public and package-internal operation inventory; PR #5373                          | one component module and one semantic action                               | One semantic action gains parallel operation names distinguished only by implementation needs                                         |
-| FR12, FR13 | PR delta/canonical-owner update check, staged owner routing, and blinded benchmark | missing delta/update, draft or current authority, and owner-ready delta    | Missing delta/owner update passes, missing current authority dead-ends rollout, draft becomes policy, or automation decides semantics |
-| FR14       | Focused regression tests against the current contract or standard                  | defect state and representative unchanged states                           | A restoration invents a new decision or lacks evidence that the regression stays fixed                                                |
-| FR15       | Type-level constraints plus runtime validation and behavior tests                  | invalid values, unsupported combinations, and legitimate composition       | The API silently renders a broken state or prevents a valid composition                                                               |
-| FR16       | Full value-domain, input-shape, and parallel-combination contract review           | semantic variants, raw or palette values, explicit overrides, and defaults | One value or shape switches the controlled axis, or a parallel input silently changes precedence                                      |
-| Burden     | Benchmark classification: allow, correct pause, false block, not applicable        | recent accepted and rejected API changes                                   | Clearly justified APIs are repeatedly paused or blocked without surfacing a real decision                                             |
+| Contract   | Verification                                                                                           | Representative states                                                                         | Mutation or failure expectation                                                                                                                        |
+| ---------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| FR1, FR5   | Blinded historical API review benchmark                                                                | recent utility, mid-range, and composition API additions                                      | Reviewer accepts a prop without identifying caller-owned semantic variation                                                                            |
+| FR2, FR3   | Component tests and real-browser layout evidence                                                       | content, container, viewport, parent context, and platform variation                          | Public API exposes a value the component can derive reliably                                                                                           |
+| FR4, FR6   | API surface review for utility, mid-range, and composition components                                  | existing slot, theme, style, layout, and behavior seams                                       | High-level component accumulates one-off tuning props instead of using its owning layer                                                                |
+| FR7, FR8   | Consumer examples and behavior tests                                                                   | default, each public value, composed use, and unsupported use                                 | Meaning depends on implementation knowledge or tests assert only classes/data attributes                                                               |
+| FR9, FR10  | Component ownership and accessibility review                                                           | owned content, external sibling content, missing or incorrect context                         | A state is correct only when the caller fulfills a promise the component cannot verify                                                                 |
+| FR11       | Public and package-internal operation inventory; PR #5373                                              | one component module and one semantic action                                                  | One semantic action gains parallel operation names distinguished only by implementation needs                                                          |
+| FR12, FR13 | PR delta/canonical-owner update check, staged owner routing, and blinded benchmark                     | missing delta/update, draft or current authority, and owner-ready delta                       | Missing delta/owner update passes, missing current authority dead-ends rollout, draft becomes policy, or automation decides semantics                  |
+| FR14       | Focused regression tests against the current contract or standard                                      | defect state and representative unchanged states                                              | A restoration invents a new decision or lacks evidence that the regression stays fixed                                                                 |
+| FR15       | Type-level constraints plus runtime validation and behavior tests                                      | invalid values, unsupported combinations, and legitimate composition                          | The API silently renders a broken state or prevents a valid composition                                                                                |
+| FR16       | Full value-domain, input-shape, and parallel-combination contract review                               | semantic variants, raw or palette values, explicit overrides, and defaults                    | One value or shape switches the controlled axis, or a parallel input silently changes precedence                                                       |
+| FR17       | Public module/utility export inventory plus implementation, test, consumer, and release-history review | construction, inspection, lookup, conversion, registration, hooks, and released compatibility | A verb hides the returned value or side effect, two public roles are fused, a non-hook utility uses `use*`, or a released mismatch is silently renamed |
+| Burden     | Benchmark classification: allow, correct pause, false block, not applicable                            | recent accepted and rejected API changes                                                      | Clearly justified APIs are repeatedly paused or blocked without surfacing a real decision                                                              |
 
 ## Decision log
 
@@ -338,6 +361,32 @@ while `success`, `warning`, and `error` mean tone plus a default themed icon, wi
 an optional `icon` that conditionally overrides representation. That shape would
 not pass current API review pending a canonical `component:Table` contract. This
 decision does not prescribe the replacement API.
+
+### DEC-7 — Public module and utility verbs disclose atomic roles
+
+**Reference:** `spec:AST-002/DEC-7`
+**Decider:** `cixzhang`, `2026-09-03`
+
+Choose a public module or utility function's verb from its primary
+caller-observable result and side effects, not from an internal implementation
+step. Distinguish construction, inspection, lookup, conversion, registration,
+and guaranteed state. `define*` constructs or normalizes and returns a durable
+typed value used by a supported consumer. Validation may be its precondition, but
+inspection or an unchanged identity result alone is not definition. `validate*`
+and `check*` inspect input and return structured results; their contracts state
+which failures are returned and which conditions throw.
+
+When construction, validation, registration, or another capability is public,
+each has its own callable role. A released mismatch follows an explicit
+deprecation and migration instead of a silent rename or behavior change. Other
+verbs receive repository-wide rules only when shipped evidence supports them.
+Component prop and event naming remains separate. CLI command verbs and their
+programmatic command twins remain with the CLI surface owner.
+
+Rejected: treating a function that only validates and returns its input as a
+`define*` function, returning a bare predicate from a public `validate*` or
+`check*` function, using `use*` for a non-hook utility, or hiding separately
+public registration inside a constructor without a compatibility plan.
 
 ## Open questions
 


### PR DESCRIPTION
## Why

Public module and utility function names need to disclose what callers receive and which side effects occur. A repository-wide audit of 15 package manifests, 157 published source/runtime entrypoints, and 634 callable exports found consistent roles that were not yet owned by a current normative record.

## What

- Make AST-002 the normative owner for atomic public module and utility function verbs.
- Define `define*` as construction or normalization of a durable typed value, and `validate*` / `check*` as structured inspection results with explicit return and throw contracts.
- Project the evidence-backed roles of `create*`, `build*`, `generate*`, `resolve*`, `parse*`, `format*`, `get*`, `is*` / `has*`, `register*`, `ensure*`, `use*`, `reset*`, `expand*`, and `merge*` into the contributor guide.
- Keep component prop/event naming separate and delegate CLI command verbs plus their programmatic command twins to the CLI surface owner.
- Require separately public capabilities to stay separately callable and released mismatches to use explicit deprecation and migration.

No implementations are renamed or changed in this pull request.

## Risk

Documentation and review policy only. Existing public behavior remains unchanged. AST-002 already exceeds the soft 200-line readability target; this keeps the full requirement, verification row, and owner decision explicit rather than compacting normative qualifiers.

## Testing

- `pnpm exec prettier --check docs/specs/AST-002/spec.md docs/contributing/api-conventions.md`
- `pnpm check:knowledge`
- `pnpm exec vitest run scripts/check-knowledge.test.mjs`
- `pnpm check:repo`
