### PR TITLE
docs(TreeList): record keyboard cancellation contract

### DIFF
--- a/packages/core/src/TreeList/TreeList.spec.md
+++ b/packages/core/src/TreeList/TreeList.spec.md
@@ -3,13 +3,13 @@ schema_version: 3
 template_version: 3
 kind: component
 id: component:TreeList
-authority: draft
+authority: current
 archive_reason: null
 superseded_by: null
-approved_by: null
-approved_at: null
+approved_by: cixzhang
+approved_at: 2026-09-04
 owners: [cixzhang]
-review_triggers: [behavior, theming, accessibility]
+review_triggers: [public-api, behavior, theming, accessibility]
 verified_by:
   [
     packages/core/src/TreeList/TreeList.test.tsx,
@@ -33,16 +33,22 @@ system_specs: [spec:AST-005/DEC-1]
 
 ## Intent
 
-TreeList presents hierarchical data as expandable tree rows. This draft records
-its current consumer anatomy, target ownership, delegated Icon glyph, and
-unreached stable parts without changing runtime behavior, styling, targets, or
-public API.
+TreeList presents hierarchical data as expandable tree rows. This record owns its
+current consumer anatomy, target ownership, delegated Icon glyph, unreached stable
+parts, and the ordering boundary between consumer key handlers and built-in tree
+navigation. It records shipped behavior without changing runtime, styling, targets,
+or public API.
 
 ## Compatibility and migration
 
 - Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, aliases, and public API remain unchanged
+- Compatibility class: additive contract recording; runtime, DOM, styling,
+  targets, aliases, and prop types remain unchanged
+- `onKeyDown` remains attached to the root `div`, so its
+  `event.currentTarget` matches the forwarded root ref. Calling
+  `event.preventDefault()` cancels built-in tree navigation only when the event
+  originated inside the tree; header-slot key events never enter internal tree
+  navigation.
 - Controlled/uncontrolled behavior: unchanged
 - Migration decision: none
 
@@ -67,17 +73,23 @@ Consumer migration instructions belong in consumer docs and release notes.
 
 ## Public concepts
 
-No new public concept is introduced. Consumer data, props, slots, and usage
-remain documented in `TreeList.doc.mjs`.
+This record adds no prop. It records the existing cancellation seam inherited
+through TreeList's root event props; complete prop syntax and examples remain in
+`TreeList.doc.mjs`.
+
+| Concept                  | Closed values or states | Meaning                                                                                     | Availability                   | Default    | Owner  | Stability | Invalid-value behavior |
+| ------------------------ | ----------------------- | ------------------------------------------------------------------------------------------- | ------------------------------ | ---------- | ------ | --------- | ---------------------- |
+| key-handler cancellation | uncanceled, canceled    | Root `onKeyDown` runs before built-in tree navigation; `preventDefault()` cancels that step | Events originating in the tree | uncanceled | Caller | released  | DOM event semantics    |
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                                                          | Basis                             | Draft review state                                                        |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------- |
-| FR1 | The current render contains one Tree list, one Item and Item label per rendered node, optional Header, Chevron, Item description, Start content, End content, and Guide parts, and delegated Chevron glyphs. | Current source, docs, and tests   | Verified current behavior; no new behavior decided                        |
-| FR2 | Tree list, Item, Chevron, Item label, and Guide carry the five current `tree-list*` targets documented below.                                                                                                | Current source and target docs    | Verified current inventory; focused placement coverage is partial         |
-| FR3 | Chevron glyph delegates to Icon's `icon` target. Header, Start content, and End content are consumer-owned and have no TreeList target.                                                                      | Current source and component docs | Verified current ownership; no target change                              |
-| FR4 | Item description is a stable library-rendered part below Item label and currently has no public target. It does not inherit through `tree-list-item-label`; both spans are siblings inside the row content.  | Current source and target docs    | Verified current reachability; long-term theming intent remains unsettled |
+| ID  | Shipped invariant                                                                                                                                                                                                                                                           | Basis                                 | Review state                                                              |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| FR1 | The current render contains one Tree list, one Item and Item label per rendered node, optional Header, Chevron, Item description, Start content, End content, and Guide parts, and delegated Chevron glyphs.                                                                | Current source, docs, and tests       | Verified current behavior; no new behavior decided                        |
+| FR2 | Tree list, Item, Chevron, Item label, and Guide carry the five current `tree-list*` targets documented below.                                                                                                                                                               | Current source and target docs        | Verified current inventory; focused placement coverage is partial         |
+| FR3 | Chevron glyph delegates to Icon's `icon` target. Header, Start content, and End content are consumer-owned and have no TreeList target.                                                                                                                                     | Current source and component docs     | Verified current ownership; no target change                              |
+| FR4 | Item description is a stable library-rendered part below Item label and currently has no public target. It does not inherit through `tree-list-item-label`; both spans are siblings inside the row content.                                                                 | Current source and target docs        | Verified current reachability; long-term theming intent remains unsettled |
+| FR5 | The root `onKeyDown` handler runs before built-in keyboard navigation for events originating in the tree. `preventDefault()` cancels that navigation without changing the root `currentTarget`; events from the public header slot do not trigger internal tree navigation. | #5606 source, tests, and owner review | Approved and shipped cancellation boundary                                |
 
 ### Allowed variation
 
@@ -91,19 +103,23 @@ remain documented in `TreeList.doc.mjs`.
 
 ### Representative states
 
-| State                    | Required invariant                                    | Allowed variation                             |
-| ------------------------ | ----------------------------------------------------- | --------------------------------------------- |
-| Empty tree               | Tree list remains; no Item instances render.          | Optional Header content.                      |
-| Flat items               | Each Item contains an Item label.                     | Description and consumer slots may be absent. |
-| Expandable item          | Item may contain Chevron and delegated Chevron glyph. | Expanded or collapsed state.                  |
-| Nested `lineGuides` tree | Guide instances show parent-child relationships.      | Count and position follow hierarchy.          |
-| `noGuides` tree          | Guide instances are absent; indentation remains.      | All other anatomy remains unchanged.          |
-| Described item           | Item description renders below Item label.            | Caller-provided description text.             |
+| State                    | Required invariant                                                                         | Allowed variation                             |
+| ------------------------ | ------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| Empty tree               | Tree list remains; no Item instances render.                                               | Optional Header content.                      |
+| Flat items               | Each Item contains an Item label.                                                          | Description and consumer slots may be absent. |
+| Expandable item          | Item may contain Chevron and delegated Chevron glyph.                                      | Expanded or collapsed state.                  |
+| Nested `lineGuides` tree | Guide instances show parent-child relationships.                                           | Count and position follow hierarchy.          |
+| `noGuides` tree          | Guide instances are absent; indentation remains.                                           | All other anatomy remains unchanged.          |
+| canceled tree key        | Root `onKeyDown` keeps the root `currentTarget`; focus and roving tab stop stay unchanged. | Any key the caller cancels.                   |
+| header-slot key          | The root handler runs; built-in tree navigation does not.                                  | Any interactive header content.               |
+| Described item           | Item description renders below Item label.                                                 | Caller-provided description text.             |
 
 ### Transformation and precedence order
 
-- No new hierarchy, focus, expansion, layout, or styling precedence rule is
-  introduced.
+- **ORD1 — Consumer cancellation precedes internal navigation.** Tree-originated
+  key events reach the root consumer handler first. If the caller cancels the
+  event, TreeList does not update roving focus or activate an item. Header-originated
+  key events remain outside the internal navigation path.
 
 ### Performance and resources
 
@@ -111,8 +127,11 @@ remain documented in `TreeList.doc.mjs`.
 
 ## Accessibility contract
 
-This draft does not change or extend TreeList's current tree, treeitem, group,
-roving-focus, expansion, selection, disabled, or activation behavior.
+TreeList keeps its current tree, treeitem, group, roving-focus, expansion,
+selection, disabled, and activation behavior. A caller may reserve a keyboard
+interaction by canceling the root `onKeyDown` event before TreeList performs its
+built-in APG navigation; uncanceled tree events keep the built-in behavior, and
+interactive header content remains outside it.
 
 ## Design relationships
 
@@ -180,8 +199,8 @@ authorize a new target.
 
 - `architecture:component-theming-surface` owns anatomy qualification, target
   mapping, delegation, and factual `none` dispositions.
-- `architecture:public-component-api` owns the stable data, props, and slot
-  surface; this documentation adds no API.
+- `architecture:public-component-api` owns the stable data, props, slots, and
+  cancellation-admission rule; FR5 records TreeList's released cancellation seam.
 - `architecture:interaction-modality` owns shared keyboard and pointer modality;
   TreeList continues to own its existing tree focus and activation behavior.
 - `family:navigation-destinations` owns the shared accept/block result for a
@@ -192,13 +211,14 @@ authorize a new target.
 
 ## Verification map
 
-| Contract            | Verification                                                                                    | Representative states                              | Mutation or failure expectation                                                                                                                                                                                                                     | Audit section            |
-| ------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| FR1                 | `TreeList.test.tsx` rendering, hierarchy, slot, and accessibility suites plus source inspection | Flat, nested, described, headed, and slotted items | Removing asserted Tree list, Header, Item, Chevron, Item label, Item description, Start content, End content, or Guide behavior fails existing role, content, hierarchy, or state assertions; Chevron glyph presence remains source-inspected only. | `audit:TreeList/anatomy` |
-| FR2                 | `TreeList.test.tsx` and `themingTargets.test.ts`                                                | Five local targets and their documented states     | Removing or moving any current local target fails focused class assertions or the global inventory.                                                                                                                                                 | `audit:TreeList/theming` |
-| FR3                 | Source inspection plus Icon public target metadata                                              | Expandable rows and caller-provided slots          | Existing focused tests do not assert the composed Icon instance; changing glyph or slot ownership requires this map and the relevant owner metadata to change.                                                                                      | `audit:TreeList/theming` |
-| FR4                 | `TreeList.test.tsx` description rendering test and source inspection                            | Item with description                              | Removing description fails content coverage; adding a target requires an explicit map update.                                                                                                                                                       | `audit:TreeList/anatomy` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                   | Canonical anatomy and five current local targets   | Missing, extra, prefixed, stale, or alias-backed mappings fail repository validation.                                                                                                                                                               | `audit:TreeList/theming` |
+| Contract            | Verification                                                                                    | Representative states                              | Mutation or failure expectation                                                                                                                                                                                                                     | Audit section             |
+| ------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| FR1                 | `TreeList.test.tsx` rendering, hierarchy, slot, and accessibility suites plus source inspection | Flat, nested, described, headed, and slotted items | Removing asserted Tree list, Header, Item, Chevron, Item label, Item description, Start content, End content, or Guide behavior fails existing role, content, hierarchy, or state assertions; Chevron glyph presence remains source-inspected only. | `audit:TreeList/anatomy`  |
+| FR2                 | `TreeList.test.tsx` and `themingTargets.test.ts`                                                | Five local targets and their documented states     | Removing or moving any current local target fails focused class assertions or the global inventory.                                                                                                                                                 | `audit:TreeList/theming`  |
+| FR3                 | Source inspection plus Icon public target metadata                                              | Expandable rows and caller-provided slots          | Existing focused tests do not assert the composed Icon instance; changing glyph or slot ownership requires this map and the relevant owner metadata to change.                                                                                      | `audit:TreeList/theming`  |
+| FR4                 | `TreeList.test.tsx` description rendering test and source inspection                            | Item with description                              | Removing description fails content coverage; adding a target requires an explicit map update.                                                                                                                                                       | `audit:TreeList/anatomy`  |
+| FR5                 | `TreeList.test.tsx` cancellation, root-target, normal-navigation, and header-isolation tests    | Canceled tree key, uncanceled tree key, header key | Reordering the consumer handler after internal navigation, changing `currentTarget`, or routing header keys into tree navigation fails focused assertions.                                                                                          | `audit:TreeList/behavior` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                   | Canonical anatomy and five current local targets   | Missing, extra, prefixed, stale, or alias-backed mappings fail repository validation.                                                                                                                                                               | `audit:TreeList/theming`  |
 
 Focused target-placement assertions cover all five local targets: Tree list,
 Item, Chevron, Item label, and Guide. Existing tests do not assert the Icon
@@ -206,8 +226,11 @@ instance that renders Chevron glyph.
 
 ## Decision log
 
-None. This draft records current facts and introduces no component-local design,
-API, behavior, or theming decision.
+- **DEC-1 — Root cancellation precedes tree navigation.** `onKeyDown` keeps the
+  forwarded root `div` as `event.currentTarget`. For events that originate in the
+  tree, `preventDefault()` cancels built-in navigation; for events from the public
+  header slot, built-in tree navigation never runs. This records the exact behavior
+  approved and shipped in #5606.
 
 ## Open questions
 


### PR DESCRIPTION
Repairs the contract-recording gap left by #5606. No runtime behavior changes.

## What

- promote the existing TreeList component record to current
- record the shipped `onKeyDown` cancellation seam as FR5 / ORD1 / DEC-1
- preserve the root `div` currentTarget guarantee
- keep header-slot keys outside built-in tree navigation
- map the existing focused tests to the contract

## Why

#5606’s final exact head was owner-approved after proving cancellation, normal navigation, root-currentTarget compatibility, and header isolation. The merged code and changeset shipped that behavior, but the component record still said no focus or activation rule had changed. This PR faithfully records the approved, already-shipped boundary.

## Validation

- `pnpm check:knowledge`
- Prettier
- `git diff --check`
- repository pre-commit checks

No Changeset: specification-only synchronization for already-released behavior.