### PR TITLE
feat(cli): add muse agent preset to init --agent

### DIFF
--- a/.changeset/muse-agent-preset.md
+++ b/.changeset/muse-agent-preset.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add `muse` preset to `astryx init --agent` targeting `AGENTS.md` for Muse Code.
+
+@oliprovscode

--- a/packages/cli/api/init/init.doc.mjs
+++ b/packages/cli/api/init/init.doc.mjs
@@ -45,7 +45,7 @@ export const doc = {
     {
       name: 'options.agent',
       type: 'string',
-      description: 'Agent preset: claude, cursor, codex, hermes, all.',
+      description: 'Agent preset: claude, cursor, codex, hermes, muse, all.',
     },
     {
       name: 'options.agentDocsPath',
@@ -75,7 +75,7 @@ export const doc = {
   throws: [
     {
       code: 'ERR_UNKNOWN_AGENT',
-      when: '`agent` is not one of claude, cursor, codex, hermes, all',
+      when: '`agent` is not one of claude, cursor, codex, hermes, muse, all',
     },
     {
       code: 'ERR_UNKNOWN_FEATURE',

--- a/packages/cli/api/init/init.type.mjs
+++ b/packages/cli/api/init/init.type.mjs
@@ -38,7 +38,7 @@
  * @property {string} [features] Comma-separated features to install (agents, theme, template).
  * @property {boolean} [all] Install all features.
  * @property {boolean} [removeAgents] Remove the managed agent-docs block instead of installing.
- * @property {string} [agent] Agent preset: claude, cursor, codex, hermes, all.
+ * @property {string} [agent] Agent preset: claude, cursor, codex, hermes, muse, all.
  * @property {string | string[]} [agentDocsPath] Explicit agent-docs file path(s).
  * @property {string} [templateName] Scaffold a named page template (programmatic only; the CLI never sets it).
  */

--- a/packages/cli/api/init/run/run.mjs
+++ b/packages/cli/api/init/run/run.mjs
@@ -28,7 +28,7 @@ import {ERROR_CODES} from '../../../foundation/response/error-codes.mjs';
 import {logger} from '../../logger.mjs';
 
 const VALID_FEATURES = ['agents', 'theme', 'template'];
-const VALID_AGENTS = ['claude', 'cursor', 'codex', 'hermes', 'all'];
+const VALID_AGENTS = ['claude', 'cursor', 'codex', 'hermes', 'muse', 'all'];
 
 /**
  * Build the "Next steps" lines printed at the end of `astryx init`.

--- a/packages/cli/assets/docs/working-with-ai.doc.mjs
+++ b/packages/cli/assets/docs/working-with-ai.doc.mjs
@@ -50,7 +50,8 @@ export const docs = {
           label: 'Manual options',
           code: `npx @astryxdesign/cli init --features agents --agent claude    # .claude/CLAUDE.md
 npx @astryxdesign/cli init --features agents --agent cursor    # .cursorrules
-npx @astryxdesign/cli init --features agents --agent codex     # AGENTS.md (Copilot, Codex, etc.)`,
+npx @astryxdesign/cli init --features agents --agent codex     # AGENTS.md (Copilot, Codex, etc.)
+npx @astryxdesign/cli init --features agents --agent muse      # AGENTS.md (Muse)`,
         },
       ],
     },

--- a/packages/cli/clients/cli/commands/init.doc.mjs
+++ b/packages/cli/clients/cli/commands/init.doc.mjs
@@ -40,9 +40,9 @@ export const doc = {
     {
       flag: '--agent <tool>',
       param: 'options.agent',
-      choices: ['claude', 'cursor', 'codex', 'hermes', 'all'],
+      choices: ['claude', 'cursor', 'codex', 'hermes', 'muse', 'all'],
       description:
-        'Target AI tool for agent docs: claude, cursor, codex, hermes, all',
+        'Target AI tool for agent docs: claude, cursor, codex, hermes, muse, all',
     },
     {
       flag: '--agent-docs-path <path...>',

--- a/packages/cli/foundation/agent-docs/agent-doc-state.mjs
+++ b/packages/cli/foundation/agent-docs/agent-doc-state.mjs
@@ -47,7 +47,7 @@ export const LEGACY_MARKER_END = '<!-- XDS:END -->';
  * targets are user-chosen and not enumerable here.)
  */
 export const AGENT_DOC_PATHS = [
-  AGENTS_MD, // Codex / ChatGPT / generic
+  AGENTS_MD, // Codex / ChatGPT / Muse / generic
   CLAUDE_MD, // Claude Code (root)
   CLAUDE_DIR_MD, // Claude Code (.claude/CLAUDE.md)
   CURSOR_RULES, // Cursor

--- a/packages/cli/foundation/agent-docs/agent-docs.mjs
+++ b/packages/cli/foundation/agent-docs/agent-docs.mjs
@@ -9,12 +9,13 @@
  * - Claude Code: CLAUDE.md (root) or .claude/CLAUDE.md
  * - Cursor: .cursorrules
  * - Codex/generic: AGENTS.md
+ * - Muse: AGENTS.md
  * - Hermes Agent: .hermes.md or HERMES.md (existing), else AGENTS.md
  *
  * Auto-detect: discovers existing files and updates them in place.
  * Default (no existing files): creates AGENTS.md (the tool-agnostic standard).
  *
- * --agent <tool>: target a specific tool preset (claude, cursor, codex, hermes, all)
+ * --agent <tool>: target a specific tool preset (claude, cursor, codex, hermes, muse, all)
  * --agent-docs-path <path>: explicit file path(s)
  */
 
@@ -96,6 +97,7 @@ const AGENT_PRESETS = {
   cursor: [CURSOR_RULES, AGENTS_MD],
   codex: [AGENTS_MD],
   hermes: [HERMES_DOT_MD, HERMES_MD, AGENTS_MD],
+  muse: [AGENTS_MD],
 };
 
 /**
@@ -178,7 +180,7 @@ export function inspectAgentDocs(targetDir, installedVersion) {
  * Searches for existing files first, falls back to default creation path.
  *
  * @param {string} targetDir
- * @param {string} agent - Preset name: 'claude', 'cursor', 'codex', 'hermes', 'all'
+ * @param {string} agent - Preset name: 'claude', 'cursor', 'codex', 'hermes', 'muse', 'all'
  * @returns {{inject: string[], create: string[]}} Files to inject into vs create fresh
  */
 export function resolveAgentPaths(targetDir, agent) {
@@ -539,7 +541,7 @@ export function removeAgentDocs(targetDir) {
  * @param {object} [options]
  * @param {boolean} [options.zh]
  * @param {string} [options.lang]
- * @param {string} [options.agent] - Tool preset: 'claude', 'cursor', 'codex', 'hermes', 'all'
+ * @param {string} [options.agent] - Tool preset: 'claude', 'cursor', 'codex', 'hermes', 'muse', 'all'
  * @param {string[]} [options.paths] - Explicit paths (overrides agent/auto-detect)
  * @param {boolean} [options.onlyReplace] - Only update files that already have Astryx markers (for upgrades)
  * @param {string[]} [options.topics] - Doc topics to list in the block; defaults
@@ -613,9 +615,9 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
   }
 
   // Nothing exists — create root AGENTS.md as the default (skip if onlyReplace).
-  // AGENTS.md is the tool-agnostic standard (Codex/Copilot, Cursor, and most
-  // agents read it), so it's the safe default. Claude-specific output is opt-in
-  // via `--agent claude` (→ .claude/CLAUDE.md); `--agent all` writes both.
+  // AGENTS.md is the tool-agnostic standard (Codex/Copilot, Cursor, Muse, and
+  // most agents read it), so it's the safe default. Claude-specific output is
+  // opt-in via `--agent claude` (→ .claude/CLAUDE.md); `--agent all` writes both.
   if (onlyReplace) return written;
 
   const defaultPath = AGENTS_MD;

--- a/packages/cli/foundation/agent-docs/agent-docs.test.mjs
+++ b/packages/cli/foundation/agent-docs/agent-docs.test.mjs
@@ -555,6 +555,15 @@ describe('installAgentDocs', () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
   });
 
+  it('respects --agent muse preset: creates AGENTS.md', () => {
+    setupCorePackage(tmpDir);
+
+    const written = installAgentDocs(tmpDir, {agent: 'muse'});
+
+    expect(written).toEqual(['AGENTS.md']);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
+  });
+
   it('respects explicit --paths', () => {
     setupCorePackage(tmpDir);
 
@@ -671,6 +680,11 @@ describe('resolveAgentPaths', () => {
     fs.writeFileSync(path.join(tmpDir, 'HERMES.md'), '');
     const result = resolveAgentPaths(tmpDir, 'hermes');
     expect(result).toEqual({inject: ['HERMES.md'], create: []});
+  });
+
+  it('muse preset creates AGENTS.md when nothing exists', () => {
+    const result = resolveAgentPaths(tmpDir, 'muse');
+    expect(result).toEqual({inject: [], create: ['AGENTS.md']});
   });
 
   it('claude preset still creates .claude/CLAUDE.md when nothing exists (hermes is additive)', () => {

--- a/packages/core/scripts/agent-doc-state.mjs
+++ b/packages/core/scripts/agent-doc-state.mjs
@@ -57,7 +57,7 @@ export const LEGACY_MARKER_END = '<!-- XDS:END -->';
  * targets are user-chosen and not enumerable here.)
  */
 export const AGENT_DOC_PATHS = [
-  AGENTS_MD, // Codex / ChatGPT / generic
+  AGENTS_MD, // Codex / ChatGPT / Muse / generic
   CLAUDE_MD, // Claude Code (root)
   CLAUDE_DIR_MD, // Claude Code (.claude/CLAUDE.md)
   CURSOR_RULES, // Cursor


### PR DESCRIPTION
Adds a `muse` preset to `astryx init --agent` targeting `AGENTS.md` for Muse Code, which reads `AGENTS.md` as project rules (verified via `muse init --dry-run`).

Changes:
- `AGENT_PRESETS` gains `muse: [AGENTS.md]`; `--agent` choices, API docs/types, and `VALID_AGENTS` accept `muse`
- Consumer doc (`working-with-ai`) lists `--agent muse`
- Two new tests in `agent-docs.test.mjs` mirroring the hermes cases
- Regenerated `packages/core/scripts/agent-doc-state.mjs` via `generate-setup-contract.mjs`
- Changeset: `[feat]` patch for `@astryxdesign/cli`

Validation: `check-changesets` (83 valid), `check-cli-structure` intact, setup-contract in sync, new tests mirrored in a plain-node smoke run against the real module code (5/5 pass; vitest could not run in this checkout — no node_modules).

CLA signed.