### PR TITLE
feat(NumberInput): add family-aligned isLoading and changeAction support

### DIFF
--- a/.changeset/numberinput-family-loading-change-action.md
+++ b/.changeset/numberinput-family-loading-change-action.md
@@ -1,0 +1,22 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] NumberInput: add family-aligned `isLoading` and `changeAction` support (#5778)
+
+`NumberInput` now exposes the input-field family's `isLoading` and `changeAction`
+concepts. `changeAction` runs after `onChange` for the same value change, inside a
+React transition, and the proposed value is presented optimistically until the
+controlled value accepts or replaces it — in the field text, in `aria-valuenow`,
+in clear-button visibility, and as the base for further stepping, so repeated
+steps during an in-flight action advance (1 → 2 → 3) instead of resubmitting the
+same number. An explicit `isLoading` and a pending `changeAction` resolve to a
+single busy presentation: one Spinner in the end lane plus `aria-busy` on the
+input, never two indicators.
+
+`changeAction` follows `onChange` through the existing `hasClear` split, widening
+to `(value: number | null)` when the field is clearable. Form submission continues
+to send the committed `value`, not a proposed one. Callsites that pass neither
+prop are unaffected.
+
+@Alif416

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -217,6 +217,19 @@ export const docs = {
       type: '() => void',
       description: 'Callback fired when the user presses the Enter key.',
     },
+    {
+      name: 'isLoading',
+      type: 'boolean',
+      description:
+        'Whether the input is in a loading state (field value is resolving or being saved).',
+      default: 'false',
+    },
+    {
+      name: 'changeAction',
+      type: '(value: number) => void | Promise<void>',
+      description:
+        'Async action on change. Fires after onChange if not prevented. Runs in a React transition for optimistic updates.',
+    },
   ],
   theming: {
     targets: [

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -221,14 +221,14 @@ export const docs = {
       name: 'isLoading',
       type: 'boolean',
       description:
-        'Whether the input is in a loading state (field value is resolving or being saved).',
+        'Whether the field value is resolving or being saved. Shares one busy presentation (spinner and aria-busy) with a pending changeAction — the two never render separate indicators.',
       default: 'false',
     },
     {
       name: 'changeAction',
-      type: '(value: number) => void | Promise<void>',
+      type: '(value: number) => void | Promise<void>  //  (value: number | null) => void | Promise<void> with hasClear',
       description:
-        'Async action on change. Fires after onChange if not prevented. Runs in a React transition for optimistic updates.',
+        'Async action run after onChange for the same value change, in a React transition. The proposed value is shown optimistically — in the field, in aria-valuenow, and as the base for further stepping — until the controlled value accepts or replaces it, and it contributes to the same busy presentation as isLoading. Widens to accept null alongside onChange when hasClear is set.',
     },
   ],
   theming: {
@@ -505,6 +505,19 @@ export const docsZh = {
       type: '() => void',
       description: '用户按下 Enter 键时触发的回调。',
     },
+    {
+      name: 'isLoading',
+      type: 'boolean',
+      description:
+        '字段值是否正在解析或保存中。与进行中的 changeAction 共用同一个繁忙呈现（加载指示器与 aria-busy），两者不会渲染各自独立的指示器。',
+      default: 'false',
+    },
+    {
+      name: 'changeAction',
+      type: '(value: number) => void | Promise<void>  //  设置 hasClear 时为 (value: number | null) => void | Promise<void>',
+      description:
+        '在同一次值变更中于 onChange 之后运行的异步操作，包裹在 React transition 中。在受控值接受或替换之前，拟定值会以乐观方式呈现——显示在输入框、aria-valuenow 以及后续步进的基准值中——并与 isLoading 共用同一个繁忙呈现。设置 hasClear 时，其类型与 onChange 一同扩展为接受 null。',
+    },
   ],
   theming: {
     targets: [
@@ -708,5 +721,9 @@ export const docsDense = {
     onFocus: 'Callback on focus.',
     onBlur: 'Callback on blur.',
     onEnter: 'Callback on Enter key.',
+    isLoading:
+      'Field value resolving or being saved. Shares one busy presentation (spinner + aria-busy) w/ pending changeAction.',
+    changeAction:
+      'Async action after onChange, in a transition. Proposed value shown optimistically (field, aria-valuenow, stepping base) until controlled value accepts it. Accepts null w/ hasClear.',
   },
 };

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -2438,3 +2438,197 @@ describe('NumberInput stepper padding coupling', () => {
     expect(css).toContain('border-radius: 2px');
   });
 });
+
+// =============================================================================
+// Family-aligned isLoading + changeAction (input-field family FR5/FR6)
+// =============================================================================
+
+describe('NumberInput changeAction and isLoading', () => {
+  /**
+   * A controlled owner that only accepts the value once its async save
+   * resolves — the shape that exposed the original bug. While the save is in
+   * flight the `value` prop still holds the old number, so anything rendering
+   * or deriving from `value` instead of the optimistic value goes stale.
+   */
+  function createDeferred() {
+    let resolve!: () => void;
+    const promise = new Promise<void>(r => {
+      resolve = r;
+    });
+    return {promise, resolve};
+  }
+
+  function DeferredOwner({
+    initialValue,
+    onSave,
+    hasClear,
+  }: {
+    initialValue: number | null;
+    onSave: (value: number | null) => Promise<void>;
+    hasClear?: true;
+  }) {
+    const [value, setValue] = useState<number | null>(initialValue);
+    return (
+      <NumberInput
+        label="Amount"
+        value={value}
+        hasClear={hasClear}
+        hasNumberSteppers
+        // The owner deliberately does NOT setValue here; it commits only after
+        // the async action resolves, like a server round-trip.
+        onChange={() => {}}
+        changeAction={async (next: number | null) => {
+          await onSave(next);
+          setValue(next);
+        }}
+      />
+    );
+  }
+
+  it('renders the optimistic value while a changeAction is in flight', async () => {
+    const deferred = createDeferred();
+    render(
+      <DeferredOwner initialValue={1} onSave={async () => deferred.promise} />,
+    );
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveValue('1');
+
+    fireEvent.click(screen.getByRole('button', {name: 'Increment Amount'}));
+
+    // The pending value is visible immediately, not after the save resolves.
+    await waitFor(() => expect(input).toHaveValue('2'));
+    expect(input).toHaveAttribute('aria-valuenow', '2');
+
+    await act(async () => {
+      deferred.resolve();
+      await deferred.promise;
+    });
+    await waitFor(() => expect(input).toHaveValue('2'));
+  });
+
+  it('exposes one busy presentation while a changeAction is in flight', async () => {
+    const deferred = createDeferred();
+    render(
+      <DeferredOwner initialValue={1} onSave={async () => deferred.promise} />,
+    );
+    const input = screen.getByRole('spinbutton');
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Increment Amount'}));
+
+    await waitFor(() => expect(input).toHaveAttribute('aria-busy', 'true'));
+    // Exactly one indicator, never a separate one per source of busyness.
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    await act(async () => {
+      deferred.resolve();
+      await deferred.promise;
+    });
+    await waitFor(() => expect(input).not.toHaveAttribute('aria-busy'));
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('steps from the optimistic value so a second step does not resubmit', async () => {
+    const deferred = createDeferred();
+    const saved: (number | null)[] = [];
+    render(
+      <DeferredOwner
+        initialValue={1}
+        onSave={async next => {
+          saved.push(next);
+          return deferred.promise;
+        }}
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+    const increment = screen.getByRole('button', {name: 'Increment Amount'});
+
+    fireEvent.click(increment);
+    await waitFor(() => expect(input).toHaveValue('2'));
+
+    // Second step while the first is still in flight must advance to 3.
+    fireEvent.click(increment);
+    await waitFor(() => expect(input).toHaveValue('3'));
+    expect(saved).toEqual([2, 3]);
+
+    await act(async () => {
+      deferred.resolve();
+      await deferred.promise;
+    });
+  });
+
+  it('renders optimistically and passes null through the clear path', async () => {
+    const deferred = createDeferred();
+    const saved: (number | null)[] = [];
+    render(
+      <DeferredOwner
+        initialValue={7}
+        hasClear
+        onSave={async next => {
+          saved.push(next);
+          return deferred.promise;
+        }}
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveValue('7');
+
+    fireEvent.click(screen.getByRole('button', {name: 'Clear Amount'}));
+
+    // Field empties immediately and the clear button retires with it.
+    await waitFor(() => expect(input).toHaveValue(''));
+    expect(saved).toEqual([null]);
+    expect(
+      screen.queryByRole('button', {name: 'Clear Amount'}),
+    ).not.toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-busy', 'true');
+
+    await act(async () => {
+      deferred.resolve();
+      await deferred.promise;
+    });
+  });
+
+  it('exposes the same busy presentation for isLoading alone', () => {
+    const {rerender} = render(
+      <NumberInput label="Amount" value={3} onChange={() => {}} />,
+    );
+    const input = screen.getByRole('spinbutton');
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <NumberInput label="Amount" value={3} onChange={() => {}} isLoading />,
+    );
+    expect(screen.getByRole('spinbutton')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+  });
+
+  it('leaves the no-changeAction path unchanged', () => {
+    const onChange = vi.fn();
+    render(
+      <NumberInput
+        label="Amount"
+        value={5}
+        onChange={onChange}
+        hasNumberSteppers
+      />,
+    );
+    const input = screen.getByRole('spinbutton');
+
+    fireEvent.keyDown(input, {key: 'ArrowUp'});
+    expect(onChange).toHaveBeenLastCalledWith(6);
+    // No changeAction means nothing is ever busy and no indicator appears.
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -24,6 +24,8 @@ import {
   useMemo,
   useCallback,
   useRef,
+  useTransition,
+  useOptimistic,
   type FocusEvent,
   type KeyboardEvent,
   type ReactNode,
@@ -399,6 +401,16 @@ interface NumberInputPropsBase extends Omit<
    * Callback fired on keydown events on the input.
    */
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
+  /**
+   * Whether the input is in a loading state (field value is resolving or being saved).
+   * @default false
+   */
+  isLoading?: boolean;
+  /**
+   * Async action on change. Fires after onChange if not prevented.
+   * Runs in a React transition for optimistic updates.
+   */
+  changeAction?: (value: number) => void | Promise<void>;
 }
 
 /**
@@ -535,6 +547,8 @@ export function NumberInput({
   statusVariant = 'attached',
   size: sizeProp,
   onChange,
+  changeAction,
+  isLoading = false,
   value,
   placeholder,
   labelTooltip,
@@ -573,6 +587,10 @@ export function NumberInput({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputGroup = useInputGroup();
+
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || optimisticValue !== value;
 
   // Pending input while user is typing (null = show formatted value)
   const [pendingInput, setPendingInput] = useState<string | null>(null);
@@ -695,12 +713,24 @@ export function NumberInput({
       if (decision.type === 'clear') {
         if (hasClear && value != null) {
           onChange(null);
+          if (changeAction) {
+            startTransition(async () => {
+              setOptimisticValue(null);
+              await changeAction(null);
+            });
+          }
         }
       } else if (decision.type === 'commit' && decision.value !== value) {
         onChange(decision.value);
+        if (changeAction) {
+          startTransition(async () => {
+            setOptimisticValue(decision.value);
+            await changeAction(decision.value);
+          });
+        }
       }
     },
-    [hasClear, isIntegerOnly, locale, max, min, onChange, pendingInput, value],
+    [hasClear, isIntegerOnly, locale, max, min, onChange, changeAction, pendingInput, value, startTransition],
   );
 
   // Blur ends the edit and displays the resulting committed value.
@@ -750,9 +780,15 @@ export function NumberInput({
       setPendingInput(null);
       if (nextValue !== value) {
         onChange(nextValue);
+        if (changeAction) {
+          startTransition(async () => {
+            setOptimisticValue(nextValue);
+            await changeAction(nextValue);
+          });
+        }
       }
     },
-    [getNextValue, isDisabled, isReadOnly, onChange, value],
+    [getNextValue, isDisabled, isReadOnly, onChange, changeAction, value, startTransition],
   );
 
   // Handle keyboard events
@@ -832,10 +868,16 @@ export function NumberInput({
   const handleClear = useCallback(() => {
     if (hasClear) {
       onChange(null);
+      if (changeAction) {
+        startTransition(async () => {
+          setOptimisticValue(null);
+          await changeAction(null);
+        });
+      }
     }
     setPendingInput(null);
     inputRef.current?.focus();
-  }, [hasClear, onChange]);
+  }, [hasClear, onChange, changeAction, startTransition]);
 
   // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
   const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -4,7 +4,8 @@
 
 /**
  * @file NumberInput.tsx
- * @input Uses React, useId, useState, useMemo, useCallback, Field, Icon, InputGroupContext
+ * @input Uses React, useId, useState, useMemo, useCallback, useTransition,
+ *   useOptimistic, Field, Icon, Spinner, InputGroupContext
  * @output Exports NumberInput component, NumberInputProps
  * @position Core implementation; consumed by index.ts, tested by NumberInput.test.tsx
  *
@@ -50,6 +51,7 @@ import {
   type FieldStatusVariant,
 } from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
+import {Spinner} from '../Spinner';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {useTooltip} from '../Tooltip';
 import {getInputARIA} from '../utils';
@@ -402,24 +404,33 @@ interface NumberInputPropsBase extends Omit<
    */
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   /**
-   * Whether the input is in a loading state (field value is resolving or being saved).
+   * Whether the field value is resolving or being saved.
+   *
+   * This is the input-family "input busy" state: it describes the value, not
+   * any component-owned data source. It shares one busy presentation with a
+   * pending `changeAction` — the two never render two separate indicators.
    * @default false
    */
   isLoading?: boolean;
-  /**
-   * Async action on change. Fires after onChange if not prevented.
-   * Runs in a React transition for optimistic updates.
-   */
-  changeAction?: (value: number) => void | Promise<void>;
 }
 
 /**
  * Without `hasClear`, onChange only receives valid numbers.
  * With `hasClear`, onChange also receives `null` when the user clears the input.
+ *
+ * `changeAction` follows `onChange` through the same split: it is handed the
+ * value that was just committed, so it widens to `null` alongside `onChange`
+ * when the field is clearable.
  */
 type NumberInputPropsNonClearable = NumberInputPropsBase & {
   hasClear?: false;
   onChange: (value: number) => void;
+  /**
+   * Async action run after `onChange` for the same value change. The proposed
+   * value is shown optimistically while it runs, and it contributes to the
+   * same busy presentation as `isLoading`.
+   */
+  changeAction?: (value: number) => void | Promise<void>;
 };
 
 type NumberInputPropsClearable = NumberInputPropsBase & {
@@ -432,6 +443,13 @@ type NumberInputPropsClearable = NumberInputPropsBase & {
    */
   hasClear: true;
   onChange: (value: number | null) => void;
+  /**
+   * Async action run after `onChange` for the same value change. The proposed
+   * value is shown optimistically while it runs, and it contributes to the
+   * same busy presentation as `isLoading`. Receives `null` when the user
+   * clears the input.
+   */
+  changeAction?: (value: number | null) => void | Promise<void>;
 };
 
 export type NumberInputProps =
@@ -590,7 +608,40 @@ export function NumberInput({
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+
+  // Everything user-visible reads this, never the raw `value` prop: while a
+  // changeAction is in flight the controlled prop still holds the old value,
+  // so rendering from it would show a stale number and — worse — would make
+  // the next step recompute from that stale base and resubmit the same value.
+  const effectiveValue = optimisticValue;
+
+  // One busy presentation for the whole family concept: an explicit isLoading
+  // and an in-flight changeAction are the same state to the user, so they
+  // resolve to a single flag driving a single indicator (never two).
   const isBusy = isLoading || optimisticValue !== value;
+
+  // Single funnel for the transition so the three value-change paths (text
+  // commit, step, clear) cannot drift apart.
+  //
+  // The cast is the one place the discriminated union has to be re-tied: the
+  // props type already guarantees changeAction accepts null exactly when
+  // hasClear is true, but destructuring severed the link TypeScript needs to
+  // see that. Every null below is inside a `hasClear` guard.
+  const runChangeAction = useCallback(
+    (nextValue: number | null) => {
+      if (!changeAction) {
+        return;
+      }
+      const action = changeAction as (
+        value: number | null,
+      ) => void | Promise<void>;
+      startTransition(async () => {
+        setOptimisticValue(nextValue);
+        await action(nextValue);
+      });
+    },
+    [changeAction, setOptimisticValue],
+  );
 
   // Pending input while user is typing (null = show formatted value)
   const [pendingInput, setPendingInput] = useState<string | null>(null);
@@ -641,11 +692,11 @@ export function NumberInput({
   );
 
   const formattedValue = useMemo(() => {
-    if (value == null) {
+    if (effectiveValue == null) {
       return '';
     }
-    return formatValue?.(value) ?? String(value);
-  }, [formatValue, value]);
+    return formatValue?.(effectiveValue) ?? String(effectiveValue);
+  }, [formatValue, effectiveValue]);
 
   // Preserve pending text while editing. Otherwise show the formatted value
   // at rest and the raw numeric value while focused so it remains editable.
@@ -653,11 +704,13 @@ export function NumberInput({
     if (pendingInput !== null) {
       return pendingInput;
     }
-    if (value == null) {
+    if (effectiveValue == null) {
       return '';
     }
-    return isFocused ? formatEditableNumber(value, locale) : formattedValue;
-  }, [formattedValue, isFocused, locale, pendingInput, value]);
+    return isFocused
+      ? formatEditableNumber(effectiveValue, locale)
+      : formattedValue;
+  }, [formattedValue, isFocused, locale, pendingInput, effectiveValue]);
 
   // Check if current pending input is valid (for styling purposes)
   const isInputValid = useMemo(() => {
@@ -710,27 +763,32 @@ export function NumberInput({
         setPendingInput(null);
       }
 
+      // Compared against the optimistic value so a commit that merely restates
+      // an already-pending change is not submitted a second time.
       if (decision.type === 'clear') {
-        if (hasClear && value != null) {
+        if (hasClear && effectiveValue != null) {
           onChange(null);
-          if (changeAction) {
-            startTransition(async () => {
-              setOptimisticValue(null);
-              await changeAction(null);
-            });
-          }
+          runChangeAction(null);
         }
-      } else if (decision.type === 'commit' && decision.value !== value) {
+      } else if (
+        decision.type === 'commit' &&
+        decision.value !== effectiveValue
+      ) {
         onChange(decision.value);
-        if (changeAction) {
-          startTransition(async () => {
-            setOptimisticValue(decision.value);
-            await changeAction(decision.value);
-          });
-        }
+        runChangeAction(decision.value);
       }
     },
-    [hasClear, isIntegerOnly, locale, max, min, onChange, changeAction, pendingInput, value, startTransition],
+    [
+      hasClear,
+      isIntegerOnly,
+      locale,
+      max,
+      min,
+      onChange,
+      runChangeAction,
+      pendingInput,
+      effectiveValue,
+    ],
   );
 
   // Blur ends the edit and displays the resulting committed value.
@@ -743,15 +801,18 @@ export function NumberInput({
     [commitPendingInput, onBlur],
   );
 
+  // Steps from the optimistic value, so repeated steps during an in-flight
+  // changeAction advance (1 -> 2 -> 3) instead of recomputing from the stale
+  // controlled value and resubmitting the same number.
   const valueForStepping = useMemo(() => {
     if (pendingInput === null) {
-      return value ?? null;
+      return effectiveValue ?? null;
     }
     if (pendingInput.trim() === '') {
       return null;
     }
-    return parseInput(pendingInput) ?? value ?? null;
-  }, [parseInput, pendingInput, value]);
+    return parseInput(pendingInput) ?? effectiveValue ?? null;
+  }, [parseInput, pendingInput, effectiveValue]);
 
   const getNextValue = useCallback(
     (direction: StepDirection) =>
@@ -778,17 +839,19 @@ export function NumberInput({
         return;
       }
       setPendingInput(null);
-      if (nextValue !== value) {
+      if (nextValue !== effectiveValue) {
         onChange(nextValue);
-        if (changeAction) {
-          startTransition(async () => {
-            setOptimisticValue(nextValue);
-            await changeAction(nextValue);
-          });
-        }
+        runChangeAction(nextValue);
       }
     },
-    [getNextValue, isDisabled, isReadOnly, onChange, changeAction, value, startTransition],
+    [
+      getNextValue,
+      isDisabled,
+      isReadOnly,
+      onChange,
+      runChangeAction,
+      effectiveValue,
+    ],
   );
 
   // Handle keyboard events
@@ -868,16 +931,11 @@ export function NumberInput({
   const handleClear = useCallback(() => {
     if (hasClear) {
       onChange(null);
-      if (changeAction) {
-        startTransition(async () => {
-          setOptimisticValue(null);
-          await changeAction(null);
-        });
-      }
+      runChangeAction(null);
     }
     setPendingInput(null);
     inputRef.current?.focus();
-  }, [hasClear, onChange, changeAction, startTransition]);
+  }, [hasClear, onChange, runChangeAction]);
 
   // Focus input when clicking anywhere on the wrapper (icons, padding, etc.)
   const {onClick: handleWrapperClick, onMouseUp: handleWrapperMouseUp} =
@@ -948,16 +1006,20 @@ export function NumberInput({
         aria-valuemin={min ?? undefined}
         aria-valuemax={max ?? undefined}
         // The ARIA value and hidden form input expose the committed value;
-        // pendingInput is still an uncommitted edit and may be invalid.
-        aria-valuenow={value ?? undefined}
+        // pendingInput is still an uncommitted edit and may be invalid. The
+        // optimistic value is what the sighted user sees, so it is what gets
+        // exposed — otherwise assistive tech would read a different number
+        // from the one on screen while a changeAction is in flight.
+        aria-valuenow={effectiveValue ?? undefined}
         aria-valuetext={
-          value == null || !formatValue ? undefined : formattedValue
+          effectiveValue == null || !formatValue ? undefined : formattedValue
         }
         aria-describedby={ariaDescribedBy}
         aria-required={isEffectivelyRequired ? 'true' : undefined}
         aria-invalid={
           status?.type === 'error' || !isInputValid ? 'true' : undefined
         }
+        aria-busy={isBusy || undefined}
         aria-labelledby={ariaLabelledBy}
         {...stylex.props(
           styles.input,
@@ -965,6 +1027,11 @@ export function NumberInput({
           !isInputValid && styles.inputInvalid,
         )}
       />
+      {/*
+        Deliberately the committed `value`, not the optimistic one: a form must
+        submit what the owner has actually accepted, never a proposed value
+        that a pending changeAction may still reject.
+      */}
       {formatValue && htmlName && !isDisabled && (
         <input
           type="hidden"
@@ -985,12 +1052,19 @@ export function NumberInput({
       <VisuallyHidden as="div" role="alert" aria-live="assertive">
         {!isInputValid ? 'Invalid number' : ''}
       </VisuallyHidden>
-      {hasClear && value != null && !isDisabled && !isReadOnly && (
+      {hasClear && effectiveValue != null && !isDisabled && !isReadOnly && (
         <InputClearButton
           label={t('@astryx.numberInput.clearLabel', {label})}
           onClick={handleClear}
         />
       )}
+      {/*
+        The single busy presentation for both isLoading and an in-flight
+        changeAction. Placed in the end lane between clear and status so it
+        takes its own space rather than overlapping either (family FR2), and
+        ordered as in TextInput so the family reads consistently.
+      */}
+      {isBusy && <Spinner size="sm" />}
       {statusIcon}
       {hasNumberSteppers && (
         <div {...stylex.props(styles.numberSteppers)}>


### PR DESCRIPTION
## Summary

Add input-family aligned async action support to NumberInput component, enabling optimistic value updates and async operations to align with the input-field family contract.

## Changes

- **isLoading prop**: Indicates when field value is resolving or being saved (does not conflate with option-source loading)
- **changeAction callback**: Async action that runs after onChange in a React transition, enabling optimistic updates
- **Optimistic state management**: Uses useOptimistic hook for immediate visual feedback while async work completes
- **Consistent value-change paths**: Apply changeAction to text commit, step increment/decrement, and clear button actions

## Implementation Details

Per the input-field family specification (FR5, FR6):
- `onChange` fires immediately when user action occurs
- Optimistic value updates show proposed change instantly
- `changeAction` runs in a React transition for async operations
- Both synchronous and asynchronous flows preserve immediate user feedback
- Maintains existing behavior for components not using changeAction

## Testing

- [x] Component accepts and uses isLoading prop
- [x] changeAction invoked on value change (text, step, clear)
- [x] Optimistic values update before async work completes
- [x] Unchanged legacy path without changeAction still works
- [x] Prop documentation added to NumberInput.doc.mjs

Fixes #5941

