### PR TITLE
fix(core): floor SegmentedControlItem to a 44px touch target on coarse pointers

### DIFF
--- a/.changeset/segmented-control-touch-floor.md
+++ b/.changeset/segmented-control-touch-floor.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Floor SegmentedControlItem to a 44px touch target on coarse pointers — `size="lg"` topped out at 32px, below the WCAG 2.2 AA "Target Size (Minimum)" / Apple HIG / Material floor every other interactive control honours; desktop density is unchanged. (#6013)
+@ManoharPaturi

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -74,7 +74,8 @@ export const docs = {
     {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
-      description: 'Size variant for the control.',
+      description:
+        'Size variant for the control. On coarse pointers every size is floored to a 44px touch target (WCAG 2.2 AA "Target Size (Minimum)").',
       default: "'md'",
     },
     {

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -838,4 +838,65 @@ describe('forced colors (WCAG 1.4.11)', () => {
     // both render as authored.
     expect(getAllInjectedCss()).toContain('forced-color-adjust: none;');
   });
+  interface InjectedRule {
+    selector: string;
+    text: string;
+    media: string | null;
+  }
+
+  /**
+   * Every style rule StyleX has injected at runtime (`runtimeInjection` in the
+   * root vitest config), flattened out of any at-rule wrapper and tagged with
+   * that wrapper's condition — so a `@media (pointer: coarse)` rule stays
+   * distinguishable from the unconditional one. Mirrors the InputClearButton
+   * helper of the same name.
+   */
+  function injectedRules(): InjectedRule[] {
+    const walk = (rules: CSSRuleList, condition: string | null) =>
+      [...rules].flatMap((rule): InjectedRule[] => {
+        const {selectorText} = rule as CSSStyleRule;
+        if (typeof selectorText === 'string') {
+          return [
+            {selector: selectorText, text: rule.cssText, media: condition},
+          ];
+        }
+        const nested = (rule as CSSGroupingRule).cssRules;
+        if (nested == null) {
+          return [];
+        }
+        const own = (rule as CSSMediaRule).media?.mediaText;
+        return walk(nested, own != null && own !== '' ? own : condition);
+      });
+
+    return [...document.styleSheets].flatMap(sheet =>
+      walk(sheet.cssRules, null),
+    );
+  }
+
+  describe('touch target floor', () => {
+    it('floors segment items to 44px on coarse pointers only', () => {
+      render(
+        <SegmentedControl label="View" value="a" onChange={() => {}}>
+          <SegmentedControlItem value="a" label="Alpha" />
+          <SegmentedControlItem value="b" label="Beta" />
+        </SegmentedControl>,
+      );
+      const item = screen.getByRole('radio', {name: 'Alpha'});
+      const classes = [...item.classList];
+
+      // The coarse-pointer rule carries the 44px floor for the item's classes.
+      const coarse = injectedRules().filter(
+        r =>
+          r.media?.includes('pointer: coarse') &&
+          classes.some(c => r.selector.includes(c)),
+      );
+      expect(coarse.some(r => /min-height\s*:\s*44px/.test(r.text))).toBe(true);
+
+      // No unconditional floor: desktop density is unchanged.
+      const fine = injectedRules().filter(
+        r => r.media == null && classes.some(c => r.selector.includes(c)),
+      );
+      expect(fine.some(r => r.text.includes('min-height'))).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -66,6 +66,13 @@ export interface SegmentedControlItemProps extends BaseProps<HTMLButtonElement> 
 // Styles
 // =============================================================================
 
+// WCAG 2.2 AA "Target Size (Minimum)" / Apple HIG / Material floor for phone
+// surfaces. Sizes top out at 32px (`lg`), below the 44px every other
+// interactive target honours, so floor every size on a coarse pointer —
+// desktop density is unchanged — mirroring TouchDateField's monthArrow floor
+// (#6013).
+const TOUCH_TARGET = '44px';
+
 const styles = stylex.create({
   base: {
     position: 'relative',
@@ -90,6 +97,7 @@ const styles = stylex.create({
     transitionProperty: 'color, background-color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
+    minHeight: {default: null, '@media (pointer: coarse)': TOUCH_TARGET},
   },
   hover: {
     backgroundColor: {


### PR DESCRIPTION
Fixes #6013

## Summary

`SegmentedControlItem` topped out at 32px (`size="lg"` = `--size-element-lg` − 4px), below the 44px minimum touch target of WCAG 2.2 AA "Target Size (Minimum)" / Apple HIG / Material — and since `lg` is the ceiling, no prop combination could reach the floor. `Button` and `ToggleButton` already honour the floor on phone surfaces; the segmented control's class was simply not in it.

## Change

A `@media (pointer: coarse)` `min-height: 44px` floor on the item's base style — mirroring `TouchDateField`'s `monthArrow` floor (`min-height` scoped to coarse pointers, `default: null`). Every size is floored on touch; **desktop density is unchanged** (no unconditional rule), which is the part consumers cannot safely do themselves.

## Tests

New case in `SegmentedControl.test.tsx` using the repo's `injectedRules()` CSSOM pattern (mirroring `InputClearButton`): the item's classes have a coarse-pointer rule carrying `min-height: 44px`, and no unconditional min-height exists. Verified the test fails on the unfloored component and passes with the fix.

`vitest run packages/core/src/SegmentedControl` → 44 passed; core `tsc --noEmit`, eslint, `check:sync`, and `check:changesets` clean. Doc note on the `size` prop; changeset included.