### PR TITLE
fix(ChatComposerInput): drop `aria-multiline` when triggers make the editable a combobox

### DIFF
--- a/.changeset/chat-composer-input-aria-multiline.md
+++ b/.changeset/chat-composer-input-aria-multiline.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatComposerInput: drop `aria-multiline` once triggers make the editable a combobox
+
+`aria-multiline` was hardcoded on the contenteditable element while `useTriggerMenu` owns its role, so configuring `triggers` switched the role to `combobox` — which ARIA 1.2 does not list `aria-multiline` under — and axe flagged `aria-allowed-attr` (critical) on the 8 ChatComposerInput trigger stories and the 2 ChatLayout stories that render one. Moves the attribute into the hook's `ariaProps`, where the role and the attributes whose validity depends on it are decided together.
+
+@Kyujenius

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -29,24 +29,9 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "ChatComposerInput::Async Search::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
       "key": "ChatComposerInput::Controlled::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "ChatComposerInput::Custom Render Item::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
-      "key": "ChatComposerInput::Custom Render::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
     },
     {
       "key": "ChatComposerInput::Disabled::color-contrast",
@@ -54,49 +39,14 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "ChatComposerInput::Grouped Items::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
-      "key": "ChatComposerInput::Mention Trigger::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
       "key": "ChatComposerInput::Mention Trigger::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "ChatComposerInput::Multiple Triggers::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
       "key": "ChatComposerInput::Multiple Triggers::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "ChatComposerInput::Slash Commands::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
-      "key": "ChatComposerInput::Token Variants::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
-      "key": "ChatLayout::Full AI Chat::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
-      "key": "ChatLayout::Panel View::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
     },
     {
       "key": "ChatReasoning::Collapsed::color-contrast",

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -83,6 +83,22 @@ describe('ChatComposerInput', () => {
       const textbox = screen.getByRole('textbox');
       expect(textbox).toHaveAttribute('contenteditable', 'false');
     });
+
+    it('marks the textbox as multiline', () => {
+      render(<ChatComposerInput />);
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-multiline',
+        'true',
+      );
+    });
+
+    // ARIA 1.2 supports aria-multiline on textbox but not on combobox, and
+    // configuring triggers switches the editable element to combobox.
+    it('drops aria-multiline once triggers make it a combobox', () => {
+      render(<ChatComposerInput triggers={[createMentionTrigger()]} />);
+      const combobox = screen.getByRole('combobox');
+      expect(combobox).not.toHaveAttribute('aria-multiline');
+    });
   });
 
   describe('change and submit', () => {

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -788,7 +788,6 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
       )}
       <div
         ref={editableRef}
-        aria-multiline="true"
         aria-label={label}
         contentEditable={!isDisabled}
         suppressContentEditableWarning

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -80,14 +80,14 @@ export interface UseTriggerMenuReturn {
   /** Reset/close the trigger menu */
   reset: () => void;
   /**
-   * ARIA props to spread onto the editable element. When triggers are
-   * configured the element becomes a `combobox` (which is the only role that
-   * permits `aria-expanded`/`aria-haspopup`/`aria-controls`/
-   * `aria-activedescendant`); otherwise it stays a plain `textbox` and no
-   * combobox attributes are emitted.
+   * ARIA props to spread onto the editable element: the role, and every
+   * attribute whose validity depends on it. Emit them as one spread — the
+   * role and its allowed attributes have to be decided together. See the
+   * construction site for which attribute forces which role.
    */
   ariaProps: {
     role: 'combobox' | 'textbox';
+    'aria-multiline'?: 'true';
     'aria-expanded'?: boolean;
     'aria-controls'?: string;
     'aria-activedescendant'?: string;
@@ -606,14 +606,18 @@ export function useTriggerMenu(
     el?.scrollIntoView({block: 'nearest'});
   }, [state.highlightedIndex, popover.isOpen, getItemId]);
 
-  // ARIA props for the editable element. Combobox attributes
-  // (aria-expanded/haspopup/controls/activedescendant) are only valid on
-  // role="combobox", so we only switch to that role — and only emit those
-  // attributes — when triggers are actually configured. With no triggers the
-  // element stays a plain role="textbox".
+  // ARIA props for the editable element. Of the attributes the trigger menu
+  // needs, only aria-expanded forces the role: aria-controls and
+  // aria-haspopup are global, and aria-activedescendant is allowed on
+  // textbox too. So the element becomes a combobox exactly when triggers are
+  // configured and there is an expanded state to report; with no triggers it
+  // stays a plain textbox. aria-multiline runs the other way — ARIA 1.2
+  // supports it on textbox but not on combobox — so it rides the textbox
+  // branch. Emitting it on the combobox branch is a critical
+  // aria-allowed-attr violation (#4681).
   const hasTriggers = (triggers?.length ?? 0) > 0;
   const ariaProps: UseTriggerMenuReturn['ariaProps'] = !hasTriggers
-    ? {role: 'textbox'}
+    ? {role: 'textbox', 'aria-multiline': 'true'}
     : state.isActive && popover.isOpen
       ? {
           role: 'combobox',


### PR DESCRIPTION
## Summary

`aria-multiline="true"` was hardcoded on the contenteditable in `ChatComposerInput.tsx`, while `useTriggerMenu.tsx` flips that element's role to `combobox` whenever `triggers` are set. ARIA supports `aria-multiline` on `textbox`, [not on `combobox`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-multiline), so axe reported `aria-allowed-attr` (critical) on all 10 stories that configure triggers.

The split across two files is why it went unnoticed, so the attribute moves into the hook's `ariaProps`, where the role is chosen.

**ARIA pattern:** [APG Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) when `triggers` are set, plain `textbox` otherwise; unchanged by this PR. The implementation diverges from the pattern in a few pre-existing ways — out of scope here, but happy to follow up separately if useful.

**[AST-009](https://github.com/facebook/astryx/blob/main/docs/specs/AST-009/spec.md) (FR8):** no real-AT trigger. FR3 applies — the claim ends at browser exposure and is proved by the accessibility tree. FR4 is not triggered: no live region changes, and no claim about what is announced.

## Test Plan

- [x] `pnpm lint:strict`, `pnpm test` (9139 passed), `pnpm build`
- [x] The new combobox test fails on an unmodified tree
- [x] `pnpm a11y:audit -- --components ChatComposerInput` and `--components ChatLayout` — the 10 violations gone, gate passes. Full-surface run: 108 → 98, **0 new**.
- [x] Accessibility tree unchanged — the browser never mapped the attribute on `combobox`:

  |                      | DOM      | computed `multiline` |
  | -------------------- | -------- | -------------------- |
  | `textbox` (control)  | `"true"` | `true`               |
  | `combobox`, after    | absent   | absent               |
  | `combobox`, re-added | `"true"` | absent               |

No rendered output or public API change; the 10 resolved baseline entries are removed per that file's `$comment`.

## Related Issues

From the weekly a11y scan #4681 (2026-09-07 run). Of its 36 findings, 28 are `color-contrast` (theme palette, worked separately); this PR addresses only the `aria-allowed-attr` one.
