### PR TITLE
fix(cli): preserve coverage for exact phrase matches

### DIFF
--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -274,7 +274,7 @@ export function scoreQuery(term, tokens, candidate) {
   // of Table-related templates each match "table" and "contents" separately
   // and accumulate a higher raw score (#5239).
   if (full && full.score >= 90) {
-    return {score: full.score + 100, reason: full.reason};
+    return asFull({score: full.score + 100, reason: full.reason});
   }
 
   // Multi-word natural language: score each content token, counting only

--- a/packages/cli/api/search/search.test.mjs
+++ b/packages/cli/api/search/search.test.mjs
@@ -80,6 +80,7 @@ describe('search leaf — exact keyword phrase outranks incidental token matches
     // pushing it out of the results entirely at the default limit.
     const r = await search('table of contents', {cwd});
     expect(r.data.results[0]?.name).toBe('Outline');
+    expect(r.data.results[0]).toMatchObject({matchedTerms: 2, queryTerms: 2});
   }, SLOW);
 
   it('surfaces Outline for its own declared keyword "heading navigation", ranked first', async () => {


### PR DESCRIPTION
## What

Keep `matched` and `total` on the reserved exact-keyword scoring path.

The exact-phrase promotion introduced for #5289 returned only `score` and `reason`, while `scoreQuery` and the public search/build result contract require coverage fields on every hit. Source tests exercised ranking but the published API declaration check caught the missing fields during the v0.5.3 version PR.

This reuses the existing `asFull` helper so exact phrases report full query coverage, and pins the public result fields in the existing regression test. It belongs to the same pending release-note unit as #5289; no additional changeset is needed.

## Testing

- `pnpm exec vitest run --project node packages/cli/api/search/search.test.mjs`
- `pnpm -F @astryxdesign/cli sync:api-types`
- `pnpm -F @astryxdesign/cli typecheck:strict`
- Prettier and repository pre-commit checks