### PR TITLE
feat(Typeahead): add isLoading and changeAction

### DIFF
--- a/.changeset/typeahead-transition-action.md
+++ b/.changeset/typeahead-transition-action.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Typeahead: isLoading and changeAction join the input family's busy and Transition Action contracts (#5941)
+
+Typeahead could show a search in flight but had no way to say its value was busy. `isLoading` marks the field value as resolving or being saved: the end-lane Spinner shows and the combobox carries `aria-busy`, while the search source and its results stay untouched (FR5). `changeAction` runs after `onChange` with the same proposed item, in a React transition, on both value paths — selection and the clear button — with the proposed item shown as the token until `value` catches up (FR6). A search in flight and a busy value share one Spinner and one `aria-busy`, never two (FR7). Callers that pass neither prop see no change beyond the disabled-reason fix below.
+
+While the field is disabled with a `disabledMessage`, the focusable-disabled input keeps receiving keys, so ArrowDown could still open the entries shown on focus and Enter select one. The base combobox now ignores keys while disabled (family FR4).
+
+@AKnassa

--- a/.changeset/typeahead-transition-action.md
+++ b/.changeset/typeahead-transition-action.md
@@ -6,6 +6,6 @@
 
 Typeahead could show a search in flight but had no way to say its value was busy. `isLoading` marks the field value as resolving or being saved: the end-lane Spinner shows and the combobox carries `aria-busy`, while the search source and its results stay untouched (FR5). `changeAction` runs after `onChange` with the same proposed item, in a React transition, on both value paths — selection and the clear button — with the proposed item shown as the token until `value` catches up (FR6). A search in flight and a busy value share one Spinner and one `aria-busy`, never two (FR7). Callers that pass neither prop see no change beyond the disabled-reason fix below.
 
-While the field is disabled with a `disabledMessage`, the focusable-disabled input keeps receiving keys, so ArrowDown could still open the entries shown on focus and Enter select one. The base combobox now ignores keys while disabled (family FR4).
+While the field is disabled with a `disabledMessage`, the focusable-disabled input keeps receiving keys and an already-open menu stays on screen, so two edits that slipped through are now blocked (family FR4): ArrowDown then Enter selecting one of the entries shown on focus, and clicking an option in a menu still open from before the field was disabled. Dismissal is not an edit: Tab still closes that open menu on the keydown itself, and Escape still closes it through the shared layer stack.
 
 @AKnassa

--- a/apps/storybook/stories/Typeahead.stories.tsx
+++ b/apps/storybook/stories/Typeahead.stories.tsx
@@ -71,6 +71,7 @@ const meta: Meta<typeof Typeahead> = {
     label: {control: 'text'},
     placeholder: {control: 'text'},
     isDisabled: {control: 'boolean'},
+    isLoading: {control: 'boolean'},
     disabledMessage: {
       control: 'text',
       description:
@@ -323,6 +324,61 @@ export const Loading: Story = {
     );
   },
   name: 'Loading (async source)',
+};
+
+/**
+ * The other busy meaning. The search is idle; the VALUE is being resolved or
+ * saved, which is what the input-field family's `isLoading` describes. The
+ * field stays editable and the source's results stay selectable.
+ */
+export const InputBusy: Story = {
+  render: () => {
+    const [value, setValue] = useState<SearchableItem | null>(fruits[0]);
+    return (
+      <div style={{width: 320}}>
+        <Typeahead
+          label="Fruit"
+          placeholder="Type to search…"
+          searchSource={fruitSource}
+          value={value}
+          onChange={setValue}
+          hasClear
+          isLoading
+        />
+      </div>
+    );
+  },
+  name: 'Input busy (isLoading)',
+};
+
+/**
+ * `changeAction` after every selection and clear. The proposed value shows at
+ * once, and the field is busy until the controlled value accepts it — here the
+ * parent commits only once the Action settles, the way a server round-trip
+ * would, so the busy state is visible. A parent that sets the value
+ * synchronously in `onChange` accepts it immediately and is never busy.
+ */
+export const TransitionAction: Story = {
+  render: () => {
+    const [value, setValue] = useState<SearchableItem | null>(null);
+    return (
+      <div style={{width: 320}}>
+        <Typeahead
+          label="Fruit"
+          placeholder="Type to search…"
+          searchSource={fruitSource}
+          value={value}
+          onChange={() => {}}
+          changeAction={async item => {
+            await new Promise<void>(resolve => setTimeout(resolve, 1200));
+            setValue(item);
+          }}
+          hasClear
+        />
+      </div>
+    );
+  },
+  name: 'Transition action (changeAction)',
 };
 
 /**

--- a/docs/families/input-fields.md
+++ b/docs/families/input-fields.md
@@ -223,7 +223,7 @@ another implementation helper.
 | Selector        | Field, FormLayout, InputGroup, size, width, `isLoading`, `changeAction`, clear, status, and disabled reason                | DEC-1 permits standalone content-sized width                                       |
 | MultiSelector   | Field, FormLayout, InputGroup, size, width, `isLoading`, `changeAction`, clear, status, and disabled reason                | trigger-display modes remain component-owned                                       |
 | ComplexSelector | Field, FormLayout, size, width, `isLoading`, `changeAction`, and status                                                    | no InputGroup or disabled-reason API                                               |
-| Typeahead       | Field, FormLayout, InputGroup, size, width, clear, status, disabled reason, and BaseTypeahead source loading               | no family `isLoading` or `changeAction`; search lifecycle is component-owned       |
+| Typeahead       | Field, FormLayout, InputGroup, size, width, `isLoading`, `changeAction`, clear, status, disabled reason, and source busy   | search lifecycle is component-owned                                                |
 | Tokenizer       | Field, FormLayout, size, width, clear, status, disabled reason, BaseTypeahead source loading, and multi-token block growth | not InputGroup-compatible on current main; no family `isLoading` or `changeAction` |
 
 ### Implementation gaps

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -27,7 +27,7 @@ import React, {
   type RefObject,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {useBusyIndicatorLane} from './busyIndicatorLane';
+import {useBusyIndicatorLane, useIsInputBusy} from './busyIndicatorLane';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
 import {useAnnounce} from '../hooks/useAnnounce';
@@ -452,6 +452,10 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   // A wrapper that owns the inline-end lane subscribes through context; see
   // busyIndicatorLane.tsx for why this is not a prop.
   const busyLane = useBusyIndicatorLane();
+  // The wrapper's half of busy: its field value resolving or being saved
+  // (`isLoading`, or a `changeAction` still pending). It reaches only the
+  // combobox's `aria-busy` below — the search lifecycle never reads it.
+  const isInputBusy = useIsInputBusy();
   const onLoadingChangeRef = useRef(busyLane?.onBusyChange);
   useIsomorphicLayoutEffect(() => {
     onLoadingChangeRef.current = busyLane?.onBusyChange;
@@ -814,6 +818,13 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         return;
       }
 
+      // A focusable-disabled input (isDisabled with a disabled reason) is
+      // readOnly but still receives keys: without this guard ArrowDown could
+      // bootstrap entries and Enter select one (family FR4).
+      if (isDisabled) {
+        return;
+      }
+
       // An IME candidate window uses Enter to commit the composition and
       // Escape/ArrowUp/ArrowDown/Home/End to navigate its own candidates.
       // Without this guard, a composing Enter both fires handleSelect AND
@@ -907,6 +918,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
       minQueryLength,
       performBootstrap,
       externalOnKeyDown,
+      isDisabled,
     ],
   );
 
@@ -963,7 +975,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
             : undefined
         }
         aria-autocomplete="list"
-        aria-busy={isLoading || undefined}
+        aria-busy={isLoading || isInputBusy || undefined}
         aria-describedby={ariaDescribedBy}
         aria-labelledby={ariaLabelledBy}
         aria-disabled={isFocusableDisabled ? 'true' : undefined}

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -737,6 +737,13 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   // Handle item selection
   const handleSelect = useCallback(
     (item: T) => {
+      // FR4's pointer half: a parent can flip the field to focusable-disabled
+      // while the menu is open (nothing closes it on the flip), and the
+      // options stay clickable. Selection is an edit, so it is blocked here
+      // the way the keydown guard blocks the keyboard paths.
+      if (isDisabled) {
+        return;
+      }
       // Bump generation to invalidate any in-flight async searches
       searchGenRef.current++;
       if (searchTimeoutRef.current) {
@@ -755,7 +762,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
       popover.hide();
       inputRef.current?.focus();
     },
-    [onChange, popover, searchSource, setLoading],
+    [isDisabled, onChange, popover, searchSource, setLoading],
   );
 
   // Handle focus
@@ -820,8 +827,14 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
 
       // A focusable-disabled input (isDisabled with a disabled reason) is
       // readOnly but still receives keys: without this guard ArrowDown could
-      // bootstrap entries and Enter select one (family FR4).
-      if (isDisabled) {
+      // bootstrap entries and Enter select one (family FR4). FR4 blocks
+      // edits, not dismissal: Tab passes through to its keydown dismissal
+      // below, which must not be left to the blur it causes — hiding a
+      // top-layer popover during focusout makes Chrome abandon the focus
+      // move and strand focus on <body>. Escape needs no passthrough: the
+      // shared layer stack (useLayerDismissal) sees the unclaimed press and
+      // closes the menu as the topmost layer, exactly as when enabled.
+      if (isDisabled && e.key !== 'Tab') {
         return;
       }
 

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -36,7 +36,7 @@ const anatomy = [
     name: 'Spinner',
     required: false,
     description:
-      'Loading indicator shown at the end of the input surface while a search is in flight.',
+      'Busy indicator at the end of the input surface while a search is in flight, or while the field value is loading or a changeAction is pending.',
   },
   {
     name: 'Clear button',
@@ -135,6 +135,12 @@ export const docs = {
       required: true,
     },
     {
+      name: 'changeAction',
+      type: '(item: T | null) => void | Promise<void>',
+      description:
+        'Async action after onChange, called with the same proposed item. Runs in a transition: the item shows optimistically and the field is busy (spinner and aria-busy) until value catches up. Selection and clear both go through it.',
+    },
+    {
       name: 'placeholder',
       type: 'string',
       description: 'Input placeholder text.',
@@ -162,6 +168,13 @@ export const docs = {
       type: 'string',
       description:
         'Explains why the input is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the field focusable via aria-disabled (activation stays blocked). Use this instead of wrapping a disabled Typeahead in Tooltip. Disabled controls swallow the hover events an external Tooltip needs.',
+    },
+    {
+      name: 'isLoading',
+      type: 'boolean',
+      description:
+        'Marks the field value as resolving or being saved: shows the busy spinner and sets aria-busy on the combobox. Search results are unaffected; a search in flight has its own busy state and shares the indicator.',
+      default: 'false',
     },
     {
       name: 'maxMenuItems',

--- a/packages/core/src/Typeahead/Typeahead.spec.md
+++ b/packages/core/src/Typeahead/Typeahead.spec.md
@@ -34,15 +34,27 @@ system_specs: []
 
 Typeahead renders a single-selection search control with an optional standalone
 Field shell and delegates its combobox engine and popup results to BaseTypeahead. This draft records current
-consumer anatomy, target reachability, and the shipped difference between the
-stable result row and its default TypeaheadItem content without changing runtime
-behavior, styling, targets, or public API.
+consumer anatomy, target reachability, the shipped difference between the
+stable result row and its default TypeaheadItem content, and the additive
+`isLoading` and `changeAction` props adopted from the input-field family,
+without changing existing runtime behavior, styling, or targets.
 
 ## Compatibility and migration
 
-- Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, and public API remain unchanged
+- Released default preserved: `yes` — `isLoading` defaults to `false` and
+  `changeAction` to unset, which renders and behaves exactly as shipped
+- Compatibility class: additive; two new public props, `isLoading` and
+  `changeAction`, with no change to existing targets, DOM, or styling, and
+  no change to behavior without them except the FR4 fix: a field disabled
+  with a reason no longer selects an item from the keyboard
+- `isLoading` is additive. It marks the value busy — one Spinner in the end
+  lane plus `aria-busy` on the combobox — and never means the option source is
+  pending (`spec:AST-001`). `changeAction` is additive. Before it, a selection
+  or clear only reported through `onChange`. After it, `onChange` still runs
+  first, then the Action runs inside a transition while the proposed value
+  shows as busy until the controlled `value` accepts it (`family:input-fields`
+  FR5–FR7). The clear button follows the accepted `value`, as Selector's
+  does, while the token follows the proposal.
 - Controlled/uncontrolled behavior: unchanged
 - Migration decision: none
 
@@ -78,9 +90,15 @@ Consumer migration instructions belong in consumer docs and release notes.
 
 ## Public concepts
 
-No new public concept is introduced. Consumer props and usage remain documented
-in `Typeahead.doc.mjs`; BaseTypeahead and TypeaheadItem retain their existing
-public component documentation.
+`isLoading` and `changeAction` are input-field family concepts adopted from
+`family:input-fields` (FR5–FR7, DEC-2, DEC-3), not Typeahead-owned concepts.
+Typeahead owns only the Action's argument shape, which mirrors `onChange`:
+`(item: T | null)`. Search busy stays BaseTypeahead-owned; both meanings share
+the one end-lane Spinner and the combobox `aria-busy`.
+
+No other public concept is introduced. Consumer props and usage remain
+documented in `Typeahead.doc.mjs`; BaseTypeahead and TypeaheadItem retain their
+existing public component documentation.
 
 ## Behavioral and layout contract
 
@@ -142,7 +160,7 @@ listbox, option, live-region, focus, or dismissal behavior.
 | Icon-rendered start icon      | Presents a semantic or component icon through Icon.                                                    | Icon component                 | Supporting        | FR6                |
 | Caller-rendered start content | Presents arbitrary caller content directly in the input surface's start slot.                          | Caller-supplied content        | Context-dependent | FR6                |
 | Selected token                | Presents the selected value outside edit mode through Token.                                           | Token component                | Prominent         | FR1, FR6           |
-| Spinner                       | Indicates a search in flight, at the end of the input surface.                                         | Spinner component              | Supporting        | FR6                |
+| Spinner                       | Indicates a search in flight or a busy value, at the end of the input surface.                         | Spinner component              | Supporting        | FR6                |
 | Clear button                  | Removes the selected value through the shared field clear action.                                      | Field component                | Supporting        | FR6                |
 | Dropdown                      | Paints the anchored listbox surface containing results or Empty state.                                 | Current source and public docs | Prominent         | FR2                |
 | Empty state                   | Presents the no-results message after a completed empty search.                                        | Current source and public docs | Prominent         | FR2                |
@@ -225,24 +243,29 @@ normalize targets.
 
 ## Verification map
 
-| Contract            | Verification                                                                          | Representative states                                              | Mutation or failure expectation                                                             | Audit section             |
-| ------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | ------------------------- |
-| FR1, FR6            | `Typeahead.test.tsx`, owner tests, and Typeahead composition source                   | Standalone/InputGroup, empty, editing, selected, clear, start icon | A documented composed part disappears, gains the wrong owner, or misreports Field presence. | `audit:Typeahead/anatomy` |
-| FR2                 | Source inspection, target inventories, empty-state test, and `TypeaheadItem.test.tsx` | Input, open Dropdown, empty search, default item                   | A current target is missed, invented, or documented on an element that does not carry it.   | `audit:Typeahead/theming` |
-| FR3, FR4, FR5       | BaseTypeahead source and result/group/selection tests                                 | Default/custom result, grouped result, selected row                | The record hides the outer/inner asymmetry or claims reachability that current code lacks.  | `audit:Typeahead/theming` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                                                         | Canonical anatomy and current target inventory                     | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.  | `audit:Typeahead/theming` |
+| Contract            | Verification                                                                          | Representative states                                                                | Mutation or failure expectation                                                                                                                                | Audit section                   |
+| ------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| FR1, FR6            | `Typeahead.test.tsx`, owner tests, and Typeahead composition source                   | Standalone/InputGroup, empty, editing, selected, clear, start icon                   | A documented composed part disappears, gains the wrong owner, or misreports Field presence.                                                                    | `audit:Typeahead/anatomy`       |
+| FR2                 | Source inspection, target inventories, empty-state test, and `TypeaheadItem.test.tsx` | Input, open Dropdown, empty search, default item                                     | A current target is missed, invented, or documented on an element that does not carry it.                                                                      | `audit:Typeahead/theming`       |
+| FR3, FR4, FR5       | BaseTypeahead source and result/group/selection tests                                 | Default/custom result, grouped result, selected row                                  | The record hides the outer/inner asymmetry or claims reachability that current code lacks.                                                                     | `audit:Typeahead/theming`       |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                         | Canonical anatomy and current target inventory                                       | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                                                     | `audit:Typeahead/theming`       |
+| Input busy          | `Typeahead.test.tsx` `input busy: isLoading and changeAction` suite                   | `isLoading`; pending selection or clear Action; settled; source-busy plus value-busy | A second Spinner appears, `aria-busy` drops while busy, the Action runs before `onChange`, or the proposed value survives an Action the parent did not accept. | `audit:Typeahead/accessibility` |
 
 Existing tests directly assert Empty state and TypeaheadItem target presence,
 selected-value Token behavior, result semantics, selection state, and standalone
 Field content. Source inspection confirms InputGroup's Field omission and, with
 public target inventories, provides the current Input surface and Dropdown target
 evidence. No test is represented here as proof of a target it does not directly
-assert.
+assert. The `input busy: isLoading and changeAction` suite asserts the one
+Spinner and `aria-busy` for both busy meanings, the `onChange` → `changeAction`
+order, and the optimistic value settling to the controlled `value`.
 
 ## Decision log
 
-None. This draft records current facts and introduces no component-local design,
-API, theming, or layer-system decision.
+None. `isLoading` and `changeAction` follow `family:input-fields` FR5–FR7
+rather than a component-local decision; this draft otherwise records current
+facts and introduces no component-local design, theming, or layer-system
+decision.
 
 ## Open questions
 

--- a/packages/core/src/Typeahead/Typeahead.spec.md
+++ b/packages/core/src/Typeahead/Typeahead.spec.md
@@ -9,7 +9,7 @@ superseded_by: null
 approved_by: null
 approved_at: null
 owners: [cixzhang]
-review_triggers: [theming]
+review_triggers: [public-api, behavior, theming, accessibility]
 verified_by:
   [
     packages/core/src/Typeahead/Typeahead.test.tsx,
@@ -36,25 +36,24 @@ Typeahead renders a single-selection search control with an optional standalone
 Field shell and delegates its combobox engine and popup results to BaseTypeahead. This draft records current
 consumer anatomy, target reachability, the shipped difference between the
 stable result row and its default TypeaheadItem content, and the additive
-`isLoading` and `changeAction` props adopted from the input-field family,
-without changing existing runtime behavior, styling, or targets.
+`isLoading` and `changeAction` props adopted from `family:input-fields`,
+without changing existing styling or targets.
 
 ## Compatibility and migration
 
 - Released default preserved: `yes` — `isLoading` defaults to `false` and
-  `changeAction` to unset, which renders and behaves exactly as shipped
+  `changeAction` to unset, which renders exactly as shipped
 - Compatibility class: additive; two new public props, `isLoading` and
   `changeAction`, with no change to existing targets, DOM, or styling, and
-  no change to behavior without them except the FR4 fix: a field disabled
-  with a reason no longer selects an item from the keyboard
-- `isLoading` is additive. It marks the value busy — one Spinner in the end
-  lane plus `aria-busy` on the combobox — and never means the option source is
-  pending (`spec:AST-001`). `changeAction` is additive. Before it, a selection
-  or clear only reported through `onChange`. After it, `onChange` still runs
-  first, then the Action runs inside a transition while the proposed value
-  shows as busy until the controlled `value` accepts it (`family:input-fields`
-  FR5–FR7). The clear button follows the accepted `value`, as Selector's
-  does, while the token follows the proposal.
+  no change to behavior without them except the `family:input-fields` FR4
+  fix: a field disabled with a reason no longer opens entries or selects an
+  item from the keyboard
+- Before: Typeahead had no input-busy state, and a selection or clear
+  reported only through `onChange`. After: `isLoading` marks the value busy,
+  and selection and clear also run `changeAction` in the family's FR6 order,
+  both with their `family:input-fields` meaning (FR5–FR7, DEC-2, DEC-3). The
+  clear button follows the accepted `value`, as Selector's does, while the
+  token follows the proposed item.
 - Controlled/uncontrolled behavior: unchanged
 - Migration decision: none
 
@@ -82,6 +81,9 @@ Consumer migration instructions belong in consumer docs and release notes.
   Field's current `input-clear-button` target.
 - Loading-indicator presentation — owned by `component:Spinner`. Typeahead
   decides only where the indicator sits.
+- Family-wide input state display, behavior, appearance, size, end-control,
+  status-placement, and disabled-reason policy — owned by current
+  `family:input-fields`.
 - General Icon presentation for an Icon-rendered start icon.
 - Arbitrary ReactNode start or item content supplied by the caller.
 - A target/state for the outer Result row, Result group heading, or selected-row
@@ -90,11 +92,11 @@ Consumer migration instructions belong in consumer docs and release notes.
 
 ## Public concepts
 
-`isLoading` and `changeAction` are input-field family concepts adopted from
-`family:input-fields` (FR5–FR7, DEC-2, DEC-3), not Typeahead-owned concepts.
-Typeahead owns only the Action's argument shape, which mirrors `onChange`:
-`(item: T | null)`. Search busy stays BaseTypeahead-owned; both meanings share
-the one end-lane Spinner and the combobox `aria-busy`.
+`isLoading` and `changeAction` carry their `family:input-fields` meaning
+(FR5–FR7, DEC-2, DEC-3). Typeahead adds three mappings: `changeAction`
+receives `onChange`'s `(item: T | null)` (AV4); selection and the clear
+button both run in the family's FR6 order; and input busy and BaseTypeahead's
+source busy share one end-lane Spinner and one combobox `aria-busy`.
 
 No other public concept is introduced. Consumer props and usage remain
 documented in `Typeahead.doc.mjs`; BaseTypeahead and TypeaheadItem retain their
@@ -127,15 +129,15 @@ existing public component documentation.
 
 ### Representative states
 
-| State                         | Required invariant                                                                                 | Allowed variation                                                       |
-| ----------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| Standalone or InputGroup      | Field is present only standalone; Input surface anatomy and targets remain the same in both paths. | InputGroup owns grouped layout and labeling support.                    |
-| Empty or editing              | Editable input remains inside the `typeahead` Input surface.                                       | Query, loading state, and popup visibility may vary.                    |
-| Selected and not editing      | Token owns the selected-value presentation while the input is collapsed.                           | Clear button may be present according to `hasClear` and disabled state. |
-| Results with default renderer | Outer Result row remains untargeted; inner TypeaheadItem carries `typeahead-item`.                 | Item label, icon/avatar, and description may vary.                      |
-| Results with custom renderer  | Outer Result row remains untargeted; custom content receives no `typeahead-item`.                  | Caller owns the inner result content.                                   |
-| Grouped and selected results  | Group heading and selected-row concept remain untargeted by Typeahead.                             | A generic Icon paints the selected check.                               |
-| Empty completed search        | Empty state carries `typeahead-empty-state` inside the Dropdown.                                   | Consumer-supplied empty text may vary.                                  |
+| State                         | Required invariant                                                                                 | Allowed variation                                                                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Standalone or InputGroup      | Field is present only standalone; Input surface anatomy and targets remain the same in both paths. | InputGroup owns grouped layout and labeling support.                                           |
+| Empty or editing              | Editable input remains inside the `typeahead` Input surface.                                       | Query, loading state, and popup visibility may vary.                                           |
+| Selected and not editing      | Token owns the selected-value presentation while the input is collapsed.                           | Clear button may be present according to `hasClear`, disabled state, and the accepted `value`. |
+| Results with default renderer | Outer Result row remains untargeted; inner TypeaheadItem carries `typeahead-item`.                 | Item label, icon/avatar, and description may vary.                                             |
+| Results with custom renderer  | Outer Result row remains untargeted; custom content receives no `typeahead-item`.                  | Caller owns the inner result content.                                                          |
+| Grouped and selected results  | Group heading and selected-row concept remain untargeted by Typeahead.                             | A generic Icon paints the selected check.                                                      |
+| Empty completed search        | Empty state carries `typeahead-empty-state` inside the Dropdown.                                   | Consumer-supplied empty text may vary.                                                         |
 
 ### Transformation and precedence order
 
@@ -148,8 +150,13 @@ existing public component documentation.
 
 ## Accessibility contract
 
-This draft does not change or extend Typeahead's existing field, combobox,
-listbox, option, live-region, focus, or dismissal behavior.
+This draft changes two combobox facts: `aria-busy` also reflects input busy
+(see Public concepts), and while the field is disabled with a reason the
+combobox's own key handling stops, so ArrowDown no longer opens the entries
+shown on focus and Enter no longer selects one (`family:input-fields` FR4).
+It adds no Typeahead-local accessibility requirement and does not otherwise
+change existing field, combobox, listbox, option, live-region, focus, or
+dismissal behavior.
 
 ## Design relationships
 
@@ -236,6 +243,11 @@ normalize targets.
   target mapping, delegation, and factual `none` dispositions.
 - `architecture:layer-runtime` owns the current Popover host, positioning, native
   light-dismiss, and visibility reconciliation used by the Dropdown.
+- `family:input-fields` owns family-wide state display, behavior, appearance,
+  size, end-control, disabled-reason, and status-placement policy, including
+  input busy (FR5, DEC-2) and the Transition Action (FR6, DEC-3). Typeahead
+  adopts `isLoading` and `changeAction` under those rules and keeps its search
+  lifecycle BaseTypeahead-owned per FR7.
 - `family:overlay-dismissal` owns shared Escape and platform-close ordering;
   Typeahead participates through its composed Popover owner.
 - Field, Token, and Icon retain ownership of their delegated targets and
@@ -243,27 +255,27 @@ normalize targets.
 
 ## Verification map
 
-| Contract            | Verification                                                                          | Representative states                                                                | Mutation or failure expectation                                                                                                                                | Audit section                   |
-| ------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| FR1, FR6            | `Typeahead.test.tsx`, owner tests, and Typeahead composition source                   | Standalone/InputGroup, empty, editing, selected, clear, start icon                   | A documented composed part disappears, gains the wrong owner, or misreports Field presence.                                                                    | `audit:Typeahead/anatomy`       |
-| FR2                 | Source inspection, target inventories, empty-state test, and `TypeaheadItem.test.tsx` | Input, open Dropdown, empty search, default item                                     | A current target is missed, invented, or documented on an element that does not carry it.                                                                      | `audit:Typeahead/theming`       |
-| FR3, FR4, FR5       | BaseTypeahead source and result/group/selection tests                                 | Default/custom result, grouped result, selected row                                  | The record hides the outer/inner asymmetry or claims reachability that current code lacks.                                                                     | `audit:Typeahead/theming`       |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                                                         | Canonical anatomy and current target inventory                                       | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                                                     | `audit:Typeahead/theming`       |
-| Input busy          | `Typeahead.test.tsx` `input busy: isLoading and changeAction` suite                   | `isLoading`; pending selection or clear Action; settled; source-busy plus value-busy | A second Spinner appears, `aria-busy` drops while busy, the Action runs before `onChange`, or the proposed value survives an Action the parent did not accept. | `audit:Typeahead/accessibility` |
+| Contract            | Verification                                                                          | Representative states                                                                                    | Mutation or failure expectation                                                                                                                                                                                       | Audit section                   |
+| ------------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| FR1, FR6            | `Typeahead.test.tsx`, owner tests, and Typeahead composition source                   | Standalone/InputGroup, empty, editing, selected, clear, start icon                                       | A documented composed part disappears, gains the wrong owner, or misreports Field presence.                                                                                                                           | `audit:Typeahead/anatomy`       |
+| FR2                 | Source inspection, target inventories, empty-state test, and `TypeaheadItem.test.tsx` | Input, open Dropdown, empty search, default item                                                         | A current target is missed, invented, or documented on an element that does not carry it.                                                                                                                             | `audit:Typeahead/theming`       |
+| FR3, FR4, FR5       | BaseTypeahead source and result/group/selection tests                                 | Default/custom result, grouped result, selected row                                                      | The record hides the outer/inner asymmetry or claims reachability that current code lacks.                                                                                                                            | `audit:Typeahead/theming`       |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                         | Canonical anatomy and current target inventory                                                           | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                                                                                                            | `audit:Typeahead/theming`       |
+| Input busy          | `Typeahead.test.tsx` `input busy: isLoading and changeAction` suite                   | `isLoading`; pending selection or clear Action; settled; source busy plus input busy; focusable-disabled | A second Spinner appears, `aria-busy` drops while either meaning is busy, selection or clear bypasses `family:input-fields` FR6, or a focusable-disabled field selects from the keyboard (`family:input-fields` FR4). | `audit:Typeahead/accessibility` |
 
 Existing tests directly assert Empty state and TypeaheadItem target presence,
 selected-value Token behavior, result semantics, selection state, and standalone
 Field content. Source inspection confirms InputGroup's Field omission and, with
 public target inventories, provides the current Input surface and Dropdown target
 evidence. No test is represented here as proof of a target it does not directly
-assert. The `input busy: isLoading and changeAction` suite asserts the one
-Spinner and `aria-busy` for both busy meanings, the `onChange` → `changeAction`
-order, and the optimistic value settling to the controlled `value`.
+assert. The `input busy: isLoading and changeAction` suite directly asserts
+the three mappings in Public concepts and the `family:input-fields` FR4
+keyboard block.
 
 ## Decision log
 
-None. `isLoading` and `changeAction` follow `family:input-fields` FR5–FR7
-rather than a component-local decision; this draft otherwise records current
+None. `isLoading` and `changeAction` are decided by `family:input-fields/DEC-2`
+and `family:input-fields/DEC-3`, not here; this draft otherwise records current
 facts and introduces no component-local design, theming, or layer-system
 decision.
 
@@ -277,4 +289,5 @@ decision.
 ## Content boundary
 
 This file does not duplicate consumer prop tables, examples, search algorithms,
-implementation steps, or shared layer and theming rules. It links to their owners.
+implementation steps, or shared family, layer, and theming rules. It links to
+their owners.

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -17,8 +17,17 @@ import {
   beforeAll,
   afterAll,
   beforeEach,
+  afterEach,
 } from 'vitest';
-import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
+import {Component, useState, type ReactNode} from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Profiler, type ProfilerOnRenderCallback} from 'react';
 import {Typeahead} from './Typeahead';
@@ -31,6 +40,7 @@ import {
 } from './busyIndicatorLane';
 import type {SearchSource, SearchableItem} from './types';
 import {InternationalizationProvider} from '../i18n';
+import {InputGroup, InputGroupText} from '../InputGroup';
 
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;
@@ -1944,5 +1954,959 @@ describe('the value is bounded by the content lane', () => {
     // keeps the pair from being over-constrained and dropping the end inset.
     expect(style.width).toBe('fit-content');
     expect(style.marginInlineEnd).toBe('auto');
+  });
+});
+
+describe('input busy: isLoading and changeAction', () => {
+  // The input-field family's second busy meaning (docs/families/input-fields.md,
+  // FR5–FR7): `isLoading` and a pending `changeAction` say the field VALUE is
+  // resolving or being saved. A search in flight is the other meaning, owned by
+  // BaseTypeahead. Both surface as the one Spinner in the end lane and one
+  // `aria-busy` on the combobox, never two.
+  const apple = fruits[0];
+
+  /** A source that stays in flight until the test settles it. */
+  const pendingSource = () => {
+    let settle: (items: SearchableItem[]) => void = () => {};
+    return {
+      source: {
+        search: async () =>
+          new Promise<SearchableItem[]>(resolve => {
+            settle = resolve;
+          }),
+        bootstrap: () => [],
+      },
+      settle: (items: SearchableItem[] = []) => settle(items),
+    };
+  };
+
+  const selectApple = async (input: HTMLElement) => {
+    fireEvent.change(input, {target: {value: 'App'}});
+    const option = await screen.findByRole('option', {
+      name: 'Apple',
+      hidden: true,
+    });
+    fireEvent.click(option);
+  };
+
+  const token = (container: HTMLElement) =>
+    container.querySelector('.astryx-token');
+
+  /**
+   * Every Action a test leaves pending. React entangles all async actions in
+   * one instance-wide scope (ReactFiberAsyncAction), so an Action one test
+   * never settles keeps every later test's transition from ever completing.
+   * Settling them here keeps each test's settlement its own.
+   */
+  const pendingActions: (() => void)[][] = [];
+
+  /** Settle a deferred Action and let React finish its transition. */
+  const settleAction = async (resolve: () => void) => {
+    await act(async () => {
+      resolve();
+      // A macrotask rather than a fixed count of microtask hops: two
+      // entangled Actions take more hops to settle than one.
+      await new Promise(r => setTimeout(r, 0));
+    });
+  };
+
+  /** An Action that stays pending until the test settles it, one resolver per call. */
+  const deferredAction = () => {
+    const resolvers: (() => void)[] = [];
+    pendingActions.push(resolvers);
+    const changeAction = vi.fn<(item: SearchableItem | null) => Promise<void>>(
+      async () =>
+        new Promise<void>(resolve => {
+          resolvers.push(resolve);
+        }),
+    );
+    return {changeAction, resolvers};
+  };
+
+  afterEach(async () => {
+    const outstanding = pendingActions.splice(0);
+    await settleAction(() => {
+      outstanding.flat().forEach(resolve => resolve());
+    });
+  });
+
+  it('isLoading marks the value busy without touching the search (FR5)', async () => {
+    const onChange = vi.fn();
+    render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        debounceMs={0}
+        isLoading
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    // Busy is a presentation, not a lock: the field stays editable and the
+    // source's results stay reachable and selectable.
+    expect(input).not.toBeDisabled();
+    expect(input).not.toHaveAttribute('readonly');
+
+    await selectApple(input);
+    expect(onChange).toHaveBeenCalledWith(apple);
+  });
+
+  it('changes nothing for a caller that passes neither prop', async () => {
+    const onChange = vi.fn();
+    render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(apple);
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('runs onChange first, then changeAction with the same proposed value (FR6)', async () => {
+    const order: string[] = [];
+    const onChange = vi.fn((item: SearchableItem | null) => {
+      order.push(`onChange:${item?.id}`);
+    });
+    const changeAction = vi.fn((item: SearchableItem | null) => {
+      order.push(`changeAction:${item?.id}`);
+    });
+    render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    await selectApple(screen.getByRole('combobox'));
+    await waitFor(() => {
+      expect(changeAction).toHaveBeenCalledWith(apple);
+    });
+    expect(order).toEqual(['onChange:1', 'changeAction:1']);
+  });
+
+  it('shows the proposed value and busy state until the Action settles, then yields to the prop', async () => {
+    let resolveAction: (() => void) | undefined;
+    const changeAction = vi.fn(
+      async () =>
+        new Promise<void>(resolve => {
+          resolveAction = resolve;
+        }),
+    );
+    // The parent never accepts the value: the proposed token must show while
+    // the Action is pending and give way to the prop once it settles.
+    const {container} = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    await act(async () => {
+      resolveAction?.();
+      await Promise.resolve();
+    });
+    expect(token(container)).toBeNull();
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the value once the parent accepts it', async () => {
+    let resolveAction: (() => void) | undefined;
+    const changeAction = vi.fn(
+      async () =>
+        new Promise<void>(resolve => {
+          resolveAction = resolve;
+        }),
+    );
+    function Harness() {
+      const [value, setValue] = useState<SearchableItem | null>(null);
+      return (
+        <Typeahead
+          label="Fruit"
+          searchSource={fruitSource}
+          value={value}
+          onChange={setValue}
+          changeAction={changeAction}
+          debounceMs={0}
+        />
+      );
+    }
+    const {container} = render(<Harness />);
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
+
+    await act(async () => {
+      resolveAction?.();
+      await Promise.resolve();
+    });
+    expect(token(container)).toHaveTextContent('Apple');
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('routes the clear button through the Action too (FR6, no clear-path gap)', async () => {
+    const order: string[] = [];
+    const onChange = vi.fn((item: SearchableItem | null) => {
+      order.push(`onChange:${item?.id ?? 'null'}`);
+    });
+    const changeAction = vi.fn((item: SearchableItem | null) => {
+      order.push(`changeAction:${item?.id ?? 'null'}`);
+    });
+    render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={apple}
+        onChange={onChange}
+        changeAction={changeAction}
+        hasClear
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Clear selection'}));
+    await waitFor(() => {
+      expect(changeAction).toHaveBeenCalledWith(null);
+    });
+    expect(order).toEqual(['onChange:null', 'changeAction:null']);
+  });
+
+  it('enters edit mode with the proposed value, not the stale prop', async () => {
+    const {changeAction} = deferredAction();
+    const {container} = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
+
+    fireEvent.click(token(container) as HTMLElement);
+    await waitFor(() => {
+      expect(input).toHaveValue('Apple');
+    });
+  });
+
+  it('paints one Spinner and one aria-busy when a search and the value are busy at once (FR7)', async () => {
+    const {source, settle} = pendingSource();
+    render(
+      <Typeahead
+        label="Fruit"
+        searchSource={source}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+        isLoading
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'App'}});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-busy', 'true');
+    });
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    // The search settles; the value is still busy, so the one indicator stays.
+    await act(async () => {
+      settle();
+      await Promise.resolve();
+    });
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    expect(input).toHaveAttribute('aria-busy', 'true');
+  });
+
+  /** Click the token, then wait for edit mode to seed the input with its label. */
+  const enterEditMode = async (
+    container: HTMLElement,
+    input: HTMLElement,
+    label: string,
+  ) => {
+    fireEvent.click(token(container) as HTMLElement);
+    await waitFor(() => {
+      expect(input).toHaveValue(label);
+    });
+  };
+
+  it('runs a second selection at once while the first Action is pending and stays busy until both settle', async () => {
+    const onChange = vi.fn<(item: SearchableItem | null) => void>();
+    const {changeAction, resolvers} = deferredAction();
+    const {container} = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
+
+    // Re-open from the proposed token and pick something else before the
+    // first Action has settled.
+    await enterEditMode(container, input, 'Apple');
+    fireEvent.change(input, {target: {value: 'Ban'}});
+    fireEvent.click(
+      await screen.findByRole('option', {name: 'Banana', hidden: true}),
+    );
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Banana');
+    });
+    // The second Action does not wait behind the first.
+    expect(changeAction.mock.calls.map(call => call[0])).toEqual([
+      apple,
+      fruits[1],
+    ]);
+    expect(onChange.mock.calls.map(call => call[0])).toEqual([
+      apple,
+      fruits[1],
+    ]);
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    // One of two pending Actions settling is not "settled": the latest
+    // proposal stays and so does busy.
+    await settleAction(resolvers[0]);
+    expect(token(container)).toHaveTextContent('Banana');
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    await settleAction(resolvers[1]);
+    expect(token(container)).toBeNull();
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears at once while a selection Action is still pending, running changeAction(null) immediately', async () => {
+    const {changeAction, resolvers} = deferredAction();
+    function Harness() {
+      const [value, setValue] = useState<SearchableItem | null>(null);
+      return (
+        <Typeahead
+          label="Fruit"
+          searchSource={fruitSource}
+          value={value}
+          onChange={setValue}
+          changeAction={changeAction}
+          debounceMs={0}
+          hasClear
+        />
+      );
+    }
+    const {container} = render(<Harness />);
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
+
+    fireEvent.click(screen.getByRole('button', {name: 'Clear selection'}));
+    expect(changeAction.mock.calls.map(call => call[0])).toEqual([apple, null]);
+    expect(token(container)).toBeNull();
+    expect(input).toHaveFocus();
+    // The parent accepted the clear synchronously, so nothing diverges.
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+
+    await settleAction(() => {
+      resolvers[0]();
+      resolvers[1]();
+    });
+    expect(token(container)).toBeNull();
+    expect(input).not.toHaveAttribute('aria-busy');
+  });
+
+  it('gates the clear button on the accepted value, not the proposed one, on both Action paths', async () => {
+    const {changeAction} = deferredAction();
+    // Selection path: a proposal the parent has not accepted offers no clear.
+    const first = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+        hasClear
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(first.container)).toHaveTextContent('Apple');
+    });
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(
+      screen.queryByRole('button', {name: 'Clear selection'}),
+    ).not.toBeInTheDocument();
+    // Once the parent accepts it, the clear button follows the prop.
+    first.rerender(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={apple}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+        hasClear
+      />,
+    );
+    expect(
+      screen.getByRole('button', {name: 'Clear selection'}),
+    ).toBeInTheDocument();
+    expect(input).not.toHaveAttribute('aria-busy');
+    first.unmount();
+
+    // Clear path: the token leaves with the proposal, the clear button stays
+    // with the prop (Selector parity).
+    const second = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={apple}
+        onChange={() => {}}
+        changeAction={changeAction}
+        hasClear
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Clear selection'}));
+    await waitFor(() => {
+      expect(token(second.container)).toBeNull();
+    });
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    expect(
+      screen.getByRole('button', {name: 'Clear selection'}),
+    ).toBeInTheDocument();
+  });
+
+  it('marks the proposed item selected in the listbox while its Action is pending', async () => {
+    const {changeAction} = deferredAction();
+    const {container} = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
+
+    await enterEditMode(container, input, 'Apple');
+    // Widen the query so the list holds more than the proposed item.
+    fireEvent.change(input, {target: {value: 'a'}});
+    const proposed = await screen.findByRole('option', {
+      name: 'Apple',
+      hidden: true,
+    });
+    expect(proposed).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.getByRole('option', {name: 'Banana', hidden: true}),
+    ).toHaveAttribute('aria-selected', 'false');
+    expect(input).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('holds busy while either isLoading or a pending Action is active, and releases only when both do', async () => {
+    const {changeAction, resolvers} = deferredAction();
+    const at = (isLoading: boolean) => (
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+        isLoading={isLoading}
+      />
+    );
+    const view = render(at(false));
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(view.container)).toHaveTextContent('Apple');
+    });
+    expect(input).toHaveAttribute('aria-busy', 'true');
+
+    view.rerender(at(true));
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    // The Action settles (the parent never accepted, so the proposal leaves)
+    // but isLoading still holds: still busy, still one indicator.
+    await settleAction(resolvers[0]);
+    expect(token(view.container)).toBeNull();
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    view.rerender(at(false));
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the one Spinner and aria-busy when isLoading turns off while a search is still in flight (FR7)', async () => {
+    const {source, settle} = pendingSource();
+    const at = (isLoading: boolean) => (
+      <Typeahead
+        label="Fruit"
+        searchSource={source}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+        isLoading={isLoading}
+      />
+    );
+    const view = render(at(true));
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'App'}});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-busy', 'true');
+    });
+
+    // The value settles first; the search-busy half alone keeps the indicator.
+    view.rerender(at(false));
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    await act(async () => {
+      settle();
+      await Promise.resolve();
+    });
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('restores the proposed token on Escape while the Action is pending, and none once it is withdrawn', async () => {
+    const onChange = vi.fn();
+    const {changeAction, resolvers} = deferredAction();
+    const {container} = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
+
+    // Escape in edit mode restores the pre-edit presentation: the proposed
+    // token, not the stale prop, and the Action is still the one pending.
+    await enterEditMode(container, input, 'Apple');
+    fireEvent.keyDown(input, {key: 'Escape'});
+    expect(token(container)).toHaveTextContent('Apple');
+    expect(input).toHaveAttribute('tabindex', '-1');
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(changeAction).toHaveBeenCalledTimes(1);
+
+    // Withdrawn while editing (the parent never accepted it): leaving edit
+    // mode has no token to restore and resurrects none from the edit state.
+    await enterEditMode(container, input, 'Apple');
+    await settleAction(resolvers[0]);
+    fireEvent.keyDown(input, {key: 'Escape'});
+    expect(token(container)).toBeNull();
+    expect(input).not.toHaveAttribute('tabindex', '-1');
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the proposal until the Action settles when the parent replaces the value, then shows the replacement', async () => {
+    const {changeAction, resolvers} = deferredAction();
+    const at = (value: SearchableItem | null) => (
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={value}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+      />
+    );
+    const view = render(at(null));
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await waitFor(() => {
+      expect(token(view.container)).toHaveTextContent('Apple');
+    });
+
+    // A different item from the parent mid-flight does not pre-empt the
+    // proposal; it lands when the transition finishes.
+    view.rerender(at(fruits[1]));
+    expect(token(view.container)).toHaveTextContent('Apple');
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+
+    await settleAction(resolvers[0]);
+    expect(token(view.container)).toHaveTextContent('Banana');
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+    // Edit mode reads the settled value, not a stale proposal.
+    await enterEditMode(view.container, input, 'Banana');
+  });
+
+  it('keeps busy feedback while focusable-disabled and blocks every Action path', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const changeAction = vi.fn();
+    const {container, unmount} = render(
+      <Typeahead
+        label="Assignee"
+        description="Pick a fruit"
+        status={{type: 'error', message: 'Selection required'}}
+        searchSource={fruitSource}
+        value={apple}
+        onChange={onChange}
+        changeAction={changeAction}
+        isDisabled
+        disabledMessage="You need the Editor role"
+        isLoading
+        hasClear
+        hasEntriesOnFocus
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    // Busy is presentation, not a lock, and the reason stays reachable (FR4,
+    // FR5): the combobox is perceivable, busy, and blocked, not natively
+    // disabled.
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(input).toHaveAttribute('aria-disabled', 'true');
+    expect(input).toHaveAttribute('readonly');
+    expect(input).not.toBeDisabled();
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    expect(
+      screen.queryByRole('button', {name: 'Clear selection'}),
+    ).not.toBeInTheDocument();
+    // The Spinner is never a description: description, status, reason only.
+    const tooltip = screen.getByRole('tooltip', {hidden: true});
+    expect(input.getAttribute('aria-describedby')?.split(' ')).toEqual([
+      screen.getByText('Pick a fruit').closest('[id]')?.id,
+      screen.getByText('Selection required').closest('[id]')?.id,
+      tooltip.id,
+    ]);
+
+    // A disabled token lets the pointer fall through to the field (Token
+    // sets pointer-events: none), so the click paths are the token and the
+    // field itself; the keyboard reaches the focused input.
+    fireEvent.click(token(container) as HTMLElement);
+    fireEvent.click(
+      container.querySelector('.astryx-typeahead') as HTMLElement,
+    );
+    input.focus();
+    await user.keyboard('App');
+    expect(input).toHaveValue('');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    // ArrowDown must not open the entries shown on focus, and Enter must not
+    // select one: the readOnly input still receives keys.
+    await user.keyboard('{ArrowDown}');
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 60));
+    });
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.queryByRole('option', {hidden: true}),
+    ).not.toBeInTheDocument();
+    await user.keyboard('{Enter}');
+    expect(token(container)).toHaveTextContent('Apple');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(changeAction).not.toHaveBeenCalled();
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    unmount();
+
+    // Without a reason the input is natively disabled and still busy.
+    render(
+      <Typeahead
+        label="Assignee"
+        searchSource={fruitSource}
+        value={apple}
+        onChange={onChange}
+        isDisabled
+        isLoading
+        hasClear
+      />,
+    );
+    const disabled = screen.getByRole('combobox');
+    expect(disabled).toBeDisabled();
+    expect(disabled).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getAllByRole('status', {name: 'Loading'})).toHaveLength(1);
+    expect(
+      screen.queryByRole('button', {name: 'Clear selection'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('surfaces a rejected changeAction to the nearest error boundary after onChange, without swallowing it', async () => {
+    class Boundary extends Component<
+      {children: ReactNode},
+      {error: Error | null}
+    > {
+      state: {error: Error | null} = {error: null};
+      static getDerivedStateFromError(error: Error) {
+        return {error};
+      }
+      render(): ReactNode {
+        return this.state.error ? (
+          <p>fallback: {this.state.error.message}</p>
+        ) : (
+          this.props.children
+        );
+      }
+    }
+    // React reports the caught error to the console; keep the run quiet.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const onChange = vi.fn();
+      const changeAction = vi.fn(async () => {
+        throw new Error('save failed');
+      });
+      render(
+        <Boundary>
+          <Typeahead
+            label="Fruit"
+            searchSource={fruitSource}
+            value={null}
+            onChange={onChange}
+            changeAction={changeAction}
+            debounceMs={0}
+          />
+        </Boundary>,
+      );
+      await selectApple(screen.getByRole('combobox'));
+      await waitFor(() => {
+        expect(screen.getByText('fallback: save failed')).toBeInTheDocument();
+      });
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(changeAction).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('leaves no stranded busy state after a synchronous, void-returning changeAction', async () => {
+    const seen: (SearchableItem | null)[] = [];
+    const changeAction = vi.fn((item: SearchableItem | null) => {
+      seen.push(item);
+    });
+    const {container} = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    await selectApple(input);
+    await settleAction(() => {});
+    expect(seen).toEqual([apple]);
+    // Nothing was awaited, so the transition is over: the proposal yields to
+    // the prop and the field is neither busy nor collapsed.
+    expect(token(container)).toBeNull();
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(input).not.toHaveAttribute('tabindex', '-1');
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('settles cleanly when unmounted while an Action is pending', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const uncaught = vi.fn();
+    window.addEventListener('error', uncaught);
+    try {
+      const {changeAction, resolvers} = deferredAction();
+      const {unmount} = render(
+        <Typeahead
+          label="Fruit"
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          changeAction={changeAction}
+          debounceMs={0}
+        />,
+      );
+      await selectApple(screen.getByRole('combobox'));
+      // Before the post-selection frame that focuses the token.
+      unmount();
+      await act(async () => {
+        await new Promise(r => requestAnimationFrame(r));
+      });
+      await settleAction(resolvers[0]);
+      expect(changeAction).toHaveBeenCalledTimes(1);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(uncaught).not.toHaveBeenCalled();
+      expect(document.body.querySelector('.astryx-token')).toBeNull();
+    } finally {
+      window.removeEventListener('error', uncaught);
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('names the value-busy Spinner from the provider catalog, not a hardcoded fallback', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{fr: {'@astryx.typeahead.loading': 'Chargement'}}}>
+        <Typeahead
+          label="Fruit"
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          isLoading
+        />
+      </InternationalizationProvider>,
+    );
+    expect(
+      screen.getByRole('status', {name: 'Chargement'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('status', {name: 'Loading'}),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('paints one named Spinner and aria-busy inside an InputGroup row without a nested Field', () => {
+    const {container} = render(
+      <InputGroup label="Favorite fruit">
+        <InputGroupText>Fruit</InputGroupText>
+        <Typeahead
+          label="Selection"
+          isLabelHidden
+          searchSource={fruitSource}
+          value={apple}
+          onChange={() => {}}
+          isLoading
+          hasClear
+        />
+      </InputGroup>,
+    );
+    const group = screen.getByRole('group', {name: 'Favorite fruit'});
+    const spinner = within(group).getByRole('status', {name: 'Loading'});
+    expect(
+      within(group).getAllByRole('status', {name: 'Loading'}),
+    ).toHaveLength(1);
+    expect(within(group).getByRole('combobox')).toHaveAttribute(
+      'aria-busy',
+      'true',
+    );
+    // Busy and clear stay one end lane, inside the field, on the group path.
+    const clear = within(group).getByRole('button', {name: 'Clear selection'});
+    expect(spinner.parentElement).toBe(clear.parentElement);
+    expect(
+      container.querySelector('.astryx-typeahead')?.contains(spinner),
+    ).toBe(true);
+    expect(container.querySelectorAll('.astryx-field')).toHaveLength(1);
+  });
+
+  it('does not run changeAction or show a proposed token on a composing (IME) Enter', async () => {
+    const onChange = vi.fn();
+    const {changeAction} = deferredAction();
+    const {container} = render(
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        changeAction={changeAction}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'App'}});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    // The Enter that commits an IME candidate (isComposing, or legacy
+    // keyCode 229) is not a selection: no onChange, no Action, no proposal.
+    fireEvent.keyDown(input, {key: 'Enter', isComposing: true});
+    fireEvent.keyDown(input, {key: 'Enter', keyCode: 229});
+    expect(onChange).not.toHaveBeenCalled();
+    expect(changeAction).not.toHaveBeenCalled();
+    expect(token(container)).toBeNull();
+    expect(input).not.toHaveAttribute('aria-busy');
+    expect(input).toHaveValue('App');
+
+    // A real Enter runs the whole path: onChange, then the Action, then the
+    // proposed token.
+    fireEvent.keyDown(input, {key: 'Enter'});
+    await waitFor(() => {
+      expect(changeAction).toHaveBeenCalledWith(apple);
+    });
+    expect(onChange).toHaveBeenCalledWith(apple);
+    await waitFor(() => {
+      expect(token(container)).toHaveTextContent('Apple');
+    });
   });
 });

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -1540,6 +1540,78 @@ describe('Typeahead disabledMessage', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  // Open the menu enabled, then flip to focusable-disabled — the shape of
+  // a parent disabling the field mid-save. Nothing closes the menu on the
+  // flip (auto-closing would flicker on short saves), so the dismissal
+  // keys must keep working: FR4 blocks edits, not dismissal.
+  const openMenuThenDisable = async (onChange: () => void) => {
+    const ui = (isDisabled: boolean) => (
+      <Typeahead
+        label="Assignee"
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        debounceMs={0}
+        isDisabled={isDisabled}
+        disabledMessage={isDisabled ? 'Saving your changes' : undefined}
+      />
+    );
+    const {rerender} = render(ui(false));
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.change(input, {target: {value: 'App'}});
+    });
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 50));
+    });
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    rerender(ui(true));
+    // The premise the tests below stand on: the flip itself leaves the
+    // menu open. If a future change closes it here, these tests would
+    // pass without exercising anything.
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    return input;
+  };
+
+  it('keeps Escape dismissing an already-open menu after the field turns focusable-disabled', async () => {
+    const onChange = vi.fn();
+    const input = await openMenuThenDisable(onChange);
+    // Not the input's own handler — while disabled it swallows Escape —
+    // but the shared layer stack (useLayerDismissal) routing the unclaimed
+    // press to the topmost layer. This locks that invariant: a disabled
+    // guard that also stopped propagation would break it.
+    await act(async () => {
+      fireEvent.keyDown(input, {key: 'Escape'});
+    });
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps Tab dismissing on keydown after the field turns focusable-disabled', async () => {
+    const onChange = vi.fn();
+    const input = await openMenuThenDisable(onChange);
+    // On the keydown itself, not the blur it causes: hiding a top-layer
+    // popover during focusout makes Chrome abandon the focus move and
+    // drop the keyboard user on <body>.
+    await act(async () => {
+      fireEvent.keyDown(input, {key: 'Tab'});
+    });
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores an option click after the field turns focusable-disabled', async () => {
+    const onChange = vi.fn();
+    await openMenuThenDisable(onChange);
+    // The still-open menu's options remain clickable; selection is an
+    // edit, and FR4 blocks it on the pointer path like the keyboard ones.
+    await act(async () => {
+      fireEvent.click(screen.getByText('Apple'));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('remains natively disabled when disabled without a reason', () => {
     render(
       <Typeahead

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -9,8 +9,9 @@
  * @position Styled wrapper; composes BaseTypeahead with Field or InputGroup
  *
  * Owns the input wrapper (border, padding, status styles), selected value
- * token with spacing compensation, and edit mode behavior. Delegates
- * search, keyboard navigation, and dropdown to BaseTypeahead.
+ * token with spacing compensation, edit mode behavior, and the input-field
+ * family's value-busy state (`isLoading`, `changeAction`). Delegates search,
+ * keyboard navigation, and dropdown to BaseTypeahead, which owns search-busy.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Typeahead/index.ts
@@ -24,6 +25,8 @@ import React, {
   useRef,
   useMemo,
   useState,
+  useOptimistic,
+  useTransition,
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
@@ -31,6 +34,7 @@ import {
   BusyIndicatorLaneProvider,
   createBusyIndicatorLane,
   useIsBusy,
+  InputBusyProvider,
   type BusyIndicatorLane,
 } from './busyIndicatorLane';
 import {BaseTypeahead} from './BaseTypeahead';
@@ -111,6 +115,14 @@ export interface TypeaheadProps<T extends SearchableItem> extends Omit<
   value: T | null;
   /** Callback when selection changes. */
   onChange: (item: T | null) => void;
+  /**
+   * Async action on change. Fires after `onChange` with the same proposed
+   * item and runs in a React transition: the item shows optimistically and
+   * the field is busy (Spinner and `aria-busy`) until `value` catches up.
+   * Selection and the clear button both go through it. See the input-field
+   * family contract in `docs/families/input-fields.md`.
+   */
+  changeAction?: (item: T | null) => void | Promise<void>;
   /** Render function for dropdown items. Default: TypeaheadItem. */
   renderItem?: (item: T) => ReactNode;
   /** Placeholder text. */
@@ -153,6 +165,14 @@ export interface TypeaheadProps<T extends SearchableItem> extends Omit<
    * ```
    */
   disabledMessage?: string;
+  /**
+   * Whether the field value is resolving or being saved. Shows the busy
+   * Spinner in the end lane and sets `aria-busy` on the combobox. The search
+   * source and its results are unaffected — a search in flight has its own,
+   * BaseTypeahead-owned busy state that shares the same indicator.
+   * @default false
+   */
+  isLoading?: boolean;
   /** Show clear button. @default true */
   hasClear?: boolean;
   /** Auto-focus on mount. @default false */
@@ -307,7 +327,7 @@ const wrapperSizeStyles = stylex.create({
 /**
  * The field's inline-end lane: the busy Spinner, then the clear button.
  *
- * A separate component so that subscribing to the busy state re-renders THIS
+ * A separate component so that subscribing to the search-busy state re-renders THIS
  * and nothing else. Subscribing from `Typeahead` itself would re-render the
  * whole field — and, in the Tokenizer that shares this design, every selected
  * token — twice per search for one glyph.
@@ -317,14 +337,20 @@ const wrapperSizeStyles = stylex.create({
  */
 function EndLane({
   lane,
+  isInputBusy,
   loadingLabel,
   clear,
 }: {
   lane: BusyIndicatorLane;
+  /** The field's own value-busy state; the lane carries the base's search-busy. */
+  isInputBusy: boolean;
   loadingLabel: string;
   clear: ReactNode;
 }) {
-  const isBusy = useIsBusy(lane);
+  const isSourceBusy = useIsBusy(lane);
+  // One indicator for both meanings: a search in flight and a value being
+  // resolved or saved share the Spinner rather than each painting one.
+  const isBusy = isInputBusy || isSourceBusy;
   if (!isBusy && clear == null) {
     return null;
   }
@@ -350,6 +376,7 @@ export function Typeahead<T extends SearchableItem>({
   searchSource,
   value,
   onChange,
+  changeAction,
   renderItem,
   placeholder,
   hasEntriesOnFocus,
@@ -358,6 +385,7 @@ export function Typeahead<T extends SearchableItem>({
   emptySearchResultsText,
   isDisabled = false,
   disabledMessage,
+  isLoading = false,
   hasClear = true,
   hasAutoFocus,
   size: sizeProp,
@@ -408,18 +436,43 @@ export function Typeahead<T extends SearchableItem>({
   const [isEditing, setIsEditing] = useState(false);
   const [editingValue, setEditingValue] = useState<T | null>(null);
 
-  // Show token when value is selected and not in edit mode
-  const showToken = value != null && !isEditing;
+  // The family's Transition Action: `onChange` first, the proposed item shown
+  // optimistically, the Action in a transition, and one busy presentation
+  // until `value` accepts or replaces it (input-fields.md FR6). With no
+  // `changeAction` the optimistic value never diverges from the prop.
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  // Value busy, as distinct from search busy: the base owns the latter and
+  // reports it through the lane. Both reach the one Spinner in the end lane
+  // and the combobox's aria-busy (FR5, FR7).
+  const isInputBusy = isLoading || optimisticValue !== value;
+
+  const commitValue = useCallback(
+    (item: T | null) => {
+      onChange(item);
+      if (changeAction) {
+        startTransition(async () => {
+          setOptimisticValue(item);
+          await changeAction(item);
+        });
+      }
+    },
+    [onChange, changeAction, setOptimisticValue],
+  );
+
+  // Show token when value is selected and not in edit mode. The optimistic
+  // value, so a pending Action's proposed item is what the token shows.
+  const showToken = optimisticValue != null && !isEditing;
 
   // Enter edit mode: remove token visually, populate input with value label
   const handleEnterEditMode = useCallback(() => {
-    if (isDisabled || !value) {
+    if (isDisabled || !optimisticValue) {
       return;
     }
-    setEditingValue(value);
+    setEditingValue(optimisticValue);
     setIsEditing(true);
     // The base will receive onChangeQuery with the value's label
-    onChangeQuery?.(value.label);
+    onChangeQuery?.(optimisticValue.label);
     requestAnimationFrame(() => {
       const input = inputRef.current;
       if (input) {
@@ -429,13 +482,13 @@ export function Typeahead<T extends SearchableItem>({
           window.HTMLInputElement.prototype,
           'value',
         )?.set;
-        nativeInputValueSetter?.call(input, value.label);
+        nativeInputValueSetter?.call(input, optimisticValue.label);
         input.dispatchEvent(new Event('input', {bubbles: true}));
         input.focus();
         input.setSelectionRange(0, input.value.length);
       }
     });
-  }, [isDisabled, value, onChangeQuery]);
+  }, [isDisabled, optimisticValue, onChangeQuery]);
 
   // Handle blur: restore token if editing and no selection was made
   const handleBlur = useCallback(
@@ -459,7 +512,7 @@ export function Typeahead<T extends SearchableItem>({
     (item: T | null) => {
       setIsEditing(false);
       setEditingValue(null);
-      onChange(item);
+      commitValue(item);
       // After selection, focus the token so keyboard users stay in the component.
       // Use requestAnimationFrame because the token renders on the next cycle.
       if (item) {
@@ -473,16 +526,16 @@ export function Typeahead<T extends SearchableItem>({
         });
       }
     },
-    [onChange],
+    [commitValue],
   );
 
   // Handle clear (explicit X button on token)
   const handleClear = useCallback(() => {
     setIsEditing(false);
     setEditingValue(null);
-    onChange(null);
+    commitValue(null);
     inputRef.current?.focus();
-  }, [onChange]);
+  }, [commitValue]);
 
   // Handle Escape during edit mode — restore token
   const handleKeyDown = useCallback(
@@ -570,48 +623,54 @@ export function Typeahead<T extends SearchableItem>({
             {showToken && (
               <Token
                 ref={tokenRef}
-                label={value.label}
+                label={optimisticValue.label}
                 size={size}
                 onClick={handleEnterEditMode}
                 isDisabled={isDisabled}
                 xstyle={styles.tokenOverlay}
               />
             )}
-            <BaseTypeahead
-              ref={inputRef}
-              searchSource={searchSource}
-              value={value}
-              onChange={handleChange}
-              renderItem={renderItem}
-              placeholder={showToken ? undefined : placeholder}
-              hasEntriesOnFocus={hasEntriesOnFocus}
-              maxMenuItems={maxMenuItems}
-              minQueryLength={minQueryLength}
-              emptySearchResultsText={emptySearchResultsText}
-              isDisabled={isDisabled}
-              hasAutoFocus={hasAutoFocus}
-              isFocusableDisabled={showsDisabledMessage}
-              inputId={inputId}
-              ariaDescribedBy={ariaDescribedBy}
-              ariaLabelledBy={ariaLabelledBy}
-              onChangeQuery={onChangeQuery}
-              onOpenChange={onOpenChange}
-              debounceMs={debounceMs}
-              anchorRef={wrapperRef}
-              onKeyDown={handleKeyDown}
-              inputXStyle={showToken ? styles.inputHidden : undefined}
-              // While the token is shown the input is invisible and inert behind
-              // it — take it out of the Tab order so keyboard users don't hit a
-              // stop they cannot see (WCAG 2.4.3 / 2.4.7). It stays
-              // programmatically focusable: entering edit mode and clearing both
-              // refocus it once the token goes away.
-              inputTabIndex={showToken ? -1 : undefined}
-              size={size}
-            />
+            {/* The field's half of busy travels the other way, so the
+                combobox's aria-busy covers a value being saved as well as a
+                search in flight. */}
+            <InputBusyProvider value={isInputBusy}>
+              <BaseTypeahead
+                ref={inputRef}
+                searchSource={searchSource}
+                value={optimisticValue}
+                onChange={handleChange}
+                renderItem={renderItem}
+                placeholder={showToken ? undefined : placeholder}
+                hasEntriesOnFocus={hasEntriesOnFocus}
+                maxMenuItems={maxMenuItems}
+                minQueryLength={minQueryLength}
+                emptySearchResultsText={emptySearchResultsText}
+                isDisabled={isDisabled}
+                hasAutoFocus={hasAutoFocus}
+                isFocusableDisabled={showsDisabledMessage}
+                inputId={inputId}
+                ariaDescribedBy={ariaDescribedBy}
+                ariaLabelledBy={ariaLabelledBy}
+                onChangeQuery={onChangeQuery}
+                onOpenChange={onOpenChange}
+                debounceMs={debounceMs}
+                anchorRef={wrapperRef}
+                onKeyDown={handleKeyDown}
+                inputXStyle={showToken ? styles.inputHidden : undefined}
+                // While the token is shown the input is invisible and inert behind
+                // it — take it out of the Tab order so keyboard users don't hit a
+                // stop they cannot see (WCAG 2.4.3 / 2.4.7). It stays
+                // programmatically focusable: entering edit mode and clearing both
+                // refocus it once the token goes away.
+                inputTabIndex={showToken ? -1 : undefined}
+                size={size}
+              />
+            </InputBusyProvider>
           </div>
         </BusyIndicatorLaneProvider>
         <EndLane
           lane={busyLane}
+          isInputBusy={isInputBusy}
           loadingLabel={t('@astryx.typeahead.loading')}
           clear={
             hasClear && value && !isDisabled ? (

--- a/packages/core/src/Typeahead/busyIndicatorLane.tsx
+++ b/packages/core/src/Typeahead/busyIndicatorLane.tsx
@@ -4,8 +4,8 @@
 
 /**
  * @file busyIndicatorLane.tsx
- * @input A wrapper's loading setter, provided around BaseTypeahead
- * @output Context the base uses to hand its busy state to that wrapper
+ * @input A wrapper's loading setter and its own input-busy flag, provided around BaseTypeahead
+ * @output Context the base uses to hand its busy state to that wrapper, and context the wrapper uses to hand its input-busy state to the base
  * @position Package-internal; not exported from the package entry point
  */
 
@@ -106,4 +106,29 @@ export const BusyIndicatorLaneProvider = BusyIndicatorLaneContext.Provider;
  */
 export function useBusyIndicatorLane(): BusyIndicatorLane | null {
   return use(BusyIndicatorLaneContext);
+}
+
+/**
+ * The wrapper's own input-busy state, travelling the other way.
+ *
+ * The input-field family's `isLoading` and a pending `changeAction` mean the
+ * field VALUE is resolving or being saved (`docs/families/input-fields.md`,
+ * FR5 and FR6). Only the wrapper knows that; the base owns source-busy — a
+ * search in flight — and nothing else. Both meanings still surface as one
+ * `aria-busy` on the combobox and one Spinner in the end lane, so the wrapper
+ * hands its half down through this context and the base ORs it into the
+ * attribute it already sets. The base's search lifecycle never reads it.
+ *
+ * A plain context value rather than a store entry: the wrapper already
+ * re-renders for the state that produces it (`useOptimistic` and the
+ * `isLoading` prop), and the base is its child, so nothing extra re-renders
+ * for it. False when the base is used directly.
+ */
+const InputBusyContext = createContext(false);
+InputBusyContext.displayName = 'InputBusyContext';
+
+export const InputBusyProvider = InputBusyContext.Provider;
+
+export function useIsInputBusy(): boolean {
+  return use(InputBusyContext);
 }


### PR DESCRIPTION
## What this does

Typeahead can now show that its value is busy, and can run a save step after a selection. `isLoading` marks the value as resolving or saving. `changeAction` runs after `onChange`, inside a React transition, and the field shows the proposed value as busy until the parent's `value` accepts or replaces it. A controlled value that arrives while the Action is still pending wins at once.

## Why

The input-field family contract gives every field the same two ideas: a busy value (FR5) and a Transition Action (FR6). Selector, MultiSelector, TextInput and others already have them. Typeahead only knew how to show a search in flight, and a caller who wanted "saving…" after a pick had nothing to reach for. #5941 lists this as a gap. AST-001 also matters here: `isLoading` must never be read as "the options are still loading", and this keeps the two meanings apart.

## What changed

- New optional `isLoading` prop: the end-lane Spinner shows and the combobox carries `aria-busy`. The search source and its results are untouched.
- New optional `changeAction` prop, called with the same item (or `null`) that `onChange` receives. `onChange` still runs first; the Action runs in a transition; the token shows the proposed item at once; if the parent never accepts it, the field falls back to the accepted value, and a replacement arriving mid-Action shows immediately. Clearing goes through the Action too.
- One Spinner and one `aria-busy` for both meanings: a search in flight and a busy value never show two indicators (FR7).
- The busy signal reaches the combobox through a package-internal context rather than a new public prop on BaseTypeahead, so the public surface grows by exactly these two props.
- The clear button keeps following the accepted `value`, not the proposed one, as Selector does.
- Fixes found while hardening: while the field is disabled with a reason, the focusable-disabled input still receives keys and an already-open menu stays on screen, so two edits slipped through. ArrowDown then Enter selected one of the entries shown on focus, and clicking an option in a menu still open from before the field was disabled committed it. Both are blocked now, by guards in the base combobox's keydown and selection paths that are byte-identical in the Tokenizer PR, so whichever lands second rebases clean. Dismissal is not an edit: Tab still closes that open menu on the keydown itself (skipping it would let the blur-time hide strand focus on `body` in Chrome), and Escape still closes it through the shared layer stack.
- Callers that pass neither prop see no change beyond that fix.
- Docs: prop entries, the component spec states the API delta and cites `family:input-fields` FR5–FR7 and DEC-2/DEC-3 for the shared semantics while recording only Typeahead's mappings, the family adoption table row, two Storybook stories ("Input busy", "Transition action"), and a patch changeset.

## How to see it

Storybook → Typeahead → "Input busy" and "Transition action". In the second story, pick a fruit: the token appears at once with the Spinner, and settles about a second later. Screenshots of the busy, pending and settled states follow in a comment.

## Evidence

The `input busy: isLoading and changeAction` suite has 23 tests (file total 105; a post-open review round added three focusable-disabled regression tests to the `disabledMessage` suite — Tab's keydown dismissal, the Escape invariant, and the option click on a menu left open by a mid-flight disable — each kept red under a one-line mutation; a second round rewrote the parent-replacement test so the replacement wins before the old Action resolves, and three one-line mutations of the display rule each turn a test red). The first 8 were red before the change. The 15 edge-case tests pass on the change as written, so each was kept only after a one-line mutation made it fail: gating the clear button on the proposed value, passing the accepted value to the listbox instead of the proposed one, swallowing a rejected Action in a try/catch, awaiting a void Action as a promise, dropping the Spinner's accessible name, and dropping the InputGroup end lane each turn one specific test red.

Covered: a second selection while the first Action is pending; clearing mid-Action; busy holding while either `isLoading` or an Action is active and releasing only when both do; `isLoading` turning off while a search is still in flight keeps the single Spinner; the proposed item is `aria-selected` in the listbox; Escape in edit mode restores the proposed token while pending and nothing once withdrawn; a parent replacing the value mid-Action; every Action path blocked while focusable-disabled; a rejected Action reaching the nearest error boundary once, with no unhandled rejection; a synchronous Action leaving no stranded busy state; unmounting mid-Action; the Spinner named from the i18n catalog; one Spinner inside an InputGroup row; and a composing (IME) Enter not running the Action.

Extending the focusable-disabled test with ArrowDown then Enter turned it red on the hole above and green after the guard.

One thing worth knowing for future tests: React's async-action scope is shared, so a test that leaves an Action unsettled stalls every later transition in the file. The suite now settles every deferred Action in `afterEach`.

Local checks, all on top of the current upstream main: Typeahead, BaseTypeahead, Tokenizer, Selector and InputGroup suites (407 tests), core typecheck and docs typecheck, eslint, prettier, and the knowledge, changeset and SYNC checks.

## Pre-existing behaviour seen along the way, not changed here

- When a token that has focus is withdrawn (the parent nulls the value, or an Action is not accepted), focus lands on `body`. The optimistic path behaves exactly like the existing controlled path.
- Leaving edit mode after the proposal was withdrawn keeps the injected label as the query text. Same as the existing controlled path.

## Rubric

`Triage: new API surface · non-breaking · low blast radius → deep path (the API shape is the maintainers' call; this is the shape #5941 and family FR5–FR7 ask for) · checks: §1 A1–A7/A11–A12, §3 P1–P7/P15–P18, §7 C1–C8/C11, §8 X5/X9–X12, §9 I1–I5, §3 P11–P12 · X20 changeset, §5b screenshots`

Part of #5941 (Typeahead `isLoading` + `changeAction` checkbox). The busy-context change in `busyIndicatorLane.tsx` and `BaseTypeahead.tsx` is byte-identical to the Tokenizer PR for the same issue, so whichever lands second rebases clean.

https://claude.ai/code/session_01N5RkmXVgx725F6rqZTGecR



