### PR TITLE
docs: define visibility transition lifecycle

### DIFF
--- a/docs/architecture/visibility-transition-lifecycle.md
+++ b/docs/architecture/visibility-transition-lifecycle.md
@@ -1,0 +1,130 @@
+---
+schema_version: 1
+template_version: 1
+kind: architecture
+id: architecture:visibility-transition-lifecycle
+authority: current
+archive_reason: null
+superseded_by: null
+approved_by: cixzhang
+approved_at: 2026-09-06
+owners: [cixzhang]
+applies_to:
+  [
+    packages/core/src/AppShell/AppShell.tsx,
+    packages/core/src/MobileNav/,
+    packages/core/src/,
+    packages/lab/src/,
+  ]
+verified_by:
+  [
+    packages/core/src/MobileNav/MobileNavCloseVisibility.test.tsx,
+    packages/core/src/MobileNav/MobileNavCloseEdgeCases.test.tsx,
+    scripts/check-knowledge.mjs,
+  ]
+deciding_specs: []
+---
+
+# Visibility transition lifecycle architecture
+
+## Purpose
+
+People should see a component's owned exit complete before its host removes that
+component from presentation. This record defines the boundary between a child's
+exit transition and an ancestor's stronger visibility or lifecycle mechanism.
+
+It does not choose animation duration, easing, CSS properties, or one React API.
+The component owns its observable exit and reduced-motion outcome. The ancestor
+owns when it deactivates, hides, or unmounts the subtree.
+
+## System model
+
+A closing surface passes through four states:
+
+1. **Visible.** The surface is mounted, paint-eligible, and interactive according
+   to its component contract.
+2. **Exiting.** Close intent has occurred. The surface remains mounted and
+   paint-eligible while its owned normal or reduced-motion exit completes.
+   Interaction may be disabled without suppressing paint.
+3. **Complete.** The child reports that its exit outcome has completed.
+4. **Deactivated.** The ancestor may now switch Activity/Offscreen to hidden,
+   conditionally unmount, apply `hidden`, or use equivalent paint suppression.
+
+Ancestor visibility mechanisms can be stronger than a child's CSS transition.
+React Activity hidden mode, for example, may write inline
+`display: none !important` before a frame paints. That declaration is evidence
+of lifecycle preemption; this record does not ban `!important` as a CSS feature.
+The fix belongs in state ordering rather than a specificity contest.
+
+Current AppShell/MobileNav composition is an adoption gap. AppShell currently
+switches its Activity boundary to hidden in the same commit as close intent, so
+framework paint suppression can precede MobileNav's owned exit.
+
+## Boundaries and invariants
+
+- **INV1 — Child exit precedes ancestor deactivation.** After close intent, an
+  ancestor MUST keep the child subtree mounted and paint-eligible until the
+  child-owned normal or reduced-motion exit reaches its completion boundary.
+- **INV2 — Paint suppression is distinct from interaction suppression.** During
+  exit, the host MAY prevent interaction or focus entry without hiding the
+  pixels needed for the transition. `inert` alone does not violate the paint
+  contract.
+- **INV3 — Strong visibility cannot preempt exit.** Before completion, the
+  ancestor MUST NOT switch Activity/Offscreen to hidden, conditionally unmount,
+  apply `hidden`, write inline `display: none !important`, or use equivalent
+  paint suppression.
+- **INV4 — Completion has one owner.** The child reports completion from its
+  observable transition contract. The ancestor does not independently guess a
+  duration that can drift from the child. Shared internal timing may implement
+  the contract only when one owner defines it.
+- **INV5 — Reduced motion uses the same lifecycle.** Reduced motion may complete
+  immediately or with minimal movement as the component contract specifies. It
+  still reports completion before ancestor deactivation.
+- **INV6 — Reopen and interruption are coherent.** Reopening during exit cancels
+  stale deactivation. A completion from an obsolete close attempt MUST NOT hide a
+  currently visible surface or fire state changes twice.
+
+## Change coupling
+
+- A parent visibility, Activity/Offscreen, conditional-rendering, or unmount
+  change inventories child-owned entrance and exit transitions.
+- A component exit change names its completion signal and verifies normal motion,
+  reduced motion, interruption, rapid reopen, unmount, Escape, backdrop, and
+  explicit close paths where applicable.
+- Real-browser painted-frame and computed-visibility evidence proves the subtree
+  remains paint-eligible through exit. jsdom DOM/style assertions alone are not
+  sufficient.
+- A framework-generated inline style is traced to its lifecycle owner. Review
+  MUST NOT respond by adding stronger CSS until the state-ordering contract is
+  satisfied.
+- Pull requests and issues may be cited as evidence only. This record never
+  assigns their review classification or disposition.
+
+## Owning code
+
+- Host components and visibility boundaries — own when a child subtree becomes
+  hidden, inactive, or unmounted.
+- Exiting components — own their normal and reduced-motion transition outcomes
+  and completion signal.
+- `packages/core/src/AppShell/AppShell.tsx` — owns when its MobileNav Activity
+  boundary becomes hidden.
+- `packages/core/src/MobileNav/` — owns MobileNav's exit outcome and completion.
+
+## Deciding specs
+
+No separate system specification changes this record. `cixzhang` approved the
+visibility and exit ownership boundary on 2026-09-06. Component contracts project
+that boundary onto their concrete states without copying its general rationale.
+
+## Verification
+
+| Invariant  | Evidence                                                                      | Failure signal                                                                                                               |
+| ---------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| INV1, INV3 | Real-browser frame sampling and computed visibility through close             | The subtree becomes non-painted before the child-owned exit completes                                                        |
+| INV2       | Interaction/focus assertions during an otherwise visible exit                 | Preventing interaction also suppresses the transition, or the closing surface remains operable when its component forbids it |
+| INV4, INV5 | Completion-count and timing-source tests under normal and reduced motion      | Parent and child use drifting duration guesses, or reduced motion deactivates before completion                              |
+| INV6       | Rapid close/reopen, interrupted exit, unmount, and stale-completion mutations | A stale completion hides reopened content, completion fires twice, or cleanup leaks                                          |
+
+The browser fixture must fail when ancestor hidden mode is coupled directly to
+close intent, including when the framework implements that mode with inline
+`display: none !important`.

--- a/packages/core/src/MobileNav/MobileNav.spec.md
+++ b/packages/core/src/MobileNav/MobileNav.spec.md
@@ -9,7 +9,7 @@ superseded_by: null
 approved_by: null
 approved_at: null
 owners: [cixzhang]
-review_triggers: [behavior, theming, accessibility]
+review_triggers: [behavior, theming, accessibility, motion]
 verified_by:
   [
     packages/core/src/MobileNav/MobileNav.test.tsx,
@@ -26,6 +26,7 @@ architecture:
     architecture:component-theming-surface,
     architecture:layer-runtime,
     architecture:public-component-api,
+    architecture:visibility-transition-lifecycle,
   ]
 contributing: []
 system_specs: []
@@ -36,17 +37,18 @@ system_specs: []
 ## Intent
 
 MobileNav presents mobile navigation in a modal drawer and exports an AppShell-
-aware Toggle button for opening and closing it. This draft records the aggregate
-consumer anatomy and theming ownership of both exports without changing runtime
-behavior, styling, targets, or public API.
+aware Toggle button for opening and closing it. This contract records aggregate
+anatomy, theming ownership, exit completion, and the boundary between MobileNav
+motion and AppShell visibility.
 
 ## Compatibility and migration
 
-- Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, aliases, and public API remain unchanged
-- Controlled/uncontrolled behavior: unchanged
-- Migration decision: none
+- Existing MobileNav and MobileNavToggle props, exports, controlled state, DOM,
+  targets, aliases, and defaults remain the public compatibility baseline.
+- Changes to close lifecycle or ancestor visibility MUST preserve normal and
+  reduced-motion exit completion, focus, dismissal, and rapid reopen behavior.
+- A change that cannot preserve valid released usage follows
+  `architecture:public-component-api` compatibility and migration requirements.
 
 Consumer migration instructions belong in consumer docs and release notes.
 
@@ -75,11 +77,12 @@ documented in `MobileNav.doc.mjs`.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                               | Basis                           | Draft review state                                 |
-| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------------------- |
-| FR1 | MobileNav renders one Navigation overlay containing a Drawer with a stable Header, Close button, and scrollable Content region.                                                   | Current source, docs, and tests | Verified current behavior; no new behavior decided |
-| FR2 | Navigation overlay carries the current `mobile-nav` target. Drawer, Header, and Content carry no MobileNav public target.                                                         | Current source and public docs  | Verified current reachability; no target change    |
-| FR3 | Close button and the separately exported Toggle button use Button's `button` target; Toggle renders only when AppShell mobile context enables it and references the drawer by ID. | Current source, docs, and tests | Verified current delegation; no ownership change   |
+| ID  | Invariant                                                                                                                                                                                                                                                                                                                                                                                                       | Evidence                        |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| FR1 | MobileNav renders one Navigation overlay containing a Drawer with a stable Header, Close button, and scrollable Content region.                                                                                                                                                                                                                                                                                 | Current source, docs, and tests |
+| FR2 | Navigation overlay carries the current `mobile-nav` target. Drawer, Header, and Content carry no MobileNav public target.                                                                                                                                                                                                                                                                                       | Current source and public docs  |
+| FR3 | Close button and the separately exported Toggle button use Button's `button` target; Toggle renders only when AppShell mobile context enables it and references the drawer by ID.                                                                                                                                                                                                                               | Current source, docs, and tests |
+| FR4 | After close intent, AppShell MUST keep the MobileNav subtree mounted and paint-eligible until MobileNav reports normal or reduced-motion exit completion. AppShell MUST NOT switch Activity/Offscreen to hidden, unmount, set `hidden`, or allow framework `display: none !important` or equivalent paint suppression to preempt that exit. Interaction MAY become inert during exit without suppressing paint. | Owner-defined exit ownership    |
 
 ### Allowed variation
 
@@ -103,8 +106,10 @@ documented in `MobileNav.doc.mjs`.
 
 ### Transformation and precedence order
 
-- No new side resolution, open-state, close timing, or styling precedence rule is
-  introduced.
+- **ORD1 — Close before deactivation.** Close intent updates MobileNav into its exit
+  state. MobileNav remains mounted and paint-eligible through normal or
+  reduced-motion completion. Only then may AppShell deactivate the containing
+  visibility boundary. A framework visibility write never outranks this order.
 
 ### Performance and resources
 
@@ -112,8 +117,10 @@ documented in `MobileNav.doc.mjs`.
 
 ## Accessibility contract
 
-This draft does not change or extend MobileNav's existing dialog naming, focus,
-Toggle relationship, Button labels, modal behavior, or dismissal behavior.
+MobileNav preserves dialog naming, focus containment and return, Toggle
+relationship, Button labels, modal behavior, and dismissal behavior throughout
+open, exiting, deactivated, and rapid-reopen states. Ancestor deactivation cannot
+remove the focus owner or dialog subtree before exit completion.
 
 ## Design relationships
 
@@ -173,28 +180,44 @@ ownership.
   records MobileNav as a current adopter.
 - `architecture:public-component-api` owns the shared API boundary; this draft
   changes neither MobileNav nor MobileNavToggle API.
+- `architecture:react-update-propagation` owns ancestor visibility and child-exit
+  ordering. AppShell deactivates its visibility boundary only after MobileNav's
+  normal or reduced-motion exit completion.
 - AppShell remains the higher-level responsive owner. This parent component
   record owns the two MobileNav exports' shared anatomy only.
 
 ## Verification map
 
-| Contract            | Verification                                                                  | Representative states                       | Mutation or failure expectation                                                                                  | Audit section              |
-| ------------------- | ----------------------------------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| FR1                 | `MobileNav.test.tsx` content/header/close assertions plus source inspection   | Standalone open and closed drawer           | Removing dialog content or the Close action fails tests; distinct Drawer/Header/Content wrappers rely on review. | `audit:MobileNav/anatomy`  |
-| FR2                 | Source inspection and `themingTargets.test.ts`                                | Overlay, Drawer, Header, and Content        | Removing the root target or documenting an unshipped child target fails evidence or inventory.                   | `audit:MobileNav/theming`  |
-| FR3                 | `MobileNavToggle.test.tsx`, `MobileNavReopen.test.tsx`, and source inspection | Closed/open AppShell drawer and toggle      | Breaking Button delegation or the ID/state relationship fails focused toggle coverage.                           | `audit:MobileNav/anatomy`  |
-| Close lifecycle     | `MobileNavCloseEdgeCases.test.tsx` and related close/visibility suites        | Escape, backdrop, close, reopen, unmount    | Leaving the modal open or disconnecting state fails existing lifecycle assertions.                               | `audit:MobileNav/behavior` |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                                                 | Canonical parent anatomy and current target | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                       | `audit:MobileNav/theming`  |
+| Contract            | Verification                                                                                 | Representative states                                                 | Mutation or failure expectation                                                                                                    | Audit section              |
+| ------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| FR1                 | `MobileNav.test.tsx` content/header/close assertions plus source inspection                  | Standalone open and closed drawer                                     | Removing dialog content or the Close action fails tests; distinct Drawer/Header/Content wrappers rely on review.                   | `audit:MobileNav/anatomy`  |
+| FR2                 | Source inspection and `themingTargets.test.ts`                                               | Overlay, Drawer, Header, and Content                                  | Removing the root target or documenting an unshipped child target fails evidence or inventory.                                     | `audit:MobileNav/theming`  |
+| FR3                 | `MobileNavToggle.test.tsx`, `MobileNavReopen.test.tsx`, and source inspection                | Closed/open AppShell drawer and toggle                                | Breaking Button delegation or the ID/state relationship fails focused toggle coverage.                                             | `audit:MobileNav/anatomy`  |
+| FR4                 | Real-browser painted-frame/computed-visibility evidence plus close/reopen/interruption tests | Escape, backdrop, close button, ordinary/reduced motion, rapid reopen | Drawer disappears before exit completes, Activity/framework hiding wins, completion fires twice, or reopen uses stale close state. | `audit:MobileNav/behavior` |
+| Close lifecycle     | `MobileNavCloseEdgeCases.test.tsx` and related close/visibility suites                       | Escape, backdrop, close, reopen, unmount                              | Leaving the modal open or disconnecting state fails existing lifecycle assertions.                                                 | `audit:MobileNav/behavior` |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                                                | Canonical parent anatomy and current target                           | Missing, extra, prefixed, stale, or multiply assigned mappings fail repository validation.                                         | `audit:MobileNav/theming`  |
 
-Current tests find header and navigation content by text and the Close action by
-role, but do not identify the distinct Drawer, Header, or Content elements. Their
-existence and nesting are source-inspected; merging or reordering those wrappers
-currently lacks focused regression evidence.
+Current unit tests cover lifecycle state and style declarations but do not prove
+that AppShell keeps the subtree paint-eligible across real composed frames. FR4
+requires real-browser evidence because jsdom cannot observe framework visibility
+writes or the rendered exit transition.
 
 ## Decision log
 
-None. This draft records current facts and introduces no component-local design,
-API, theming, responsive, or layer-system decision.
+### DEC-1 — MobileNav owns exit completion before AppShell deactivation
+
+**Reference:** `component:MobileNav/DEC-1`
+**Decider:** `cixzhang`, `2026-09-06`
+
+Close intent begins MobileNav's owned exit. AppShell keeps the subtree mounted and
+paint-eligible until normal or reduced-motion completion, then deactivates its
+visibility boundary. A framework-generated inline visibility override does not
+replace that ordering.
+
+Rejected: switching Activity/Offscreen to hidden in the same commit as close
+intent and attempting to recover the exit by increasing CSS specificity. The
+ancestor lifecycle write wins before a frame can paint, so the fix belongs to
+visibility coordination rather than a stronger drawer style.
 
 ## Open questions
 
@@ -205,5 +228,6 @@ API, theming, responsive, or layer-system decision.
 ## Content boundary
 
 This file does not duplicate consumer prop tables/examples, AppShell responsive
-policy, close-timing mechanics, shared layer rules, current audit results, or
-implementation steps. It links to their owners.
+policy, shared layer rules, current audit results, or implementation steps. It
+owns MobileNav's exit completion boundary and links ancestor visibility ordering
+to its architecture owner.

--- a/packages/core/src/MobileNav/MobileNav.spec.md
+++ b/packages/core/src/MobileNav/MobileNav.spec.md
@@ -180,9 +180,9 @@ ownership.
   records MobileNav as a current adopter.
 - `architecture:public-component-api` owns the shared API boundary; this draft
   changes neither MobileNav nor MobileNavToggle API.
-- `architecture:react-update-propagation` owns ancestor visibility and child-exit
-  ordering. AppShell deactivates its visibility boundary only after MobileNav's
-  normal or reduced-motion exit completion.
+- `architecture:visibility-transition-lifecycle` owns ancestor visibility and
+  child-exit ordering. AppShell deactivates its visibility boundary only after
+  MobileNav's normal or reduced-motion exit completion.
 - AppShell remains the higher-level responsive owner. This parent component
   record owns the two MobileNav exports' shared anatomy only.
 


### PR DESCRIPTION
## Summary

- defines the lifecycle order for child-owned exits and ancestor visibility/deactivation
- distinguishes paint suppression from interaction suppression: an exiting surface may become inert without becoming invisible
- prevents Activity/Offscreen hidden mode, conditional unmounting, `hidden`, framework `display: none !important`, or equivalent paint suppression from preempting an owned exit
- requires one completion owner, reduced-motion parity, and stale-close/rapid-reopen safety
- projects the shared rule into MobileNav: close intent → MobileNav exit completion → AppShell deactivation

## Trigger

Issue #5701 exposed AppShell hiding MobileNav through React Activity before MobileNav's slide-out could paint. The inline `!important` declaration is evidence of lifecycle preemption, not a blanket CSS prohibition.

## Verification

- `node scripts/check-knowledge.mjs`
- Prettier
- `git diff --check`

No runtime implementation changes. No changeset.