### PR TITLE
Spec: generate the visual-prop contract from TypeScript

### DIFF
--- a/.changeset/theme-adaptations.md
+++ b/.changeset/theme-adaptations.md
@@ -1,0 +1,42 @@
+---
+'@astryxdesign/core': minor
+'@astryxdesign/cli': minor
+---
+
+[breaking] Add ordered environmental adaptations to `defineTheme`
+
+Themes can now opt into CSS-first token, theme-local token, and component
+changes for named viewport widths, primary-pointer precision, contrast
+preference, and motion preference:
+
+```ts
+defineTheme({
+  name: 'acme',
+  adaptations: {
+    widthBreakpoints: {sm: 640, md: 768, lg: 1024, xl: 1280, '2xl': 1536},
+    rules: [
+      {
+        when: {width: {from: 'lg', below: 'xl'}, pointer: 'coarse'},
+        value: {tokens: {'--size-element-md': '44px'}},
+      },
+    ],
+  },
+});
+```
+
+Condition fields are ANDed. `width.from` is inclusive, `width.below` is
+exclusive, and rules cascade in declaration order so later matching writes win.
+Theme extension preserves the effective breakpoint map and inherited rule order;
+static builds retain the metadata needed for source-equivalent extension.
+
+`AppShell` now accepts `xl` and `2xl` for `mobileNav.breakpoint` and resolves all
+five names through the nearest Theme. Mobile mode now uses the documented
+exclusive boundary (`width < breakpoint`), so an AppShell exactly at the named
+point renders the wider layout instead of the mobile layout.
+
+`defineTheme` now rejects malformed token values instead of coercing non-string
+scalars or accepting arrays with a length other than two. It also validates the
+combined portable and theme-local token graph for every reachable set of matching
+adaptation rules, rejecting cycles before CSS is emitted.
+
+@imdreamrunner

--- a/.changeset/theme-adaptations.md
+++ b/.changeset/theme-adaptations.md
@@ -37,6 +37,8 @@ point renders the wider layout instead of the mobile layout.
 `defineTheme` now rejects malformed token values instead of coercing non-string
 scalars or accepting arrays with a length other than two. It also validates the
 combined portable and theme-local token graph for every reachable set of matching
-adaptation rules, rejecting cycles before CSS is emitted.
+adaptation rules, rejecting cycles before CSS is emitted. Rule-only visual-prop
+values are rejected when tooling can enumerate the finite built-in domain; opaque
+alias-backed domains retain the known validation boundary shared with root themes.
 
 @imdreamrunner

--- a/docs/architecture/component-theming-surface.md
+++ b/docs/architecture/component-theming-surface.md
@@ -30,7 +30,7 @@ verified_by:
     packages/core/src/theme/extensibleAxes.test.ts,
     packages/core/src/theme/derivedVarRegistry.test.ts,
   ]
-deciding_specs: []
+deciding_specs: [spec:AST-012/DEC-2, spec:AST-012/DEC-3]
 ---
 
 # Component theming surface
@@ -79,6 +79,11 @@ public `.doc.mjs` `theming.targets[].visualProps` / `states` metadata, and check
 component-spec metadata describe those selector axes without exposing maintainer
 dispositions to consumers; they do not declare which CSS properties have
 guaranteed behavior.
+
+An adaptation rule may style an existing visual-prop value but does not create a
+conditional type surface. A custom value is introduced on the effective root
+`components` map, where build tooling can generate unconditional module
+augmentation; adaptation rules may then restyle that value under conditions.
 
 The shared guaranteed-property catalog is:
 
@@ -174,6 +179,10 @@ but acceptance alone is best effort, not a compatibility promise.
   silently changing geometry, alignment, or composition. Behavioral, structural,
   placement, directional, and state-machine axes remain closed regardless. A
   theme may redefine an existing value on a closed axis, but it may not add one.
+- **INV15 — Conditional styling does not create conditional API.** Adaptation
+  rules may style only visual-prop values already present in the built-in or
+  effective root surface. New values are declared at the root before any rule
+  uses them, so generated types do not depend on a media condition.
 
 This record does not own semantic token definitions, theme authoring precedence,
 how themes become output, or the design rationale for a component's appearance.
@@ -240,8 +249,8 @@ how themes become output, or the design rationale for a component's appearance.
 
 ## Deciding specs
 
-None. The qualification rule, consumer boundary, property support tiers, and
-capability-based package scope were selected by the system owner.
+- `spec:AST-012/DEC-2` and `spec:AST-012/DEC-3` constrain adaptation component
+  writes to the closed ordered rule model.
 
 ## Verification
 
@@ -256,6 +265,7 @@ capability-based package scope were selected by the system owner.
 | INV10, INV11 | Existing registry/public-var/runtime tests (partial; gaps below)                                                   | A public semantic var bypasses admission, or a consumer must write a private var to reach promised behavior                 |
 | INV12, INV13 | Alias and family-owner fixtures                                                                                    | Deprecated aliases count as current parts or cross-doc ownership remains implicit                                           |
 | INV14        | Component contract, owner review, focused no-match fallback test, and structural `extensibleAxes.test.ts` coverage | An ineligible axis opens, a missing rule changes behavior unpredictably, or the map/reflection/docs wiring drifts           |
+| INV15        | Theme build adaptation fixtures                                                                                    | A rule-only custom value creates conditional CSS without an unconditional public type surface                               |
 
 Known conformance and verification gaps:
 

--- a/docs/architecture/component-theming-surface.md
+++ b/docs/architecture/component-theming-surface.md
@@ -182,7 +182,10 @@ but acceptance alone is best effort, not a compatibility promise.
 - **INV15 — Conditional styling does not create conditional API.** Adaptation
   rules may style only visual-prop values already present in the built-in or
   effective root surface. New values are declared at the root before any rule
-  uses them, so generated types do not depend on a media condition.
+  uses them, so generated types do not depend on a media condition. Tooling
+  enforces this when it can resolve the finite built-in domain; opaque alias-backed
+  domains retain the known validation boundary shared with root themes, and
+  pass-through acceptance does not make an axis extensible.
 
 This record does not own semantic token definitions, theme authoring precedence,
 how themes become output, or the design rationale for a component's appearance.
@@ -254,20 +257,25 @@ how themes become output, or the design rationale for a component's appearance.
 
 ## Verification
 
-| Invariant    | Evidence                                                                                                           | Failure signal                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| INV1         | Cross-package target/documentation inventory                                                                       | An exported target in a participating package is invisible to metadata or CLI validation                                    |
-| INV2, INV3   | Bidirectional anatomy-disposition/target check                                                                     | A current target has no semantic part owner, anatomy mechanically creates targets, or `none` silently becomes future policy |
-| INV4, INV5   | Component review plus rendered DOM inspection                                                                      | Public target lands on non-painting plumbing or aliases a child primitive without distinct semantics                        |
-| INV6         | `themingTargets.test.ts` and `extensibleAxes.test.ts`                                                              | State/variant is invisible to the owner target or becomes an unnecessary parallel target                                    |
-| INV7, INV8   | Existing property fixtures (partial; gaps below)                                                                   | A declared property is missing evidence, or an unlisted counterpart is treated as implied                                   |
-| INV9         | API docs and compatibility review                                                                                  | Generic property acceptance is presented as a supported compatibility promise                                               |
-| INV10, INV11 | Existing registry/public-var/runtime tests (partial; gaps below)                                                   | A public semantic var bypasses admission, or a consumer must write a private var to reach promised behavior                 |
-| INV12, INV13 | Alias and family-owner fixtures                                                                                    | Deprecated aliases count as current parts or cross-doc ownership remains implicit                                           |
-| INV14        | Component contract, owner review, focused no-match fallback test, and structural `extensibleAxes.test.ts` coverage | An ineligible axis opens, a missing rule changes behavior unpredictably, or the map/reflection/docs wiring drifts           |
-| INV15        | Theme build adaptation fixtures                                                                                    | A rule-only custom value creates conditional CSS without an unconditional public type surface                               |
+| Invariant    | Evidence                                                                                                           | Failure signal                                                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| INV1         | Cross-package target/documentation inventory                                                                       | An exported target in a participating package is invisible to metadata or CLI validation                                      |
+| INV2, INV3   | Bidirectional anatomy-disposition/target check                                                                     | A current target has no semantic part owner, anatomy mechanically creates targets, or `none` silently becomes future policy   |
+| INV4, INV5   | Component review plus rendered DOM inspection                                                                      | Public target lands on non-painting plumbing or aliases a child primitive without distinct semantics                          |
+| INV6         | `themingTargets.test.ts` and `extensibleAxes.test.ts`                                                              | State/variant is invisible to the owner target or becomes an unnecessary parallel target                                      |
+| INV7, INV8   | Existing property fixtures (partial; gaps below)                                                                   | A declared property is missing evidence, or an unlisted counterpart is treated as implied                                     |
+| INV9         | API docs and compatibility review                                                                                  | Generic property acceptance is presented as a supported compatibility promise                                                 |
+| INV10, INV11 | Existing registry/public-var/runtime tests (partial; gaps below)                                                   | A public semantic var bypasses admission, or a consumer must write a private var to reach promised behavior                   |
+| INV12, INV13 | Alias and family-owner fixtures                                                                                    | Deprecated aliases count as current parts or cross-doc ownership remains implicit                                             |
+| INV14        | Component contract, owner review, focused no-match fallback test, and structural `extensibleAxes.test.ts` coverage | An ineligible axis opens, a missing rule changes behavior unpredictably, or the map/reflection/docs wiring drifts             |
+| INV15        | Theme build adaptation fixtures covering resolvable and opaque prop domains                                        | A resolvable rule-only custom value creates conditional CSS, or opaque-domain pass-through is mistaken for an extension point |
 
 Known conformance and verification gaps:
+
+- Alias-backed finite prop domains that build tooling cannot currently enumerate
+  share the root-theme validation boundary: a rule-only value may pass through
+  even though the axis is not extensible. This is a validation gap, not API
+  admission; resolvable domains remain fail-closed.
 
 - The component schema has no machine-readable axis-classification or fallback
   field. `extensibleAxes.test.ts` therefore checks only structural consistency;

--- a/docs/architecture/public-component-api.md
+++ b/docs/architecture/public-component-api.md
@@ -24,7 +24,13 @@ verified_by:
     packages/core/src/docPropLiterals.test.ts,
     packages/core/src/docPropReferences.test.ts,
   ]
-deciding_specs: [spec:AST-002/DEC-1, spec:AST-005/DEC-1]
+deciding_specs:
+  [
+    spec:AST-002/DEC-1,
+    spec:AST-005/DEC-1,
+    spec:AST-012/DEC-1,
+    spec:AST-012/DEC-2,
+  ]
 ---
 
 # Public component API
@@ -94,6 +100,9 @@ guidance owns the process used to propose and test APIs.
   CSS property set cannot express. Its theming record owns the exact purpose,
   stable default/fallback, scope, documentation, evidence, and compatibility
   contract; an internal styling gap alone does not justify public API.
+- **INV12 — Shared breakpoint names keep one meaning.** Components that accept a
+  theme width point use `sm`/`md`/`lg`/`xl`/`2xl` from the active Theme. A
+  `below` boundary is exclusive, so equality belongs to the wider side.
 
 This record applies to stable public packages. Lab components are not stable
 public promises until promotion.
@@ -116,6 +125,9 @@ public promises until promotion.
   theming/component records.
 - A released breaking change includes the compatibility decision and migration
   evidence required by the release process.
+- A component exposing a named theme width point uses the fixed vocabulary and
+  exclusive upper-edge behavior from `spec:AST-012`; it does not maintain a
+  parallel hardcoded breakpoint table.
 - Changes to a family-owned API update the family contract rather than copying
   its rule into this record or every component.
 - A component that accepts or derives a navigation destination follows
@@ -136,6 +148,8 @@ public promises until promotion.
   component cannot derive.
 - `spec:AST-005/DEC-1` — every Astryx-owned navigation exit follows one
   destination-safety decision.
+- `spec:AST-012/DEC-1` and `spec:AST-012/DEC-2` — components reuse the fixed
+  theme width names and inclusive-`from`/exclusive-`below` edge meanings.
 
 Transition Action sequencing and pending behavior belong to their component or
 family contract. This record links that owner once it is current; it does not
@@ -151,6 +165,7 @@ copy the component matrix.
 | INV5, INV6, INV7        | BaseProps/passthrough lint and representative runtime tests     | Consumer ARIA/data/style/events are dropped, clobber component semantics, or fail to compose |
 | INV9                    | Published-surface, Changeset, migration, and public-type checks | A released API changes without explicit compatibility evidence                               |
 | INV11                   | Public-API admission review plus owning theming/component tests | A public semantic custom property exposes derivable or unsupported implementation detail     |
+| INV12                   | `AppShell.test.tsx`                                             | A component hardcodes a divergent point or treats equality as below                          |
 | Consumer-doc projection | `docPropReferences.test.ts` and `docPropLiterals.test.ts`       | Docs name a nonexistent prop or omit public literal choices                                  |
 
 Known verification gaps:

--- a/docs/architecture/theme-application.md
+++ b/docs/architecture/theme-application.md
@@ -15,6 +15,7 @@ applies_to:
     packages/core/src/theme/MediaTheme.tsx,
     packages/core/src/theme/useTheme.ts,
     packages/core/src/theme/themeRegistry.ts,
+    packages/core/src/AppShell/AppShell.tsx,
   ]
 verified_by:
   [
@@ -22,8 +23,9 @@ verified_by:
     packages/core/src/theme/MediaTheme.dom.test.tsx,
     packages/core/src/theme/useTheme.test.tsx,
     packages/core/src/theme/themeRegistry.test.ts,
+    packages/core/src/AppShell/AppShell.test.tsx,
   ]
-deciding_specs: []
+deciding_specs: [spec:AST-012/DEC-1]
 ---
 
 # Theme application
@@ -71,6 +73,11 @@ that needs a nested theme must keep that provider context in the same React tree
 off. Compiled theme CSS uses that marker to switch surface tokens while keeping
 the parent theme's component rules.
 
+`AppShell` uses the same provider/root-fallback identity path to resolve named
+mobile-navigation width points. The nearest Theme wins; without provider context
+it follows the registered root theme, and without an active theme it uses the
+standard width map.
+
 ## Boundaries and invariants
 
 - **INV1 — The nearest provider wins.** Children read the closest Theme context
@@ -97,6 +104,10 @@ the parent theme's component rules.
 - **INV9 — Application does not change compiled rules.** The provider may mount,
   share, and remove compiler output. It must not create different theme-to-CSS
   behavior from the build path.
+- **INV10 — Named responsive consumers share Theme metadata.** AppShell resolves
+  `sm`/`md`/`lg`/`xl`/`2xl` from the nearest active theme through the same root
+  fallback as other no-provider consumers. Its mobile side is strictly below the
+  point; equality belongs to the wider layout.
 
 This record does not own theme authoring, token definitions, compiler output, or
 which component parts are public theme targets.
@@ -123,11 +134,12 @@ which component parts are public theme targets.
   detached consumers. Its observation and subscription logic stays
   single-owned; extracting another module is not part of this contract.
 - `MediaTheme.tsx` owns local light/dark surface context.
+- `AppShell.tsx` consumes the nearest effective width map for mobile navigation.
 - `architecture:theme-compilation` owns the CSS that Theme mounts.
 
 ## Deciding specs
 
-None. This record captures the approved Theme provider and hook behavior.
+- `spec:AST-012/DEC-1` owns the fixed width-point vocabulary AppShell consumes.
 
 ## Verification
 
@@ -138,3 +150,4 @@ None. This record captures the approved Theme provider and hook behavior.
 | INV6, INV7       | `useTheme.test.tsx`                       | Provider consumers observe the DOM, fallback observers leak, or system mode resolves incorrectly   |
 | INV8             | `MediaTheme.dom.test.tsx`                 | Surface mode replaces the theme, loses parent component rules, or remounts children                |
 | INV9             | Runtime/build compiler comparison         | Provider-mounted CSS differs from built CSS for the same theme                                     |
+| INV10            | `AppShell.test.tsx`                       | A named point ignores the nearest theme or treats equality as mobile                               |

--- a/docs/architecture/theme-authoring-contract.md
+++ b/docs/architecture/theme-authoring-contract.md
@@ -12,6 +12,7 @@ owners: [cixzhang, imdreamrunner]
 applies_to:
   [
     packages/core/src/theme/defineTheme.ts,
+    packages/core/src/theme/themeAdaptations.ts,
     packages/core/src/theme/syntax/defineSyntaxTheme.ts,
     packages/core/src/theme/expandColorScale.ts,
     packages/core/src/theme/expandTypeScale.ts,
@@ -26,6 +27,7 @@ applies_to:
 verified_by:
   [
     packages/core/src/theme/defineTheme.test.ts,
+    packages/core/src/theme/themeAdaptations.test.ts,
     packages/core/src/theme/syntax/serverSafeSyntax.test.ts,
     packages/core/src/theme/expandColorScale.test.ts,
     packages/core/src/theme/expandTypeScale.test.ts,
@@ -41,6 +43,10 @@ deciding_specs:
     spec:AST-006/DEC-3,
     spec:AST-006/DEC-4,
     spec:AST-006/DEC-6,
+    spec:AST-012/DEC-1,
+    spec:AST-012/DEC-2,
+    spec:AST-012/DEC-3,
+    spec:AST-012/DEC-4,
     spec:AST-017/DEC-1,
   ]
 ---
@@ -66,8 +72,9 @@ source configuration independently.
 - optional theme-family-local token declarations;
 - component target/style-key overrides;
 - icon and indicator registries;
-- syntax tokens; and
-- `onDark` / `onLight` surface overrides.
+- syntax tokens;
+- `onDark` / `onLight` surface overrides; and
+- ordered environmental `adaptations` with a fixed named width map.
 
 `defineTheme` resolves that input into a flat `DefinedTheme`. An extended theme
 contains the resolved values it inherits, so a build does not need the base
@@ -108,17 +115,23 @@ style key, and CSS property rather than replacing the entire inherited target.
 - **INV8 — Local-token enrollment is explicit and closed.** Supplying
   `localTokens`, or extending an exact enrolled base, produces a flattened local
   declaration map plus ownership and lineage metadata. Enrolled themes validate
-  exact namespaces, case-insensitive `var()` references, cycles, and collisions
-  with `tokens`; unenrolled themes retain their legacy behavior.
+  exact namespaces, case-insensitive `var()` references, cycles—including cycles
+  reachable only after co-matching adaptation rules cascade—and collisions with
+  `tokens`; unenrolled themes retain their legacy behavior.
 - **INV9 — Authoring and output are separate systems.** This record owns the
   normalized theme definition. The shared compiler owns turning it into styles;
   runtime and build own using or saving that output.
-- **INV10 — `defineTheme` validates only what it constructs.** It owns theme
+- **INV10 — Adaptations are ordered normalized intent.** Every effective theme
+  retains its complete `sm`/`md`/`lg`/`xl`/`2xl` width map, generative-axis
+  metadata, and inherited-then-local `{when, value}` rule order. Rules re-resolve
+  against a child theme's effective root metadata; they do not mutate root token
+  reads or introduce identity, registries, media surfaces, or new local names.
+- **INV11 — `defineTheme` validates only what it constructs.** It owns theme
   creation and normalization. It may reject malformed input that affects normalized
   theme behavior or generated values as a construction precondition. Authoring or
   reference data used only for validation stays outside `DefineThemeInput` and
   `DefinedTheme`.
-- **INV11 — Theme `define*` helpers construct theme values.** They transform,
+- **INV12 — Theme `define*` helpers construct theme values.** They transform,
   derive, or normalize input into a durable typed theme value used by a current
   supported consumer; validating and returning the exact input unchanged is
   insufficient.
@@ -167,6 +180,9 @@ public surface belongs to
   and on-media composition; no layer invents its own merge rule.
 - A new generated scale states which semantic tokens it may produce and confirms
   explicit token overrides still win.
+- An adaptation change preserves the fixed condition vocabulary, inclusive
+  `from`/exclusive `below` width edges, authored rule order, root-only local-name
+  enrollment, and source/built extension parity.
 - Authoring fields unavailable to the runtime-only path remain prohibited.
   Build/CLI metadata without a normalized-theme effect may exist only for a named
   current supported reader, stays outside `DefineThemeInput` and `DefinedTheme`,
@@ -177,6 +193,8 @@ public surface belongs to
 
 - `packages/core/src/theme/defineTheme.ts` owns the public input, normalized IR,
   orchestration, and extension behavior.
+- `themeAdaptations.ts` owns the fixed breakpoint/condition vocabulary,
+  validation, inherited rule ordering, axis completion, and concrete rule writes.
 - `syntax/defineSyntaxTheme.ts` constructs syntax themes before `defineTheme`
   adopts their tokens.
 - `expandColorScale.ts`, `expandTypeScale.ts`, `expandRadiusScale.ts`, and
@@ -192,10 +210,10 @@ public surface belongs to
 
 AST-006 decisions 1–4 and 6 establish the shipped theme-local authoring shape,
 exact naming and inheritance rules, enrolled-only validation, and shared value
-contract. The remaining authoring and normalization architecture predates that
-spec and remains unchanged. AST-017 decision 1 owns released compatibility
-classification and migration; this record identifies only the theme/Core trigger
-that enters that path.
+contract. AST-012 decisions 1–4 establish the fixed width map, named closed
+conditions, ordered rule cascade, and source/built adaptation metadata parity.
+AST-017 decision 1 owns released compatibility classification and migration; this
+record identifies only the theme/Core trigger that enters that path.
 
 ## Verification
 
@@ -206,7 +224,8 @@ that enters that path.
 | INV6                     | component merge tests across base/generated/explicit rules                                              | Restating one property drops inherited component styles                                             |
 | INV7                     | `onMediaTokens.test.ts` and generated surface-rule tests                                                | A child loses inherited surface customization or surface precedence changes                         |
 | INV8                     | `defineTheme.test.ts` and CLI source/built inheritance tests                                            | Enrollment, validation, or lineage differs across runtime and static authoring paths                |
-| INV10                    | `DefineThemeInput`/output diff plus runtime/build fixtures                                              | Validation-only data enters the normalized theme, or productive input loses construction validation |
-| INV11                    | Core theme export diff, constructed-value evidence, and current-consumer callsite                       | A theme `define*` helper only checks input and returns that exact input unchanged                   |
+| INV10                    | `themeAdaptations.test.ts` and CLI build fixtures                                                       | Width metadata, rule order, or child re-resolution diverges across source and built themes          |
+| INV11                    | `DefineThemeInput`/output diff plus runtime/build fixtures                                              | Validation-only data enters the normalized theme, or productive input loses construction validation |
+| INV12                    | Core theme export diff, constructed-value evidence, and current-consumer callsite                       | A theme `define*` helper only checks input and returns that exact input unchanged                   |
 | Theme/Core compatibility | Maintained theme source/build against the minimum Core in its currently supported peer/dependency range | A theme update silently requires newer in-range Core or bypasses the `spec:AST-017` path            |
 | Authoring projection     | `scripts/check-theme-template.test.mjs`                                                                 | A supported authoring concept is missing or misstated in the template                               |

--- a/docs/architecture/theme-compilation.md
+++ b/docs/architecture/theme-compilation.md
@@ -12,6 +12,7 @@ owners: [cixzhang, imdreamrunner]
 applies_to:
   [
     packages/core/src/theme/generateThemeRules.ts,
+    packages/core/src/theme/themeAdaptations.ts,
     packages/core/src/theme/derivedVarRegistry.ts,
     packages/core/src/theme/Theme.tsx,
     packages/cli/api/theme/build/build.mjs,
@@ -20,11 +21,18 @@ applies_to:
 verified_by:
   [
     packages/core/src/theme/generateThemeRules.test.ts,
+    packages/core/src/theme/themeAdaptations.test.ts,
     packages/core/src/theme/derivedVarRegistry.test.ts,
     packages/cli/api/theme/build/build.test.mjs,
     packages/cli/api/theme/build/build.public-component-vars.test.mjs,
   ]
-deciding_specs: [spec:AST-006/DEC-2, spec:AST-006/DEC-4]
+deciding_specs:
+  [
+    spec:AST-006/DEC-2,
+    spec:AST-006/DEC-4,
+    spec:AST-012/DEC-3,
+    spec:AST-012/DEC-4,
+  ]
 ---
 
 # Theme compilation
@@ -48,13 +56,17 @@ The current web compiler works like this:
 
 1. `generateThemeRules` turns portable tokens, theme-local tokens, and component
    overrides into CSS rules.
-2. The same code adds state rules, media-surface rules, scopes, and layers.
-3. The `Theme` provider mounts those rules when a theme was not built ahead of
+2. Ordered adaptation rules compile to separate media blocks after root rules.
+   Blocks preserve author order and are never merged or value-diffed; media-surface
+   overrides compile after them.
+3. The same code adds state rules, media-surface rules, scopes, and layers.
+4. The `Theme` provider mounts those rules when a theme was not built ahead of
    time.
-4. The CLI saves those rules into CSS and packages the related JavaScript and
+5. The CLI saves those rules into CSS and packages the related JavaScript and
    types.
-5. A built theme preserves local-token ownership and lineage metadata and is
-   marked so the provider does not compile or inject it again.
+6. A built theme preserves local-token ownership, effective width points,
+   generative-axis metadata, and normalized ordered rules, and is marked so the
+   provider does not compile or inject it again.
 
 For top-level declarations in base component target rules, the compiler preserves
 generic CSS properties as written. When a guaranteed property needs to reach
@@ -106,6 +118,10 @@ Platform-specific details stay inside that compiler.
   emits the normalized `localTokens` map beside portable declarations without
   rewriting names or values. Runtime and static output use the same rules, and
   invalid enrolled input is rejected before either path writes partial CSS.
+- **INV12 — Adaptation order is observable.** Root declarations emit first,
+  adaptation blocks remain separate in authored order, and media-surface
+  overrides emit last. Duplicate conditions and later root-restoring writes are
+  preserved exactly; runtime and static output use the same blocks.
 
 This record does not own:
 
@@ -135,6 +151,9 @@ This record does not own:
 - Changing scope or layer output tests both source and distribution builds.
 - Changing local-token emission or packaging verifies exact-name runtime/static
   parity, atomic failure, and preservation of built-theme lineage metadata.
+- Changing adaptation output verifies authored block order, duplicate conditions,
+  root-restoring writes, media-surface precedence, derived component lowering,
+  and source/built extension parity.
 - Adding a platform compiler names the shared concepts it supports and tests
   that they keep the same meaning. Unsupported concepts fail clearly instead of
   disappearing.
@@ -158,9 +177,10 @@ This record does not own:
 ## Deciding specs
 
 AST-006 decisions 2 and 4 establish exact local-token output and atomic shared
-validation for enrolled themes. The system owner separately selected one
-definition with platform-specific outputs and the guaranteed, best-effort,
-public-semantic, and private implementation tiers.
+validation for enrolled themes. AST-012 decisions 3 and 4 establish ordered
+adaptation blocks and source/built metadata parity. The system owner separately
+selected one definition with platform-specific outputs and the guaranteed,
+best-effort, public-semantic, and private implementation tiers.
 
 ## Verification
 
@@ -173,6 +193,7 @@ public-semantic, and private implementation tiers.
 | INV8             | Component target metadata and compatibility review                 | Successful generic emission is treated as a guaranteed public behavior                          |
 | INV9, INV10      | Platform compiler tests when another compiler ships                | CSS details enter shared authoring, or shared theme intent silently disappears                  |
 | INV11            | `defineTheme.test.ts` and `build.test.mjs` local-token fixtures    | Runtime/static output rewrites a local name, disagrees, or leaves partial output after failure  |
+| INV12            | `themeAdaptations.test.ts` and CLI adaptation build fixtures       | Rule blocks merge/reorder/drop, surfaces lose precedence, or runtime/static CSS diverges        |
 | Built themes     | Theme and CLI build tests                                          | Runtime recompiles a built theme, or built output omits canonical rules                         |
 
 ## Known conformance and verification gaps

--- a/docs/specs/AST-012/spec.md
+++ b/docs/specs/AST-012/spec.md
@@ -110,8 +110,13 @@ A breakpoint map alone emits no CSS. Only rules with adaptation values do.
   generative axis expands against the root axis metadata, and every produced leaf
   counts as a write by that rule. Missing required scale fields MUST be supplied
   rather than synthesized from approximate built-in defaults. A rule may style an
-  existing component visual-prop value but MUST NOT introduce a new value; states
-  are component-owned and never theme-generated.
+  existing component visual-prop value and is not an enrollment surface for new
+  values. When tooling can resolve a prop's finite built-in domain, it MUST reject
+  a rule-only value that is neither built in nor present on the effective root
+  component surface. An opaque alias-backed domain that current validation cannot
+  resolve MAY retain the same pass-through behavior as root-theme validation;
+  accepting such a value does not make the axis extensible. States are
+  component-owned and never theme-generated.
 - **FR5 — Media surfaces remain more specific.** Adaptation values resolve over the
   root theme. When an `onDark` or `onLight` override and an adaptation write the
   same resolved leaf, the media-surface value wins. Adaptations do not create a
@@ -157,7 +162,10 @@ A breakpoint map alone emits no CSS. Only rules with adaptation values do.
   private-variable checks, font notices, and `light-dark()` color-scheme detection
   MUST inspect values declared only in rules. Generated variant/type validation
   MUST reject a rule-only visual-prop value absent from the effective root
-  component surface.
+  component surface when the prop's finite built-in domain is resolvable. For an
+  opaque alias-backed domain that the current validator cannot enumerate, tooling
+  MAY retain the existing root-theme validation boundary instead of failing
+  closed; this is a known validation limitation, not a new extension point.
 - **IR4 — Built themes preserve extension semantics.** A built theme's JavaScript
   module retains the effective width-breakpoint map, normalized generative-axis
   metadata, enrolled local-token lineage, and ordered normalized rules required
@@ -195,13 +203,13 @@ extension metadata remain useful implementation evidence.
 
 ## Verification
 
-| Contract | Verification                                                  | Representative states                                                                                                                                                    | Failure signal                                                                                                                                          |
-| -------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| FR1–FR3  | Width-breakpoint and condition matrix plus browser boundaries | defaults/overrides; from/below/range; pointer/contrast/motion; multi-field AND; empty/no rules                                                                           | A point acts as an upper bound, intervals gap/overlap, fields OR together, or an unused map emits CSS.                                                  |
-| FR4–FR7  | Shared resolver, surface, cascade-order, and extension tests  | enrolled/unenrolled local tokens; incomplete scales; later generated vs earlier explicit leaves; surface collisions; broad/narrow reorder; child append/removal attempts | A rule enrolls a local name, widens vocabulary, approximates missing input, escapes order, beats a surface, or loses inherited order.                   |
-| FR8      | Theme/AppShell integration                                    | all names/`none`; SSR hint; no/nearest/root/nested theme; exact boundaries                                                                                               | AppShell uses the wrong map, equality, or scope.                                                                                                        |
-| IR1–IR3  | Runtime/build and CLI positive/negative fixtures              | invalid map/range/field; source axis metadata; duplicate `when`; root-restoring rules; declaration targets; rule-only visual values; non-CSS token reads                 | Invalid input writes output, metadata disappears, blocks merge/reorder/drop, targets diverge, adaptation leaks into JS reads, or tooling misses values. |
-| IR4      | Generated-module import and size tests                        | no rules/rules; source/built parent and child; generative/local-token metadata                                                                                           | Breakpoints, rules, order, or metadata disappear; extension diverges; CSS text enters the module; or resolved layers duplicate.                         |
+| Contract | Verification                                                  | Representative states                                                                                                                                                                                           | Failure signal                                                                                                                                                                                          |
+| -------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR1–FR3  | Width-breakpoint and condition matrix plus browser boundaries | defaults/overrides; from/below/range; pointer/contrast/motion; multi-field AND; empty/no rules                                                                                                                  | A point acts as an upper bound, intervals gap/overlap, fields OR together, or an unused map emits CSS.                                                                                                  |
+| FR4–FR7  | Shared resolver, surface, cascade-order, and extension tests  | enrolled/unenrolled local tokens; incomplete scales; resolvable/opaque visual-prop domains; later generated vs earlier explicit leaves; surface collisions; broad/narrow reorder; child append/removal attempts | A rule enrolls a local name, a resolvable rule-only value widens vocabulary, an opaque-domain pass-through is treated as an extension point, missing input is approximated, or inherited order is lost. |
+| FR8      | Theme/AppShell integration                                    | all names/`none`; SSR hint; no/nearest/root/nested theme; exact boundaries                                                                                                                                      | AppShell uses the wrong map, equality, or scope.                                                                                                                                                        |
+| IR1–IR3  | Runtime/build and CLI positive/negative fixtures              | invalid map/range/field; source axis metadata; duplicate `when`; root-restoring rules; declaration targets; resolvable and opaque rule-only visual values; non-CSS token reads                                  | Invalid input writes output, metadata disappears, blocks merge/reorder/drop, targets diverge, adaptation leaks into JS reads, or tooling misses a resolvable value.                                     |
+| IR4      | Generated-module import and size tests                        | no rules/rules; source/built parent and child; generative/local-token metadata                                                                                                                                  | Breakpoints, rules, order, or metadata disappear; extension diverges; CSS text enters the module; or resolved layers duplicate.                                                                         |
 
 ## Decision log
 

--- a/docs/specs/AST-031/spec.md
+++ b/docs/specs/AST-031/spec.md
@@ -1,0 +1,297 @@
+---
+schema_version: 1
+template_version: 1
+kind: system-spec
+id: spec:AST-031
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+phase: proposed
+owners: [cixzhang, imdreamrunner]
+affects_architecture:
+  [architecture:component-theming-surface, architecture:theme-compilation]
+affects_families: []
+affects_contributing: [contributing:api-conventions]
+affects_consumer_docs: [theme]
+---
+
+# Generated visual-prop contract system spec
+
+## Intent
+
+Theme validation, generated type augmentation, target discovery, and visual
+probes should agree about every public component selector axis without parsing
+human-readable type strings or shipping a TypeScript compiler in the CLI.
+
+Astryx already declares the relevant facts in executable source: `themeProps()`
+call sites name rendered targets and the values they reflect; TypeScript types
+describe finite and open value domains; public augmentation interfaces identify
+axes already wired for module augmentation; and component theming docs declare the
+public target inventory. This change derives one versioned contract from those
+facts during repository builds and publishes it with Core.
+
+The contract records mechanically provable facts. It does not infer whether a
+new extension point is desirable or whether an axis has a safe visual fallback.
+Those remain component-contract and owner-review decisions.
+
+## Non-goals
+
+- Change theme authoring syntax or add fields to `defineTheme`.
+- Ask component authors to duplicate finite values in `.doc.mjs` metadata.
+- Treat every technically augmentable type as approved for theme extension.
+- Make the published CLI depend on TypeScript or parse consumer source at runtime.
+- Prove arbitrary third-party integration contracts that do not ship an
+  equivalent generated artifact.
+- Turn a failed derivation into evidence that an axis is open or extensible.
+- Replace component specs, family contracts, or owner review for semantic API
+  decisions.
+
+## Terms
+
+- **Visual-prop contract:** the generated, versioned inventory keyed by public
+  theming target and visual-prop name.
+- **Finite values:** the set of string and number literals proven by the
+  TypeScript type of the reflected value after nullish members are removed.
+- **Open primitives:** independently proven unconstrained `string` or `number`
+  members. An axis may carry finite sentinels and an open primitive together,
+  such as `'single' | 'multi' | number`.
+- **Unresolved domain:** a documented visual prop whose domain cannot be proven
+  from the current source graph. Unresolved is a derivation result, not a public
+  extension point.
+- **Augmentation-wired axis:** a visual prop whose checked type is derived from a
+  public module-augmentation interface consumed by the prop type. Newer axes
+  normally use `*Map`; historical interfaces such as `CustomTextTypes` remain
+  valid existing wiring. This is a mechanical fact, not approval for a new API.
+
+## Requirements
+
+### Source-derived contract
+
+- **FR1 — Public docs own the inventory; source proves it.** Current
+  `.doc.mjs` `theming.targets` entries remain the closed public inventory of
+  targets, visual props, and states. Generation MUST reconcile that inventory
+  against every supported rendering mechanism, including `themeProps()`, direct
+  stable classes, delegated surfaces, and documented legacy aliases. It MUST use
+  TypeScript's binding and type rules to derive visual-prop domains from the
+  actual reflected expression or, for a documented composition-only axis, from
+  the checked public prop type of its documented owner. Missing or conflicting
+  evidence MUST be reported rather than guessed.
+- **FR2 — Visual props and states remain distinct.** Each generated selector key
+  MUST carry the role declared by public docs. Only `visualProp` entries receive
+  finite, open, or unresolved value domains and augmentation wiring. `state`
+  entries remain bare selector capabilities; they are never treated as
+  theme-generated value domains or module-augmentation points.
+- **FR3 — Every public visual prop receives a derivation result.** The contract
+  MUST classify every current documented target/visual-prop pair as resolved or
+  unresolved. A resolved entry independently records normalized finite values and
+  open primitive kinds, so `'single' | 'multi' | number` does not widen to
+  arbitrary strings. Generation follows proven coercions back to the originating
+  public prop type when the reflected expression has erased that distinction.
+  Values normalize exactly as `themeProps()` does with `String(value)`; equal
+  normalized values collapse to one selector, and strings sort lexically after
+  numbers sort numerically. Unresolved entries use a versioned reason enum:
+  `opaque-expression`, `unsupported-type`, or `missing-owner`. Conflicting
+  ownership or incompatible evidence is a generation failure, never an unresolved
+  result. Generation MUST NOT silently omit an entry.
+- **FR4 — Generation records every augmentation path without inventing one.**
+  The artifact MUST record a public augmentation interface when the checked prop
+  type is derived from that interface and the value reaches a documented visual
+  prop. It MUST exclude unrelated registry maps and similar names that are not in
+  the prop's binding chain. Accepting this specification admits the audited set
+  of existing public prop-augmentation interfaces as custom-value enrollment
+  paths; each MUST have current fallback evidence before this record can become
+  `current`. Adding or changing a path remains an owner-reviewed component API
+  change with the same evidence requirement.
+
+### Generated artifact and consumers
+
+- **FR5 — Core publishes one versioned artifact.** The generated visual-prop
+  contract MUST ship with the exact `@astryxdesign/core` package whose source it
+  describes. Its bytes MUST be deterministic, repository-relative, free of
+  absolute paths, and validated against a versioned schema. The source package
+  and packed package MUST expose the same artifact.
+- **FR6 — Production consumers do not run TypeScript.** `astryx theme build`,
+  target discovery, generated variant declarations, and visual-probe generation
+  MUST consume the generated artifact. They MUST NOT compile or scan Core
+  TypeScript at command runtime. TypeScript remains a repository build and check
+  dependency only.
+- **FR7 — Finite closed axes fail closed.** A value on a finite axis without
+  augmentation wiring MUST be one of the generated built-ins in every
+  non-adaptation component layer. A rule value on that axis MUST also be built
+  in; placing an unsupported value outside the rule MUST NOT launder it into a
+  valid adaptation value.
+- **FR8 — Existing augmentation wiring preserves enrollment behavior.** A custom
+  finite value is eligible for generated declarations only when its contract
+  entry names the existing public augmentation module and interface. Adaptation
+  rules continue to use AST-012's effective-root requirement: a custom value with
+  augmentation wiring MUST already be present on the effective root component
+  surface, and a rule-only value MUST fail before output. This specification does
+  not add or remove enrollment layers.
+- **FR9 — Open and unresolved domains remain distinct.** An open axis MAY accept
+  values of its proven primitive kind only when the value's canonical
+  `String(value)` form is representable by the shared selector grammar; a theme
+  key that would split, reinterpret, or fail to match the runtime class MUST be
+  rejected. Open numeric values use canonical finite-number serialization, while
+  generated finite sentinels remain valid alongside them. An unresolved axis
+  follows the documented compatibility boundary in `spec:AST-012`; pass-through
+  acceptance MUST NOT mark it open, finite, or augmentation-wired and MUST remain
+  visible in repository coverage reports.
+- **FR10 — Component-writing layers share one contract.** Root components,
+  root-owned media-surface component layers, and adaptation component layers MUST
+  use the same target, prop role, and domain facts. Existing warning-versus-error
+  policy remains unchanged unless another accepted contract changes it. Equivalent
+  unknown-target and unknown-prop conditions MUST emit the same warning string in
+  the existing `warnings: string[]` receipt and human CLI channel across layers.
+
+### Compatibility and evolution
+
+- **FR11 — Version fallback is deterministic.** The CLI MUST read the artifact
+  from the installed Core package it is already using. A present schema version
+  supported by that CLI is authoritative. A missing artifact or unsupported
+  schema version MUST use the existing doc-based compatibility path and MUST NOT
+  substitute an artifact bundled for another Core version. A syntactically
+  malformed artifact claiming a supported schema MUST fail theme build with
+  `ERR_THEME_INVALID` before output.
+- **FR12 — Integrations may adopt the contract independently.** A third-party
+  component integration MAY ship a compatible generated contract for its own
+  targets. Until it does, the CLI retains that integration's existing validation
+  boundary. Core completeness MUST NOT be weakened because an integration is
+  incomplete.
+
+### Implementation constraints
+
+- **IR1 — Generation is reproducible and checkable.** One generator MUST support
+  write and check modes. Repository CI and package prepack MUST fail when the
+  committed artifact differs from current source, docs, public extension wiring,
+  or schema.
+- **IR2 — Compiler scope is bounded.** Generation MUST use the repository's
+  supported TypeScript configuration and only the package source needed to resolve
+  Core selector expressions and public extension wiring. The artifact MUST not
+  contain compiler-internal symbol IDs or depend on traversal order.
+- **IR3 — One parser serves all consumers.** Artifact loading, schema validation,
+  normalization, and compatibility handling MUST live in one shared module. Theme
+  build and visual tooling MUST NOT grow independent fallback alias resolvers.
+- **IR4 — Failure and fallback are atomic.** A malformed supported artifact or
+  conflicting current source evidence MUST fail before theme CSS, JavaScript,
+  declarations, or probe fixtures are partially written. Missing and unsupported
+  artifact versions MUST select the legacy path under FR11 before any output is
+  planned.
+
+### Platform support
+
+- Supported feature/engine floor: the Node and TypeScript versions already
+  required to build the Astryx repository; published CLI execution keeps its
+  existing Node floor and adds no TypeScript runtime requirement.
+- Unsupported behavior: dynamic target names, opaque props bags, or types that the
+  generator cannot prove are recorded as unresolved and handled under FR9; they
+  are never guessed.
+- Browser evidence: none for contract generation itself. Existing component and
+  visual-gate evidence continues to prove that generated selectors reach the
+  rendered pixels.
+
+## Current-state impact
+
+Today `astryx theme build` scans component docs at runtime and extracts quoted
+strings and top-level numbers from authored type text. This covers most current
+Core target/axis pairs but misses imported aliases such as `AvatarSize`, cannot
+trace values reflected by derived subtargets, and cannot distinguish intentional
+open domains from failed inference. Visual-probe generation maintains a second
+alias-resolution path, so validator and probe coverage can drift.
+
+The generated contract replaces those runtime discovery paths for Core. It fixes
+closed-root laundering, gives adaptations the same finite-domain facts, and makes
+all current targets visible as finite, open, or unresolved without adding theme
+syntax. The accepted opaque-domain boundary in `spec:AST-012` remains available
+for genuinely unresolved expressions and older packages.
+
+This proposed record affects `architecture:component-theming-surface` and
+`architecture:theme-compilation`. If accepted and implemented, those records add
+the generated artifact to owning code and verification, and consumer theme docs
+explain only user-visible diagnostics—not the maintainer extraction mechanism.
+
+## Verification
+
+| Contract         | Verification                                                         | Representative states                                                                                                             | Mutation or failure expectation                                                                                  |
+| ---------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| FR1–FR3          | Generator unit tests plus full Core inventory check                  | local union; imported alias; derived expression; optional value; open string; deprecated alias; opaque bag                        | Removing type resolution or one target produces a named missing/conflicting entry rather than a smaller manifest |
+| FR4              | Existing augmentation structural guard plus component fallback tests | closed finite axis; existing public augmentation interface; unrelated registry map; map re-export only                            | An unrelated interface is recorded as augmentation wiring or a new extension bypasses owner review               |
+| FR5–FR6, IR1–IR3 | Deterministic generation, pack test, and consumer parity tests       | clean write/check; stale artifact; packed Core; CLI without TypeScript; build/probe same lookup                                   | Generated bytes drift, absolute paths appear, TypeScript enters CLI dependencies, or consumers disagree          |
+| FR7–FR10         | Root/media/adaptation validation matrix                              | built-in; closed custom; augmentation-wired root custom; rule-only custom; root laundering; open; unresolved; unknown target/prop | Unsupported finite values emit output, a root value launders a closed axis, or equivalent layers disagree        |
+| FR11–FR12        | Version/absence compatibility fixtures                               | matching Core; older Core without artifact; unsupported schema; integration with/without contract                                 | CLI silently uses another version's facts or weakens Core validation because an integration is incomplete        |
+| IR4              | Output-directory mutation tests                                      | malformed supported artifact; conflicting source evidence; missing/unsupported fallback                                           | Any output changes before failure, or fallback begins after partial output                                       |
+
+### Completion criteria
+
+This spec moves from `accepted` to `shipped` only when:
+
+- every current Core target/visual-prop pair appears in the generated artifact;
+- repository checks report finite, open, and unresolved counts without silent
+  omissions;
+- root, media-surface, and adaptation validation consume the same artifact;
+- visual probes consume the same artifact instead of a separate alias resolver;
+- every recorded augmentation path has current component-contract and focused
+  fallback evidence;
+- the packed Core package contains the checked artifact;
+- the published CLI has no TypeScript runtime dependency; and
+- existing themes with only built-in or valid augmentation-wired values build
+  unchanged.
+
+## Decision log
+
+### DEC-1 — Derive selector domains at build time and publish the result
+
+**Reference:** `spec:AST-031/DEC-1`
+**Decider:** unassigned
+
+TypeScript already owns binding and type semantics, while the CLI needs a small,
+stable runtime contract. Running the compiler during repository builds preserves
+that source of truth without adding compiler cost or complexity to every theme
+build.
+
+Rejected: parse `.doc.mjs` type strings at runtime. Those strings are consumer
+documentation, not a complete binding graph, and unresolved aliases are
+indistinguishable from intentional open domains.
+
+Rejected: ship TypeScript in the CLI and inspect Core source on every build. That
+adds substantial installation and cold-start cost while still leaving semantic
+extension permission outside the type system.
+
+Rejected: hand-maintain every finite allowed-value list. It duplicates the public
+component types and creates a second value source that can drift.
+
+### DEC-2 — Existing public augmentation paths become the enrollment signal
+
+**Reference:** `spec:AST-031/DEC-2`
+**Decider:** unassigned
+
+A public augmentation interface consumed by a prop type proves the mechanical path
+that existing theme builds use for generated declarations. Accepting this proposal
+also accepts the audited existing set as the custom-value enrollment signal used
+by validation. That acceptance is conditional on every existing path having the
+current component-contract and fallback evidence required by
+`architecture:component-theming-surface`; the artifact itself does not supply that
+evidence. A future path remains an owner-reviewed API change with the same proof.
+
+Rejected: label every interface ending in `Map` as an enrollment path. Registry
+maps and interfaces outside a checked prop binding can share that syntax without
+sharing component visual-prop semantics.
+
+### DEC-3 — Unresolved is explicit, never equivalent to open
+
+**Reference:** `spec:AST-031/DEC-3`
+**Decider:** unassigned
+
+A complete inventory can include entries whose domain is not yet mechanically
+provable. Recording them keeps coverage honest and lets AST-012's compatibility
+boundary remain narrow and measurable.
+
+Rejected: omit unresolved axes or treat them as `string`. Both choices convert a
+derivation gap into accidental API permission.
+
+## Open questions
+
+None. The owner decisions recorded above remain unassigned while this record is
+`draft`; accepting the proposal assigns them without changing existing target
+ownership, enrollment layers, warning severity, or package compatibility ranges.

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -30,7 +30,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL, fileURLToPath} from 'node:url';
+import {fileURLToPath} from 'node:url';
 import {createJiti} from 'jiti';
 import {getCliInvocation} from '../../../foundation/env/package-manager.mjs';
 import {CLI_ROOT, findCoreDir} from '../../../foundation/fs/paths.mjs';
@@ -59,6 +59,7 @@ import {collectUnloadedFonts, formatFontLoadingHelp} from './font-warning.mjs';
 /** @type {any} */ let _defineTheme = null;
 /** @type {any} */ let _generateThemeRulesSplit = null;
 /** @type {any} */ let _generateOnMediaCSS = null;
+/** @type {any} */ let _generateAdaptationCSS = null;
 /** @type {any} */ let _dataTokenDefaults = null;
 /** @type {any} */ let _coreImportError = null;
 try {
@@ -66,6 +67,7 @@ try {
   _defineTheme = coreTheme.defineTheme;
   _generateThemeRulesSplit = coreTheme.generateThemeRulesSplit;
   _generateOnMediaCSS = coreTheme.generateOnMediaCSS;
+  _generateAdaptationCSS = coreTheme.generateAdaptationCSS;
   _dataTokenDefaults = coreTheme.dataTokenDefaults;
 } catch (e) {
   // Capture the reason so the theme action can surface a precise, actionable
@@ -201,90 +203,135 @@ function toPascalCase(name) {
     .join('');
 }
 
+/** @type {Promise<Record<string, Record<string, string[]>>> | null} */
+let _knownValuesIndexPromise = null;
+
 /**
- * Load known built-in values for a component's visual props from its .doc.mjs file.
- * Parses the type string (e.g. "'info' | 'warning' | 'error' | 'success'") to extract values.
- * Returns a map of { propName: string[] } for props that are visual (listed in theming targets).
- * @param {string} componentName
- * @returns {Promise<Record<string, string[]>>}
+ * Build one target-keyed index of built-in visual-prop values from every core
+ * component doc. A rendered target often lives in a sibling doc (for example,
+ * `astryx-heading` is documented by Text/Heading.doc.mjs), so directory-name
+ * guessing is not a valid lookup strategy.
  */
-async function loadKnownValues(componentName) {
-  // Resolve core src relative to the CLI package, not cwd (which may be a theme package)
-  const cliDir = path.dirname(fileURLToPath(import.meta.url));
-  const coreSrc = path.resolve(cliDir, '../../../../core/src');
-  if (!fs.existsSync(coreSrc)) return {};
-  // Map component name to directory (e.g. 'banner' → 'Banner',
-  // 'dropdown-menu' → 'DropdownMenu'). Theme keys use the rendered class
-  // token, which hyphenates multi-word names, so strip non-letters from BOTH
-  // sides before comparing.
-  const dirs = fs
-    .readdirSync(coreSrc, {withFileTypes: true})
-    .filter(d => d.isDirectory())
-    .map(d => d.name);
-  const target = componentName.toLowerCase().replace(/[^a-z]/g, '');
-  const dir = dirs.find(d => d.toLowerCase().replace(/[^a-z]/g, '') === target);
-  if (!dir) return {};
+async function loadKnownValuesIndex() {
+  const coreRoot = resolveCoreRoot();
+  const coreSrc = coreRoot ? path.join(coreRoot, 'src') : null;
+  if (!coreSrc || !fs.existsSync(coreSrc)) return {};
 
-  const docPath = path.join(coreSrc, dir, `${dir}.doc.mjs`);
-  if (!fs.existsSync(docPath)) return {};
-
-  try {
-    const docModule = await import(pathToFileURL(docPath).href);
-    const doc = docModule.docs;
-    if (!doc?.theming?.targets) return {};
-
-    // Collect all props — from doc.props or doc.components[].props
-    const allProps = [];
-    if (doc.props) allProps.push(...doc.props);
-    if (doc.components) {
-      for (const comp of doc.components) {
-        if (comp.props) allProps.push(...comp.props);
+  /** @type {any[]} */
+  const docs = [];
+  /** @param {string} dir */
+  async function scan(dir) {
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== 'node_modules' && entry.name !== '__tests__') {
+          await scan(full);
+        }
+        continue;
+      }
+      if (!entry.name.endsWith('.doc.mjs')) continue;
+      try {
+        docs.push(await loadComponentDoc(full));
+      } catch {
+        // One malformed or optional doc must not erase validation for the rest.
       }
     }
-    if (allProps.length === 0) return {};
+  }
+  await scan(coreSrc);
 
-    // Collect visual prop names from theming targets
-    /** @type {Set<string>} */
-    const visualProps = new Set();
-    for (const target of doc.theming.targets) {
-      if (target.visualProps) {
-        for (const vp of target.visualProps) visualProps.add(vp);
-      }
-    }
-
-    // Extract values from prop type strings
-    /** @type {Record<string, string[]>} */
+  /** @param {string} value */
+  const targetName = value =>
+    value
+      .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+      .replace(/\s+/g, '-')
+      .toLowerCase();
+  /**
+   * @param {any[]} props
+   * @returns {Record<string, Set<string>>}
+   */
+  const valuesFromProps = props => {
+    /** @type {Record<string, Set<string>>} */
     const result = {};
-    for (const prop of allProps) {
-      if (!visualProps.has(prop.name)) continue;
-      if (!prop.type || typeof prop.type !== 'string') continue;
+    for (const prop of props ?? []) {
+      if (typeof prop?.name !== 'string' || typeof prop?.type !== 'string') {
+        continue;
+      }
+      /** @type {Set<string>} */
+      const values = new Set();
+      for (const match of prop.type.match(/'([^']+)'/g) ?? []) {
+        values.add(match.slice(1, -1));
+      }
+      for (const part of prop.type
+        .split('|')
+        .map((/** @type {string} */ value) => value.trim())) {
+        if (/^-?\d+(?:\.\d+)?$/.test(part)) values.add(part);
+      }
+      if (values.size > 0) result[prop.name] = values;
+    }
+    return result;
+  };
 
-      // Parse union type: "'info' | 'warning' | 'error' | 'success'" → ['info', 'warning', 'error', 'success']
-      const matches = prop.type.match(/'([^']+)'/g);
-      if (matches) {
-        result[prop.name] = matches.map((/** @type {string} */ m) =>
-          m.replace(/'/g, ''),
+  /** @type {Record<string, Record<string, Set<string>>>} */
+  const valuesByOwner = {};
+  for (const doc of docs) {
+    if (typeof doc?.name === 'string') {
+      valuesByOwner[targetName(doc.name)] = valuesFromProps(doc.props);
+    }
+    for (const component of /** @type {any[]} */ (doc?.components ?? [])) {
+      if (typeof component?.name === 'string') {
+        valuesByOwner[targetName(component.name)] = valuesFromProps(
+          component.props,
         );
       }
     }
-    return result;
-  } catch {
-    return {};
   }
+
+  /** @type {Record<string, Record<string, Set<string>>>} */
+  const collected = {};
+  for (const doc of docs) {
+    const localValues = valuesFromProps([
+      ...(doc?.props ?? []),
+      ...(doc?.components ?? []).flatMap(
+        (/** @type {any} */ component) => component?.props ?? [],
+      ),
+    ]);
+    for (const target of doc?.theming?.targets ?? []) {
+      if (typeof target?.className !== 'string') continue;
+      const componentName = target.className.replace(/^astryx-/, '');
+      const ownerValues = valuesByOwner[componentName] ?? {};
+      if (!collected[componentName]) collected[componentName] = {};
+      for (const prop of target.visualProps ?? []) {
+        if (!collected[componentName][prop]) {
+          collected[componentName][prop] = new Set();
+        }
+        for (const value of [
+          ...(localValues[prop] ?? []),
+          ...(ownerValues[prop] ?? []),
+        ]) {
+          collected[componentName][prop].add(value);
+        }
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(collected).map(([component, props]) => [
+      component,
+      Object.fromEntries(
+        Object.entries(props).map(([prop, values]) => [prop, [...values]]),
+      ),
+    ]),
+  );
 }
 
-// Cache for loaded known values
-/** @type {Map<string, Record<string, string[]>>} */
-const _knownValuesCache = new Map();
 /**
  * @param {string} componentName
  * @returns {Promise<Record<string, string[]>>}
  */
 async function getKnownValues(componentName) {
-  if (!_knownValuesCache.has(componentName)) {
-    _knownValuesCache.set(componentName, await loadKnownValues(componentName));
-  }
-  return _knownValuesCache.get(componentName) ?? {};
+  _knownValuesIndexPromise ??= loadKnownValuesIndex();
+  const index = await _knownValuesIndexPromise;
+  return index[componentName] ?? {};
 }
 
 /**
@@ -477,6 +524,124 @@ function componentHasAugmentableInterface(pascalName, interfaceName) {
   // sibling interface for consumers of the real FieldStatus subpath.
   const re = new RegExp(String.raw`\binterface\s+${interfaceName}\b`);
   return re.test(decl);
+}
+
+/**
+ * Adaptation values from resolved runtime rules, raw input, or normalized built
+ * metadata. Built modules intentionally omit `__adaptationRules`, so every CLI
+ * diagnostic that reads rule intent must also understand `__adaptations`.
+ *
+ * @param {Record<string, any>} themeDef
+ * @returns {Record<string, any>[]}
+ */
+function adaptationRuleValues(themeDef) {
+  if (themeDef.__adaptationRules) {
+    return themeDef.__adaptationRules;
+  }
+  return (themeDef.adaptations?.rules ?? themeDef.__adaptations?.rules ?? [])
+    .map((/** @type {any} */ rule) => rule?.value)
+    .filter(Boolean);
+}
+
+/**
+ * Every `[component, rules]` pair a theme may emit, including ordered
+ * adaptation rules. Validators, private-variable checks, and notices must see
+ * rule-only values even though variant augmentation is root-owned.
+ *
+ * @param {Record<string, any>} themeDef
+ * @returns {[string, Record<string, any>][]}
+ */
+function themedComponentEntries(themeDef) {
+  const maps = [
+    themeDef.components,
+    ...adaptationRuleValues(themeDef).map(
+      (/** @type {any} */ value) => value.components,
+    ),
+  ];
+
+  /** @type {[string, Record<string, any>][]} */
+  const entries = [];
+  for (const map of maps) {
+    if (map) entries.push(...Object.entries(map));
+  }
+  return entries;
+}
+
+/**
+ * Root component entries are the only surface allowed to introduce variants.
+ * @param {Record<string, any>} themeDef
+ * @returns {[string, Record<string, any>][]}
+ */
+function rootComponentEntries(themeDef) {
+  return themeDef.components ? Object.entries(themeDef.components) : [];
+}
+
+/**
+ * Component entries written only by adaptation rules.
+ * @param {Record<string, any>} themeDef
+ * @returns {[string, Record<string, any>][]}
+ */
+function adaptationComponentEntries(themeDef) {
+  const maps = adaptationRuleValues(themeDef).map(
+    (/** @type {any} */ value) => value.components,
+  );
+  return maps.flatMap((/** @type {any} */ map) =>
+    map ? Object.entries(map) : [],
+  );
+}
+
+/**
+ * Reject visual-prop values introduced only inside an adaptation. Built-in
+ * values remain legal; custom values must first exist on the effective root
+ * component surface so generated module augmentation is unconditional.
+ * @param {Record<string, any>} themeDef
+ * @returns {Promise<string[]>}
+ */
+async function validateAdaptationVariantValues(themeDef) {
+  const adaptationEntries = adaptationComponentEntries(themeDef);
+  if (adaptationEntries.length === 0) {
+    return [];
+  }
+
+  /** @type {Set<string>} */
+  const rootValues = new Set();
+  for (const [component, rules] of rootComponentEntries(themeDef)) {
+    for (const key of Object.keys(rules)) {
+      for (const pair of key.split('+')) {
+        if (pair.includes(':')) rootValues.add(`${component}:${pair}`);
+      }
+    }
+  }
+
+  /** @type {string[]} */
+  const errors = [];
+  for (const [component, rules] of adaptationEntries) {
+    const known = await getKnownValues(component);
+    for (const key of Object.keys(rules)) {
+      if (key === 'base') continue;
+      for (const pair of key.split('+')) {
+        const colon = pair.indexOf(':');
+        const prop = colon === -1 ? pair : pair.slice(0, colon);
+        if (colon === -1) continue;
+        const value = pair.slice(colon + 1);
+        // Some public prop types are opaque aliases rather than literal unions.
+        // When docs cannot enumerate an axis, avoid turning that discovery gap
+        // into a false hard failure; the normal component validator still checks
+        // that the axis itself exists.
+        if (!known[prop] || known[prop].length === 0) continue;
+        if (
+          known[prop].includes(value) ||
+          rootValues.has(`${component}:${pair}`)
+        ) {
+          continue;
+        }
+        errors.push(
+          `Adaptation rule introduces "${component}.${prop}:${value}". Declare custom visual-prop values on the root theme first; rules may only style an existing value.`,
+        );
+      }
+    }
+  }
+  return [...new Set(errors)];
 }
 
 /**
@@ -826,10 +991,12 @@ function generateBuiltModule(themeDef, iconInfo, iconsSpecifier) {
    * there is nothing to emit.
    * @param {string} field
    * @param {unknown} value
+   * @param {boolean} [includeEmpty]
    * @returns {string}
    */
-  const serializeField = (field, value) => {
-    if (!value || Object.keys(value).length === 0) return '';
+  const serializeField = (field, value, includeEmpty = false) => {
+    if (value == null || (!includeEmpty && Object.keys(value).length === 0))
+      return '';
     const body = JSON.stringify(value, null, 2)
       .split('\n')
       .map((line, i) => (i === 0 ? line : '  ' + line))
@@ -837,6 +1004,9 @@ function generateBuiltModule(themeDef, iconInfo, iconsSpecifier) {
     return `  ${field}: ${body},\n`;
   };
 
+  // Everything a theme that `extends` this built one has to be able to read
+  // back. A field missing here is silently lost by the extending theme.
+  // SYNC: packages/core/src/theme/defineTheme.ts (DefinedTheme)
   const inheritableFields =
     (themeDef.__localTokenLineage !== undefined
       ? `  localTokens: ${JSON.stringify(themeDef.localTokens ?? {}, null, 2)
@@ -855,7 +1025,9 @@ function generateBuiltModule(themeDef, iconInfo, iconsSpecifier) {
       : '') +
     serializeField('components', themeDef.components) +
     serializeField('__onDark', themeDef.__onDark) +
-    serializeField('__onLight', themeDef.__onLight);
+    serializeField('__onLight', themeDef.__onLight) +
+    serializeField('__adaptations', themeDef.__adaptations) +
+    serializeField('__axes', themeDef.__axes ?? {}, true);
 
   return `${iconImport}/**
  * ${themeDef.name} theme — built by \`${getCliInvocation()} theme build\`
@@ -949,12 +1121,13 @@ async function getKnownComponents() {
 async function validateComponentOverrides(themeDef) {
   /** @type {string[]} */
   const warnings = [];
-  if (!themeDef.components) return warnings;
+  const componentEntries = themedComponentEntries(themeDef);
+  if (componentEntries.length === 0) return warnings;
 
   const knownComponents = await getKnownComponents();
   if (knownComponents == null) return warnings;
 
-  for (const [component, rules] of Object.entries(themeDef.components)) {
+  for (const [component, rules] of componentEntries) {
     // Check component name
     if (!(component in knownComponents)) {
       const similar = Object.keys(knownComponents)
@@ -1005,7 +1178,7 @@ async function validateComponentOverrides(themeDef) {
     }
   }
 
-  return warnings;
+  return [...new Set(warnings)];
 }
 
 /**
@@ -1021,23 +1194,33 @@ async function validateComponentOverrides(themeDef) {
 function validatePrivateVars(themeDef) {
   /** @type {string[]} */
   const errors = [];
-  if (!themeDef.components) return errors;
 
-  for (const [component, rules] of Object.entries(themeDef.components)) {
+  for (const [component, rules] of themedComponentEntries(themeDef)) {
     for (const [key, styles] of Object.entries(rules)) {
-      for (const prop of Object.keys(styles)) {
-        if (typeof prop === 'string' && prop.startsWith('--_')) {
-          errors.push(
-            `Component "${component}" (${key}) sets private var "${prop}". ` +
-              `Private vars (--_*) are internal — use standard CSS properties ` +
-              `(e.g. borderRadius, padding) instead. The pipeline expands them automatically.`,
-          );
+      /**
+       * @param {unknown} value
+       * @param {string[]} [path]
+       */
+      const visit = (value, path = []) => {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+        for (const [prop, nested] of Object.entries(value)) {
+          if (prop.startsWith('--_')) {
+            errors.push(
+              `Component "${component}" (${[key, ...path].join(' ')}) sets private var "${prop}". ` +
+                `Private vars (--_*) are internal — use standard CSS properties ` +
+                `(e.g. borderRadius, padding) instead. The pipeline expands them automatically.`,
+            );
+          }
+          visit(nested, [...path, prop]);
         }
-      }
+      };
+      visit(styles);
     }
   }
 
-  return errors;
+  // One entry per distinct message: a component declared both at the root and
+  // in one or more adaptations would otherwise report the same problem twice.
+  return [...new Set(errors)];
 }
 
 const BUILTIN_HEADING_TYPES = new Set(['display-1', 'display-2', 'display-3']);
@@ -1293,7 +1476,7 @@ export async function themeBuild(
   // `astryx theme build` and the `<Theme>` runtime MUST emit identical CSS, so
   // there is exactly one generation path: @astryxdesign/core/theme. If core could not
   // be imported, fail hard rather than silently producing divergent output.
-  if (!_defineTheme || !_generateThemeRulesSplit) {
+  if (!_defineTheme || !_generateThemeRulesSplit || !_generateAdaptationCSS) {
     throw new AstryxError(
       'Could not load @astryxdesign/core/theme — `astryx theme build` requires a ' +
         'built, resolvable @astryxdesign/core so it emits the same CSS as the ' +
@@ -1316,6 +1499,11 @@ export async function themeBuild(
     // theme has none of them — and hand the WHOLE object over: picking fields
     // by name is how `extends` (and `color`, and `syntax`) used to be dropped
     // on the way in.
+    // Fields that only ever appear on RAW defineTheme() input, never on an
+    // already-resolved theme. Their presence is how the build tells the two
+    // apart and decides to run defineTheme() itself. A field missing from this
+    // list is dropped without a word, so every new input field belongs here.
+    // SYNC: packages/core/src/theme/defineTheme.ts (DefineThemeInput)
     const INPUT_ONLY_FIELDS = [
       'extends',
       'typography',
@@ -1325,15 +1513,39 @@ export async function themeBuild(
       'syntax',
       'onDark',
       'onLight',
+      'adaptations',
     ];
     const needsResolution =
       INPUT_ONLY_FIELDS.some(field => themeDef[field] !== undefined) ||
       ('localTokens' in themeDef && themeDef.__localTokenLineage === undefined);
     if (needsResolution) {
-      resolvedTheme = _defineTheme({...themeDef});
+      try {
+        resolvedTheme = _defineTheme({...themeDef});
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Theme normalization failed.';
+        throw new AstryxError(
+          message,
+          undefined,
+          ERROR_CODES.ERR_THEME_INVALID,
+        );
+      }
     } else {
       resolvedTheme = themeDef;
     }
+
+    const adaptationValueErrors =
+      await validateAdaptationVariantValues(resolvedTheme);
+    if (adaptationValueErrors.length > 0) {
+      throw new AstryxError(
+        adaptationValueErrors.join('\n'),
+        undefined,
+        ERROR_CODES.ERR_THEME_INVALID,
+      );
+    }
+
     const scopeSelector = themeScopeStart(themeDef.name);
     const scopeTo = THEME_SCOPE_TO;
 
@@ -1349,26 +1561,52 @@ export async function themeBuild(
         `@layer reset {\n@scope (${scopeSelector}) to (${scopeTo}) {\n${proseInner}\n}\n}`,
       );
     }
-    if (component.length > 0) {
-      const componentInner = component.join('\n\n');
-      const componentScope = `@scope (${scopeSelector}) to (${scopeTo}) {\n${componentInner}\n}`;
-      // #3658: also emit attribute-specific rules so <Theme mode> can override color-scheme.
-      // Decided from the theme's own values, not the generated CSS: that CSS
-      // also carries the data-token defaults, which are light-dark() pairs, so
-      // a substring check on it would fire for every theme.
-      const themeOwnValues = JSON.stringify([
-        resolvedTheme.tokens ?? {},
-        resolvedTheme.localTokens ?? {},
-        resolvedTheme.components ?? {},
-      ]);
-      const colorSchemeDecl = themeOwnValues.includes('light-dark(')
+    // Ordered adaptation rules use the same generator as the runtime path.
+    let adaptationCss;
+    try {
+      adaptationCss = _generateAdaptationCSS(resolvedTheme);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Theme normalization failed.';
+      throw new AstryxError(message, undefined, ERROR_CODES.ERR_THEME_INVALID);
+    }
+    const componentInner = component.join('\n\n');
+    const componentScope =
+      component.length > 0
+        ? `@scope (${scopeSelector}) to (${scopeTo}) {\n${componentInner}\n}`
+        : '';
+
+    // #3658: also emit attribute-specific rules so <Theme mode> can override
+    // color-scheme. Inspect root and rule-owned values, not generated CSS, which
+    // also carries theme-independent data-token defaults with light-dark().
+    const themeOwnValues = JSON.stringify([
+      resolvedTheme.tokens ?? {},
+      resolvedTheme.localTokens ?? {},
+      resolvedTheme.components ?? {},
+      ...(resolvedTheme.__adaptationRules ?? []).flatMap(
+        (
+          /** @type {{tokens?: Record<string, string>, localTokens?: Record<string, string>, components?: object}} */ rule,
+        ) => [rule.tokens ?? {}, rule.localTokens ?? {}, rule.components ?? {}],
+      ),
+    ]);
+    const colorSchemeDecl =
+      themeOwnValues.includes('light-dark(') ||
+      adaptationCss.component.includes('light-dark(')
         ? '  :root { color-scheme: light dark; }\n  html[data-theme="light"] { color-scheme: light; }\n  html[data-theme="dark"] { color-scheme: dark; }\n\n'
         : '';
+    if (colorSchemeDecl || componentScope) {
       cssParts.push(
         `@layer astryx-theme {\n${colorSchemeDecl}${componentScope}\n}`,
       );
     }
-    // On-media rules (MediaTheme dark/light surface overrides)
+    if (adaptationCss.prose) {
+      cssParts.push(`@layer reset {\n${adaptationCss.prose}\n}`);
+    }
+    if (adaptationCss.component) {
+      cssParts.push(`@layer astryx-theme {\n${adaptationCss.component}\n}`);
+    }
+    // Media-surface rules come last so onDark/onLight win over matching
+    // adaptations on the same resolved leaf.
     if (_generateOnMediaCSS) {
       const onMediaCss = _generateOnMediaCSS(resolvedTheme);
       if (onMediaCss) {
@@ -1605,7 +1843,16 @@ Or with a <link> tag:
   // theme with a webfont, including a perfect one, and as a warning it made
   // every such build read as defective (it also put the shipped template
   // permanently in violation of its own "compiles with no warnings" guard).
-  const unloadedFonts = collectUnloadedFonts(resolvedTheme);
+  // Adaptation rules are resolved theme writes in their own right, so a family
+  // named only inside one needs the same notice as one named at the root.
+  const unloadedFonts = [
+    ...new Set([
+      ...collectUnloadedFonts(resolvedTheme),
+      ...adaptationRuleValues(resolvedTheme).flatMap(
+        (/** @type {any} */ value) => collectUnloadedFonts(value),
+      ),
+    ]),
+  ];
   for (const family of unloadedFonts) {
     const msg = `Font "${family}" is named by this theme but not loaded — add a <link> or @font-face in your app (recipe: astryx docs typography)`;
     noticeMessages.push(msg);

--- a/packages/cli/api/theme/build/font-warning.mjs
+++ b/packages/cli/api/theme/build/font-warning.mjs
@@ -8,15 +8,16 @@
  * fallback typeface on every machine whose app never loads it, and no step
  * says so. These helpers close that gap at build time.
  *
- * `collectUnloadedFonts` inspects a RESOLVED theme (raw typography configs
- * are already collapsed into `--font-family-*` tokens by the time the build
- * sees the theme, so tokens + component-override `fontFamily` values are the
- * complete font surface on both load paths) and returns the families that
+ * `collectUnloadedFonts` inspects a resolved theme or serialized adaptation
+ * value. Resolved values use `--font-family-*` tokens and component
+ * `fontFamily` properties; serialized adaptation values may also retain their
+ * typography role configs. It returns the families that
  * are neither CSS generics nor known preinstalled system fonts. Unrecognized
  * names are assumed to be webfonts on purpose: a missed warning hides the
  * bug, a spurious one costs a glance.
  *
- * @input A resolved theme object ({tokens, components}) from build.mjs.
+ * @input A resolved theme or serialized adaptation value ({tokens, components,
+ *   typography}).
  * @output Ordered, case-insensitively deduped family names, and the human
  *   help snippet (<link> pair + @font-face) printed after the install
  *   instructions.
@@ -132,7 +133,7 @@ function splitFamilies(value) {
  * minus generics, CSS-wide keywords, `var()` references, and known system
  * families. Source order, first-seen casing, deduped case-insensitively.
  *
- * @param {{tokens?: Record<string, string>, components?: object}} resolvedTheme
+ * @param {{tokens?: Record<string, string>, components?: object, typography?: {body?: {family?: string, fallbacks?: string}, heading?: {family?: string, fallbacks?: string}, code?: {family?: string, fallbacks?: string}}}} resolvedTheme
  * @returns {string[]}
  */
 export function collectUnloadedFonts(resolvedTheme) {
@@ -154,6 +155,25 @@ export function collectUnloadedFonts(resolvedTheme) {
 
   for (const [token, value] of Object.entries(resolvedTheme?.tokens ?? {})) {
     if (token.startsWith('--font-family-')) consider(value);
+  }
+
+  // Built modules retain normalized adaptation intent instead of resolved rule
+  // layers. Those rule values still carry authored role families here. A
+  // fallback without a family is inert in core's buildFontFamily().
+  const body = resolvedTheme?.typography?.body;
+  if (body?.family) {
+    consider(body.family);
+    consider(body.fallbacks);
+  }
+  const heading = resolvedTheme?.typography?.heading;
+  if (heading?.family) {
+    consider(heading.family);
+    consider(heading.fallbacks);
+  }
+  const code = resolvedTheme?.typography?.code;
+  if (code?.family) {
+    consider(code.family);
+    consider(code.fallbacks);
   }
 
   // Component overrides are plain CSS maps of unknown depth (style keys,

--- a/packages/cli/api/theme/build/font-warning.test.mjs
+++ b/packages/cli/api/theme/build/font-warning.test.mjs
@@ -118,6 +118,28 @@ describe('collectUnloadedFonts', () => {
     ).toEqual(['Orbitron', 'Bungee']);
   });
 
+  it('collects families from serialized adaptation typography', () => {
+    expect(
+      collectUnloadedFonts({
+        typography: {
+          body: {family: 'Revision Webfont', fallbacks: 'sans-serif'},
+          heading: {family: 'Display Face', fallbacks: 'Georgia, serif'},
+        },
+      }),
+    ).toEqual(['Revision Webfont', 'Display Face']);
+  });
+
+  it('ignores serialized fallbacks that have no family', () => {
+    expect(
+      collectUnloadedFonts({
+        typography: {
+          body: {fallbacks: 'Phantom Serif'},
+          heading: {family: 'Display Face', fallbacks: 'Georgia, serif'},
+        },
+      }),
+    ).toEqual(['Display Face']);
+  });
+
   it('matches known system families case-insensitively', () => {
     expect(
       collectUnloadedFonts({

--- a/packages/cli/assets/docs/theme.doc.dense.mjs
+++ b/packages/cli/assets/docs/theme.doc.dense.mjs
@@ -5,17 +5,154 @@
 export const docsDense = {
   description: 'Theme provider, custom themes, light/dark, component overrides',
   sections: [
-    { section: 'Quick Start', title: 'Quick Start', content: [null, null, null, null, { type: 'prose', text: 'default import = runtime injection. /built import = pre-compiled CSS (pair with theme.css).' }] },
-    { section: 'Available Themes', title: 'Themes', content: [null, null, { type: 'prose', text: 'published: neutral (start here), butter, chocolate, gothic (dark-only), matcha, stone, y2k. @astryxdesign/theme-{name} = source (runtime). @astryxdesign/theme-{name}/built = optimized (+ theme.css).' }] },
-    { section: 'Theme Props', title: 'Props', content: [null] },
-    { section: 'Creating a Custom Theme', title: 'Custom Theme', content: [{ type: 'prose', text: '`theme list` + `theme add <slug>` to start from a shipped theme, or defineTheme from scratch. only override tokens that differ.' }, null, { type: 'prose', text: '`astryx theme template` writes theme.template.ts: every defineTheme field + token families + override syntax, annotated, with the CLI command that prints each reference.' }] },
-    { section: 'defineTheme', title: 'defineTheme', content: [{ type: 'prose', text: 'scale configs (color, typography, radius, motion) + explicit token overrides + component overrides. color derives full palette from accent via HCT; accent = hex or [light, dark] tuple (per-scheme palettes). tokens overrides win token-by-token; --color-on-accent stays baked from color.accent, so prefer a tuple accent over overriding --color-accent.' }, null, null] },
-    { section: 'Component Style Overrides', title: 'Component Overrides', content: [{ type: 'prose', text: 'components field uses semantic component keys + style keys (base, variant:value, stateName), not raw selectors. for external CSS, prefer data-* selectors from `astryx docs styling`. write standard CSS (borderRadius, padding) — pipeline expands to internal vars. public vars (--button-focus-offset etc) set directly. private vars (--_*) cannot be set — use CSS properties. run `astryx theme targets [Name]` to enumerate every themeable key (--json for lint), `astryx component <Name>` for one component.' }, null, null, null, null] },
-    { section: 'Custom Variants', title: 'Custom Variants', content: [{ type: 'prose', text: 'any unknown prop:value in components becomes a new variant. astryx theme build generates TS augmentations. works on any extensible prop axis (variant, status, etc).' }, null, null, null, null] },
-    { section: 'Building Themes for Production', title: 'Build for Production', content: [{ type: 'prose', text: 'astryx theme build compiles defineTheme to static CSS. outputs .css + .js (__built:true) + .d.ts.' }, null, null, null, null] },
-    { section: 'Runtime vs Built Themes', title: 'Runtime vs Built', content: [{ type: 'prose', text: 'runtime: useInsertionEffect injects styles client-side. built: static CSS on first paint. USE /built + theme.css FOR SSR.' }, null, null, null] },
-    { section: 'Light/Dark Mode', title: 'Light/Dark', content: [{ type: 'prose', text: 'light-dark() in token values via [light, dark] tuples. mode=system follows OS.' }, null, null] },
-    { section: 'Nesting Themes', title: 'Nesting', content: [{ type: 'prose', text: 'wrap sections in separate <Theme> providers' }, null] },
-    { section: 'useTheme Hook', title: 'useTheme', content: [null, { type: 'prose', text: 'read-only. manage state at app level.' }] },
+    {
+      section: 'Quick Start',
+      title: 'Quick Start',
+      content: [
+        null,
+        null,
+        null,
+        null,
+        {
+          type: 'prose',
+          text: 'default import = runtime injection. /built import = pre-compiled CSS (pair with theme.css).',
+        },
+      ],
+    },
+    {
+      section: 'Available Themes',
+      title: 'Themes',
+      content: [
+        null,
+        null,
+        {
+          type: 'prose',
+          text: 'published: neutral (start here), butter, chocolate, gothic (dark-only), matcha, stone, y2k. @astryxdesign/theme-{name} = source (runtime). @astryxdesign/theme-{name}/built = optimized (+ theme.css).',
+        },
+      ],
+    },
+    {section: 'Theme Props', title: 'Props', content: [null]},
+    {
+      section: 'Creating a Custom Theme',
+      title: 'Custom Theme',
+      content: [
+        {
+          type: 'prose',
+          text: '`theme list` + `theme add <slug>` to start from a shipped theme, or defineTheme from scratch. only override tokens that differ.',
+        },
+        null,
+        {
+          type: 'prose',
+          text: '`astryx theme template` writes theme.template.ts: every defineTheme field + token families + override syntax, annotated, with the CLI command that prints each reference.',
+        },
+      ],
+    },
+    {
+      section: 'defineTheme',
+      title: 'defineTheme',
+      content: [
+        {
+          type: 'prose',
+          text: 'scale configs (color, typography, radius, motion) + explicit token overrides + component overrides. color derives full palette from accent via HCT; accent = hex or [light, dark] tuple (per-scheme palettes). tokens overrides win token-by-token; --color-on-accent stays baked from color.accent, so prefer a tuple accent over overriding --color-accent.',
+        },
+        null,
+        null,
+      ],
+    },
+    {
+      section: 'Theme Adaptations',
+      title: 'Adaptations',
+      content: [
+        {
+          type: 'prose',
+          text: 'adaptations = ordered {when,value} rules over width/pointer/contrast/motion. widthBreakpoints fixed sm|md|lg|xl|2xl defaults 640|768|1024|1280|1536; map alone emits no CSS. width.from inclusive, width.below exclusive; condition fields AND. root first, then matching rules in authored order (later writes win), then onDark/onLight. rules can write typography/color/radius/motion/tokens/localTokens/components; local names and custom visual-prop values must already exist on root. Co-matching token/localToken writes are validated together; any reachable var() cycle fails. extends inherits breakpoints + ordered rules, appends child rules, re-resolves against child axes. CSS-only; use built themes for SSR first paint.',
+        },
+        null,
+        null,
+      ],
+    },
+    {
+      section: 'Component Style Overrides',
+      title: 'Component Overrides',
+      content: [
+        {
+          type: 'prose',
+          text: 'components field uses semantic component keys + style keys (base, variant:value, stateName), not raw selectors. for external CSS, prefer data-* selectors from `astryx docs styling`. write standard CSS (borderRadius, padding) — pipeline expands to internal vars. public vars (--button-focus-offset etc) set directly. private vars (--_*) cannot be set — use CSS properties. run `astryx theme targets [Name]` to enumerate every themeable key (--json for lint), `astryx component <Name>` for one component.',
+        },
+        null,
+        null,
+        null,
+        null,
+      ],
+    },
+    {
+      section: 'Custom Variants',
+      title: 'Custom Variants',
+      content: [
+        {
+          type: 'prose',
+          text: 'any unknown prop:value in components becomes a new variant. astryx theme build generates TS augmentations. works on any extensible prop axis (variant, status, etc).',
+        },
+        null,
+        null,
+        null,
+        null,
+      ],
+    },
+    {
+      section: 'Building Themes for Production',
+      title: 'Build for Production',
+      content: [
+        {
+          type: 'prose',
+          text: 'astryx theme build compiles defineTheme to static CSS. outputs .css + .js (__built:true) + .d.ts.',
+        },
+        null,
+        null,
+        null,
+        null,
+      ],
+    },
+    {
+      section: 'Runtime vs Built Themes',
+      title: 'Runtime vs Built',
+      content: [
+        {
+          type: 'prose',
+          text: 'runtime: useInsertionEffect injects styles client-side. built: static CSS on first paint. USE /built + theme.css FOR SSR.',
+        },
+        null,
+        null,
+        null,
+      ],
+    },
+    {
+      section: 'Light/Dark Mode',
+      title: 'Light/Dark',
+      content: [
+        {
+          type: 'prose',
+          text: 'light-dark() in token values via [light, dark] tuples. mode=system follows OS.',
+        },
+        null,
+        null,
+      ],
+    },
+    {
+      section: 'Nesting Themes',
+      title: 'Nesting',
+      content: [
+        {type: 'prose', text: 'wrap sections in separate <Theme> providers'},
+        null,
+      ],
+    },
+    {
+      section: 'useTheme Hook',
+      title: 'useTheme',
+      content: [
+        null,
+        {type: 'prose', text: 'read-only. manage state at app level.'},
+      ],
+    },
   ],
 };

--- a/packages/cli/assets/docs/theme.doc.dense.mjs
+++ b/packages/cli/assets/docs/theme.doc.dense.mjs
@@ -65,7 +65,7 @@ export const docsDense = {
       content: [
         {
           type: 'prose',
-          text: 'adaptations = ordered {when,value} rules over width/pointer/contrast/motion. widthBreakpoints fixed sm|md|lg|xl|2xl defaults 640|768|1024|1280|1536; map alone emits no CSS. width.from inclusive, width.below exclusive; condition fields AND. root first, then matching rules in authored order (later writes win), then onDark/onLight. rules can write typography/color/radius/motion/tokens/localTokens/components; local names and custom visual-prop values must already exist on root. Co-matching token/localToken writes are validated together; any reachable var() cycle fails. extends inherits breakpoints + ordered rules, appends child rules, re-resolves against child axes. CSS-only; use built themes for SSR first paint.',
+          text: 'adaptations = ordered {when,value} rules over width/pointer/contrast/motion. widthBreakpoints fixed sm|md|lg|xl|2xl defaults 640|768|1024|1280|1536; map alone emits no CSS. width.from inclusive, width.below exclusive; condition fields AND. root first, then matching rules in authored order (later writes win), then onDark/onLight. rules can write typography/color/radius/motion/tokens/localTokens/components; local names and custom visual-prop values belong on root. Validator rejects resolvable rule-only values; opaque alias domains retain the known root-validation boundary and are not extension points. Co-matching token/localToken writes are validated together; any reachable var() cycle fails. extends inherits breakpoints + ordered rules, appends child rules, re-resolves against child axes. CSS-only; use built themes for SSR first paint.',
         },
         null,
         null,

--- a/packages/cli/assets/docs/theme.doc.mjs
+++ b/packages/cli/assets/docs/theme.doc.mjs
@@ -12,7 +12,7 @@ export const docs = {
   sections: [
     {
       title: 'Quick Start',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'code',
@@ -63,7 +63,7 @@ function App() {
     },
     {
       title: 'Available Themes',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -118,7 +118,7 @@ function App() {
     },
     {
       title: 'Theme Props',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'table',
@@ -138,7 +138,7 @@ function App() {
     },
     {
       title: 'Creating a Custom Theme',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -158,7 +158,7 @@ function App() {
     },
     {
       title: 'defineTheme',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -231,7 +231,7 @@ const myTheme = defineTheme({
     },
     {
       title: 'Extending a Theme',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -258,23 +258,126 @@ const brandTheme = defineTheme({
           type: 'table',
           headers: ['Field', 'Merge behavior'],
           rows: [
-            ['tokens', 'Base tokens are copied first, then child tokens override on top.'],
-            ['components', 'Deep-merged: child component rules override matching keys from the base.'],
-            ['icons', 'Shallow-merged: child icons override matching names from the base.'],
-            ['indicators', 'Shallow-merged: child indicators override matching names from the base.'],
-            ['onDark, onLight', "Deep-merged per surface: the base's resolved surface first, then the child's overrides."],
-            ['typography, motion, radius, color', 'Child config replaces base entirely (these are scale inputs, not additive).'],
+            [
+              'tokens',
+              'Base tokens are copied first, then child tokens override on top.',
+            ],
+            [
+              'components',
+              'Deep-merged: child component rules override matching keys from the base.',
+            ],
+            [
+              'icons',
+              'Shallow-merged: child icons override matching names from the base.',
+            ],
+            [
+              'indicators',
+              'Shallow-merged: child indicators override matching names from the base.',
+            ],
+            [
+              'onDark, onLight',
+              "Deep-merged per surface: the base's resolved surface first, then the child's overrides.",
+            ],
+            [
+              'typography, motion, radius, color',
+              'Child config replaces base entirely (these are scale inputs, not additive).',
+            ],
+            [
+              'adaptations',
+              'Width-breakpoint overrides merge by fixed name. Inherited ordered rules keep their relative order; child rules append and re-resolve against the child root axes.',
+            ],
           ],
         },
         {
           type: 'prose',
-          text: 'Inheritance is resolved when the theme is defined, so an extended theme is flat: `astryx theme build` emits one self-contained stylesheet holding everything the child inherited, and the base theme\'s CSS does not need to be loaded next to it. A base that is not a theme (most often an import that missed) is a build error rather than a theme that silently inherits nothing.',
+          text: "Inheritance is resolved when the theme is defined, so an extended theme is flat: `astryx theme build` emits one self-contained stylesheet holding everything the child inherited, and the base theme's CSS does not need to be loaded next to it. A base that is not a theme (most often an import that missed) is a build error rather than a theme that silently inherits nothing.",
+        },
+      ],
+    },
+    {
+      title: 'Theme Adaptations',
+      category: 'guide',
+      content: [
+        {
+          type: 'prose',
+          text: 'Use `adaptations` for opt-in token, theme-local token, and component changes under viewport width, primary-pointer precision, contrast preference, or motion preference. Conditions in one `when` are ANDed. Rules are ordinary ordered objects, and later matching writes win.',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Width and pointer adaptations',
+          code: `const acmeTheme = defineTheme({
+  name: 'acme',
+  adaptations: {
+    widthBreakpoints: {
+      sm: 640,
+      md: 768,
+      lg: 1024,
+      xl: 1280,
+      '2xl': 1536,
+    },
+    rules: [
+      {
+        when: {width: {below: 'md'}},
+        value: {tokens: {'--spacing-4': '12px'}},
+      },
+      {
+        when: {pointer: 'coarse'},
+        value: {
+          tokens: {
+            '--size-element-sm': '36px',
+            '--size-element-md': '40px',
+            '--size-element-lg': '44px',
+          },
+        },
+      },
+      {
+        when: {
+          width: {from: 'lg', below: 'xl'},
+          pointer: 'coarse',
+          contrast: 'more',
+        },
+        value: {components: {card: {base: {borderWidth: '2px'}}}},
+      },
+    ],
+  },
+});`,
+        },
+        {
+          type: 'table',
+          headers: ['Condition', 'Values'],
+          rows: [
+            ['width.from / width.below', 'sm | md | lg | xl | 2xl'],
+            ['pointer', 'coarse | fine'],
+            ['contrast', 'more | less | no-preference'],
+            ['motion', 'reduce | no-preference'],
+          ],
+        },
+        {
+          type: 'prose',
+          text: '`widthBreakpoints` are fixed named start points. Defaults are 640 / 768 / 1024 / 1280 / 1536 CSS pixels. `from` includes its point; `below` excludes it. Breakpoint configuration alone emits no CSS.',
+        },
+        {
+          type: 'prose',
+          text: '**Precedence follows rule order.** Root theme values apply first, then every matching rule in declaration order. A later rule may deliberately restore a root value. `onDark` and `onLight` media-surface overrides apply after adaptations and win on the same leaf.',
+        },
+        {
+          type: 'prose',
+          text: "`extends` preserves the base rule order and appends child rules. Inherited conditions use the child's effective breakpoint map, and partial generative axes complete from the child root metadata. An empty child rule is a no-op, not a removal operator.",
+        },
+        {
+          type: 'prose',
+          text: 'A rule may replace a theme-local token only when the exact name is already enrolled by root `localTokens` or an enrolled base. Custom component visual-prop values must also be declared on the root theme before an adaptation styles them. When rules can match together, their ordered portable and local token writes are validated as one effective graph; any reachable cycle fails before CSS is emitted.',
+        },
+        {
+          type: 'prose',
+          text: 'Adaptations compile to CSS media queries with no resize listener or styling rerender. Runtime and `astryx theme build` use the same compiler, but only a built theme is present at first paint in an SSR app.',
         },
       ],
     },
     {
       title: 'Component Style Overrides',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -307,7 +410,7 @@ const brandTheme = defineTheme({
         },
         {
           type: 'prose',
-          text: 'Run `astryx theme targets` for every themeable key in the system (`astryx theme targets <Name>` to scope it, `--json` to lint a theme against it), and `astryx component <Name>` for one component\'s theming targets, public CSS variables, and which standard CSS properties are supported.',
+          text: "Run `astryx theme targets` for every themeable key in the system (`astryx theme targets <Name>` to scope it, `--json` to lint a theme against it), and `astryx component <Name>` for one component's theming targets, public CSS variables, and which standard CSS properties are supported.",
         },
         {
           type: 'list',
@@ -328,11 +431,11 @@ const brandTheme = defineTheme({
     },
     {
       title: 'Custom Variants',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
-          text: 'Themes can add new prop values to any component. Any `prop:value` key where the value isn\'t a built-in gets treated as a new variant. Use `astryx theme build` to generate TypeScript augmentations for type safety.',
+          text: "Themes can add new prop values to any component. Any `prop:value` key where the value isn't a built-in gets treated as a new variant. Use `astryx theme build` to generate TypeScript augmentations for type safety.",
         },
         {
           type: 'code',
@@ -371,13 +474,13 @@ const brandTheme = defineTheme({
         },
         {
           type: 'prose',
-          text: 'Custom variants only work when the theme that defines them is active. The component\'s variant map is extended via module augmentation, with no changes to the component source needed.',
+          text: "Custom variants only work when the theme that defines them is active. The component's variant map is extended via module augmentation, with no changes to the component source needed.",
         },
       ],
     },
     {
       title: 'Building Themes for Production',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -411,7 +514,7 @@ const brandTheme = defineTheme({
             ],
             [
               'ocean.variants.d.ts',
-              '(Optional) Module augmentations for custom component prop values found in the theme\'s component overrides',
+              "(Optional) Module augmentations for custom component prop values found in the theme's component overrides",
             ],
           ],
         },
@@ -432,13 +535,13 @@ import './themes/ocean.css';
         },
         {
           type: 'prose',
-          text: 'The build also warns when the theme names font families it does not load (webfonts like Fraunces) and prints the `<link>`/`@font-face` to add. The built CSS only sets font-family, so loading the font files stays the app\'s job. See `astryx docs typography` for the full recipe.',
+          text: "The build also warns when the theme names font families it does not load (webfonts like Fraunces) and prints the `<link>`/`@font-face` to add. The built CSS only sets font-family, so loading the font files stays the app's job. See `astryx docs typography` for the full recipe.",
         },
       ],
     },
     {
       title: 'Runtime vs Built Themes',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -450,13 +553,13 @@ import './themes/ocean.css';
           rows: [
             [
               'Import (published theme)',
-              "@astryxdesign/theme-{name}",
-              "@astryxdesign/theme-{name}/built + theme.css",
+              '@astryxdesign/theme-{name}',
+              '@astryxdesign/theme-{name}/built + theme.css',
             ],
             [
               'Import (custom theme)',
               'defineTheme() directly',
-              "Built .js + .css from `astryx theme build`",
+              'Built .js + .css from `astryx theme build`',
             ],
             [
               'How it works',
@@ -494,14 +597,14 @@ import './themes/ocean.css';
           style: 'dont',
           items: [
             'Use runtime themes in production SSR apps; component overrides will flash on hydration.',
-            'Import /built without the CSS file; component overrides won\'t apply.',
+            "Import /built without the CSS file; component overrides won't apply.",
           ],
         },
       ],
     },
     {
       title: 'Light/Dark Mode',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -530,7 +633,7 @@ import './themes/ocean.css';
     },
     {
       title: 'Nesting Themes',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -556,7 +659,7 @@ import './themes/ocean.css';
     },
     {
       title: 'Token Utilities',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',
@@ -599,7 +702,7 @@ const chartTheme = {
     },
     {
       title: 'useTheme Hook',
-  category: 'guide',
+      category: 'guide',
       content: [
         {
           type: 'prose',

--- a/packages/cli/assets/docs/theme.doc.mjs
+++ b/packages/cli/assets/docs/theme.doc.mjs
@@ -367,7 +367,7 @@ const brandTheme = defineTheme({
         },
         {
           type: 'prose',
-          text: 'A rule may replace a theme-local token only when the exact name is already enrolled by root `localTokens` or an enrolled base. Custom component visual-prop values must also be declared on the root theme before an adaptation styles them. When rules can match together, their ordered portable and local token writes are validated as one effective graph; any reachable cycle fails before CSS is emitted.',
+          text: 'A rule may replace a theme-local token only when the exact name is already enrolled by root `localTokens` or an enrolled base. Custom component visual-prop values are introduced on the root theme before an adaptation styles them. Build validation rejects rule-only values when it can enumerate the prop domain; opaque alias-backed domains retain the same known validation boundary as root themes and are not thereby extensible. When rules can match together, their ordered portable and local token writes are validated as one effective graph; any reachable cycle fails before CSS is emitted.',
         },
         {
           type: 'prose',

--- a/packages/cli/assets/theme.template.ts
+++ b/packages/cli/assets/theme.template.ts
@@ -327,4 +327,60 @@ export const myTheme = defineTheme({
    */
   // onDark: {tokens: {'--color-accent': '#90CAF9'}, components: {button: {'variant:ghost': {borderWidth: '1px'}}}},
   // onLight: {tokens: {'--color-accent': '#0B5FCC'}},
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Theme adaptations
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Opt-in values for reviewed environmental conditions. Width points use the
+   * fixed names `sm`, `md`, `lg`, `xl`, and `2xl`; overriding the map alone
+   * emits no CSS. Fields inside `when` are ANDed, and matching rules cascade in
+   * authored order so later writes win.
+   *
+   * `from` includes its point; `below` excludes it. The other supported axes
+   * are primary-pointer precision, contrast preference, and motion preference.
+   * A rule may replace only theme-local names and custom visual-prop values
+   * already declared by the root theme or its exact base lineage.
+   */
+  // adaptations is opt-in. Replace this empty block with the commented
+  // example below when the theme needs environmental values.
+  adaptations: {rules: []},
+  // adaptations: {
+  //   widthBreakpoints: {
+  //     sm: 640,
+  //     md: 768,
+  //     lg: 1024,
+  //     xl: 1280,
+  //     '2xl': 1536,
+  //   },
+  //   rules: [
+  //     {
+  //       // Narrow at every pointer precision.
+  //       when: {width: {below: 'md'}},
+  //       value: {tokens: {'--spacing-4': '12px'}},
+  //     },
+  //     {
+  //       // Taller controls under a finger or stylus at every width.
+  //       when: {pointer: 'coarse'},
+  //       value: {
+  //         tokens: {
+  //           '--size-element-sm': '36px',
+  //           '--size-element-md': '40px',
+  //           '--size-element-lg': '44px',
+  //         },
+  //       },
+  //     },
+  //     // Combined conditions are peers, not nested syntax:
+  //     // {
+  //     //   when: {
+  //     //     width: {from: 'lg', below: 'xl'},
+  //     //     pointer: 'coarse',
+  //     //     contrast: 'more',
+  //     //     motion: 'reduce',
+  //     //   },
+  //     //   value: {components: {card: {base: {borderWidth: '2px'}}}},
+  //     // },
+  //   ],
+  // },
 });

--- a/packages/cli/assets/theme.template.ts
+++ b/packages/cli/assets/theme.template.ts
@@ -340,8 +340,10 @@ export const myTheme = defineTheme({
    *
    * `from` includes its point; `below` excludes it. The other supported axes
    * are primary-pointer precision, contrast preference, and motion preference.
-   * A rule may replace only theme-local names and custom visual-prop values
-   * already declared by the root theme or its exact base lineage.
+   * Custom visual-prop values are introduced at the root before a rule uses
+   * them. Build validation rejects rule-only values when it can enumerate the
+   * prop domain; opaque alias-backed domains retain the known root-validation
+   * boundary and are not extension points.
    */
   // adaptations is opt-in. Replace this empty block with the commented
   // example below when the theme needs environmental values.

--- a/packages/cli/clients/cli/commands/build-theme.adaptations.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.adaptations.test.mjs
@@ -1,0 +1,525 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Ensures `astryx theme build` preserves AST-012 adaptation semantics.
+ * Runtime and static output share core's compiler; this suite guards the CLI
+ * loading, diagnostics, serialization, and extension boundaries around it.
+ */
+
+import {afterEach, beforeAll, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {ensureCoreBuilt} from './ensure-core-built.mjs';
+import {runCli} from '../../../test-utils/run-cli.mjs';
+
+function writeTheme(dir, name, inputSource) {
+  fs.mkdirSync(dir, {recursive: true});
+  const file = path.join(dir, `${name}.mjs`);
+  fs.writeFileSync(
+    file,
+    `import {defineTheme} from '@astryxdesign/core/theme';\n` +
+      `export default defineTheme(${inputSource});\n`,
+  );
+  return file;
+}
+
+function writePlainTheme(dir, name, inputSource) {
+  fs.mkdirSync(dir, {recursive: true});
+  const file = path.join(dir, `${name}.mjs`);
+  fs.writeFileSync(file, `export default ${inputSource};\n`);
+  return file;
+}
+
+async function build(project, themeFile) {
+  return runCli(['theme', 'build', path.relative(project, themeFile)], project);
+}
+
+beforeAll(() => {
+  ensureCoreBuilt();
+}, 200_000);
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'astryx-build-theme-adaptations-'),
+  );
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('theme build adaptations', () => {
+  it('emits ordered closed conditions after root values', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'ordered',
+      `{
+        name: 'ordered',
+        tokens: {'--spacing-4': '16px'},
+        adaptations: {
+          widthBreakpoints: {md: 800, lg: 1100},
+          rules: [
+            {
+              when: {width: {from: 'md', below: 'lg'}, pointer: 'coarse'},
+              value: {tokens: {'--spacing-4': '12px'}},
+            },
+            {
+              when: {contrast: 'more', motion: 'reduce'},
+              value: {tokens: {'--spacing-4': '20px'}},
+            },
+          ],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+
+    const css = fs.readFileSync(path.join(themesDir, 'ordered.css'), 'utf-8');
+    expect(css).toContain(
+      '@media (width >= 800px) and (width < 1100px) and (pointer: coarse)',
+    );
+    expect(css).toContain(
+      '@media (prefers-contrast: more) and (prefers-reduced-motion: reduce)',
+    );
+    expect(css.indexOf('--spacing-4: 16px')).toBeLessThan(
+      css.indexOf('--spacing-4: 12px'),
+    );
+    expect(css.indexOf('--spacing-4: 12px')).toBeLessThan(
+      css.indexOf('--spacing-4: 20px'),
+    );
+  });
+
+  it('resolves a plain object whose only input-only field is adaptations', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writePlainTheme(
+      themesDir,
+      'plain-adaptive',
+      `{
+        name: 'plain-adaptive',
+        adaptations: {
+          rules: [{
+            when: {pointer: 'coarse'},
+            value: {tokens: {'--color-accent': ['#111111', '#eeeeee']}},
+          }],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+
+    const css = fs.readFileSync(
+      path.join(themesDir, 'plain-adaptive.css'),
+      'utf-8',
+    );
+    expect(css).toContain('@media (pointer: coarse)');
+    expect(css).toContain('light-dark(#111111, #eeeeee)');
+    expect(css).not.toContain('#111111,#eeeeee');
+  });
+
+  it('emits the color-scheme guard for a tuple declared only in a rule', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'rule-tuple',
+      `{
+        name: 'rule-tuple',
+        adaptations: {
+          rules: [{
+            when: {pointer: 'coarse'},
+            value: {tokens: {'--color-accent': ['#0077B6', '#48CAE4']}},
+          }],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+
+    const css = fs.readFileSync(
+      path.join(themesDir, 'rule-tuple.css'),
+      'utf-8',
+    );
+    expect(css).toContain(':root { color-scheme: light dark; }');
+    expect(css).toContain('html[data-theme="light"] { color-scheme: light; }');
+    expect(css).toContain('html[data-theme="dark"] { color-scheme: dark; }');
+  });
+
+  it('keeps media-surface overrides after adaptation rules', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'surface-order',
+      `{
+        name: 'surface-order',
+        tokens: {'--color-background-body': '#ffffff'},
+        adaptations: {
+          rules: [{
+            when: {contrast: 'more'},
+            value: {tokens: {'--color-background-body': '#eeeeee'}},
+          }],
+        },
+        onDark: {tokens: {'--color-background-body': '#111111'}},
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+
+    const css = fs.readFileSync(
+      path.join(themesDir, 'surface-order.css'),
+      'utf-8',
+    );
+    expect(css.indexOf('#eeeeee')).toBeLessThan(css.lastIndexOf('#111111'));
+    expect(css.lastIndexOf('[data-astryx-media="dark"]')).toBeGreaterThan(
+      css.indexOf('@media (prefers-contrast: more)'),
+    );
+  });
+
+  it('serializes normalized intent and axes, not resolved rule CSS', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'built-base',
+      `{
+        name: 'built-base',
+        typography: {scale: {base: 14, ratio: 1.25}},
+        adaptations: {
+          widthBreakpoints: {sm: 700},
+          rules: [{
+            when: {width: {below: 'sm'}},
+            value: {
+              typography: {
+                scale: {base: 16},
+                body: {family: 'Revision Webfont'},
+              },
+              tokens: {'--color-accent': ['#111111', '#eeeeee']},
+            },
+          }],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+
+    const jsPath = path.join(themesDir, 'built-base.js');
+    const js = fs.readFileSync(jsPath, 'utf-8');
+    expect(js).toContain('__adaptations');
+    expect(js).toContain('__axes');
+    expect(js).not.toContain('__adaptationRules');
+    expect(js).not.toContain('@media');
+    expect(
+      Buffer.byteLength(js.slice(js.indexOf('__adaptations'))),
+    ).toBeLessThan(1_500);
+
+    const {builtBaseTheme} = await import(
+      `${pathToFileURL(jsPath).href}?test=${Date.now()}`
+    );
+    const {defineTheme} = await import('@astryxdesign/core/theme');
+    const child = defineTheme({
+      name: 'built-child',
+      extends: builtBaseTheme,
+      adaptations: {widthBreakpoints: {sm: 720}},
+    });
+    expect(child.__adaptationRules?.[0].query).toBe('(width < 720px)');
+    expect(child.__adaptationRules?.[0].tokens['--font-size-lg']).toBe(
+      '1.25rem',
+    );
+
+    const rebuildDir = path.join(project, 'rebuild');
+    fs.mkdirSync(rebuildDir, {recursive: true});
+    const rebuiltInput = path.join(rebuildDir, 'rebuilt.mjs');
+    fs.writeFileSync(
+      rebuiltInput,
+      `export {builtBaseTheme as default} from '../themes/built-base.js';\n`,
+    );
+    const rebuilt = await build(project, rebuiltInput);
+    expect(rebuilt.code).toBe(0);
+    const rebuiltCss = fs.readFileSync(
+      path.join(rebuildDir, 'built-base.css'),
+      'utf-8',
+    );
+    expect(rebuiltCss).toContain('@media (width < 700px)');
+    expect(rebuiltCss).toContain('--font-size-lg: 1.25rem');
+    expect(rebuiltCss).toContain('light-dark(#111111, #eeeeee)');
+    expect(rebuiltCss).toContain(':root { color-scheme: light dark; }');
+    expect(`${rebuilt.stdout}${rebuilt.stderr}`).toContain(
+      'Font "Revision Webfont" is named by this theme but not loaded',
+    );
+  });
+
+  it('retains the effective width map even when no rules emit CSS', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'points-only',
+      `{
+        name: 'points-only',
+        tokens: {'--spacing-4': '18px'},
+        adaptations: {widthBreakpoints: {xl: 1400}},
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+
+    const css = fs.readFileSync(
+      path.join(themesDir, 'points-only.css'),
+      'utf-8',
+    );
+    const js = fs.readFileSync(path.join(themesDir, 'points-only.js'), 'utf-8');
+    expect(css).not.toContain('@media');
+    expect(js).toMatch(/"xl": 1400/);
+    expect(js).toContain('__adaptations');
+  });
+
+  it('allows an existing built-in visual value inside a rule', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'builtin-variant',
+      `{
+        name: 'builtin-variant',
+        adaptations: {
+          rules: [{
+            when: {pointer: 'coarse'},
+            value: {
+              components: {
+                button: {'variant:secondary': {borderWidth: '3px'}},
+                heading: {'level:1': {letterSpacing: '-0.01em'}},
+              },
+            },
+          }],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+    const css = fs.readFileSync(
+      path.join(themesDir, 'builtin-variant.css'),
+      'utf-8',
+    );
+    expect(css).toContain('border-width: 3px');
+    expect(css).toContain('letter-spacing: -0.01em');
+  });
+
+  it('warns rather than hard-failing unknown rule targets and axes', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'unknown-rule-axis',
+      `{
+        name: 'unknown-rule-axis',
+        adaptations: {
+          rules: [{
+            when: {pointer: 'coarse'},
+            value: {
+              components: {table: {'density:compact': {borderWidth: '3px'}}},
+            },
+          }],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      'Unknown prop "density" on component "table"',
+    );
+    expect(
+      fs.readFileSync(path.join(themesDir, 'unknown-rule-axis.css'), 'utf-8'),
+    ).toContain('border-width: 3px');
+  });
+
+  it('requires custom visual values on the root surface before rules use them', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const badFile = writeTheme(
+      themesDir,
+      'rule-only-variant',
+      `{
+        name: 'rule-only-variant',
+        adaptations: {
+          rules: [{
+            when: {pointer: 'coarse'},
+            value: {
+              components: {button: {'variant:brandy': {borderWidth: '3px'}}},
+            },
+          }],
+        },
+      }`,
+    );
+
+    const bad = await build(project, badFile);
+    expect(bad.code).not.toBe(0);
+    expect(`${bad.stdout}${bad.stderr}`).toContain(
+      'Declare custom visual-prop values on the root theme first',
+    );
+    expect(fs.existsSync(path.join(themesDir, 'rule-only-variant.css'))).toBe(
+      false,
+    );
+
+    const goodFile = writeTheme(
+      themesDir,
+      'root-variant',
+      `{
+        name: 'root-variant',
+        components: {button: {'variant:brandy': {borderWidth: '1px'}}},
+        adaptations: {
+          rules: [{
+            when: {pointer: 'coarse'},
+            value: {
+              components: {button: {'variant:brandy': {borderWidth: '3px'}}},
+            },
+          }],
+        },
+      }`,
+    );
+
+    const good = await build(project, goodFile);
+    expect(good.code).toBe(0);
+    expect(
+      fs.readFileSync(
+        path.join(themesDir, 'root-variant.variants.d.ts'),
+        'utf-8',
+      ),
+    ).toContain('brandy');
+  });
+
+  it('validates private variables declared only in a rule', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(
+      themesDir,
+      'rule-private',
+      `{
+        name: 'rule-private',
+        adaptations: {
+          rules: [{
+            when: {pointer: 'coarse'},
+            value: {
+              components: {button: {base: {'--_button-pad': '3px'}}},
+            },
+          }],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(`${result.stdout}${result.stderr}`).toContain('private var');
+  });
+
+  it('rejects cycles across co-matching rules before writing output', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const a = '--astryx-theme-overlap-build-a';
+    const b = '--astryx-theme-overlap-build-b';
+    const themeFile = writePlainTheme(
+      themesDir,
+      'overlap-build',
+      `{
+        name: 'overlap-build',
+        localTokens: {'${a}': '1px', '${b}': '2px'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {localTokens: {'${a}': 'var(${b})'}},
+            },
+            {
+              when: {contrast: 'more'},
+              value: {localTokens: {'${b}': 'var(${a})'}},
+            },
+          ],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toMatch(
+      /overlapping rules \[0, 1\].*cycle detected/i,
+    );
+    expect(fs.existsSync(path.join(themesDir, 'overlap-build.css'))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(themesDir, 'overlap-build.js'))).toBe(false);
+  });
+
+  it('reports invalid serialized adaptation metadata as ERR_THEME_INVALID', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writePlainTheme(
+      themesDir,
+      'stale-built',
+      `{
+        name: 'stale-built',
+        __built: true,
+        tokens: {'--spacing-4': '16px'},
+        __adaptations: {
+          widthBreakpoints: {
+            sm: 640, md: 768, lg: 1024, xl: 1280, '2xl': 1536,
+          },
+          rules: [{
+            when: {pointer: 'sideways'},
+            value: {tokens: {'--spacing-4': '12px'}},
+          }],
+        },
+        __axes: {},
+      }`,
+    );
+
+    const result = await runCli(
+      ['theme', 'build', path.relative(project, themeFile), '--json'],
+      project,
+    );
+    expect(result.code).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain('ERR_THEME_INVALID');
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      "when.pointer must be 'coarse' or 'fine'",
+    );
+    expect(fs.existsSync(path.join(themesDir, 'stale-built.css'))).toBe(false);
+  });
+
+  it('rejects invalid metadata before writing any output', async () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writePlainTheme(
+      themesDir,
+      'invalid-range',
+      `{
+        name: 'invalid-range',
+        adaptations: {
+          rules: [{
+            when: {width: {from: 'xl', below: 'md'}},
+            value: {tokens: {'--spacing-4': '12px'}},
+          }],
+        },
+      }`,
+    );
+
+    const result = await build(project, themeFile);
+    expect(result.code).not.toBe(0);
+    expect(`${result.stdout}${result.stderr}`).toContain(
+      'must resolve to `from < below`',
+    );
+    expect(fs.existsSync(path.join(themesDir, 'invalid-range.css'))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(themesDir, 'invalid-range.js'))).toBe(false);
+  });
+});

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -7,27 +7,103 @@ export const docs = {
   displayName: 'App Shell',
   group: 'AppShell',
   category: 'Layout',
-  keywords: ["appshell","layout","scaffold","sidebar","sidenav","topnav","header","navigation","dashboard","shell","page","frame"],
+  keywords: [
+    'appshell',
+    'layout',
+    'scaffold',
+    'sidebar',
+    'sidenav',
+    'topnav',
+    'header',
+    'navigation',
+    'dashboard',
+    'shell',
+    'page',
+    'frame',
+  ],
   usage: {
     description:
       'AppShell is the page shell for an application. It provides slots for top navigation, side navigation, banners, and main content. Use it as the root wrapper for every page. It handles responsive mobile navigation and skip-to-content automatically. Configure side nav collapse on SideNav with its collapsible prop.',
     bestPractices: [
-      {guidance: true, description: 'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
-      {guidance: true, description: 'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.'},
-      {guidance: true, description: 'Give every nav slot an accessible name. AppShell renders TopNav and SideNav as separate navigation landmarks, and a screen reader lists them by name, so pass `label` to each one.'},
-      {guidance: true, description: 'Start the page heading inside `children`. AppShell owns the skip link, the banner landmark and the main landmark, but it renders no heading, so the first heading in the content area is the page h1.'},
-      {guidance: false, description: "Nest one AppShell inside another; it's the outermost layout frame."},
-      {guidance: false, description: 'Use for sub-page layouts; use Layout for content areas within AppShell.'},
-      {guidance: false, description: 'Add your own skip link or <main> element. AppShell already renders both, and a second main landmark makes the first ambiguous.'},
+      {
+        guidance: true,
+        description:
+          'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give every nav slot an accessible name. AppShell renders TopNav and SideNav as separate navigation landmarks, and a screen reader lists them by name, so pass `label` to each one.',
+      },
+      {
+        guidance: true,
+        description:
+          'Start the page heading inside `children`. AppShell owns the skip link, the banner landmark and the main landmark, but it renders no heading, so the first heading in the content area is the page h1.',
+      },
+      {
+        guidance: false,
+        description:
+          "Nest one AppShell inside another; it's the outermost layout frame.",
+      },
+      {
+        guidance: false,
+        description:
+          'Use for sub-page layouts; use Layout for content areas within AppShell.',
+      },
+      {
+        guidance: false,
+        description:
+          'Add your own skip link or <main> element. AppShell already renders both, and a second main landmark makes the first ambiguous.',
+      },
     ],
     anatomy: [
-      {name: 'Page shell', required: true, description: 'Outermost application frame that owns page-level navigation, responsive shell behavior, and the main content landmark.'},
-      {name: 'Skip link', required: true, description: 'First focusable element on the page. Visually hidden until focused, then moves focus to the main content area.'},
-      {name: 'Banner', required: false, description: 'The banner slot, for system-wide announcements. Renders above the top nav, inside the banner landmark.'},
-      {name: 'Top navigation', required: false, description: 'The topNav slot, typically TopNav. Below the mobile breakpoint it becomes a compact bar carrying the nav toggle.'},
-      {name: 'Side navigation', required: false, description: 'The sideNav slot, typically SideNav. Inline above the breakpoint, moved into the mobile drawer below it.'},
-      {name: 'Main content', required: true, description: 'children, rendered in the main landmark. Scrolls internally when height is fill, and with the page when it is auto.'},
-      {name: 'Mobile nav drawer', required: false, description: 'Generated below the breakpoint from the nav slots unless mobileNav disables or replaces it. A modal dialog: it traps focus and returns focus to the toggle on close.'},
+      {
+        name: 'Page shell',
+        required: true,
+        description:
+          'Outermost application frame that owns page-level navigation, responsive shell behavior, and the main content landmark.',
+      },
+      {
+        name: 'Skip link',
+        required: true,
+        description:
+          'First focusable element on the page. Visually hidden until focused, then moves focus to the main content area.',
+      },
+      {
+        name: 'Banner',
+        required: false,
+        description:
+          'The banner slot, for system-wide announcements. Renders above the top nav, inside the banner landmark.',
+      },
+      {
+        name: 'Top navigation',
+        required: false,
+        description:
+          'The topNav slot, typically TopNav. Below the mobile breakpoint it becomes a compact bar carrying the nav toggle.',
+      },
+      {
+        name: 'Side navigation',
+        required: false,
+        description:
+          'The sideNav slot, typically SideNav. Inline above the breakpoint, moved into the mobile drawer below it.',
+      },
+      {
+        name: 'Main content',
+        required: true,
+        description:
+          'children, rendered in the main landmark. Scrolls internally when height is fill, and with the page when it is auto.',
+      },
+      {
+        name: 'Mobile nav drawer',
+        required: false,
+        description:
+          'Generated below the breakpoint from the nav slots unless mobileNav disables or replaces it. A modal dialog: it traps focus and returns focus to the toggle on close.',
+      },
     ],
   },
   props: [
@@ -65,7 +141,7 @@ export const docs = {
       // coincidence. The legal values live in the description instead (#1645).
       type: 'ReactNode',
       description:
-        "Mobile navigation configuration. Accepts false (disable), a config object (tune auto behavior), or ReactNode (full custom drawer). The config object is {hasToggle?: boolean, isOpen?: boolean, onOpenChange?: (isOpen: boolean) => void, content?: ReactNode, breakpoint?: 'sm' | 'md' | 'lg' | 'none', defaultIsMobile?: boolean}; breakpoint defaults to 'md'.",
+        "Mobile navigation configuration. Accepts false (disable), a config object (tune auto behavior), or ReactNode (full custom drawer). The config object is {hasToggle?: boolean, isOpen?: boolean, onOpenChange?: (isOpen: boolean) => void, content?: ReactNode, breakpoint?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'none', defaultIsMobile?: boolean}; breakpoint defaults to 'md', resolves through the nearest Theme's widthBreakpoints, and switches to the wider layout at equality.",
       slotElements: [{__element: 'MobileNav', props: {}}],
     },
     {
@@ -73,7 +149,12 @@ export const docs = {
       type: 'ReactNode',
       description:
         'Banner slot for system-wide announcements, placed above the topNav.',
-      slotElements: [{__element: 'Banner', props: {title: 'Info', status: 'info', container: 'section'}}],
+      slotElements: [
+        {
+          __element: 'Banner',
+          props: {title: 'Info', status: 'info', container: 'section'},
+        },
+      ],
     },
     {
       name: 'height',
@@ -102,13 +183,19 @@ export const docs = {
       contentPadding: 4,
       topNav: {
         __element: 'TopNav',
-        props: {label: 'Navigation', heading: {__element: 'TopNavHeading', props: {heading: 'My App'}}},
+        props: {
+          label: 'Navigation',
+          heading: {__element: 'TopNavHeading', props: {heading: 'My App'}},
+        },
       },
       sideNav: {
         __element: 'SideNav',
         props: {},
         children: [
-          {__element: 'SideNavItem', props: {label: 'Dashboard', isSelected: true}},
+          {
+            __element: 'SideNavItem',
+            props: {label: 'Dashboard', isSelected: true},
+          },
           {__element: 'SideNavItem', props: {label: 'Settings'}},
           {__element: 'SideNavItem', props: {label: 'Help'}},
         ],
@@ -118,7 +205,11 @@ export const docs = {
         props: {gap: 3},
         children: [
           {__element: 'Heading', props: {level: 2}, children: 'Dashboard'},
-          {__element: 'Text', props: {type: 'body', color: 'secondary'}, children: 'Welcome back. Here is an overview of your workspace.'},
+          {
+            __element: 'Text',
+            props: {type: 'body', color: 'secondary'},
+            children: 'Welcome back. Here is an overview of your workspace.',
+          },
         ],
       },
     },
@@ -140,14 +231,34 @@ export const docsZh = {
     description:
       'AppShell is the page shell for an application. It provides slots for top navigation, side navigation, banners, and main content. Use it as the root wrapper for every page. It handles responsive mobile navigation and skip-to-content automatically. Configure side nav collapse on SideNav with its collapsible prop.',
     bestPractices: [
-      {guidance: true, description: 'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
-      {guidance: true, description: 'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.'},
-      {guidance: false, description: "Nest one AppShell inside another; it's the outermost layout frame."},
-      {guidance: false, description: 'Use for sub-page layouts; use Layout for content areas within AppShell.'},
+      {
+        guidance: true,
+        description:
+          'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.',
+      },
+      {
+        guidance: false,
+        description:
+          "Nest one AppShell inside another; it's the outermost layout frame.",
+      },
+      {
+        guidance: false,
+        description:
+          'Use for sub-page layouts; use Layout for content areas within AppShell.',
+      },
     ],
   },
   props: [
-    {name: 'children', type: 'ReactNode', description: '主内容区域，渲染在 <main> 元素内部。'},
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: '主内容区域，渲染在 <main> 元素内部。',
+    },
     {
       name: 'contentPadding',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
@@ -155,10 +266,27 @@ export const docsZh = {
         '主内容区域的内边距。根据页面主要内容模式设置：4（16px）适用于表单/设置/文本页面，0 适用于仪表盘/地图/表格。可通过 Section 覆盖个别区域。',
       default: '0',
     },
-    {name: 'topNav', type: 'ReactNode', description: '顶部导航插槽，通常为 TopNav。'},
-    {name: 'sideNav', type: 'ReactNode', description: '侧边导航插槽，通常为 SideNav。'},
-    {name: 'mobileNav', type: 'ReactNode', description: "移动端导航配置。接受 false（禁用）、配置对象（调整自动行为）或 ReactNode（完全自定义抽屉）。配置对象为 {hasToggle?, isOpen?, onOpenChange?, content?, breakpoint?: 'sm' | 'md' | 'lg' | 'none', defaultIsMobile?}；breakpoint 默认为 'md'。"},
-    {name: 'banner', type: 'ReactNode', description: '横幅插槽，用于全局公告，放置在 topNav 上方。'},
+    {
+      name: 'topNav',
+      type: 'ReactNode',
+      description: '顶部导航插槽，通常为 TopNav。',
+    },
+    {
+      name: 'sideNav',
+      type: 'ReactNode',
+      description: '侧边导航插槽，通常为 SideNav。',
+    },
+    {
+      name: 'mobileNav',
+      type: 'ReactNode',
+      description:
+        "移动端导航配置。接受 false（禁用）、配置对象（调整自动行为）或 ReactNode（完全自定义抽屉）。配置对象为 {hasToggle?, isOpen?, onOpenChange?, content?, breakpoint?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'none', defaultIsMobile?}；breakpoint 默认为 'md'，从最近 Theme 的 widthBreakpoints 解析，并在等于断点时切换到较宽布局。",
+    },
+    {
+      name: 'banner',
+      type: 'ReactNode',
+      description: '横幅插槽，用于全局公告，放置在 topNav 上方。',
+    },
     {
       name: 'height',
       type: "'fill' | 'auto'",
@@ -184,9 +312,7 @@ export const docsZh = {
     targets: [
       {
         className: 'astryx-app-shell',
-        visualProps: [
-          'variant',
-        ],
+        visualProps: ['variant'],
       },
       {className: 'astryx-app-shell-header', visualProps: ['variant']},
       {className: 'astryx-app-shell-sidenav', visualProps: ['variant']},
@@ -202,20 +328,49 @@ export const docsDense = {
     description:
       'AppShell is the page shell for an application. It provides slots for top navigation, side navigation, banners, and main content. Use it as the root wrapper for every page. It handles responsive mobile navigation and skip-to-content automatically. Configure side nav collapse on SideNav with its collapsible prop.',
     bestPractices: [
-      {guidance: true, description: 'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
-      {guidance: true, description: 'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.'},
-      {guidance: true, description: 'Give every nav slot an accessible name: TopNav and SideNav are separate navigation landmarks, so pass `label` to each.'},
-      {guidance: true, description: 'Start the page heading inside `children`: AppShell owns the skip link, banner, and main landmarks but renders no heading, so the first content heading is the page h1.'},
-      {guidance: false, description: "Nest one AppShell inside another; it's the outermost layout frame."},
-      {guidance: false, description: 'Use for sub-page layouts; use Layout for content areas within AppShell.'},
-      {guidance: false, description: 'Add your own skip link or <main>; AppShell renders both, and a second main landmark makes the first ambiguous.'},
+      {
+        guidance: true,
+        description:
+          'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.',
+      },
+      {
+        guidance: true,
+        description:
+          'Give every nav slot an accessible name: TopNav and SideNav are separate navigation landmarks, so pass `label` to each.',
+      },
+      {
+        guidance: true,
+        description:
+          'Start the page heading inside `children`: AppShell owns the skip link, banner, and main landmarks but renders no heading, so the first content heading is the page h1.',
+      },
+      {
+        guidance: false,
+        description:
+          "Nest one AppShell inside another; it's the outermost layout frame.",
+      },
+      {
+        guidance: false,
+        description:
+          'Use for sub-page layouts; use Layout for content areas within AppShell.',
+      },
+      {
+        guidance: false,
+        description:
+          'Add your own skip link or <main>; AppShell renders both, and a second main landmark makes the first ambiguous.',
+      },
     ],
   },
   propDescriptions: {
     children: 'main content area, rendered inside <main>',
     topNav: 'top nav slot, typically TopNav',
     sideNav: 'side nav slot, typically SideNav',
-    mobileNav: 'mobile nav config: false | MobileNavConfig | ReactNode',
+    mobileNav:
+      'mobile nav config: false | ReactNode | config with theme-resolved sm|md|lg|xl|2xl|none breakpoint (exclusive upper edge)',
     banner: 'slot for system-wide announcements above topNav',
     height:
       'fill=viewport 100dvh w/ independent scroll; auto=content-driven w/ sticky nav',

--- a/packages/core/src/AppShell/AppShell.test.tsx
+++ b/packages/core/src/AppShell/AppShell.test.tsx
@@ -18,7 +18,7 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {act, render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {AppShell} from './AppShell';
 import {InternationalizationProvider} from '../i18n';
@@ -26,6 +26,7 @@ import {MobileNav} from '../MobileNav';
 import {SideNav, SideNavItem, SideNavSection} from '../SideNav';
 import {TopNav, TopNavHeading, TopNavItem} from '../TopNav';
 import {useAppShellMobile} from './AppShellMobileContext';
+import {Theme, defineTheme} from '../theme';
 
 // jsdom doesn't implement showModal/close on <dialog>, so we mock them
 beforeAll(() => {
@@ -109,6 +110,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  act(() => {
+    document.documentElement.removeAttribute('data-astryx-theme');
+  });
 });
 
 describe('AppShell', () => {
@@ -296,15 +300,140 @@ describe('AppShell', () => {
   // Responsive breakpoint
   // ===========================================================================
 
-  it('tracks breakpoint changes', () => {
+  it('uses the default named breakpoint with an exclusive upper edge', () => {
     render(
       <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'md'}}>
         <div>Content</div>
       </AppShell>,
     );
 
-    // matchMedia should have been called for the breakpoint
-    expect(window.matchMedia).toHaveBeenCalled();
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 768px)');
+  });
+
+  it('resolves all named points through the nearest Theme', () => {
+    const theme = {
+      ...defineTheme({
+        name: 'app-shell-points',
+        adaptations: {widthBreakpoints: {xl: 1400, '2xl': 1800}},
+      }),
+      __built: true as const,
+    };
+
+    render(
+      <Theme theme={theme}>
+        <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: '2xl'}}>
+          <div>Content</div>
+        </AppShell>
+      </Theme>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 1800px)');
+  });
+
+  it('uses the provider object when another theme shares its name', () => {
+    const outer = {
+      ...defineTheme({
+        name: 'same-name',
+        adaptations: {widthBreakpoints: {md: 700}},
+      }),
+      __built: true as const,
+    };
+    const inner = {
+      ...defineTheme({
+        name: 'same-name',
+        adaptations: {widthBreakpoints: {md: 900}},
+      }),
+      __built: true as const,
+    };
+
+    render(
+      <Theme theme={outer}>
+        <Theme theme={inner}>
+          <div>Nested</div>
+        </Theme>
+        <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'md'}}>
+          <div>Content</div>
+        </AppShell>
+      </Theme>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 700px)');
+  });
+
+  it('uses a built theme object from provider context', () => {
+    const builtTheme = {
+      ...defineTheme({
+        name: 'built-app-shell-points',
+        adaptations: {widthBreakpoints: {'2xl': 1700}},
+      }),
+      __built: true as const,
+      __adaptationRules: undefined,
+    };
+
+    render(
+      <Theme theme={builtTheme}>
+        <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: '2xl'}}>
+          <div>Content</div>
+        </AppShell>
+      </Theme>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 1700px)');
+  });
+
+  it('falls back per key when built metadata has a partial width map', () => {
+    const partialBuiltTheme = {
+      ...defineTheme({name: 'partial-built-app-shell-points'}),
+      __built: true as const,
+      __adaptations: {
+        widthBreakpoints: {md: 700},
+        rules: [],
+      },
+    } as unknown as ReturnType<typeof defineTheme>;
+
+    render(
+      <Theme theme={partialBuiltTheme}>
+        <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'xl'}}>
+          <div>Content</div>
+        </AppShell>
+      </Theme>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 1280px)');
+  });
+
+  it('follows the registered root theme without provider context', () => {
+    defineTheme({
+      name: 'root-app-shell-points',
+      adaptations: {widthBreakpoints: {lg: 1111}},
+    });
+    const originalGetAttribute = document.documentElement.getAttribute.bind(
+      document.documentElement,
+    );
+    vi.spyOn(document.documentElement, 'getAttribute').mockImplementation(
+      name =>
+        name === 'data-astryx-theme'
+          ? 'root-app-shell-points'
+          : originalGetAttribute(name),
+    );
+
+    render(
+      <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'lg'}}>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 1111px)');
+  });
+
+  it('supports the added xl breakpoint without a Theme provider', () => {
+    render(
+      <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'xl'}}>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 1280px)');
   });
 
   it('does not enter mobile mode when mobileNav breakpoint is none', () => {
@@ -314,7 +443,7 @@ describe('AppShell', () => {
       </AppShell>,
     );
 
-    // breakpoint 'none' uses (max-width: 0px) which never matches,
+    // breakpoint 'none' uses (width < 0px), which never matches,
     // so sideNav stays inline and no mobile nav toggle appears
     expect(screen.getByText('Nav')).toBeInTheDocument();
     expect(

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -56,6 +56,11 @@ import {useMediaQuery} from '../hooks/useMediaQuery';
 import {observeResize} from '../utils/sharedResizeObserver';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import {useThemeDefinition} from '../theme/useTheme';
+import {
+  DEFAULT_WIDTH_BREAKPOINTS,
+  type WidthBreakpointName,
+} from '../theme/themeAdaptations';
 import type {AppShellVariantMap} from './index';
 
 import {useMergedRefs} from '../hooks/useMergedRefs';
@@ -74,13 +79,6 @@ const ActivityWrapper = HasActivity
 // Constants
 // =============================================================================
 
-const BREAKPOINT_VALUES: Record<AppShellBreakpoint, number> = {
-  sm: 640,
-  md: 768,
-  lg: 1024,
-  none: 0,
-};
-
 const MAIN_CONTENT_ID = 'astryx-app-shell-main';
 
 // =============================================================================
@@ -88,13 +86,10 @@ const MAIN_CONTENT_ID = 'astryx-app-shell-main';
 // =============================================================================
 
 /**
- * SideNav breakpoint options.
- * - `sm`: 640px
- * - `md`: 768px
- * - `lg`: 1024px
- * - `none`: Never auto-collapse
+ * SideNav breakpoint options. Named points resolve through the nearest Theme;
+ * without an active theme they use Astryx's default width-breakpoint map.
  */
-export type AppShellBreakpoint = 'sm' | 'md' | 'lg' | 'none';
+export type AppShellBreakpoint = WidthBreakpointName | 'none';
 
 /**
  * Navigation background style:
@@ -141,7 +136,10 @@ export interface MobileNavConfig {
   content?: ReactNode;
 
   /**
-   * Breakpoint below which mobile nav activates.
+   * Named Theme width point below which mobile nav activates. `sm`, `md`,
+   * `lg`, `xl`, and `2xl` resolve through the nearest Theme's effective
+   * `adaptations.widthBreakpoints`; equality belongs to the wider layout.
+   * Use `none` to disable automatic mobile mode.
    * @default 'md'
    */
   breakpoint?: AppShellBreakpoint;
@@ -469,6 +467,7 @@ export function AppShell({
   ...rest
 }: AppShellProps) {
   const t = useTranslator();
+  const activeTheme = useThemeDefinition();
   // =========================================================================
   // Parse mobileNav prop — normalize to config, custom element, or disabled
   // =========================================================================
@@ -504,10 +503,14 @@ export function AppShell({
   // =========================================================================
   // Mobile nav open state (controlled + uncontrolled)
   // =========================================================================
+  const activeWidthBreakpoints = activeTheme?.__adaptations?.widthBreakpoints;
   const breakpointQuery =
     sideNavBreakpoint === 'none'
-      ? '(max-width: 0px)'
-      : `(max-width: ${BREAKPOINT_VALUES[sideNavBreakpoint]}px)`;
+      ? '(width < 0px)'
+      : `(width < ${
+          activeWidthBreakpoints?.[sideNavBreakpoint] ??
+          DEFAULT_WIDTH_BREAKPOINTS[sideNavBreakpoint]
+        }px)`;
   const isBelowBreakpoint = useMediaQuery(
     breakpointQuery,
     mobileNavConfig?.defaultIsMobile,

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -13,7 +13,7 @@
  * - A [light, dark] tuple: converted to light-dark(light, dark)
  *
  * @example
- * ```tsx
+ * ```
  * const oceanTheme = defineTheme({
  *   name: 'ocean',
  *   tokens: {
@@ -47,7 +47,7 @@ type ThemeIconOverrides = Partial<
   Record<IconName | NamespacedIconName, ReactNode>
 >;
 import type {IndicatorRegistry} from '../Indicator/types';
-import type {TypographyConfig, FontWeight} from './types';
+import type {TypographyConfig} from './types';
 import {
   resolveOnMedia,
   type OnMediaOverrides,
@@ -68,20 +68,24 @@ import {
   fontWeightDefaults,
   typeScaleDefaults,
 } from './tokens.stylex';
+import type {MotionScaleConfig} from './expandMotionScale';
+import type {RadiusScaleConfig} from './expandRadiusScale';
+import type {ColorScaleConfig} from './expandColorScale';
+import {resolveThemeValues, type ThemeValuesInput} from './resolveThemeValues';
 import {
-  expandTypeScale,
-  generateTypeScaleComponents,
-  type TypeScaleConfig,
-} from './expandTypeScale';
-import {expandMotionScale, type MotionScaleConfig} from './expandMotionScale';
-import {expandRadiusScale, type RadiusScaleConfig} from './expandRadiusScale';
-import {expandColorScale, type ColorScaleConfig} from './expandColorScale';
+  normalizeThemeAdaptations,
+  resolveThemeAdaptationRules,
+  resolveThemeGenerativeAxes,
+  type NormalizedThemeAdaptations,
+  type ResolvedThemeAdaptationRule,
+  type ThemeAdaptations,
+  type ThemeGenerativeAxes,
+} from './themeAdaptations';
 
 import type {DomainTokenName} from './domainTokens';
 import {domainTokenDefaults} from './domainTokens';
 import type {SyntaxThemeDefinition} from './syntax';
 import {registerTheme} from './themeRegistry';
-import {deepMergeComponents} from './mergeComponents';
 import {resolveLocalTokenContract} from './localTokens';
 
 // =============================================================================
@@ -154,7 +158,7 @@ export type StyleOverrides = Record<string, string | Record<string, string>>;
  * to override interaction states without CSS custom property escape hatches.
  *
  * @example
- * ```tsx
+ * ```
  * components: {
  *   button: {
  *     base: { fontWeight: '600' },
@@ -194,7 +198,7 @@ export interface DefineThemeInput {
    * (e.g. icons, accent color) without re-specifying the full theme.
    *
    * @example
-   * ```tsx
+   * ```
    * import {neutralTheme} from '@astryxdesign/theme-neutral';
    *
    * const myTheme = defineTheme({
@@ -216,7 +220,7 @@ export interface DefineThemeInput {
    * @import for your fonts before rendering the theme.
    *
    * @example
-   * ```tsx
+   * ```
    * typography: {
    *   scale: { base: 14, ratio: 1.2 },
    *   body: { family: 'Geist', fallbacks: '-apple-system, sans-serif' },
@@ -254,7 +258,7 @@ export interface DefineThemeInput {
    * Explicit `tokens` overrides take precedence over radius-generated values.
    *
    * @example
-   * ```tsx
+   * ```
    * radius: { base: 4, multiplier: 1 }
    *
    * // Sharp/brutalist — all radii become 0
@@ -321,7 +325,7 @@ export interface DefineThemeInput {
    * and generate TypeScript module augmentations for type-safe extensibility.
    *
    * @example
-   * ```tsx
+   * ```
    * components: {
    *   button: {
    *     base: { fontWeight: '600' },
@@ -356,7 +360,7 @@ export interface DefineThemeInput {
    * per-region (or per-instance) by wrapping in SyntaxTheme.
    *
    * @example
-   * ```tsx
+   * ```
    * import {dracula} from '@astryxdesign/core/theme/syntax';
    * defineTheme({ name: 'my-theme', syntax: dracula, ... })
    * ```
@@ -372,7 +376,7 @@ export interface DefineThemeInput {
    * background.
    *
    * @example
-   * ```tsx
+   * ```
    * onDark: {
    *   tokens: { '--color-accent': '#90CAF9' },
    *   components: {
@@ -387,6 +391,33 @@ export interface DefineThemeInput {
    * but for the inverse case (e.g. dark-mode page with a light popover).
    */
   onLight?: OnMediaOverrides;
+  /**
+   * Ordered environment-conditioned token and component adaptations.
+   *
+   * Width points use the fixed names `sm`, `md`, `lg`, `xl`, and `2xl` and
+   * default to 640, 768, 1024, 1280, and 1536 CSS pixels. Breakpoint
+   * configuration alone emits no CSS. Rules are emitted in declaration order;
+   * fields inside `when` are ANDed and later matching writes win.
+   *
+   * @example
+   * ```
+   * adaptations: {
+   *   widthBreakpoints: {lg: 1024, xl: 1280},
+   *   rules: [
+   *     {
+   *       when: {
+   *         width: {from: 'lg', below: 'xl'},
+   *         pointer: 'coarse',
+   *       },
+   *       value: {
+   *         tokens: {'--size-element-md': '44px'},
+   *       },
+   *     },
+   *   ],
+   * }
+   * ```
+   */
+  adaptations?: ThemeAdaptations;
 }
 
 /** A defined theme — ready to pass to <Theme> */
@@ -428,7 +459,23 @@ export interface DefinedTheme {
    * @internal
    */
   __onLight?: ResolvedOnMedia;
+  /**
+   * Effective breakpoint map and ordered normalized rule inputs retained for
+   * source-equivalent extension, including from a built theme.
+   * @internal
+   */
+  __adaptations?: NormalizedThemeAdaptations;
+  /** Concrete ordered rule writes used by the runtime CSS compiler. @internal */
+  __adaptationRules?: ResolvedThemeAdaptationRule[];
+  /** Effective root generative-axis metadata used to resolve child rules. @internal */
+  __axes?: ThemeGenerativeAxes;
 }
+
+/** A theme produced by the current defineTheme implementation. */
+export type ResolvedDefinedTheme = DefinedTheme & {
+  __adaptations: NormalizedThemeAdaptations;
+  __axes: ThemeGenerativeAxes;
+};
 
 // =============================================================================
 // All defaults merged into a single flat map
@@ -455,50 +502,6 @@ export const tokenDefaults: Record<string, string> = {
 // =============================================================================
 // defineTheme
 // =============================================================================
-
-/**
- * Resolve a token value to a CSS string.
- * - String values pass through as-is
- * - [light, dark] tuples become light-dark(light, dark)
- */
-function resolveTokenValue(value: TokenValue): string {
-  if (Array.isArray(value)) {
-    return `light-dark(${value[0]}, ${value[1]})`;
-  }
-  return value;
-}
-
-/**
- * Resolve a FontWeight name to a var() reference.
- * Named weights map to var(--font-weight-*); raw values pass through.
- */
-function resolveFontWeight(weight: FontWeight): string {
-  const named: Record<string, string> = {
-    normal: 'var(--font-weight-normal)',
-    medium: 'var(--font-weight-medium)',
-    semibold: 'var(--font-weight-semibold)',
-    bold: 'var(--font-weight-bold)',
-  };
-  return named[weight] ?? weight;
-}
-
-/**
- * Build the full CSS font-family value from family + fallbacks.
- * Quotes the family name if it contains spaces.
- */
-function buildFontFamily(
-  family?: string,
-  fallbacks?: string,
-): string | undefined {
-  if (!family) {
-    return undefined;
-  }
-  const quoted = family.includes(' ') ? `"${family}"` : family;
-  if (fallbacks) {
-    return `${quoted}, ${fallbacks}`;
-  }
-  return quoted;
-}
 
 /**
  * Describe a rejected `extends` value for the error message — enough to tell a
@@ -528,10 +531,8 @@ function describeBadBase(value: unknown): string {
  * that are merged into the token map. Explicit `tokens` entries take
  * precedence over generated values.
  */
-export function defineTheme(input: DefineThemeInput): DefinedTheme {
-  const tokens: Record<string, string> = {};
-
-  // 0. Pre-seed from base theme when `extends` is provided (lowest precedence).
+export function defineTheme(input: DefineThemeInput): ResolvedDefinedTheme {
+  // Pre-seed from the base theme when `extends` is provided (lowest precedence).
   // A base that is not a theme is refused rather than ignored: `extends` used
   // to inherit nothing when its value was undefined, which is what a named
   // import silently resolving to the wrong module hands over, and the theme
@@ -545,142 +546,34 @@ export function defineTheme(input: DefineThemeInput): DefinedTheme {
     );
   }
   const base = input.extends;
-  if (base) {
-    for (const [key, value] of Object.entries(base.tokens)) {
-      tokens[key] = value;
-    }
-  }
 
-  // Build typeScale config from typography if present
-  const typo = input.typography;
-  let typeScaleConfig: TypeScaleConfig | undefined;
-  if (typo?.scale) {
-    // Collect weight overrides from typography roles
-    const headingWeights: Partial<Record<1 | 2 | 3 | 4 | 5 | 6, string>> = {};
-    const headingRole = typo.heading;
-    if (headingRole?.weights) {
-      for (const [level, w] of Object.entries(headingRole.weights)) {
-        if (w) {
-          headingWeights[Number(level) as 1 | 2 | 3 | 4 | 5 | 6] =
-            resolveFontWeight(w);
-        }
-      }
-    }
-    // Default heading weight from role
-    const defaultHeadingWeight = headingRole?.weight
-      ? resolveFontWeight(headingRole.weight)
-      : undefined;
-    if (defaultHeadingWeight) {
-      for (let i = 1; i <= 6; i++) {
-        if (!(i in headingWeights)) {
-          headingWeights[i as 1 | 2 | 3 | 4 | 5 | 6] = defaultHeadingWeight;
-        }
-      }
-    }
+  // The theme's own value axes and the resolved base an `extends` supplies.
+  // The same axis metadata is retained so adaptation rules can complete partial
+  // configs without approximating values from unrelated built-in defaults.
+  const ownValues: ThemeValuesInput = {
+    typography: input.typography,
+    color: input.color,
+    radius: input.radius,
+    motion: input.motion,
+    syntax: input.syntax,
+    tokens: input.tokens,
+    components: input.components,
+  };
+  const ownAxes: ThemeGenerativeAxes = {
+    typography: input.typography,
+    color: input.color,
+    radius: input.radius,
+    motion: input.motion,
+  };
+  const seed = base
+    ? {tokens: base.tokens, components: base.components}
+    : undefined;
 
-    // Text weight overrides from roles
-    const textWeights: Partial<Record<string, string>> = {};
-    if (typo.body?.weight) {
-      textWeights.body = resolveFontWeight(typo.body.weight);
-    }
-    if (typo.code?.weight) {
-      textWeights.code = resolveFontWeight(typo.code.weight);
-    }
+  const {tokens, components} = resolveThemeValues(ownValues, seed);
 
-    typeScaleConfig = {
-      base: typo.scale.base,
-      ratio: typo.scale.ratio,
-      weights: {
-        ...(Object.keys(headingWeights).length > 0
-          ? {heading: headingWeights}
-          : {}),
-        ...(Object.keys(textWeights).length > 0 ? {text: textWeights} : {}),
-      },
-    };
-  }
-
-  // 1. Apply color-generated tokens (lowest precedence for colors)
-  if (input.color) {
-    const colorTokens = expandColorScale(input.color);
-    for (const [key, value] of Object.entries(colorTokens)) {
-      tokens[key] = value;
-    }
-  }
-
-  // 1a. Apply typeScale-generated tokens (lowest precedence for type)
-  if (typeScaleConfig) {
-    const typeScaleTokens = expandTypeScale(typeScaleConfig);
-    for (const [key, value] of Object.entries(typeScaleTokens)) {
-      tokens[key] = value;
-    }
-  }
-
-  // 1b. Apply radius-generated tokens (lowest precedence for radius)
-  if (input.radius) {
-    const radiusTokens = expandRadiusScale(input.radius);
-    for (const [key, value] of Object.entries(radiusTokens)) {
-      tokens[key] = value;
-    }
-  }
-
-  // 1c. Apply motion-generated tokens (same precedence as typeScale)
-  if (input.motion) {
-    const motionTokens = expandMotionScale(input.motion);
-    for (const [key, value] of Object.entries(motionTokens)) {
-      tokens[key] = value;
-    }
-  }
-
-  // 1d. Apply typography font family tokens
-  if (typo) {
-    // Heading inherits from body if not specified
-    const bodyFamily = buildFontFamily(typo.body?.family, typo.body?.fallbacks);
-    const headingFamily =
-      buildFontFamily(typo.heading?.family, typo.heading?.fallbacks) ??
-      bodyFamily;
-    const codeFamily = buildFontFamily(typo.code?.family, typo.code?.fallbacks);
-
-    if (bodyFamily) {
-      tokens['--font-family-body'] = bodyFamily;
-    }
-    if (headingFamily) {
-      tokens['--font-family-heading'] = headingFamily;
-    }
-    if (codeFamily) {
-      tokens['--font-family-code'] = codeFamily;
-    }
-  }
-
-  // 1e. Apply syntax theme tokens (before explicit overrides)
-  if (input.syntax) {
-    const syntaxMap = input.syntax.tokens;
-    const prefix = '--color-syntax-';
-    for (const [key, value] of Object.entries(syntaxMap)) {
-      tokens[prefix + key] = value;
-    }
-  }
-
-  // 2. Apply explicit token overrides (highest precedence — overwrites generated tokens)
-  if (input.tokens) {
-    for (const [key, value] of Object.entries(input.tokens)) {
-      if (value !== undefined) {
-        tokens[key] = resolveTokenValue(value);
-      }
-    }
-  }
-
-  // 3. Generate component overrides: base (lowest) → typeScale → explicit (highest)
-  let components = input.components;
-  if (typeScaleConfig) {
-    const generated = generateTypeScaleComponents(typeScaleConfig);
-    components = deepMergeComponents(generated, input.components);
-  }
-  if (base?.components) {
-    components = deepMergeComponents(base.components, components);
-  }
-
-  // 4. Resolve on-media token overrides (base's resolved surface, then
-  // defaults, then this theme's own overrides)
+  // On-media token overrides (base's resolved surface, then defaults, then
+  // this theme's own overrides). They compile after adaptations so the
+  // media-surface value stays more specific in the authored cascade.
   const __onDark = resolveOnMedia('dark', input.onDark, base?.__onDark);
   const __onLight = resolveOnMedia('light', input.onLight, base?.__onLight);
 
@@ -693,7 +586,24 @@ export function defineTheme(input: DefineThemeInput): DefinedTheme {
     __onLight,
   );
 
-  // 5. Merge icons — input icons override base icons
+  // Adaptations inherit their breakpoint map and ordered rules. Every rule is
+  // re-resolved against this theme's effective root axes, so a child can change
+  // the root scale while preserving the base rule's authored intent.
+  const __axes = resolveThemeGenerativeAxes(base?.__axes, ownAxes);
+  const __adaptations = normalizeThemeAdaptations(
+    input.name,
+    base?.__adaptations,
+    input.adaptations,
+  );
+  const __adaptationRules = resolveThemeAdaptationRules(
+    input.name,
+    __adaptations,
+    __axes,
+    tokens,
+    localTokenContract?.localTokens,
+  );
+
+  // Icons — input icons override base icons
   const icons =
     input.icons && base?.icons
       ? {...base.icons, ...input.icons}
@@ -706,7 +616,7 @@ export function defineTheme(input: DefineThemeInput): DefinedTheme {
       ? {...base.indicators, ...input.indicators}
       : (input.indicators ?? base?.indicators);
 
-  const theme: DefinedTheme = {
+  const theme: ResolvedDefinedTheme = {
     name: input.name,
     tokens,
     ...(localTokenContract
@@ -725,6 +635,9 @@ export function defineTheme(input: DefineThemeInput): DefinedTheme {
         : undefined,
     __onDark,
     __onLight,
+    __adaptations,
+    __adaptationRules,
+    __axes,
   };
 
   registerTheme(theme);
@@ -739,6 +652,7 @@ export {
   generateThemeRules,
   generateThemeRulesSplit,
   generateOnMediaCSS,
+  generateAdaptationCSS,
   generateThemeCSS,
   type ThemeRulesSplit,
   type ThemeCSSOutput,

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -207,14 +207,15 @@ describe('generateThemeRules', () => {
 
   // --- Prose rules ---
 
-  it('includes prose heading rules with computed values', () => {
+  it('includes prose heading rules linked to semantic tokens', () => {
     const h1Rule = rules.find(
       r => r.trimStart().startsWith(':where(h1)') || r.includes(':where(h1)'),
     );
     expect(h1Rule).toBeDefined();
-    // Prose rules use val() helper which resolves to the token value (now a var ref)
-    expect(h1Rule).toContain('var(--font-size-2xl)');
-    expect(h1Rule).toContain('var(--font-weight-semibold)');
+    // Keep prose linked to semantic variables so conditional token writes apply
+    // through CSS without duplicating these selectors inside every media rule.
+    expect(h1Rule).toContain('var(--text-heading-1-size)');
+    expect(h1Rule).toContain('var(--text-heading-1-weight)');
     // Prose defaults intentionally carry NO block margins: reset.css zeroes
     // raw element margins and the Markdown/Heading components own their spacing
     // via StyleX (@layer astryx-base). Emitting margins here would re-introduce
@@ -223,12 +224,12 @@ describe('generateThemeRules', () => {
     expect(h1Rule).not.toContain('margin-block-end');
   });
 
-  it('includes prose p rule with computed values', () => {
+  it('includes prose p rule linked to semantic tokens', () => {
     const pRule = rules.find(
       r => r.trimStart().startsWith(':where(p)') || r.includes(':where(p)'),
     );
     expect(pRule).toBeDefined();
-    expect(pRule).toContain('var(--font-size-base)');
+    expect(pRule).toContain('var(--text-body-size)');
     expect(pRule).toContain('font-family: var(--font-family-body)');
     expect(pRule).toContain('var(--color-text-primary)');
     // No margins on the prose paragraph default (see heading rule note).
@@ -354,12 +355,12 @@ describe('generateThemeRules with weight overrides', () => {
     );
   });
 
-  it('reflects weight override in prose h3', () => {
+  it('keeps prose h3 linked to the semantic weight token', () => {
     const h3Rule = rules.find(
       r => r.trimStart().startsWith(':where(h3)') || r.includes(':where(h3)'),
     );
     expect(h3Rule).toBeDefined();
-    expect(h3Rule).toContain('var(--font-weight-bold)');
+    expect(h3Rule).toContain('var(--text-heading-3-weight)');
   });
 });
 

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -15,7 +15,11 @@
  * @position packages/core/src/theme/generateThemeRules.ts
  */
 
-import type {DefinedTheme} from './defineTheme';
+import type {ComponentStyleMap, DefinedTheme} from './defineTheme';
+import {
+  normalizeThemeAdaptations,
+  resolveThemeAdaptationRules,
+} from './themeAdaptations';
 import {parseStyleKey} from '../utils/parseStyleKey';
 import {getDerivedVars} from './derivedVarRegistry';
 import {dataTokenDefaults} from './domainTokens/dataTokens';
@@ -279,6 +283,7 @@ function parsePadding(props: [string, string][]): ParsedPadding {
 function expandContainerPadding(
   component: string,
   parsed: ParsedPadding,
+  resetInheritedSpecificity = false,
 ): [string, string][] {
   const prefix = cssVar(`${component}-padding`);
   const tokens: [string, string][] = [];
@@ -301,26 +306,47 @@ function expandContainerPadding(
 
   if (allSame) {
     tokens.push([prefix, effectiveInlineStart ?? '']);
-    return tokens;
+  } else {
+    // Directional tokens
+    if (parsed.inlineStart != null || parsed.inlineEnd != null) {
+      // Asymmetric inline — emit start and end separately
+      if (effectiveInlineStart != null) {
+        tokens.push([`${prefix}-inline-start`, effectiveInlineStart]);
+      }
+      if (effectiveInlineEnd != null) {
+        tokens.push([`${prefix}-inline-end`, effectiveInlineEnd]);
+      }
+    } else if (parsed.inline != null) {
+      tokens.push([`${prefix}-inline`, parsed.inline]);
+    }
+    if (parsed.blockStart != null) {
+      tokens.push([`${prefix}-block-start`, parsed.blockStart]);
+    }
+    if (parsed.blockEnd != null) {
+      tokens.push([`${prefix}-block-end`, parsed.blockEnd]);
+    }
   }
 
-  // Directional tokens
-  if (parsed.inlineStart != null || parsed.inlineEnd != null) {
-    // Asymmetric inline — emit start and end separately
-    if (effectiveInlineStart != null) {
-      tokens.push([`${prefix}-inline-start`, effectiveInlineStart]);
+  if (resetInheritedSpecificity) {
+    const emitted = new Set(tokens.map(([name]) => name));
+    const moreSpecific = emitted.has(prefix)
+      ? [
+          `${prefix}-inline`,
+          `${prefix}-inline-start`,
+          `${prefix}-inline-end`,
+          `${prefix}-block-start`,
+          `${prefix}-block-end`,
+        ]
+      : emitted.has(`${prefix}-inline`)
+        ? [`${prefix}-inline-start`, `${prefix}-inline-end`]
+        : [];
+    for (const name of moreSpecific) {
+      if (!emitted.has(name)) {
+        // `initial` makes a custom property guaranteed-invalid so var() follows
+        // its fallback, clearing a more-specific declaration from a root rule.
+        tokens.push([name, 'initial']);
+      }
     }
-    if (effectiveInlineEnd != null) {
-      tokens.push([`${prefix}-inline-end`, effectiveInlineEnd]);
-    }
-  } else if (parsed.inline != null) {
-    tokens.push([`${prefix}-inline`, parsed.inline]);
-  }
-  if (parsed.blockStart != null) {
-    tokens.push([`${prefix}-block-start`, parsed.blockStart]);
-  }
-  if (parsed.blockEnd != null) {
-    tokens.push([`${prefix}-block-end`, parsed.blockEnd]);
   }
 
   return tokens;
@@ -336,13 +362,31 @@ function expandContainerPadding(
  * Returns an array of CSS rule strings — the shared format used by both
  * the runtime path (useInsertionEffect) and the build path (astryx theme build).
  */
-export function generateThemeRules(theme: DefinedTheme): string[] {
+/**
+ * The parts of a theme that turn into CSS rules.
+ *
+ * Narrower than `DefinedTheme` on purpose: an adaptation rule is not a whole
+ * theme, and it calls this with only the values that rule writes. Typing the
+ * parameter as `DefinedTheme` would let a future field be read here and silently
+ * lost for every conditional rule, with no type error to catch it.
+ */
+export interface ThemeRuleSource {
+  /** Resolved portable token values. */
+  tokens: Record<string, string>;
+  /** Resolved theme-local token values. */
+  localTokens?: Record<string, string>;
+  /** Resolved component style overrides. */
+  components?: ComponentStyleMap;
+}
+
+export function generateThemeRules(theme: ThemeRuleSource): string[] {
   const parts: string[] = [];
   const tokens = theme.tokens;
 
-  // Helper: resolve a token value — tokens always have computed values
-  // since defineTheme runs expandTypeScale to produce them.
-  const val = (key: string): string => tokens[key] || `var(${key})`;
+  // Bare prose rules reference semantic variables instead of baking the root
+  // value. That lets adaptation token writes take effect through CSS alone
+  // without duplicating prose selectors inside every media query.
+  const val = (key: string): string => `var(${key})`;
 
   // 1. Token block — CSS custom properties on :scope
   const tokenEntries = [
@@ -389,6 +433,7 @@ function generateComponentRules(
     Record<string, Record<string, string | Record<string, string>>>
   >,
   parts: string[],
+  resetInheritedPaddingSpecificity = false,
 ): void {
   for (const [component, rules] of Object.entries(components)) {
     for (const [key, styles] of Object.entries(rules)) {
@@ -467,7 +512,11 @@ function generateComponentRules(
           ([p]) => !CONTAINER_PADDING_PROPS.has(p),
         );
         const parsed = parsePadding(paddingProps);
-        const containerTokens = expandContainerPadding(component, parsed);
+        const containerTokens = expandContainerPadding(
+          component,
+          parsed,
+          resetInheritedPaddingSpecificity,
+        );
         finalProps = [...nonPaddingProps, ...containerTokens];
       }
 
@@ -762,6 +811,78 @@ export function generateOnMediaCSS(theme: DefinedTheme): string {
   return `@scope (${scopeSelector}) to (${THEME_SCOPE_TO}) {\n${inner}\n}`;
 }
 
+/** Generate only the declarations one adaptation rule writes. */
+function generateAdaptationRuleRules(rule: ThemeRuleSource): string[] {
+  const parts: string[] = [];
+  const tokenEntries = [
+    ...Object.entries(rule.tokens),
+    ...Object.entries(rule.localTokens ?? {}),
+  ];
+  if (tokenEntries.length > 0) {
+    const declarations = tokenEntries
+      .map(([prop, value]) => `    ${prop}: ${value};`)
+      .join('\n');
+    parts.push(`  :scope {\n${declarations}\n  }`);
+  }
+
+  if (rule.components) {
+    generateComponentRules(rule.components, parts, true);
+    generateColorOverrides(rule.components, parts);
+    generateSizeOverrides(rule.components, parts);
+  }
+  return parts;
+}
+
+/**
+ * Generate CSS for a theme's ordered adaptation rules.
+ *
+ * Each authored rule stays a separate media block in declaration order. Blocks
+ * are never merged, reordered, or value-diffed: a later rule that deliberately
+ * writes a root value must remain present so it can override an earlier matching
+ * rule. Bare prose follows semantic variables, so token writes need no duplicate
+ * prose selectors here.
+ */
+export function generateAdaptationCSS(theme: DefinedTheme): ThemeCSSOutput {
+  const rules =
+    theme.__adaptationRules ??
+    (theme.__adaptations?.rules?.length
+      ? resolveThemeAdaptationRules(
+          theme.name,
+          normalizeThemeAdaptations(theme.name, theme.__adaptations, undefined),
+          theme.__axes ?? {},
+          theme.tokens,
+          theme.localTokens,
+        )
+      : undefined);
+  if (!rules || rules.length === 0) {
+    return {prose: '', component: ''};
+  }
+
+  const scopeSelector = themeScopeStart(theme.name);
+  const blocks: string[] = [];
+  for (const rule of rules) {
+    const parts = generateAdaptationRuleRules(rule);
+    if (parts.length === 0) {
+      continue;
+    }
+    blocks.push(
+      `@media ${rule.query} {\n  @scope (${scopeSelector}) to (${THEME_SCOPE_TO}) {\n${parts
+        .map(indentRule)
+        .join('\n\n')}\n  }\n}`,
+    );
+  }
+
+  return {prose: '', component: blocks.join('\n\n')};
+}
+
+/** Indent a generated rule one level further, for nesting inside `@media`. */
+function indentRule(rule: string): string {
+  return rule
+    .split('\n')
+    .map(line => (line.length > 0 ? `  ${line}` : line))
+    .join('\n');
+}
+
 /**
  * The `--color-data-*` defaults as one unscoped `:root` block.
  *
@@ -817,6 +938,15 @@ export function generateThemeCSS(theme: DefinedTheme): ThemeCSSOutput {
   if (component.length > 0) {
     const componentInner = component.join('\n\n');
     componentCss = `@scope (${scopeSelector}) to (${scopeTo}) {\n${componentInner}\n}`;
+  }
+
+  // Adaptations follow the root theme in authored order. Media-surface rules
+  // follow adaptations so onDark/onLight keep their specified precedence.
+  const adaptationCss = generateAdaptationCSS(theme);
+  if (adaptationCss.component) {
+    componentCss = componentCss
+      ? `${componentCss}\n\n${adaptationCss.component}`
+      : adaptationCss.component;
   }
 
   const onMediaCss = generateOnMediaCSS(theme);

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -22,6 +22,7 @@ export {
   defineTheme,
   generateThemeCSS,
   generateOnMediaCSS,
+  generateAdaptationCSS,
   generateThemeRules,
   generateThemeRulesSplit,
   type ThemeCSSOutput,
@@ -38,12 +39,29 @@ export {
 export type {
   DefineThemeInput,
   DefinedTheme,
+  ResolvedDefinedTheme,
   CoreTokenName,
   TokenName,
   TokenValue,
   ComponentStyleMap,
   StyleOverrides,
 } from './defineTheme';
+
+// Ordered environment-conditioned theme adaptations
+export {
+  DEFAULT_WIDTH_BREAKPOINTS,
+  WIDTH_BREAKPOINT_NAMES,
+} from './themeAdaptations';
+export type {
+  WidthBreakpointName,
+  WidthBreakpoints,
+  ThemeAdaptations,
+  ThemeAdaptationCondition,
+  ThemeAdaptationWidthCondition,
+  ThemeAdaptationRule,
+  ThemeAdaptationValue,
+  ThemeAdaptationTypographyConfig,
+} from './themeAdaptations';
 
 export type {
   SyntaxTokenName,

--- a/packages/core/src/theme/localTokens.ts
+++ b/packages/core/src/theme/localTokens.ts
@@ -43,7 +43,10 @@ function resolveTokenValue(value: TokenValue, path: string): string {
   );
 }
 
-function collectLocalReferences(value: unknown, refs: Set<string>): void {
+function collectCustomPropertyReferences(
+  value: unknown,
+  refs: Set<string>,
+): void {
   if (typeof value === 'string') {
     CSS_VAR_PATTERN.lastIndex = 0;
     for (
@@ -51,58 +54,144 @@ function collectLocalReferences(value: unknown, refs: Set<string>): void {
       match;
       match = CSS_VAR_PATTERN.exec(value)
     ) {
-      const name = match[1];
-      if (name.startsWith(LOCAL_TOKEN_PREFIX)) {
-        refs.add(name);
-      }
+      refs.add(match[1]);
     }
     return;
   }
   if (Array.isArray(value)) {
     for (const item of value) {
-      collectLocalReferences(item, refs);
+      collectCustomPropertyReferences(item, refs);
     }
     return;
   }
   if (value && typeof value === 'object') {
     for (const nested of Object.values(value)) {
-      collectLocalReferences(nested, refs);
+      collectCustomPropertyReferences(nested, refs);
     }
   }
 }
 
-function assertNoLocalTokenCycles(localTokens: Record<string, string>): void {
+function collectLocalReferences(value: unknown, refs: Set<string>): void {
+  const customProperties = new Set<string>();
+  collectCustomPropertyReferences(value, customProperties);
+  for (const name of customProperties) {
+    if (name.startsWith(LOCAL_TOKEN_PREFIX)) {
+      refs.add(name);
+    }
+  }
+}
+
+export function assertNoTokenCycles(
+  tokenValues: Record<string, string>,
+  context?: string,
+  relevantNames?: ReadonlySet<string>,
+): void {
   const dependencies = new Map<string, string[]>();
-  for (const [name, value] of Object.entries(localTokens)) {
+  for (const [name, value] of Object.entries(tokenValues)) {
     const refs = new Set<string>();
-    collectLocalReferences(value, refs);
+    collectCustomPropertyReferences(value, refs);
     dependencies.set(
       name,
-      [...refs].filter(reference => hasOwn(localTokens, reference)),
+      [...refs].filter(reference => hasOwn(tokenValues, reference)),
     );
   }
 
-  const visiting = new Set<string>();
-  const visited = new Set<string>();
-  const visit = (name: string, path: string[]): void => {
-    if (visiting.has(name)) {
-      const start = path.indexOf(name);
-      const cycle = [...path.slice(start), name].join(' -> ');
-      throw new Error(`Theme-local token cycle detected: ${cycle}.`);
-    }
-    if (visited.has(name)) {
-      return;
-    }
-    visiting.add(name);
-    for (const dependency of dependencies.get(name) ?? []) {
-      visit(dependency, [...path, name]);
-    }
-    visiting.delete(name);
-    visited.add(name);
+  const findCyclePath = (
+    start: string,
+    component: ReadonlySet<string>,
+  ): string[] => {
+    const path = [start];
+    const onPath = new Set(path);
+    const search = (name: string): boolean => {
+      for (const dependency of dependencies.get(name) ?? []) {
+        if (!component.has(dependency)) {
+          continue;
+        }
+        if (dependency === start) {
+          path.push(start);
+          return true;
+        }
+        if (onPath.has(dependency)) {
+          continue;
+        }
+        path.push(dependency);
+        onPath.add(dependency);
+        if (search(dependency)) {
+          return true;
+        }
+        onPath.delete(dependency);
+        path.pop();
+      }
+      return false;
+    };
+    search(start);
+    return path;
   };
 
-  for (const name of Object.keys(localTokens)) {
-    visit(name, []);
+  let nextIndex = 0;
+  const indexes = new Map<string, number>();
+  const lowlinks = new Map<string, number>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+
+  const visit = (name: string): void => {
+    const index = nextIndex++;
+    indexes.set(name, index);
+    lowlinks.set(name, index);
+    stack.push(name);
+    onStack.add(name);
+
+    for (const dependency of dependencies.get(name) ?? []) {
+      if (!indexes.has(dependency)) {
+        visit(dependency);
+        lowlinks.set(
+          name,
+          Math.min(lowlinks.get(name) ?? index, lowlinks.get(dependency) ?? 0),
+        );
+      } else if (onStack.has(dependency)) {
+        lowlinks.set(
+          name,
+          Math.min(lowlinks.get(name) ?? index, indexes.get(dependency) ?? 0),
+        );
+      }
+    }
+
+    if (lowlinks.get(name) !== index) {
+      return;
+    }
+
+    const component: string[] = [];
+    let member: string;
+    do {
+      member = stack.pop() ?? name;
+      onStack.delete(member);
+      component.push(member);
+    } while (member !== name);
+
+    const hasCycle =
+      component.length > 1 ||
+      (dependencies.get(component[0]) ?? []).includes(component[0]);
+    if (
+      !hasCycle ||
+      (relevantNames &&
+        !component.some(componentName => relevantNames.has(componentName)))
+    ) {
+      return;
+    }
+
+    const start =
+      component.find(componentName => relevantNames?.has(componentName)) ??
+      component[0];
+    const cycle = findCyclePath(start, new Set(component)).join(' -> ');
+    throw new Error(
+      `${context ? `${context}: ` : ''}Theme token cycle detected: ${cycle}.`,
+    );
+  };
+
+  for (const name of Object.keys(tokenValues)) {
+    if (!indexes.has(name)) {
+      visit(name);
+    }
   }
 }
 
@@ -262,11 +351,75 @@ export function resolveLocalTokenContract(
   }
 
   assertDeclaredReferences(localTokens, components, onDark, onLight);
-  assertNoLocalTokenCycles(localTokens);
+  assertNoTokenCycles(localTokens, `defineTheme("${input.name}").localTokens`);
 
   return {
     localTokens,
     owners,
     lineage: [...(base?.__localTokenLineage ?? []), input.name],
   };
+}
+
+/**
+ * Resolve theme-local values written by one adaptation rule.
+ *
+ * Adaptations may replace names already enrolled by the root theme lineage, but
+ * they never enroll names of their own. The effective root declarations remain
+ * the reference and cycle baseline for the conditional override.
+ */
+export function resolveAdaptationLocalTokens(
+  themeName: string,
+  ruleIndex: number,
+  declarations: Record<string, TokenValue> | undefined,
+  rootLocalTokens: Record<string, string> | undefined,
+  tokens: Record<string, string>,
+  components: ComponentStyleMap | undefined,
+): Record<string, string> | undefined {
+  const path = `defineTheme("${themeName}").adaptations.rules[${ruleIndex}].value.localTokens`;
+  if (declarations === undefined) {
+    const refs = new Set<string>();
+    collectLocalReferences(tokens, refs);
+    collectLocalReferences(components, refs);
+    for (const reference of refs) {
+      if (!rootLocalTokens || !hasOwn(rootLocalTokens, reference)) {
+        throw new Error(
+          `${path}: theme-local token reference "${reference}" has no declaration in the enrolled root theme lineage.`,
+        );
+      }
+    }
+    return undefined;
+  }
+  if (
+    declarations === null ||
+    typeof declarations !== 'object' ||
+    Array.isArray(declarations)
+  ) {
+    throw new Error(`${path} must be a token map.`);
+  }
+
+  const resolved: Record<string, string> = {};
+  for (const [name, value] of Object.entries(declarations)) {
+    if (!rootLocalTokens || !hasOwn(rootLocalTokens, name)) {
+      throw new Error(
+        `${path}["${name}"] cannot enroll a theme-local token. Declare it in the root theme or an exact enrolled base first.`,
+      );
+    }
+    resolved[name] = resolveTokenValue(value, `${path}["${name}"]`);
+  }
+
+  const effective = {...rootLocalTokens, ...resolved};
+  const refs = new Set<string>();
+  collectLocalReferences(resolved, refs);
+  collectLocalReferences(tokens, refs);
+  collectLocalReferences(components, refs);
+  for (const reference of refs) {
+    if (!hasOwn(effective, reference)) {
+      throw new Error(
+        `${path}: theme-local token reference "${reference}" has no declaration in the enrolled root theme lineage.`,
+      );
+    }
+  }
+  assertNoTokenCycles(effective, path);
+
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
 }

--- a/packages/core/src/theme/resolveThemeValues.ts
+++ b/packages/core/src/theme/resolveThemeValues.ts
@@ -1,0 +1,308 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file resolveThemeValues.ts
+ * @input The value-bearing axes of a theme input (typography, color, radius,
+ *        motion, syntax, tokens, components) and an optional resolved seed
+ * @output A resolved token map and component style map
+ * @position Theme system core; consumed by defineTheme and themeAdaptations
+ *
+ * One resolution pipeline, shared by every layer that turns declarative theme
+ * axes into concrete values. `defineTheme` runs its top-level input over an
+ * optional base seed. An adaptation rule completes partial axes from root
+ * metadata first, then runs its own value without a seed to obtain exactly the
+ * leaves that rule writes.
+ *
+ * Precedence inside one resolved layer, lowest to highest: seed → color → type
+ * scale → radius → motion → font families → syntax → explicit `tokens`.
+ * Ordered rule-vs-root and rule-vs-rule precedence is owned by
+ * `themeAdaptations` and CSS source order, outside this value resolver.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/theme/defineTheme.ts (its only other caller)
+ * - /packages/core/src/theme/themeAdaptations.ts
+ */
+
+import type {ComponentStyleMap, TokenName, TokenValue} from './defineTheme';
+import type {TypographyConfig, FontWeight} from './types';
+import type {SyntaxThemeDefinition} from './syntax';
+import {
+  expandTypeScale,
+  generateTypeScaleComponents,
+  type TypeScaleConfig,
+} from './expandTypeScale';
+import {expandMotionScale, type MotionScaleConfig} from './expandMotionScale';
+import {expandRadiusScale, type RadiusScaleConfig} from './expandRadiusScale';
+import {expandColorScale, type ColorScaleConfig} from './expandColorScale';
+import {deepMergeComponents} from './mergeComponents';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * The value-bearing axes of a theme — everything that resolves to tokens or
+ * component styles. Deliberately excludes identity (`name`), inheritance
+ * (`extends`), the registries (`icons`, `indicators`), the surface overrides
+ * (`onDark`/`onLight`) and the tiers themselves: none of those participate in
+ * value resolution.
+ */
+export interface ThemeValuesInput {
+  /** Typography — fonts, scale, and weights. */
+  typography?: TypographyConfig;
+  /** Color scale configuration. */
+  color?: ColorScaleConfig;
+  /** Radius scale configuration. */
+  radius?: RadiusScaleConfig;
+  /** Motion scale configuration. */
+  motion?: MotionScaleConfig;
+  /** Syntax highlighting theme. */
+  syntax?: SyntaxThemeDefinition;
+  /** Explicit token overrides — highest precedence. */
+  tokens?: Partial<Record<TokenName, TokenValue>>;
+  /** Component style overrides. */
+  components?: ComponentStyleMap;
+}
+
+/** Already-resolved values to start from — the lowest precedence layer. */
+export interface ThemeValuesSeed {
+  /** Resolved token values. */
+  tokens?: Record<string, string>;
+  /** Resolved component styles. */
+  components?: ComponentStyleMap;
+}
+
+/** The resolved output of one theme layer. */
+export interface ResolvedThemeValues {
+  /** Resolved token CSS values. */
+  tokens: Record<string, string>;
+  /** Resolved component style overrides, if any. */
+  components?: ComponentStyleMap;
+}
+
+// =============================================================================
+// Value helpers
+// =============================================================================
+
+/**
+ * Resolve a token value to a CSS string.
+ * - String values pass through as-is
+ * - [light, dark] tuples become light-dark(light, dark)
+ */
+export function resolveTokenValue(value: TokenValue): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === 'string' &&
+    typeof value[1] === 'string'
+  ) {
+    return `light-dark(${value[0]}, ${value[1]})`;
+  }
+  throw new Error(
+    'Theme token values must be CSS strings or [light, dark] string tuples.',
+  );
+}
+
+/**
+ * Resolve a FontWeight name to a var() reference.
+ * Named weights map to var(--font-weight-*); raw values pass through.
+ */
+export function resolveFontWeight(weight: FontWeight): string {
+  const named: Record<string, string> = {
+    normal: 'var(--font-weight-normal)',
+    medium: 'var(--font-weight-medium)',
+    semibold: 'var(--font-weight-semibold)',
+    bold: 'var(--font-weight-bold)',
+  };
+  return named[weight] ?? weight;
+}
+
+/**
+ * Build the full CSS font-family value from family + fallbacks.
+ * Quotes the family name if it contains spaces.
+ */
+export function buildFontFamily(
+  family?: string,
+  fallbacks?: string,
+): string | undefined {
+  if (!family) {
+    return undefined;
+  }
+  const quoted = family.includes(' ') ? `"${family}"` : family;
+  if (fallbacks) {
+    return `${quoted}, ${fallbacks}`;
+  }
+  return quoted;
+}
+
+// =============================================================================
+// Axis builders
+// =============================================================================
+
+/**
+ * Build the type-scale config from a typography config, collecting the weight
+ * overrides its roles imply.
+ *
+ * Returns undefined when the config declares no scale — font families and
+ * weights alone do not produce one.
+ */
+export function buildTypeScaleConfig(
+  typo: TypographyConfig,
+): TypeScaleConfig | undefined {
+  if (!typo.scale) {
+    return undefined;
+  }
+
+  // Collect weight overrides from typography roles
+  const headingWeights: Partial<Record<1 | 2 | 3 | 4 | 5 | 6, string>> = {};
+  const headingRole = typo.heading;
+  if (headingRole?.weights) {
+    for (const [level, w] of Object.entries(headingRole.weights)) {
+      if (w) {
+        headingWeights[Number(level) as 1 | 2 | 3 | 4 | 5 | 6] =
+          resolveFontWeight(w);
+      }
+    }
+  }
+  // Default heading weight from role
+  const defaultHeadingWeight = headingRole?.weight
+    ? resolveFontWeight(headingRole.weight)
+    : undefined;
+  if (defaultHeadingWeight) {
+    for (let i = 1; i <= 6; i++) {
+      if (!(i in headingWeights)) {
+        headingWeights[i as 1 | 2 | 3 | 4 | 5 | 6] = defaultHeadingWeight;
+      }
+    }
+  }
+
+  // Text weight overrides from roles
+  const textWeights: Partial<Record<string, string>> = {};
+  if (typo.body?.weight) {
+    textWeights.body = resolveFontWeight(typo.body.weight);
+  }
+  if (typo.code?.weight) {
+    textWeights.code = resolveFontWeight(typo.code.weight);
+  }
+
+  return {
+    base: typo.scale.base,
+    ratio: typo.scale.ratio,
+    weights: {
+      ...(Object.keys(headingWeights).length > 0
+        ? {heading: headingWeights}
+        : {}),
+      ...(Object.keys(textWeights).length > 0 ? {text: textWeights} : {}),
+    },
+  };
+}
+
+/**
+ * Build the `--font-family-*` token overrides implied by a typography config.
+ * Heading inherits from body when it declares no family of its own.
+ */
+export function buildFontFamilyTokens(
+  typo: TypographyConfig,
+): Record<string, string> {
+  const tokens: Record<string, string> = {};
+
+  const bodyFamily = buildFontFamily(typo.body?.family, typo.body?.fallbacks);
+  const headingFamily =
+    buildFontFamily(typo.heading?.family, typo.heading?.fallbacks) ??
+    bodyFamily;
+  const codeFamily = buildFontFamily(typo.code?.family, typo.code?.fallbacks);
+
+  if (bodyFamily) {
+    tokens['--font-family-body'] = bodyFamily;
+  }
+  if (headingFamily) {
+    tokens['--font-family-heading'] = headingFamily;
+  }
+  if (codeFamily) {
+    tokens['--font-family-code'] = codeFamily;
+  }
+
+  return tokens;
+}
+
+// =============================================================================
+// Resolution
+// =============================================================================
+
+/**
+ * Resolve one theme layer's declarative axes into tokens and component styles.
+ *
+ * `seed` is the already-resolved layer underneath — the base theme for an
+ * `extends`, or nothing for a root theme. It sits below everything this input
+ * declares.
+ */
+export function resolveThemeValues(
+  input: ThemeValuesInput,
+  seed?: ThemeValuesSeed,
+): ResolvedThemeValues {
+  const tokens: Record<string, string> = {...seed?.tokens};
+
+  const typo = input.typography;
+  const typeScaleConfig = typo ? buildTypeScaleConfig(typo) : undefined;
+
+  // 1. Color-generated tokens (lowest precedence for colors)
+  if (input.color) {
+    Object.assign(tokens, expandColorScale(input.color));
+  }
+
+  // 2. Type-scale-generated tokens
+  if (typeScaleConfig) {
+    Object.assign(tokens, expandTypeScale(typeScaleConfig));
+  }
+
+  // 3. Radius-generated tokens
+  if (input.radius) {
+    Object.assign(tokens, expandRadiusScale(input.radius));
+  }
+
+  // 4. Motion-generated tokens
+  if (input.motion) {
+    Object.assign(tokens, expandMotionScale(input.motion));
+  }
+
+  // 5. Font family tokens
+  if (typo) {
+    Object.assign(tokens, buildFontFamilyTokens(typo));
+  }
+
+  // 6. Syntax theme tokens
+  if (input.syntax) {
+    const prefix = '--color-syntax-';
+    for (const [key, value] of Object.entries(input.syntax.tokens)) {
+      tokens[prefix + key] = value;
+    }
+  }
+
+  // 7. Explicit token overrides — highest precedence within this input layer.
+  // A generated axis in the same root or adaptation value cannot beat them.
+  if (input.tokens) {
+    for (const [key, value] of Object.entries(input.tokens)) {
+      if (value !== undefined) {
+        tokens[key] = resolveTokenValue(value);
+      }
+    }
+  }
+
+  // Components: generated type-scale rules (lowest) → this input's own →
+  // all of it over the seed's.
+  let components = input.components;
+  if (typeScaleConfig) {
+    components = deepMergeComponents(
+      generateTypeScaleComponents(typeScaleConfig),
+      input.components,
+    );
+  }
+  if (seed?.components) {
+    components = deepMergeComponents(seed.components, components);
+  }
+
+  return {tokens, components};
+}

--- a/packages/core/src/theme/themeAdaptations.test.ts
+++ b/packages/core/src/theme/themeAdaptations.test.ts
@@ -1,0 +1,1123 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file themeAdaptations.test.ts
+ * Tests AST-012's ordered, closed, CSS-first theme adaptation contract.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {
+  DEFAULT_WIDTH_BREAKPOINTS,
+  WIDTH_BREAKPOINT_NAMES,
+  defineTheme,
+  generateAdaptationCSS,
+  generateThemeCSS,
+  type DefineThemeInput,
+  type DefinedTheme,
+} from './index';
+
+function adaptationInput(
+  rules: NonNullable<NonNullable<DefineThemeInput['adaptations']>['rules']>,
+): DefineThemeInput {
+  return {name: 'adaptive', adaptations: {rules}};
+}
+
+function mediaPreludes(css: string): string[] {
+  return [...css.matchAll(/@media ([^{]+) \{/g)].map(match => match[1]);
+}
+
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe('width breakpoint metadata', () => {
+  it('provides the accepted fixed names and defaults', () => {
+    const theme = defineTheme({name: 'defaults'});
+
+    expect(WIDTH_BREAKPOINT_NAMES).toEqual(['sm', 'md', 'lg', 'xl', '2xl']);
+    expect(DEFAULT_WIDTH_BREAKPOINTS).toEqual({
+      sm: 640,
+      md: 768,
+      lg: 1024,
+      xl: 1280,
+      '2xl': 1536,
+    });
+    expect(theme.__adaptations).toEqual({
+      widthBreakpoints: DEFAULT_WIDTH_BREAKPOINTS,
+      rules: [],
+    });
+  });
+
+  it('lets a theme override fixed points without emitting CSS', () => {
+    const theme = defineTheme({
+      name: 'points-only',
+      adaptations: {widthBreakpoints: {md: 800, lg: 1100}},
+    });
+
+    expect(theme.__adaptations.widthBreakpoints).toEqual({
+      ...DEFAULT_WIDTH_BREAKPOINTS,
+      md: 800,
+      lg: 1100,
+    });
+    expect(generateAdaptationCSS(theme)).toEqual({prose: '', component: ''});
+    expect(generateThemeCSS(theme).component).not.toContain('@media');
+  });
+
+  it.each([
+    [{phone: 500}, /phone is not supported/],
+    [{md: 0}, /md must be a finite positive number/],
+    [{md: Number.NaN}, /md must be a finite positive number/],
+    [{md: 1100, lg: 1000}, /strictly increasing/],
+  ])('rejects an invalid breakpoint map %#', (widthBreakpoints, message) => {
+    expect(() =>
+      defineTheme({
+        name: 'bad-points',
+        adaptations: {
+          widthBreakpoints,
+        } as unknown as DefineThemeInput['adaptations'],
+      }),
+    ).toThrow(message);
+  });
+});
+
+describe('closed conditions and media queries', () => {
+  it('lowers inclusive from and exclusive below edges', () => {
+    const theme = defineTheme(
+      adaptationInput([
+        {
+          when: {width: {below: 'sm'}},
+          value: {tokens: {'--spacing-4': '12px'}},
+        },
+        {
+          when: {width: {from: 'lg', below: 'xl'}},
+          value: {tokens: {'--spacing-4': '20px'}},
+        },
+        {
+          when: {width: {from: '2xl'}},
+          value: {tokens: {'--spacing-4': '24px'}},
+        },
+      ]),
+    );
+
+    expect(mediaPreludes(generateAdaptationCSS(theme).component)).toEqual([
+      '(width < 640px)',
+      '(width >= 1024px) and (width < 1280px)',
+      '(width >= 1536px)',
+    ]);
+  });
+
+  it('ANDs width, pointer, contrast, and motion in a stable order', () => {
+    const theme = defineTheme(
+      adaptationInput([
+        {
+          when: {
+            motion: 'reduce',
+            pointer: 'coarse',
+            width: {from: 'md', below: 'xl'},
+            contrast: 'more',
+          },
+          value: {tokens: {'--duration-fast': '0ms'}},
+        },
+      ]),
+    );
+
+    expect(mediaPreludes(generateAdaptationCSS(theme).component)).toEqual([
+      '(width >= 768px) and (width < 1280px) and (pointer: coarse) and (prefers-contrast: more) and (prefers-reduced-motion: reduce)',
+    ]);
+  });
+
+  it.each([
+    [{}, /must contain at least one condition/],
+    [{pointer: undefined}, /must contain at least one condition/],
+    [{width: {}}, /must contain `from`, `below`, or both/],
+    [{width: {from: 'lg', below: 'md'}}, /must resolve to `from < below`/],
+    [{hover: true}, /hover is not supported/],
+    [{pointer: 'any'}, /pointer must be 'coarse' or 'fine'/],
+  ])('rejects an invalid condition %#', (when, message) => {
+    expect(() =>
+      defineTheme(
+        adaptationInput([
+          {
+            when,
+            value: {tokens: {'--spacing-4': '12px'}},
+          } as never,
+        ]),
+      ),
+    ).toThrow(message);
+  });
+
+  it('rejects positional rules and root-owned fields in a rule value', () => {
+    expect(() =>
+      defineTheme({
+        name: 'tuple-rule',
+        adaptations: {
+          rules: [[{pointer: 'coarse'}, {tokens: {'--spacing-4': '12px'}}]],
+        },
+      } as unknown as DefineThemeInput),
+    ).toThrow(/must be an object/);
+
+    expect(() =>
+      defineTheme({
+        name: 'identity-in-rule',
+        adaptations: {
+          rules: [{when: {pointer: 'coarse'}, value: {icons: {}}}],
+        },
+      } as unknown as DefineThemeInput),
+    ).toThrow(/value.icons is not supported/);
+  });
+});
+
+describe('rule order and writes', () => {
+  it('preserves duplicate conditions and later root-restoring writes', () => {
+    const theme = defineTheme({
+      name: 'ordered',
+      tokens: {'--spacing-4': '16px'},
+      adaptations: {
+        rules: [
+          {
+            when: {pointer: 'coarse'},
+            value: {tokens: {'--spacing-4': '12px'}},
+          },
+          {
+            when: {pointer: 'coarse'},
+            value: {tokens: {'--spacing-4': '16px'}},
+          },
+        ],
+      },
+    });
+    const css = generateAdaptationCSS(theme).component;
+
+    expect(count(css, '@media (pointer: coarse)')).toBe(2);
+    expect(css.indexOf('--spacing-4: 12px')).toBeLessThan(
+      css.indexOf('--spacing-4: 16px'),
+    );
+  });
+
+  it('uses declaration order rather than inferred condition specificity', () => {
+    const theme = defineTheme(
+      adaptationInput([
+        {
+          when: {width: {from: 'md', below: 'lg'}, pointer: 'coarse'},
+          value: {tokens: {'--spacing-4': '12px'}},
+        },
+        {
+          when: {pointer: 'coarse'},
+          value: {tokens: {'--spacing-4': '20px'}},
+        },
+      ]),
+    );
+    const css = generateAdaptationCSS(theme).component;
+
+    expect(css.indexOf('--spacing-4: 12px')).toBeLessThan(
+      css.indexOf('--spacing-4: 20px'),
+    );
+  });
+
+  it('emits no block for an empty value while retaining the normalized rule', () => {
+    const theme = defineTheme(
+      adaptationInput([
+        {when: {pointer: 'coarse'}, value: {}},
+        {
+          when: {pointer: 'fine'},
+          value: {tokens: {'--spacing-4': '18px'}},
+        },
+      ]),
+    );
+
+    expect(theme.__adaptations.rules).toHaveLength(2);
+    expect(count(generateAdaptationCSS(theme).component, '@media')).toBe(1);
+  });
+
+  it('lets explicit values beat generated values within one rule', () => {
+    const theme = defineTheme({
+      name: 'rule-precedence',
+      color: {accent: '#0064E0'},
+      adaptations: {
+        rules: [
+          {
+            when: {contrast: 'more'},
+            value: {
+              color: {accent: '#00AA00'},
+              tokens: {'--color-accent': '#FF0000'},
+            },
+          },
+        ],
+      },
+    });
+
+    expect(theme.__adaptationRules?.[0].tokens['--color-accent']).toBe(
+      '#FF0000',
+    );
+  });
+
+  it('treats generated leaves as rule writes above root token pins', () => {
+    const theme = defineTheme({
+      name: 'generated-write',
+      typography: {scale: {base: 14, ratio: 1.2}},
+      tokens: {'--font-size-base': '2rem'},
+      adaptations: {
+        rules: [
+          {
+            when: {width: {below: 'sm'}},
+            value: {typography: {scale: {base: 16}}},
+          },
+        ],
+      },
+    });
+
+    expect(theme.tokens['--font-size-base']).toBe('2rem');
+    expect(theme.__adaptationRules?.[0].tokens['--font-size-base']).toBe(
+      '1rem',
+    );
+  });
+
+  it('writes font families without re-expanding an untouched root scale', () => {
+    const theme = defineTheme({
+      name: 'family-only',
+      typography: {scale: {base: 14, ratio: 1.2}},
+      adaptations: {
+        rules: [
+          {
+            when: {pointer: 'coarse'},
+            value: {typography: {body: {family: 'Geist'}}},
+          },
+        ],
+      },
+    });
+
+    const rule = theme.__adaptationRules?.[0];
+    expect(rule?.tokens['--font-family-body']).toBe('Geist');
+    expect(rule?.tokens['--font-size-base']).toBeUndefined();
+    expect(rule?.components).toBeUndefined();
+  });
+
+  it('completes partial scales from root metadata and refuses approximations', () => {
+    const complete = defineTheme({
+      name: 'complete-scale',
+      typography: {scale: {base: 14, ratio: 1.25}},
+      radius: {base: 6, multiplier: 1},
+      adaptations: {
+        rules: [
+          {
+            when: {width: {below: 'md'}},
+            value: {
+              typography: {scale: {base: 16}},
+              radius: {multiplier: 2},
+            },
+          },
+        ],
+      },
+    });
+
+    expect(complete.__adaptationRules?.[0].tokens['--font-size-lg']).toBe(
+      '1.25rem',
+    );
+    expect(complete.__adaptationRules?.[0].tokens['--radius-element']).toBe(
+      '24px',
+    );
+
+    expect(() =>
+      defineTheme({
+        name: 'missing-scale',
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {motion: {fast: 100}},
+            },
+          ],
+        },
+      }),
+    ).toThrow(/must supply `fast`, `medium`, and `ratio`/);
+  });
+
+  it('lowers component writes through the ordinary derived-variable path', () => {
+    const theme = defineTheme(
+      adaptationInput([
+        {
+          when: {pointer: 'coarse'},
+          value: {components: {button: {base: {borderRadius: '20px'}}}},
+        },
+      ]),
+    );
+
+    const css = generateAdaptationCSS(theme).component;
+    expect(css).toContain('--_button-radius: 20px');
+  });
+});
+
+describe('theme-local adaptation values', () => {
+  const localName = '--astryx-theme-local-root-control-height';
+
+  it('replaces an enrolled exact name and permits rule references to it', () => {
+    const theme = defineTheme({
+      name: 'local-root',
+      localTokens: {[localName]: '32px'},
+      adaptations: {
+        rules: [
+          {
+            when: {pointer: 'coarse'},
+            value: {
+              localTokens: {[localName]: '44px'},
+              components: {
+                button: {base: {minHeight: `var(${localName})`}},
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(theme.__adaptationRules?.[0].localTokens).toEqual({
+      [localName]: '44px',
+    });
+    expect(generateAdaptationCSS(theme).component).toContain(
+      `${localName}: 44px`,
+    );
+  });
+
+  it('does not let a rule enroll or misroute a local name', () => {
+    expect(() =>
+      defineTheme({
+        name: 'rule-enroll',
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {
+                localTokens: {
+                  '--astryx-theme-rule-enroll-new-name': '44px',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/cannot enroll a theme-local token/);
+
+    expect(() =>
+      defineTheme({
+        name: 'local-root',
+        localTokens: {[localName]: '32px'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {tokens: {[localName]: '44px'}},
+            },
+          ],
+        },
+      } as unknown as DefineThemeInput),
+    ).toThrow(/write it through value.localTokens/);
+  });
+
+  it('rejects undeclared references and conditional cycles', () => {
+    expect(() =>
+      defineTheme({
+        name: 'local-root',
+        localTokens: {[localName]: '32px'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {
+                components: {
+                  button: {
+                    base: {
+                      minHeight: 'var(--astryx-theme-local-root-missing-name)',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/has no declaration/);
+
+    const a = '--astryx-theme-cycle-local-a';
+    const b = '--astryx-theme-cycle-local-b';
+    expect(() =>
+      defineTheme({
+        name: 'cycle-local',
+        localTokens: {[a]: '1px', [b]: `var(${a})`},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {localTokens: {[a]: `var(${b})`}},
+            },
+          ],
+        },
+      }),
+    ).toThrow(/Theme token cycle detected/);
+  });
+
+  it('rejects a cycle formed only by simultaneously matching rules', () => {
+    const a = '--astryx-theme-overlap-cycle-a';
+    const b = '--astryx-theme-overlap-cycle-b';
+
+    expect(() =>
+      defineTheme({
+        name: 'overlap-cycle',
+        localTokens: {[a]: '1px', [b]: '2px'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {localTokens: {[a]: `var(${b})`}},
+            },
+            {
+              when: {contrast: 'more'},
+              value: {localTokens: {[b]: `var(${a})`}},
+            },
+          ],
+        },
+      }),
+    ).toThrow(/overlapping rules \[0, 1\].*cycle detected/i);
+  });
+
+  it('rejects cycles routed through portable adaptation tokens', () => {
+    const local = '--astryx-theme-portable-cycle-a';
+    expect(() =>
+      defineTheme({
+        name: 'portable-cycle',
+        localTokens: {[local]: '1px'},
+        tokens: {'--color-background-body': 'white'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {
+                tokens: {'--color-background-body': `var(${local})`},
+              },
+            },
+            {
+              when: {contrast: 'more'},
+              value: {
+                localTokens: {[local]: 'var(--color-background-body)'},
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/overlapping rules \[0, 1\].*cycle detected/i);
+
+    const singleLocal = '--astryx-theme-single-portable-cycle-a';
+    expect(() =>
+      defineTheme({
+        name: 'single-portable-cycle',
+        localTokens: {[singleLocal]: '1px'},
+        tokens: {'--color-background-body': 'white'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {
+                tokens: {
+                  '--color-background-body': `var(${singleLocal})`,
+                },
+                localTokens: {
+                  [singleLocal]: 'var(--color-background-body)',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/adaptations rule \[0\].*cycle detected/i);
+
+    expect(() =>
+      defineTheme({
+        name: 'portable-only-cycle',
+        tokens: {
+          '--color-background-body': 'white',
+          '--color-background-surface': 'gray',
+        },
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {
+                tokens: {
+                  '--color-background-body': 'var(--color-background-surface)',
+                },
+              },
+            },
+            {
+              when: {contrast: 'more'},
+              value: {
+                tokens: {
+                  '--color-background-surface': 'var(--color-background-body)',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/overlapping rules \[0, 1\].*cycle detected/i);
+  });
+
+  it('does not attribute an unrelated pre-existing root cycle to a rule', () => {
+    expect(() =>
+      defineTheme({
+        name: 'unrelated-root-cycle',
+        tokens: {
+          '--color-background-body': 'var(--color-background-surface)',
+          '--color-background-surface': 'var(--color-background-body)',
+        },
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {tokens: {'--spacing-4': '12px'}},
+            },
+          ],
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects a rule cycle that shares an edge with a root-only cycle', () => {
+    expect(() =>
+      defineTheme({
+        name: 'shared-cycle-edge',
+        tokens: {
+          '--color-background-body':
+            'linear-gradient(var(--color-background-surface), var(--color-background-muted))',
+          '--color-background-surface': 'var(--color-background-card)',
+          '--color-background-card': 'var(--color-background-body)',
+          '--color-background-muted': 'white',
+        },
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {
+                tokens: {
+                  '--color-background-muted': 'var(--color-background-card)',
+                },
+              },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/adaptations rule \[0\].*cycle detected/i);
+  });
+
+  it('rejects a three-rule cycle that no pair creates', () => {
+    const a = '--astryx-theme-three-way-cycle-a';
+    const b = '--astryx-theme-three-way-cycle-b';
+    const c = '--astryx-theme-three-way-cycle-c';
+
+    expect(() =>
+      defineTheme({
+        name: 'three-way-cycle',
+        localTokens: {[a]: '1px', [b]: '2px', [c]: '3px'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {localTokens: {[a]: `var(${b})`}},
+            },
+            {
+              when: {contrast: 'more'},
+              value: {localTokens: {[b]: `var(${c})`}},
+            },
+            {
+              when: {motion: 'reduce'},
+              value: {localTokens: {[c]: `var(${a})`}},
+            },
+          ],
+        },
+      }),
+    ).toThrow(/overlapping rules \[0, 1, 2\].*cycle detected/i);
+  });
+
+  it('allows mutually exclusive writes and a later matching cycle repair', () => {
+    const exclusiveA = '--astryx-theme-exclusive-cycle-a';
+    const exclusiveB = '--astryx-theme-exclusive-cycle-b';
+    expect(() =>
+      defineTheme({
+        name: 'exclusive-cycle',
+        localTokens: {[exclusiveA]: '1px', [exclusiveB]: '2px'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {localTokens: {[exclusiveA]: `var(${exclusiveB})`}},
+            },
+            {
+              when: {pointer: 'fine'},
+              value: {localTokens: {[exclusiveB]: `var(${exclusiveA})`}},
+            },
+          ],
+        },
+      }),
+    ).not.toThrow();
+
+    const widthA = '--astryx-theme-width-exclusive-cycle-a';
+    const widthB = '--astryx-theme-width-exclusive-cycle-b';
+    expect(() =>
+      defineTheme({
+        name: 'width-exclusive-cycle',
+        localTokens: {[widthA]: '1px', [widthB]: '2px'},
+        adaptations: {
+          rules: [
+            {
+              when: {width: {below: 'md'}},
+              value: {localTokens: {[widthA]: `var(${widthB})`}},
+            },
+            {
+              when: {width: {from: 'md'}},
+              value: {localTokens: {[widthB]: `var(${widthA})`}},
+            },
+          ],
+        },
+      }),
+    ).not.toThrow();
+
+    const repairedA = '--astryx-theme-repaired-cycle-a';
+    const repairedB = '--astryx-theme-repaired-cycle-b';
+    expect(() =>
+      defineTheme({
+        name: 'repaired-cycle',
+        localTokens: {[repairedA]: '1px', [repairedB]: '2px'},
+        adaptations: {
+          rules: [
+            {
+              when: {pointer: 'coarse'},
+              value: {localTokens: {[repairedA]: `var(${repairedB})`}},
+            },
+            {
+              when: {contrast: 'more'},
+              value: {localTokens: {[repairedB]: `var(${repairedA})`}},
+            },
+            {
+              when: {pointer: 'coarse', contrast: 'more'},
+              value: {localTokens: {[repairedB]: '4px'}},
+            },
+          ],
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('checks inherited and child rules in the same reachable cascade', () => {
+    const a = '--astryx-theme-cycle-base-a';
+    const b = '--astryx-theme-cycle-base-b';
+    const base = defineTheme({
+      name: 'cycle-base',
+      localTokens: {[a]: '1px', [b]: '2px'},
+      adaptations: {
+        rules: [
+          {
+            when: {pointer: 'coarse'},
+            value: {localTokens: {[a]: `var(${b})`}},
+          },
+        ],
+      },
+    });
+
+    expect(() =>
+      defineTheme({
+        name: 'cycle-child',
+        extends: base,
+        adaptations: {
+          rules: [
+            {
+              when: {contrast: 'more'},
+              value: {localTokens: {[b]: `var(${a})`}},
+            },
+          ],
+        },
+      }),
+    ).toThrow(
+      /overlapping rules \[0, 1\].*pointer: coarse.*prefers-contrast: more.*cycle detected/i,
+    );
+  });
+});
+
+describe('extension semantics and built metadata', () => {
+  it('inherits breakpoint overrides and appends child rules', () => {
+    const base = defineTheme({
+      name: 'base-order',
+      adaptations: {
+        widthBreakpoints: {md: 800},
+        rules: [
+          {
+            when: {width: {from: 'md'}},
+            value: {tokens: {'--spacing-4': '18px'}},
+          },
+        ],
+      },
+    });
+    const child = defineTheme({
+      name: 'child-order',
+      extends: base,
+      adaptations: {
+        widthBreakpoints: {md: 820},
+        rules: [
+          {
+            when: {pointer: 'coarse'},
+            value: {tokens: {'--size-element-md': '44px'}},
+          },
+        ],
+      },
+    });
+
+    expect(child.__adaptations.widthBreakpoints.md).toBe(820);
+    expect(child.__adaptations.rules).toHaveLength(2);
+    expect(mediaPreludes(generateAdaptationCSS(child).component)).toEqual([
+      '(width >= 820px)',
+      '(pointer: coarse)',
+    ]);
+  });
+
+  it("re-resolves inherited rules against the child's effective root axis", () => {
+    const base = defineTheme({
+      name: 'base-axis',
+      typography: {scale: {base: 14, ratio: 1.2}},
+      adaptations: {
+        rules: [
+          {
+            when: {width: {below: 'sm'}},
+            value: {typography: {scale: {base: 16}}},
+          },
+        ],
+      },
+    });
+    const child = defineTheme({
+      name: 'child-axis',
+      extends: base,
+      typography: {scale: {base: 15, ratio: 1.25}},
+    });
+
+    expect(child.__adaptationRules?.[0].tokens['--font-size-lg']).toBe(
+      '1.25rem',
+    );
+  });
+
+  it("merges a child's partial typography axis before re-resolving inherited rules", () => {
+    const base = defineTheme({
+      name: 'partial-typography-base',
+      typography: {
+        scale: {base: 14, ratio: 1.25},
+        body: {family: 'Inter', fallbacks: 'sans-serif'},
+        heading: {family: 'Playfair', fallbacks: 'serif'},
+      },
+      adaptations: {
+        rules: [
+          {
+            when: {width: {from: 'lg'}},
+            value: {typography: {scale: {base: 18}}},
+          },
+        ],
+      },
+    });
+    const child = defineTheme({
+      name: 'partial-typography-child',
+      extends: base,
+      typography: {body: {family: 'Georgia'}},
+    });
+
+    expect(child.__axes.typography?.scale).toEqual({base: 14, ratio: 1.25});
+    expect(child.__axes.typography?.body?.family).toBe('Georgia');
+    expect(child.__axes.typography?.body?.fallbacks).toBeUndefined();
+    expect(child.__axes.typography?.heading?.family).toBeUndefined();
+    expect(child.__axes.typography?.heading?.fallbacks).toBeUndefined();
+    expect(child.tokens['--font-family-heading']).toBe('Georgia');
+    expect(child.__adaptationRules?.[0].tokens['--font-family-body']).toBe(
+      'Georgia',
+    );
+    expect(child.__adaptationRules?.[0].tokens['--font-family-heading']).toBe(
+      'Georgia',
+    );
+    expect(child.__adaptationRules?.[0].tokens['--font-size-lg']).toBe(
+      '1.4375rem',
+    );
+  });
+
+  it('keeps typography weights owned by the last config that declares a scale', () => {
+    const rule = {
+      when: {width: {from: 'lg' as const}},
+      value: {typography: {scale: {base: 18}}},
+    };
+    const weightedBase = defineTheme({
+      name: 'weight-owner-base',
+      typography: {
+        scale: {base: 14, ratio: 1.25},
+        body: {weight: 'medium'},
+        heading: {weight: 'bold'},
+      },
+      adaptations: {rules: [rule]},
+    });
+    const newScale = defineTheme({
+      name: 'weight-owner-new-scale',
+      extends: weightedBase,
+      typography: {scale: {base: 16, ratio: 1.2}},
+    });
+
+    expect(newScale.__adaptationRules?.[0].tokens['--text-body-weight']).toBe(
+      newScale.tokens['--text-body-weight'],
+    );
+    expect(
+      newScale.__adaptationRules?.[0].tokens['--text-heading-1-weight'],
+    ).toBe(newScale.tokens['--text-heading-1-weight']);
+
+    const defaultBase = defineTheme({
+      name: 'weight-owner-default-base',
+      typography: {scale: {base: 14, ratio: 1.25}},
+      adaptations: {rules: [rule]},
+    });
+    const weightWithoutScale = defineTheme({
+      name: 'weight-owner-no-scale',
+      extends: defaultBase,
+      typography: {heading: {weight: 'bold'}},
+    });
+
+    expect(
+      weightWithoutScale.__adaptationRules?.[0].tokens[
+        '--text-heading-1-weight'
+      ],
+    ).toBe(weightWithoutScale.tokens['--text-heading-1-weight']);
+  });
+
+  it('ignores a child fallback that has no family, matching root resolution', () => {
+    const base = defineTheme({
+      name: 'fallback-only-base',
+      typography: {
+        scale: {base: 14, ratio: 1.25},
+        heading: {family: 'Playfair', fallbacks: 'sans-serif'},
+      },
+      adaptations: {
+        rules: [
+          {
+            when: {width: {from: 'lg'}},
+            value: {typography: {scale: {base: 18}}},
+          },
+        ],
+      },
+    });
+    const child = defineTheme({
+      name: 'fallback-only-child',
+      extends: base,
+      typography: {heading: {fallbacks: 'serif'}},
+    });
+
+    expect(child.tokens['--font-family-heading']).toBe('Playfair, sans-serif');
+    expect(child.__adaptationRules?.[0].tokens['--font-family-heading']).toBe(
+      child.tokens['--font-family-heading'],
+    );
+  });
+
+  it("uses a child's own color axis when re-resolving inherited rules", () => {
+    const rule = {
+      when: {contrast: 'more' as const},
+      value: {color: {contrast: 'high' as const}},
+    };
+    const base = defineTheme({
+      name: 'partial-color-base',
+      color: {accent: '#B7410E'},
+      adaptations: {rules: [rule]},
+    });
+    const child = defineTheme({
+      name: 'partial-color-child',
+      extends: base,
+      color: {neutralStyle: 'warm'},
+    });
+    const expected = defineTheme({
+      name: 'partial-color-expected',
+      color: {neutralStyle: 'warm', contrast: 'high'},
+    });
+
+    expect(child.__axes.color).toEqual({neutralStyle: 'warm'});
+    expect(child.__adaptationRules?.[0].tokens).toEqual(expected.tokens);
+  });
+
+  it("keeps inherited rules above the child's root values", () => {
+    const base = defineTheme({
+      name: 'base-rule',
+      adaptations: {
+        rules: [
+          {
+            when: {pointer: 'coarse'},
+            value: {tokens: {'--spacing-4': '12px'}},
+          },
+        ],
+      },
+    });
+    const child = defineTheme({
+      name: 'child-root',
+      extends: base,
+      tokens: {'--spacing-4': '20px'},
+    });
+
+    expect(child.tokens['--spacing-4']).toBe('20px');
+    expect(child.__adaptationRules?.[0].tokens['--spacing-4']).toBe('12px');
+  });
+
+  it('recomputes inherited rules from built-theme metadata without CSS text', () => {
+    const live = defineTheme({
+      name: 'built-base',
+      typography: {scale: {base: 14, ratio: 1.25}},
+      adaptations: {
+        widthBreakpoints: {sm: 700},
+        rules: [
+          {
+            when: {width: {below: 'sm'}},
+            value: {typography: {scale: {base: 16}}},
+          },
+        ],
+      },
+    });
+    const built = {
+      name: live.name,
+      __built: true,
+      tokens: live.tokens,
+      components: live.components,
+      __adaptations: live.__adaptations,
+      __axes: live.__axes,
+    } as DefinedTheme;
+
+    const child = defineTheme({name: 'built-child', extends: built});
+    expect(child.__adaptationRules?.[0].query).toBe('(width < 700px)');
+    expect(child.__adaptationRules?.[0].tokens['--font-size-lg']).toBe(
+      '1.25rem',
+    );
+    expect(JSON.stringify(built)).not.toContain('@media');
+  });
+});
+
+describe('CSS cascade placement', () => {
+  it('emits root values, then adaptations, then media-surface overrides', () => {
+    const theme = defineTheme({
+      name: 'surface-order',
+      tokens: {'--color-background-body': '#ffffff'},
+      adaptations: {
+        rules: [
+          {
+            when: {contrast: 'more'},
+            value: {tokens: {'--color-background-body': '#eeeeee'}},
+          },
+        ],
+      },
+      onDark: {tokens: {'--color-background-body': '#111111'}},
+    });
+
+    const css = generateThemeCSS(theme).component;
+    expect(css.indexOf('#ffffff')).toBeLessThan(css.indexOf('#eeeeee'));
+    expect(css.indexOf('#eeeeee')).toBeLessThan(css.lastIndexOf('#111111'));
+  });
+
+  it('makes rule shorthand padding override root directional container padding', () => {
+    const theme = defineTheme({
+      name: 'conditional-container-padding',
+      components: {
+        card: {base: {paddingBlock: '8px', paddingInline: '16px'}},
+        section: {base: {paddingBlock: '10px', paddingInline: '18px'}},
+      },
+      adaptations: {
+        rules: [
+          {
+            when: {width: {from: 'lg'}},
+            value: {
+              components: {
+                card: {base: {padding: '32px'}},
+                section: {base: {padding: '32px'}},
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const rootCss = generateThemeCSS(theme).component;
+    expect(rootCss).toContain('--astryx-card-padding-block-start: 8px');
+    expect(rootCss).toContain('--astryx-section-padding-inline: 18px');
+
+    const ruleCss = generateAdaptationCSS(theme).component;
+    for (const component of ['card', 'section']) {
+      expect(ruleCss).toContain(`--astryx-${component}-padding: 32px`);
+      expect(ruleCss).toContain(
+        `--astryx-${component}-padding-inline: initial`,
+      );
+      expect(ruleCss).toContain(
+        `--astryx-${component}-padding-inline-start: initial`,
+      );
+      expect(ruleCss).toContain(
+        `--astryx-${component}-padding-inline-end: initial`,
+      );
+      expect(ruleCss).toContain(
+        `--astryx-${component}-padding-block-start: initial`,
+      );
+      expect(ruleCss).toContain(
+        `--astryx-${component}-padding-block-end: initial`,
+      );
+    }
+  });
+
+  it('resets only the more-specific inline siblings for a rule paddingInline write', () => {
+    const theme = defineTheme({
+      name: 'conditional-inline-padding',
+      components: {card: {base: {padding: '16px'}}},
+      adaptations: {
+        rules: [
+          {
+            when: {width: {from: 'lg'}},
+            value: {components: {card: {base: {paddingInline: '32px'}}}},
+          },
+        ],
+      },
+    });
+
+    const ruleCss = generateAdaptationCSS(theme).component;
+    expect(ruleCss).toContain('--astryx-card-padding-inline: 32px');
+    expect(ruleCss).toContain('--astryx-card-padding-inline-start: initial');
+    expect(ruleCss).toContain('--astryx-card-padding-inline-end: initial');
+    expect(ruleCss).not.toContain('--astryx-card-padding: initial');
+    expect(ruleCss).not.toContain('--astryx-card-padding-block-start: initial');
+  });
+
+  it('keeps media-surface component writes above matching adaptations', () => {
+    const theme = defineTheme({
+      name: 'surface-component-order',
+      components: {button: {base: {borderWidth: '1px'}}},
+      adaptations: {
+        rules: [
+          {
+            when: {contrast: 'more'},
+            value: {components: {button: {base: {borderWidth: '2px'}}}},
+          },
+        ],
+      },
+      onDark: {components: {button: {base: {borderWidth: '3px'}}}},
+    });
+
+    const css = generateThemeCSS(theme).component;
+    expect(css.indexOf('border-width: 1px')).toBeLessThan(
+      css.indexOf('border-width: 2px'),
+    );
+    expect(css.indexOf('border-width: 2px')).toBeLessThan(
+      css.lastIndexOf('border-width: 3px'),
+    );
+  });
+
+  it('keeps JavaScript token reads on root values', () => {
+    const theme = defineTheme({
+      name: 'css-first',
+      tokens: {'--spacing-4': '16px'},
+      adaptations: {
+        rules: [
+          {
+            when: {pointer: 'coarse'},
+            value: {tokens: {'--spacing-4': '12px'}},
+          },
+        ],
+      },
+    });
+
+    expect(theme.tokens['--spacing-4']).toBe('16px');
+    expect(theme.__adaptationRules?.[0].tokens['--spacing-4']).toBe('12px');
+  });
+});

--- a/packages/core/src/theme/themeAdaptations.ts
+++ b/packages/core/src/theme/themeAdaptations.ts
@@ -1,0 +1,955 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file themeAdaptations.ts
+ * @input Ordered environment-conditioned theme value rules from defineTheme
+ * @output Validated breakpoint metadata and resolved CSS-first rule layers
+ * @position Theme system core; consumed by defineTheme, AppShell, and the CSS compiler
+ *
+ * Adaptations are deliberately closed and ordered. Width points are fixed names,
+ * condition fields are ANDed, and rule order is the precedence model: every
+ * matching rule writes after the root theme and later matching writes win.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/theme/defineTheme.ts (`DefineThemeInput.adaptations`)
+ * - /packages/core/src/theme/generateThemeRules.ts (`generateAdaptationCSS`)
+ * - /packages/core/src/AppShell/AppShell.tsx (named breakpoint consumption)
+ * - /packages/cli/assets/theme.template.ts
+ * - /packages/cli/assets/docs/theme.doc.mjs
+ * - /packages/cli/api/theme/build/build.mjs
+ */
+
+import type {ComponentStyleMap, TokenName, TokenValue} from './defineTheme';
+import type {TypographyConfig, TypographyRole} from './types';
+import type {MotionScaleConfig} from './expandMotionScale';
+import type {RadiusScaleConfig} from './expandRadiusScale';
+import type {ColorScaleConfig} from './expandColorScale';
+import {resolveThemeValues, type ThemeValuesInput} from './resolveThemeValues';
+import {assertNoTokenCycles, resolveAdaptationLocalTokens} from './localTokens';
+
+// =============================================================================
+// Public authoring vocabulary
+// =============================================================================
+
+/** Fixed names for viewport-width tier start points. */
+export const WIDTH_BREAKPOINT_NAMES = ['sm', 'md', 'lg', 'xl', '2xl'] as const;
+
+/** One fixed viewport-width breakpoint name. */
+export type WidthBreakpointName = (typeof WIDTH_BREAKPOINT_NAMES)[number];
+
+/** A complete, validated map of viewport-width tier start points in CSS px. */
+export type WidthBreakpoints = Record<WidthBreakpointName, number>;
+
+/** The default Astryx viewport-width tier start points in CSS px. */
+export const DEFAULT_WIDTH_BREAKPOINTS: Readonly<WidthBreakpoints> =
+  Object.freeze({
+    sm: 640,
+    md: 768,
+    lg: 1024,
+    xl: 1280,
+    '2xl': 1536,
+  });
+
+/** Inclusive lower and exclusive upper edges for one width condition. */
+export interface ThemeAdaptationWidthCondition {
+  /** Match at and above this named point. */
+  from?: WidthBreakpointName;
+  /** Match strictly below this named point. */
+  below?: WidthBreakpointName;
+}
+
+/** Closed environmental condition vocabulary. Fields are ANDed. */
+export interface ThemeAdaptationCondition {
+  /** Viewport-width range, using named start points. */
+  width?: ThemeAdaptationWidthCondition;
+  /** Primary pointing-device precision. */
+  pointer?: 'coarse' | 'fine';
+  /** User contrast preference. */
+  contrast?: 'more' | 'less' | 'no-preference';
+  /** User reduced-motion preference. */
+  motion?: 'reduce' | 'no-preference';
+}
+
+/** Typography overrides inside an adaptation rule. */
+export interface ThemeAdaptationTypographyConfig extends Omit<
+  TypographyConfig,
+  'scale'
+> {
+  /** Partial type scale, completed from the effective root axis. */
+  scale?: Partial<NonNullable<TypographyConfig['scale']>>;
+}
+
+/** Theme values an adaptation rule may write. */
+export interface ThemeAdaptationValue {
+  /** Typography axis overrides, completed from root metadata. */
+  typography?: ThemeAdaptationTypographyConfig;
+  /** Color axis overrides, completed from root metadata. */
+  color?: Partial<ColorScaleConfig>;
+  /** Radius axis overrides, completed from root metadata. */
+  radius?: Partial<RadiusScaleConfig>;
+  /** Motion axis overrides, completed from root metadata. */
+  motion?: Partial<MotionScaleConfig>;
+  /** Portable semantic-token writes. */
+  tokens?: Partial<Record<TokenName, TokenValue>>;
+  /** Replacements for exact theme-local names enrolled by the root lineage. */
+  localTokens?: Record<string, TokenValue>;
+  /** Component target/style-key writes. */
+  components?: ComponentStyleMap;
+}
+
+/** One ordered condition-to-value adaptation rule. */
+export interface ThemeAdaptationRule {
+  /** Environmental fields that must all match. */
+  when: ThemeAdaptationCondition;
+  /** Theme values written while the condition matches. */
+  value: ThemeAdaptationValue;
+}
+
+/** Adaptation authoring input accepted by defineTheme. */
+export interface ThemeAdaptations {
+  /** Overrides for the five fixed width points. Configuration alone emits no CSS. */
+  widthBreakpoints?: Partial<WidthBreakpoints>;
+  /** Ordered condition-to-value rules. */
+  rules?: ThemeAdaptationRule[];
+}
+
+// =============================================================================
+// Normalized and resolved metadata
+// =============================================================================
+
+/** Validated authoring data retained for source-equivalent theme extension. */
+export interface NormalizedThemeAdaptations {
+  /** Effective complete width map, including defaults and inherited overrides. */
+  widthBreakpoints: WidthBreakpoints;
+  /** Inherited rules followed by child-authored rules, preserving order. */
+  rules: ThemeAdaptationRule[];
+}
+
+/** Generative-axis metadata needed to complete partial adaptation values. */
+export interface ThemeGenerativeAxes {
+  typography?: TypographyConfig;
+  color?: ColorScaleConfig;
+  radius?: RadiusScaleConfig;
+  motion?: MotionScaleConfig;
+}
+
+/** One rule lowered to concrete CSS writes. */
+export interface ResolvedThemeAdaptationRule {
+  /** Validated condition, retained for diagnostics. */
+  when: ThemeAdaptationCondition;
+  /** CSS media-query prelude without the `@media` keyword. */
+  query: string;
+  /** Concrete portable token writes produced by this rule. */
+  tokens: Record<string, string>;
+  /** Concrete theme-local token writes produced by this rule. */
+  localTokens?: Record<string, string>;
+  /** Concrete component writes produced by this rule. */
+  components?: ComponentStyleMap;
+}
+
+// =============================================================================
+// Structural validation
+// =============================================================================
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assertRecord(
+  value: unknown,
+  path: string,
+): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object.`);
+  }
+}
+
+function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      throw new Error(`${path}.${key} is not supported.`);
+    }
+  }
+}
+
+function cloneData<T>(value: T): T {
+  if (Array.isArray(value)) {
+    const cloned: unknown[] = [];
+    for (const item of value) {
+      cloned.push(cloneData(item));
+    }
+    return cloned as T;
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, cloneData(nested)]),
+    ) as T;
+  }
+  return value;
+}
+
+const BREAKPOINT_NAMES = new Set<string>(WIDTH_BREAKPOINT_NAMES);
+const ADAPTATION_KEYS = new Set(['widthBreakpoints', 'rules']);
+const RULE_KEYS = new Set(['when', 'value']);
+const CONDITION_AXES = [
+  'width',
+  'pointer',
+  'contrast',
+  'motion',
+] as const satisfies ReadonlyArray<keyof ThemeAdaptationCondition>;
+type UnhandledConditionAxis = Exclude<
+  keyof ThemeAdaptationCondition,
+  (typeof CONDITION_AXES)[number]
+>;
+const CONDITION_KEYS: UnhandledConditionAxis extends never
+  ? ReadonlySet<keyof ThemeAdaptationCondition>
+  : never = new Set(CONDITION_AXES);
+const WIDTH_CONDITION_KEYS = new Set(['from', 'below']);
+const VALUE_KEYS = new Set([
+  'typography',
+  'color',
+  'radius',
+  'motion',
+  'tokens',
+  'localTokens',
+  'components',
+]);
+
+function normalizeBreakpointOverrides(
+  value: unknown,
+  path: string,
+): Partial<WidthBreakpoints> {
+  assertRecord(value, path);
+  assertAllowedKeys(value, BREAKPOINT_NAMES, path);
+  const result: Partial<WidthBreakpoints> = {};
+  for (const name of WIDTH_BREAKPOINT_NAMES) {
+    const point = value[name];
+    if (point === undefined) {
+      continue;
+    }
+    if (typeof point !== 'number' || !Number.isFinite(point) || point <= 0) {
+      throw new Error(
+        `${path}.${name} must be a finite positive number of CSS pixels.`,
+      );
+    }
+    result[name] = point;
+  }
+  return result;
+}
+
+function assertCompleteBreakpoints(
+  value: unknown,
+  path: string,
+): WidthBreakpoints {
+  const overrides = normalizeBreakpointOverrides(value, path);
+  for (const name of WIDTH_BREAKPOINT_NAMES) {
+    if (overrides[name] === undefined) {
+      throw new Error(
+        `${path}.${name} is missing from the effective breakpoint map.`,
+      );
+    }
+  }
+  return overrides as WidthBreakpoints;
+}
+
+function assertIncreasingBreakpoints(
+  points: WidthBreakpoints,
+  path: string,
+): void {
+  let previous: WidthBreakpointName | undefined;
+  for (const name of WIDTH_BREAKPOINT_NAMES) {
+    if (previous !== undefined && points[name] <= points[previous]) {
+      throw new Error(
+        `${path} must be strictly increasing: ${name} (${points[name]}) is not above ${previous} (${points[previous]}).`,
+      );
+    }
+    previous = name;
+  }
+}
+
+function normalizeCondition(
+  value: unknown,
+  path: string,
+): ThemeAdaptationCondition {
+  assertRecord(value, path);
+  assertAllowedKeys(value, CONDITION_KEYS, path);
+  const defined = Object.fromEntries(
+    Object.entries(value).filter(([, nested]) => nested !== undefined),
+  );
+  if (Object.keys(defined).length === 0) {
+    throw new Error(`${path} must contain at least one condition.`);
+  }
+
+  const condition = cloneData(defined) as ThemeAdaptationCondition;
+  if (condition.width !== undefined) {
+    assertRecord(condition.width, `${path}.width`);
+    assertAllowedKeys(condition.width, WIDTH_CONDITION_KEYS, `${path}.width`);
+    if (
+      condition.width.from === undefined &&
+      condition.width.below === undefined
+    ) {
+      throw new Error(
+        `${path}.width must contain \`from\`, \`below\`, or both.`,
+      );
+    }
+    for (const edge of ['from', 'below'] as const) {
+      const name = condition.width[edge];
+      if (
+        name !== undefined &&
+        (typeof name !== 'string' || !BREAKPOINT_NAMES.has(name))
+      ) {
+        throw new Error(
+          `${path}.width.${edge} must be one of ${WIDTH_BREAKPOINT_NAMES.join(', ')}.`,
+        );
+      }
+    }
+  }
+
+  if (
+    condition.pointer !== undefined &&
+    condition.pointer !== 'coarse' &&
+    condition.pointer !== 'fine'
+  ) {
+    throw new Error(`${path}.pointer must be 'coarse' or 'fine'.`);
+  }
+  if (
+    condition.contrast !== undefined &&
+    condition.contrast !== 'more' &&
+    condition.contrast !== 'less' &&
+    condition.contrast !== 'no-preference'
+  ) {
+    throw new Error(
+      `${path}.contrast must be 'more', 'less', or 'no-preference'.`,
+    );
+  }
+  if (
+    condition.motion !== undefined &&
+    condition.motion !== 'reduce' &&
+    condition.motion !== 'no-preference'
+  ) {
+    throw new Error(`${path}.motion must be 'reduce' or 'no-preference'.`);
+  }
+
+  return condition;
+}
+
+function normalizeValue(value: unknown, path: string): ThemeAdaptationValue {
+  assertRecord(value, path);
+  assertAllowedKeys(value, VALUE_KEYS, path);
+  for (const key of VALUE_KEYS) {
+    const nested = value[key];
+    if (nested !== undefined && !isRecord(nested)) {
+      throw new Error(`${path}.${key} must be an object.`);
+    }
+  }
+  return cloneData(value);
+}
+
+function normalizeRule(value: unknown, path: string): ThemeAdaptationRule {
+  assertRecord(value, path);
+  assertAllowedKeys(value, RULE_KEYS, path);
+  if (!Object.prototype.hasOwnProperty.call(value, 'when')) {
+    throw new Error(`${path}.when is required.`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(value, 'value')) {
+    throw new Error(`${path}.value is required.`);
+  }
+  return {
+    when: normalizeCondition(value.when, `${path}.when`),
+    value: normalizeValue(value.value, `${path}.value`),
+  };
+}
+
+function normalizeRules(value: unknown, path: string): ThemeAdaptationRule[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${path} must be an array of {when, value} objects.`);
+  }
+  return value.map((rule, index) => normalizeRule(rule, `${path}[${index}]`));
+}
+
+/**
+ * Merge and validate inherited plus locally-authored adaptation metadata.
+ * Inherited rules retain order; child rules append.
+ */
+export function normalizeThemeAdaptations(
+  themeName: string,
+  inherited: NormalizedThemeAdaptations | undefined,
+  input: ThemeAdaptations | undefined,
+): NormalizedThemeAdaptations {
+  const rootPath = `defineTheme("${themeName}").adaptations`;
+
+  let inheritedPoints: WidthBreakpoints = {...DEFAULT_WIDTH_BREAKPOINTS};
+  let inheritedRules: ThemeAdaptationRule[] = [];
+  if (inherited !== undefined) {
+    assertRecord(
+      inherited,
+      `defineTheme("${themeName}").extends.__adaptations`,
+    );
+    assertAllowedKeys(
+      inherited,
+      new Set(['widthBreakpoints', 'rules']),
+      `defineTheme("${themeName}").extends.__adaptations`,
+    );
+    inheritedPoints = assertCompleteBreakpoints(
+      inherited.widthBreakpoints,
+      `defineTheme("${themeName}").extends.__adaptations.widthBreakpoints`,
+    );
+    inheritedRules = normalizeRules(
+      inherited.rules,
+      `defineTheme("${themeName}").extends.__adaptations.rules`,
+    );
+  }
+
+  let ownPoints: Partial<WidthBreakpoints> = {};
+  let ownRules: ThemeAdaptationRule[] = [];
+  if (input !== undefined) {
+    assertRecord(input, rootPath);
+    assertAllowedKeys(input, ADAPTATION_KEYS, rootPath);
+    if (input.widthBreakpoints !== undefined) {
+      ownPoints = normalizeBreakpointOverrides(
+        input.widthBreakpoints,
+        `${rootPath}.widthBreakpoints`,
+      );
+    }
+    if (input.rules !== undefined) {
+      ownRules = normalizeRules(input.rules, `${rootPath}.rules`);
+    }
+  }
+
+  const widthBreakpoints: WidthBreakpoints = {
+    ...inheritedPoints,
+    ...ownPoints,
+  };
+  assertIncreasingBreakpoints(widthBreakpoints, `${rootPath}.widthBreakpoints`);
+
+  return {
+    widthBreakpoints,
+    rules: [...inheritedRules, ...ownRules],
+  };
+}
+
+// =============================================================================
+// Axis completion and rule resolution
+// =============================================================================
+
+function mergeRole(
+  root: TypographyRole | undefined,
+  rule: TypographyRole | undefined,
+): TypographyRole | undefined {
+  if (!root) {
+    return rule;
+  }
+  if (!rule) {
+    return root;
+  }
+  return {
+    ...root,
+    ...rule,
+    weights:
+      root.weights || rule.weights
+        ? {...root.weights, ...rule.weights}
+        : undefined,
+  };
+}
+
+function assertFiniteNumber(
+  value: unknown,
+  path: string,
+): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`${path} must be a finite number.`);
+  }
+}
+
+function completeTypography(
+  root: TypographyConfig | undefined,
+  rule: ThemeAdaptationTypographyConfig,
+  path: string,
+): TypographyConfig {
+  const writesScale =
+    rule.scale !== undefined ||
+    [rule.body, rule.heading, rule.code].some(
+      role => role?.weight !== undefined || role?.weights !== undefined,
+    );
+  let scale = writesScale ? root?.scale : undefined;
+  if (rule.scale !== undefined) {
+    const base = rule.scale.base ?? root?.scale?.base;
+    const ratio = rule.scale.ratio ?? root?.scale?.ratio;
+    if (base === undefined || ratio === undefined) {
+      throw new Error(
+        `${path}.scale must supply both \`base\` and \`ratio\` unless the missing field exists on the effective root typography axis.`,
+      );
+    }
+    assertFiniteNumber(base, `${path}.scale.base`);
+    assertFiniteNumber(ratio, `${path}.scale.ratio`);
+    scale = {base, ratio};
+  } else if (writesScale && scale === undefined) {
+    throw new Error(
+      `${path} sets typography weights without an effective root scale. Supply \`scale.base\` and \`scale.ratio\` in the same rule.`,
+    );
+  }
+
+  return {
+    ...(scale ? {scale} : {}),
+    body: mergeRole(root?.body, rule.body),
+    heading: mergeRole(root?.heading, rule.heading),
+    code: mergeRole(root?.code, rule.code),
+  };
+}
+
+function completeRadius(
+  root: RadiusScaleConfig | undefined,
+  rule: Partial<RadiusScaleConfig>,
+  path: string,
+): RadiusScaleConfig {
+  const base = rule.base ?? root?.base;
+  const multiplier = rule.multiplier ?? root?.multiplier;
+  if (base === undefined || multiplier === undefined) {
+    throw new Error(
+      `${path} must supply both \`base\` and \`multiplier\` unless the missing field exists on the effective root radius axis.`,
+    );
+  }
+  assertFiniteNumber(base, `${path}.base`);
+  assertFiniteNumber(multiplier, `${path}.multiplier`);
+  return {base, multiplier};
+}
+
+function completeMotion(
+  root: MotionScaleConfig | undefined,
+  rule: Partial<MotionScaleConfig>,
+  path: string,
+): MotionScaleConfig {
+  const fast = rule.fast ?? root?.fast;
+  const medium = rule.medium ?? root?.medium;
+  const ratio = rule.ratio ?? root?.ratio;
+  if (fast === undefined || medium === undefined || ratio === undefined) {
+    throw new Error(
+      `${path} must supply \`fast\`, \`medium\`, and \`ratio\` unless each missing field exists on the effective root motion axis.`,
+    );
+  }
+  assertFiniteNumber(fast, `${path}.fast`);
+  assertFiniteNumber(medium, `${path}.medium`);
+  assertFiniteNumber(ratio, `${path}.ratio`);
+  const slow = rule.slow ?? root?.slow;
+  if (slow !== undefined) {
+    assertFiniteNumber(slow, `${path}.slow`);
+  }
+  const easing = rule.easing ?? root?.easing;
+  return {
+    fast,
+    medium,
+    ratio,
+    ...(slow !== undefined ? {slow} : {}),
+    ...(easing !== undefined ? {easing} : {}),
+  };
+}
+
+function valueToThemeInput(
+  themeName: string,
+  ruleIndex: number,
+  value: ThemeAdaptationValue,
+  axes: ThemeGenerativeAxes,
+): ThemeValuesInput {
+  const path = `defineTheme("${themeName}").adaptations.rules[${ruleIndex}].value`;
+  return {
+    typography: value.typography
+      ? completeTypography(
+          axes.typography,
+          value.typography,
+          `${path}.typography`,
+        )
+      : undefined,
+    color: value.color ? {...axes.color, ...value.color} : undefined,
+    radius: value.radius
+      ? completeRadius(axes.radius, value.radius, `${path}.radius`)
+      : undefined,
+    motion: value.motion
+      ? completeMotion(axes.motion, value.motion, `${path}.motion`)
+      : undefined,
+    tokens: value.tokens,
+    components: value.components,
+  };
+}
+
+function assertConcreteLeaf(value: unknown, path: string): void {
+  if (typeof value === 'string') {
+    if (/\b(?:NaN|undefined)\b/.test(value)) {
+      throw new Error(`${path} resolved to the invalid CSS value "${value}".`);
+    }
+    return;
+  }
+  if (isRecord(value)) {
+    for (const [key, nested] of Object.entries(value)) {
+      assertConcreteLeaf(nested, `${path}.${key}`);
+    }
+    return;
+  }
+  throw new Error(`${path} must resolve to a concrete CSS string.`);
+}
+
+function mediaQueryForCondition(
+  themeName: string,
+  ruleIndex: number,
+  condition: ThemeAdaptationCondition,
+  points: WidthBreakpoints,
+): string {
+  const path = `defineTheme("${themeName}").adaptations.rules[${ruleIndex}].when`;
+  const parts: string[] = [];
+
+  if (condition.width) {
+    const from = condition.width.from;
+    const below = condition.width.below;
+    if (
+      from !== undefined &&
+      below !== undefined &&
+      points[from] >= points[below]
+    ) {
+      throw new Error(
+        `${path}.width must resolve to \`from < below\`; ${from} is ${points[from]}px and ${below} is ${points[below]}px.`,
+      );
+    }
+    if (from !== undefined) {
+      parts.push(`(width >= ${points[from]}px)`);
+    }
+    if (below !== undefined) {
+      parts.push(`(width < ${points[below]}px)`);
+    }
+  }
+  if (condition.pointer !== undefined) {
+    parts.push(`(pointer: ${condition.pointer})`);
+  }
+  if (condition.contrast !== undefined) {
+    parts.push(`(prefers-contrast: ${condition.contrast})`);
+  }
+  if (condition.motion !== undefined) {
+    parts.push(`(prefers-reduced-motion: ${condition.motion})`);
+  }
+
+  if (parts.length === 0) {
+    throw new Error(`${path} must contain at least one concrete condition.`);
+  }
+  return parts.join(' and ');
+}
+
+type PointerEnvironment =
+  NonNullable<ThemeAdaptationCondition['pointer']> | 'none';
+type ContrastEnvironment =
+  NonNullable<ThemeAdaptationCondition['contrast']> | 'custom';
+type MotionEnvironment = NonNullable<ThemeAdaptationCondition['motion']>;
+
+interface AdaptationEnvironment {
+  width: number;
+  pointer: PointerEnvironment;
+  contrast: ContrastEnvironment;
+  motion: MotionEnvironment;
+}
+
+const ENVIRONMENT_VALUES = {
+  pointer: ['coarse', 'fine', 'none'],
+  contrast: ['more', 'less', 'no-preference', 'custom'],
+  motion: ['reduce', 'no-preference'],
+} as const satisfies {
+  pointer: ReadonlyArray<PointerEnvironment>;
+  contrast: ReadonlyArray<ContrastEnvironment>;
+  motion: ReadonlyArray<MotionEnvironment>;
+};
+type EnvironmentTypes = {
+  pointer: PointerEnvironment;
+  contrast: ContrastEnvironment;
+  motion: MotionEnvironment;
+};
+const COMPLETE_ENVIRONMENT_VALUES: {
+  [Axis in keyof EnvironmentTypes]: Exclude<
+    EnvironmentTypes[Axis],
+    (typeof ENVIRONMENT_VALUES)[Axis][number]
+  > extends never
+    ? (typeof ENVIRONMENT_VALUES)[Axis]
+    : never;
+} = ENVIRONMENT_VALUES;
+
+/** Whether one normalized rule matches one representative environment cell. */
+function conditionMatchesEnvironment(
+  condition: ThemeAdaptationCondition,
+  points: WidthBreakpoints,
+  environment: AdaptationEnvironment,
+): boolean {
+  const from = condition.width?.from;
+  if (from !== undefined && environment.width < points[from]) {
+    return false;
+  }
+  const below = condition.width?.below;
+  if (below !== undefined && environment.width >= points[below]) {
+    return false;
+  }
+  if (
+    condition.pointer !== undefined &&
+    condition.pointer !== environment.pointer
+  ) {
+    return false;
+  }
+  if (
+    condition.contrast !== undefined &&
+    condition.contrast !== environment.contrast
+  ) {
+    return false;
+  }
+  if (
+    condition.motion !== undefined &&
+    condition.motion !== environment.motion
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Reject token cycles reachable in any matching adaptation-rule cascade.
+ *
+ * Conditions use a finite, closed vocabulary. Sampling zero and each named
+ * width boundary covers every distinct width truth region; the discrete axes
+ * enumerate every browser state relevant to the supported queries. For each
+ * reachable match set, portable and local writes are applied in authored order
+ * before checking the effective graph, so a later matching rule may
+ * intentionally repair an earlier cycle just as it does in CSS.
+ */
+function assertNoReachableTokenCycles(
+  themeName: string,
+  points: WidthBreakpoints,
+  rootTokens: Record<string, string>,
+  rootLocalTokens: Record<string, string> | undefined,
+  rules: ResolvedThemeAdaptationRule[],
+): void {
+  const tokenRuleIndexes = rules.flatMap((rule, index) =>
+    Object.keys(rule.tokens).length > 0 ||
+    (rule.localTokens && Object.keys(rule.localTokens).length > 0)
+      ? [index]
+      : [],
+  );
+  if (tokenRuleIndexes.length === 0) {
+    return;
+  }
+
+  const widthEnvironments = [
+    0,
+    ...WIDTH_BREAKPOINT_NAMES.map(name => points[name]),
+  ];
+  const checkedMatchSets = new Set<string>();
+
+  for (const width of widthEnvironments) {
+    for (const pointer of COMPLETE_ENVIRONMENT_VALUES.pointer) {
+      for (const contrast of COMPLETE_ENVIRONMENT_VALUES.contrast) {
+        for (const motion of COMPLETE_ENVIRONMENT_VALUES.motion) {
+          const environment = {width, pointer, contrast, motion};
+          const matchingRuleIndexes = tokenRuleIndexes.filter(index =>
+            conditionMatchesEnvironment(rules[index].when, points, environment),
+          );
+          if (matchingRuleIndexes.length === 0) {
+            continue;
+          }
+
+          const signature = matchingRuleIndexes.join(',');
+          if (checkedMatchSets.has(signature)) {
+            continue;
+          }
+          checkedMatchSets.add(signature);
+
+          const effective = {...rootTokens, ...rootLocalTokens};
+          const relevantNames = new Set<string>();
+          for (const index of matchingRuleIndexes) {
+            const rule = rules[index];
+            Object.assign(effective, rule.tokens, rule.localTokens);
+            for (const name of Object.keys(rule.tokens)) {
+              relevantNames.add(name);
+            }
+            for (const name of Object.keys(rule.localTokens ?? {})) {
+              relevantNames.add(name);
+            }
+          }
+
+          const indexes = matchingRuleIndexes.join(', ');
+          const queries = matchingRuleIndexes
+            .map(index => rules[index].query)
+            .join('; ');
+          assertNoTokenCycles(
+            effective,
+            `defineTheme("${themeName}").adaptations ${
+              matchingRuleIndexes.length === 1 ? 'rule' : 'overlapping rules'
+            } [${indexes}] (${queries})`,
+            relevantNames,
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Resolve the effective root generative metadata through a theme extension.
+ * An explicitly supplied root axis replaces the inherited axis; omission inherits.
+ */
+export function resolveThemeGenerativeAxes(
+  inherited: ThemeGenerativeAxes | undefined,
+  own: ThemeGenerativeAxes,
+): ThemeGenerativeAxes {
+  const inheritedTypography = inherited?.typography;
+  const ownTypography = own.typography;
+  const resolveFamily = (
+    inheritedRole: TypographyRole | undefined,
+    ownRole: TypographyRole | undefined,
+    followsOwnBody = false,
+  ): TypographyRole | undefined => {
+    const merged = mergeRole(inheritedRole, ownRole);
+    if (!merged) {
+      return undefined;
+    }
+    if (ownRole?.family) {
+      return {
+        ...merged,
+        family: ownRole.family,
+        fallbacks: ownRole.fallbacks,
+      };
+    }
+    if (followsOwnBody) {
+      return {...merged, family: undefined, fallbacks: undefined};
+    }
+    // A fallback without a family is inert in buildFontFamilyTokens(), so it
+    // cannot replace the fallback attached to an inherited effective family.
+    return {
+      ...merged,
+      family: inheritedRole?.family,
+      fallbacks: inheritedRole?.fallbacks,
+    };
+  };
+
+  let body = resolveFamily(inheritedTypography?.body, ownTypography?.body);
+  let heading = resolveFamily(
+    inheritedTypography?.heading,
+    ownTypography?.heading,
+    Boolean(ownTypography?.body?.family && !ownTypography?.heading?.family),
+  );
+  let code = resolveFamily(inheritedTypography?.code, ownTypography?.code);
+
+  // Weights reach tokens only when a scale is expanded. The most recent
+  // config that declares a scale owns every weight; omitted weights become the
+  // expander defaults rather than resurrecting values from an earlier scale.
+  const weightOwner = ownTypography?.scale
+    ? ownTypography
+    : inheritedTypography?.scale
+      ? inheritedTypography
+      : undefined;
+  const applyWeights = (
+    role: TypographyRole | undefined,
+    owner: TypographyRole | undefined,
+  ): TypographyRole | undefined =>
+    role
+      ? {...role, weight: owner?.weight, weights: owner?.weights}
+      : undefined;
+  body = applyWeights(body, weightOwner?.body);
+  heading = applyWeights(heading, weightOwner?.heading);
+  code = applyWeights(code, weightOwner?.code);
+
+  const typography =
+    inheritedTypography || ownTypography
+      ? {
+          ...inheritedTypography,
+          ...ownTypography,
+          scale: ownTypography?.scale ?? inheritedTypography?.scale,
+          body,
+          heading,
+          code,
+        }
+      : undefined;
+  // A color config regenerates its neutral ramp even when `accent` is omitted,
+  // so an authored child config replaces rather than field-merges the base axis.
+  const color = own.color ?? inherited?.color;
+  const radius = own.radius
+    ? {...inherited?.radius, ...own.radius}
+    : inherited?.radius;
+  const motion = own.motion
+    ? {...inherited?.motion, ...own.motion}
+    : inherited?.motion;
+
+  return {
+    ...(typography ? {typography} : {}),
+    ...(color ? {color} : {}),
+    ...(radius ? {radius} : {}),
+    ...(motion ? {motion} : {}),
+  };
+}
+
+/** Lower ordered normalized rules to concrete CSS writes. */
+export function resolveThemeAdaptationRules(
+  themeName: string,
+  adaptations: NormalizedThemeAdaptations,
+  axes: ThemeGenerativeAxes,
+  rootTokens: Record<string, string>,
+  rootLocalTokens: Record<string, string> | undefined,
+): ResolvedThemeAdaptationRule[] | undefined {
+  if (adaptations.rules.length === 0) {
+    return undefined;
+  }
+
+  const resolvedRules = adaptations.rules.map((rule, index) => {
+    const resolved = resolveThemeValues(
+      valueToThemeInput(themeName, index, rule.value, axes),
+    );
+    for (const [name, value] of Object.entries(resolved.tokens)) {
+      assertConcreteLeaf(
+        value,
+        `defineTheme("${themeName}").adaptations.rules[${index}].value.tokens["${name}"]`,
+      );
+    }
+    if (resolved.components) {
+      assertConcreteLeaf(
+        resolved.components,
+        `defineTheme("${themeName}").adaptations.rules[${index}].value.components`,
+      );
+    }
+
+    for (const name of Object.keys(rule.value.tokens ?? {})) {
+      if (
+        rootLocalTokens &&
+        Object.prototype.hasOwnProperty.call(rootLocalTokens, name)
+      ) {
+        throw new Error(
+          `defineTheme("${themeName}").adaptations.rules[${index}].value.tokens["${name}"] targets an enrolled theme-local name; write it through value.localTokens instead.`,
+        );
+      }
+    }
+
+    const localTokens = resolveAdaptationLocalTokens(
+      themeName,
+      index,
+      rule.value.localTokens,
+      rootLocalTokens,
+      resolved.tokens,
+      resolved.components,
+    );
+
+    return {
+      when: rule.when,
+      query: mediaQueryForCondition(
+        themeName,
+        index,
+        rule.when,
+        adaptations.widthBreakpoints,
+      ),
+      tokens: resolved.tokens,
+      localTokens,
+      components: resolved.components,
+    };
+  });
+
+  assertNoReachableTokenCycles(
+    themeName,
+    adaptations.widthBreakpoints,
+    rootTokens,
+    rootLocalTokens,
+    resolvedRules,
+  );
+  return resolvedRules;
+}

--- a/packages/core/src/theme/useTheme.ts
+++ b/packages/core/src/theme/useTheme.ts
@@ -5,7 +5,7 @@
 /**
  * @file useTheme.ts
  * @input ThemeContext provided by Theme
- * @output Exports useTheme and useThemeName hooks for programmatic theme access
+ * @output Exports useTheme, useThemeName, and internal theme-object access
  * @position Theme hook; used by data viz, canvas, and non-CSS consumers
  *
  * Provides synchronous access to theme token values resolved for the
@@ -235,6 +235,18 @@ export function useThemeName(): string | null {
   const rootThemeName = useRootThemeNameAttr(hasCtx);
 
   return ctx?.theme.name ?? rootThemeName;
+}
+
+/**
+ * Return the nearest theme object, falling back to the registered root theme
+ * only when no provider context is available.
+ * @internal
+ */
+export function useThemeDefinition(): DefinedTheme | undefined {
+  const ctx = use(ThemeContext);
+  const hasCtx = ctx != null;
+  const rootThemeName = useRootThemeNameAttr(hasCtx);
+  return ctx?.theme ?? getRegisteredTheme(rootThemeName) ?? undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

- propose a generated, versioned Core visual-prop contract derived from checked TypeScript and reconciled with public component docs
- keep visual props separate from states and preserve mixed finite/open domains
- record existing public augmentation wiring without introducing theme syntax or a TypeScript runtime dependency
- define deterministic Core/CLI fallback behavior and one contract for theme validation, declarations, discovery, and probes

## Non-goals

- no public theme-authoring syntax change
- no hand-maintained allowed-value tables
- no automatic approval of unrelated extension interfaces
- no implementation changes in this PR

## Validation

- `pnpm check:knowledge`
- independent architecture review completed with no remaining actionable findings

This draft targets `feat/theme-tiers` so it can be reviewed separately from the implementation in #6061.
