### PR TITLE
fix(docsite): bridge Selector's onChange preview even without a seeded value

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -444,6 +444,33 @@ describe('component detail preview state', () => {
     expect(onPropChange).toHaveBeenCalledWith('value', 42);
   });
 
+  it('bridges Selector onChange even though its optional value prop is not seeded (#5909 follow-up)', () => {
+    const knobs = pickPrimaryProps('Selector', [
+      prop({name: 'label', type: 'string', required: true}),
+      prop({name: 'options', type: 'SelectorOption[]', required: true}),
+      prop({name: 'value', type: 'string'}),
+      prop({name: 'onChange', type: '(value: string) => void'}),
+    ]);
+
+    const state = buildInitialState(knobs, {
+      defaults: {
+        label: 'Fruit',
+        options: [
+          {value: 'apple', label: 'Apple'},
+          {value: 'orange', label: 'Orange'},
+        ],
+      },
+    });
+    expect(state.value).toBeUndefined();
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+
+    const onPropChange = vi.fn();
+    const runtimeState = buildRuntimePreviewState(state, onPropChange, {knobs});
+
+    (runtimeState.onChange as (value: string) => void)('orange');
+    expect(onPropChange).toHaveBeenCalledWith('value', 'orange');
+  });
+
   it('bridges a Tokenizer removal back to its controlled value', () => {
     const knobs = pickPrimaryProps('Tokenizer', [
       prop({name: 'label', type: 'string', required: true}),

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -293,26 +293,35 @@ function getCallbackTargetProp(type: string): string | null {
 /**
  * The state prop a change handler writes back to, or `null` when the preview
  * cannot tell. Prefers the first parameter's name; for `onChange` falls back
- * to the controlled `value` prop, whose payload it carries by convention.
+ * to the controlled `value` prop, whose payload it carries by convention. The
+ * primary `onChange` pair may target an optional, unseeded value prop; secondary
+ * change handlers still require their target to be present in preview state.
  */
 function resolveChangeTarget(
   name: string,
   type: string,
   state: Record<string, unknown>,
+  knownProps: ReadonlySet<string>,
 ): string | null {
   const named = getCallbackTargetProp(type);
-  if (named != null && named in state) {
+  if (
+    named != null &&
+    (named in state || (name === 'onChange' && knownProps.has(named)))
+  ) {
     return named;
   }
-  return name === 'onChange' && 'value' in state ? 'value' : null;
+  return name === 'onChange' && ('value' in state || knownProps.has('value'))
+    ? 'value'
+    : null;
 }
 
 /**
  * Wires controlled-component change handlers back into playground state so the
  * preview reflects interaction (clicking a Pagination page, etc.). A callback
- * whose first parameter names a value prop in `state` (page/onChange,
- * value/onChange, pageSize/onPageSizeChange) replaces its noop with one that
- * updates that prop. isOpen/onOpenChange stays gated behind canControlOpenState.
+ * whose first parameter names a value prop in preview state (page/onChange,
+ * pageSize/onPageSizeChange), or the primary `value` prop for literal
+ * `onChange`, replaces its noop with one that updates that prop.
+ * isOpen/onOpenChange stays gated behind canControlOpenState.
  *
  * `onChange` is the exception to the name match: it conventionally documents
  * its first parameter after the payload it carries (`checked`, `items`,
@@ -330,10 +339,12 @@ export function buildRuntimePreviewState(
     return state;
   }
 
+  const knobs = options?.knobs ?? [];
+  const knownProps = new Set(knobs.map(knob => knob.row.name));
   const next: Record<string, unknown> = {...state};
   let changed = false;
 
-  for (const {row, control} of options?.knobs ?? []) {
+  for (const {row, control} of knobs) {
     if (control.kind !== 'callback') {
       continue;
     }
@@ -342,7 +353,7 @@ export function buildRuntimePreviewState(
     if (!/^on[A-Z].*Change$/.test(row.name) && row.name !== 'onChange') {
       continue;
     }
-    const target = resolveChangeTarget(row.name, row.type, state);
+    const target = resolveChangeTarget(row.name, row.type, state, knownProps);
     if (target == null) {
       continue;
     }


### PR DESCRIPTION
Fixes the Selector Properties-preview regression exposed by #5909. Does not touch anything from #5963.

### Problem

#5909 seeded `options`/`label` playground defaults for `Selector` so its Properties preview stops showing the "missing required props" placeholder. It correctly left `value` unseeded — "closed with no value" is itself a required representative state (Selector.spec.md, FR1: *"Selecting an enabled option updates the one selected value..."*).

That change exposed a latent bug in `buildRuntimePreviewState` (`apps/docsite/src/components/component-detail/interactiveState.ts`): it only bridges a controlled callback back into playground state when its target prop already has a value in `state`. Since Selector's `value` has no seeded default, `onChange` was never wired up, so the live preview stayed frozen on the placeholder no matter which option you clicked — Selector's own `value`/`onChange` contract has no internal uncontrolled fallback (`Selector.tsx` renders strictly from the `value` prop), so nothing else could make the trigger update.

### Fix

Generalized the bridge instead of patching Selector specifically: the literal `value`/`onChange` pair — a component's one primary controlled value — now bridges whenever `target` names a real prop, even an optional one with no seeded default.

Secondary paired callbacks (`onIndexChange`, `onPageSizeChange`, `onOpenChange`, ...) keep the original opt-in behavior: they only bridge once their target already has a value in state. This preserves each preview's chosen representative starting state — verified by the existing Lightbox gallery-index and overlay tests, unchanged and still passing.

No arbitrary selected value was seeded anywhere; Selector's playground still starts "closed with no value," and selecting an option now correctly updates it.

### Testing

- New focused regression test: `bridges Selector onChange even though its optional value prop is not seeded` — confirmed red on unfixed source (`onChange` was `undefined` in the preview's runtime props), green after the fix.
- Full docsite suite: 34 files, 475 tests passing.
- `tsc --noEmit`: no new errors (pre-existing `@astryxdesign/theme-*/built` errors are from unbuilt theme packages in this worktree, present identically before this change).
- `eslint` on both changed files: clean.
- `check:package-boundaries`: clean.
- Pre-commit `check:repo` (knowledge, sync, i18n, changesets, etc.): clean.

### Scope

Touches only docsite preview infrastructure and its test:
- `apps/docsite/src/components/component-detail/interactiveState.ts`
- `apps/docsite/src/__tests__/component-preview-state.test.ts`

No Selector source, doc, or spec changes were necessary — the fix is general, not Selector-specific. Excludes all `#5963` (theme appearance-nesting tokens) work.

### Residual risk

The generalized rule also newly enables bridging for any other component's optional `value`/`onChange` pair that currently has no playground default (previously frozen the same way Selector was). I did not find any component where this is undesirable — for HTML-backed inputs (e.g. `TextInput`) this was already visually working via native uncontrolled-input fallback, so this is additive rather than a behavior change — but it's a wider blast radius than Selector alone, worth a quick visual pass across the docsite Properties tabs if anyone wants extra confidence before merge.