### PR TITLE
Resizable: pin #5934's legacy maxSizePx shrink-after-drag clamp

### DIFF
--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -705,6 +705,51 @@ describe('useResizable percentage configuration (AST-010)', () => {
       // always done.
       expect(result.current.size).toBe(80);
     });
+
+    it('re-clamps a legacy numeric maxSizePx recomputed by the caller, not just a percentage bound', () => {
+      // #5934: a table-inbox reading pane derives `maxSizePx` itself, as
+      // `Math.max(paneFloor, surfaceWidth - listFloor)`, from a plain
+      // ResizeObserver measurement — no `containerRef`/`maxSize` percentage
+      // in play, so this is the caller-recomputed-literal path, not FR1's
+      // basis tracking. #5783 (commit 311deefc) made this path re-resolve
+      // and clamp the selection every render like any other bound, per FR4;
+      // this pins the exact table-inbox pane-widen-then-surface-narrow
+      // sequence from the #5934 review so no fix on either side can drop it.
+      const {result, rerender} = renderHook(
+        ({maxSizePx}: {maxSizePx: number}) =>
+          useResizable({defaultSize: 400, minSizePx: 300, maxSizePx}),
+        {initialProps: {maxSizePx: 1500}},
+      );
+
+      // The user drags the separator out to 1066px, well inside the
+      // 1500px ceiling the wide surface currently allows.
+      act(() => result.current.resize(1066));
+      expect(result.current.size).toBe(1066);
+
+      // The surface then narrows (no drag involved), so the derived ceiling
+      // drops under the size the user chose.
+      rerender({maxSizePx: 834});
+
+      expect(result.current.size).toBe(834);
+      expect(result.current.props._size).toBe(834);
+      expect(result.current.props._maxSizePx).toBe(834);
+    });
+
+    it('leaves an in-range user choice alone when a legacy maxSizePx shrinks', () => {
+      // The other half of #5934's fix: clamping must not become a second
+      // proportional-resize mode. A selection that still fits the new
+      // ceiling is the user's answer and stays exactly where they left it.
+      const {result, rerender} = renderHook(
+        ({maxSizePx}: {maxSizePx: number}) =>
+          useResizable({defaultSize: 400, minSizePx: 300, maxSizePx}),
+        {initialProps: {maxSizePx: 1500}},
+      );
+
+      act(() => result.current.resize(700));
+      rerender({maxSizePx: 834});
+
+      expect(result.current.size).toBe(700);
+    });
   });
 
   describe('structured percent sizes', () => {


### PR DESCRIPTION
## What

Test-only closure for a same-head review finding on #5934 (`table-inbox`).

The reading pane in the table-inbox template derives `maxSizePx` itself — `Math.max(paneFloor, surfaceWidth - listFloor)` from a plain ResizeObserver measurement, not a `containerRef` percentage bound. A dismissed same-head review on #5934 found that after widening the pane past a later surface-derived maximum, the pane stayed oversized and overlapped the list instead of clamping to the new ceiling.

## Investigation

Reproducing the review's exact sequence — drag the pane to 1066px, then narrow the surface so the derived max drops to 834px — at both the `useResizable` hook level and a page.tsx-composition-level replica shows it already clamps correctly on current `main`. `useResizable`'s general FR4 bounds-reclamp (landed in #5783, commit `311deefc`) re-resolves `resolvedMax` from a changed caller-supplied `maxSizePx` on every render and re-clamps the committed selection — independent of whether the bound is a percentage or a plain number. No template or hook behavior change is needed.

## The change

Adds the reproduction directly to `useResizable`'s FR4/FR6 suite (AST-010) so this caller-recomputed-pixel path — distinct from the existing containerRef/percentage-basis tests already there — can't silently regress:

- clamps the selection and the ARIA-visible `_maxSizePx`/`_size` when a legacy numeric `maxSizePx` shrinks below the user's chosen size;
- leaves an in-range user choice untouched (clamping is not a second proportional-resize mode, per FR4).

## Risk

None — test-only, no runtime change.

## Testing

- `vitest run packages/core/src/Resizable/` — 150/150 passing (112 in `useResizable.test.ts`, incl. the 2 new tests)
- `tsc --noEmit`, `eslint` on the changed file — clean
- `pnpm check:repo` — clean

Refs #5934, #5783. AST-010 FR4/FR6.