### PR TITLE
fix(docsite): close the template preview on teardown, and cap its header height

### DIFF
--- a/apps/docsite/src/components/TemplatePreviewDialog.tsx
+++ b/apps/docsite/src/components/TemplatePreviewDialog.tsx
@@ -26,6 +26,7 @@ import {
   useCallback,
   useEffect,
   useDeferredValue,
+  useRef,
   useState,
   useTransition,
 } from 'react';
@@ -264,6 +265,30 @@ export function TemplatePreviewDialog({
   const [cmdCopied, setCmdCopied] = useState(false);
   const [isPending, startTransition] = useTransition();
 
+  // Release the top layer when this dialog is torn down while still open.
+  //
+  // `showModal()` makes the rest of the document inert, and `close()` is the
+  // only thing that undoes it — removing the element does not. Dialog closes on
+  // an `isOpen` transition, which never happens here: "Open in Playground" is a
+  // client-side navigation, so React tears this subtree down with the dialog
+  // still open and the playground arrives with an invisible modal holding the
+  // whole page inert, unclickable until a reload.
+  //
+  // The element is captured on mount rather than read during cleanup, because
+  // by cleanup time this tree is on its way out and `closest()` may no longer
+  // reach it. Teardown, not unmount: React destroys effects when a subtree is
+  // hidden too, which is what a router does to the outgoing route — and that is
+  // the path that was breaking.
+  const hostRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const dialog = hostRef.current?.closest('dialog');
+    return () => {
+      if (dialog?.open) {
+        dialog.close();
+      }
+    };
+  }, []);
+
   const count = items.length;
   const current = items[index];
   // The deferred index drives the heavy preview surface — it lags behind
@@ -354,7 +379,7 @@ export function TemplatePreviewDialog({
         }
         content={
           <LayoutContent isScrollable={false} padding={0}>
-            <div {...stylex.props(styles.body)}>
+            <div {...stylex.props(styles.body)} ref={hostRef}>
               <TemplatePreviewSurface
                 key={deferredCurrent.slug}
                 slug={deferredCurrent.slug}

--- a/apps/docsite/src/components/TemplatePreviewDialog.tsx
+++ b/apps/docsite/src/components/TemplatePreviewDialog.tsx
@@ -106,6 +106,21 @@ const styles = stylex.create({
     width: '100%',
     minWidth: 0,
   },
+  // The CLI command shrinks before the buttons do, and stays on one line.
+  commandGroup: {
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  commandCode: {
+    flexShrink: 1,
+    minWidth: 0,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  noShrink: {
+    flexShrink: 0,
+  },
   skeletonOverlay: {
     position: 'absolute',
     insetInline: '16px',
@@ -159,7 +174,7 @@ function TemplatePreviewHeader({
       }>
       <Heading level={2}>{item.name}</Heading>
       {item.description && (
-        <Text type="body" color="secondary">
+        <Text type="body" color="secondary" maxLines={2}>
           {item.description}
         </Text>
       )}
@@ -167,8 +182,11 @@ function TemplatePreviewHeader({
   );
 
   const copyButton = (
-    <HStack gap={2} vAlign="center">
-      <Code>{`npx @astryxdesign/cli template ${item.slug}`}</Code>
+    <HStack gap={2} vAlign="center" xstyle={styles.commandGroup}>
+      <Code
+        xstyle={
+          styles.commandCode
+        }>{`npx @astryxdesign/cli template ${item.slug}`}</Code>
       <Button
         variant="ghost"
         isIconOnly
@@ -176,6 +194,7 @@ function TemplatePreviewHeader({
         label={cmdCopied ? 'Copied!' : 'Copy install command'}
         icon={<Icon icon={cmdCopied ? 'check' : 'copy'} color="inherit" />}
         onClick={onCopyCommand}
+        xstyle={styles.noShrink}
       />
     </HStack>
   );
@@ -193,6 +212,7 @@ function TemplatePreviewHeader({
           category: item.category,
         });
       }}
+      xstyle={styles.noShrink}
     />
   );
 


### PR DESCRIPTION
## What

Two fixes to the templates gallery's preview dialog. Both are docsite-only — nothing in `packages/` is touched.

### 1. The playground arrived dead when opened from a preview

Open a template preview, click "Open in Playground", and the playground was frequently unclickable until a reload. It read as an intermittent playground bug; it is neither intermittent nor the playground.

`showModal()` makes the rest of the document inert, and `close()` is the only thing that undoes it — removing the element from the DOM does not. `Dialog` closes on an `isOpen` transition, which never happens on this path: "Open in Playground" is a client-side navigation, so React tears this subtree down with the dialog still open. The next route then mounts underneath an invisible modal — `display: none`, zero-sized — that is still holding the whole page inert.

Closing on teardown is the fix:

```ts
const hostRef = useRef<HTMLDivElement>(null);
useEffect(() => {
  const dialog = hostRef.current?.closest('dialog');
  return () => {
    if (dialog?.open) {
      dialog.close();
    }
  };
}, []);
```

The element is captured on mount rather than looked up during cleanup, because by cleanup time this tree is on its way out and `closest()` may no longer reach it. Teardown rather than unmount is deliberate: React destroys a subtree's effects when the subtree is *hidden* as well, which is what the router does to the outgoing route — and that is the path that was breaking.

### 2. The preview header had no height ceiling

The description ran to its full length and the CLI command wrapped. On a phone the two together took about fourteen lines before the preview started — most of the screen spent on chrome, with the template itself pushed off the bottom.

- The description clamps to two lines with `Text`'s own `maxLines`, so a clipped one keeps its truncation tooltip and the full text stays reachable.
- The command truncates to one line, with the copy and Playground buttons pinned (`flex-shrink: 0`) so the command is what gives way rather than the controls.

## Before / after

Phone (393px) — the header goes from ~14 lines to 4, and the preview starts above the fold:

**Before**

![before](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/preview-header/mobile-before.png)

**After**

![after](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/preview-header/mobile-after.png)

Desktop (1440px) — the command already fitted and does not move; the description drops from four lines to two and the preview gains that height:

**Before**

![before](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/preview-header/desktop-before.png)

**After**

![after](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/preview-header/desktop-after.png)

## On fixing this here rather than in core

`Dialog` has the same gap generally — any consumer whose dialog is torn down while open leaks an inert document — so there is a case for a teardown cleanup in `packages/core/src/Dialog/Dialog.tsx`, which fixes every caller at once. That was #6070, now closed in favour of this.

Keeping it local is the smaller claim: it fixes the reported bug without changing a lifecycle every dialog in the system depends on, and it does not need a core release to reach the docsite. The core-level version is still worth doing on its own merits and can land separately; this component would then simply be redundant rather than wrong.

## Why it is safe

The cleanup runs only on teardown, and only closes a dialog that is still open — the ordinary close-then-unmount path is untouched, so nothing about opening, closing, focus restoration or the exit animation changes.

The header change takes nothing away: the full description is still reachable through the clamp's tooltip, and the full command is still what the copy button writes to the clipboard — only its rendering is shortened. The shrink priorities are the part worth reviewing: the command chip gets `flex-shrink: 1; min-width: 0` and the buttons `flex-shrink: 0`, so the row degrades by shortening the command rather than by squeezing "Open in Playground", which is the control people came for.

## Test plan

- Reproduced and fixed, measured rather than eyeballed, against the running docsite in Chromium. Same run, same steps, with only this component's change reverted in between:

  | | `:modal` on `/playground` | first control clickable |
  |---|---|---|
  | without the fix | 1 | no |
  | with the fix | 0 | yes |

  With the fix `document.elementFromPoint` at the top of the page returns the preview `<iframe>`; without it, `<html>` — the inert document swallowing the hit.
- Header measured at 393px and 1440px (shots above), and checked that a description short enough not to clamp still renders unclamped.
- Swept every template in the registry at 393px: no description over 2 lines, no command over 1, "Open in Playground" on screen and unclipped throughout.
- `tsc --noEmit` and eslint clean on the docsite.

@ernestt
