### PR TITLE
chore(changesets): add exact phrase hardening receipt

### DIFF
--- a/.changeset/cli-search-exact-keyword-phrase-ranking.md
+++ b/.changeset/cli-search-exact-keyword-phrase-ranking.md
@@ -6,4 +6,6 @@
 
 A query that exactly matches a candidate's declared keyword (or name) verbatim is now promoted to a top-tier score, so it always outranks a candidate that only coincidentally contains several of the query's individual words. Single-word queries and queries that don't exactly match a keyword are unaffected.
 
+Follow-up #6001 preserves the required coverage fields on exact-phrase results.
+
 @nynexman4464


### PR DESCRIPTION
## What

Add merged follow-up #6001 to the existing exact-keyword ranking release note as its final hardening receipt.

This preserves one release-note unit for #5289 and #6001, with no duplicate entry and no attribution change.

## Testing

- `pnpm check:changesets`
- Prettier
- repository pre-commit checks
- public scrub