### PR TITLE
chore(changesets): cover final v0.6.0 behavior

### DIFF
--- a/.changeset/cli-debug-command-log.md
+++ b/.changeset/cli-debug-command-log.md
@@ -2,7 +2,7 @@
 '@astryxdesign/cli': patch
 ---
 
-[feat] CLI: record every command run and hand it to a function you supply.
+[feat] CLI: record every command run and hand it to a function you supply. (#4812)
 
 ```js
 // astryx.config.mjs
@@ -17,7 +17,7 @@ Each event carries the command, its arguments and flags (with their Commander so
 
 `event` is a published contract: `DebugEvent` is exported from `@astryxdesign/cli/debug` with a sealed zod validator, `parseDebugEvent`, drift-locked to the type so the recorder cannot add a field without publishing it. `schemaVersion` is a literal, so widening it turns every consumer's branch into a compile error rather than a silent misread.
 
-The handler runs synchronously at exit — a returned promise is never awaited, so network delivery from inside it will not work; write a file or spawn a detached child. It receives a copy, so a handler that throws, or mutates what it was given, can neither fail the command nor affect anything else. Two things it still can do to its own command, because they happen after the CLI has finished: calling `process.exit` replaces the exit code, and writing to stdout appends to the command's own output, which breaks a `--json` consumer parsing that stream. Both are documented on the handler type.
+The handler runs synchronously at exit — a returned promise is never awaited, so network delivery from inside it will not work; write a file or spawn a detached child. It receives a copy, so a handler that throws, or mutates what it was given, can neither fail the command nor affect anything else. Follow-up hardening keeps a handler from replacing the command's exit code and routes handler writes away from stdout so a `--json` envelope stays valid. (#5929)
 
 Nothing changes for a project that has not set `debug`. Startup is unmoved: the environment probe is deferred to delivery rather than run in `begin`, because its first `Intl` call initialises ICU and that alone was ~9% of the CLI's startup for everyone. Nor does the config run: `Project.load` evaluates the config module and loads its integrations, which most commands never did, so the file is read as text first and only loaded when the word `debug` appears in it. Measured across eight commands, no command evaluates a config that did not already.
 

--- a/.changeset/searchable-table-template.md
+++ b/.changeset/searchable-table-template.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Rebuild the `table-page` template as a searchable, filterable, sortable table pattern with filter-aware totals, row detail, a scrolling document masthead, and guidance organized around narrowing, sorting, and communicating filtered state. (#5865)
+
+@ernestt

--- a/.changeset/work-item-detail-template.md
+++ b/.changeset/work-item-detail-template.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add the `work-item-detail` page template for task, ticket, issue, story, bug, card, and request detail surfaces. It includes responsive main-content and details-rail layouts, editable metadata, subtasks, attachments, comments, activity, and a narrow-viewport details dialog. (#5926)
+
+@kentonquatman


### PR DESCRIPTION
## Why

The v0.6.0 release audit found two published CLI template changes without changesets and one pending CLI debug release note that described behavior superseded by its same-cycle hardening follow-up.

## What

- add a CLI patch changeset for the new `work-item-detail` template from #5926 (`@kentonquatman`)
- add a CLI patch changeset for the rebuilt searchable `table-page` template from #5865 (`@ernestt`)
- keep #4812 and #5929 as one CLI debug release-note unit, retaining `@josephfarina` and updating the handler-containment description

`@astryxdesign/lab` CircularProgress #5916 remains a documented private/canary-only exception. The other scanner rows are existing covered follow-ups or previously classified docs/knowledge/Crowdin exceptions.

## Validation

- verified source PRs, contributors, and package scope through commit history and GitHub metadata
- `pnpm check:changesets`
- Prettier on all three files
- repository pre-commit checks
- public-content scrub