### PR TITLE
fix(docsite): show CheckIndicator in properties preview

### DIFF
--- a/.changeset/check-indicator-playground-default.md
+++ b/.changeset/check-indicator-playground-default.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckIndicator: start the docsite properties preview in the checked state (#5972)
+
+Seeds a `checked` playground default so the properties-tab preview shows a visible indicator on first load instead of an empty stage.
+
+@Kyujenius

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -981,6 +981,19 @@ describe('Card playground defaults', () => {
   });
 });
 
+describe('CheckIndicator playground defaults (#5890)', () => {
+  it('starts the Properties preview in its visible checked state', () => {
+    const checkIndicator = Object.values(components)
+      .flat()
+      .find(component => component.name === 'CheckIndicator');
+
+    expect(checkIndicator).toBeDefined();
+    expect(checkIndicator!.playground?.defaults).toMatchObject({
+      state: 'checked',
+    });
+  });
+});
+
 describe('DropdownMenu adaptive-presentation example', () => {
   it('documents the presentation choice for the Properties tab', () => {
     const dropdownMenu = Object.values(components)

--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -89,6 +89,9 @@ export const docs = {
             'Rendered INSTEAD of the mark, in every state: a host showing a pending Spinner passes it through whether or not the row is chosen.',
         },
       ],
+      playground: {
+        defaults: {state: 'checked'},
+      },
     },
     {
       name: 'RadioIndicator',


### PR DESCRIPTION
## Summary

- Start the CheckIndicator Properties preview in its visible `checked` state.
- Cover the generated component registry default so the preview cannot silently regress to an empty stage.

Fixes #5890

## Verification

- `pnpm -F @astryxdesign/docsite generate && pnpm -F @astryxdesign/docsite test` (456 tests passed)
- `pnpm -F @astryxdesign/core typecheck:docs`

## Screenshot

|AS-IS|TO-BE|
|---|---|
|<img width="1512" height="953" alt="image" src="https://github.com/user-attachments/assets/b1554d77-56c2-4fcc-b59d-28e346cd9b95" />|<img width="1512" height="954" alt="screenshot-2026-09-04" src="https://github.com/user-attachments/assets/dfad921c-8857-4140-951c-49b8985ba659" />|

