### PR TITLE
feat(core): support theme-owned Icon sizes

### DIFF
--- a/.changeset/extensible-icon-sizes.md
+++ b/.changeset/extensible-icon-sizes.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[feature] Allow generated themes to add typed, theme-owned Icon size names while keeping
+the existing built-in sizes and a safe `md` fallback when theme CSS is absent.
+
+@rubyycheung

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -47,10 +47,7 @@ import {
   collectThemingTargets,
   targetsByKey,
 } from '../../../foundation/discovery/theming-targets.mjs';
-import {
-  collectUnloadedFonts,
-  formatFontLoadingHelp,
-} from './font-warning.mjs';
+import {collectUnloadedFonts, formatFontLoadingHelp} from './font-warning.mjs';
 
 // Import shared theme processing from core. `astryx theme build` MUST produce the
 // exact same CSS as the `<Theme>` runtime, so it has exactly one generation
@@ -343,7 +340,6 @@ function readComponentDeclarations(pascalName) {
   return contents;
 }
 
-
 /** @type {Map<string, Array<{moduleName: string, interfacePrefix: string}>>} */
 const _augmentationTargetCache = new Map();
 
@@ -402,7 +398,8 @@ async function resolveAugmentationTargetCandidates(componentName) {
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        if (entry.name === 'node_modules' || entry.name === '__tests__')
+          continue;
         await scan(full);
         continue;
       }
@@ -539,12 +536,13 @@ async function generateVariantDeclarationsAsync(themeDef) {
       if (values.size === 0) continue;
 
       const propPascal = prop.charAt(0).toUpperCase() + prop.slice(1);
-      const target = (await resolveAugmentationTargetCandidates(component)).find(
-        candidate =>
-          componentHasAugmentableInterface(
-            candidate.moduleName,
-            `${candidate.interfacePrefix}${propPascal}Map`,
-          ),
+      const target = (
+        await resolveAugmentationTargetCandidates(component)
+      ).find(candidate =>
+        componentHasAugmentableInterface(
+          candidate.moduleName,
+          `${candidate.interfacePrefix}${propPascal}Map`,
+        ),
       );
 
       // Only augment interfaces that actually exist as an extension point in
@@ -1031,6 +1029,60 @@ function validatePrivateVars(themeDef) {
   return errors;
 }
 
+const BUILTIN_ICON_SIZES = new Set(['xsm', 'sm', 'md', 'lg']);
+const REQUIRED_ICON_SIZE_PROPERTIES = ['width', 'height', 'fontSize'];
+
+/**
+ * Generated type augmentation makes every custom Icon size callable, so each
+ * name must have a complete standalone rule. Requiring all three properties
+ * keeps component and registry icon rendering equivalent.
+ *
+ * @param {{components?: Record<string, Record<string, unknown>>}} themeDef
+ * @returns {string[]}
+ */
+function validateCustomIconSizes(themeDef) {
+  const iconRules = themeDef.components?.icon;
+  if (!iconRules || typeof iconRules !== 'object') return [];
+
+  const customSizes = new Set();
+  for (const key of Object.keys(iconRules)) {
+    for (const pair of key.split('+')) {
+      const colon = pair.indexOf(':');
+      if (colon === -1 || pair.slice(0, colon) !== 'size') continue;
+      const value = pair.slice(colon + 1);
+      if (value && !BUILTIN_ICON_SIZES.has(value)) customSizes.add(value);
+    }
+  }
+
+  const errors = [];
+  for (const size of customSizes) {
+    const standalone = iconRules[`size:${size}`];
+    if (
+      standalone == null ||
+      typeof standalone !== 'object' ||
+      Array.isArray(standalone)
+    ) {
+      errors.push(
+        `Custom Icon size "${size}" needs a standalone ` +
+          `components.icon["size:${size}"] rule.`,
+      );
+      continue;
+    }
+
+    const missing = REQUIRED_ICON_SIZE_PROPERTIES.filter(
+      property => !Object.hasOwn(standalone, property),
+    );
+    if (missing.length > 0) {
+      errors.push(
+        `Custom Icon size "${size}" must define ${REQUIRED_ICON_SIZE_PROPERTIES.join(
+          ', ',
+        )}; missing ${missing.join(', ')}.`,
+      );
+    }
+  }
+  return errors;
+}
+
 /**
  * Compile a defineTheme file to CSS + JS + .d.ts (and an optional
  * `.variants.d.ts`). Performs the writes and returns a `theme.build` receipt,
@@ -1117,6 +1169,15 @@ export async function themeBuild(
   if (privateVarErrors.length > 0) {
     logger.error(
       `\n  ${privateVarErrors.length} private var error(s). Use standard CSS properties instead.`,
+    );
+  }
+
+  const customIconErrors = validateCustomIconSizes(themeDef);
+  if (customIconErrors.length > 0) {
+    throw new AstryxError(
+      customIconErrors.join('\n'),
+      undefined,
+      ERROR_CODES.ERR_THEME_INVALID,
     );
   }
 

--- a/packages/cli/clients/cli/commands/build-theme.variants.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.variants.test.mjs
@@ -55,7 +55,9 @@ beforeAll(() => {
 
 let tmpDir;
 beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-build-theme-variants-'));
+  tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'astryx-build-theme-variants-'),
+  );
 });
 afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});
@@ -92,7 +94,7 @@ describe('theme build custom-variant augmentations', () => {
     expect(dts).not.toMatch(/XDSButtonVariantMap/);
   });
 
-  it('skips props with no augmentation point (Button size, Heading type)', async () => {
+  it('emits Icon custom sizes and skips props with no augmentation point', async () => {
     const themeFile = writeTheme(
       tmpDir,
       `export default {
@@ -104,6 +106,9 @@ describe('theme build custom-variant augmentations', () => {
             'size:jumbo': { paddingBlock: '40px' },
           },
           heading: { 'type:hero': { fontSize: '80px' } },
+          icon: {
+            'size:hero': { width: '3rem', height: '3rem', fontSize: '3rem' },
+          },
         },
       };\n`,
     );
@@ -118,12 +123,44 @@ describe('theme build custom-variant augmentations', () => {
     expect(fs.existsSync(variantsPath)).toBe(true);
     const dts = fs.readFileSync(variantsPath, 'utf-8');
 
-    // The augmentable variant is emitted…
+    // The augmentable values are emitted…
     expect(dts).toMatch(/interface ButtonVariantMap\b/);
+    expect(dts).toMatch(/interface IconSizeMap\b/);
+    expect(dts).toContain("declare module '@astryxdesign/core/Icon'");
+    expect(dts).toContain("'hero': true;");
     // …but closed literal-union props get no dead augmentation.
     expect(dts).not.toMatch(/ButtonSizeMap/);
     expect(dts).not.toMatch(/HeadingTypeMap/);
     expect(dts).not.toContain("declare module '@astryxdesign/core/Heading'");
+  });
+
+  it('rejects incomplete or combination-only custom Icon sizes', async () => {
+    const themeFile = writeTheme(
+      tmpDir,
+      `export default {
+        name: 'variants-theme',
+        tokens: { '--color-bg': '#fff' },
+        components: {
+          icon: {
+            'size:hero': { width: '3rem', height: '3rem' },
+            'size:poster+color:accent': { width: '4rem', height: '4rem', fontSize: '4rem' },
+          },
+        },
+      };\n`,
+    );
+
+    const result = await runCli(
+      ['theme', 'build', path.relative(tmpDir, themeFile)],
+      tmpDir,
+    );
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(
+      'Custom Icon size "hero" must define width, height, fontSize; missing fontSize.',
+    );
+    expect(result.stderr).toContain(
+      'Custom Icon size "poster" needs a standalone',
+    );
   });
 
   it('does not emit a .variants.d.ts when every custom value is non-augmentable', async () => {
@@ -172,6 +209,7 @@ describe('theme build custom-variant augmentations', () => {
           progressbar: { 'variant:customProgressBar': { backgroundColor: 'transparent' } },
           section: { 'variant:customSection': { backgroundColor: 'transparent' } },
           statusdot: { 'variant:customStatusDot': { backgroundColor: 'transparent' } },
+          icon: { 'size:customIcon': { width: '2rem', height: '2rem', fontSize: '2rem' } },
           text: { 'color:customTextColor': { color: 'currentColor' } },
           token: { 'color:customTokenColor': { backgroundColor: 'transparent' } },
         },
@@ -185,7 +223,10 @@ describe('theme build custom-variant augmentations', () => {
     );
     expect(result.code).toBe(0);
 
-    const projectDir = path.join(CLI_ROOT, `.tmp-variant-consumer-${process.pid}`);
+    const projectDir = path.join(
+      CLI_ROOT,
+      `.tmp-variant-consumer-${process.pid}`,
+    );
     fs.rmSync(projectDir, {recursive: true, force: true});
     fs.mkdirSync(projectDir);
     fs.copyFileSync(
@@ -213,6 +254,7 @@ describe('theme build custom-variant augmentations', () => {
         `import {ProgressBar} from '@astryxdesign/core/ProgressBar';\n` +
         `import {Section} from '@astryxdesign/core/Section';\n` +
         `import {StatusDot} from '@astryxdesign/core/StatusDot';\n` +
+        `import {Icon} from '@astryxdesign/core/Icon';\n` +
         `import {Text} from '@astryxdesign/core/Text';\n` +
         `import {Token} from '@astryxdesign/core/Token';\n\n` +
         `export function Probe() {\n` +
@@ -232,6 +274,7 @@ describe('theme build custom-variant augmentations', () => {
         `      <ProgressBar label="Progress" value={50} variant="customProgressBar" />\n` +
         `      <Section variant="customSection">Section</Section>\n` +
         `      <StatusDot label="Status" variant="customStatusDot" />\n` +
+        `      <Icon icon="check" size="customIcon" />\n` +
         `      <Text color="customTextColor">Text</Text>\n` +
         `      <Token label="Token" color="customTokenColor" />\n` +
         `    </>\n` +
@@ -258,10 +301,14 @@ describe('theme build custom-variant augmentations', () => {
     );
 
     try {
-      execFileSync('pnpm', ['exec', 'tsc', '--project', 'tsconfig.json', '--noEmit'], {
-        cwd: projectDir,
-        stdio: 'pipe',
-      });
+      execFileSync(
+        'pnpm',
+        ['exec', 'tsc', '--project', 'tsconfig.json', '--noEmit'],
+        {
+          cwd: projectDir,
+          stdio: 'pipe',
+        },
+      );
     } finally {
       fs.rmSync(projectDir, {recursive: true, force: true});
     }

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -48,8 +48,9 @@ export const docs = {
     },
     {
       name: 'size',
-      type: "'xsm' | 'sm' | 'md' | 'lg'",
-      description: 'Icon size.',
+      type: "'xsm' | 'sm' | 'md' | 'lg' | theme-owned size",
+      description:
+        'Icon size. Themes may add typed size names with generated width, height, and font-size styling.',
       default: "'md'",
     },
     {
@@ -152,8 +153,8 @@ export const docsZh = {
     },
     {
       name: 'size',
-      type: "'xsm' | 'sm' | 'md' | 'lg'",
-      description: '图标尺寸。',
+      type: "'xsm' | 'sm' | 'md' | 'lg' | 主题自有尺寸",
+      description: '图标尺寸。主题可以添加带类型的自定义尺寸名称。',
       default: "'md'",
     },
     {

--- a/packages/core/src/Icon/Icon.spec.md
+++ b/packages/core/src/Icon/Icon.spec.md
@@ -21,7 +21,7 @@ architecture:
     architecture:public-component-api,
   ]
 contributing: []
-system_specs: []
+system_specs: [spec:AST-025]
 ---
 
 # Icon component contract
@@ -34,8 +34,8 @@ semantics. Consumer usage remains documented in `Icon.doc.mjs`.
 ## Compatibility and migration
 
 - Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling, and
-  public API remain unchanged
+- Compatibility class: additive public API; built-in names and rendering remain
+  unchanged while themes may add typed custom size names
 - Controlled/uncontrolled behavior: not applicable
 - Migration decision: none; this record characterizes the released component
 
@@ -60,12 +60,12 @@ Consumer migration instructions belong in consumer docs and release notes.
 
 ## Public concepts
 
-| Concept       | Closed values or states                                   | Meaning                                                   | Availability by variant/orientation/state | Default    | Owner            | Stability | Invalid-value behavior                                 |
-| ------------- | --------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------- | ---------- | ---------------- | --------- | ------------------------------------------------------ |
-| Glyph source  | semantic key, namespaced extension key, or icon component | Selects the visual symbol.                                | Every render                              | Required   | `component:Icon` | Stable    | TypeScript rejects unsupported built-in string values. |
-| Size          | `xsm`, `sm`, `md`, `lg`                                   | Selects the icon box size.                                | Every rendered glyph                      | `md`       | `component:Icon` | Stable    | TypeScript rejects unsupported values.                 |
-| Color         | documented semantic and palette values                    | Selects the glyph color or inherits it from context.      | Every rendered glyph                      | `inherit`  | `component:Icon` | Stable    | TypeScript rejects unsupported values.                 |
-| Accessibility | decorative or meaningfully labelled                       | Controls whether assistive technology receives the glyph. | Every rendered glyph                      | Decorative | `component:Icon` | Stable    | Empty labels use the decorative behavior.              |
+| Concept       | Closed values or states                                   | Meaning                                                   | Availability by variant/orientation/state | Default    | Owner            | Stability | Invalid-value behavior                                  |
+| ------------- | --------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------- | ---------- | ---------------- | --------- | ------------------------------------------------------- |
+| Glyph source  | semantic key, namespaced extension key, or icon component | Selects the visual symbol.                                | Every render                              | Required   | `component:Icon` | Stable    | TypeScript rejects unsupported built-in string values.  |
+| Size          | `xsm`, `sm`, `md`, `lg`, or a theme-owned custom name     | Selects the icon box size.                                | Every rendered glyph                      | `md`       | `component:Icon` | Stable    | TypeScript rejects names absent from the extension map. |
+| Color         | documented semantic and palette values                    | Selects the glyph color or inherits it from context.      | Every rendered glyph                      | `inherit`  | `component:Icon` | Stable    | TypeScript rejects unsupported values.                  |
+| Accessibility | decorative or meaningfully labelled                       | Controls whether assistive technology receives the glyph. | Every rendered glyph                      | Decorative | `component:Icon` | Stable    | Empty labels use the decorative behavior.               |
 
 A namespaced key that does not resolve currently renders nothing. This is
 existing behavior, not an intentional fallback promise.
@@ -75,12 +75,12 @@ existing behavior, not an intentional fallback promise.
 Requirements identify their basis so observed code is not mistaken for an
 intentional decision.
 
-| ID  | Candidate invariant                                                                                                                                                                               | Basis                                      | Draft review state                                      |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
-| FR1 | Icon MUST present at most one glyph from the supplied semantic key, namespaced key, or icon component.                                                                                            | Documented promise and current tests.      | Settled intent.                                         |
-| FR2 | Every rendered glyph MUST carry the `icon` theming target with its selected size and color reflected as target data.                                                                              | Current source, docs, and theming tests.   | Settled intent.                                         |
-| FR3 | Icon MUST apply the selected size as width and height for every glyph, plus font size where needed for 1em-based icon sources. This sizing contract MUST NOT promise an HTML or SVG element type. | Human decision, current source, and tests. | Settled intent.                                         |
-| FR4 | Supported SVG and styling escape hatches MUST retain their established merge and override behavior.                                                                                               | Current source and regression tests.       | Current compatibility behavior; verify before changing. |
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                         | Basis                                      | Draft review state                                      |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
+| FR1 | Icon MUST present at most one glyph from the supplied semantic key, namespaced key, or icon component.                                                                                                                                                                                                      | Documented promise and current tests.      | Settled intent.                                         |
+| FR2 | Every rendered glyph MUST carry the `icon` theming target with its selected size and color reflected as target data.                                                                                                                                                                                        | Current source, docs, and theming tests.   | Settled intent.                                         |
+| FR3 | Icon MUST apply the selected size as width and height for every glyph, plus font size where needed for 1em-based icon sources. A custom name without loaded theme CSS MUST retain the `md` baseline instead of rendering without a size. This sizing contract MUST NOT promise an HTML or SVG element type. | Human decision, current source, and tests. | Settled intent.                                         |
+| FR4 | Supported SVG and styling escape hatches MUST retain their established merge and override behavior.                                                                                                                                                                                                         | Current source and regression tests.       | Current compatibility behavior; verify before changing. |
 
 ### Allowed variation
 
@@ -181,6 +181,18 @@ a `span`, `svg`, or other element.
 
 Rejected: separate wrapper and SVG anatomy entries, because those describe
 implementation strategies rather than stable consumer concepts.
+
+### DEC-2 — Theme-owned names extend, rather than replace, built-in sizes
+
+**Reference:** `component:Icon/DEC-2`
+**Decider:** cixzhang, 2026-09-04
+
+The public size type is map-backed so generated theme declarations can add
+names without weakening typo detection for every consumer. Each custom rule
+must define one canonical size that tooling expands to width, height, and font
+size. Missing theme CSS retains the `md` baseline. This change does not resize
+icons hidden inside parent components or add new parent size props; those are
+separate, explicit component decisions.
 
 ## Open questions
 

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -19,6 +19,12 @@ import {resetThemes} from '../theme/themeRegistry';
 import {Icon} from './Icon';
 import {registerIcons, resetIcons} from './globalIconRegistry';
 
+declare module './index' {
+  interface IconSizeMap {
+    hero: true;
+  }
+}
+
 describe('Icon', () => {
   it('renders the icon component', () => {
     render(<Icon icon={TestIcon} data-testid="icon" />);
@@ -145,6 +151,27 @@ describe('Icon', () => {
       expect(style.fontSize).toBe(expected);
       unmount();
     }
+  });
+
+  it('accepts a custom component-mode size and keeps the md baseline until theme CSS applies', () => {
+    render(<Icon icon={TestIcon} size="hero" data-testid="icon" />);
+
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('data-size', 'hero');
+    expect(icon).toHaveClass('hero');
+    expect(getComputedStyle(icon).width).toBe('1.25rem');
+    expect(getComputedStyle(icon).height).toBe('1.25rem');
+  });
+
+  it('accepts a custom registry size and keeps the md baseline until theme CSS applies', () => {
+    render(<Icon icon="check" size="hero" data-testid="icon" />);
+
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('data-size', 'hero');
+    expect(icon).toHaveClass('hero');
+    expect(getComputedStyle(icon).width).toBe('1.25rem');
+    expect(getComputedStyle(icon).height).toBe('1.25rem');
+    expect(getComputedStyle(icon).fontSize).toBe('1.25rem');
   });
 
   it('forwards ref correctly', () => {

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -31,6 +31,7 @@ import {getIcon} from './globalIconRegistry';
 import type {IconName, NamespacedIconName} from './globalIconRegistry';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import type {IconSizeMap} from './index';
 
 // =============================================================================
 // Styles
@@ -178,7 +179,12 @@ const spanSizeStyles = stylex.create({
 // =============================================================================
 
 export type IconColor = keyof typeof colorStyles;
-export type IconSize = keyof typeof sizeStyles;
+export type IconSize = keyof IconSizeMap;
+type BuiltinIconSize = keyof typeof sizeStyles;
+
+function resolveBuiltinIconSize(size: IconSize): BuiltinIconSize {
+  return size === 'xsm' || size === 'sm' || size === 'lg' ? size : 'md';
+}
 
 /**
  * Type for icon components that can be passed to Icon.
@@ -308,6 +314,7 @@ export function Icon({
   // Derive ARIA from `label`: decorative (aria-hidden) by default, or a
   // meaningful image (role="img" + aria-label) when `label` is non-empty.
   const a11yProps = getIconA11yProps(label);
+  const baselineSize = resolveBuiltinIconSize(size);
 
   // String mode: resolve from icon registry, wrap in styled span
   if (typeof icon === 'string') {
@@ -316,6 +323,7 @@ export function Icon({
         name={icon}
         color={color}
         size={size}
+        baselineSize={baselineSize}
         a11yProps={a11yProps}
         className={className}
         style={style}
@@ -341,7 +349,12 @@ export function Icon({
       // precedence as escape hatches.
       {...mergeProps(
         themeProps('icon', {size, color}),
-        stylex.props(styles.root, colorStyles[color], sizeStyles[size], xstyle),
+        stylex.props(
+          styles.root,
+          colorStyles[color],
+          sizeStyles[baselineSize],
+          xstyle,
+        ),
         className ?? undefined,
         style,
       )}
@@ -367,6 +380,7 @@ function IconFromRegistry({
   name,
   color,
   size,
+  baselineSize,
   a11yProps,
   className,
   style,
@@ -376,6 +390,7 @@ function IconFromRegistry({
   name: IconName | NamespacedIconName;
   color: IconColor;
   size: IconSize;
+  baselineSize: BuiltinIconSize;
   a11yProps: {role: 'img'; 'aria-label': string} | {'aria-hidden': 'true'};
   className?: string;
   style?: React.CSSProperties;
@@ -410,7 +425,7 @@ function IconFromRegistry({
         stylex.props(
           styles.span,
           colorStyles[color],
-          spanSizeStyles[size],
+          spanSizeStyles[baselineSize],
           xstyle,
         ),
         className ?? undefined,

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -5,11 +5,24 @@
 /**
  * @file index.ts
  * @input Imports Icon component/types, icon registry, and global registration
- * @output Exports Icon, icon registry helpers, registerIcons, getIconRegistry, getIcon
+ * @output Exports Icon, extensible size types, and icon registry helpers
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Icon/Icon.doc.mjs
  */
+
+/**
+ * Public extension map for theme-owned Icon size names.
+ *
+ * Themes may add names through module augmentation. The generated theme CSS
+ * remains responsible for styling every custom name.
+ */
+export interface IconSizeMap {
+  xsm: true;
+  sm: true;
+  md: true;
+  lg: true;
+}
 
 export {Icon, renderIconSlot} from './Icon';
 export {useIcon} from './useIcon';


### PR DESCRIPTION
## Summary

- makes `Icon` size names extensible through `IconSizeMap`
- generates typed theme augmentation for custom Icon sizes
- applies custom names consistently to direct SVG and registry icons
- requires complete width, height, and font-size styling for generated custom names

## Risk controls

- additive API; `xsm`, `sm`, `md`, and `lg` remain unchanged
- a custom name keeps the existing `md` baseline until its theme CSS loads
- incomplete and combination-only custom size definitions fail the theme build
- does not change parent component size props or resize icons inside parent components
- implementation is stacked on the AST-025 specification in #6025

## Verification

- Core typecheck and production build
- 38 focused Icon component tests
- 6 CLI generation and real consumer typecheck tests
- full pre-commit repository checks

## Changeset

Included for Core and CLI.
