### PR TITLE
fix(ci): let release visual plans use safety budget

### DIFF
--- a/.github/scripts/visual-gate/gate-context.test.mjs
+++ b/.github/scripts/visual-gate/gate-context.test.mjs
@@ -67,6 +67,9 @@ describe('stable release plan authority', () => {
     expect(source).not.toContain('shots = withBaselineCoverage(');
     expect(source).toContain('const baselineManifest = rawBaseline;');
     expect(source).toContain(
+      'configuredLimit: releaseMode\n    ? config.visualPlanSafetyLimit',
+    );
+    expect(source).toContain(
       'readThemeCatalog(REPO_ROOT, config.baselineThemes)',
     );
   });

--- a/.github/scripts/visual-gate/gate.mjs
+++ b/.github/scripts/visual-gate/gate.mjs
@@ -101,7 +101,9 @@ const maxShots = resolvePrVisualTotalShotLimit({
   components,
   matrixThemes,
   tiers,
-  configuredLimit: config.prVisualShotLimit,
+  configuredLimit: releaseMode
+    ? config.visualPlanSafetyLimit
+    : config.prVisualShotLimit,
   safetyLimit: config.visualPlanSafetyLimit,
 });
 const storyPackages = (flag('story-packages') ?? config.stableStoryPackages.join(','))


### PR DESCRIPTION
## Summary
Use the visual-plan safety ceiling for the canonical release lane while keeping the 240-frame review ceiling for ordinary broad PR plans.

## Why
The first production run of the new 380-frame baseline policy correctly built the canonical plan, but skipped capture because release mode still inherited the 240-frame PR review budget.

## Test plan
- focused visual gate context and planner tests
- `pnpm check:repo`
- `git diff --check`
- production diagnosis: Release Gate run 33762855484