### PR TITLE
fix(ci): fail closed on missing visual coverage

### DIFF
--- a/.github/scripts/visual-gate/README.md
+++ b/.github/scripts/visual-gate/README.md
@@ -114,6 +114,18 @@ The daily gate uses the same boundary: `stableStoryPackages` in
 hold a stable release. Pass `--story-packages '*'` only for an explicit
 non-release audit.
 
+Ownership decides which stories may own canonical frames, and a Storybook title
+is only evidence of it. When the index records the source file of the component
+a story declares, that source decides: a Core component keeps its frames even
+when its story is titled under another group, and a composed demo cannot earn
+one by importing Core. `stableStoryGroups` is the fallback for the stories that
+declare no component at all, where the title group is the only signal there is.
+
+An empty plan is refused rather than reported clean, in every lane. A plan with
+no shots compares nothing, so a scope whose keys are missing from the accepted
+baseline fails closed and says so; seed the missing frames through the manual
+baseline workflow.
+
 `.github/scripts/visual-scope.mjs` owns that classification from package
 metadata; workflow YAML does not hard-code today's package names.
 

--- a/.github/scripts/visual-gate/gate-context.test.mjs
+++ b/.github/scripts/visual-gate/gate-context.test.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {execFileSync} from 'node:child_process';
+import {execFileSync, spawnSync} from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -63,7 +63,7 @@ describe('stable release plan authority', () => {
   it('owns a closed Neutral and Probe baseline without preserving obsolete keys', () => {
     const source = fs.readFileSync(SCRIPT, 'utf8');
     expect(source).toContain("const RELEASE_TIERS = ['surface', 'probe'];");
-    expect(source).toContain('storiesInStorybookGroups(');
+    expect(source).toContain('canonicalBaselineStories(');
     expect(source).not.toContain('shots = withBaselineCoverage(');
     expect(source).toContain('const baselineManifest = rawBaseline;');
     expect(source).toContain(
@@ -72,6 +72,25 @@ describe('stable release plan authority', () => {
     expect(source).toContain(
       'readThemeCatalog(REPO_ROOT, config.baselineThemes)',
     );
+  });
+});
+
+describe('empty visual plans', () => {
+  it('refuses to capture a plan with no shots instead of reporting it clean', () => {
+    fs.writeFileSync(plan, JSON.stringify([]));
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, 'check', '--plan-file', plan, '--out', output],
+      {encoding: 'utf8'},
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(
+      /The exact trusted plan planned no shots;.*manual baseline workflow\./,
+    );
+    // The refusal comes before the shutter: nothing is captured, nothing is
+    // compared, and there is no clean verdict for a reader to trust.
+    expect(fs.existsSync(path.join(output, 'manifest.json'))).toBe(false);
+    expect(fs.existsSync(path.join(output, 'verdict.json'))).toBe(false);
   });
 });
 

--- a/.github/scripts/visual-gate/gate.mjs
+++ b/.github/scripts/visual-gate/gate.mjs
@@ -40,14 +40,15 @@ import {
   accountBaseline,
   baselineVisualStories,
   buildPlan,
+  canonicalBaselineStories,
   createReleasePlan,
+  emptyVisualPlanMessage,
   exceedsPrVisualShotLimit,
   existingComponentBaselinePlan,
   readStoryIndex,
   readThemeCatalog,
   resolvePrVisualTotalShotLimit,
   storiesInPackages,
-  storiesInStorybookGroups,
   summarizeBaselineAccounting,
   withThemeMetadata,
 } from './lib/plan.mjs';
@@ -196,10 +197,10 @@ async function plan() {
     REPO_ROOT,
   );
   const packageStories = storiesInPackages(indexedStories, storyPackages);
-  const stories = storiesInStorybookGroups(
-    packageStories,
-    config.stableStoryGroups,
-  );
+  const stories = canonicalBaselineStories(packageStories, {
+    groups: config.stableStoryGroups,
+    packages: storyPackages,
+  });
   const {manifest: baselineManifest} = readBaseline(baselineDir);
   const componentThemes = acceptedVisualThemes(
     baselineManifest,
@@ -300,7 +301,20 @@ async function plan() {
   };
 }
 
+/** How this run describes what it planned, for a refusal a human has to act on. */
+function plannedScope() {
+  if (planFile) return 'The exact trusted plan';
+  if (components.length) return `Component scope ${components.join(', ')}`;
+  return `Tier scope ${tiers.join(', ')}`;
+}
+
 async function runCapture(shots, releasePlan = null) {
+  // An empty plan is not a clean run. Every lane that captures pixels refuses
+  // one here, on the way in, so a scope whose keys are missing from the
+  // accepted baseline cannot report the absence of evidence as evidence.
+  if (shots.length === 0) {
+    throw new Error(emptyVisualPlanMessage(plannedScope()));
+  }
   if (shots.length > config.visualPlanSafetyLimit) {
     throw new Error(
       `Visual plan has ${shots.length} shots; safety limit is ${config.visualPlanSafetyLimit}.`,

--- a/.github/scripts/visual-gate/lib/plan.mjs
+++ b/.github/scripts/visual-gate/lib/plan.mjs
@@ -134,6 +134,12 @@ function storyPackageNames(entry, storybookDir, repoRoot, catalog) {
   return {
     packageNames: names.length ? names : [owner],
     packageName: owner,
+    // The package that OWNS the component's source, when Storybook recorded
+    // one. `packageName` can be inferred from imports or from the title, so it
+    // says which package a story belongs to; this says which package publishes
+    // the thing it photographs, and only that answers "may this story own a
+    // canonical baseline frame".
+    componentPackage: fromComponent ?? null,
     stableVisual: eligible(catalog.get(owner)),
   };
 }
@@ -336,7 +342,7 @@ export function createReleasePlan(shots) {
  *
  * @param {string} storybookDir
  * @param {Iterable<string>} excluded - story ids (or `prefix*`) excluded by config
- * @returns {Array<{id: string, title: string, name: string, component: string, tags: string[]}>}
+ * @returns {Array<{id: string, title: string, name: string, component: string, tags: string[], packageNames: string[], packageName: string, componentPackage: string | null, stableVisual: boolean}>}
  */
 export function readStoryIndex(storybookDir, excluded = [], repoRoot) {
   const exclusions = [...excluded];
@@ -391,15 +397,43 @@ function componentOf(entry) {
  */
 export function storiesInPackages(stories, packages) {
   if (packages.includes('*')) return stories;
-  const wanted = new Set(packages.map(name => name.startsWith('@') ? name : `@astryxdesign/${name.toLowerCase()}`));
+  const wanted = new Set(packages.map(configuredPackageName));
   return stories.filter(story => story.stableVisual && story.packageNames.some(name => wanted.has(name)));
 }
 
-/** Restrict canonical baselines to named Storybook title groups. */
-export function storiesInStorybookGroups(stories, groups) {
+/** Config names a package either by its Storybook group (`Core`) or in full. */
+function configuredPackageName(name) {
+  return name.startsWith('@') ? name : `@astryxdesign/${name.toLowerCase()}`;
+}
+
+/**
+ * Which stories may own canonical baseline frames.
+ *
+ * The question is ownership, and a Storybook title is only ever evidence of
+ * it. A story that merely IMPORTS Core components must not own a canonical
+ * frame; a component Core publishes must not lose its frames because its story
+ * happens to be titled under another group. Storybook records the source file
+ * of the component a story declares, and `readStoryIndex` resolves that file
+ * to its workspace package, so when the index has that fact it decides.
+ * `groups` is the fallback for stories that declare no component at all —
+ * composed demos and template pages — where the title group is the only
+ * ownership signal there is.
+ *
+ * `*` is an explicit audit override in either list, never the release default.
+ *
+ * @param {ReturnType<typeof readStoryIndex>} stories
+ * @param {{groups: string[], packages: string[]}} owners
+ */
+export function canonicalBaselineStories(stories, {groups, packages}) {
   if (groups.includes('*')) return stories;
-  const wanted = new Set(groups);
-  return stories.filter(story => wanted.has(String(story.title).split('/')[0]));
+  const everyPackage = packages.includes('*');
+  const wantedGroups = new Set(groups);
+  const wantedPackages = new Set(packages.map(configuredPackageName));
+  return stories.filter(story =>
+    story.componentPackage
+      ? everyPackage || wantedPackages.has(story.componentPackage)
+      : wantedGroups.has(String(story.title).split('/')[0]),
+  );
 }
 
 /**
@@ -528,6 +562,22 @@ export function resolvePrVisualTotalShotLimit({
 /** Component review budgets are shared by the ordinary and trusted planners. */
 export function exceedsPrVisualShotLimit(count, limit) {
   return count > limit;
+}
+
+/**
+ * Why every lane refuses an empty plan.
+ *
+ * A run that captures nothing compares nothing, so a clean verdict from one
+ * reports the absence of evidence as evidence. Every lane reaches that state
+ * the same way — a scope whose keys are not in the accepted baseline — so they
+ * refuse it with one sentence rather than three behaviors, and they name the
+ * one path that can seed the missing frames.
+ *
+ * @param {string} scope - what the lane planned, named for the message
+ * @returns {string}
+ */
+export function emptyVisualPlanMessage(scope) {
+  return `${scope} planned no shots; an empty plan compares nothing and cannot report clean. Seed coverage through the manual baseline workflow.`;
 }
 
 /**

--- a/.github/scripts/visual-gate/lib/plan.test.mjs
+++ b/.github/scripts/visual-gate/lib/plan.test.mjs
@@ -11,7 +11,9 @@ import {
   accountBaseline,
   baselineVisualStories,
   buildPlan,
+  canonicalBaselineStories,
   createReleasePlan,
+  emptyVisualPlanMessage,
   exceedsPrVisualShotLimit,
   existingComponentBaselinePlan,
   readStoryIndex,
@@ -20,7 +22,6 @@ import {
   resolvePrVisualTotalShotLimit,
   shotKey,
   storiesInPackages,
-  storiesInStorybookGroups,
   summarizeBaselineAccounting,
   uncoveredTargets,
 } from './plan.mjs';
@@ -67,8 +68,10 @@ describe('storiesInPackages', () => {
   });
 });
 
-describe('storiesInStorybookGroups', () => {
-  it('keeps only canonical title groups even when another group imports Core', () => {
+describe('canonicalBaselineStories', () => {
+  const owners = {groups: ['Core'], packages: ['Core']};
+
+  it('keeps only canonical title groups when no story declares a component', () => {
     const mixed = [
       ...stories,
       story({
@@ -85,8 +88,48 @@ describe('storiesInStorybookGroups', () => {
       }),
     ];
     expect(
-      storiesInStorybookGroups(mixed, ['Core']).map(story => story.id),
+      canonicalBaselineStories(mixed, owners).map(story => story.id),
     ).toEqual(stories.map(story => story.id));
+  });
+
+  it('keeps a published component whose only story is titled under another group', () => {
+    const resizable = story({
+      id: 'lab-resizable--horizontal-split',
+      title: 'Lab/Resizable',
+      name: 'Horizontal Split',
+      component: 'Resizable',
+      componentPackage: '@astryxdesign/core',
+    });
+    expect(
+      canonicalBaselineStories([...stories, resizable], owners).map(
+        story => story.id,
+      ),
+    ).toContain('lab-resizable--horizontal-split');
+  });
+
+  it('drops a canary component even when its story is titled under a canonical group', () => {
+    const labInCore = story(
+      {
+        id: 'core-drawer--default',
+        title: 'Core/Drawer',
+        name: 'Default',
+        component: 'Drawer',
+        componentPackage: '@astryxdesign/lab',
+      },
+      '@astryxdesign/lab',
+      false,
+    );
+    expect(
+      canonicalBaselineStories([...stories, labInCore], owners).map(
+        story => story.id,
+      ),
+    ).toEqual(stories.map(story => story.id));
+  });
+
+  it('allows an explicit all-groups audit without changing the release default', () => {
+    expect(canonicalBaselineStories(stories, {...owners, groups: ['*']})).toEqual(
+      stories,
+    );
   });
 });
 
@@ -221,6 +264,14 @@ describe('exceedsPrVisualShotLimit', () => {
   it('allows the exact configured ceiling and rejects one more', () => {
     expect(exceedsPrVisualShotLimit(240, 240)).toBe(false);
     expect(exceedsPrVisualShotLimit(241, 240)).toBe(true);
+  });
+});
+
+describe('emptyVisualPlanMessage', () => {
+  it('names the scope that planned nothing and the one path that seeds frames', () => {
+    expect(emptyVisualPlanMessage('Component scope Resizable')).toMatch(
+      /^Component scope Resizable planned no shots;.*manual baseline workflow\.$/,
+    );
   });
 });
 
@@ -441,6 +492,7 @@ describe('readStoryIndex package metadata', () => {
     fs.mkdirSync(path.join(storybook, 'stories'), {recursive: true});
     fs.mkdirSync(dist);
     fs.writeFileSync(path.join(storybook, 'stories/Composite.stories.tsx'), "import {Table} from '@astryxdesign/core/Table';");
+    fs.writeFileSync(path.join(storybook, 'stories/Dune.stories.tsx'), "import {Table} from '@astryxdesign/core/Table';");
     fs.writeFileSync(path.join(storybook, 'stories/Lab.stories.tsx'), "import {Thing} from '@astryxdesign/lab'; import {Button} from '@astryxdesign/core/Button';");
     fs.writeFileSync(path.join(storybook, 'stories/CoreMixed.stories.tsx'), "import {Thing} from '@astryxdesign/lab'; import {Layer} from '@astryxdesign/core/Layer';");
     fs.writeFileSync(path.join(storybook, 'stories/Probe.stories.tsx'), "import {Button} from '@astryxdesign/core/Button';");
@@ -452,6 +504,10 @@ describe('readStoryIndex package metadata', () => {
       mixed: {type: 'story', id: 'core-layer--default', title: 'Core/Layer', name: 'Default', importPath: './stories/CoreMixed.stories.tsx'},
       probe: {type: 'story', id: 'core-probe--default', title: 'Core/Themes/Probe Theme', name: 'Default', importPath: './stories/Probe.stories.tsx'},
       prOnly: {type: 'story', id: 'core-new--default', title: 'Core/New', name: 'Default', importPath: './stories/NewPrOnly.stories.tsx'},
+      // A Core component whose only story sits under another title group, and a
+      // template page that merely composes Core components.
+      elsewhere: {type: 'story', id: 'lab-resizable--split', title: 'Lab/Resizable', name: 'Split', componentPath: '../../packages/core/src/Resizable/index.ts', importPath: './stories/Resizable.stories.tsx'},
+      template: {type: 'story', id: 'dune--overview', title: 'Dune', name: 'Overview', importPath: './stories/Dune.stories.tsx'},
       skipped: {type: 'story', id: 'core-skip--default', title: 'Core/Skip', name: 'Default', tags: ['no-visual']},
     }}));
     return {root, dist};
@@ -469,6 +525,33 @@ describe('readStoryIndex package metadata', () => {
       expect(indexed.find(value => value.id === 'core-probe--default')).toMatchObject({packageName: '@astryxdesign/theme-probe', stableVisual: false});
       expect(indexed.find(value => value.id === 'core-new--default')).toMatchObject({packageName: '@astryxdesign/core', packageNames: ['@astryxdesign/core'], stableVisual: true});
       expect(indexed.some(value => value.id === 'core-skip--default')).toBe(false);
+    } finally {
+      fs.rmSync(root, {recursive: true, force: true});
+    }
+  });
+
+  it('resolves canonical ownership from the declared component, not the title group', () => {
+    const {root, dist} = fixture();
+    try {
+      const indexed = readStoryIndex(dist, [], root);
+      expect(indexed.find(value => value.id === 'lab-resizable--split')).toMatchObject({
+        component: 'Resizable',
+        packageName: '@astryxdesign/core',
+        componentPackage: '@astryxdesign/core',
+      });
+      expect(indexed.find(value => value.id === 'dune--overview')).toMatchObject({
+        packageName: '@astryxdesign/core',
+        componentPackage: null,
+      });
+      const canonical = canonicalBaselineStories(
+        storiesInPackages(indexed, ['Core']),
+        {groups: ['Core'], packages: ['Core']},
+      ).map(value => value.id);
+      // A published Core component keeps its frames wherever its story is
+      // titled; a template page that only imports Core still owns none.
+      expect(canonical).toContain('lab-resizable--split');
+      expect(canonical).not.toContain('dune--overview');
+      expect(canonical).not.toContain('charts-bar--default');
     } finally {
       fs.rmSync(root, {recursive: true, force: true});
     }

--- a/.github/scripts/visual-gate/visual-acceptance.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.mjs
@@ -22,7 +22,9 @@ import {canonicalizePng} from './lib/canonical-png.mjs';
 import {
   acceptedVisualThemes,
   baselineVisualStories,
+  canonicalBaselineStories,
   componentVisualStories,
+  emptyVisualPlanMessage,
   exceedsPrVisualShotLimit,
   readStoryIndex,
   readThemeCatalog,
@@ -30,7 +32,6 @@ import {
   shotKey,
   stableBaseline,
   storiesInPackages,
-  storiesInStorybookGroups,
   VISUAL_BASELINE_TAG,
   withThemeMetadata,
 } from './lib/plan.mjs';
@@ -738,10 +739,10 @@ function trustedPlan() {
     allIndexed,
     config.stableStoryPackages,
   );
-  const indexed = storiesInStorybookGroups(
-    packageStories,
-    config.stableStoryGroups,
-  );
+  const indexed = canonicalBaselineStories(packageStories, {
+    groups: config.stableStoryGroups,
+    packages: config.stableStoryPackages,
+  });
   const {baseline} = readTrustedBaseline(allIndexed);
   const baselineKeys = new Set(Object.keys(baseline.shots));
 
@@ -819,9 +820,7 @@ function trustedPlan() {
     fail('trusted stable plan includes a private or canary theme');
   }
   if (unique.length === 0) {
-    fail(
-      'trusted component scope has no existing baseline frames; seed coverage through the manual baseline workflow',
-    );
+    fail(emptyVisualPlanMessage('The trusted component scope'));
   }
   if (unique.length > config.visualPlanSafetyLimit) {
     fail(

--- a/.github/scripts/visual-gate/visual-acceptance.test.mjs
+++ b/.github/scripts/visual-gate/visual-acceptance.test.mjs
@@ -573,6 +573,90 @@ describe('visual acceptance', () => {
     ).toEqual(['core-button--default__neutral-light']);
   });
 
+  it('plans a published component whose only story is titled under another group', () => {
+    const storybook = path.join(root, 'storybook-foreign-group');
+    fs.mkdirSync(storybook);
+    writeJSON(path.join(storybook, 'index.json'), {
+      entries: {
+        resizable: {
+          type: 'story',
+          id: 'lab-resizable--split',
+          title: 'Lab/Resizable',
+          name: 'Default',
+          componentPath: '../../packages/core/src/Resizable/index.ts',
+          tags: [],
+        },
+      },
+    });
+    const baselineFile = path.join(
+      pages,
+      'visual-gate',
+      'baseline',
+      'manifest.json',
+    );
+    const baseline = JSON.parse(fs.readFileSync(baselineFile, 'utf8'));
+    baseline.shots['lab-resizable--split__neutral-light'] = {
+      ...baseline.shots[KEY],
+      key: 'lab-resizable--split__neutral-light',
+      storyId: 'lab-resizable--split',
+      title: 'Lab/Resizable',
+      name: 'Default',
+      component: 'Resizable',
+    };
+    writeJSON(baselineFile, baseline);
+    const scope = path.join(root, 'scope-foreign-group.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: ['Resizable'],
+      stableThemes: [],
+    });
+    const output = path.join(root, 'foreign-group-plan.json');
+    run('trusted-plan', {
+      scope,
+      baseline: path.join(pages, 'visual-gate', 'baseline'),
+      'storybook-dir': storybook,
+      output,
+    });
+    expect(
+      JSON.parse(fs.readFileSync(output, 'utf8')).map(shot => shot.key),
+    ).toEqual(['lab-resizable--split__neutral-light']);
+  });
+
+  it('refuses an empty trusted plan in the words every lane refuses one', () => {
+    const storybook = path.join(root, 'storybook-unseeded');
+    fs.mkdirSync(storybook);
+    writeJSON(path.join(storybook, 'index.json'), {
+      entries: {
+        card: {
+          type: 'story',
+          id: 'core-card--default',
+          title: 'Core/Card',
+          name: 'Default',
+          componentPath: '../../packages/core/src/Card/index.ts',
+          tags: [],
+        },
+      },
+    });
+    const scope = path.join(root, 'scope-unseeded.json');
+    writeJSON(scope, {
+      hasStableVisual: true,
+      broadStableVisual: false,
+      stableComponents: ['Card'],
+      stableThemes: [],
+    });
+    expect(
+      fail('trusted-plan', {
+        scope,
+        baseline: path.join(pages, 'visual-gate', 'baseline'),
+        'storybook-dir': storybook,
+        output: path.join(root, 'unseeded-plan.json'),
+      }),
+    ).toMatch(
+      /The trusted component scope planned no shots;.*manual baseline workflow\./,
+    );
+  });
+
   it('fails closed when any touched component has no representative story', () => {
     const storybook = path.join(root, 'storybook-missing-component');
     fs.mkdirSync(storybook);

--- a/.github/scripts/visual-gate/visual-gate.config.json
+++ b/.github/scripts/visual-gate/visual-gate.config.json
@@ -7,7 +7,7 @@
   "baselineThemes": ["neutral", "probe"],
   "$stableStoryPackages": "Only these workspace packages may own stable visual stories.",
   "stableStoryPackages": ["Core"],
-  "$stableStoryGroups": "Only these Storybook title groups may own canonical baseline frames, even when another group imports Core components.",
+  "$stableStoryGroups": "Ownership fallback for stories that declare no component: only these Storybook title groups may own canonical baseline frames, so a story from another group cannot earn one merely by importing Core. A story that DOES declare a component published by stableStoryPackages owns its frames wherever it is titled.",
   "stableStoryGroups": ["Core"],
   "$prVisualShotLimit": "Review ceiling for focused component shots and broad shared-infrastructure plans. Theme-only matrices are not component-budgeted.",
   "prVisualShotLimit": 240,


### PR DESCRIPTION
## Summary

- resolve canonical visual ownership from a story's declared component before falling back to its title group
- restore Resizable to the published Core visual baseline even though its story is titled under `Lab/`
- reject zero-shot visual plans consistently across capture, check, release, flaky, and trusted planning lanes

## Why

A published Core component could lose all canonical frames when its Storybook title used another group. Separately, an empty visual plan could report a clean result outside the trusted planner. Both cases must fail closed or provide a recoverable baseline path.

## Test plan

- `npx vitest run .github/scripts/visual-gate --project node` (303 passed)
- `pnpm check:portable-scripts`
- `pnpm check:executable-bits`
- `pnpm prettier --check .github/scripts/visual-gate`
- `pnpm check:repo`
- built the real Storybook index and verified the canonical set adds Resizable without removing any component
- verified the new regression tests fail against the pre-fix implementation
