### PR TITLE
fix(core): close a modal Dialog when it is torn down while open

### DIFF
--- a/.changeset/dialog-close-on-teardown.md
+++ b/.changeset/dialog-close-on-teardown.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Dialog` now closes itself when it is torn down while open. `showModal()` is a document-wide side effect — an open modal puts the element in the top layer and makes the rest of the page inert — and `close()` is the only thing that undoes it; removing the element from the DOM does not. The open/close effect only closed on an `isOpen` transition, so any dialog destroyed while still open left an invisible modal (zero-sized, `display: none`) holding the whole document inert, with every click swallowed until a reload.
+
+Teardown rather than unmount is the case that bites: React destroys a subtree's effects when the subtree is hidden as well as when it unmounts, which is exactly what a client-side router does to the outgoing route. Following a link out of an open dialog — the docsite's own "Open in Playground", for one — landed the next page dead on arrival. The fix is a teardown-only cleanup with an empty dependency list, so the open and close transitions stay entirely with the effect that already owns them and nothing about opening, closing, focus restoration, or the exit animation changes.
+
+@ernestt

--- a/packages/core/src/Dialog/Dialog.test.tsx
+++ b/packages/core/src/Dialog/Dialog.test.tsx
@@ -842,6 +842,36 @@ describe('Dialog', () => {
     });
   });
 
+  describe('teardown while open', () => {
+    // An open modal makes the rest of the document inert, and only close()
+    // undoes it — removing the element does not. React destroys effects when a
+    // subtree is hidden as well as when it unmounts, which is what a router
+    // does to the outgoing route on a client-side navigation: leave a page from
+    // inside an open dialog and the next page arrives with an invisible modal
+    // holding it inert, unclickable until a reload.
+    it('closes the dialog when unmounted while open', () => {
+      const {unmount} = render(
+        <Dialog isOpen={true} onOpenChange={() => {}}>
+          Content
+        </Dialog>,
+      );
+      expect(HTMLDialogElement.prototype.close).not.toHaveBeenCalled();
+
+      unmount();
+      expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+    });
+
+    it('does not call close when unmounted already closed', () => {
+      const {unmount} = render(
+        <Dialog isOpen={false} onOpenChange={() => {}}>
+          Content
+        </Dialog>,
+      );
+      unmount();
+      expect(HTMLDialogElement.prototype.close).not.toHaveBeenCalled();
+    });
+  });
+
   describe('isInline', () => {
     it('renders children in a div without a <dialog> element', () => {
       const {container} = render(

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -546,6 +546,30 @@ export function Dialog({
     }
   }, [isOpen, isInline]);
 
+  // Release the top layer when this dialog goes away while still open.
+  //
+  // `showModal()` is a document-wide side effect: an open modal makes the rest
+  // of the page inert, and closing the element is the only thing that undoes
+  // it. Removing the element is not enough — the effect above only closes on an
+  // `isOpen` transition, so a dialog that is torn down while open leaves an
+  // invisible modal holding the whole document inert, and nothing on the page
+  // can be clicked until a reload.
+  //
+  // Teardown, not unmount: React destroys effects when a subtree is hidden by
+  // `<Activity>` as well as when it unmounts, and a router that keeps the
+  // outgoing route alive across a client-side navigation hits exactly that
+  // path — leave a page from inside an open dialog and the next page arrives
+  // dead. An empty dependency list is what keeps this to teardown; the open and
+  // close transitions stay entirely with the effect above.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    return () => {
+      if (dialog?.open) {
+        dialog.close();
+      }
+    };
+  }, []);
+
   // Lock body scroll when dialog is open (iOS Safari workaround)
   // Skip for inline rendering — no modal overlay to compensate for.
   useScrollLock(isOpen && !isInline);


### PR DESCRIPTION
## What

`Dialog` did not release the top layer when it was torn down while open.

`showModal()` is a document-wide side effect: the element joins the top layer and the rest of the page goes inert. `close()` is the only thing that undoes it — removing the element from the DOM does not. `Dialog`'s open/close effect only closed on an `isOpen` transition, so a dialog destroyed while still open left an invisible modal behind: `display: none`, zero-sized, and holding the entire document inert. Every click on the next page went nowhere until a reload.

**Unmount is not the case that bites — teardown is.** React destroys a subtree's effects when the subtree is *hidden* as well as when it unmounts, and that is exactly what a client-side router does to the outgoing route. So following a link out of an open dialog landed you on a dead page.

The docsite hits this on its own templates gallery: open a template preview and click "Open in Playground", and the playground arrives unclickable. That is how this was found — it reads as intermittent because it only happens when the dialog is still open at navigation time and the router keeps the old tree alive.

The fix is a teardown-only cleanup with an empty dependency list. The open and close transitions stay entirely with the effect that already owns them, so nothing about opening, closing, focus restoration or the exit animation changes.

```ts
useEffect(() => {
  const dialog = dialogRef.current;
  return () => {
    if (dialog?.open) {
      dialog.close();
    }
  };
}, []);
```

## Why it is safe

The cleanup runs only on teardown, which is the one moment the component can no longer act on its own element. A dialog that is already closed at teardown is not touched (`if (dialog?.open)`), so the ordinary open → close → unmount path calls `close()` exactly once, as it does today. A hidden-then-shown subtree re-runs the open/close effect on the way back, which reopens a dialog whose `isOpen` is still true.

## Test plan

- `vitest run packages/core/src/Dialog` — 71 passed, including two new cases under `teardown while open`. The first fails on `main` and passes here; the second guards the already-closed path so the fix cannot start double-closing.
- `vitest run packages/core/src` — 8030 passed. (Three `useTableRowExpansion` failures in my working tree are unrelated local WIP and are not on this branch.)
- Reproduced the dead page in Chromium against the running docsite: open a template preview, click "Open in Playground", and on `/playground` the document still holds one `:modal` element and `document.elementFromPoint` returns `<html>` — no control can be clicked, and calling `close()` by hand restores it immediately. With this branch the same run reports zero modals and the playground is interactive on arrival.

## Note on `pr-rtl`

`pr-rtl` reports **0 pass / 0 fail / 1 N-A** and exits 1 on the coverage gap, not on a finding: a modal `Dialog` cannot be measured in the Storybook iframe at all, so every dimension resolves N/A. It is pre-existing for this component, unrelated to a change that adds no styles, and the job is `continue-on-error` and not a required check.

---

The docsite-side fix this came from — the template preview header — is split out into its own PR, since it is unrelated to core.

@ernestt
