### PR TITLE
fix(cli): report coverage on verbatim phrase matches in search (unbreaks main)

### DIFF
--- a/.changeset/cli-search-phrase-coverage.md
+++ b/.changeset/cli-search-phrase-coverage.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Report coverage on verbatim phrase matches in CLI search, which were returning without it and failing the published type surface. (#PENDING)
+
+@ernestt
+
+`scoreQuery` declares `{score, reason, matched, total}`, and the top-tier branch added by #5289 — a whole-query match on a name or a declared keyword, promoted above the token-sum path — returned only `{score, reason}`. So the strongest possible hit was also the one hit that told callers nothing about coverage, and `build`, which gates its pages group on exactly that, saw `undefined`. It now goes through the same `asFull` helper as the other whole-phrase branches: a verbatim match on the whole query has answered every concept in it by definition.
+
+This also unbreaks `main`. The mismatch is a type error under `checkJs`, so the "Verify the published CLI ./api type surface" step fails, and with it the `test` check and the Storybook build every PR's visual evidence depends on.

--- a/.changeset/cli-search-phrase-coverage.md
+++ b/.changeset/cli-search-phrase-coverage.md
@@ -2,7 +2,7 @@
 '@astryxdesign/cli': patch
 ---
 
-[fix] Report coverage on verbatim phrase matches in CLI search, which were returning without it and failing the published type surface. (#PENDING)
+[fix] Report coverage on verbatim phrase matches in CLI search, which were returning without it and failing the published type surface. (#5996)
 
 @ernestt
 

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -274,7 +274,7 @@ export function scoreQuery(term, tokens, candidate) {
   // of Table-related templates each match "table" and "contents" separately
   // and accumulate a higher raw score (#5239).
   if (full && full.score >= 90) {
-    return {score: full.score + 100, reason: full.reason};
+    return asFull({score: full.score + 100, reason: full.reason});
   }
 
   // Multi-word natural language: score each content token, counting only


### PR DESCRIPTION
## What

`main` is red, and this one-line change is what fixes it.

`scoreQuery` in `packages/cli/api/search/search.mjs` declares its return as `{score, reason, matched, total} | null`. The top-tier branch added by #5289 — the whole query matching a name or a declared keyword verbatim, promoted above the token-sum path — returns only `{score, reason}`:

```js
if (full && full.score >= 90) {
  return {score: full.score + 100, reason: full.reason};
}
```

Two consequences, one cosmetic in CI and one real.

**It fails the build.** Under `checkJs` that is `TS2739`, so the "Verify the published CLI ./api type surface" step exits non-zero:

```
api/search/search.mjs(277,5): error TS2739: Type '{ score: number; reason: string; }' is missing
the following properties from type '{ score: number; reason: string; matched: number; total: number; }':
matched, total
```

That step sits ahead of `Run pnpm test`, so on every PR the `test` check fails without a single test running. It also fails `build-storybook` and `build-sandbox`, which skips the visual-evidence job, so `visual-acceptance` fails too with "Stable visual evidence could not be published" and no frame report. Both of my open PRs are red on this and neither has anything to do with it.

**It also loses real information.** `matched`/`total` exist so callers can tell "matched one word of three" from "matched all three" — `build` gates its pages group on that, and the JSDoc says as much. The strongest possible hit was the one hit that reported nothing, so that caller was reading `undefined`.

## The fix

The function already has an `asFull` helper for precisely this case, used by both other whole-phrase branches:

```js
// A whole-phrase hit answered the whole query by definition.
const asFull = hit => ({...hit, matched: total, total});
```

The promoted branch is a whole-phrase hit too — more emphatically so, since it requires a verbatim match on a name or an authored keyword. So it routes through the same helper. Scores and ordering are untouched; the object just carries the two fields it always claimed to.

## Test plan

- Reproduced the failure locally against `main`'s copy of the file — same `TS2739`, same line — then confirmed `node .github/scripts/cli-api-types-verify.mjs` goes green with the change: "All published type-surface checks passed."
- `vitest run packages/cli/api/search` against `main`'s test file — 30 passed, including the ranking tests #5289 added. No expectations needed changing, which is the point: this is additive to the returned object.

## Provenance

Introduced in f44af810cbc (#5289). It landed after `main`'s last CI run, and that run had already failed on an unrelated "package.json exports are stale!", so the break went unnoticed.

Changeset included.

Made with [Cursor](https://cursor.com)
