### PR TITLE
chore(changesets): cover appearance nesting tokens

### DIFF
--- a/.changeset/appearance-nesting-tokens.md
+++ b/.changeset/appearance-nesting-tokens.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Export typed `appearanceDefaults` and `appearanceVars` nesting tokens for shared container and layer stacking bands, and migrate built-in Core surfaces to those bands while preserving their published stacking behavior. (#5963)
+
+@cixzhang


### PR DESCRIPTION
## What

Add the missing Core patch changeset for #5963.

The release note names the exported typed `appearanceDefaults` and `appearanceVars` nesting tokens and the migration of built-in Core surfaces to their shared stacking bands while preserving published stacking behavior. Attribution is `@cixzhang`, matching the source PR.

## Evidence

#5963 exact head `2314d2934cc13c4451f82481a963aeb0c3c8ae6a` has green `pr-a11y`, stable visual regression, `pr-rtl`, and visual acceptance.

## Testing

- `pnpm check:changesets`
- release changeset audit
- Prettier
- repository pre-commit checks
- public scrub