### PR TITLE
test(Resizable): keep legacy bound clamps permanent

### DIFF
--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -706,7 +706,7 @@ describe('useResizable percentage configuration (AST-010)', () => {
       expect(result.current.size).toBe(80);
     });
 
-    it('re-clamps a legacy numeric maxSizePx recomputed by the caller, not just a percentage bound', () => {
+    it('permanently re-clamps a legacy numeric maxSizePx recomputed by the caller', () => {
       // #5934: a table-inbox reading pane derives `maxSizePx` itself, as
       // `Math.max(paneFloor, surfaceWidth - listFloor)`, from a plain
       // ResizeObserver measurement — no `containerRef`/`maxSize` percentage
@@ -733,6 +733,13 @@ describe('useResizable percentage configuration (AST-010)', () => {
       expect(result.current.size).toBe(834);
       expect(result.current.props._size).toBe(834);
       expect(result.current.props._maxSizePx).toBe(834);
+
+      // Growing the surface again must not revive the pre-clamp selection.
+      rerender({maxSizePx: 1500});
+
+      expect(result.current.size).toBe(834);
+      expect(result.current.props._size).toBe(834);
+      expect(result.current.props._maxSizePx).toBe(1500);
     });
 
     it('leaves an in-range user choice alone when a legacy maxSizePx shrinks', () => {


### PR DESCRIPTION
## Why

#6041 merged before its same-head review request was incorporated. Without the final grow step, the regression could still pass if a legacy numeric `maxSizePx` clamp were only temporary and the earlier pane width revived when the surface widened again.

## What

Extend the existing table-inbox regression through the complete sequence: drag to 1066px, clamp to 834px, then grow the maximum back to 1500px. The test asserts that the committed selection and handle geometry stay at 834px while the advertised maximum updates.

## Risk

None — test-only, with no runtime or public API change.

## Testing

- `vitest run packages/core/src/Resizable/useResizable.test.ts` — 112/112 passing
- ESLint on the changed file — clean

Follow-up to #6041.
