### PR TITLE
fix(Stepper): contain horizontal layout styling

### DIFF
--- a/packages/core/src/Stepper/Stepper.test.tsx
+++ b/packages/core/src/Stepper/Stepper.test.tsx
@@ -1029,12 +1029,12 @@ describe('Stepper', () => {
     const SUMMARY = '.astryx-stepper-summary';
 
     /**
-     * jsdom has no layout, so the width the public Stepper root measures is
+     * jsdom has no layout, so the width the public Stepper list measures is
      * described by hand. The frame deliberately reports a wide parent: this
-     * keeps the test honest about measuring the consumer-styled/ref'd `<ol>`
-     * rather than the unstyled wrapper around it. The value has to be in place
-     * before the first render because the shared resize observer takes its
-     * opening measurement synchronously during commit.
+     * catches any accidental switch to measuring an unconstrained wrapper, while
+     * the regression below separately pins consumer layout styling to that frame.
+     * The value has to be in place before the first render because the shared
+     * resize observer takes its opening measurement synchronously during commit.
      */
     function atWidth(width: number, ui: React.ReactElement) {
       const original = Object.getOwnPropertyDescriptor(
@@ -1081,7 +1081,30 @@ describe('Stepper', () => {
       expect(document.querySelector(FRAME)).toBeInTheDocument();
     });
 
-    it('measures the public styled and ref-forwarding root', () => {
+    it('keeps a consumer-constrained summary inside the styled component box', () => {
+      atWidth(
+        320,
+        <div style={{width: 1000}}>
+          <Stepper activeStep={1} style={{width: 320}}>
+            <Step step={0} label="Cart" />
+            <Step step={1} label="Shipping" />
+            <Step step={2} label="Delivery" />
+            <Step step={3} label="Payment" />
+          </Stepper>
+        </div>,
+      );
+
+      const list = screen.getByRole<HTMLOListElement>('list');
+      const frame = list.parentElement as HTMLElement;
+      const summary = document.querySelector<HTMLElement>(SUMMARY);
+      expect(summary).not.toBeNull();
+      expect(frame).toHaveClass('astryx-stepper-frame');
+      expect(frame).toHaveStyle({width: '320px'});
+      expect(summary!.parentElement).toBe(frame);
+      expect(list.style.width).toBe('');
+    });
+
+    it('puts horizontal className on the frame without moving list DOM props or ref', () => {
       const ref = createRef<HTMLOListElement>();
       atWidth(
         320,
@@ -1089,7 +1112,8 @@ describe('Stepper', () => {
           ref={ref}
           activeStep={1}
           className="consumer-stepper"
-          style={{width: 320}}>
+          data-testid="public-stepper-list"
+          aria-describedby="stepper-help">
           <Step step={0} label="Cart" />
           <Step step={1} label="Shipping" />
           <Step step={2} label="Delivery" />
@@ -1097,11 +1121,14 @@ describe('Stepper', () => {
         </Stepper>,
       );
 
-      const list = screen.getByRole('list');
+      const list = screen.getByTestId('public-stepper-list');
+      const frame = list.parentElement as HTMLElement;
       expect(ref.current).toBe(list);
-      expect(list).toHaveClass('consumer-stepper');
-      expect(list).toHaveStyle({width: '320px'});
-      expect(document.querySelector(SUMMARY)).toBeInTheDocument();
+      expect(list).toHaveAttribute('aria-describedby', 'stepper-help');
+      expect(list).not.toHaveClass('consumer-stepper');
+      expect(frame).toHaveClass('consumer-stepper');
+      expect(frame).not.toHaveAttribute('data-testid');
+      expect(frame).not.toHaveAttribute('aria-describedby');
     });
 
     it('drops the labels and names the current step once they no longer fit', () => {

--- a/packages/core/src/Stepper/Stepper.tsx
+++ b/packages/core/src/Stepper/Stepper.tsx
@@ -11,9 +11,9 @@
  * Besides the props it is given, this component tracks the `activeStep` it
  * last rendered with and publishes it on the context. Steps need the distance
  * and direction of a change to choreograph their connector fill; see the
- * CONNECTOR FILL block in Step.tsx. When a horizontal Stepper becomes compact,
- * this component measures its public list root and owns previous/next controls
- * that move between enabled steps below the presentational track.
+ * CONNECTOR FILL block in Step.tsx. A horizontal Stepper applies public layout
+ * styling to the frame that contains both the list and compact summary, while
+ * the semantic `<ol>` remains the measured ref and DOM pass-through target.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Stepper/Stepper.doc.mjs (props table, features, implementation notes)
@@ -166,8 +166,9 @@ const styles = stylex.create({
     flexDirection: 'column',
     gap: 0,
   },
-  // The element the collapse threshold is measured against, and the one that
-  // stacks the track directly above the row naming the step it is on.
+  // The horizontal component's public layout box: consumer styling sizes and
+  // places the track and compact summary together. The list fills this frame,
+  // so observing its width still measures the complete component constraint.
   frame: {
     display: 'flex',
     flexDirection: 'column',
@@ -325,8 +326,10 @@ export function Stepper({
 
   // A vertical stepper gives every label a row of its own and can never run
   // out of width for them, so it opts out of all of this and renders exactly
-  // the DOM it always has. Horizontal Stepper sizing follows the public list
-  // root because that is where consumer refs and width styles are applied.
+  // the DOM it always has. A horizontal Stepper's public layout styles live on
+  // its frame so they size the list and summary together; the semantic list
+  // still owns the ref and DOM pass-throughs and fills that frame, so its width
+  // is the effective component width to observe.
   const [rootWidth, setRootWidth] = useState(0);
   const stopObservingRootRef = useRef<(() => void) | null>(null);
   const attachRoot = useCallback(
@@ -412,6 +415,13 @@ export function Stepper({
         ? styles.verticalOnTrack
         : styles.vertical;
 
+  // Horizontal Stepper has two roots with separate contracts: the frame owns
+  // public layout styling because it contains the complete visual component,
+  // while the ordered list keeps its theme target, ref, and native DOM props.
+  // Vertical Stepper has no frame, so its list remains both roots as before.
+  const listXstyle = isHorizontal ? undefined : xstyle;
+  const listClassName = isHorizontal ? undefined : className;
+  const listStyle = isHorizontal ? undefined : style;
   const list = (
     <ol
       ref={rootRef}
@@ -419,9 +429,9 @@ export function Stepper({
       {...rest}
       {...mergeProps(
         themeProps('stepper', {orientation, indicatorPosition}),
-        stylex.props(styles.root, orientationStyle, xstyle),
-        className,
-        style,
+        stylex.props(styles.root, orientationStyle, listXstyle),
+        listClassName,
+        listStyle,
       )}>
       {/* Each step renders its own progress bar segment; no child
           introspection needed — steps derive state from context. */}
@@ -504,7 +514,9 @@ export function Stepper({
       <div
         {...mergeProps(
           themeProps('stepper-frame'),
-          stylex.props(styles.frame),
+          stylex.props(styles.frame, xstyle),
+          className,
+          style,
         )}>
         {list}
         {showsSummary && (


### PR DESCRIPTION
## Summary

- apply horizontal Stepper `style`, `xstyle`, and `className` to the frame that contains both the track and compact summary
- preserve the public `<ol>` ref, semantic target, and native DOM/ARIA/data pass-throughs
- add regressions for a consumer-constrained Stepper inside a wider parent and for class/ref/pass-through placement

## Test plan

- `pnpm exec vitest run packages/core/src/Stepper/Stepper.test.tsx`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm exec prettier --check packages/core/src/Stepper/Stepper.tsx packages/core/src/Stepper/Stepper.test.tsx`
- `pnpm check:knowledge`
- `pnpm check:repo`
- `pnpm lint:strict`
- `pnpm build`
- `pnpm exec vitest run --maxWorkers=4 --testTimeout=120000`
- `git diff --check`