### PR TITLE
docs: Fix docsite URL in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ serves the edited source, so the story updates on save — no rebuild, no restar
 ### Running the Doc Site
 
 The doc site (`apps/docsite/`) is a Next.js app that renders the component
-documentation at https://astryx.dev. To run it locally:
+documentation at https://astryx.atmeta.com. To run it locally:
 
 ```bash
 # First time only — build the workspace packages it depends on


### PR DESCRIPTION
## Summary                                                                                                  
Updates the docsite URL in CONTRIBUTING.md from `https://astryx.dev` to [https://astryx.atmeta.com](https://astryx.atmeta.com).
Keeps the contributor setup docs aligned with the root README and docsite deployment docs.               
                                                                                                            
## Why
The contributor guide still points to the old docsite URL, while the rest of the repository uses `https://astryx.atmeta.com`.                                                                               
                                                                                                            
## Scope                                                                                                    
Documentation only.                                                                                      
                                                                                                            
## Verification                                                                                             
Documentation-only change.                                                                               
No Changeset: root contributor documentation only, no published package behavior changed.