### PR TITLE
fix(cli): align search test with internal coverage

### DIFF
--- a/.changeset/cli-search-exact-keyword-phrase-ranking.md
+++ b/.changeset/cli-search-exact-keyword-phrase-ranking.md
@@ -6,6 +6,6 @@
 
 A query that exactly matches a candidate's declared keyword (or name) verbatim is now promoted to a top-tier score, so it always outranks a candidate that only coincidentally contains several of the query's individual words. Single-word queries and queries that don't exactly match a keyword are unaffected.
 
-Follow-up #6001 preserves the required coverage fields on exact-phrase results.
+Follow-ups #6001 and #5994 preserve the coverage counts needed by build ranking while keeping them out of the public search result shape.
 
 @nynexman4464


### PR DESCRIPTION
## What

Update the existing #5289 release unit to describe the final contract after #6001 and #5994.

The stale public-field assertion was already absorbed into main by #5963 while this PR ran CI, so the exact-main restack now contains only the final release receipt. No duplicate changeset is added and `@nynexman4464` remains the attribution.

## Testing

- `pnpm check:changesets`
- repository pre-commit checks
- public scrub