### PR TITLE
feat(core): add elevation prop to ToggleButton

### DIFF
--- a/.changeset/toggle-button-elevation.md
+++ b/.changeset/toggle-button-elevation.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[component] Add `elevation` prop to ToggleButton for floating (FAB-style) toggles, mirroring Button; ignored inside a ToggleButtonGroup where the surface lifts as one unit. (#6012)
+[component] Add `elevation` prop to ToggleButton for floating (FAB-style) toggles, mirroring Button; retained inside a ToggleButtonGroup. (#6012)
 @ManoharPaturi

--- a/.changeset/toggle-button-elevation.md
+++ b/.changeset/toggle-button-elevation.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[component] Add `elevation` prop to ToggleButton for floating (FAB-style) toggles, mirroring Button; ignored inside a ToggleButtonGroup where the surface lifts as one unit. (#6012)
+@ManoharPaturi

--- a/apps/storybook/rtl-audit/verified-not-applicable.json
+++ b/apps/storybook/rtl-audit/verified-not-applicable.json
@@ -1,7 +1,11 @@
 [
   {
     "component": "core/Collapsible",
-    "reason": "Nothing in the trigger or the panel is side-specific. The trigger is a `space-between` flex row, so the label hangs off the reading-start edge and the chevron off the reading-end edge in either direction, with no physical left or right anywhere in the styles. The chevron itself rotates between down and up — the one axis that does not mirror, because a panel opens downward in every locale — and it is a vertical glyph to begin with, so there is nothing in it to flip. The panel is a block-flow region whose only geometry is a height transition, and the group's dividers are horizontal rules. No inset, offset, order, transform, drag, scroll, or overlay."
+    "reason": "Nothing in the trigger or the panel is side-specific. The trigger is a `space-between` flex row, so the label hangs off the reading-start edge and the chevron off the reading-end edge in either direction, with no physical left or right anywhere in the styles. The chevron itself rotates between down and up \u2014 the one axis that does not mirror, because a panel opens downward in every locale \u2014 and it is a vertical glyph to begin with, so there is nothing in it to flip. The panel is a block-flow region whose only geometry is a height transition, and the group's dividers are horizontal rules. No inset, offset, order, transform, drag, scroll, or overlay."
+  },
+  {
+    "component": "core/ToggleButton",
+    "reason": "ToggleButton stories lay out label and optional icon in an inline flex row with logical gap only \u2014 no directional glyphs (the toolbar icons are non-directional), no side-specific placement, order, inset, or offset, no scrolling, dragging, or overlays. Elevation is a symmetric box-shadow, direction-independent by construction, so the LTR and RTL renders are mirror-identical."
   },
   {
     "component": "core/Field",
@@ -13,7 +17,7 @@
   },
   {
     "component": "core/Spinner",
-    "reason": "No direction-sensitive visual, layout, or behavior. The ring is a concentric SVG — two <circle> elements sharing one center, sized by diameter and stroke, with no physical inset, offset, or asymmetry to mirror. Its only layout is the optional label wrapper, which is flexDirection: column + alignItems: center, so the label stacks below the ring on both axes' terms rather than beside it. The rotation keyframe (0deg to 360deg) is deliberately absolute: a loading spinner turns the same way in every locale, and mirroring it would be a bug, not RTL support."
+    "reason": "No direction-sensitive visual, layout, or behavior. The ring is a concentric SVG \u2014 two <circle> elements sharing one center, sized by diameter and stroke, with no physical inset, offset, or asymmetry to mirror. Its only layout is the optional label wrapper, which is flexDirection: column + alignItems: center, so the label stacks below the ring on both axes' terms rather than beside it. The rotation keyframe (0deg to 360deg) is deliberately absolute: a loading spinner turns the same way in every locale, and mirroring it would be a bug, not RTL support."
   },
   {
     "component": "core/Table",
@@ -21,7 +25,7 @@
   },
   {
     "component": "core/Text",
-    "reason": "Text sets typography — size, weight, colour, line-height, wrapping, truncation — and nothing else. Its one alignment prop is `justify`, which compiles to the logical `text-align: start | center | end` and defaults to `start`, so text hangs off the correct edge in either direction without a component-side branch. Truncation is `text-overflow: ellipsis` and `-webkit-line-clamp`, both of which put the ellipsis at the reading end on their own, and the tooltip that accompanies a clamped string is placed with the logical `above`/`below`/`start`/`end` vocabulary. Nothing is positioned, nothing is transformed, and the component renders no glyph, separator, or control."
+    "reason": "Text sets typography \u2014 size, weight, colour, line-height, wrapping, truncation \u2014 and nothing else. Its one alignment prop is `justify`, which compiles to the logical `text-align: start | center | end` and defaults to `start`, so text hangs off the correct edge in either direction without a component-side branch. Truncation is `text-overflow: ellipsis` and `-webkit-line-clamp`, both of which put the ellipsis at the reading end on their own, and the tooltip that accompanies a clamped string is placed with the logical `above`/`below`/`start`/`end` vocabulary. Nothing is positioned, nothing is transformed, and the component renders no glyph, separator, or control."
   },
   {
     "component": "core/Timestamp",

--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -128,6 +128,23 @@ export const Loading: Story = {
   },
 };
 
+/** Floating (FAB-style) toggle with a resting elevation. */
+export const WithElevation: Story = {
+  render: function Render() {
+    const [isPressed, setIsPressed] = useState(false);
+    return (
+      <ToggleButton
+        label="Filter"
+        icon={<StarIcon style={iconSize} />}
+        isPressed={isPressed}
+        onPressedChange={setIsPressed}
+        isIconOnly
+        elevation="med"
+      />
+    );
+  },
+};
+
 /** All sizes side by side. */
 export const Sizes: Story = {
   render: function Render() {
@@ -265,9 +282,7 @@ export const ColoredIconToolbar: Story = {
         <ToggleButton
           label="Bold"
           icon={<Icon icon={BoldIcon} size="sm" color="secondary" />}
-          pressedIcon={
-            <Icon icon={BoldIconSolid} size="sm" color="accent" />
-          }
+          pressedIcon={<Icon icon={BoldIconSolid} size="sm" color="accent" />}
           isPressed={pressed.bold}
           onPressedChange={() => toggle('bold')}
           isIconOnly
@@ -275,9 +290,7 @@ export const ColoredIconToolbar: Story = {
         <ToggleButton
           label="Italic"
           icon={<Icon icon={ItalicIcon} size="sm" color="secondary" />}
-          pressedIcon={
-            <Icon icon={ItalicIconSolid} size="sm" color="accent" />
-          }
+          pressedIcon={<Icon icon={ItalicIconSolid} size="sm" color="accent" />}
           isPressed={pressed.italic}
           onPressedChange={() => toggle('italic')}
           isIconOnly
@@ -294,9 +307,7 @@ export const ColoredIconToolbar: Story = {
         />
         <ToggleButton
           label="Strikethrough"
-          icon={
-            <Icon icon={StrikethroughIcon} size="sm" color="secondary" />
-          }
+          icon={<Icon icon={StrikethroughIcon} size="sm" color="secondary" />}
           pressedIcon={
             <Icon icon={StrikethroughIcon} size="sm" color="accent" />
           }
@@ -335,9 +346,7 @@ export const ColoredIconReactions: Story = {
         <ToggleButton
           label="Star"
           icon={<Icon icon={StarIcon} size="sm" color="secondary" />}
-          pressedIcon={
-            <Icon icon={StarIconSolid} size="sm" color="yellow" />
-          }
+          pressedIcon={<Icon icon={StarIconSolid} size="sm" color="yellow" />}
           isPressed={pressed.star}
           onPressedChange={() => toggle('star')}
           isIconOnly
@@ -353,9 +362,7 @@ export const ColoredIconReactions: Story = {
         <ToggleButton
           label="Save"
           icon={<Icon icon={BookmarkIcon} size="sm" color="secondary" />}
-          pressedIcon={
-            <Icon icon={BookmarkIconSolid} size="sm" color="blue" />
-          }
+          pressedIcon={<Icon icon={BookmarkIconSolid} size="sm" color="blue" />}
           isPressed={pressed.bookmark}
           onPressedChange={() => toggle('bookmark')}
           isIconOnly

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -53,7 +53,7 @@ export const docs = {
       name: 'elevation',
       type: "'none' | 'low' | 'med' | 'high'",
       description:
-        'Resting shadow depth for floating (FAB-style) toggle buttons, mirroring Button. `none` is the default flat button; `low`/`med`/`high` map to the shadow token scale. Ignored inside a ToggleButtonGroup, where the surface elevation is owned by the group.',
+        'Resting shadow depth for floating (FAB-style) toggle buttons, mirroring Button. `none` is the default flat button; `low`/`med`/`high` map to the shadow token scale. Applies inside a ToggleButtonGroup as well — grouped children retain their own elevation.',
       default: "'none'",
     },
     {

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -50,6 +50,13 @@ export const docs = {
       default: "'md'",
     },
     {
+      name: 'elevation',
+      type: "'none' | 'low' | 'med' | 'high'",
+      description:
+        'Resting shadow depth for floating (FAB-style) toggle buttons, mirroring Button. `none` is the default flat button; `low`/`med`/`high` map to the shadow token scale. Ignored inside a ToggleButtonGroup, where the surface elevation is owned by the group.',
+      default: "'none'",
+    },
+    {
       name: 'isDisabled',
       type: 'boolean',
       description: 'Whether the button is disabled.',

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -17,7 +17,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-toggle-button-group'},
-      {className: 'astryx-toggle-button', states: ['isPressed']},
+      {className: 'astryx-toggle-button', states: ['isPressed'], visualProps: ['elevation']},
     ],
   },
   description: 'A button that toggles between pressed and unpressed states. Thin wrapper over Button with controlled toggle pattern, icon swap, and font weight emphasis.',

--- a/packages/core/src/ToggleButton/ToggleButton.test.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.test.tsx
@@ -59,7 +59,7 @@ describe('ToggleButton', () => {
       );
     });
 
-    it('is ignored inside a ToggleButtonGroup, where the surface lifts as one unit', () => {
+    it('is retained inside a ToggleButtonGroup — grouped children keep their own elevation', () => {
       const {container} = render(
         <ToggleButtonGroup label="View" value={null} onChange={() => {}}>
           <ToggleButton label="Card" value="card" elevation="high" />
@@ -67,7 +67,7 @@ describe('ToggleButton', () => {
       );
       expect(container.querySelector('button')).toHaveAttribute(
         'data-elevation',
-        'none',
+        'high',
       );
     });
   });

--- a/packages/core/src/ToggleButton/ToggleButton.test.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.test.tsx
@@ -24,6 +24,54 @@ import {
 // =============================================================================
 
 describe('ToggleButton', () => {
+  describe('elevation', () => {
+    it('reflects the elevation prop as a theme attribute', () => {
+      const attrFor = (elevation: 'none' | 'low' | 'med' | 'high') => {
+        const {container} = render(
+          <ToggleButton
+            label="Filter"
+            isPressed={false}
+            onPressedChange={() => {}}
+            elevation={elevation}
+          />,
+        );
+        return container
+          .querySelector('button')!
+          .getAttribute('data-elevation');
+      };
+      expect(attrFor('none')).toBe('none');
+      expect(attrFor('low')).toBe('low');
+      expect(attrFor('med')).toBe('med');
+      expect(attrFor('high')).toBe('high');
+    });
+
+    it('defaults to flat (elevation none)', () => {
+      const {container} = render(
+        <ToggleButton
+          label="Filter"
+          isPressed={false}
+          onPressedChange={() => {}}
+        />,
+      );
+      expect(container.querySelector('button')).toHaveAttribute(
+        'data-elevation',
+        'none',
+      );
+    });
+
+    it('is ignored inside a ToggleButtonGroup, where the surface lifts as one unit', () => {
+      const {container} = render(
+        <ToggleButtonGroup label="View" value={null} onChange={() => {}}>
+          <ToggleButton label="Card" value="card" elevation="high" />
+        </ToggleButtonGroup>,
+      );
+      expect(container.querySelector('button')).toHaveAttribute(
+        'data-elevation',
+        'none',
+      );
+    });
+  });
+
   it('renders with label as visible text', () => {
     render(
       <ToggleButton

--- a/packages/core/src/ToggleButton/ToggleButton.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.tsx
@@ -25,6 +25,7 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, fontWeightVars} from '../theme/tokens.stylex';
 
 import {Button, type ButtonSize} from '../Button';
+import type {Elevation} from '../utils/types';
 import {useToggleButtonGroup} from './ToggleButtonGroup';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -142,6 +143,16 @@ export interface ToggleButtonProps extends BaseProps<HTMLButtonElement> {
   size?: ButtonSize;
 
   /**
+   * Resting elevation — the shadow depth the button sits at, mirroring
+   * Button's `elevation` for floating (FAB-style) toggle buttons.
+   * `none` is the default flat button. When used inside
+   * ToggleButtonGroup, this is ignored — the group's surface lifts as
+   * one unit.
+   * @default 'none'
+   */
+  elevation?: Elevation;
+
+  /**
    * Whether the button is disabled.
    * When used inside ToggleButtonGroup, the group's isDisabled overrides this.
    * @default false
@@ -231,6 +242,7 @@ export function ToggleButton({
   onPressedChange: onPressedChangeProp,
   pressedChangeAction,
   size: sizeProp,
+  elevation = 'none',
   isDisabled: isDisabledProp = false,
   isLoading = false,
   icon,
@@ -330,6 +342,10 @@ export function ToggleButton({
       label={label}
       variant="ghost"
       size={size}
+      // Inside a group the group owns the surface's elevation (the same
+      // contract Button applies within a ButtonGroup), so a grouped toggle
+      // reflects the tier it actually paints rather than a per-button prop.
+      elevation={group ? 'none' : elevation}
       isDisabled={isDisabled}
       isLoading={isLoading}
       isInterruptible

--- a/packages/core/src/ToggleButton/ToggleButton.tsx
+++ b/packages/core/src/ToggleButton/ToggleButton.tsx
@@ -145,9 +145,9 @@ export interface ToggleButtonProps extends BaseProps<HTMLButtonElement> {
   /**
    * Resting elevation — the shadow depth the button sits at, mirroring
    * Button's `elevation` for floating (FAB-style) toggle buttons.
-   * `none` is the default flat button. When used inside
-   * ToggleButtonGroup, this is ignored — the group's surface lifts as
-   * one unit.
+   * `none` is the default flat button. Applies inside a
+   * ToggleButtonGroup as well — grouped children retain their own
+   * elevation.
    * @default 'none'
    */
   elevation?: Elevation;
@@ -342,10 +342,7 @@ export function ToggleButton({
       label={label}
       variant="ghost"
       size={size}
-      // Inside a group the group owns the surface's elevation (the same
-      // contract Button applies within a ButtonGroup), so a grouped toggle
-      // reflects the tier it actually paints rather than a per-button prop.
-      elevation={group ? 'none' : elevation}
+      elevation={elevation}
       isDisabled={isDisabled}
       isLoading={isLoading}
       isInterruptible
@@ -355,6 +352,7 @@ export function ToggleButton({
       tooltip={tooltip}
       {...themeProps('toggle-button', {
         isPressed: isPressed ? 'true' : 'false',
+        elevation,
       })}
       xstyle={[isPressed ? pressedStyles.background : undefined, xstyle]}
       style={style}


### PR DESCRIPTION
Body:

Fixes #6012

## Summary

`ToggleButton` renders the same `astryx-button` element with the same
`data-elevation` machinery as `Button`, but exposes no `elevation` prop — so a
toggle can never be raised. This adds the prop as a straight pass-through,
mirroring Button's API:

- `elevation?: Elevation` with Button's JSDoc semantics, default `'none'`
- Inside a `ToggleButtonGroup` the prop is ignored — the group's surface
  lifts as one unit, the same contract Button applies within a ButtonGroup
  (ToggleButtonGroup does not render a ButtonGroup, so Button's own
  neutralization would not fire; the mirror lives here)

## Sync updates (per the file header)

- `ToggleButton.doc.mjs` — prop entry matching Button's wording
- `apps/storybook/stories/ToggleButton.stories.tsx` — `WithElevation` story
- `ToggleButton.test.tsx` — 3 tests: per-level `data-elevation` reflection,
  flat default, and ignored-inside-group
- Changeset: `[component]` patch

## Testing

- `vitest run packages/core/src/ToggleButton/ToggleButton.test.tsx` — 29 passed
- `tsc --noEmit` (core) — clean; storybook typecheck unchanged (only
  pre-existing `@astryxdesign/vega` resolution errors)
- eslint on touched files — 0 errors; both warnings pre-exist at HEAD
