### PR TITLE
fix(ci): make spec owner approval fail closed

### DIFF
--- a/.github/REVIEW_GATE.md
+++ b/.github/REVIEW_GATE.md
@@ -33,10 +33,31 @@ with their read-only token, so an approver uses an issue comment containing
 `/approve-spec <full-head-sha>` instead; that command runs from the trusted
 default branch and a new commit invalidates it.
 
+Only that exact form decides the gate. The command must start the comment,
+lowercase and unindented, because the workflow trigger matches the raw comment
+body — an indented or capitalized command never starts the workflow, so the
+parser refuses it too rather than counting a comment nobody's run ever saw. The
+SHA itself may be either casing. A command that names no commit, names
+something other than one full 40-character SHA, or names a superseded commit
+changes nothing — so the gate replies once per head with the exact command to
+copy, rather than leaving the owner believing they approved.
+
+The gate never re-decides a merged or closed head. A run that starts after the
+merge publishes nothing, and neither does a run yielding to a newer one.
+GitHub has no conditional status write, so the window between the last read and
+the write cannot be closed; the gate makes it one API call wide by reading the
+live pull request last, and if a status still lands on a head that settled
+during that window, the run logs the status as unverified and stops before
+auto-merge.
+
 When a DESIGNOWNER authors a PR, marking it ready for review attests that exact
-head for the design-approval group. That evidence also counts when the PR
-contains non-design current records, but every other applicable code or
-spec-owner group remains separately required.
+head **for the design-approval group only**. The attestation is published only
+for a `.github/DESIGNOWNERS` handle, and it is read back only for a handle that
+is still in that file — a marker left by someone since removed, or published
+before this rule existed, authorizes nothing. It satisfies no other group: the
+spec and theme groups always need a real exact-head review or command from
+someone in their own list. A spec or engineering owner cannot attest their own
+head.
 
 The attestation does not grant auto-merge by itself. The existing gate may enable
 squash auto-merge only when every changed path is a recognized spec record,
@@ -142,6 +163,48 @@ internal contributors' PRs. Owners still self-serve their own domain.
 "1 approving review" requirement. Because a required check blocks non-admin
 merges regardless of write access, this holds internal contributors who have
 write but are not owners. (Repo admins can still bypass.)
+
+`spec-owner-approval` must be a required status context on `main` as well. It is
+published on every PR — `success` when no knowledge records changed — so
+requiring it does not permanently strand unrelated work. **Until it is in the
+required list, a pending owner gate is advisory and does not block the merge
+button.** If the repository ever enables a merge queue, this gate also has to
+report on `merge_group` before the context is required, or queued entries stall
+waiting for a status nothing publishes.
+
+### Making it required (ordered; do not reorder)
+
+An open PR whose head predates the gate has no `spec-owner-approval` status at
+all. Requiring the context first would block those heads on a status no event
+will produce, because the gate only runs on a new event. Backfill first.
+
+1. Land the gate changes, so the default branch has the `backfill` dispatch
+   input. `workflow_dispatch` always runs the default branch's copy.
+2. List the heads that would strand:
+
+   ```sh
+   gh pr list --state open --limit 300 --json number,headRefOid \
+     --jq '.[]|"\(.number) \(.headRefOid)"' \
+   | while read -r pr sha; do
+       state=$(gh api "repos/facebook/astryx/commits/$sha/status" \
+         --jq '[.statuses[]|select(.context=="spec-owner-approval")|.state]
+               | if length==0 then "MISSING" else .[0] end')
+       [ "$state" = MISSING ] && echo "$pr"
+     done
+   ```
+
+3. Backfill each one. `backfill=true` publishes the status and returns before
+   auto-merge, so a reconcile cannot land a PR nobody asked to land:
+
+   ```sh
+   gh workflow run spec-owner-gate.yml -f pr=<number> -f backfill=true
+   ```
+
+4. Re-run the step 2 query and confirm it prints nothing.
+5. Only then add `spec-owner-approval` to the required status checks on `main`.
+
+A `pending` result from the backfill is the correct outcome for a PR that
+genuinely awaits an owner, not a stranded head.
 
 ## Why a commit status (not a check run)
 

--- a/.github/scripts/spec-owner-decision.cjs
+++ b/.github/scripts/spec-owner-decision.cjs
@@ -15,12 +15,62 @@ const GATE_STATUS_CONTEXT = 'spec-owner-approval';
 const READY_STATUS_PREFIX = 'spec-owner-ready/';
 const TRUSTED_STATUS_CREATOR = 'github-actions[bot]';
 
+// The workflow trigger filters comments with GitHub's `startsWith` against the
+// raw body, which neither trims nor lowercases. Every parser below applies the
+// same precondition, so a comment the trigger drops can never be read as a
+// decision by a run started for some other event.
+const OWNER_COMMAND_PREFIXES = ['/approve-spec', '/revoke-spec'];
+
+function isDispatchableOwnerCommand(body) {
+  return (
+    typeof body === 'string' &&
+    OWNER_COMMAND_PREFIXES.some(prefix => body.startsWith(prefix))
+  );
+}
+
 function parseOwnerCommand(body, headSha) {
+  if (!isDispatchableOwnerCommand(body)) return null;
+  // The command prefix must match the trigger exactly, but a commit SHA is
+  // case-insensitive everywhere else in git and GitHub. Accept either casing
+  // rather than silently ignoring a copy-pasted uppercase head.
   const match = body
     .trim()
-    .match(/^\/(approve|revoke)-spec\s+([0-9a-f]{40})$/i);
-  if (!match || headSha !== match[2].toLowerCase()) return null;
-  return match[1].toLowerCase() === 'approve';
+    .match(/^\/(approve|revoke)-spec\s+([0-9a-fA-F]{40})$/);
+  if (!match || headSha.toLowerCase() !== match[2].toLowerCase()) return null;
+  return match[1] === 'approve';
+}
+
+/**
+ * Recognize that a comment was meant as an owner command, whatever it names.
+ * Only the exact-head form in `parseOwnerCommand` decides the gate; this looser
+ * shape exists so a near-miss command is answered instead of ignored.
+ */
+function parseOwnerCommandIntent(body) {
+  if (!isDispatchableOwnerCommand(body)) return null;
+  const match = body
+    .trimEnd()
+    .match(/^\/(approve|revoke)-spec(?![-\w])([\s\S]*)$/);
+  if (!match) return null;
+  return {verb: match[1], argument: match[2].trim()};
+}
+
+/**
+ * Explain why a recognized owner command does not decide the gate, or return
+ * null when it does. The reasons are the two silent failures owners hit: a
+ * command that names no full head SHA, and one that names a superseded commit.
+ */
+function describeOwnerCommandProblem(intent, headSha) {
+  if (!intent) return null;
+  if (!intent.argument) {
+    return 'it did not name a commit';
+  }
+  if (!/^[0-9a-f]{40}$/i.test(intent.argument)) {
+    return 'it did not name exactly one full 40-character commit SHA';
+  }
+  if (intent.argument.toLowerCase() !== headSha.toLowerCase()) {
+    return `it named ${intent.argument.slice(0, 7)}, which is not the current head`;
+  }
+  return null;
 }
 
 function candidateTime(candidate) {
@@ -162,7 +212,12 @@ function isTrustedWorkflowStatus(status, repository) {
   );
 }
 
-function parseReadyAttestations(statuses, {repository, headSha}) {
+function parseReadyAttestations(statuses, {repository, headSha, owners}) {
+  // A ready marker is only design-group evidence, and only from a handle that
+  // is a design owner *now*. Markers published before that rule existed, or
+  // by someone since removed from .github/DESIGNOWNERS, are historical noise
+  // and must not authorize anything.
+  const allowed = new Set((owners ?? []).map(owner => owner.toLowerCase()));
   const attestations = [];
   for (const status of statuses) {
     if (
@@ -175,7 +230,7 @@ function parseReadyAttestations(statuses, {repository, headSha}) {
     const owner = status.context
       .slice(READY_STATUS_PREFIX.length)
       .toLowerCase();
-    if (!/^[a-z0-9-]+$/.test(owner)) continue;
+    if (!/^[a-z0-9-]+$/.test(owner) || !allowed.has(owner)) continue;
     const match = status.description?.match(
       /^Owner ready at (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z)\.$/,
     );
@@ -241,13 +296,17 @@ function requiresOwnerApproval(records, options = {}) {
 
 module.exports = {
   GATE_STATUS_CONTEXT,
+  OWNER_COMMAND_PREFIXES,
   READY_STATUS_PREFIX,
   canonicalRunUrl,
+  describeOwnerCommandProblem,
+  isDispatchableOwnerCommand,
   newestGateRun,
   parseAuthority,
   parseCanonicalRunId,
   parseKind,
   parseOwnerCommand,
+  parseOwnerCommandIntent,
   parseOwnerFile,
   parseReadyAttestations,
   requiredApprovalGroups,

--- a/.github/scripts/spec-owner-decision.test.mjs
+++ b/.github/scripts/spec-owner-decision.test.mjs
@@ -5,10 +5,14 @@ import {describe, expect, it} from 'vitest';
 
 const require = createRequire(import.meta.url);
 const {
+  OWNER_COMMAND_PREFIXES,
   canonicalRunUrl,
+  describeOwnerCommandProblem,
+  isDispatchableOwnerCommand,
   newestGateRun,
   parseCanonicalRunId,
   parseOwnerCommand,
+  parseOwnerCommandIntent,
   parseOwnerFile,
   parseReadyAttestations,
   requiredApprovalGroups,
@@ -344,7 +348,7 @@ describe('spec owner decision', () => {
         {...trusted, target_url: 'https://example.com/forged'},
         {...trusted, description: 'owner says ready'},
       ],
-      {repository, headSha: head},
+      {repository, headSha: head, owners: ['cixzhang']},
     );
 
     expect(attestations).toEqual([
@@ -489,5 +493,215 @@ describe('spec owner decision', () => {
       9007199254740993n,
     );
     expect(newestGateRun(statuses, repository)?.runId).toBe(9007199254740993n);
+  });
+
+  it('accepts a ready marker only from a current design owner', () => {
+    const repository = 'facebook/astryx';
+    const marker = login => ({
+      context: `spec-owner-ready/${login}`,
+      state: 'success',
+      description: 'Owner ready at 2026-08-30T10:00:00.000Z.',
+      target_url: canonicalRunUrl(repository, '42', '1'),
+      creator: {login: 'github-actions[bot]'},
+    });
+    const statuses = [marker('ernestt'), marker('imdreamrunner')];
+
+    // imdreamrunner is a spec owner and a design *approver*, but not a design
+    // owner. A marker they published — including one predating the rule that
+    // only design owners self-attest — is not evidence for any group.
+    expect(
+      parseReadyAttestations(statuses, {
+        repository,
+        headSha: head,
+        owners: ['ernestt', 'rubyycheung'],
+      }).map(attestation => attestation.owner),
+    ).toEqual(['ernestt']);
+
+    // A handle removed from DESIGNOWNERS stops counting immediately.
+    expect(
+      parseReadyAttestations(statuses, {
+        repository,
+        headSha: head,
+        owners: ['rubyycheung'],
+      }),
+    ).toEqual([]);
+    expect(
+      parseReadyAttestations(statuses, {repository, headSha: head}),
+    ).toEqual([]);
+  });
+
+  it('does not let a stale ready marker approve the design group', () => {
+    const repository = 'facebook/astryx';
+    const designApprovers = ['cixzhang', 'imdreamrunner', 'ernestt'];
+    const stale = [
+      {
+        context: 'spec-owner-ready/imdreamrunner',
+        state: 'success',
+        description: 'Owner ready at 2026-09-04T05:54:18.000Z.',
+        target_url: canonicalRunUrl(repository, '42', '1'),
+        creator: {login: 'github-actions[bot]'},
+      },
+    ];
+
+    expect(
+      resolveOwnerDecision({
+        owners: designApprovers,
+        headSha: head,
+        reviews: [],
+        comments: [],
+        readyAttestations: parseReadyAttestations(stale, {
+          repository,
+          headSha: head,
+          owners: ['ernestt', 'rubyycheung'],
+        }),
+      }).approved,
+    ).toBe(false);
+  });
+
+  describe('recognizing a command that does not decide the gate', () => {
+    it('recognizes the owner-command shape whatever it names', () => {
+      expect(parseOwnerCommandIntent('/approve-spec')).toEqual({
+        verb: 'approve',
+        argument: '',
+      });
+      expect(parseOwnerCommandIntent(`/revoke-spec ${head}  `)).toEqual({
+        verb: 'revoke',
+        argument: head,
+      });
+      expect(parseOwnerCommandIntent('/approve-spec abc1234 thanks')).toEqual({
+        verb: 'approve',
+        argument: 'abc1234 thanks',
+      });
+    });
+
+    it.each([
+      undefined,
+      '',
+      'Looks good to me',
+      '/approve-specs abc',
+      '/approve-spec-now',
+      `Please run /approve-spec ${head}`,
+      `  /approve-spec ${head}`,
+      `\t/approve-spec ${head}`,
+      `/APPROVE-SPEC ${head}`,
+      `> /approve-spec ${head}`,
+    ])('does not read %s as an owner command', body => {
+      expect(parseOwnerCommandIntent(body)).toBe(null);
+    });
+
+    it('refuses to decide on a comment the workflow trigger would drop', () => {
+      // resolveOwnerDecision reads every comment on the pull request, not just
+      // the one that started the run. A comment GitHub's `startsWith` filter
+      // never dispatches must not become approval evidence either.
+      for (const body of [
+        `  /approve-spec ${head}`,
+        `/APPROVE-SPEC ${head}`,
+        `> /approve-spec ${head}`,
+      ]) {
+        expect(isDispatchableOwnerCommand(body)).toBe(false);
+        expect(parseOwnerCommand(body, head)).toBe(null);
+        expect(
+          resolveOwnerDecision({
+            reviews: [],
+            comments: [{user: owner, body, created_at: '2026-08-30T10:00:00Z'}],
+            owners: ['cixzhang'],
+            headSha: head,
+          }).approved,
+        ).toBe(false);
+      }
+    });
+
+    it('admits exactly what the workflow trigger admits', () => {
+      // The trigger is `startsWith(github.event.comment.body, '<prefix>')`:
+      // the raw body, untrimmed and case-sensitive.
+      const triggerAdmits = body =>
+        OWNER_COMMAND_PREFIXES.some(prefix => String(body).startsWith(prefix));
+
+      for (const body of [
+        `/approve-spec ${head}`,
+        '/approve-spec',
+        '/revoke-spec',
+        `/revoke-spec ${head}`,
+        '/approve-spec abc1234',
+        '/approve-spec-now',
+        `  /approve-spec ${head}`,
+        `/APPROVE-SPEC ${head}`,
+        'Looks good to me',
+        '',
+      ]) {
+        expect(isDispatchableOwnerCommand(body), body).toBe(
+          triggerAdmits(body),
+        );
+      }
+    });
+
+    it('explains each way a recognized command misses the head', () => {
+      const stale = '1111111111111111111111111111111111111111';
+      expect(
+        describeOwnerCommandProblem(
+          parseOwnerCommandIntent('/approve-spec'),
+          head,
+        ),
+      ).toContain('did not name a commit');
+      expect(
+        describeOwnerCommandProblem(
+          parseOwnerCommandIntent('/approve-spec abc1234'),
+          head,
+        ),
+      ).toContain('full 40-character commit SHA');
+      expect(
+        describeOwnerCommandProblem(
+          parseOwnerCommandIntent(`/approve-spec ${stale}`),
+          head,
+        ),
+      ).toContain('1111111');
+    });
+
+    it('accepts a commit SHA in either casing', () => {
+      const upper = head.toUpperCase();
+
+      // A SHA copied from a UI that renders it uppercase is the same commit.
+      // The validator and the parser must agree, or the gate reports no
+      // problem while silently ignoring the command.
+      expect(parseOwnerCommand(`/approve-spec ${upper}`, head)).toBe(true);
+      expect(parseOwnerCommand(`/revoke-spec ${upper}`, head)).toBe(false);
+      expect(
+        describeOwnerCommandProblem(
+          parseOwnerCommandIntent(`/approve-spec ${upper}`),
+          head,
+        ),
+      ).toBe(null);
+      expect(parseOwnerCommand(`/approve-spec ${head}`, upper)).toBe(true);
+    });
+
+    it('agrees with the help validator on every recognized command', () => {
+      const stale = '1111111111111111111111111111111111111111';
+
+      for (const body of [
+        `/approve-spec ${head}`,
+        `/approve-spec ${head.toUpperCase()}`,
+        `/revoke-spec ${head}`,
+        '/approve-spec',
+        '/approve-spec abc1234',
+        `/approve-spec ${stale}`,
+        `/approve-spec ${stale.toUpperCase()}`,
+        `/approve-spec ${head} please`,
+      ]) {
+        const intent = parseOwnerCommandIntent(body);
+        const decided = parseOwnerCommand(body, head) !== null;
+        const problem = describeOwnerCommandProblem(intent, head);
+        // Exactly one of the two is true: the command decides the gate, or
+        // the gate can say why it did not.
+        expect(decided, body).toBe(problem === null);
+      }
+    });
+
+    it('reports no problem for the exact form the gate accepts', () => {
+      const intent = parseOwnerCommandIntent(`/approve-spec ${head}`);
+
+      expect(describeOwnerCommandProblem(intent, head)).toBe(null);
+      expect(parseOwnerCommand(`/approve-spec ${head}`, head)).toBe(true);
+      expect(describeOwnerCommandProblem(null, head)).toBe(null);
+    });
   });
 });

--- a/.github/scripts/spec-owner-reconcile.cjs
+++ b/.github/scripts/spec-owner-reconcile.cjs
@@ -11,8 +11,10 @@ const {
   GATE_STATUS_CONTEXT,
   READY_STATUS_PREFIX,
   canonicalRunUrl,
+  describeOwnerCommandProblem,
   newestGateRun,
   parseOwnerCommand,
+  parseOwnerCommandIntent,
   parseOwnerFile,
   parseReadyAttestations,
   requiredApprovalGroups,
@@ -22,9 +24,7 @@ const {
 
 function isCommandComment(eventName, payload) {
   if (eventName !== 'issue_comment') return true;
-  return /^\/(approve|revoke)-spec [0-9a-f]{40}$/i.test(
-    payload.comment?.body?.trim() ?? '',
-  );
+  return parseOwnerCommandIntent(payload.comment?.body) !== null;
 }
 
 function isAuthorizedEvent(eventName, payload, owners) {
@@ -43,6 +43,27 @@ function isAuthorizedEvent(eventName, payload, owners) {
 
 function labelNames(pr) {
   return new Set(pr.labels.map(label => label.name));
+}
+
+function ownerCommandHelpMarker(headSha) {
+  return `<!-- spec-owner-command-help:${headSha} -->`;
+}
+
+function ownerCommandHelpBody({verb, headSha, problem}) {
+  return [
+    ownerCommandHelpMarker(headSha),
+    `That \`/${verb}-spec\` comment did not change \`${GATE_STATUS_CONTEXT}\`: ${problem}.`,
+    '',
+    'The gate only accepts the exact current head, so post this instead:',
+    '',
+    `    /${verb}-spec ${headSha}`,
+    '',
+    'A new commit invalidates the command, so repeat it after any push.',
+  ].join('\n');
+}
+
+function isSettled(pr) {
+  return Boolean(pr.merged_at) || pr.state === 'closed';
 }
 
 async function reconcileSpecOwnerGate({
@@ -93,6 +114,11 @@ async function reconcileSpecOwnerGate({
   }
 
   const runId = BigInt(String(context.runId));
+  // A boolean workflow_dispatch input arrives as a real boolean; a string
+  // input arrives as text. Only an explicit true opts in.
+  const backfillOnly =
+    context.eventName === 'workflow_dispatch' &&
+    String(context.payload.inputs?.backfill ?? 'false') === 'true';
   const runUrl = canonicalRunUrl(
     repository,
     String(context.runId),
@@ -139,16 +165,57 @@ async function reconcileSpecOwnerGate({
     return newestGateRun(await listStatuses(headSha), repository);
   }
 
+  /**
+   * The freshest possible answer to "may this head still be written at all".
+   * A settled or moved head is never writable, whichever run is current: an
+   * approval that lands after the merge it claims to gate is not evidence.
+   * Any read that throws propagates and nothing is published.
+   */
+  async function isLiveHeadWritable(headSha) {
+    const live = await getPullRequest();
+    if (isSettled(live)) {
+      core.info(
+        'The pull request settled while this run reconciled; leaving the head status as it merged.',
+      );
+      return false;
+    }
+    if (live.head.sha !== headSha) {
+      core.info(
+        'The head moved while this run reconciled; leaving the status to the run for the new head.',
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * The last read before a terminal write. GitHub has no conditional status
+   * write, so the window cannot be closed — it can only be made as small as
+   * one API call and made to fail closed. Read the run currency first and the
+   * live pull request last, so the head/settlement facts are the freshest
+   * thing known at the moment of the write.
+   */
+  async function isPublishable(headSha) {
+    if (!(await isCurrentRun(headSha))) return false;
+    return isLiveHeadWritable(headSha);
+  }
+
   async function restoreNewerStatus(headSha) {
     const newest = await newestRun(headSha);
     if (newest === null || newest.runId <= runId) return false;
-    await createStatus({
-      sha: headSha,
-      context: GATE_STATUS_CONTEXT,
-      state: newest.status.state,
-      description: newest.status.description,
-      targetUrl: newest.status.target_url,
-    });
+    // Yielding is still a write. A newer run's status is no more publishable
+    // on a merged or moved head than this run's own would be, so the restore
+    // takes the same live guard — and still reports the yield, because this
+    // run's claim on the head is over either way.
+    if (await isLiveHeadWritable(headSha)) {
+      await createStatus({
+        sha: headSha,
+        context: GATE_STATUS_CONTEXT,
+        state: newest.status.state,
+        description: newest.status.description,
+        targetUrl: newest.status.target_url,
+      });
+    }
     core.info(
       `Run ${context.runId} yielded to newer run ${newest.runId.toString()}.`,
     );
@@ -163,18 +230,28 @@ async function reconcileSpecOwnerGate({
   async function currentPullForRun(headSha) {
     const current = await getPullRequest();
     if (current.head.sha !== headSha) return null;
+    if (isSettled(current)) return null;
     if (!(await isCurrentRun(headSha))) return null;
     return current;
   }
 
   async function setFinalStatus(headSha, state, description) {
-    if (!(await isCurrentRun(headSha))) return false;
+    if (!(await isPublishable(headSha))) return false;
     await createStatus({
       sha: headSha,
       context: GATE_STATUS_CONTEXT,
       state,
       description,
     });
+    // The write cannot be undone, so verify what it landed on. A success that
+    // raced a merge is reported loudly and stops this run before auto-merge.
+    const after = await getPullRequest();
+    if (isSettled(after) || after.head.sha !== headSha) {
+      core.warning(
+        `Published ${state} for ${headSha.slice(0, 7)} as the pull request settled or moved; treat that status as unverified.`,
+      );
+      return false;
+    }
     return !(await restoreNewerStatus(headSha));
   }
 
@@ -340,6 +417,15 @@ async function reconcileSpecOwnerGate({
   }
 
   const initialPr = await getPullRequest();
+  // Nothing about a merged or closed head is still being decided. Reconciling
+  // one can only publish a decision that arrives after the merge it claims to
+  // gate, so stop before writing any status.
+  if (isSettled(initialPr)) {
+    core.info(
+      'The pull request is already merged or closed; the gate does not rewrite a settled head.',
+    );
+    return;
+  }
   const initialHead = initialPr.head.sha;
   await createStatus({
     sha: initialHead,
@@ -352,12 +438,15 @@ async function reconcileSpecOwnerGate({
   const actor = context.actor?.toLowerCase();
   const eventHead = context.payload.pull_request?.head?.sha;
   const eventTime = context.payload.pull_request?.updated_at;
+  // Only a DESIGNOWNER author may self-attest a head, and only for the design
+  // approval group (.github/DESIGNOWNERS). A spec or engineering owner marking
+  // their own pull request ready is not an approval by anyone else.
   if (
     context.eventName === 'pull_request_target' &&
     context.payload.action === 'ready_for_review' &&
     actor &&
     actor === initialPr.user.login.toLowerCase() &&
-    allOwners.has(actor) &&
+    designOwners.includes(actor) &&
     eventHead === initialHead &&
     eventTime &&
     !Number.isNaN(Date.parse(eventTime))
@@ -401,6 +490,31 @@ async function reconcileSpecOwnerGate({
   }
 
   const {pr, scope, records, reviews, comments, timeline, statuses} = snapshot;
+
+  // A near-miss owner command used to do nothing at all, so an owner could
+  // believe they had approved a head the gate never read. Answer it once per
+  // head with the exact command instead of leaving it silent.
+  if (context.eventName === 'issue_comment' && commentAuthor) {
+    const intent = parseOwnerCommandIntent(context.payload.comment?.body);
+    const problem = describeOwnerCommandProblem(intent, initialHead);
+    const marker = ownerCommandHelpMarker(initialHead);
+    if (problem && !comments.some(entry => entry.body?.includes(marker))) {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: pullNumber,
+        body: ownerCommandHelpBody({
+          verb: intent.verb,
+          headSha: initialHead,
+          problem,
+        }),
+      });
+      core.info(
+        `Answered an inexact ${intent.verb} command on ${initialHead}.`,
+      );
+    }
+  }
+
   if (!scope.touchesKnowledgeRecords) {
     await disableAutoMerge(pr);
     await removeLabel(env.REVIEW_LABEL);
@@ -442,19 +556,26 @@ async function reconcileSpecOwnerGate({
   const readyAttestations = parseReadyAttestations(statuses, {
     repository,
     headSha: initialHead,
+    owners: designOwners,
   });
   const decisionInput = {
     reviews,
     comments,
-    readyAttestations,
     dismissalEvents: timeline,
     headSha: initialHead,
   };
+  // A ready-for-review attestation is the design group's own self-attestation
+  // path. It is not evidence for the spec or theme groups, which stay on real
+  // exact-head reviews and commands.
   const specDecision = requiredGroups.spec
     ? resolveOwnerDecision({...decisionInput, owners: specOwners})
     : {approved: true, owner: null};
   const designDecision = requiredGroups.design
-    ? resolveOwnerDecision({...decisionInput, owners: designApprovers})
+    ? resolveOwnerDecision({
+        ...decisionInput,
+        readyAttestations,
+        owners: designApprovers,
+      })
     : {approved: true, owner: null};
   const themeDecision = requiredGroups.theme
     ? resolveOwnerDecision({...decisionInput, owners: themeApprovers})
@@ -530,6 +651,14 @@ async function reconcileSpecOwnerGate({
     return;
   }
   await removeLabel(env.REVIEW_LABEL);
+
+  // A backfill exists to give an old head its missing status before the
+  // context becomes required. Landing the pull request is a separate decision
+  // its author has not asked this run to make.
+  if (backfillOnly) {
+    core.info('Backfill run: published the gate status without auto-merge.');
+    return;
+  }
 
   let enabledAutoMergeByThisRun = false;
   if (!pr.auto_merge) {

--- a/.github/scripts/spec-owner-reconcile.test.mjs
+++ b/.github/scripts/spec-owner-reconcile.test.mjs
@@ -92,6 +92,7 @@ function createHarness({
   autoMerge = null,
   draft = false,
   onPullGet,
+  onCreateStatus,
   onEnableAutoMerge,
   changedFile = {
     filename: 'docs/specs/owner-ready/spec.md',
@@ -109,11 +110,14 @@ function createHarness({
     reviews: [...reviews],
     timeline: [...timeline],
     calls: [],
+    reads: [],
     labels: new Set(labels),
     knownLabels: new Set(labels),
     pr: {
       number: 17,
       node_id: 'PR_node',
+      state: 'open',
+      merged_at: null,
       user: {login: author},
       head: {sha: head, repo: {full_name: headRepository}},
       base: {
@@ -135,6 +139,7 @@ function createHarness({
   const methods = {
     getPull: async () => {
       state.pullGets += 1;
+      state.reads.push('pull');
       onPullGet?.(state.pullGets, state);
       syncLabels();
       return {data: state.pr};
@@ -143,9 +148,10 @@ function createHarness({
     listReviews: async () => ({data: state.reviews}),
     listComments: async () => ({data: state.comments}),
     listTimeline: async () => ({data: state.timeline}),
-    listStatuses: async ({ref}) => ({
-      data: state.statuses.filter(status => status.sha === ref),
-    }),
+    listStatuses: async ({ref}) => {
+      state.reads.push('statuses');
+      return {data: state.statuses.filter(status => status.sha === ref)};
+    },
   };
 
   const github = {
@@ -185,10 +191,21 @@ function createHarness({
           syncLabels();
           state.calls.push(`remove-label:${name}`);
         },
+        createComment: async ({body}) => {
+          state.comments.push({
+            user: {login: 'github-actions[bot]'},
+            body,
+            created_at: '2026-08-30T10:00:30Z',
+          });
+          state.calls.push('create-comment');
+          return {data: {body}};
+        },
       },
       repos: {
         listCommitStatusesForRef: methods.listStatuses,
         createCommitStatus: async input => {
+          onCreateStatus?.(input, state);
+          state.reads.push(`status:${input.context}:${input.state}`);
           const status = {
             ...input,
             creator: {login: 'github-actions[bot]'},
@@ -249,6 +266,19 @@ const designRecord = {
 };
 const currentDesign = 'kind: design\nauthority: current\n';
 
+// Exact-head approval by a real spec owner. The auto-merge mechanics below
+// need an approved head; they must not borrow the design self-attestation.
+const specOwnerReview = {
+  user: {login: 'imdreamrunner'},
+  state: 'APPROVED',
+  commit_id: head,
+  submitted_at: '2026-08-30T09:59:00Z',
+};
+
+function createApprovedHarness(options = {}) {
+  return createHarness({reviews: [specOwnerReview], ...options});
+}
+
 function createDesignHarness(options = {}) {
   return createHarness({
     author: 'ernestt',
@@ -265,17 +295,54 @@ function hasReadyAttestation(state, owner = 'ernestt') {
 }
 
 describe('spec owner workflow reconciliation', () => {
-  it('treats an eligible owner-author ready event as exact-head approval', async () => {
+  it('never lets a spec-owner author self-attest their own head', async () => {
     const harness = createHarness();
 
     await run(harness, context({runId: 100n}));
 
     expect(
-      harness.state.statuses.some(
-        status => status.context === 'spec-owner-ready/cixzhang',
+      harness.state.statuses.some(status =>
+        status.context.startsWith('spec-owner-ready/'),
       ),
-    ).toBe(true);
-    expect(latestGateStatus(harness.state).state).toBe('success');
+    ).toBe(false);
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'pending',
+      description: expect.stringContaining('spec owner'),
+    });
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+    expect(harness.state.pr.auto_merge).toBe(null);
+  });
+
+  it('keeps a DESIGNOWNER ready attestation out of the spec approval group', async () => {
+    const harness = createHarness({
+      author: 'ernestt',
+      headContent: 'kind: architecture\nauthority: current\n',
+    });
+
+    await run(
+      harness,
+      context({runId: 100n, actor: 'ernestt', author: 'ernestt'}),
+    );
+
+    // The attestation is published for the design group, and the spec group
+    // still waits for a real exact-head owner decision.
+    expect(hasReadyAttestation(harness.state)).toBe(true);
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'pending',
+      description: expect.stringContaining('spec owner'),
+    });
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+  });
+
+  it('clears the gate on an exact-head spec-owner review', async () => {
+    const harness = createApprovedHarness();
+
+    await run(harness, context({runId: 100n}));
+
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'success',
+      description: expect.stringContaining('Approved by @imdreamrunner'),
+    });
     expect(harness.state.calls).toContain('enable-auto-merge');
   });
 
@@ -399,7 +466,7 @@ describe('spec owner workflow reconciliation', () => {
   });
 
   it('publishes owner approval and keeps conservative ownership when enablement is rejected', async () => {
-    const harness = createHarness({
+    const harness = createApprovedHarness({
       onEnableAutoMerge: () => {
         const error = new Error('Resource not accessible by integration');
         error.status = 403;
@@ -411,7 +478,7 @@ describe('spec owner workflow reconciliation', () => {
 
     expect(latestGateStatus(harness.state)).toMatchObject({
       state: 'success',
-      description: expect.stringContaining('Approved by @cixzhang'),
+      description: expect.stringContaining('Approved by @imdreamrunner'),
     });
     const terminalStatus = harness.state.calls.indexOf(
       'status:spec-owner-approval:success',
@@ -429,7 +496,7 @@ describe('spec owner workflow reconciliation', () => {
   });
 
   it('preserves the marker when an ambiguous enable error follows a successful mutation', async () => {
-    const harness = createHarness({
+    const harness = createApprovedHarness({
       onEnableAutoMerge: state => {
         state.pr.auto_merge = {merge_method: 'squash'};
         state.calls.push('auto-merge-applied-before-error');
@@ -449,7 +516,7 @@ describe('spec owner workflow reconciliation', () => {
   });
 
   it('does not let an old failure erase newer same-head auto-merge ownership', async () => {
-    const harness = createHarness({
+    const harness = createApprovedHarness({
       onEnableAutoMerge: state => {
         // The old run added the marker, then a newer run for the same exact
         // head enabled auto-merge before the old request returned an error.
@@ -722,7 +789,7 @@ describe('spec owner workflow reconciliation', () => {
   });
 
   it('disables gate-owned auto-merge before reconciling a later revoke', async () => {
-    const harness = createHarness();
+    const harness = createApprovedHarness();
     await run(harness, context({runId: 100n}));
     harness.state.comments.push({
       user: {login: 'cixzhang'},
@@ -752,7 +819,7 @@ describe('spec owner workflow reconciliation', () => {
   });
 
   it('undoes its own enable when a revoke supersedes it after the ownership label is removed', async () => {
-    const harness = createHarness({
+    const harness = createApprovedHarness({
       onEnableAutoMerge: state => {
         state.statuses.unshift(trustedStatus({runId: 101n}));
         state.labels.delete('spec-auto-merge');
@@ -991,5 +1058,362 @@ describe('spec owner workflow reconciliation', () => {
       }),
     );
     expect(harness.state.pullGets).toBe(0);
+  });
+
+  describe('a settled head is never re-decided', () => {
+    it('publishes nothing once the pull request has merged', async () => {
+      const harness = createApprovedHarness();
+      harness.state.pr.merged_at = '2026-08-30T09:58:00Z';
+      harness.state.pr.state = 'closed';
+
+      await run(harness, context({runId: 100n}));
+
+      expect(harness.state.statuses).toEqual([]);
+      expect(harness.state.calls).toEqual([
+        'info:The pull request is already merged or closed; the gate does not rewrite a settled head.',
+      ]);
+    });
+
+    it('publishes nothing once the pull request has closed unmerged', async () => {
+      const harness = createApprovedHarness();
+      harness.state.pr.state = 'closed';
+
+      await run(harness, context({runId: 100n}));
+
+      expect(harness.state.statuses).toEqual([]);
+      expect(harness.state.calls).not.toContain(
+        'status:spec-owner-approval:pending',
+      );
+    });
+
+    it('does not upgrade a head that merges while the run reconciles', async () => {
+      // The incident shape: the owner event arrives, the pull request merges
+      // unapproved, and the late run must not write approval onto that head.
+      const harness = createApprovedHarness({
+        onPullGet: (count, state) => {
+          if (count >= 3) {
+            state.pr.merged_at = '2026-08-30T10:00:15Z';
+            state.pr.state = 'closed';
+          }
+        },
+      });
+
+      await run(harness, context({runId: 100n}));
+
+      expect(
+        harness.state.statuses.some(
+          status =>
+            status.context === 'spec-owner-approval' &&
+            status.state === 'success',
+        ),
+      ).toBe(false);
+      expect(harness.state.calls).not.toContain('enable-auto-merge');
+      expect(
+        harness.state.calls.some(call =>
+          call.includes('settled while this run reconciled'),
+        ),
+      ).toBe(true);
+    });
+
+    it('reports a success that raced the merge and stops before auto-merge', async () => {
+      // The window between the last read and the write cannot be closed with
+      // GitHub's APIs. When it loses, the run must say so and go no further.
+      let publishedAt = null;
+      const harness = createApprovedHarness({
+        onPullGet: (count, state) => {
+          if (publishedAt !== null && count > publishedAt) {
+            state.pr.merged_at = '2026-08-30T10:00:20Z';
+            state.pr.state = 'closed';
+          }
+        },
+        onCreateStatus: (input, state) => {
+          if (
+            input.context === 'spec-owner-approval' &&
+            input.state === 'success'
+          ) {
+            publishedAt = state.pullGets;
+          }
+        },
+      });
+
+      await run(harness, context({runId: 100n}));
+
+      expect(harness.state.calls).not.toContain('enable-auto-merge');
+      expect(harness.state.pr.auto_merge).toBe(null);
+      expect(
+        harness.state.calls.some(call =>
+          call.includes('treat that status as unverified'),
+        ),
+      ).toBe(true);
+    });
+
+    it('reads the live pull request as the last call before publishing', async () => {
+      const harness = createApprovedHarness();
+
+      await run(harness, context({runId: 100n}));
+
+      const reads = harness.state.reads;
+      const publish = reads.indexOf('status:spec-owner-approval:success');
+      expect(publish).toBeGreaterThan(0);
+      expect(reads[publish - 1]).toBe('pull');
+    });
+
+    it('does not enable auto-merge on a head that settled after the status landed', async () => {
+      // Past the terminal write and its verification, the enable path has its
+      // own read; that read must also refuse a settled pull request.
+      let publishedAt = null;
+      const harness = createApprovedHarness({
+        onPullGet: (count, state) => {
+          if (publishedAt !== null && count >= publishedAt + 2) {
+            state.pr.merged_at = '2026-08-30T10:00:25Z';
+            state.pr.state = 'closed';
+          }
+        },
+        onCreateStatus: (input, state) => {
+          if (
+            input.context === 'spec-owner-approval' &&
+            input.state === 'success'
+          ) {
+            publishedAt = state.pullGets;
+          }
+        },
+      });
+
+      await run(harness, context({runId: 100n}));
+
+      expect(latestGateStatus(harness.state).state).toBe('success');
+      expect(harness.state.calls).not.toContain('enable-auto-merge');
+      expect(harness.state.pr.auto_merge).toBe(null);
+    });
+  });
+
+  it('ignores a ready marker from a handle that is not a design owner', async () => {
+    // Live shape from PR #5543: a spec owner marked their own PR ready before
+    // the design-only rule, leaving a trusted spec-owner-ready status on the
+    // head. It must not satisfy the design group it is not a member of.
+    const harness = createDesignHarness({
+      author: 'imdreamrunner',
+      statuses: [
+        trustedStatus({
+          runId: 90n,
+          statusContext: 'spec-owner-ready/imdreamrunner',
+          state: 'success',
+          description: 'Owner ready at 2026-09-04T05:54:18.000Z.',
+        }),
+      ],
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        actor: 'imdreamrunner',
+        author: 'imdreamrunner',
+      }),
+    );
+
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'pending',
+      description: expect.stringContaining('design approver'),
+    });
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+  });
+
+  it('still honours a ready marker from a current design owner', async () => {
+    const harness = createDesignHarness({
+      statuses: [
+        trustedStatus({
+          runId: 90n,
+          statusContext: 'spec-owner-ready/ernestt',
+          state: 'success',
+          description: 'Owner ready at 2026-08-30T09:59:00.000Z.',
+        }),
+      ],
+    });
+
+    await run(
+      harness,
+      context({
+        runId: 100n,
+        action: 'synchronize',
+        actor: 'ernestt',
+        author: 'ernestt',
+      }),
+    );
+
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'success',
+      description: expect.stringContaining('@ernestt'),
+    });
+  });
+
+  it('does not restore a newer run\u2019s status onto a settled head', async () => {
+    // Yielding writes too. If the pull request merged while this run worked,
+    // the newer run's status is no more publishable than this run's own.
+    const harness = createApprovedHarness({
+      statuses: [trustedStatus({runId: 101n, state: 'success'})],
+      onPullGet: (count, state) => {
+        if (count >= 2) {
+          state.pr.merged_at = '2026-08-30T10:00:10Z';
+          state.pr.state = 'closed';
+        }
+      },
+    });
+
+    await run(harness, context({runId: 100n}));
+
+    expect(
+      harness.state.statuses.filter(
+        status =>
+          status.context === 'spec-owner-approval' &&
+          status.target_url === canonicalRunUrl(repository, '101', '1'),
+      ),
+    ).toHaveLength(1);
+    expect(harness.state.calls).not.toContain('enable-auto-merge');
+  });
+
+  it('still restores a newer run\u2019s status on a live head', async () => {
+    const harness = createApprovedHarness({
+      statuses: [trustedStatus({runId: 101n, state: 'success'})],
+    });
+
+    await run(harness, context({runId: 100n}));
+
+    expect(latestGateStatus(harness.state)).toMatchObject({
+      state: 'success',
+      target_url: canonicalRunUrl(repository, '101', '1'),
+    });
+    expect(
+      harness.state.calls.some(call => call.includes('yielded to newer run')),
+    ).toBe(true);
+  });
+
+  describe('a backfill run publishes status without landing anything', () => {
+    function backfillContext(runId) {
+      return {
+        actor: 'cixzhang',
+        eventName: 'workflow_dispatch',
+        runId,
+        runAttempt: 1,
+        repo: {owner: 'facebook', repo: 'astryx'},
+        payload: {inputs: {pr: '17', backfill: true}},
+      };
+    }
+
+    it('publishes the missing status and never enables auto-merge', async () => {
+      const harness = createApprovedHarness();
+
+      await run(harness, backfillContext(100n));
+
+      expect(latestGateStatus(harness.state)).toMatchObject({
+        state: 'success',
+        description: expect.stringContaining('Approved by @imdreamrunner'),
+      });
+      expect(harness.state.calls).not.toContain('enable-auto-merge');
+      expect(harness.state.pr.auto_merge).toBe(null);
+      expect(
+        harness.state.calls.some(call => call.includes('Backfill run')),
+      ).toBe(true);
+    });
+
+    it('still enables auto-merge on an ordinary dispatch', async () => {
+      const harness = createApprovedHarness();
+      const ordinary = backfillContext(100n);
+      ordinary.payload.inputs.backfill = false;
+
+      await run(harness, ordinary);
+
+      expect(harness.state.calls).toContain('enable-auto-merge');
+    });
+
+    it('treats a string input the same way the form submits it', async () => {
+      const harness = createApprovedHarness();
+      const stringInput = backfillContext(100n);
+      stringInput.payload.inputs.backfill = 'true';
+
+      await run(harness, stringInput);
+
+      expect(harness.state.calls).not.toContain('enable-auto-merge');
+    });
+
+    it('still refuses to publish onto an already merged head', async () => {
+      const harness = createApprovedHarness();
+      harness.state.pr.merged_at = '2026-08-30T09:00:00Z';
+      harness.state.pr.state = 'closed';
+
+      await run(harness, backfillContext(100n));
+
+      expect(harness.state.statuses).toEqual([]);
+    });
+  });
+
+  describe('an owner command that misses the exact head is answered', () => {
+    function commandRun(body, harness = createHarness()) {
+      const comment = {
+        user: {login: 'cixzhang'},
+        body,
+        created_at: '2026-08-30T10:00:00Z',
+      };
+      harness.state.comments.push(comment);
+      return {
+        harness,
+        comment,
+        promise: run(
+          harness,
+          context({
+            runId: 100n,
+            eventName: 'issue_comment',
+            action: 'created',
+            comment,
+          }),
+        ),
+      };
+    }
+
+    it.each([
+      ['/approve-spec', 'did not name a commit'],
+      ['/approve-spec abc1234', 'full 40-character commit SHA'],
+      [`/approve-spec ${nextHead}`, 'is not the current head'],
+    ])('answers %s instead of ignoring it', async (body, reason) => {
+      const {harness, promise} = commandRun(body);
+      await promise;
+
+      const help = harness.state.comments.at(-1);
+      expect(harness.state.calls).toContain('create-comment');
+      expect(help.body).toContain(`<!-- spec-owner-command-help:${head} -->`);
+      expect(help.body).toContain(reason);
+      expect(help.body).toContain(`/approve-spec ${head}`);
+      expect(latestGateStatus(harness.state).state).toBe('pending');
+      expect(harness.state.calls).not.toContain('enable-auto-merge');
+    });
+
+    it('names the revoke verb the owner actually used', async () => {
+      const {harness, promise} = commandRun('/revoke-spec');
+      await promise;
+
+      expect(harness.state.comments.at(-1).body).toContain(
+        `/revoke-spec ${head}`,
+      );
+    });
+
+    it('answers a given head only once', async () => {
+      const {harness, promise} = commandRun('/approve-spec');
+      await promise;
+      const {promise: second} = commandRun('/approve-spec', harness);
+      await second;
+
+      expect(
+        harness.state.calls.filter(call => call === 'create-comment'),
+      ).toHaveLength(1);
+    });
+
+    it('stays quiet when the command names the exact head', async () => {
+      const {harness, promise} = commandRun(`/approve-spec ${head}`);
+      await promise;
+
+      expect(harness.state.calls).not.toContain('create-comment');
+      expect(latestGateStatus(harness.state).state).toBe('success');
+    });
   });
 });

--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -4,7 +4,10 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {spawnSync} from 'node:child_process';
+import {createRequire} from 'node:module';
 import {describe, expect, it} from 'vitest';
+
+const require = createRequire(import.meta.url);
 
 const root = path.resolve(import.meta.dirname, '../..');
 const read = relative => fs.readFileSync(path.join(root, relative), 'utf8');
@@ -160,17 +163,22 @@ describe('spec-only workflow contract', () => {
       .replace(/\s+/g, ' ')
       .trim();
     expect(reconcileCondition).toBe(
-      "(github.event_name != 'pull_request_review' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'issue_comment' || (github.event.issue.pull_request != null && (startsWith(github.event.comment.body, '/approve-spec ') || startsWith(github.event.comment.body, '/revoke-spec '))))",
+      "(github.event_name != 'pull_request_review' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'issue_comment' || (github.event.issue.pull_request != null && (startsWith(github.event.comment.body, '/approve-spec') || startsWith(github.event.comment.body, '/revoke-spec'))))",
     );
     expect(workflow).toContain('pull_request_review:');
     expect(workflow).toContain('issue_comment:');
     expect(workflow).toContain('permissions: {}');
     expect(workflow).not.toContain('pull_request_review_target');
+    // The filter must admit a command that omits the head SHA so the
+    // reconciler can answer it; a trailing space would drop it silently.
     expect(workflow).toContain(
-      "startsWith(github.event.comment.body, '/approve-spec ')",
+      "startsWith(github.event.comment.body, '/approve-spec')",
     );
     expect(workflow).toContain(
-      "startsWith(github.event.comment.body, '/revoke-spec ')",
+      "startsWith(github.event.comment.body, '/revoke-spec')",
+    );
+    expect(workflow).not.toContain(
+      "startsWith(github.event.comment.body, '/approve-spec ')",
     );
     expect(reconciler).toContain('expectedCount: after.changed_files');
     expect(reconciler).toContain('scope.touchesKnowledgeRecords');
@@ -184,6 +192,15 @@ describe('spec-only workflow contract', () => {
     expect(reconciler).not.toContain(
       '...new Set([...specOwners, ...engineeringOwners, ...designOwners])',
     );
+    // Only a DESIGNOWNER author self-attests, and only the design group
+    // reads that attestation.
+    expect(reconciler).toContain('designOwners.includes(actor)');
+    expect(reconciler).not.toContain('allOwners.has(actor)');
+    expect(reconciler).toContain(
+      'readyAttestations,\n        owners: designApprovers',
+    );
+    expect(reconciler).toContain('isSettled(initialPr)');
+    expect(reconciler).toContain('isPublishable(headSha)');
     expect(reconciler).toContain('specDecision.approved');
     expect(reconciler).toContain('designDecision.approved');
     expect(reconciler).toContain('themeDecision.approved');
@@ -191,6 +208,84 @@ describe('spec-only workflow contract', () => {
     expect(reconciler).toContain('expectedHeadOid: $oid');
     expect(reconciler).toContain('mergeMethod: SQUASH');
     expect(reconciler).toContain('disablePullRequestAutoMerge');
+  });
+
+  it('derives the comment trigger from the parser\u2019s own prefixes', () => {
+    const workflow = read('.github/workflows/spec-owner-gate.yml');
+    const {OWNER_COMMAND_PREFIXES} = require(
+      path.join(root, '.github/scripts/spec-owner-decision.cjs'),
+    );
+
+    // Every prefix the parser accepts must appear in the trigger, and the
+    // trigger must name no prefix the parser does not accept. A mismatch is
+    // the silent failure mode: a comment that parses but never dispatches.
+    const triggerPrefixes = [
+      ...workflow.matchAll(
+        /startsWith\(github\.event\.comment\.body, '([^']+)'\)/g,
+      ),
+    ].map(match => match[1]);
+    expect(new Set(triggerPrefixes)).toEqual(new Set(OWNER_COMMAND_PREFIXES));
+    for (const prefix of triggerPrefixes) {
+      expect(prefix.trimEnd(), prefix).toBe(prefix);
+    }
+  });
+
+  it('offers a backfill dispatch that publishes status without landing', () => {
+    const workflow = read('.github/workflows/spec-owner-gate.yml');
+    const reconciler = read('.github/scripts/spec-owner-reconcile.cjs');
+
+    expect(workflow).toContain('backfill:');
+    expect(workflow).toContain('type: boolean');
+    expect(reconciler).toContain("context.eventName === 'workflow_dispatch'");
+    expect(reconciler).toContain('backfillOnly');
+    // The guard must sit after the terminal status and before enablement.
+    const publish = reconciler.indexOf(
+      "setFinalStatus(initialHead, 'success', successDescription)",
+    );
+    const guard = reconciler.indexOf('if (backfillOnly) {');
+    const enable = reconciler.indexOf('enablePullRequestAutoMerge');
+    expect(publish).toBeGreaterThan(-1);
+    expect(guard).toBeGreaterThan(publish);
+    expect(enable).toBeGreaterThan(guard);
+  });
+
+  it('keeps the last read before a terminal write on the live pull request', () => {
+    const reconciler = read('.github/scripts/spec-owner-reconcile.cjs');
+    const guard = reconciler.slice(
+      reconciler.indexOf('async function isLiveHeadWritable('),
+      reconciler.indexOf('async function restoreNewerStatus('),
+    );
+
+    expect(guard).toContain('isSettled(live)');
+    expect(guard).toContain('live.head.sha !== headSha');
+    // isPublishable checks run currency first, then delegates the live read,
+    // so the freshest fact at the moment of the write is the pull request.
+    const publishable = reconciler.slice(
+      reconciler.indexOf('async function isPublishable('),
+      reconciler.indexOf('async function restoreNewerStatus('),
+    );
+    expect(publishable.indexOf('await isCurrentRun(headSha)')).toBeLessThan(
+      publishable.indexOf('isLiveHeadWritable(headSha)'),
+    );
+    expect(reconciler).toContain('treat that status as unverified');
+
+    // Every gate-status write goes through a live guard, restores included.
+    const restore = reconciler.slice(
+      reconciler.indexOf('async function restoreNewerStatus('),
+      reconciler.indexOf('async function isCurrentRun('),
+    );
+    expect(restore).toContain('await isLiveHeadWritable(headSha)');
+    expect(restore.indexOf('await isLiveHeadWritable(headSha)')).toBeLessThan(
+      restore.indexOf('createStatus('),
+    );
+  });
+
+  it('reads a ready attestation back only for a current design owner', () => {
+    const reconciler = read('.github/scripts/spec-owner-reconcile.cjs');
+    const decision = read('.github/scripts/spec-owner-decision.cjs');
+
+    expect(reconciler).toContain('owners: designOwners');
+    expect(decision).toContain('!allowed.has(owner)');
   });
 
   it('does not run the privileged visual-report path for spec-only PRs', () => {

--- a/.github/workflows/spec-owner-gate.yml
+++ b/.github/workflows/spec-owner-gate.yml
@@ -32,6 +32,14 @@ on:
         description: Pull request number to reconcile
         required: true
         type: string
+      backfill:
+        description: >-
+          Publish the gate status only. Use this when backfilling heads that
+          predate the required check, so a reconcile cannot also enable
+          auto-merge on a pull request nobody asked to land.
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -44,13 +52,15 @@ jobs:
   reconcile:
     # Fork review events have read-only tokens. Same-repo reviews reconcile
     # automatically; fork approvals use the trusted issue_comment command path.
+    # The comment filter admits any owner-command shape, including one missing
+    # the head SHA, so the reconciler answers it instead of ignoring it.
     if: >-
       (github.event_name != 'pull_request_review' ||
        github.event.pull_request.head.repo.full_name == github.repository) &&
       (github.event_name != 'issue_comment' ||
        (github.event.issue.pull_request != null &&
-        (startsWith(github.event.comment.body, '/approve-spec ') ||
-         startsWith(github.event.comment.body, '/revoke-spec '))))
+        (startsWith(github.event.comment.body, '/approve-spec') ||
+         startsWith(github.event.comment.body, '/revoke-spec'))))
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- align owner-command dispatch and parsing, including corrective replies for malformed commands and case-insensitive commit SHAs
- restrict design ready-attestations to current DESIGNOWNERS
- guard terminal and restored statuses with live exact-head/open-state checks
- add a backfill-only dispatch mode that publishes status without enabling auto-merge
- document the ordered rollout for making `spec-owner-approval` required

## Why

Knowledge-record PRs could merge while approval was still pending because the status was not required. Several command, historical-attestation, and status-publication edge cases also failed open or silently ignored owner intent.

## Test plan

- `node --test .github/scripts/spec-owner-*.test.cjs` (105 passed)
- `pnpm check:knowledge`
- formatting checks
- mutation checks for uppercase SHA parsing, DESIGNOWNER filtering, live status guards, backfill no-auto-merge, and command trigger/parser consistency
- live read-only verification of current missing status contexts and branch protection prerequisites
