### PR TITLE
fix(PowerSearch): use DateRangeInput for range values

### DIFF
--- a/.changeset/power-search-ordered-date-range.md
+++ b/.changeset/power-search-ordered-date-range.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Reuse `DateRangeInput` for PowerSearch date-range values so endpoint selection always emits an ordered range.
+
+@freddymeta

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -47,6 +47,23 @@
     }
   },
   {
+    "component": "PowerSearch",
+    "storyId": "core-powersearch--with-date-filters",
+    "dims": [
+      "D2"
+    ],
+    "setup": {
+      "click": [
+        "button:has-text(\"Created: is between\")",
+        "button[aria-label=\"Open calendar\"]"
+      ]
+    },
+    "selectors": {
+      "prev": "button[aria-label=\"Previous month\"]",
+      "next": "button[aria-label=\"Next month\"]"
+    }
+  },
+  {
     "component": "RadioList",
     "storyId": "core-radiolist--rich-content",
     "dims": [

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -274,6 +274,11 @@ const fullConfig: PowerSearchConfig = {
             isFutureAllowed: false,
           },
         },
+        {
+          key: 'between',
+          label: 'is between',
+          value: {type: 'date_range'},
+        },
       ],
     },
     {
@@ -728,10 +733,19 @@ export const WithDateFilters: Story = {
     const [filters, setFilters] = useState<PowerSearchFilter[]>([
       {
         field: 'created',
-        operator: 'after',
+        operator: 'between',
         value: {
-          type: 'date_absolute',
-          unixSeconds: Math.floor(new Date('2025-01-15').getTime() / 1000),
+          type: 'date_range',
+          value: {
+            start: {
+              type: 'ABSOLUTE',
+              unixSeconds: Date.parse('2026-01-05T00:00:00Z') / 1000,
+            },
+            end: {
+              type: 'ABSOLUTE',
+              unixSeconds: Date.parse('2026-01-07T00:00:00Z') / 1000,
+            },
+          },
         },
       },
     ]);

--- a/packages/core/src/PowerSearch/PowerSearchFilterEditor.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchFilterEditor.test.tsx
@@ -46,6 +46,13 @@ const config: PowerSearchConfig = {
       label: 'Priority',
       operators: [{key: 'equals', label: 'equals', value: {type: 'string'}}],
     },
+    {
+      key: 'created',
+      label: 'Created',
+      operators: [
+        {key: 'between', label: 'is between', value: {type: 'date_range'}},
+      ],
+    },
   ],
 };
 
@@ -60,6 +67,32 @@ const priorityFilter: PartialFilter = {
   operator: 'equals',
   value: {type: 'string', value: 'high'},
 };
+
+const dateRangeFilter: PartialFilter = {
+  field: 'created',
+  operator: 'between',
+  value: {
+    type: 'date_range',
+    value: {
+      start: {
+        type: 'ABSOLUTE',
+        unixSeconds: Date.parse('2026-01-05T00:00:00Z') / 1000,
+      },
+      end: {
+        type: 'ABSOLUTE',
+        unixSeconds: Date.parse('2026-01-07T00:00:00Z') / 1000,
+      },
+    },
+  },
+};
+
+function dateButton(date: string): HTMLButtonElement {
+  const button = document.querySelector(`button[data-date="${date}"]`);
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected calendar button for ${date}`);
+  }
+  return button;
+}
 
 function valueInput(): HTMLInputElement {
   return screen.getByRole('textbox', {name: 'Value'});
@@ -189,6 +222,46 @@ describe('PowerSearchFilterEditor', () => {
       field: 'status',
       operator: 'is',
       value: {type: 'string', value: 'closed'},
+    });
+  });
+
+  it('saves an ordered date range after reverse endpoint selection', () => {
+    const onSave = vi.fn();
+    render(
+      <PowerSearchFilterEditor
+        config={config}
+        filter={dateRangeFilter}
+        mode="edit"
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole('button', {name: 'Open calendar'})).toHaveLength(
+      1,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Open calendar'}));
+    fireEvent.click(dateButton('2026-01-20'));
+    fireEvent.click(dateButton('2026-01-10'));
+    fireEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith({
+      field: 'created',
+      operator: 'between',
+      value: {
+        type: 'date_range',
+        value: {
+          start: {
+            type: 'ABSOLUTE',
+            unixSeconds: Date.parse('2026-01-10T00:00:00Z') / 1000,
+          },
+          end: {
+            type: 'ABSOLUTE',
+            unixSeconds: Date.parse('2026-01-20T00:00:00Z') / 1000,
+          },
+        },
+      },
     });
   });
 

--- a/packages/core/src/PowerSearch/PowerSearchFilterEditor.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchFilterEditor.test.tsx
@@ -265,6 +265,56 @@ describe('PowerSearchFilterEditor', () => {
     });
   });
 
+  it('saves an ordered date range after keyboard endpoint selection and Apply', () => {
+    const onSave = vi.fn();
+    render(
+      <PowerSearchFilterEditor
+        config={config}
+        filter={dateRangeFilter}
+        mode="edit"
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: 'Open calendar'}));
+
+    const later = dateButton('2026-01-20');
+    later.focus();
+    fireEvent.keyDown(later, {key: 'Enter'});
+    expect(onSave).not.toHaveBeenCalled();
+    // jsdom does not synthesize the native button click from Enter.
+    fireEvent.click(later);
+
+    const earlier = dateButton('2026-01-10');
+    earlier.focus();
+    fireEvent.keyDown(earlier, {key: 'Enter'});
+    expect(onSave).not.toHaveBeenCalled();
+    fireEvent.click(earlier);
+
+    expect(onSave).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave).toHaveBeenCalledWith({
+      field: 'created',
+      operator: 'between',
+      value: {
+        type: 'date_range',
+        value: {
+          start: {
+            type: 'ABSOLUTE',
+            unixSeconds: Date.parse('2026-01-10T00:00:00Z') / 1000,
+          },
+          end: {
+            type: 'ABSOLUTE',
+            unixSeconds: Date.parse('2026-01-20T00:00:00Z') / 1000,
+          },
+        },
+      },
+    });
+  });
+
   it('forwards onCancel to the cancel action', () => {
     const onCancel = vi.fn();
     render(

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file PowerSearchValueEditor.test.tsx
  * @input Uses vitest, @testing-library/react, PowerSearchValueEditor
- * @output Unit tests for PowerSearch editor bugs #1103, #1106, #1107
+ * @output Unit tests for PowerSearch value editors, including date-range ordering
  * @position Testing; validates PowerSearchValueEditor.tsx
  */
 
@@ -246,9 +246,125 @@ describe('numeric editor commit timing', () => {
   });
 });
 
-// =============================================================================
-// #1106 — EntityListEditor drops photo, no renderItem
-// =============================================================================
+describe('DateRangeEditor', () => {
+  it('uses one ordered range picker for reverse endpoint selection', () => {
+    const onChange = vi.fn();
+    render(
+      <PowerSearchValueEditor
+        operatorValue={{type: 'date_range'}}
+        filterValue={{
+          type: 'date_range',
+          value: {
+            start: {
+              type: 'ABSOLUTE',
+              unixSeconds: Date.parse('2026-01-05T00:00:00Z') / 1000,
+            },
+            end: {
+              type: 'ABSOLUTE',
+              unixSeconds: Date.parse('2026-01-07T00:00:00Z') / 1000,
+            },
+          },
+        }}
+        onChange={onChange}
+        config={stubConfig}
+      />,
+    );
+
+    const calendarTriggers = screen.getAllByRole('button', {
+      name: 'Open calendar',
+    });
+    expect(calendarTriggers).toHaveLength(1);
+    fireEvent.click(calendarTriggers[0]);
+
+    const later = document.querySelector<HTMLButtonElement>(
+      'button[data-date="2026-01-20"]',
+    );
+    const earlier = document.querySelector<HTMLButtonElement>(
+      'button[data-date="2026-01-10"]',
+    );
+    expect(later).not.toBeNull();
+    expect(earlier).not.toBeNull();
+    fireEvent.click(later!);
+    fireEvent.click(earlier!);
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: 'date_range',
+      value: {
+        start: {
+          type: 'ABSOLUTE',
+          unixSeconds: Date.parse('2026-01-10T00:00:00Z') / 1000,
+        },
+        end: {
+          type: 'ABSOLUTE',
+          unixSeconds: Date.parse('2026-01-20T00:00:00Z') / 1000,
+        },
+      },
+    });
+  });
+
+  it('renders an absolute-to-now range without changing the filter', () => {
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValue(Date.parse('2026-01-20T12:00:00Z'));
+    const onChange = vi.fn();
+    try {
+      render(
+        <PowerSearchValueEditor
+          operatorValue={{type: 'date_range'}}
+          filterValue={{
+            type: 'date_range',
+            value: {
+              start: {
+                type: 'ABSOLUTE',
+                unixSeconds: Date.parse('2026-01-05T00:00:00Z') / 1000,
+              },
+              end: {type: 'NOW'},
+            },
+          }}
+          onChange={onChange}
+          config={stubConfig}
+        />,
+      );
+
+      expect(
+        screen.getByRole('button', {name: /^date range:/i}),
+      ).toHaveTextContent('Jan 5 – Jan 20');
+      expect(onChange).not.toHaveBeenCalled();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('renders a relative-to-now range without changing the filter', () => {
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValue(Date.parse('2026-01-20T12:00:00Z'));
+    const onChange = vi.fn();
+    try {
+      render(
+        <PowerSearchValueEditor
+          operatorValue={{type: 'date_range'}}
+          filterValue={{
+            type: 'date_range',
+            value: {
+              start: {type: 'RELATIVE', backValue: 10, unit: 'day'},
+              end: {type: 'NOW'},
+            },
+          }}
+          onChange={onChange}
+          config={stubConfig}
+        />,
+      );
+
+      expect(
+        screen.getByRole('button', {name: /^date range:/i}),
+      ).toHaveTextContent('Jan 10 – Jan 20');
+      expect(onChange).not.toHaveBeenCalled();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});
 
 describe('EntityListEditor (#1106)', () => {
   const entitiesWithPhoto: PowerSearchEntity[] = [

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -40,6 +40,7 @@ import {
 } from '../NumberInput/numberInputCommit';
 import {DateInput} from '../DateInput';
 import {DateRangeInput, type DateRange} from '../DateRangeInput';
+import {resolveDateTimeRangePart} from './resolveDateTimeRangePart';
 import {TimeInput} from '../TimeInput';
 import {Selector} from '../Selector';
 import {Tokenizer} from '../Tokenizer';
@@ -85,33 +86,11 @@ function enumItemsToSearchableItems(
   }));
 }
 
-function resolveDateRangePart(
-  part: DateTimeRangePart,
-  nowSeconds: number,
-): number {
-  if (part.type === 'NOW') {
-    return nowSeconds;
-  }
-  if (part.type === 'ABSOLUTE') {
-    return part.unixSeconds;
-  }
-  const secondsByUnit = {
-    second: 1,
-    minute: 60,
-    hour: 3600,
-    day: 86400,
-    week: 604800,
-    month: 2592000,
-    year: 31536000,
-  } as const;
-  return nowSeconds - part.backValue * secondsByUnit[part.unit];
-}
-
 function dateRangePartToISO(
   part: DateTimeRangePart,
   nowSeconds: number,
 ): ISODateString {
-  return new Date(resolveDateRangePart(part, nowSeconds) * 1000)
+  return new Date(resolveDateTimeRangePart(part, nowSeconds) * 1000)
     .toISOString()
     .split('T')[0] as ISODateString;
 }
@@ -513,7 +492,7 @@ function DateRangeEditor({
       return null;
     }
     const {start, end} = filterValue.value;
-    const nowSeconds = Math.floor(Date.now() / 1000);
+    const nowSeconds = Date.now() / 1000;
     return {
       start: dateRangePartToISO(start, nowSeconds),
       end: dateRangePartToISO(end, nowSeconds),

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -24,6 +24,7 @@ import type {
   FilterValue,
   EnumItem,
   PowerSearchEntity,
+  DateTimeRangePart,
 } from './types';
 import type {InternalConfig} from './useInternalConfig';
 import type {SearchableItem, SearchSource} from '../Typeahead/types';
@@ -38,6 +39,7 @@ import {
   type NumberInputCommitDecision,
 } from '../NumberInput/numberInputCommit';
 import {DateInput} from '../DateInput';
+import {DateRangeInput, type DateRange} from '../DateRangeInput';
 import {TimeInput} from '../TimeInput';
 import {Selector} from '../Selector';
 import {Tokenizer} from '../Tokenizer';
@@ -81,6 +83,37 @@ function enumItemsToSearchableItems(
     id: item.value,
     label: item.label,
   }));
+}
+
+function resolveDateRangePart(
+  part: DateTimeRangePart,
+  nowSeconds: number,
+): number {
+  if (part.type === 'NOW') {
+    return nowSeconds;
+  }
+  if (part.type === 'ABSOLUTE') {
+    return part.unixSeconds;
+  }
+  const secondsByUnit = {
+    second: 1,
+    minute: 60,
+    hour: 3600,
+    day: 86400,
+    week: 604800,
+    month: 2592000,
+    year: 31536000,
+  } as const;
+  return nowSeconds - part.backValue * secondsByUnit[part.unit];
+}
+
+function dateRangePartToISO(
+  part: DateTimeRangePart,
+  nowSeconds: number,
+): ISODateString {
+  return new Date(resolveDateRangePart(part, nowSeconds) * 1000)
+    .toISOString()
+    .split('T')[0] as ISODateString;
 }
 
 // =============================================================================
@@ -475,85 +508,48 @@ function DateRangeEditor({
   onChange: (value: FilterValue) => void;
 }) {
   const t = useTranslator();
-  const startValue = useMemo(() => {
+  const currentValue = useMemo<DateRange | null>(() => {
     if (filterValue?.type !== 'date_range') {
-      return undefined;
+      return null;
     }
-    const part = filterValue.value.start;
-    if (part.type === 'ABSOLUTE') {
-      return new Date(part.unixSeconds * 1000)
-        .toISOString()
-        .split('T')[0] as ISODateString;
-    }
-    return undefined;
+    const {start, end} = filterValue.value;
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    return {
+      start: dateRangePartToISO(start, nowSeconds),
+      end: dateRangePartToISO(end, nowSeconds),
+    };
   }, [filterValue]);
 
-  const endValue = useMemo(() => {
-    if (filterValue?.type !== 'date_range') {
-      return undefined;
-    }
-    const part = filterValue.value.end;
-    if (part.type === 'ABSOLUTE') {
-      return new Date(part.unixSeconds * 1000)
-        .toISOString()
-        .split('T')[0] as ISODateString;
-    }
-    return undefined;
-  }, [filterValue]);
-
-  const handleStartChange = useCallback(
-    (value: string | undefined) => {
-      const startUnix = value
-        ? Math.floor(new Date(value).getTime() / 1000)
-        : 0;
-      const existingEnd =
-        filterValue?.type === 'date_range'
-          ? filterValue.value.end
-          : {type: 'NOW' as const};
+  const handleChange = useCallback(
+    (range: DateRange | null) => {
+      if (range == null) {
+        return;
+      }
       onChange({
         type: 'date_range',
         value: {
-          start: {type: 'ABSOLUTE', unixSeconds: startUnix},
-          end: existingEnd,
+          start: {
+            type: 'ABSOLUTE',
+            unixSeconds: Date.parse(`${range.start}T00:00:00Z`) / 1000,
+          },
+          end: {
+            type: 'ABSOLUTE',
+            unixSeconds: Date.parse(`${range.end}T00:00:00Z`) / 1000,
+          },
         },
       });
     },
-    [filterValue, onChange],
-  );
-
-  const handleEndChange = useCallback(
-    (value: string | undefined) => {
-      const endUnix = value ? Math.floor(new Date(value).getTime() / 1000) : 0;
-      const existingStart =
-        filterValue?.type === 'date_range'
-          ? filterValue.value.start
-          : {type: 'NOW' as const};
-      onChange({
-        type: 'date_range',
-        value: {
-          start: existingStart,
-          end: {type: 'ABSOLUTE', unixSeconds: endUnix},
-        },
-      });
-    },
-    [filterValue, onChange],
+    [onChange],
   );
 
   return (
-    <>
-      <DateInput
-        label={t('@astryx.powersearch.valueEditor.startDate')}
-        isLabelHidden
-        value={startValue}
-        onChange={handleStartChange}
-      />
-      <DateInput
-        label={t('@astryx.powersearch.valueEditor.endDate')}
-        isLabelHidden
-        value={endValue}
-        onChange={handleEndChange}
-      />
-    </>
+    <DateRangeInput
+      label={t('@astryx.powersearch.valueEditor.dateRange')}
+      isLabelHidden
+      value={currentValue}
+      onChange={handleChange}
+      hasClear={false}
+    />
   );
 }
 

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -542,14 +542,24 @@ function DateRangeEditor({
     [onChange],
   );
 
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    // DateRangeInput owns an inner popover. Its Enter activation must not reach
+    // the parent PowerSearch shortcut before the focused button's click runs.
+    if (event.key === 'Enter') {
+      event.stopPropagation();
+    }
+  }, []);
+
   return (
-    <DateRangeInput
-      label={t('@astryx.powersearch.valueEditor.dateRange')}
-      isLabelHidden
-      value={currentValue}
-      onChange={handleChange}
-      hasClear={false}
-    />
+    <div onKeyDown={handleKeyDown}>
+      <DateRangeInput
+        label={t('@astryx.powersearch.valueEditor.dateRange')}
+        isLabelHidden
+        value={currentValue}
+        onChange={handleChange}
+        hasClear={false}
+      />
+    </div>
   );
 }
 

--- a/packages/core/src/PowerSearch/resolveDateTimeRangePart.test.ts
+++ b/packages/core/src/PowerSearch/resolveDateTimeRangePart.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {resolveDateTimeRangePart} from './resolveDateTimeRangePart';
+
+const NOW_SECONDS = 2_000_000_000.75;
+
+describe('resolveDateTimeRangePart', () => {
+  it('resolves NOW from the supplied evaluation time', () => {
+    expect(resolveDateTimeRangePart({type: 'NOW'}, NOW_SECONDS)).toBe(
+      2_000_000_000,
+    );
+  });
+
+  it('preserves an absolute timestamp', () => {
+    expect(
+      resolveDateTimeRangePart(
+        {type: 'ABSOLUTE', unixSeconds: 1_700_000_000},
+        NOW_SECONDS,
+      ),
+    ).toBe(1_700_000_000);
+  });
+
+  it.each([
+    ['second', 1],
+    ['minute', 60],
+    ['hour', 3_600],
+    ['day', 86_400],
+    ['week', 604_800],
+    ['month', 2_592_000],
+    ['year', 31_536_000],
+  ] as const)('resolves relative %s values', (unit, seconds) => {
+    expect(
+      resolveDateTimeRangePart(
+        {type: 'RELATIVE', backValue: 2, unit},
+        NOW_SECONDS,
+      ),
+    ).toBe(Math.floor(NOW_SECONDS - 2 * seconds));
+  });
+});

--- a/packages/core/src/PowerSearch/resolveDateTimeRangePart.ts
+++ b/packages/core/src/PowerSearch/resolveDateTimeRangePart.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file resolveDateTimeRangePart.ts
+ * @input DateTimeRangePart and an optional shared evaluation time
+ * @output Resolves absolute, now, and relative range parts to Unix seconds
+ * @position Internal PowerSearch date-range utility; shared by filtering and editing
+ */
+
+import type {DateTimeRangePart} from './types';
+
+const SECONDS_BY_UNIT = {
+  second: 1,
+  minute: 60,
+  hour: 3600,
+  day: 86400,
+  week: 604800,
+  month: 2592000,
+  year: 31536000,
+} as const;
+
+/** Resolves a range part against one caller-supplied instant. */
+export function resolveDateTimeRangePart(
+  part: DateTimeRangePart,
+  nowSeconds = Date.now() / 1000,
+): number {
+  switch (part.type) {
+    case 'NOW':
+      return Math.floor(nowSeconds);
+    case 'ABSOLUTE':
+      return part.unixSeconds;
+    case 'RELATIVE':
+      return Math.floor(
+        nowSeconds - part.backValue * SECONDS_BY_UNIT[part.unit],
+      );
+  }
+}

--- a/packages/core/src/PowerSearch/usePowerSearchConfig.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchConfig.test.ts
@@ -7,7 +7,7 @@
  * @position Testing; validates usePowerSearchConfig.ts
  */
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import {createPowerSearchConfig} from './usePowerSearchConfig';
 import type {InferData} from './usePowerSearchConfig';
 import type {PowerSearchFilter} from './types';
@@ -475,6 +475,31 @@ describe('applyFilters', () => {
         data,
       );
       expect(result).toHaveLength(4);
+    });
+
+    it('resolves both endpoints against one evaluation instant', () => {
+      const nowSpy = vi
+        .spyOn(Date, 'now')
+        .mockReturnValue(1_700_100_000 * 1000);
+      try {
+        const result = applyFilters(
+          [
+            filter('createdAt', 'between', {
+              type: 'date_range',
+              value: {
+                start: {type: 'RELATIVE', backValue: 2, unit: 'day'},
+                end: {type: 'NOW'},
+              },
+            }),
+          ],
+          data.slice(0, 1),
+        );
+
+        expect(result).toHaveLength(1);
+        expect(nowSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/core/src/PowerSearch/usePowerSearchConfig.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchConfig.ts
@@ -11,13 +11,13 @@
 
 import {useMemo} from 'react';
 import type {
-  DateTimeRangePart,
   EnumItem,
   PowerSearchConfig,
   PowerSearchField,
   PowerSearchFilter,
   PowerSearchOperator,
 } from './types';
+import {resolveDateTimeRangePart} from './resolveDateTimeRangePart';
 
 // =============================================================================
 // Public Types
@@ -390,28 +390,6 @@ function toStringValues(value: unknown): string[] | null {
   return null;
 }
 
-function resolveRangePart(part: DateTimeRangePart): number {
-  switch (part.type) {
-    case 'NOW':
-      return Math.floor(Date.now() / 1000);
-    case 'ABSOLUTE':
-      return part.unixSeconds;
-    case 'RELATIVE': {
-      const now = Date.now() / 1000;
-      const multipliers: Record<string, number> = {
-        second: 1,
-        minute: 60,
-        hour: 3600,
-        day: 86400,
-        week: 604800,
-        month: 2592000,
-        year: 31536000,
-      };
-      return Math.floor(now - part.backValue * (multipliers[part.unit] ?? 0));
-    }
-  }
-}
-
 function matchesFilter(
   row: Record<string, unknown>,
   filter: PowerSearchFilter,
@@ -481,8 +459,12 @@ function matchesFilter(
       }
       const ts = toUnixSeconds(fieldValue);
       if (operator === DateOps.BETWEEN) {
-        const start = resolveRangePart(filterValue.value.start);
-        const end = resolveRangePart(filterValue.value.end);
+        const nowSeconds = Date.now() / 1000;
+        const start = resolveDateTimeRangePart(
+          filterValue.value.start,
+          nowSeconds,
+        );
+        const end = resolveDateTimeRangePart(filterValue.value.end, nowSeconds);
         return ts >= start && ts <= end;
       }
       return true;


### PR DESCRIPTION
## Summary

- replace PowerSearch's two independent date inputs with the existing `DateRangeInput`
- preserve PowerSearch's absolute, NOW, and relative range semantics while keeping the UTC timestamp wire format
- add a date-range Storybook case and regression coverage for reverse endpoint selection

Fixes #6003.

## Why

`DateRangeInput` already owns ordered range selection, including the reverse-click case. Reusing it removes the second range-selection mechanism that allowed `end < start`.

Existing ABSOLUTE/NOW/RELATIVE filter values are resolved only for the editor display. The stored filter is unchanged until the user selects a new range.

## Test plan

- `pnpm exec vitest run packages/core/src/PowerSearch/PowerSearchValueEditor.test.tsx packages/core/src/DateRangeInput packages/core/src/Calendar` — 255 passed
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm lint:strict`
- `pnpm build`
- `pnpm -F @astryxdesign/storybook build`
- Chromium Storybook: exactly one calendar trigger; selecting Jan 20 then Jan 10 rendered `Jan 10 – Jan 20` and announced the ordered selected range
- Independent delta review verified ABSOLUTE→NOW and RELATIVE→NOW render without invoking `onChange`

`pnpm test` did not finish cleanly locally: eight failures were outside the touched surface. Five reproduced on clean `origin/main` (ContextMenu, score-ledger, and local-server/proxy tests); three CLI tests passed in isolation on `main` but timed out only under full-suite load. Related coverage above is green; CI remains authoritative.