### PR TITLE
fix(Tokenizer): avoid blank trailing input row

### DIFF
--- a/.changeset/quiet-tokens-share.md
+++ b/.changeset/quiet-tokens-share.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Prevent an empty Tokenizer input from creating a blank trailing row.
+@imdreamrunner

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -167,13 +167,22 @@ async function capturePowerSearchEvidence(browser) {
       ['AFTER', ''],
     ]) {
       const page = await context.newPage();
+      await page.addInitScript(recordStoryOutcome);
       await page.goto(
         `http://localhost:${port}/iframe.html?id=core-powersearch--near-full-token-row&viewMode=story${query}`,
         {waitUntil: 'networkidle', timeout: 30000},
       );
       await page.locator('.astryx-tokenizer').waitFor();
+      await page.waitForFunction(
+        () => window.__storyOutcome && window.__storyOutcome.done === true,
+        null,
+        { timeout: 30000 }
+      );
       await page.evaluate(async () => {
         await document.fonts.ready;
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur();
+        }
         await new Promise(resolve =>
           requestAnimationFrame(() => requestAnimationFrame(resolve)),
         );

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -41,13 +41,16 @@ const TARGETS = [
   {
     component: 'PowerSearch',
     story: 'core-powersearch--near-full-token-row',
+    hasTouch: true,
     guards:
-      'an empty trailing combobox stays on the nearly full token row without overlapping Clear all',
+      'on a coarse pointer, an empty trailing combobox stays on the nearly full token row without overlapping the full Clear all hit area',
   },
   {
     component: 'PowerSearch',
     story: 'core-powersearch--near-full-token-row-rtl',
-    guards: 'the compact combobox and Clear all remain separate in RTL as well',
+    hasTouch: true,
+    guards:
+      'on a coarse pointer, the compact combobox and full Clear all hit area remain separate in RTL as well',
   },
   {
     component: 'TabList',
@@ -165,11 +168,11 @@ async function run() {
   let failures = 0;
 
   try {
-    const context = await browser.newContext({
-      viewport: { width: 1280, height: 900 },
-    });
-
     for (const target of TARGETS) {
+      const context = await browser.newContext({
+        viewport: { width: 1280, height: 900 },
+        hasTouch: target.hasTouch === true,
+      });
       const page = await context.newPage();
       try {
         const outcome = await probe(page, target);
@@ -190,6 +193,7 @@ async function run() {
         );
       } finally {
         await page.close();
+        await context.close();
       }
     }
   } finally {

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -41,7 +41,13 @@ const TARGETS = [
   {
     component: 'PowerSearch',
     story: 'core-powersearch--near-full-token-row',
-    guards: 'an empty trailing combobox stays on the nearly full token row',
+    guards:
+      'an empty trailing combobox stays on the nearly full token row without overlapping Clear all',
+  },
+  {
+    component: 'PowerSearch',
+    story: 'core-powersearch--near-full-token-row-rtl',
+    guards: 'the compact combobox and Clear all remain separate in RTL as well',
   },
   {
     component: 'TabList',

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -156,48 +156,6 @@ async function probe(page, target) {
   return page.evaluate(() => window.__storyOutcome);
 }
 
-async function capturePowerSearchEvidence(browser) {
-  const context = await browser.newContext({
-    viewport: {width: 629, height: 100},
-    deviceScaleFactor: 2,
-  });
-  try {
-    for (const [label, query] of [
-      ['BEFORE', '&visualBaseline=before'],
-      ['AFTER', ''],
-    ]) {
-      const page = await context.newPage();
-      await page.addInitScript(recordStoryOutcome);
-      await page.goto(
-        `http://localhost:${port}/iframe.html?id=core-powersearch--near-full-token-row&viewMode=story${query}`,
-        {waitUntil: 'networkidle', timeout: 30000},
-      );
-      await page.locator('.astryx-tokenizer').waitFor();
-      await page.waitForFunction(
-        () => window.__storyOutcome && window.__storyOutcome.done === true,
-        null,
-        { timeout: 30000 }
-      );
-      await page.evaluate(async () => {
-        await document.fonts.ready;
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur();
-        }
-        await new Promise(resolve =>
-          requestAnimationFrame(() => requestAnimationFrame(resolve)),
-        );
-      });
-      const png = await page.screenshot({
-        clip: {x: 0, y: 0, width: 629, height: 100},
-      });
-      console.log(`POWERSEARCH_${label}_PNG_BASE64=${png.toString('base64')}`);
-      await page.close();
-    }
-  } finally {
-    await context.close();
-  }
-}
-
 async function run() {
   const dir = path.resolve(process.cwd(), storybookDir);
   if (!fs.existsSync(dir)) {
@@ -238,7 +196,6 @@ async function run() {
         await context.close();
       }
     }
-    await capturePowerSearchEvidence(browser);
   } finally {
     await browser.close();
     server.close();

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -21,13 +21,13 @@
  * a story that cannot boot must not pass by silence.
  */
 
-const { chromium } = require('playwright');
+const {chromium} = require('playwright');
 const fs = require('node:fs');
 const path = require('node:path');
 const http = require('node:http');
 
 const args = process.argv.slice(2);
-const getArg = (name) => {
+const getArg = name => {
   const idx = args.indexOf(`--${name}`);
   return idx !== -1 ? args[idx + 1] : null;
 };
@@ -71,7 +71,7 @@ const CONTENT_TYPES = {
 };
 
 function createServer(dir, listenPort) {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     const server = http.createServer((req, res) => {
       const filePath = path
         .join(dir, req.url === '/' ? 'index.html' : req.url)
@@ -91,8 +91,7 @@ function createServer(dir, listenPort) {
           return;
         }
         res.writeHead(200, {
-          'Content-Type':
-            CONTENT_TYPES[path.extname(resolved)] || 'text/plain',
+          'Content-Type': CONTENT_TYPES[path.extname(resolved)] || 'text/plain',
         });
         res.end(data);
       });
@@ -106,7 +105,7 @@ function createServer(dir, listenPort) {
 // is emitted only after the play function resolves; every failure mode has
 // its own event. Attached before any preview code runs so no event is missed.
 function recordStoryOutcome() {
-  window.__storyOutcome = { done: false, errors: [] };
+  window.__storyOutcome = {done: false, errors: []};
   const ERROR_EVENTS = [
     'playFunctionThrewException',
     'unhandledErrorsWhilePlaying',
@@ -114,7 +113,7 @@ function recordStoryOutcome() {
     'storyErrored',
     'storyMissing',
   ];
-  const describe = (payload) => {
+  const describe = payload => {
     if (payload == null) return '';
     if (typeof payload === 'string') return payload;
     return [payload.name, payload.title, payload.message, payload.description]
@@ -131,9 +130,9 @@ function recordStoryOutcome() {
       window.__storyOutcome.done = true;
     });
     for (const event of ERROR_EVENTS) {
-      channel.on(event, (payload) => {
+      channel.on(event, payload => {
         window.__storyOutcome.errors.push(
-          `${event}${describe(payload) ? ` — ${describe(payload)}` : ''}`
+          `${event}${describe(payload) ? ` — ${describe(payload)}` : ''}`,
         );
         window.__storyOutcome.done = true;
       });
@@ -147,14 +146,47 @@ async function probe(page, target) {
   const pointerQuery = target.hasTouch ? '&storyPlayPointer=coarse' : '';
   await page.goto(
     `http://localhost:${port}/iframe.html?id=${target.story}&viewMode=story${pointerQuery}`,
-    { waitUntil: 'domcontentloaded', timeout: 30000 }
+    {waitUntil: 'domcontentloaded', timeout: 30000},
   );
   await page.waitForFunction(
     () => window.__storyOutcome && window.__storyOutcome.done === true,
     null,
-    { timeout: 30000 }
+    {timeout: 30000},
   );
   return page.evaluate(() => window.__storyOutcome);
+}
+
+async function capturePowerSearchEvidence(browser) {
+  const context = await browser.newContext({
+    viewport: {width: 629, height: 100},
+    deviceScaleFactor: 2,
+  });
+  try {
+    for (const [label, query] of [
+      ['BEFORE', '&visualBaseline=before'],
+      ['AFTER', ''],
+    ]) {
+      const page = await context.newPage();
+      await page.goto(
+        `http://localhost:${port}/iframe.html?id=core-powersearch--near-full-token-row&viewMode=story${query}`,
+        {waitUntil: 'networkidle', timeout: 30000},
+      );
+      await page.locator('.astryx-tokenizer').waitFor();
+      await page.evaluate(async () => {
+        await document.fonts.ready;
+        await new Promise(resolve =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve)),
+        );
+      });
+      const png = await page.screenshot({
+        clip: {x: 0, y: 0, width: 629, height: 100},
+      });
+      console.log(`POWERSEARCH_${label}_PNG_BASE64=${png.toString('base64')}`);
+      await page.close();
+    }
+  } finally {
+    await context.close();
+  }
 }
 
 async function run() {
@@ -171,7 +203,7 @@ async function run() {
   try {
     for (const target of TARGETS) {
       const context = await browser.newContext({
-        viewport: { width: 1280, height: 900 },
+        viewport: {width: 1280, height: 900},
         hasTouch: target.hasTouch === true,
       });
       const page = await context.newPage();
@@ -180,30 +212,33 @@ async function run() {
         if (outcome.errors.length > 0) {
           failures++;
           console.error(
-            `✗ ${target.component} (${target.story}):\n    ${outcome.errors.join('\n    ')}`
+            `✗ ${target.component} (${target.story}):\n    ${outcome.errors.join('\n    ')}`,
           );
         } else {
           console.log(
-            `✓ ${target.component} (${target.story}): play passed — ${target.guards}`
+            `✓ ${target.component} (${target.story}): play passed — ${target.guards}`,
           );
         }
       } catch (e) {
         failures++;
         console.error(
-          `✗ ${target.component} (${target.story}): no play outcome — ${e.message}`
+          `✗ ${target.component} (${target.story}): no play outcome — ${e.message}`,
         );
       } finally {
         await page.close();
         await context.close();
       }
     }
+    await capturePowerSearchEvidence(browser);
   } finally {
     await browser.close();
     server.close();
   }
 
   if (failures > 0) {
-    console.error(`\nFailing: ${failures} story play function(s) did not pass.`);
+    console.error(
+      `\nFailing: ${failures} story play function(s) did not pass.`,
+    );
     return 1;
   }
   console.log('\nAll story play guards passed.');
@@ -211,10 +246,10 @@ async function run() {
 }
 
 run()
-  .then((code) => {
+  .then(code => {
     process.exitCode = code;
   })
-  .catch((e) => {
+  .catch(e => {
     console.error('Story play guard failed:', e);
     process.exit(1);
   });

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -39,6 +39,11 @@ const port = Number(getArg('port') || 6010);
 // whole cost of promoting its play function into required CI.
 const TARGETS = [
   {
+    component: 'PowerSearch',
+    story: 'core-powersearch--near-full-token-row',
+    guards: 'an empty trailing combobox stays on the nearly full token row',
+  },
+  {
     component: 'TabList',
     story: 'core-tablist--full-bleed-geometry',
     guards:

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -144,8 +144,9 @@ function recordStoryOutcome() {
 
 async function probe(page, target) {
   await page.addInitScript(recordStoryOutcome);
+  const pointerQuery = target.hasTouch ? '&storyPlayPointer=coarse' : '';
   await page.goto(
-    `http://localhost:${port}/iframe.html?id=${target.story}&viewMode=story`,
+    `http://localhost:${port}/iframe.html?id=${target.story}&viewMode=story${pointerQuery}`,
     { waitUntil: 'domcontentloaded', timeout: 30000 }
   );
   await page.waitForFunction(

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -579,18 +579,45 @@ export const NearFullTokenRow: Story = {
     const input = wrapper?.querySelector<HTMLInputElement>('[role="combobox"]');
     const tokens = wrapper?.querySelectorAll<HTMLElement>(':scope > span');
     const finalToken = tokens?.item((tokens?.length ?? 0) - 1);
-    if (!wrapper || !input || !finalToken) {
+    const clearButton = wrapper?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Clear all"]',
+    );
+    if (!wrapper || !input || !finalToken || !clearButton) {
       throw new Error('Near-full token-row fixture did not render as expected');
     }
 
     const inputRect = input.getBoundingClientRect();
     const tokenRect = finalToken.getBoundingClientRect();
+    const clearRect = clearButton.getBoundingClientRect();
     if (inputRect.top >= tokenRect.bottom) {
       throw new Error(
         `Empty combobox wrapped onto a blank row: input top ${inputRect.top.toFixed(2)}, final token bottom ${tokenRect.bottom.toFixed(2)}`,
       );
     }
+    if (inputRect.width <= 0) {
+      throw new Error('Empty combobox has no pointer hit target');
+    }
+    const overlap =
+      Math.min(inputRect.right, clearRect.right) -
+      Math.max(inputRect.left, clearRect.left);
+    if (overlap > 0) {
+      throw new Error(
+        `Empty combobox overlaps Clear all by ${overlap.toFixed(2)}px`,
+      );
+    }
   },
+};
+
+export const NearFullTokenRowRTL: Story = {
+  ...NearFullTokenRow,
+  decorators: [
+    Story => (
+      <div dir="rtl">
+        <Story />
+      </div>
+    ),
+  ],
+  name: 'Near-full Token Row (RTL)',
 };
 
 export const FullFeatured: Story = {

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -535,6 +535,64 @@ export const WithPresetFilters: Story = {
   name: 'Pre-set Filters',
 };
 
+/**
+ * A nearly full token row keeps its empty combobox on that row instead of
+ * growing the field with a blank trailing row. Typing still restores the
+ * input's normal editing width and may wrap visibly when space is exhausted.
+ */
+export const NearFullTokenRow: Story = {
+  render: args => {
+    const [filters, setFilters] = useState<PowerSearchFilter[]>([
+      {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
+      {
+        field: 'priority',
+        operator: 'is',
+        value: {type: 'enum', value: 'p1'},
+      },
+      {
+        field: 'title',
+        operator: 'contains',
+        value: {type: 'string', value: 'aaaaaaaaaaaaaaaaaaaaaaaa'},
+      },
+    ]);
+    return (
+      <PowerSearch
+        {...args}
+        config={basicConfig}
+        filters={filters}
+        onChange={newFilters => setFilters([...newFilters])}
+      />
+    );
+  },
+  args: {
+    placeholder: 'Add more filters...',
+  },
+  name: 'Near-full Token Row',
+  play: async ({canvasElement}) => {
+    await document.fonts.ready;
+    await new Promise<void>(resolve =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+
+    const wrapper =
+      canvasElement.querySelector<HTMLElement>('.astryx-tokenizer');
+    const input = wrapper?.querySelector<HTMLInputElement>('[role="combobox"]');
+    const tokens = wrapper?.querySelectorAll<HTMLElement>(':scope > span');
+    const finalToken = tokens?.item((tokens?.length ?? 0) - 1);
+    if (!wrapper || !input || !finalToken) {
+      throw new Error('Near-full token-row fixture did not render as expected');
+    }
+
+    const inputRect = input.getBoundingClientRect();
+    const tokenRect = finalToken.getBoundingClientRect();
+    if (inputRect.top >= tokenRect.bottom) {
+      throw new Error(
+        `Empty combobox wrapped onto a blank row: input top ${inputRect.top.toFixed(2)}, final token bottom ${tokenRect.bottom.toFixed(2)}`,
+      );
+    }
+  },
+};
+
 export const FullFeatured: Story = {
   render: args => {
     const [filters, setFilters] = useState<PowerSearchFilter[]>([]);

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -580,6 +580,9 @@ export const NearFullTokenRow: Story = {
     if (!wrapper || !input || !finalToken || !clearButton) {
       throw new Error('Near-full token-row fixture did not render as expected');
     }
+    if (!matchMedia('(pointer: coarse)').matches) {
+      throw new Error('Near-full token-row guard requires a coarse pointer');
+    }
 
     await document.fonts.ready;
     const reserveDeadline = performance.now() + 2000;
@@ -600,6 +603,20 @@ export const NearFullTokenRow: Story = {
     const inputRect = input.getBoundingClientRect();
     const tokenRect = finalToken.getBoundingClientRect();
     const clearRect = clearButton.getBoundingClientRect();
+    const clearHitStyle = getComputedStyle(clearButton, '::after');
+    const clearHitLeft = Number.parseFloat(clearHitStyle.left);
+    const clearHitRight = Number.parseFloat(clearHitStyle.right);
+    if (
+      clearHitStyle.content === 'none' ||
+      !Number.isFinite(clearHitLeft) ||
+      !Number.isFinite(clearHitRight)
+    ) {
+      throw new Error('Clear all did not expose its coarse-pointer hit area');
+    }
+    const clearHitRect = {
+      left: clearRect.left + clearHitLeft,
+      right: clearRect.right - clearHitRight,
+    };
     if (inputRect.top >= tokenRect.bottom) {
       throw new Error(
         `Empty combobox wrapped onto a blank row: input top ${inputRect.top.toFixed(2)}, final token bottom ${tokenRect.bottom.toFixed(2)}`,
@@ -609,11 +626,11 @@ export const NearFullTokenRow: Story = {
       throw new Error('Empty combobox has no pointer hit target');
     }
     const overlap =
-      Math.min(inputRect.right, clearRect.right) -
-      Math.max(inputRect.left, clearRect.left);
+      Math.min(inputRect.right, clearHitRect.right) -
+      Math.max(inputRect.left, clearHitRect.left);
     if (overlap > 0) {
       throw new Error(
-        `Empty combobox overlaps Clear all by ${overlap.toFixed(2)}px`,
+        `Empty combobox overlaps the coarse-pointer Clear all hit area by ${overlap.toFixed(2)}px`,
       );
     }
     const clearHitTarget = document.elementFromPoint(

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -542,9 +542,6 @@ export const WithPresetFilters: Story = {
  */
 export const NearFullTokenRow: Story = {
   render: args => {
-    const showsBaselineLayout =
-      new URLSearchParams(window.location.search).get('visualBaseline') ===
-      'before';
     const [filters, setFilters] = useState<PowerSearchFilter[]>([
       {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
       {
@@ -559,31 +556,12 @@ export const NearFullTokenRow: Story = {
       },
     ]);
     return (
-      <div data-visual-baseline={showsBaselineLayout ? 'before' : undefined}>
-        {showsBaselineLayout && (
-          <style>{`
-            [data-visual-baseline="before"] .astryx-tokenizer [role="combobox"] {
-              position: relative !important;
-              inset-inline-start: auto !important;
-              inset-block-start: auto !important;
-              transform: none !important;
-              box-sizing: content-box !important;
-              min-width: 40px !important;
-              flex: 1 1 40px !important;
-              width: 0 !important;
-              padding-inline-start: 5px !important;
-              padding-inline-end: var(--_tokenizer-end-lane-reserve, 0px) !important;
-              text-align: start !important;
-            }
-          `}</style>
-        )}
-        <PowerSearch
-          {...args}
-          config={basicConfig}
-          filters={filters}
-          onChange={newFilters => setFilters([...newFilters])}
-        />
-      </div>
+      <PowerSearch
+        {...args}
+        config={basicConfig}
+        filters={filters}
+        onChange={newFilters => setFilters([...newFilters])}
+      />
     );
   },
   args: {
@@ -591,12 +569,6 @@ export const NearFullTokenRow: Story = {
   },
   name: 'Near-full Token Row',
   play: async ({canvasElement}) => {
-    if (
-      new URLSearchParams(window.location.search).get('visualBaseline') ===
-      'before'
-    ) {
-      return;
-    }
     const wrapper =
       canvasElement.querySelector<HTMLElement>('.astryx-tokenizer');
     const input = wrapper?.querySelector<HTMLInputElement>('[role="combobox"]');

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -555,7 +555,7 @@ export const NearFullTokenRow: Story = {
       {
         field: 'title',
         operator: 'contains',
-        value: {type: 'string', value: 'aaaaaaaaaaaaaaaaaaaaaaaa'},
+        value: {type: 'string', value: 'aaaaaaaaaaaaaaaaaa'},
       },
     ]);
     return (
@@ -601,11 +601,12 @@ export const NearFullTokenRow: Story = {
       canvasElement.querySelector<HTMLElement>('.astryx-tokenizer');
     const input = wrapper?.querySelector<HTMLInputElement>('[role="combobox"]');
     const tokens = wrapper?.querySelectorAll<HTMLElement>(':scope > span');
+    const firstToken = tokens?.item(0);
     const finalToken = tokens?.item((tokens?.length ?? 0) - 1);
     const clearButton = wrapper?.querySelector<HTMLButtonElement>(
       'button[aria-label="Clear all"]',
     );
-    if (!wrapper || !input || !finalToken || !clearButton) {
+    if (!wrapper || !input || !firstToken || !finalToken || !clearButton) {
       throw new Error('Near-full token-row fixture did not render as expected');
     }
     const isCoarsePointer = matchMedia('(pointer: coarse)').matches;
@@ -633,6 +634,7 @@ export const NearFullTokenRow: Story = {
     );
 
     const inputRect = input.getBoundingClientRect();
+    const firstTokenRect = firstToken.getBoundingClientRect();
     const tokenRect = finalToken.getBoundingClientRect();
     const clearRect = clearButton.getBoundingClientRect();
     let clearHitLeft = 0;
@@ -653,6 +655,11 @@ export const NearFullTokenRow: Story = {
       left: clearRect.left + clearHitLeft,
       right: clearRect.right - clearHitRight,
     };
+    if (Math.abs(firstTokenRect.top - tokenRect.top) > 0.5) {
+      throw new Error(
+        `Fixture tokens wrapped before the empty combobox check: first token top ${firstTokenRect.top.toFixed(2)}, final token top ${tokenRect.top.toFixed(2)}`,
+      );
+    }
     if (inputRect.top >= tokenRect.bottom) {
       throw new Error(
         `Empty combobox wrapped onto a blank row: input top ${inputRect.top.toFixed(2)}, final token bottom ${tokenRect.bottom.toFixed(2)}`,

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -542,6 +542,9 @@ export const WithPresetFilters: Story = {
  */
 export const NearFullTokenRow: Story = {
   render: args => {
+    const showsBaselineLayout =
+      new URLSearchParams(window.location.search).get('visualBaseline') ===
+      'before';
     const [filters, setFilters] = useState<PowerSearchFilter[]>([
       {field: 'status', operator: 'is', value: {type: 'enum', value: 'open'}},
       {
@@ -556,12 +559,31 @@ export const NearFullTokenRow: Story = {
       },
     ]);
     return (
-      <PowerSearch
-        {...args}
-        config={basicConfig}
-        filters={filters}
-        onChange={newFilters => setFilters([...newFilters])}
-      />
+      <div data-visual-baseline={showsBaselineLayout ? 'before' : undefined}>
+        {showsBaselineLayout && (
+          <style>{`
+            [data-visual-baseline="before"] .astryx-tokenizer [role="combobox"] {
+              position: relative !important;
+              inset-inline-start: auto !important;
+              inset-block-start: auto !important;
+              transform: none !important;
+              box-sizing: content-box !important;
+              min-width: 40px !important;
+              flex: 1 1 40px !important;
+              width: 0 !important;
+              padding-inline-start: 5px !important;
+              padding-inline-end: var(--_tokenizer-end-lane-reserve, 0px) !important;
+              text-align: start !important;
+            }
+          `}</style>
+        )}
+        <PowerSearch
+          {...args}
+          config={basicConfig}
+          filters={filters}
+          onChange={newFilters => setFilters([...newFilters])}
+        />
+      </div>
     );
   },
   args: {
@@ -569,6 +591,12 @@ export const NearFullTokenRow: Story = {
   },
   name: 'Near-full Token Row',
   play: async ({canvasElement}) => {
+    if (
+      new URLSearchParams(window.location.search).get('visualBaseline') ===
+      'before'
+    ) {
+      return;
+    }
     const wrapper =
       canvasElement.querySelector<HTMLElement>('.astryx-tokenizer');
     const input = wrapper?.querySelector<HTMLInputElement>('[role="combobox"]');

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -616,14 +616,36 @@ export const NearFullTokenRow: Story = {
         `Empty combobox overlaps Clear all by ${overlap.toFixed(2)}px`,
       );
     }
-    const inputHitTarget = document.elementFromPoint(
-      inputRect.left + inputRect.width / 2,
-      inputRect.top + inputRect.height / 2,
+    const clearHitTarget = document.elementFromPoint(
+      clearRect.left + clearRect.width / 2,
+      clearRect.top + clearRect.height / 2,
     );
-    if (inputHitTarget !== input) {
+    if (!clearHitTarget || !clearButton.contains(clearHitTarget)) {
       throw new Error(
-        `Empty combobox center is hit-tested as ${inputHitTarget?.tagName ?? 'nothing'}`,
+        `Clear all center is hit-tested as ${clearHitTarget?.tagName ?? 'nothing'}`,
       );
+    }
+    const tokenHitTarget = document.elementFromPoint(
+      tokenRect.left + tokenRect.width / 2,
+      tokenRect.top + tokenRect.height / 2,
+    );
+    if (!tokenHitTarget || !finalToken.contains(tokenHitTarget)) {
+      throw new Error(
+        `Final token center is hit-tested as ${tokenHitTarget?.tagName ?? 'nothing'}`,
+      );
+    }
+
+    const hitY = inputRect.top + inputRect.height / 2;
+    let inputHitTarget: Element | null = null;
+    for (let x = Math.ceil(inputRect.left); x < inputRect.right; x += 1) {
+      const candidate = document.elementFromPoint(x + 0.5, hitY);
+      if (candidate === input) {
+        inputHitTarget = candidate;
+        break;
+      }
+    }
+    if (!inputHitTarget) {
+      throw new Error('Empty combobox has no exposed pointer hit target');
     }
     inputHitTarget.dispatchEvent(new MouseEvent('click', {bubbles: true}));
     if (document.activeElement !== input) {

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -569,11 +569,6 @@ export const NearFullTokenRow: Story = {
   },
   name: 'Near-full Token Row',
   play: async ({canvasElement}) => {
-    await document.fonts.ready;
-    await new Promise<void>(resolve =>
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-    );
-
     const wrapper =
       canvasElement.querySelector<HTMLElement>('.astryx-tokenizer');
     const input = wrapper?.querySelector<HTMLInputElement>('[role="combobox"]');
@@ -585,6 +580,22 @@ export const NearFullTokenRow: Story = {
     if (!wrapper || !input || !finalToken || !clearButton) {
       throw new Error('Near-full token-row fixture did not render as expected');
     }
+
+    await document.fonts.ready;
+    const reserveDeadline = performance.now() + 2000;
+    while (
+      wrapper.style.getPropertyValue('--_tokenizer-end-lane-reserve') === ''
+    ) {
+      if (performance.now() >= reserveDeadline) {
+        throw new Error('Clear-all lane reserve was not measured');
+      }
+      await new Promise<void>(resolve =>
+        requestAnimationFrame(() => resolve()),
+      );
+    }
+    await new Promise<void>(resolve =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
 
     const inputRect = input.getBoundingClientRect();
     const tokenRect = finalToken.getBoundingClientRect();
@@ -604,6 +615,19 @@ export const NearFullTokenRow: Story = {
       throw new Error(
         `Empty combobox overlaps Clear all by ${overlap.toFixed(2)}px`,
       );
+    }
+    const inputHitTarget = document.elementFromPoint(
+      inputRect.left + inputRect.width / 2,
+      inputRect.top + inputRect.height / 2,
+    );
+    if (inputHitTarget !== input) {
+      throw new Error(
+        `Empty combobox center is hit-tested as ${inputHitTarget?.tagName ?? 'nothing'}`,
+      );
+    }
+    inputHitTarget.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+    if (document.activeElement !== input) {
+      throw new Error('Clicking the empty combobox did not focus it');
     }
   },
 };

--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -580,7 +580,11 @@ export const NearFullTokenRow: Story = {
     if (!wrapper || !input || !finalToken || !clearButton) {
       throw new Error('Near-full token-row fixture did not render as expected');
     }
-    if (!matchMedia('(pointer: coarse)').matches) {
+    const isCoarsePointer = matchMedia('(pointer: coarse)').matches;
+    const requiresCoarsePointer =
+      new URLSearchParams(window.location.search).get('storyPlayPointer') ===
+      'coarse';
+    if (requiresCoarsePointer && !isCoarsePointer) {
       throw new Error('Near-full token-row guard requires a coarse pointer');
     }
 
@@ -603,15 +607,19 @@ export const NearFullTokenRow: Story = {
     const inputRect = input.getBoundingClientRect();
     const tokenRect = finalToken.getBoundingClientRect();
     const clearRect = clearButton.getBoundingClientRect();
-    const clearHitStyle = getComputedStyle(clearButton, '::after');
-    const clearHitLeft = Number.parseFloat(clearHitStyle.left);
-    const clearHitRight = Number.parseFloat(clearHitStyle.right);
-    if (
-      clearHitStyle.content === 'none' ||
-      !Number.isFinite(clearHitLeft) ||
-      !Number.isFinite(clearHitRight)
-    ) {
-      throw new Error('Clear all did not expose its coarse-pointer hit area');
+    let clearHitLeft = 0;
+    let clearHitRight = 0;
+    if (isCoarsePointer) {
+      const clearHitStyle = getComputedStyle(clearButton, '::after');
+      clearHitLeft = Number.parseFloat(clearHitStyle.left);
+      clearHitRight = Number.parseFloat(clearHitStyle.right);
+      if (
+        clearHitStyle.content === 'none' ||
+        !Number.isFinite(clearHitLeft) ||
+        !Number.isFinite(clearHitRight)
+      ) {
+        throw new Error('Clear all did not expose its coarse-pointer hit area');
+      }
     }
     const clearHitRect = {
       left: clearRect.left + clearHitLeft,

--- a/packages/core/src/Tokenizer/Tokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.test.tsx
@@ -416,6 +416,29 @@ describe('Tokenizer', () => {
     expect(input).not.toHaveAttribute('placeholder', 'Search people...');
   });
 
+  it('uses a non-painting placeholder to collapse only an empty trailing input', () => {
+    const onChangeQuery = vi.fn();
+    render(
+      <Tokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0]]}
+        onChange={() => {}}
+        onChangeQuery={onChangeQuery}
+        hasClear
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('placeholder', ' ');
+
+    fireEvent.change(input, {target: {value: 'Al'}});
+    expect(input).toHaveValue('Al');
+    expect(onChangeQuery).toHaveBeenLastCalledWith('Al');
+
+    fireEvent.change(input, {target: {value: ''}});
+    expect(onChangeQuery).toHaveBeenLastCalledWith('');
+  });
+
   it('shows placeholder when no tokens are present', () => {
     render(
       <Tokenizer

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -244,6 +244,9 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
 // because the input's reserve is derived from the same value.
 const END_LANE_INSET = spacingVars['--spacing-2'];
 const TOKEN_ROW_INSET = `calc(${spacingVars['--spacing-1']} - 1px)`;
+// InputClearButton grows 2px past its visible box under `(pointer: coarse)`.
+// Keep this maximum reserve in sync with Field/InputClearButton.tsx.
+const INPUT_CLEAR_COARSE_POINTER_OUTSET = '2px';
 // Kept in sync with useEndLaneReserve: inputCompact reads the custom property
 // directly so its empty-query pseudo-class can suppress the inner reserve.
 const END_LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
@@ -323,13 +326,14 @@ const styles = stylex.create({
     },
     width: {
       default: 0,
-      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - 1px)`,
+      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - ${INPUT_CLEAR_COARSE_POINTER_OUTSET} - 1px)`,
     },
     // The empty input is a first-row background hit surface. Taking it out of
     // flex layout means it can neither become a blank final row nor compete
     // with the pills for width. Logical insets stop it before the measured end
-    // lane; tokens and controls sit above it, leaving only genuine whitespace
-    // clickable as search. Typing restores the ordinary in-flow input.
+    // lane plus InputClearButton's maximum invisible pointer outset; tokens and
+    // controls sit above it, leaving only genuine whitespace clickable as
+    // search. Typing restores the ordinary in-flow input.
     paddingInlineStart: {
       default: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
       ':placeholder-shown': 0,

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -243,6 +243,9 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
 // How far the end lane sits from the field's inline-end border, named once
 // because the input's reserve is derived from the same value.
 const END_LANE_INSET = spacingVars['--spacing-2'];
+// Kept in sync with useEndLaneReserve: inputCompact reads the custom property
+// directly so its empty-query pseudo-class can suppress the reserve.
+const END_LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
 
 const styles = stylex.create({
   wrapper: {
@@ -294,12 +297,32 @@ const styles = stylex.create({
     position: 'absolute',
   },
   inputCompact: {
-    minWidth: '40px',
-    flex: '1 1 40px',
+    minWidth: {
+      default: '40px',
+      ':placeholder-shown': 0,
+    },
+    flex: {
+      default: '1 1 40px',
+      ':placeholder-shown': '1 1 0',
+    },
     width: 0,
-    // Restore normal text inset when input follows tokens, since the
-    // wrapper padding is reduced for border concentricity.
-    paddingInlineStart: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
+    // An empty flex item must not become an otherwise blank final row when
+    // tokens leave less than the normal 40px editing width. The negative
+    // margin cancels the flex gap in the item's outer size, while equal inner
+    // padding preserves the visual gap before the caret. As soon as a query
+    // exists, the normal editing width and end-lane reserve return.
+    marginInlineStart: {
+      default: 0,
+      ':placeholder-shown': `calc(-1 * ${spacingVars['--spacing-1']})`,
+    },
+    paddingInlineStart: {
+      default: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
+      ':placeholder-shown': spacingVars['--spacing-1'],
+    },
+    paddingInlineEnd: {
+      default: `var(${END_LANE_RESERVE_VAR}, 0px)`,
+      ':placeholder-shown': 0,
+    },
   },
   truncatedWrapper: {
     flexWrap: 'nowrap',
@@ -874,7 +897,9 @@ export function Tokenizer<T extends SearchableItem>({
           value={null}
           onChange={handleAdd}
           renderItem={renderItem}
-          placeholder={value.length === 0 ? placeholder : ''}
+          // A space keeps :placeholder-shown available as the CSS-only empty
+          // query signal without painting placeholder text beside tokens.
+          placeholder={value.length === 0 ? placeholder : ' '}
           hasEntriesOnFocus={isAtMax ? false : hasEntriesOnFocus}
           maxMenuItems={maxMenuItems}
           menuWidth={menuWidth}
@@ -897,12 +922,10 @@ export function Tokenizer<T extends SearchableItem>({
               : value.length > 0
                 ? styles.inputCompact
                 : undefined,
-            // Not for the collapsed states above: those give the input no width
-            // to pad, and `inputAtMax` zeroes its padding outright.
-            // Applied whether or not a lane is up: the reserve resolves to
-            // zero until the lane publishes a width, so this does not need to
-            // know about the busy state.
-            !(isAtMax || isTruncated) && laneReserve,
+            // The compact-token style owns the same reserve with an empty-query
+            // exception. This standalone rule is only for an empty Tokenizer;
+            // it still resolves to zero until the lane publishes a width.
+            !(isAtMax || isTruncated || value.length > 0) && laneReserve,
           ]}
         />
       </BusyIndicatorLaneProvider>

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -244,8 +244,7 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
 // because the input's reserve is derived from the same value.
 const END_LANE_INSET = spacingVars['--spacing-2'];
 // Kept in sync with useEndLaneReserve: inputCompact reads the custom property
-// directly so its empty-query pseudo-class can move the reserve outside the
-// input's hit target.
+// directly so its empty-query pseudo-class can suppress the inner reserve.
 const END_LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
 
 const styles = stylex.create({
@@ -304,23 +303,20 @@ const styles = stylex.create({
     },
     flex: {
       default: '1 1 40px',
-      ':placeholder-shown': '1 1 0',
+      ':placeholder-shown': '0 1 1px',
     },
     width: 0,
     // An empty flex item must not become an otherwise blank final row when
     // tokens leave less than the normal 40px editing width. The negative
     // margin cancels the flex gap in the item's outer size, while equal inner
-    // padding preserves the visual gap before the caret. The end-lane reserve
-    // becomes an outer margin: unlike padding, it does not enlarge the empty
-    // input itself, and it stops that input's hit target before Clear all. As
-    // soon as a query exists, the normal editing width and inner reserve return.
+    // padding preserves a small, positive caret and pointer target. It does not
+    // grow while empty: the wrapper is already the larger click-to-focus target,
+    // and growth would put the input underneath the absolutely positioned end
+    // lane. As soon as a query exists, the normal editing width and inner
+    // reserve return.
     marginInlineStart: {
       default: 0,
       ':placeholder-shown': `calc(-1 * ${spacingVars['--spacing-1']})`,
-    },
-    marginInlineEnd: {
-      default: 0,
-      ':placeholder-shown': `var(${END_LANE_RESERVE_VAR}, 0px)`,
     },
     paddingInlineStart: {
       default: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -243,6 +243,7 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
 // How far the end lane sits from the field's inline-end border, named once
 // because the input's reserve is derived from the same value.
 const END_LANE_INSET = spacingVars['--spacing-2'];
+const TOKEN_ROW_INSET = `calc(${spacingVars['--spacing-1']} - 1px)`;
 // Kept in sync with useEndLaneReserve: inputCompact reads the custom property
 // directly so its empty-query pseudo-class can suppress the inner reserve.
 const END_LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
@@ -263,19 +264,23 @@ const styles = stylex.create({
     // (radius-1: 4px) sits concentric with wrapper border-radius
     // (radius-2: 8px) when inset = radius-2 - radius-1 - border
     // = 8 - 4 - 1 = 3px.
-    paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
-    paddingInline: `calc(${spacingVars['--spacing-1']} - 1px)`,
+    paddingBlock: TOKEN_ROW_INSET,
+    paddingInline: TOKEN_ROW_INSET,
     // Row gap must match paddingBlock so wrapped rows look evenly spaced.
-    rowGap: `calc(${spacingVars['--spacing-1']} - 1px)`,
+    rowGap: TOKEN_ROW_INSET,
   },
   startIconWithTokens: {
     // Restore the default 8px inline-start inset when tokens are present,
     // since wrapperWithTokens reduces padding to 3px for border concentricity.
     marginInlineStart: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
+    position: 'relative',
+    zIndex: 1,
   },
   token: {
     display: 'flex',
     flexShrink: 0,
+    position: 'relative',
+    zIndex: 1,
   },
   endSection: {
     position: 'absolute',
@@ -287,6 +292,7 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
+    zIndex: 1,
   },
   inputAtMax: {
     width: 0,
@@ -297,34 +303,44 @@ const styles = stylex.create({
     position: 'absolute',
   },
   inputCompact: {
+    position: {
+      default: 'relative',
+      ':placeholder-shown': 'absolute',
+    },
+    boxSizing: 'border-box',
+    insetInlineStart: {
+      default: 'auto',
+      ':placeholder-shown': TOKEN_ROW_INSET,
+    },
+    zIndex: 0,
     minWidth: {
       default: '40px',
-      ':placeholder-shown': 0,
+      ':placeholder-shown': '1px',
     },
     flex: {
       default: '1 1 40px',
-      ':placeholder-shown': '0 1 1px',
+      ':placeholder-shown': '0 0 auto',
     },
-    width: 0,
-    // An empty flex item must not become an otherwise blank final row when
-    // tokens leave less than the normal 40px editing width. The negative
-    // margin cancels the flex gap in the item's outer size, while equal inner
-    // padding preserves a small, positive caret and pointer target. It does not
-    // grow while empty: the wrapper is already the larger click-to-focus target,
-    // and growth would put the input underneath the absolutely positioned end
-    // lane. As soon as a query exists, the normal editing width and inner
-    // reserve return.
-    marginInlineStart: {
+    width: {
       default: 0,
-      ':placeholder-shown': `calc(-1 * ${spacingVars['--spacing-1']})`,
+      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - 1px)`,
     },
+    // The empty input is a first-row background hit surface. Taking it out of
+    // flex layout means it can neither become a blank final row nor compete
+    // with the pills for width. Logical insets stop it before the measured end
+    // lane; tokens and controls sit above it, leaving only genuine whitespace
+    // clickable as search. Typing restores the ordinary in-flow input.
     paddingInlineStart: {
       default: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
-      ':placeholder-shown': spacingVars['--spacing-1'],
+      ':placeholder-shown': 0,
     },
     paddingInlineEnd: {
       default: `var(${END_LANE_RESERVE_VAR}, 0px)`,
-      ':placeholder-shown': 0,
+      ':placeholder-shown': spacingVars['--spacing-1'],
+    },
+    textAlign: {
+      default: 'start',
+      ':placeholder-shown': 'end',
     },
   },
   truncatedWrapper: {
@@ -364,6 +380,39 @@ const endSectionSizeStyles = stylex.create({
   lg: {
     top: `calc(${sizeVars['--size-element-lg']} / 2 - 1px)`,
     transform: 'translateY(-50%)',
+  },
+});
+
+const compactInputSizeStyles = stylex.create({
+  sm: {
+    insetBlockStart: {
+      default: 'auto',
+      ':placeholder-shown': `calc(${sizeVars['--size-element-sm']} / 2 - 1px)`,
+    },
+    transform: {
+      default: 'none',
+      ':placeholder-shown': 'translateY(-50%)',
+    },
+  },
+  md: {
+    insetBlockStart: {
+      default: 'auto',
+      ':placeholder-shown': `calc(${sizeVars['--size-element-md']} / 2 - 1px)`,
+    },
+    transform: {
+      default: 'none',
+      ':placeholder-shown': 'translateY(-50%)',
+    },
+  },
+  lg: {
+    insetBlockStart: {
+      default: 'auto',
+      ':placeholder-shown': `calc(${sizeVars['--size-element-lg']} / 2 - 1px)`,
+    },
+    transform: {
+      default: 'none',
+      ':placeholder-shown': 'translateY(-50%)',
+    },
   },
 });
 
@@ -923,7 +972,7 @@ export function Tokenizer<T extends SearchableItem>({
             isAtMax || isTruncated
               ? styles.inputAtMax
               : value.length > 0
-                ? styles.inputCompact
+                ? [styles.inputCompact, compactInputSizeStyles[size]]
                 : undefined,
             // The compact-token style owns the same reserve with an empty-query
             // exception. This standalone rule is only for an empty Tokenizer;

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -244,6 +244,9 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
 // because the input's reserve is derived from the same value.
 const END_LANE_INSET = spacingVars['--spacing-2'];
 const TOKEN_ROW_INSET = `calc(${spacingVars['--spacing-1']} - 1px)`;
+// InputClearButton grows 2px past its visible box under `(pointer: coarse)`.
+// Keep this maximum reserve in sync with Field/InputClearButton.tsx.
+const INPUT_CLEAR_COARSE_POINTER_OUTSET = '2px';
 // Kept in sync with useEndLaneReserve: inputCompact reads the custom property
 // directly so its empty-query pseudo-class can suppress the inner reserve.
 const END_LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
@@ -323,13 +326,14 @@ const styles = stylex.create({
     },
     width: {
       default: 0,
-      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - 1px)`,
+      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - ${INPUT_CLEAR_COARSE_POINTER_OUTSET} - 1px)`,
     },
     // The empty input is a first-row background hit surface. Taking it out of
     // flex layout means it can neither become a blank final row nor compete
     // with the pills for width. Logical insets stop it before the measured end
-    // lane; tokens and controls sit above it, leaving only genuine whitespace
-    // clickable as search. Typing restores the ordinary in-flow input.
+    // lane plus InputClearButton's maximum invisible pointer outset; tokens and
+    // controls sit above it, leaving only genuine whitespace clickable as
+    // search. Typing restores the ordinary in-flow input.
     paddingInlineStart: {
       default: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
       ':placeholder-shown': 0,
@@ -341,16 +345,6 @@ const styles = stylex.create({
     textAlign: {
       default: 'start',
       ':placeholder-shown': 'end',
-    },
-  },
-  inputCompactWithClear: {
-    // InputClearButton's coarse-pointer ::after target extends 2px beyond its
-    // visible box. Reserve that maximum outset in every pointer mode so the
-    // background input and clear action never share a hit-test coordinate.
-    // The real-browser story reads the pseudo-element geometry, so this fails
-    // if InputClearButton's outset changes without this reserve changing too.
-    width: {
-      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - 3px)`,
     },
   },
   truncatedWrapper: {
@@ -981,11 +975,7 @@ export function Tokenizer<T extends SearchableItem>({
             isAtMax || isTruncated
               ? styles.inputAtMax
               : value.length > 0
-                ? [
-                    styles.inputCompact,
-                    hasClearButton && styles.inputCompactWithClear,
-                    compactInputSizeStyles[size],
-                  ]
+                ? [styles.inputCompact, compactInputSizeStyles[size]]
                 : undefined,
             // The compact-token style owns the same reserve with an empty-query
             // exception. This standalone rule is only for an empty Tokenizer;

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -244,9 +244,6 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
 // because the input's reserve is derived from the same value.
 const END_LANE_INSET = spacingVars['--spacing-2'];
 const TOKEN_ROW_INSET = `calc(${spacingVars['--spacing-1']} - 1px)`;
-// InputClearButton grows 2px past its visible box under `(pointer: coarse)`.
-// Keep this maximum reserve in sync with Field/InputClearButton.tsx.
-const INPUT_CLEAR_COARSE_POINTER_OUTSET = '2px';
 // Kept in sync with useEndLaneReserve: inputCompact reads the custom property
 // directly so its empty-query pseudo-class can suppress the inner reserve.
 const END_LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
@@ -326,14 +323,13 @@ const styles = stylex.create({
     },
     width: {
       default: 0,
-      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - ${INPUT_CLEAR_COARSE_POINTER_OUTSET} - 1px)`,
+      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - 1px)`,
     },
     // The empty input is a first-row background hit surface. Taking it out of
     // flex layout means it can neither become a blank final row nor compete
     // with the pills for width. Logical insets stop it before the measured end
-    // lane plus InputClearButton's maximum invisible pointer outset; tokens and
-    // controls sit above it, leaving only genuine whitespace clickable as
-    // search. Typing restores the ordinary in-flow input.
+    // lane; tokens and controls sit above it, leaving only genuine whitespace
+    // clickable as search. Typing restores the ordinary in-flow input.
     paddingInlineStart: {
       default: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,
       ':placeholder-shown': 0,
@@ -345,6 +341,16 @@ const styles = stylex.create({
     textAlign: {
       default: 'start',
       ':placeholder-shown': 'end',
+    },
+  },
+  inputCompactWithClear: {
+    // InputClearButton's coarse-pointer ::after target extends 2px beyond its
+    // visible box. Reserve that maximum outset in every pointer mode so the
+    // background input and clear action never share a hit-test coordinate.
+    // The real-browser story reads the pseudo-element geometry, so this fails
+    // if InputClearButton's outset changes without this reserve changing too.
+    width: {
+      ':placeholder-shown': `calc(100% - ${TOKEN_ROW_INSET} - var(${END_LANE_RESERVE_VAR}, ${TOKEN_ROW_INSET}) - 3px)`,
     },
   },
   truncatedWrapper: {
@@ -606,9 +612,8 @@ export function Tokenizer<T extends SearchableItem>({
   // is the leaf's own business — folding it in here would mean reading the
   // busy state during this render, which is exactly the re-render the store
   // exists to avoid.
-  const hasStaticEndLane = Boolean(
-    endContent || (hasClear && value.length > 0 && !isDisabled),
-  );
+  const hasClearButton = hasClear && value.length > 0 && !isDisabled;
+  const hasStaticEndLane = Boolean(endContent || hasClearButton);
   const [isFocusedWithin, setIsFocusedWithin] = useState(false);
   const isTruncated =
     !isFocusedWithin && tokenOverflowBehavior !== 'none' && value.length > 0;
@@ -976,7 +981,11 @@ export function Tokenizer<T extends SearchableItem>({
             isAtMax || isTruncated
               ? styles.inputAtMax
               : value.length > 0
-                ? [styles.inputCompact, compactInputSizeStyles[size]]
+                ? [
+                    styles.inputCompact,
+                    hasClearButton && styles.inputCompactWithClear,
+                    compactInputSizeStyles[size],
+                  ]
                 : undefined,
             // The compact-token style owns the same reserve with an empty-query
             // exception. This standalone rule is only for an empty Tokenizer;
@@ -1004,7 +1013,7 @@ export function Tokenizer<T extends SearchableItem>({
         loadingLabel={t('@astryx.typeahead.loading')}
         hasStaticContent={hasStaticEndLane}>
         {endContent}
-        {hasClear && value.length > 0 && !isDisabled && (
+        {hasClearButton && (
           <InputClearButton
             label={t('@astryx.tokenizer.clearAll')}
             onClick={e => {

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -244,7 +244,8 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
 // because the input's reserve is derived from the same value.
 const END_LANE_INSET = spacingVars['--spacing-2'];
 // Kept in sync with useEndLaneReserve: inputCompact reads the custom property
-// directly so its empty-query pseudo-class can suppress the reserve.
+// directly so its empty-query pseudo-class can move the reserve outside the
+// input's hit target.
 const END_LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
 
 const styles = stylex.create({
@@ -309,11 +310,17 @@ const styles = stylex.create({
     // An empty flex item must not become an otherwise blank final row when
     // tokens leave less than the normal 40px editing width. The negative
     // margin cancels the flex gap in the item's outer size, while equal inner
-    // padding preserves the visual gap before the caret. As soon as a query
-    // exists, the normal editing width and end-lane reserve return.
+    // padding preserves the visual gap before the caret. The end-lane reserve
+    // becomes an outer margin: unlike padding, it does not enlarge the empty
+    // input itself, and it stops that input's hit target before Clear all. As
+    // soon as a query exists, the normal editing width and inner reserve return.
     marginInlineStart: {
       default: 0,
       ':placeholder-shown': `calc(-1 * ${spacingVars['--spacing-1']})`,
+    },
+    marginInlineEnd: {
+      default: 0,
+      ':placeholder-shown': `var(${END_LANE_RESERVE_VAR}, 0px)`,
     },
     paddingInlineStart: {
       default: `calc(${spacingVars['--spacing-2']} - ${spacingVars['--spacing-1']} + 1px)`,

--- a/packages/core/src/Tokenizer/useEndLaneReserve.ts
+++ b/packages/core/src/Tokenizer/useEndLaneReserve.ts
@@ -82,9 +82,11 @@ const reserveStyles = stylex.create({
  * Takes the lane's inset from the field's inline-end border, as the CSS
  * expression that positions it. Returns a ref callback for the lane, and the
  * ordinary input reserve style. Tokenizer's compact input reads the same custom
- * property directly so it can suppress an unnecessary reserve while its query
- * is empty. With no lane mounted the variable is absent and either rule resolves
- * the padding to zero, so neither path needs to know whether a search is running.
+ * property directly so it can turn the empty query's reserve into an outer
+ * margin, keeping the input's hit target out from under the lane without making
+ * its flex base wide enough to wrap. With no lane mounted the variable is absent
+ * and either rule resolves to zero, so neither path needs to know whether a
+ * search is running.
  */
 export function useEndLaneReserve(
   laneInset: string,

--- a/packages/core/src/Tokenizer/useEndLaneReserve.ts
+++ b/packages/core/src/Tokenizer/useEndLaneReserve.ts
@@ -82,11 +82,9 @@ const reserveStyles = stylex.create({
  * Takes the lane's inset from the field's inline-end border, as the CSS
  * expression that positions it. Returns a ref callback for the lane, and the
  * ordinary input reserve style. Tokenizer's compact input reads the same custom
- * property directly so it can turn the empty query's reserve into an outer
- * margin, keeping the input's hit target out from under the lane without making
- * its flex base wide enough to wrap. With no lane mounted the variable is absent
- * and either rule resolves to zero, so neither path needs to know whether a
- * search is running.
+ * property directly so it can suppress an unnecessary inner reserve while its
+ * query is empty. With no lane mounted the variable is absent and either rule
+ * resolves to zero, so neither path needs to know whether a search is running.
  */
 export function useEndLaneReserve(
   laneInset: string,

--- a/packages/core/src/Tokenizer/useEndLaneReserve.ts
+++ b/packages/core/src/Tokenizer/useEndLaneReserve.ts
@@ -48,9 +48,8 @@ const LANE_RESERVE_VAR = '--_tokenizer-end-lane-reserve';
 // The variable carries the WHOLE reserve, not just the width, so its absence
 // means "no lane" rather than "a lane of zero width": with no lane up, the
 // fallback resolves the padding to 0 and the input keeps its full content box.
-// That is what lets the caller apply this style unconditionally, which in turn
-// is what keeps the field from having to know whether a search is running.
-// The rule stays static either way — one class, generated once, never
+// That is what lets every input state read the property without knowing whether
+// a search is running. The rule stays static either way — it is never
 // regenerated as the lane changes.
 const reserveStyles = stylex.create({
   reserve: {
@@ -82,9 +81,10 @@ const reserveStyles = stylex.create({
  *
  * Takes the lane's inset from the field's inline-end border, as the CSS
  * expression that positions it. Returns a ref callback for the lane, and the
- * style for the input — which the caller applies unconditionally: with no lane
- * mounted the variable is absent and the padding resolves to zero, so the
- * caller never has to know whether a search is running.
+ * ordinary input reserve style. Tokenizer's compact input reads the same custom
+ * property directly so it can suppress an unnecessary reserve while its query
+ * is empty. With no lane mounted the variable is absent and either rule resolves
+ * the padding to zero, so neither path needs to know whether a search is running.
  */
 export function useEndLaneReserve(
   laneInset: string,

--- a/packages/core/src/Tokenizer/useEndLaneReserve.ts
+++ b/packages/core/src/Tokenizer/useEndLaneReserve.ts
@@ -82,9 +82,9 @@ const reserveStyles = stylex.create({
  * Takes the lane's inset from the field's inline-end border, as the CSS
  * expression that positions it. Returns a ref callback for the lane, and the
  * ordinary input reserve style. Tokenizer's compact input reads the same custom
- * property directly so it can suppress an unnecessary inner reserve while its
- * query is empty. With no lane mounted the variable is absent and either rule
- * resolves to zero, so neither path needs to know whether a search is running.
+ * property directly so its empty-query hit surface can stop before the lane.
+ * With no lane mounted the variable is absent and either rule resolves to its
+ * no-lane fallback, so neither path needs to know whether a search is running.
  */
 export function useEndLaneReserve(
   laneInset: string,


### PR DESCRIPTION
## Summary

- remove Tokenizer's empty trailing combobox from flex layout so it cannot create a blank final row
- bound the empty search hit surface before the measured end-control lane, including the Clear all button's 2px coarse-pointer hit outset
- keep pills and controls above the background input, while restoring the normal in-flow editing width as soon as a query is entered
- add deterministic real-Chromium guards for LTR and RTL layout, hit testing, focus, and coarse-pointer behavior

## Why

In a nearly full PowerSearch row, the mounted combobox still participated in flex layout. Its minimum editing width could wrap by itself and make the field 55px tall even though no content appeared on the second row.

The empty input is now an absolutely positioned first-row background hit surface. It does not consume flex space, so it cannot create a row, and the pills and controls remain the foreground hit targets. Its inline end stops 3px before the measured end lane: 2px for InputClearButton's invisible 24px coarse-pointer target plus 1px separation. Typing restores the ordinary in-flow input.

## Apples-to-apples visual verification

Both images below were captured in the same Linux Chromium run with identical data, neutral/light theme, 600 CSS-pixel fixture, 629 × 100 viewport, 2× device scale, and settled fonts. The before capture restores only the PR base's input-layout rules; the after capture uses this branch.

Before — the tokens fit row one, but the empty combobox creates a blank second row (55px field):

![Before: empty combobox creates a blank second row](https://files.catbox.moe/5o5iqk.png)

After — the identical fixture stays one row (32px field):

![After: identical PowerSearch fixture stays on one row](https://files.catbox.moe/yyqwn2.png)

The earlier screenshots were removed because they mixed the original deployed story with the PR-preview story and therefore had different token styling; they were not a valid visual comparison.

## Verification

- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm vitest run packages/core/src/Tokenizer/Tokenizer.test.tsx packages/core/src/PowerSearch/PowerSearch.test.tsx` — 106 passed
- [Coarse-pointer reproduction on the unfixed commit](https://github.com/facebook/astryx/actions/runs/33941690649/job/101240905930) — fails with exactly 1.00px overlap in both LTR and RTL
- [Coarse-pointer verification on the final clean head](https://github.com/facebook/astryx/actions/runs/33944223219/job/101247861651) — passes both LTR and RTL

The browser guard requires all pills to remain on row one, the empty combobox to share that row, a positive exposed input hit target, no overlap with the full Clear all touch target, correct token/Clear all hit testing, and focus after clicking the input.

[Open the LTR regression story](https://facebook.github.io/astryx/pr/6057/iframe.html?id=core-powersearch--near-full-token-row&viewMode=story) or [the RTL variant](https://facebook.github.io/astryx/pr/6057/iframe.html?id=core-powersearch--near-full-token-row-rtl&viewMode=story).
