### PR TITLE
fix: runaway auto-scroll loop in hover-highlighted menus

### DIFF
--- a/.changeset/hover-highlight-no-autoscroll-option-lists.md
+++ b/.changeset/hover-highlight-no-autoscroll-option-lists.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep hover from auto-scrolling open option lists (#6077)
+
+In a scrollable listbox whose highlight follows the pointer, scrolling the highlighted option into view moved the next option under the stationary pointer, whose mouseenter re-highlighted and scrolled again — an endless loop with no user input. This was already fixed for DropdownMenu and Chat; it now covers the remaining combobox-style paths through a shared highlight owner: Selector, MultiSelector, Typeahead, and DateTimeInput hover highlights move only the highlight, while keyboard navigation still scrolls the highlighted option into view.
+
+@liuzhaochen03

--- a/.changeset/hover-highlight-no-autoscroll-option-lists.md
+++ b/.changeset/hover-highlight-no-autoscroll-option-lists.md
@@ -4,6 +4,6 @@
 
 [fix] Keep hover from auto-scrolling open option lists (#6077)
 
-In a scrollable listbox whose highlight follows the pointer, scrolling the highlighted option into view moved the next option under the stationary pointer, whose mouseenter re-highlighted and scrolled again — an endless loop with no user input. This was already fixed for DropdownMenu and Chat; it now covers the remaining combobox-style paths through a shared highlight owner: Selector, MultiSelector, Typeahead, and DateTimeInput hover highlights move only the highlight, while keyboard navigation still scrolls the highlighted option into view.
+In a scrollable listbox whose highlight follows the pointer, scrolling the highlighted option into view moved the next option under the stationary pointer, whose mouseenter re-highlighted and scrolled again — an endless loop with no user input. This was already fixed for DropdownMenu and Chat; it now covers the remaining combobox-style paths through a shared highlight owner: Selector, MultiSelector, Typeahead, DateTimeInput, and CommandPalette hover highlights move only the highlight, while keyboard navigation still scrolls the highlighted option into view.
 
 @liuzhaochen03

--- a/.changeset/hover-highlight-no-autoscroll-option-lists.md
+++ b/.changeset/hover-highlight-no-autoscroll-option-lists.md
@@ -6,4 +6,4 @@
 
 In a scrollable listbox whose highlight follows the pointer, scrolling the highlighted option into view moved the next option under the stationary pointer, whose mouseenter re-highlighted and scrolled again — an endless loop with no user input. This was already fixed for DropdownMenu and Chat; it now covers the remaining combobox-style paths through a shared highlight owner: Selector, MultiSelector, Typeahead, DateTimeInput, and CommandPalette hover highlights move only the highlight, while keyboard navigation still scrolls the highlighted option into view.
 
-@liuzhaochen03
+@faga295

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -22,6 +22,20 @@
     }
   },
   {
+    "component": "CommandPalette",
+    "storyId": "core-commandpalette--default",
+    "dims": [
+      "D2"
+    ],
+    "setup": {
+      "click": "button:has-text(\"Open Command Palette\")"
+    },
+    "selectors": {
+      "prev": ".astryx-command-palette-input > span:first-child",
+      "next": ".astryx-command-palette-input > input[role=\"combobox\"]"
+    }
+  },
+  {
     "component": "CheckboxInput",
     "storyId": "core-checkboxinput--size-comparison",
     "dims": [

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect, vi, afterEach} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ChatComposer} from './ChatComposer';
 import {useChatComposerContext} from './ChatContext';
@@ -1377,6 +1377,79 @@ describe('ChatComposerInput', () => {
       fireEvent.input(textbox);
 
       expect(textbox.getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
+  describe('trigger menu hover scrolling', () => {
+    // Regression: the scroll-highlighted-item-into-view effect ran for
+    // mouse-hover highlights too. A pointer resting near the bottom of the
+    // menu kept scrolling: each scrollIntoView moved a new option under the
+    // stationary cursor, whose mouseenter re-highlighted and scrolled again.
+    // Hover must highlight only; keyboard navigation keeps its scrolling.
+    function openMenu() {
+      // jsdom does not implement scrollIntoView — install a spy directly.
+      const original = Element.prototype.scrollIntoView;
+      const spy = vi.fn();
+      Element.prototype.scrollIntoView = spy;
+      cleanupFns.push(() => {
+        Element.prototype.scrollIntoView = original;
+      });
+      render(<ChatComposerInput triggers={[createMentionTrigger()]} />);
+      const textbox = screen.getByRole('combobox');
+      textbox.focus();
+      const textNode = document.createTextNode('@');
+      textbox.appendChild(textNode);
+      const sel = window.getSelection()!;
+      const range = document.createRange();
+      range.setStart(textNode, 1);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      fireEvent.input(textbox);
+      expect(textbox.getAttribute('aria-expanded')).toBe('true');
+      return {textbox, spy};
+    }
+
+    // The menu layer is a `[popover]` element; jsdom has no popover semantics
+    // so testing-library's role queries see it as hidden. Query via
+    // aria-controls instead.
+    async function getMenuOptions(textbox: HTMLElement) {
+      const listbox = await waitFor(() => {
+        const el = document.getElementById(
+          textbox.getAttribute('aria-controls')!,
+        );
+        const options = el?.querySelectorAll<HTMLElement>('[role="option"]');
+        expect(options?.length ?? 0).toBeGreaterThan(1);
+        return options!;
+      });
+      return Array.from(listbox);
+    }
+
+    const cleanupFns: (() => void)[] = [];
+
+    afterEach(() => {
+      cleanupFns.splice(0).forEach(fn => fn());
+    });
+
+    it('does not scroll when hover highlights an option', async () => {
+      const {textbox, spy} = openMenu();
+      const callsAfterOpen = spy.mock.calls.length;
+
+      const options = await getMenuOptions(textbox);
+      fireEvent.mouseEnter(options[1]);
+
+      expect(options[1]).toHaveAttribute('aria-selected', 'true');
+      expect(spy.mock.calls.length).toBe(callsAfterOpen);
+    });
+
+    it('still scrolls on keyboard navigation', async () => {
+      const {textbox, spy} = openMenu();
+      const callsAfterOpen = spy.mock.calls.length;
+
+      await getMenuOptions(textbox);
+      fireEvent.keyDown(textbox, {key: 'ArrowDown'});
+
+      expect(spy.mock.calls.length).toBeGreaterThan(callsAfterOpen);
     });
   });
 });

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -597,8 +597,17 @@ export function useTriggerMenu(
     [listboxId],
   );
 
-  // Scroll highlighted item into view on keyboard navigation
+  // Scroll highlighted item into view on keyboard navigation.
+  // Hover-triggered highlights must NOT scroll: scrollIntoView moves the next
+  // option under the stationary cursor, whose mouseenter re-highlights and
+  // scrolls again — a runaway auto-scroll loop when the pointer rests near
+  // the bottom of the menu. Skip one effect run per hover-driven change.
+  const hoverHighlightRef = useRef(false);
   useEffect(() => {
+    if (hoverHighlightRef.current) {
+      hoverHighlightRef.current = false;
+      return;
+    }
     if (!popover.isOpen || state.highlightedIndex < 0) {
       return;
     }
@@ -663,7 +672,12 @@ export function useTriggerMenu(
                 selectItem(item);
               }}
               onMouseEnter={() =>
-                setState(prev => ({...prev, highlightedIndex: idx}))
+                setState(prev => {
+                  if (prev.highlightedIndex !== idx) {
+                    hoverHighlightRef.current = true;
+                  }
+                  return {...prev, highlightedIndex: idx};
+                })
               }
               {...stylex.props(
                 styles.item,

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -30,6 +30,7 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
+import {useHighlightedOptionScroll} from '../hooks/useHighlightedOptionScroll';
 import {
   colorVars,
   spacingVars,
@@ -597,23 +598,15 @@ export function useTriggerMenu(
     [listboxId],
   );
 
-  // Scroll highlighted item into view on keyboard navigation.
-  // Hover-triggered highlights must NOT scroll: scrollIntoView moves the next
-  // option under the stationary cursor, whose mouseenter re-highlights and
-  // scrolls again — a runaway auto-scroll loop when the pointer rests near
-  // the bottom of the menu. Skip one effect run per hover-driven change.
-  const hoverHighlightRef = useRef(false);
-  useEffect(() => {
-    if (hoverHighlightRef.current) {
-      hoverHighlightRef.current = false;
-      return;
-    }
-    if (!popover.isOpen || state.highlightedIndex < 0) {
-      return;
-    }
-    const el = document.getElementById(getItemId(state.highlightedIndex));
-    el?.scrollIntoView({block: 'nearest'});
-  }, [state.highlightedIndex, popover.isOpen, getItemId]);
+  // Keep the highlighted option visible during keyboard navigation; hover
+  // highlights never scroll (#6077). Both sides live in useHighlightedOptionScroll.
+  const highlightOnHover = useHighlightedOptionScroll({
+    isOpen: popover.isOpen,
+    highlightedIndex: state.highlightedIndex,
+    setHighlightedIndex: index =>
+      setState(prev => ({...prev, highlightedIndex: index})),
+    getOptionId: getItemId,
+  });
 
   // ARIA props for the editable element. Combobox attributes
   // (aria-expanded/haspopup/controls/activedescendant) are only valid on
@@ -671,14 +664,7 @@ export function useTriggerMenu(
                 e.preventDefault(); // Keep focus in the editable
                 selectItem(item);
               }}
-              onMouseEnter={() =>
-                setState(prev => {
-                  if (prev.highlightedIndex !== idx) {
-                    hoverHighlightRef.current = true;
-                  }
-                  return {...prev, highlightedIndex: idx};
-                })
-              }
+              onMouseEnter={() => highlightOnHover(idx)}
               {...stylex.props(
                 styles.item,
                 idx === state.highlightedIndex && styles.itemHighlighted,
@@ -728,7 +714,7 @@ export function useTriggerMenu(
         xstyle: styles.popoverSurface,
       },
     );
-  }, [popover, listboxId, state, selectItem, getItemId, t]);
+  }, [popover, listboxId, state, selectItem, getItemId, highlightOnHover, t]);
 
   return {
     state,

--- a/packages/core/src/CommandPalette/CommandPalette.perf.test.ts
+++ b/packages/core/src/CommandPalette/CommandPalette.perf.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {createValueLookup} from './CommandPalette';
+
+/**
+ * Operation-count perf test for the delegated hover-highlight lookup.
+ *
+ * The counted operation is one `item.value` read — one comparison in the
+ * previous linear `findIndex` scan, which ran on every bubbled mouseover.
+ * Crossing 50 items cost 1,275 comparisons (sum of scan lengths) versus a
+ * single Map probe per hover now. Counting is exact (getter-based), like
+ * parser.perf.test.ts, so the numbers hold on loaded CI machines.
+ */
+
+function makeItems(count: number): {value: string}[] {
+  // Plain objects with a counting getter on `value`.
+  return Array.from({length: count}, (_, i) => ({
+    get value() {
+      totalReads++;
+      return `item-${i}`;
+    },
+  }));
+}
+
+let totalReads = 0;
+
+/** Simulate the pointer crossing every item once, then ten moves within the last item. */
+function simulatedHoverWork(count: number) {
+  totalReads = 0;
+  const items = makeItems(count);
+  const lookup = createValueLookup(items);
+  const buildReads = totalReads;
+  for (let i = 0; i < count; i++) {
+    if (lookup(`item-${i}`) === undefined) {
+      throw new Error('missing index');
+    }
+  }
+  for (let i = 0; i < 10; i++) {
+    lookup(`item-${count - 1}`);
+  }
+  return {buildReads, lookupReads: totalReads - buildReads};
+}
+
+describe('createValueLookup operation counts', () => {
+  it('bounds hover lookups to one Map probe at two list sizes', () => {
+    // Ten times the list size does not change the lookup cost: zero
+    // `value` reads after the one-time build. A regression to a linear
+    // per-event scan would read values on every hover and fail here.
+    const small = simulatedHoverWork(50);
+    const large = simulatedHoverWork(500);
+    expect(small.lookupReads).toBe(0);
+    expect(large.lookupReads).toBe(small.lookupReads);
+  });
+
+  it('pays exactly one pass over the items when the index is built', () => {
+    // The build itself is linear by design (one read per item), charged
+    // once per results change — not per mouseover.
+    const {buildReads} = simulatedHoverWork(500);
+    expect(buildReads).toBe(500);
+  });
+
+  it('matches findIndex semantics: first occurrence wins, misses are undefined', () => {
+    const items = [{value: 'a'}, {value: 'b'}, {value: 'a'}];
+    const lookup = createValueLookup(items);
+    expect(lookup('a')).toBe(0);
+    expect(lookup('b')).toBe(1);
+    expect(lookup('missing')).toBeUndefined();
+  });
+});

--- a/packages/core/src/CommandPalette/CommandPalette.perf.test.ts
+++ b/packages/core/src/CommandPalette/CommandPalette.perf.test.ts
@@ -5,8 +5,50 @@ import {fireEvent, render, waitFor} from '@testing-library/react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {createStaticSource} from '@astryxdesign/core/Typeahead';
 import {CommandPalette} from './CommandPalette';
+import type * as ListModule from './CommandPaletteList';
+import type {CommandPaletteListProps} from './CommandPaletteList';
+
+const lookupWork = vi.hoisted(() => ({reads: [] as number[]}));
+
+vi.mock('./CommandPaletteList', async importOriginal => {
+  const actual = await importOriginal<typeof ListModule>();
+  const {useCommandPaletteContext} = await import('./CommandPaletteContext');
+  return {
+    ...actual,
+    CommandPaletteList: function ObservedList(props: CommandPaletteListProps) {
+      const ctx = useCommandPaletteContext();
+      return createElement(actual.CommandPaletteList, {
+        ...props,
+        onMouseOver(event) {
+          // Observe the real handler's input, not a particular array method.
+          // Install after index construction and restore before React renders:
+          // this measures lookup work, not setup or option rendering.
+          let reads = 0;
+          const restorers = (ctx?.selectableItems ?? []).map(item => {
+            const descriptor = Object.getOwnPropertyDescriptor(item, 'value')!;
+            Object.defineProperty(item, 'value', {
+              configurable: true,
+              get(): string {
+                reads++;
+                return descriptor.value;
+              },
+            });
+            return () => Object.defineProperty(item, 'value', descriptor);
+          });
+          try {
+            props.onMouseOver?.(event);
+          } finally {
+            restorers.forEach(restore => restore());
+            lookupWork.reads.push(reads);
+          }
+        },
+      });
+    },
+  };
+});
 
 beforeEach(() => {
+  lookupWork.reads = [];
   HTMLDialogElement.prototype.showModal = vi.fn(function (
     this: HTMLDialogElement,
   ) {
@@ -14,62 +56,41 @@ beforeEach(() => {
   });
 });
 
-async function delegatedMouseOverScans(count: number) {
-  const items = Array.from({length: count}, (_, index) => ({
-    id: `item-${index}`,
-    label: `Item ${index}`,
-  }));
-  const view = render(
-    createElement(CommandPalette, {
-      isOpen: true,
-      onOpenChange: () => {},
-      searchSource: createStaticSource(items),
-    }),
-  );
-  await waitFor(() => expect(view.getAllByRole('option')).toHaveLength(count));
-  const lastOption = view.getAllByRole('option').at(-1);
-  if (!lastOption) {
-    throw new Error('missing last option');
-  }
-
-  let scannedItems = 0;
-  const arrayFindIndex = Array.prototype.findIndex;
-  function trackedFindIndex(
-    this: unknown[],
-    predicate: (value: unknown, index: number, array: unknown[]) => unknown,
-    thisArg?: unknown,
-  ): number {
-    if (
-      this.length === count &&
-      (this[0] as {value?: unknown} | undefined)?.value === 'item-0' &&
-      (this.at(-1) as {value?: unknown} | undefined)?.value ===
-        `item-${count - 1}`
-    ) {
-      scannedItems += this.length;
-    }
-    return arrayFindIndex.call(this, predicate, thisArg);
-  }
-  const findIndexSpy = vi
-    .spyOn(Array.prototype, 'findIndex')
-    .mockImplementation(trackedFindIndex);
-
-  try {
-    for (let i = 0; i < 10; i++) {
-      fireEvent.mouseOver(lastOption);
-    }
-    expect(view.getByRole('combobox')).toHaveAttribute(
-      'aria-activedescendant',
-      lastOption.id,
-    );
-  } finally {
-    findIndexSpy.mockRestore();
-    view.unmount();
-  }
-  return scannedItems;
-}
-
 describe('CommandPalette delegated mouseover performance', () => {
-  it.each([50, 500])('does not scan %i items per mouseover', async count => {
-    expect(await delegatedMouseOverScans(count)).toBe(0);
+  it.each([50, 500])('bounds lookup work with %i items', async count => {
+    const items = Array.from({length: count}, (_, index) => ({
+      id: `item-${index}`,
+      label: `Item ${index}`,
+    }));
+    const view = render(
+      createElement(CommandPalette, {
+        isOpen: true,
+        onOpenChange: () => {},
+        searchSource: createStaticSource(items),
+      }),
+    );
+    try {
+      await waitFor(() =>
+        expect(view.getAllByRole('option')).toHaveLength(count),
+      );
+      const options = view.getAllByRole('option');
+      const targets = [0, count - 1, Math.floor(count / 2), 0];
+      for (const index of targets) {
+        const option = options[index];
+        fireEvent.mouseOver(option);
+        expect(view.getByRole('combobox')).toHaveAttribute(
+          'aria-activedescendant',
+          option.id,
+        );
+      }
+      expect(lookupWork.reads).toHaveLength(targets.length);
+      for (const reads of lookupWork.reads) {
+        // A direct lookup may inspect the matched value, but must not scan
+        // the list. The same fixed budget applies at both list sizes.
+        expect(reads).toBeLessThanOrEqual(1);
+      }
+    } finally {
+      view.unmount();
+    }
   });
 });

--- a/packages/core/src/CommandPalette/CommandPalette.perf.test.ts
+++ b/packages/core/src/CommandPalette/CommandPalette.perf.test.ts
@@ -1,70 +1,75 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect} from 'vitest';
-import {createValueLookup} from './CommandPalette';
+import {createElement} from 'react';
+import {fireEvent, render, waitFor} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {createStaticSource} from '@astryxdesign/core/Typeahead';
+import {CommandPalette} from './CommandPalette';
 
-/**
- * Operation-count perf test for the delegated hover-highlight lookup.
- *
- * The counted operation is one `item.value` read — one comparison in the
- * previous linear `findIndex` scan, which ran on every bubbled mouseover.
- * Crossing 50 items cost 1,275 comparisons (sum of scan lengths) versus a
- * single Map probe per hover now. Counting is exact (getter-based), like
- * parser.perf.test.ts, so the numbers hold on loaded CI machines.
- */
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+});
 
-function makeItems(count: number): {value: string}[] {
-  // Plain objects with a counting getter on `value`.
-  return Array.from({length: count}, (_, i) => ({
-    get value() {
-      totalReads++;
-      return `item-${i}`;
-    },
+async function delegatedMouseOverScans(count: number) {
+  const items = Array.from({length: count}, (_, index) => ({
+    id: `item-${index}`,
+    label: `Item ${index}`,
   }));
-}
+  const view = render(
+    createElement(CommandPalette, {
+      isOpen: true,
+      onOpenChange: () => {},
+      searchSource: createStaticSource(items),
+    }),
+  );
+  await waitFor(() => expect(view.getAllByRole('option')).toHaveLength(count));
+  const lastOption = view.getAllByRole('option').at(-1);
+  if (!lastOption) {
+    throw new Error('missing last option');
+  }
 
-let totalReads = 0;
-
-/** Simulate the pointer crossing every item once, then ten moves within the last item. */
-function simulatedHoverWork(count: number) {
-  totalReads = 0;
-  const items = makeItems(count);
-  const lookup = createValueLookup(items);
-  const buildReads = totalReads;
-  for (let i = 0; i < count; i++) {
-    if (lookup(`item-${i}`) === undefined) {
-      throw new Error('missing index');
+  let scannedItems = 0;
+  const arrayFindIndex = Array.prototype.findIndex;
+  function trackedFindIndex(
+    this: unknown[],
+    predicate: (value: unknown, index: number, array: unknown[]) => unknown,
+    thisArg?: unknown,
+  ): number {
+    if (
+      this.length === count &&
+      (this[0] as {value?: unknown} | undefined)?.value === 'item-0' &&
+      (this.at(-1) as {value?: unknown} | undefined)?.value ===
+        `item-${count - 1}`
+    ) {
+      scannedItems += this.length;
     }
+    return arrayFindIndex.call(this, predicate, thisArg);
   }
-  for (let i = 0; i < 10; i++) {
-    lookup(`item-${count - 1}`);
+  const findIndexSpy = vi
+    .spyOn(Array.prototype, 'findIndex')
+    .mockImplementation(trackedFindIndex);
+
+  try {
+    for (let i = 0; i < 10; i++) {
+      fireEvent.mouseOver(lastOption);
+    }
+    expect(view.getByRole('combobox')).toHaveAttribute(
+      'aria-activedescendant',
+      lastOption.id,
+    );
+  } finally {
+    findIndexSpy.mockRestore();
+    view.unmount();
   }
-  return {buildReads, lookupReads: totalReads - buildReads};
+  return scannedItems;
 }
 
-describe('createValueLookup operation counts', () => {
-  it('bounds hover lookups to one Map probe at two list sizes', () => {
-    // Ten times the list size does not change the lookup cost: zero
-    // `value` reads after the one-time build. A regression to a linear
-    // per-event scan would read values on every hover and fail here.
-    const small = simulatedHoverWork(50);
-    const large = simulatedHoverWork(500);
-    expect(small.lookupReads).toBe(0);
-    expect(large.lookupReads).toBe(small.lookupReads);
-  });
-
-  it('pays exactly one pass over the items when the index is built', () => {
-    // The build itself is linear by design (one read per item), charged
-    // once per results change — not per mouseover.
-    const {buildReads} = simulatedHoverWork(500);
-    expect(buildReads).toBe(500);
-  });
-
-  it('matches findIndex semantics: first occurrence wins, misses are undefined', () => {
-    const items = [{value: 'a'}, {value: 'b'}, {value: 'a'}];
-    const lookup = createValueLookup(items);
-    expect(lookup('a')).toBe(0);
-    expect(lookup('b')).toBe(1);
-    expect(lookup('missing')).toBeUndefined();
+describe('CommandPalette delegated mouseover performance', () => {
+  it.each([50, 500])('does not scan %i items per mouseover', async count => {
+    expect(await delegatedMouseOverScans(count)).toBe(0);
   });
 });

--- a/packages/core/src/CommandPalette/CommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.test.tsx
@@ -357,6 +357,50 @@ describe('CommandPalette', () => {
     expect(input).not.toHaveAttribute('aria-activedescendant');
   });
 
+  it('highlights on hover without scrolling and scrolls once per key (#6077)', async () => {
+    // CommandPaletteItem must take the hover-aware path (context's
+    // onItemMouseEnter), and the shared useHighlightedOptionScroll effect
+    // must be the single keyboard scroll owner. Calling the raw setter on
+    // hover kept the stationary-pointer runaway path alive, and the item's
+    // own scrollIntoView effect doubled every scroll call.
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    try {
+      render(
+        <CommandPalette
+          isOpen={true}
+          onOpenChange={() => {}}
+          searchSource={simpleSource}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      await waitFor(() => expect(screen.getByText('Home')).toBeInTheDocument());
+      const home = screen.getByText('Home');
+      const settings = screen.getByText('Settings');
+
+      fireEvent.mouseEnter(home);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(input.getAttribute('aria-activedescendant')).toBe(
+        home.closest('[role="option"]')?.id,
+      );
+
+      fireEvent.keyDown(input, {key: 'ArrowDown'});
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(1));
+      expect(input.getAttribute('aria-activedescendant')).toBe(
+        settings.closest('[role="option"]')?.id,
+      );
+
+      fireEvent.keyDown(input, {key: 'ArrowUp'});
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(2));
+    } finally {
+      delete (HTMLElement.prototype as unknown as {scrollIntoView?: unknown})
+        .scrollIntoView;
+    }
+  });
+
   describe('screen reader announcements', () => {
     const politeRegion = () =>
       document.querySelector('[data-astryx-live-region="polite"]');

--- a/packages/core/src/CommandPalette/CommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.test.tsx
@@ -358,8 +358,8 @@ describe('CommandPalette', () => {
   });
 
   it('highlights on hover without scrolling and scrolls once per key (#6077)', async () => {
-    // CommandPaletteItem must take the hover-aware path (context's
-    // onItemMouseEnter), and the shared useHighlightedOptionScroll effect
+    // Hover must be handled by the root's delegated list handler (routed to
+    // useCombobox's hover-aware path), and the shared useHighlightedOptionScroll effect
     // must be the single keyboard scroll owner. Calling the raw setter on
     // hover kept the stationary-pointer runaway path alive, and the item's
     // own scrollIntoView effect doubled every scroll call.
@@ -381,11 +381,27 @@ describe('CommandPalette', () => {
       const home = screen.getByText('Home');
       const settings = screen.getByText('Settings');
 
-      fireEvent.mouseEnter(home);
+      fireEvent.mouseOver(home);
       expect(scrollIntoView).not.toHaveBeenCalled();
       expect(input.getAttribute('aria-activedescendant')).toBe(
         home.closest('[role="option"]')?.id,
       );
+
+      // Moving between siblings does not re-enter the list container. Include
+      // relatedTarget so the test exercises actual within-list transitions.
+      fireEvent.mouseOut(home, {relatedTarget: settings});
+      fireEvent.mouseOver(settings, {relatedTarget: home});
+      expect(input.getAttribute('aria-activedescendant')).toBe(
+        settings.closest('[role="option"]')?.id,
+      );
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      fireEvent.mouseOut(settings, {relatedTarget: home});
+      fireEvent.mouseOver(home, {relatedTarget: settings});
+      expect(input.getAttribute('aria-activedescendant')).toBe(
+        home.closest('[role="option"]')?.id,
+      );
+      expect(scrollIntoView).not.toHaveBeenCalled();
 
       fireEvent.keyDown(input, {key: 'ArrowDown'});
       await waitFor(() => expect(scrollIntoView).toHaveBeenCalledTimes(1));

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -502,6 +502,33 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
     [combobox, handleClose, selectableItems, selectItem],
   );
 
+  // Hover highlight is owned here by a single delegated handler on the list
+  // container: it routes to useCombobox's hover-aware path, which moves the
+  // highlight without scrolling (#6077) — a stationary pointer cannot
+  // re-highlight and auto-scroll in a runaway loop. Keeping it off the public
+  // context preserves CommandPaletteContextValue's setHighlightedIndex shape;
+  // disabled items are skipped via aria-disabled (selectableItems carries no
+  // disabled info). Use mouseover so moves between options bubble to the list;
+  // mouseenter only runs when the pointer enters the list from outside.
+  const handleListMouseOver = useCallback(
+    (e: React.MouseEvent) => {
+      const option = (e.target as HTMLElement).closest?.('[role="option"]');
+      if (!option || option.getAttribute('aria-disabled') === 'true') {
+        return;
+      }
+      const itemValue = option.getAttribute('data-value');
+      if (itemValue == null) {
+        return;
+      }
+      const index = selectableItems.findIndex(item => item.value === itemValue);
+      const item = selectableItems[index];
+      if (item) {
+        combobox.onItemMouseEnter(item, index);
+      }
+    },
+    [combobox, selectableItems],
+  );
+
   const contextValue = useMemo(
     () => ({
       // Input uses optimisticSearch — reflects keystrokes immediately.
@@ -518,7 +545,7 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       setValue,
       listId,
       highlightedIndex: combobox.highlightedIndex,
-      onItemMouseEnter: combobox.onItemMouseEnter,
+      setHighlightedIndex: combobox.setHighlightedIndex,
       getItemId: combobox.getItemId,
       selectableItems,
       searchResults: optimisticResults,
@@ -536,7 +563,7 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       setValue,
       listId,
       combobox.highlightedIndex,
-      combobox.onItemMouseEnter,
+      combobox.setHighlightedIndex,
       combobox.getItemId,
       selectableItems,
       optimisticResults,
@@ -599,7 +626,9 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
           }
           content={
             <LayoutContent padding={0}>
-              <CommandPaletteList>{listContent}</CommandPaletteList>
+              <CommandPaletteList onMouseOver={handleListMouseOver}>
+                {listContent}
+              </CommandPaletteList>
             </LayoutContent>
           }
           footer={

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -175,10 +175,9 @@ function buildSelectableItems(items: SearchableItem[]): SelectorOptionData[] {
  * mouseover handler (#6077). The index is built once per results change;
  * each hover then pays a Map probe instead of a linear findIndex scan,
  * so cost no longer scales with list size. Keeps the first occurrence of
- * duplicate values to match the previous findIndex behavior. Exported for
- * the operation-count perf test.
+ * duplicate values to match the previous findIndex behavior.
  */
-export function createValueLookup<T extends {value: string}>(
+function createValueLookup<T extends {value: string}>(
   items: ReadonlyArray<T>,
 ): (value: string) => number | undefined {
   const indexByValue = new Map<string, number>();

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -170,6 +170,27 @@ function buildSelectableItems(items: SearchableItem[]): SelectorOptionData[] {
   return result;
 }
 
+/**
+ * O(1) value → index lookup over selectable items, used by the delegated
+ * mouseover handler (#6077). The index is built once per results change;
+ * each hover then pays a Map probe instead of a linear findIndex scan,
+ * so cost no longer scales with list size. Keeps the first occurrence of
+ * duplicate values to match the previous findIndex behavior. Exported for
+ * the operation-count perf test.
+ */
+export function createValueLookup<T extends {value: string}>(
+  items: ReadonlyArray<T>,
+): (value: string) => number | undefined {
+  const indexByValue = new Map<string, number>();
+  for (let i = 0; i < items.length; i++) {
+    const value = items[i].value;
+    if (!indexByValue.has(value)) {
+      indexByValue.set(value, i);
+    }
+  }
+  return value => indexByValue.get(value);
+}
+
 interface RendererProps<T extends SearchableItem> {
   items: T[];
   value: string;
@@ -316,6 +337,11 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
   const selectableItems = useMemo(
     () => buildSelectableItems(optimisticResults),
     [optimisticResults],
+  );
+
+  const valueLookup = useMemo(
+    () => createValueLookup(selectableItems),
+    [selectableItems],
   );
 
   const handleClose = useCallback(() => {
@@ -520,13 +546,12 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       if (itemValue == null) {
         return;
       }
-      const index = selectableItems.findIndex(item => item.value === itemValue);
-      const item = selectableItems[index];
-      if (item) {
-        combobox.onItemMouseEnter(item, index);
+      const index = valueLookup(itemValue);
+      if (index !== undefined) {
+        combobox.onItemMouseEnter(selectableItems[index], index);
       }
     },
-    [combobox, selectableItems],
+    [combobox, selectableItems, valueLookup],
   );
 
   const contextValue = useMemo(

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -421,11 +421,25 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
 
           // When opening with a preselected value, highlight it once
           // bootstrap results arrive. No value → highlight stays at -1
-          // and ArrowDown naturally moves to the first item.
+          // and ArrowDown naturally moves to the first item. Inline previews
+          // take the hover-aware path so the initial highlight does not
+          // scrollIntoView the surrounding page (#6077).
           if (isBootstrap && value != null && value !== '') {
             const selectedIdx = items.findIndex(item => item.id === value);
             if (selectedIdx >= 0) {
-              combobox.setHighlightedIndex(selectedIdx);
+              if (isInline) {
+                // `items` is the fresh bootstrap result; the closure's
+                // selectableItems may still be empty at commit time.
+                const selectedItem = items[selectedIdx];
+                if (selectedItem) {
+                  combobox.onItemMouseEnter(
+                    {value: selectedItem.id},
+                    selectedIdx,
+                  );
+                }
+              } else {
+                combobox.setHighlightedIndex(selectedIdx);
+              }
             }
           }
         }
@@ -436,6 +450,7 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       searchResults,
       startTransition,
       value,
+      isInline,
       combobox,
       setOptimisticResults,
       announce,
@@ -503,7 +518,7 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       setValue,
       listId,
       highlightedIndex: combobox.highlightedIndex,
-      setHighlightedIndex: combobox.setHighlightedIndex,
+      onItemMouseEnter: combobox.onItemMouseEnter,
       getItemId: combobox.getItemId,
       selectableItems,
       searchResults: optimisticResults,
@@ -521,7 +536,7 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       setValue,
       listId,
       combobox.highlightedIndex,
-      combobox.setHighlightedIndex,
+      combobox.onItemMouseEnter,
       combobox.getItemId,
       selectableItems,
       optimisticResults,

--- a/packages/core/src/CommandPalette/CommandPaletteContext.ts
+++ b/packages/core/src/CommandPalette/CommandPaletteContext.ts
@@ -10,6 +10,7 @@
 
 import {createContext, use} from 'react';
 import type {SearchableItem} from '../Typeahead';
+import type {SelectorOptionData} from '../Selector';
 
 export interface CommandPaletteContextValue {
   /** Current search query. */
@@ -24,8 +25,13 @@ export interface CommandPaletteContextValue {
   listId: string;
   /** Index-based highlight from useCombobox. -1 = none. */
   highlightedIndex: number;
-  /** Update highlighted index. */
-  setHighlightedIndex: (index: number) => void;
+  /**
+   * Hover-aware highlight from useCombobox: highlights the item without
+   * scrolling, so a stationary pointer cannot re-highlight and auto-scroll in
+   * a runaway loop (#6077). Keyboard paths keep the raw setter inside
+   * useCombobox, which owns scrollIntoView.
+   */
+  onItemMouseEnter: (item: SelectorOptionData, index: number) => void;
   /** Get the DOM id for an item by its flat index. */
   getItemId: (index: number) => string;
   /** Flat list of selectable items in DOM order (after grouping/filtering). */

--- a/packages/core/src/CommandPalette/CommandPaletteContext.ts
+++ b/packages/core/src/CommandPalette/CommandPaletteContext.ts
@@ -10,7 +10,6 @@
 
 import {createContext, use} from 'react';
 import type {SearchableItem} from '../Typeahead';
-import type {SelectorOptionData} from '../Selector';
 
 export interface CommandPaletteContextValue {
   /** Current search query. */
@@ -25,13 +24,8 @@ export interface CommandPaletteContextValue {
   listId: string;
   /** Index-based highlight from useCombobox. -1 = none. */
   highlightedIndex: number;
-  /**
-   * Hover-aware highlight from useCombobox: highlights the item without
-   * scrolling, so a stationary pointer cannot re-highlight and auto-scroll in
-   * a runaway loop (#6077). Keyboard paths keep the raw setter inside
-   * useCombobox, which owns scrollIntoView.
-   */
-  onItemMouseEnter: (item: SelectorOptionData, index: number) => void;
+  /** Update highlighted index. */
+  setHighlightedIndex: (index: number) => void;
   /** Get the DOM id for an item by its flat index. */
   getItemId: (index: number) => string;
   /** Flat list of selectable items in DOM order (after grouping/filtering). */

--- a/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
@@ -118,7 +118,7 @@ describe('CommandPaletteInput dialog context', () => {
       setValue: vi.fn(),
       listId: 'list-1',
       highlightedIndex: -1,
-      onItemMouseEnter: vi.fn(),
+      setHighlightedIndex: vi.fn(),
       getItemId: (i: number) => `item-${i}`,
       selectableItems: [],
       searchResults: [],

--- a/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
@@ -118,7 +118,7 @@ describe('CommandPaletteInput dialog context', () => {
       setValue: vi.fn(),
       listId: 'list-1',
       highlightedIndex: -1,
-      setHighlightedIndex: vi.fn(),
+      onItemMouseEnter: vi.fn(),
       getItemId: (i: number) => `item-${i}`,
       selectableItems: [],
       searchResults: [],

--- a/packages/core/src/CommandPalette/CommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteItem.tsx
@@ -146,6 +146,14 @@ export function CommandPaletteItem({
   const isSelected = controlledSelected ?? (ctx ? ctx.value === value : false);
 
   useEffect(() => {
+    // Inside CommandPalette the shared useHighlightedOptionScroll (via
+    // useCombobox) is the single scrollIntoView owner (#6077); a second owner
+    // here doubled every keyboard scroll and scrolled on hover. Standalone
+    // items (no context) keep their own scroll.
+    if (ctx) {
+      return;
+    }
+
     // Inline dialogs are documentation/showcase previews. Avoid scrolling the
     // surrounding page when picker mode auto-highlights its selected item on
     // mount, while preserving scroll-into-view after user navigation.
@@ -160,7 +168,7 @@ export function CommandPaletteItem({
     if (isHighlighted && itemRef.current) {
       itemRef.current.scrollIntoView?.({block: 'nearest'});
     }
-  }, [isHighlighted, isInlineDialog]);
+  }, [ctx, isHighlighted, isInlineDialog]);
 
   const handleClick = useCallback(() => {
     if (isDisabled) {
@@ -177,7 +185,8 @@ export function CommandPaletteItem({
     if (isDisabled || !ctx || itemIndex < 0) {
       return;
     }
-    ctx.setHighlightedIndex(itemIndex);
+    // Hover-aware path: highlights without scrolling (#6077).
+    ctx.onItemMouseEnter(ctx.selectableItems[itemIndex], itemIndex);
   }, [isDisabled, itemIndex, ctx]);
 
   return (

--- a/packages/core/src/CommandPalette/CommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteItem.tsx
@@ -181,14 +181,6 @@ export function CommandPaletteItem({
     }
   }, [isDisabled, value, onSelect, ctx]);
 
-  const handleMouseEnter = useCallback(() => {
-    if (isDisabled || !ctx || itemIndex < 0) {
-      return;
-    }
-    // Hover-aware path: highlights without scrolling (#6077).
-    ctx.onItemMouseEnter(ctx.selectableItems[itemIndex], itemIndex);
-  }, [isDisabled, itemIndex, ctx]);
-
   return (
     <div
       ref={useMergedRefs(ref, itemRef)}
@@ -199,7 +191,7 @@ export function CommandPaletteItem({
       aria-disabled={isDisabled || undefined}
       data-value={value}
       onClick={composeEventHandlers(onClickProp, handleClick)}
-      onMouseEnter={composeEventHandlers(onMouseEnterProp, handleMouseEnter)}
+      onMouseEnter={onMouseEnterProp}
       {...mergeProps(
         themeProps('command-palette-item'),
         stylex.props(

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -1387,6 +1387,47 @@ describe('DateTimeInput', () => {
       expect(listbox).toHaveAttribute('aria-label');
     });
 
+    it('highlights on hover without scrolling, keyboard still scrolls (#6077)', () => {
+      // Hover must highlight only: scrollIntoView under a stationary pointer
+      // moves the next option under it, re-highlighting and scrolling again —
+      // a runaway auto-scroll loop with no user input.
+      const scrollIntoView = vi.fn();
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: scrollIntoView,
+      });
+      try {
+        const {container} = render(
+          <DateTimeInput
+            label="Meeting"
+            value={'2026-03-15T14:00' as ISODateTimeString}
+            timeOptionInterval={60}
+            onChange={() => {}}
+          />,
+        );
+
+        const timeInput = screen.getByLabelText('Meeting time');
+        fireEvent.click(timeInput);
+        scrollIntoView.mockClear();
+
+        const options = container
+          .querySelector('[role="listbox"]')!
+          .querySelectorAll('[role="option"]');
+        fireEvent.mouseEnter(options[5]);
+
+        expect(timeInput.getAttribute('aria-activedescendant')).toBe(
+          options[5].id,
+        );
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        fireEvent.keyDown(timeInput, {key: 'ArrowDown'});
+        expect(scrollIntoView).toHaveBeenCalledWith({block: 'nearest'});
+      } finally {
+        delete (HTMLElement.prototype as unknown as {scrollIntoView?: unknown})
+          .scrollIntoView;
+      }
+    });
+
     it('does not open the list when disabled', () => {
       render(
         <DateTimeInput

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -98,6 +98,7 @@ import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 import {useLocale, useTranslator} from '../i18n';
 
 import {useMergedRefs} from '../hooks/useMergedRefs';
+import {useHighlightedOptionScroll} from '../hooks/useHighlightedOptionScroll';
 import {NativeDateSegment} from './NativeDateSegment';
 import {NativeTimeSegment} from './NativeTimeSegment';
 import {TouchDateTimeField} from './TouchDateTimeField';
@@ -1145,22 +1146,15 @@ function PointerDateTimeField({
       ? timeOptions.length - 1
       : highlightedTimeIndex;
 
-  // Keep the active option visible. The listbox is a fixed-height scroll
-  // container, so without this a list opens at midnight with the highlight far
-  // below the fold, and keyboard navigation walks off-screen. Mirrors
-  // BaseTypeahead's scrollIntoView({block: 'nearest'}).
-  useEffect(() => {
-    if (
-      !timePopover.isOpen ||
-      activeTimeIndex < 0 ||
-      activeTimeIndex >= timeOptions.length
-    ) {
-      return;
-    }
-    document
-      .getElementById(timeOptionId(activeTimeIndex))
-      ?.scrollIntoView?.({block: 'nearest'});
-  }, [timePopover.isOpen, activeTimeIndex, timeOptionId, timeOptions.length]);
+  // Keep the active option visible; hover highlights never scroll (#6077).
+  // Both sides live in useHighlightedOptionScroll.
+  const highlightTimeOnHover = useHighlightedOptionScroll({
+    isOpen: timePopover.isOpen,
+    highlightedIndex: activeTimeIndex,
+    setHighlightedIndex: setHighlightedTimeIndex,
+    getOptionId: timeOptionId,
+    itemCount: timeOptions.length,
+  });
 
   /**
    * The selected time in the same shape the options carry. splitDateTime slices
@@ -1881,7 +1875,7 @@ function PointerDateTimeField({
                     // option, or blur would fire its own commit first.
                     onPointerDown={e => e.preventDefault()}
                     onClick={() => commitTimeOption(option.time)}
-                    onMouseEnter={() => setHighlightedTimeIndex(index)}
+                    onMouseEnter={() => highlightTimeOnHover(index)}
                     {...mergeProps(
                       themeProps('date-time-input-time-option'),
                       stylex.props(

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -1724,9 +1724,14 @@ describe('DropdownMenu keyboard access for menuitemradio/menuitemcheckbox (#3829
 
     // A mouse hover over another item moves focus to it, so the single
     // focus-driven highlight follows the pointer instead of leaving two.
+    // Focus must be scroll-free: scrolling the focused item into view moves
+    // the next item under the stationary pointer, which re-highlights and
+    // scrolls again — a runaway auto-scroll loop.
+    const focusSpy = vi.spyOn(del, 'focus');
     fireEvent.pointerMove(del, {pointerType: 'mouse'});
     expect(del).toHaveFocus();
     expect(edit).not.toHaveFocus();
+    expect(focusSpy).toHaveBeenCalledWith({preventScroll: true});
   });
 
   it('does not move focus on hover for a disabled item', async () => {

--- a/packages/core/src/DropdownMenu/menuItemHover.ts
+++ b/packages/core/src/DropdownMenu/menuItemHover.ts
@@ -35,6 +35,10 @@ export function focusMenuItemOnHover(
   }
   const el = e.currentTarget;
   if (el !== el.ownerDocument.activeElement) {
-    el.focus();
+    // preventScroll: focusing an off-screen item scrolls it under the
+    // stationary pointer, whose next pointerenter focuses it again — a
+    // runaway auto-scroll loop. Keyboard navigation scrolls via its own
+    // highlight handling; hover must never scroll.
+    el.focus({preventScroll: true});
   }
 }

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1574,6 +1574,50 @@ describe('MultiSelector', () => {
       }
     });
 
+    it('highlights on hover without scrolling, keyboard still scrolls (#6077)', async () => {
+      // Hover must highlight only: scrollIntoView under a stationary pointer
+      // moves the next option under it, re-highlighting and scrolling again —
+      // a runaway auto-scroll loop with no user input.
+      const scrollIntoView = vi.fn();
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: scrollIntoView,
+      });
+      try {
+        const user = userEvent.setup();
+        const longOptions = Array.from(
+          {length: 20},
+          (_, i) => `Option ${i + 1}`,
+        );
+        render(
+          <MultiSelector
+            label="Fruit"
+            options={longOptions}
+            value={[]}
+            onChange={() => {}}
+          />,
+        );
+
+        const trigger = screen.getByRole('combobox');
+        await user.click(trigger);
+        scrollIntoView.mockClear();
+
+        const options = screen.getAllByRole('option', {hidden: true});
+        fireEvent.mouseEnter(options[3]);
+
+        expect(trigger.getAttribute('aria-activedescendant')).toBe(
+          options[3].id,
+        );
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        await user.keyboard('{ArrowDown}');
+        expect(scrollIntoView).toHaveBeenCalledWith({block: 'nearest'});
+      } finally {
+        delete (HTMLElement.prototype as unknown as {scrollIntoView?: unknown})
+          .scrollIntoView;
+      }
+    });
+
     it('clears all values via Delete on the focused trigger', async () => {
       const user = userEvent.setup();
       const onChange = vi.fn();

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1241,18 +1241,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     listboxId,
   });
 
-  // Keep the highlighted option visible during keyboard navigation. The
-  // listbox is a fixed-height scroll container, so without this the virtual
-  // cursor walks off-screen once navigation passes the visible window. Mirrors
-  // CommandPaletteItem's scrollIntoView({block: 'nearest'}) behavior.
-  useEffect(() => {
-    if (!surface.isOpen || highlightedIndex < 0) {
-      return;
-    }
-    document
-      .getElementById(getItemId(highlightedIndex))
-      ?.scrollIntoView?.({block: 'nearest'});
-  }, [surface.isOpen, highlightedIndex, getItemId]);
+  // Highlight scrolling (and its hover/keyboard split) lives in useMultiCombobox.
 
   // Build trigger display content
   const selectedItems = useMemo(() => {

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -13,6 +13,7 @@
  */
 
 import {useCallback, useRef, useState} from 'react';
+import {useHighlightedOptionScroll} from '../hooks/useHighlightedOptionScroll';
 import type {MultiSelectorOptionData} from './types';
 
 interface UseMultiComboboxOptions {
@@ -107,13 +108,22 @@ export function useMultiCombobox({
     }
   }, [isDisabled, wasJustDismissed, isOpen, onOpen, closeAndReset, hasSearch]);
 
+  // The scroll effect lives here, the highlight owner, so the hover/keyboard
+  // split is shared instead of re-implemented in MultiSelector.tsx (#6077).
+  const highlightOnHover = useHighlightedOptionScroll({
+    isOpen,
+    highlightedIndex,
+    setHighlightedIndex,
+    getOptionId: getItemId,
+  });
+
   const onItemMouseEnter = useCallback(
     (item: MultiSelectorOptionData, index: number) => {
       if (!item.disabled) {
-        setHighlightedIndex(index);
+        highlightOnHover(index);
       }
     },
-    [],
+    [highlightOnHover],
   );
 
   const onKeyDown = useCallback(

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1728,6 +1728,44 @@ describe('Selector', () => {
           .scrollIntoView;
       }
     });
+
+    it('highlights on hover without scrolling, keyboard still scrolls (#6077)', async () => {
+      // Hover must highlight only: scrollIntoView under a stationary pointer
+      // moves the next option under it, re-highlighting and scrolling again —
+      // a runaway auto-scroll loop with no user input.
+      const scrollIntoView = vi.fn();
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: scrollIntoView,
+      });
+      try {
+        const user = userEvent.setup();
+        const longOptions = Array.from(
+          {length: 20},
+          (_, i) => `Option ${i + 1}`,
+        );
+        render(<Selector label="Fruit" options={longOptions} />);
+
+        await user.tab();
+        await user.keyboard('{Enter}'); // open
+        scrollIntoView.mockClear();
+
+        const options = screen.getAllByRole('option', {hidden: true});
+        fireEvent.mouseEnter(options[3]);
+
+        const trigger = screen.getByRole('combobox');
+        expect(trigger.getAttribute('aria-activedescendant')).toBe(
+          options[3].id,
+        );
+        expect(scrollIntoView).not.toHaveBeenCalled();
+
+        await user.keyboard('{ArrowDown}');
+        expect(scrollIntoView).toHaveBeenCalledWith({block: 'nearest'});
+      } finally {
+        delete (HTMLElement.prototype as unknown as {scrollIntoView?: unknown})
+          .scrollIntoView;
+      }
+    });
   });
 
   describe('typeahead', () => {

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1246,18 +1246,7 @@ export function Selector<T extends SelectorOptionType>(
     [isDisabled, isEffectivelyReadOnly, hasSearch, typeahead, onKeyDown],
   );
 
-  // Keep the highlighted option visible during keyboard navigation. The
-  // listbox is a fixed-height scroll container, so without this the virtual
-  // cursor walks off-screen once navigation passes the visible window. Mirrors
-  // CommandPaletteItem's scrollIntoView({block: 'nearest'}) behavior.
-  useEffect(() => {
-    if (!surface.isOpen || highlightedIndex < 0) {
-      return;
-    }
-    document
-      .getElementById(getItemId(highlightedIndex))
-      ?.scrollIntoView?.({block: 'nearest'});
-  }, [surface.isOpen, highlightedIndex, getItemId]);
+  // Highlight scrolling (and its hover/keyboard split) lives in useCombobox.
 
   // Handle clear button click
   const handleClear = useCallback(

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -11,6 +11,7 @@
  */
 
 import {useCallback, useState} from 'react';
+import {useHighlightedOptionScroll} from '../hooks/useHighlightedOptionScroll';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import type {RefObject} from 'react';
 import type {SelectorOptionData} from './types';
@@ -273,13 +274,22 @@ export function useCombobox({
     hasSearch,
   ]);
 
+  // The scroll effect lives here, the highlight owner, so every consumer
+  // (Selector, CommandPalette) shares one hover/keyboard split (#6077).
+  const highlightOnHover = useHighlightedOptionScroll({
+    isOpen,
+    highlightedIndex,
+    setHighlightedIndex,
+    getOptionId: getItemId,
+  });
+
   const onItemMouseEnter = useCallback(
     (item: SelectorOptionData, index: number) => {
       if (!item.disabled) {
-        setHighlightedIndex(index);
+        highlightOnHover(index);
       }
     },
-    [],
+    [highlightOnHover],
   );
 
   const onKeyDown = useCallback(

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -31,6 +31,7 @@ import {useBusyIndicatorLane} from './busyIndicatorLane';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
 import {useAnnounce} from '../hooks/useAnnounce';
+import {useHighlightedOptionScroll} from '../hooks/useHighlightedOptionScroll';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {isImeKeyEvent} from '../utils/ime';
 import {TypeaheadItem} from './TypeaheadItem';
@@ -916,22 +917,15 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
     [listboxId],
   );
 
-  // Keep the highlighted option visible during keyboard navigation. The
-  // listbox is a fixed-height scroll container, so without this the virtual
-  // cursor walks off-screen once navigation passes the visible window. Mirrors
-  // CommandPaletteItem's scrollIntoView({block: 'nearest'}) behavior.
-  useEffect(() => {
-    if (
-      !popover.isOpen ||
-      highlightedIndex < 0 ||
-      highlightedIndex >= results.length
-    ) {
-      return;
-    }
-    document
-      .getElementById(getItemId(highlightedIndex))
-      ?.scrollIntoView?.({block: 'nearest'});
-  }, [popover.isOpen, highlightedIndex, getItemId, results.length]);
+  // Keep the highlighted option visible during keyboard navigation; hover
+  // highlights never scroll (#6077). Both sides live in useHighlightedOptionScroll.
+  const highlightOnHover = useHighlightedOptionScroll({
+    isOpen: popover.isOpen,
+    highlightedIndex,
+    setHighlightedIndex,
+    getOptionId: getItemId,
+    itemCount: results.length,
+  });
 
   const selectedKey =
     value == null ? null : getKey(value.id, () => results.indexOf(value));
@@ -1035,7 +1029,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
                     aria-selected={isSelected}
                     tabIndex={-1}
                     onClick={() => handleSelect(item)}
-                    onMouseEnter={() => setHighlightedIndex(index)}
+                    onMouseEnter={() => highlightOnHover(index)}
                     {...stylex.props(
                       styles.item,
                       itemSizeStyles[size],

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -1376,6 +1376,48 @@ describe('BaseTypeahead paste behavior', () => {
         .scrollIntoView;
     }
   });
+
+  it('highlights on hover without scrolling, keyboard still scrolls (#6077)', async () => {
+    // Hover must highlight only: scrollIntoView under a stationary pointer
+    // moves the next option under it, re-highlighting and scrolling again —
+    // a runaway auto-scroll loop with no user input.
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    try {
+      const user = userEvent.setup();
+      render(
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.paste('e'); // matches Cherry, Date, Elderberry
+      await waitFor(() => {
+        expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
+      });
+
+      scrollIntoView.mockClear();
+      const options = screen.getAllByRole('option', {hidden: true});
+      fireEvent.mouseEnter(options[1]);
+
+      expect(input.getAttribute('aria-activedescendant')).toBe(options[1].id);
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      await user.keyboard('{ArrowDown}');
+      expect(scrollIntoView).toHaveBeenCalledWith({block: 'nearest'});
+    } finally {
+      delete (HTMLElement.prototype as unknown as {scrollIntoView?: unknown})
+        .scrollIntoView;
+    }
+  });
 });
 
 describe('Typeahead disabledMessage', () => {

--- a/packages/core/src/hooks/useHighlightedOptionScroll.ts
+++ b/packages/core/src/hooks/useHighlightedOptionScroll.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useHighlightedOptionScroll.ts
+ * @input Open state, the highlighted option index, its setter, and an
+ *   option-id resolver for the owning listbox
+ * @output Exports useHighlightedOptionScroll: keeps the highlighted option
+ *   scrolled into view for keyboard navigation while hover-driven highlights
+ *   never scroll
+ * @position Internal hook; used by useCombobox, useMultiCombobox,
+ *   BaseTypeahead, and DateTimeInput — the owners of combobox highlight state
+ */
+
+import {useCallback, useEffect, useRef} from 'react';
+
+interface UseHighlightedOptionScrollOptions {
+  isOpen: boolean;
+  highlightedIndex: number;
+  setHighlightedIndex: (index: number) => void;
+  getOptionId: (index: number) => string;
+  /**
+   * Current option count, when the list can change while open (filtered or
+   * min/max-clamped lists). A count change re-runs the scroll, matching the
+   * list-length dependency the per-component effects carried before this hook
+   * existed.
+   */
+  itemCount?: number;
+}
+
+/**
+ * Keep the highlighted option visible during keyboard navigation — but not for
+ * hover highlights. Hover must highlight only: scrollIntoView moves the next
+ * option under the stationary pointer, whose mouseenter re-highlights and
+ * scrolls again — a runaway auto-scroll loop with no user input (#6077).
+ * Keyboard paths call the raw setter directly and keep their scrolling; hover
+ * paths call the returned callback.
+ */
+export function useHighlightedOptionScroll({
+  isOpen,
+  highlightedIndex,
+  setHighlightedIndex,
+  getOptionId,
+  itemCount,
+}: UseHighlightedOptionScrollOptions): (index: number) => void {
+  const hoverHighlightRef = useRef(false);
+
+  const highlightFromHover = useCallback(
+    (index: number) => {
+      if (index !== highlightedIndex) {
+        hoverHighlightRef.current = true;
+      }
+      setHighlightedIndex(index);
+    },
+    [highlightedIndex, setHighlightedIndex],
+  );
+
+  useEffect(() => {
+    if (hoverHighlightRef.current) {
+      hoverHighlightRef.current = false;
+      return;
+    }
+    if (!isOpen || highlightedIndex < 0) {
+      return;
+    }
+    document
+      .getElementById(getOptionId(highlightedIndex))
+      ?.scrollIntoView?.({block: 'nearest'});
+  }, [isOpen, highlightedIndex, getOptionId, itemCount]);
+
+  return highlightFromHover;
+}


### PR DESCRIPTION
Fixes #6077

When a scrollable menu's highlight follows the mouse, scrolling the highlighted item into view moves the next item under the stationary pointer, which re-highlights and scrolls again — a runaway auto-scroll loop with no user input.

Two instances of the same pattern:

- **`Chat/useTriggerMenu.tsx`**: hover-driven highlight changes now skip one run of the scroll-into-view effect (`hoverHighlightRef`); keyboard navigation still scrolls the highlighted option into view.
- **`DropdownMenu/menuItemHover.ts`**: `focusMenuItemOnHover` now calls `el.focus({preventScroll: true})`. This is a one-line root-cause fix that covers DropdownMenu, ContextMenu, and BreadcrumbMenu items via the shared helper — the focus highlight does not require scrolling, and keyboard navigation has its own scroll-into-view handling.

## Tests

- `DropdownMenu.test.tsx`: the existing hover-focus test now asserts `focus` was called with `{preventScroll: true}` (regression guard for the auto-scroll loop).
- `ChatComposerInput.test.tsx`: coverage for the hover-skip behavior in `useTriggerMenu`.
