### PR TITLE
perf(ci): give the heavier test lane the larger runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,13 +180,14 @@ jobs:
   #
   # The projects are independent by construction (see vitest.config.ts: `ui` is
   # jsdom + StyleX, `node` is everything else), so running them as two jobs
-  # costs no duplicate execution and each lane carries roughly half the work.
-  # `node` is the heavier lane — locally 570s against the ui project's 244s —
-  # so it takes the larger supported runner while `ui` stays on the 2-core arm
-  # box.
+  # costs no duplicate execution. They do NOT carry half the work each: on this
+  # CI, `ui` is ~5x the heavier lane, so it takes the larger runner.
   #
-  # The repo-wide guardrail steps ride the LIGHTER lane, so the slow one is
-  # nothing but tests.
+  # The earlier local figure that put `node` ahead (570s vs 244s) was not a
+  # comparable measurement — only the node run was bounded to a small worker
+  # pool, and node is the project whose cost is per-assertion CLI subprocesses.
+  #
+  # The repo-wide guardrail steps ride `test-ui` (~18s of it).
   #
   # `test` remains a job, so the required check of that name still exists and
   # still reports for every PR. This mirrors the `build` join over
@@ -194,7 +195,7 @@ jobs:
   test-ui:
     needs: [check-scope]
     if: ${{ always() && !cancelled() }}
-    runs-on: 2-core-ubuntu-arm
+    runs-on: 4-core-ubuntu
     permissions:
       contents: read
     steps:
@@ -252,7 +253,7 @@ jobs:
   test-node:
     needs: [check-scope]
     if: ${{ always() && !cancelled() }}
-    runs-on: 4-core-ubuntu
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,8 +79,11 @@ jobs:
   # independent by construction (vitest.config.ts), so they split cleanly; the
   # typecheck gates need the `pnpm build` they follow, so they stay together in
   # their own lane and take the build with them.
+  #
+  # `ui` is the heavier project by ~4x here, so it takes the larger runner (see
+  # ci.yml's lane comment).
   test-ui:
-    runs-on: 2-core-ubuntu-arm
+    runs-on: 4-core-ubuntu
     permissions:
       contents: read
     steps:
@@ -93,7 +96,7 @@ jobs:
       - run: pnpm vitest run --project ui
 
   test-node:
-    runs-on: 4-core-ubuntu
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Why

`test-ui` and `test-node` hold their runners the wrong way round relative to the work they carry.

| lane | runner | job | suite step |
|---|---|---|---|
| `test-ui` | `2-core-ubuntu-arm` | **14m52s** | 834s |
| `test-node` | `4-core-ubuntu` | 3m18s | 165s |

Run [34000689684](https://github.com/facebook/astryx/actions/runs/34000689684) (`main`, success). Reproduced on 33994177354 (926s/189s) and 33980770638 (974s/194s), and on deploy runs 33980455596 and 33952374356.

The 4-core box is under the three-minute lane. The fifteen-minute lane — the one nearest the ~20 minute wall the lane comment itself describes — is on the 2-core arm box.

## The number that put it there

The comment introduced with the lane split says:

> `node` is the heavier lane — locally 570s against the ui project's 244s — so it takes the larger supported runner while `ui` stays on the 2-core arm box.

That comparison does not appear to be like-for-like. #6051's own validation notes record the node suite as run **"with bounded workers"**; the ui line carries no such note. And `node` is precisely the project that a bounded pool penalises — `vitest.config.ts` documents that it runs on the forks pool because CLI tests call `process.chdir()`, and that "several CLI suites spawn a fresh `node bin/astryx.mjs` **per assertion** (real process boundary)".

The CI numbers are hard to reconcile with 570s any other way: unbounded, the node lane finishes in 165s **while also paying** the cold `ensureCoreBuilt()` core build that a warm local tree skips (`build-theme.data-tokens.test.mjs:117` — "ensureCoreBuilt() only checks that dist exists"). The local run had strictly less work and still took 3.5x longer.

I've rewritten the comment to state what CI measures, and to record why the local figure isn't comparable.

## What this changes

Four `runs-on:` values, two in each workflow. `deploy.yml` carried the same allocation.

Nothing else moves. In particular the repo-wide guardrail steps stay on `test-ui`, so the "they ride the LIGHTER lane" claim is now simply corrected in place rather than acted on — they cost ~18s of an 892s job, and moving them is a separate change that isn't worth coupling to this one.

## Verification

`.github/scripts/ci-test-routing.test.mjs` passes unchanged — **17/17**. Both labels are already in `KNOWN_RUNNERS` (`:47-52`) and no assertion in the file binds a lane to a runner, which is why this needed no test edit.

The real verification is this PR's own CI run: it reports the swapped allocation directly, against the numbers above.

## What this does not do

This does not close [#4339](https://github.com/facebook/astryx/issues/4339)'s original criterion. On run 34000689684 `test-ui` finished 385s after `build-sandbox`, and the workflow ended 17s later — the test lane is still the critical path, just no longer a re-push casualty. Subdividing `ui` is the next lever and is deliberately not in this PR; a `strategy: matrix` inside the existing `test-ui` job passes all 17 contract cases, so it can land separately on measured numbers.

Filed because the headroom is thin: `test-ui` is at 14m52s against a wall its own comment puts at ~20 minutes, and the ui project went 439s → 834s in roughly three weeks.
