### PR TITLE
feat(Table): make row expansion behave like its sibling plugins

### DIFF
--- a/.changeset/cli-search-exact-keyword-phrase-ranking.md
+++ b/.changeset/cli-search-exact-keyword-phrase-ranking.md
@@ -6,4 +6,6 @@
 
 A query that exactly matches a candidate's declared keyword (or name) verbatim is now promoted to a top-tier score, so it always outranks a candidate that only coincidentally contains several of the query's individual words. Single-word queries and queries that don't exactly match a keyword are unaffected.
 
+Follow-up #6001 preserves the required coverage fields on exact-phrase results.
+
 @nynexman4464

--- a/.changeset/table-row-expansion-chevron-and-indent.md
+++ b/.changeset/table-row-expansion-chevron-and-indent.md
@@ -3,7 +3,6 @@
 ---
 
 [fix] Turn only the chevron glyph in `useTableRowExpansion`, and start its detail panel at the first column rather than the row edge. (#5995)
-
 @ernestt
 
 The rotation was on the `<button>`, which is the hit target and carries the hover chip, so opening a row swung that rounded rectangle and its highlight a quarter turn along with the arrow — most visible mid-animation, where the chip passes through a diamond. It now sits on the glyph, and the button stays put.

--- a/.changeset/table-row-expansion-chevron-and-indent.md
+++ b/.changeset/table-row-expansion-chevron-and-indent.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Turn only the chevron glyph in `useTableRowExpansion`, and start its detail panel at the first column rather than the row edge. (#PENDING)
+[fix] Turn only the chevron glyph in `useTableRowExpansion`, and start its detail panel at the first column rather than the row edge. (#5995)
 
 @ernestt
 

--- a/.changeset/table-row-expansion-chevron-and-indent.md
+++ b/.changeset/table-row-expansion-chevron-and-indent.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Turn only the chevron glyph in `useTableRowExpansion`, and start its detail panel at the first column rather than the row edge. (#PENDING)
+
+@ernestt
+
+The rotation was on the `<button>`, which is the hit target and carries the hover chip, so opening a row swung that rounded rectangle and its highlight a quarter turn along with the arrow — most visible mid-animation, where the chip passes through a diamond. It now sits on the glyph, and the button stays put.
+
+The panel was a full-width cell with a flat inline padding, which left its content under the chevron, a column to the left of every label it describes. It now indents by the chevron column's width plus the inline padding a cell of that density gives its own content, read off the table context so it follows `density`, and written as a logical property so RTL mirrors it. Neither is configurable: a panel that started anywhere else read as a misalignment rather than as a choice.

--- a/.changeset/table-row-expansion-divider-placement.md
+++ b/.changeset/table-row-expansion-divider-placement.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Draw the row divider below a `useTableRowExpansion` detail panel rather than above it. (#5995)
+
+@ernestt
+
+An expanded row and its panel are one unit, but the divider was landing between them: the row drew its own bottom border, which put a line between the row and the detail it had just opened, and the panel drew none, so it ran flush into the next row. Both halves of that are backwards — the pair was split down the middle and then fused to the row below.
+
+The expanded row now gives up its border and the panel takes one. On a table with no row dividers the suppression removes a border that was never there and the panel's is never applied, so neither side has to consult the divider mode; only the panel does, to know whether to draw at all. The panel row carries `tableRowMarker`, which is how `TableCell` scopes its "no trailing line under the last row" rule, so an expanded last row still ends the table cleanly.

--- a/.changeset/table-row-expansion-divider-placement.md
+++ b/.changeset/table-row-expansion-divider-placement.md
@@ -3,7 +3,6 @@
 ---
 
 [fix] Draw the row divider below a `useTableRowExpansion` detail panel rather than above it. (#5995)
-
 @ernestt
 
 An expanded row and its panel are one unit, but the divider was landing between them: the row drew its own bottom border, which put a line between the row and the detail it had just opened, and the panel drew none, so it ran flush into the next row. Both halves of that are backwards — the pair was split down the middle and then fused to the row below.

--- a/.changeset/table-row-expansion-panel-variant.md
+++ b/.changeset/table-row-expansion-panel-variant.md
@@ -3,7 +3,6 @@
 ---
 
 [feat] `useTableRowExpansion` accepts `panelVariant`, so the detail panel can sit on the surface behind the table instead of on its own wash. (#5995)
-
 @ernestt
 
 The panel row painted `--color-background-muted` unconditionally, and being a `<tr>` the plugin builds itself, nothing a caller rendered could reach it. That wash is the right default — in a bare table it is the only thing distinguishing a detail panel from another row of data — but it is wrong for a table already sitting on a `Card` or `Section`, where it reads as a third surface stacked on the second rather than as a distinction.

--- a/.changeset/table-row-expansion-panel-variant.md
+++ b/.changeset/table-row-expansion-panel-variant.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] `useTableRowExpansion` accepts `panelVariant`, so the detail panel can sit on the surface behind the table instead of on its own wash. (#5995)
+
+@ernestt
+
+The panel row painted `--color-background-muted` unconditionally, and being a `<tr>` the plugin builds itself, nothing a caller rendered could reach it. That wash is the right default — in a bare table it is the only thing distinguishing a detail panel from another row of data — but it is wrong for a table already sitting on a `Card` or `Section`, where it reads as a third surface stacked on the second rather than as a distinction.
+
+`transparent` is the other option, matching `Card`'s vocabulary. Default is unchanged.
+
+One thing worth knowing when picking: `--color-background-muted` is a low-alpha near-black, so over a dark card it is very nearly invisible — dark themes have effectively been rendering `transparent` all along. `muted` is a light-theme effect, which is also why turning it off costs less than it appears to.

--- a/.changeset/table-row-expansion-row-click.md
+++ b/.changeset/table-row-expansion-row-click.md
@@ -3,7 +3,6 @@
 ---
 
 [feat] `useTableRowExpansion` accepts `hasRowClickExpansion`, so a row opens when you click anywhere on it and not only on its chevron. (#5995)
-
 @ernestt
 
 `useTableTreeData` has had this since it shipped, under the same name and with the same behaviour. The detail-panel plugin is the other half of the same pair — one expands into child rows, one expands into a panel — and a caller who moved between them lost whole-row clicking without anything saying why. There was no way to add it back either: a click handler on the row has to know not to fire on a checkbox, a link or the end of a text drag, and none of that is reachable from the outside.

--- a/.changeset/table-row-expansion-row-click.md
+++ b/.changeset/table-row-expansion-row-click.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] `useTableRowExpansion` accepts `hasRowClickExpansion`, so a row opens when you click anywhere on it and not only on its chevron. (#5995)
+
+@ernestt
+
+`useTableTreeData` has had this since it shipped, under the same name and with the same behaviour. The detail-panel plugin is the other half of the same pair — one expands into child rows, one expands into a panel — and a caller who moved between them lost whole-row clicking without anything saying why. There was no way to add it back either: a click handler on the row has to know not to fire on a checkbox, a link or the end of a text drag, and none of that is reachable from the outside.
+
+Off by default, and pointer-only when on. The chevron button stays the accessible control, so keyboard and assistive-tech users are unaffected — this adds a shortcut for a mouse, not a second way to operate the table. Clicks that land on interactive cell content, clicks that end a text selection, and clicks on rows `getIsItemExpandable` has ruled out all pass through untouched. The chevron already stops propagation, so it does not toggle twice.
+
+Collapsed rows are wired up as well as expanded ones, which is most of the point: the row you want to click is the one that has not opened yet.

--- a/docs/specs/AST-020/spec.md
+++ b/docs/specs/AST-020/spec.md
@@ -1,0 +1,267 @@
+---
+schema_version: 1
+template_version: 1
+kind: system-spec
+id: spec:AST-020
+authority: current
+archive_reason: null
+superseded_by: null
+approved_by: cixzhang
+approved_at: 2026-09-03
+phase: accepted
+owners: [cixzhang]
+affects_architecture: []
+affects_families: []
+affects_contributing: []
+affects_consumer_docs: []
+---
+
+# Accessibility spec-test authoring system spec
+
+## Intent
+
+People using Astryx components should get the keyboard, focus, meaning, and state
+promised by [WCAG 2.2](https://www.w3.org/TR/WCAG22/) and the
+[WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/) widget pattern
+Astryx adopts. Reusable accessibility spec tests turn those promises into
+reviewable contracts instead of requiring each component author to reinterpret
+the standards.
+
+A spec test states one user-observable requirement, cites its source, names the
+evidence layer that can prove it, and runs unchanged against every conforming
+binding. The test suite complements axe, browser checks, and assistive-technology
+review. It does not claim that one automated pass proves complete accessibility.
+
+## Non-goals
+
+- Implementing the spec-test package or CI jobs in this specification pull request.
+- Defining how existing component tests migrate; that is owned by
+  [AST-021](../AST-021/spec.md).
+- Publishing the first implementation as a supported package.
+- Reimplementing axe rules or replacing browser, visual, manual, or real-AT
+  verification.
+- Treating WAI-ARIA Authoring Practices as a substitute for WCAG conformance.
+- Using the WCAG 3.0 working draft as a pass/fail baseline before it is ready.
+- Encoding page-owned requirements in an isolated component contract when the
+  component cannot satisfy them.
+
+## Requirements
+
+### Normative basis and scope
+
+- **FR1 — WCAG 2.2 A and AA are the conformance baseline.** Every WCAG
+  conformance expectation MUST cite an applicable WCAG 2.2 Level A or AA success
+  criterion. A pattern expectation MAY instead cite an exact APG requirement when
+  APG supplies the interaction detail. In that case it MUST identify the WCAG 2.2
+  user outcome it supports without inventing a success-criterion mapping. WCAG 3.0
+  principles MAY inform plain-language intent, user needs, and future research, but
+  a WCAG 3.0 draft requirement MUST NOT create or clear a pass/fail check without a
+  later current Astryx record.
+- **FR2 — APG defines an adopted widget pattern, not universal conformance.** When
+  Astryx adopts a WAI-ARIA APG pattern, the pattern contract MUST cite the exact APG
+  roles, states, properties, or keyboard interaction it adopts and the WCAG 2.2
+  outcome those mechanics support. A component MAY use another standards-valid
+  model only when its current component, family, or system contract records that
+  choice; the spec test MUST follow the owning contract rather than forcing an APG
+  example mechanically.
+- **FR3 — Contracts have two layers.** Every pattern review MUST consider both:
+  broad component-owned requirements that apply across patterns, and
+  pattern-specific role, state, relationship, keyboard, and focus requirements.
+  A component part may bind to more than one pattern. A whole component MUST NOT be
+  forced into one pattern when its parts have distinct roles.
+
+### Expectation contract
+
+- **FR4 — Every expectation is traceable.** An expectation MUST have a stable id,
+  a short user outcome, an exact normative source (WCAG 2.2 success criterion, APG
+  requirement, current Astryx contract, or an applicable combination),
+  applicability conditions, an evidence layer, and an enforcement class. The test
+  name and failure output MUST expose the expectation id and source reference so a
+  failure can be understood without opening the runner implementation.
+- **FR5 — Applicability is explicit.** For every checklist dimension, an author
+  MUST either encode an applicable expectation or record why the dimension is not
+  owned by this pattern, binding, or evidence layer. Silence is not an exemption.
+  An exemption MUST name the actual owner or verification method; it MUST NOT be a
+  generic “not applicable” escape hatch.
+- **FR6 — Evidence layers keep distinct proof boundaries.** Expectations are
+  classified as unit, DOM, accessibility-tree, axe, real-browser, visual, lint,
+  manual, or real-AT checks. A lower layer MUST NOT claim a result only a higher
+  layer observes. Announcement wording or timing, virtual-cursor entry, and known
+  AT/browser divergence follow [AST-009](../AST-009/spec.md); an accessibility-tree
+  snapshot does not satisfy that real-AT contract.
+- **FR7 — Contracts assert outcomes, not Astryx internals.** A reusable expectation
+  MUST query and act through public semantics and observable behavior. It MUST NOT
+  depend on Astryx class names, private DOM wrappers, implementation callbacks, or
+  source layout unless an owning current record makes that structure contractual.
+  Component-specific API effects remain in component tests.
+- **FR8 — Interactive expectations prove the complete transition.** Keyboard,
+  pointer, state, and focus expectations MUST exercise the relevant starting state,
+  action, resulting state, and reverse or dismissal path when the pattern supports
+  one. Merely finding a role or proving one direction of a toggle is insufficient.
+- **FR9 — Enforcement is separate from severity and tool coverage.** A directly
+  applicable WCAG 2.2 Level A or AA expectation is `required`. An APG or
+  Astryx-specific expectation is `required` only when a current Astryx record adopts
+  that outcome. `Advisory` expectations report best practice, an unsettled choice,
+  or an outcome not yet adopted as an Astryx contract. `Advisory` expectations
+  report only; `required` expectations gate new or changed behavior at a layer that
+  can objectively verify them. A coverage score, tool capability, or ease of
+  automation MUST NOT promote or demote either class.
+
+### Completeness and review
+
+- **FR10 — Every pattern uses one completeness review.** The review starts with
+  the source map below, then adds applicable WCAG 2.2 component outcomes such as
+  focus not obscured, status messages, target size, contrast, forced colors, and
+  the pattern's APG interactions. Page-owned rows are considered only for fixtures
+  or surfaces that own a page. Every row follows FR5 and FR6 rather than being
+  forced into the reusable runtime contract.
+
+| WCAG 2.2 source                     | Outcome to consider                                                                        | Usual ownership                       |
+| ----------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------- |
+| 1.1.1 Non-text Content              | Informative non-text content has an equivalent alternative; decorative content is ignored. | Component or content                  |
+| 1.3.1 Info and Relationships        | Visual structure and relationships are programmatically available.                         | Component or composition              |
+| 1.3.2 Meaningful Sequence           | Programmatic reading sequence preserves meaning.                                           | Component or composition              |
+| 1.4.1 Use of Color                  | Color is not the only way to convey information or state.                                  | Component, theme, and caller content  |
+| 1.4.3 Contrast (Minimum)            | Text and images of text meet the required contrast.                                        | Component and theme                   |
+| 1.4.11 Non-text Contrast            | Controls, states, and meaningful graphics meet non-text contrast.                          | Component and theme                   |
+| 2.1.1 Keyboard                      | Every component-owned function is operable by keyboard.                                    | Component                             |
+| 2.1.2 No Keyboard Trap              | Keyboard focus can leave any component unless the user has a documented exit.              | Component or composition              |
+| 2.4.2 Page Titled                   | A page has a descriptive title.                                                            | Page only                             |
+| 2.4.3 Focus Order                   | Sequential focus preserves meaning and operation.                                          | Component or composition              |
+| 2.4.4 Link Purpose (In Context)     | A link's purpose is determinable.                                                          | Component and caller content          |
+| 2.4.6 Headings and Labels           | Headings and labels describe their topic or purpose.                                       | Component and caller content          |
+| 2.4.7 Focus Visible                 | Keyboard focus has a visible indicator.                                                    | Component and theme                   |
+| 2.4.11 Focus Not Obscured (Minimum) | Focused content is not entirely hidden by author-created content.                          | Component or composition              |
+| 2.5.8 Target Size (Minimum)         | Pointer targets meet the minimum size or an allowed exception.                             | Component or composition              |
+| 3.1.1 Language of Page              | The page language is programmatically available.                                           | Page only                             |
+| 3.2.4 Consistent Identification     | Repeated functions are identified consistently.                                            | System, component, and caller content |
+| 3.3.2 Labels or Instructions        | Inputs have persistent labels or needed instructions.                                      | Component and caller content          |
+| 4.1.2 Name, Role, Value             | Name, role, state, value, and changes are programmatically available.                      | Component                             |
+| 4.1.3 Status Messages               | Status changes are exposed without moving focus.                                           | Component or composition              |
+
+- **FR11 — The contract itself has positive and negative proof.** Each expectation
+  MUST pass against a minimally conforming fixture or binding and fail when its
+  required outcome is deliberately removed. Pattern-level tests MUST distinguish a
+  real violation from an unsupported harness operation or fixture error.
+- **FR12 — Completion requires an independent accessibility review.** A pattern is
+  complete only when every checklist dimension is encoded or explicitly assigned
+  elsewhere, all expectations are traceable, representative bindings pass or expose
+  exact known gaps, mutation evidence proves required expectations can fail, and an
+  accessibility subject-matter reviewer finds no unaccounted contract-encodable
+  requirement.
+- **FR13 — The pull request describes the spec test in readable form.** A new or
+  materially changed pattern pull request MUST state who is affected, the adopted
+  pattern and scope, the expectation table with source and evidence layer, explicit
+  exemptions, representative bindings and states, known component gaps, and the
+  mutations or failures that prove the contract. The description is the readable
+  specification of the test; the executable contract remains the checked source of
+  truth.
+- **FR14 — Stable ids survive refactors.** Renaming files, helpers, or harnesses MUST
+  preserve expectation ids. Splitting, combining, narrowing, or changing the user
+  outcome creates an explicit contract change and migration for every binding and
+  known-gap record that refers to the affected ids.
+
+### Platform support
+
+- Supported feature/engine floor: the affected component's current browser-support
+  contract under [AST-013](../AST-013/spec.md).
+- Unsupported behavior: a harness that cannot observe an assigned evidence layer
+  reports that limitation; it does not pass, skip silently, or substitute a lower
+  layer.
+- Browser evidence: browser-class expectations run in a real shipping engine. A
+  DOM emulator cannot prove focus navigation, native top-layer behavior, computed
+  accessibility-tree exposure, contrast, target geometry, or forced-color paint.
+
+## Current-state impact
+
+[Issue #4112](https://github.com/facebook/astryx/issues/4112) established the
+reusable pattern-contract direction. The closed
+[Switch prototype](https://github.com/facebook/astryx/pull/4113) demonstrated one
+contract running through jsdom and Chromium bindings, source-linked expectation ids,
+and exact known failures. It also showed why axe and pattern contracts are
+complementary: axe finds broad markup violations, while the contract verifies the
+state and interaction that make a switch behave as a switch.
+
+The prototype is evidence, not current policy. Its package name, scoring model,
+priority names, and harness shape remain implementation choices unless this or
+another current record adopts them. This spec keeps the proven contract boundary
+while correcting two risks before scale-out: a numeric score must not stand in for
+conformance, and each expectation must name the evidence layer that can actually
+observe its outcome.
+
+The completeness review incorporates recurrent component-owned failures such as
+text alternatives, semantic relationships and order, focus order and visibility,
+descriptive labels and links, consistent identification, persistent instructions,
+and name/role/value/state. It updates that review to WCAG 2.2 and keeps page-owned,
+browser-owned, and real-AT-owned checks outside a component runtime contract when
+that is the honest boundary.
+
+This accepted spec creates no tests, package, CLI documentation, component behavior,
+or CI gate. Those changes follow in implementation work governed by this record.
+
+## Verification
+
+| Contract  | Verification                                                                  | Representative states                                                                                  | Mutation or failure expectation                                                                                                                  |
+| --------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| FR1–FR3   | Source and ownership review against WCAG 2.2, APG, and current Astryx records | component-owned A/AA criterion; page-owned criterion; one component with multiple parts                | A draft WCAG 3.0 statement gates CI, an APG example is treated as universal WCAG, or one component is forced into one pattern                    |
+| FR4–FR9   | Contract schema and runner self-tests                                         | required/advisory; unit/DOM/tree/axe/browser/manual/AT; toggle round trip; component-specific callback | A check lacks a source or layer, passes from an unsupported harness, depends on private markup, or one-way behavior hides a reverse-path failure |
+| FR10–FR12 | Completed checklist, positive/negative fixture suite, and independent review  | simple control; composite widget; overlay; page-owned criterion                                        | A dimension disappears silently, a mutation still passes, or review finds an unrecorded contract-encodable requirement                           |
+| FR13–FR14 | Pull-request template check plus id migration tests                           | new pattern; narrowed expectation; file-only refactor                                                  | Reviewers cannot understand the test from the PR, or an id change orphans bindings and gaps                                                      |
+| Platform  | Real-browser and AST-009 evidence-boundary checks                             | focus navigation; accessibility tree; forced colors; announcement timing                               | jsdom or a tree snapshot is credited with pixels, browser behavior, or spoken output it cannot observe                                           |
+
+### Completion criteria
+
+This spec moves from `accepted` to `shipped` only when:
+
+- the reusable contract schema enforces FR4–FR6 and FR9;
+- the authoring guide and pull-request template implement FR10–FR13;
+- contract self-tests include conforming and deliberately violating fixtures under
+  FR11;
+- at least one pattern runs against representative jsdom and browser bindings
+  without relying on Astryx-private structure;
+- unsupported harness capabilities fail honestly rather than passing or skipping;
+- no aggregate coverage score is presented as proof of conformance; and
+- the shipped guide links AST-009 for real-AT claims and AST-021 for migration.
+
+## Decision log
+
+### DEC-1 — Use WCAG 2.2 for conformance and WCAG 3.0 only for forward-looking intent
+
+**Reference:** `spec:AST-020/DEC-1`
+**Decider:** `cixzhang`, `2026-09-03`
+
+WCAG 2.2 Level A and AA provide the current testable baseline. WCAG 3.0 may help
+frame user needs, assistive-technology experience, and future evaluation, but its
+working draft does not decide current pass/fail results.
+
+Rejected: waiting for WCAG 3.0 or treating a draft outcome as a current conformance
+requirement.
+
+### DEC-2 — Author one reusable outcome contract per adopted pattern
+
+**Reference:** `spec:AST-020/DEC-2`
+**Decider:** `cixzhang`, `2026-09-03`
+
+Separate the standards-derived pattern contract from component bindings. This lets
+multiple components share one interpretation while allowing a component's parts to
+bind to different patterns and keeping component-specific API behavior local.
+
+Rejected: copying APG assertions into every component test or forcing all
+accessibility checks into one global scanner.
+
+### DEC-3 — Make the pull request a readable specification of the executable test
+
+**Reference:** `spec:AST-020/DEC-3`
+**Decider:** `cixzhang`, `2026-09-03`
+
+A reviewer must be able to judge the user outcome, standards basis, evidence layer,
+exemptions, bindings, and mutation proof without reverse-engineering runner code.
+The checked contract remains executable truth; the pull request makes that truth
+reviewable by accessibility specialists and maintainers.
+
+Rejected: code-only review or a generic accessibility checklist with no exact
+mapping to executable expectations.
+
+## Open questions
+
+None.

--- a/docs/specs/AST-021/spec.md
+++ b/docs/specs/AST-021/spec.md
@@ -1,0 +1,260 @@
+---
+schema_version: 1
+template_version: 1
+kind: system-spec
+id: spec:AST-021
+authority: current
+archive_reason: null
+superseded_by: null
+approved_by: cixzhang
+approved_at: 2026-09-03
+phase: accepted
+owners: [cixzhang]
+affects_architecture: []
+affects_families: []
+affects_contributing: []
+affects_consumer_docs: []
+---
+
+# Component accessibility-test migration system spec
+
+## Intent
+
+People using existing Astryx components should gain the same standards-traceable
+protection as new components without waiting for a repository-wide rewrite. Astryx
+migrates accessibility assertions progressively into reusable spec-test contracts,
+locks in behavior that already passes, and exposes each existing failure as owned
+work instead of hiding it behind missing or skipped tests.
+
+Migration separates shared pattern behavior from component-specific behavior. A
+component binding says which pattern and states it implements. The reusable contract
+owns the shared WCAG 2.2/APG outcome; the component suite keeps API, composition, and
+implementation-specific regression coverage.
+
+## Non-goals
+
+- Defining how accessibility spec tests are authored; that is owned by
+  [AST-020](../AST-020/spec.md).
+- Fixing every accessibility defect in the same pull request that reveals it.
+- Deleting component-specific tests merely because they mention ARIA or keyboard
+  input.
+- Treating a known failure, skipped expectation, or high coverage percentage as a
+  passing accessibility result.
+- Blocking all existing components on every historical gap before migration can
+  begin.
+- Migrating page-level, visual, or real-AT requirements into a component runtime
+  contract that cannot prove them.
+
+## Requirements
+
+### Migration inventory and unit of work
+
+- **FR1 — Migration depends on the authoring contract.** This spec MUST NOT become
+  `current` before AST-020 is `current`. Every migrated pattern and binding MUST
+  satisfy AST-020's traceability, applicability, evidence-layer, review, and
+  readable-pull-request requirements.
+- **FR2 — Inventory precedes deletion.** Before changing tests for a component, the
+  migration MUST record each interactive part, its adopted pattern or patterns,
+  representative states, existing shared-pattern assertions, component-specific
+  assertions, assigned evidence layers, and known failures. A component with
+  multiple interactive parts MUST map each part separately.
+- **FR3 — Migration pull requests stay bounded.** A pull request SHOULD add or
+  materially revise one reusable pattern contract and its first representative
+  bindings, or migrate one bounded set of bindings to an already-current contract.
+  It MUST NOT combine unrelated patterns, broad component remediation, or visual
+  redesign merely to raise coverage.
+- **FR4 — Representative states are explicit.** Each binding MUST cover every
+  component state that can change the adopted pattern outcome. Depending on the
+  component, that includes default and changed value, controlled and uncontrolled,
+  enabled and disabled, focusable-disabled, required or invalid, open and closed,
+  orientation, direction, loading, error, and relevant composed parts. The inventory
+  records why omitted states cannot change the shared outcome.
+
+### Moving and retaining coverage
+
+- **FR5 — Move only equivalent assertions.** An existing test moves into the shared
+  contract only when its user outcome, applicability, and evidence layer are the
+  same for every binding. Tests for callback payloads, public props, form submission,
+  component-owned composition, styling, or a deliberate component exception remain
+  local even when they also inspect ARIA or keyboard events.
+- **FR6 — Duplicate ownership ends in the migration pull request.** Once a contract
+  and binding prove an existing shared outcome at the same or stronger layer, the
+  exact local assertion MUST be removed or rewritten to cover only the remaining
+  component-specific contract. Temporary duplication requires a named removal
+  blocker; “extra coverage” is not a permanent reason to keep two owners.
+- **FR7 — Existing behavior is preserved unless a separate change authorizes it.**
+  A migration pull request records observed failures but does not silently change
+  component API, interaction, focus, semantics, visuals, or compatibility. A small
+  prerequisite fix may land first or in a separately reviewable commit and pull
+  request under its owning current records.
+
+### Known failures and regression gates
+
+- **FR8 — Every known failure is exact and actionable.** A known-failure record MUST
+  name the expectation id, component binding and state, observed user impact,
+  standards reference, evidence layer, public tracking issue, and reason the
+  migration does not fix it. Wildcards, whole-pattern suppression, and unowned text
+  reasons are prohibited.
+- **FR9 — A known failure changes only its exact gate result.** A binding with a
+  known failure still runs the expectation and reports `known-failure`, never
+  `pass`. Only that exact expected result stops gating the first migration. A
+  different error, another state, a new expectation, or a wider failure MUST fail.
+  When the expectation starts passing, CI MUST report an unexpected pass and
+  require removal of the stale record rather than continuing to count it as debt.
+- **FR10 — Migration locks the baseline without calling debt conformance.** Required
+  expectations that pass gate immediately for that binding. Recorded historical
+  failures remain visibly failing debt but do not prevent the first migration.
+  New components and newly supported states MUST NOT add a required known failure.
+  Adding or widening a known failure after the baseline requires an explicit owner
+  decision and linked defect; it is not a routine test update.
+- **FR11 — Reports show facts, not one quality score.** Coverage output MUST report
+  patterns, bindings, applicable expectations, passes, known failures, unrun layers,
+  and exemptions separately. It MUST NOT collapse those states into one percentage
+  or grade presented as component accessibility or conformance. A pattern with one
+  required failure is not “mostly conformant.”
+
+### Repository integration and review
+
+- **FR12 — Current component records point to the new owner.** When a migrated
+  component has a current component or module record, its `verified_by` metadata and
+  verification map MUST name the binding and keep separate evidence for outcomes the
+  shared contract does not own. Migration does not create a component record solely
+  to satisfy this backlink.
+- **FR13 — New work uses an existing contract first.** Once a pattern contract is
+  current, a new component or newly added component part that adopts that pattern
+  MUST bind to it from its first implementation. Authors MUST NOT create a parallel
+  ad hoc copy of the shared assertions. If the contract is incomplete, extend and
+  review the contract before relying on local tests.
+- **FR14 — The migration pull request is a readable ledger.** Its description MUST
+  name the affected users and pattern, component parts and states bound, assertions
+  moved, local tests retained and why, exact known failures and linked issues,
+  evidence layers run, and mutation or before/after evidence. The description MUST
+  distinguish test migration from component remediation.
+- **FR15 — Progress is ordered by user leverage.** The first binding remains the
+  Switch reference proven by the prototype. Later work prioritizes widely reused
+  interactive patterns, components with known keyboard/focus/semantic failures, and
+  shared primitives whose correction protects multiple components. Repository order
+  or ease of producing a high count MUST NOT override user impact.
+
+### Platform support
+
+- Supported feature/engine floor: each binding follows its component's current
+  support contract and AST-020's assigned evidence layer.
+- Unsupported behavior: an unrun browser, visual, manual, or real-AT layer remains
+  explicitly unrun; jsdom success does not clear it.
+- Browser evidence: component changes that can affect browser-owned pattern behavior
+  run the relevant real-browser binding. Real-AT outcomes follow
+  [AST-009](../AST-009/spec.md) and keep their durable receipts and release boundary.
+
+## Current-state impact
+
+Current component suites mix shared accessibility outcomes with public API,
+implementation, visual, and regression tests. For example, Switch currently tests
+role, accessible name and description, checked and disabled states, activation,
+form participation, loading and error semantics, disabled-reason composition,
+forced-color CSS, callback payloads, and layout details in one file. The shared
+Switch pattern can own only the standards-derived role, name, state, focusability,
+and activation outcomes. Form data, callback payloads, tooltip composition, and
+component styling remain Switch-owned.
+
+[Issue #4112](https://github.com/facebook/astryx/issues/4112) and the closed
+[Switch prototype](https://github.com/facebook/astryx/pull/4113) prove that an
+existing component can bind to one reusable contract in jsdom and Chromium. The
+prototype's `expectedFailures` mechanism is retained only with FR8–FR10's exactness:
+a known failure is visible debt, never a pass or a broad skip.
+
+The accessibility program tracker
+[#4475](https://github.com/facebook/astryx/issues/4475) remains the public place to
+order pattern migrations and component defects. Migration pull requests add newly
+found defects there or to focused public issues. They do not depend on a private
+backlog or private review link.
+
+### Progressive rollout
+
+1. **Reference pattern.** Rebuild the Switch prototype under current AST-020 types,
+   self-tests, evidence boundaries, and reporting. Bind the current Switch states
+   without changing behavior.
+2. **Simple controls.** Migrate other single-control patterns where role, name,
+   state, disabled behavior, and keyboard activation can be isolated cleanly.
+3. **Composite widgets.** Migrate selection, navigation, grid, tree, and menu parts
+   with orientation, direction, roving focus, typeahead, and open/closed states.
+4. **Overlays and async outcomes.** Add browser-owned focus, top-layer, inert, and
+   dismissal checks, while routing announcement and virtual-cursor claims through
+   AST-009.
+
+The tracker may reorder components within these phases by user impact. A later phase
+MUST NOT weaken the evidence boundaries or known-failure rules to increase throughput.
+
+This accepted spec changes no component test, behavior, package, public API, or CI
+gate. Those changes follow in implementation work governed by this record.
+
+## Verification
+
+| Contract  | Verification                                                               | Representative states                                                                         | Mutation or failure expectation                                                                                                        |
+| --------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| FR1–FR4   | Migration inventory schema and review                                      | one control; component with trigger and popup; controlled/disabled/error/RTL states           | Migration starts without an applicable current contract, treats a whole component as one part, or omits a state that changes semantics |
+| FR5–FR7   | Before/after assertion ownership review and unchanged component suites     | shared role/state check; callback payload; form data; style rule; discovered component defect | Shared assertion remains duplicated, component-specific proof is deleted, or migration silently changes behavior                       |
+| FR8–FR10  | Runner tests for exact known failures, new failures, and unexpected passes | one historical gap; wrong error; second state; fixed expectation                              | A wildcard masks regression, a stale gap remains, or new work adds debt without decision                                               |
+| FR11      | Coverage-report snapshot and assertions                                    | pass; known failure; exemption; unrun browser layer                                           | One percentage hides a required failure or reports an unrun layer as pass                                                              |
+| FR12–FR14 | Knowledge validation, component verification map, and PR-template check    | current component record; component with no record; first new adopter                         | Backlink points to deleted local tests, parallel ad hoc assertions appear, or the PR hides migration/remediation scope                 |
+| FR15      | Public tracker review                                                      | high-use control; known keyboard defect; easy low-impact component                            | Work is ordered only to maximize migrated counts                                                                                       |
+| Platform  | Existing unit/axe/browser checks plus AST-009 classification               | jsdom behavior; real focus; tree exposure; spoken announcement                                | A lower layer clears browser pixels or real-AT output it cannot observe                                                                |
+
+### Completion criteria
+
+A pattern migration is complete only when:
+
+- its contract is current under AST-020 and passes its positive and negative
+  self-tests;
+- every affected component part and relevant state has a binding or an explicit
+  ownership reason for exclusion;
+- equivalent shared assertions have one owner and component-specific tests remain;
+- every historical failure has the exact public debt record required by FR8;
+- required passing expectations gate regressions and unexpected passes remove stale
+  debt;
+- reporting separates passes, known failures, exemptions, and unrun layers;
+- current component or module records point to the new binding when those records
+  exist; and
+- the pull request presents the readable migration ledger required by FR14.
+
+The repository migration is complete only when every shipped interactive component
+part is mapped to a current pattern contract or explicitly records why no reusable
+pattern applies, and no duplicate ad hoc test remains for a shared expectation.
+
+## Decision log
+
+### DEC-1 — Migrate progressively with exact known failures
+
+**Reference:** `spec:AST-021/DEC-1`
+**Decider:** `cixzhang`, `2026-09-03`
+
+Apply contracts one pattern and bounded binding set at a time. Preserve historical
+failures as exact, runnable, public debt while immediately gating outcomes that
+already pass. This adds protection now without pretending existing defects are
+conformant or waiting for a repository-wide remediation.
+
+Rejected: all-or-nothing migration, silent skips, and enabling one broad report-only
+suite that cannot stop regressions.
+
+### DEC-2 — Keep one owner for shared tests and preserve historical failures exactly
+
+**Reference:** `spec:AST-021/DEC-2`
+**Decider:** `cixzhang`, `2026-09-03`
+
+Keep test migration separate from component remediation. Move only reusable
+standards-derived outcomes into pattern contracts; retain component-specific API,
+composition, form, styling, and callback tests with the component. Existing defects
+stay as exact runnable `known-failure` results tied to one expectation, binding,
+state, and public issue. They never count as passing, cannot mask a different or
+wider failure, and become unexpected passes when fixed so stale debt is removed.
+
+Report passes, known failures, exemptions, and unrun layers as separate facts rather
+than averaging them into one accessibility score.
+
+Rejected: changing component behavior inside migration work, deleting
+component-owned tests, broad skips, and a percentage that can make a required
+failure look conformant.
+
+## Open questions
+
+None.

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -274,7 +274,7 @@ export function scoreQuery(term, tokens, candidate) {
   // of Table-related templates each match "table" and "contents" separately
   // and accumulate a higher raw score (#5239).
   if (full && full.score >= 90) {
-    return {score: full.score + 100, reason: full.reason};
+    return asFull({score: full.score + 100, reason: full.reason});
   }
 
   // Multi-word natural language: score each content token, counting only

--- a/packages/cli/api/search/search.test.mjs
+++ b/packages/cli/api/search/search.test.mjs
@@ -80,6 +80,7 @@ describe('search leaf — exact keyword phrase outranks incidental token matches
     // pushing it out of the results entirely at the default limit.
     const r = await search('table of contents', {cwd});
     expect(r.data.results[0]?.name).toBe('Outline');
+    expect(r.data.results[0]).toMatchObject({matchedTerms: 2, queryTerms: 2});
   }, SLOW);
 
   it('surfaces Outline for its own declared keyword "heading navigation", ranked first', async () => {

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
@@ -61,6 +61,7 @@ function Harness({
   density,
   hasRowClickExpansion,
   columnsOverride,
+  panelVariant,
 }: {
   initialExpanded?: Set<string>;
   isItemExpandable?: (item: Row) => boolean;
@@ -68,6 +69,7 @@ function Harness({
   density?: 'compact' | 'balanced' | 'spacious';
   hasRowClickExpansion?: boolean;
   columnsOverride?: TableColumn<Row>[];
+  panelVariant?: 'muted' | 'transparent';
 }) {
   const [expandedKeys, setExpandedKeys] = useState(initialExpanded);
   const expansion = useTableRowExpansion<Row>({
@@ -86,6 +88,7 @@ function Harness({
     renderExpanded,
     getIsItemExpandable: isItemExpandable,
     hasRowClickExpansion,
+    panelVariant,
   });
   return (
     <Table
@@ -234,6 +237,27 @@ describe('useTableRowExpansion (detail panel)', () => {
     render(<Harness initialExpanded={new Set(['a'])} density="spacious" />);
     expect(screen.getByTestId('panel').closest('td')).toHaveStyle({
       paddingInlineStart: 'calc(40px + var(--spacing-4))',
+    });
+  });
+
+  describe('panel variant', () => {
+    const panelRow = () =>
+      screen.getByTestId('panel').closest('tr') as HTMLTableRowElement;
+
+    it('washes the panel by default', () => {
+      render(<Harness initialExpanded={new Set(['a'])} />);
+      expect(panelRow()).toHaveStyle({
+        backgroundColor: 'var(--color-background-muted)',
+      });
+    });
+
+    it('leaves the panel on the surface behind the table when transparent', () => {
+      render(
+        <Harness initialExpanded={new Set(['a'])} panelVariant="transparent" />,
+      );
+      expect(panelRow()).not.toHaveStyle({
+        backgroundColor: 'var(--color-background-muted)',
+      });
     });
   });
 

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
@@ -62,6 +62,7 @@ function Harness({
   hasRowClickExpansion,
   columnsOverride,
   panelVariant,
+  dividers,
 }: {
   initialExpanded?: Set<string>;
   isItemExpandable?: (item: Row) => boolean;
@@ -70,6 +71,7 @@ function Harness({
   hasRowClickExpansion?: boolean;
   columnsOverride?: TableColumn<Row>[];
   panelVariant?: 'muted' | 'transparent';
+  dividers?: 'rows' | 'columns' | 'grid' | 'none';
 }) {
   const [expandedKeys, setExpandedKeys] = useState(initialExpanded);
   const expansion = useTableRowExpansion<Row>({
@@ -96,6 +98,7 @@ function Harness({
       columns={columnsOverride ?? columns}
       idKey="id"
       density={density}
+      dividers={dividers}
       plugins={{expansion}}
     />
   );
@@ -237,6 +240,48 @@ describe('useTableRowExpansion (detail panel)', () => {
     render(<Harness initialExpanded={new Set(['a'])} density="spacious" />);
     expect(screen.getByTestId('panel').closest('td')).toHaveStyle({
       paddingInlineStart: 'calc(40px + var(--spacing-4))',
+    });
+  });
+
+  describe('row divider placement', () => {
+    const panelCell = () =>
+      screen.getByTestId('panel').closest('td') as HTMLTableCellElement;
+    const cellsOf = (name: string) => [
+      ...(screen.getByText(name).closest('tr') as HTMLTableRowElement).cells,
+    ];
+
+    it('closes the pair below the panel rather than splitting it', () => {
+      // The row and its panel are one unit. A divider between them cuts the
+      // row off from the detail it opened, and leaves the panel running flush
+      // into the next row — the wrong way round on both counts.
+      render(<Harness initialExpanded={new Set(['a'])} />);
+      for (const cell of cellsOf('Ada')) {
+        expect(cell).toHaveStyle({borderBottomWidth: '0'});
+      }
+      expect(panelCell()).toHaveStyle({
+        borderBottomWidth: 'var(--border-width)',
+      });
+    });
+
+    it('leaves collapsed rows keeping their own divider', () => {
+      render(<Harness initialExpanded={new Set(['a'])} />);
+      for (const cell of cellsOf('Bo')) {
+        expect(cell).not.toHaveStyle({borderBottomWidth: '0'});
+      }
+    });
+
+    it('draws no panel divider on a table without row dividers', () => {
+      render(<Harness initialExpanded={new Set(['a'])} dividers="none" />);
+      expect(panelCell()).not.toHaveStyle({
+        borderBottomWidth: 'var(--border-width)',
+      });
+    });
+
+    it('draws the panel divider under grid dividers too', () => {
+      render(<Harness initialExpanded={new Set(['a'])} dividers="grid" />);
+      expect(panelCell()).toHaveStyle({
+        borderBottomWidth: 'var(--border-width)',
+      });
     });
   });
 

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
@@ -59,11 +59,15 @@ function Harness({
   isItemExpandable,
   renderExpanded = defaultRenderExpanded,
   density,
+  hasRowClickExpansion,
+  columnsOverride,
 }: {
   initialExpanded?: Set<string>;
   isItemExpandable?: (item: Row) => boolean;
   renderExpanded?: (item: Row) => React.ReactNode;
   density?: 'compact' | 'balanced' | 'spacious';
+  hasRowClickExpansion?: boolean;
+  columnsOverride?: TableColumn<Row>[];
 }) {
   const [expandedKeys, setExpandedKeys] = useState(initialExpanded);
   const expansion = useTableRowExpansion<Row>({
@@ -81,11 +85,12 @@ function Harness({
     getRowKey: item => item.id,
     renderExpanded,
     getIsItemExpandable: isItemExpandable,
+    hasRowClickExpansion,
   });
   return (
     <Table
       data={rows}
-      columns={columns}
+      columns={columnsOverride ?? columns}
       idKey="id"
       density={density}
       plugins={{expansion}}
@@ -229,6 +234,96 @@ describe('useTableRowExpansion (detail panel)', () => {
     render(<Harness initialExpanded={new Set(['a'])} density="spacious" />);
     expect(screen.getByTestId('panel').closest('td')).toHaveStyle({
       paddingInlineStart: 'calc(40px + var(--spacing-4))',
+    });
+  });
+
+  describe('whole-row-click expansion', () => {
+    const rowFor = (name: string) =>
+      screen.getByText(name).closest('tr') as HTMLTableRowElement;
+
+    it('leaves the row body inert by default', () => {
+      render(<Harness />);
+      fireEvent.click(screen.getByText('Ada'));
+      expect(screen.queryByTestId('panel')).not.toBeInTheDocument();
+    });
+
+    it('expands a collapsed row when its body is clicked', () => {
+      // The collapsed row is the one that has to respond: the early return
+      // that skips panel rendering must not skip the click handler with it.
+      render(<Harness hasRowClickExpansion />);
+      fireEvent.click(screen.getByText('Ada'));
+      expect(screen.getByTestId('panel')).toHaveTextContent('Ada: Ada bio');
+    });
+
+    it('collapses an expanded row when its body is clicked', () => {
+      render(<Harness hasRowClickExpansion initialExpanded={new Set(['a'])} />);
+      fireEvent.click(screen.getByText('Ada'));
+      expect(screen.queryByTestId('panel')).not.toBeInTheDocument();
+    });
+
+    it('does not double-toggle when the chevron itself is clicked', () => {
+      // The chevron stops propagation, so the row handler must not also fire —
+      // two toggles would land back where they started.
+      render(<Harness hasRowClickExpansion />);
+      fireEvent.click(screen.getAllByRole('button', {name: /expand row/i})[0]);
+      expect(screen.getByTestId('panel')).toBeInTheDocument();
+    });
+
+    it('yields to interactive cell content', () => {
+      // A composed link or action button does not stop propagation the way the
+      // chevron does, so the row handler has to check what was hit.
+      const onAction = vi.fn();
+      render(
+        <Harness
+          hasRowClickExpansion
+          columnsOverride={[
+            {
+              key: 'name',
+              header: 'Name',
+              renderCell: item => (
+                <button type="button" onClick={onAction}>
+                  {`Act on ${item.name}`}
+                </button>
+              ),
+            },
+          ]}
+        />,
+      );
+      fireEvent.click(screen.getByText('Act on Ada'));
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('panel')).not.toBeInTheDocument();
+    });
+
+    it('yields to a text selection', () => {
+      // Dragging across a cell to copy it ends in a click. Toggling then would
+      // shift the row out from under the text the reader just selected.
+      render(<Harness hasRowClickExpansion />);
+      const selection = {toString: () => 'Ada'} as Selection;
+      const spy = vi.spyOn(window, 'getSelection').mockReturnValue(selection);
+      fireEvent.click(screen.getByText('Ada'));
+      expect(screen.queryByTestId('panel')).not.toBeInTheDocument();
+      spy.mockRestore();
+    });
+
+    it('leaves non-expandable rows inert', () => {
+      render(
+        <Harness
+          hasRowClickExpansion
+          isItemExpandable={item => item.id !== 'a'}
+        />,
+      );
+      fireEvent.click(screen.getByText('Ada'));
+      expect(screen.queryByTestId('panel')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('Bo'));
+      expect(screen.getByTestId('panel')).toHaveTextContent('Bo: Bo bio');
+    });
+
+    it('marks the row as interactive only when the click is wired up', () => {
+      const {unmount} = render(<Harness hasRowClickExpansion />);
+      expect(rowFor('Ada')).toHaveStyle({cursor: 'pointer'});
+      unmount();
+      render(<Harness />);
+      expect(rowFor('Ada')).not.toHaveStyle({cursor: 'pointer'});
     });
   });
 

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
@@ -58,10 +58,12 @@ function Harness({
   initialExpanded = EMPTY_KEYS,
   isItemExpandable,
   renderExpanded = defaultRenderExpanded,
+  density,
 }: {
   initialExpanded?: Set<string>;
   isItemExpandable?: (item: Row) => boolean;
   renderExpanded?: (item: Row) => React.ReactNode;
+  density?: 'compact' | 'balanced' | 'spacious';
 }) {
   const [expandedKeys, setExpandedKeys] = useState(initialExpanded);
   const expansion = useTableRowExpansion<Row>({
@@ -81,7 +83,13 @@ function Harness({
     getIsItemExpandable: isItemExpandable,
   });
   return (
-    <Table data={rows} columns={columns} idKey="id" plugins={{expansion}} />
+    <Table
+      data={rows}
+      columns={columns}
+      idKey="id"
+      density={density}
+      plugins={{expansion}}
+    />
   );
 }
 
@@ -194,6 +202,34 @@ describe('useTableRowExpansion (detail panel)', () => {
       screen.getAllByRole('menuitem', {name: /expand row/i, hidden: true})
         .length,
     ).toBeGreaterThan(0);
+  });
+
+  it('turns the glyph without turning the button beneath it', () => {
+    // The button is the hit target and carries the hover chip. Rotating it
+    // swings that rounded rectangle around with the arrow, so the transform
+    // has to sit on the glyph instead.
+    render(<Harness initialExpanded={new Set(['a'])} />);
+    const button = screen.getAllByRole('button', {name: /collapse row/i})[0];
+    const glyph = button.querySelector('svg')?.parentElement;
+    expect(glyph).toHaveStyle({transform: 'rotate(90deg)'});
+    expect(button).not.toHaveStyle({transform: 'rotate(90deg)'});
+  });
+
+  it('starts the panel at the first column, not at the row edge', () => {
+    // Left to itself the panel begins under the chevron, a column to the left
+    // of every label it describes. It should start where the first column's
+    // content does: the chevron column's width plus a cell's own padding.
+    render(<Harness initialExpanded={new Set(['a'])} />);
+    expect(screen.getByTestId('panel').closest('td')).toHaveStyle({
+      paddingInlineStart: 'calc(40px + var(--spacing-3))',
+    });
+  });
+
+  it('tracks the table density it is rendered at', () => {
+    render(<Harness initialExpanded={new Set(['a'])} density="spacious" />);
+    expect(screen.getByTestId('panel').closest('td')).toHaveStyle({
+      paddingInlineStart: 'calc(40px + var(--spacing-4))',
+    });
   });
 
   it('localizes the chevron aria-label through the i18n catalog', () => {

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.test.tsx
@@ -232,14 +232,14 @@ describe('useTableRowExpansion (detail panel)', () => {
     // content does: the chevron column's width plus a cell's own padding.
     render(<Harness initialExpanded={new Set(['a'])} />);
     expect(screen.getByTestId('panel').closest('td')).toHaveStyle({
-      paddingInlineStart: 'calc(40px + var(--spacing-3))',
+      paddingInlineStart: 'calc(var(--spacing-10) + var(--spacing-3))',
     });
   });
 
   it('tracks the table density it is rendered at', () => {
     render(<Harness initialExpanded={new Set(['a'])} density="spacious" />);
     expect(screen.getByTestId('panel').closest('td')).toHaveStyle({
-      paddingInlineStart: 'calc(40px + var(--spacing-4))',
+      paddingInlineStart: 'calc(var(--spacing-10) + var(--spacing-4))',
     });
   });
 

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -20,7 +20,13 @@
 
 import {useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {spacingVars, colorVars, radiusVars} from '../../../theme/tokens.stylex';
+import {
+  spacingVars,
+  colorVars,
+  radiusVars,
+  borderVars,
+} from '../../../theme/tokens.stylex';
+import {tableRowMarker} from '../../table.stylex';
 import {Icon} from '../../../Icon';
 import {VisuallyHidden} from '../../../VisuallyHidden';
 import {resolveContextActions} from '../../tableContextMenu';
@@ -169,6 +175,33 @@ const expansionStyles = stylex.create({
 });
 
 /**
+ * An expanded row and its panel are one unit, so the row divider belongs after
+ * the pair rather than between them — left alone, the row's own bottom border
+ * draws a line cutting it off from the detail it just opened, and the panel
+ * then runs flush into the next row, which is the wrong way round.
+ *
+ * So the row gives up its border and the panel takes one. On a table with no
+ * row dividers the suppression is a no-op (there was no border to remove) and
+ * the panel's is never applied, so neither needs to consult the divider mode.
+ */
+const dividerStyles = stylex.create({
+  expandedRowCell: {
+    borderBottomWidth: 0,
+  },
+  panelCell: {
+    borderBottomWidth: {
+      default: borderVars['--border-width'],
+      // Same rule TableCell uses: no trailing line under the last row of the
+      // table. Scoped to the marker so <tbody>, also a :last-child, does not
+      // match and suppress every panel's border.
+      [stylex.when.ancestor(':last-child', tableRowMarker)]: '0',
+    },
+    borderBottomStyle: 'solid',
+    borderBottomColor: colorVars['--color-border'],
+  },
+});
+
+/**
  * Start inset for the detail panel, one per density.
  *
  * The panel is one cell spanning the whole row, so left to itself its content
@@ -234,9 +267,10 @@ function ExpansionChevron({
 
 /**
  * The detail panel's cell. A component rather than a bare `<td>` so it can
- * read the table's density off the context and indent itself to match the
- * first column — the plugin builds this row outside the Table's own render,
- * where that context is not otherwise in hand.
+ * read the table's density and divider mode off the context — to indent itself
+ * to match the first column, and to carry the row divider its own row gave up.
+ * The plugin builds this row outside the Table's own render, where that
+ * context is not otherwise in hand.
  */
 function ExpansionPanelCell({
   colSpan,
@@ -246,12 +280,14 @@ function ExpansionPanelCell({
   children: ReactNode;
 }) {
   const ctx = useTableContext();
+  const hasRowDividers = ctx?.dividers === 'rows' || ctx?.dividers === 'grid';
   return (
     <td
       colSpan={colSpan}
       {...stylex.props(
         expansionStyles.expandedCell,
         panelIndentStyles[ctx?.density ?? 'balanced'],
+        hasRowDividers && dividerStyles.panelCell,
       )}>
       {children}
     </td>
@@ -364,6 +400,11 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
         const isExpanded = expandedKeys.has(key);
         return {
           ...props,
+          // Hand the row divider to the panel below, so the line closes the
+          // row-plus-panel pair instead of splitting it.
+          xstyle: isExpanded
+            ? [...props.xstyle, dividerStyles.expandedRowCell]
+            : props.xstyle,
           contextMenuActions: () => [
             ...resolveContextActions(props.contextMenuActions),
             {
@@ -437,6 +478,9 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
           <tr
             key={`${key}-expanded`}
             {...stylex.props(
+              // Carries the marker so the panel cell's divider can ask whether
+              // this row is the table's last, the same way TableCell does.
+              tableRowMarker,
               panelVariant === 'muted' && expansionStyles.expandedRow,
             )}>
             <ExpansionPanelCell colSpan={columnCountRef.current}>

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -63,6 +63,22 @@ export interface UseTableRowExpansionConfig<T extends Record<string, unknown>> {
    */
   getIsItemExpandable?: (item: T) => boolean;
   /**
+   * Background behind the detail panel.
+   *
+   * - `muted` (default): a wash marking the panel as commentary on the row
+   *   above rather than another row of data. In a bare table — no card, no
+   *   dividers — it is the only thing that says so.
+   * - `transparent`: the panel takes whatever surface is behind the table.
+   *   For a table already sitting on a Card or Section, where a second tint
+   *   reads as a third surface rather than as a distinction.
+   *
+   * Worth knowing when choosing: the wash is a low-alpha near-black, so over a
+   * dark card it is close to invisible. `muted` is largely a light-theme
+   * effect, and `transparent` is what dark themes look like already.
+   * @default 'muted'
+   */
+  panelVariant?: 'muted' | 'transparent';
+  /**
    * Toggle a row by clicking anywhere on it, not only on its chevron.
    *
    * This is a pointer-only convenience layered over the chevron: keyboard and
@@ -283,6 +299,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
     renderExpanded,
     getIsItemExpandable,
     hasRowClickExpansion,
+    panelVariant = 'muted',
   } = config;
 
   const t = useTranslator();
@@ -419,7 +436,9 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
         const panel = (
           <tr
             key={`${key}-expanded`}
-            {...stylex.props(expansionStyles.expandedRow)}>
+            {...stylex.props(
+              panelVariant === 'muted' && expansionStyles.expandedRow,
+            )}>
             <ExpansionPanelCell colSpan={columnCountRef.current}>
               {renderExpanded(item)}
             </ExpansionPanelCell>
@@ -445,6 +464,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
       renderExpanded,
       getIsItemExpandable,
       hasRowClickExpansion,
+      panelVariant,
       onToggle,
       t,
       expansionColumn,

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -62,6 +62,17 @@ export interface UseTableRowExpansionConfig<T extends Record<string, unknown>> {
    * context-menu action, and never render a panel. @default all rows expandable
    */
   getIsItemExpandable?: (item: T) => boolean;
+  /**
+   * Toggle a row by clicking anywhere on it, not only on its chevron.
+   *
+   * This is a pointer-only convenience layered over the chevron: keyboard and
+   * assistive-tech users toggle via the chevron button (which stays the
+   * accessible control). Clicks originating from interactive cell content
+   * (buttons, links, form controls) or a text selection do not toggle.
+   * Non-expandable rows stay inert.
+   * @default false (only the chevron toggles expansion).
+   */
+  hasRowClickExpansion?: boolean;
 }
 
 // =============================================================================
@@ -131,6 +142,13 @@ const expansionStyles = stylex.create({
   expandedCell: {
     paddingBlock: spacingVars['--spacing-4'],
     paddingInlineEnd: spacingVars['--spacing-5'],
+  },
+  /** Whole-row-click expansion: signal the row is interactive. */
+  clickableRow: {
+    cursor: {
+      default: 'pointer',
+      ':is(:disabled,[aria-disabled="true"])': 'default',
+    },
   },
 });
 
@@ -264,6 +282,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
     getRowKey,
     renderExpanded,
     getIsItemExpandable,
+    hasRowClickExpansion,
   } = config;
 
   const t = useTranslator();
@@ -360,8 +379,41 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
           return props;
         }
         const key = getRowKey(item);
+
+        // Whole-row-click expansion (opt-in), applied before the collapsed
+        // early-return: a collapsed row is precisely the one a click has to
+        // reach, since opening it is the whole point.
+        const withClick = hasRowClickExpansion
+          ? {
+              ...props,
+              htmlProps: {
+                ...props.htmlProps,
+                onClick: (event: React.MouseEvent<HTMLTableRowElement>) => {
+                  // Don't hijack clicks on interactive cell content (the
+                  // chevron already stops propagation, but a composed
+                  // selection checkbox, link, or action button does not) or a
+                  // text selection.
+                  const target = event.target as HTMLElement;
+                  if (
+                    target.closest(
+                      'button, a, input, select, textarea, [role="button"], [role="checkbox"], [contenteditable="true"]',
+                    )
+                  ) {
+                    return;
+                  }
+                  if ((window.getSelection()?.toString() ?? '') !== '') {
+                    return;
+                  }
+                  props.htmlProps.onClick?.(event);
+                  onToggle(key);
+                },
+              },
+              xstyle: [...props.xstyle, expansionStyles.clickableRow],
+            }
+          : props;
+
         if (!expandedKeys.has(key)) {
-          return props;
+          return withClick;
         }
 
         const panel = (
@@ -375,10 +427,10 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
         );
 
         return {
-          ...props,
-          afterRow: props.afterRow ? (
+          ...withClick,
+          afterRow: withClick.afterRow ? (
             <>
-              {props.afterRow}
+              {withClick.afterRow}
               {panel}
             </>
           ) : (
@@ -392,6 +444,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
       getRowKey,
       renderExpanded,
       getIsItemExpandable,
+      hasRowClickExpansion,
       onToggle,
       t,
       expansionColumn,

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -4,7 +4,8 @@
 
 /**
  * @file useTableRowExpansion.tsx
- * @input React, StyleX, Icon, Table types, i18n (useTranslator)
+ * @input React, StyleX, Icon, Table types, table context (density), i18n
+ *   (useTranslator)
  * @output Exports useTableRowExpansion hook + config type
  * @position Row-expansion plugin (detail panel); consumed by Table via plugins prop
  *
@@ -23,6 +24,7 @@ import {spacingVars, colorVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {VisuallyHidden} from '../../../VisuallyHidden';
 import {resolveContextActions} from '../../tableContextMenu';
+import {useTableContext} from '../../useTableCellStyles';
 import {useTranslator} from '../../../i18n';
 import {rtlStyles} from '../../../utils';
 import type {
@@ -66,7 +68,11 @@ export interface UseTableRowExpansionConfig<T extends Record<string, unknown>> {
 // Styles
 // =============================================================================
 
-const EXPANSION_COLUMN_WIDTH = {type: 'pixel' as const, value: 40};
+const EXPANSION_COLUMN_WIDTH_PX = 40;
+const EXPANSION_COLUMN_WIDTH = {
+  type: 'pixel' as const,
+  value: EXPANSION_COLUMN_WIDTH_PX,
+};
 
 const expansionStyles = stylex.create({
   chevronButton: {
@@ -83,7 +89,10 @@ const expansionStyles = stylex.create({
       ':is(:disabled,[aria-disabled="true"])': 'default',
     },
     color: colorVars['--color-icon-secondary'],
-    transitionProperty: 'transform, color',
+    // Colour only. The rotation belongs to the glyph, not to the button: the
+    // button is the hit target and carries the hover chip, and turning that
+    // swings the rounded rectangle and its highlight around with the arrow.
+    transitionProperty: 'color',
     transitionDuration: '150ms',
     padding: 0,
     // Match IconButton ghost hover: subtle overlay background.
@@ -96,6 +105,10 @@ const expansionStyles = stylex.create({
     ':hover:where(:not(:disabled,[aria-disabled="true"]))': {
       color: colorVars['--color-icon-primary'],
     },
+  },
+  chevron: {
+    transitionProperty: 'transform',
+    transitionDuration: '150ms',
   },
   // The RTL mirror is folded into each state's transform rather than living
   // on a parent span, matching TreeListItem's chevron (both are `transform`,
@@ -117,7 +130,31 @@ const expansionStyles = stylex.create({
   },
   expandedCell: {
     paddingBlock: spacingVars['--spacing-4'],
-    paddingInline: spacingVars['--spacing-5'],
+    paddingInlineEnd: spacingVars['--spacing-5'],
+  },
+});
+
+/**
+ * Start inset for the detail panel, one per density.
+ *
+ * The panel is one cell spanning the whole row, so left to itself its content
+ * starts at the row's edge — under the chevron, a column to the left of every
+ * label it describes. These line it up with the first real column instead: the
+ * chevron column's fixed width, plus the inline padding a cell of that density
+ * gives its own content.
+ *
+ * Written as a logical property so RTL mirrors it, and kept in `calc` so the
+ * padding half still tracks the spacing scale.
+ */
+const panelIndentStyles = stylex.create({
+  compact: {
+    paddingInlineStart: `calc(${EXPANSION_COLUMN_WIDTH_PX}px + ${spacingVars['--spacing-2']})`,
+  },
+  balanced: {
+    paddingInlineStart: `calc(${EXPANSION_COLUMN_WIDTH_PX}px + ${spacingVars['--spacing-3']})`,
+  },
+  spacious: {
+    paddingInlineStart: `calc(${EXPANSION_COLUMN_WIDTH_PX}px + ${spacingVars['--spacing-4']})`,
   },
 });
 
@@ -136,12 +173,7 @@ function ExpansionChevron({
   return (
     <button
       type="button"
-      {...stylex.props(
-        expansionStyles.chevronButton,
-        isExpanded
-          ? expansionStyles.chevronExpanded
-          : expansionStyles.chevronCollapsed,
-      )}
+      {...stylex.props(expansionStyles.chevronButton)}
       onClick={e => {
         e.stopPropagation();
         onToggle();
@@ -152,8 +184,43 @@ function ExpansionChevron({
           : t('@astryx.tableRowExpansion.expandRow')
       }
       aria-expanded={isExpanded}>
-      <Icon icon="chevronRight" size="xsm" />
+      <Icon
+        icon="chevronRight"
+        size="xsm"
+        xstyle={[
+          expansionStyles.chevron,
+          isExpanded
+            ? expansionStyles.chevronExpanded
+            : expansionStyles.chevronCollapsed,
+        ]}
+      />
     </button>
+  );
+}
+
+/**
+ * The detail panel's cell. A component rather than a bare `<td>` so it can
+ * read the table's density off the context and indent itself to match the
+ * first column — the plugin builds this row outside the Table's own render,
+ * where that context is not otherwise in hand.
+ */
+function ExpansionPanelCell({
+  colSpan,
+  children,
+}: {
+  colSpan: number;
+  children: ReactNode;
+}) {
+  const ctx = useTableContext();
+  return (
+    <td
+      colSpan={colSpan}
+      {...stylex.props(
+        expansionStyles.expandedCell,
+        panelIndentStyles[ctx?.density ?? 'balanced'],
+      )}>
+      {children}
+    </td>
   );
 }
 
@@ -301,11 +368,9 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
           <tr
             key={`${key}-expanded`}
             {...stylex.props(expansionStyles.expandedRow)}>
-            <td
-              colSpan={columnCountRef.current}
-              {...stylex.props(expansionStyles.expandedCell)}>
+            <ExpansionPanelCell colSpan={columnCountRef.current}>
               {renderExpanded(item)}
-            </td>
+            </ExpansionPanelCell>
           </tr>
         );
 

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -215,13 +215,13 @@ const dividerStyles = stylex.create({
  */
 const panelIndentStyles = stylex.create({
   compact: {
-    paddingInlineStart: `calc(${EXPANSION_COLUMN_WIDTH_PX}px + ${spacingVars['--spacing-2']})`,
+    paddingInlineStart: `calc(${spacingVars['--spacing-10']} + ${spacingVars['--spacing-2']})`,
   },
   balanced: {
-    paddingInlineStart: `calc(${EXPANSION_COLUMN_WIDTH_PX}px + ${spacingVars['--spacing-3']})`,
+    paddingInlineStart: `calc(${spacingVars['--spacing-10']} + ${spacingVars['--spacing-3']})`,
   },
   spacious: {
-    paddingInlineStart: `calc(${EXPANSION_COLUMN_WIDTH_PX}px + ${spacingVars['--spacing-4']})`,
+    paddingInlineStart: `calc(${spacingVars['--spacing-10']} + ${spacingVars['--spacing-4']})`,
   },
 });
 

--- a/packages/core/src/Table/useTableRowExpansion.doc.mjs
+++ b/packages/core/src/Table/useTableRowExpansion.doc.mjs
@@ -42,6 +42,13 @@ export const docs = {
         'Control which rows are expandable. Non-expandable rows show no chevron, no context-menu action, and never render a panel. Defaults to all rows expandable.',
     },
     {
+      name: 'panelVariant',
+      type: "'muted' | 'transparent'",
+      description:
+        "Background behind the detail panel. 'muted' washes it, marking it as commentary on the row above rather than another row of data — in a bare table with no dividers that wash is the only cue. 'transparent' takes whatever surface is behind the table, for a table already on a Card or Section where a second tint reads as a third surface. The wash is a low-alpha near-black, so it is close to invisible over a dark card: 'muted' is largely a light-theme effect.",
+      default: "'muted'",
+    },
+    {
       name: 'hasRowClickExpansion',
       type: 'boolean',
       description:
@@ -113,6 +120,8 @@ export const docsDense = {
       'Render the full-width detail panel below an expanded row. Receives the row item.',
     getIsItemExpandable:
       'Control which rows are expandable. Defaults to all rows expandable.',
+    panelVariant:
+      "Detail panel background: 'muted' (default) washes it; 'transparent' takes the surface behind the table, for a table already on a Card.",
     hasRowClickExpansion:
       'Toggle a row by clicking anywhere on it, not just the chevron; pointer-only, skips interactive cell content and text selections. Defaults to false.',
   },

--- a/packages/core/src/Table/useTableRowExpansion.doc.mjs
+++ b/packages/core/src/Table/useTableRowExpansion.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableRowExpansion',
   description:
-    'Hook that returns a TablePlugin which expands a full-width detail panel below a row, rendered by the consumer via renderExpanded(item). Adds a leading chevron column and a right-click "Expand/Collapse row" action; the consumer owns the expandedKeys set. Use it for master-detail rows (order details, forms, charts, nested tables). For hierarchical data where child rows reuse the parent columns, use useTableTreeData + useTableTreeState instead.',
+    'Hook that returns a TablePlugin which expands a full-width detail panel below a row, rendered by the consumer via renderExpanded(item). Adds a leading chevron column and a right-click "Expand/Collapse row" action; the consumer owns the expandedKeys set. The panel spans the row but starts its content at the first column, past the chevron, so detail lines up with the labels above it; the inset follows the table density. Use it for master-detail rows (order details, forms, charts, nested tables). For hierarchical data where child rows reuse the parent columns, use useTableTreeData + useTableTreeState instead.',
   props: [
     {
       name: 'expandedKeys',
@@ -97,7 +97,7 @@ const tree = useTableTreeData({
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   description:
-    'Returns a TablePlugin that expands a full-width detail panel below a row via renderExpanded(item). Adds a chevron column + right-click expand/collapse action; consumer owns expandedKeys. For nested child rows that reuse parent columns, use useTableTreeData + useTableTreeState instead.',
+    'Returns a TablePlugin that expands a full-width detail panel below a row via renderExpanded(item). Adds a chevron column + right-click expand/collapse action; consumer owns expandedKeys. Panel content starts at the first column (past the chevron), inset by density. For nested child rows that reuse parent columns, use useTableTreeData + useTableTreeState instead.',
   propDescriptions: {
     expandedKeys: 'Set of currently-expanded row keys. Consumer-owned.',
     onToggle: 'Called with a row key when its expansion is toggled.',

--- a/packages/core/src/Table/useTableRowExpansion.doc.mjs
+++ b/packages/core/src/Table/useTableRowExpansion.doc.mjs
@@ -41,6 +41,13 @@ export const docs = {
       description:
         'Control which rows are expandable. Non-expandable rows show no chevron, no context-menu action, and never render a panel. Defaults to all rows expandable.',
     },
+    {
+      name: 'hasRowClickExpansion',
+      type: 'boolean',
+      description:
+        'Toggle a row by clicking anywhere on it, not only on its chevron. A pointer-only convenience layered over the chevron, which stays the accessible control for keyboard and assistive tech. Clicks on interactive cell content (buttons, links, form controls) or on a text selection do not toggle, and non-expandable rows stay inert.',
+      default: 'false',
+    },
   ],
   examples: [
     {
@@ -106,5 +113,7 @@ export const docsDense = {
       'Render the full-width detail panel below an expanded row. Receives the row item.',
     getIsItemExpandable:
       'Control which rows are expandable. Defaults to all rows expandable.',
+    hasRowClickExpansion:
+      'Toggle a row by clicking anywhere on it, not just the chevron; pointer-only, skips interactive cell content and text selections. Defaults to false.',
   },
 };


### PR DESCRIPTION
## What

Four changes to `useTableRowExpansion`. Two are fixes to where things sit, two close gaps against the plugin's siblings. Grouped because they are one read of the same file, and each one is small enough that splitting them costs more in review overhead than it saves.

| | |
|---|---|
| `fix` | the chevron turned the button, not the arrow |
| `fix` | the detail panel started at the row edge |
| `fix` | the row divider split a row from its own panel |
| `feat` | `hasRowClickExpansion` — the whole row toggles, as in `useTableTreeData` |
| `feat` | `panelVariant` — opt the panel's wash out |

---

## fix — the divider split a row from its own detail

A row and its panel are one unit, but the line was landing between them. The row drew its own bottom border, putting a divider between the row and the detail it had just opened; the panel drew none, so it ran flush into the next row. The pair was cut down the middle and fused to the row below — the reverse of the grouping it should express.

The expanded row now gives up its border and the panel takes one.

**Before** — the line sits under `Operating`, and its detail runs straight into `Payroll`:

![divider before](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/divider-before.png)

**After** — the row and its detail read as one block, and the line closes underneath:

![divider after](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/divider-after.png)

Only the panel consults the divider mode, and only to know whether to draw at all. On a table with no row dividers the suppression removes a border that was never there, and the panel's is never applied. The panel row carries `tableRowMarker` — the same marker `TableCell` scopes its "no trailing line under the last row" rule to — so an expanded last row still ends the table cleanly.

## fix — the chevron turned the button, not the arrow

`transform: rotate(90deg)` was on the `<button>`, which is the hit target and carries the ghost hover chip, so expanding a row swung that rounded rectangle and its highlight through a quarter turn along with the glyph. A finished 90° turn on a 24px rounded square lands back on itself, so this only shows up in motion, where the chip passes through a diamond. The transform now sits on the glyph; the button stays put.

Frames are mid-animation, transition stretched from 150ms to 3s so the middle is photographable.

**Before** — the chip is a diamond, dragged round by the arrow:

![chevron before](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/chevron-before.png)

**After** — the chip is square and still; only the arrow moves:

![chevron after](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/chevron-after.png)

## fix — the panel started at the row edge

The panel is one cell spanning the whole row with a flat `20px` inline padding, so its content began under the chevron — a column to the left of every label it describes. It now indents to the first real column:

![panel alignment](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/panel-alignment.png)

The start padding is the chevron column's fixed width plus the inline padding a cell of that density gives its own content — `calc(40px + var(--spacing-3))` at `balanced`. Density comes off the table context, which is why the panel had to become a small component (`ExpansionPanelCell`) rather than a bare `<td>`: the plugin builds this row inside `transformBodyRow`, outside the Table's own render, so the context is not otherwise in hand.

It is a logical property, so RTL mirrors it, and it is not configurable — a panel starting anywhere else reads as a misalignment rather than as a choice.

## feat — `hasRowClickExpansion`

`useTableTreeData` already lets the row body toggle its own disclosure; this plugin only accepted the chevron, so two tables with the same affordance behaved differently depending on which plugin drew it. Same prop name, same default of `false`, so nothing changes for existing callers.

```tsx
useTableRowExpansion({
  renderExpanded: item => <AccountDetail account={item} />,
  hasRowClickExpansion: true,
});
```

The handler steps aside for anything that has its own answer to a click — `button`, `a`, `input`, `select`, `textarea`, `[role="button"]`, `[role="checkbox"]`, `[contenteditable]` — and for a live text selection, so dragging across a cell to copy a figure does not also collapse what you were reading. The chevron is a `button`, so it is covered by the same guard rather than by a special case, and does not double-toggle. Rows the predicate says are not expandable stay inert and keep the default cursor.

![row hover](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/rowclick-hover.png)

![row opened](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/rowclick-opened.png)

## feat — `panelVariant`

The panel's muted wash was hardcoded. It reads well on a table sitting on the page, but inside a card the panel becomes a third surface between the card and the row and the band works against the grouping. `panelVariant: 'transparent'` drops it and lets the panel inherit whatever is behind the table.

| `'muted'` (default) | `'transparent'` |
|---|---|
| ![muted](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/panel-muted.png) | ![transparent](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/row-expansion/panel-transparent.png) |

Worth knowing before you reach for it: **the default is close to a no-op in dark mode.** `--color-background-muted` and `--color-background-card` resolve to the same value in the dark theme, so a panel inside a card already looks transparent there. The prop is really about light mode; in dark mode it mostly changes what happens when the theme later separates those two tokens. Kept `'muted'` as the default anyway, since flipping it would move every existing panel.

## Two things worth a reviewer's eye

**The indent lands 1px short, and that 1px is not mine.** Measured in the browser: panel content at x=184, first column's text at x=185. The formula is exact; the gap is the UA stylesheet's `td { padding: 1px }` leaking into cells that own a context menu. `TableCell` relocates density padding onto the right-click trigger for those cells and leaves the `<td>` with `font/box-sizing only — no padding`, which is true of the authored rules but not of the computed result. This plugin puts a context menu on every cell, so every one of them carries the stray pixel. The fix is a one-line `padding: 0` in `TableCell`, but it shifts every context-menu cell in the system by 1px in both axes, so it wants its own PR and its own visual pass rather than riding along here.

**The indent assumes the chevron column is the leading one.** It is, for every current caller, and the plugin already makes exactly this assumption for the panel's `colSpan` (`columnCountRef` is captured in `transformColumns`, so a plugin that prepended a column later would throw both off). No regression, but it is the same latent limit in a second place.

## Test plan

- `vitest run packages/core/src/Table` — 517 passed across 23 files, up from 503.
- 14 new cases in `useTableRowExpansion.test.tsx`:
  - **placement** (3) — the glyph carries the rotation and the button does not; the panel's start padding is `calc(40px + var(--spacing-3))` at the default density; it follows `density` to `--spacing-4` at `spacious`.
  - **whole-row-click expansion** (8) — inert by default; expands; collapses; no double-toggle from the chevron; yields to interactive cell content; yields to a text selection; leaves non-expandable rows inert; `cursor: pointer` only when wired up.
  - **panel variant** (2) — washed by default, on the surface behind the table when `transparent`.
  - **row divider placement** (4) — closes below the panel; collapsed rows keep their own; nothing drawn on a table without row dividers; drawn under `grid` dividers too.
- `tsc --noEmit` and `eslint` clean.
- Measured before/after in the grouped-accounts template: panel start padding 20px → 48px, content x=156 → x=184 against a first column at x=185.

Four changesets included, one per change.

Made with [Cursor](https://cursor.com)
