### PR TITLE
fix(ci): keep failed PR evidence from reddening main

### DIFF
--- a/.github/scripts/visual-gate/workflow-concurrency.test.mjs
+++ b/.github/scripts/visual-gate/workflow-concurrency.test.mjs
@@ -238,6 +238,47 @@ describe('visual acceptance workflow concurrency', () => {
     );
   });
 
+  it('skips trusted visual evidence work when source CI fails', () => {
+    const value = workflow('pr-comment.yml');
+    const guardedSteps = [
+      [
+        'Download Storybook for trusted visual capture',
+        'Cross-check artifact identity',
+      ],
+      [
+        'Fetch the trusted visual baseline',
+        'Capture the trusted stable visual scope',
+      ],
+      [
+        'Capture the trusted stable visual scope',
+        'Derive trusted broad visual deferral',
+      ],
+      [
+        'Derive trusted broad visual deferral',
+        'The Storybook bundle is untrusted',
+      ],
+      [
+        'Derive trusted visual evidence and report',
+        'Resolve trusted visual evidence path',
+      ],
+      [
+        'Resolve trusted visual evidence path',
+        'Publish immutable visual evidence',
+      ],
+    ];
+
+    for (const [name, next] of guardedSteps) {
+      const start = value.indexOf(`      - name: ${name}`);
+      const end = value.indexOf(next, start + 1);
+      expect(start, `${name} start`).toBeGreaterThan(-1);
+      expect(end, `${name} end`).toBeGreaterThan(start);
+      const step = value.slice(start, end);
+      expect(step, name).toContain(
+        "steps.identity.outputs.source_conclusion == 'success'",
+      );
+    }
+  });
+
   it('uses the documented collaborator permission response shape', () => {
     const value = workflow('visual-acceptance.yml');
     const authorize = value.slice(

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -405,6 +405,7 @@ jobs:
       - name: Download Storybook for trusted visual capture
         if: >-
           steps.identity.outputs.valid == 'true' &&
+          steps.identity.outputs.source_conclusion == 'success' &&
           steps.scope.outputs.stable == 'true' &&
           steps.scope.outputs.broad != 'true'
         uses: actions/download-artifact@v8
@@ -440,7 +441,10 @@ jobs:
           NODE
 
       - name: Fetch the trusted visual baseline
-        if: steps.identity.outputs.valid == 'true' && steps.scope.outputs.stable == 'true'
+        if: >-
+          steps.identity.outputs.valid == 'true' &&
+          steps.identity.outputs.source_conclusion == 'success' &&
+          steps.scope.outputs.stable == 'true'
         run: |
           rm -rf /tmp/gh-pages
           git clone --depth=1 --single-branch --branch gh-pages \
@@ -449,6 +453,7 @@ jobs:
       - name: Capture the trusted stable visual scope
         if: >-
           steps.identity.outputs.valid == 'true' &&
+          steps.identity.outputs.source_conclusion == 'success' &&
           steps.scope.outputs.stable == 'true' &&
           steps.scope.outputs.broad != 'true'
         env:
@@ -472,6 +477,7 @@ jobs:
       - name: Derive trusted broad visual deferral
         if: >-
           steps.identity.outputs.valid == 'true' &&
+          steps.identity.outputs.source_conclusion == 'success' &&
           steps.scope.outputs.stable == 'true' &&
           steps.scope.outputs.broad == 'true'
         env:
@@ -498,6 +504,7 @@ jobs:
       - name: Derive trusted visual evidence and report
         if: >-
           steps.identity.outputs.valid == 'true' &&
+          steps.identity.outputs.source_conclusion == 'success' &&
           steps.scope.outputs.stable == 'true' &&
           steps.scope.outputs.broad != 'true'
         env:
@@ -520,6 +527,7 @@ jobs:
         id: visual
         if: >-
           steps.identity.outputs.valid == 'true' &&
+          steps.identity.outputs.source_conclusion == 'success' &&
           steps.scope.outputs.stable == 'true'
         env:
           PR_NUMBER: ${{ steps.identity.outputs.pr_number }}


### PR DESCRIPTION
## Why

`PR Comment` is a trusted `workflow_run` projector. GitHub attributes those runs to the current default-branch SHA, so a source PR CI failure must be reported on the PR without turning the projector run red on `main`.

When source CI failed before Storybook upload, the projector still attempted trusted visual capture, failed on the missing artifact, and made `main` appear broken.

## What

Skip artifact-dependent visual evidence work unless the source CI conclusion is `success`. Comment reconciliation and publication of the PR-head `visual-acceptance` status still run, so failed source CI remains visible where it belongs.

## Testing

- `pnpm vitest run .github/scripts/visual-gate/workflow-concurrency.test.mjs --project node --maxWorkers=1`
- `pnpm lint`
- `git diff --check`

The new regression test failed before the workflow guard and passes after it.