### PR TITLE
ci: skip all Storybook work for spec-only PRs

### DIFF
--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -132,6 +132,22 @@ describe('spec-only workflow contract', () => {
     );
   });
 
+  it('skips every Storybook build command for spec-only changes', () => {
+    const ci = read('.github/workflows/ci.yml');
+    const jobStart = ci.indexOf('  build-storybook:');
+    const jobEnd = ci.indexOf('\n  build-sandbox:', jobStart);
+    const buildJob = ci.slice(jobStart, jobEnd);
+    const steps = buildJob.split(/\n      - name: /).slice(1);
+    const commandSteps = steps.filter(step =>
+      /\n        run: (?:pnpm|node)/.test(step),
+    );
+
+    expect(commandSteps.length).toBeGreaterThan(0);
+    for (const step of commandSteps) {
+      expect(step).toContain("needs.check-scope.outputs.spec_only != 'true'");
+    }
+  });
+
   it('fails closed when file APIs are truncated or scope classification fails', () => {
     const ci = read('.github/workflows/ci.yml');
     expect(ci).toContain('if: ${{ always() && !cancelled() }}');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,11 +349,11 @@ jobs:
         run: pnpm -F @astryxdesign/charts typecheck:docs
 
       - name: Typecheck rich text docs
-        if: needs.check-scope.outputs.docsite_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
         run: pnpm -F @astryxdesign/richtext typecheck:docs
 
       - name: Typecheck Vega docs
-        if: needs.check-scope.outputs.docsite_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
         run: pnpm -F @astryxdesign/vega typecheck:docs
 
       - name: Typecheck template docs


### PR DESCRIPTION
## Summary

- skip Rich Text and Vega docs typechecks when `spec_only` is true, matching every other `build-storybook` command
- add a workflow regression test requiring every `pnpm`/`node` command in that job to carry the spec-only skip

## Why

A one-file system-spec PR correctly skipped checkout/setup but still ran these two commands, so `pnpm` was unavailable and the required `build-storybook`/`build` checks failed.

## Validation

- `pnpm vitest run --project node .github/scripts/spec-owner-workflow.test.mjs`
- Prettier check

This CI repair is intentionally separate from #6032.