### PR TITLE
Add optional Selector trigger indicator

### DIFF
--- a/.changeset/selector-trigger-indicator.md
+++ b/.changeset/selector-trigger-indicator.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[component] Add `triggerIndicator` to Selector so callers can omit the editable trigger's disclosure chevron without changing interaction, accessibility, or status behavior.
+
+@nikackermann

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -65,6 +65,12 @@ const meta: Meta<typeof Selector> = {
       options: ['input', 'ghost'],
       description: 'Visual trigger style',
     },
+    triggerIndicator: {
+      control: 'radio',
+      options: ['chevron', 'none'],
+      description:
+        'Disclosure indicator shown at the end of an editable trigger',
+    },
     placement: {
       control: 'select',
       options: ['above', 'below', 'start', 'end'],
@@ -152,6 +158,21 @@ export const ReadOnly: Story = {
     hasSearch: true,
     htmlName: 'owner',
     isReadOnly: true,
+  },
+};
+
+export const WithoutTriggerIndicator: Story = {
+  render: () => {
+    const [value, setValue] = useState('In progress');
+    return (
+      <Selector
+        label="Status"
+        options={['Open', 'In progress', 'Done']}
+        value={value}
+        onChange={setValue}
+        triggerIndicator="none"
+      />
+    );
   },
 };
 

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -42,7 +42,7 @@ const anatomy = [
     name: 'Indicator icon',
     required: false,
     description:
-      'Trailing chevron shown when status presentation does not replace it; reflects collapsed or expanded state.',
+      'Optional trailing chevron shown when status presentation does not replace it; reflects collapsed or expanded state.',
   },
   {
     name: 'Search row',
@@ -253,6 +253,13 @@ export const docs = {
       description:
         'Visual trigger style. input is the bordered input treatment for forms; ghost is borderless and matches ghost buttons for toolbar usage.',
       default: "'input'",
+    },
+    {
+      name: 'triggerIndicator',
+      type: "'chevron' | 'none'",
+      description:
+        'Disclosure indicator shown at the end of an editable trigger. none removes only the chevron; popup semantics, keyboard behavior, and status icons are unchanged.',
+      default: "'chevron'",
     },
     {
       name: 'isDisabled',

--- a/packages/core/src/Selector/Selector.spec.md
+++ b/packages/core/src/Selector/Selector.spec.md
@@ -51,6 +51,9 @@ connection between the closed trigger and its selection surface.
 - `isReadOnly` is additive and defaults to `false`. It preserves the selected
   value, focus, and form participation while removing selection-surface and
   editing affordances. `isDisabled` takes precedence when both are set.
+- `triggerIndicator` is additive and defaults to `chevron`. `none` removes only
+  the editable trigger's disclosure chevron; interaction and accessibility
+  behavior remain unchanged.
 - `spec:AST-004/DEC-1` accepts a future change that collapses an empty indicator
   column. It is not shipped behavior and does not replace FR3 until implementation,
   visual verification, and an update to this current contract land together.
@@ -89,6 +92,7 @@ and examples remain in `Selector.doc.mjs`.
 | popup semantics        | `listbox`; modal dialog containing one | Semantics follow the active presentation                 | Popover; bottom sheet                     | `listbox` | Selector | released  | No separate role prop is public |
 | option-row state       | `selected`, `disabled`                 | Stable theming state on each option row                  | Every rendered option                     | neither   | Selector | released  | Unknown states are not emitted  |
 | read-only state        | `false`, `true`                        | Preserves and submits value without selection affordance | Closed trigger                            | `false`   | Caller   | additive  | Boolean normalization           |
+| trigger indicator      | `chevron`, `none`                      | Shows or omits the editable trigger's disclosure chevron | Editable closed trigger                   | `chevron` | Caller   | additive  | TypeScript rejects other values |
 
 ## Behavioral and layout contract
 
@@ -102,6 +106,7 @@ These requirements describe shipped behavior on current `main`.
 | FR4 | `popover` uses an anchored Popover. `bottom-sheet` uses a modal BottomSheet. `adaptive` resolves to the modal bottom sheet on compact coarse-pointer screens and Popover otherwise.                               | Presentation controller and adaptive-presentation tests     |
 | FR5 | While `isLoading` is true, the trigger exposes busy state and the listbox suppresses empty and no-results output.                                                                                                 | Loading, empty-state, and announcement tests                |
 | FR6 | While `isReadOnly` is true, the selected value remains focusable and form-submittable, while the selection surface, clear action, disclosure indicator, and every value-change path are unavailable.              | Read-only interaction, form, and accessibility tests        |
+| FR7 | `triggerIndicator="none"` omits the editable trigger's disclosure chevron without changing popup semantics, keyboard behavior, selection, clear actions, or status icons.                                         | Trigger-indicator interaction and status tests              |
 
 ### Allowed variation
 
@@ -126,6 +131,7 @@ These requirements describe shipped behavior on current `main`.
 | loading                  | Trigger is busy; empty and no-results output is suppressed                                | Consumer loading duration                              |
 | disabled with reason     | Trigger remains focusable enough to expose the reason while activation stays blocked      | Consumer reason text                                   |
 | read-only                | Value stays focusable and submittable; menu, clear, and disclosure affordances are absent | Value rendering, status, and busy presentation         |
+| editable without chevron | Trigger remains focusable and editable with unchanged popup and keyboard semantics        | Consumer context supplies sufficient disclosure        |
 | selected/unselected rows | Row semantics and theming state are correct; both reserve the indicator column            | Start/end position and themed indicator representation |
 
 ### Transformation and precedence order
@@ -136,6 +142,9 @@ These requirements describe shipped behavior on current `main`.
 - **ORD2 — Caller-selected content wins deliberately.** `startIcon` takes
   precedence over a selected option's icon; explicit placement takes precedence
   over selected-item overlay alignment.
+- **ORD3 — Status remains visible.** Attached and tooltip status icons retain
+  their trailing slot when `triggerIndicator="none"`; read-only state still
+  removes ordinary disclosure affordances.
 
 ### Performance and resources
 
@@ -282,6 +291,7 @@ in `spec:AST-004` as current runtime behavior.
 | FR4, AR1, AR2         | presentation tests plus `aria-haspopup` source review                                      | pointer, compact coarse pointer, search/non-search                | Wrong Popover/dialog roles or focus destinations fail tests; `aria-haspopup` values require source/a11y review | `audit:Selector/accessibility`   |
 | FR5                   | loading, empty-state, and live-region tests                                                | empty options, unmatched search, loading                          | Empty/no-results output appears or is announced while loading                                                  | `audit:Selector/behavior`        |
 | FR6, AR4              | read-only interaction, form, ARIA, and theme-state tests                                   | search/non-search, clearable, open→read-only, disabled precedence | A value changes, popup or edit affordance remains, form value disappears, or read-only semantics are absent    | `audit:Selector/accessibility`   |
+| FR7                   | trigger-indicator interaction and status tests                                             | default chevron, omitted chevron, status                          | Omission changes keyboard/popup semantics or suppresses status feedback                                        | `audit:Selector/behavior`        |
 | source-build contract | `Selector.source-build.test.mjs`                                                           | package source compiled by consumer Babel                         | Moving evaluated StyleX values outside the supported source form fails compilation                             | `audit:Selector/code-health`     |
 
 ## Decision log

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -3111,6 +3111,49 @@ describe('Selector indicator (chevron) icon theme target', () => {
     expect(icon).toHaveAttribute('data-state', 'collapsed');
   });
 
+  it('can omit the chevron without changing editable keyboard behavior', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={onChange}
+        triggerIndicator="none"
+      />,
+    );
+    const trigger = screen.getByRole('combobox', {name: 'Fruit'});
+
+    expect(
+      container.querySelector('.astryx-selector-indicator-icon'),
+    ).toBeNull();
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.tab();
+    expect(trigger).toHaveFocus();
+    await user.keyboard('{Enter}{ArrowDown}{Enter}');
+
+    expect(onChange).toHaveBeenCalled();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps a status icon when the chevron is omitted', () => {
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        status={{type: 'error', message: 'Required'}}
+        triggerIndicator="none"
+      />,
+    );
+
+    expect(
+      container.querySelector('.astryx-selector-indicator-icon'),
+    ).toBeNull();
+    expect(container.querySelector('.astryx-icon')).not.toBeNull();
+  });
+
   it('reflects the expanded state on the chevron when the popover is open', async () => {
     const user = userEvent.setup();
     const {container} = render(

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -464,6 +464,8 @@ export type SelectorSize = 'sm' | 'md' | 'lg';
 
 export type SelectorVariant = 'input' | 'ghost';
 
+export type SelectorTriggerIndicator = 'chevron' | 'none';
+
 export type SelectorPresentation = AdaptivePresentation;
 
 export type SelectorStatusType = 'warning' | 'error' | 'success';
@@ -584,6 +586,14 @@ interface SelectorPropsBase<
    * @default 'input'
    */
   variant?: SelectorVariant;
+
+  /**
+   * Disclosure indicator shown at the end of an editable trigger.
+   * `none` removes only the chevron; popup semantics, keyboard behavior, and
+   * status icons are unchanged.
+   * @default 'chevron'
+   */
+  triggerIndicator?: SelectorTriggerIndicator;
 
   /**
    * Status indicator for the selector.
@@ -835,6 +845,7 @@ export function Selector<T extends SelectorOptionType>(
     placeholder: placeholderFromProps,
     size: sizeProp,
     variant = 'input',
+    triggerIndicator = 'chevron',
     status,
     statusVariant = 'attached',
     labelTooltip,
@@ -1865,7 +1876,7 @@ export function Selector<T extends SelectorOptionType>(
               xstyle={styles.triggerIcon}
             />
           )
-        ) : !isEffectivelyReadOnly ? (
+        ) : !isEffectivelyReadOnly && triggerIndicator === 'chevron' ? (
           <Icon
             icon="chevronDown"
             size="sm"

--- a/packages/core/src/Selector/index.ts
+++ b/packages/core/src/Selector/index.ts
@@ -15,6 +15,7 @@ export {
   type SelectorSize,
   type SelectorStatus,
   type SelectorStatusType,
+  type SelectorTriggerIndicator,
 } from './Selector';
 export {SelectorOption} from './SelectorOption';
 export type {


### PR DESCRIPTION
## Summary

- Add `triggerIndicator="none"` as an opt-in way to omit Selector's disclosure chevron.
- Preserve the released `chevron` default and keep popup, keyboard, ARIA, clear-action, and status behavior unchanged.
- Document the API in the current Selector contract and consumer docs, with regression tests and a Storybook example.

## API proposal

- **Owner:** [Selector component contract](https://github.com/facebook/astryx/blob/main/packages/core/src/Selector/Selector.spec.md), `current`.
- **Semantic before → after:** An editable Selector always rendered a disclosure chevron; callers may now omit that visual indicator without changing the control's selection semantics.
- **Classification:** `novel-human`.
- **Representative syntax:**

  ```tsx
  <Selector
    label="Status"
    options={statuses}
    value={status}
    onChange={setStatus}
    triggerIndicator="none"
  />
  ```

### Caller ownership

Two otherwise identical editable selectors can need different trigger treatment:

1. A standalone form field needs the default chevron to disclose its popup.
2. A dense inline property control can omit the chevron when its surrounding property-editing pattern already supplies that context.

The caller owns that surrounding context. Selector cannot derive it from value, size, variant, content, platform, or open state.

### Combination semantics

- `chevron` remains the default.
- `none` suppresses only the ordinary disclosure chevron.
- Attached and tooltip status icons remain visible because status feedback is independent of disclosure treatment.
- Read-only state continues to remove all selection affordances.
- Option-row selection indicators and `indicatorPosition` are unaffected.

## Verification

- `pnpm lint:strict`
- `pnpm build`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core typecheck:docs`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm exec vitest run packages/core/src/Selector/Selector.test.tsx` (194 passed)
- `pnpm exec vitest run packages/core/src/docPropLiterals.test.ts packages/core/src/docPropReferences.test.ts packages/core/src/Selector/Selector.source-build.test.mjs` (23 passed)
- Manual Storybook check: no closed-state chevron; mouse open and ArrowDown/Enter selection preserve the combobox and listbox behavior.

The complete local suite reached 14,882 passing tests. Three unrelated `internal/vibe-tests/setup-test/setup-workspace.test.mjs` cases fail on macOS because BSD `cp` does not support `--reflink=auto`; the focused and contract suites above are green.
