### PR TITLE
feat(Layout): add region height control for middle scrolling

### DIFF
--- a/.changeset/layout-content-full-width-scrollport.md
+++ b/.changeset/layout-content-full-width-scrollport.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Layout: add region `height="auto" | "fill"` control for shared middle scrolling.
+
+`LayoutContent` and `LayoutPanel` now accept `height`, defaulting to `"fill"` for compatibility. In a fill-height `Layout`, regions with `height="auto"` use their natural height and move together in a keyboard-focusable middle scrollport, while `height="fill"` regions remain pinned. `isScrollable` retains its released meaning and only controls each region's own overflow. The full start + content + end composition stays inside `contentWidth`; for arithmetic widths the middle scrollbar can extend through the surrounding Layout gutters.
+
+@kentonquatman

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -2,9 +2,7 @@
   {
     "component": "AppShell",
     "storyId": "core-appshell--top-nav-with-side-nav",
-    "dims": [
-      "D4"
-    ],
+    "dims": ["D4"],
     "selectors": {
       "overlay": ".astryx-app-shell-sidenav",
       "overlayRoot": ".astryx-app-shell"
@@ -13,9 +11,7 @@
   {
     "component": "ButtonGroup",
     "storyId": "core-buttongroup--horizontal",
-    "dims": [
-      "D2"
-    ],
+    "dims": ["D2"],
     "selectors": {
       "prev": "[role=\"group\"] button:first-child",
       "next": "[role=\"group\"] button:last-child"
@@ -24,9 +20,7 @@
   {
     "component": "CheckboxInput",
     "storyId": "core-checkboxinput--size-comparison",
-    "dims": [
-      "D7"
-    ],
+    "dims": ["D7"],
     "sizes": ["sm", "md"],
     "selectors": {
       "inputSelectorBySize": {
@@ -38,9 +32,7 @@
   {
     "component": "CheckboxList",
     "storyId": "core-checkboxlist--rich-descriptions",
-    "dims": [
-      "D2"
-    ],
+    "dims": ["D2"],
     "selectors": {
       "prev": ".astryx-checkbox-input",
       "next": "[data-testid=\"checkbox-end-content\"]"
@@ -49,10 +41,7 @@
   {
     "component": "RadioList",
     "storyId": "core-radiolist--rich-content",
-    "dims": [
-      "D2",
-      "D7"
-    ],
+    "dims": ["D2", "D7"],
     "sizes": ["sm", "md"],
     "selectors": {
       "prev": "input[aria-label=\"Pro\"]",
@@ -63,9 +52,7 @@
   {
     "component": "Switch",
     "storyId": "core-switch--default",
-    "dims": [
-      "D7"
-    ],
+    "dims": ["D7"],
     "sizes": ["sm", "md"],
     "selectors": {
       "inputSelector": "input[type=\"checkbox\"]"
@@ -74,9 +61,7 @@
   {
     "component": "Calendar",
     "storyId": "core-calendar--default",
-    "dims": [
-      "D2"
-    ],
+    "dims": ["D2"],
     "selectors": {
       "prev": "button[aria-label=\"Previous month\"]",
       "next": "button[aria-label=\"Next month\"]"
@@ -85,9 +70,7 @@
   {
     "component": "Carousel",
     "storyId": "core-carousel--default",
-    "dims": [
-      "D3"
-    ],
+    "dims": ["D3"],
     "selectors": {
       "scroller": "[aria-roledescription=\"carousel\"] > div:first-child",
       "nextButton": "button[aria-label=\"Scroll right\"]"
@@ -96,9 +79,7 @@
   {
     "component": "Chat",
     "storyId": "core-chat--mixed-content",
-    "dims": [
-      "D2"
-    ],
+    "dims": ["D2"],
     "selectors": {
       "prev": ".astryx-chat-message-bubble[data-sender=\"assistant\"]",
       "next": ".astryx-chat-message-bubble[data-sender=\"user\"]"
@@ -131,9 +112,7 @@
   {
     "component": "Lightbox",
     "storyId": "core-lightbox--gallery",
-    "dims": [
-      "D2"
-    ],
+    "dims": ["D2"],
     "setup": {
       "click": "img, [role=button]"
     },
@@ -145,20 +124,16 @@
   {
     "component": "Layout",
     "storyId": "core-layout--dual-panels",
-    "dims": [
-      "D2"
-    ],
+    "dims": ["D2"],
     "selectors": {
-      "prev": ".astryx-layout-panel:first-of-type",
-      "next": ".astryx-layout-panel:last-of-type"
+      "prev": "[data-layout-start-lane] .astryx-layout-panel",
+      "next": "[data-layout-end-lane] .astryx-layout-panel"
     }
   },
   {
     "component": "Resizable",
     "storyId": "core-resizable--horizontal-split",
-    "dims": [
-      "D4"
-    ],
+    "dims": ["D4"],
     "selectors": {
       "overlay": ".astryx-resize-handle",
       "overlayRoot": ".astryx-layout"
@@ -167,9 +142,7 @@
   {
     "component": "Stepper",
     "storyId": "core-stepper--default-horizontal",
-    "dims": [
-      "D2"
-    ],
+    "dims": ["D2"],
     "selectors": {
       "prev": ".astryx-stepper > li:first-child",
       "next": ".astryx-stepper > li:last-child"
@@ -178,9 +151,7 @@
   {
     "component": "TabList",
     "storyId": "core-tablist--overflow",
-    "dims": [
-      "D3"
-    ],
+    "dims": ["D3"],
     "selectors": {
       "scroller": ".astryx-tab-strip",
       "nextButton": ".astryx-tab-scroll-button"
@@ -189,9 +160,7 @@
   {
     "component": "Typeahead",
     "storyId": "core-typeahead--rtl-end-lane",
-    "dims": [
-      "D4"
-    ],
+    "dims": ["D4"],
     "selectors": {
       "overlay": "button[aria-label=\"Clear selection\"]",
       "overlayRoot": ".astryx-typeahead"
@@ -200,9 +169,7 @@
   {
     "component": "Tokenizer",
     "storyId": "core-tokenizer--rtl-end-lane",
-    "dims": [
-      "D4"
-    ],
+    "dims": ["D4"],
     "selectors": {
       "overlay": "button[aria-label=\"Clear all\"]",
       "overlayRoot": ".astryx-tokenizer"
@@ -211,9 +178,7 @@
   {
     "component": "Tooltip",
     "storyId": "core-tooltip--rtl-logical-placement",
-    "dims": [
-      "D4"
-    ],
+    "dims": ["D4"],
     "selectors": {
       "overlay": ".astryx-tooltip",
       "overlayRoot": "button:has-text(\"RTL placement target\")"
@@ -222,9 +187,7 @@
   {
     "component": "Toast",
     "storyId": "core-toast--logical-placement",
-    "dims": [
-      "D4"
-    ],
+    "dims": ["D4"],
     "setup": {
       "click": "button:has-text(\"Show toast\")"
     },

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -125,6 +125,9 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-container'],
     overflow: 'hidden',
   },
+  cwContainerScrollable: {
+    height: 320,
+  },
   cwContainer900: {
     width: 900,
   },
@@ -216,6 +219,7 @@ interface PlaygroundArgs {
   headerPadding: SpacingStep;
   // Content props
   contentPadding: SpacingStep;
+  contentHeight: 'fill' | 'auto';
   contentIsScrollable: boolean;
   // Footer props
   showFooter: boolean;
@@ -225,11 +229,13 @@ interface PlaygroundArgs {
   showStartPanel: boolean;
   startPanelWidth: number;
   startPanelHasDivider: boolean;
+  startPanelHeight: 'fill' | 'auto';
   startPanelIsScrollable: boolean;
   // End panel props
   showEndPanel: boolean;
   endPanelWidth: number;
   endPanelHasDivider: boolean;
+  endPanelHeight: 'fill' | 'auto';
   endPanelIsScrollable: boolean;
 }
 
@@ -247,6 +253,7 @@ export const Playground = {
     headerPadding: 4,
     // Content defaults
     contentPadding: 4,
+    contentHeight: 'fill',
     contentIsScrollable: true,
     // Footer defaults
     showFooter: true,
@@ -256,11 +263,13 @@ export const Playground = {
     showStartPanel: true,
     startPanelWidth: 160,
     startPanelHasDivider: true,
+    startPanelHeight: 'fill',
     startPanelIsScrollable: true,
     // End panel defaults
     showEndPanel: false,
     endPanelWidth: 200,
     endPanelHasDivider: true,
+    endPanelHeight: 'fill',
     endPanelIsScrollable: true,
   },
   argTypes: {
@@ -303,6 +312,12 @@ export const Playground = {
       description: 'Content padding (0 for edge-to-edge content)',
       table: {category: 'Content'},
     },
+    contentHeight: {
+      control: 'select',
+      options: ['fill', 'auto'],
+      description: 'Fill the middle viewport or use natural height',
+      table: {category: 'Content'},
+    },
     contentIsScrollable: {
       control: 'boolean',
       description: 'Enable scrollable overflow',
@@ -340,6 +355,12 @@ export const Playground = {
       description: 'Add a border to the start panel',
       table: {category: 'Start Panel'},
     },
+    startPanelHeight: {
+      control: 'select',
+      options: ['fill', 'auto'],
+      description: 'Fill the middle viewport or use natural height',
+      table: {category: 'Start Panel'},
+    },
     startPanelIsScrollable: {
       control: 'boolean',
       description: 'Enable scrollable overflow for start panel',
@@ -359,6 +380,12 @@ export const Playground = {
     endPanelHasDivider: {
       control: 'boolean',
       description: 'Add a border to the end panel',
+      table: {category: 'End Panel'},
+    },
+    endPanelHeight: {
+      control: 'select',
+      options: ['fill', 'auto'],
+      description: 'Fill the middle viewport or use natural height',
       table: {category: 'End Panel'},
     },
     endPanelIsScrollable: {
@@ -385,6 +412,7 @@ export const Playground = {
             args.showStartPanel ? (
               <LayoutPanel
                 width={args.startPanelWidth}
+                height={args.startPanelHeight}
                 hasDivider={args.startPanelHasDivider}
                 isScrollable={args.startPanelIsScrollable}
                 role="navigation">
@@ -398,6 +426,7 @@ export const Playground = {
           content={
             <LayoutContent
               padding={args.contentPadding}
+              height={args.contentHeight}
               isScrollable={args.contentIsScrollable}>
               <h4 {...stylex.props(styles.subheading)}>Main Content Area</h4>
               <br />
@@ -408,8 +437,8 @@ export const Playground = {
               <br />
               <p {...stylex.props(styles.bodyText)}>
                 Try setting padding to 0 to see how content can extend to the
-                edges, or toggle &quot;isScrollable&quot; to change overflow
-                behavior.
+                edges, switch height to auto to move with the middle scrollport,
+                or toggle isScrollable to change local overflow behavior.
               </p>
               <br />
               <div {...stylex.props(styles.placeholder)}>
@@ -421,6 +450,7 @@ export const Playground = {
             args.showEndPanel ? (
               <LayoutPanel
                 width={args.endPanelWidth}
+                height={args.endPanelHeight}
                 hasDivider={args.endPanelHasDivider}
                 isScrollable={args.endPanelIsScrollable}
                 role="complementary">
@@ -936,10 +966,15 @@ export const ContentWidthWithDividers: Story = {
   render: () => (
     <VStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=640 in a 900px container; dividers remain full-bleed while
-        content is constrained
+        contentWidth=640 in a 900px container; aligned content stays constrained
+        while the single-column scrollbar remains at the container edge
       </p>
-      <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
+      <div
+        {...stylex.props(
+          styles.cwContainer,
+          styles.cwContainer900,
+          styles.cwContainerScrollable,
+        )}>
         <Layout
           contentWidth={640}
           defaultHasDividers
@@ -952,15 +987,21 @@ export const ContentWidthWithDividers: Story = {
             </LayoutHeader>
           }
           content={
-            <LayoutContent>
+            <LayoutContent
+              height="auto"
+              role="region"
+              label="Scrollable content width example">
               <p {...stylex.props(styles.bodyText)}>
-                Main content is constrained to 640px and centered. The dividers
-                above and below span the full width of the container.
+                Main content is constrained to 640px and centered. The content
+                area still spans the container, so its scrollbar stays at the
+                outer edge.
               </p>
               <br />
-              <div {...stylex.props(styles.placeholder)}>
-                Placeholder content block
-              </div>
+              {Array.from({length: 8}, (_, index) => (
+                <div key={index} {...stylex.props(styles.placeholder)}>
+                  Scrollable content block {index + 1}
+                </div>
+              ))}
             </LayoutContent>
           }
           footer={
@@ -986,10 +1027,15 @@ export const ContentWidthWithStartPanel: Story = {
   render: () => (
     <VStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=640 with a 200px start panel: the middle row (panel +
-        content) is constrained
+        contentWidth=640 with a 200px independently scrolling start panel; the
+        content uses the full-width middle scrollport
       </p>
-      <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
+      <div
+        {...stylex.props(
+          styles.cwContainer,
+          styles.cwContainer900,
+          styles.cwContainerScrollable,
+        )}>
         <Layout
           contentWidth={640}
           defaultHasDividers
@@ -1007,13 +1053,22 @@ export const ContentWidthWithStartPanel: Story = {
             </LayoutPanel>
           }
           content={
-            <LayoutContent>
+            <LayoutContent
+              height="auto"
+              role="region"
+              label="Scrollable settings content">
               <h4 {...stylex.props(styles.subheading)}>General Settings</h4>
               <br />
               <p {...stylex.props(styles.bodyText)}>
-                The start panel and content area together are constrained to
-                640px and centered within the container.
+                The start panel and content area remain inside the 640px frame.
+                The panel stays pinned with its own scrollport while this
+                content moves in the Layout middle scrollport.
               </p>
+              {Array.from({length: 8}, (_, index) => (
+                <div key={index} {...stylex.props(styles.placeholder)}>
+                  Settings content block {index + 1}
+                </div>
+              ))}
             </LayoutContent>
           }
           footer={
@@ -1075,6 +1130,74 @@ export const ContentWidthWithBothPanels: Story = {
             <LayoutFooter>
               <p {...stylex.props(styles.bodyText)}>3 items</p>
             </LayoutFooter>
+          }
+        />
+      </div>
+    </VStack>
+  ),
+};
+
+export const ContentWidthMixedScrolling: Story = {
+  name: 'Content Width — Mixed Region Scrolling',
+  render: () => (
+    <VStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        Start scrolls independently; content and end move together in the Layout
+        middle scrollport
+      </p>
+      <div
+        {...stylex.props(
+          styles.cwContainer,
+          styles.cwContainer1200,
+          styles.cwContainerScrollable,
+        )}>
+        <Layout
+          contentWidth={800}
+          defaultHasDividers
+          start={
+            <LayoutPanel
+              width={200}
+              hasDivider
+              isScrollable
+              tabIndex={0}
+              role="navigation"
+              label="Independent navigation">
+              <p {...stylex.props(styles.sectionLabel)}>Folders</p>
+              {Array.from({length: 12}, (_, index) => (
+                <NavItem key={index}>Folder {index + 1}</NavItem>
+              ))}
+            </LayoutPanel>
+          }
+          content={
+            <LayoutContent
+              height="auto"
+              role="region"
+              label="Shared document content">
+              {Array.from({length: 10}, (_, index) => (
+                <div key={index} {...stylex.props(styles.placeholder)}>
+                  Document section {index + 1}
+                </div>
+              ))}
+            </LayoutContent>
+          }
+          end={
+            <LayoutPanel
+              width={200}
+              hasDivider
+              height="auto"
+              role="complementary"
+              label="Shared details">
+              <p {...stylex.props(styles.sectionLabel)}>Details</p>
+              <p {...stylex.props(styles.bodyText)}>
+                This panel moves with the document while navigation stays
+                pinned.
+              </p>
+              {Array.from({length: 8}, (_, index) => (
+                <div key={index} {...stylex.props(styles.placeholder)}>
+                  Detail block {index + 1}
+                </div>
+              ))}
+            </LayoutPanel>
           }
         />
       </div>

--- a/docs/families/layout-regions.md
+++ b/docs/families/layout-regions.md
@@ -77,11 +77,13 @@ wrapper, or a header-like visual treatment.
 - Section owns the generic painted page/content region, including its variant,
   selected divider edges, component padding, and nested Section behavior.
 - Layout owns its five-slot topology, slot presence, region position, shared
-  outer/inner inset, height mode, content-width propagation, and default
-  header/footer divider context. It does not own the page shell.
+  outer/inner inset, height mode, content-width propagation, the fill-height
+  middle scrollport, and default header/footer divider context. It does not own
+  the page shell.
 - LayoutHeader, LayoutContent, LayoutFooter, and LayoutPanel own their region
-  element, optional landmark role/name, local padding, and region-specific size
-  or scrolling behavior.
+  element, optional landmark role/name, local padding, region-specific size,
+  and whether they scroll independently or participate in Layout's middle
+  scrollport.
 - Toolbar owns the contextual action region, its start/center/end lanes,
   toolbar semantics, keyboard movement, and size cascade. It delegates its
   painted surface, variant, and selected divider edges to Section.
@@ -91,17 +93,17 @@ wrapper, or a header-like visual treatment.
 
 ## Canonical concepts
 
-| Concept               | Values or states                                                    | Default semantics                                                           | Stability              |
-| --------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------- | ---------------------- |
-| generic region        | Section                                                             | Related page/content area with an optional painted treatment                | current                |
-| five-slot topology    | header, start, content, end, footer                                 | Layout places provided regions in logical reading direction                 | current                |
-| contextual actions    | start, optional center, end                                         | Toolbar groups controls within a bounded content region                     | current                |
-| outer and inner inset | Layout edge or adjacent-region edge                                 | A Layout region uses the inset appropriate to the edges it touches          | current                |
-| boundary              | absent or divider                                                   | A member may draw only the edges its component contract exposes             | current                |
-| region scroll         | clipped, scrollable, or page-owned where exposed                    | LayoutContent and LayoutPanel own their current overflow choice             | component-owned        |
-| landmark              | no explicit role, or caller-supplied role and label                 | A region does not infer page-level landmark semantics from visual placement | current                |
-| region size           | intrinsic, fixed, fill/auto, capped, or resize-driven where exposed | Each member owns its applicable size axis                                   | component-owned        |
-| responsive adaptation | retained, omitted, or replaced by caller composition                | No shared automatic region swap exists                                      | caller/component-owned |
+| Concept               | Values or states                                                    | Default semantics                                                                                                                      | Stability              |
+| --------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| generic region        | Section                                                             | Related page/content area with an optional painted treatment                                                                           | current                |
+| five-slot topology    | header, start, content, end, footer                                 | Layout places provided regions in logical reading direction                                                                            | current                |
+| contextual actions    | start, optional center, end                                         | Toolbar groups controls within a bounded content region                                                                                | current                |
+| outer and inner inset | Layout edge or adjacent-region edge                                 | A Layout region uses the inset appropriate to the edges it touches                                                                     | current                |
+| boundary              | absent or divider                                                   | A member may draw only the edges its component contract exposes                                                                        | current                |
+| region scroll         | independent, middle-owned, or page-owned where exposed              | `height="fill"` keeps a bounded region; `height="auto"` joins the fill-height middle flow; `isScrollable` only controls local overflow | component/Layout-owned |
+| landmark              | no explicit role, or caller-supplied role and label                 | A region does not infer page-level landmark semantics from visual placement                                                            | current                |
+| region size           | intrinsic, fixed, fill/auto, capped, or resize-driven where exposed | Each member owns its applicable size axis                                                                                              | component-owned        |
+| responsive adaptation | retained, omitted, or replaced by caller composition                | No shared automatic region swap exists                                                                                                 | caller/component-owned |
 
 ## Cross-component invariants
 
@@ -126,14 +128,21 @@ wrapper, or a header-like visual treatment.
   and Toolbar expose selected edges. LayoutPanel may draw its content-facing
   edge, and ResizeHandle may also draw it; current code does not prevent both.
   A resizable panel composition must set `LayoutPanel hasDivider={false}` when
-  the adjacent ResizeHandle owns the divider.
+  the adjacent ResizeHandle owns the divider. Auto-height panels stretch across
+  the shared row so their panel-owned divider spans the full middle region.
 - **FR6 — Divider absence may change spacing.** Layout regions currently collapse
   the interior spacing associated with an absent header, footer, or panel
   divider; an explicit divider preserves the fenced boundary.
-- **FR7 — Scrolling is explicit and local.** LayoutContent and LayoutPanel own
-  their current `isScrollable` behavior. Section and Toolbar do not become
-  scroll containers through family membership. Layout `height="fill"` contains
-  region scrolling; `height="auto"` lets the containing page grow.
+- **FR7 — Scrolling is explicit and composable.** LayoutContent and LayoutPanel
+  default `height` to `fill`, preserving their released bounded sizing, and
+  default `isScrollable` to true, preserving local scrollable overflow. In a
+  fill-height Layout, each slot whose top-level rendered region has
+  `height="auto"` participates in the focusable Layout middle scrollport;
+  fill-height sibling slots and non-region slot content remain pinned. Multiple
+  top-level region roots within one slot must agree on `height`; mixed values
+  conservatively keep that slot pinned. In an auto-height Layout, the page or
+  ancestor remains the scroll owner and no middle scrollport is created. Section
+  and Toolbar do not become scroll containers through family membership.
 - **FR8 — Landmark semantics remain explicit.** Named visual placement does not
   automatically assign `banner`, `main`, `navigation`, `complementary`, or
   `contentinfo`. A caller supplies a supported role and label for the context.
@@ -161,9 +170,11 @@ wrapper, or a header-like visual treatment.
   treatments. Family membership does not unify their visual API.
 - **AV3 — Region content.** Header, footer, panel, content, and toolbar lanes may
   hold any content allowed by their component contracts.
-- **AV4 — Size model.** Layout owns fill/auto container height and content-width
-  propagation; individual regions own applicable height, width, padding, and
-  scroll props; Section owns its box-size props.
+- **AV4 — Size and scroll model.** Layout owns fill/auto container height,
+  content-width propagation, and the fill-height middle scrollport; individual
+  regions own applicable height, width, padding, and whether they scroll
+  independently or participate in that middle scrollport. Section owns its
+  box-size props.
 - **AV5 — Interaction.** Toolbar owns roving focus and keyboard hints. Other
   members add no toolbar behavior. Resizable owns resize interaction.
 - **AV6 — Composition mechanism.** Members may use Stack utilities, direct CSS
@@ -174,27 +185,27 @@ wrapper, or a header-like visual treatment.
 
 ## Representative matrix
 
-| Member and state                                 | Shared invariant                                                | Deliberate variation                                                                 |
-| ------------------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| Section / default, transparent, or muted         | Owns one generic region and publishes its applied inset         | Variant and selected divider edges are Section-local                                 |
-| Layout / content only                            | Slot presence selects Layout-edge inset                         | Children are a shorthand for the content slot; explicit content wins                 |
-| Layout / all regions                             | Start/end stay logical; named regions receive outer/inner inset | Header, content, footer, and panels expose different size/scroll controls            |
-| LayoutHeader or LayoutFooter / divider inherited | One boundary owner and explicit landmark semantics              | Parent `defaultHasDividers` supplies the default; local false may override it        |
-| LayoutContent / scrollable or page-owned         | Region owns current overflow choice                             | `isScrollable={false}` supports parent/page scrolling and sticky descendants         |
-| LayoutPanel / fixed or resize-driven             | Panel position selects edge treatment                           | useResizable may replace width ownership; ResizeHandle retains interaction ownership |
-| Toolbar / two or three lanes                     | Contextual action region delegates its surface to Section       | Center content switches internal arrangement; toolbar alone owns keyboard behavior   |
+| Member and state                                 | Shared invariant                                                | Deliberate variation                                                                                                         |
+| ------------------------------------------------ | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Section / default, transparent, or muted         | Owns one generic region and publishes its applied inset         | Variant and selected divider edges are Section-local                                                                         |
+| Layout / content only                            | Slot presence selects Layout-edge inset                         | Content defaults to fill height with its released local overflow; `height="auto"` opts into the full-width middle scrollport |
+| Layout / all regions                             | Start/end stay logical; named regions receive outer/inner inset | Each region independently chooses pinned fill height or natural-height participation in the middle scrollport                |
+| LayoutHeader or LayoutFooter / divider inherited | One boundary owner and explicit landmark semantics              | Parent `defaultHasDividers` supplies the default; local false may override it                                                |
+| LayoutContent / fill, auto, or page-owned        | Region height composes with Layout height                       | Fill is pinned by default; auto joins the fill-height middle flow; `isScrollable` controls local overflow                    |
+| LayoutPanel / fixed or resize-driven             | Panel position selects edge treatment                           | A fill panel stays pinned in middle-scroll mode; useResizable may replace width ownership                                    |
+| Toolbar / two or three lanes                     | Contextual action region delegates its surface to Section       | Center content switches internal arrangement; toolbar alone owns keyboard behavior                                           |
 
 ## Adoption and exceptions
 
-| Component or concern | Adoption                                                          | Current gap or exception                                                                                                                                                             |
-| -------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Section              | Generic region and container-padding publisher                    | Its nested escape is always inline but only first/last child on the block axis                                                                                                       |
-| Layout container     | Five-slot region owner with slot contexts                         | Source applies `contentWidth` to the middle row and propagates it to header/footer wrappers, but tests do not prove contentWidth-specific style or rendered panel/content allocation |
-| LayoutContent        | Reads slot presence and applies outer/inner inset                 | Its no-start path writes the outer value to both inline geometry variables, while no-end changes padding without the matching variable update                                        |
-| LayoutPanel          | Applies position-aware padding and may accept resize-driven width | Automatic Layout-edge padding leaves baseline inner geometry variables; an adjacent `ResizeHandle hasDivider` can double the line unless the caller sets panel `hasDivider={false}`  |
-| LayoutHeader/Footer  | Region-specific inset, boundary, and landmarks                    | Cross-region computed-style parity is not covered by one browser matrix                                                                                                              |
-| Toolbar              | Section-backed surface plus toolbar behavior                      | Inline inset and edge compensation follow the composed Section's current padding context                                                                                             |
-| Responsive regions   | Caller/AppShell composition                                       | LayoutPanel has no current shared responsive visibility contract                                                                                                                     |
+| Component or concern | Adoption                                                          | Current gap or exception                                                                                                                                                                                                                                                                                                                                |
+| -------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Section              | Generic region and container-padding publisher                    | Its nested escape is always inline but only first/last child on the block axis                                                                                                                                                                                                                                                                          |
+| Layout container     | Five-slot region owner with slot contexts                         | `contentWidth` always contains the complete middle composition. In fill height, a slot whose top-level rendered region has `height="auto"` activates the focusable middle scrollport; known arithmetic widths let it span the Layout while preserving the centered frame, and intrinsic or unresolved-variable widths keep that scrollport constrained. |
+| LayoutContent        | Reads slot presence and applies outer/inner inset                 | Its no-start path writes the outer value to both inline geometry variables, while no-end changes padding without the matching variable update                                                                                                                                                                                                           |
+| LayoutPanel          | Applies position-aware padding and may accept resize-driven width | Automatic Layout-edge padding leaves baseline inner geometry variables; an adjacent `ResizeHandle hasDivider` can double the line unless the caller sets panel `hasDivider={false}`. Auto-height panels stretch their panel-owned divider across the shared row.                                                                                        |
+| LayoutHeader/Footer  | Region-specific inset, boundary, and landmarks                    | Cross-region computed-style parity is not covered by one browser matrix                                                                                                                                                                                                                                                                                 |
+| Toolbar              | Section-backed surface plus toolbar behavior                      | Inline inset and edge compensation follow the composed Section's current padding context                                                                                                                                                                                                                                                                |
+| Responsive regions   | Caller/AppShell composition                                       | LayoutPanel has no current shared responsive visibility contract                                                                                                                                                                                                                                                                                        |
 
 These rows describe shipped behavior and verification gaps. They are not approved
 exceptions to silently change in a documentation pull request.
@@ -220,18 +231,18 @@ exceptions to silently change in a documentation pull request.
 
 ## Verification map
 
-| Contract             | Verification                                                  | What the evidence proves                                                                                                     | Missing evidence                                                                                                                                                                             |
-| -------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| FR1                  | Section/Layout/Toolbar render and slot tests                  | Caller content renders inside the current region structure; Toolbar exposes its current lanes                                | Tests do not independently prove that product semantics remain caller-owned                                                                                                                  |
-| FR2                  | Logical-property source review plus Layout area-context tests | Start/end slots are identified logically and source selects logical divider/padding properties                               | No real-browser LTR/RTL geometry matrix covers every region                                                                                                                                  |
-| FR3                  | `Layout.test.tsx` and `childrenAsContent.test.tsx`            | Slot presence/context and content precedence are pinned; omitted slots do not render area providers                          | Tests do not assert computed outer/inner inset or exact descendant geometry; the published-variable mismatch is a named conformance gap                                                      |
-| FR4                  | Section padding class-set tests and Layout region source      | Section's explicit edge overrides move matching variables; region source has automatic, explicit, and zero-padding branches  | Layout tests mostly assert acceptance/rendering, not computed padding or automatic-variable parity                                                                                           |
-| FR5, FR6             | `Layout.test.tsx` and `LayoutSlots.test.tsx`                  | Header/footer divider defaults and explicit false overrides are reflected in `data-divider`; source contains collapse styles | No rendered test prevents a LayoutPanel and adjacent ResizeHandle from both drawing a divider, or proves computed collapse spacing                                                           |
-| FR7                  | LayoutContent/LayoutPanel source and local class/render tests | The two regions expose their current `isScrollable` branches; Layout exposes fill/auto state                                 | No browser test proves scroll ownership across every shell/region composition                                                                                                                |
-| FR8                  | `LayoutSlots.test.tsx` landmark assertions                    | Supplied roles and labels reach Header, Content, Footer, and Panel elements                                                  | No family-wide accessibility-tree test covers repeated landmarks                                                                                                                             |
-| Layout content width | `contentWidth.test.tsx`                                       | Header/footer always have distinct inner wrappers, and divider state remains on their outer region elements                  | The middle-row assertion checks only for a truthy class and does not prove contentWidth-specific style; computed width, panel/content allocation, and consumer-doc wording remain unverified |
-| Toolbar variation    | `Toolbar.test.tsx`                                            | Lanes, role/name/orientation, Section variant delegation, and current keyboard behavior have focused assertions              | No computed inset/edge-compensation test covers non-default parent padding                                                                                                                   |
-| FR10                 | LayoutPanel coverage in `LayoutSlots.test.tsx`                | Hook-provided `_size` overrides the fixed width prop                                                                         | Resize interaction, persistence, snapping, and collapse are verified only by Resizable's own tests                                                                                           |
+| Contract             | Verification                                                                   | What the evidence proves                                                                                                                                                                                                    | Missing evidence                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR1                  | Section/Layout/Toolbar render and slot tests                                   | Caller content renders inside the current region structure; Toolbar exposes its current lanes                                                                                                                               | Tests do not independently prove that product semantics remain caller-owned                                                                          |
+| FR2                  | Logical-property source review plus Layout area-context tests                  | Start/end slots are identified logically and source selects logical divider/padding properties                                                                                                                              | No real-browser LTR/RTL geometry matrix covers every region                                                                                          |
+| FR3                  | `Layout.test.tsx` and `childrenAsContent.test.tsx`                             | Slot presence/context and content precedence are pinned; omitted slots do not render area providers                                                                                                                         | Tests do not assert computed outer/inner inset or exact descendant geometry; the published-variable mismatch is a named conformance gap              |
+| FR4                  | Section padding class-set tests and Layout region source                       | Section's explicit edge overrides move matching variables; region source has automatic, explicit, and zero-padding branches                                                                                                 | Layout tests mostly assert acceptance/rendering, not computed padding or automatic-variable parity                                                   |
+| FR5, FR6             | `Layout.test.tsx` and `LayoutSlots.test.tsx`                                   | Header/footer divider defaults and explicit false overrides are reflected in `data-divider`; source contains collapse styles                                                                                                | No rendered test prevents a LayoutPanel and adjacent ResizeHandle from both drawing a divider, or proves computed collapse spacing                   |
+| FR7                  | Layout/LayoutContent/LayoutPanel unit tests plus Storybook mixed-scroll states | Defaults preserve fill sizing and released local overflow; auto-height top-level region roots activate middle scrolling only in fill-height Layouts; fill siblings remain pinned                                            | Browser evidence verifies actual scroll motion, independent-region pinning, keyboard focusability, and scrollbar placement across mixed combinations |
+| FR8                  | `LayoutSlots.test.tsx` landmark assertions                                     | Supplied roles and labels reach Header, Content, Footer, and Panel elements                                                                                                                                                 | No family-wide accessibility-tree test covers repeated landmarks                                                                                     |
+| Layout content width | `contentWidth.test.tsx` and Storybook content-width states                     | Header/footer retain aligned wrappers; every region remains inside the shared width; arithmetic widths allow the opted-in middle scrollport to span Layout gutters while intrinsic widths preserve a constrained scrollport | Browser evidence verifies computed alignment, scrollbar placement, and mixed pinned/moving regions                                                   |
+| Toolbar variation    | `Toolbar.test.tsx`                                                             | Lanes, role/name/orientation, Section variant delegation, and current keyboard behavior have focused assertions                                                                                                             | No computed inset/edge-compensation test covers non-default parent padding                                                                           |
+| FR10                 | LayoutPanel coverage in `LayoutSlots.test.tsx`                                 | Hook-provided `_size` overrides the fixed width prop                                                                                                                                                                        | Resize interaction, persistence, snapping, and collapse are verified only by Resizable's own tests                                                   |
 
 The current tests prove selected structure, attributes, callbacks, and class/style
 branches. They do not prove one computed visual alignment across every Section,

--- a/packages/cli/assets/templates/blocks/components/Layout/LayoutContentWidth.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Layout/LayoutContentWidth.doc.mjs
@@ -7,8 +7,18 @@ export const doc = {
   name: 'Layout — Content Width',
   displayName: 'Layout — Content Width',
   description:
-    'A layout using contentWidth to constrain and center content while keeping dividers full-bleed.',
+    'A layout using contentWidth to align header, body, and footer content while natural-height LayoutContent participates in the full-width middle scrollport.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Layout', 'LayoutHeader', 'LayoutContent', 'LayoutFooter', 'Button', 'HStack', 'VStack', 'Text', 'Heading'],
+  componentsUsed: [
+    'Layout',
+    'LayoutHeader',
+    'LayoutContent',
+    'LayoutFooter',
+    'Button',
+    'HStack',
+    'VStack',
+    'Text',
+    'Heading',
+  ],
 };

--- a/packages/cli/assets/templates/blocks/components/Layout/LayoutContentWidth.tsx
+++ b/packages/cli/assets/templates/blocks/components/Layout/LayoutContentWidth.tsx
@@ -24,12 +24,13 @@ export default function LayoutContentWidth() {
         </LayoutHeader>
       }
       content={
-        <LayoutContent>
+        <LayoutContent height="auto">
           <VStack gap={3}>
             <Text type="body">
-              The contentWidth prop constrains content to a maximum width and
-              centers it within the layout. Dividers remain full-bleed while
-              content stays narrow and readable.
+              The contentWidth prop aligns header, body, and footer content to a
+              shared maximum width. Setting LayoutContent height="auto" moves
+              the body into the full-width Layout middle scrollport while its
+              content stays aligned.
             </Text>
             <Text type="body" color="secondary">
               Common widths: 640 for forms, 960 for content pages.

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1438,5 +1438,9 @@
   "@astryx.transferListSelector.triggerLabel": {
     "defaultMessage": "{count, number} selected",
     "description": "Default summary on the closed trigger of a lab TransferListSelector, stating how many options are currently chosen. Consumers usually override this with a domain phrase (e.g. \"7 columns\")."
+  },
+  "@astryx.layout.middleScrollRegion": {
+    "defaultMessage": "Scrollable natural-height layout regions",
+    "description": "Accessible name for the shared middle scrollport in a fill-height Layout when one or more regions use height=auto."
   }
 }

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -41,24 +41,59 @@ export const docs = {
   displayName: 'Layout',
   group: 'Layout',
   category: 'Layout',
-  keywords: ["layout","container","content","flex","box","wrapper","page","regions"],
+  keywords: [
+    'layout',
+    'container',
+    'content',
+    'flex',
+    'box',
+    'wrapper',
+    'page',
+    'regions',
+  ],
   playground: {
     defaults: {
-      header: {__element: 'LayoutHeader', props: {}, children: {__element: 'Heading', props: {level: 3}, children: 'Page Title'}},
-      content: {__element: 'LayoutContent', props: {}, children: {__element: 'Text', props: {type: 'body', color: 'secondary'}, children: 'Main content area. This is the scrollable center section of the layout.'}},
-      footer: {__element: 'LayoutFooter', props: {}, children: {__element: 'Text', props: {type: 'supporting', color: 'secondary'}, children: 'Footer: status bar or actions'}},
+      header: {
+        __element: 'LayoutHeader',
+        props: {},
+        children: {
+          __element: 'Heading',
+          props: {level: 3},
+          children: 'Page Title',
+        },
+      },
+      content: {
+        __element: 'LayoutContent',
+        props: {},
+        children: {
+          __element: 'Text',
+          props: {type: 'body', color: 'secondary'},
+          children:
+            'Main content area. This is the scrollable center section of the layout.',
+        },
+      },
+      footer: {
+        __element: 'LayoutFooter',
+        props: {},
+        children: {
+          __element: 'Text',
+          props: {type: 'supporting', color: 'secondary'},
+          children: 'Footer: status bar or actions',
+        },
+      },
     },
   },
   theming: {
     targets: [
       {className: 'astryx-layout', visualProps: ['height']},
-      {className: 'astryx-layout-content'},
+      {className: 'astryx-layout-content', visualProps: ['height']},
       {className: 'astryx-layout-footer'},
       {className: 'astryx-layout-header'},
-      {className: 'astryx-layout-panel'},
+      {className: 'astryx-layout-panel', visualProps: ['height']},
     ],
   },
-  description: 'General five-slot layout primitive for arranging header, start, content, end, and footer regions.',
+  description:
+    'General five-slot layout primitive for arranging header, start, content, end, and footer regions.',
   props: [
     {
       name: 'content',
@@ -135,7 +170,7 @@ export const docs = {
       name: 'contentWidth',
       type: 'SizeValue',
       description:
-        'Maximum width of the content within each slot (header, content, footer, panels), centered when narrower than the available space. Dividers stay full-bleed. Numbers are treated as pixels, strings are used as-is (e.g. `60ch`). Common page widths: 640 for forms, settings, and text-focused pages; 960 for content pages and wider layouts.',
+        'Maximum width of the aligned content within each slot (header, content, footer, panels), centered when narrower than the available space. This width always includes the complete start + content + end composition. In a fill-height Layout, regions with `height="auto"` use their natural height and move together in the full-width middle scrollport, while regions with the default `height="fill"` stay pinned. `isScrollable` independently controls each region’s own overflow. Non-region slot content stays pinned in an independently scrollable lane. When one slot renders multiple top-level LayoutContent or LayoutPanel roots, they must use the same height; mixed values conservatively keep that slot pinned. Dividers stay full-bleed. Numbers are treated as pixels, strings are used as-is (e.g. `60ch`). Bare `var(...)` values use the constrained fallback because they may resolve to an intrinsic keyword; use `calc(var(...))` for a variable guaranteed to resolve to a length. Common page widths: 640 for forms, settings, and text-focused pages; 960 for content pages and wider layouts.',
     },
     {
       name: 'padding',
@@ -162,10 +197,31 @@ export const docs = {
     description:
       'Layout is a general five-slot primitive for arranging header, start, content, end, and footer regions within a page or bounded container. AppShell owns the page shell and app-wide navigation behavior; use HStack or VStack for simple directional stacking.',
     bestPractices: [
-      { guidance: true, description: 'Use Layout when content needs named header, start, content, end, or footer regions.' },
-      { guidance: true, description: 'Use HStack and VStack for simple directional stacking within a content area.' },
-      { guidance: false, description: 'Use Layout for simple stacking layouts; use HStack or VStack instead.' },
-      { guidance: false, description: 'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.' },
+      {
+        guidance: true,
+        description:
+          'Use Layout when content needs named header, start, content, end, or footer regions.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use HStack and VStack for simple directional stacking within a content area.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep region height at fill for pinned regions; use height="auto" when a top-level LayoutContent or LayoutPanel should move with the fill-height middle scrollport. Use isScrollable only to control local overflow.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout for simple stacking layouts; use HStack or VStack instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.',
+      },
     ],
     anatomy,
   },
@@ -177,10 +233,31 @@ export const docsZh = {
     description:
       'Layout is a general five-slot primitive for arranging header, start, content, end, and footer regions within a page or bounded container. AppShell owns the page shell and app-wide navigation behavior; use HStack or VStack for simple directional stacking.',
     bestPractices: [
-      { guidance: true, description: 'Use Layout when content needs named header, start, content, end, or footer regions.' },
-      { guidance: true, description: 'Use HStack and VStack for simple directional stacking within a content area.' },
-      { guidance: false, description: 'Use Layout for simple stacking layouts; use HStack or VStack instead.' },
-      { guidance: false, description: 'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.' },
+      {
+        guidance: true,
+        description:
+          'Use Layout when content needs named header, start, content, end, or footer regions.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use HStack and VStack for simple directional stacking within a content area.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep region height at fill for pinned regions; use height="auto" when a top-level LayoutContent or LayoutPanel should move with the fill-height middle scrollport. Use isScrollable only to control local overflow.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout for simple stacking layouts; use HStack or VStack instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.',
+      },
     ],
   },
 };
@@ -193,10 +270,31 @@ export const docsDense = {
     description:
       'Layout is a general five-slot primitive for arranging header, start, content, end, and footer regions within a page or bounded container. AppShell owns the page shell and app-wide navigation behavior; use HStack or VStack for simple directional stacking.',
     bestPractices: [
-      { guidance: true, description: 'Use Layout when content needs named header, start, content, end, or footer regions.' },
-      { guidance: true, description: 'Use HStack and VStack for simple directional stacking within a content area.' },
-      { guidance: false, description: 'Use Layout for simple stacking layouts; use HStack or VStack instead.' },
-      { guidance: false, description: 'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.' },
+      {
+        guidance: true,
+        description:
+          'Use Layout when content needs named header, start, content, end, or footer regions.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use HStack and VStack for simple directional stacking within a content area.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep region height at fill for pinned regions; use height="auto" when a top-level LayoutContent or LayoutPanel should move with the fill-height middle scrollport. Use isScrollable only to control local overflow.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout for simple stacking layouts; use HStack or VStack instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Layout as the page shell or for app-wide navigation; use AppShell for that responsibility.',
+      },
     ],
     anatomy,
   },

--- a/packages/core/src/Layout/Layout.spec.md
+++ b/packages/core/src/Layout/Layout.spec.md
@@ -39,17 +39,19 @@ system_specs: []
 Layout is a general layout primitive that arranges five optional named slots:
 Header, logical-start Panel, Content area, logical-end Panel, and Footer. It can
 structure regions within a page or bounded container, while AppShell owns the
-page shell. This draft records the current aggregate consumer anatomy and
-theming ownership without changing runtime behavior, DOM, styling, targets, or
-public API.
+page shell. This draft records the aggregate consumer anatomy, theming
+ownership, and the region-level scroll ownership coordinated by Layout.
 
 ## Compatibility and migration
 
-- Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, aliases, and public API remain unchanged
+- Released defaults preserved: `yes`; LayoutContent and LayoutPanel keep
+  `isScrollable=true`, and the new `height` prop defaults to `fill`
+- Compatibility class: additive opt-in; existing `isScrollable={false}` keeps
+  its released overflow behavior, while `height="auto"` joins the fill-height
+  Layout middle scrollport
 - Controlled/uncontrolled behavior: not applicable
-- Migration decision: none
+- Migration decision: none; all existing callers retain their sizing and
+  overflow behavior
 
 Consumer migration instructions belong in consumer docs and release notes.
 
@@ -65,6 +67,8 @@ Consumer migration instructions belong in consumer docs and release notes.
   `layout-header`, `layout-panel`, `layout-content`, and `layout-footer` targets.
 - One LayoutPanel concept and `layout-panel` target shared by instances supplied
   to the logical-start and logical-end slots.
+- The fill-height middle scrollport that coordinates top-level LayoutContent and
+  LayoutPanel region roots whose `height="auto"` opts into natural sizing.
 
 **Does not own / non-goals**
 
@@ -77,18 +81,19 @@ Consumer migration instructions belong in consumer docs and release notes.
 - Correcting current container-padding publication mismatches or preventing two
   adjacent divider owners from both painting; those remain current gaps and
   caller obligations recorded below.
-- New runtime behavior, API, target, alias, or region wrapper.
 
 ## Public concepts
 
 The current public topology has five independent ReactNode slots. Slot position
 is not rendered anatomy and does not add a target to arbitrary content.
 
-| Concept       | Current values                                | Meaning                                                                                      |
-| ------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| slot topology | `header`, `start`, `content`, `end`, `footer` | Positions caller content in the five-slot arrangement; omitted slots render no area wrapper. |
-| slot content  | any ReactNode                                 | The caller may supply Layout region components or unrelated content.                         |
-| panel anatomy | LayoutPanel in `start` and/or `end`           | Both positions use one optional Panel anatomy concept and one `layout-panel` target.         |
+| Concept        | Current values                                | Meaning                                                                                                  |
+| -------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| slot topology  | `header`, `start`, `content`, `end`, `footer` | Positions caller content in the five-slot arrangement; omitted slots render no area wrapper.             |
+| slot content   | any ReactNode                                 | The caller may supply Layout region components or unrelated content.                                     |
+| panel anatomy  | LayoutPanel in `start` and/or `end`           | Both positions use one optional Panel anatomy concept and one `layout-panel` target.                     |
+| region height  | `fill` or `auto`                              | Fill keeps the region pinned to the middle viewport; auto uses natural height and joins the middle flow. |
+| local overflow | scrollable or clipped                         | `isScrollable` independently preserves the released overflow toggle.                                     |
 
 Consumer syntax, defaults, and recommended region components remain documented
 in `Layout.doc.mjs` and the region subcomponent docs. `family:layout-regions`
@@ -97,14 +102,15 @@ the broader container system shared with Section, Table, Toolbar, and Divider.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                                                                                                              | Basis                                     | Draft review state                                 |
-| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------- |
-| FR1 | Layout renders one general Layout container carrying the current `layout` target and places arbitrary caller-provided ReactNode content in the `header`, `start`, `content`, `end`, and `footer` slots. Slot placement alone adds no region component or target. | Current source, docs, and tests           | Verified current behavior; no new behavior decided |
-| FR2 | When the caller supplies LayoutHeader, LayoutContent, or LayoutFooter, that component carries its current `layout-header`, `layout-content`, or `layout-footer` target; Layout does not add those targets to arbitrary slot content.                             | Current source and target metadata        | Verified current inventory; no target change       |
-| FR3 | LayoutPanel instances supplied to logical start or end share one aggregate Panel anatomy part and the current `layout-panel` target; slot position does not create a second anatomy part or target.                                                              | Current source, docs, tests, and family   | Verified current ownership; no API change          |
-| FR4 | `Layout.doc.mjs` is the canonical aggregate consumer document for the five current `layout*` targets and maps each target once; region subcomponent docs continue to document their own props and usage.                                                         | Current documentation organization        | Verified current ownership                         |
-| FR5 | LayoutContent and LayoutPanel retain their shipped automatic container-padding publication behavior, including the mismatches recorded by `architecture:container-padding`; this documentation does not claim exact parity.                                      | Current source and architecture record    | Current conformance gap; not fixed here            |
-| FR6 | When an adjacent ResizeHandle owns a panel divider, the caller must keep `LayoutPanel hasDivider={false}`; current composition does not prevent both components from painting the same boundary.                                                                 | Current source, docs, and family contract | Current caller obligation; not fixed here          |
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                                                                                                                                                               | Basis                                   | Draft review state                                         |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------------------------------------- |
+| FR1 | Layout renders one general Layout container carrying the current `layout` target and places arbitrary caller-provided ReactNode content in the `header`, `start`, `content`, `end`, and `footer` slots. Slot placement alone adds no region component or target.                                                                                                                                                                                  | Current source, docs, and tests         | Verified current behavior; no new behavior decided         |
+| FR2 | When the caller supplies LayoutHeader, LayoutContent, or LayoutFooter, that component carries its current `layout-header`, `layout-content`, or `layout-footer` target; Layout does not add those targets to arbitrary slot content.                                                                                                                                                                                                              | Current source and target metadata      | Verified current inventory; no target change               |
+| FR3 | LayoutPanel instances supplied to logical start or end share one aggregate Panel anatomy part and the current `layout-panel` target; slot position does not create a second anatomy part or target.                                                                                                                                                                                                                                               | Current source, docs, tests, and family | Verified current ownership; no API change                  |
+| FR4 | `Layout.doc.mjs` is the canonical aggregate consumer document for the five current `layout*` targets and maps each target once; region subcomponent docs continue to document their own props and usage.                                                                                                                                                                                                                                          | Current documentation organization      | Verified current ownership                                 |
+| FR5 | LayoutContent and LayoutPanel retain their shipped automatic container-padding publication behavior, including the mismatches recorded by `architecture:container-padding`; this documentation does not claim exact parity.                                                                                                                                                                                                                       | Current source and architecture record  | Current conformance gap; not fixed here                    |
+| FR6 | When an adjacent ResizeHandle owns a panel divider, the caller must keep `LayoutPanel hasDivider={false}`; current composition does not prevent both components from painting the same boundary. Auto-height panels stretch across the shared row so their panel-owned divider spans the full middle region.                                                                                                                                      | Current source, docs, tests, and family | Caller obligation preserved; auto-height geometry proposed |
+| FR7 | LayoutContent and LayoutPanel preserve their released `isScrollable` overflow behavior. Their new `height` prop defaults to `fill`; in a fill-height Layout, top-level region roots with `height="auto"` participate in the focusable middle scrollport while fill-height sibling slots remain pinned. Multiple region roots in one slot must agree; mixed heights keep that slot pinned. In auto-height Layout, no middle scrollport is created. | Current source, docs, tests, and family | Proposed additive behavior; defaults preserved             |
 
 ### Current evidence and gaps
 
@@ -131,21 +137,31 @@ the broader container system shared with Section, Table, Toolbar, and Divider.
 - **AV3 — Panel position.** LayoutPanel may occupy logical start or end, or both
   positions may be supplied; all instances remain one Panel anatomy concept and
   target.
+- **AV4 — Height and overflow.** Direct LayoutContent and LayoutPanel regions
+  preserve their independent `isScrollable` overflow toggle. `height` defaults
+  to `fill`; `height="auto"` participates in the fill-height middle scrollport.
+  Multiple region roots in one slot must agree on height, otherwise the slot
+  stays pinned. Auto-height Layouts remain page/ancestor-scrolled.
 
 ### Representative states
 
-| State                          | Required invariant                                                                         | Allowed variation                                      |
-| ------------------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
-| Arbitrary content only         | Layout container carries `layout`; arbitrary content gains no region target from its slot. | Caller content and current height/width configuration. |
-| Composed header/content/footer | Supplied Layout region components retain their own anatomy and targets.                    | Any region may instead be absent or arbitrary content. |
-| Start or end LayoutPanel       | Either logical position uses the one Panel anatomy part and `layout-panel` target.         | Position, width, scrolling, padding, and caller role.  |
-| Two LayoutPanels               | Both instances remain repetitions of the same Panel anatomy part and target.               | Independent content, width, and local configuration.   |
-| ResizeHandle-adjacent          | Divider ownership follows the current caller obligation in FR6.                            | Resize state remains owned by the resize components.   |
+| State                          | Required invariant                                                                         | Allowed variation                                           |
+| ------------------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| Arbitrary content only         | Layout container carries `layout`; arbitrary content gains no region target from its slot. | Caller content and current height/width configuration.      |
+| Composed header/content/footer | Supplied Layout region components retain their own anatomy and targets.                    | Any region may instead be absent or arbitrary content.      |
+| Start or end LayoutPanel       | Either logical position uses the one Panel anatomy part and `layout-panel` target.         | Position, width, scrolling, padding, and caller role.       |
+| Two LayoutPanels               | Both instances remain repetitions of the same Panel anatomy part and target.               | Fill or natural height may be selected per panel.           |
+| Mixed heights                  | Auto regions move in the middle scrollport; fill regions remain pinned.                    | Any direct content/start/end subset may use natural height. |
+| ResizeHandle-adjacent          | Divider ownership follows the current caller obligation in FR6.                            | Resize state remains owned by the resize components.        |
 
 ### Transformation and precedence order
 
-- No new slot, padding, content-width, divider, scrolling, sizing, or styling
-  precedence rule is introduced.
+- Region `height` defaults to `fill`. In a fill-height Layout, explicit `auto`
+  opts a top-level rendered region root into the middle scrollport; in an
+  auto-height Layout, the page/ancestor remains the scroll owner.
+- Region `isScrollable` retains its released, independent overflow behavior.
+- No new slot, padding, content-width, divider, sizing, or styling precedence
+  rule is introduced.
 
 ### Performance and resources
 
@@ -153,9 +169,11 @@ the broader container system shared with Section, Table, Toolbar, and Divider.
 
 ## Accessibility contract
 
-This draft does not add inferred landmark semantics. LayoutHeader,
-LayoutContent, LayoutFooter, and LayoutPanel retain their current explicit
-caller-supplied role and label behavior.
+This draft does not add inferred landmark semantics to individual regions.
+LayoutHeader, LayoutContent, LayoutFooter, and LayoutPanel retain their current
+explicit caller-supplied role and label behavior. An active middle scrollport is
+keyboard focusable and exposed as a named group, using the first participating
+region label when available and a localized fallback otherwise.
 
 ## Design relationships
 
@@ -200,17 +218,19 @@ end, or both. It does not map the `start` and `end` slots themselves.
 - `architecture:component-theming-surface` owns anatomy qualification and exact
   target mapping rules.
 - `architecture:public-component-api` owns the stable slots, props, exports, and
-  compatibility boundary; this documentation adds no API.
+  compatibility boundary; the additive height prop preserves existing defaults
+  and behavior.
 
 ## Verification map
 
-| Contract      | Verification                                                                                   | Representative states                                                              | Mutation or failure expectation                                                                                                                                                   | Audit section                |
-| ------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| FR1–FR3       | Layout render, slot-context, children-as-content, region-component, and target inventory tests | Arbitrary slot content, optional region components, logical start/end LayoutPanels | Removing slot placement, a composed region, or a current target fails existing structure, context, or target assertions; arbitrary slot content is not asserted to gain a target. | `audit:Layout/anatomy`       |
-| FR4           | `scripts/check-knowledge.mjs`                                                                  | Canonical aggregate doc and exact five-target map                                  | Missing, extra, prefixed, or stale target mappings fail repository validation.                                                                                                    | `audit:Layout/theming`       |
-| FR5           | Source inspection plus `architecture:container-padding` verification evidence                  | Automatic outer-edge Content area and Panel paths                                  | This draft adds no parity assertion; a runtime correction requires separate compatibility evidence.                                                                               | `audit:Layout/layout`        |
-| FR6           | LayoutPanel source/docs plus `family:layout-regions` verification evidence                     | Panel beside a divider-owning ResizeHandle                                         | This draft adds no prevention assertion; changing ownership requires separate runtime coverage.                                                                                   | `audit:Layout/layout`        |
-| Accessibility | `LayoutSlots.test.tsx` landmark assertions                                                     | Header, Content area, Footer, and Panel roles                                      | Supplied role or label no longer reaches the region element.                                                                                                                      | `audit:Layout/accessibility` |
+| Contract      | Verification                                                                                         | Representative states                                                                                                               | Mutation or failure expectation                                                                                                                                                       | Audit section                |
+| ------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| FR1–FR3       | Layout render, slot-context, children-as-content, region-component, and target inventory tests       | Arbitrary slot content, optional region components, logical start/end LayoutPanels                                                  | Removing slot placement, a composed region, or a current target fails existing structure, context, or target assertions; arbitrary slot content is not asserted to gain a target.     | `audit:Layout/anatomy`       |
+| FR4           | `scripts/check-knowledge.mjs`                                                                        | Canonical aggregate doc and exact five-target map                                                                                   | Missing, extra, prefixed, or stale target mappings fail repository validation.                                                                                                        | `audit:Layout/theming`       |
+| FR5           | Source inspection plus `architecture:container-padding` verification evidence                        | Automatic outer-edge Content area and Panel paths                                                                                   | This draft adds no parity assertion; a runtime correction requires separate compatibility evidence.                                                                                   | `audit:Layout/layout`        |
+| FR6           | LayoutPanel source/docs, `contentWidth.test.tsx`, plus `family:layout-regions` verification evidence | Fill and auto panel-owned dividers, including auto stretch across the shared row, plus a panel beside a divider-owning ResizeHandle | Removing full-height auto-panel stretch fails focused tests; duplicate ResizeHandle divider ownership remains a caller obligation.                                                    | `audit:Layout/layout`        |
+| FR7           | `Layout.test.tsx`, `LayoutSlots.test.tsx`, `contentWidth.test.tsx`, and Storybook browser evidence   | Content-only, one-panel, and mixed three-region height modes in fill/auto Layouts                                                   | Changing defaults, `isScrollable` compatibility, auto-region participation, fill-region pinning, focusability, or contentWidth containment fails focused structure or browser checks. | `audit:Layout/layout`        |
+| Accessibility | `LayoutSlots.test.tsx` landmark assertions and the Layout Storybook accessibility audit              | Header, Content area, Footer, Panel, and active middle scrollport                                                                   | Supplied region semantics stop forwarding, or the middle scrollport loses its focus stop or accessible name.                                                                          | `audit:Layout/accessibility` |
 
 ## Decision log
 

--- a/packages/core/src/Layout/Layout.test.tsx
+++ b/packages/core/src/Layout/Layout.test.tsx
@@ -16,6 +16,7 @@ import {use, createRef} from 'react';
 import {Layout} from './Layout';
 import {LayoutHeader} from './LayoutHeader';
 import {LayoutFooter} from './LayoutFooter';
+import {LayoutContent} from './LayoutContent';
 import {LayoutAreaContext} from './LayoutAreaContext';
 import {LayoutSlotsContext} from './LayoutSlotsContext';
 
@@ -127,6 +128,8 @@ describe('Layout', () => {
         hasFooter: false,
         hasStart: true,
         hasEnd: false,
+        hasMiddleScroll: false,
+        hasExpandedMiddleScroll: false,
       });
     });
 
@@ -138,7 +141,40 @@ describe('Layout', () => {
         hasFooter: false,
         hasStart: false,
         hasEnd: false,
+        hasMiddleScroll: false,
+        hasExpandedMiddleScroll: false,
       });
+    });
+
+    it('reports middle-scroll participation to descendants', () => {
+      render(
+        <Layout
+          content={
+            <LayoutContent height="auto">
+              <SlotsProbe />
+            </LayoutContent>
+          }
+        />,
+      );
+      const slots = JSON.parse(screen.getByTestId('slots').textContent ?? '{}');
+      expect(slots.hasMiddleScroll).toBe(true);
+      expect(slots.hasExpandedMiddleScroll).toBe(true);
+    });
+
+    it('does not create a middle scrollport in auto-height layouts', () => {
+      render(
+        <Layout
+          height="auto"
+          content={
+            <LayoutContent height="auto">
+              <SlotsProbe />
+            </LayoutContent>
+          }
+        />,
+      );
+      const slots = JSON.parse(screen.getByTestId('slots').textContent ?? '{}');
+      expect(slots.hasMiddleScroll).toBe(false);
+      expect(slots.hasExpandedMiddleScroll).toBe(false);
     });
 
     it('reports every slot filled', () => {
@@ -157,6 +193,8 @@ describe('Layout', () => {
         hasFooter: true,
         hasStart: true,
         hasEnd: true,
+        hasMiddleScroll: false,
+        hasExpandedMiddleScroll: false,
       });
     });
   });

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -28,6 +28,10 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
+import {useTranslator} from '../i18n';
+import {focusVars} from '../theme/tokens.stylex';
+import {useLayoutRegionGeometry} from './useLayoutRegionGeometry';
 import {
   layoutPaddingOuterXVarStyles,
   layoutPaddingOuterYVarStyles,
@@ -67,6 +71,68 @@ const styles = stylex.create({
   middle: {
     flex: 1,
     minHeight: 0,
+    width: '100%',
+  },
+  middleConstrained: {
+    boxSizing: 'border-box',
+    maxWidth: 'var(--layout-content-width, none)',
+    marginInline: 'auto',
+  },
+  middleScrollable: {
+    overflow: 'auto',
+  },
+  middleScrollableExpanded: {
+    scrollbarGutter: 'stable both-edges',
+  },
+  middleConstrainedRow: {
+    boxSizing: 'border-box',
+    width: '100%',
+    minHeight: '100%',
+  },
+  middleExpandedRow: {
+    boxSizing: 'border-box',
+    width: '100%',
+    maxWidth: 'var(--layout-content-width, none)',
+    minHeight: '100%',
+    marginInline: 'auto',
+  },
+  middleRowPassthrough: {
+    display: 'contents',
+  },
+  middleFocusInset: {
+    outlineOffset: {
+      default: null,
+      ':focus-visible': `calc(-1 * ${focusVars['--focus-outline-width']})`,
+    },
+  },
+  contentLanePinned: {
+    alignSelf: 'flex-start',
+    height: '100%',
+    overflow: 'auto',
+    position: 'sticky',
+    top: 0,
+  },
+  contentLanePinnedExpanded: {
+    height: 'var(--layout-middle-client-height, 100%)',
+    maxHeight: 'var(--layout-middle-client-height, 100%)',
+  },
+  sideLaneShared: {
+    display: 'flex',
+    flexShrink: 0,
+    minHeight: 'var(--layout-middle-client-height, 100%)',
+  },
+  sideLanePinned: {
+    alignSelf: 'flex-start',
+    display: 'flex',
+    flexShrink: 0,
+    height: '100%',
+    overflow: 'auto',
+    position: 'sticky',
+    top: 0,
+  },
+  sideLanePinnedExpanded: {
+    height: 'var(--layout-middle-client-height, 100%)',
+    maxHeight: 'var(--layout-middle-client-height, 100%)',
   },
   // When full bleed, set outer padding variables to 0 so child components touch container edges
   fullBleed: {
@@ -78,11 +144,6 @@ const styles = stylex.create({
 const dynamicStyles = stylex.create({
   contentWidthVar: (width: SizeValue) => ({
     '--layout-content-width': typeof width === 'number' ? `${width}px` : width,
-  }),
-  contentWidth: (width: SizeValue) => ({
-    width: '100%',
-    maxWidth: typeof width === 'number' ? `${width}px` : width,
-    marginInline: 'auto',
   }),
 });
 
@@ -98,11 +159,23 @@ export interface LayoutProps extends Omit<BaseProps, 'content'> {
   content?: ReactNode;
 
   /**
-   * Maximum width of the content within each slot (header, content, footer,
-   * panels). Dividers remain full-bleed. Content is centered with
+   * Maximum width of the aligned content within each slot (header, content,
+   * footer, panels). Dividers remain full-bleed. Content is centered with
    * `margin-inline: auto` when narrower than the available space.
    *
+   * `contentWidth` always includes the complete start + content + end
+   * composition. In a fill-height layout, slots whose top-level rendered region
+   * is a LayoutContent or LayoutPanel with `height="auto"` move together in the
+   * middle scrollport, while regions with the default `height="fill"` remain
+   * pinned. `isScrollable` independently controls local overflow. Non-region
+   * slot content also remains pinned in an independently scrollable lane. If a
+   * slot renders multiple top-level LayoutContent or LayoutPanel roots, they
+   * must agree on `height`; mixed values conservatively keep that slot pinned.
+   *
    * Numbers are treated as pixels, strings are used as-is (e.g., '60ch').
+   * Bare `var(...)` values use the constrained-scrollport fallback because
+   * their resolved value may be intrinsic; wrap a guaranteed length in
+   * `calc(...)` to use the expanded middle scrollport.
    * Common page widths:
    * - `640` — forms, settings, text-focused pages
    * - `960` — content pages, component demos, wider layouts
@@ -222,7 +295,7 @@ function AreaProvider({
  * />
  * ```
  */
-export function Layout({
+function LayoutWrapper({
   children,
   content,
   contentWidth,
@@ -238,6 +311,7 @@ export function Layout({
   className,
   style,
 }: LayoutProps) {
+  const t = useTranslator();
   const isFill = height === 'fill';
   // Children are a shorthand for the content slot; an explicit `content` prop
   // wins when both are provided.
@@ -253,9 +327,96 @@ export function Layout({
   const hasFooter = footer != null;
   const hasStart = start != null;
   const hasEnd = end != null;
+  const {
+    contentUsesMiddleScroll,
+    detectedRegions,
+    endUsesMiddleScroll,
+    hasExpandedMiddleScroll,
+    hasMiddleScroll,
+    layoutInnerRef,
+    middleRef,
+    startUsesMiddleScroll,
+  } = useLayoutRegionGeometry({contentWidth, isFill});
+
+  const startIsPinned = hasMiddleScroll && hasStart && !startUsesMiddleScroll;
+  const endIsPinned = hasMiddleScroll && hasEnd && !endUsesMiddleScroll;
+  const contentIsPinned = hasMiddleScroll && !contentUsesMiddleScroll;
+  const middleScrollLabel =
+    (startUsesMiddleScroll ? detectedRegions.start.label : undefined) ??
+    (contentUsesMiddleScroll ? detectedRegions.content.label : undefined) ??
+    (endUsesMiddleScroll ? detectedRegions.end.label : undefined) ??
+    t('@astryx.layout.middleScrollRegion');
   const slotsValue = useMemo<LayoutSlots>(
-    () => ({hasHeader, hasFooter, hasStart, hasEnd}),
-    [hasHeader, hasFooter, hasStart, hasEnd],
+    () => ({
+      hasHeader,
+      hasFooter,
+      hasStart,
+      hasEnd,
+      hasMiddleScroll,
+      hasExpandedMiddleScroll,
+    }),
+    [
+      hasHeader,
+      hasFooter,
+      hasStart,
+      hasEnd,
+      hasMiddleScroll,
+      hasExpandedMiddleScroll,
+    ],
+  );
+
+  const middleStyles = [
+    styles.middle,
+    !hasExpandedMiddleScroll && styles.middleConstrained,
+    hasMiddleScroll && styles.middleScrollable,
+    hasMiddleScroll && styles.middleScrollableExpanded,
+    hasMiddleScroll && styles.middleFocusInset,
+  ] as const;
+  const middleStyleProps = hasMiddleScroll
+    ? focusOutlineProps.focusVisible(...middleStyles)
+    : stylex.props(...middleStyles);
+  const middleRegions = (
+    <>
+      <div
+        data-layout-start-lane=""
+        {...stylex.props(
+          hasMiddleScroll
+            ? startIsPinned
+              ? styles.sideLanePinned
+              : styles.sideLaneShared
+            : styles.middleRowPassthrough,
+          startIsPinned &&
+            hasExpandedMiddleScroll &&
+            styles.sideLanePinnedExpanded,
+        )}>
+        <AreaProvider area="start">{start}</AreaProvider>
+      </div>
+      <div
+        data-layout-content-lane=""
+        {...stylex.props(
+          ...stackItem({size: 'fill'}),
+          contentIsPinned && styles.contentLanePinned,
+          contentIsPinned &&
+            hasExpandedMiddleScroll &&
+            styles.contentLanePinnedExpanded,
+        )}>
+        <AreaProvider area="content">{resolvedContent}</AreaProvider>
+      </div>
+      <div
+        data-layout-end-lane=""
+        {...stylex.props(
+          hasMiddleScroll
+            ? endIsPinned
+              ? styles.sideLanePinned
+              : styles.sideLaneShared
+            : styles.middleRowPassthrough,
+          endIsPinned &&
+            hasExpandedMiddleScroll &&
+            styles.sideLanePinnedExpanded,
+        )}>
+        <AreaProvider area="end">{end}</AreaProvider>
+      </div>
+    </>
   );
 
   const tree = (
@@ -273,6 +434,7 @@ export function Layout({
           style,
         )}>
         <div
+          ref={layoutInnerRef}
           {...stylex.props(
             stylex.defaultMarker(),
             styles.layoutInner,
@@ -283,20 +445,33 @@ export function Layout({
             padding != null && layoutPaddingOuterYVarStyles[padding],
             contentWidth != null && dynamicStyles.contentWidthVar(contentWidth),
           )}>
-          <AreaProvider area="header">{header}</AreaProvider>
           <div
-            {...stylex.props(
-              ...stack({direction: 'horizontal'}),
-              styles.middle,
-              contentWidth != null && dynamicStyles.contentWidth(contentWidth),
-            )}>
-            <AreaProvider area="start">{start}</AreaProvider>
-            <div {...stylex.props(...stackItem({size: 'fill'}))}>
-              <AreaProvider area="content">{resolvedContent}</AreaProvider>
-            </div>
-            <AreaProvider area="end">{end}</AreaProvider>
+            data-layout-header-lane=""
+            {...stylex.props(styles.middleRowPassthrough)}>
+            <AreaProvider area="header">{header}</AreaProvider>
           </div>
-          <AreaProvider area="footer">{footer}</AreaProvider>
+          <div
+            ref={middleRef}
+            tabIndex={hasMiddleScroll ? 0 : undefined}
+            role={hasMiddleScroll ? 'group' : undefined}
+            aria-label={hasMiddleScroll ? middleScrollLabel : undefined}
+            {...middleStyleProps}>
+            <div
+              data-layout-middle-row=""
+              {...stylex.props(
+                ...stack({direction: 'horizontal'}),
+                hasExpandedMiddleScroll
+                  ? styles.middleExpandedRow
+                  : styles.middleConstrainedRow,
+              )}>
+              {middleRegions}
+            </div>
+          </div>
+          <div
+            data-layout-footer-lane=""
+            {...stylex.props(styles.middleRowPassthrough)}>
+            <AreaProvider area="footer">{footer}</AreaProvider>
+          </div>
         </div>
       </div>
     </LayoutSlotsContext>
@@ -311,6 +486,11 @@ export function Layout({
   }
 
   return tree;
+}
+
+/** Renders the public Layout through the environment-observing ownership wrapper. */
+export function Layout(props: LayoutProps) {
+  return <LayoutWrapper {...props} />;
 }
 
 Layout.displayName = 'Layout';

--- a/packages/core/src/Layout/LayoutContent.doc.mjs
+++ b/packages/core/src/Layout/LayoutContent.doc.mjs
@@ -21,9 +21,17 @@ export const docs = {
         'Internal padding using the spacing scale. Overrides the default padding from the layout container.',
     },
     {
+      name: 'height',
+      type: "'fill' | 'auto'",
+      description:
+        "Block-axis sizing. 'fill' fills the Layout middle region; 'auto' uses natural height and moves with the fill-height Layout's middle scrollport.",
+      default: "'fill'",
+    },
+    {
       name: 'isScrollable',
       type: 'boolean',
-      description: 'Enable scrollable overflow.',
+      description:
+        'Enables scrollable overflow for this content area independently of its height.',
       default: 'true',
     },
     {
@@ -56,9 +64,16 @@ export const docsZh = {
       description: '使用间距比例的内边距。覆盖布局容器的默认内边距。',
     },
     {
+      name: 'height',
+      type: "'fill' | 'auto'",
+      description:
+        "区块轴尺寸。'fill' 填满 Layout 中间区域；'auto' 使用自然高度并随填充高度 Layout 的中间滚动区域移动。",
+      default: "'fill'",
+    },
+    {
       name: 'isScrollable',
       type: 'boolean',
-      description: '启用可滚动溢出。',
+      description: '独立于高度控制此内容区域是否启用滚动溢出。',
       default: 'true',
     },
     {
@@ -81,8 +96,11 @@ export const docsDense = {
   description: 'Scrollable main content area.',
   propDescriptions: {
     children: 'Content.',
-    padding: 'Internal padding on spacing scale. Overrides layout container default.',
-    isScrollable: 'Enable scrollable overflow.',
+    padding:
+      'Internal padding on spacing scale. Overrides layout container default.',
+    height:
+      'Fill the Layout middle region or use natural height and move with its middle scrollport.',
+    isScrollable: 'Enable scrollable overflow independently of height.',
     label: 'Accessible label for landmark element.',
     role: 'ARIA landmark role.',
   },

--- a/packages/core/src/Layout/LayoutContent.tsx
+++ b/packages/core/src/Layout/LayoutContent.tsx
@@ -34,10 +34,7 @@ import {
 const styles = stylex.create({
   content: {
     boxSizing: 'border-box',
-    height: '100%',
     flex: 1,
-    minHeight: 0,
-    overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
     paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
     paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
@@ -45,14 +42,14 @@ const styles = stylex.create({
       default: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
       // When header has no divider, collapse top padding for seamless visual flow
       [stylex.when.ancestor(
-        ':has(> .astryx-layout-header:not([data-divider]))',
+        ':has(> [data-layout-header-lane] > .astryx-layout-header:not([data-divider]))',
       )]: 0,
     },
     paddingBlockEnd: {
       default: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
       // When footer has no divider, collapse bottom padding for seamless visual flow
       [stylex.when.ancestor(
-        ':has(> .astryx-layout-footer:not([data-divider]))',
+        ':has(> [data-layout-footer-lane] > .astryx-layout-footer:not([data-divider]))',
       )]: 0,
     },
     // Publish container padding vars for bleed children (Table, Divider, etc.)
@@ -81,7 +78,19 @@ const styles = stylex.create({
     paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
     '--container-padding-block-end': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
-  scrollable: {
+  heightFill: {
+    height: '100%',
+    minHeight: 0,
+  },
+  heightAuto: {
+    alignSelf: 'flex-start',
+    height: 'auto',
+    minHeight: 0,
+  },
+  overflowStatic: {
+    overflow: 'clip',
+  },
+  overflowScrollable: {
     overflow: 'auto',
   },
   fullBleed: {
@@ -95,6 +104,8 @@ const styles = stylex.create({
     '--container-padding-block-end': '0px',
   },
 });
+
+export type LayoutRegionHeight = 'fill' | 'auto';
 
 export interface LayoutContentProps extends BaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
@@ -111,9 +122,18 @@ export interface LayoutContentProps extends BaseProps<HTMLDivElement> {
   padding?: SpacingStep;
 
   /**
+   * Controls this region's block-axis sizing.
+   * - `fill`: fills the Layout middle region (default).
+   * - `auto`: uses its natural height and moves with the fill-height Layout's
+   *   middle scrollport.
+   * @default 'fill'
+   */
+  height?: LayoutRegionHeight;
+
+  /**
    * Enables scrollable overflow for the content area.
-   * Set to false for auto-height layouts where sticky positioning
-   * needs to work with parent containers.
+   * Set to false for non-scrolling overflow behavior, including sticky
+   * descendants that need the parent scroll container.
    * @default true
    */
   isScrollable?: boolean;
@@ -135,8 +155,10 @@ export interface LayoutContentProps extends BaseProps<HTMLDivElement> {
  * Scrollable main content area for Layout. Wraps the primary body content
  * with automatic scroll containment and context-aware padding.
  *
- * Already provides its own padding and scroll — don't add padding or
- * overflow to children. Use `padding={0}` if you need edge-to-edge content.
+ * Provides context-aware padding and controls height and overflow independently.
+ * `height="auto"` moves the region with a fill-height Layout's middle scrollport.
+ * Don't add padding or overflow to children. Use `padding={0}` if you need
+ * edge-to-edge content.
  *
  * @example
  * ```
@@ -168,6 +190,7 @@ export interface LayoutContentProps extends BaseProps<HTMLDivElement> {
  */
 export function LayoutContent({
   children,
+  height = 'fill',
   isScrollable = true,
   padding,
   label,
@@ -188,15 +211,16 @@ export function LayoutContent({
       role={role}
       aria-label={label}
       {...mergeProps(
-        themeProps('layout-content'),
+        themeProps('layout-content', {height}),
         stylex.props(
           styles.content,
+          height === 'fill' ? styles.heightFill : styles.heightAuto,
+          isScrollable ? styles.overflowScrollable : styles.overflowStatic,
           // Outer padding on container edges (unless content is full bleed)
           !hasStart && !isZeroPadding && padding == null && styles.noStart,
           !hasEnd && !isZeroPadding && padding == null && styles.noEnd,
           !hasHeader && !isZeroPadding && padding == null && styles.noHeader,
           !hasFooter && !isZeroPadding && padding == null && styles.noFooter,
-          isScrollable && styles.scrollable,
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],
@@ -207,7 +231,9 @@ export function LayoutContent({
         className,
         style,
       )}
-      {...props}>
+      {...props}
+      data-layout-region="content"
+      data-layout-height={height}>
       {children}
     </div>
   );

--- a/packages/core/src/Layout/LayoutFooter.tsx
+++ b/packages/core/src/Layout/LayoutFooter.tsx
@@ -7,7 +7,9 @@
  * @input Uses React StyleX
  * @output Exports LayoutFooter component and LayoutFooterProps
  * @position Bottom bar / footer area for Layout. Use for action bars,
- *   pagination, status bars, or any fixed-height content at the bottom of a layout.
+ *   pagination, status bars, or any fixed-height content at the bottom of a
+ *   layout. Mirrors the expanded middle scrollport's stable scrollbar gutters
+ *   for alignment.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Layout/Layout.doc.mjs
@@ -36,11 +38,28 @@ const styles = stylex.create({
   footer: {
     flexShrink: 0,
   },
+  alignedScrollGutter: {
+    boxSizing: {
+      default: null,
+      ':is([data-layout-scroll-state="aligned"])': 'border-box',
+    },
+    paddingInlineStart: {
+      default: null,
+      ':is([data-layout-scroll-state="aligned"])':
+        'var(--layout-scroll-gutter-inline, 0px)',
+    },
+    paddingInlineEnd: {
+      default: null,
+      ':is([data-layout-scroll-state="aligned"])':
+        'var(--layout-scroll-gutter-inline, 0px)',
+    },
+  },
   // Inner wrapper: owns padding and optional content-width constraint.
   // When --layout-content-width is not set, maxWidth defaults to 'none' (inert).
   inner: {
     boxSizing: 'border-box',
-    maxWidth: 'var(--layout-content-width, none)',
+    maxWidth:
+      'var(--layout-aligned-content-width, var(--layout-content-width, none))',
     marginInline: 'auto',
     // Default: outer padding on edges that touch container, inner on interior edges
     paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
@@ -162,6 +181,7 @@ export function LayoutFooter({
         themeProps('layout-footer'),
         stylex.props(
           styles.footer,
+          styles.alignedScrollGutter,
           dynamicStyles.sizing(height ?? null),
 
           resolvedHasDivider && styles.divider,
@@ -170,7 +190,8 @@ export function LayoutFooter({
         className,
         style,
       )}
-      {...props}>
+      {...props}
+      data-layout-region="footer">
       <div
         {...stylex.props(
           styles.inner,

--- a/packages/core/src/Layout/LayoutHeader.tsx
+++ b/packages/core/src/Layout/LayoutHeader.tsx
@@ -7,7 +7,8 @@
  * @input Uses React StyleX
  * @output Exports LayoutHeader component and LayoutHeaderProps
  * @position Top bar / header area for Layout. Use for page titles, app bars,
- *   toolbar areas, or any fixed-height content at the top of a layout.
+ *   toolbar areas, or any fixed-height content at the top of a layout. Mirrors
+ *   the expanded middle scrollport's stable scrollbar gutters for alignment.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Layout/Layout.doc.mjs
@@ -36,11 +37,28 @@ const styles = stylex.create({
   header: {
     flexShrink: 0,
   },
+  alignedScrollGutter: {
+    boxSizing: {
+      default: null,
+      ':is([data-layout-scroll-state="aligned"])': 'border-box',
+    },
+    paddingInlineStart: {
+      default: null,
+      ':is([data-layout-scroll-state="aligned"])':
+        'var(--layout-scroll-gutter-inline, 0px)',
+    },
+    paddingInlineEnd: {
+      default: null,
+      ':is([data-layout-scroll-state="aligned"])':
+        'var(--layout-scroll-gutter-inline, 0px)',
+    },
+  },
   // Inner wrapper: owns padding and optional content-width constraint.
   // When --layout-content-width is not set, maxWidth defaults to 'none' (inert).
   inner: {
     boxSizing: 'border-box',
-    maxWidth: 'var(--layout-content-width, none)',
+    maxWidth:
+      'var(--layout-aligned-content-width, var(--layout-content-width, none))',
     marginInline: 'auto',
     // Default: outer padding on edges that touch container, inner on interior edges
     paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
@@ -162,6 +180,7 @@ export function LayoutHeader({
         themeProps('layout-header'),
         stylex.props(
           styles.header,
+          styles.alignedScrollGutter,
           dynamicStyles.sizing(height ?? null),
 
           resolvedHasDivider && styles.divider,
@@ -170,7 +189,8 @@ export function LayoutHeader({
         className,
         style,
       )}
-      {...props}>
+      {...props}
+      data-layout-region="header">
       <div
         {...stylex.props(
           styles.inner,

--- a/packages/core/src/Layout/LayoutPanel.doc.mjs
+++ b/packages/core/src/Layout/LayoutPanel.doc.mjs
@@ -17,7 +17,8 @@ export const docs = {
     {
       name: 'hasDivider',
       type: 'boolean',
-      description: 'Border on the appropriate edge.',
+      description:
+        'Border on the appropriate edge. Auto-height panels stretch across the shared row so the divider spans the full middle region.',
       default: 'false',
     },
     {
@@ -27,9 +28,17 @@ export const docs = {
         'Internal padding using the spacing scale. Overrides the default padding from the layout container.',
     },
     {
+      name: 'height',
+      type: "'fill' | 'auto'",
+      description:
+        "Block-axis sizing. 'fill' fills the Layout middle viewport. With 'auto', panel content contributes its natural height to the shared row and the panel box stretches across that row so its background and divider remain continuous.",
+      default: "'fill'",
+    },
+    {
       name: 'isScrollable',
       type: 'boolean',
-      description: 'Enable scrollable overflow.',
+      description:
+        'Enables scrollable overflow for this panel independently of its height.',
       default: 'true',
     },
     {
@@ -71,7 +80,8 @@ export const docsZh = {
     {
       name: 'hasDivider',
       type: 'boolean',
-      description: '相应边缘的边框。',
+      description:
+        '相应边缘的边框。自动高度面板会沿共享行拉伸，使分隔线覆盖整个中间区域。',
       default: 'false',
     },
     {
@@ -80,9 +90,16 @@ export const docsZh = {
       description: '使用间距比例的内边距。覆盖布局容器的默认内边距。',
     },
     {
+      name: 'height',
+      type: "'fill' | 'auto'",
+      description:
+        "区块轴尺寸。'fill' 填满 Layout 中间视口；使用 'auto' 时，面板内容以自然高度参与共享行，而面板盒会拉伸到整行，使背景和分隔线保持连续。",
+      default: "'fill'",
+    },
+    {
       name: 'isScrollable',
       type: 'boolean',
-      description: '启用可滚动溢出。',
+      description: '独立于高度控制此面板是否启用滚动溢出。',
       default: 'true',
     },
     {
@@ -117,10 +134,13 @@ export const docsDense = {
   description: 'Sidebar for navigation, settings, inspector panels.',
   propDescriptions: {
     children: 'Panel content.',
-    hasDivider: 'Border on appropriate edge.',
+    hasDivider:
+      'Border on the appropriate edge; auto-height panels stretch it across the full middle region.',
     padding:
       'Internal padding on spacing scale. Overrides layout container default.',
-    isScrollable: 'Enable scrollable overflow.',
+    height:
+      'Fill the middle viewport, or let content contribute natural row height while the panel box stretches for continuous background/dividers.',
+    isScrollable: 'Enable scrollable overflow independently of height.',
     label: 'Accessible label for landmark element.',
     role: 'ARIA landmark role.',
     width:

--- a/packages/core/src/Layout/LayoutPanel.tsx
+++ b/packages/core/src/Layout/LayoutPanel.tsx
@@ -22,6 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {LayoutAreaContext} from './LayoutAreaContext';
 import {LayoutSlotsContext} from './LayoutSlotsContext';
+import type {LayoutRegionHeight} from './LayoutContent';
 import {mergeProps} from '../utils';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import type {ResizableProps} from '../Resizable/useResizable';
@@ -37,7 +38,6 @@ const styles = stylex.create({
   panel: {
     boxSizing: 'border-box',
     flexShrink: 0,
-    overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
     paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
     paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
@@ -74,7 +74,18 @@ const styles = stylex.create({
     '--container-padding-block-start': '0px',
     '--container-padding-block-end': '0px',
   },
-  scrollable: {
+  heightFill: {
+    height: '100%',
+    minHeight: 0,
+  },
+  heightAuto: {
+    height: 'auto',
+    minHeight: 0,
+  },
+  overflowStatic: {
+    overflow: 'clip',
+  },
+  overflowScrollable: {
     overflow: 'auto',
   },
   // For start panel: divider on end edge
@@ -119,6 +130,8 @@ export interface LayoutPanelProps extends BaseProps<HTMLDivElement> {
    * - Start panel: border on end edge (right in LTR)
    * - End panel: border on start edge (left in LTR)
    * When false, spacing collapse is applied automatically for seamless visual flow.
+   * Auto-height panels stretch to the shared row's cross-size, so their divider
+   * continues through the full middle region without creating a local scrollport.
    *
    * Note: When using `resizable` with an adjacent `ResizeHandle hasDivider`,
    * set this to `false` to avoid a double-line artifact.
@@ -134,9 +147,19 @@ export interface LayoutPanelProps extends BaseProps<HTMLDivElement> {
   padding?: SpacingStep;
 
   /**
+   * Controls this panel's block-axis sizing.
+   * - `fill`: fills the Layout middle region (default).
+   * - `auto`: content contributes its natural height to the shared row; the panel
+   *   box stretches to that row so backgrounds and dividers remain continuous.
+   *   In a fill-height Layout, the row moves with the middle scrollport.
+   * @default 'fill'
+   */
+  height?: LayoutRegionHeight;
+
+  /**
    * Enables scrollable overflow for the panel.
-   * Set to false for auto-height layouts where sticky positioning
-   * needs to work with parent containers.
+   * Set to false for non-scrolling overflow behavior, including sticky
+   * descendants that need the parent scroll container.
    * @default true
    */
   isScrollable?: boolean;
@@ -183,8 +206,10 @@ export interface LayoutPanelProps extends BaseProps<HTMLDivElement> {
  * Renders with optional divider and context-aware padding.
  * Divider position is auto-detected based on which slot the panel is in.
  *
- * Already provides its own padding and scroll — don't add padding or
- * overflow to children. Use `padding={0}` if you need edge-to-edge content.
+ * Provides context-aware padding and controls height and overflow independently.
+ * `height="auto"` moves the panel with a fill-height Layout's middle scrollport.
+ * Don't add padding or overflow to children. Use `padding={0}` if you need
+ * edge-to-edge content.
  *
  * @example
  * ```
@@ -208,6 +233,7 @@ export interface LayoutPanelProps extends BaseProps<HTMLDivElement> {
 export function LayoutPanel({
   children,
   hasDivider = false,
+  height = 'fill',
   isScrollable = true,
   label,
   padding,
@@ -256,9 +282,11 @@ export function LayoutPanel({
       role={role}
       aria-label={label}
       {...mergeProps(
-        themeProps('layout-panel'),
+        themeProps('layout-panel', {height}),
         stylex.props(
+          height === 'fill' ? styles.heightFill : styles.heightAuto,
           styles.panel,
+          isScrollable ? styles.overflowScrollable : styles.overflowStatic,
           dynamicStyles.sizing(effectiveWidth ?? null),
           // Outer padding on container edges (unless component is full bleed)
           isStartPanel &&
@@ -268,7 +296,6 @@ export function LayoutPanel({
           isEndPanel && !isZeroPadding && padding == null && styles.endPanel,
           !hasHeader && !isZeroPadding && padding == null && styles.noHeader,
           !hasFooter && !isZeroPadding && padding == null && styles.noFooter,
-          isScrollable && styles.scrollable,
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],
@@ -281,7 +308,9 @@ export function LayoutPanel({
         className,
         style,
       )}
-      {...props}>
+      {...props}
+      data-layout-region="panel"
+      data-layout-height={height}>
       {children}
     </div>
   );

--- a/packages/core/src/Layout/LayoutSlotsContext.ts
+++ b/packages/core/src/Layout/LayoutSlotsContext.ts
@@ -29,6 +29,10 @@ export interface LayoutSlots {
   hasStart: boolean;
   /** Whether an end panel is rendered */
   hasEnd: boolean;
+  /** Whether one or more regions participate in the middle scrollport */
+  hasMiddleScroll: boolean;
+  /** Whether the middle scrollport spans Layout gutters around a constrained row */
+  hasExpandedMiddleScroll: boolean;
 }
 
 /**
@@ -39,6 +43,8 @@ const defaultSlots: LayoutSlots = {
   hasFooter: false,
   hasStart: false,
   hasEnd: false,
+  hasMiddleScroll: false,
+  hasExpandedMiddleScroll: false,
 };
 
 /**

--- a/packages/core/src/Layout/__tests__/contentWidth.test.tsx
+++ b/packages/core/src/Layout/__tests__/contentWidth.test.tsx
@@ -6,31 +6,852 @@
  * @output Unit tests for Layout contentWidth prop
  */
 
-import {describe, it, expect} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi} from 'vitest';
+import {useState} from 'react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {Layout} from '../Layout';
 import {LayoutHeader} from '../LayoutHeader';
 import {LayoutFooter} from '../LayoutFooter';
 import {LayoutContent} from '../LayoutContent';
+import {LayoutPanel} from '../LayoutPanel';
+
+function Widget({height: _height}: {height?: 'auto' | 'fill'}) {
+  return <div data-testid="widget">Widget</div>;
+}
+
+function WrappedContent() {
+  return (
+    <LayoutContent height="auto" data-testid="wrapped-content">
+      Wrapped
+    </LayoutContent>
+  );
+}
+
+function NestedContent() {
+  return (
+    <div data-testid="content-wrapper">
+      <LayoutContent height="auto" data-testid="nested-content">
+        Nested
+      </LayoutContent>
+    </div>
+  );
+}
+
+function SwitchingContent() {
+  const [isRegion, setIsRegion] = useState(false);
+  return isRegion ? (
+    <LayoutContent height="auto">
+      <button type="button" onClick={() => setIsRegion(false)}>
+        Reset root
+      </button>
+    </LayoutContent>
+  ) : (
+    <button type="button" onClick={() => setIsRegion(true)}>
+      Use region root
+    </button>
+  );
+}
 
 describe('Layout contentWidth', () => {
   describe('Layout', () => {
-    it('applies max-width constraint to the middle row', () => {
+    it('observes only direct slot roots instead of the Layout subtree', () => {
+      const observe = vi.fn();
+      const disconnect = vi.fn();
+      const OriginalMutationObserver = globalThis.MutationObserver;
+      vi.stubGlobal(
+        'MutationObserver',
+        class {
+          constructor(_callback: MutationCallback) {}
+          observe = observe;
+          disconnect = disconnect;
+          takeRecords = vi.fn(() => []);
+        },
+      );
+
+      try {
+        render(
+          <Layout
+            content={<LayoutContent height="auto">Body</LayoutContent>}
+          />,
+        );
+
+        expect(observe).toHaveBeenCalled();
+        for (const [, options] of observe.mock.calls) {
+          expect(options).not.toHaveProperty('subtree', true);
+        }
+      } finally {
+        vi.stubGlobal('MutationObserver', OriginalMutationObserver);
+      }
+    });
+
+    it('keeps the released independent-scroll default for single-column content', () => {
       render(
         <Layout
           contentWidth={640}
           content={
-            <LayoutContent>
+            <LayoutContent data-testid="content-region">Body</LayoutContent>
+          }
+        />,
+      );
+
+      const contentRegion = screen.getByTestId('content-region');
+      const middleRow = contentRegion.parentElement!.parentElement!;
+
+      expect(contentRegion).toHaveTextContent('Body');
+      expect(middleRow).not.toHaveAttribute('role');
+      expect(middleRow).not.toHaveAttribute('tabindex');
+    });
+
+    it('preserves isScrollable=false without changing fill-height ownership', () => {
+      render(
+        <Layout
+          content={
+            <LayoutContent isScrollable={false} data-testid="static-content">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
+      expect(
+        getComputedStyle(screen.getByTestId('static-content')).overflow,
+      ).toBe('clip');
+      expect(
+        getComputedStyle(screen.getByTestId('static-content')).height,
+      ).toBe('100%');
+    });
+
+    it('preserves LayoutPanel isScrollable=false without changing fill-height ownership', () => {
+      render(
+        <Layout
+          start={
+            <LayoutPanel isScrollable={false} data-testid="static-panel">
+              Navigation
+            </LayoutPanel>
+          }
+          content={<LayoutContent>Body</LayoutContent>}
+        />,
+      );
+
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
+      expect(
+        getComputedStyle(screen.getByTestId('static-panel')).overflow,
+      ).toBe('clip');
+      expect(getComputedStyle(screen.getByTestId('static-panel')).height).toBe(
+        '100%',
+      );
+    });
+
+    it('keeps height and overflow controls independent', () => {
+      render(
+        <Layout
+          content={
+            <LayoutContent
+              height="auto"
+              isScrollable={false}
+              data-testid="natural-static-content">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      expect(screen.getByRole('group')).toBeInTheDocument();
+      expect(
+        getComputedStyle(screen.getByTestId('natural-static-content')).overflow,
+      ).toBe('clip');
+      expect(
+        getComputedStyle(screen.getByTestId('natural-static-content')).height,
+      ).toBe('auto');
+    });
+
+    it('uses the middle scrollport when content uses natural height', () => {
+      render(
+        <Layout
+          contentWidth={640}
+          content={
+            <LayoutContent
+              height="auto"
+              label="Document"
+              data-testid="content-region">
               <span data-testid="body">Body</span>
             </LayoutContent>
           }
         />,
       );
-      const bodyEl = screen.getByTestId('body');
-      const contentDiv = bodyEl.parentElement!;
-      const stackItemDiv = contentDiv.parentElement!;
-      const middleRow = stackItemDiv.parentElement!;
-      expect(middleRow.className).toBeTruthy();
+
+      const contentRegion = screen.getByTestId('content-region');
+      const middleRow = screen.getByRole('group', {name: 'Document'});
+
+      expect(screen.getByTestId('body').parentElement).toBe(contentRegion);
+      expect(middleRow).toHaveAttribute('role', 'group');
+      expect(middleRow).toHaveAttribute('aria-label', 'Document');
+      expect(middleRow).toHaveAttribute('tabindex', '0');
+      expect(getComputedStyle(middleRow).overflow).toBe('auto');
+      expect(getComputedStyle(middleRow).scrollbarGutter).toBe(
+        'stable both-edges',
+      );
+    });
+
+    it('supports percentage widths in the middle scrollport', () => {
+      render(
+        <Layout
+          contentWidth="50%"
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      const middleRow = screen.getByRole('group');
+      expect(middleRow).toHaveAttribute('role', 'group');
+    });
+
+    it('keeps bare CSS variable widths on the constrained path', () => {
+      const {rerender} = render(
+        <Layout
+          contentWidth="var(--page-width)"
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      const middleRow = () => screen.getByRole('group');
+      const variableWidthClassName = middleRow().className;
+
+      rerender(
+        <Layout
+          contentWidth="fit-content"
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      expect(middleRow()).toHaveAttribute('role', 'group');
+      expect(middleRow().className).toBe(variableWidthClassName);
+    });
+
+    it('expands calculated CSS variable widths', () => {
+      render(
+        <Layout
+          contentWidth="calc(var(--page-width))"
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      expect(getComputedStyle(screen.getByRole('group')).scrollbarGutter).toBe(
+        'stable both-edges',
+      );
+    });
+
+    it('keeps intrinsic width keywords on the constrained middle scrollport', () => {
+      const {rerender} = render(
+        <Layout
+          contentWidth="fit-content"
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      const middleRow = () => screen.getByRole('group');
+      const fitContentClassName = middleRow().className;
+
+      rerender(
+        <Layout
+          contentWidth="max-content"
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      expect(middleRow()).toHaveAttribute('role', 'group');
+      expect(middleRow().className).toBe(fitContentClassName);
+    });
+
+    it('supports mixed independent and middle-scroll regions', () => {
+      render(
+        <Layout
+          contentWidth={640}
+          start={
+            <LayoutPanel isScrollable data-testid="start-region">
+              Navigation
+            </LayoutPanel>
+          }
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+          end={
+            <LayoutPanel height="auto" data-testid="end-region">
+              Details
+            </LayoutPanel>
+          }
+        />,
+      );
+
+      const middleRow = screen.getByRole('group');
+
+      expect(middleRow).toHaveAttribute('role', 'group');
+      expect(
+        getComputedStyle(screen.getByTestId('start-region').parentElement!)
+          .position,
+      ).toBe('sticky');
+      expect(getComputedStyle(screen.getByTestId('end-region')).height).toBe(
+        'auto',
+      );
+      expect(
+        getComputedStyle(screen.getByTestId('end-region')).alignSelf,
+      ).not.toBe('flex-start');
+      expect(screen.getByTestId('start-region').className).not.toBe(
+        screen.getByTestId('end-region').className,
+      );
+    });
+
+    it('keeps auto-height panel dividers on the stretching panel box', async () => {
+      render(
+        <Layout
+          start={
+            <LayoutPanel
+              height="auto"
+              hasDivider
+              data-testid="auto-start-panel">
+              Navigation
+            </LayoutPanel>
+          }
+          content={<LayoutContent height="auto">Body</LayoutContent>}
+          end={
+            <LayoutPanel height="auto" hasDivider data-testid="auto-end-panel">
+              Details
+            </LayoutPanel>
+          }
+        />,
+      );
+
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+      const startPanel = screen.getByTestId('auto-start-panel');
+      const endPanel = screen.getByTestId('auto-end-panel');
+
+      expect(getComputedStyle(startPanel).borderInlineEndWidth).toBe('1px');
+      expect(getComputedStyle(endPanel).borderInlineStartWidth).toBe('1px');
+      expect(getComputedStyle(startPanel).alignSelf).not.toBe('flex-start');
+      expect(getComputedStyle(endPanel).alignSelf).not.toBe('flex-start');
+    });
+
+    it('keeps auto-height dividers in page-owned layouts', () => {
+      render(
+        <Layout
+          height="auto"
+          start={
+            <LayoutPanel height="auto" hasDivider data-testid="page-panel">
+              Navigation
+            </LayoutPanel>
+          }
+          content={<LayoutContent height="auto">Body</LayoutContent>}
+        />,
+      );
+
+      expect(
+        getComputedStyle(screen.getByTestId('page-panel')).borderInlineEndWidth,
+      ).toBe('1px');
+    });
+
+    it('keeps each divider on its panel in multi-panel slots', async () => {
+      render(
+        <Layout
+          start={
+            <>
+              <LayoutPanel height="auto" hasDivider data-testid="first-panel">
+                First
+              </LayoutPanel>
+              <span data-testid="resize-handle" />
+              <LayoutPanel height="auto" hasDivider data-testid="second-panel">
+                Second
+              </LayoutPanel>
+            </>
+          }
+          content={<LayoutContent height="auto">Body</LayoutContent>}
+        />,
+      );
+
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+      expect(
+        getComputedStyle(screen.getByTestId('first-panel'))
+          .borderInlineEndWidth,
+      ).toBe('1px');
+      expect(
+        getComputedStyle(screen.getByTestId('second-panel'))
+          .borderInlineEndWidth,
+      ).toBe('1px');
+      expect(screen.getByTestId('resize-handle')).toBeInTheDocument();
+    });
+
+    it('keeps fill-height panel dividers on the panel itself', () => {
+      render(
+        <Layout
+          start={
+            <LayoutPanel hasDivider data-testid="fill-panel">
+              Navigation
+            </LayoutPanel>
+          }
+          content={<LayoutContent>Body</LayoutContent>}
+        />,
+      );
+
+      const panel = screen.getByTestId('fill-panel');
+      expect(getComputedStyle(panel).borderInlineEndWidth).toBe('1px');
+      expect(panel.parentElement).not.toHaveAttribute(
+        'data-layout-divider-end',
+      );
+    });
+
+    it('pins a panel rendered beside a sibling in the same slot', async () => {
+      render(
+        <Layout
+          start={
+            <>
+              <LayoutPanel data-testid="fragment-panel">Navigation</LayoutPanel>
+              <span data-testid="resize-handle" />
+            </>
+          }
+          content={<LayoutContent height="auto">Body</LayoutContent>}
+        />,
+      );
+
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          getComputedStyle(screen.getByTestId('fragment-panel').parentElement!)
+            .position,
+        ).toBe('sticky'),
+      );
+      expect(screen.getByTestId('resize-handle')).toBeInTheDocument();
+    });
+
+    it('uses shared scrolling when every panel root uses natural height', async () => {
+      render(
+        <Layout
+          start={
+            <>
+              <LayoutPanel height="auto" data-testid="shared-panel-a">
+                Navigation
+              </LayoutPanel>
+              <span data-testid="shared-resize-handle" />
+              <LayoutPanel height="auto" data-testid="shared-panel-b">
+                Filters
+              </LayoutPanel>
+            </>
+          }
+          content={<LayoutContent>Body</LayoutContent>}
+        />,
+      );
+
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+      expect(screen.getByTestId('shared-panel-a')).toHaveAttribute(
+        'data-layout-scroll-state',
+        'middle',
+      );
+      expect(screen.getByTestId('shared-panel-b')).toHaveAttribute(
+        'data-layout-scroll-state',
+        'middle',
+      );
+      expect(
+        getComputedStyle(
+          screen.getByTestId('shared-resize-handle').parentElement!,
+        ).display,
+      ).toBe('flex');
+    });
+
+    it('keeps a slot pinned when its panel roots use mixed heights', async () => {
+      const {rerender} = render(
+        <Layout
+          start={
+            <>
+              <LayoutPanel data-testid="self-panel">Navigation</LayoutPanel>
+              <LayoutPanel height="auto" data-testid="shared-panel">
+                Filters
+              </LayoutPanel>
+            </>
+          }
+          content={<LayoutContent>Body</LayoutContent>}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole('group')).not.toBeInTheDocument(),
+      );
+      expect(screen.getByTestId('self-panel')).not.toHaveAttribute(
+        'data-layout-scroll-state',
+      );
+      expect(screen.getByTestId('shared-panel')).not.toHaveAttribute(
+        'data-layout-scroll-state',
+      );
+      expect(
+        getComputedStyle(screen.getByTestId('shared-panel')).overflow,
+      ).toBe('auto');
+
+      rerender(
+        <Layout
+          start={
+            <>
+              <LayoutPanel height="auto" data-testid="shared-panel">
+                Filters
+              </LayoutPanel>
+              <LayoutPanel data-testid="self-panel">Navigation</LayoutPanel>
+            </>
+          }
+          content={<LayoutContent>Body</LayoutContent>}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole('group')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('pins arbitrary side-slot content when another region uses middle scrolling', async () => {
+      render(
+        <Layout
+          start={<span data-testid="arbitrary-start">Utility</span>}
+          content={<LayoutContent height="auto">Body</LayoutContent>}
+        />,
+      );
+
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+      expect(
+        getComputedStyle(screen.getByTestId('arbitrary-start').parentElement!)
+          .position,
+      ).toBe('sticky');
+      expect(
+        getComputedStyle(screen.getByTestId('arbitrary-start').parentElement!)
+          .overflow,
+      ).toBe('auto');
+    });
+
+    it('keeps arbitrary content independently scrollable beside a shared region', async () => {
+      render(
+        <Layout
+          start={<LayoutPanel height="auto">Navigation</LayoutPanel>}
+          content={<div data-testid="arbitrary-content">Tall content</div>}
+        />,
+      );
+
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+      const contentLane =
+        screen.getByTestId('arbitrary-content').parentElement!;
+      expect(getComputedStyle(contentLane).position).toBe('sticky');
+      expect(getComputedStyle(contentLane).overflow).toBe('auto');
+    });
+
+    it('aligns header and footer without clipping their overflow', () => {
+      render(
+        <Layout
+          contentWidth={640}
+          header={<LayoutHeader data-testid="header">Header</LayoutHeader>}
+          content={
+            <LayoutContent height="auto" data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+          footer={<LayoutFooter data-testid="footer">Footer</LayoutFooter>}
+        />,
+      );
+
+      const middle = screen.getByRole('group');
+      expect(getComputedStyle(middle).scrollbarGutter).toBe(
+        'stable both-edges',
+      );
+      expect(getComputedStyle(screen.getByTestId('header')).overflowY).not.toBe(
+        'hidden',
+      );
+      expect(getComputedStyle(screen.getByTestId('footer')).overflowY).not.toBe(
+        'hidden',
+      );
+      expect(
+        middle.parentElement?.style.getPropertyValue(
+          '--layout-scroll-gutter-inline',
+        ),
+      ).toBe('0px');
+    });
+
+    it('recomputes aligned bar gutters when contentWidth changes', async () => {
+      const {rerender} = render(
+        <Layout
+          contentWidth="fit-content"
+          header={<LayoutHeader data-testid="header">Header</LayoutHeader>}
+          content={<LayoutContent height="auto">Body</LayoutContent>}
+          footer={<LayoutFooter data-testid="footer">Footer</LayoutFooter>}
+        />,
+      );
+      expect(screen.getByTestId('header')).toHaveAttribute(
+        'data-layout-scroll-state',
+        'aligned',
+      );
+      expect(screen.getByTestId('footer')).toHaveAttribute(
+        'data-layout-scroll-state',
+        'aligned',
+      );
+      expect(
+        screen
+          .getByTestId('header')
+          .style.getPropertyValue('--layout-aligned-content-width'),
+      ).toBe('0px');
+
+      rerender(
+        <Layout
+          contentWidth={640}
+          header={<LayoutHeader data-testid="header">Header</LayoutHeader>}
+          content={<LayoutContent height="auto">Body</LayoutContent>}
+          footer={<LayoutFooter data-testid="footer">Footer</LayoutFooter>}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(
+          screen
+            .getByTestId('header')
+            .style.getPropertyValue('--layout-aligned-content-width'),
+        ).toBe(''),
+      );
+      expect(screen.getByTestId('footer')).toHaveAttribute(
+        'data-layout-scroll-state',
+        'aligned',
+      );
+    });
+
+    it('detects a slot that resolves to a region root through a wrapper', async () => {
+      render(<Layout content={<WrappedContent />} />);
+
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+      expect(screen.getByTestId('wrapped-content')).toHaveAttribute(
+        'data-layout-scroll-state',
+        'middle',
+      );
+    });
+
+    it('tracks a transparent child whose top-level region root changes', async () => {
+      render(<Layout content={<SwitchingContent />} />);
+
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', {name: 'Use region root'}));
+      expect(await screen.findByRole('group')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', {name: 'Reset root'}));
+      await waitFor(() =>
+        expect(screen.queryByRole('group')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('does not leak direct ownership into nested regions', () => {
+      render(
+        <Layout
+          start={
+            <LayoutPanel height="auto">
+              <LayoutPanel data-testid="nested-panel">Nested</LayoutPanel>
+            </LayoutPanel>
+          }
+          content={<NestedContent />}
+        />,
+      );
+
+      expect(screen.getByRole('group')).toBeInTheDocument();
+      expect(screen.getByTestId('nested-content')).not.toHaveAttribute(
+        'data-layout-scroll-state',
+      );
+      expect(screen.getByTestId('nested-panel')).not.toHaveAttribute(
+        'data-layout-scroll-state',
+      );
+    });
+
+    it('does not apply aligned scrollbar gutters to headers nested under arbitrary content', () => {
+      render(
+        <Layout
+          start={<LayoutPanel height="auto">Panel</LayoutPanel>}
+          content={
+            <div>
+              <LayoutHeader data-testid="nested-header">Nested</LayoutHeader>
+            </div>
+          }
+        />,
+      );
+
+      expect(
+        getComputedStyle(screen.getByTestId('nested-header')).scrollbarGutter,
+      ).not.toBe('stable both-edges');
+    });
+
+    it('does not apply aligned gutters to nested bars in header/footer slots', () => {
+      render(
+        <Layout
+          header={
+            <div>
+              <LayoutHeader data-testid="wrapped-header">Header</LayoutHeader>
+            </div>
+          }
+          content={<LayoutContent height="auto">Content</LayoutContent>}
+          footer={
+            <div>
+              <LayoutFooter data-testid="wrapped-footer">Footer</LayoutFooter>
+            </div>
+          }
+        />,
+      );
+
+      expect(
+        getComputedStyle(screen.getByTestId('wrapped-header'))
+          .paddingInlineStart,
+      ).not.toContain('--layout-scroll-gutter-inline');
+      expect(
+        getComputedStyle(screen.getByTestId('wrapped-footer'))
+          .paddingInlineStart,
+      ).not.toContain('--layout-scroll-gutter-inline');
+    });
+
+    it('preserves natural panel height when Layout scrolling is page-owned', () => {
+      render(
+        <Layout
+          height="auto"
+          start={
+            <LayoutPanel height="auto" data-testid="auto-panel">
+              Panel
+            </LayoutPanel>
+          }
+          content={<LayoutContent height="auto">Content</LayoutContent>}
+        />,
+      );
+
+      expect(
+        getComputedStyle(screen.getByTestId('auto-panel')).alignSelf,
+      ).not.toBe('flex-start');
+    });
+
+    it('clears fill-only ownership when height changes to auto', async () => {
+      const {rerender} = render(
+        <Layout
+          height="fill"
+          start={
+            <LayoutPanel data-testid="transition-panel">Panel</LayoutPanel>
+          }
+          content={<LayoutContent height="auto">Content</LayoutContent>}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(
+          getComputedStyle(
+            screen.getByTestId('transition-panel').parentElement!,
+          ).position,
+        ).toBe('sticky'),
+      );
+
+      rerender(
+        <Layout
+          height="auto"
+          start={
+            <LayoutPanel data-testid="transition-panel">Panel</LayoutPanel>
+          }
+          content={<LayoutContent height="auto">Content</LayoutContent>}
+        />,
+      );
+
+      await waitFor(() =>
+        expect(
+          getComputedStyle(
+            screen.getByTestId('transition-panel').parentElement!,
+          ).position,
+        ).not.toBe('sticky'),
+      );
+      expect(screen.getByText('Content')).not.toHaveAttribute(
+        'data-layout-scroll-state',
+      );
+    });
+
+    it('does not clear ownership state from a nested Layout', async () => {
+      render(
+        <Layout
+          content={
+            <LayoutContent height="auto" data-testid="outer-content">
+              <Layout
+                content={
+                  <LayoutContent height="auto" data-testid="inner-content">
+                    Inner
+                  </LayoutContent>
+                }
+              />
+            </LayoutContent>
+          }
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('outer-content')).toHaveAttribute(
+          'data-layout-scroll-state',
+          'middle',
+        );
+        expect(screen.getByTestId('inner-content')).toHaveAttribute(
+          'data-layout-scroll-state',
+          'middle',
+        );
+      });
+    });
+
+    it('shadows measured height inside nested constrained layouts', async () => {
+      const {container} = render(
+        <Layout
+          contentWidth={640}
+          content={
+            <LayoutContent height="auto">
+              <Layout
+                contentWidth="fit-content"
+                content={<LayoutContent height="auto">Inner</LayoutContent>}
+              />
+            </LayoutContent>
+          }
+        />,
+      );
+
+      await waitFor(() => {
+        const layoutInners = container.querySelectorAll('.astryx-layout > div');
+        expect(
+          (
+            layoutInners.item(layoutInners.length - 1) as HTMLElement
+          ).style.getPropertyValue('--layout-middle-client-height'),
+        ).toBe('100%');
+      });
+    });
+
+    it('does not treat arbitrary component height props as region ownership', () => {
+      render(<Layout content={<Widget height="auto" />} />);
+
+      const middleRow =
+        screen.getByTestId('widget').parentElement!.parentElement!;
+      expect(middleRow).not.toHaveAttribute('role');
+      expect(middleRow).not.toHaveAttribute('tabindex');
+    });
+
+    it('keeps arbitrary single-column content constrained', () => {
+      render(<Layout contentWidth={640} content={<div>Body</div>} />);
+      const middleRow = screen.getByText('Body').parentElement!.parentElement!;
+      expect(middleRow).not.toHaveAttribute('role');
     });
 
     it('does not crash when contentWidth is not set', () => {

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -74,7 +74,7 @@ export {LayoutFooter} from './LayoutFooter';
 export type {LayoutFooterProps} from './LayoutFooter';
 
 export {LayoutContent} from './LayoutContent';
-export type {LayoutContentProps} from './LayoutContent';
+export type {LayoutContentProps, LayoutRegionHeight} from './LayoutContent';
 
 export {LayoutPanel} from './LayoutPanel';
 export type {LayoutPanelProps} from './LayoutPanel';

--- a/packages/core/src/Layout/useLayoutRegionGeometry.ts
+++ b/packages/core/src/Layout/useLayoutRegionGeometry.ts
@@ -1,0 +1,316 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useLayoutRegionGeometry.ts
+ * @input Layout height mode, content width, and rendered region DOM markers
+ * @output Stable refs plus synchronized region height and scroll geometry
+ * @position Internal Layout hook. This is the single source of truth for
+ *   rendered region geometry across direct JSX, RSC/Flight, and transparent
+ *   wrappers.
+ */
+
+import {useRef, useState} from 'react';
+import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
+import type {SizeValue} from '../utils/types';
+
+interface DetectedRegion {
+  usesMiddleScroll: boolean;
+  label?: string;
+}
+
+interface DetectedRegions {
+  start: DetectedRegion;
+  content: DetectedRegion;
+  end: DetectedRegion;
+}
+
+const EMPTY_REGIONS: DetectedRegions = {
+  start: {
+    usesMiddleScroll: false,
+  },
+  content: {
+    usesMiddleScroll: false,
+  },
+  end: {
+    usesMiddleScroll: false,
+  },
+};
+
+function sameDetectedRegion(a: DetectedRegion, b: DetectedRegion): boolean {
+  return a.usesMiddleScroll === b.usesMiddleScroll && a.label === b.label;
+}
+
+function sameDetectedRegions(a: DetectedRegions, b: DetectedRegions): boolean {
+  return (
+    sameDetectedRegion(a.start, b.start) &&
+    sameDetectedRegion(a.content, b.content) &&
+    sameDetectedRegion(a.end, b.end)
+  );
+}
+
+function detectDomRegions(
+  elements: Element[],
+  expectedRegion: 'content' | 'panel',
+): DetectedRegion {
+  const regions = elements.filter(
+    element => element.getAttribute('data-layout-region') === expectedRegion,
+  );
+  const autoRegions = regions.filter(
+    element => element.getAttribute('data-layout-height') === 'auto',
+  );
+  return {
+    // A slot is one region. Multiple top-level region roots must agree before
+    // the slot opts into natural-height middle scrolling.
+    usesMiddleScroll:
+      regions.length > 0 && autoRegions.length === regions.length,
+    label:
+      autoRegions
+        .map(element => element.getAttribute('aria-label'))
+        .find((label): label is string => label != null) ?? undefined,
+  };
+}
+
+/**
+ * Full-width scroll alignment requires subtracting contentWidth in CSS.
+ * Intrinsic sizing keywords cannot participate in that arithmetic, so they
+ * preserve the constrained-row behavior.
+ */
+export function supportsFullWidthScrollport(
+  width: SizeValue | undefined,
+): boolean {
+  if (width == null || typeof width === 'number') {
+    return true;
+  }
+
+  const value = width.trim().toLowerCase();
+  return (
+    value === '0' ||
+    /^-?(?:\d+(?:\.\d+)?|\.\d+)(?:[a-z]+|%)$/.test(value) ||
+    /^(?:calc|min|max|clamp)\(/.test(value)
+  );
+}
+
+export function useLayoutRegionGeometry({
+  contentWidth,
+  isFill,
+}: {
+  contentWidth: SizeValue | undefined;
+  isFill: boolean;
+}) {
+  const middleRef = useRef<HTMLDivElement>(null);
+
+  const layoutInnerRef = useRef<HTMLDivElement>(null);
+
+  const ownedRegionElementsRef = useRef<Set<Element>>(new Set());
+
+  const [detectedRegions, setDetectedRegions] =
+    useState<DetectedRegions>(EMPTY_REGIONS);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!isFill) {
+      for (const element of ownedRegionElementsRef.current) {
+        element.removeAttribute('data-layout-scroll-state');
+        if (element instanceof HTMLElement) {
+          element.style.removeProperty('--layout-aligned-content-width');
+        }
+      }
+      ownedRegionElementsRef.current.clear();
+      return;
+    }
+    const middle = middleRef.current;
+    const layoutInner = layoutInnerRef.current;
+    if (middle == null || layoutInner == null) {
+      return;
+    }
+
+    const synchronizeRegionOwnership = () => {
+      const row =
+        middle.querySelector(':scope > [data-layout-middle-row]') ?? middle;
+      const startLane = row.querySelector(':scope > [data-layout-start-lane]');
+      const contentLane = row.querySelector(
+        ':scope > [data-layout-content-lane]',
+      );
+      const endLane = row.querySelector(':scope > [data-layout-end-lane]');
+      const headerLane = layoutInner.querySelector(
+        ':scope > [data-layout-header-lane]',
+      );
+      const footerLane = layoutInner.querySelector(
+        ':scope > [data-layout-footer-lane]',
+      );
+      if (contentLane == null) {
+        return;
+      }
+      const findRegions = (container: Element | null, region: string) =>
+        Array.from(container?.children ?? []).filter(
+          element => element.getAttribute('data-layout-region') === region,
+        );
+      const headerRegions = findRegions(headerLane, 'header');
+      const startRegions = findRegions(startLane, 'panel');
+      const contentRegions = findRegions(contentLane, 'content');
+      const endRegions = findRegions(endLane, 'panel');
+      const footerRegions = findRegions(footerLane, 'footer');
+      const next: DetectedRegions = {
+        start: detectDomRegions(startRegions, 'panel'),
+        content: detectDomRegions(contentRegions, 'content'),
+        end: detectDomRegions(endRegions, 'panel'),
+      };
+      const nextHasMiddleScroll =
+        next.start.usesMiddleScroll ||
+        next.content.usesMiddleScroll ||
+        next.end.usesMiddleScroll;
+      const nextHasExpandedMiddleScroll =
+        nextHasMiddleScroll && supportsFullWidthScrollport(contentWidth);
+
+      for (const element of ownedRegionElementsRef.current) {
+        element.removeAttribute('data-layout-scroll-state');
+        if (element instanceof HTMLElement) {
+          element.style.removeProperty('--layout-aligned-content-width');
+        }
+      }
+      const nextOwnedRegionElements = new Set<Element>();
+      const setOwnedRegionState = (element: Element, state: string) => {
+        element.setAttribute('data-layout-scroll-state', state);
+        nextOwnedRegionElements.add(element);
+      };
+      const setMiddleState = (detected: DetectedRegion, regions: Element[]) => {
+        if (detected.usesMiddleScroll) {
+          for (const region of regions) {
+            setOwnedRegionState(region, 'middle');
+          }
+        }
+      };
+      setMiddleState(next.start, startRegions);
+      setMiddleState(next.content, contentRegions);
+      setMiddleState(next.end, endRegions);
+
+      if (nextHasMiddleScroll) {
+        for (const region of [...headerRegions, ...footerRegions]) {
+          setOwnedRegionState(region, 'aligned');
+          if (!nextHasExpandedMiddleScroll && region instanceof HTMLElement) {
+            region.style.setProperty(
+              '--layout-aligned-content-width',
+              `${middle.clientWidth}px`,
+            );
+          }
+        }
+      }
+      ownedRegionElementsRef.current = nextOwnedRegionElements;
+      // eslint-disable-next-line @eslint-react/set-state-in-effect
+      setDetectedRegions(current =>
+        sameDetectedRegions(current, next) ? current : next,
+      );
+
+      mutationObserver.disconnect();
+      for (const lane of [
+        headerLane,
+        startLane,
+        contentLane,
+        endLane,
+        footerLane,
+      ]) {
+        if (lane != null) {
+          mutationObserver.observe(lane, {childList: true});
+        }
+      }
+      for (const region of [
+        ...headerRegions,
+        ...startRegions,
+        ...contentRegions,
+        ...endRegions,
+        ...footerRegions,
+      ]) {
+        mutationObserver.observe(region, {
+          attributes: true,
+          attributeFilter: [
+            'aria-label',
+            'data-layout-region',
+            'data-layout-height',
+          ],
+        });
+      }
+    };
+
+    // Observe only slot roots and region height attributes—not the Layout subtree.
+
+    const mutationObserver = new MutationObserver(synchronizeRegionOwnership);
+    synchronizeRegionOwnership();
+    return () => mutationObserver.disconnect();
+  }, [isFill, contentWidth]);
+
+  const startUsesMiddleScroll = detectedRegions.start.usesMiddleScroll;
+  const contentUsesMiddleScroll = detectedRegions.content.usesMiddleScroll;
+  const endUsesMiddleScroll = detectedRegions.end.usesMiddleScroll;
+  const hasMiddleScroll =
+    isFill &&
+    (startUsesMiddleScroll || contentUsesMiddleScroll || endUsesMiddleScroll);
+  const hasExpandedMiddleScroll =
+    hasMiddleScroll && supportsFullWidthScrollport(contentWidth);
+
+  useIsomorphicLayoutEffect(() => {
+    const middle = middleRef.current;
+    const layoutInner = layoutInnerRef.current;
+    if (middle == null || layoutInner == null) {
+      return;
+    }
+    const getAlignedBars = () =>
+      Array.from(
+        layoutInner.querySelectorAll(
+          ':scope > [data-layout-header-lane] > [data-layout-region="header"], :scope > [data-layout-footer-lane] > [data-layout-region="footer"]',
+        ),
+      ).filter(
+        (element): element is HTMLElement => element instanceof HTMLElement,
+      );
+    const updateScrollGeometry = () => {
+      const alignedBars = getAlignedBars();
+      if (!hasMiddleScroll) {
+        layoutInner.style.setProperty('--layout-scroll-gutter-inline', '0px');
+        layoutInner.style.setProperty('--layout-middle-client-height', '100%');
+        for (const bar of alignedBars) {
+          bar.style.removeProperty('--layout-aligned-content-width');
+        }
+        return;
+      }
+      const gutter = Math.max(0, (middle.offsetWidth - middle.clientWidth) / 2);
+      layoutInner.style.setProperty(
+        '--layout-scroll-gutter-inline',
+        `${gutter}px`,
+      );
+      layoutInner.style.setProperty(
+        '--layout-middle-client-height',
+        hasExpandedMiddleScroll ? `${middle.clientHeight}px` : '100%',
+      );
+      for (const bar of alignedBars) {
+        if (hasExpandedMiddleScroll) {
+          bar.style.removeProperty('--layout-aligned-content-width');
+        } else {
+          bar.style.setProperty(
+            '--layout-aligned-content-width',
+            `${middle.clientWidth}px`,
+          );
+        }
+      }
+    };
+
+    updateScrollGeometry();
+    if (!hasMiddleScroll || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(updateScrollGeometry);
+    resizeObserver.observe(middle);
+    return () => resizeObserver.disconnect();
+  }, [hasExpandedMiddleScroll, hasMiddleScroll]);
+
+  return {
+    contentUsesMiddleScroll,
+    detectedRegions,
+    endUsesMiddleScroll,
+    hasExpandedMiddleScroll,
+    hasMiddleScroll,
+    layoutInnerRef,
+    middleRef,
+    startUsesMiddleScroll,
+  };
+}


### PR DESCRIPTION
## Summary

- add `height="fill" | "auto"` to `LayoutContent` and `LayoutPanel`
- keep `height="fill"` as the default, preserving the existing bounded region geometry
- let `height="auto"` regions use natural content height and move together in a fill-height Layout's middle scrollport
- allow mixed layouts where fill-height regions stay pinned while auto-height regions move together
- keep the complete start + content + end composition, header, and footer aligned within `contentWidth`
- keep panel dividers continuous across the full shared row, including auto-height panels

## Examples

```tsx
// Content moves in the Layout middle scrollport
<Layout
  content={<LayoutContent height="auto">...</LayoutContent>}
/>

// Start stays pinned; content and end move together
<Layout
  start={<LayoutPanel height="fill">...</LayoutPanel>}
  content={<LayoutContent height="auto">...</LayoutContent>}
  end={<LayoutPanel height="auto" hasDivider>...</LayoutPanel>}
/>
```

## Compatibility

- the new `height` prop defaults to `"fill"`, so existing callers keep their current sizing and scroll ownership
- `isScrollable` is unchanged and continues to control only each region's local overflow
- existing `isScrollable={false}` callers retain their released behavior
- `Layout height="auto"` continues to grow with content and use page/ancestor scrolling

## Details

- the shared middle scrollport is keyboard focusable and has an accessible name
- numeric, percentage, and calculated `contentWidth` values can place the scrollbar at the Layout edge while keeping content aligned
- intrinsic and unresolved variable widths use a constrained middle scrollport
- auto-height panel content determines the shared row height; the panel box stretches across that row so backgrounds and dividers remain continuous
- start/end behavior follows logical direction in LTR and RTL

## Validation

- 175 focused Layout and AppShell tests
- full workspace, core, and Storybook builds
- template documentation typecheck and knowledge validation
- Layout accessibility audit: 0 violations
- Layout RTL audit: passing
- Chromium verification for mixed fill/auto scrolling, classic scrollbar alignment, intrinsic-width scrolling, and full-height auto-panel dividers

## Review note

This updates `family:layout-regions` and the draft Layout component record because region height now composes with Layout's middle scrolling behavior.
