### PR TITLE
docs(spec): define keyboard-reachable scroll containers

### DIFF
--- a/docs/specs/AST-019/spec.md
+++ b/docs/specs/AST-019/spec.md
@@ -1,0 +1,156 @@
+---
+schema_version: 1
+template_version: 1
+kind: system-spec
+id: spec:AST-019
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+phase: proposed
+owners: [cixzhang, imdreamrunner]
+affects_architecture:
+  [architecture:interaction-modality, architecture:public-component-api]
+affects_families: []
+affects_contributing: []
+affects_consumer_docs:
+  [accessibility-checklist, BottomSheet, useScrollableTabStop]
+---
+
+# Keyboard-reachable scroll containers system spec
+
+## Intent
+
+People using a keyboard must be able to reach and scroll Astryx-owned scroll
+containers. Astryx adds a fallback sequential-focus stop only when real overflow
+needs one. A fitting box, a box that only clips content, or a region already
+reachable through a visible sequential-focus descendant must not gain a dead or
+duplicate stop.
+
+This shared rule prevents each component from making a different `tabindex`
+decision. BottomSheet is the first proposed adopter in
+[#5553](https://github.com/facebook/astryx/pull/5553), following the defect in
+[#5207](https://github.com/facebook/astryx/issues/5207).
+
+## Non-goals
+
+- Making every element with `overflow: auto` a tab stop before it actually
+  overflows.
+- Treating clipped or hidden overflow as keyboard-scrollable.
+- Adding a generic stop before a visible descendant already in the sequential
+  focus order.
+- Assigning a landmark role or accessible name when the content already
+  identifies the region.
+- Defining scroll geometry, scrollbars, overscroll behavior, or focus-indicator
+  design.
+- Requiring real assistive-technology evidence for an ordinary browser Tab-order
+  and keyboard-scrolling claim.
+
+## Requirements
+
+| ID  | Rule                                                                                                                                                                                                                                                         |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| FR1 | An Astryx-owned container with user-scrollable overflow on either axis MUST have a route in the sequential keyboard focus order.                                                                                                                             |
+| FR2 | A visible sequential-focus descendant satisfies that route. The container MUST NOT add a generic fallback stop before it. Hidden, inert, disabled, or negative-`tabindex` descendants do not satisfy the route.                                              |
+| FR3 | When no descendant satisfies FR2, the scroll container MUST own one fallback stop with `tabindex="0"`.                                                                                                                                                       |
+| FR4 | The fallback condition MUST be derived per axis. Content must exceed the available box on that axis, and that axis must use a user-scrollable overflow mode such as `auto` or `scroll`. `hidden`, `clip`, and fitting content MUST NOT create the stop.      |
+| FR5 | The route MUST stay current when content size, container size, overflow mode, descendant visibility, or descendant focusability changes.                                                                                                                     |
+| FR6 | If the container itself is focused when the fallback condition becomes false, it MUST keep focus and its temporary stop until focus leaves. It MUST then remove the stale stop.                                                                              |
+| FR7 | A managed fallback MUST NOT overwrite or remove a `tabindex` owned by the component or consumer. Disabling or detaching the shared behavior removes only the stop it created.                                                                                |
+| FR8 | Keyboard focus on the fallback container MUST have one visible shared focus indicator in every supported theme. `architecture:interaction-modality` continues to own when keyboard focus indication is visible; the adopting component owns where it paints. |
+| FR9 | The container MUST have an accessible name when its content does not already identify the focused region. The shared behavior does not infer or generate that name.                                                                                          |
+
+### Public primitive and resources
+
+- **IR1 — One shared primitive.** Components that need this behavior MUST use the
+  shared implementation rather than repeat overflow, descendant-focus, and
+  cleanup logic.
+- **IR2 — Derive the answer.** The proposed public hook is
+  `useScrollableTabStop(options?: {enabled?: boolean})`. It returns a ref for the
+  scrolling element. `enabled` controls whether the behavior participates; the
+  caller does not mirror overflow or descendant-focus state in React props.
+- **IR3 — Compose ownership.** An adopting component composes the returned ref
+  with existing gesture, measurement, or consumer refs on the same scrolling
+  element.
+- **IR4 — Bound measurement.** One observer delivery MUST schedule at most one
+  pending measurement for an instance. Detach MUST cancel pending work and
+  release every observer and listener owned by that instance.
+- **IR5 — Client boundary is explicit.** The primitive reads rendered layout and
+  is client-only. Adoption MUST NOT move a server-safe component behind a client
+  boundary without a separate component or API decision.
+
+### Platform support
+
+- Supported feature/engine floor: [AST-013](../AST-013/spec.md) owns supported
+  browsers. Each adopter must work in every browser covered by that record.
+- Unsupported behavior: no fallback stop is added where the browser reports no
+  user-scrollable overflow. Content access must not depend on a stop whose scroll
+  operation the browser cannot perform.
+- Browser evidence: a real browser must prove Tab reachability, visible focus,
+  and keyboard scrolling for overflowing content, plus the unchanged fitting and
+  descendant-owned paths. Under [AST-009](../AST-009/spec.md), this is ordinary
+  browser focus and keyboard behavior, so it does not require a real-AT matrix
+  unless the change makes an additional AT-specific claim.
+
+## Current-state impact
+
+The proposed implementation in
+[#5553](https://github.com/facebook/astryx/pull/5553) introduces the shared hook
+and uses BottomSheet's existing scrolling content element as the first owner.
+Text-only overflowing sheets gain the fallback stop. Sheets with a visible
+button, link, input, or other sequential-focus descendant keep their existing
+Tab order.
+
+The current Accessibility Checklist does not state this rule and cannot create
+policy by itself. After this spec is accepted, that worksheet should add the
+shared primitive and link back here. The BottomSheet component draft links this
+spec directly so its accessibility section no longer says focus behavior is
+unchanged.
+
+This is additive behavior and an additive public hook. Existing component and
+consumer-owned `tabindex` values retain precedence under FR7.
+
+## Verification
+
+| Contract               | Verification                                                                | Representative states                                                                                                                              | Mutation or failure expectation                                                                                                            |
+| ---------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| FR1–FR4                | Unit decision tests plus real-browser keyboard probe                        | block or inline overflow; fitting content; `auto`/`scroll`; `hidden`/`clip`; visible, hidden, inert, disabled, and negative-`tabindex` descendants | An unreachable scroller remains, or a dead or duplicate stop enters Tab order.                                                             |
+| FR5–FR7                | Mutation, resize, focus-exit, author-ownership, and detach tests            | content grows/fits; overflow changes; descendant appears/disappears; focused fallback becomes unnecessary; explicit `tabindex`; unmount            | State becomes stale, focus is dropped, author state is overwritten, or cleanup changes an unowned attribute.                               |
+| FR8–FR9                | Real-browser focus-visible check plus accessibility-tree/name review        | every supported theme; content-identified and explicitly named regions                                                                             | Focus has no visible owner, two indicators paint, or an otherwise unidentified region receives a silent stop.                              |
+| IR1–IR5                | Source, export, ref-composition, observer-count, and server-boundary review | direct hook use; component adoption; resize batch; detach; server-safe candidate                                                                   | Logic forks by component, one delivery causes repeated measurement, resources survive detach, or adoption silently adds a client boundary. |
+| AST-009 classification | PR accessibility statement                                                  | browser-only keyboard claim; later AT-specific claim                                                                                               | A browser claim is over-gated, or an AT-specific claim ships without its required matrix.                                                  |
+
+## Decision log
+
+### DEC-1 — The scroll owner is a fallback, not an unconditional stop
+
+**Reference:** `spec:AST-019/DEC-1`
+**Decider:** pending owner approval
+
+A visible sequential-focus descendant owns keyboard entry when one exists.
+Otherwise, and only while the container actually scrolls, the container owns a
+fallback stop. This gives keyboard users access to read-only overflow without
+adding an extra stop to control-bearing or fitting regions.
+
+Rejected: unconditional `tabindex="0"`, because it adds dead and duplicate stops;
+and component-local checks, because content, focusability, overflow changes,
+focus stability, and cleanup would drift between adopters.
+
+### DEC-2 — Scrollability is derived from rendered behavior
+
+**Reference:** `spec:AST-019/DEC-2`
+**Decider:** pending owner approval
+
+Astryx derives the fallback from actual per-axis overflow and the rendered
+overflow mode. Callers may enable or disable participation, but they do not
+maintain a second source of truth for whether content currently scrolls or
+whether a descendant owns entry.
+
+Rejected: a caller-maintained `isOverflowing` or `hasFocusableChild` API, because
+those values duplicate DOM state and become stale across nested updates.
+
+## Open questions
+
+None. Both decisions remain proposals until an authorized owner approves this
+record and it becomes `current`.

--- a/packages/core/src/BottomSheet/BottomSheet.spec.md
+++ b/packages/core/src/BottomSheet/BottomSheet.spec.md
@@ -22,7 +22,7 @@ design_specs: []
 architecture:
   [architecture:component-theming-surface, architecture:layer-runtime]
 contributing: []
-system_specs: []
+system_specs: [spec:AST-019]
 ---
 
 # BottomSheet component contract
@@ -30,16 +30,17 @@ system_specs: []
 ## Intent
 
 BottomSheet presents caller-provided content in a panel that rises from the
-bottom edge. This draft records current consumer anatomy and theming reachability
-without changing runtime behavior, styling, targets, or public API.
+bottom edge. This draft records current consumer anatomy and projects the
+keyboard-reachable scrolling contract proposed by `spec:AST-019`. It does not
+change runtime behavior, styling, targets, or public API on its own.
 
 ## Compatibility and migration
 
 - Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, and public API remain unchanged
+- Compatibility class: additive keyboard behavior proposed by `spec:AST-019`;
+  existing component and consumer-owned `tabindex` values retain precedence
 - Controlled/uncontrolled behavior: unchanged
-- Migration decision: none
+- Migration decision: `spec:AST-019/DEC-1` and `spec:AST-019/DEC-2`
 
 Consumer migration instructions belong in consumer docs and release notes.
 
@@ -49,6 +50,8 @@ Consumer migration instructions belong in consumer docs and release notes.
 
 - The visual Sheet panel and its current `bottom-sheet` target.
 - The scrolling Content area and decorative Handle inside the panel.
+- The Content area's keyboard route when rendered overflow requires scrolling,
+  as proposed by `spec:AST-019`.
 - Standalone sheet presentation, including its optional native-dialog Scrim.
 
 **Does not own / non-goals**
@@ -67,10 +70,11 @@ in `BottomSheet.doc.mjs`.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                | Basis                           | Draft review state                                 |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- | -------------------------------------------------- |
-| FR1 | The current presented sheet contains one Sheet panel, one scrolling Content area, and one decorative Handle; a Scrim is present only in scrim-backed presentation. | Current source, docs, and tests | Verified current behavior; no new behavior decided |
-| FR2 | The Sheet panel carries `bottom-sheet`; Content area, Handle, and Scrim carry no BottomSheet public target.                                                        | Current source, docs, and tests | Verified current behavior; no target change        |
+| ID  | Candidate invariant                                                                                                                                                                                                                 | Basis                                      | Draft review state                                 |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | -------------------------------------------------- |
+| FR1 | The current presented sheet contains one Sheet panel, one scrolling Content area, and one decorative Handle; a Scrim is present only in scrim-backed presentation.                                                                  | Current source, docs, and tests            | Verified current behavior; no new behavior decided |
+| FR2 | The Sheet panel carries `bottom-sheet`; Content area, Handle, and Scrim carry no BottomSheet public target.                                                                                                                         | Current source, docs, and tests            | Verified current behavior; no target change        |
+| FR3 | Under the proposed `spec:AST-019` contract, an actually overflowing Content area with no visible sequential-focus descendant owns the fallback keyboard stop; control-bearing, fitting, clipped, and hidden-overflow states do not. | `spec:AST-019` and implementation PR #5553 | Proposed shared behavior; implementation pending   |
 
 ### Allowed variation
 
@@ -92,21 +96,26 @@ in `BottomSheet.doc.mjs`.
 
 ### Performance and resources
 
-- No new performance or resource rule is introduced.
+- `spec:AST-019/IR4` proposes one pending measurement per observer delivery
+  and complete cleanup when the Content area detaches.
 
 ## Accessibility contract
 
-This draft does not change or extend BottomSheet's existing dialog naming,
-focus, Handle, keyboard, or dismissal behavior.
+`spec:AST-019` proposes that the scrolling Content area remain reachable in the
+sequential keyboard focus order whenever it actually overflows. A visible
+sequential-focus descendant owns that route when one exists; otherwise Content
+owns the temporary fallback stop and shared visible focus indicator. The
+fallback does not change BottomSheet's dialog naming, focus trap, Handle,
+keyboard, or dismissal behavior.
 
 ## Design relationships
 
-| Anatomy or state | Design requirement                                                                    | Representation authority       | Hierarchy role | Component contract |
-| ---------------- | ------------------------------------------------------------------------------------- | ------------------------------ | -------------- | ------------------ |
-| Sheet panel      | Presents the painted bottom-edge surface and owns panel geometry and motion.          | Current source and public docs | Prominent      | FR1, FR2           |
-| Content area     | Provides the scrolling area for caller-provided sheet content.                        | Current source and tests       | Prominent      | FR1, FR2           |
-| Handle           | Presents the decorative grab affordance and owns the panel's drag interaction region. | Current source and tests       | Supporting     | FR1, FR2           |
-| Scrim            | Dims and blocks the page in a scrim-backed host.                                      | Current source and public docs | Supporting     | FR1, FR2           |
+| Anatomy or state | Design requirement                                                                                                          | Representation authority                  | Hierarchy role | Component contract |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------- | ------------------ |
+| Sheet panel      | Presents the painted bottom-edge surface and owns panel geometry and motion.                                                | Current source and public docs            | Prominent      | FR1, FR2           |
+| Content area     | Provides the scrolling area for caller-provided sheet content and the proposed fallback keyboard stop when FR3 requires it. | Current source, tests, and `spec:AST-019` | Prominent      | FR1, FR2, FR3      |
+| Handle           | Presents the decorative grab affordance and owns the panel's drag interaction region.                                       | Current source and tests                  | Supporting     | FR1, FR2           |
+| Scrim            | Dims and blocks the page in a scrim-backed host.                                                                            | Current source and public docs            | Supporting     | FR1, FR2           |
 
 Content area, Handle, and Scrim are stable visible parts, but no current public
 target reaches them. Their `none` dispositions record factual reachability, not
@@ -139,6 +148,8 @@ a decision that they must remain unthemeable.
 
 ## Family and system relationships
 
+- `spec:AST-019` owns the proposed shared fallback-stop condition, focus
+  stability, public primitive, resource bounds, and browser-evidence boundary.
 - `architecture:component-theming-surface` owns anatomy qualification, target
   mapping, and factual `none` dispositions.
 - `architecture:layer-runtime` owns the current native-dialog host distinction
@@ -149,12 +160,13 @@ a decision that they must remain unthemeable.
 
 ## Verification map
 
-| Contract            | Verification                                                              | Representative states                          | Mutation or failure expectation                                                                 | Audit section               |
-| ------------------- | ------------------------------------------------------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------- |
-| FR1                 | `BottomSheet.test.tsx` render, content, Handle, and scrim behavior suites | Modal, non-modal, and switcher presentations   | Removing a documented part fails existing content, structure, or dismissal assertions.          | `audit:BottomSheet/anatomy` |
-| FR2                 | Panel target assertion, source inspection, and theming target inventories | Sheet panel, Content area, Handle, and Scrim   | Removing the panel target or documenting an unshipped child target fails evidence or inventory. | `audit:BottomSheet/theming` |
-| Layout evidence     | `BottomSheetPanel.test.tsx`                                               | Floating Handle and scrolling Content area     | Reordering or merging the stable parts fails existing panel structure and style assertions.     | `audit:BottomSheet/anatomy` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                                             | Canonical anatomy and current target inventory | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.      | `audit:BottomSheet/theming` |
+| Contract            | Verification                                                                                                                  | Representative states                                                                                   | Mutation or failure expectation                                                                                        | Audit section                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| FR1                 | `BottomSheet.test.tsx` render, content, Handle, and scrim behavior suites                                                     | Modal, non-modal, and switcher presentations                                                            | Removing a documented part fails existing content, structure, or dismissal assertions.                                 | `audit:BottomSheet/anatomy`       |
+| FR2                 | Panel target assertion, source inspection, and theming target inventories                                                     | Sheet panel, Content area, Handle, and Scrim                                                            | Removing the panel target or documenting an unshipped child target fails evidence or inventory.                        | `audit:BottomSheet/theming`       |
+| FR3                 | Proposed `useScrollableTabStop` unit tests, BottomSheet panel tests, open Storybook fixture, and real-Chromium keyboard probe | Text-only overflow; visible/hidden/negative-tabindex descendant; fitting content; overflow-mode changes | Content becomes unreachable, a duplicate/dead stop appears, focus drops, or keyboard scrolling/focus indication fails. | `audit:BottomSheet/accessibility` |
+| Layout evidence     | `BottomSheetPanel.test.tsx`                                                                                                   | Floating Handle and scrolling Content area                                                              | Reordering or merging the stable parts fails existing panel structure and style assertions.                            | `audit:BottomSheet/anatomy`       |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                                                 | Canonical anatomy and current target inventory                                                          | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                             | `audit:BottomSheet/theming`       |
 
 Existing tests directly assert the Sheet panel target, Content area placement,
 Handle structure, and scrim behavior. Source and public target metadata confirm
@@ -162,8 +174,11 @@ that the other three parts have no public target.
 
 ## Decision log
 
-None. This draft records current facts and introduces no component-local design,
-API, theming, or layer-system decision.
+The current anatomy and theming facts introduce no component-local design,
+API, theming, or layer-system decision. `spec:AST-019/DEC-1` and
+`spec:AST-019/DEC-2` propose the shared accessibility and derivation decisions
+used by FR3; they are not authoritative until that system spec becomes
+`current`.
 
 ## Open questions
 


### PR DESCRIPTION
## Why

Keyboard users cannot reach an Astryx-owned scroll container when it overflows but contains no visible sequential-focus control. PR #5553 adds a shared public solution, but no current accessibility contract owns when that fallback stop should exist. The BottomSheet draft also still says focus behavior is unchanged.

## What

- Adds draft system spec `AST-019` for keyboard-reachable scroll containers: actual per-axis scrollability, descendant ownership, focus stability, author-owned `tabindex`, visible focus, naming, resource bounds, and browser evidence.
- Keeps assistive-technology verification with AST-009: ordinary Tab order and keyboard scrolling require real-browser evidence, not a real-AT matrix unless the change makes an AT-specific claim.
- Links the BottomSheet draft contract to AST-019 and projects the proposed behavior and verification from #5553.

## Ordering

This is the proposed shared contract below implementation PR #5553. It remains `draft` until an authorized owner approves the two decisions and promotes it to `current`; #5553 should then be reconciled with the accepted exact head.

## Validation

- Astryx CLI bootstrap and `astryx component BottomSheet --dense`
- `pnpm check:knowledge -- --base origin/main`
- Prettier
- `git diff --check`

No Changeset: specification records only.
