### PR TITLE
Honor the last suffix on template demo assets

### DIFF
--- a/.changeset/template-asset-unrecognized-format.md
+++ b/.changeset/template-asset-unrecognized-format.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Report the fixture path when a template demo asset has an unsupported format (#6039)
+@Hashim1999164

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -166,7 +166,9 @@ const PLACEHOLDER_IMAGE =
  *
  * @type {Set<string>}
  */
-const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv']);
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv', 'm4v']);
+
+const IMAGE_EXTENSIONS = new Set(['svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'ico']);
 
 /**
  * Demo-asset sources to strip from scaffolded projects. Template demo imagery
@@ -179,7 +181,7 @@ const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv']);
  *
  * @type {RegExp}
  */
-const DEMO_ASSET_PATTERN = /\/template-assets\/[\w-]+\.(\w+)/g;
+const DEMO_ASSET_PATTERN = /\/template-assets\/[\w.-]+\.(\w+)/g;
 
 /**
  * Normalize path into Unix path (using forward slashes) for consistent comparison
@@ -203,9 +205,16 @@ function toPosixPath(p) {
  * @returns {string} Source with demo asset references replaced.
  */
 export function stripTemplateAssetRefs(source) {
-  return source.replace(DEMO_ASSET_PATTERN, (match, extension) =>
-    VIDEO_EXTENSIONS.has(extension.toLowerCase()) ? '' : PLACEHOLDER_IMAGE,
-  );
+  return source.replace(DEMO_ASSET_PATTERN, (match, extension) => {
+    const ext = extension.toLowerCase()
+    if (VIDEO_EXTENSIONS.has(ext)) {
+      return ''
+    }
+    if (IMAGE_EXTENSIONS.has(ext)) {
+      return PLACEHOLDER_IMAGE
+    }
+    throw new Error(`Unrecognized template asset extension: ${ext}`)
+  });
 }
 /**
  * Load a template-spec module and return its metadata object. Supports both

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -168,7 +168,16 @@ const PLACEHOLDER_IMAGE =
  */
 const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv', 'm4v']);
 
-const IMAGE_EXTENSIONS = new Set(['svg', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'ico']);
+const IMAGE_EXTENSIONS = new Set([
+  'svg',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'avif',
+  'ico',
+]);
 
 /**
  * Demo-asset sources to strip from scaffolded projects. Template demo imagery
@@ -206,14 +215,14 @@ function toPosixPath(p) {
  */
 export function stripTemplateAssetRefs(source) {
   return source.replace(DEMO_ASSET_PATTERN, (match, extension) => {
-    const ext = extension.toLowerCase()
+    const ext = extension.toLowerCase();
     if (VIDEO_EXTENSIONS.has(ext)) {
-      return ''
+      return '';
     }
     if (IMAGE_EXTENSIONS.has(ext)) {
-      return PLACEHOLDER_IMAGE
+      return PLACEHOLDER_IMAGE;
     }
-    throw new Error(`Unrecognized template asset extension: ${ext}`)
+    throw new Error(`Unrecognized template asset format ${ext} for ${match}`);
   });
 }
 /**
@@ -331,7 +340,9 @@ async function discoverBlocks() {
     const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
     if (!fs.existsSync(tsxPath)) continue;
     const doc = await loadDocModule(docPath);
-    const relPath = toPosixPath(path.relative(BLOCKS_DIR, path.dirname(docPath)));
+    const relPath = toPosixPath(
+      path.relative(BLOCKS_DIR, path.dirname(docPath)),
+    );
     blocks.push({
       type: 'block',
       dirName: basename,
@@ -348,7 +359,6 @@ async function discoverBlocks() {
   }
   return blocks;
 }
-
 
 /**
  * Discover blocks from external packages that declare `astryx.blocks` in
@@ -371,7 +381,9 @@ async function discoverExternalBlocks(cwd = process.cwd()) {
       const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
       if (!fs.existsSync(tsxPath)) continue;
       const doc = await loadDocModule(docPath);
-      const relPath = toPosixPath(path.relative(ext.blocksDir, path.dirname(docPath)));
+      const relPath = toPosixPath(
+        path.relative(ext.blocksDir, path.dirname(docPath)),
+      );
       blocks.push({
         type: 'block',
         dirName: basename,
@@ -458,7 +470,9 @@ function findIntegrationDocFiles(root) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (ALL_TEMPLATE_SUFFIXES.some(suffix => entry.name.endsWith(suffix))) {
+      } else if (
+        ALL_TEMPLATE_SUFFIXES.some(suffix => entry.name.endsWith(suffix))
+      ) {
         results.push(full);
       }
     }
@@ -613,7 +627,9 @@ export async function discoverIntegrationTemplatesForOne(integration) {
 export async function findRelatedBlocks(componentName, cwd) {
   const blocks = await discoverAllBlocks(cwd);
   return blocks.filter(b =>
-    (b.componentsUsed ?? []).some(c => c.toLowerCase() === componentName.toLowerCase()),
+    (b.componentsUsed ?? []).some(
+      c => c.toLowerCase() === componentName.toLowerCase(),
+    ),
   );
 }
 

--- a/packages/cli/foundation/discovery/template-adapter.test.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.test.mjs
@@ -16,7 +16,7 @@ import {describe, it, expect, beforeAll, afterAll} from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {extractComponents} from './template-adapter.mjs';
+import {extractComponents, stripTemplateAssetRefs} from './template-adapter.mjs';
 
 /** @type {string} */
 let dir;
@@ -132,5 +132,30 @@ describe('extractComponents — TypeScript generics are not components', () => {
       }`,
     );
     expect(extractComponents(file)).toEqual(['Card']);
+  });
+});
+
+describe('stripTemplateAssetRefs', () => {
+  it('uses the last extension on dotted demo asset names', () => {
+    const src = 'src="/template-assets/clip.min.mp4"'
+    expect(stripTemplateAssetRefs(src)).toBe('src=""')
+  });
+
+  it('strips m4v demo assets as video', () => {
+    const src = 'src="/template-assets/demo.m4v"'
+    expect(stripTemplateAssetRefs(src)).toBe('src=""')
+  });
+
+  it('keeps the image placeholder for known image extensions', () => {
+    const src = 'src="/template-assets/hero.png"'
+    const out = stripTemplateAssetRefs(src)
+    expect(out).toContain('data:image/svg+xml')
+    expect(out).not.toContain('/template-assets/hero.png')
+  });
+
+  it('throws for an unrecognized demo asset extension', () => {
+    expect(() => stripTemplateAssetRefs('src="/template-assets/clip.bin"')).toThrow(
+      /Unrecognized template asset extension: bin/,
+    )
   });
 });

--- a/packages/cli/foundation/discovery/template-adapter.test.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.test.mjs
@@ -16,7 +16,10 @@ import {describe, it, expect, beforeAll, afterAll} from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import {extractComponents, stripTemplateAssetRefs} from './template-adapter.mjs';
+import {
+  extractComponents,
+  stripTemplateAssetRefs,
+} from './template-adapter.mjs';
 
 /** @type {string} */
 let dir;
@@ -137,25 +140,27 @@ describe('extractComponents — TypeScript generics are not components', () => {
 
 describe('stripTemplateAssetRefs', () => {
   it('uses the last extension on dotted demo asset names', () => {
-    const src = 'src="/template-assets/clip.min.mp4"'
-    expect(stripTemplateAssetRefs(src)).toBe('src=""')
+    const src = 'src="/template-assets/clip.min.mp4"';
+    expect(stripTemplateAssetRefs(src)).toBe('src=""');
   });
 
   it('strips m4v demo assets as video', () => {
-    const src = 'src="/template-assets/demo.m4v"'
-    expect(stripTemplateAssetRefs(src)).toBe('src=""')
+    const src = 'src="/template-assets/demo.m4v"';
+    expect(stripTemplateAssetRefs(src)).toBe('src=""');
   });
 
   it('keeps the image placeholder for known image extensions', () => {
-    const src = 'src="/template-assets/hero.png"'
-    const out = stripTemplateAssetRefs(src)
-    expect(out).toContain('data:image/svg+xml')
-    expect(out).not.toContain('/template-assets/hero.png')
+    const src = 'src="/template-assets/hero.png"';
+    const out = stripTemplateAssetRefs(src);
+    expect(out).toContain('data:image/svg+xml');
+    expect(out).not.toContain('/template-assets/hero.png');
   });
 
   it('throws for an unrecognized demo asset extension', () => {
-    expect(() => stripTemplateAssetRefs('src="/template-assets/clip.bin"')).toThrow(
-      /Unrecognized template asset extension: bin/,
-    )
+    expect(() =>
+      stripTemplateAssetRefs('src="/template-assets/clip.bin"'),
+    ).toThrow(
+      /Unrecognized template asset format bin for \/template-assets\/clip\.bin/,
+    );
   });
 });


### PR DESCRIPTION
Unknown template asset extensions now throw instead of becoming the image placeholder. Video names with extra dots and m4v files are treated as video.

Closes #5423