### PR TITLE
theme build: add opt-in --tokens JSON dump (#5923)

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -17,3 +17,9 @@ foundation/*.d.mts
 # Transient fixture dir written by authoring-migration.tsc.test.mjs (runs the
 # real tsc over migrated output); created + removed per test run.
 .codemod-tsc-*/
+
+# Transient fixture dirs for tests whose theme files need to
+# `import {defineTheme} from '@astryxdesign/core/theme'` and therefore have
+# to live under a real node_modules tree; created + removed per test run.
+.tmp-extends-*/
+.tmp-tokens-*/

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -1039,11 +1039,14 @@ function validatePrivateVars(themeDef) {
  * `logger` (silent by default).
  *
  * @param {string} file - Theme file path, resolved against `cwd`.
- * @param {{out?: string, check?: boolean, iconsSpecifier?: string}} [options] -
+ * @param {{out?: string, check?: boolean, iconsSpecifier?: string, tokens?: boolean}} [options] -
  *   `out` overrides the output CSS path; `check` compares against on-disk outputs
  *   instead of writing. `iconsSpecifier` overrides the icon registry import
  *   specifier in the generated module (e.g. `./icons.mjs`); when omitted, the
- *   specifier scraped from the theme source is emitted unchanged.
+ *   specifier scraped from the theme source is emitted unchanged. `tokens`
+ *   additionally emits a `<name>.tokens.json` machine-readable dump of the
+ *   theme's resolved CSS custom properties (see #5923) — off by default so
+ *   existing builds and `--check` baselines are unaffected.
  * @param {{cwd?: string}} [ctx]
  * @returns {Promise<import('../theme.type.mjs').ThemeBuildResponse | import('../theme.type.mjs').ThemeBuildCheckResponse | null>}
  */
@@ -1272,6 +1275,9 @@ export async function themeBuild(
   const outDir = path.dirname(outPath);
   const jsPath = path.join(outDir, `${baseName}.js`);
   const dtsPath = path.join(outDir, `${baseName}.d.ts`);
+  const tokensJsonPath = options.tokens
+    ? path.join(outDir, `${baseName}.tokens.json`)
+    : null;
 
   const iconInfo = extractIconInfo(filePath);
 
@@ -1306,6 +1312,37 @@ export async function themeBuild(
     generatedHeader(sourceRelative, 'ts', buildCommand, versions) +
     generateBuiltTypes(themeDef, iconInfo, variantsFileName);
 
+  // Machine-readable token dump (opt-in via `--tokens`, see #5923). This is
+  // the same `resolvedTheme` object the CSS generator above already
+  // consumes — nothing is re-resolved, so the dump can never drift from the
+  // CSS it describes. Consumers (e.g. a Figma variable sync script) read
+  // `tokens`/`localTokens` as flat `{cssCustomPropertyName: value}` maps
+  // keyed exactly as they appear in the generated CSS (`--color-accent`,
+  // not a bare token name), so no separate name-mapping step is needed on
+  // the reading side. JSON has no comment syntax, so provenance that would
+  // otherwise sit in a `@generated` header comment is a `$generated` key
+  // instead. Deliberately excludes the invocation string (unlike the CSS/JS
+  // headers' `Command:` line, which `--check` strips before comparing) so
+  // this file has no field that's volatile across otherwise-identical
+  // builds — `--check` compares it byte for byte, with no normalization.
+  const tokensJsonContent = tokensJsonPath
+    ? JSON.stringify(
+        {
+          $generated: {
+            by: 'astryx theme build --tokens',
+            source: sourceRelative,
+            cli: versions.cli,
+            core: versions.core,
+          },
+          name: themeDef.name,
+          tokens: displayTheme.tokens ?? {},
+          localTokens: displayTheme.localTokens ?? {},
+        },
+        null,
+        2,
+      ) + '\n'
+    : null;
+
   // Atomic-ish write: stage every file as `<dest>.tmp`, then rename
   // each into place. If any stage step fails we clean up partials and
   // exit; if a rename fails mid-way we still have the originals (or
@@ -1317,6 +1354,9 @@ export async function themeBuild(
   ];
   if (variantDtsPath && variantContent) {
     writes.push({dest: variantDtsPath, content: variantContent});
+  }
+  if (tokensJsonPath && tokensJsonContent) {
+    writes.push({dest: tokensJsonPath, content: tokensJsonContent});
   }
 
   // Check mode: compare generated content against what's on disk instead of
@@ -1400,6 +1440,9 @@ export async function themeBuild(
       `✓ ${path.relative(cwd, variantDtsPath)} (${augCount} type augmentations)`,
     );
   }
+  if (tokensJsonPath && tokensJsonContent) {
+    logger.log(`✓ ${path.relative(cwd, tokensJsonPath)}`);
+  }
 
   const relOutDir = path.relative(cwd, outDir) || '.';
   const cssBase = path.basename(outPath, '.css');
@@ -1459,6 +1502,9 @@ Or with a <link> tag:
         dts: path.relative(cwd, dtsPath),
         ...(variantDecl && variantDtsPath
           ? {variantsDts: path.relative(cwd, variantDtsPath)}
+          : {}),
+        ...(tokensJsonPath
+          ? {tokensJson: path.relative(cwd, tokensJsonPath)}
           : {}),
       },
       warnings: warningMessages,

--- a/packages/cli/api/theme/build/build.tokens-json.test.mjs
+++ b/packages/cli/api/theme/build/build.tokens-json.test.mjs
@@ -1,0 +1,189 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Tests for the opt-in `{tokens: true}` / `--tokens` output of `themeBuild()`
+ * (see #5923): a `<name>.tokens.json` dump of the theme's resolved CSS custom
+ * properties, for syncing into tooling outside the runtime (for example, a
+ * design tool's variables).
+ *
+ * Companion to build.test.mjs; split out because it exercises a single
+ * concern (the JSON dump) across several thin cases rather than the general
+ * receipt contract.
+ */
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {themeBuild} from './build.mjs';
+
+vi.setConfig({testTimeout: 30000});
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-theme-build-tokens-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+/**
+ * A theme fixture that `import {defineTheme} from '@astryxdesign/core/theme'`
+ * — the way a real theme file does — has to sit somewhere that specifier
+ * resolves; an OS temp dir has no node_modules above it, so `jiti` fails to
+ * import it and `themeBuild()` silently falls back to its regex/eval legacy
+ * extractor, which reads the raw object literal without ever invoking
+ * `defineTheme()` — so a `[light, dark]` tuple never gets converted to
+ * `light-dark(...)`. (Same gotcha documented in build.test.mjs's `— extends`
+ * describe block.) Fixtures that actually need `defineTheme()` to run go in
+ * `resolvedDir` instead of `tmpDir`.
+ */
+let resolvedDir;
+beforeEach(() => {
+  resolvedDir = fs.mkdtempSync(
+    path.join(path.resolve(import.meta.dirname, '../../..'), '.tmp-tokens-'),
+  );
+});
+afterEach(() => {
+  fs.rmSync(resolvedDir, {recursive: true, force: true});
+});
+
+describe('themeBuild({tokens: true})', () => {
+  it('does not write a tokens.json file by default', async () => {
+    const themeFile = path.join(tmpDir, 'notokens.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default { name: 'notokens', tokens: { '--color-bg': '#0a0a0a' } };\n`,
+    );
+
+    const result = await themeBuild('notokens.mjs', {}, {cwd: tmpDir});
+
+    expect(result?.data.outputs.tokensJson).toBeUndefined();
+    expect(fs.existsSync(path.join(tmpDir, 'notokens.tokens.json'))).toBe(
+      false,
+    );
+  });
+
+  it('writes <name>.tokens.json with resolved tokens when {tokens: true}', async () => {
+    const themeFile = path.join(resolvedDir, 'withtokens.mjs');
+    // Authored via defineTheme() — as every real theme is — so the
+    // [light, dark] tuple actually goes through resolution. See the
+    // resolvedDir comment above for why this can't live in an OS temp dir.
+    fs.writeFileSync(
+      themeFile,
+      `import {defineTheme} from '@astryxdesign/core/theme';
+      export default defineTheme({
+        name: 'withtokens',
+        tokens: { '--color-accent': ['#0077b6', '#48cae4'] },
+      });\n`,
+    );
+
+    const result = await themeBuild(
+      'withtokens.mjs',
+      {tokens: true},
+      {cwd: resolvedDir},
+    );
+
+    expect(result?.data.outputs.tokensJson).toBe('withtokens.tokens.json');
+    const jsonPath = path.join(resolvedDir, 'withtokens.tokens.json');
+    expect(fs.existsSync(jsonPath)).toBe(true);
+
+    const dump = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    expect(dump.name).toBe('withtokens');
+    // Values are the fully resolved CSS the runtime/CSS output use — a
+    // light/dark pair becomes light-dark(), not the raw two-element array —
+    // so a reader never has to duplicate theme-resolution logic.
+    expect(dump.tokens['--color-accent']).toBe(
+      'light-dark(#0077b6, #48cae4)',
+    );
+    expect(dump.localTokens).toEqual({});
+    expect(dump.$generated.by).toBe('astryx theme build --tokens');
+    expect(dump.$generated.source).toBe('withtokens.mjs');
+  });
+
+  it('includes localTokens in the dump', async () => {
+    const themeFile = path.join(resolvedDir, 'localtokens.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `import {defineTheme} from '@astryxdesign/core/theme';
+      export default defineTheme({
+        name: 'localtokens',
+        localTokens: {
+          '--astryx-theme-localtokens-color-status-fill-accent': ['#0077b6', '#48cae4'],
+        },
+        components: {
+          badge: {
+            'variant:info': {
+              backgroundColor: 'var(--astryx-theme-localtokens-color-status-fill-accent)',
+            },
+          },
+        },
+      });\n`,
+    );
+
+    const result = await themeBuild(
+      'localtokens.mjs',
+      {tokens: true},
+      {cwd: resolvedDir},
+    );
+
+    const dump = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          resolvedDir,
+          /** @type {string} */ (result?.data.outputs.tokensJson),
+        ),
+        'utf8',
+      ),
+    );
+    expect(
+      dump.localTokens['--astryx-theme-localtokens-color-status-fill-accent'],
+    ).toBe('light-dark(#0077b6, #48cae4)');
+  });
+
+  it('reports a missing tokens.json as stale under --check', async () => {
+    const themeFile = path.join(tmpDir, 'checked.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default { name: 'checked', tokens: { '--color-bg': '#0a0a0a' } };\n`,
+    );
+
+    // Build without --tokens first (no tokens.json on disk yet), then run
+    // --check WITH --tokens: the dump is expected but absent, so it must
+    // show up as a missing output rather than being silently skipped.
+    await themeBuild('checked.mjs', {}, {cwd: tmpDir});
+    const checkResult = await themeBuild(
+      'checked.mjs',
+      {tokens: true, check: true},
+      {cwd: tmpDir},
+    );
+
+    expect(checkResult?.type).toBe('theme.build.check');
+    expect(checkResult?.data.upToDate).toBe(false);
+    expect(checkResult?.data.stale).toContainEqual({
+      path: 'checked.tokens.json',
+      reason: 'missing',
+    });
+  });
+
+  it('is stable across rebuilds with identical input (no spurious drift)', async () => {
+    const themeFile = path.join(tmpDir, 'stable.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default { name: 'stable', tokens: { '--color-bg': '#0a0a0a' } };\n`,
+    );
+
+    await themeBuild('stable.mjs', {tokens: true}, {cwd: tmpDir});
+    // Rebuild with a differently-shaped invocation (an explicit --out
+    // wouldn't apply here since tokens.json is keyed off outDir/baseName,
+    // but re-running itself must not perturb the file it just wrote).
+    const second = await themeBuild(
+      'stable.mjs',
+      {tokens: true, check: true},
+      {cwd: tmpDir},
+    );
+
+    expect(second?.data.upToDate).toBe(true);
+    expect(second?.data.stale).toEqual([]);
+  });
+});

--- a/packages/cli/api/theme/theme.type.mjs
+++ b/packages/cli/api/theme/theme.type.mjs
@@ -27,7 +27,7 @@
  * `warnings` are defects the theme author should fix. `notices` are advisories
  * about a correct theme — most of them cannot be fixed in a theme file at all,
  * so folding them into `warnings` makes a clean build look dirty.
- * @property {{name: string, tokenCount: number, componentCount: number, sizeKB: number, outputs: {css: string, js: string, dts: string, variantsDts?: string}, warnings: string[], notices: string[]}} data
+ * @property {{name: string, tokenCount: number, componentCount: number, sizeKB: number, outputs: {css: string, js: string, dts: string, variantsDts?: string, tokensJson?: string}, warnings: string[], notices: string[]}} data
  */
 
 /**

--- a/packages/cli/api/theme/themeBuild.doc.mjs
+++ b/packages/cli/api/theme/themeBuild.doc.mjs
@@ -22,10 +22,13 @@ export const doc = {
     'theme adds custom prop values). When another build step emits the icon registry, ' +
     '{iconsSpecifier} declares the fully specified module path for the generated JS import. ' +
     'With {check: true} it writes nothing and instead compares ' +
-    'each output against disk, returning the drift: the CI guard for committed, generated theme CSS.',
+    'each output against disk, returning the drift: the CI guard for committed, generated theme CSS. ' +
+    'With {tokens: true} it additionally writes <name>.tokens.json, a flat dump of the same ' +
+    'resolved tokens keyed by CSS custom property name, for syncing into tooling outside the ' +
+    'runtime (for example, a design tool\'s variables).',
   importPath: '@astryxdesign/cli/api',
   signature:
-    'themeBuild(file: string, options?: {out?: string, check?: boolean, iconsSpecifier?: string}, ctx?: {cwd?: string}): Promise<ThemeBuildResponse | ThemeBuildCheckResponse | null>',
+    'themeBuild(file: string, options?: {out?: string, check?: boolean, iconsSpecifier?: string, tokens?: boolean}, ctx?: {cwd?: string}): Promise<ThemeBuildResponse | ThemeBuildCheckResponse | null>',
   keywords: [
     'theme',
     'build',
@@ -63,6 +66,13 @@ export const doc = {
         'Override the icon-registry import specifier in the generated JS module, for example ./icons.mjs. When omitted, the source specifier is preserved.',
     },
     {
+      name: 'options.tokens',
+      type: 'boolean',
+      description:
+        'Also write <name>.tokens.json: {tokens, localTokens} as flat {cssCustomPropertyName: value} maps, resolved from the same object the CSS is generated from. Off by default so existing builds and --check baselines are unaffected.',
+      default: 'false',
+    },
+    {
       name: 'ctx.cwd',
       type: 'string',
       description:
@@ -73,7 +83,7 @@ export const doc = {
     {
       type: 'theme.build',
       description:
-        'Build receipt: theme name, token- and component-override counts, output size in KB, the written outputs {css, js, dts, and variantsDts when custom prop values were augmented}, and any validation warnings. Resolves to null instead when the theme produced no CSS (nothing to build).',
+        'Build receipt: theme name, token- and component-override counts, output size in KB, the written outputs {css, js, dts, variantsDts when custom prop values were augmented, and tokensJson when {tokens: true}}, and any validation warnings. Resolves to null instead when the theme produced no CSS (nothing to build).',
     },
     {
       type: 'theme.build.check',
@@ -113,6 +123,10 @@ export const doc = {
     {
       label: 'Use a separately compiled icon registry',
       code: "const r = await themeBuild('src/themes/ocean.ts', {iconsSpecifier: './icons.mjs'});",
+    },
+    {
+      label: 'Emit a token dump alongside the usual outputs',
+      code: "const r = await themeBuild('src/themes/ocean.ts', {tokens: true});",
     },
   ],
   command: 'theme build',

--- a/packages/cli/clients/cli/commands/build-theme.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.mjs
@@ -69,7 +69,7 @@ function resolveCliBin() {
  * Resolves with the child's exit code; never rejects.
  *
  * @param {string} file - The theme file argument, as the user passed it.
- * @param {{out?: string, iconsSpecifier?: string}} options - Parsed command
+ * @param {{out?: string, iconsSpecifier?: string, tokens?: boolean}} options - Parsed command
  *   options that affect generated output.
  * @returns {Promise<number>}
  */
@@ -78,6 +78,7 @@ function runThemeBuildOnceChild(file, options) {
   const args = [cliBin, 'theme', 'build', file];
   if (options.out) args.push('--out', options.out);
   if (options.iconsSpecifier) args.push('--icons-specifier', options.iconsSpecifier);
+  if (options.tokens) args.push('--tokens');
   return new Promise((/** @type {(code: number) => void} */ resolve) => {
     const child = spawn(process.execPath, args, {
       stdio: 'inherit',
@@ -98,7 +99,7 @@ function runThemeBuildOnceChild(file, options) {
  *
  * @param {Array<{file: string, filePath: string}>} entries - The theme file
  *   arguments as the user passed them, with their resolved absolute paths.
- * @param {{out?: string, iconsSpecifier?: string}} options - Parsed command options.
+ * @param {{out?: string, iconsSpecifier?: string, tokens?: boolean}} options - Parsed command options.
  * @returns {Promise<void>} Resolves when the watcher is stopped (Ctrl-C).
  */
 async function runThemeBuildWatch(entries, options) {
@@ -274,7 +275,7 @@ export function registerTheme(program) {
     fn: themeBuildFn,
     action: async (
       /** @type {string[]} */ files,
-      /** @type {{out?: string, watch?: boolean, check?: boolean, iconsSpecifier?: string}} */ options,
+      /** @type {{out?: string, watch?: boolean, check?: boolean, iconsSpecifier?: string, tokens?: boolean}} */ options,
     ) => {
       const json = program.opts().json || false;
       const entries = files.map(file => ({
@@ -355,6 +356,7 @@ export function registerTheme(program) {
               out: options.out,
               check: options.check,
               iconsSpecifier: options.iconsSpecifier,
+              tokens: options.tokens,
             },
             {cwd: process.cwd()},
           );

--- a/packages/cli/clients/cli/commands/theme-build.doc.mjs
+++ b/packages/cli/clients/cli/commands/theme-build.doc.mjs
@@ -22,7 +22,10 @@ export const doc = {
     'failure; an app with several themes does not need a shell loop. With --check it writes ' +
     'nothing and instead reports whether the committed outputs have drifted from source. ' +
     'When a separate build step emits the icon registry, --icons-specifier declares the ' +
-    'fully specified module path that the generated JS should import.',
+    'fully specified module path that the generated JS should import. --tokens additionally ' +
+    'writes <name>.tokens.json, a flat {cssCustomPropertyName: value} dump of the same ' +
+    'resolved tokens the CSS is generated from — for feeding an external sync (for example, ' +
+    'into a design tool\'s variables) rather than for use by the runtime.',
   fn: 'themeBuild',
   args: [{name: 'files', param: 'file', required: true, variadic: true}],
   options: [
@@ -43,6 +46,12 @@ export const doc = {
       description:
         'Verify the committed outputs match the source without writing; exit non-zero if stale',
     },
+    {
+      flag: '--tokens',
+      param: 'options.tokens',
+      description:
+        'Also write <name>.tokens.json, a flat dump of the theme\'s resolved CSS custom properties',
+    },
   ],
   examples: [
     {
@@ -60,6 +69,10 @@ export const doc = {
     {
       label: 'Build against a separately compiled icon registry',
       cli: 'astryx theme build ./src/themes/ocean.ts --icons-specifier ./icons.mjs',
+    },
+    {
+      label: 'Emit a token dump alongside the usual outputs',
+      cli: 'astryx theme build ./src/themes/ocean.ts --tokens',
     },
   ],
   exitCodes: [


### PR DESCRIPTION
## What
Adds an opt-in `--tokens` flag to `astryx theme build` that additionally writes `<name>.tokens.json` — a flat `{cssCustomPropertyName: value}` dump of the theme's fully resolved tokens (`tokens` + `localTokens`), keyed exactly as they appear in the generated CSS (`--color-accent`, not a bare token name).

This is the CLI-side half of the direction proposed in #5923: the build already resolves every token before generating CSS, so this reuses that same `resolvedTheme` object rather than re-resolving anything — the dump can never drift from the CSS it describes.

## Why
#5923 found that the Astryx Figma library ships 18 empty theme-mode collections with no code-to-Figma path to populate them. #5922 already has a verified Figma-variable-name ↔ CSS-custom-property mapping across all 166 base variables. This PR provides the missing piece on the CLI side: a machine-readable source of resolved values that a Figma-side sync script ("the Librarian", per #5923) could read against that mapping to actually populate the theme modes.

**This PR does not touch Figma at all** — it's scoped to the CLI output only. Writing values into Figma variable modes is separate follow-up work.

## Why opt-in / off by default
`--tokens` defaults to `false` so existing builds and `--check` baselines are completely unaffected — no new file appears for any project unless they ask for it.

## Details
- `tokensJsonPath`/`tokensJsonContent` slot into the existing atomic stage-then-rename write pipeline as a fifth output alongside css/js/dts.
- Deliberately excludes the invocation string that the CSS/JS headers' `Command:` line carries (which `--check` strips before comparing) — JSON has no comment syntax, so there's no field to normalize away, and the file is compared byte-for-byte under `--check`.
- Wired through the CLI flag parser, including the watch-mode child process spawn, plus updated `--help`/API docs and the `ThemeBuildResponse` typedef.

## Testing
New `build.tokens-json.test.mjs` (5 tests): default-off behavior, JSON shape/values (including `[light, dark]` tuple → `light-dark()` resolution), `localTokens` inclusion, `--check` staleness detection, and no spurious drift across identical rebuilds.

All 94 pre-existing tests in `packages/cli/api/theme/**` still pass unmodified.

Refs #5923, #5922.