### PR TITLE
docs(spec): define cross-package range compatibility

### DIFF
--- a/docs/specs/AST-017/spec.md
+++ b/docs/specs/AST-017/spec.md
@@ -76,8 +76,11 @@ preserves the released contract.
   carries a patch bump. Documentation-only, test-only, and private-package-only
   changes need no Changeset. `pnpm changeset:new` is the authoring path and
   `pnpm check:changesets` enforces the current category/bump coupling. Classify
-  each published package update in multi-package work; when categories differ,
-  use separate Changesets so every package entry follows its own classification.
+  each published package update in multi-package work. A fixed-group version-only
+  co-bump needs no Changeset entry by itself, but a generated dependency or peer
+  range edit is part of that package's update and must be classified and named in a
+  Changeset. When categories differ, use separate Changesets so every package entry
+  follows its own classification.
 - **FR8 — Migration evidence matches the affected surface.** Every breaking change
   names the old valid usage, the replacement, and how consumers migrate. Supply an
   `astryx upgrade` codemod when consumer source can be rewritten mechanically.
@@ -107,8 +110,10 @@ preserves the released contract.
   any such combination stop working unchanged, including by narrowing or raising
   the range. A coordinated upgrade that works does not change that classification.
   A dependency bump is not breaking when every previously supported combination
-  keeps working. Preserve the old range, provide an adapter, or classify a narrower
-  range as breaking and meet FR8's migration and release-note obligations.
+  keeps working. Keep every previously supported version in range and provide an
+  adapter when needed; otherwise classify the narrower or higher-floor range as
+  breaking, describe the range change in its Changeset release note, and meet FR8's
+  migration obligation.
 
 ### Platform support
 
@@ -195,8 +200,8 @@ installation scenario as its compatibility promise. Consumers may upgrade that
 package with any companion version the range still allows; a coordinated release
 cannot require an undeclared lockstep upgrade. Classify the package update that
 creates the mismatch. Supporting package updates keep their own classifications.
-A coordinated breaking range change remains allowed when its classification and
-FR8 migration and release notes tell consumers how to move.
+A coordinated breaking range change remains allowed when its Changeset release note
+describes the new range and its FR8 migration tells consumers how to move.
 
 Rejected: marking every dependency bump breaking, which would freeze compatible
 maintenance, or calling an update nonbreaking merely because a coordinated upgrade

--- a/docs/specs/AST-017/spec.md
+++ b/docs/specs/AST-017/spec.md
@@ -75,7 +75,9 @@ preserves the released contract.
   `0.x`, that category carries a minor bump; every nonbreaking published category
   carries a patch bump. Documentation-only, test-only, and private-package-only
   changes need no Changeset. `pnpm changeset:new` is the authoring path and
-  `pnpm check:changesets` enforces the current category/bump coupling.
+  `pnpm check:changesets` enforces the current category/bump coupling. Classify
+  each published package update in multi-package work; when categories differ,
+  use separate Changesets so every package entry follows its own classification.
 - **FR8 — Migration evidence matches the affected surface.** Every breaking change
   names the old valid usage, the replacement, and how consumers migrate. Supply an
   `astryx upgrade` codemod when consumer source can be rewritten mechanically.
@@ -98,6 +100,15 @@ preserves the released contract.
   contractual surfaces under FR3. Individual catalog values returned through that
   schema, including template slugs, names, descriptions, categories, keywords, and
   starter content, are not independently stable API identifiers.
+- **FR12 — Supported inter-package ranges are contracts.** For an update to a
+  published package, its latest stable release's documented installation scenarios
+  and declared dependency or peer ranges define the supported companion package
+  versions. The update is breaking for that package when upgrading it alone makes
+  any such combination stop working unchanged, including by narrowing or raising
+  the range. A coordinated upgrade that works does not change that classification.
+  A dependency bump is not breaking when every previously supported combination
+  keeps working. Preserve the old range, provide an adapter, or classify a narrower
+  range as breaking and meet FR8's migration and release-note obligations.
 
 ### Platform support
 
@@ -130,12 +141,13 @@ not the individual entries currently present in the template catalog.
 
 ## Verification
 
-| Contract | Verification                                                     | Representative states                                                      | Mutation or failure expectation                                                                         |
-| -------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| FR1–FR3  | PR compatibility statement plus latest stable package inspection | released export, behavior, CLI command; unreleased and private surface     | A change is labeled from diff size or possibility alone, or a released contract change is missed        |
-| FR4–FR6  | Old-usage type/runtime/CLI regression test                       | alias retained, deprecation warning, broad rewrite, low-adoption caller    | Contractual old usage fails despite a nonbreaking label, or risk is substituted for compatibility       |
-| FR7–FR8  | `pnpm check:changesets` plus migration review                    | breaking and patch Changesets; codemoddable and non-codemoddable migration | Category and bump diverge, or a breaking release gives no usable migration path                         |
-| FR9–FR11 | CLI contract tests plus template catalog and output tests        | slug rename, metadata edit, source rebuild, command or schema change       | Catalog data is frozen as API, or a command/schema incompatibility is mislabeled as a catalog-only edit |
+| Contract | Verification                                                                             | Representative states                                                      | Mutation or failure expectation                                                                                           |
+| -------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| FR1–FR3  | PR compatibility statement plus latest stable package inspection                         | released export, behavior, CLI command; unreleased and private surface     | A change is labeled from diff size or possibility alone, or a released contract change is missed                          |
+| FR4–FR6  | Old-usage type/runtime/CLI regression test                                               | alias retained, deprecation warning, broad rewrite, low-adoption caller    | Contractual old usage fails despite a nonbreaking label, or risk is substituted for compatibility                         |
+| FR7–FR8  | `pnpm check:changesets` plus migration review                                            | breaking and patch Changesets; codemoddable and non-codemoddable migration | Category and bump diverge, or a breaking release gives no usable migration path                                           |
+| FR9–FR11 | CLI contract tests plus template catalog and output tests                                | slug rename, metadata edit, source rebuild, command or schema change       | Catalog data is frozen as API, or a command/schema incompatibility is mislabeled as a catalog-only edit                   |
+| FR12     | Minimum and representative supported-version tests plus manifest and release-note review | retained range, narrowed range, adapter, coordinated upgrade               | An in-range combination breaks under a nonbreaking label, or release coordination hides the affected package or migration |
 
 ## Decision log
 
@@ -172,6 +184,23 @@ without confusing current catalog contents with the interface that serves them.
 Rejected: treating a slug as stable API merely because it is interpolated into an
 exact CLI invocation. That would freeze catalog data and discourage clearer naming
 without protecting a contract the template system intends to make.
+
+### DEC-3 — Package updates keep their own range promises
+
+**Reference:** `spec:AST-017/DEC-3`
+**Decider:** `cixzhang`, `2026-09-03`
+
+Treat the latest stable package's declared dependency or peer range and documented
+installation scenario as its compatibility promise. Consumers may upgrade that
+package with any companion version the range still allows; a coordinated release
+cannot require an undeclared lockstep upgrade. Classify the package update that
+creates the mismatch. Supporting package updates keep their own classifications.
+A coordinated breaking range change remains allowed when its classification and
+FR8 migration and release notes tell consumers how to move.
+
+Rejected: marking every dependency bump breaking, which would freeze compatible
+maintenance, or calling an update nonbreaking merely because a coordinated upgrade
+works, which would break supported independent consumers.
 
 ## Open questions
 


### PR DESCRIPTION
## Why

Consumers can upgrade one Astryx package and break a supported installation when that update starts requiring a newer companion package while its published dependency or peer range still permits older versions. A coordinated upgrade may work, but that does not preserve the independent upgrade scenario promised by the range.

## What

Amends current AST-017 so that:

- the latest stable package's documented installation scenario and declared inter-package range define its supported combinations;
- an update is breaking for that package when upgrading it alone breaks any still-supported combination, including by narrowing or raising the range;
- multi-package work classifies each published package update independently, treats generated dependency or peer range edits as part of that package's update, and uses separate Changesets when categories differ; and
- compatibility is preserved by retaining the range, providing an adapter, or using the breaking classification with FR8 migration and release notes.

The verification map now requires the minimum and representative supported versions at cross-package boundaries.

## Risk

Specification only. No package behavior or release tooling changes, and no Changeset is required.

AST-017 is 212 lines after this amendment. Keeping the one new rule, its verification evidence, and its durable rationale together preserves the current spec's single ownership boundary; splitting them would make the classification harder to apply.

## Testing

- Prettier
- `pnpm check:knowledge -- --base origin/main`
- 89 focused knowledge tests
- pre-commit `pnpm check:repo`
- `git diff --check`
