### PR TITLE
Add shadcn Registry compatibility

### DIFF
--- a/.changeset/experimental-shadcn-registry.md
+++ b/.changeset/experimental-shadcn-registry.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add an experimental shadcn Registry compatibility guide and doc-derived registry identity metadata. It explains the package boundary, stable organized paths, copied composition model, upgrade behavior, and when to use the richer Astryx CLI.
+
+@josephfarina

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ yarn.lock
 .tool-versions
 mise.toml
 
+# Generated shadcn Registry output (rebuilt by the docsite generate step)
+apps/docsite/public/shadcn/
+
 # Generated i18n artifacts (rebuilt from en.json)
 packages/core/locales/pseudo.json
 

--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -43,6 +43,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
     "@babel/preset-react": "^8.0.1",
     "@babel/preset-typescript": "^7.29.7",
     "@stylexjs/babel-plugin": "catalog:",
@@ -51,6 +52,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.5.2",
+    "shadcn": "4.19.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -21,6 +21,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {execFileSync} from 'node:child_process';
+import {createRequire} from 'node:module';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {resolveContentRoot} from './resolve-content-root.mjs';
 import {template as queryTemplates} from '@astryxdesign/cli/api';
@@ -30,8 +31,14 @@ import {
   buildTypeDefinitionIndex,
   collectPropTypeRefs,
 } from '../src/lib/typeDefinitions.mjs';
+import {generateShadcnRegistry} from './generate-shadcn-registry.mjs';
+import {
+  blockRegistryIdentity,
+  resolveShadcnRegistryOrigin,
+} from '../src/lib/shadcnRegistry.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 const DOCSITE_ROOT = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(DOCSITE_ROOT, '..', '..');
 const OUT_DIR = path.join(DOCSITE_ROOT, 'src', 'generated');
@@ -329,6 +336,22 @@ function discoverPackageDirs() {
     .sort();
 }
 
+const REGISTRY_EXTERNAL_DEPENDENCIES = [
+  '@heroicons/react',
+  '@stylexjs/stylex',
+  'lucide-react',
+  'recharts',
+];
+
+function registryExternalDependencySpecs() {
+  return Object.fromEntries(
+    REGISTRY_EXTERNAL_DEPENDENCIES.map(packageName => {
+      const version = require(`${packageName}/package.json`).version;
+      return [packageName, `${packageName}@${version}`];
+    }),
+  );
+}
+
 // ── 1. Package Registry ────────────────────────────────────────────────
 
 function generatePackageRegistry() {
@@ -584,6 +607,7 @@ async function generateComponentRegistry() {
         const topDescription = doc.usage?.description || doc.description || '';
         const usage = doc.usage ? sanitizeForJson(doc.usage) : null;
         const theming = doc.theming ? sanitizeForJson(doc.theming) : null;
+        const registry = doc.registry ? sanitizeForJson(doc.registry) : null;
         const playground = doc.playground
           ? sanitizeForJson(doc.playground)
           : null;
@@ -622,6 +646,7 @@ async function generateComponentRegistry() {
               description: doc.description || parentMeta.topDescription || '',
               keywords: parentMeta.keywords ?? keywords,
               hidden: parentMeta.hidden ?? hidden,
+              registry,
               parentDoc: doc.subComponentOf,
               props: isHookEntry
                 ? []
@@ -685,6 +710,7 @@ async function generateComponentRegistry() {
               description: doc.description || topDescription,
               keywords,
               hidden,
+              registry,
               parentDoc: name,
               props: sanitizeForJson(doc.props),
               usage,
@@ -752,6 +778,7 @@ async function generateComponentRegistry() {
               description: sub.description || topDescription,
               keywords,
               hidden,
+              registry: sub.registry ? sanitizeForJson(sub.registry) : null,
               parentDoc: doc.name,
               props: isHookEntry
                 ? []
@@ -796,6 +823,7 @@ async function generateComponentRegistry() {
             description: topDescription,
             keywords,
             hidden,
+            registry,
             parentDoc: dirPrimaryDoc,
             props: [],
             usage,
@@ -830,6 +858,7 @@ async function generateComponentRegistry() {
             description: topDescription,
             keywords,
             hidden,
+            registry,
             parentDoc: null,
             props: Array.isArray(doc.props) ? sanitizeForJson(doc.props) : [],
             usage,
@@ -1090,6 +1119,7 @@ export interface ComponentEntry {
   hidden: boolean;
   /** Whether this component is ready for the stable documentation line. */
   isReady: boolean;
+  registry: {slug?: string; aliases?: string[]} | null;
   parentDoc: string | null;
   props: PropDoc[];
   /** Declarations for every type referenced from \`props[]\`, \`params[]\`, or
@@ -1368,7 +1398,10 @@ async function generateBlockRegistry() {
     let isShowcase = false;
     let aspectRatio = 1;
     let componentsUsed = [];
-    let exampleFor = '';
+    let exampleFor = null;
+    let alsoExampleFor = [];
+    let alsoShowcaseFor = [];
+    let registry = null;
     try {
       const content = fs.readFileSync(docPath, 'utf-8');
       isShowcase = /isShowcase:\s*true/.test(content);
@@ -1389,8 +1422,20 @@ async function generateBlockRegistry() {
       if (efMatch) {
         exampleFor = efMatch[1];
       }
+      alsoExampleFor = extractStringArrayField(content, 'alsoExampleFor');
+      alsoShowcaseFor = extractStringArrayField(content, 'alsoShowcaseFor');
+      const module = await import(pathToFileURL(docPath).href);
+      registry = module.doc?.registry
+        ? sanitizeForJson(module.doc.registry)
+        : null;
     } catch {
       /* ignore */
+    }
+
+    if (isShowcase && !exampleFor) {
+      throw new Error(
+        `Block ${path.relative(REPO_ROOT, docPath)} sets isShowcase without exampleFor`,
+      );
     }
 
     let source = '';
@@ -1414,7 +1459,10 @@ async function generateBlockRegistry() {
       ),
       description: meta.description,
       exampleFor,
+      alsoExampleFor,
+      alsoShowcaseFor,
       isShowcase,
+      registry,
       aspectRatio,
       componentsUsed,
       category: relCategory,
@@ -1443,10 +1491,11 @@ async function generateBlockRegistry() {
         name: entry.name,
         displayName: entry.displayName || entry.name,
         description: entry.description,
-        exampleFor: entry.exampleFor || '',
+        exampleFor: entry.exampleFor || null,
         alsoExampleFor: entry.alsoExampleFor ?? [],
         alsoShowcaseFor: entry.alsoShowcaseFor ?? [],
         isShowcase: entry.isShowcase ?? false,
+        registry: entry.registry ?? null,
         aspectRatio: entry.aspectRatio ?? 1,
         componentsUsed: entry.componentsUsed ?? [],
         category: entry.category || entry.package,
@@ -1474,11 +1523,12 @@ export interface BlockEntry {
    */
   displayName: string;
   description: string;
-  /** The component this block is an example of (e.g. 'Button', 'Dialog') */
-  exampleFor: string;
-  alsoExampleFor?: string[];
-  alsoShowcaseFor?: string[];
+  /** Optional component ownership. Null means a standalone block. */
+  exampleFor: string | null;
+  alsoExampleFor: string[];
+  alsoShowcaseFor: string[];
   isShowcase: boolean;
+  registry: {slug?: string; aliases?: string[]} | null;
   aspectRatio: number;
   componentsUsed: string[];
   /** Category path, e.g. 'components/Button' */
@@ -1555,6 +1605,7 @@ async function generateTemplateRegistry() {
       isReady: doc.isReady ?? true,
       category: doc.category || '',
       isHiddenFromOverview: doc.isHiddenFromOverview ?? false,
+      registry: doc.registry ? sanitizeForJson(doc.registry) : null,
       source,
     });
   }
@@ -1573,6 +1624,7 @@ export interface TemplateEntry {
   category: string;
   /** When true, hide from the Templates overview gallery (still CLI-available). */
   isHiddenFromOverview: boolean;
+  registry: {slug?: string; aliases?: string[]} | null;
   source: string;
 }
 
@@ -1607,6 +1659,9 @@ async function generateDocsRegistry() {
     if (file.includes('.doc.zh.') || file.includes('.doc.dense.')) continue;
 
     const topic = match[1];
+    if (DOCSITE_TARGET !== 'canary' && topic === 'shadcn-compatibility') {
+      continue;
+    }
     const docPath = path.join(DOCS_DIR, file);
 
     let title = '';
@@ -1825,97 +1880,112 @@ function importsPackageMissingFromDocsite(tsxSource) {
   return imports.some(pkg => _docsiteDeps[pkg] == null);
 }
 
-function generateShowcaseRegistry(blocks) {
+function blockSourcePath(block) {
+  if (block.sourcePackage) {
+    return null;
+  }
+  return path.join(
+    CLI_ROOT,
+    'assets',
+    'templates',
+    'blocks',
+    block.category,
+    `${block.dirName}.tsx`,
+  );
+}
+
+function writeBlockPreview(block, outDir, basename) {
+  const destFile = `${basename}.tsx`;
+  const destination = path.join(outDir, destFile);
+  const sourcePath = blockSourcePath(block);
+  if (sourcePath) {
+    if (!fs.existsSync(sourcePath)) {
+      return null;
+    }
+    fs.copyFileSync(sourcePath, destination);
+  } else {
+    fs.writeFileSync(destination, block.source, 'utf8');
+  }
+  return destFile;
+}
+
+function generateShowcaseRegistry(blocks, availableRegistryPaths) {
   console.log('Generating showcase registry...');
 
-  const BLOCKS_DIR = path.join(CLI_ROOT, 'assets', 'templates', 'blocks');
   const SHOWCASE_OUT = path.join(OUT_DIR, 'showcases');
-
-  // Clean and recreate
-  if (fs.existsSync(SHOWCASE_OUT)) {
-    fs.rmSync(SHOWCASE_OUT, {recursive: true});
-  }
+  fs.rmSync(SHOWCASE_OUT, {recursive: true, force: true});
   fs.mkdirSync(SHOWCASE_OUT, {recursive: true});
 
-  const docFiles = findDocFilesRecursive(BLOCKS_DIR);
   const entries = [];
-
-  for (const docPath of docFiles) {
-    const content = fs.readFileSync(docPath, 'utf-8');
-    const isShowcase = /isShowcase:\s*true/.test(content);
-
-    const efMatch = content.match(/exampleFor:\s*['"]([^'"]+)['"]/);
-    if (!efMatch) continue;
-
-    const exampleFor = efMatch[1];
-    const basename = path.basename(docPath, '.doc.mjs');
-    const tsxSrc = path.join(path.dirname(docPath), basename + '.tsx');
-    if (!fs.existsSync(tsxSrc)) continue;
-
-    // Skip blocks that reference a package the docsite cannot resolve.
-    const tsxContent = fs.readFileSync(tsxSrc, 'utf-8');
-    if (importsPackageMissingFromDocsite(tsxContent)) {
-      console.log(
-        `  skipping showcase ${basename} — imports a package not installed in the docsite`,
-      );
-      continue;
-    }
-
-    const alsoShowcaseFor = extractStringArrayField(content, 'alsoShowcaseFor');
-
-    if (isShowcase) {
-      // Copy the TSX file into generated/showcases/
-      const destFile = `${basename}.tsx`;
-      fs.copyFileSync(tsxSrc, path.join(SHOWCASE_OUT, destFile));
-      entries.push({exampleFor, basename, destFile});
-    }
-
-    // Blocks can opt into serving as the visual showcase for additional
-    // component or hook pages. This is explicit metadata instead of source
-    // inspection so authors control where examples appear.
-    for (const target of alsoShowcaseFor) {
-      const aliasBasename = `${basename}__${target}`;
-      const destFile = `${aliasBasename}.tsx`;
-      fs.copyFileSync(tsxSrc, path.join(SHOWCASE_OUT, destFile));
-      entries.push({exampleFor: target, basename: aliasBasename, destFile});
-    }
-  }
-
   for (const block of blocks) {
-    if (!block.sourcePackage || !block.isShowcase || !block.exampleFor) {
-      continue;
-    }
     if (importsPackageMissingFromDocsite(block.source)) {
       console.log(
         `  skipping showcase ${block.dirName} — imports a package not installed in the docsite`,
       );
       continue;
     }
-    const basename = `integration-${block.dirName}`;
-    const targets = [block.exampleFor, ...(block.alsoShowcaseFor ?? [])];
-    for (const [index, target] of targets.entries()) {
-      const targetBasename = index === 0 ? basename : `${basename}__${target}`;
-      const destFile = `${targetBasename}.tsx`;
-      fs.writeFileSync(
-        path.join(SHOWCASE_OUT, destFile),
-        block.source,
-        'utf-8',
-      );
-      entries.push({exampleFor: target, basename: targetBasename, destFile});
+
+    const identity = blockRegistryIdentity(
+      block.name,
+      block.exampleFor,
+      block.isShowcase,
+      block.registry,
+    );
+    const registryItemPath = availableRegistryPaths?.has(identity.path)
+      ? identity.path
+      : null;
+
+    if (block.isShowcase && block.exampleFor) {
+      const basename = block.sourcePackage
+        ? `integration-${block.dirName}`
+        : block.dirName;
+      const destFile = writeBlockPreview(block, SHOWCASE_OUT, basename);
+      if (destFile) {
+        entries.push({
+          exampleFor: block.exampleFor,
+          basename,
+          destFile,
+          registryItemPath,
+        });
+      }
+    }
+
+    for (const target of block.alsoShowcaseFor ?? []) {
+      const base = block.sourcePackage
+        ? `integration-${block.dirName}`
+        : block.dirName;
+      const basename = `${base}__${target}`;
+      const destFile = writeBlockPreview(block, SHOWCASE_OUT, basename);
+      if (destFile) {
+        entries.push({
+          exampleFor: target,
+          basename,
+          destFile,
+          registryItemPath,
+        });
+      }
     }
   }
 
-  // Deduplicate: one showcase per component (first wins)
   const seen = new Set();
-  const uniqueEntries = entries.filter(e => {
-    if (seen.has(e.exampleFor)) return false;
-    seen.add(e.exampleFor);
+  const uniqueEntries = entries.filter(entry => {
+    if (seen.has(entry.exampleFor)) return false;
+    seen.add(entry.exampleFor);
     return true;
   });
 
-  // Generate the registry with dynamic imports
   const importLines = uniqueEntries
-    .map(e => `  '${e.exampleFor}': () => import('./showcases/${e.basename}'),`)
+    .map(
+      entry =>
+        `  '${entry.exampleFor}': () => import('./showcases/${entry.basename}'),`,
+    )
+    .join('\n');
+  const itemPathLines = uniqueEntries
+    .filter(entry => entry.registryItemPath)
+    .map(
+      entry =>
+        `  '${entry.exampleFor}': ${JSON.stringify(entry.registryItemPath)},`,
+    )
     .join('\n');
 
   const registryContent = `// Auto-generated by scripts/generate-data.mjs — do not edit
@@ -1925,6 +1995,10 @@ type ShowcaseLoader = () => Promise<{default: ComponentType}>;
 
 export const showcaseRegistry: Record<string, ShowcaseLoader> = {
 ${importLines}
+};
+
+export const showcaseRegistryItemPaths: Record<string, string> = {
+${itemPathLines}
 };
 `;
 
@@ -1937,142 +2011,80 @@ ${importLines}
 
 // ── Main
 
-function generateExampleRegistry(blocks) {
+function generateExampleRegistry(blocks, availableRegistryPaths) {
   console.log('Generating example registry...');
 
-  const BLOCKS_DIR = path.join(CLI_ROOT, 'assets', 'templates', 'blocks');
   const EXAMPLES_OUT = path.join(OUT_DIR, 'examples');
-
-  if (fs.existsSync(EXAMPLES_OUT)) {
-    fs.rmSync(EXAMPLES_OUT, {recursive: true});
-  }
+  fs.rmSync(EXAMPLES_OUT, {recursive: true, force: true});
   fs.mkdirSync(EXAMPLES_OUT, {recursive: true});
 
-  const docFiles = findDocFilesRecursive(BLOCKS_DIR);
   const entries = [];
-
-  for (const docPath of docFiles) {
-    const content = fs.readFileSync(docPath, 'utf-8');
-    const isShowcase = /isShowcase:\s*true/.test(content);
-
-    const efMatch = content.match(/exampleFor:\s*['"]([^'"]+)['"]/);
-    if (!efMatch) continue;
-
-    const exampleFor = efMatch[1];
-    const basename = path.basename(docPath, '.doc.mjs');
-    const tsxSrc = path.join(path.dirname(docPath), basename + '.tsx');
-    if (!fs.existsSync(tsxSrc)) continue;
-
-    // Read name and description from doc meta
-    const name = extractQuotedField(content, 'name');
-    const description = extractQuotedField(content, 'description');
-
-    let source = '';
-    try {
-      source = fs.readFileSync(tsxSrc, 'utf-8');
-    } catch {
-      /* ignore */
-    }
-
-    // Skip live-preview entries for blocks the docsite cannot resolve — they'd
-    // break `next build`. The block's code is still shown via the block
-    // registry; only the rendered preview is withheld until the package is a
-    // docsite dependency.
-    if (importsPackageMissingFromDocsite(source)) {
-      console.log(
-        `  skipping example ${basename} — imports a package not installed in the docsite`,
-      );
-      continue;
-    }
-
-    const alsoExampleFor = extractStringArrayField(content, 'alsoExampleFor');
-
-    if (!isShowcase) {
-      fs.copyFileSync(tsxSrc, path.join(EXAMPLES_OUT, `${basename}.tsx`));
-      entries.push({
-        exampleFor,
-        basename,
-        name: name || basename,
-        description: description || '',
-        source,
-      });
-    }
-
-    // Blocks can explicitly appear as examples for additional component or
-    // hook pages. This supports component examples doubling as hook examples
-    // without inferring intent from the TSX source.
-    for (const target of alsoExampleFor) {
-      const aliasBasename = `${basename}__${target}`;
-      fs.copyFileSync(tsxSrc, path.join(EXAMPLES_OUT, `${aliasBasename}.tsx`));
-      entries.push({
-        exampleFor: target,
-        basename: aliasBasename,
-        name: name || basename,
-        description: description || `Example using ${target}.`,
-        source,
-      });
-    }
-  }
-
   for (const block of blocks) {
-    if (!block.sourcePackage) {
-      continue;
-    }
     if (importsPackageMissingFromDocsite(block.source)) {
       console.log(
         `  skipping example ${block.dirName} — imports a package not installed in the docsite`,
       );
       continue;
     }
-    const basename = `integration-${block.dirName}`;
+
+    const identity = blockRegistryIdentity(
+      block.name,
+      block.exampleFor,
+      block.isShowcase,
+      block.registry,
+    );
+    const registryItemPath = availableRegistryPaths?.has(identity.path)
+      ? identity.path
+      : null;
+    const base = block.sourcePackage
+      ? `integration-${block.dirName}`
+      : block.dirName;
+
     if (!block.isShowcase && block.exampleFor) {
-      fs.writeFileSync(
-        path.join(EXAMPLES_OUT, `${basename}.tsx`),
-        block.source,
-        'utf-8',
-      );
-      entries.push({
-        exampleFor: block.exampleFor,
-        basename,
-        name: block.name,
-        description: block.description,
-        source: block.source,
-      });
+      const destFile = writeBlockPreview(block, EXAMPLES_OUT, base);
+      if (destFile) {
+        entries.push({
+          exampleFor: block.exampleFor,
+          basename: base,
+          registryItemPath,
+          name: block.name || block.dirName,
+          description: block.description || '',
+          source: block.source,
+        });
+      }
     }
+
     for (const target of block.alsoExampleFor ?? []) {
-      const aliasBasename = `${basename}__${target}`;
-      fs.writeFileSync(
-        path.join(EXAMPLES_OUT, `${aliasBasename}.tsx`),
-        block.source,
-        'utf-8',
-      );
-      entries.push({
-        exampleFor: target,
-        basename: aliasBasename,
-        name: block.name,
-        description: block.description || `Example using ${target}.`,
-        source: block.source,
-      });
+      const basename = `${base}__${target}`;
+      const destFile = writeBlockPreview(block, EXAMPLES_OUT, basename);
+      if (destFile) {
+        entries.push({
+          exampleFor: target,
+          basename,
+          registryItemPath,
+          name: block.name || block.dirName,
+          description: block.description || `Example using ${target}.`,
+          source: block.source,
+        });
+      }
     }
   }
 
-  // Group by component
   const grouped = {};
-  for (const e of entries) {
-    if (!grouped[e.exampleFor]) grouped[e.exampleFor] = [];
-    grouped[e.exampleFor].push(e);
+  for (const entry of entries) {
+    if (!grouped[entry.exampleFor]) grouped[entry.exampleFor] = [];
+    grouped[entry.exampleFor].push(entry);
   }
 
-  // Generate registry: component name → array of example metadata + loaders
   const componentLines = Object.entries(grouped)
-    .map(([comp, examples]) => {
+    .map(([component, examples]) => {
       const exampleLines = examples
         .map(
-          e =>
-            `    {name: ${JSON.stringify(e.name)}, description: ${JSON.stringify(e.description)}, source: ${JSON.stringify(e.source)}, load: () => import('./examples/${e.basename}')},`,
+          entry =>
+            `    {name: ${JSON.stringify(entry.name)}, description: ${JSON.stringify(entry.description)}, registryItemPath: ${JSON.stringify(entry.registryItemPath)}, source: ${JSON.stringify(entry.source)}, load: () => import('./examples/${entry.basename}')},`,
         )
         .join('\n');
-      return `  '${comp}': [\n${exampleLines}\n  ],`;
+      return `  '${component}': [\n${exampleLines}\n  ],`;
     })
     .join('\n');
 
@@ -2082,6 +2094,7 @@ import type {ComponentType} from 'react';
 export interface ExampleEntry {
   name: string;
   description: string;
+  registryItemPath: string | null;
   source: string;
   load: () => Promise<{default: ComponentType}>;
 }
@@ -2111,8 +2124,8 @@ async function generateBlogRegistry() {
       .href
   );
 
-  // Exclude drafts from production output; include them only in dev.
-  const includeDrafts = process.env.NODE_ENV !== 'production';
+  // Local development and every draft/preview deployment use the canary target.
+  const includeDrafts = DOCSITE_TARGET === 'canary';
   const posts = discoverPosts(POSTS_DIR, {includeDrafts});
   const types = collectTypes(posts);
   const tags = collectTags(posts);
@@ -2161,6 +2174,35 @@ export const blogDarkImages: string[] = ${JSON.stringify(darkImages, null, 2)};
   return {blogPostCount: posts.length, blogTypeCount: types.length};
 }
 
+function checkShadcnRouteLock(contracts) {
+  const lockPath = path.join(
+    REPO_ROOT,
+    'internal',
+    'shadcn-registry',
+    'routes.lock.json',
+  );
+  const lock = {version: 1, items: contracts};
+  const serialized = `${JSON.stringify(lock, null, 2)}\n`;
+
+  if (process.env.UPDATE_SHADCN_ROUTE_LOCK === '1') {
+    fs.writeFileSync(lockPath, serialized, 'utf8');
+    console.log(`  updated ${path.relative(REPO_ROOT, lockPath)}`);
+    return;
+  }
+
+  if (!fs.existsSync(lockPath)) {
+    throw new Error(
+      `Missing ${path.relative(REPO_ROOT, lockPath)}. Run UPDATE_SHADCN_ROUTE_LOCK=1 node apps/docsite/scripts/generate-data.mjs and review the public route contract.`,
+    );
+  }
+  const current = fs.readFileSync(lockPath, 'utf8');
+  if (current !== serialized) {
+    throw new Error(
+      `Generated ShadCN names or routes changed. Preserve old paths with doc.registry.aliases, or intentionally refresh the reviewed lock with UPDATE_SHADCN_ROUTE_LOCK=1 node apps/docsite/scripts/generate-data.mjs.`,
+    );
+  }
+}
+
 async function main() {
   console.log('Generating docsite data...\n');
 
@@ -2170,13 +2212,56 @@ async function main() {
     await generateComponentRegistry();
   generateComponentPreviewRegistry(allComponents);
   generateGroupedComponentRegistry(allComponents);
-  const {blocks, blockCount, showcaseCount} = await generateBlockRegistry();
+  const {blocks, blockCount} = await generateBlockRegistry();
   generatePackageStyles(packages, blocks, allComponents);
-  const {templateCount} = await generateTemplateRegistry();
+  const {templates, templateCount} = await generateTemplateRegistry();
   const {docsCount} = await generateDocsRegistry();
   const {blogPostCount} = await generateBlogRegistry();
-  const showcaseCopied = generateShowcaseRegistry(blocks);
-  const examplesCopied = generateExampleRegistry(blocks);
+  const shadcnCounts =
+    DOCSITE_TARGET === 'canary'
+      ? generateShadcnRegistry({
+          outDir: path.join(DOCSITE_ROOT, 'public', 'shadcn'),
+          packages,
+          allComponents,
+          blocks,
+          templates,
+          cliRoot: CLI_ROOT,
+          dependencyTag: 'canary',
+          externalDependencySpecs: registryExternalDependencySpecs(),
+        })
+      : null;
+  if (shadcnCounts) {
+    checkShadcnRouteLock(shadcnCounts.contracts);
+  } else {
+    fs.rmSync(path.join(DOCSITE_ROOT, 'public', 'shadcn'), {
+      recursive: true,
+      force: true,
+    });
+  }
+  // `/r` stays unclaimed for a future Astryx-native registry.
+  fs.rmSync(path.join(DOCSITE_ROOT, 'public', 'r'), {
+    recursive: true,
+    force: true,
+  });
+  const showcaseCopied = generateShowcaseRegistry(
+    blocks,
+    shadcnCounts?.itemPaths,
+  );
+  const examplesCopied = generateExampleRegistry(
+    blocks,
+    shadcnCounts?.itemPaths,
+  );
+  const registryOrigin = resolveShadcnRegistryOrigin(process.env);
+  const registryIsPreview =
+    DOCSITE_TARGET === 'canary' &&
+    registryOrigin !== 'https://astryx.atmeta.com/shadcn';
+  writeRegistry(
+    'shadcnRegistry.ts',
+    `// Auto-generated — do not edit
+export const shadcnRegistryOrigin = ${JSON.stringify(registryOrigin)};
+export const shadcnRegistryIsPreview = ${registryIsPreview};
+`,
+  );
 
   console.log(`\nSummary:`);
   console.log(`  ${packages.length} packages`);
@@ -2188,6 +2273,19 @@ async function main() {
   console.log(`  ${docsCount} doc topics`);
   console.log(`  ${blogPostCount} blog posts`);
   console.log(`  ${themeCount} themes`);
+  if (shadcnCounts) {
+    console.log(
+      `  ${shadcnCounts.total} ShadCN registry items ` +
+        `(${shadcnCounts.components} components, ${shadcnCounts.hooks} hooks, ` +
+        `${shadcnCounts.showcases} showcases, ${shadcnCounts.examples} examples, ` +
+        `${shadcnCounts.blocks} standalone blocks, ${shadcnCounts.pages} pages; ` +
+        `${shadcnCounts.skippedUnpublishedComponents} unpublished components, ` +
+        `${shadcnCounts.skippedUnpublishedBlocks} blocks, and ` +
+        `${shadcnCounts.skippedUnpublishedPages} pages skipped)`,
+    );
+  } else {
+    console.log('  ShadCN registry disabled for the production target');
+  }
   console.log('Done.');
 }
 

--- a/apps/docsite/scripts/generate-shadcn-registry.mjs
+++ b/apps/docsite/scripts/generate-shadcn-registry.mjs
@@ -1,0 +1,497 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Generate a shadcn-compatible registry from the docsite's existing
+ * component, block, and page catalogs.
+ * @input The generated docsite package, component, block, and page records.
+ * @output Static standard-registry JSON under the configured output directory.
+ * @position Build-time serializer between Astryx's catalog and shadcn clients.
+ *
+ * The registry keeps Astryx packages as real dependencies. Component and hook
+ * items create public re-exports; blocks and pages copy app-level composition
+ * source that already imports published package paths.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import babel from '@babel/core';
+import stylexPlugin from '@stylexjs/babel-plugin';
+import ts from 'typescript';
+import {registryItemSchema, registrySchema} from 'shadcn/schema';
+import {
+  blockRegistryIdentity,
+  componentRegistryIdentity,
+  pageRegistryIdentity,
+} from '../src/lib/shadcnRegistry.mjs';
+
+const REGISTRY_SCHEMA = 'https://ui.shadcn.com/schema/registry.json';
+const REGISTRY_ITEM_SCHEMA = 'https://ui.shadcn.com/schema/registry-item.json';
+const HOMEPAGE = 'https://astryx.atmeta.com';
+const ASTRYX_CSS = {
+  '@import "@astryxdesign/core/reset.css"': {},
+  '@import "@astryxdesign/core/astryx.css"': {},
+};
+
+class UnpublishedAstryxDependencyError extends Error {
+  constructor(packageName) {
+    super(`No published package version found for ${packageName}`);
+    this.name = 'UnpublishedAstryxDependencyError';
+    this.packageName = packageName;
+  }
+}
+
+function packageNameFromSpecifier(specifier) {
+  if (specifier.startsWith('@')) {
+    return specifier.split('/').slice(0, 2).join('/');
+  }
+  return specifier.split('/')[0];
+}
+
+function readImportSpecifiers(source, fileName) {
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TSX,
+  );
+  const specifiers = new Set();
+
+  function visit(node) {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.add(node.moduleSpecifier.text);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      specifiers.add(node.arguments[0].text);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return [...specifiers].sort();
+}
+
+function dependencySpec(packageName, packageDependencies) {
+  const spec = packageDependencies.get(packageName);
+  if (spec) {
+    return spec;
+  }
+  if (packageName.startsWith('@astryxdesign/')) {
+    throw new UnpublishedAstryxDependencyError(packageName);
+  }
+  return packageName;
+}
+
+function precompileStylexSource(source, fileName) {
+  if (!source.includes('stylex.create')) {
+    return {source, extension: 'tsx', precompiledStylex: false};
+  }
+
+  const result = babel.transformSync(source, {
+    filename: fileName,
+    babelrc: false,
+    configFile: false,
+    presets: [['@babel/preset-typescript', {allExtensions: true, isTSX: true}]],
+    plugins: [
+      [
+        stylexPlugin,
+        {
+          dev: false,
+          runtimeInjection: true,
+          classNamePrefix: 'p',
+          treeshakeCompensation: true,
+          unstable_moduleResolution: {type: 'commonJS'},
+        },
+      ],
+    ],
+    parserOpts: {plugins: ['typescript', 'jsx']},
+  });
+  if (!result?.code) {
+    throw new Error(`StyleX precompile produced no code for ${fileName}`);
+  }
+  if (result.code.includes('stylex.create')) {
+    throw new Error(`Uncompiled stylex.create remains in ${fileName}`);
+  }
+  return {
+    source: `${result.code}\n`,
+    extension: 'jsx',
+    precompiledStylex: true,
+  };
+}
+
+function dependenciesForSource(source, fileName, packageDependencies) {
+  const packages = new Set();
+  for (const specifier of readImportSpecifiers(source, fileName)) {
+    if (specifier.startsWith('.')) {
+      throw new Error(
+        `${fileName} has a relative import (${specifier}); registry compositions ` +
+          'must use published package paths',
+      );
+    }
+    if (
+      specifier.startsWith('node:') ||
+      specifier === 'react' ||
+      specifier.startsWith('react/') ||
+      specifier === 'react-dom' ||
+      specifier.startsWith('react-dom/')
+    ) {
+      continue;
+    }
+    packages.add(packageNameFromSpecifier(specifier));
+  }
+  return [...packages]
+    .map(packageName => dependencySpec(packageName, packageDependencies))
+    .sort();
+}
+
+function withCoreDependency(dependencies, packageDependencies) {
+  return [
+    ...new Set([
+      ...dependencies,
+      dependencySpec('@astryxdesign/core', packageDependencies),
+      dependencySpec('@stylexjs/stylex', packageDependencies),
+    ]),
+  ].sort();
+}
+
+function componentItem(packageName, component, packageDependencies) {
+  if (!component.importPath) {
+    throw new Error(
+      `${packageName}/${component.name} has no public import path`,
+    );
+  }
+  const isHook = component.name.startsWith('use') || component.params != null;
+  const type = isHook ? 'registry:hook' : 'registry:component';
+  const targetRoot = isHook ? 'hooks/astryx' : 'components/astryx';
+  const identity = componentRegistryIdentity(
+    packageName,
+    component.name,
+    isHook,
+    component.registry,
+  );
+  const itemName = identity.name;
+  const content = `export * from '${component.importPath}';\n`;
+
+  return {
+    $schema: REGISTRY_ITEM_SCHEMA,
+    name: itemName,
+    type,
+    title: component.displayName || component.name,
+    description:
+      component.description ||
+      `Public ${isHook ? 'hook' : 'component'} entry for ${component.name}.`,
+    author: 'Astryx',
+    dependencies: withCoreDependency(
+      [dependencySpec(packageName, packageDependencies)],
+      packageDependencies,
+    ),
+    css: ASTRYX_CSS,
+    files: [
+      {
+        path: `registry/${itemName}/${component.name}.ts`,
+        type,
+        target: `${targetRoot}/${component.name}.ts`,
+        content,
+      },
+    ],
+    astryx: {
+      kind: isHook ? 'hook' : 'component',
+      path: identity.path,
+      aliases: identity.aliases,
+      packageName,
+      importPath: component.importPath,
+      hidden: component.hidden === true,
+    },
+  };
+}
+
+function blockItem(block, packageDependencies, cliRoot) {
+  const identity = blockRegistryIdentity(
+    block.name,
+    block.exampleFor,
+    block.isShowcase,
+    block.registry,
+  );
+  const itemName = identity.name;
+  const kind = identity.kind;
+  const fileName = path.join(
+    cliRoot,
+    'assets',
+    'templates',
+    'blocks',
+    block.category,
+    `${block.dirName}.tsx`,
+  );
+  const compiled = precompileStylexSource(block.source, fileName);
+  return {
+    $schema: REGISTRY_ITEM_SCHEMA,
+    name: itemName,
+    type: 'registry:block',
+    title: block.displayName || block.name,
+    description: block.description || `Astryx ${kind}: ${block.name}.`,
+    author: 'Astryx',
+    dependencies: withCoreDependency(
+      dependenciesForSource(compiled.source, fileName, packageDependencies),
+      packageDependencies,
+    ),
+    css: ASTRYX_CSS,
+    files: [
+      {
+        path: `registry/${itemName}/${block.dirName}.${compiled.extension}`,
+        type: 'registry:block',
+        target: `components/astryx/${kind === 'block' ? 'blocks' : `${kind}s`}/${block.dirName}.${compiled.extension}`,
+        content: compiled.source,
+      },
+    ],
+    astryx: {
+      kind,
+      path: identity.path,
+      aliases: identity.aliases,
+      exampleFor: block.exampleFor || null,
+      category: block.category,
+      componentsUsed: block.componentsUsed,
+      precompiledStylex: compiled.precompiledStylex,
+    },
+  };
+}
+
+function pageItem(template, packageDependencies, cliRoot) {
+  const identity = pageRegistryIdentity(template.slug, template.registry);
+  const itemName = identity.name;
+  const fileName = path.join(
+    cliRoot,
+    'assets',
+    'templates',
+    'pages',
+    template.slug,
+    'page.tsx',
+  );
+  const compiled = precompileStylexSource(template.source, fileName);
+  return {
+    $schema: REGISTRY_ITEM_SCHEMA,
+    name: itemName,
+    type: 'registry:page',
+    title: template.name,
+    description: template.description || `Astryx page: ${template.name}.`,
+    author: 'Astryx',
+    dependencies: withCoreDependency(
+      dependenciesForSource(compiled.source, fileName, packageDependencies),
+      packageDependencies,
+    ),
+    css: ASTRYX_CSS,
+    files: [
+      {
+        path: `registry/${itemName}/page.${compiled.extension}`,
+        // shadcn 4.19.0 silently skips files typed registry:page. The item
+        // remains registry:page while its source file uses the working type.
+        type: 'registry:block',
+        target: `app/astryx/${template.slug}/page.${compiled.extension}`,
+        content: compiled.source,
+      },
+    ],
+    astryx: {
+      kind: 'page',
+      path: identity.path,
+      aliases: identity.aliases,
+      category: template.category,
+      isReady: template.isReady,
+      isHiddenFromOverview: template.isHiddenFromOverview,
+      precompiledStylex: compiled.precompiledStylex,
+    },
+  };
+}
+
+function assertUniqueItemNames(items) {
+  const names = new Set();
+  for (const item of items) {
+    if (names.has(item.name)) {
+      throw new Error(`Duplicate shadcn registry item name: ${item.name}`);
+    }
+    names.add(item.name);
+  }
+}
+
+function assertUniqueItemPaths(items) {
+  const paths = new Map();
+  for (const item of items) {
+    for (const itemPath of [item.astryx.path, ...item.astryx.aliases]) {
+      const existing = paths.get(itemPath);
+      if (existing) {
+        throw new Error(
+          `Duplicate shadcn registry path ${itemPath}: ${existing} and ${item.name}`,
+        );
+      }
+      paths.set(itemPath, item.name);
+    }
+  }
+}
+
+function validateItem(item) {
+  const result = registryItemSchema.safeParse(item);
+  if (!result.success) {
+    throw new Error(
+      `${item.name} does not match the shadcn registry item schema:\n${result.error}`,
+    );
+  }
+}
+
+export function buildShadcnRegistry({
+  packages,
+  allComponents,
+  blocks,
+  templates,
+  cliRoot = process.cwd(),
+  dependencyTag = null,
+  externalDependencySpecs = {},
+}) {
+  const packageDependencies = new Map([
+    ...packages.map(pkg => [
+      pkg.name,
+      dependencyTag
+        ? `${pkg.name}@${dependencyTag}`
+        : `${pkg.name}@${pkg.version}`,
+    ]),
+    ...Object.entries(externalDependencySpecs),
+  ]);
+  const componentEntries = Object.entries(allComponents);
+  const skippedComponents = componentEntries
+    .filter(([packageName]) => !packageDependencies.has(packageName))
+    .reduce((count, [, components]) => count + components.length, 0);
+  const componentItems = componentEntries
+    .filter(([packageName]) => packageDependencies.has(packageName))
+    .flatMap(([packageName, components]) =>
+      components.map(component =>
+        componentItem(packageName, component, packageDependencies),
+      ),
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const blockItems = [];
+  let skippedUnpublishedBlocks = 0;
+  for (const block of blocks) {
+    try {
+      blockItems.push(blockItem(block, packageDependencies, cliRoot));
+    } catch (error) {
+      if (error instanceof UnpublishedAstryxDependencyError) {
+        skippedUnpublishedBlocks++;
+        continue;
+      }
+      throw error;
+    }
+  }
+  blockItems.sort((a, b) => a.name.localeCompare(b.name));
+
+  const pageItems = [];
+  let skippedUnpublishedPages = 0;
+  for (const template of templates) {
+    try {
+      pageItems.push(pageItem(template, packageDependencies, cliRoot));
+    } catch (error) {
+      if (error instanceof UnpublishedAstryxDependencyError) {
+        skippedUnpublishedPages++;
+        continue;
+      }
+      throw error;
+    }
+  }
+  pageItems.sort((a, b) => a.name.localeCompare(b.name));
+  const items = [...componentItems, ...blockItems, ...pageItems];
+
+  assertUniqueItemNames(items);
+  assertUniqueItemPaths(items);
+  for (const item of items) validateItem(item);
+
+  const registry = {
+    $schema: REGISTRY_SCHEMA,
+    name: 'astryx',
+    homepage: HOMEPAGE,
+    items: items.map(item => ({
+      ...item,
+      files: item.files.map(({content: _content, ...file}) => file),
+    })),
+  };
+  const registryResult = registrySchema.safeParse(registry);
+  if (!registryResult.success) {
+    throw new Error(
+      `Generated registry does not match the shadcn registry schema:\n${registryResult.error}`,
+    );
+  }
+
+  return {
+    registry,
+    items,
+    counts: {
+      components: componentItems.filter(
+        item => item.astryx.kind === 'component',
+      ).length,
+      hooks: componentItems.filter(item => item.astryx.kind === 'hook').length,
+      showcases: blockItems.filter(item => item.astryx.kind === 'showcase')
+        .length,
+      examples: blockItems.filter(item => item.astryx.kind === 'example')
+        .length,
+      blocks: blockItems.filter(item => item.astryx.kind === 'block').length,
+      skippedUnpublishedComponents: skippedComponents,
+      skippedUnpublishedBlocks,
+      pages: pageItems.length,
+      skippedUnpublishedPages,
+      total: items.length,
+    },
+  };
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), {recursive: true});
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export function generateShadcnRegistry({
+  outDir,
+  packages,
+  allComponents,
+  blocks,
+  templates,
+  cliRoot,
+  dependencyTag,
+  externalDependencySpecs,
+}) {
+  const result = buildShadcnRegistry({
+    packages,
+    allComponents,
+    blocks,
+    templates,
+    cliRoot,
+    dependencyTag,
+    externalDependencySpecs,
+  });
+  fs.rmSync(outDir, {recursive: true, force: true});
+  fs.mkdirSync(outDir, {recursive: true});
+  writeJson(path.join(outDir, 'registry.json'), result.registry);
+  for (const item of result.items) {
+    for (const itemPath of [item.astryx.path, ...item.astryx.aliases]) {
+      writeJson(path.join(outDir, `${itemPath}.json`), item);
+    }
+  }
+  return {
+    ...result.counts,
+    itemNames: new Set(result.items.map(item => item.name)),
+    itemPaths: new Set(result.items.map(item => item.astryx.path)),
+    routes: result.items.flatMap(item => [
+      item.astryx.path,
+      ...item.astryx.aliases,
+    ]),
+    contracts: result.items
+      .map(item => ({
+        name: item.name,
+        path: item.astryx.path,
+        aliases: item.astryx.aliases,
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path)),
+  };
+}

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -873,7 +873,9 @@ describe('blockRegistry', () => {
       expect(block.aspectRatio).not.toBeNaN();
       expect(Array.isArray(block.componentsUsed)).toBe(true);
       expect(block.category).toBeDefined();
-      expect(typeof block.exampleFor).toBe('string');
+      expect(
+        block.exampleFor === null || typeof block.exampleFor === 'string',
+      ).toBe(true);
     }
   });
 
@@ -912,8 +914,8 @@ describe('blockRegistry', () => {
     expect(chartShowcase?.source).toContain("from '@astryxdesign/charts'");
   });
 
-  it('every block has exampleFor set', () => {
-    const missing = blocks.filter(b => !b.exampleFor);
+  it('showcases always declare component ownership', () => {
+    const missing = blocks.filter(b => b.isShowcase && !b.exampleFor);
     expect(missing.map(b => b.dirName)).toEqual([]);
   });
 
@@ -921,10 +923,12 @@ describe('blockRegistry', () => {
     const showcases = blocks.filter(b => b.isShowcase);
     const seen = new Map<string, string[]>();
     for (const s of showcases) {
-      if (!seen.has(s.exampleFor)) {
-        seen.set(s.exampleFor, []);
+      expect(s.exampleFor).not.toBeNull();
+      const owner = s.exampleFor!;
+      if (!seen.has(owner)) {
+        seen.set(owner, []);
       }
-      seen.get(s.exampleFor)!.push(s.dirName);
+      seen.get(owner)!.push(s.dirName);
     }
     const dupes = [...seen.entries()].filter(([, v]) => v.length > 1);
     // Some components may legitimately have multiple showcases, but flag them

--- a/apps/docsite/src/app/mcp/route.ts
+++ b/apps/docsite/src/app/mcp/route.ts
@@ -340,13 +340,16 @@ const handler = createMcpHandler(
 
           const showcase = blocks.find(
             (b: BlockEntry) =>
-              exampleNames.includes(b.exampleFor.toLowerCase()) && b.isShowcase,
+              b.exampleFor != null &&
+              exampleNames.includes(b.exampleFor.toLowerCase()) &&
+              b.isShowcase,
           );
 
           // Find related blocks (non-showcase, limit 1 for budget)
           const relatedBlocks = blocks
             .filter(
               (b: BlockEntry) =>
+                b.exampleFor != null &&
                 exampleNames.includes(b.exampleFor.toLowerCase()) &&
                 !b.isShowcase,
             )

--- a/apps/docsite/src/components/TemplatePreviewDialog.tsx
+++ b/apps/docsite/src/components/TemplatePreviewDialog.tsx
@@ -48,6 +48,15 @@ import {Tooltip} from '@astryxdesign/core/Tooltip';
 import {TemplatePreviewSurface} from './TemplatePreviewSurface';
 import {buildTemplatePlaygroundHref} from './playgroundLink';
 import {trackCopy, trackOpenPlayground, trackNavigate} from '../lib/analytics';
+import {CURRENT_TARGET} from '../lib/docsVersions';
+import {
+  shadcnRegistryIsPreview,
+  shadcnRegistryOrigin,
+} from '../generated/shadcnRegistry';
+import {
+  shadcnInstallCommand,
+  shadcnPageItemPath,
+} from '../lib/shadcnRegistry.mjs';
 
 export interface TemplatePreviewItem {
   slug: string;
@@ -150,18 +159,20 @@ const styles = stylex.create({
   },
 });
 
+type CopiedCommand = 'astryx' | 'shadcn' | null;
+
 interface TemplatePreviewHeaderProps {
   item: TemplatePreviewItem;
   isFullscreen: boolean;
-  cmdCopied: boolean;
-  onCopyCommand: () => void;
+  copiedCommand: CopiedCommand;
+  onCopyCommand: (kind: Exclude<CopiedCommand, null>) => void;
   onClose: () => void;
 }
 
 function TemplatePreviewHeader({
   item,
   isFullscreen,
-  cmdCopied,
+  copiedCommand,
   onCopyCommand,
   onClose,
 }: TemplatePreviewHeaderProps) {
@@ -183,21 +194,62 @@ function TemplatePreviewHeader({
   );
 
   const copyButton = (
-    <HStack gap={2} vAlign="center" xstyle={styles.commandGroup}>
-      <Code
-        xstyle={
-          styles.commandCode
-        }>{`npx @astryxdesign/cli template ${item.slug}`}</Code>
-      <Button
-        variant="ghost"
-        isIconOnly
-        size="lg"
-        label={cmdCopied ? 'Copied!' : 'Copy install command'}
-        icon={<Icon icon={cmdCopied ? 'check' : 'copy'} color="inherit" />}
-        onClick={onCopyCommand}
-        xstyle={styles.noShrink}
-      />
-    </HStack>
+    <VStack gap={1}>
+      <HStack gap={2} vAlign="center" xstyle={styles.commandGroup}>
+        <Text type="supporting" color="secondary">
+          Astryx CLI
+        </Text>
+        <Code
+          xstyle={
+            styles.commandCode
+          }>{`npx @astryxdesign/cli template ${item.slug}`}</Code>
+        <Button
+          variant="ghost"
+          isIconOnly
+          size="lg"
+          label={copiedCommand === 'astryx' ? 'Copied!' : 'Copy Astryx command'}
+          icon={
+            <Icon
+              icon={copiedCommand === 'astryx' ? 'check' : 'copy'}
+              color="inherit"
+            />
+          }
+          onClick={() => onCopyCommand('astryx')}
+          xstyle={styles.noShrink}
+        />
+      </HStack>
+      {CURRENT_TARGET === 'canary' && (
+        <HStack gap={2} vAlign="center" xstyle={styles.commandGroup}>
+          <Text type="supporting" color="secondary">
+            {shadcnRegistryIsPreview ? 'shadcn preview (expires)' : 'shadcn'}
+          </Text>
+          <Code xstyle={styles.commandCode}>
+            {shadcnInstallCommand(
+              shadcnPageItemPath(item.slug),
+              shadcnRegistryOrigin,
+            )}
+          </Code>
+          <Button
+            variant="ghost"
+            isIconOnly
+            size="lg"
+            label={
+              copiedCommand === 'shadcn'
+                ? 'Copied!'
+                : 'Copy ShadCN install command'
+            }
+            icon={
+              <Icon
+                icon={copiedCommand === 'shadcn' ? 'check' : 'copy'}
+                color="inherit"
+              />
+            }
+            onClick={() => onCopyCommand('shadcn')}
+            xstyle={styles.noShrink}
+          />
+        </HStack>
+      )}
+    </VStack>
   );
 
   const playgroundButton = (
@@ -262,7 +314,7 @@ export function TemplatePreviewDialog({
   onIndexChange,
   variant,
 }: TemplatePreviewDialogProps) {
-  const [cmdCopied, setCmdCopied] = useState(false);
+  const [copiedCommand, setCopiedCommand] = useState<CopiedCommand>(null);
   const [isPending, startTransition] = useTransition();
 
   // Release the top layer when this dialog is torn down while still open.
@@ -330,28 +382,39 @@ export function TemplatePreviewDialog({
     return () => window.removeEventListener('keydown', onKey);
   }, [isOpen, index, count]);
 
-  // Reset the share-copied state when switching templates.
+  // Reset copied state when switching templates.
   useEffect(() => {
-    setCmdCopied(false);
+    setCopiedCommand(null);
   }, [index]);
 
   if (!current) {
     return null;
   }
 
-  const useCommand = `npx @astryxdesign/cli template ${current.slug} ./src/app/${current.slug}`;
-  const handleCopyCmd = useCallback(() => {
-    navigator.clipboard.writeText(useCommand).then(() => {
-      setCmdCopied(true);
-      trackCopy({
-        page: 'templates',
-        target: 'cli_command',
-        item: current.slug,
-        category: current.category,
+  const astryxCommand = `npx @astryxdesign/cli template ${current.slug} ./src/app/${current.slug}`;
+  const shadcnCommand = shadcnInstallCommand(
+    shadcnPageItemPath(current.slug),
+    shadcnRegistryOrigin,
+  );
+  const handleCopyCmd = useCallback(
+    (kind: Exclude<CopiedCommand, null>) => {
+      if (kind === 'shadcn' && CURRENT_TARGET !== 'canary') {
+        return;
+      }
+      const command = kind === 'astryx' ? astryxCommand : shadcnCommand;
+      navigator.clipboard.writeText(command).then(() => {
+        setCopiedCommand(kind);
+        trackCopy({
+          page: 'templates',
+          target: kind === 'astryx' ? 'cli_command' : 'install_command',
+          item: current.slug,
+          category: current.category,
+        });
+        setTimeout(() => setCopiedCommand(null), 2000);
       });
-      setTimeout(() => setCmdCopied(false), 2000);
-    });
-  }, [useCommand, current.slug, current.category]);
+    },
+    [astryxCommand, shadcnCommand, current.slug, current.category],
+  );
 
   const isFullscreen = variant === 'fullscreen';
 
@@ -371,7 +434,7 @@ export function TemplatePreviewDialog({
             <TemplatePreviewHeader
               item={current}
               isFullscreen={isFullscreen}
-              cmdCopied={cmdCopied}
+              copiedCommand={copiedCommand}
               onCopyCommand={handleCopyCmd}
               onClose={() => onOpenChange(false)}
             />

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -36,7 +36,15 @@ import type {ComponentEntry} from '../../generated/componentRegistry';
 import type {BlockEntry} from '../../generated/blockRegistry';
 import {showcaseRegistry} from '../../generated/showcaseRegistry';
 import {exampleRegistry} from '../../generated/exampleRegistry';
+import {
+  shadcnRegistryIsPreview,
+  shadcnRegistryOrigin,
+} from '../../generated/shadcnRegistry';
 import {trackNavigate} from '../../lib/analytics';
+import {
+  shadcnComponentItemPath,
+  shadcnInstallCommand,
+} from '../../lib/shadcnRegistry.mjs';
 
 const styles = stylex.create({
   section: {
@@ -87,6 +95,7 @@ interface ComponentDetailClientProps {
 function OverviewContent({
   comp,
   pkg,
+  pkgVersion,
   showcase: _showcase,
   hasShowcase,
 }: ComponentDetailClientProps & {hasShowcase: boolean}) {
@@ -158,6 +167,37 @@ function OverviewContent({
             {(exampleRegistry[comp.name] || []).map((entry, i) => (
               <ExampleBlock key={i} entry={entry} componentName={comp.name} />
             ))}
+          </VStack>
+        </>
+      )}
+
+      {CURRENT_TARGET === 'canary' && pkg && pkgVersion && (
+        <>
+          <Divider />
+          <VStack gap={2}>
+            <Heading level={2} type="display-3">
+              Use with shadcn
+            </Heading>
+            <MarkdownText type="body">
+              Already using the shadcn registry workflow? Install the real
+              Astryx package and a local public re-export. Component
+              implementation source stays in Astryx. [How compatibility
+              works](/docs/shadcn-compatibility).
+            </MarkdownText>
+            {shadcnRegistryIsPreview && (
+              <Text type="supporting" color="secondary">
+                This install URL expires with the draft preview.
+              </Text>
+            )}
+            <CodeExampleBlock
+              code={shadcnInstallCommand(
+                shadcnComponentItemPath(pkg, comp.name, isHook, comp.registry),
+                shadcnRegistryOrigin,
+              )}
+              language="bash"
+              width="100%"
+              hasCopyButton
+            />
           </VStack>
         </>
       )}

--- a/apps/docsite/src/components/component-detail/ExampleBlock.tsx
+++ b/apps/docsite/src/components/component-detail/ExampleBlock.tsx
@@ -11,13 +11,18 @@ import {CodeExampleBlock} from '../CodeExampleBlock';
 import {TabList, Tab} from '@astryxdesign/core/TabList';
 import {Spinner} from '@astryxdesign/core/Spinner';
 import {Button} from '@astryxdesign/core/Button';
-import {HStack} from '@astryxdesign/core/Layout';
+import {HStack, VStack} from '@astryxdesign/core/Layout';
 import type {ExampleEntry} from '../../generated/exampleRegistry';
 import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {buildPlaygroundHref} from '../playgroundLink';
 import {trackOpenPlayground} from '../../lib/analytics';
 import {MarkdownText} from '../MarkdownText';
 import {preventPreviewNavigation} from './previewNavigation';
+import {
+  shadcnRegistryIsPreview,
+  shadcnRegistryOrigin,
+} from '../../generated/shadcnRegistry';
+import {shadcnInstallCommand} from '../../lib/shadcnRegistry.mjs';
 
 function LivePreview({
   entry,
@@ -101,6 +106,9 @@ export function ExampleBlock({entry, componentName}: ExampleBlockProps) {
             <TabList value={tab} onChange={setTab} size="sm">
               <Tab value="description" label="Description" />
               <Tab value="code" label="Code" />
+              {entry.registryItemPath && (
+                <Tab value="install" label="Install" />
+              )}
             </TabList>
             {entry.source && (
               <Button
@@ -123,7 +131,7 @@ export function ExampleBlock({entry, componentName}: ExampleBlockProps) {
             <MarkdownText type="body">
               {entry.description || 'No description available.'}
             </MarkdownText>
-          ) : (
+          ) : tab === 'code' ? (
             <CodeExampleBlock
               code={entry.source}
               language="tsx"
@@ -131,7 +139,25 @@ export function ExampleBlock({entry, componentName}: ExampleBlockProps) {
               container="section"
               width="100%"
             />
-          )}
+          ) : entry.registryItemPath ? (
+            <VStack gap={2}>
+              {shadcnRegistryIsPreview && (
+                <Text type="supporting" color="secondary">
+                  This install URL expires with the draft preview.
+                </Text>
+              )}
+              <CodeExampleBlock
+                code={shadcnInstallCommand(
+                  entry.registryItemPath,
+                  shadcnRegistryOrigin,
+                )}
+                language="bash"
+                hasCopyButton
+                container="section"
+                width="100%"
+              />
+            </VStack>
+          ) : null}
         </Section>
       </Card>
     </ComponentPreviewTheme>

--- a/apps/docsite/src/content/blog/posts/meet-astryx-from-shadcn.md
+++ b/apps/docsite/src/content/blog/posts/meet-astryx-from-shadcn.md
@@ -1,0 +1,81 @@
+---
+title: 'Meet people where they already build'
+description: 'An experiment that lets shadcn users install Astryx components, examples, blocks, and pages without giving up the Astryx package or CLI.'
+date: '2026-09-02'
+type: 'engineering'
+draft: true
+authors:
+  - 'josephfarina'
+tags:
+  - 'CLI'
+  - 'Components'
+  - 'Templates'
+relatedDocs:
+  - title: 'Use Astryx with shadcn'
+    href: '/docs/shadcn-compatibility'
+  - title: 'Migration guide'
+    href: '/docs/migration'
+  - title: 'Components'
+    href: '/components'
+---
+
+A lot of teams already have a shadcn app. Asking them to replace their setup before they can try one Astryx component is a bad first date.
+
+So we tried a smaller idea: what if Astryx met them inside the workflow they already use?
+
+## The registry is a delivery truck
+
+shadcn has a [Registry protocol](https://ui.shadcn.com/docs/registry). A registry is static JSON that tells its CLI which packages to install and which source files to add to an app. Independent libraries use that protocol because it gives them a familiar install command without making them part of shadcn.
+
+Astryx can do the same thing.
+
+```bash
+npx shadcn@latest add <registry-origin>/templates/dashboard.json
+```
+
+The important bit is what happens after that command. Astryx does not become a pile of copied component source. The command installs the real `@astryxdesign/core` package. The dashboard code it copies imports `Card`, `Table`, `Button`, `ProgressBar`, and everything else from that package.
+
+Astryx still owns component behavior, accessibility, styling, and fixes. The app owns the dashboard composition it asked for.
+
+## Copy the composition, not the design system
+
+This splits the catalog into two useful kinds of install:
+
+- A **component** entry installs the package and writes a tiny local re-export.
+- An **example, block, or page** entry copies editable application code that imports the package.
+
+That distinction matters. Copying a complete Button implementation into every app makes upgrades harder and lets every copy drift. Copying a dashboard that uses the published Button is normal application development. The design system stays a dependency. The page stays yours.
+
+Deep customization still exists, but it remains explicit through `astryx swizzle`. A normal registry install does not cross that line for you.
+
+## We tried the whole catalog
+
+The first experiment generated registry entries from the same catalog that powers the CLI and docsite. It covered every published component and hook, every showcase and example block, and every ready page template.
+
+Then we created a clean shadcn Vite app and installed a Button entry, a Button showcase, a Button example, and a complete analytics dashboard through the shadcn CLI. The CLI installed the Astryx package and other dependencies, added the required CSS, wrote the four files into the app, and the untouched app built successfully.
+
+The experiment matters because it is small. The registry is generated JSON. The docsite already has the catalog, source, package versions, and pages. We are not building another component system.
+
+## This does not replace the Astryx CLI
+
+The shadcn CLI is good transport. It can fetch a known item and put it in the right place.
+
+The Astryx CLI knows the system. It can help you find what fits a prompt, explain the component contract, assemble a page from multiple pieces, compile themes, validate an installation, and apply upgrades.
+
+The two paths can sit next to each other:
+
+```bash
+# I know the exact item and already use shadcn
+npx shadcn@latest add <registry-origin>/examples/button/variants.json
+
+# I need help finding and maintaining the right pieces
+astryx build "analytics dashboard with filters"
+astryx doctor
+astryx upgrade --apply
+```
+
+## Why bother?
+
+Incremental adoption is the point. A team can try one Astryx block inside its current app. It can add a full page when that is useful. It does not need to declare a migration project or learn a new tool before seeing value.
+
+If the experiment holds up, Astryx gets a wider front door without giving up the package boundary or the richer CLI experience. We meet people where they already build, and give them a reason to come further in.

--- a/apps/docsite/src/lib/shadcnRegistry.d.mts
+++ b/apps/docsite/src/lib/shadcnRegistry.d.mts
@@ -1,0 +1,65 @@
+export interface RegistryItemIdentity {
+  kind: 'component' | 'hook' | 'showcase' | 'example' | 'block' | 'page';
+  name: string;
+  path: string;
+  aliases: string[];
+}
+
+export const SHADCN_REGISTRY_ORIGIN: string;
+export const SHADCN_REGISTRY_IS_PREVIEW: boolean;
+export function resolveShadcnRegistryOrigin(
+  env?: Record<string, string | undefined>,
+): string;
+export function slugifyRegistryName(value: string): string;
+export function componentRegistryIdentity(
+  packageName: string,
+  componentName: string,
+  isHook?: boolean,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): RegistryItemIdentity;
+export function blockRegistryIdentity(
+  blockName: string,
+  exampleFor?: string | null,
+  isShowcase: boolean,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): RegistryItemIdentity;
+export function pageRegistryIdentity(
+  templateSlug: string,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): RegistryItemIdentity;
+export function shadcnComponentItemName(
+  packageName: string,
+  componentName: string,
+  isHook?: boolean,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): string;
+export function shadcnComponentItemPath(
+  packageName: string,
+  componentName: string,
+  isHook?: boolean,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): string;
+export function shadcnBlockItemName(
+  blockName: string,
+  exampleFor?: string | null,
+  isShowcase: boolean,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): string;
+export function shadcnBlockItemPath(
+  blockName: string,
+  exampleFor?: string | null,
+  isShowcase: boolean,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): string;
+export function shadcnPageItemName(
+  templateSlug: string,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): string;
+export function shadcnPageItemPath(
+  templateSlug: string,
+  registry?: {slug?: string; aliases?: string[]} | null,
+): string;
+export function shadcnInstallCommand(
+  itemPath: string,
+  registryOrigin?: string,
+): string;

--- a/apps/docsite/src/lib/shadcnRegistry.mjs
+++ b/apps/docsite/src/lib/shadcnRegistry.mjs
@@ -1,0 +1,268 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Shared identities, paths, and commands for Astryx shadcn Registry items.
+ * @input Stable doc names, template slugs, and optional registry overrides.
+ * @output Deterministic global item names, organized paths, aliases, and commands.
+ * @position Shared contract between registry generation and docsite UI.
+ */
+
+const CORE_PACKAGE = '@astryxdesign/core';
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const RELATIVE_PATH_PATTERN =
+  /^[a-z0-9]+(?:-[a-z0-9]+)*(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)*$/;
+const REGISTRY_IDENTITY_KEYS = new Set(['slug', 'aliases']);
+
+export function resolveShadcnRegistryOrigin(env = process.env) {
+  const explicitOrigin = env.NEXT_PUBLIC_ASTRYX_REGISTRY_ORIGIN;
+  if (explicitOrigin) {
+    return explicitOrigin.replace(/\/$/, '');
+  }
+
+  const siteOrigin =
+    env.NEXT_PUBLIC_SITE_URL ??
+    (env.VERCEL_URL
+      ? `https://${env.VERCEL_URL}`
+      : 'https://astryx.atmeta.com');
+  return `${siteOrigin.replace(/\/$/, '')}/shadcn`;
+}
+
+export const SHADCN_REGISTRY_ORIGIN = resolveShadcnRegistryOrigin();
+
+export const SHADCN_REGISTRY_IS_PREVIEW =
+  SHADCN_REGISTRY_ORIGIN !== 'https://astryx.atmeta.com/shadcn';
+
+export function slugifyRegistryName(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+}
+
+function assertSlug(value, label) {
+  if (!SLUG_PATTERN.test(value)) {
+    throw new Error(
+      `${label} must be a lowercase kebab-case slug; received ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
+function registrySlug(registry, fallback, label) {
+  if (registry == null) {
+    return assertSlug(slugifyRegistryName(fallback), label);
+  }
+  if (typeof registry !== 'object' || Array.isArray(registry)) {
+    throw new Error(`${label} registry metadata must be an object`);
+  }
+  const unknownKeys = Object.keys(registry).filter(
+    key => !REGISTRY_IDENTITY_KEYS.has(key),
+  );
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `${label} registry metadata has unknown field(s): ${unknownKeys.join(', ')}`,
+    );
+  }
+  return assertSlug(
+    registry.slug ?? slugifyRegistryName(fallback),
+    `${label} registry.slug`,
+  );
+}
+
+function registryAliases(registry, root, defaultParent, canonicalPath, label) {
+  if (registry?.aliases == null) {
+    return [];
+  }
+  if (!Array.isArray(registry.aliases)) {
+    throw new Error(`${label} registry.aliases must be an array`);
+  }
+  const aliases = registry.aliases.map(alias => {
+    if (typeof alias !== 'string' || !RELATIVE_PATH_PATTERN.test(alias)) {
+      throw new Error(
+        `${label} registry alias must be a lowercase kebab-case relative path; received ${JSON.stringify(alias)}`,
+      );
+    }
+    const relativePath = alias.includes('/')
+      ? alias
+      : defaultParent
+        ? `${defaultParent}/${alias}`
+        : alias;
+    return `${root}/${relativePath}`;
+  });
+  if (aliases.includes(canonicalPath)) {
+    throw new Error(`${label} registry.aliases contains its canonical path`);
+  }
+  return [...new Set(aliases)].sort();
+}
+
+function packageSlug(packageName) {
+  return slugifyRegistryName(packageName.replace(/^@astryxdesign\//, ''));
+}
+
+export function componentRegistryIdentity(
+  packageName,
+  componentName,
+  isHook = false,
+  registry = null,
+) {
+  const kind = isHook ? 'hook' : 'component';
+  const root = isHook ? 'hooks' : 'components';
+  const slug = registrySlug(
+    registry,
+    componentName,
+    `${kind} ${componentName}`,
+  );
+  const packagePart =
+    packageName === CORE_PACKAGE ? '' : `${packageSlug(packageName)}/`;
+  const namePackagePart =
+    packageName === CORE_PACKAGE ? '' : `${packageSlug(packageName)}-`;
+  const path = `${root}/${packagePart}${slug}`;
+  return {
+    kind,
+    name: `${kind}-${namePackagePart}${slug}`,
+    path,
+    aliases: registryAliases(
+      registry,
+      root,
+      packagePart.replace(/\/$/, ''),
+      path,
+      `${kind} ${componentName}`,
+    ),
+  };
+}
+
+function blockLeafSlug(blockName, exampleFor, registry, kind) {
+  const fullSlug = slugifyRegistryName(blockName);
+  const parentSlug = slugifyRegistryName(exampleFor);
+  const derived = fullSlug.startsWith(`${parentSlug}-`)
+    ? fullSlug.slice(parentSlug.length + 1)
+    : fullSlug === parentSlug
+      ? 'default'
+      : fullSlug;
+  const fallback = derived === kind ? 'default' : derived;
+  return registrySlug(registry, fallback, `${kind} ${blockName}`);
+}
+
+export function blockRegistryIdentity(
+  blockName,
+  exampleFor = null,
+  isShowcase = false,
+  registry = null,
+) {
+  if (!exampleFor) {
+    if (isShowcase) {
+      throw new Error(
+        `showcase ${blockName} requires exampleFor; standalone blocks cannot be component showcases`,
+      );
+    }
+    const slug = registrySlug(registry, blockName, `block ${blockName}`);
+    const path = `blocks/${slug}`;
+    return {
+      kind: 'block',
+      name: `block-${slug}`,
+      path,
+      aliases: registryAliases(
+        registry,
+        'blocks',
+        '',
+        path,
+        `block ${blockName}`,
+      ),
+    };
+  }
+
+  const kind = isShowcase ? 'showcase' : 'example';
+  const root = isShowcase ? 'showcases' : 'examples';
+  const parentSlug = assertSlug(
+    slugifyRegistryName(exampleFor),
+    `${kind} ${blockName} exampleFor`,
+  );
+  const slug = blockLeafSlug(blockName, exampleFor, registry, kind);
+  const path = `${root}/${parentSlug}/${slug}`;
+  return {
+    kind,
+    name: `${kind}-${parentSlug}-${slug}`,
+    path,
+    aliases: registryAliases(
+      registry,
+      root,
+      parentSlug,
+      path,
+      `${kind} ${blockName}`,
+    ),
+  };
+}
+
+export function pageRegistryIdentity(templateSlug, registry = null) {
+  const slug = registrySlug(registry, templateSlug, `template ${templateSlug}`);
+  const path = `templates/${slug}`;
+  return {
+    kind: 'page',
+    name: `template-${slug}`,
+    path,
+    aliases: registryAliases(
+      registry,
+      'templates',
+      '',
+      path,
+      `template ${templateSlug}`,
+    ),
+  };
+}
+
+export function shadcnComponentItemName(
+  packageName,
+  componentName,
+  isHook = false,
+  registry = null,
+) {
+  return componentRegistryIdentity(packageName, componentName, isHook, registry)
+    .name;
+}
+
+export function shadcnComponentItemPath(
+  packageName,
+  componentName,
+  isHook = false,
+  registry = null,
+) {
+  return componentRegistryIdentity(packageName, componentName, isHook, registry)
+    .path;
+}
+
+export function shadcnBlockItemName(
+  blockName,
+  exampleFor = null,
+  isShowcase = false,
+  registry = null,
+) {
+  return blockRegistryIdentity(blockName, exampleFor, isShowcase, registry)
+    .name;
+}
+
+export function shadcnBlockItemPath(
+  blockName,
+  exampleFor = null,
+  isShowcase = false,
+  registry = null,
+) {
+  return blockRegistryIdentity(blockName, exampleFor, isShowcase, registry)
+    .path;
+}
+
+export function shadcnPageItemName(templateSlug, registry = null) {
+  return pageRegistryIdentity(templateSlug, registry).name;
+}
+
+export function shadcnPageItemPath(templateSlug, registry = null) {
+  return pageRegistryIdentity(templateSlug, registry).path;
+}
+
+export function shadcnInstallCommand(
+  itemPath,
+  registryOrigin = SHADCN_REGISTRY_ORIGIN,
+) {
+  return `npx shadcn@latest add ${registryOrigin}/${itemPath}.json`;
+}

--- a/docs/specs/AST-026/spec.md
+++ b/docs/specs/AST-026/spec.md
@@ -1,0 +1,206 @@
+---
+schema_version: 1
+template_version: 1
+kind: system-spec
+id: spec:AST-026
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+phase: implementing
+owners: [cixzhang, josephfarina]
+affects_architecture: [architecture:public-component-api]
+affects_families: []
+affects_contributing: [contributing:templates]
+affects_consumer_docs: [shadcn-compatibility, templates, components]
+---
+
+# shadcn Registry compatibility system spec
+
+## Intent
+
+Let builders install Astryx components, component showcases, example blocks, and
+page templates through the standard shadcn Registry protocol without making
+Astryx a shadcn-based library or copying Astryx component implementations into
+consumer repositories.
+
+The compatibility layer meets builders inside an existing shadcn workflow. The
+Astryx CLI remains the primary, richer interface for discovery, composition,
+integrations, themes, validation, and upgrades.
+
+This record governs the approved compatibility foundation. The implementation
+may merge behind the canary docsite while copied-composition upgrades and public
+support ownership remain launch gates for the production endpoint and announcement.
+
+## Non-goals
+
+- Replacing the Astryx CLI with the shadcn CLI.
+- Defining a second, Astryx-only registry format.
+- Copying Core or Lab component implementation source during a normal install.
+- Treating generated examples, blocks, or pages as byte-stable public API.
+- Publishing an unsupported service-level agreement or making copied
+  compositions package-controlled implementation source.
+- Changing the explicit `astryx swizzle` escape hatch for deep customization.
+
+## Requirements
+
+- **FR1 — Standard protocol.** Every experimental item MUST validate against the
+  standard shadcn Registry schema and use a standard registry item type. A
+  standard shadcn client MUST NOT need Astryx-specific code to read or install
+  the item.
+- **FR2 — Preserve the package boundary.** A component install MUST add the
+  published Astryx package dependency and create only consumer-facing import or
+  re-export source. It MUST NOT copy the component implementation, private
+  helpers, or uncompiled StyleX source.
+- **FR3 — Complete requested catalog.** The experiment MUST cover every public
+  component or hook, every component showcase and example block, every other
+  block, and every ready page template available from the same catalog the CLI
+  and docsite use.
+- **FR4 — Editable compositions.** Showcase, example, block, and page items MAY
+  copy application-level composition source. That source MUST import Astryx
+  through published package paths, declare all non-React package dependencies,
+  and contain no relative import that escapes the copied item.
+- **FR5 — Deterministic, stable identity.** Item names, organized URL paths,
+  target paths, dependency lists, and JSON output MUST be deterministic and
+  collision-free. Identity MUST derive from stable doc/catalog fields, not
+  display labels or source filenames. Display-name changes MUST NOT change
+  install URLs. Published renames MUST preserve prior routes as aliases.
+- **FR6 — One catalog, two clients.** The shadcn client consumes standard fields.
+  The Astryx CLI MAY read optional `astryx` metadata from the raw JSON for
+  integration, provenance, and upgrade guidance. Standard clients may discard
+  that metadata without changing the install.
+- **FR7 — Discoverable compatibility.** The public docsite MUST describe the
+  compatibility boundary and show a secondary copyable install command at the
+  end of each applicable component, example, block, and page surface. The
+  normal Astryx documentation remains the human browse experience; raw
+  `/shadcn/` paths remain machine endpoints.
+- **FR8 — Staged launch.** Preview builds MUST serve the full registry from their
+  own `/shadcn` origin with `@canary` package dependencies. Production MUST use
+  exact released package versions and remain disabled until copied-composition
+  upgrades and public support ownership are ready.
+- **IR1 — Generated from current sources.** Registry output MUST come from the
+  existing docsite and CLI catalogs, never a parallel handwritten item list.
+- **IR2 — Build-time static output.** The docsite build MUST generate static JSON
+  under one registry root. Generated JSON MUST NOT be committed when a clean
+  build can reproduce it.
+- **IR3 — Failure is loud.** Missing source, duplicate names, invalid schemas,
+  unresolved package versions, escaping relative imports, and stale generated
+  output MUST fail generation or verification.
+- **IR4 — End-to-end evidence.** Verification MUST install representative
+  component, showcase, block, and page items into a clean shadcn-style app and
+  build that app. The full catalog MUST receive schema, uniqueness, dependency,
+  and source-boundary checks.
+- **IR5 — Stable route contract.** Generated item names and canonical paths MUST
+  match the reviewed route lock. Display-name edits MUST NOT change them. An
+  intentional rename MUST retain old paths through `registry.aliases` unless a
+  separately reviewed breaking change approves removal.
+
+### Platform support
+
+- Supported feature/engine floor: the current Astryx Node floor and the pinned
+  shadcn version used by the experiment.
+- Unsupported behavior: copying Astryx implementation source without an
+  explicit `astryx swizzle` action; installing hidden, incomplete, or
+  non-resolvable catalog entries.
+- Browser evidence: a representative installed page MUST render in real Chrome
+  in both light and dark modes before publication is proposed.
+
+## Current-state impact
+
+The CLI already ships components, 161 blocks, and 47 ready page templates. The
+docsite generator already discovers components, individual showcases and
+examples, blocks, pages, package versions, and source. The experiment adds a
+serializer over that existing catalog rather than a second discovery system.
+
+Prior evidence installed all 921 generated entries through shadcn 4.19.0 into
+a clean Vite application, wrote every component, hook, block, and page file with
+zero install failures, and compiled all 6,620 imported modules in one build.
+Fourteen compositions that author local StyleX are precompiled to compiler-free
+JSX during generation; all other composition source stays typed TSX. Component
+implementation copying failed because private imports and uncompiled StyleX
+crossed the package boundary; FR2 avoids that path by installing the package and
+creating a public re-export only.
+
+## Verification
+
+| Contract | Verification                                                        | Representative states                           | Mutation or failure expectation                            |
+| -------- | ------------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| FR1, FR5 | shadcn schema validation and deterministic snapshot                 | component, showcase, example, block, page       | Unknown type, duplicate name, or unstable output fails     |
+| FR2      | clean consumer install plus source inspection                       | Core component, hook, non-Core package          | Implementation source or private import fails              |
+| FR3, IR1 | reconcile registry counts and names with generated docsite catalogs | visible and hidden entries, grouped families    | Missing or extra catalog entry fails                       |
+| FR4, IR3 | dependency extraction and relative-import audit                     | heroicons, recharts, StyleX import, page source | Escaping import or undeclared package fails                |
+| FR6      | raw JSON and shadcn parse tests                                     | optional `astryx` metadata present              | shadcn install changes or Astryx metadata becomes required |
+| FR7      | docsite tests and copy-button interaction                           | component, block, page, compatibility guide     | Command is absent, stale, or misstates copy behavior       |
+| FR8      | canary preview plus production-target assertion                     | preview and released package dependencies       | Production enables before both launch gates pass           |
+| IR4      | clean shadcn-style fixture install, build, and Chrome screenshot    | one of each item kind; light and dark           | Install, build, or render fails                            |
+
+## Decision log
+
+### DEC-1 — Use shadcn as a compatibility protocol, not an Astryx foundation
+
+**Reference:** `spec:AST-026/DEC-1`
+**Decider:** `josephfarina`, `2026-09-02`
+
+Generate standard registry JSON so an existing shadcn user can install Astryx
+without changing tools. Keep the Astryx CLI as the primary product and the
+source of richer knowledge and maintenance behavior.
+
+Rejected: a custom Astryx registry format. It gives third-party clients no
+interoperability and requires Astryx adoption before Astryx can be discovered.
+
+### DEC-2 — Copy composition, not component implementation
+
+**Reference:** `spec:AST-026/DEC-2`
+**Decider:** `josephfarina`, `2026-09-02`
+
+A normal install keeps `@astryxdesign/core` or the owning Astryx package as a
+real dependency. Component items create a public re-export; showcases, blocks,
+and pages copy editable composition code that imports the package.
+
+Rejected: copying Core implementation source. It breaks package-controlled
+upgrades and crosses private-import and uncompiled-StyleX boundaries.
+
+### DEC-3 — Stage the launch behind the canary docsite
+
+**Reference:** `spec:AST-026/DEC-3`
+**Decider:** `josephfarina`, `2026-09-09`
+
+Merge the compatibility foundation after end-to-end verification, but keep the
+production registry and broad announcement disabled until copied-composition
+upgrades and public support ownership are ready.
+
+### DEC-4 — Derive stable IDs from docs and organize URLs by item kind
+
+**Reference:** `spec:AST-026/DEC-4`
+**Decider:** `josephfarina`, `2026-09-03`
+
+Treat registry names and paths as public API before publication. Derive them
+from stable component/hook names, block `name` plus `exampleFor`, and the
+existing template slug. Keep `displayName` editorial. Use these path families:
+`components`, `hooks`, `showcases/<component>`, `examples/<component>`,
+`blocks`, and `templates`. A block without `exampleFor` is standalone under
+`blocks`; a block with component ownership is an example or showcase.
+
+Allow a doc to override its leaf with `registry.slug` and retain old relative
+paths with `registry.aliases`. Check all names and paths against a reviewed lock
+so a rename cannot silently break existing install commands.
+
+### DEC-5 — Use `/shadcn`, exact releases, and canary previews
+
+**Reference:** `spec:AST-026/DEC-5`
+**Decider:** `josephfarina`, `2026-09-09`
+
+Use `https://astryx.atmeta.com/shadcn` as the canonical production root and
+reserve `/r` for a future Astryx-native protocol. Production items pin exact
+released Astryx package versions; preview items use the matching preview origin
+and `@canary` dependencies.
+
+## Open questions
+
+- **OQ1 — Support operations.** (`human-api`) Which maintainer and public channel
+  own registry support, and what response promise is documented?
+- **OQ2 — Copied-composition upgrades.** (`engineering`) What provenance and
+  upgrade flow keeps copied showcases, examples, blocks, and pages maintainable?
+- **OQ3 — Catalog visibility.** (`human-design`) Should hidden or not-ready
+  catalog entries stay addressable by URL, or be omitted entirely?

--- a/internal/shadcn-registry/generate-shadcn-registry.test.mjs
+++ b/internal/shadcn-registry/generate-shadcn-registry.test.mjs
@@ -1,0 +1,530 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Registry serializer contract tests.
+ * @input Minimal component, block, page, and StyleX fixtures.
+ * @output Regression coverage for schema, package boundaries, names, and output.
+ * @position Node test lane for ShadCN compatibility.
+ */
+
+import {execFile} from 'node:child_process';
+import {createServer} from 'node:http';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
+import {promisify} from 'node:util';
+import {describe, expect, it} from 'vitest';
+import {
+  buildShadcnRegistry,
+  generateShadcnRegistry,
+} from '../../apps/docsite/scripts/generate-shadcn-registry.mjs';
+import {
+  blockRegistryIdentity,
+  componentRegistryIdentity,
+  pageRegistryIdentity,
+  resolveShadcnRegistryOrigin,
+} from '../../apps/docsite/src/lib/shadcnRegistry.mjs';
+
+const execFileAsync = promisify(execFile);
+
+const packages = [{name: '@astryxdesign/core', version: '0.5.2'}];
+
+function fixture(overrides = {}) {
+  return {
+    packages,
+    allComponents: {
+      '@astryxdesign/core': [
+        {
+          name: 'Button',
+          displayName: 'Button',
+          description: 'Runs an action.',
+          importPath: '@astryxdesign/core/Button',
+          hidden: false,
+          params: null,
+        },
+      ],
+    },
+    blocks: [
+      {
+        dirName: 'ButtonShowcase',
+        name: 'Button — Variants',
+        displayName: 'Button — Variants',
+        description: 'Shows a primary button.',
+        exampleFor: 'Button',
+        isShowcase: true,
+        category: 'components/Button',
+        componentsUsed: ['Button'],
+        source:
+          "import {Button} from '@astryxdesign/core/Button';\n" +
+          'export default function ButtonShowcase() { return <Button label="Save" />; }\n',
+      },
+    ],
+    templates: [
+      {
+        slug: 'dashboard',
+        name: 'Dashboard',
+        description: 'A metrics dashboard.',
+        category: 'Dashboard',
+        isReady: true,
+        isHiddenFromOverview: false,
+        source:
+          "import {Card} from '@astryxdesign/core/Card';\n" +
+          'export default function Page() { return <Card />; }\n',
+      },
+    ],
+    externalDependencySpecs: {
+      '@stylexjs/stylex': '@stylexjs/stylex@0.19.0',
+    },
+    ...overrides,
+  };
+}
+
+function writeConsumerProject(project) {
+  mkdirSync(path.join(project, 'src'), {recursive: true});
+  writeFileSync(
+    path.join(project, 'package.json'),
+    JSON.stringify({
+      name: 'registry-consumer-test',
+      private: true,
+      version: '0.0.0',
+    }),
+  );
+  writeFileSync(
+    path.join(project, 'components.json'),
+    JSON.stringify({
+      $schema: 'https://ui.shadcn.com/schema.json',
+      style: 'nova',
+      rsc: false,
+      tsx: true,
+      tailwind: {
+        config: '',
+        css: 'src/index.css',
+        baseColor: '',
+        cssVariables: true,
+        prefix: '',
+      },
+      aliases: {
+        components: '@/components',
+        utils: '@/lib/utils',
+        ui: '@/components/ui',
+        lib: '@/lib',
+        hooks: '@/hooks',
+      },
+      iconLibrary: 'lucide',
+    }),
+  );
+  writeFileSync(
+    path.join(project, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        baseUrl: '.',
+        paths: {'@/*': ['./src/*']},
+      },
+    }),
+  );
+  writeFileSync(path.join(project, 'src', 'index.css'), '');
+}
+
+describe('resolveShadcnRegistryOrigin', () => {
+  it('prefers an explicit registry origin', () => {
+    expect(
+      resolveShadcnRegistryOrigin({
+        NEXT_PUBLIC_ASTRYX_REGISTRY_ORIGIN: 'https://example.com/custom/',
+        VERCEL_URL: 'ignored.vercel.app',
+      }),
+    ).toBe('https://example.com/custom');
+  });
+
+  it('uses the Vercel deployment URL for preview builds', () => {
+    expect(
+      resolveShadcnRegistryOrigin({
+        VERCEL_URL: 'astryx-git-example.vercel.app',
+      }),
+    ).toBe('https://astryx-git-example.vercel.app/shadcn');
+  });
+});
+
+describe('registry identities', () => {
+  it('derives organized paths from stable doc identity', () => {
+    expect(
+      componentRegistryIdentity('@astryxdesign/core', 'Button'),
+    ).toMatchObject({name: 'component-button', path: 'components/button'});
+    expect(
+      componentRegistryIdentity(
+        '@astryxdesign/core',
+        'useAppShellMobile',
+        true,
+      ),
+    ).toMatchObject({
+      name: 'hook-use-app-shell-mobile',
+      path: 'hooks/use-app-shell-mobile',
+    });
+    expect(
+      blockRegistryIdentity('Button — Leading Icon', 'Button', false),
+    ).toMatchObject({
+      name: 'example-button-leading-icon',
+      path: 'examples/button/leading-icon',
+    });
+    expect(blockRegistryIdentity('Filter Toolbar', null, false)).toMatchObject({
+      kind: 'block',
+      name: 'block-filter-toolbar',
+      path: 'blocks/filter-toolbar',
+    });
+    expect(pageRegistryIdentity('analytics-dashboard')).toMatchObject({
+      name: 'template-analytics-dashboard',
+      path: 'templates/analytics-dashboard',
+    });
+  });
+
+  it('supports an explicit stable slug and prior path aliases', () => {
+    expect(
+      blockRegistryIdentity('Button — Icon', 'Button', false, {
+        slug: 'leading-icon',
+        aliases: ['button/icon'],
+      }),
+    ).toEqual({
+      kind: 'example',
+      name: 'example-button-leading-icon',
+      path: 'examples/button/leading-icon',
+      aliases: ['examples/button/icon'],
+    });
+  });
+
+  it('rejects a standalone block marked as a component showcase', () => {
+    expect(() => blockRegistryIdentity('Hero Layout', null, true)).toThrow(
+      /requires exampleFor/,
+    );
+  });
+
+  it('rejects malformed or unknown registry identity fields', () => {
+    expect(() =>
+      pageRegistryIdentity('dashboard', {slug: 'Dashboard'}),
+    ).toThrow(/lowercase kebab-case/);
+    expect(() => pageRegistryIdentity('dashboard', {owner: 'docs'})).toThrow(
+      /unknown field/,
+    );
+  });
+});
+
+describe('buildShadcnRegistry', () => {
+  it('creates standard component, showcase, and page items', () => {
+    const {registry, items, counts} = buildShadcnRegistry(fixture());
+
+    expect(counts).toEqual({
+      components: 1,
+      hooks: 0,
+      showcases: 1,
+      examples: 0,
+      blocks: 0,
+      skippedUnpublishedComponents: 0,
+      skippedUnpublishedBlocks: 0,
+      pages: 1,
+      skippedUnpublishedPages: 0,
+      total: 3,
+    });
+    expect(registry.items).toHaveLength(3);
+    expect(items.map(item => item.name)).toEqual([
+      'component-button',
+      'showcase-button-variants',
+      'template-dashboard',
+    ]);
+    expect(items.map(item => item.astryx.path)).toEqual([
+      'components/button',
+      'showcases/button/variants',
+      'templates/dashboard',
+    ]);
+  });
+
+  it('writes canonical nested paths and compatibility aliases', () => {
+    const outDir = mkdtempSync(path.join(tmpdir(), 'astryx-shadcn-routes-'));
+    try {
+      const input = fixture();
+      input.blocks[0].registry = {
+        slug: 'button-styles',
+        aliases: ['button/variants'],
+      };
+      input.blocks.push({
+        ...input.blocks[0],
+        dirName: 'FilterToolbar',
+        name: 'Filter Toolbar',
+        displayName: 'Filter Toolbar',
+        exampleFor: null,
+        isShowcase: false,
+        registry: null,
+      });
+      const result = generateShadcnRegistry({
+        ...input,
+        outDir,
+        cliRoot: outDir,
+      });
+
+      expect(existsSync(path.join(outDir, 'components', 'button.json'))).toBe(
+        true,
+      );
+      expect(
+        existsSync(
+          path.join(outDir, 'showcases', 'button', 'button-styles.json'),
+        ),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(outDir, 'showcases', 'button', 'variants.json')),
+      ).toBe(true);
+      expect(
+        existsSync(path.join(outDir, 'blocks', 'filter-toolbar.json')),
+      ).toBe(true);
+      expect(existsSync(path.join(outDir, 'templates', 'dashboard.json'))).toBe(
+        true,
+      );
+      expect(result.routes).toContain('showcases/button/variants');
+      expect(result.routes).toContain('blocks/filter-toolbar');
+    } finally {
+      rmSync(outDir, {recursive: true, force: true});
+    }
+  });
+
+  it('creates a first-class standalone block item', () => {
+    const standalone = {
+      ...fixture().blocks[0],
+      dirName: 'FilterToolbar',
+      name: 'Filter Toolbar',
+      displayName: 'Filter Toolbar',
+      exampleFor: null,
+      isShowcase: false,
+    };
+    const {items} = buildShadcnRegistry(fixture({blocks: [standalone]}));
+    const block = items.find(item => item.name === 'block-filter-toolbar');
+
+    expect(block.astryx).toMatchObject({
+      kind: 'block',
+      path: 'blocks/filter-toolbar',
+      exampleFor: null,
+    });
+    expect(block.files[0].target).toBe(
+      'components/astryx/blocks/FilterToolbar.tsx',
+    );
+  });
+
+  it('keeps component implementation inside the package', () => {
+    const {items} = buildShadcnRegistry(fixture());
+    const component = items.find(item => item.name === 'component-button');
+
+    expect(component.dependencies).toEqual([
+      '@astryxdesign/core@0.5.2',
+      '@stylexjs/stylex@0.19.0',
+    ]);
+    expect(component.css).toEqual({
+      '@import "@astryxdesign/core/reset.css"': {},
+      '@import "@astryxdesign/core/astryx.css"': {},
+    });
+    expect(component.files).toEqual([
+      expect.objectContaining({
+        target: 'components/astryx/Button.ts',
+        content: "export * from '@astryxdesign/core/Button';\n",
+      }),
+    ]);
+  });
+
+  it('uses the shadcn page-file workaround without changing item semantics', () => {
+    const {items} = buildShadcnRegistry(fixture());
+    const page = items.find(item => item.name === 'template-dashboard');
+
+    expect(page.type).toBe('registry:page');
+    expect(page.files[0].type).toBe('registry:block');
+    expect(page.files[0].target).toBe('app/astryx/dashboard/page.tsx');
+  });
+
+  it('writes a page through the pinned shadcn CLI workaround', async () => {
+    const project = mkdtempSync(path.join(tmpdir(), 'astryx-shadcn-page-'));
+    try {
+      writeConsumerProject(project);
+
+      const page = {
+        $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+        name: 'astryx-page-test',
+        type: 'registry:page',
+        files: [
+          {
+            path: 'registry/astryx-page-test/page.tsx',
+            type: 'registry:block',
+            target: 'app/astryx/test/page.tsx',
+            content: 'export default function Page() { return null; }\n',
+          },
+        ],
+      };
+      const itemPath = path.join(project, 'page.json');
+      writeFileSync(itemPath, JSON.stringify(page));
+      await execFileAsync(
+        path.resolve('node_modules/.bin/shadcn'),
+        ['add', itemPath, '--yes'],
+        {cwd: project, timeout: 30_000},
+      );
+
+      expect(
+        existsSync(
+          path.join(project, 'src', 'app', 'astryx', 'test', 'page.tsx'),
+        ),
+      ).toBe(true);
+    } finally {
+      rmSync(project, {recursive: true, force: true});
+    }
+  });
+
+  it('resolves arbitrary nested item URLs and full-URL dependencies', async () => {
+    const project = mkdtempSync(path.join(tmpdir(), 'astryx-shadcn-url-'));
+    const requests = [];
+    let origin = '';
+    const dependency = {
+      $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+      name: 'astryx-nested-dependency',
+      type: 'registry:component',
+      files: [
+        {
+          path: 'registry/astryx-nested-dependency/Dependency.ts',
+          type: 'registry:component',
+          target: 'components/astryx/Dependency.ts',
+          content: 'export const dependencyValue = 1;\n',
+        },
+      ],
+    };
+    const server = createServer((request, response) => {
+      requests.push(request.url);
+      let body;
+      if (request.url === '/shadcn/components/dependency.json') {
+        body = dependency;
+      } else if (request.url === '/shadcn/examples/parent.json') {
+        body = {
+          $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+          name: 'astryx-nested-parent',
+          type: 'registry:block',
+          registryDependencies: [`${origin}/shadcn/components/dependency.json`],
+          files: [
+            {
+              path: 'registry/astryx-nested-parent/Parent.tsx',
+              type: 'registry:block',
+              target: 'components/astryx/Parent.tsx',
+              content:
+                "import {dependencyValue} from './Dependency';\n" +
+                'export function Parent() { return <div>{dependencyValue}</div>; }\n',
+            },
+          ],
+        };
+      }
+
+      if (!body) {
+        response.writeHead(404);
+        response.end('not found');
+        return;
+      }
+      response.writeHead(200, {'content-type': 'application/json'});
+      response.end(JSON.stringify(body));
+    });
+
+    try {
+      await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+      });
+      const address = server.address();
+      expect(address).not.toBeNull();
+      expect(typeof address).not.toBe('string');
+      origin = `http://127.0.0.1:${address.port}`;
+      writeConsumerProject(project);
+
+      await execFileAsync(
+        path.resolve('node_modules/.bin/shadcn'),
+        ['add', `${origin}/shadcn/examples/parent.json`, '--yes'],
+        {
+          cwd: project,
+          timeout: 30_000,
+          env: {
+            ...process.env,
+            NO_PROXY: '127.0.0.1,localhost',
+            no_proxy: '127.0.0.1,localhost',
+          },
+        },
+      );
+
+      expect(
+        existsSync(
+          path.join(project, 'src', 'components', 'astryx', 'Parent.tsx'),
+        ),
+      ).toBe(true);
+      expect(
+        existsSync(
+          path.join(project, 'src', 'components', 'astryx', 'Dependency.ts'),
+        ),
+      ).toBe(true);
+      expect(requests).toContain('/shadcn/examples/parent.json');
+      expect(requests).toContain('/shadcn/components/dependency.json');
+    } finally {
+      if (server.listening) {
+        await new Promise((resolve, reject) => {
+          server.close(error => (error ? reject(error) : resolve()));
+        });
+      }
+      rmSync(project, {recursive: true, force: true});
+    }
+  });
+
+  it('rejects composition source that escapes through a relative import', () => {
+    const bad = fixture({
+      blocks: [
+        {
+          ...fixture().blocks[0],
+          source:
+            "import {fixture} from '../fixture';\nexport default fixture;\n",
+        },
+      ],
+    });
+
+    expect(() => buildShadcnRegistry(bad)).toThrow(/relative import/);
+  });
+
+  it('targets canary packages in preview registries', () => {
+    const {items} = buildShadcnRegistry({
+      ...fixture(),
+      dependencyTag: 'canary',
+    });
+    const component = items.find(item => item.name === 'component-button');
+    expect(component.dependencies).toEqual([
+      '@astryxdesign/core@canary',
+      '@stylexjs/stylex@0.19.0',
+    ]);
+  });
+
+  it('precompiles local StyleX with runtime CSS injection', () => {
+    const styled = fixture({
+      blocks: [
+        {
+          ...fixture().blocks[0],
+          source:
+            "import * as stylex from '@stylexjs/stylex';\n" +
+            "import {Button} from '@astryxdesign/core/Button';\n" +
+            "const styles = stylex.create({root: {width: '100%'}});\n" +
+            'export default function Styled() { return <div {...stylex.props(styles.root)}><Button label="Save" /></div>; }\n',
+        },
+      ],
+    });
+
+    const {items} = buildShadcnRegistry(styled);
+    const block = items.find(item => item.name === 'showcase-button-variants');
+    expect(block.files[0].content).toContain('stylex-inject');
+    expect(block.files[0].content).not.toContain('stylex.create');
+    expect(block.files[0].target).toMatch(/\.jsx$/);
+    expect(block.dependencies).toContain('@stylexjs/stylex@0.19.0');
+  });
+
+  it('keeps Astryx metadata in raw JSON while standard clients can strip it', () => {
+    const {items} = buildShadcnRegistry(fixture());
+
+    expect(items[0].astryx).toEqual(
+      expect.objectContaining({kind: 'component'}),
+    );
+  });
+});

--- a/internal/shadcn-registry/routes.lock.json
+++ b/internal/shadcn-registry/routes.lock.json
@@ -1,0 +1,4849 @@
+{
+  "version": 1,
+  "items": [
+    {
+      "name": "component-alert-dialog",
+      "path": "components/alert-dialog",
+      "aliases": []
+    },
+    {
+      "name": "component-app-shell",
+      "path": "components/app-shell",
+      "aliases": []
+    },
+    {
+      "name": "component-aspect-ratio",
+      "path": "components/aspect-ratio",
+      "aliases": []
+    },
+    {
+      "name": "component-avatar",
+      "path": "components/avatar",
+      "aliases": []
+    },
+    {
+      "name": "component-avatar-group",
+      "path": "components/avatar-group",
+      "aliases": []
+    },
+    {
+      "name": "component-avatar-group-overflow",
+      "path": "components/avatar-group-overflow",
+      "aliases": []
+    },
+    {
+      "name": "component-avatar-status-dot",
+      "path": "components/avatar-status-dot",
+      "aliases": []
+    },
+    {
+      "name": "component-badge",
+      "path": "components/badge",
+      "aliases": []
+    },
+    {
+      "name": "component-banner",
+      "path": "components/banner",
+      "aliases": []
+    },
+    {
+      "name": "component-base-typeahead",
+      "path": "components/base-typeahead",
+      "aliases": []
+    },
+    {
+      "name": "component-blockquote",
+      "path": "components/blockquote",
+      "aliases": []
+    },
+    {
+      "name": "component-bottom-sheet",
+      "path": "components/bottom-sheet",
+      "aliases": []
+    },
+    {
+      "name": "component-bottom-sheet-switcher",
+      "path": "components/bottom-sheet-switcher",
+      "aliases": []
+    },
+    {
+      "name": "component-breadcrumb-item",
+      "path": "components/breadcrumb-item",
+      "aliases": []
+    },
+    {
+      "name": "component-breadcrumbs",
+      "path": "components/breadcrumbs",
+      "aliases": []
+    },
+    {
+      "name": "component-button",
+      "path": "components/button",
+      "aliases": []
+    },
+    {
+      "name": "component-button-group",
+      "path": "components/button-group",
+      "aliases": []
+    },
+    {
+      "name": "component-calendar",
+      "path": "components/calendar",
+      "aliases": []
+    },
+    {
+      "name": "component-card",
+      "path": "components/card",
+      "aliases": []
+    },
+    {
+      "name": "component-carousel",
+      "path": "components/carousel",
+      "aliases": []
+    },
+    {
+      "name": "component-center",
+      "path": "components/center",
+      "aliases": []
+    },
+    {
+      "name": "component-charts-chart",
+      "path": "components/charts/chart",
+      "aliases": []
+    },
+    {
+      "name": "component-charts-chart-swatch",
+      "path": "components/charts/chart-swatch",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-composer",
+      "path": "components/chat-composer",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-composer-drawer",
+      "path": "components/chat-composer-drawer",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-composer-input",
+      "path": "components/chat-composer-input",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-composer-token-element",
+      "path": "components/chat-composer-token-element",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-dictation-button",
+      "path": "components/chat-dictation-button",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-layout",
+      "path": "components/chat-layout",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-layout-scroll-button",
+      "path": "components/chat-layout-scroll-button",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-message",
+      "path": "components/chat-message",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-message-bubble",
+      "path": "components/chat-message-bubble",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-message-list",
+      "path": "components/chat-message-list",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-message-metadata",
+      "path": "components/chat-message-metadata",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-send-button",
+      "path": "components/chat-send-button",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-system-message",
+      "path": "components/chat-system-message",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-tokenized-text",
+      "path": "components/chat-tokenized-text",
+      "aliases": []
+    },
+    {
+      "name": "component-chat-tool-calls",
+      "path": "components/chat-tool-calls",
+      "aliases": []
+    },
+    {
+      "name": "component-check-indicator",
+      "path": "components/check-indicator",
+      "aliases": []
+    },
+    {
+      "name": "component-checkbox-indicator",
+      "path": "components/checkbox-indicator",
+      "aliases": []
+    },
+    {
+      "name": "component-checkbox-input",
+      "path": "components/checkbox-input",
+      "aliases": []
+    },
+    {
+      "name": "component-checkbox-list",
+      "path": "components/checkbox-list",
+      "aliases": []
+    },
+    {
+      "name": "component-checkbox-list-item",
+      "path": "components/checkbox-list-item",
+      "aliases": []
+    },
+    {
+      "name": "component-citation",
+      "path": "components/citation",
+      "aliases": []
+    },
+    {
+      "name": "component-clickable-card",
+      "path": "components/clickable-card",
+      "aliases": []
+    },
+    {
+      "name": "component-code",
+      "path": "components/code",
+      "aliases": []
+    },
+    {
+      "name": "component-code-block",
+      "path": "components/code-block",
+      "aliases": []
+    },
+    {
+      "name": "component-collapsible",
+      "path": "components/collapsible",
+      "aliases": []
+    },
+    {
+      "name": "component-collapsible-group",
+      "path": "components/collapsible-group",
+      "aliases": []
+    },
+    {
+      "name": "component-command-palette",
+      "path": "components/command-palette",
+      "aliases": []
+    },
+    {
+      "name": "component-command-palette-empty",
+      "path": "components/command-palette-empty",
+      "aliases": []
+    },
+    {
+      "name": "component-command-palette-footer",
+      "path": "components/command-palette-footer",
+      "aliases": []
+    },
+    {
+      "name": "component-command-palette-group",
+      "path": "components/command-palette-group",
+      "aliases": []
+    },
+    {
+      "name": "component-command-palette-input",
+      "path": "components/command-palette-input",
+      "aliases": []
+    },
+    {
+      "name": "component-command-palette-item",
+      "path": "components/command-palette-item",
+      "aliases": []
+    },
+    {
+      "name": "component-command-palette-list",
+      "path": "components/command-palette-list",
+      "aliases": []
+    },
+    {
+      "name": "component-complex-selector",
+      "path": "components/complex-selector",
+      "aliases": []
+    },
+    {
+      "name": "component-context-menu",
+      "path": "components/context-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-context-menu-item",
+      "path": "components/context-menu-item",
+      "aliases": []
+    },
+    {
+      "name": "component-date-input",
+      "path": "components/date-input",
+      "aliases": []
+    },
+    {
+      "name": "component-date-range-input",
+      "path": "components/date-range-input",
+      "aliases": []
+    },
+    {
+      "name": "component-date-time-input",
+      "path": "components/date-time-input",
+      "aliases": []
+    },
+    {
+      "name": "component-dialog",
+      "path": "components/dialog",
+      "aliases": []
+    },
+    {
+      "name": "component-dialog-header",
+      "path": "components/dialog-header",
+      "aliases": []
+    },
+    {
+      "name": "component-divider",
+      "path": "components/divider",
+      "aliases": []
+    },
+    {
+      "name": "component-dropdown-menu",
+      "path": "components/dropdown-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-dropdown-menu-checkbox-item",
+      "path": "components/dropdown-menu-checkbox-item",
+      "aliases": []
+    },
+    {
+      "name": "component-dropdown-menu-divider",
+      "path": "components/dropdown-menu-divider",
+      "aliases": []
+    },
+    {
+      "name": "component-dropdown-menu-item",
+      "path": "components/dropdown-menu-item",
+      "aliases": []
+    },
+    {
+      "name": "component-dropdown-menu-radio-group",
+      "path": "components/dropdown-menu-radio-group",
+      "aliases": []
+    },
+    {
+      "name": "component-dropdown-menu-radio-item",
+      "path": "components/dropdown-menu-radio-item",
+      "aliases": []
+    },
+    {
+      "name": "component-dropdown-menu-sub-menu",
+      "path": "components/dropdown-menu-sub-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-empty-state",
+      "path": "components/empty-state",
+      "aliases": []
+    },
+    {
+      "name": "component-field",
+      "path": "components/field",
+      "aliases": []
+    },
+    {
+      "name": "component-field-label",
+      "path": "components/field-label",
+      "aliases": []
+    },
+    {
+      "name": "component-field-status",
+      "path": "components/field-status",
+      "aliases": []
+    },
+    {
+      "name": "component-file-input",
+      "path": "components/file-input",
+      "aliases": []
+    },
+    {
+      "name": "component-form-layout",
+      "path": "components/form-layout",
+      "aliases": []
+    },
+    {
+      "name": "component-grid",
+      "path": "components/grid",
+      "aliases": []
+    },
+    {
+      "name": "component-grid-span",
+      "path": "components/grid-span",
+      "aliases": []
+    },
+    {
+      "name": "component-h-stack",
+      "path": "components/h-stack",
+      "aliases": []
+    },
+    {
+      "name": "component-heading",
+      "path": "components/heading",
+      "aliases": []
+    },
+    {
+      "name": "component-hover-card",
+      "path": "components/hover-card",
+      "aliases": []
+    },
+    {
+      "name": "component-icon",
+      "path": "components/icon",
+      "aliases": []
+    },
+    {
+      "name": "component-icon-button",
+      "path": "components/icon-button",
+      "aliases": []
+    },
+    {
+      "name": "component-input-group",
+      "path": "components/input-group",
+      "aliases": []
+    },
+    {
+      "name": "component-input-group-text",
+      "path": "components/input-group-text",
+      "aliases": []
+    },
+    {
+      "name": "component-internationalization-provider",
+      "path": "components/internationalization-provider",
+      "aliases": []
+    },
+    {
+      "name": "component-item",
+      "path": "components/item",
+      "aliases": []
+    },
+    {
+      "name": "component-kbd",
+      "path": "components/kbd",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-area",
+      "path": "components/lab/chart-area",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-bar",
+      "path": "components/lab/chart-bar",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-candlestick",
+      "path": "components/lab/chart-candlestick",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-dot",
+      "path": "components/lab/chart-dot",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-dot-gl",
+      "path": "components/lab/chart-dot-gl",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-dot-gl-interactive",
+      "path": "components/lab/chart-dot-gl-interactive",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-heatmap-gl",
+      "path": "components/lab/chart-heatmap-gl",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-line",
+      "path": "components/lab/chart-line",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chart-stream-gl",
+      "path": "components/lab/chart-stream-gl",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chat-emoji-picker",
+      "path": "components/lab/chat-emoji-picker",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chat-reaction-bar",
+      "path": "components/lab/chat-reaction-bar",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chat-reasoning",
+      "path": "components/lab/chat-reasoning",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chat-typing-indicator",
+      "path": "components/lab/chat-typing-indicator",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-chat-unread-divider",
+      "path": "components/lab/chat-unread-divider",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-circular-progress",
+      "path": "components/lab/circular-progress",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-code-editor",
+      "path": "components/lab/code-editor",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-drawer",
+      "path": "components/lab/drawer",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-info-tip",
+      "path": "components/lab/info-tip",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-list-input",
+      "path": "components/lab/list-input",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-log-stream",
+      "path": "components/lab/log-stream",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-radial-chart",
+      "path": "components/lab/radial-chart",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-sankey-chart",
+      "path": "components/lab/sankey-chart",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-schedule",
+      "path": "components/lab/schedule",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-stat",
+      "path": "components/lab/stat",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-svg-icon",
+      "path": "components/lab/svg-icon",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-three-d-bar",
+      "path": "components/lab/three-d-bar",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-three-d-chart",
+      "path": "components/lab/three-d-chart",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-three-d-scatter",
+      "path": "components/lab/three-d-scatter",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-three-d-scatter-gl",
+      "path": "components/lab/three-d-scatter-gl",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-three-d-surface",
+      "path": "components/lab/three-d-surface",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-tour",
+      "path": "components/lab/tour",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-tour-step",
+      "path": "components/lab/tour-step",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-transfer-list",
+      "path": "components/lab/transfer-list",
+      "aliases": []
+    },
+    {
+      "name": "component-lab-transfer-list-selector",
+      "path": "components/lab/transfer-list-selector",
+      "aliases": []
+    },
+    {
+      "name": "component-layer-provider",
+      "path": "components/layer-provider",
+      "aliases": []
+    },
+    {
+      "name": "component-layout",
+      "path": "components/layout",
+      "aliases": []
+    },
+    {
+      "name": "component-layout-content",
+      "path": "components/layout-content",
+      "aliases": []
+    },
+    {
+      "name": "component-layout-footer",
+      "path": "components/layout-footer",
+      "aliases": []
+    },
+    {
+      "name": "component-layout-header",
+      "path": "components/layout-header",
+      "aliases": []
+    },
+    {
+      "name": "component-layout-panel",
+      "path": "components/layout-panel",
+      "aliases": []
+    },
+    {
+      "name": "component-lightbox",
+      "path": "components/lightbox",
+      "aliases": []
+    },
+    {
+      "name": "component-link",
+      "path": "components/link",
+      "aliases": []
+    },
+    {
+      "name": "component-link-provider",
+      "path": "components/link-provider",
+      "aliases": []
+    },
+    {
+      "name": "component-list",
+      "path": "components/list",
+      "aliases": []
+    },
+    {
+      "name": "component-list-item",
+      "path": "components/list-item",
+      "aliases": []
+    },
+    {
+      "name": "component-markdown",
+      "path": "components/markdown",
+      "aliases": []
+    },
+    {
+      "name": "component-media-theme",
+      "path": "components/media-theme",
+      "aliases": []
+    },
+    {
+      "name": "component-metadata-list",
+      "path": "components/metadata-list",
+      "aliases": []
+    },
+    {
+      "name": "component-metadata-list-item",
+      "path": "components/metadata-list-item",
+      "aliases": []
+    },
+    {
+      "name": "component-mobile-nav",
+      "path": "components/mobile-nav",
+      "aliases": []
+    },
+    {
+      "name": "component-mobile-nav-toggle",
+      "path": "components/mobile-nav-toggle",
+      "aliases": []
+    },
+    {
+      "name": "component-more-menu",
+      "path": "components/more-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-multi-selector",
+      "path": "components/multi-selector",
+      "aliases": []
+    },
+    {
+      "name": "component-nav-heading-menu",
+      "path": "components/nav-heading-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-nav-icon",
+      "path": "components/nav-icon",
+      "aliases": []
+    },
+    {
+      "name": "component-number-input",
+      "path": "components/number-input",
+      "aliases": []
+    },
+    {
+      "name": "component-outline",
+      "path": "components/outline",
+      "aliases": []
+    },
+    {
+      "name": "component-overflow-list",
+      "path": "components/overflow-list",
+      "aliases": []
+    },
+    {
+      "name": "component-overlay",
+      "path": "components/overlay",
+      "aliases": []
+    },
+    {
+      "name": "component-pagination",
+      "path": "components/pagination",
+      "aliases": []
+    },
+    {
+      "name": "component-popover",
+      "path": "components/popover",
+      "aliases": []
+    },
+    {
+      "name": "component-power-search",
+      "path": "components/power-search",
+      "aliases": []
+    },
+    {
+      "name": "component-progress-bar",
+      "path": "components/progress-bar",
+      "aliases": []
+    },
+    {
+      "name": "component-radio-indicator",
+      "path": "components/radio-indicator",
+      "aliases": []
+    },
+    {
+      "name": "component-radio-list",
+      "path": "components/radio-list",
+      "aliases": []
+    },
+    {
+      "name": "component-radio-list-item",
+      "path": "components/radio-list-item",
+      "aliases": []
+    },
+    {
+      "name": "component-resize-handle",
+      "path": "components/resize-handle",
+      "aliases": []
+    },
+    {
+      "name": "component-richtext-rich-text-editor",
+      "path": "components/richtext/rich-text-editor",
+      "aliases": []
+    },
+    {
+      "name": "component-section",
+      "path": "components/section",
+      "aliases": []
+    },
+    {
+      "name": "component-segmented-control",
+      "path": "components/segmented-control",
+      "aliases": []
+    },
+    {
+      "name": "component-segmented-control-item",
+      "path": "components/segmented-control-item",
+      "aliases": []
+    },
+    {
+      "name": "component-selectable-card",
+      "path": "components/selectable-card",
+      "aliases": []
+    },
+    {
+      "name": "component-selector",
+      "path": "components/selector",
+      "aliases": []
+    },
+    {
+      "name": "component-selector-option",
+      "path": "components/selector-option",
+      "aliases": []
+    },
+    {
+      "name": "component-side-nav",
+      "path": "components/side-nav",
+      "aliases": []
+    },
+    {
+      "name": "component-side-nav-collapse-button",
+      "path": "components/side-nav-collapse-button",
+      "aliases": []
+    },
+    {
+      "name": "component-side-nav-heading",
+      "path": "components/side-nav-heading",
+      "aliases": []
+    },
+    {
+      "name": "component-side-nav-item",
+      "path": "components/side-nav-item",
+      "aliases": []
+    },
+    {
+      "name": "component-side-nav-section",
+      "path": "components/side-nav-section",
+      "aliases": []
+    },
+    {
+      "name": "component-skeleton",
+      "path": "components/skeleton",
+      "aliases": []
+    },
+    {
+      "name": "component-slider",
+      "path": "components/slider",
+      "aliases": []
+    },
+    {
+      "name": "component-spinner",
+      "path": "components/spinner",
+      "aliases": []
+    },
+    {
+      "name": "component-stack",
+      "path": "components/stack",
+      "aliases": []
+    },
+    {
+      "name": "component-stack-item",
+      "path": "components/stack-item",
+      "aliases": []
+    },
+    {
+      "name": "component-status-dot",
+      "path": "components/status-dot",
+      "aliases": []
+    },
+    {
+      "name": "component-step",
+      "path": "components/step",
+      "aliases": []
+    },
+    {
+      "name": "component-stepper",
+      "path": "components/stepper",
+      "aliases": []
+    },
+    {
+      "name": "component-switch",
+      "path": "components/switch",
+      "aliases": []
+    },
+    {
+      "name": "component-syntax-theme",
+      "path": "components/syntax-theme",
+      "aliases": []
+    },
+    {
+      "name": "component-tab",
+      "path": "components/tab",
+      "aliases": []
+    },
+    {
+      "name": "component-tab-list",
+      "path": "components/tab-list",
+      "aliases": []
+    },
+    {
+      "name": "component-tab-menu",
+      "path": "components/tab-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-table",
+      "path": "components/table",
+      "aliases": []
+    },
+    {
+      "name": "component-table-body",
+      "path": "components/table-body",
+      "aliases": []
+    },
+    {
+      "name": "component-table-cell",
+      "path": "components/table-cell",
+      "aliases": []
+    },
+    {
+      "name": "component-table-footer",
+      "path": "components/table-footer",
+      "aliases": []
+    },
+    {
+      "name": "component-table-header",
+      "path": "components/table-header",
+      "aliases": []
+    },
+    {
+      "name": "component-table-header-cell",
+      "path": "components/table-header-cell",
+      "aliases": []
+    },
+    {
+      "name": "component-table-row",
+      "path": "components/table-row",
+      "aliases": []
+    },
+    {
+      "name": "component-text",
+      "path": "components/text",
+      "aliases": []
+    },
+    {
+      "name": "component-text-area",
+      "path": "components/text-area",
+      "aliases": []
+    },
+    {
+      "name": "component-text-input",
+      "path": "components/text-input",
+      "aliases": []
+    },
+    {
+      "name": "component-theme",
+      "path": "components/theme",
+      "aliases": []
+    },
+    {
+      "name": "component-thumbnail",
+      "path": "components/thumbnail",
+      "aliases": []
+    },
+    {
+      "name": "component-time-input",
+      "path": "components/time-input",
+      "aliases": []
+    },
+    {
+      "name": "component-timestamp",
+      "path": "components/timestamp",
+      "aliases": []
+    },
+    {
+      "name": "component-toast",
+      "path": "components/toast",
+      "aliases": []
+    },
+    {
+      "name": "component-toggle-button",
+      "path": "components/toggle-button",
+      "aliases": []
+    },
+    {
+      "name": "component-toggle-button-group",
+      "path": "components/toggle-button-group",
+      "aliases": []
+    },
+    {
+      "name": "component-token",
+      "path": "components/token",
+      "aliases": []
+    },
+    {
+      "name": "component-tokenizer",
+      "path": "components/tokenizer",
+      "aliases": []
+    },
+    {
+      "name": "component-toolbar",
+      "path": "components/toolbar",
+      "aliases": []
+    },
+    {
+      "name": "component-tooltip",
+      "path": "components/tooltip",
+      "aliases": []
+    },
+    {
+      "name": "component-top-nav",
+      "path": "components/top-nav",
+      "aliases": []
+    },
+    {
+      "name": "component-top-nav-heading",
+      "path": "components/top-nav-heading",
+      "aliases": []
+    },
+    {
+      "name": "component-top-nav-item",
+      "path": "components/top-nav-item",
+      "aliases": []
+    },
+    {
+      "name": "component-top-nav-mega-menu",
+      "path": "components/top-nav-mega-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-top-nav-mega-menu-featured-card",
+      "path": "components/top-nav-mega-menu-featured-card",
+      "aliases": []
+    },
+    {
+      "name": "component-top-nav-mega-menu-item",
+      "path": "components/top-nav-mega-menu-item",
+      "aliases": []
+    },
+    {
+      "name": "component-top-nav-menu",
+      "path": "components/top-nav-menu",
+      "aliases": []
+    },
+    {
+      "name": "component-tree-list",
+      "path": "components/tree-list",
+      "aliases": []
+    },
+    {
+      "name": "component-typeahead",
+      "path": "components/typeahead",
+      "aliases": []
+    },
+    {
+      "name": "component-typeahead-item",
+      "path": "components/typeahead-item",
+      "aliases": []
+    },
+    {
+      "name": "component-v-stack",
+      "path": "components/v-stack",
+      "aliases": []
+    },
+    {
+      "name": "component-vega-vega-chart",
+      "path": "components/vega/vega-chart",
+      "aliases": []
+    },
+    {
+      "name": "component-visually-hidden",
+      "path": "components/visually-hidden",
+      "aliases": []
+    },
+    {
+      "name": "example-alert-dialog-loading",
+      "path": "examples/alert-dialog/loading",
+      "aliases": []
+    },
+    {
+      "name": "example-app-shell-content-only",
+      "path": "examples/app-shell/content-only",
+      "aliases": []
+    },
+    {
+      "name": "example-app-shell-side-nav-only",
+      "path": "examples/app-shell/side-nav-only",
+      "aliases": []
+    },
+    {
+      "name": "example-app-shell-top-nav-only",
+      "path": "examples/app-shell/top-nav-only",
+      "aliases": []
+    },
+    {
+      "name": "example-app-shell-top-nav-with-side-nav",
+      "path": "examples/app-shell/top-nav-with-side-nav",
+      "aliases": []
+    },
+    {
+      "name": "example-app-shell-with-banner",
+      "path": "examples/app-shell/with-banner",
+      "aliases": []
+    },
+    {
+      "name": "example-aspect-ratio-16-9-widescreen-image",
+      "path": "examples/aspect-ratio/16-9-widescreen-image",
+      "aliases": []
+    },
+    {
+      "name": "example-aspect-ratio-circle-image",
+      "path": "examples/aspect-ratio/circle-image",
+      "aliases": []
+    },
+    {
+      "name": "example-aspect-ratio-image-gallery",
+      "path": "examples/aspect-ratio/image-gallery",
+      "aliases": []
+    },
+    {
+      "name": "example-aspect-ratio-loading-skeleton",
+      "path": "examples/aspect-ratio/loading-skeleton",
+      "aliases": []
+    },
+    {
+      "name": "example-aspect-ratio-square-image",
+      "path": "examples/aspect-ratio/square-image",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-group-overflow-custom-text",
+      "path": "examples/avatar-group-overflow/custom-text",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-group-overflow-default-count",
+      "path": "examples/avatar-group-overflow/default-count",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-group-default",
+      "path": "examples/avatar-group/default",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-group-interactive",
+      "path": "examples/avatar-group/interactive",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-status-dot-variants",
+      "path": "examples/avatar-status-dot/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-fallback-chain",
+      "path": "examples/avatar/fallback-chain",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-initials",
+      "path": "examples/avatar/initials",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-interactive",
+      "path": "examples/avatar/interactive",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-photo",
+      "path": "examples/avatar/photo",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-status-dot",
+      "path": "examples/avatar/status-dot",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-tooltip",
+      "path": "examples/avatar/tooltip",
+      "aliases": []
+    },
+    {
+      "name": "example-avatar-user-card",
+      "path": "examples/avatar/user-card",
+      "aliases": []
+    },
+    {
+      "name": "example-badge-colors",
+      "path": "examples/badge/colors",
+      "aliases": []
+    },
+    {
+      "name": "example-badge-counts",
+      "path": "examples/badge/counts",
+      "aliases": []
+    },
+    {
+      "name": "example-badge-status",
+      "path": "examples/badge/status",
+      "aliases": []
+    },
+    {
+      "name": "example-banner-action",
+      "path": "examples/banner/action",
+      "aliases": []
+    },
+    {
+      "name": "example-banner-collapsible",
+      "path": "examples/banner/collapsible",
+      "aliases": []
+    },
+    {
+      "name": "example-banner-dismiss",
+      "path": "examples/banner/dismiss",
+      "aliases": []
+    },
+    {
+      "name": "example-banner-floating",
+      "path": "examples/banner/floating",
+      "aliases": []
+    },
+    {
+      "name": "example-banner-full-width",
+      "path": "examples/banner/full-width",
+      "aliases": []
+    },
+    {
+      "name": "example-banner-statuses",
+      "path": "examples/banner/statuses",
+      "aliases": []
+    },
+    {
+      "name": "example-base-typeahead-custom-search-bar",
+      "path": "examples/base-typeahead/custom-search-bar",
+      "aliases": []
+    },
+    {
+      "name": "example-blockquote-testimonials",
+      "path": "examples/blockquote/testimonials",
+      "aliases": []
+    },
+    {
+      "name": "example-blockquote-with-attribution",
+      "path": "examples/blockquote/with-attribution",
+      "aliases": []
+    },
+    {
+      "name": "example-bottom-sheet-height-variants",
+      "path": "examples/bottom-sheet/height-variants",
+      "aliases": []
+    },
+    {
+      "name": "example-bottom-sheet-mobile-keyboard",
+      "path": "examples/bottom-sheet/mobile-keyboard",
+      "aliases": []
+    },
+    {
+      "name": "example-bottom-sheet-no-scrim",
+      "path": "examples/bottom-sheet/no-scrim",
+      "aliases": []
+    },
+    {
+      "name": "example-bottom-sheet-snap-points",
+      "path": "examples/bottom-sheet/snap-points",
+      "aliases": []
+    },
+    {
+      "name": "example-breadcrumb-item-basic",
+      "path": "examples/breadcrumb-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-breadcrumbs-deep-path",
+      "path": "examples/breadcrumbs/deep-path",
+      "aliases": []
+    },
+    {
+      "name": "example-breadcrumbs-icons",
+      "path": "examples/breadcrumbs/icons",
+      "aliases": []
+    },
+    {
+      "name": "example-breadcrumbs-menu-item",
+      "path": "examples/breadcrumbs/menu-item",
+      "aliases": []
+    },
+    {
+      "name": "example-breadcrumbs-separators",
+      "path": "examples/breadcrumbs/separators",
+      "aliases": []
+    },
+    {
+      "name": "example-breadcrumbs-variants",
+      "path": "examples/breadcrumbs/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-button-group-basic",
+      "path": "examples/button-group/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-button-group-floating",
+      "path": "examples/button-group/floating",
+      "aliases": []
+    },
+    {
+      "name": "example-button-end-slot",
+      "path": "examples/button/end-slot",
+      "aliases": []
+    },
+    {
+      "name": "example-button-floating",
+      "path": "examples/button/floating",
+      "aliases": []
+    },
+    {
+      "name": "example-button-icon",
+      "path": "examples/button/icon",
+      "aliases": []
+    },
+    {
+      "name": "example-button-sizes",
+      "path": "examples/button/sizes",
+      "aliases": []
+    },
+    {
+      "name": "example-button-variants",
+      "path": "examples/button/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-calendar-constraints",
+      "path": "examples/calendar/constraints",
+      "aliases": []
+    },
+    {
+      "name": "example-calendar-range",
+      "path": "examples/calendar/range",
+      "aliases": []
+    },
+    {
+      "name": "example-calendar-single",
+      "path": "examples/calendar/single",
+      "aliases": []
+    },
+    {
+      "name": "example-calendar-two-months",
+      "path": "examples/calendar/two-months",
+      "aliases": []
+    },
+    {
+      "name": "example-card-callout",
+      "path": "examples/card/callout",
+      "aliases": []
+    },
+    {
+      "name": "example-card-elevations",
+      "path": "examples/card/elevations",
+      "aliases": []
+    },
+    {
+      "name": "example-card-layout",
+      "path": "examples/card/layout",
+      "aliases": []
+    },
+    {
+      "name": "example-card-simple",
+      "path": "examples/card/simple",
+      "aliases": []
+    },
+    {
+      "name": "example-card-variants",
+      "path": "examples/card/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-carousel-cards",
+      "path": "examples/carousel/cards",
+      "aliases": []
+    },
+    {
+      "name": "example-carousel-snap",
+      "path": "examples/carousel/snap",
+      "aliases": []
+    },
+    {
+      "name": "example-center-horizontal-center",
+      "path": "examples/center/horizontal-center",
+      "aliases": []
+    },
+    {
+      "name": "example-center-vertical-horizontal-center",
+      "path": "examples/center/vertical-horizontal-center",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-drawer-attachments",
+      "path": "examples/chat-composer-drawer/attachments",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-drawer-collapsible",
+      "path": "examples/chat-composer-drawer/collapsible",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-drawer-feedback",
+      "path": "examples/chat-composer-drawer/feedback",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-drawer-with-progress",
+      "path": "examples/chat-composer-drawer/with-progress",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-input-controlled",
+      "path": "examples/chat-composer-input/controlled",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-input-disabled",
+      "path": "examples/chat-composer-input/disabled",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-input-mentions",
+      "path": "examples/chat-composer-input/mentions",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-input-multiple-triggers",
+      "path": "examples/chat-composer-input/multiple-triggers",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-input-slash-commands",
+      "path": "examples/chat-composer-input/slash-commands",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-attachments",
+      "path": "examples/chat-composer/attachments",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-flat",
+      "path": "examples/chat-composer/flat",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-footer-actions",
+      "path": "examples/chat-composer/footer-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-full-featured",
+      "path": "examples/chat-composer/full-featured",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-simple",
+      "path": "examples/chat-composer/simple",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-streaming",
+      "path": "examples/chat-composer/streaming",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-composer-validation",
+      "path": "examples/chat-composer/validation",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-dictation-button-basic",
+      "path": "examples/chat-dictation-button/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-dictation-button-in-composer",
+      "path": "examples/chat-dictation/button-in-composer",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-dictation-button-sizes",
+      "path": "examples/chat-dictation/button-sizes",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-dictation-button-states",
+      "path": "examples/chat-dictation/button-states",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-layout-scroll-button-labels",
+      "path": "examples/chat-layout-scroll-button/labels",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-layout-panel-view",
+      "path": "examples/chat-layout/panel-view",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-bubble-custom-content",
+      "path": "examples/chat-message-bubble/custom-content",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-bubble-density",
+      "path": "examples/chat-message-bubble/density",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-bubble-grouping",
+      "path": "examples/chat-message-bubble/grouping",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-bubble-metadata",
+      "path": "examples/chat-message-bubble/metadata",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-bubble-variants",
+      "path": "examples/chat-message-bubble/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-list-density",
+      "path": "examples/chat-message-list/density",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-list-full-featured",
+      "path": "examples/chat-message-list/full-featured",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-metadata-footer-actions",
+      "path": "examples/chat-message-metadata/footer-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-metadata-status",
+      "path": "examples/chat-message-metadata/status",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-metadata-timestamps",
+      "path": "examples/chat-message-metadata/timestamps",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-avatar-name",
+      "path": "examples/chat-message/avatar-name",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-ghost",
+      "path": "examples/chat-message/ghost",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-message-multi-bubble",
+      "path": "examples/chat-message/multi-bubble",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-send-button-custom-icon",
+      "path": "examples/chat-send-button/custom-icon",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-send-button-in-composer",
+      "path": "examples/chat-send-button/in-composer",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-send-button-states",
+      "path": "examples/chat-send-button/states",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-system-message-icon",
+      "path": "examples/chat-system-message/icon",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-system-message-status-updates",
+      "path": "examples/chat-system-message/status-updates",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-system-message-variants",
+      "path": "examples/chat-system-message/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-tokenized-text-basic",
+      "path": "examples/chat-tokenized-text/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-tokenized-text-colors",
+      "path": "examples/chat-tokenized-text/colors",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-tool-calls-expandable",
+      "path": "examples/chat-tool-calls/expandable",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-tool-calls-simple",
+      "path": "examples/chat-tool-calls/simple",
+      "aliases": []
+    },
+    {
+      "name": "example-chat-tool-calls-statuses",
+      "path": "examples/chat-tool-calls/statuses",
+      "aliases": []
+    },
+    {
+      "name": "example-checkbox-input-indeterminate",
+      "path": "examples/checkbox-input/indeterminate",
+      "aliases": []
+    },
+    {
+      "name": "example-checkbox-input-states",
+      "path": "examples/checkbox-input/states",
+      "aliases": []
+    },
+    {
+      "name": "example-checkbox-input-status",
+      "path": "examples/checkbox-input/status",
+      "aliases": []
+    },
+    {
+      "name": "example-checkbox-list-item-basic",
+      "path": "examples/checkbox-list-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-checkbox-list-select-all-with-indeterminate",
+      "path": "examples/checkbox-list/select-all-with-indeterminate",
+      "aliases": []
+    },
+    {
+      "name": "example-checkbox-list-with-end-content",
+      "path": "examples/checkbox-list/with-end-content",
+      "aliases": []
+    },
+    {
+      "name": "example-citation-inline-text",
+      "path": "examples/citation/inline-text",
+      "aliases": []
+    },
+    {
+      "name": "example-citation-source-list",
+      "path": "examples/citation/source-list",
+      "aliases": []
+    },
+    {
+      "name": "example-clickable-card-elevated",
+      "path": "examples/clickable-card/elevated",
+      "aliases": []
+    },
+    {
+      "name": "example-clickable-card-with-nested-button",
+      "path": "examples/clickable-card/with-nested-button",
+      "aliases": []
+    },
+    {
+      "name": "example-code-block-code-config",
+      "path": "examples/code-block/code-config",
+      "aliases": []
+    },
+    {
+      "name": "example-code-block-code-highlighted",
+      "path": "examples/code-block/code-highlighted",
+      "aliases": []
+    },
+    {
+      "name": "example-code-block-code-scrollable",
+      "path": "examples/code-block/code-scrollable",
+      "aliases": []
+    },
+    {
+      "name": "example-code-block-code-snippet",
+      "path": "examples/code-block/code-snippet",
+      "aliases": []
+    },
+    {
+      "name": "example-code-block-code-terminal",
+      "path": "examples/code-block/code-terminal",
+      "aliases": []
+    },
+    {
+      "name": "example-code-content-types",
+      "path": "examples/code/content-types",
+      "aliases": []
+    },
+    {
+      "name": "example-code-inline",
+      "path": "examples/code/inline",
+      "aliases": []
+    },
+    {
+      "name": "example-code-text-sizes",
+      "path": "examples/code/text-sizes",
+      "aliases": []
+    },
+    {
+      "name": "example-collapsible-group-density",
+      "path": "examples/collapsible-group/density",
+      "aliases": [
+        "examples/collapsible-group/accordion"
+      ]
+    },
+    {
+      "name": "example-collapsible-controlled",
+      "path": "examples/collapsible/controlled",
+      "aliases": []
+    },
+    {
+      "name": "example-collapsible-faq",
+      "path": "examples/collapsible/faq",
+      "aliases": [
+        "examples/collapsible/divided-accordion"
+      ]
+    },
+    {
+      "name": "example-collapsible-multiple-mode",
+      "path": "examples/collapsible/multiple-mode",
+      "aliases": []
+    },
+    {
+      "name": "example-collapsible-single-mode",
+      "path": "examples/collapsible/single-mode",
+      "aliases": []
+    },
+    {
+      "name": "example-collapsible-with-dividers",
+      "path": "examples/collapsible/with-dividers",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-empty-basic",
+      "path": "examples/command-palette-empty/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-footer-basic",
+      "path": "examples/command-palette-footer/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-group-basic",
+      "path": "examples/command-palette-group/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-input-with-end-content",
+      "path": "examples/command-palette-input/with-end-content",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-item-basic",
+      "path": "examples/command-palette-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-list-item-states",
+      "path": "examples/command-palette-list/item-states",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-async-search",
+      "path": "examples/command-palette/async-search",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-custom-footer",
+      "path": "examples/command-palette/custom-footer",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-grouped",
+      "path": "examples/command-palette/grouped",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-picker-mode",
+      "path": "examples/command-palette/picker-mode",
+      "aliases": []
+    },
+    {
+      "name": "example-command-palette-rich-items",
+      "path": "examples/command-palette/rich-items",
+      "aliases": []
+    },
+    {
+      "name": "example-complex-selector-deadline-picker",
+      "path": "examples/complex-selector/deadline-picker",
+      "aliases": []
+    },
+    {
+      "name": "example-complex-selector-tree-search",
+      "path": "examples/complex-selector/tree-search",
+      "aliases": []
+    },
+    {
+      "name": "example-context-menu-item-basic",
+      "path": "examples/context-menu-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-context-menu-basic",
+      "path": "examples/context-menu/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-context-menu-bottom-sheet",
+      "path": "examples/context-menu/bottom-sheet",
+      "aliases": []
+    },
+    {
+      "name": "example-date-input-clearable",
+      "path": "examples/date-input/clearable",
+      "aliases": []
+    },
+    {
+      "name": "example-date-input-description",
+      "path": "examples/date-input/description",
+      "aliases": []
+    },
+    {
+      "name": "example-date-input-formats",
+      "path": "examples/date-input/formats",
+      "aliases": []
+    },
+    {
+      "name": "example-date-input-min-max-constraints",
+      "path": "examples/date-input/min-max-constraints",
+      "aliases": []
+    },
+    {
+      "name": "example-date-input-validation",
+      "path": "examples/date-input/validation",
+      "aliases": []
+    },
+    {
+      "name": "example-date-range-input-validation",
+      "path": "examples/date-range-input/validation",
+      "aliases": []
+    },
+    {
+      "name": "example-date-range-input-with-presets",
+      "path": "examples/date-range-input/with-presets",
+      "aliases": []
+    },
+    {
+      "name": "example-date-time-input-validation",
+      "path": "examples/date-time-input/validation",
+      "aliases": []
+    },
+    {
+      "name": "example-dialog-header-basic",
+      "path": "examples/dialog-header/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-dialog-adaptive-presentation",
+      "path": "examples/dialog/adaptive-presentation",
+      "aliases": []
+    },
+    {
+      "name": "example-dialog-confirmation",
+      "path": "examples/dialog/confirmation",
+      "aliases": []
+    },
+    {
+      "name": "example-dialog-form",
+      "path": "examples/dialog/form",
+      "aliases": []
+    },
+    {
+      "name": "example-dialog-fullscreen",
+      "path": "examples/dialog/fullscreen",
+      "aliases": []
+    },
+    {
+      "name": "example-dialog-required",
+      "path": "examples/dialog/required",
+      "aliases": []
+    },
+    {
+      "name": "example-dialog-scrollable",
+      "path": "examples/dialog/scrollable",
+      "aliases": []
+    },
+    {
+      "name": "example-divider-full-bleed",
+      "path": "examples/divider/full-bleed",
+      "aliases": []
+    },
+    {
+      "name": "example-divider-variants",
+      "path": "examples/divider/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-divider-vertical",
+      "path": "examples/divider/vertical",
+      "aliases": []
+    },
+    {
+      "name": "example-dropdown-menu-item-basic",
+      "path": "examples/dropdown-menu-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-dropdown-menu-actions",
+      "path": "examples/dropdown-menu/actions",
+      "aliases": []
+    },
+    {
+      "name": "example-dropdown-menu-adaptive-presentation",
+      "path": "examples/dropdown-menu/adaptive-presentation",
+      "aliases": []
+    },
+    {
+      "name": "example-dropdown-menu-disabled",
+      "path": "examples/dropdown-menu/disabled",
+      "aliases": []
+    },
+    {
+      "name": "example-dropdown-menu-icon-trigger",
+      "path": "examples/dropdown-menu/icon-trigger",
+      "aliases": []
+    },
+    {
+      "name": "example-dropdown-menu-sections",
+      "path": "examples/dropdown-menu/sections",
+      "aliases": []
+    },
+    {
+      "name": "example-dropdown-menu-submenu",
+      "path": "examples/dropdown-menu/submenu",
+      "aliases": []
+    },
+    {
+      "name": "example-empty-state-actions",
+      "path": "examples/empty-state/actions",
+      "aliases": []
+    },
+    {
+      "name": "example-empty-state-compact",
+      "path": "examples/empty-state/compact",
+      "aliases": []
+    },
+    {
+      "name": "example-empty-state-container",
+      "path": "examples/empty-state/container",
+      "aliases": []
+    },
+    {
+      "name": "example-field-label-basic",
+      "path": "examples/field-label/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-field-status-basic",
+      "path": "examples/field-status/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-field-description",
+      "path": "examples/field/description",
+      "aliases": []
+    },
+    {
+      "name": "example-field-required-optional",
+      "path": "examples/field/required-optional",
+      "aliases": []
+    },
+    {
+      "name": "example-field-validation-states",
+      "path": "examples/field/validation-states",
+      "aliases": []
+    },
+    {
+      "name": "example-file-input-basic",
+      "path": "examples/file-input/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-form-layout-horizontal",
+      "path": "examples/form-layout/horizontal",
+      "aliases": []
+    },
+    {
+      "name": "example-form-layout-mixed-controls",
+      "path": "examples/form-layout/mixed-controls",
+      "aliases": []
+    },
+    {
+      "name": "example-form-layout-nested-address-form",
+      "path": "examples/form-layout/nested-address-form",
+      "aliases": []
+    },
+    {
+      "name": "example-form-layout-settings-form",
+      "path": "examples/form-layout/settings-form",
+      "aliases": []
+    },
+    {
+      "name": "example-grid-span-columns",
+      "path": "examples/grid-span/columns",
+      "aliases": []
+    },
+    {
+      "name": "example-grid-card-gallery",
+      "path": "examples/grid/card-gallery",
+      "aliases": []
+    },
+    {
+      "name": "example-grid-column-spanning",
+      "path": "examples/grid/column-spanning",
+      "aliases": []
+    },
+    {
+      "name": "example-grid-dashboard-layout",
+      "path": "examples/grid/dashboard-layout",
+      "aliases": []
+    },
+    {
+      "name": "example-grid-responsive-auto-fit",
+      "path": "examples/grid/responsive-auto-fit",
+      "aliases": []
+    },
+    {
+      "name": "example-h-stack-basic",
+      "path": "examples/h-stack/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-heading-card-grid",
+      "path": "examples/heading/card-grid",
+      "aliases": []
+    },
+    {
+      "name": "example-heading-page-hierarchy",
+      "path": "examples/heading/page-hierarchy",
+      "aliases": []
+    },
+    {
+      "name": "example-heading-truncation",
+      "path": "examples/heading/truncation",
+      "aliases": []
+    },
+    {
+      "name": "example-hover-card-definition",
+      "path": "examples/hover-card/definition",
+      "aliases": []
+    },
+    {
+      "name": "example-hover-card-link-preview",
+      "path": "examples/hover-card/link-preview",
+      "aliases": []
+    },
+    {
+      "name": "example-hover-card-profile-preview",
+      "path": "examples/hover-card/profile-preview",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-button-action-bar",
+      "path": "examples/icon-button/action-bar",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-button-floating",
+      "path": "examples/icon-button/floating",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-button-loading-state",
+      "path": "examples/icon-button/loading-state",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-button-with-tooltips",
+      "path": "examples/icon-button/with-tooltips",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-non-semantic-colors",
+      "path": "examples/icon/non-semantic-colors",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-semantic-colors",
+      "path": "examples/icon/semantic-colors",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-size-variants",
+      "path": "examples/icon/size-variants",
+      "aliases": []
+    },
+    {
+      "name": "example-icon-status-indicators",
+      "path": "examples/icon/status-indicators",
+      "aliases": []
+    },
+    {
+      "name": "example-input-group-basic",
+      "path": "examples/input-group/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-internationalization-provider-overrides",
+      "path": "examples/internationalization-provider/overrides",
+      "aliases": []
+    },
+    {
+      "name": "example-internationalization-provider-rtl-direction",
+      "path": "examples/internationalization-provider/rtl-direction",
+      "aliases": []
+    },
+    {
+      "name": "example-internationalization-provider-shipped-locale",
+      "path": "examples/internationalization-provider/shipped-locale",
+      "aliases": []
+    },
+    {
+      "name": "example-item-basic",
+      "path": "examples/item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-item-metadata",
+      "path": "examples/item/metadata",
+      "aliases": []
+    },
+    {
+      "name": "example-item-start-content",
+      "path": "examples/item/start-content",
+      "aliases": []
+    },
+    {
+      "name": "example-kbd-inline-instructions",
+      "path": "examples/kbd/inline-instructions",
+      "aliases": []
+    },
+    {
+      "name": "example-kbd-menu-shortcuts",
+      "path": "examples/kbd/menu-shortcuts",
+      "aliases": []
+    },
+    {
+      "name": "example-kbd-modifier-combinations",
+      "path": "examples/kbd/modifier-combinations",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-content-basic",
+      "path": "examples/layout-content/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-footer-actions",
+      "path": "examples/layout-footer/actions",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-header-with-actions",
+      "path": "examples/layout-header/with-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-panel-navigation",
+      "path": "examples/layout-panel/navigation",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-basic-card",
+      "path": "examples/layout/basic-card",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-content-only",
+      "path": "examples/layout/content-only",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-content-width",
+      "path": "examples/layout/content-width",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-dual-panel",
+      "path": "examples/layout/dual-panel",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-full-bleed-content",
+      "path": "examples/layout/full-bleed-content",
+      "aliases": []
+    },
+    {
+      "name": "example-layout-sidebar-navigation",
+      "path": "examples/layout/sidebar-navigation",
+      "aliases": []
+    },
+    {
+      "name": "example-lightbox-gallery",
+      "path": "examples/lightbox/gallery",
+      "aliases": []
+    },
+    {
+      "name": "example-lightbox-video",
+      "path": "examples/lightbox/video",
+      "aliases": []
+    },
+    {
+      "name": "example-lightbox-zoom",
+      "path": "examples/lightbox/zoom",
+      "aliases": []
+    },
+    {
+      "name": "example-link-provider-custom-link-component",
+      "path": "examples/link-provider/custom-link-component",
+      "aliases": []
+    },
+    {
+      "name": "example-link-external-links",
+      "path": "examples/link/external-links",
+      "aliases": []
+    },
+    {
+      "name": "example-link-inline-text",
+      "path": "examples/link/inline-text",
+      "aliases": []
+    },
+    {
+      "name": "example-link-with-tooltips",
+      "path": "examples/link/with-tooltips",
+      "aliases": []
+    },
+    {
+      "name": "example-list-item-basic",
+      "path": "examples/list-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-list-item-media",
+      "path": "examples/list-item/media",
+      "aliases": []
+    },
+    {
+      "name": "example-list-item-metadata",
+      "path": "examples/list-item/metadata",
+      "aliases": []
+    },
+    {
+      "name": "example-list-basic",
+      "path": "examples/list/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-list-bulleted-features",
+      "path": "examples/list/bulleted-features",
+      "aliases": []
+    },
+    {
+      "name": "example-list-message-list",
+      "path": "examples/list/message-list",
+      "aliases": []
+    },
+    {
+      "name": "example-list-ordered-steps",
+      "path": "examples/list/ordered-steps",
+      "aliases": []
+    },
+    {
+      "name": "example-markdown-cited-content",
+      "path": "examples/markdown/cited-content",
+      "aliases": []
+    },
+    {
+      "name": "example-markdown-compact-ai-response",
+      "path": "examples/markdown/compact-ai-response",
+      "aliases": []
+    },
+    {
+      "name": "example-markdown-data-table",
+      "path": "examples/markdown/data-table",
+      "aliases": []
+    },
+    {
+      "name": "example-markdown-rich-content",
+      "path": "examples/markdown/rich-content",
+      "aliases": []
+    },
+    {
+      "name": "example-media-theme-image-overlay",
+      "path": "examples/media-theme/image-overlay",
+      "aliases": []
+    },
+    {
+      "name": "example-media-theme-light-scrim",
+      "path": "examples/media-theme/light-scrim",
+      "aliases": []
+    },
+    {
+      "name": "example-metadata-list-item-basic",
+      "path": "examples/metadata-list-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-metadata-list-basic",
+      "path": "examples/metadata-list/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-metadata-list-collapsible",
+      "path": "examples/metadata-list/collapsible",
+      "aliases": []
+    },
+    {
+      "name": "example-metadata-list-horizontal",
+      "path": "examples/metadata-list/horizontal",
+      "aliases": []
+    },
+    {
+      "name": "example-metadata-list-multi-column",
+      "path": "examples/metadata-list/multi-column",
+      "aliases": []
+    },
+    {
+      "name": "example-mobile-nav-toggle-basic",
+      "path": "examples/mobile-nav-toggle/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-mobile-nav-basic-drawer",
+      "path": "examples/mobile-nav/basic-drawer",
+      "aliases": []
+    },
+    {
+      "name": "example-mobile-nav-end-side-drawer",
+      "path": "examples/mobile-nav/end-side-drawer",
+      "aliases": []
+    },
+    {
+      "name": "example-mobile-nav-without-title",
+      "path": "examples/mobile-nav/without-title",
+      "aliases": []
+    },
+    {
+      "name": "example-more-menu-bottom-sheet",
+      "path": "examples/more-menu/bottom-sheet",
+      "aliases": []
+    },
+    {
+      "name": "example-more-menu-default",
+      "path": "examples/more-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "example-more-menu-with-dividers",
+      "path": "examples/more-menu/with-dividers",
+      "aliases": []
+    },
+    {
+      "name": "example-more-menu-with-sections",
+      "path": "examples/more-menu/with-sections",
+      "aliases": []
+    },
+    {
+      "name": "example-multi-selector-bottom-sheet",
+      "path": "examples/multi-selector/bottom-sheet",
+      "aliases": []
+    },
+    {
+      "name": "example-multi-selector-column-visibility",
+      "path": "examples/multi-selector/column-visibility",
+      "aliases": []
+    },
+    {
+      "name": "example-multi-selector-form-composition",
+      "path": "examples/multi-selector/form-composition",
+      "aliases": []
+    },
+    {
+      "name": "example-multi-selector-ghost-toolbar",
+      "path": "examples/multi-selector/ghost-toolbar",
+      "aliases": []
+    },
+    {
+      "name": "example-multi-selector-searchable",
+      "path": "examples/multi-selector/searchable",
+      "aliases": []
+    },
+    {
+      "name": "example-multi-selector-sectioned-permissions",
+      "path": "examples/multi-selector/sectioned-permissions",
+      "aliases": []
+    },
+    {
+      "name": "example-nav-icon-basic",
+      "path": "examples/nav-icon/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-number-input-clearable",
+      "path": "examples/number-input/clearable",
+      "aliases": []
+    },
+    {
+      "name": "example-number-input-range-constrained",
+      "path": "examples/number-input/range-constrained",
+      "aliases": []
+    },
+    {
+      "name": "example-number-input-status-variants",
+      "path": "examples/number-input/status-variants",
+      "aliases": []
+    },
+    {
+      "name": "example-number-input-with-units",
+      "path": "examples/number-input/with-units",
+      "aliases": []
+    },
+    {
+      "name": "example-outline-controlled",
+      "path": "examples/outline/controlled",
+      "aliases": []
+    },
+    {
+      "name": "example-outline-deep-nesting",
+      "path": "examples/outline/deep-nesting",
+      "aliases": []
+    },
+    {
+      "name": "example-outline-density",
+      "path": "examples/outline/density",
+      "aliases": []
+    },
+    {
+      "name": "example-overflow-list-badge-tags",
+      "path": "examples/overflow-list/badge-tags",
+      "aliases": []
+    },
+    {
+      "name": "example-overflow-list-capped-toolbar",
+      "path": "examples/overflow-list/capped-toolbar",
+      "aliases": []
+    },
+    {
+      "name": "example-overflow-list-collapse-from-start",
+      "path": "examples/overflow-list/collapse-from-start",
+      "aliases": []
+    },
+    {
+      "name": "example-overflow-list-dropdown-actions",
+      "path": "examples/overflow-list/dropdown-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-overflow-list-multi-row-tags",
+      "path": "examples/overflow-list/multi-row-tags",
+      "aliases": []
+    },
+    {
+      "name": "example-overlay-bottom-strip",
+      "path": "examples/overlay/bottom-strip",
+      "aliases": []
+    },
+    {
+      "name": "example-overlay-hover-reveal",
+      "path": "examples/overlay/hover-reveal",
+      "aliases": []
+    },
+    {
+      "name": "example-pagination-dots-carousel",
+      "path": "examples/pagination/dots-carousel",
+      "aliases": []
+    },
+    {
+      "name": "example-pagination-page-size-selector",
+      "path": "examples/pagination/page-size-selector",
+      "aliases": []
+    },
+    {
+      "name": "example-pagination-with-table",
+      "path": "examples/pagination/with-table",
+      "aliases": []
+    },
+    {
+      "name": "example-popover-bottom-sheet-alternative",
+      "path": "examples/popover/bottom-sheet-alternative",
+      "aliases": []
+    },
+    {
+      "name": "example-popover-confirm-action",
+      "path": "examples/popover/confirm-action",
+      "aliases": []
+    },
+    {
+      "name": "example-popover-filter-panel",
+      "path": "examples/popover/filter-panel",
+      "aliases": []
+    },
+    {
+      "name": "example-popover-keyboard-shortcuts",
+      "path": "examples/popover/keyboard-shortcuts",
+      "aliases": []
+    },
+    {
+      "name": "example-popover-settings-panel",
+      "path": "examples/popover/settings-panel",
+      "aliases": []
+    },
+    {
+      "name": "example-power-search-content-search",
+      "path": "examples/power-search/content-search",
+      "aliases": []
+    },
+    {
+      "name": "example-power-search-full-featured",
+      "path": "examples/power-search/full-featured",
+      "aliases": []
+    },
+    {
+      "name": "example-power-search-preset-filters",
+      "path": "examples/power-search/preset-filters",
+      "aliases": []
+    },
+    {
+      "name": "example-power-search-search-with-table",
+      "path": "examples/power-search/search-with-table",
+      "aliases": []
+    },
+    {
+      "name": "example-progress-bar-custom-format",
+      "path": "examples/progress-bar/custom-format",
+      "aliases": []
+    },
+    {
+      "name": "example-progress-bar-indeterminate",
+      "path": "examples/progress-bar/indeterminate",
+      "aliases": []
+    },
+    {
+      "name": "example-progress-bar-semantic-variants",
+      "path": "examples/progress-bar/semantic-variants",
+      "aliases": []
+    },
+    {
+      "name": "example-progress-bar-with-value-label",
+      "path": "examples/progress-bar/with-value-label",
+      "aliases": []
+    },
+    {
+      "name": "example-radio-list-item-basic",
+      "path": "examples/radio-list-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-radio-list-horizontal-layout",
+      "path": "examples/radio-list/horizontal-layout",
+      "aliases": []
+    },
+    {
+      "name": "example-radio-list-pricing-tier",
+      "path": "examples/radio-list/pricing-tier",
+      "aliases": []
+    },
+    {
+      "name": "example-radio-list-with-descriptions",
+      "path": "examples/radio-list/with-descriptions",
+      "aliases": []
+    },
+    {
+      "name": "example-radio-list-with-validation",
+      "path": "examples/radio-list/with-validation",
+      "aliases": []
+    },
+    {
+      "name": "example-resize-handle-resizable-collapsible-with-snap-points",
+      "path": "examples/resize-handle/resizable-collapsible-with-snap-points",
+      "aliases": []
+    },
+    {
+      "name": "example-section-default-with-wash",
+      "path": "examples/section/default-with-wash",
+      "aliases": []
+    },
+    {
+      "name": "example-section-with-dividers",
+      "path": "examples/section/with-dividers",
+      "aliases": []
+    },
+    {
+      "name": "example-segmented-control-item-basic",
+      "path": "examples/segmented-control-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-segmented-control-disabled-item",
+      "path": "examples/segmented-control/disabled-item",
+      "aliases": []
+    },
+    {
+      "name": "example-segmented-control-fill-layout",
+      "path": "examples/segmented-control/fill-layout",
+      "aliases": []
+    },
+    {
+      "name": "example-segmented-control-icon-only",
+      "path": "examples/segmented-control/icon-only",
+      "aliases": []
+    },
+    {
+      "name": "example-segmented-control-with-icons",
+      "path": "examples/segmented-control/with-icons",
+      "aliases": []
+    },
+    {
+      "name": "example-selectable-card-elevated",
+      "path": "examples/selectable-card/elevated",
+      "aliases": []
+    },
+    {
+      "name": "example-selectable-card-multi",
+      "path": "examples/selectable-card/multi",
+      "aliases": []
+    },
+    {
+      "name": "example-selector-option-basic",
+      "path": "examples/selector-option/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-selector-bottom-sheet",
+      "path": "examples/selector/bottom-sheet",
+      "aliases": []
+    },
+    {
+      "name": "example-selector-clearable",
+      "path": "examples/selector/clearable",
+      "aliases": []
+    },
+    {
+      "name": "example-selector-ghost-toolbar",
+      "path": "examples/selector/ghost-toolbar",
+      "aliases": []
+    },
+    {
+      "name": "example-selector-grouped-sections",
+      "path": "examples/selector/grouped-sections",
+      "aliases": []
+    },
+    {
+      "name": "example-selector-option-descriptions",
+      "path": "examples/selector/option-descriptions",
+      "aliases": []
+    },
+    {
+      "name": "example-selector-validation-states",
+      "path": "examples/selector/validation-states",
+      "aliases": []
+    },
+    {
+      "name": "example-side-nav-collapse-button-basic",
+      "path": "examples/side-nav-collapse-button/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-side-nav-heading-basic",
+      "path": "examples/side-nav-heading/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-side-nav-item-basic",
+      "path": "examples/side-nav-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-side-nav-section-basic",
+      "path": "examples/side-nav-section/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-side-nav-end-content",
+      "path": "examples/side-nav/end-content",
+      "aliases": []
+    },
+    {
+      "name": "example-side-nav-header-with-menu",
+      "path": "examples/side-nav/header-with-menu",
+      "aliases": []
+    },
+    {
+      "name": "example-side-nav-nested-items",
+      "path": "examples/side-nav/nested-items",
+      "aliases": []
+    },
+    {
+      "name": "example-skeleton-card-loading",
+      "path": "examples/skeleton/card-loading",
+      "aliases": []
+    },
+    {
+      "name": "example-skeleton-staggered-list",
+      "path": "examples/skeleton/staggered-list",
+      "aliases": []
+    },
+    {
+      "name": "example-skeleton-table-rows",
+      "path": "examples/skeleton/table-rows",
+      "aliases": []
+    },
+    {
+      "name": "example-slider-formatted-value",
+      "path": "examples/slider/formatted-value",
+      "aliases": []
+    },
+    {
+      "name": "example-slider-range",
+      "path": "examples/slider/range",
+      "aliases": []
+    },
+    {
+      "name": "example-slider-validation-states",
+      "path": "examples/slider/validation-states",
+      "aliases": []
+    },
+    {
+      "name": "example-slider-with-marks",
+      "path": "examples/slider/with-marks",
+      "aliases": []
+    },
+    {
+      "name": "example-spinner-on-media-shade",
+      "path": "examples/spinner/on-media-shade",
+      "aliases": []
+    },
+    {
+      "name": "example-spinner-sizes",
+      "path": "examples/spinner/sizes",
+      "aliases": []
+    },
+    {
+      "name": "example-spinner-with-label",
+      "path": "examples/spinner/with-label",
+      "aliases": []
+    },
+    {
+      "name": "example-stack-item-fill",
+      "path": "examples/stack-item/fill",
+      "aliases": []
+    },
+    {
+      "name": "example-stack-alignment",
+      "path": "examples/stack/alignment",
+      "aliases": []
+    },
+    {
+      "name": "example-stack-fill-item",
+      "path": "examples/stack/fill-item",
+      "aliases": []
+    },
+    {
+      "name": "example-status-dot-pulsing",
+      "path": "examples/status-dot/pulsing",
+      "aliases": []
+    },
+    {
+      "name": "example-status-dot-status-indicators",
+      "path": "examples/status-dot/status-indicators",
+      "aliases": []
+    },
+    {
+      "name": "example-status-dot-variants",
+      "path": "examples/status-dot/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-step-content-slot",
+      "path": "examples/step/content-slot",
+      "aliases": []
+    },
+    {
+      "name": "example-step-indicator",
+      "path": "examples/step/indicator",
+      "aliases": []
+    },
+    {
+      "name": "example-step-states",
+      "path": "examples/step/states",
+      "aliases": []
+    },
+    {
+      "name": "example-stepper-custom-content",
+      "path": "examples/stepper/custom-content",
+      "aliases": []
+    },
+    {
+      "name": "example-stepper-horizontal-narrow-collapsed",
+      "path": "examples/stepper/horizontal-narrow-collapsed",
+      "aliases": []
+    },
+    {
+      "name": "example-stepper-indicator-modes",
+      "path": "examples/stepper/indicator-modes",
+      "aliases": []
+    },
+    {
+      "name": "example-stepper-on-track-horizontal",
+      "path": "examples/stepper/on-track-horizontal",
+      "aliases": []
+    },
+    {
+      "name": "example-stepper-on-track-vertical",
+      "path": "examples/stepper/on-track-vertical",
+      "aliases": []
+    },
+    {
+      "name": "example-stepper-validation-status",
+      "path": "examples/stepper/validation-status",
+      "aliases": []
+    },
+    {
+      "name": "example-switch-disabled",
+      "path": "examples/switch/disabled",
+      "aliases": []
+    },
+    {
+      "name": "example-switch-settings-panel",
+      "path": "examples/switch/settings-panel",
+      "aliases": []
+    },
+    {
+      "name": "example-switch-with-description",
+      "path": "examples/switch/with-description",
+      "aliases": []
+    },
+    {
+      "name": "example-switch-with-status",
+      "path": "examples/switch/with-status",
+      "aliases": []
+    },
+    {
+      "name": "example-syntax-theme-dark-preset",
+      "path": "examples/syntax-theme/dark-preset",
+      "aliases": []
+    },
+    {
+      "name": "example-syntax-theme-light-preset",
+      "path": "examples/syntax-theme/light-preset",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-list-fill-layout",
+      "path": "examples/tab-list/fill-layout",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-list-with-actions",
+      "path": "examples/tab-list/with-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-list-with-badge",
+      "path": "examples/tab-list/with-badge",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-list-with-icons",
+      "path": "examples/tab-list/with-icons",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-list-with-overflow-menu",
+      "path": "examples/tab-list/with-overflow-menu",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-list-with-status-dot",
+      "path": "examples/tab-list/with-status-dot",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-menu-basic",
+      "path": "examples/tab-menu/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-tab-selected-icon",
+      "path": "examples/tab/selected-icon",
+      "aliases": []
+    },
+    {
+      "name": "example-table-column-settings",
+      "path": "examples/table/column-settings",
+      "aliases": []
+    },
+    {
+      "name": "example-table-grid-dividers",
+      "path": "examples/table/grid-dividers",
+      "aliases": []
+    },
+    {
+      "name": "example-table-in-card",
+      "path": "examples/table/in-card",
+      "aliases": []
+    },
+    {
+      "name": "example-table-inline-filters",
+      "path": "examples/table/inline-filters",
+      "aliases": []
+    },
+    {
+      "name": "example-table-paginated-data",
+      "path": "examples/table/paginated-data",
+      "aliases": []
+    },
+    {
+      "name": "example-table-popover-filters",
+      "path": "examples/table/popover-filters",
+      "aliases": []
+    },
+    {
+      "name": "example-table-resizable-columns",
+      "path": "examples/table/resizable-columns",
+      "aliases": []
+    },
+    {
+      "name": "example-table-rich-cell-content",
+      "path": "examples/table/rich-cell-content",
+      "aliases": []
+    },
+    {
+      "name": "example-table-row-selection",
+      "path": "examples/table/row-selection",
+      "aliases": []
+    },
+    {
+      "name": "example-table-sortable-columns",
+      "path": "examples/table/sortable-columns",
+      "aliases": []
+    },
+    {
+      "name": "example-table-striped-rows",
+      "path": "examples/table/striped-rows",
+      "aliases": []
+    },
+    {
+      "name": "example-text-area-character-count",
+      "path": "examples/text-area/character-count",
+      "aliases": []
+    },
+    {
+      "name": "example-text-area-icon",
+      "path": "examples/text-area/icon",
+      "aliases": []
+    },
+    {
+      "name": "example-text-area-states",
+      "path": "examples/text-area/states",
+      "aliases": []
+    },
+    {
+      "name": "example-text-area-validation",
+      "path": "examples/text-area/validation",
+      "aliases": []
+    },
+    {
+      "name": "example-text-input-icon",
+      "path": "examples/text-input/icon",
+      "aliases": []
+    },
+    {
+      "name": "example-text-input-search",
+      "path": "examples/text-input/search",
+      "aliases": []
+    },
+    {
+      "name": "example-text-input-sizes",
+      "path": "examples/text-input/sizes",
+      "aliases": []
+    },
+    {
+      "name": "example-text-input-states",
+      "path": "examples/text-input/states",
+      "aliases": []
+    },
+    {
+      "name": "example-text-input-status-variant",
+      "path": "examples/text-input/status-variant",
+      "aliases": []
+    },
+    {
+      "name": "example-text-input-types",
+      "path": "examples/text-input/types",
+      "aliases": []
+    },
+    {
+      "name": "example-text-colors",
+      "path": "examples/text/colors",
+      "aliases": []
+    },
+    {
+      "name": "example-text-heading-levels",
+      "path": "examples/text/heading-levels",
+      "aliases": []
+    },
+    {
+      "name": "example-text-inline",
+      "path": "examples/text/inline",
+      "aliases": []
+    },
+    {
+      "name": "example-text-truncation",
+      "path": "examples/text/truncation",
+      "aliases": []
+    },
+    {
+      "name": "example-text-types",
+      "path": "examples/text/types",
+      "aliases": []
+    },
+    {
+      "name": "example-text-weight",
+      "path": "examples/text/weight",
+      "aliases": []
+    },
+    {
+      "name": "example-text-word-break",
+      "path": "examples/text/word-break",
+      "aliases": []
+    },
+    {
+      "name": "example-text-wrap",
+      "path": "examples/text/wrap",
+      "aliases": []
+    },
+    {
+      "name": "example-theme-apply-theme",
+      "path": "examples/theme/apply-theme",
+      "aliases": []
+    },
+    {
+      "name": "example-theme-nested-theme",
+      "path": "examples/theme/nested-theme",
+      "aliases": []
+    },
+    {
+      "name": "example-theme-switch-themes",
+      "path": "examples/theme/switch-themes",
+      "aliases": []
+    },
+    {
+      "name": "example-thumbnail-disabled",
+      "path": "examples/thumbnail/disabled",
+      "aliases": []
+    },
+    {
+      "name": "example-thumbnail-gallery",
+      "path": "examples/thumbnail/gallery",
+      "aliases": []
+    },
+    {
+      "name": "example-thumbnail-removable",
+      "path": "examples/thumbnail/removable",
+      "aliases": []
+    },
+    {
+      "name": "example-thumbnail-states",
+      "path": "examples/thumbnail/states",
+      "aliases": []
+    },
+    {
+      "name": "example-time-input-constrained",
+      "path": "examples/time-input/constrained",
+      "aliases": []
+    },
+    {
+      "name": "example-time-input-formats",
+      "path": "examples/time-input/formats",
+      "aliases": []
+    },
+    {
+      "name": "example-time-input-increment",
+      "path": "examples/time-input/increment",
+      "aliases": []
+    },
+    {
+      "name": "example-time-input-states",
+      "path": "examples/time-input/states",
+      "aliases": []
+    },
+    {
+      "name": "example-timestamp-auto",
+      "path": "examples/timestamp/auto",
+      "aliases": []
+    },
+    {
+      "name": "example-timestamp-colors",
+      "path": "examples/timestamp/colors",
+      "aliases": []
+    },
+    {
+      "name": "example-timestamp-formats",
+      "path": "examples/timestamp/formats",
+      "aliases": []
+    },
+    {
+      "name": "example-timestamp-relative",
+      "path": "examples/timestamp/relative",
+      "aliases": []
+    },
+    {
+      "name": "example-timestamp-timezone",
+      "path": "examples/timestamp/timezone",
+      "aliases": []
+    },
+    {
+      "name": "example-timestamp-tooltip-time-zones",
+      "path": "examples/timestamp/tooltip-time-zones",
+      "aliases": []
+    },
+    {
+      "name": "example-toast-action",
+      "path": "examples/toast/action",
+      "aliases": []
+    },
+    {
+      "name": "example-toast-deduplication",
+      "path": "examples/toast/deduplication",
+      "aliases": []
+    },
+    {
+      "name": "example-toast-dismiss",
+      "path": "examples/toast/dismiss",
+      "aliases": []
+    },
+    {
+      "name": "example-toast-stacking",
+      "path": "examples/toast/stacking",
+      "aliases": []
+    },
+    {
+      "name": "example-toast-types",
+      "path": "examples/toast/types",
+      "aliases": []
+    },
+    {
+      "name": "example-toggle-button-group-default",
+      "path": "examples/toggle-button-group/default",
+      "aliases": []
+    },
+    {
+      "name": "example-toggle-button-group-vertical",
+      "path": "examples/toggle-button-group/vertical",
+      "aliases": []
+    },
+    {
+      "name": "example-toggle-button-color",
+      "path": "examples/toggle-button/color",
+      "aliases": []
+    },
+    {
+      "name": "example-toggle-button-icon-swap",
+      "path": "examples/toggle-button/icon-swap",
+      "aliases": []
+    },
+    {
+      "name": "example-toggle-button-label",
+      "path": "examples/toggle-button/label",
+      "aliases": []
+    },
+    {
+      "name": "example-toggle-button-states",
+      "path": "examples/toggle-button/states",
+      "aliases": []
+    },
+    {
+      "name": "example-token-clickable",
+      "path": "examples/token/clickable",
+      "aliases": []
+    },
+    {
+      "name": "example-token-colors",
+      "path": "examples/token/colors",
+      "aliases": []
+    },
+    {
+      "name": "example-token-end-content",
+      "path": "examples/token/end-content",
+      "aliases": []
+    },
+    {
+      "name": "example-token-icon",
+      "path": "examples/token/icon",
+      "aliases": []
+    },
+    {
+      "name": "example-token-removable",
+      "path": "examples/token/removable",
+      "aliases": []
+    },
+    {
+      "name": "example-tokenizer-clear",
+      "path": "examples/tokenizer/clear",
+      "aliases": []
+    },
+    {
+      "name": "example-tokenizer-creatable",
+      "path": "examples/tokenizer/creatable",
+      "aliases": []
+    },
+    {
+      "name": "example-tokenizer-end-content",
+      "path": "examples/tokenizer/end-content",
+      "aliases": []
+    },
+    {
+      "name": "example-tokenizer-icon",
+      "path": "examples/tokenizer/icon",
+      "aliases": []
+    },
+    {
+      "name": "example-tokenizer-max-entries",
+      "path": "examples/tokenizer/max-entries",
+      "aliases": []
+    },
+    {
+      "name": "example-tokenizer-overflow",
+      "path": "examples/tokenizer/overflow",
+      "aliases": []
+    },
+    {
+      "name": "example-tokenizer-states",
+      "path": "examples/tokenizer/states",
+      "aliases": []
+    },
+    {
+      "name": "example-toolbar-bulk-actions",
+      "path": "examples/toolbar/bulk-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-toolbar-card-header",
+      "path": "examples/toolbar/card-header",
+      "aliases": []
+    },
+    {
+      "name": "example-toolbar-sizes",
+      "path": "examples/toolbar/sizes",
+      "aliases": []
+    },
+    {
+      "name": "example-toolbar-tab-navigation",
+      "path": "examples/toolbar/tab-navigation",
+      "aliases": []
+    },
+    {
+      "name": "example-toolbar-table-filter",
+      "path": "examples/toolbar/table-filter",
+      "aliases": []
+    },
+    {
+      "name": "example-tooltip-action-bar",
+      "path": "examples/tooltip/action-bar",
+      "aliases": []
+    },
+    {
+      "name": "example-tooltip-hook-usage",
+      "path": "examples/tooltip/hook-usage",
+      "aliases": []
+    },
+    {
+      "name": "example-tooltip-inline-text",
+      "path": "examples/tooltip/inline-text",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-heading-basic",
+      "path": "examples/top-nav-heading/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-item-basic",
+      "path": "examples/top-nav-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-mega-menu-featured-card-basic",
+      "path": "examples/top-nav-mega-menu-featured-card/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-mega-menu-item-basic",
+      "path": "examples/top-nav-mega-menu-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-mega-menu-basic",
+      "path": "examples/top-nav-mega-menu/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-menu-basic",
+      "path": "examples/top-nav-menu/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-centered-navigation",
+      "path": "examples/top-nav/centered-navigation",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-enterprise-dashboard",
+      "path": "examples/top-nav/enterprise-dashboard",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-hover-menu",
+      "path": "examples/top-nav/hover-menu",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-mega-menu",
+      "path": "examples/top-nav/mega-menu",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-multiple-dropdowns",
+      "path": "examples/top-nav/multiple-dropdowns",
+      "aliases": []
+    },
+    {
+      "name": "example-top-nav-with-logo",
+      "path": "examples/top-nav/with-logo",
+      "aliases": []
+    },
+    {
+      "name": "example-tree-list-file-tree-with-icons",
+      "path": "examples/tree-list/file-tree-with-icons",
+      "aliases": []
+    },
+    {
+      "name": "example-tree-list-interactive-settings",
+      "path": "examples/tree-list/interactive-settings",
+      "aliases": []
+    },
+    {
+      "name": "example-tree-list-mailbox-tree",
+      "path": "examples/tree-list/mailbox-tree",
+      "aliases": []
+    },
+    {
+      "name": "example-tree-list-navigation-tree",
+      "path": "examples/tree-list/navigation-tree",
+      "aliases": []
+    },
+    {
+      "name": "example-tree-list-variants",
+      "path": "examples/tree-list/variants",
+      "aliases": []
+    },
+    {
+      "name": "example-typeahead-item-basic",
+      "path": "examples/typeahead-item/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-typeahead-limited-results",
+      "path": "examples/typeahead/limited-results",
+      "aliases": []
+    },
+    {
+      "name": "example-typeahead-search-field",
+      "path": "examples/typeahead/search-field",
+      "aliases": []
+    },
+    {
+      "name": "example-typeahead-with-helper-text",
+      "path": "examples/typeahead/with-helper-text",
+      "aliases": []
+    },
+    {
+      "name": "example-typeahead-with-validation",
+      "path": "examples/typeahead/with-validation",
+      "aliases": []
+    },
+    {
+      "name": "example-use-app-shell-mobile-custom-mobile-trigger",
+      "path": "examples/use-app-shell-mobile/custom-mobile-trigger",
+      "aliases": []
+    },
+    {
+      "name": "example-use-collapsible-custom-disclosure",
+      "path": "examples/use-collapsible/custom-disclosure",
+      "aliases": []
+    },
+    {
+      "name": "example-use-container-reveal-reveal-on-hover-row-actions",
+      "path": "examples/use-container-reveal/reveal-on-hover-row-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-use-hover-card-profile-preview",
+      "path": "examples/use-hover-card/profile-preview",
+      "aliases": []
+    },
+    {
+      "name": "example-use-keyboard-hint-arrow-key-hint",
+      "path": "examples/use-keyboard-hint/arrow-key-hint",
+      "aliases": []
+    },
+    {
+      "name": "example-use-layer-anchored-layer",
+      "path": "examples/use-layer/anchored-layer",
+      "aliases": []
+    },
+    {
+      "name": "example-use-popover-quick-actions",
+      "path": "examples/use-popover/quick-actions",
+      "aliases": []
+    },
+    {
+      "name": "example-use-streaming-text-streaming-response",
+      "path": "examples/use-streaming-text/streaming-response",
+      "aliases": []
+    },
+    {
+      "name": "example-use-table-column-resize-draggable-columns",
+      "path": "examples/use-table-column-resize/draggable-columns",
+      "aliases": []
+    },
+    {
+      "name": "example-use-table-grouped-rows-collapsible-groups",
+      "path": "examples/use-table-grouped-rows/collapsible-groups",
+      "aliases": []
+    },
+    {
+      "name": "example-use-table-row-expansion-tree-table",
+      "path": "examples/use-table-row-expansion/tree-table",
+      "aliases": []
+    },
+    {
+      "name": "example-use-table-row-index-numbered-rows",
+      "path": "examples/use-table-row-index/numbered-rows",
+      "aliases": []
+    },
+    {
+      "name": "example-use-table-row-status-semantic-and-custom-markers",
+      "path": "examples/use-table-row-status/semantic-and-custom-markers",
+      "aliases": []
+    },
+    {
+      "name": "example-use-table-sticky-columns-pinned-columns",
+      "path": "examples/use-table-sticky-columns/pinned-columns",
+      "aliases": []
+    },
+    {
+      "name": "example-use-table-tree-data-tree-table",
+      "path": "examples/use-table-tree-data/tree-table",
+      "aliases": []
+    },
+    {
+      "name": "example-use-theme-token-values",
+      "path": "examples/use-theme/token-values",
+      "aliases": []
+    },
+    {
+      "name": "example-v-stack-basic",
+      "path": "examples/v-stack/basic",
+      "aliases": []
+    },
+    {
+      "name": "example-visually-hidden-live-region",
+      "path": "examples/visually-hidden/live-region",
+      "aliases": []
+    },
+    {
+      "name": "example-visually-hidden-structural-heading",
+      "path": "examples/visually-hidden/structural-heading",
+      "aliases": []
+    },
+    {
+      "name": "example-visually-hidden-supplementary-context",
+      "path": "examples/visually-hidden/supplementary-context",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-announce",
+      "path": "hooks/use-announce",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-app-shell-mobile",
+      "path": "hooks/use-app-shell-mobile",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-clickable-container",
+      "path": "hooks/use-clickable-container",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-clipboard",
+      "path": "hooks/use-clipboard",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-collapsible",
+      "path": "hooks/use-collapsible",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-collator",
+      "path": "hooks/use-collator",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-container-reveal",
+      "path": "hooks/use-container-reveal",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-dev-warning",
+      "path": "hooks/use-dev-warning",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-entry-animation",
+      "path": "hooks/use-entry-animation",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-focus-trap",
+      "path": "hooks/use-focus-trap",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-grid-focus",
+      "path": "hooks/use-grid-focus",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-hotkeys",
+      "path": "hooks/use-hotkeys",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-hover-card",
+      "path": "hooks/use-hover-card",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-image-mode",
+      "path": "hooks/use-image-mode",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-imperative-alert-dialog",
+      "path": "hooks/use-imperative-alert-dialog",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-imperative-dialog",
+      "path": "hooks/use-imperative-dialog",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-indicator-focus-ring",
+      "path": "hooks/use-indicator-focus-ring",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-input-container",
+      "path": "hooks/use-input-container",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-input-status-icon",
+      "path": "hooks/use-input-status-icon",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-interactive-role",
+      "path": "hooks/use-interactive-role",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-keyboard-hint",
+      "path": "hooks/use-keyboard-hint",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-layer",
+      "path": "hooks/use-layer",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-list-focus",
+      "path": "hooks/use-list-focus",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-locale",
+      "path": "hooks/use-locale",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-long-press",
+      "path": "hooks/use-long-press",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-media-query",
+      "path": "hooks/use-media-query",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-merged-refs",
+      "path": "hooks/use-merged-refs",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-overflow",
+      "path": "hooks/use-overflow",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-popover",
+      "path": "hooks/use-popover",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-resizable",
+      "path": "hooks/use-resizable",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-scroll-lock",
+      "path": "hooks/use-scroll-lock",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-scroll-overflow",
+      "path": "hooks/use-scroll-overflow",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-streaming-text",
+      "path": "hooks/use-streaming-text",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-column-resize",
+      "path": "hooks/use-table-column-resize",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-column-settings",
+      "path": "hooks/use-table-column-settings",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-filter-state",
+      "path": "hooks/use-table-filter-state",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-filtering",
+      "path": "hooks/use-table-filtering",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-grouped-rows",
+      "path": "hooks/use-table-grouped-rows",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-pagination",
+      "path": "hooks/use-table-pagination",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-row-expansion",
+      "path": "hooks/use-table-row-expansion",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-row-index",
+      "path": "hooks/use-table-row-index",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-row-status",
+      "path": "hooks/use-table-row-status",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-selection",
+      "path": "hooks/use-table-selection",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-selection-state",
+      "path": "hooks/use-table-selection-state",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-sortable",
+      "path": "hooks/use-table-sortable",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-sticky-columns",
+      "path": "hooks/use-table-sticky-columns",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-tree-data",
+      "path": "hooks/use-table-tree-data",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-table-tree-state",
+      "path": "hooks/use-table-tree-state",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-theme",
+      "path": "hooks/use-theme",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-toast",
+      "path": "hooks/use-toast",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-tooltip",
+      "path": "hooks/use-tooltip",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-translator",
+      "path": "hooks/use-translator",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-tree-focus",
+      "path": "hooks/use-tree-focus",
+      "aliases": []
+    },
+    {
+      "name": "hook-use-typeahead",
+      "path": "hooks/use-typeahead",
+      "aliases": []
+    },
+    {
+      "name": "showcase-alert-dialog-delete",
+      "path": "showcases/alert-dialog/delete",
+      "aliases": []
+    },
+    {
+      "name": "showcase-app-shell-default",
+      "path": "showcases/app-shell/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-aspect-ratio-default",
+      "path": "showcases/aspect-ratio/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-avatar-group-overflow-default",
+      "path": "showcases/avatar-group-overflow/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-avatar-group-default",
+      "path": "showcases/avatar-group/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-avatar-status-dot-default",
+      "path": "showcases/avatar-status-dot/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-avatar-default",
+      "path": "showcases/avatar/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-badge-variants",
+      "path": "showcases/badge/variants",
+      "aliases": []
+    },
+    {
+      "name": "showcase-banner-statuses",
+      "path": "showcases/banner/statuses",
+      "aliases": []
+    },
+    {
+      "name": "showcase-blockquote-default",
+      "path": "showcases/blockquote/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-bottom-sheet-switcher-default",
+      "path": "showcases/bottom-sheet-switcher/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-bottom-sheet-default",
+      "path": "showcases/bottom-sheet/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-breadcrumb-item-default",
+      "path": "showcases/breadcrumb-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-breadcrumbs-default",
+      "path": "showcases/breadcrumbs/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-button-group-default",
+      "path": "showcases/button-group/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-button-variants",
+      "path": "showcases/button/variants",
+      "aliases": []
+    },
+    {
+      "name": "showcase-calendar-default",
+      "path": "showcases/calendar/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-card-default",
+      "path": "showcases/card/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-carousel-default",
+      "path": "showcases/carousel/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-center-default",
+      "path": "showcases/center/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chart-default",
+      "path": "showcases/chart/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-composer-drawer-default",
+      "path": "showcases/chat-composer-drawer/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-composer-input-default",
+      "path": "showcases/chat-composer-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-composer-default",
+      "path": "showcases/chat-composer/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-dictation-button-default",
+      "path": "showcases/chat-dictation-button/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-layout-scroll-button-default",
+      "path": "showcases/chat-layout-scroll-button/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-layout-default",
+      "path": "showcases/chat-layout/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-message-bubble-default",
+      "path": "showcases/chat-message-bubble/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-message-list-default",
+      "path": "showcases/chat-message-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-message-metadata-default",
+      "path": "showcases/chat-message-metadata/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-message-default",
+      "path": "showcases/chat-message/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-send-button-default",
+      "path": "showcases/chat-send-button/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-system-message-default",
+      "path": "showcases/chat-system-message/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-tokenized-text-default",
+      "path": "showcases/chat-tokenized-text/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-chat-tool-calls-default",
+      "path": "showcases/chat-tool-calls/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-checkbox-input-default",
+      "path": "showcases/checkbox-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-checkbox-list-item-default",
+      "path": "showcases/checkbox-list-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-checkbox-list-default",
+      "path": "showcases/checkbox-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-citation-default",
+      "path": "showcases/citation/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-clickable-card-default",
+      "path": "showcases/clickable-card/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-code-block-default",
+      "path": "showcases/code-block/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-code-default",
+      "path": "showcases/code/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-collapsible-group-default",
+      "path": "showcases/collapsible-group/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-collapsible-default",
+      "path": "showcases/collapsible/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-command-palette-empty-default",
+      "path": "showcases/command-palette-empty/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-command-palette-footer-default",
+      "path": "showcases/command-palette-footer/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-command-palette-group-default",
+      "path": "showcases/command-palette-group/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-command-palette-input-default",
+      "path": "showcases/command-palette-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-command-palette-item-default",
+      "path": "showcases/command-palette-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-command-palette-list-default",
+      "path": "showcases/command-palette-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-command-palette-default",
+      "path": "showcases/command-palette/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-complex-selector-default",
+      "path": "showcases/complex-selector/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-context-menu-item-default",
+      "path": "showcases/context-menu-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-context-menu-default",
+      "path": "showcases/context-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-date-input-default",
+      "path": "showcases/date-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-date-range-input-default",
+      "path": "showcases/date-range-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-date-time-input-default",
+      "path": "showcases/date-time-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-dialog-header-default",
+      "path": "showcases/dialog-header/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-dialog-default",
+      "path": "showcases/dialog/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-divider-variants",
+      "path": "showcases/divider/variants",
+      "aliases": []
+    },
+    {
+      "name": "showcase-dropdown-menu-item-default",
+      "path": "showcases/dropdown-menu-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-dropdown-menu-default",
+      "path": "showcases/dropdown-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-empty-state-default",
+      "path": "showcases/empty-state/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-field-label-default",
+      "path": "showcases/field-label/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-field-status-default",
+      "path": "showcases/field-status/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-field-default",
+      "path": "showcases/field/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-file-input-default",
+      "path": "showcases/file-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-form-layout-default",
+      "path": "showcases/form-layout/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-grid-span-default",
+      "path": "showcases/grid-span/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-grid-default",
+      "path": "showcases/grid/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-h-stack-default",
+      "path": "showcases/h-stack/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-heading-default",
+      "path": "showcases/heading/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-hover-card-default",
+      "path": "showcases/hover-card/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-icon-button-default",
+      "path": "showcases/icon-button/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-icon-default",
+      "path": "showcases/icon/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-input-group-default",
+      "path": "showcases/input-group/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-item-default",
+      "path": "showcases/item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-kbd-default",
+      "path": "showcases/kbd/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-layout-content-default",
+      "path": "showcases/layout-content/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-layout-footer-default",
+      "path": "showcases/layout-footer/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-layout-header-default",
+      "path": "showcases/layout-header/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-layout-panel-default",
+      "path": "showcases/layout-panel/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-layout-default",
+      "path": "showcases/layout/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-lightbox-default",
+      "path": "showcases/lightbox/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-link-default",
+      "path": "showcases/link/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-list-item-default",
+      "path": "showcases/list-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-list-default",
+      "path": "showcases/list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-markdown-default",
+      "path": "showcases/markdown/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-media-theme-media-overlay",
+      "path": "showcases/media-theme/media-overlay",
+      "aliases": []
+    },
+    {
+      "name": "showcase-metadata-list-item-default",
+      "path": "showcases/metadata-list-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-metadata-list-default",
+      "path": "showcases/metadata-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-mobile-nav-toggle-default",
+      "path": "showcases/mobile-nav-toggle/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-mobile-nav-default",
+      "path": "showcases/mobile-nav/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-more-menu-default",
+      "path": "showcases/more-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-multi-selector-default",
+      "path": "showcases/multi-selector/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-nav-heading-menu-default",
+      "path": "showcases/nav-heading-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-nav-icon-default",
+      "path": "showcases/nav-icon/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-number-input-default",
+      "path": "showcases/number-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-outline-default",
+      "path": "showcases/outline/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-overflow-list-default",
+      "path": "showcases/overflow-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-overlay-default",
+      "path": "showcases/overlay/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-pagination-variants",
+      "path": "showcases/pagination/variants",
+      "aliases": []
+    },
+    {
+      "name": "showcase-popover-default",
+      "path": "showcases/popover/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-power-search-default",
+      "path": "showcases/power-search/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-progress-bar-default",
+      "path": "showcases/progress-bar/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-radio-list-item-default",
+      "path": "showcases/radio-list-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-radio-list-default",
+      "path": "showcases/radio-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-resizable-default",
+      "path": "showcases/resizable/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-rich-text-editor-default",
+      "path": "showcases/rich-text-editor/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-section-variants",
+      "path": "showcases/section/variants",
+      "aliases": []
+    },
+    {
+      "name": "showcase-segmented-control-item-default",
+      "path": "showcases/segmented-control-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-segmented-control-default",
+      "path": "showcases/segmented-control/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-selectable-card-default",
+      "path": "showcases/selectable-card/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-selector-option-default",
+      "path": "showcases/selector-option/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-selector-default",
+      "path": "showcases/selector/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-side-nav-collapse-button-default",
+      "path": "showcases/side-nav-collapse-button/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-side-nav-heading-default",
+      "path": "showcases/side-nav-heading/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-side-nav-item-default",
+      "path": "showcases/side-nav-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-side-nav-section-default",
+      "path": "showcases/side-nav-section/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-side-nav-default",
+      "path": "showcases/side-nav/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-skeleton-default",
+      "path": "showcases/skeleton/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-slider-default",
+      "path": "showcases/slider/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-spinner-default",
+      "path": "showcases/spinner/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-stack-item-default",
+      "path": "showcases/stack-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-stack-directions",
+      "path": "showcases/stack/directions",
+      "aliases": []
+    },
+    {
+      "name": "showcase-status-dot-default",
+      "path": "showcases/status-dot/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-step-default",
+      "path": "showcases/step/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-stepper-checkout-progress",
+      "path": "showcases/stepper/checkout-progress",
+      "aliases": []
+    },
+    {
+      "name": "showcase-switch-default",
+      "path": "showcases/switch/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-syntax-theme-compact-preset",
+      "path": "showcases/syntax-theme/compact-preset",
+      "aliases": []
+    },
+    {
+      "name": "showcase-tab-list-default",
+      "path": "showcases/tab-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-tab-menu-default",
+      "path": "showcases/tab-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-tab-default",
+      "path": "showcases/tab/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-table-default",
+      "path": "showcases/table/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-text-area-default",
+      "path": "showcases/text-area/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-text-input-default",
+      "path": "showcases/text-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-text-default",
+      "path": "showcases/text/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-theme-distinct-themes",
+      "path": "showcases/theme/distinct-themes",
+      "aliases": []
+    },
+    {
+      "name": "showcase-thumbnail-default",
+      "path": "showcases/thumbnail/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-time-input-default",
+      "path": "showcases/time-input/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-timestamp-default",
+      "path": "showcases/timestamp/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-toast-default",
+      "path": "showcases/toast/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-toggle-button-group-default",
+      "path": "showcases/toggle-button-group/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-toggle-button-default",
+      "path": "showcases/toggle-button/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-token-default",
+      "path": "showcases/token/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-tokenizer-default",
+      "path": "showcases/tokenizer/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-toolbar-three-slot",
+      "path": "showcases/toolbar/three-slot",
+      "aliases": []
+    },
+    {
+      "name": "showcase-tooltip-default",
+      "path": "showcases/tooltip/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-top-nav-heading-default",
+      "path": "showcases/top-nav-heading/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-top-nav-item-default",
+      "path": "showcases/top-nav-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-top-nav-mega-menu-featured-card-default",
+      "path": "showcases/top-nav-mega-menu-featured-card/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-top-nav-mega-menu-item-default",
+      "path": "showcases/top-nav-mega-menu-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-top-nav-mega-menu-default",
+      "path": "showcases/top-nav-mega-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-top-nav-menu-default",
+      "path": "showcases/top-nav-menu/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-top-nav-default",
+      "path": "showcases/top-nav/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-tree-list-default",
+      "path": "showcases/tree-list/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-typeahead-item-default",
+      "path": "showcases/typeahead-item/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-typeahead-default",
+      "path": "showcases/typeahead/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-v-stack-default",
+      "path": "showcases/v-stack/default",
+      "aliases": []
+    },
+    {
+      "name": "showcase-visually-hidden-default",
+      "path": "showcases/visually-hidden/default",
+      "aliases": []
+    },
+    {
+      "name": "template-ai-chat",
+      "path": "templates/ai-chat",
+      "aliases": []
+    },
+    {
+      "name": "template-ai-chat-landing",
+      "path": "templates/ai-chat-landing",
+      "aliases": []
+    },
+    {
+      "name": "template-centered-hero",
+      "path": "templates/centered-hero",
+      "aliases": []
+    },
+    {
+      "name": "template-checkout-wizard",
+      "path": "templates/checkout-wizard",
+      "aliases": []
+    },
+    {
+      "name": "template-classic-gallery",
+      "path": "templates/classic-gallery",
+      "aliases": []
+    },
+    {
+      "name": "template-contact-form",
+      "path": "templates/contact-form",
+      "aliases": []
+    },
+    {
+      "name": "template-dashboard",
+      "path": "templates/dashboard",
+      "aliases": []
+    },
+    {
+      "name": "template-dashboard-alert-rail",
+      "path": "templates/dashboard-alert-rail",
+      "aliases": []
+    },
+    {
+      "name": "template-dashboard-cohort-funnel",
+      "path": "templates/dashboard-cohort-funnel",
+      "aliases": []
+    },
+    {
+      "name": "template-dashboard-comparison",
+      "path": "templates/dashboard-comparison",
+      "aliases": []
+    },
+    {
+      "name": "template-dashboard-composition",
+      "path": "templates/dashboard-composition",
+      "aliases": []
+    },
+    {
+      "name": "template-dashboard-progress",
+      "path": "templates/dashboard-progress",
+      "aliases": []
+    },
+    {
+      "name": "template-dashboard-scorecard",
+      "path": "templates/dashboard-scorecard",
+      "aliases": []
+    },
+    {
+      "name": "template-detail-page",
+      "path": "templates/detail-page",
+      "aliases": []
+    },
+    {
+      "name": "template-documentation",
+      "path": "templates/documentation",
+      "aliases": []
+    },
+    {
+      "name": "template-documentation-design",
+      "path": "templates/documentation-design",
+      "aliases": []
+    },
+    {
+      "name": "template-documentation-technical",
+      "path": "templates/documentation-technical",
+      "aliases": []
+    },
+    {
+      "name": "template-editor",
+      "path": "templates/editor",
+      "aliases": []
+    },
+    {
+      "name": "template-file-explorer",
+      "path": "templates/file-explorer",
+      "aliases": []
+    },
+    {
+      "name": "template-form-two-column",
+      "path": "templates/form-two-column",
+      "aliases": []
+    },
+    {
+      "name": "template-form-wizard",
+      "path": "templates/form-wizard",
+      "aliases": []
+    },
+    {
+      "name": "template-form-wizard-dialog",
+      "path": "templates/form-wizard-dialog",
+      "aliases": []
+    },
+    {
+      "name": "template-form-wizard-inline",
+      "path": "templates/form-wizard-inline",
+      "aliases": []
+    },
+    {
+      "name": "template-form-wizard-vertical",
+      "path": "templates/form-wizard-vertical",
+      "aliases": []
+    },
+    {
+      "name": "template-gallery-hero",
+      "path": "templates/gallery-hero",
+      "aliases": []
+    },
+    {
+      "name": "template-ide",
+      "path": "templates/ide",
+      "aliases": []
+    },
+    {
+      "name": "template-incident-console",
+      "path": "templates/incident-console",
+      "aliases": []
+    },
+    {
+      "name": "template-kanban-board",
+      "path": "templates/kanban-board",
+      "aliases": []
+    },
+    {
+      "name": "template-library",
+      "path": "templates/library",
+      "aliases": []
+    },
+    {
+      "name": "template-login",
+      "path": "templates/login",
+      "aliases": []
+    },
+    {
+      "name": "template-login-card",
+      "path": "templates/login-card",
+      "aliases": []
+    },
+    {
+      "name": "template-login-split",
+      "path": "templates/login-split",
+      "aliases": []
+    },
+    {
+      "name": "template-login-sso",
+      "path": "templates/login-sso",
+      "aliases": []
+    },
+    {
+      "name": "template-messaging-shell",
+      "path": "templates/messaging-shell",
+      "aliases": []
+    },
+    {
+      "name": "template-mixed-gallery",
+      "path": "templates/mixed-gallery",
+      "aliases": []
+    },
+    {
+      "name": "template-payment-form",
+      "path": "templates/payment-form",
+      "aliases": []
+    },
+    {
+      "name": "template-product-detail",
+      "path": "templates/product-detail",
+      "aliases": []
+    },
+    {
+      "name": "template-product-gallery",
+      "path": "templates/product-gallery",
+      "aliases": []
+    },
+    {
+      "name": "template-settings",
+      "path": "templates/settings",
+      "aliases": []
+    },
+    {
+      "name": "template-settings-dialog",
+      "path": "templates/settings-dialog",
+      "aliases": []
+    },
+    {
+      "name": "template-settings-sidebar",
+      "path": "templates/settings-sidebar",
+      "aliases": []
+    },
+    {
+      "name": "template-shell-nav",
+      "path": "templates/shell-nav",
+      "aliases": []
+    },
+    {
+      "name": "template-shell-side-nav",
+      "path": "templates/shell-side-nav",
+      "aliases": []
+    },
+    {
+      "name": "template-shell-top-nav",
+      "path": "templates/shell-top-nav",
+      "aliases": []
+    },
+    {
+      "name": "template-side-gallery",
+      "path": "templates/side-gallery",
+      "aliases": []
+    },
+    {
+      "name": "template-table",
+      "path": "templates/table",
+      "aliases": []
+    },
+    {
+      "name": "template-table-filter",
+      "path": "templates/table-filter",
+      "aliases": []
+    },
+    {
+      "name": "template-table-grouped",
+      "path": "templates/table-grouped",
+      "aliases": []
+    },
+    {
+      "name": "template-table-inbox",
+      "path": "templates/table-inbox",
+      "aliases": []
+    },
+    {
+      "name": "template-table-page",
+      "path": "templates/table-page",
+      "aliases": []
+    },
+    {
+      "name": "template-theme-showcase",
+      "path": "templates/theme-showcase",
+      "aliases": []
+    },
+    {
+      "name": "template-work-item-detail",
+      "path": "templates/work-item-detail",
+      "aliases": []
+    }
+  ]
+}

--- a/packages/cli/assets/docs/shadcn-compatibility.doc.mjs
+++ b/packages/cli/assets/docs/shadcn-compatibility.doc.mjs
@@ -1,0 +1,171 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').ReferenceDoc} */
+
+export const docs = {
+  name: 'shadcn-compatibility',
+  title: 'Use Astryx with shadcn',
+  category: 'guide',
+  description:
+    'Install Astryx components, examples, blocks, and pages through the shadcn Registry workflow without replacing the Astryx package or CLI.',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'Astryx supports the shadcn Registry as a compatibility and distribution protocol. This does not make Astryx a shadcn-based library. The Astryx packages remain the implementation and the Astryx CLI remains the primary interface for discovery, composition, theming, validation, and upgrades.',
+        },
+        {
+          type: 'prose',
+          text: 'A shadcn registry is static JSON that tells the shadcn CLI which package dependencies to install, which application-level files to copy, and which CSS imports to add. Read the protocol documentation at https://ui.shadcn.com/docs/registry.',
+        },
+        {
+          type: 'prose',
+          text: 'This compatibility path is experimental. Use it to test incremental adoption in an existing shadcn-style application. Do not treat the registry URL or generated catalog as a stable support promise until Astryx announces it as supported.',
+        },
+      ],
+    },
+    {
+      title: 'Naming and URL Stability',
+      content: [
+        {
+          type: 'prose',
+          text: 'Registry URLs are organized by item kind and derived from stable Astryx doc identity: component and hook `name`, block `name` plus `exampleFor`, and the existing page-template slug. `displayName` remains free to change without changing an install URL.',
+        },
+        {
+          type: 'code',
+          lang: 'text',
+          label: 'Registry path families',
+          code: `/shadcn/components/button.json
+/shadcn/hooks/use-app-shell-mobile.json
+/shadcn/showcases/button/variants.json
+/shadcn/examples/button/icon.json
+/shadcn/blocks/filter-toolbar.json
+/shadcn/templates/dashboard.json`,
+        },
+        {
+          type: 'prose',
+          text: 'A doc may set `registry.slug` when the derived slug is not the intended public name. After publication, keep prior relative paths in `registry.aliases`. Generation compares every name and path with a reviewed route lock, so an accidental rename fails instead of silently breaking old commands.',
+        },
+      ],
+    },
+    {
+      title: 'What Gets Installed',
+      content: [
+        {
+          type: 'table',
+          headers: ['Item', 'What the CLI adds', 'Who owns updates'],
+          rows: [
+            [
+              'Component or hook',
+              'The published Astryx package plus a local public re-export',
+              'Astryx updates the implementation through the package',
+            ],
+            [
+              'Showcase or example',
+              'Editable application-level composition source that imports Astryx packages',
+              'Your app owns the composition; Astryx owns the imported components',
+            ],
+            [
+              'Block',
+              'A larger editable composition plus its package dependencies',
+              'Your app owns the composition; Astryx owns the imported components',
+            ],
+            [
+              'Page',
+              'A complete editable page plus its package dependencies',
+              'Your app owns the page; Astryx owns the imported components',
+            ],
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'A normal registry install never copies Astryx component implementation source. Deep source customization remains an explicit `astryx swizzle <Name>` action because copied implementation source leaves the package upgrade path.',
+        },
+      ],
+    },
+    {
+      title: 'Install with shadcn',
+      content: [
+        {
+          type: 'prose',
+          text: 'Use the install command shown on a component, example, or template page. The shadcn CLI reads the item, installs the declared dependencies, writes the local composition or re-export, and adds the Astryx CSS imports to your configured stylesheet.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Install the Button package entry',
+          code: 'npx shadcn@latest add <registry-origin>/components/button.json',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Install the editable Button showcase',
+          code: 'npx shadcn@latest add <registry-origin>/showcases/button/variants.json',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Install the complete dashboard page',
+          code: 'npx shadcn@latest add <registry-origin>/templates/dashboard.json',
+        },
+      ],
+    },
+    {
+      title: 'What the Command Changes',
+      content: [
+        {
+          type: 'prose',
+          text: 'For a component entry, the command installs `@astryxdesign/core` and writes a small local file such as `src/components/astryx/Button.ts` that re-exports `@astryxdesign/core/Button`. Behavior, accessibility, styling, and fixes still come from the package.',
+        },
+        {
+          type: 'code',
+          lang: 'ts',
+          label: 'Generated public re-export',
+          code: "export * from '@astryxdesign/core/Button';",
+        },
+        {
+          type: 'prose',
+          text: 'For an example, block, or page, the command writes editable TSX into your app. That TSX imports public Astryx package paths. It does not reach into package internals and it does not require a StyleX compiler in your app.',
+        },
+      ],
+    },
+    {
+      title: 'Use the Astryx CLI for the Richer Path',
+      content: [
+        {
+          type: 'prose',
+          text: 'Use shadcn when you already use its registry workflow and know the exact item you want. Use the Astryx CLI when you need to discover the right component, compose a page from a natural-language request, inspect complete guidance, build a theme, validate an installation, or apply an upgrade codemod.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Astryx discovery and maintenance',
+          code: `astryx build "analytics dashboard with filters"
+astryx component Button
+astryx template dashboard
+astryx doctor
+astryx upgrade --apply`,
+        },
+      ],
+    },
+    {
+      title: 'Upgrade Model and Limits',
+      content: [
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Package upgrades update Astryx components, hooks, behavior, accessibility, and compiled styles.',
+            'Copied examples, blocks, and pages are application code. They do not update automatically when the catalog changes.',
+            'The experimental catalog excludes unpublished packages because an external package manager cannot install them.',
+            'Your project needs a valid components.json and TypeScript configuration for the shadcn CLI to resolve target paths.',
+            'The compatibility layer is additive. It does not require replacing existing shadcn components or migrating the whole application.',
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/cli/assets/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.doc.mjs
@@ -6,6 +6,7 @@ export const doc = {
   exampleFor: 'Collapsible',
   name: 'Collapsible — FAQ',
   displayName: 'Collapsible — FAQ',
+  registry: {aliases: ['collapsible/divided-accordion']},
   description:
     "FAQ built with hasDividers: row hairlines and density padding with no custom CSS. Questions set their own type — body at semibold, not the trigger's default 17px large — so a list of questions reads as rows rather than a stack of headings, and question and answer separate on weight and color instead of size.",
   isReady: true,

--- a/packages/cli/assets/templates/blocks/components/CollapsibleGroup/CollapsibleGroupAccordion.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/CollapsibleGroup/CollapsibleGroupAccordion.doc.mjs
@@ -6,6 +6,7 @@ export const doc = {
   exampleFor: 'CollapsibleGroup',
   name: 'CollapsibleGroup — Density',
   displayName: 'CollapsibleGroup — Density',
+  registry: {aliases: ['collapsible-group/accordion']},
   description:
     "density sets the block padding on every row in the group, so a list of sections can be tuned to the surface it sits on without touching the rows. compact for dense surfaces like sidebars and inspectors, balanced (the default) for page content, spacious for a short list that is the main thing on the page. It follows Table's scale and pairs with hasDividers, which turns it on at balanced.",
   isReady: true,

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -5,6 +5,21 @@
  */
 
 /**
+ * Stable public identity for generated registry resources.
+ *
+ * The converter derives a slug from the doc's stable `name` by default. Set
+ * `slug` only when the public URL must differ from that derived value. When a
+ * published slug changes, keep prior relative paths in `aliases` so existing
+ * install commands continue to work.
+ */
+export interface RegistryDocIdentity {
+  /** Lowercase kebab-case leaf slug override. */
+  slug?: string;
+  /** Prior paths within the item's kind root, without `.json`. */
+  aliases?: string[];
+}
+
+/**
  * Documents one element in a component's anatomy breakdown.
  * Anatomy describes the visual/structural parts that make up a component
  * (e.g. a Button has: left icon, label, end content, container).

--- a/packages/cli/authoring/doctypes/component/component.doc.mjs
+++ b/packages/cli/authoring/doctypes/component/component.doc.mjs
@@ -30,7 +30,7 @@ export const doc = {
       name: 'name',
       type: 'string',
       description:
-        "Directory name without the Astryx prefix, PascalCase. e.g. 'Button', 'TextInput', 'AppShell'.",
+        "Stable machine identity and directory name without the Astryx prefix, PascalCase. e.g. 'Button', 'TextInput', 'AppShell'. Change `displayName`, not `name`, to edit the visible label; registry URLs derive from this identity by default.",
       required: true,
     },
     {
@@ -39,6 +39,12 @@ export const doc = {
       description:
         "Human-readable display name with spaces between words ('AppShell' → 'App Shell'). Drives the docsite gallery and sidebar label.",
       required: true,
+    },
+    {
+      name: 'registry',
+      type: 'RegistryDocIdentity',
+      description:
+        'Optional public registry identity. The converter derives a stable kebab-case slug from `name`; set `slug` only to override it, and keep prior relative paths in `aliases` after a published rename.',
     },
     {
       name: 'keywords',

--- a/packages/cli/authoring/doctypes/component/type.ts
+++ b/packages/cli/authoring/doctypes/component/type.ts
@@ -16,6 +16,7 @@ import type {
   ComponentThemingVar,
   HookParamDoc,
   HookReturnDoc,
+  RegistryDocIdentity,
   UsageDoc,
 } from '../base/type';
 
@@ -29,8 +30,12 @@ export interface ComponentBaseDoc {
    *  `export const docs = {...}` docs omit it, and `parseDoc` falls back to
    *  shape-sniffing when it is absent. */
   type?: 'component';
-  /** Directory name without the Astryx prefix, PascalCase.
-   *  e.g. `"Button"`, `"Table"`, `"TextInput"`, `"AppShell"` */
+  /**
+   * Stable machine identity and directory name without the Astryx prefix,
+   * PascalCase (for example `Button`, `Table`, or `AppShell`). Do not change
+   * this to edit the visible label; use `displayName` for that. Registry URLs
+   * derive from this value by default.
+   */
   name: string;
   /** Human-readable display name with spaces between words, used by the
    *  docsite gallery and sidebar. Matches the import name visually (so
@@ -100,6 +105,8 @@ export interface ComponentBaseDoc {
    *  only make sense within a parent (e.g. BreadcrumbItem, DialogHeader)
    *  or internal primitives that shouldn't appear in the gallery. */
   isHiddenFromOverview?: boolean;
+  /** Optional stable slug override and prior aliases for registry output. */
+  registry?: RegistryDocIdentity;
   /** Theming configuration. Documents the stable selector surface rendered
    *  by this component: `xds-*` classes plus data-attribute reflections that
    *  themes can target via `@scope` selectors in `defineTheme`. */
@@ -171,6 +178,8 @@ export interface ComponentEntry {
   /** One-sentence description of what this specific component does.
    *  For sub-components, explain the role within the parent composition. */
   description: string;
+  /** Optional stable slug override and prior aliases for this entry. */
+  registry?: RegistryDocIdentity;
   /** All public props for this component. Omit for hook entries. */
   props?: ComponentPropDoc[];
   /** Hook parameters or options object fields. Use for `use*` entries. */

--- a/packages/cli/authoring/doctypes/hook/hook.doc.mjs
+++ b/packages/cli/authoring/doctypes/hook/hook.doc.mjs
@@ -29,7 +29,7 @@ export const doc = {
       name: 'name',
       type: 'string',
       description:
-        "Hook name exactly as exported, e.g. 'useMediaQuery', 'useFocusTrap'.",
+        "Stable hook name exactly as exported, e.g. 'useMediaQuery', 'useFocusTrap'. Change `displayName`, not `name`, to edit the visible label; registry URLs derive from this identity by default.",
       required: true,
     },
     {
@@ -38,6 +38,12 @@ export const doc = {
       description:
         "Human-readable display name. Hooks read better as the raw identifier ('useMediaQuery') than spaced, so keep the identifier verbatim.",
       required: true,
+    },
+    {
+      name: 'registry',
+      type: 'RegistryDocIdentity',
+      description:
+        'Optional public registry identity. The converter derives a stable kebab-case slug from `name`; set `slug` only to override it, and keep prior relative paths in `aliases` after a published rename.',
     },
     {
       name: 'group',

--- a/packages/cli/authoring/doctypes/hook/type.ts
+++ b/packages/cli/authoring/doctypes/hook/type.ts
@@ -9,6 +9,7 @@ import type {
   ComponentBestPractice,
   HookParamDoc,
   HookReturnDoc,
+  RegistryDocIdentity,
   UsageDoc,
 } from '../base/type';
 
@@ -41,6 +42,8 @@ export interface HookDoc {
   group?: string;
   /** Search keywords for CLI discovery. */
   keywords?: string[];
+  /** Optional stable slug override and prior aliases for registry output. */
+  registry?: RegistryDocIdentity;
   /** Hook parameters or options object fields. */
   params: HookParamDoc[];
   /** Return value documentation. For object returns, list each field.

--- a/packages/cli/authoring/doctypes/template/parse.mjs
+++ b/packages/cli/authoring/doctypes/template/parse.mjs
@@ -20,6 +20,22 @@ const previewSchema = z
   })
   .strict();
 
+const registryIdentitySchema = z
+  .object({
+    slug: z
+      .string()
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+      .optional(),
+    aliases: z
+      .array(
+        z
+          .string()
+          .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*(?:\/[a-z0-9]+(?:-[a-z0-9]+)*)*$/),
+      )
+      .optional(),
+  })
+  .strict();
+
 const baseTemplateFields = {
   name: z.string().min(1, 'name is required'),
   displayName: z.string().min(1).optional(),
@@ -30,28 +46,45 @@ const baseTemplateFields = {
   isReady: z.boolean().optional(),
   scaffold: z.boolean().optional(),
   isHiddenFromOverview: z.boolean().optional(),
+  registry: registryIdentitySchema.optional(),
 };
 
-const templateEnvelopeSchema = z.discriminatedUnion('type', [
-  z.object({...baseTemplateFields, type: z.literal('page')}).strict(),
-  z
-    .object({
-      ...baseTemplateFields,
-      type: z.literal('block'),
-      exampleFor: z.string().optional(),
-      alsoExampleFor: z.array(z.string()).optional(),
-      alsoShowcaseFor: z.array(z.string()).optional(),
-      aspectRatio: z.number().positive().optional(),
-      scale: z.number().positive().optional(),
-      isShowcase: z.boolean().optional(),
-    })
-    .strict(),
-]);
+const pageTemplateSchema = z
+  .object({...baseTemplateFields, type: z.literal('page')})
+  .strict();
+const blockTemplateSchema = z
+  .object({
+    ...baseTemplateFields,
+    type: z.literal('block'),
+    exampleFor: z.string().min(1).optional(),
+    alsoExampleFor: z.array(z.string()).optional(),
+    alsoShowcaseFor: z.array(z.string()).optional(),
+    aspectRatio: z.number().positive().optional(),
+    scale: z.number().positive().optional(),
+    isShowcase: z.boolean().optional(),
+  })
+  .strict();
+
+const templateEnvelopeSchema = z
+  .discriminatedUnion('type', [pageTemplateSchema, blockTemplateSchema])
+  .superRefine((template, context) => {
+    if (
+      template.type === 'block' &&
+      template.isShowcase &&
+      !template.exampleFor
+    ) {
+      context.addIssue({
+        code: 'custom',
+        path: ['exampleFor'],
+        message: 'exampleFor is required when isShowcase is true',
+      });
+    }
+  });
 
 /**
  * Validate an unknown value as a stamped template doc, or throw. The zod schema
- * validates the minimal integration-template envelope; the returned value is
- * typed as the public {@link TemplateDoc}.
+ * validates the integration-template envelope; the returned value is typed as
+ * the public {@link TemplateDoc}.
  *
  * @param {unknown} input
  * @param {string} [label]

--- a/packages/cli/authoring/doctypes/template/parse.test.mjs
+++ b/packages/cli/authoring/doctypes/template/parse.test.mjs
@@ -63,6 +63,51 @@ describe('parseTemplate (load boundary)', () => {
     });
   });
 
+  it('accepts a standalone block without component ownership', () => {
+    const parsed = parseTemplate({
+      type: 'block',
+      name: 'FilterToolbar',
+      description: 'Filters a data view.',
+      aspectRatio: 16 / 9,
+    });
+    expect(parsed.exampleFor).toBeUndefined();
+  });
+
+  it('requires component ownership for a showcase', () => {
+    expect(() =>
+      parseTemplate({
+        type: 'block',
+        name: 'HeroShowcase',
+        description: 'A component hero.',
+        isShowcase: true,
+      }),
+    ).toThrow(/exampleFor/);
+  });
+
+  it('accepts stable registry slug and alias metadata', () => {
+    const parsed = parseTemplate({
+      type: 'page',
+      name: 'Landing',
+      description: 'A landing page.',
+      registry: {slug: 'landing', aliases: ['old-landing']},
+    });
+    expect(parsed.registry).toEqual({
+      slug: 'landing',
+      aliases: ['old-landing'],
+    });
+  });
+
+  it('rejects invalid registry paths', () => {
+    expect(() =>
+      parseTemplate({
+        type: 'page',
+        name: 'Landing',
+        description: 'A landing page.',
+        registry: {slug: 'Landing Page'},
+      }),
+    ).toThrow(/registry/);
+  });
+
   it('rejects a missing name', () => {
     expect(reason({type: 'page', description: 'x'})).toContain('name');
   });

--- a/packages/cli/authoring/doctypes/template/template.doc.mjs
+++ b/packages/cli/authoring/doctypes/template/template.doc.mjs
@@ -16,22 +16,22 @@ export const doc = {
   description:
     'The doc-type for template metadata. A discriminated union of PageTemplateDoc ' +
     "(type: 'page') for full page templates and BlockTemplateDoc (type: 'block') for " +
-    'component example blocks. Both share BaseTemplateDoc; block templates add ' +
-    'example/preview fields.',
+    'editable compositions. A block can stand alone or use `exampleFor` to attach ' +
+    'to one component; `isShowcase` requires that component ownership.',
   appliesTo: '<Name>.template.mjs',
   fields: [
     {
       name: 'type',
       type: "'page' | 'block'",
       description:
-        "Discriminant selecting the variant: 'page' for a full page template, 'block' for a component example block.",
+        "Discriminant selecting the variant: 'page' for a full page template, 'block' for an editable composition that may be standalone or component-owned.",
       required: true,
     },
     {
       name: 'name',
       type: 'string',
       description:
-        'Identifier. For block templates it matches the React component import name; for page templates it is a human-readable label.',
+        'Stable identifier for block templates; change `displayName`, not `name`, to edit their visible label. For page templates it is a human-readable label, while the existing template-directory/CLI slug owns the default registry path.',
       required: true,
     },
     {
@@ -40,6 +40,12 @@ export const doc = {
       description:
         "Human-readable label for the gallery/CLI. Spaces out block names that mirror a PascalCase component ('ChatMessageMetadata' → 'Chat Message Metadata').",
       required: true,
+    },
+    {
+      name: 'registry',
+      type: 'RegistryDocIdentity',
+      description:
+        'Optional public registry identity. The converter derives a stable kebab-case slug from `name` (or the existing page-template slug); set `slug` only to override it, and keep prior relative paths in `aliases` after a published rename.',
     },
     {
       name: 'description',
@@ -74,7 +80,7 @@ export const doc = {
       name: 'exampleFor',
       type: 'string',
       description:
-        "Block templates only (required): the component this block is an example of, matching the component's doc name (e.g. 'Button'). Powers examples on component detail pages.",
+        'Block templates only: optional component ownership. Set this when the block is specifically an example of one component. Omit it for a standalone composition.',
     },
     {
       name: 'alsoExampleFor',
@@ -110,7 +116,7 @@ export const doc = {
       name: 'isShowcase',
       type: 'boolean',
       description:
-        "Block templates only: when true this block is the canonical 'hero' showcase for its `exampleFor` component.",
+        'Block templates only: when true this block is the canonical hero showcase for its `exampleFor` component. Requires `exampleFor`.',
     },
   ],
   examples: [
@@ -144,14 +150,14 @@ export const doc = {
   notes: [
     {
       type: 'prose',
-      text: "TemplateDoc is a discriminated union keyed by `type`. Set `type: 'page'` for a standalone page template (only the BaseTemplateDoc fields apply) or `type: 'block'` for a component example (the exampleFor/aspectRatio/showcase fields apply).",
+      text: "TemplateDoc is a discriminated union keyed by `type`. Set `type: 'page'` for a full page template. Set `type: 'block'` for an editable composition; add `exampleFor` only when one component owns the example.",
     },
     {
       type: 'list',
       style: 'unordered',
       items: [
         "PageTemplateDoc (type: 'page'): a full page template; `name` doubles as its display value.",
-        "BlockTemplateDoc (type: 'block'): an example of a component; requires `exampleFor` and `aspectRatio`.",
+        "BlockTemplateDoc (type: 'block'): an editable composition. `exampleFor` is optional component ownership; omit it for a standalone block. `isShowcase` requires `exampleFor`.",
       ],
     },
     {

--- a/packages/cli/authoring/doctypes/template/type.ts
+++ b/packages/cli/authoring/doctypes/template/type.ts
@@ -4,6 +4,8 @@
  * @file Template doc types.
  */
 
+import type {RegistryDocIdentity} from '../base/type';
+
 export interface BaseTemplateDoc {
   /** Identifier name for the template. For block templates this matches
    *  the React component import name (e.g. `"ChatMessageMetadata"`); for
@@ -21,6 +23,8 @@ export interface BaseTemplateDoc {
   /** One-sentence description of what the template provides. */
   description?: string;
 
+  /** Optional stable slug override and prior aliases for registry output. */
+  registry?: RegistryDocIdentity;
   /** Whether this template is ready for use. Templates with
    *  isReady: false show as "(WIP)" in the gallery and CLI. */
   isReady?: boolean;
@@ -45,10 +49,9 @@ export interface BaseTemplateDoc {
 
 export interface BlockTemplateDoc extends BaseTemplateDoc {
   type: 'block';
-  /** The component this block is an example of.
-   *  Matches the component's doc name (e.g. 'Button', 'Dialog', 'Stack').
-   *  Used by the docsite to show relevant examples on component detail pages. */
-  exampleFor: string;
+  /** The component this block is an example of. When omitted, the block is a
+   *  standalone composition and is not owned by any component doc page. */
+  exampleFor?: string;
   /** Additional component or hook doc pages whose Examples section should
    *  include this block. Use when a component example is also the canonical
    *  usage example for one of that component's hooks. */
@@ -64,7 +67,8 @@ export interface BlockTemplateDoc extends BaseTemplateDoc {
   /** Component names this block uses, for cross-referencing.
    *  Powers "See also" and "Used in" sections — not for primary attribution. */
   componentsUsed?: string[];
-  /** When true this block is the canonical "hero" showcase for a component. */
+  /** When true this block is the canonical hero showcase for `exampleFor`.
+   *  Requires `exampleFor`; standalone blocks cannot be component showcases. */
   isShowcase?: boolean;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7
       '@babel/preset-react':
         specifier: ^8.0.1
         version: 8.0.1(@babel/core@7.29.7)
@@ -245,6 +248,9 @@ importers:
       autoprefixer:
         specifier: ^10.5.2
         version: 10.5.2(postcss@8.5.25)
+      shadcn:
+        specifier: 4.19.0
+        version: 4.19.0(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1397,6 +1403,13 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dotenvx/dotenvx@1.75.1':
+    resolution: {integrity: sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ==}
+    hasBin: true
+
+  '@dotenvx/primitives@0.8.0':
+    resolution: {integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==}
 
   '@dual-bundle/import-meta-resolve@4.2.1':
     resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
@@ -3311,6 +3324,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -3550,6 +3570,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@ts-morph/common@0.27.0':
+    resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -3648,6 +3671,9 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@types/validate-npm-package-name@4.0.2':
+    resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -3846,6 +3872,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -3915,6 +3949,10 @@ packages:
 
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+
+  atomically@1.7.0:
+    resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
+    engines: {node: '>=10.12.0'}
 
   autoprefixer@10.5.2:
     resolution: {integrity: sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==}
@@ -3996,6 +4034,10 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001800:
     resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
 
@@ -4046,6 +4088,10 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
   cli-truncate@5.2.0:
     resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
     engines: {node: '>=20'}
@@ -4075,6 +4121,9 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -4103,6 +4152,10 @@ packages:
 
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
+  conf@10.2.0:
+    resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
+    engines: {node: '>=12'}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -4137,6 +4190,15 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4250,6 +4312,10 @@ packages:
     resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
     engines: {node: '>=20'}
 
+  debounce-fn@4.0.0:
+    resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
+    engines: {node: '>=10'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -4265,12 +4331,24 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
@@ -4279,6 +4357,14 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
+
+  default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -4306,6 +4392,10 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -4322,6 +4412,14 @@ packages:
 
   dompurify@3.4.14:
     resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
+
+  dot-prop@6.0.1:
+    resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
+    engines: {node: '>=10'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4360,9 +4458,16 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -4514,6 +4619,14 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -4561,6 +4674,10 @@ packages:
 
   fflate@0.8.3:
     resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4619,6 +4736,10 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
+    engines: {node: '>=14.14'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -4639,6 +4760,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fuzzysort@3.1.0:
+    resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
 
   generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
@@ -4664,9 +4788,21 @@ packages:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
 
+  get-own-enumerable-keys@1.0.0:
+    resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
+    engines: {node: '>=14.16'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4743,6 +4879,14 @@ packages:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
     hasBin: true
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -4766,6 +4910,10 @@ packages:
 
   immer@11.1.9:
     resolution: {integrity: sha512-sc/z0Cyti70bZa0ZU4sWfAElfovFb9Ni8tArJZLuklYWxegPiK3pDOql1Rq5H0FIRAW9LSQRG6OX4KqBldbhBA==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4796,9 +4944,17 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -4817,14 +4973,34 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
@@ -4836,13 +5012,37 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
@@ -4850,6 +5050,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
@@ -4918,11 +5122,17 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@7.0.3:
+    resolution: {integrity: sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
@@ -4941,12 +5151,23 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -5074,6 +5295,10 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -5149,6 +5374,9 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -5164,6 +5392,14 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  mimic-fn@3.1.0:
+    resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
+    engines: {node: '>=8'}
 
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
@@ -5261,6 +5497,14 @@ packages:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -5268,6 +5512,10 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  object-treeify@1.1.33:
+    resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
+    engines: {node: '>= 10'}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
@@ -5280,6 +5528,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -5288,9 +5540,21 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  open@11.0.2:
+    resolution: {integrity: sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==}
+    engines: {node: '>=20'}
+
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -5337,12 +5601,27 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -5355,6 +5634,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -5411,6 +5694,10 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  pkg-up@3.1.0:
+    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
+    engines: {node: '>=8'}
+
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
@@ -5454,6 +5741,14 @@ packages:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  powershell-utils@0.2.1:
+    resolution: {integrity: sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==}
+    engines: {node: '>=20'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5472,9 +5767,17 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  pretty-ms@9.3.1:
+    resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
+    engines: {node: '>=18'}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -5615,6 +5918,10 @@ packages:
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -5696,6 +6003,11 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  shadcn@4.19.0:
+    resolution: {integrity: sha512-EQF6R+CUXTsEP2BpyhxrUEAFesrtFD1POvVOf5jM+wkgtA4kG1EW1+1Wlmi9LqiprSL681JJXBcS0u8WkVVVyQ==}
+    engines: {node: '>=20.18.1'}
+    hasBin: true
+
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
@@ -5736,9 +6048,15 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -5755,6 +6073,14 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks@2.8.10:
+    resolution: {integrity: sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5787,6 +6113,10 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   storybook@10.4.6:
     resolution: {integrity: sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A==}
     hasBin: true
@@ -5817,6 +6147,10 @@ packages:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
+  stringify-object@5.0.0:
+    resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
+    engines: {node: '>=14.16'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -5832,6 +6166,14 @@ packages:
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -5872,6 +6214,12 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  systeminformation@5.33.8:
+    resolution: {integrity: sha512-v4F6OGYGh7wDvV68YmjOmZwGixV9A/GQ7d2b84t0UF4CaOy9jipNWIJDkHqYDYiTPuiojqlwVQd0hfUKOUN7tQ==}
+    engines: {node: '>=10.0.0'}
+    os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
+    hasBin: true
 
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
@@ -5974,6 +6322,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-morph@26.0.0:
+    resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
+
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
@@ -6034,9 +6385,21 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -6115,6 +6478,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -6349,6 +6716,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -6389,6 +6761,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  wsl-utils@1.0.0:
+    resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
+    engines: {node: '>=20'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -6426,6 +6802,14 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-spinner@1.2.2:
+    resolution: {integrity: sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==}
+    engines: {node: '>=18.19'}
+
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
+    engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -7015,6 +7399,27 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dotenvx/dotenvx@1.75.1':
+    dependencies:
+      '@dotenvx/primitives': 0.8.0
+      commander: 11.1.0
+      conf: 10.2.0
+      dotenv: 17.4.2
+      enquirer: 2.4.1
+      env-paths: 2.2.1
+      execa: 5.1.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      ignore: 5.3.2
+      object-treeify: 1.1.33
+      open: 8.4.2
+      picomatch: 4.0.4
+      systeminformation: 5.33.8
+      undici: 7.29.0
+      which: 4.0.0
+      yocto-spinner: 1.2.2
+
+  '@dotenvx/primitives@0.8.0': {}
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
@@ -7726,6 +8131,28 @@ snapshots:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
       react: 19.2.7
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.1.0(hono@4.13.1)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.13.1
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
@@ -8638,6 +9065,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -8896,6 +9327,12 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@ts-morph/common@0.27.0':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 10.2.6
+      path-browserify: 1.0.1
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -8992,6 +9429,8 @@ snapshots:
   '@types/trusted-types@2.0.7': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -9204,6 +9643,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -9263,6 +9706,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  atomically@1.7.0: {}
 
   autoprefixer@10.5.2(postcss@8.5.25):
     dependencies:
@@ -9348,6 +9793,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  callsites@3.1.0: {}
+
   caniuse-lite@1.0.30001800: {}
 
   chai@5.3.3:
@@ -9392,6 +9839,8 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
+  cli-spinners@2.9.2: {}
+
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
@@ -9427,6 +9876,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  code-block-writer@13.0.3: {}
+
   commander@11.1.0: {}
 
   commander@12.1.0: {}
@@ -9442,6 +9893,19 @@ snapshots:
   commondir@1.0.1: {}
 
   compare-versions@6.1.1: {}
+
+  conf@10.2.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      atomically: 1.7.0
+      debounce-fn: 4.0.0
+      dot-prop: 6.0.1
+      env-paths: 2.2.1
+      json-schema-typed: 7.0.3
+      onetime: 5.1.2
+      pkg-up: 3.1.0
+      semver: 7.8.5
 
   confbox@0.1.8: {}
 
@@ -9463,6 +9927,15 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cosmiconfig@9.0.2(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -9570,6 +10043,10 @@ snapshots:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
 
+  debounce-fn@4.0.0:
+    dependencies:
+      mimic-fn: 3.1.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -9578,9 +10055,13 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  dedent@1.7.2: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
 
@@ -9588,6 +10069,13 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  default-browser@5.5.1:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
 
@@ -9605,6 +10093,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  diff@8.0.4: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -9620,6 +10110,12 @@ snapshots:
   dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  dot-prop@6.0.1:
+    dependencies:
+      is-obj: 2.0.0
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -9651,7 +10147,13 @@ snapshots:
 
   entities@8.0.0: {}
 
+  env-paths@2.2.1: {}
+
   environment@1.1.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-define-property@1.0.1: {}
 
@@ -9890,6 +10392,33 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.0
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.1
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.2.0
+
   expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
@@ -9958,6 +10487,10 @@ snapshots:
 
   fflate@0.8.3: {}
 
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -10022,6 +10555,12 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -10041,6 +10580,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fuzzysort@3.1.0: {}
 
   generic-pool@3.9.0: {}
 
@@ -10065,10 +10606,19 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
+  get-own-enumerable-keys@1.0.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   glob-parent@5.1.2:
     dependencies:
@@ -10160,6 +10710,10 @@ snapshots:
 
   human-id@4.2.0: {}
 
+  human-signals@2.1.0: {}
+
+  human-signals@8.0.1: {}
+
   husky@9.1.7: {}
 
   iconv-lite@0.6.3:
@@ -10175,6 +10729,11 @@ snapshots:
   ignore@7.0.5: {}
 
   immer@11.1.9: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
 
@@ -10197,9 +10756,13 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-arrayish@0.2.1: {}
+
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.4
+
+  is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
 
@@ -10213,11 +10776,21 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ssh@1.0.0: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
 
+  is-interactive@2.0.0: {}
+
   is-number@7.0.0: {}
+
+  is-obj@2.0.0: {}
+
+  is-obj@3.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-plain-object@2.0.4:
     dependencies:
@@ -10227,17 +10800,33 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-regexp@3.1.0: {}
+
+  is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
   is-windows@1.0.2: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
 
   isobject@3.0.1: {}
 
@@ -10325,9 +10914,13 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@7.0.3: {}
 
   json-schema-typed@8.0.2: {}
 
@@ -10341,11 +10934,21 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
   kind-of@6.0.3: {}
+
+  kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   levn@0.4.1:
     dependencies:
@@ -10449,6 +11052,11 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.3.0
@@ -10515,6 +11123,8 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -10527,6 +11137,10 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mimic-fn@2.1.0: {}
+
+  mimic-fn@3.1.0: {}
 
   mimic-function@5.0.1: {}
 
@@ -10623,9 +11237,20 @@ snapshots:
 
   node-releases@2.0.50: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-treeify@1.1.33: {}
 
   obug@2.1.3: {}
 
@@ -10636,6 +11261,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   onetime@7.0.0:
     dependencies:
@@ -10648,6 +11277,21 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
+  open@11.0.2:
+    dependencies:
+      default-browser: 5.5.1
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.2.1
+      wsl-utils: 1.0.0
+
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -10656,6 +11300,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
 
   outdent@0.5.0: {}
 
@@ -10738,17 +11394,34 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parse-ms@4.0.0: {}
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -10791,6 +11464,10 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  pkg-up@3.1.0:
+    dependencies:
+      find-up: 3.0.0
+
   playwright-core@1.61.1: {}
 
   playwright@1.61.1:
@@ -10823,6 +11500,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  powershell-utils@0.1.0: {}
+
+  powershell-utils@0.2.1: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -10835,7 +11516,16 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-ms@9.3.1:
+    dependencies:
+      parse-ms: 4.0.0
+
   prismjs@1.30.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   proxy-addr@2.0.7:
     dependencies:
@@ -10989,6 +11679,8 @@ snapshots:
 
   reselect@5.2.0: {}
 
+  resolve-from@4.0.0: {}
+
   resolve-from@5.0.0: {}
 
   resolve@1.22.12:
@@ -11120,6 +11812,47 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  shadcn@4.19.0(typescript@6.0.3):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@dotenvx/dotenvx': 1.75.1
+      '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
+      '@types/validate-npm-package-name': 4.0.2
+      browserslist: 4.28.4
+      commander: 14.0.3
+      cosmiconfig: 9.0.2(typescript@6.0.3)
+      dedent: 1.7.2
+      deepmerge: 4.3.1
+      diff: 8.0.4
+      execa: 9.6.1
+      fast-glob: 3.3.3
+      fs-extra: 11.4.0
+      fuzzysort: 3.1.0
+      kleur: 4.1.5
+      open: 11.0.2
+      ora: 8.2.0
+      postcss: 8.5.25
+      postcss-selector-parser: 7.1.5
+      prompts: 2.4.2
+      recast: 0.23.12
+      socks: 2.8.10
+      stringify-object: 5.0.0
+      tailwind-merge: 3.6.0
+      ts-morph: 26.0.0
+      tsconfig-paths: 4.2.0
+      undici: 7.29.0
+      validate-npm-package-name: 7.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - babel-plugin-macros
+      - supports-color
+      - typescript
+
   shallow-clone@3.0.1:
     dependencies:
       kind-of: 6.0.3
@@ -11194,7 +11927,11 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 
@@ -11209,6 +11946,13 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  smart-buffer@4.2.0: {}
+
+  socks@2.8.10:
+    dependencies:
+      ip-address: 10.4.0
+      smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
 
@@ -11233,6 +11977,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
+
+  stdin-discarder@0.2.2: {}
 
   storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7):
     dependencies:
@@ -11275,6 +12021,12 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
+  stringify-object@5.0.0:
+    dependencies:
+      get-own-enumerable-keys: 1.0.0
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -11286,6 +12038,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-bom@4.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
@@ -11319,6 +12075,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  systeminformation@5.33.8: {}
 
   tabbable@6.5.0: {}
 
@@ -11393,6 +12151,11 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-morph@26.0.0:
+    dependencies:
+      '@ts-morph/common': 0.27.0
+      code-block-writer: 13.0.3
+
   ts-pattern@5.9.0: {}
 
   tsconfig-paths@4.2.0:
@@ -11464,7 +12227,13 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici@7.29.0: {}
+
+  unicorn-magic@0.3.0: {}
+
   universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 
@@ -11516,6 +12285,8 @@ snapshots:
       react: 19.2.7
 
   util-deprecate@1.0.2: {}
+
+  validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
 
@@ -11851,6 +12622,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -11883,6 +12658,11 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
+  wsl-utils@1.0.0:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -11912,6 +12692,16 @@ snapshots:
       lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
+
+  yocto-spinner@1.2.2:
+    dependencies:
+      yoctocolors: 2.2.0
+
+  yoctocolors@2.2.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## Summary

- generate a standard shadcn Registry projection from the existing Astryx component and template catalogs
- keep components package-backed while copying editable showcases, examples, blocks, and pages
- add secondary per-page install commands, a compatibility guide, and a draft blog post

## Architecture

The existing `.doc.mjs` metadata, sibling composition source, and owning `package.json` remain the source of truth. The docsite generator emits a static registry index and one JSON item per installable surface. There is no parallel hand-authored catalog.

The normal Astryx component and template documentation remains the human browse experience. Applicable pages show a secondary shadcn command after their primary documentation. Raw machine routes are organized under `/shadcn/components`, `/shadcn/hooks`, `/shadcn/showcases/<component>`, `/shadcn/examples/<component>`, `/shadcn/blocks`, and `/shadcn/templates`. `exampleFor` is optional. Unowned compositions are standalone blocks, while component-owned records become examples or showcases. IDs derive from stable doc/catalog identity, with optional `registry.slug`, compatibility aliases, collision checks, and a reviewed route lock.

Component items install the owning Astryx package and write a public re-export. Composition items write editable app code that imports published Astryx package paths. Fourteen compositions with local StyleX declarations are precompiled to compiler-free JSX during generation.

## Launch boundary

The compatibility foundation is approved and preview builds emit the full registry from their own `/shadcn` origin with `@canary` dependencies. The production `latest` target stays disabled until copied-composition upgrades and public support ownership are ready. `/r` remains reserved for a future Astryx-native protocol.

## Validation

- 968 generated items: 216 components, 54 hooks, 160 showcases, 486 component examples, 0 standalone blocks, and 52 pages
- every prior locked route remains available as a canonical path or alias
- all items validate against the pinned shadcn 4.19.0 schema
- real shadcn 4.19.0 install from an arbitrary nested `/shadcn/...` URL with a full-URL `registryDependencies` item
- prior whole-catalog proof installed all 921 entries into a clean Vite app and built 6,620 modules
- workspace build and full docsite production build
- CLI typecheck and 3,577 CLI tests
- docsite typecheck and 495 docsite tests
- 30 focused registry and authoring contract tests
- strict lint, repository checks, and knowledge checks

