### PR TITLE
feat(ComplexSelector): add disabledMessage

### DIFF
--- a/.changeset/complexselector-disabled-message.md
+++ b/.changeset/complexselector-disabled-message.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] ComplexSelector: disabledMessage keeps a disabled trigger reachable and explains why it is disabled (#5941)
+
+A disabled ComplexSelector could not say why. `disabledMessage` adopts the input-field family's disabled-reason contract: with `isDisabled`, the trigger stays focusable via `aria-disabled`, a tooltip shows the reason on hover and keyboard focus and is linked through `aria-describedby`, and opening the popup stays blocked by pointer, keyboard, and the imperative handle. Without a reason the trigger is natively disabled exactly as before. Same recipe as Selector and MultiSelector.
+
+@AKnassa

--- a/apps/storybook/stories/ComplexSelector.stories.tsx
+++ b/apps/storybook/stories/ComplexSelector.stories.tsx
@@ -829,3 +829,46 @@ export const ControlledToolbarTrigger: Story = {
     },
   },
 };
+
+// Disabled with an explanation tooltip. Hover or keyboard-focus the trigger to
+// see why it's disabled — the reason is announced to assistive tech via
+// aria-describedby, and the trigger stays focusable (activation is still
+// blocked). Use disabledMessage instead of wrapping a disabled ComplexSelector
+// in Tooltip: disabled controls swallow the pointer events a Tooltip wrapper
+// needs.
+export const DisabledWithMessage: Story = {
+  name: 'Disabled with message',
+  render: () => {
+    const value: FruitValue = {fruit: 'Apple', ripeness: 'Juicy'};
+
+    return (
+      <VStack gap={4} xstyle={styles.wrapper}>
+        <ComplexSelector<FruitValue>
+          label="Fruit blend"
+          value={value}
+          triggerLabel={formatFruitValue(value)}
+          isDisabled
+          disabledMessage="You need the Editor role to change this"
+          contentXstyle={styles.fruitContent}>
+          {(selectedValue, onChange, close) => (
+            <FruitRipenessMatrix
+              value={selectedValue}
+              onChange={nextValue => {
+                onChange(nextValue);
+                close();
+              }}
+            />
+          )}
+        </ComplexSelector>
+      </VStack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A disabled selector that explains why. The reason shows as a tooltip on hover and keyboard focus and is linked through aria-describedby; the trigger stays focusable via aria-disabled while opening the popup stays blocked.',
+      },
+    },
+  },
+};

--- a/docs/families/input-fields.md
+++ b/docs/families/input-fields.md
@@ -222,7 +222,7 @@ another implementation helper.
 | FileInput       | Field, FormLayout, width, `isLoading`, `changeAction`, clear, status, and disabled reason                                  | no public `size`; compact and dropzone modes are component-owned                   |
 | Selector        | Field, FormLayout, InputGroup, size, width, `isLoading`, `changeAction`, clear, status, and disabled reason                | DEC-1 permits standalone content-sized width                                       |
 | MultiSelector   | Field, FormLayout, InputGroup, size, width, `isLoading`, `changeAction`, clear, status, and disabled reason                | trigger-display modes remain component-owned                                       |
-| ComplexSelector | Field, FormLayout, size, width, `isLoading`, `changeAction`, and status                                                    | no InputGroup or disabled-reason API                                               |
+| ComplexSelector | Field, FormLayout, size, width, `isLoading`, `changeAction`, status, and disabled reason                                   | no InputGroup support                                                              |
 | Typeahead       | Field, FormLayout, InputGroup, size, width, clear, status, disabled reason, and BaseTypeahead source loading               | no family `isLoading` or `changeAction`; search lifecycle is component-owned       |
 | Tokenizer       | Field, FormLayout, size, width, clear, status, disabled reason, BaseTypeahead source loading, and multi-token block growth | not InputGroup-compatible on current main; no family `isLoading` or `changeAction` |
 

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -133,6 +133,12 @@ export const docs = {
           description: 'Disables the selector.',
         },
         {
+          name: 'disabledMessage',
+          type: 'string',
+          description:
+            'Explains why the selector is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (activation stays blocked). Use this instead of wrapping a disabled ComplexSelector in Tooltip. Disabled controls swallow the hover events an external Tooltip needs.',
+        },
+        {
           name: 'isLoading',
           type: 'boolean',
           description: 'Shows loading state on the trigger.',
@@ -247,6 +253,11 @@ export const docs = {
         description:
           'Do not use ComplexSelector for a plain single-column text list; use Selector instead.',
       },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled ComplexSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
+      },
     ],
   },
 };
@@ -308,6 +319,11 @@ export const docsDense = {
         description:
           'Do not use ComplexSelector for a plain single-column text list; use Selector instead.',
       },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled ComplexSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
+      },
     ],
   },
   propDescriptions: {
@@ -315,6 +331,8 @@ export const docsDense = {
     value: 'Controlled value.',
     onChange: 'Commit value.',
     changeAction: 'Async action after onChange; drives optimistic value/busy.',
+    disabledMessage:
+      'why disabled; w/ isDisabled shows tooltip on hover/focus, trigger stays focusable via aria-disabled; use instead of Tooltip wrapper',
     children: 'Render custom dialog content from (value,onChange,close,state).',
     triggerLabel: 'Closed trigger label/content.',
     variant: 'input for forms; ghost for toolbar triggers.',

--- a/packages/core/src/ComplexSelector/ComplexSelector.spec.md
+++ b/packages/core/src/ComplexSelector/ComplexSelector.spec.md
@@ -32,14 +32,21 @@ system_specs: []
 
 ComplexSelector renders a field-owned shell, an owned trigger, and a dialog
 popup for caller-provided rich selection content. This draft records current
-consumer anatomy and theming ownership without changing runtime behavior,
-styling, targets, or public API.
+consumer anatomy and theming ownership, plus the additive `disabledMessage`
+prop adopted from the input-field family, without changing existing runtime
+behavior, styling, or targets.
 
 ## Compatibility and migration
 
-- Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, and public API remain unchanged
+- Released default preserved: `yes` — `disabledMessage` defaults to unset,
+  which keeps the natively disabled trigger exactly as shipped
+- Compatibility class: additive; one new public prop, `disabledMessage`, with
+  no change to rendered parts, targets, styling, or behavior without it
+- `disabledMessage` is additive. Before it, `isDisabled` always rendered a
+  natively disabled trigger. After it, `isDisabled` with a reason keeps the
+  trigger focusable via `aria-disabled` and exposes the reason as a tooltip
+  linked through `aria-describedby`; opening stays blocked either way
+  (`family:input-fields` FR4).
 - Controlled/uncontrolled behavior: unchanged
 - Migration decision: none
 
@@ -68,8 +75,11 @@ Consumer migration instructions belong in consumer docs and release notes.
 
 ## Public concepts
 
-No new public concept is introduced. Consumer props and usage remain documented
-in `ComplexSelector.doc.mjs`.
+`disabledMessage` adopts the input-field family's disabled-reason contract
+(`family:input-fields` FR4): with `isDisabled`, the trigger stays focusable via
+`aria-disabled` and exposes the reason as a tooltip while activation stays
+blocked. Consumer props and usage remain documented in
+`ComplexSelector.doc.mjs`.
 
 ## Behavioral and layout contract
 
@@ -107,7 +117,10 @@ in `ComplexSelector.doc.mjs`.
 
 ## Accessibility contract
 
-This draft does not change or extend ComplexSelector's existing field, trigger,
+Beyond the disabled-reason extension — a trigger with `isDisabled` and
+`disabledMessage` stays focusable via `aria-disabled`, links the reason tooltip
+through `aria-describedby`, and still blocks pointer, keyboard, and imperative
+opening — this draft does not change ComplexSelector's existing field, trigger,
 dialog, focus, or keyboard behavior.
 
 ## Design relationships
@@ -160,24 +173,29 @@ content remains outside the owned anatomy inventory.
 
 ## Verification map
 
-| Contract            | Verification                                                               | Representative states                            | Mutation or failure expectation                                                               | Audit section                   |
-| ------------------- | -------------------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------- | ------------------------------- |
-| FR1                 | `ComplexSelector.test.tsx` render, ghost-trigger, and popup suites         | Default closed, ghost start branches, open Popup | Removing a documented part fails existing role, content, or structure assertions.             | `audit:ComplexSelector/anatomy` |
-| FR2                 | Component target suites, source inspection, and theming target inventories | Closed/open Popup; expanded Indicator icon       | Removing or renaming a current local target fails component assertions or target inventories. | `audit:ComplexSelector/theming` |
-| FR3, FR4            | Icon owner tests and `renderIconSlot` source inspection                    | Semantic/component icon; arbitrary ReactNode     | A branch gains the wrong owner, loses its target, or receives an invented local target.       | `audit:ComplexSelector/theming` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                                              | Canonical anatomy and current local targets      | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.    | `audit:ComplexSelector/theming` |
+| Contract            | Verification                                                               | Representative states                                                      | Mutation or failure expectation                                                                                              | Audit section                         |
+| ------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| FR1                 | `ComplexSelector.test.tsx` render, ghost-trigger, and popup suites         | Default closed, ghost start branches, open Popup                           | Removing a documented part fails existing role, content, or structure assertions.                                            | `audit:ComplexSelector/anatomy`       |
+| FR2                 | Component target suites, source inspection, and theming target inventories | Closed/open Popup; expanded Indicator icon                                 | Removing or renaming a current local target fails component assertions or target inventories.                                | `audit:ComplexSelector/theming`       |
+| FR3, FR4            | Icon owner tests and `renderIconSlot` source inspection                    | Semantic/component icon; arbitrary ReactNode                               | A branch gains the wrong owner, loses its target, or receives an invented local target.                                      | `audit:ComplexSelector/theming`       |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                              | Canonical anatomy and current local targets                                | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                   | `audit:ComplexSelector/theming`       |
+| Disabled reason     | `ComplexSelector.test.tsx` `ComplexSelector disabledMessage` suite         | Natively disabled; focusable-disabled with a reason; re-enabled at runtime | A reason leaves the trigger natively disabled, drops out of `aria-describedby`, or the popup opens while focusable-disabled. | `audit:ComplexSelector/accessibility` |
 
 Current component tests directly assert the Trigger and Popup targets. Source
 inspection confirms that non-lazy `useLayer` keeps the Popup mounted while
 closed. The Indicator icon target is covered by source inspection and shared
 target inventories rather than a dedicated component assertion. `renderIconSlot`
 and Icon owner tests distinguish the Icon-rendered branch from arbitrary
-caller-owned ReactNode content.
+caller-owned ReactNode content. The `ComplexSelector disabledMessage` suite
+asserts the focusable-disabled trigger, the reason tooltip on hover and focus,
+its `aria-describedby` link, and blocked opening by pointer, keyboard, and the
+imperative handle.
 
 ## Decision log
 
-None. This draft records current facts and introduces no component-local design,
-API, theming, or layer-system decision.
+None. `disabledMessage` follows `family:input-fields` FR4 rather than a
+component-local decision; this draft otherwise records current facts and
+introduces no component-local design, theming, or layer-system decision.
 
 ## Open questions
 

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file ComplexSelector.test.tsx
  * @input Uses vitest, Testing Library, user-event, and ComplexSelector
- * @output Unit tests for selection, trigger variants, positioning, and the imperative handle
+ * @output Unit tests for selection, trigger variants, positioning, the imperative handle, and the disabled reason
  * @position Tests; validates the ComplexSelector public interaction contract
  *
  * SYNC: When ComplexSelector.tsx API changes, update these tests.
@@ -11,9 +11,17 @@
 
 import React from 'react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ComplexSelector, type ComplexSelectorHandle} from './ComplexSelector';
+import {readAnchorNames} from '../Layer/anchorName';
 
 const originalMatches = HTMLElement.prototype.matches;
 
@@ -599,5 +607,652 @@ describe('ComplexSelector onOpenChange', () => {
     await user.click(trigger);
     act(() => handleRef.current?.open());
     expect(onOpenChange.mock.calls).toEqual([[true]]);
+  });
+});
+
+// The reason tooltip opens through the same Popover API, so count only the
+// show calls made on the selector popup itself.
+function popupShowCalls(popup: Element | null): number {
+  return vi
+    .mocked(HTMLElement.prototype.showPopover)
+    .mock.contexts.filter(context => context === popup).length;
+}
+
+describe('ComplexSelector disabledMessage', () => {
+  it('shows the reason tooltip on hover when disabled with a reason', async () => {
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled
+        disabledMessage="You need the Editor role"
+        data-testid="view-options">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+
+    const container = screen.getByTestId('view-options');
+    const tooltip = screen.getByRole('tooltip', h);
+    expect(tooltip).toHaveTextContent('You need the Editor role');
+
+    fireEvent.mouseEnter(container);
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+
+    fireEvent.mouseLeave(container);
+    await waitFor(() => {
+      expect(tooltip).not.toHaveAttribute('popover-open');
+    });
+  });
+
+  it('shows the reason tooltip on keyboard focus', async () => {
+    const user = userEvent.setup();
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+
+    const tooltip = screen.getByRole('tooltip', h);
+    await user.tab();
+    expect(screen.getByRole('button', {name: 'View options'})).toHaveFocus();
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+  });
+
+  it('does not render a tooltip when not disabled', () => {
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+  });
+
+  it('does not render a tooltip when disabled without a reason', () => {
+    render(
+      <ComplexSelector label="View options" value={[]} isDisabled>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+  });
+
+  it('keeps the trigger focusable via aria-disabled when a reason is provided', () => {
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    expect(trigger).not.toBeDisabled();
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('links the reason tooltip from the trigger via aria-describedby', () => {
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const tooltip = screen.getByRole('tooltip', h);
+    expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
+  });
+
+  it('blocks activation while focusable-disabled', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const handleRef = React.createRef<ComplexSelectorHandle>();
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        onChange={onChange}
+        handleRef={handleRef}
+        isDisabled
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const popup = screen.getByRole('dialog', h).closest('[popover]');
+    expect(popup).not.toBeNull();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    await user.keyboard('{ArrowDown}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(popup).not.toHaveAttribute('popover-open');
+    expect(popupShowCalls(popup)).toBe(0);
+
+    act(() => handleRef.current?.open());
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(handleRef.current?.isOpen()).toBe(false);
+    expect(popupShowCalls(popup)).toBe(0);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('remains non-focusable when disabled without a reason', () => {
+    render(
+      <ComplexSelector label="View options" value={[]} isDisabled>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    expect(trigger).toBeDisabled();
+    expect(trigger).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('never pairs native disabled with aria-disabled, and treats an empty reason as no reason', () => {
+    const tree = (isDisabled: boolean, disabledMessage?: string) => (
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled={isDisabled}
+        disabledMessage={disabledMessage}>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>
+    );
+    const trigger = () => screen.getByRole('button', {name: 'View options'});
+    const expectPlainEnabled = () => {
+      expect(trigger()).not.toBeDisabled();
+      expect(trigger()).not.toHaveAttribute('aria-disabled');
+      expect(trigger()).not.toHaveAttribute('aria-describedby');
+      expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+    };
+    const expectNativelyDisabled = () => {
+      expect(trigger()).toBeDisabled();
+      expect(trigger()).not.toHaveAttribute('aria-disabled');
+      expect(trigger()).not.toHaveAttribute('aria-describedby');
+      expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+    };
+
+    const {rerender} = render(tree(false));
+    expectPlainEnabled();
+
+    rerender(tree(false, 'You need the Editor role'));
+    expectPlainEnabled();
+
+    rerender(tree(true));
+    expectNativelyDisabled();
+
+    // An empty reason is no reason: nothing to describe, so the trigger falls
+    // back to native disabled rather than exposing an unnamed tooltip.
+    rerender(tree(true, ''));
+    expectNativelyDisabled();
+
+    rerender(tree(true, 'You need the Editor role'));
+    expect(trigger()).not.toBeDisabled();
+    expect(trigger()).toHaveAttribute('aria-disabled', 'true');
+    expect(trigger()).toHaveAttribute(
+      'aria-describedby',
+      screen.getByRole('tooltip', h).id,
+    );
+  });
+
+  it('orders aria-describedby as description, status message, then the reason, with every id resolving', () => {
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        description="Pick the columns to show"
+        status={{type: 'error', message: 'At least one column is required'}}
+        isDisabled
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const tooltip = screen.getByRole('tooltip', h);
+
+    const ids = (trigger.getAttribute('aria-describedby') ?? '').split(/\s+/);
+    expect(ids).toHaveLength(3);
+    const described = ids.map(id => document.getElementById(id));
+    expect(described[0]).toHaveTextContent('Pick the columns to show');
+    expect(described[1]).toHaveTextContent('At least one column is required');
+    expect(described[2]).toBe(tooltip);
+    expect(trigger).toHaveAttribute('aria-invalid', 'true');
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('keeps onOpenChange silent and toggle() a no-op while focusable-disabled', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const handleRef = React.createRef<ComplexSelectorHandle>();
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        handleRef={handleRef}
+        onOpenChange={onOpenChange}
+        isDisabled
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const popup = screen.getByRole('dialog', h).closest('[popover]');
+
+    await user.click(trigger);
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    await user.keyboard('{ArrowDown}');
+    act(() => handleRef.current?.toggle());
+    act(() => handleRef.current?.open());
+    act(() => handleRef.current?.close());
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(handleRef.current?.isOpen()).toBe(false);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(popup).not.toHaveAttribute('popover-open');
+  });
+
+  it('re-enabling at runtime drops aria-disabled, the tooltip, and its describedby id without moving focus, and re-disabling restores them', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const tree = (isDisabled: boolean) => (
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        description="Pick the columns to show"
+        isDisabled={isDisabled}
+        disabledMessage="You need the Editor role"
+        onOpenChange={onOpenChange}>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>
+    );
+    const {rerender} = render(tree(true));
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const tooltipId = screen.getByRole('tooltip', h).id;
+
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip', h)).toHaveAttribute('popover-open');
+    });
+
+    rerender(tree(false));
+    expect(trigger).toHaveFocus();
+    expect(trigger).not.toBeDisabled();
+    expect(trigger).not.toHaveAttribute('aria-disabled');
+    expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+    const ids = (trigger.getAttribute('aria-describedby') ?? '')
+      .split(/\s+/)
+      .filter(Boolean);
+    expect(ids).not.toContain(tooltipId);
+    for (const id of ids) {
+      expect(document.getElementById(id)).not.toBeNull();
+    }
+
+    await user.keyboard('{ArrowDown}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(onOpenChange.mock.calls).toEqual([[true]]);
+    await user.keyboard('{Escape}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveFocus();
+
+    rerender(tree(true));
+    expect(trigger).toHaveFocus();
+    expect(trigger).not.toBeDisabled();
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+    const restored = screen.getByRole('tooltip', h);
+    expect(trigger.getAttribute('aria-describedby')).toContain(restored.id);
+  });
+
+  it('dismisses only the reason tooltip on Escape, keeping focus on the trigger and the popup closed', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        onOpenChange={onOpenChange}
+        isDisabled
+        disabledMessage="You need the Editor role">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const tooltip = screen.getByRole('tooltip', h);
+    const popup = screen.getByRole('dialog', h).closest('[popover]');
+
+    await user.tab();
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(tooltip).not.toHaveAttribute('popover-open');
+    });
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(popup).not.toHaveAttribute('popover-open');
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // Dismissing the tip does not strip the description.
+    expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
+
+    // A second Escape has nothing left to dismiss and touches nothing.
+    await user.keyboard('{Escape}');
+    expect(trigger).toHaveFocus();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('hides the reason tooltip when keyboard focus leaves the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <ComplexSelector
+          label="View options"
+          value={[]}
+          isDisabled
+          disabledMessage="You need the Editor role">
+          {() => <button type="button">Apply</button>}
+        </ComplexSelector>
+        <button type="button">After</button>
+      </>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const tooltip = screen.getByRole('tooltip', h);
+
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+
+    // focusout bubbles from the button to the container the tooltip listens
+    // on, so leaving the trigger hides the reason.
+    await user.tab();
+    expect(trigger).not.toHaveFocus();
+    await waitFor(() => {
+      expect(tooltip).not.toHaveAttribute('popover-open');
+    });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps busy and the disabled reason independent: settling clears only aria-busy', async () => {
+    const user = userEvent.setup();
+    const settlers: (() => void)[] = [];
+    const changeAction = vi.fn(async () => {
+      await new Promise<void>(resolve => {
+        settlers.push(resolve);
+      });
+    });
+    const initial: FruitValue = {fruit: 'Apple', ripeness: 'Ripe'};
+    const tree = (isDisabled: boolean) => (
+      <ComplexSelector
+        label="Fruit blend"
+        value={initial}
+        onChange={() => {}}
+        changeAction={changeAction}
+        triggerLabel="Apple Ripe"
+        isDisabled={isDisabled}
+        disabledMessage={isDisabled ? 'You need the Editor role' : undefined}
+        data-testid="fruit-blend">
+        {(value, onChange, close) => (
+          <FruitGrid
+            value={value}
+            onChange={nextValue => {
+              onChange(nextValue);
+              close();
+            }}
+          />
+        )}
+      </ComplexSelector>
+    );
+    const {rerender} = render(tree(false));
+    const trigger = screen.getByRole('button', {name: 'Fruit blend'});
+    const container = screen.getByTestId('fruit-blend');
+
+    await user.click(trigger);
+    await user.click(
+      screen.getByRole('gridcell', {name: 'Banana Crisp', ...h}),
+    );
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-busy', 'true');
+    });
+
+    rerender(tree(true));
+    expect(trigger).toHaveAttribute('aria-busy', 'true');
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+    expect(trigger).not.toBeDisabled();
+    expect(
+      within(container).getByRole('status', {name: 'Loading'}),
+    ).toBeInTheDocument();
+    const tooltip = screen.getByRole('tooltip', h);
+    expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
+    fireEvent.mouseEnter(container);
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+
+    await act(async () => {
+      settlers.forEach(settle => settle());
+    });
+    await waitFor(() => {
+      expect(trigger).not.toHaveAttribute('aria-busy');
+    });
+    expect(within(container).queryByRole('status')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+    expect(trigger).not.toBeDisabled();
+    expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
+  });
+
+  it('anchors the popup and the reason tooltip to the same container and keeps both, plus the open tip, across a rerender', async () => {
+    const tree = (triggerLabel: string) => (
+      <ComplexSelector
+        label="View options"
+        value={triggerLabel}
+        triggerLabel={triggerLabel}
+        isDisabled
+        disabledMessage="You need the Editor role"
+        data-testid="view-options">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>
+    );
+    const {rerender} = render(tree('A'));
+    const container = screen.getByTestId('view-options');
+    const popup = screen.getByRole('dialog', h).closest('[popover]');
+    const tooltip = screen.getByRole('tooltip', h);
+    const anchorOf = (el: Element | null) =>
+      /position-anchor:\s*([^;]+)/
+        .exec(el?.getAttribute('style') ?? '')?.[1]
+        .trim();
+
+    // Two layers, two anchor names on one element: neither clobbers the other.
+    const names = [...readAnchorNames(container)].sort();
+    expect(names).toHaveLength(2);
+    expect(new Set(names).size).toBe(2);
+    expect(anchorOf(popup)).toBeDefined();
+    expect(anchorOf(tooltip)).toBeDefined();
+    expect(anchorOf(popup)).not.toBe(anchorOf(tooltip));
+    expect(names).toContain(anchorOf(popup));
+    expect(names).toContain(anchorOf(tooltip));
+
+    fireEvent.mouseEnter(container);
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+
+    // The inline composed ref is recreated every render, so React detaches and
+    // re-attaches both hooks. That churn must not close the tip, drop an
+    // anchor, or lose the hover listeners.
+    rerender(tree('B'));
+    expect(screen.getByRole('tooltip', h)).toBe(tooltip);
+    expect(tooltip).toHaveAttribute('popover-open');
+    expect([...readAnchorNames(container)].sort()).toEqual(names);
+
+    fireEvent.mouseLeave(container);
+    await waitFor(() => {
+      expect(tooltip).not.toHaveAttribute('popover-open');
+    });
+    fireEvent.mouseEnter(container);
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+  });
+
+  it('restores focus to the aria-disabled trigger when the popup closes after the field was disabled mid-open', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const tree = (isDisabled: boolean) => (
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled={isDisabled}
+        disabledMessage={isDisabled ? 'You need the Editor role' : undefined}
+        onOpenChange={onOpenChange}>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>
+    );
+    const {rerender} = render(tree(false));
+    const trigger = screen.getByRole('button', {name: 'View options'});
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    // jsdom does not run the popup's autofocus; put focus inside as a browser
+    // would, so closing has something to restore from.
+    act(() => screen.getByRole('button', {name: 'Apply', ...h}).focus());
+
+    rerender(tree(true));
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+    expect(trigger).not.toBeDisabled();
+
+    // A keyboard-driven close restores keyboard focus, which a browser reports
+    // as `:focus-visible`. jsdom's answer depends on what earlier tests
+    // focused, so stand it up here.
+    const realMatches = trigger.matches.bind(trigger);
+    vi.spyOn(trigger, 'matches').mockImplementation((selector: string) =>
+      selector === ':focus-visible' ? true : realMatches(selector),
+    );
+
+    await user.keyboard('{Escape}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
+    // A natively disabled button could not take this focus restore; the
+    // reason-bearing trigger can, and the reason surfaces on that focus.
+    expect(trigger).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip', h)).toHaveAttribute('popover-open');
+    });
+  });
+
+  it('reveals the reason on a touch tap without opening the popup', () => {
+    render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled
+        disabledMessage="You need the Editor role"
+        data-testid="view-options">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const container = screen.getByTestId('view-options');
+    const tooltip = screen.getByRole('tooltip', h);
+    const popup = screen.getByRole('dialog', h).closest('[popover]');
+
+    // A finger's arrival lands on the container (pointerenter does not
+    // bubble); the press and the click it produces land on the button and
+    // bubble up to the container's listeners.
+    fireEvent.pointerEnter(container, {pointerType: 'touch'});
+    fireEvent.pointerDown(trigger, {pointerType: 'touch'});
+    fireEvent.pointerUp(trigger, {pointerType: 'touch'});
+    fireEvent.mouseEnter(container);
+    fireEvent.click(trigger);
+
+    // Touch skips the hover delay: the reason is visible synchronously.
+    expect(tooltip).toHaveAttribute('popover-open');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(popup).not.toHaveAttribute('popover-open');
+    expect(popupShowCalls(popup)).toBe(0);
+
+    // The next tap toggles the reason away.
+    fireEvent.pointerDown(trigger, {pointerType: 'touch'});
+    expect(tooltip).not.toHaveAttribute('popover-open');
+    expect(popupShowCalls(popup)).toBe(0);
+  });
+
+  it('delivers a consumer onClick from the focusable-disabled trigger without opening, as Selector does', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const tree = (disabledMessage?: string) => (
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        isDisabled
+        disabledMessage={disabledMessage}
+        onClick={onClick}>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>
+    );
+    const {rerender} = render(tree());
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    const popup = screen.getByRole('dialog', h).closest('[popover]');
+
+    // Natively disabled: the click never happens.
+    await user.click(trigger);
+    expect(onClick).not.toHaveBeenCalled();
+
+    // Focusable-disabled: the click happens and reaches the consumer, but
+    // activation stays blocked.
+    rerender(tree('You need the Editor role'));
+    await user.click(trigger);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(popup).not.toHaveAttribute('popover-open');
+  });
+
+  it('keeps aria-disabled and the reason on the ghost toolbar trigger', async () => {
+    const {container} = render(
+      <ComplexSelector
+        label="View options"
+        value={[]}
+        variant="ghost"
+        startIcon="viewColumns"
+        isDisabled
+        disabledMessage="You need the Editor role"
+        data-testid="view-options">
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+
+    expect(container.querySelector('.astryx-complex-selector')).toHaveAttribute(
+      'data-variant',
+      'ghost',
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+    expect(trigger).not.toBeDisabled();
+    expect(trigger).toHaveAttribute('aria-disabled', 'true');
+
+    const tooltip = screen.getByRole('tooltip', h);
+    fireEvent.mouseEnter(screen.getByTestId('view-options'));
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
   });
 });

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -4,8 +4,8 @@
 
 /**
  * @file ComplexSelector.tsx
- * @input Uses React, StyleX, Field, Icon slots, Layer positioning, and usePopover
- * @output Exports a rich-selector shell with exact token-sized input and ghost triggers, plus an imperative open/close handle
+ * @input Uses React, StyleX, Field, Icon slots, Layer positioning, usePopover, and useTooltip
+ * @output Exports a rich-selector shell with exact token-sized input and ghost triggers, an imperative open/close handle, and a focusable disabled-reason tooltip
  * @position Core implementation; consumed by index.ts
  *
  * SYNC: When modified, update:
@@ -31,6 +31,7 @@ import type {BaseProps} from '../BaseProps';
 import {Field, inputWrapperStyles, type FieldStatusVariant} from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Spinner} from '../Spinner';
+import {useTooltip} from '../Tooltip';
 import {useTranslator} from '../i18n';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
@@ -255,6 +256,28 @@ export interface ComplexSelectorProps<Value> extends Omit<
   isRequired?: boolean;
   /** Disables the selector. */
   isDisabled?: boolean;
+  /**
+   * Explains why the selector is disabled. When set together with
+   * `isDisabled`, the selector shows a tooltip with this text on hover and
+   * keyboard focus, and the trigger stays focusable (via `aria-disabled`)
+   * so the reason is discoverable by keyboard and assistive technology.
+   * Activation stays blocked.
+   *
+   * Use this instead of wrapping a disabled selector in `Tooltip` — disabled
+   * controls don't emit the pointer events an external tooltip needs.
+   *
+   * @example
+   * ```
+   * <ComplexSelector
+   *   label="Fruit blend"
+   *   value={value}
+   *   isDisabled
+   *   disabledMessage="You need the Editor role to change this">
+   *   {(value, onChange, close) => <FruitGrid ... />}
+   * </ComplexSelector>
+   * ```
+   */
+  disabledMessage?: string;
   /** Shows loading state on the trigger. */
   isLoading?: boolean;
   /** Validation status. */
@@ -334,6 +357,7 @@ export function ComplexSelector<Value>({
   isOptional = false,
   isRequired = false,
   isDisabled = false,
+  disabledMessage,
   isLoading = false,
   status,
   statusVariant = 'attached',
@@ -367,10 +391,26 @@ export function ComplexSelector<Value>({
   const contentId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();
+
+  // Disabled-reason tooltip. Disabled controls swallow pointer events, so the
+  // tooltip listeners attach to the trigger container (which already exists)
+  // and the trigger button stays perceivable via aria-disabled instead of the
+  // disabled attribute. Activation is blocked by the isDisabled guards in
+  // handleTriggerClick, the ArrowDown handler, and the imperative handle.
+  const showsDisabledMessage = isDisabled && !!disabledMessage;
+  const disabledMessageTooltip = useTooltip({
+    placement: 'above',
+    // The container div is not naturally focusable; focusin bubbles up from
+    // the trigger button, so always attach focus listeners.
+    focusTrigger: 'always',
+    isEnabled: showsDisabledMessage,
+  });
+
   const ariaDescribedBy =
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
+      showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
     ]
       .filter((id): id is string => id != null)
       .join(' ') || undefined;
@@ -476,7 +516,13 @@ export function ComplexSelector<Value>({
   const selectorContent = (
     <>
       <div
-        ref={popover.triggerRef}
+        ref={el => {
+          popover.triggerRef(el);
+          // Anchor + hover/focus listeners for the disabled-message tooltip.
+          // Handlers are gated internally by isEnabled, and anchor names
+          // compose, so attaching unconditionally is safe.
+          disabledMessageTooltip.ref(el);
+        }}
         data-testid={testId}
         {...props}
         onClick={composeEventHandlers(onClickProp, handleTriggerClick)}
@@ -519,7 +565,11 @@ export function ComplexSelector<Value>({
           aria-required={isEffectivelyRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
-          disabled={isDisabled}
+          // With a disabledMessage the trigger keeps focusability via
+          // aria-disabled so the reason is focus-discoverable; activation is
+          // still blocked by the isDisabled guards.
+          disabled={isDisabled && !showsDisabledMessage}
+          aria-disabled={showsDisabledMessage ? 'true' : undefined}
           onKeyDown={event => {
             if (event.key === 'ArrowDown' && !isOpen && !isDisabled) {
               event.preventDefault();
@@ -555,6 +605,9 @@ export function ComplexSelector<Value>({
         offset: spacingVars['--spacing-1'],
         xstyle: [styles.popover, layerAnimations[placement]],
       })}
+
+      {showsDisabledMessage &&
+        disabledMessageTooltip.renderTooltip(disabledMessage)}
     </>
   );
 


### PR DESCRIPTION
## What this does

ComplexSelector can now say why it is disabled. Pass `disabledMessage` together with `isDisabled` and the trigger stays reachable by keyboard, shows the reason on hover and focus, and still refuses to open.

## Why

The input-field family contract (FR4) says a field that can be disabled should be able to explain why, the way Selector, MultiSelector and TextInput already do. ComplexSelector was the one selector without it, and #5941 lists that as a gap to close. Without a reason, a disabled control is a dead end for keyboard and screen-reader users.

## What changed

- A new optional `disabledMessage` prop on ComplexSelector, using the same recipe Selector and MultiSelector use.
- With a reason, the trigger uses `aria-disabled` instead of native `disabled`, the reason shows as a tooltip on hover, keyboard focus and touch, and the tooltip is linked through `aria-describedby` after the description and the status message.
- Without a reason, nothing changes: the trigger is natively disabled exactly as before.
- Opening stays blocked on every path while focusable-disabled (click, Enter, Space, ArrowDown, and the imperative handle), and `onOpenChange` stays silent.
- Docs: the prop entry, the component spec now records the API delta (before → after plus a verification row), the family adoption table row, a "Disabled with message" Storybook story, and a patch changeset.

## How to see it

Storybook → ComplexSelector → "Disabled with message". Hover the trigger, or Tab to it. Screenshots of the hover and focus states follow in a comment.

## Evidence

The `ComplexSelector disabledMessage` suite has 20 tests (file total 41). The first 8 were red before the change and are green after it. The 12 edge-case tests pass on the change as written, so each was kept only after a one-line mutation of the production code made it fail: flipping the reason check to accept an empty string, moving the reason id first in `aria-describedby`, dropping the disabled guard from `toggle()`, dropping the tooltip ref from the composed container ref, clobbering the anchor name instead of composing it, and hiding the Spinner while disabled all turn one specific test red.

Covered: the full `{isDisabled, disabledMessage}` matrix including an empty string; `aria-describedby` order with every id resolving; Escape hides only the tooltip and keeps focus; focus leaving hides it; re-enabling at runtime removes `aria-disabled`, the tooltip and its id without moving focus, and re-disabling restores them; busy and disabled-reason states stay independent; both the popup and the tooltip stay anchored to the same container across a rerender; a touch tap reveals the reason without opening; a consumer `onClick` still arrives from the focusable-disabled trigger, as it does on Selector; and the ghost toolbar variant keeps `aria-disabled` and the reason.

Local checks, all on top of the current upstream main: ComplexSelector, Selector and MultiSelector suites (383 tests), core typecheck and docs typecheck, eslint with zero warnings, prettier, and the knowledge, changeset and SYNC checks.

## Pre-existing gaps seen along the way, not changed here

- `statusVariant="tooltip"` leaves a status id in `aria-describedby` that resolves to nothing. ComplexSelector never renders a status tooltip, and this happens without `disabledMessage` too.
- Popup content can still commit a value if the field becomes disabled while the popup is open. `commitValue` is unguarded on main, with or without a reason.
- If the reason tooltip is open when the field is re-enabled and then disabled again, it re-shows unprompted. Reproduced on Selector, so it belongs to the shared tooltip hook, in a separate PR.

## Rubric

`Triage: new API surface · non-breaking · low blast radius → deep path (the API shape is the maintainers' call; this is the shape #5941 and family FR4 ask for) · checks: §1 A1–A7/A11–A12, §3 P1–P7/P15–P18, §7 C1–C8/C11, §8 X5/X9–X12, §9 I1–I5, §3 P11–P12 · X20 changeset, §5b screenshots`

Part of #5941 (ComplexSelector `disabledMessage` checkbox).

