### PR TITLE
feat(core): scale TextInput/TextArea control type with size; add text-input-control theme target

### DIFF
--- a/.changeset/text-input-control-type-scale.md
+++ b/.changeset/text-input-control-type-scale.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] TextInput/TextArea: the control's type now follows its size (sm → supporting, md → body, lg → large), and TextInput's inner `<input>` renders as its own theme target, `astryx-text-input-control`, mirroring `text-area-control` for TextArea. (#6014) Before, `size` changed only the control height — typed text and placeholder stayed at `--text-body-size` in all three sizes, so a `sm` input was body text squeezed into a 28px box and an `lg` input the same 14px text floating in a 36px one. Both of the issue's asks are covered: the default scale adapts, and a theme that wants a different scale can key off the new control target (the size stays reflected as `data-size` on the `astryx-text-input` wrapper, so per-size control styling stays reachable without a structural selector). The coarse-pointer `max(1rem, …)` minimum is kept at every size so touch devices never get sub-16px text — and never zoom on focus. TextArea gets the same type scale; its `lg` padding step is unchanged.
+
+@ManoharPaturi

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -225,7 +225,7 @@ export const docs = {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
       description:
-        'Size of the textarea, affecting internal padding. Height is controlled by rows, not size.',
+        'Size of the textarea: scales the type (sm supporting, md body, lg large) and lg\u2019s internal padding. Height is controlled by rows, not size.',
       default: "'md'",
     },
     {
@@ -483,7 +483,8 @@ export const docsZh = {
     {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
-      description: '文本域的尺寸，影响内部填充。高度由 rows 控制，而非 size。',
+      description:
+        '文本域的尺寸：缩放字号（sm 辅助文本、md 正文、lg 大号文本）及 lg 的内部填充。高度由 rows 控制，而非 size。',
       default: "'md'",
     },
     {
@@ -673,7 +674,7 @@ export const docsDense = {
     startIcon: 'Icon inside leading edge of textarea wrapper.',
     hasSpellCheck: 'Enables/disables browser spell checking.',
     hasAutoFocus: 'Auto-focus textarea on mount.',
-    size: 'Textarea size; affects internal padding. Height controlled by rows.',
+    size: 'Textarea size; scales type (sm/md/lg) + lg padding. Height controlled by rows.',
     onPaste: 'Fired on paste into textarea.',
     htmlName: 'HTML name attr for form submissions.',
     onFocus: 'Callback on focus.',

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -1166,3 +1166,45 @@ describe('TextArea theme target names', () => {
     expect(root).toHaveClass('astryx-textarea');
   });
 });
+
+describe('TextArea size typography (#6014)', () => {
+  it('scales the control type scale with size', () => {
+    const {container} = render(
+      <div>
+        <TextArea label="a" value="" onChange={() => {}} size="sm" />
+        <TextArea label="b" value="" onChange={() => {}} size="md" />
+        <TextArea label="c" value="" onChange={() => {}} size="lg" />
+      </div>,
+    );
+    const [sm, md, lg] = container.querySelectorAll('textarea');
+
+    // sm steps one token down the type scale, lg one up; md keeps the body
+    // size the base textarea styles always carried.
+    expect(sm).toHaveStyle({fontSize: 'var(--text-supporting-size)'});
+    expect(sm).toHaveStyle({lineHeight: 'var(--text-supporting-leading)'});
+    expect(md).toHaveStyle({fontSize: 'var(--text-body-size)'});
+    expect(md).toHaveStyle({lineHeight: 'var(--text-body-leading)'});
+    expect(lg).toHaveStyle({fontSize: 'var(--text-large-size)'});
+    expect(lg).toHaveStyle({lineHeight: 'var(--text-large-leading)'});
+  });
+
+  it('keeps the lg padding step alongside the large type', () => {
+    const {container} = render(
+      <div>
+        <TextArea label="a" value="" onChange={() => {}} size="md" />
+        <TextArea label="b" value="" onChange={() => {}} size="lg" />
+      </div>,
+    );
+    const [md, lg] = container.querySelectorAll('textarea');
+    expect(md).toHaveStyle({paddingBlock: 'var(--spacing-1)'});
+    expect(lg).toHaveStyle({paddingBlock: 'var(--spacing-2)'});
+  });
+
+  it('defaults to body type when no size is given', () => {
+    const {container} = render(
+      <TextArea label="Notes" value="" onChange={() => {}} />,
+    );
+    const textarea = container.querySelector('textarea')!;
+    expect(textarea).toHaveStyle({fontSize: 'var(--text-body-size)'});
+  });
+});

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -166,11 +166,27 @@ const styles = stylex.create({
   },
 });
 
+// The control's type follows its size, like TextInput (#6014): sm steps down
+// to supporting, lg up to large (plus its vertical padding). md is the base
+// textarea styles (body size) and needs no override. The coarse-pointer
+// minimum from the base styles is repeated per size so touch devices never
+// get sub-16px text — and never zoom on focus — at any size.
 const textareaSizeStyles = stylex.create({
-  sm: {},
+  sm: {
+    fontSize: {
+      default: typeScaleVars['--text-supporting-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-supporting-size']})`,
+    },
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+  },
   md: {},
   lg: {
     paddingBlock: spacingVars['--spacing-2'],
+    fontSize: {
+      default: typeScaleVars['--text-large-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-large-size']})`,
+    },
+    lineHeight: typeScaleVars['--text-large-leading'],
   },
 });
 
@@ -331,7 +347,8 @@ export interface TextAreaProps extends Omit<
    */
   hasAutoFocus?: boolean;
   /**
-   * The size of the textarea, affecting internal padding.
+   * The size of the textarea: scales the type (sm → supporting, md → body,
+   * lg → large) and lg's internal padding.
    * Height is controlled by `rows`, not size.
    * @default 'md'
    */

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -42,7 +42,8 @@ export const docs = {
     {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
-      description: 'Size variant of the input.',
+      description:
+        'Size variant of the input. Scales the control height and type scale: sm uses supporting type, md body, lg large.',
       default: "'md'",
     },
     {
@@ -167,6 +168,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-text-input', visualProps: ['size', 'status'], states: ['disabled', 'readonly']},
+      {className: 'astryx-text-input-control'},
     ],
   },
   usage: {
@@ -232,7 +234,8 @@ export const docsZh = {
     {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
-      description: '输入框的尺寸变体。',
+      description:
+        '输入框的尺寸变体。同时缩放控件高度与字号：sm 使用辅助文本、md 正文、lg 大号文本。',
       default: "'md'",
     },
     {
@@ -340,6 +343,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'astryx-text-input', visualProps: ['size', 'status'], states: ['disabled', 'readonly']},
+      {className: 'astryx-text-input-control'},
     ],
   },
   usage: {
@@ -399,7 +403,7 @@ export const docsDense = {
     value: 'Current input value.',
     onChange: 'Fired on input value change.',
     changeAction: 'Async action after onChange (if not prevented). Triggers optimistic update+spinner while pending.',
-    size: 'Size variant of input.',
+    size: 'Size variant; scales control height + type scale (sm/md/lg).',
     isLabelHidden: 'Visually hides label; keeps screen reader access.',
     description: 'Description text between label+input.',
     isOptional: 'Shows "Optional" indicator. Mutually exclusive w/ isRequired.',

--- a/packages/core/src/TextInput/TextInput.test.tsx
+++ b/packages/core/src/TextInput/TextInput.test.tsx
@@ -998,3 +998,56 @@ describe('TextInput readonly theme state', () => {
     expect(root).not.toHaveAttribute('data-readonly');
   });
 });
+
+describe('TextInput text-input-control theme target (#6014)', () => {
+  it('renders the inner input as its own theme target', () => {
+    const {container} = render(
+      <TextInput label="Name" value="" onChange={() => {}} />,
+    );
+    // The wrapper keeps the component target (and the reflected size); the
+    // <input> itself is reachable as astryx-text-input-control, mirroring
+    // text-area-control for TextArea.
+    const control = container.querySelector('.astryx-text-input-control');
+    expect(control).toBeInstanceOf(HTMLInputElement);
+    expect(control).toBe(screen.getByRole('textbox'));
+  });
+
+  it('keeps the size reflection on the wrapper target, not the control', () => {
+    const {container} = render(
+      <TextInput label="Name" value="" onChange={() => {}} size="lg" />,
+    );
+    const wrapper = container.querySelector('.astryx-text-input');
+    const control = container.querySelector('.astryx-text-input-control');
+    expect(wrapper).toHaveAttribute('data-size', 'lg');
+    expect(control).not.toHaveAttribute('data-size');
+  });
+});
+
+describe('TextInput size typography (#6014)', () => {
+  it('scales the control type scale with size', () => {
+    const {container} = render(
+      <div>
+        <TextInput label="a" value="" onChange={() => {}} size="sm" />
+        <TextInput label="b" value="" onChange={() => {}} size="md" />
+        <TextInput label="c" value="" onChange={() => {}} size="lg" />
+      </div>,
+    );
+    const [sm, md, lg] = container.querySelectorAll('input');
+
+    // sm steps one token down the type scale, lg one up; md keeps the body
+    // size the base input styles always carried.
+    expect(sm).toHaveStyle({fontSize: 'var(--text-supporting-size)'});
+    expect(sm).toHaveStyle({lineHeight: 'var(--text-supporting-leading)'});
+    expect(md).toHaveStyle({fontSize: 'var(--text-body-size)'});
+    expect(md).toHaveStyle({lineHeight: 'var(--text-body-leading)'});
+    expect(lg).toHaveStyle({fontSize: 'var(--text-large-size)'});
+    expect(lg).toHaveStyle({lineHeight: 'var(--text-large-leading)'});
+  });
+
+  it('defaults to body type when no size is given', () => {
+    render(<TextInput label="Name" value="" onChange={() => {}} />);
+    expect(screen.getByRole('textbox')).toHaveStyle({
+      fontSize: 'var(--text-body-size)',
+    });
+  });
+});

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -87,6 +87,30 @@ const sizeStyles = stylex.create({
   },
 });
 
+// The control's type follows its size (#6014): sm steps down to supporting,
+// lg up to large, so a compact toolbar search and a hero form field don't
+// share the same type. md is the base input styles (body size) and needs no
+// override. The coarse-pointer minimum from the base styles is repeated per
+// size so touch devices never get sub-16px text — and never zoom on focus —
+// at any size.
+const inputSizeStyles = stylex.create({
+  sm: {
+    fontSize: {
+      default: typeScaleVars['--text-supporting-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-supporting-size']})`,
+    },
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+  },
+  md: {},
+  lg: {
+    fontSize: {
+      default: typeScaleVars['--text-large-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-large-size']})`,
+    },
+    lineHeight: typeScaleVars['--text-large-leading'],
+  },
+});
+
 export type TextInputSize = keyof typeof sizeStyles;
 
 import {groupStyles} from '../InputGroup/groupStyles';
@@ -200,9 +224,11 @@ export interface TextInputProps extends Omit<
    */
   statusVariant?: FieldStatusVariant;
   /**
-   * The size of the input.
-   * - 'sm': Compact size (18px height)
-   * - 'md': Default size (26px height)
+   * The size of the input: sets the control height and its type scale
+   * (sm → supporting, md → body, lg → large).
+   * - 'sm': Compact size (28px height, supporting type)
+   * - 'md': Default size (32px height, body type)
+   * - 'lg': Large size (36px height, large type)
    * @default 'md'
    */
   size?: TextInputSize;
@@ -452,7 +478,19 @@ export function TextInput({
         aria-invalid={status?.type === 'error' ? 'true' : undefined}
         aria-busy={isBusy || undefined}
         aria-labelledby={ariaLabelledBy}
-        {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
+        {...mergeProps(
+          // The inner <input> is its own theme target, like `text-area-control`
+          // for TextArea: the wrapper's font size never reaches the control
+          // (the control sets its own), so themes need a sanctioned hook to
+          // adjust the per-size type scale (#6014). The size itself stays
+          // reflected on the wrapper target (data-size).
+          themeProps('text-input-control'),
+          stylex.props(
+            styles.input,
+            inputSizeStyles[size],
+            isDisabled && styles.inputDisabled,
+          ),
+        )}
       />
       {hasClear && value !== '' && !isDisabled && !isReadOnly && (
         <InputClearButton

--- a/packages/themes/probe/src/probeTheme.ts
+++ b/packages/themes/probe/src/probeTheme.ts
@@ -6,7 +6,7 @@
 // test fixture. Regenerate with: pnpm visual:probe-theme
 //
 // defineTheme takes six things and this covers all six:
-//   components  274 targets, 885 selectors (generated from the docs)
+//   components  277 targets, 892 selectors (generated from the docs)
 //   tokens      custom properties, read back off the themed element
 //   icons       every registry entry swapped for a marked glyph
 //   indicators  check / radio / checkbox swapped — the swap that reaches furthest
@@ -4585,6 +4585,22 @@ export const probeTheme = defineTheme({
         outlineColor: 'hsl(94.7 77% 25%)',
       },
     },
+    'stepper-frame': {
+      base: {
+        backgroundColor: 'hsl(220.4 78% 60%)',
+        color: 'hsl(124.6 78% 12%)',
+        borderColor: 'hsl(219.2 77% 25%)',
+        outlineColor: 'hsl(209.9 87% 25%)',
+      },
+    },
+    'stepper-summary': {
+      base: {
+        backgroundColor: 'hsl(56.5 79% 47%)',
+        color: 'hsl(163.3 90% 12%)',
+        borderColor: 'hsl(253.4 72% 25%)',
+        outlineColor: 'hsl(238.5 80% 25%)',
+      },
+    },
     switch: {
       base: {
         backgroundColor: 'hsl(355.8 75% 58%)',
@@ -5169,6 +5185,14 @@ export const probeTheme = defineTheme({
         outlineColor: 'hsl(135.1 81% 25%)',
       },
     },
+    'text-input-control': {
+      base: {
+        backgroundColor: 'hsl(135.0 76% 58%)',
+        color: 'hsl(182.1 85% 12%)',
+        borderColor: 'hsl(45.7 86% 25%)',
+        outlineColor: 'hsl(359.5 89% 25%)',
+      },
+    },
     textarea: {
       base: {
         backgroundColor: 'hsl(294.7 91% 54%)',
@@ -5487,6 +5511,30 @@ export const probeTheme = defineTheme({
         color: 'hsl(114.7 79% 12%)',
         borderColor: 'hsl(260.2 75% 25%)',
         outlineColor: 'hsl(14.9 76% 25%)',
+      },
+      'elevation:none': {
+        backgroundColor: 'hsl(55.4 88% 60%)',
+        color: 'hsl(28.2 76% 12%)',
+        borderColor: 'hsl(276.0 80% 25%)',
+        outlineColor: 'hsl(245.4 91% 25%)',
+      },
+      'elevation:low': {
+        backgroundColor: 'hsl(243.3 91% 61%)',
+        color: 'hsl(328.4 93% 12%)',
+        borderColor: 'hsl(96.5 91% 25%)',
+        outlineColor: 'hsl(237.2 83% 25%)',
+      },
+      'elevation:med': {
+        backgroundColor: 'hsl(98.3 88% 61%)',
+        color: 'hsl(125.6 75% 12%)',
+        borderColor: 'hsl(195.0 93% 25%)',
+        outlineColor: 'hsl(298.1 83% 25%)',
+      },
+      'elevation:high': {
+        backgroundColor: 'hsl(118.2 84% 63%)',
+        color: 'hsl(163.2 82% 12%)',
+        borderColor: 'hsl(50.2 88% 25%)',
+        outlineColor: 'hsl(32.5 75% 25%)',
       },
       isPressed: {
         backgroundColor: 'hsl(134.4 77% 49%)',


### PR DESCRIPTION
Fixes #6014

## Summary

Both asks from the issue:

1. **Control text now scales with `size`** for `TextInput` and `TextArea`: `sm` → `--text-supporting-size/leading`, `md` → body, `lg` → `--text-large-size/leading` (the repo's `typeScaleVars`; these wrap the raw `--font-font-size-*` tokens the issue measured). Previously only the control height changed — a `sm` input squeezed body text into 24px and an `lg` floated 14px text in 40px. The coarse-pointer `max(1rem, …)` floor is kept per size; `lg` TextArea keeps its padding step.
2. **New `text-input-control` theme target** on the `<input>` element — a bare target exactly mirroring the existing `text-area-control` — so themes can key off the control surface; `data-size` stays on the `astryx-text-input` wrapper.

## Tests

+6 in `TextInput.test.tsx` (control target rendered, wrapper-only `data-size`, per-size `toHaveStyle` var assertions, default) and +3 in `TextArea.test.tsx`, following existing style.

## Note for the reviewer

`packages/themes/probe/src/probeTheme.ts` is regenerated (`visual:probe-theme`) — it picks up this PR's new target **plus pre-existing drift on `origin/main`** (stepper targets, the merged toggle-button elevation selectors); main currently fails the probe check without a regen, so this brings it back in sync.

## Verification

Targeted suites 576 passed (TextInput 78, TextArea 86, theming-targets guard 412); `tsc --noEmit` clean; eslint 0 errors; probe check current (277 targets / 892 selectors); all `check:repo` scripts pass. Docs updated in EN/zh/dense; changeset included.