### PR TITLE
fix(core): close streamed content and lifecycle regressions

### DIFF
--- a/.changeset/chat-composer-history-after-focus.md
+++ b/.changeset/chat-composer-history-after-focus.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatComposerInput no longer discards a pending draft when you click the
+composer's padding and press ArrowUp. Focusing a contentEditable collapses the
+caret to the start of the draft, which is the one position where ArrowUp means
+"recall history", so the first ArrowUp after that click replaced what you had
+typed. The composer now places the caret after the draft when it focuses
+itself — clicking the space after the text means "put me there" — so ArrowUp
+moves the caret with a draft present and still recalls history when the
+composer is empty. Multi-line caret navigation is unchanged.
+
+@cixzhang

--- a/.changeset/markdown-streamed-escaped-pipe.md
+++ b/.changeset/markdown-streamed-escaped-pipe.md
@@ -1,0 +1,12 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Streamed Markdown no longer goes blank when the line still arriving
+contains an escaped pipe. A `\|` is literal text, not a table-cell delimiter,
+so a line carrying only escaped pipes is ordinary prose and renders as it
+streams instead of being held back as an unfinished table header. Genuine
+partial table syntax is still suppressed, and incremental parsing stays bounded
+to the stream tail.
+
+@cixzhang

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -2,7 +2,9 @@
 
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {ChatComposer} from './ChatComposer';
+import {useChatComposerContext} from './ChatContext';
 import {ChatComposerInput} from './ChatComposerInput';
 import type {
   ChatComposerTrigger,
@@ -564,6 +566,13 @@ describe('ChatComposerInput', () => {
       window.getSelection()?.removeAllRanges();
     }
 
+    /** Type a message and send it, so history has something to recall. */
+    function submitMessage(textbox: HTMLElement, value: string) {
+      textbox.textContent = value;
+      fireEvent.input(textbox);
+      fireEvent.keyDown(textbox, {key: 'Enter'});
+    }
+
     it('paste inserts plain text after a focus() with no selection range', () => {
       const onChange = vi.fn();
       render(<ChatComposerInput onChange={onChange} />);
@@ -642,6 +651,313 @@ describe('ChatComposerInput', () => {
 
       handle!.insertText('hello');
       expect(textbox.textContent).toContain('hello');
+    });
+
+    // History recall reads where the caret sits, so where a programmatic
+    // focus leaves it decides whether ArrowUp recalls or moves the caret.
+    // Measured in Chromium: `focus()` collapses the caret to offset 0 —
+    // the START of the draft — so a composer that trusted it would let the
+    // first ArrowUp after a padding click replace whatever was typed. The
+    // composer states the caret itself instead: after the draft.
+    describe('caret placement on programmatic focus', () => {
+      /** What Chromium does to the Selection on `editable.focus()`. */
+      function focusLikeChromium(editable: HTMLElement) {
+        editable.focus();
+        const selection = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(editable.firstChild ?? editable, 0);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      function caretOffsetFromEnd(editable: HTMLElement): number {
+        const selection = window.getSelection()!;
+        const range = selection.getRangeAt(0);
+        const toEnd = document.createRange();
+        toEnd.selectNodeContents(editable);
+        toEnd.setStart(range.endContainer, range.endOffset);
+        return toEnd.toString().length;
+      }
+
+      it('puts the caret after the draft when the composer shell focuses it', async () => {
+        const user = userEvent.setup();
+        render(
+          <ChatComposer onSubmit={() => {}} input={<ChatComposerInput />} />,
+        );
+        const textbox = screen.getByRole('textbox');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+
+        // Walk to the composer body: editable → input root → inputArea → body.
+        const body = textbox.parentElement!.parentElement!.parentElement!;
+        await user.click(body);
+
+        expect(document.activeElement).toBe(textbox);
+        expect(caretOffsetFromEnd(textbox)).toBe(0);
+      });
+
+      // The click path overrides rather than restores: clicking the space
+      // after the text says where the user wants to be, so a caret left
+      // over from earlier does not win. Driving the shell's registered
+      // control directly is what makes this distinguishable — jsdom's
+      // synthetic click clears the selection on its own, so a click alone
+      // would pass either way.
+      it('overrides a stale mid-draft caret when the shell focuses it', () => {
+        let shellFocus: (() => void) | undefined;
+        function GrabControl() {
+          const ctx = useChatComposerContext();
+          shellFocus = () => {
+            ctx?.inputControlRef?.current?.focus();
+          };
+          return null;
+        }
+        render(
+          <ChatComposer
+            onSubmit={() => {}}
+            input={
+              <>
+                <ChatComposerInput />
+                <GrabControl />
+              </>
+            }
+          />,
+        );
+        const textbox = screen.getByRole('textbox');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+        const selection = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(textbox.firstChild!, 3);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        shellFocus!();
+
+        expect(caretOffsetFromEnd(textbox)).toBe(0);
+      });
+
+      it('keeps a pending draft when ArrowUp follows a click on the composer padding', async () => {
+        const user = userEvent.setup();
+        render(
+          <ChatComposer onSubmit={() => {}} input={<ChatComposerInput />} />,
+        );
+        const textbox = screen.getByRole('textbox');
+        submitMessage(textbox, 'first');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+
+        const body = textbox.parentElement!.parentElement!.parentElement!;
+        await user.click(body);
+        const prevented = !fireEvent.keyDown(textbox, {key: 'ArrowUp'});
+
+        // Caret movement, not recall: the draft survives untouched.
+        expect(prevented).toBe(false);
+        expect(textbox.textContent).toBe('pending draft');
+      });
+
+      it('recalls history when ArrowUp follows a padding click on an empty composer', async () => {
+        const user = userEvent.setup();
+        render(
+          <ChatComposer onSubmit={() => {}} input={<ChatComposerInput />} />,
+        );
+        const textbox = screen.getByRole('textbox');
+        submitMessage(textbox, 'first');
+
+        const body = textbox.parentElement!.parentElement!.parentElement!;
+        await user.click(body);
+        const prevented = !fireEvent.keyDown(textbox, {key: 'ArrowUp'});
+
+        // An empty draft is at its start and its end at once.
+        expect(prevented).toBe(true);
+        expect(textbox.textContent).toBe('first');
+      });
+
+      it('puts the caret after the draft on the imperative focus() with no prior caret', () => {
+        let handle: ChatComposerInputHandle | null = null;
+        render(
+          <ChatComposerInput
+            handleRef={h => {
+              handle = h;
+            }}
+          />,
+        );
+        const textbox = screen.getByRole('textbox');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+        clearSelection();
+
+        handle!.focus();
+
+        expect(document.activeElement).toBe(textbox);
+        expect(caretOffsetFromEnd(textbox)).toBe(0);
+      });
+
+      // A consumer calling focus() to return the user to the composer must
+      // not move them: the caret they left behind is theirs, not ours.
+      it('keeps a mid-draft caret across the imperative focus()', () => {
+        let handle: ChatComposerInputHandle | null = null;
+        render(
+          <ChatComposerInput
+            handleRef={h => {
+              handle = h;
+            }}
+          />,
+        );
+        const textbox = screen.getByRole('textbox');
+        const draft = 'pending draft';
+        textbox.textContent = draft;
+        fireEvent.input(textbox);
+        // Caret between "pending" and " draft".
+        const selection = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(textbox.firstChild!, 7);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        handle!.focus();
+
+        expect(document.activeElement).toBe(textbox);
+        expect(caretOffsetFromEnd(textbox)).toBe(draft.length - 7);
+      });
+
+      it('keeps a ranged selection across the imperative focus()', () => {
+        let handle: ChatComposerInputHandle | null = null;
+        render(
+          <ChatComposerInput
+            handleRef={h => {
+              handle = h;
+            }}
+          />,
+        );
+        const textbox = screen.getByRole('textbox');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+        const selection = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(textbox.firstChild!, 0);
+        range.setEnd(textbox.firstChild!, 7);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        handle!.focus();
+
+        const after = window.getSelection()!;
+        expect(after.isCollapsed).toBe(false);
+        expect(after.toString()).toBe('pending');
+      });
+
+      it('keeps a start-of-draft caret across the imperative focus(), so ArrowUp still recalls', () => {
+        let handle: ChatComposerInputHandle | null = null;
+        render(
+          <ChatComposerInput
+            onSubmit={() => {}}
+            handleRef={h => {
+              handle = h;
+            }}
+          />,
+        );
+        const textbox = screen.getByRole('textbox');
+        submitMessage(textbox, 'first');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+        // The user deliberately put the caret at the start.
+        const selection = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(textbox.firstChild!, 0);
+        range.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        handle!.focus();
+        fireEvent.keyDown(textbox, {key: 'ArrowUp'});
+
+        // Their caret is honored, not overridden into "end of draft".
+        expect(textbox.textContent).toBe('first');
+      });
+
+      it('ignores a selection outside the editable on the imperative focus()', () => {
+        let handle: ChatComposerInputHandle | null = null;
+        const {container} = render(
+          <div>
+            <p>elsewhere</p>
+            <ChatComposerInput
+              handleRef={h => {
+                handle = h;
+              }}
+            />
+          </div>,
+        );
+        const textbox = screen.getByRole('textbox');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+        const outside = container.querySelector('p')!;
+        const selection = window.getSelection()!;
+        const range = document.createRange();
+        range.selectNodeContents(outside);
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        handle!.focus();
+
+        // Not the user's position in the composer, so it does not count.
+        expect(caretOffsetFromEnd(textbox)).toBe(0);
+      });
+
+      it('keeps a pending draft when the caret is the one Chromium leaves on a bare focus()', () => {
+        render(<ChatComposerInput onSubmit={() => {}} />);
+        const textbox = screen.getByRole('textbox');
+        submitMessage(textbox, 'first');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+
+        // A consumer focusing the DOM node directly bypasses our focus
+        // control, so this is the caret the engine chose.
+        focusLikeChromium(textbox);
+        const prevented = !fireEvent.keyDown(textbox, {key: 'ArrowUp'});
+
+        // The user did put the caret at the start here as far as the DOM can
+        // tell, so recall is the documented behavior — but the draft must be
+        // recoverable, not lost.
+        expect(prevented).toBe(true);
+        expect(textbox.textContent).toBe('first');
+        fireEvent.keyDown(textbox, {key: 'ArrowDown'});
+        expect(textbox.textContent).toBe('pending draft');
+      });
+
+      it('recalls history on ArrowUp when no caret exists inside the editable', () => {
+        render(<ChatComposerInput onSubmit={() => {}} />);
+        const textbox = screen.getByRole('textbox');
+        submitMessage(textbox, 'first');
+
+        // An engine that creates no Range on focus, or a consumer that never
+        // focused at all: the composer falls back to a caret after the draft.
+        textbox.focus();
+        clearSelection();
+        expect(window.getSelection()?.rangeCount ?? 0).toBe(0);
+
+        const prevented = !fireEvent.keyDown(textbox, {key: 'ArrowUp'});
+
+        expect(prevented).toBe(true);
+        expect(textbox.textContent).toBe('first');
+      });
+
+      it('keeps a pending draft when no caret exists inside the editable', () => {
+        render(<ChatComposerInput onSubmit={() => {}} />);
+        const textbox = screen.getByRole('textbox');
+        submitMessage(textbox, 'first');
+        textbox.textContent = 'pending draft';
+        fireEvent.input(textbox);
+        textbox.focus();
+        clearSelection();
+
+        const prevented = !fireEvent.keyDown(textbox, {key: 'ArrowUp'});
+
+        expect(prevented).toBe(false);
+        expect(textbox.textContent).toBe('pending draft');
+      });
     });
 
     it('paste falls through to plain-text path when pasteAsToken={false}', () => {

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -51,6 +51,9 @@ import {
   insertTextAtCursor,
   isSelectionAtStart,
   isSelectionAtEnd,
+  placeCaretAtEnd,
+  getSelectionRangeInside,
+  restoreSelectionRange,
 } from './chatComposerSelection';
 import {ChatPastedTextToken} from './ChatPastedTextToken';
 import {
@@ -382,11 +385,66 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
   // when a parent attaches a ref — without this, paste-as-token would
   // silently no-op whenever `ChatComposerInput` is rendered without
   // a forwarded ref (e.g. inside `ChatComposer`).
+  /**
+   * Focus the editable and put the caret after the draft.
+   *
+   * A bare `focus()` is not enough: Chromium collapses the caret to the
+   * start of the content, which is the one position where ArrowUp means
+   * "recall history" — so focusing a composer that already holds a draft
+   * would arm the next ArrowUp to replace it. Landing after the text is
+   * also what a click on the composer's trailing space means.
+   */
+  /**
+   * Focus the editable, keeping a caret or selection the user already has
+   * inside it.
+   *
+   * A bare `focus()` is not enough on its own: Chromium collapses the caret
+   * to the start of the content, which is the one position where ArrowUp
+   * means "recall history" — so focusing a composer that already holds a
+   * draft would arm the next ArrowUp to replace it. But a consumer calling
+   * `focus()` to return the user to where they were must not have their
+   * caret moved either, so an existing in-editor selection is captured
+   * before focusing and restored after. Only when there is none does the
+   * caret land after the draft.
+   */
+  const focusEditable = useCallback(() => {
+    const editable = editableRef.current;
+    if (!editable) {
+      return;
+    }
+    // Read before focusing: `focus()` itself creates the offset-0 caret, so
+    // asking afterwards cannot tell the user's own caret from the engine's.
+    const existing = getSelectionRangeInside(editable);
+    editable.focus();
+    if (existing) {
+      restoreSelectionRange(existing);
+      return;
+    }
+    placeCaretAtEnd(editable);
+  }, []);
+
+  /**
+   * Focus the editable and put the caret after the draft, whatever the
+   * selection was.
+   *
+   * This is the composer shell's click-to-focus path: clicking the empty
+   * space after a draft means "put me after the text", so it overrides a
+   * stale caret rather than restoring one.
+   */
+  const focusEditableAtEnd = useCallback(() => {
+    const editable = editableRef.current;
+    if (!editable) {
+      return;
+    }
+    editable.focus();
+    placeCaretAtEnd(editable);
+  }, []);
+
   const handle: ChatComposerInputHandle = {
     insertToken: (token: ChatComposerToken) => insertTokenRef.current(token),
     expandToken: (id: string) => tokens.expandToken(id),
     insertText: (text: string) => insertTextRef.current(text),
-    focus: () => editableRef.current?.focus(),
+    focus: focusEditable,
     getValue: () =>
       serialize(editableRef.current ?? document.createElement('div')),
   };
@@ -401,11 +459,11 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     if (!inputControlRef) {
       return;
     }
-    inputControlRef.current = {focus: () => editableRef.current?.focus()};
+    inputControlRef.current = {focus: focusEditableAtEnd};
     return () => {
       inputControlRef.current = null;
     };
-  }, [inputControlRef]);
+  }, [inputControlRef, focusEditableAtEnd]);
 
   useEffect(() => {
     if (controlledValue === undefined || !editableRef.current) {
@@ -609,6 +667,13 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
           return;
         }
         const editable = editableRef.current;
+        // Last-resort fallback for a caret we never placed: an engine that
+        // leaves no Range inside the editable on focus, or a consumer that
+        // focused the DOM node directly instead of through our focus
+        // control. Place it where the focus control would have, so a
+        // pending draft is never mistaken for a caret at the start. A no-op
+        // whenever a real caret exists — including one the user moved.
+        ensureCaretInside(editable);
         const isCollapsed = window.getSelection()?.isCollapsed ?? true;
         const atStart = isSelectionAtStart(editable);
         const atEnd = isSelectionAtEnd(editable);

--- a/packages/core/src/Chat/chatComposerSelection.ts
+++ b/packages/core/src/Chat/chatComposerSelection.ts
@@ -11,14 +11,26 @@
  * Selection helpers for the contentEditable chat input. Both the
  * imperative `insertToken` / `insertText` APIs and the paste pipeline
  * need a valid Range inside the editable before they can mutate the
- * DOM. Browsers do NOT create a Selection range when an element is
- * programmatically focused — a Range only exists once the user has
- * clicked inside the editable or we've created one explicitly.
+ * DOM, and history recall needs to know where the caret sits.
  *
- * `ensureCaretInside` centralizes the fallback: if the current
- * Selection has no Range inside the given editable, place a collapsed
- * caret at the end of the editable. Callers can then read
- * `selection.getRangeAt(0)` safely.
+ * What a programmatic `focus()` does to the Selection is browser- and
+ * state-dependent, and it is never what a click on the composer's padding
+ * means. Measured in Chromium: focusing a contentEditable collapses the
+ * caret to offset 0 — the *start* of the draft — whether or not a
+ * selection existed before, and whether the editable is empty or not.
+ * Other engines may instead leave no Range inside the editable at all.
+ *
+ * So the composer never infers the caret from a bare `focus()`:
+ * - `placeCaretAtEnd` states the caret outright, and is what the composer
+ *   shell's click-to-focus uses, because clicking the space after a draft
+ *   means "put me after the text" in every chat composer.
+ * - `getSelectionRangeInside` + `restoreSelectionRange` let the imperative
+ *   `focus()` keep a caret or selection the user already had: it is read
+ *   before focusing, since afterwards the engine's own caret is
+ *   indistinguishable from theirs.
+ * - `ensureCaretInside` is the weaker fallback for callers that only
+ *   need *a* valid Range (paste, imperative insertion): it respects a
+ *   caret that already exists and creates one at the end otherwise.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/ChatComposerInput.tsx (consumer)
@@ -26,11 +38,70 @@
  */
 
 /**
+ * The current Selection's range when it lies inside `editable`, or `null`.
+ *
+ * Callers use this to read the caret *before* focusing, because `focus()`
+ * creates a caret of its own and afterwards the two are indistinguishable.
+ * The range is cloned, so later DOM work cannot mutate the saved position.
+ */
+export function getSelectionRangeInside(editable: HTMLElement): Range | null {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  if (
+    !editable.contains(range.startContainer) ||
+    !editable.contains(range.endContainer)
+  ) {
+    return null;
+  }
+  return range.cloneRange();
+}
+
+/** Make `range` the current Selection again. */
+export function restoreSelectionRange(range: Range): void {
+  const selection = window.getSelection();
+  if (!selection) {
+    return;
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+/**
+ * Collapse the Selection to the very end of `editable`'s content,
+ * replacing whatever the Selection held before.
+ *
+ * Unlike {@link ensureCaretInside} this is unconditional: a caret the
+ * browser placed on `focus()` is overwritten, which is the point — that
+ * caret lands at the start of the draft, where ArrowUp means "recall
+ * history" and would discard what the user had typed.
+ *
+ * Returns `true` when the caret was placed, `false` if the Selection API
+ * is unavailable (e.g. a detached document).
+ */
+export function placeCaretAtEnd(editable: HTMLElement): boolean {
+  const selection = window.getSelection();
+  if (!selection) {
+    return false;
+  }
+  const range = document.createRange();
+  range.selectNodeContents(editable);
+  range.collapse(false); // collapse to end
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
+}
+
+/**
  * Ensure the current Selection has a Range inside `editable`.
  *
  * If `window.getSelection()` already has a Range whose `startContainer`
- * is inside `editable`, this is a no-op. Otherwise a collapsed caret
- * is placed at the end of `editable` and the Selection is updated.
+ * is inside `editable`, this is a no-op — including the start-of-draft
+ * caret a `focus()` leaves behind, which is why callers that care where
+ * the caret lands want {@link placeCaretAtEnd} instead. Otherwise a
+ * collapsed caret is placed at the end of `editable`.
  *
  * Returns the live `Selection` on success, or `null` if no Selection
  * is available at all (e.g. detached document, JSDOM without selection
@@ -100,12 +171,7 @@ export function isSelectionAtEnd(editable: HTMLElement): boolean {
     return false;
   }
   const range = selection.getRangeAt(0);
-  return isBoundaryAtEdge(
-    editable,
-    range.endContainer,
-    range.endOffset,
-    'end',
-  );
+  return isBoundaryAtEdge(editable, range.endContainer, range.endOffset, 'end');
 }
 
 /**
@@ -126,7 +192,7 @@ function isBoundaryAtEdge(
     return false;
   }
 
-  for (let node: Node | null = container; node && node !== editable; ) {
+  for (let node: Node | null = container; node && node !== editable;) {
     if (hasContentSibling(node, edge)) {
       return false;
     }

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import type {ReactNode} from 'react';
 import {Markdown} from './Markdown';
 import type {MarkdownInlinePlugin} from './Markdown';
+import {stubMatchMedia} from '../__tests__/stubMatchMedia';
 import {parseOutlineFromMarkdown} from '../Outline/parseOutlineFromMarkdown';
 
 describe('Markdown', () => {
@@ -479,6 +480,90 @@ describe('Markdown', () => {
     const {container} = render(<Markdown>{'Hello'}</Markdown>);
     const cursor = container.querySelector('span[aria-hidden]');
     expect(cursor).not.toBeInTheDocument();
+  });
+
+  // A reader watching a reply arrive sees the DOM, not the parsed nodes.
+  // A `\|` is literal text, so the line must stay legible as it streams;
+  // the parser once classified it as an unfinished table header and held
+  // the whole line back, blanking the message.
+  describe('streamed text containing an escaped pipe', () => {
+    // Reduced motion makes the reveal synchronous, so each render shows
+    // exactly the prefix under test rather than a rAF-driven fraction.
+    beforeEach(() => {
+      stubMatchMedia({reduceMotion: true});
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    /** The text of each rendered block, in document order. */
+    function blockTexts(container: HTMLElement): string[] {
+      const doc = container.querySelector('[role="document"]')!;
+      return Array.from(doc.children).map(block =>
+        (block.textContent ?? '').replace(/\s+/g, ' ').trim(),
+      );
+    }
+
+    it('shows every prefix of the line, escaped pipe rendered literally', () => {
+      const text = 'Costs 5 \\| 10 per unit';
+      const {container, rerender} = render(
+        <Markdown isStreaming>{text.slice(0, 1)}</Markdown>,
+      );
+
+      for (let length = 1; length <= text.length; length++) {
+        const prefix = text.slice(0, length);
+        rerender(<Markdown isStreaming>{prefix}</Markdown>);
+
+        // Every `\|` reads as one literal pipe, and no backslash survives.
+        expect(blockTexts(container)).toEqual([
+          prefix.replace(/\\\|/g, '|').trim(),
+        ]);
+      }
+    });
+
+    it('shows every prefix below settled content, both kept on screen', () => {
+      const settled = 'Intro\n\n';
+      const text = `${settled}Costs 5 \\| 10 per unit`;
+      const {container, rerender} = render(
+        <Markdown isStreaming>{settled}</Markdown>,
+      );
+
+      for (let length = settled.length + 1; length <= text.length; length++) {
+        const prefix = text.slice(0, length);
+        rerender(<Markdown isStreaming>{prefix}</Markdown>);
+
+        const tail = text.slice(settled.length, length).replace(/\\\|/g, '|');
+        // The settled paragraph stays on screen and the tail is legible.
+        expect(blockTexts(container)).toEqual(['Intro', tail.trim()]);
+      }
+    });
+
+    it('renders the finished line as one paragraph with the literal pipe', () => {
+      const {container} = render(
+        <Markdown isStreaming>{'Costs 5 \\| 10 per unit'}</Markdown>,
+      );
+
+      const paragraphs = container.querySelectorAll('[role="paragraph"]');
+      expect(paragraphs).toHaveLength(1);
+      expect(paragraphs[0].textContent).toBe('Costs 5 | 10 per unit');
+      // Prose, not a table: no cell was ever split out of it.
+      expect(container.querySelector('table')).toBeNull();
+    });
+
+    it('still renders a real streamed table containing an escaped pipe', () => {
+      const {container} = render(
+        <Markdown isStreaming>
+          {'| Col1 | Col2 |\n| --- | --- |\n| a \\| b | c |'}
+        </Markdown>,
+      );
+
+      const cells = container.querySelectorAll('tbody td');
+      expect(Array.from(cells).map(cell => cell.textContent)).toEqual([
+        'a | b',
+        'c',
+      ]);
+    });
   });
 
   it('applies compact density', () => {

--- a/packages/core/src/Markdown/incremental.test.ts
+++ b/packages/core/src/Markdown/incremental.test.ts
@@ -5,6 +5,7 @@ import {
   parseMarkdown,
   parseMarkdownIncremental,
   createIncrementalState,
+  getIncrementalParseWork,
   trimStreamingArtifacts,
 } from './parser';
 import type {BlockNode, InlineNode} from './parser';
@@ -428,6 +429,164 @@ describe('streaming structural suppression', () => {
     if (table?.type === 'table') {
       expect(table.rows).toHaveLength(1);
     }
+  });
+
+  // A `\|` is literal text, not a cell delimiter, so an unfinished line
+  // carrying only escaped pipes is ordinary prose. Holding it back hid the
+  // text — and when it was the whole document, rendered nothing at all.
+  describe('escaped pipes in the unsettled tail', () => {
+    it('renders an unfinished first line whose only pipes are escaped', () => {
+      const text = 'Costs 5 \\| 10 per unit';
+      const state = createIncrementalState();
+
+      const blocks = parseMarkdownIncremental(text, state);
+
+      expect(blocks).toEqual(parseMarkdown(text));
+      expect(blocks).toHaveLength(1);
+    });
+
+    it('renders an unfinished tail line after a settled block', () => {
+      const text = 'Intro\n\nCosts 5 \\| 10 per unit';
+      const state = createIncrementalState();
+
+      const blocks = parseMarkdownIncremental(text, state);
+
+      expect(blocks).toEqual(parseMarkdown(text));
+      expect(blocks).toHaveLength(2);
+    });
+
+    /** The text a reader would see for one block. */
+    function visibleText(block: BlockNode): string {
+      const fromInline = (nodes: InlineNode[]): string =>
+        nodes
+          .map(node => {
+            switch (node.type) {
+              case 'text':
+              case 'code':
+                return node.content;
+              case 'bold':
+              case 'italic':
+              case 'strikethrough':
+              case 'link':
+                return fromInline(node.children);
+              case 'break':
+                return '\n';
+              case 'image':
+                return node.alt;
+              case 'citation':
+                return '';
+            }
+          })
+          .join('');
+      switch (block.type) {
+        case 'heading':
+        case 'paragraph':
+          return fromInline(block.children);
+        case 'codeblock':
+          return block.content;
+        case 'blockquote':
+          return block.children.map(visibleText).join('\n');
+        case 'list':
+          return block.items
+            .map(item => item.children.map(visibleText).join('\n'))
+            .join('\n');
+        case 'table':
+          return [block.headers, ...block.rows]
+            .map(row => row.map(cell => fromInline(cell.children)).join(' '))
+            .join('\n');
+        case 'image':
+          return block.alt;
+        case 'hr':
+          return '';
+      }
+    }
+
+    /**
+     * What the tail of a streamed prose line should read as once rendered:
+     * every `\|` is one literal pipe, and the parser trims the unsettled
+     * tail's surrounding whitespace.
+     */
+    function expectedTail(source: string): string {
+      return source.replace(/\\\|/g, '|').trim();
+    }
+
+    it('keeps the whole tail visible at every prefix, with no settled text', () => {
+      const text = 'Costs 5 \\| 10 per unit';
+      const state = createIncrementalState();
+
+      for (let length = 1; length <= text.length; length++) {
+        const blocks = parseMarkdownIncremental(text.slice(0, length), state);
+        const tail = expectedTail(text.slice(0, length));
+
+        expect(blocks).toHaveLength(1);
+        expect(visibleText(blocks[0])).toBe(tail);
+      }
+    });
+
+    it('keeps the whole tail visible at every prefix, after a settled block', () => {
+      const settled = 'Intro\n\n';
+      const text = `${settled}Costs 5 \\| 10 per unit`;
+      const state = createIncrementalState();
+
+      for (let length = settled.length + 1; length <= text.length; length++) {
+        const blocks = parseMarkdownIncremental(text.slice(0, length), state);
+        const tail = expectedTail(text.slice(settled.length, length));
+
+        // The settled paragraph stays put and the tail is fully readable.
+        expect(blocks).toHaveLength(2);
+        expect(visibleText(blocks[0])).toBe('Intro');
+        expect(visibleText(blocks[1])).toBe(tail);
+      }
+
+      expect(parseMarkdownIncremental(text, state)).toEqual(
+        parseMarkdown(text),
+      );
+    });
+
+    it('keeps parsing bounded to the tail as the line streams in', () => {
+      const prefix = 'Filler paragraph.\n\n'.repeat(40);
+      const text = `${prefix}Costs 5 \\| 10 per unit`;
+      const state = createIncrementalState();
+      // Prime the cache: the first call has nothing settled yet and reads the
+      // whole snapshot by definition.
+      parseMarkdownIncremental(`${prefix}C`, state);
+      let worstSplitCharacters = 0;
+
+      for (let length = prefix.length + 2; length <= text.length; length++) {
+        parseMarkdownIncremental(text.slice(0, length), state);
+        worstSplitCharacters = Math.max(
+          worstSplitCharacters,
+          getIncrementalParseWork(state).splitCharacters,
+        );
+      }
+
+      // Only the unsettled tail is re-split, never the settled filler.
+      expect(worstSplitCharacters).toBeLessThan(
+        text.length - prefix.length + 5,
+      );
+    });
+
+    it('still holds back a lone header whose pipes are unescaped', () => {
+      const state = createIncrementalState();
+
+      const blocks = parseMarkdownIncremental('Col1 | Col2', state);
+
+      expect(blocks).toHaveLength(0);
+    });
+
+    it('streams table rows containing escaped pipes once the table exists', () => {
+      const text = '| Col1 | Col2 |\n| --- | --- |\n| a \\| b | c |';
+      const state = createIncrementalState();
+
+      const blocks = parseMarkdownIncremental(text, state);
+
+      const table = blocks.find(b => b.type === 'table');
+      expect(table?.type).toBe('table');
+      if (table?.type === 'table') {
+        expect(table.rows).toHaveLength(1);
+        expect(table.rows[0]).toHaveLength(2);
+      }
+    });
   });
 
   it('suppresses ordered list marker without content', () => {

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -1083,6 +1083,28 @@ function isHorizontalRule(line: string): boolean {
   return true;
 }
 
+/**
+ * Whether a line holds a pipe that could delimit table cells.
+ *
+ * A backslash-escaped `\|` is literal text inside one cell — `splitTableRow`
+ * keeps it verbatim — so a line whose only pipes are escaped shows no partial
+ * table syntax while it streams. Used by `trimUnsettledStructural` to decide
+ * whether an unfinished trailing line is a table header worth holding back.
+ */
+function hasUnescapedPipe(line: string): boolean {
+  for (let index = 0; index < line.length; index++) {
+    if (line[index] === '\\') {
+      // Skip the escaped character, whatever it is.
+      index++;
+      continue;
+    }
+    if (line[index] === '|') {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** GFM separator row: cells contain only dashes/colons. */
 function isTableSeparator(line: string): boolean {
   if (!line.includes('|')) {
@@ -1903,12 +1925,16 @@ function trimUnsettledStructural(text: string): string {
     }
 
     // Table: only suppress if this is a lone header without a separator.
-    // If the line has `|` and the line before it is NOT a separator,
-    // and THIS line is not a separator, and there's no established table
-    // above (header + separator pair), hold it back.
-    if (trimmed.includes('|') && !isTableSeparator(last)) {
+    // If the line has an unescaped `|` and the line before it is NOT a
+    // separator, and THIS line is not a separator, and there's no established
+    // table above (header + separator pair), hold it back. An escaped `\|` is
+    // ordinary prose, not a cell delimiter, so a line carrying only those is
+    // never held back — holding it back blanks the text while it streams.
+    if (hasUnescapedPipe(trimmed) && !isTableSeparator(last)) {
       // Is there a separator anywhere above that would make this part of
-      // an established table? Walk up to find header+separator pair.
+      // an established table? Walk up to find header+separator pair. The
+      // header test mirrors the block parser's own `includes('|')`, which
+      // accepts an escaped-only header line once its separator arrives.
       let tableEstablished = false;
       for (let i = lines.length - 2; i >= 1; i--) {
         if (isTableSeparator(lines[i]) && lines[i - 1].includes('|')) {

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -17,6 +17,7 @@ Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github
 | `tsup.config.ts`    | Config    | Build config: CJS + ESM + `.d.ts` outputs                    |
 | `src/index.ts`      | Barrel    | Public API surface                                           |
 | `src/VegaChart.tsx` | Component | Inspects `$schema`, compiles or renders, owns View lifecycle |
+| `src/viewInputs.ts` | Utility   | Detects value changes in the props that own the View         |
 | `src/schema.ts`     | Utility   | Parses and validates Vega/Vega-Lite `$schema` URLs           |
 | `src/types.ts`      | Types     | Shared TypeScript types for this package                     |
 
@@ -133,9 +134,51 @@ import {VegaChart} from '@astryxdesign/vega';
 | -------------------- | --------- | --------------------------------------------------------- |
 | `ast`                | `boolean` | Retain expression AST in the runtime (useful for tooling) |
 
+### View lifecycle
+
+`<VegaChart>` builds a Vega `View` on mount and finalizes it on unmount. In
+between, it rebuilds the View only when `spec`, `compileOptions`,
+`parseConfig`, `parseOptions`, or `viewOptions` **changes value** — these props
+are compared by value against the values the live View was built from, not by
+reference. Two consequences, and you need neither `useMemo` nor a discipline
+about object identity for either:
+
+- an object literal rebuilt inline on every render does **not** tear the chart
+  down;
+- a spec you edit **in place** — held in a ref, a module constant, or shared
+  between renders — **is** picked up, because the comparison is against a copy
+  taken when the View was built, not against the previous props.
+
+Functions inside those props (a `tooltip` handler, `logger`, `loader`, `expr`,
+or `fieldTitle`) and class instances are compared by reference, since their
+behavior lives in methods a copy cannot capture: replace the value rather than
+mutating it.
+
+Two shapes cannot be copied for comparison: a subtree that re-enters an object
+already on its own path (a reference cycle), and one nested deeper than 100
+levels. Those parts are compared **by reference**, so passing the **same**
+object again is stable — a chart built from a cyclic spec is not rebuilt on
+every render — while passing a **new** object rebuilds the View even when it
+holds equal values.
+
+What that costs differs between the two:
+
+- **A cycle hides nothing.** Its re-entry edge points back at an object the
+  copy already walked, so an in-place edit anywhere in a cyclic spec is still
+  detected normally.
+- **Past 100 levels, an in-place edit is invisible** — the reference did not
+  change and the values below were never copied. Replace the object, or drive
+  the View through `onReady`, to update from down there.
+
+Everything the copy did reach is compared by value either way, so a mutation
+elsewhere in the spec is picked up even when part of it is opaque.
+
+Everything else is inert to the lifecycle: `data`, `className`, `style`,
+`onReady`, and `onError` never rebuild the View.
+
 ### Data loading
 
-`data` maps dataset names to tuple arrays and is applied via `view.data(name, tuples)` during View initialization, before the first render. It is _not reactive_; changes after mount are ignored.
+`data` maps dataset names to tuple arrays and is applied via `view.data(name, tuples)` during View initialization, before the first render. It is _not reactive_; changes after mount are ignored, and a new `data` object never rebuilds the View by itself. (When something else rebuilds the View, the new View loads whatever `data` holds at that moment.)
 
 To update data dynamically after render, use `onReady` to get the live View and drive it yourself:
 

--- a/packages/vega/src/VegaChart.test.tsx
+++ b/packages/vega/src/VegaChart.test.tsx
@@ -153,16 +153,231 @@ describe('VegaChart', () => {
       );
     });
 
-    it('tears down the old View and builds a new one when the spec identity changes', () => {
+    it('tears down the old View and builds a new one when the spec changes', () => {
       const {rerender} = render(<VegaChart spec={VEGA_SPEC} />);
       expect(views).toHaveLength(1);
 
-      rerender(<VegaChart spec={{...VEGA_SPEC}} />);
+      rerender(
+        <VegaChart
+          spec={{...VEGA_SPEC, background: 'red'} as unknown as AnySpec}
+        />,
+      );
 
       expect(views).toHaveLength(2);
       expect(views[0].finalize).toHaveBeenCalledTimes(1);
       expect(views[1].finalize).not.toHaveBeenCalled();
       expect(parseMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // The View is the expensive thing this component owns, and rebuilding it
+  // throws away the chart's zoom, hover, and signal state. So a rebuild
+  // follows a change of value, not a change of object identity -- the
+  // documented usage passes spec, options, and data as inline literals.
+  describe('View rebuild policy', () => {
+    it('keeps the View when a re-render passes an equal spec object', () => {
+      const {rerender} = render(<VegaChart spec={VEGA_SPEC} />);
+      expect(views).toHaveLength(1);
+
+      rerender(<VegaChart spec={{...VEGA_SPEC}} />);
+
+      expect(views).toHaveLength(1);
+      expect(views[0].finalize).not.toHaveBeenCalled();
+      expect(parseMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the View when a re-render passes an equal options object', () => {
+      const {rerender} = render(
+        <VegaChart spec={VEGA_SPEC} viewOptions={{renderer: 'canvas'}} />,
+      );
+
+      rerender(
+        <VegaChart spec={VEGA_SPEC} viewOptions={{renderer: 'canvas'}} />,
+      );
+
+      expect(views).toHaveLength(1);
+    });
+
+    it('rebuilds when an options value actually changes', () => {
+      const {rerender} = render(
+        <VegaChart spec={VEGA_SPEC} viewOptions={{renderer: 'canvas'}} />,
+      );
+
+      rerender(<VegaChart spec={VEGA_SPEC} viewOptions={{renderer: 'svg'}} />);
+
+      expect(views).toHaveLength(2);
+      expect(views[1].options).toMatchObject({renderer: 'svg'});
+    });
+
+    it('rebuilds when a function inside the options changes identity', () => {
+      // Two tooltip handlers can look alike and behave differently, so
+      // functions are compared by reference, not walked.
+      const {rerender} = render(
+        <VegaChart spec={VEGA_SPEC} viewOptions={{tooltip: () => {}}} />,
+      );
+
+      rerender(
+        <VegaChart spec={VEGA_SPEC} viewOptions={{tooltip: () => {}}} />,
+      );
+
+      expect(views).toHaveLength(2);
+    });
+
+    // A caller that holds its spec in a ref or a module constant and edits it
+    // in place leaves both renders pointing at the same object. Comparing
+    // props to props sees nothing; the chart would keep rendering old data.
+    it('rebuilds when a nested object shared across renders is mutated', () => {
+      const encoding = {x: {field: 'a', type: 'ordinal'}};
+      const specWith = () =>
+        ({
+          $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+          mark: 'bar',
+          encoding,
+        }) as unknown as AnySpec;
+      const {rerender} = render(<VegaChart spec={specWith()} />);
+      expect(views).toHaveLength(1);
+
+      encoding.x.field = 'b';
+      rerender(<VegaChart spec={specWith()} />);
+
+      expect(views).toHaveLength(2);
+      expect(views[0].finalize).toHaveBeenCalledTimes(1);
+      expect(compileMock.mock.calls[1][0]).toMatchObject({
+        encoding: {x: {field: 'b'}},
+      });
+    });
+
+    it('rebuilds when the very same spec object is mutated in place', () => {
+      const spec = {
+        $schema: 'https://vega.github.io/schema/vega/v6.json',
+        marks: [] as unknown[],
+      } as unknown as AnySpec;
+      const {rerender} = render(<VegaChart spec={spec} />);
+
+      (spec as unknown as {marks: unknown[]}).marks.push({type: 'rect'});
+      rerender(<VegaChart spec={spec} />);
+
+      expect(views).toHaveLength(2);
+    });
+
+    it('hands Vega the caller’s own spec object, not a copy', () => {
+      render(<VegaChart spec={VEGA_SPEC} />);
+
+      expect(parseMock.mock.calls[0][0]).toBe(VEGA_SPEC);
+    });
+
+    // A spec the comparison cannot copy — a reference cycle, or nesting past
+    // its depth bound — is compared by reference instead. That verdict runs
+    // during render, so an "always changed" answer would re-render forever
+    // ("Too many re-renders") and never paint a chart at all.
+    describe('inputs the comparison cannot copy', () => {
+      function nest(depth: number): Record<string, unknown> {
+        let node: Record<string, unknown> = {leaf: 'a'};
+        for (let index = 0; index < depth; index++) {
+          node = {node};
+        }
+        return node;
+      }
+
+      function cyclicSpec(): AnySpec {
+        const spec: Record<string, unknown> = {
+          $schema: 'https://vega.github.io/schema/vega/v6.json',
+          marks: [],
+        };
+        spec.self = spec;
+        return spec as unknown as AnySpec;
+      }
+
+      it('mounts a cyclic spec and builds exactly one View', () => {
+        expect(() => render(<VegaChart spec={cyclicSpec()} />)).not.toThrow();
+
+        expect(views).toHaveLength(1);
+      });
+
+      it('keeps the View across re-renders of the same cyclic spec', () => {
+        const spec = cyclicSpec();
+        const {rerender} = render(<VegaChart spec={spec} />);
+
+        rerender(<VegaChart spec={spec} />);
+        rerender(<VegaChart spec={spec} />);
+
+        expect(views).toHaveLength(1);
+        expect(views[0].finalize).not.toHaveBeenCalled();
+      });
+
+      it('rebuilds exactly once when the cyclic spec is replaced', () => {
+        const {rerender} = render(<VegaChart spec={cyclicSpec()} />);
+        const replacement = cyclicSpec();
+
+        rerender(<VegaChart spec={replacement} />);
+        rerender(<VegaChart spec={replacement} />);
+
+        expect(views).toHaveLength(2);
+        expect(views[0].finalize).toHaveBeenCalledTimes(1);
+      });
+
+      it('mounts a spec nested past the depth bound and keeps its View', () => {
+        const spec = {
+          $schema: 'https://vega.github.io/schema/vega/v6.json',
+          deep: nest(150),
+        } as unknown as AnySpec;
+
+        const {rerender} = render(<VegaChart spec={spec} />);
+        rerender(<VegaChart spec={spec} />);
+
+        expect(views).toHaveLength(1);
+      });
+
+      it('still rebuilds on a shallow change beside a cycle', () => {
+        const spec: Record<string, unknown> = {
+          $schema: 'https://vega.github.io/schema/vega/v6.json',
+          background: 'red',
+        };
+        spec.self = spec;
+        const {rerender} = render(
+          <VegaChart spec={spec as unknown as AnySpec} />,
+        );
+
+        spec.background = 'blue';
+        rerender(<VegaChart spec={spec as unknown as AnySpec} />);
+
+        expect(views).toHaveLength(2);
+      });
+    });
+
+    // `data` is documented as initial values, read once per View. It used to
+    // sit in the Effect's dependencies, so the documented usage -- an inline
+    // `data={{table: rows}}` -- tore the View down on every parent render.
+    it('keeps the View when only data changes', () => {
+      const {rerender} = render(
+        <VegaChart spec={VEGA_SPEC} data={{table: [{a: 1}]}} />,
+      );
+      expect(views).toHaveLength(1);
+      expect(views[0].data).toHaveBeenCalledTimes(1);
+
+      rerender(<VegaChart spec={VEGA_SPEC} data={{table: [{a: 2}]}} />);
+
+      expect(views).toHaveLength(1);
+      expect(views[0].finalize).not.toHaveBeenCalled();
+      // Not reactive: the live View is left exactly as it was.
+      expect(views[0].data).toHaveBeenCalledTimes(1);
+      expect(views[0].data).toHaveBeenCalledWith('table', [{a: 1}]);
+    });
+
+    it('loads the current data when something else rebuilds the View', () => {
+      const {rerender} = render(
+        <VegaChart spec={VEGA_SPEC} data={{table: [{a: 1}]}} />,
+      );
+
+      rerender(
+        <VegaChart
+          spec={{...VEGA_SPEC, background: 'red'} as unknown as AnySpec}
+          data={{table: [{a: 2}]}}
+        />,
+      );
+
+      expect(views).toHaveLength(2);
+      expect(views[1].data).toHaveBeenCalledWith('table', [{a: 2}]);
     });
   });
 

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -9,10 +9,12 @@
  * SYNC: When modified, update /packages/vega/README.md
  */
 
-import React, {useEffect, useEffectEvent, useRef} from 'react';
+import React, {useEffect, useEffectEvent, useRef, useState} from 'react';
 import {parse, View} from 'vega';
 import {compile} from 'vega-lite';
 import {parseSchema} from './schema';
+import {latchViewInputs, latchIsCurrent} from './viewInputs';
+import type {ViewInputs} from './viewInputs';
 import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
 
 /**
@@ -30,17 +32,24 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
  *   new vega.View(runtime, { ...viewOptions, container })
  *
  * Initial dataset values can be provided via `data`. They are loaded once
- * during View initialization, before the first render, and are not reactive.
+ * during View initialization, before the first render, and are not reactive:
+ * a change to `data` alone never rebuilds the View, and is not applied to the
+ * live one. Use `onReady` to drive data after mount.
  *
  * It owns the full `View` lifecycle: creates the view on mount, re-creates
- * it when `spec`, `parseConfig`, `parseOptions`, or `viewOptions` changes,
- * and calls `view.finalize()` on cleanup to release all runtime resources.
+ * it when `spec`, `compileOptions`, `parseConfig`, `parseOptions`, or
+ * `viewOptions` changes, and calls `view.finalize()` on cleanup to release
+ * all runtime resources.
+ *
+ * "Changes" means the value changed, not the reference: those props are
+ * compared by value against a copy taken when the live View was built, so an
+ * inline spec or options object rebuilt on every render keeps the live View
+ * (and its zoom, hover, and signal state), while a spec mutated in place is
+ * still picked up. Nothing needs to be memoized for either to hold.
  *
  * Callbacks (`onReady`, `onError`) are non-reactive Effect Events -- they
  * always see the latest props and never re-run the View lifecycle, so you
- * don't need to memoize them. Pass stable references (or `useMemo`)
- * for `parseConfig`, `parseOptions`, `viewOptions`, and `data` to avoid
- * unnecessary re-renders.
+ * don't need to memoize them.
  *
  * Note: this component does not accept `xstyle` because `@astryxdesign/vega` does not
  * depend on StyleX. Use `className` or `style` for layout overrides.
@@ -87,6 +96,25 @@ export function VegaChart({
 }: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Rebuild only when a value the runtime is built from actually differs.
+  // The latch holds both the props the live View was built from and a copy of
+  // their values, so a spec mutated in place is caught too -- comparing
+  // against the previous props could not see that, because a mutation leaves
+  // both sides pointing at the same object. Updating state during render is
+  // React's own way to derive state from props; the check is reflexive, so it
+  // settles in one extra pass.
+  const inputs: ViewInputs = {
+    spec,
+    compileOptions,
+    parseConfig,
+    parseOptions,
+    viewOptions,
+  };
+  const [latch, setLatch] = useState(() => latchViewInputs(inputs));
+  if (!latchIsCurrent(latch, inputs)) {
+    setLatch(latchViewInputs(inputs));
+  }
+
   // The Effect fires these callbacks without treating them as reactive
   // dependencies, so the View isn't torn down and rebuilt when a parent
   // passes fresh inline callbacks on every render.
@@ -97,12 +125,30 @@ export function VegaChart({
     onErrorProp?.(error);
   });
 
+  // Same treatment for `data`: an Effect Event reads the latest value at View
+  // initialization without making `data` a reactive dependency. That is the
+  // documented contract -- initial dataset values, applied once per View,
+  // never reactive -- and it keeps a fresh `data` object literal from tearing
+  // down a perfectly good View on every parent render.
+  const loadInitialData = useEffectEvent((view: View) => {
+    if (!data) {
+      return;
+    }
+    for (const [name, tuples] of Object.entries(data)) {
+      view.data(name, tuples);
+    }
+  });
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) {
       return;
     }
 
+    // Read from the latch, never the props: these are the values the live
+    // View is built from, and they only change when a value changes. The
+    // caller's own objects are handed to Vega, not the comparison copy.
+    const {spec} = latch.inputs;
     let cancelled = false;
     let view: View | null = null;
 
@@ -123,26 +169,26 @@ export function VegaChart({
       // Compile Vega-Lite -> Vega if needed; otherwise use the spec directly.
       const vegaSpec: VegaSpec =
         schemaResult.library === 'vega-lite'
-          ? compile(spec as VegaLiteSpec, compileOptions).spec
+          ? compile(spec as VegaLiteSpec, latch.inputs.compileOptions).spec
           : (spec as VegaSpec);
 
       // parse(spec, config?, options?) -> Runtime
-      const runtime = parse(vegaSpec, parseConfig, parseOptions);
+      const runtime = parse(
+        vegaSpec,
+        latch.inputs.parseConfig,
+        latch.inputs.parseOptions,
+      );
 
       // new View(runtime, viewOptions) -- container is always injected by us.
       view = new View(runtime, {
         hover: true,
-        ...viewOptions,
+        ...latch.inputs.viewOptions,
         container,
       });
 
       // Load initial data into named datasets before the first render.
       // data is not reactive -- changes after mount are ignored.
-      if (data) {
-        for (const [name, tuples] of Object.entries(data)) {
-          view.data(name, tuples);
-        }
-      }
+      loadInitialData(view);
 
       view
         .runAsync()
@@ -164,7 +210,7 @@ export function VegaChart({
       cancelled = true;
       view?.finalize();
     };
-  }, [spec, data, compileOptions, parseConfig, parseOptions, viewOptions]);
+  }, [latch]);
 
   return (
     <div

--- a/packages/vega/src/viewInputs.test.ts
+++ b/packages/vega/src/viewInputs.test.ts
@@ -1,0 +1,297 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file viewInputs.test.ts
+ * @input Uses vitest, latchViewInputs and latchIsCurrent
+ * @output Unit tests for the View-lifecycle change detector
+ * @position Colocated test for viewInputs.ts
+ */
+
+import {describe, it, expect} from 'vitest';
+import {latchViewInputs, latchIsCurrent} from './viewInputs';
+import type {ViewInputs} from './viewInputs';
+import type {AnySpec} from './types';
+
+function inputs(overrides: Partial<ViewInputs> = {}): ViewInputs {
+  return {
+    spec: {
+      $schema: 'https://vega.github.io/schema/vega/v6.json',
+      marks: [],
+    } as unknown as AnySpec,
+    ...overrides,
+  };
+}
+
+describe('latchIsCurrent', () => {
+  it('holds when the same values arrive as fresh object literals', () => {
+    const latch = latchViewInputs(inputs({viewOptions: {renderer: 'canvas'}}));
+
+    expect(
+      latchIsCurrent(latch, inputs({viewOptions: {renderer: 'canvas'}})),
+    ).toBe(true);
+  });
+
+  it('holds for the very objects it latched', () => {
+    const current = inputs({parseConfig: {background: 'red'}});
+
+    expect(latchIsCurrent(latchViewInputs(current), current)).toBe(true);
+  });
+
+  it('breaks when a value differs', () => {
+    const latch = latchViewInputs(inputs({viewOptions: {renderer: 'canvas'}}));
+
+    expect(
+      latchIsCurrent(latch, inputs({viewOptions: {renderer: 'svg'}})),
+    ).toBe(false);
+  });
+
+  it('breaks when a key is added or removed', () => {
+    const latch = latchViewInputs(inputs({parseConfig: {background: 'red'}}));
+
+    expect(
+      latchIsCurrent(
+        latch,
+        inputs({parseConfig: {background: 'red', autosize: 'pad'}}),
+      ),
+    ).toBe(false);
+    expect(latchIsCurrent(latch, inputs({parseConfig: {}}))).toBe(false);
+  });
+
+  // The reason the latch keeps a copy rather than the previous props: on a
+  // mutation both sides are the same object, so a props-to-props comparison
+  // has nothing left to notice and the chart silently goes stale.
+  describe('mutation through a shared reference', () => {
+    it('breaks when a nested object shared across renders is mutated', () => {
+      const encoding = {x: {field: 'a', type: 'ordinal'}};
+      const latch = latchViewInputs(
+        inputs({
+          spec: {
+            $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+            mark: 'bar',
+            encoding,
+          } as unknown as AnySpec,
+        }),
+      );
+
+      encoding.x.field = 'b';
+
+      expect(
+        latchIsCurrent(
+          latch,
+          inputs({
+            spec: {
+              $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+              mark: 'bar',
+              encoding,
+            } as unknown as AnySpec,
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('breaks when the latched spec itself is mutated in place', () => {
+      const spec = {
+        $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+        mark: 'bar',
+      } as unknown as AnySpec;
+      const latch = latchViewInputs(inputs({spec}));
+
+      (spec as unknown as {mark: string}).mark = 'line';
+
+      expect(latchIsCurrent(latch, inputs({spec}))).toBe(false);
+    });
+
+    it('breaks when an element is pushed onto a shared array', () => {
+      const marks: unknown[] = [{type: 'rect'}];
+      const latch = latchViewInputs(
+        inputs({spec: {$schema: 'x', marks} as unknown as AnySpec}),
+      );
+
+      marks.push({type: 'line'});
+
+      expect(
+        latchIsCurrent(
+          latch,
+          inputs({spec: {$schema: 'x', marks} as unknown as AnySpec}),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('values compared by reference', () => {
+    it('holds for the same function and breaks for an equivalent one', () => {
+      const tooltip = () => {};
+      const latch = latchViewInputs(inputs({viewOptions: {tooltip}}));
+
+      expect(latchIsCurrent(latch, inputs({viewOptions: {tooltip}}))).toBe(
+        true,
+      );
+      expect(
+        latchIsCurrent(latch, inputs({viewOptions: {tooltip: () => {}}})),
+      ).toBe(false);
+    });
+
+    it('treats a class instance as opaque, mutation included', () => {
+      class Loader {
+        base = 'a';
+      }
+      const loader = new Loader();
+      const latch = latchViewInputs(inputs({viewOptions: {loader} as never}));
+
+      // Documented limit: behavior lives in methods a copy cannot capture,
+      // so only the reference is compared.
+      loader.base = 'b';
+      expect(
+        latchIsCurrent(latch, inputs({viewOptions: {loader} as never})),
+      ).toBe(true);
+      expect(
+        latchIsCurrent(
+          latch,
+          inputs({viewOptions: {loader: new Loader()} as never}),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it('is stable for a self-referencing spec passed by the same reference', () => {
+    const spec: Record<string, unknown> = {$schema: 'x'};
+    spec.self = spec;
+    const latch = latchViewInputs(inputs({spec: spec as unknown as AnySpec}));
+
+    // A cycle cannot be copied, so the reference is compared. Stable — an
+    // "always changed" verdict here loops React during render.
+    expect(
+      latchIsCurrent(latch, inputs({spec: spec as unknown as AnySpec})),
+    ).toBe(true);
+  });
+
+  it('breaks once when a self-referencing spec is replaced', () => {
+    const first: Record<string, unknown> = {$schema: 'x'};
+    first.self = first;
+    const second: Record<string, unknown> = {$schema: 'x'};
+    second.self = second;
+    const latch = latchViewInputs(inputs({spec: first as unknown as AnySpec}));
+
+    expect(
+      latchIsCurrent(latch, inputs({spec: second as unknown as AnySpec})),
+    ).toBe(false);
+    // And the new latch settles on the new reference rather than churning.
+    const next = latchViewInputs(inputs({spec: second as unknown as AnySpec}));
+    expect(
+      latchIsCurrent(next, inputs({spec: second as unknown as AnySpec})),
+    ).toBe(true);
+  });
+
+  it('still sees a mutation beside a cycle', () => {
+    const spec: Record<string, unknown> = {$schema: 'x', mark: 'bar'};
+    spec.self = spec;
+    const latch = latchViewInputs(inputs({spec: spec as unknown as AnySpec}));
+
+    // The cycle is opaque; everything the copy did reach is still compared.
+    spec.mark = 'line';
+
+    expect(
+      latchIsCurrent(latch, inputs({spec: spec as unknown as AnySpec})),
+    ).toBe(false);
+  });
+
+  // A cycle's re-entry edge always points back at an object the copy has
+  // already walked, so the cycle itself hides nothing — worth pinning,
+  // because the depth boundary below behaves differently.
+  it('sees a mutation on an object that also sits on a cycle', () => {
+    const nested: Record<string, unknown> = {field: 'a'};
+    const spec: Record<string, unknown> = {$schema: 'x', nested};
+    nested.parent = spec;
+    const latch = latchViewInputs(inputs({spec: spec as unknown as AnySpec}));
+
+    nested.field = 'b';
+
+    expect(
+      latchIsCurrent(latch, inputs({spec: spec as unknown as AnySpec})),
+    ).toBe(false);
+  });
+
+  it('walks the same object twice in sibling positions', () => {
+    const shared = {field: 'a'};
+    const spec = () =>
+      ({$schema: 'x', x: shared, y: shared}) as unknown as AnySpec;
+    const latch = latchViewInputs(inputs({spec: spec()}));
+
+    // Sharing is not a cycle: both positions are copied, so a mutation of
+    // the shared object is caught.
+    expect(latchIsCurrent(latch, inputs({spec: spec()}))).toBe(true);
+    shared.field = 'b';
+    expect(latchIsCurrent(latch, inputs({spec: spec()}))).toBe(false);
+  });
+
+  describe('deeper than the copy walks', () => {
+    /** A chain of `depth` nested objects ending in `leaf`. */
+    function nest(depth: number, leaf: unknown): Record<string, unknown> {
+      let node: Record<string, unknown> = {leaf} as Record<string, unknown>;
+      for (let index = 0; index < depth; index++) {
+        node = {node};
+      }
+      return node;
+    }
+
+    it('is stable for a too-deep spec passed by the same reference', () => {
+      const deep = nest(150, 'a');
+      const spec = {$schema: 'x', deep} as unknown as AnySpec;
+      const latch = latchViewInputs(inputs({spec}));
+
+      expect(latchIsCurrent(latch, inputs({spec}))).toBe(true);
+    });
+
+    it('breaks when the too-deep subtree is replaced by a new object', () => {
+      const spec = () =>
+        ({$schema: 'x', deep: nest(150, 'a')}) as unknown as AnySpec;
+      const latch = latchViewInputs(inputs({spec: spec()}));
+
+      // Beyond the bound the reference is all there is, so an equal-valued
+      // rebuild counts as changed — a rebuild, never a stale chart.
+      expect(latchIsCurrent(latch, inputs({spec: spec()}))).toBe(false);
+    });
+
+    it('does not see a mutation only reachable past the depth bound', () => {
+      const deep = nest(150, 'a');
+      const spec = {$schema: 'x', deep} as unknown as AnySpec;
+      const latch = latchViewInputs(inputs({spec}));
+
+      // Walk to the far end and edit it in place. Past the bound only the
+      // reference is compared, and it did not change — the documented
+      // limitation, and why a caller replaces the object instead.
+      let node = deep;
+      while (node.node) {
+        node = node.node as Record<string, unknown>;
+      }
+      node.leaf = 'b';
+
+      expect(latchIsCurrent(latch, inputs({spec}))).toBe(true);
+    });
+
+    it('still sees a shallow mutation beside a too-deep subtree', () => {
+      const deep = nest(150, 'a');
+      const spec: Record<string, unknown> = {
+        $schema: 'x',
+        mark: 'bar',
+        deep,
+      };
+      const latch = latchViewInputs(inputs({spec: spec as unknown as AnySpec}));
+
+      spec.mark = 'line';
+
+      expect(
+        latchIsCurrent(latch, inputs({spec: spec as unknown as AnySpec})),
+      ).toBe(false);
+    });
+  });
+
+  it('distinguishes absent from present optional inputs', () => {
+    const latch = latchViewInputs(inputs());
+
+    expect(latchIsCurrent(latch, inputs())).toBe(true);
+    expect(latchIsCurrent(latch, inputs({parseOptions: {ast: true}}))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/vega/src/viewInputs.ts
+++ b/packages/vega/src/viewInputs.ts
@@ -1,0 +1,187 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file viewInputs.ts
+ * @input The VegaChart props that own the Vega View lifecycle
+ * @output The ViewInputs type plus latch/compare helpers VegaChart rebuilds on
+ * @position Internal utility; used by VegaChart to decide when to rebuild
+ *
+ * SYNC: When modified, update /packages/vega/README.md
+ */
+
+import type {VegaChartProps} from './types';
+
+/**
+ * The props the Vega runtime is built from. A change to any of them produces
+ * a different runtime, so the View is torn down and rebuilt. `data`,
+ * `className`, `style`, and the callbacks are absent because none of them
+ * change the runtime.
+ */
+export type ViewInputs = Pick<
+  VegaChartProps,
+  'spec' | 'compileOptions' | 'parseConfig' | 'parseOptions' | 'viewOptions'
+>;
+
+/**
+ * The inputs the live View was built from, beside a structural copy of their
+ * values at that moment.
+ *
+ * The copy is the whole point. Comparing the incoming props against the
+ * *previous props* cannot see a spec mutated in place — both sides are the
+ * same object, so the old value is already gone and the chart silently goes
+ * stale. Comparing against a copy taken when the View was built can.
+ *
+ * The copy is also compared during render, so its verdict must be stable for
+ * an unchanged input: a part that always reported "changed" would loop React
+ * forever. See {@link Opaque} for the parts that cannot be copied.
+ */
+export type ViewInputsLatch = {
+  /** The caller's own objects, handed to Vega untouched. */
+  readonly inputs: ViewInputs;
+  readonly snapshot: unknown;
+};
+
+/**
+ * Deepest structure the copy walks. Vega and Vega-Lite specs nest far
+ * shallower; the bound exists so a pathological input cannot make the walk
+ * cost unbounded. Anything deeper is kept by reference (see {@link Opaque}).
+ */
+const MAX_DEPTH = 100;
+
+/**
+ * Stands in for a value the copy would not walk: a subtree deeper than
+ * {@link MAX_DEPTH}, or one that re-enters an object already on the path (a
+ * reference cycle).
+ *
+ * It keeps the reference it stood for, and that is the whole design. An
+ * opaque part that always compared unequal would make `latchIsCurrent` false
+ * on every render — and since the latch is refreshed during render, React
+ * would re-render forever ("Too many re-renders"). Comparing the reference
+ * instead is stable while the caller passes the same object, and rebuilds
+ * exactly once when they pass a different one.
+ *
+ * What the narrowing costs differs by case. A cycle's re-entry edge points
+ * back at an object the walk already copied, so a cyclic spec still has every
+ * mutation detected. Past {@link MAX_DEPTH} the values below were never
+ * copied, so an in-place edit down there is invisible until the caller passes
+ * a different object — documented in the package README.
+ */
+type Opaque = {readonly [OPAQUE]: unknown};
+
+const OPAQUE = Symbol('astryx.vega.opaque');
+
+function opaque(value: unknown): Opaque {
+  return {[OPAQUE]: value};
+}
+
+function isOpaque(value: unknown): value is Opaque {
+  return typeof value === 'object' && value !== null && OPAQUE in value;
+}
+
+export function latchViewInputs(inputs: ViewInputs): ViewInputsLatch {
+  return {inputs, snapshot: snapshotValue(inputs, 0, new Set())};
+}
+
+/**
+ * Whether `inputs` still carries the values the latched View was built from.
+ *
+ * Plain objects and arrays are compared entry by entry, so a spec or options
+ * bag rebuilt inline on every render counts as unchanged. Everything else --
+ * functions (tooltip handlers, loggers, loaders, field-title formatters),
+ * class instances, dates -- compares by reference, because two instances can
+ * behave differently even when they look alike, and the View built from them
+ * would too.
+ */
+export function latchIsCurrent(
+  latch: ViewInputsLatch,
+  inputs: ViewInputs,
+): boolean {
+  return matchesSnapshot(latch.snapshot, inputs);
+}
+
+/**
+ * Copy the plain-object structure of `value`, keeping everything else by
+ * reference. Not a general-purpose clone: it exists only so a later
+ * comparison has the old values to look at.
+ *
+ * `path` holds the objects currently being walked, so re-entering one is
+ * recognized as a cycle and kept by reference rather than followed.
+ */
+function snapshotValue(
+  value: unknown,
+  depth: number,
+  path: Set<unknown>,
+): unknown {
+  if (!isWalkable(value)) {
+    return value;
+  }
+  if (depth >= MAX_DEPTH || path.has(value)) {
+    return opaque(value);
+  }
+  path.add(value);
+  const copy = Array.isArray(value)
+    ? value.map(item => snapshotValue(item, depth + 1, path))
+    : Object.fromEntries(
+        Object.entries(value).map(([key, entry]) => [
+          key,
+          snapshotValue(entry, depth + 1, path),
+        ]),
+      );
+  // Only an ancestor is a cycle; the same object twice in sibling positions
+  // is ordinary sharing and is walked both times.
+  path.delete(value);
+  return copy;
+}
+
+/**
+ * Compare a value against a snapshot. The walk is guided by the snapshot,
+ * which is finite and acyclic by construction, so a cyclic `value` cannot
+ * make this recurse forever.
+ */
+function matchesSnapshot(snapshot: unknown, value: unknown): boolean {
+  if (isOpaque(snapshot)) {
+    // Could not be walked, so the reference is all there is to compare.
+    return Object.is(snapshot[OPAQUE], value);
+  }
+  if (Array.isArray(snapshot)) {
+    return (
+      Array.isArray(value) &&
+      snapshot.length === value.length &&
+      snapshot.every((item, index) => matchesSnapshot(item, value[index]))
+    );
+  }
+  if (isPlainObject(snapshot)) {
+    if (!isPlainObject(value)) {
+      return false;
+    }
+    const keys = Object.keys(snapshot);
+    return (
+      keys.length === Object.keys(value).length &&
+      keys.every(
+        key =>
+          Object.prototype.hasOwnProperty.call(value, key) &&
+          matchesSnapshot(snapshot[key], value[key]),
+      )
+    );
+  }
+  // Primitives (Object.is also pairs both `undefined`s and both `NaN`s), and
+  // every value compared by reference.
+  return Object.is(snapshot, value);
+}
+
+function isWalkable(value: unknown): value is Record<string, unknown> {
+  return Array.isArray(value) || isPlainObject(value);
+}
+
+/**
+ * A `{...}` object literal or a null-prototype object -- the shapes a spec,
+ * config, or options bag is made of. Class instances are excluded on purpose:
+ * their behavior lives in methods a structural copy cannot capture.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}


### PR DESCRIPTION
## Summary

- keep escaped-pipe text visible while Markdown is streaming without prematurely rendering real partial tables
- preserve an existing ChatComposer selection during imperative focus while padding clicks place the caret at the end
- retain Vega views across equivalent inputs while rebuilding for meaningful nested mutations
- make cyclic and deeply nested Vega inputs stable instead of entering render loops

## Why

Recent performance and keyboard fixes left three edge cases: streamed escaped pipes could blank, padding focus could replace a pending draft via history recall, and Vega view lifecycle either rebuilt too often or became stale/looped on complex inputs.

## Test plan

- 994 tests across Chat, Markdown, Outline, hooks, and Vega
- 16/16 Markdown performance tests
- Core and Vega typechecks
- ESLint and Prettier on changed files
- `pnpm check:repo`
- real Chromium probes for every escaped-pipe streaming prefix and all focus/selection paths
- Vega mount/rerender probes for equivalent literals, nested and in-place mutation, cycles, and depth limits
