### PR TITLE
docs(LayoutFooter): seed playground preview fixture (#5895)

### DIFF
--- a/.changeset/layoutfooter-properties-preview.md
+++ b/.changeset/layoutfooter-properties-preview.md
@@ -2,4 +2,8 @@
 '@astryxdesign/core': patch
 ---
 
-[docs] LayoutFooter: seed example content via playground defaults (footer text plus a Layout parent wrapper) so the docsite properties-tab preview renders a working footer instead of an empty stage. (#5895)
+[docs] LayoutFooter: seed playground defaults and a Layout footer-slot wrapper for the docsite preview (#5895)
+
+Prevents the properties-tab preview on the docsite from rendering an empty stage by seeding representative footer content and mounting LayoutFooter in the Layout wrapper's footer slot, so the preview shows a docked footer instead of a centred label.
+
+@Rijul202

--- a/.changeset/layoutfooter-properties-preview.md
+++ b/.changeset/layoutfooter-properties-preview.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] LayoutFooter: seed example content via playground defaults (footer text plus a Layout parent wrapper) so the docsite properties-tab preview renders a working footer instead of an empty stage. (#5895)

--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -220,6 +220,22 @@ describe('component detail preview state', () => {
     },
   );
 
+  it('seeds LayoutFooter children from playground defaults so the preview is not empty (#5895)', () => {
+    const knobs = pickPrimaryProps('LayoutFooter', [
+      prop({name: 'children', type: 'ReactNode'}),
+      prop({name: 'hasDivider', type: 'boolean'}),
+      prop({name: 'height', type: 'SizeValue'}),
+    ]);
+
+    const state = buildInitialState(knobs, {
+      defaults: {children: 'Showing 1–10 of 24', hasDivider: true},
+    });
+
+    expect(state.children).toBe('Showing 1–10 of 24');
+    expect(state.hasDivider).toBe(true);
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+  });
+
   it("satisfies Icon's required, non-generatable icon prop via playground defaults", () => {
     const knobs = pickPrimaryProps('Icon', [
       prop({

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -465,6 +465,19 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('LayoutFooter declares a playground wrapper and default content so preview is not empty (#5895)', () => {
+    const core = components['@astryxdesign/core'];
+    const layoutFooter = core.find(c => c.name === 'LayoutFooter');
+    expect(layoutFooter).toBeDefined();
+    expect(layoutFooter!.playground?.defaults).toMatchObject({
+      children: expect.any(String),
+      hasDivider: true,
+    });
+    expect(layoutFooter!.playground?.wrapper).toMatchObject({
+      component: 'Layout',
+    });
+  });
+
   it('Lightbox declares an overlay playground with a closed initial state (#3657)', () => {
     const core = components['@astryxdesign/core'];
     const lightbox = core.find(c => c.name === 'Lightbox');

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -475,6 +475,9 @@ describe('componentRegistry', () => {
     });
     expect(layoutFooter!.playground?.wrapper).toMatchObject({
       component: 'Layout',
+      // Mount into Layout's footer slot, not its default (centred) content
+      // slot, so the preview shows a docked footer.
+      slotProp: 'footer',
     });
   });
 

--- a/packages/core/src/Layout/LayoutFooter.doc.mjs
+++ b/packages/core/src/Layout/LayoutFooter.doc.mjs
@@ -8,6 +8,19 @@ export const docs = {
   displayName: 'Layout Footer',
   isHiddenFromOverview: true,
   description: 'Bottom bar for action bars, pagination, and status bars.',
+  playground: {
+    // LayoutFooter is a Layout landmark region and renders an empty bar on its
+    // own. Seed representative footer content and wrap it in a Layout so the
+    // properties-tab preview shows a visible footer on first load, mirroring
+    // the sibling LayoutHeader fixture.
+    defaults: {
+      children: 'Showing 1–10 of 24',
+      hasDivider: true,
+    },
+    wrapper: {
+      component: 'Layout',
+    },
+  },
   props: [
     {
       name: 'children',

--- a/packages/core/src/Layout/LayoutFooter.doc.mjs
+++ b/packages/core/src/Layout/LayoutFooter.doc.mjs
@@ -10,15 +10,17 @@ export const docs = {
   description: 'Bottom bar for action bars, pagination, and status bars.',
   playground: {
     // LayoutFooter is a Layout landmark region and renders an empty bar on its
-    // own. Seed representative footer content and wrap it in a Layout so the
-    // properties-tab preview shows a visible footer on first load, mirroring
-    // the sibling LayoutHeader fixture.
+    // own. Seed representative footer content and mount it in the Layout
+    // wrapper's footer slot (not the default content slot, which would centre
+    // the text) so the properties-tab preview shows a docked footer on first
+    // load.
     defaults: {
       children: 'Showing 1–10 of 24',
       hasDivider: true,
     },
     wrapper: {
       component: 'Layout',
+      slotProp: 'footer',
     },
   },
   props: [


### PR DESCRIPTION
Seeds a playground preview fixture for **LayoutFooter** so the docsite properties-tab preview renders a working footer instead of an empty landmark bar on first load.

- Adds `playground.defaults` (footer text + `hasDivider`) and a `Layout` parent wrapper, mirroring the sibling `LayoutHeader` fixture.
- Docsite tests cover the non-empty preview state (`component-preview-state`) and the registry shape (`data-extraction`).

Rebased on latest `main` (clears the earlier conflict). Per @cixzhang's review, this PR is now **scoped to LayoutFooter only** — the DropdownMenuRadioGroup half is dropped here so the radio-item accessibility fix can converge in #5976.

Closes #5895.