### PR TITLE
fix(build): refuse a Turbopack config in withAstryx instead of building unstyled

### DIFF
--- a/.changeset/refuse-turbopack-in-with-astryx.md
+++ b/.changeset/refuse-turbopack-in-with-astryx.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/build': minor
+---
+
+[breaking] `withAstryx()` refuses a Turbopack config instead of building an unstyled app. Every alias the helper installs lives in `nextConfig.webpack`, which Turbopack never calls, so the app resolved `@astryxdesign/*` to dist while PostCSS compiled the library from source — disjoint class names, an exit code of 0, and an unstyled page. It now throws, naming both ways out: `--webpack`, or drop the helper and consume the pre-built package. Also warns when no package yields a `source` entry, which reaches the same unstyled state by another route. (#6109)
+@joaodotwork

--- a/.changeset/refuse-turbopack-in-with-astryx.md
+++ b/.changeset/refuse-turbopack-in-with-astryx.md
@@ -1,6 +1,6 @@
 ---
-'@astryxdesign/build': minor
+'@astryxdesign/build': patch
 ---
 
-[breaking] `withAstryx()` refuses a Turbopack config instead of building an unstyled app. Every alias the helper installs lives in `nextConfig.webpack`, which Turbopack never calls, so the app resolved `@astryxdesign/*` to dist while PostCSS compiled the library from source — disjoint class names, an exit code of 0, and an unstyled page. It now throws, naming both ways out: `--webpack`, or drop the helper and consume the pre-built package. Also warns when no package yields a `source` entry, which reaches the same unstyled state by another route. (#6109)
+[fix] `withAstryx()` refuses a Turbopack config instead of building an unstyled app. Every alias the helper installs lives in `nextConfig.webpack`, which Turbopack never calls, so the app resolved `@astryxdesign/*` to dist while PostCSS compiled the library from source — disjoint class names, an exit code of 0, and an unstyled page. It now throws, naming both ways out: `--webpack`, or drop the helper and consume the pre-built package. Also warns when the merged alias map claims none of the packages, which reaches the same unstyled state by another route. (#6109)
 @joaodotwork

--- a/apps/example-nextjs-source/README.md
+++ b/apps/example-nextjs-source/README.md
@@ -2,6 +2,25 @@
 
 Reference application for compiling **@astryxdesign/core** from raw TypeScript + StyleX source alongside product code. Uses `@astryxdesign/build` for independent CSS layer separation.
 
+> **Runs on webpack, not Turbopack.** The source build configures resolution through
+> `nextConfig.webpack`, which Turbopack never calls — under Turbopack the app loads
+> `dist` while PostCSS compiles the library from `source`, and the page renders unstyled
+> without erroring.
+>
+> This example pins Next 15, where webpack is still the default, so its plain
+> `next dev` / `next build` scripts are correct as they stand. **On Next 16 the default
+> flips to Turbopack**, and a source build has to name the bundler:
+>
+> ```bash
+> next dev --webpack
+> next build --webpack
+> ```
+>
+> (`--webpack` is a Next 16 flag; Next 15 does not accept it.) `withAstryx()` throws
+> under Turbopack rather than producing the unstyled build. If you would rather not pin
+> the bundler, take the pre-built approach in
+> [example-nextjs](../example-nextjs/) instead.
+
 ## Why source build?
 
 |               | Source build                                       | Dist build                   |

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -18,11 +18,11 @@ StyleX generates atomic CSS: same declaration = same class name. Without separat
 
 ## Packages
 
-| Export               | Purpose                                       | Platform                    |
-| -------------------- | --------------------------------------------- | --------------------------- |
-| `@astryxdesign/build/babel`   | Babel plugin: splits class prefixes per file  | Next.js, any babel pipeline |
-| `@astryxdesign/build/postcss` | PostCSS plugin: compiles + splits CSS layers  | Next.js                     |
-| `@astryxdesign/build/vite`    | Vite plugin: wraps unplugin + splits layers   | Vite, Storybook             |
+| Export                        | Purpose                                      | Platform                    |
+| ----------------------------- | -------------------------------------------- | --------------------------- |
+| `@astryxdesign/build/babel`   | Babel plugin: splits class prefixes per file | Next.js, any babel pipeline |
+| `@astryxdesign/build/postcss` | PostCSS plugin: compiles + splits CSS layers | Next.js                     |
+| `@astryxdesign/build/vite`    | Vite plugin: wraps unplugin + splits layers  | Vite, Storybook             |
 
 ## Install
 
@@ -40,6 +40,27 @@ npm install -D @stylexjs/unplugin
 
 ## Next.js Setup
 
+> **Requires the webpack bundler.** Every step below configures resolution through
+> `nextConfig.webpack`, and Turbopack never calls that hook. Under Turbopack the app
+> resolves `@astryxdesign/*` to `dist` while the PostCSS pass compiles the library from
+> `source` — the two emit disjoint class names, so the build succeeds and the page
+> renders unstyled with nothing logged.
+>
+> Next.js 16 selects Turbopack by default, so name the bundler explicitly:
+>
+> ```bash
+> next dev --webpack
+> next build --webpack
+> ```
+>
+> `withAstryx()` throws when it sees `TURBOPACK` set rather than letting that through.
+> Next 16 also rejects a `webpack` config with no `turbopack` config on its own when no
+> bundler flag is given.
+>
+> If you would rather not pin the bundler, take the pre-built package instead: import
+> `@astryxdesign/core/astryx.css` and skip the babel and PostCSS setup entirely. See
+> [example-nextjs](../../apps/example-nextjs/).
+
 ### 1. babel.config.js
 
 ```js
@@ -56,8 +77,12 @@ module.exports = {
         treeshakeCompensation: true,
         enableInlinedConditionalMerge: true,
         aliases: {
-          '@astryxdesign/core/*': [path.join(__dirname, 'node_modules/@astryxdesign/core/*')],
-          '@astryxdesign/core': [path.join(__dirname, 'node_modules/@astryxdesign/core')],
+          '@astryxdesign/core/*': [
+            path.join(__dirname, 'node_modules/@astryxdesign/core/*'),
+          ],
+          '@astryxdesign/core': [
+            path.join(__dirname, 'node_modules/@astryxdesign/core'),
+          ],
         },
         unstable_moduleResolution: {type: 'commonJS'},
       },
@@ -84,8 +109,12 @@ module.exports = {
             treeshakeCompensation: true,
             enableInlinedConditionalMerge: true,
             aliases: {
-              '@astryxdesign/core/*': [path.join(__dirname, 'node_modules/@astryxdesign/core/*')],
-              '@astryxdesign/core': [path.join(__dirname, 'node_modules/@astryxdesign/core')],
+              '@astryxdesign/core/*': [
+                path.join(__dirname, 'node_modules/@astryxdesign/core/*'),
+              ],
+              '@astryxdesign/core': [
+                path.join(__dirname, 'node_modules/@astryxdesign/core'),
+              ],
             },
             unstable_moduleResolution: {type: 'commonJS'},
           },
@@ -97,6 +126,10 @@ module.exports = {
 ```
 
 ### 3. next.config.mjs
+
+Or `withAstryx()` from `@astryxdesign/build/next`, which sets both of these for you.
+Either way the work happens in the `webpack` hook, so the build has to run with
+`--webpack` — see the note at the top of this section.
 
 ```js
 const nextConfig = {
@@ -164,7 +197,10 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@astryxdesign/core': path.resolve(__dirname, 'node_modules/@astryxdesign/core/src'),
+      '@astryxdesign/core': path.resolve(
+        __dirname,
+        'node_modules/@astryxdesign/core/src',
+      ),
     },
   },
   optimizeDeps: {

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -197,8 +197,19 @@ function sourceEntryAliases(packages, context) {
  * compiles the library from source.
  */
 function aliasCoversAstryx(alias, packages) {
-  const claims = request =>
-    packages.some(name => request === name || request.startsWith(`${name}/`));
+  const claims = request => {
+    // A wildcard key claims by pattern, not by literal name: `@astryxdesign/*`
+    // routes every package under the scope even though it matches none of them
+    // as a string. Same matcher `withoutCallerOverrides` uses to decide which
+    // generated entries a caller has already spoken for.
+    if (request.includes('*')) {
+      const pattern = wildcardPattern(request);
+      return packages.some(name => pattern.test(name));
+    }
+    return packages.some(
+      name => request === name || request.startsWith(`${name}/`),
+    );
+  };
   if (Array.isArray(alias)) {
     return alias.some(
       entry => entry && typeof entry.name === 'string' && claims(entry.name),

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -20,6 +20,35 @@ const path = require('path');
 const ASTRYX_MODULE = /[\\/]node_modules[\\/]@astryxdesign[\\/]/;
 
 /**
+ * Every alias this helper installs lives in `nextConfig.webpack`, and Turbopack
+ * never calls that hook. So `withAstryx()` under Turbopack reinstates exactly
+ * the failure the aliases exist to prevent: the app resolves the library
+ * through `default` to dist, whose runtime class names are disjoint from the
+ * CSS the PostCSS pass compiles out of source, and the build succeeds with an
+ * unstyled page and nothing logged.
+ *
+ * There is no configuration in which the combination does what the author
+ * intended, so this refuses rather than warning — an unstyled production deploy
+ * costs more than a failed build. Next sets `TURBOPACK` for both
+ * `next dev --turbopack` and `next build --turbopack`, in the parent process
+ * and in each build worker.
+ */
+function assertWebpack() {
+  if (!process.env.TURBOPACK) {
+    return;
+  }
+  throw new Error(
+    'withAstryx() requires the webpack bundler: it configures resolution ' +
+      'through nextConfig.webpack, which Turbopack does not call, so the app ' +
+      'would resolve @astryxdesign/* to dist while the CSS is compiled from ' +
+      'source and render unstyled.\n' +
+      'Run the source build with `next build --webpack` / `next dev --webpack`, ' +
+      'or drop withAstryx() and consume the pre-built package instead — import ' +
+      "'@astryxdesign/core/astryx.css' and skip the babel and PostCSS setup.",
+  );
+}
+
+/**
  * Locate an installed package's directory by walking `node_modules` up from
  * the app, the way Node resolves a bare specifier. Returns null when the
  * package is not installed.
@@ -164,6 +193,8 @@ function sourceEntryAliases(packages, context) {
  * - Sets conditionNames to resolve source exports
  */
 function withAstryx(nextConfig = {}) {
+  assertWebpack();
+
   const astryxPackages = [
     '@astryxdesign/core',
     '@astryxdesign/theme-neutral',
@@ -227,10 +258,26 @@ function withAstryx(nextConfig = {}) {
       // where the resolver, taking the first match, loads astryx source
       // instead. Only a byte-identical `$` key would have replaced ours.
       merged.resolve = merged.resolve || {};
-      merged.resolve.alias = mergeAliases(
-        sourceEntryAliases(astryxPackages, context),
-        merged.resolve.alias,
-      );
+      const generated = sourceEntryAliases(astryxPackages, context);
+
+      // Skipping a package that is not installed is correct on its own — an app
+      // need not depend on all three. Skipping every one of them is not: the
+      // result is zero aliases, which is the pre-0.5.3 config, and the app goes
+      // back to resolving dist against source-compiled CSS. That reads as
+      // working right up to the unstyled page, so say it instead. A warning
+      // rather than a throw because an install layout this helper cannot walk
+      // is not proof the build is wrong.
+      if (Object.keys(generated).length === 0) {
+        console.warn(
+          '[@astryxdesign/build] withAstryx() resolved no `source` entries for ' +
+            `${astryxPackages.join(', ')}. Either none is installed where the ` +
+            'app can see it, or their export maps ship no `source` condition. ' +
+            'The app will resolve them to dist while the PostCSS pass compiles ' +
+            'the library from source, and render unstyled.',
+        );
+      }
+
+      merged.resolve.alias = mergeAliases(generated, merged.resolve.alias);
       return merged;
     },
   };

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -190,43 +190,52 @@ function sourceEntryAliases(packages, context) {
 /**
  * Whether the resolved alias map routes any astryx request at all.
  *
- * The test is webpack's own matching rule rather than a list of shapes: a
+ * The test is webpack's own matching rule rather than a list of shapes. A
  * non-exact alias `key` intercepts a request `R` when `R === key` or `R` starts
- * with `${key}/`. So an entry covers the packages when one of them sits at or
- * below its key — `'@astryxdesign'` claims `@astryxdesign/core` even though it
- * matches no package name as a string. A key *under* a package counts too,
- * because that is the shape of the entries this helper generates, and a `*` key
- * claims by pattern, using the same matcher `withoutCallerOverrides` applies.
+ * with `${key}/`, so an entry covers the packages when one of them sits at or
+ * below its key: `'@astryxdesign'` claims `@astryxdesign/core`. A key *under* a
+ * package counts too, because that is the shape of the entries this helper
+ * generates, and a `*` key claims by pattern, using the same matcher
+ * `withoutCallerOverrides` applies.
+ *
+ * Exactness — a trailing `$` on an object key, `onlyModule: true` on an array
+ * entry — restricts an entry to the literal request, which removes the
+ * ancestor case and only that one. `'@astryxdesign/core$'` still routes a real
+ * request; `'@astryxdesign$'` routes only the bare scope specifier, which
+ * nothing imports, so it covers nothing.
  *
  * Where a caller points its alias is its business; the only thing worth saying
- * is that nothing routes the packages at all, which is the pre-0.5.3 config. A
- * false positive here tells someone their working build is broken, while a false
- * negative merely stays quiet — so this errs toward silence.
+ * is that no entry routes the packages at all. A false positive tells someone
+ * their working build is broken, so an ambiguous config stays quiet — but an
+ * exact-scope key is not ambiguous, it is determinately ineffective.
  */
 function aliasCoversAstryx(alias, packages) {
-  const covers = key => {
-    if (key.includes('*')) {
-      const pattern = wildcardPattern(key);
+  const covers = (key, exact) => {
+    const bare = key.endsWith('$') ? key.slice(0, -1) : key;
+    const isExact = exact || key.endsWith('$');
+    if (bare.includes('*')) {
+      const pattern = wildcardPattern(bare);
       return packages.some(name => pattern.test(name));
     }
     return packages.some(
       name =>
-        name === key ||
-        name.startsWith(`${key}/`) ||
-        key.startsWith(`${name}/`),
+        name === bare ||
+        bare.startsWith(`${name}/`) ||
+        (!isExact && name.startsWith(`${bare}/`)),
     );
   };
   if (Array.isArray(alias)) {
     return alias.some(
-      entry => entry && typeof entry.name === 'string' && covers(entry.name),
+      entry =>
+        entry &&
+        typeof entry.name === 'string' &&
+        covers(entry.name, entry.onlyModule === true),
     );
   }
   if (alias == null || typeof alias !== 'object') {
     return false;
   }
-  return Object.keys(alias).some(key =>
-    covers(key.endsWith('$') ? key.slice(0, -1) : key),
-  );
+  return Object.keys(alias).some(key => covers(key, false));
 }
 
 /**
@@ -316,12 +325,14 @@ function withAstryx(nextConfig = {}) {
       // not proof the build is wrong.
       if (!aliasCoversAstryx(merged.resolve.alias, astryxPackages)) {
         console.warn(
-          '[@astryxdesign/build] withAstryx() produced no alias for ' +
-            `${astryxPackages.join(', ')}, and none was configured. Either they ` +
-            'are not installed where the app can see them, or their export maps ' +
-            'ship no `source` condition. Source resolution is not in effect, so ' +
-            'the app will load dist while the PostCSS pass compiles the library ' +
-            'from source.',
+          '[@astryxdesign/build] withAstryx(): no alias routes ' +
+            `${astryxPackages.join(', ')} to their \`source\` entries. Either they ` +
+            'are not installed where the app can see them, their export maps ' +
+            'ship no `source` condition, or a configured alias does not match ' +
+            'the requests — an exact key such as `@astryxdesign$` matches only ' +
+            'the bare specifier. Source resolution is not in effect, so the app ' +
+            'will load dist while the PostCSS pass compiles the library from ' +
+            'source.',
         );
       }
 

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -188,38 +188,44 @@ function sourceEntryAliases(packages, context) {
 }
 
 /**
- * Whether the resolved alias map claims any astryx request at all. Both alias
- * shapes are ordered first-match-wins, so a caller entry that covers a package
- * is as effective as a generated one — where it points is the caller's business,
- * not this helper's. The question is only whether resolution has been directed
- * somewhere, because an alias map that names none of the packages is the
- * pre-0.5.3 config: the app falls through `default` to dist while PostCSS
- * compiles the library from source.
+ * Whether the resolved alias map routes any astryx request at all.
+ *
+ * The test is webpack's own matching rule rather than a list of shapes: a
+ * non-exact alias `key` intercepts a request `R` when `R === key` or `R` starts
+ * with `${key}/`. So an entry covers the packages when one of them sits at or
+ * below its key — `'@astryxdesign'` claims `@astryxdesign/core` even though it
+ * matches no package name as a string. A key *under* a package counts too,
+ * because that is the shape of the entries this helper generates, and a `*` key
+ * claims by pattern, using the same matcher `withoutCallerOverrides` applies.
+ *
+ * Where a caller points its alias is its business; the only thing worth saying
+ * is that nothing routes the packages at all, which is the pre-0.5.3 config. A
+ * false positive here tells someone their working build is broken, while a false
+ * negative merely stays quiet — so this errs toward silence.
  */
 function aliasCoversAstryx(alias, packages) {
-  const claims = request => {
-    // A wildcard key claims by pattern, not by literal name: `@astryxdesign/*`
-    // routes every package under the scope even though it matches none of them
-    // as a string. Same matcher `withoutCallerOverrides` uses to decide which
-    // generated entries a caller has already spoken for.
-    if (request.includes('*')) {
-      const pattern = wildcardPattern(request);
+  const covers = key => {
+    if (key.includes('*')) {
+      const pattern = wildcardPattern(key);
       return packages.some(name => pattern.test(name));
     }
     return packages.some(
-      name => request === name || request.startsWith(`${name}/`),
+      name =>
+        name === key ||
+        name.startsWith(`${key}/`) ||
+        key.startsWith(`${name}/`),
     );
   };
   if (Array.isArray(alias)) {
     return alias.some(
-      entry => entry && typeof entry.name === 'string' && claims(entry.name),
+      entry => entry && typeof entry.name === 'string' && covers(entry.name),
     );
   }
   if (alias == null || typeof alias !== 'object') {
     return false;
   }
   return Object.keys(alias).some(key =>
-    claims(key.endsWith('$') ? key.slice(0, -1) : key),
+    covers(key.endsWith('$') ? key.slice(0, -1) : key),
   );
 }
 

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -188,6 +188,31 @@ function sourceEntryAliases(packages, context) {
 }
 
 /**
+ * Whether the resolved alias map claims any astryx request at all. Both alias
+ * shapes are ordered first-match-wins, so a caller entry that covers a package
+ * is as effective as a generated one — where it points is the caller's business,
+ * not this helper's. The question is only whether resolution has been directed
+ * somewhere, because an alias map that names none of the packages is the
+ * pre-0.5.3 config: the app falls through `default` to dist while PostCSS
+ * compiles the library from source.
+ */
+function aliasCoversAstryx(alias, packages) {
+  const claims = request =>
+    packages.some(name => request === name || request.startsWith(`${name}/`));
+  if (Array.isArray(alias)) {
+    return alias.some(
+      entry => entry && typeof entry.name === 'string' && claims(entry.name),
+    );
+  }
+  if (alias == null || typeof alias !== 'object') {
+    return false;
+  }
+  return Object.keys(alias).some(key =>
+    claims(key.endsWith('$') ? key.slice(0, -1) : key),
+  );
+}
+
+/**
  * Wraps a Next.js config to enable Astryx source builds.
  * - Adds transpilePackages for @astryxdesign/* packages
  * - Sets conditionNames to resolve source exports
@@ -258,26 +283,31 @@ function withAstryx(nextConfig = {}) {
       // where the resolver, taking the first match, loads astryx source
       // instead. Only a byte-identical `$` key would have replaced ours.
       merged.resolve = merged.resolve || {};
-      const generated = sourceEntryAliases(astryxPackages, context);
+      merged.resolve.alias = mergeAliases(
+        sourceEntryAliases(astryxPackages, context),
+        merged.resolve.alias,
+      );
 
-      // Skipping a package that is not installed is correct on its own — an app
-      // need not depend on all three. Skipping every one of them is not: the
-      // result is zero aliases, which is the pre-0.5.3 config, and the app goes
-      // back to resolving dist against source-compiled CSS. That reads as
-      // working right up to the unstyled page, so say it instead. A warning
-      // rather than a throw because an install layout this helper cannot walk
-      // is not proof the build is wrong.
-      if (Object.keys(generated).length === 0) {
+      // Generating no entries is not itself a fault: a package may simply not be
+      // installed, and a caller alias that already routes the packages is a
+      // working config this helper has nothing to add to. What is a fault is
+      // ending up with an alias map that claims none of them — that is the
+      // pre-0.5.3 config, where the app resolves dist while PostCSS compiles the
+      // library from source and the page renders unstyled with nothing logged.
+      // So the check is on the merged result, not on what we generated, and it
+      // warns rather than throws: an install layout this helper cannot walk is
+      // not proof the build is wrong.
+      if (!aliasCoversAstryx(merged.resolve.alias, astryxPackages)) {
         console.warn(
-          '[@astryxdesign/build] withAstryx() resolved no `source` entries for ' +
-            `${astryxPackages.join(', ')}. Either none is installed where the ` +
-            'app can see it, or their export maps ship no `source` condition. ' +
-            'The app will resolve them to dist while the PostCSS pass compiles ' +
-            'the library from source, and render unstyled.',
+          '[@astryxdesign/build] withAstryx() produced no alias for ' +
+            `${astryxPackages.join(', ')}, and none was configured. Either they ` +
+            'are not installed where the app can see them, or their export maps ' +
+            'ship no `source` condition. Source resolution is not in effect, so ' +
+            'the app will load dist while the PostCSS pass compiles the library ' +
+            'from source.',
         );
       }
 
-      merged.resolve.alias = mergeAliases(generated, merged.resolve.alias);
       return merged;
     },
   };

--- a/packages/build/src/next.test.mjs
+++ b/packages/build/src/next.test.mjs
@@ -488,6 +488,46 @@ describe('withAstryx alias coverage', () => {
     }
   });
 
+  // A scope-level key matches no package name as a string, but webpack resolves
+  // `@astryxdesign/core` through it — the key is an ancestor of the request.
+  const scoped = (label, build) =>
+    it(`stays quiet for a scope-prefix alias ${label}`, () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const dir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-scope-')),
+      );
+      try {
+        build(dir, path.join(dir, 'customRoot'));
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(dir, {recursive: true, force: true});
+      }
+    });
+
+  scoped('in the config', (dir, target) =>
+    withAstryx().webpack({resolve: {alias: {'@astryxdesign': target}}}, {dir}),
+  );
+
+  scoped('in array form', (dir, target) =>
+    withAstryx().webpack(
+      {
+        resolve: {
+          alias: [{name: '@astryxdesign', onlyModule: false, alias: target}],
+        },
+      },
+      {dir},
+    ),
+  );
+
+  scoped('from the caller webpack hook', (dir, target) =>
+    withAstryx({
+      webpack: cfg => {
+        cfg.resolve.alias['@astryxdesign'] = target;
+        return cfg;
+      },
+    }).webpack({resolve: {alias: {}}}, {dir}),
+  );
+
   it('stays quiet when the caller routes them from its webpack hook', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const empty = fs.realpathSync(

--- a/packages/build/src/next.test.mjs
+++ b/packages/build/src/next.test.mjs
@@ -124,6 +124,19 @@ function corePath(...segments) {
 }
 
 describe('withAstryx', () => {
+  // Every case in this block is a config that resolves successfully, so none of
+  // them may warn. Asserting it here rather than per-test means a future
+  // coverage check that misreads a working alias — as one did for wildcards —
+  // fails the suite instead of quietly logging into it.
+  let warned;
+  beforeEach(() => {
+    warned = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    expect(warned).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
   it('resolves the package root to its source entry', () => {
     expect(resolveFromApp('@astryxdesign/core')).toBe(corePath('src/index.ts'));
   });

--- a/packages/build/src/next.test.mjs
+++ b/packages/build/src/next.test.mjs
@@ -14,7 +14,7 @@
  *   `config.resolve.alias` cannot tell a winning entry from a shadowed one.
  */
 
-import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import {describe, it, expect, beforeAll, afterAll, afterEach, vi} from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -362,5 +362,67 @@ describe('withAstryx', () => {
 
     expect(config.marker).toBe(true);
     expect(config.resolve.alias['@astryxdesign/core$']).toBeDefined();
+  });
+});
+
+describe('withAstryx bundler guard', () => {
+  afterEach(() => {
+    delete process.env.TURBOPACK;
+    vi.restoreAllMocks();
+  });
+
+  it('refuses to build a config under Turbopack', () => {
+    process.env.TURBOPACK = '1';
+    expect(() => withAstryx()).toThrow(/requires the webpack bundler/);
+  });
+
+  it('names both ways out in the message', () => {
+    process.env.TURBOPACK = '1';
+    // The two supported routes: keep the source build and pick webpack, or drop
+    // the source build entirely and consume the pre-built package.
+    expect(() => withAstryx()).toThrow(/--webpack/);
+    expect(() => withAstryx()).toThrow(/astryx\.css/);
+  });
+
+  it('refuses before touching the caller config', () => {
+    process.env.TURBOPACK = '1';
+    const webpack = vi.fn();
+    expect(() => withAstryx({webpack})).toThrow();
+    expect(webpack).not.toHaveBeenCalled();
+  });
+
+  it('builds normally when Turbopack is not in play', () => {
+    expect(() => withAstryx()).not.toThrow();
+  });
+});
+
+describe('withAstryx alias coverage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns when no package yields a source entry', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // An app directory with no astryx packages installed: every lookup is
+    // skipped, the alias map comes out empty, and that is the pre-0.5.3 config
+    // rather than a partial one.
+    const empty = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-none-')),
+    );
+    try {
+      withAstryx().webpack({resolve: {}}, {dir: empty});
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toMatch(/resolved no `source` entries/);
+    } finally {
+      fs.rmSync(empty, {recursive: true, force: true});
+    }
+  });
+
+  it('stays quiet when at least one package resolves', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Only @astryxdesign/core is installed in the fixture; theme-neutral and
+    // lab are absent and skipped. A partial map is the normal case, not a fault.
+    resolveConfig();
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/build/src/next.test.mjs
+++ b/packages/build/src/next.test.mjs
@@ -424,7 +424,7 @@ describe('withAstryx alias coverage', () => {
     try {
       withAstryx().webpack({resolve: {}}, {dir: empty});
       expect(warn).toHaveBeenCalledOnce();
-      expect(warn.mock.calls[0][0]).toMatch(/produced no alias for/);
+      expect(warn.mock.calls[0][0]).toMatch(/no alias routes/);
     } finally {
       fs.rmSync(empty, {recursive: true, force: true});
     }
@@ -490,6 +490,92 @@ describe('withAstryx alias coverage', () => {
 
   // A scope-level key matches no package name as a string, but webpack resolves
   // `@astryxdesign/core` through it — the key is an ancestor of the request.
+  // An exact key restricted to the bare scope matches only `@astryxdesign`,
+  // which nothing imports, so it routes no package and must not buy silence.
+  // These need an app with nothing installed: with a package present the
+  // generated entries route it and there is correctly nothing to report.
+  const ineffective = (label, build) =>
+    it(`warns for an exact scope-only alias ${label}`, () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const dir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-exact-')),
+      );
+      try {
+        build(dir, path.join(dir, 'customRoot'));
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0][0]).toMatch(/no alias routes/);
+      } finally {
+        fs.rmSync(dir, {recursive: true, force: true});
+      }
+    });
+
+  ineffective('in the config', (dir, target) =>
+    withAstryx().webpack({resolve: {alias: {'@astryxdesign$': target}}}, {dir}),
+  );
+
+  ineffective('in array form', (dir, target) =>
+    withAstryx().webpack(
+      {
+        resolve: {
+          alias: [{name: '@astryxdesign', onlyModule: true, alias: target}],
+        },
+      },
+      {dir},
+    ),
+  );
+
+  ineffective('from the caller webpack hook', (dir, target) =>
+    withAstryx({
+      webpack: cfg => {
+        cfg.resolve.alias['@astryxdesign$'] = target;
+        return cfg;
+      },
+    }).webpack({resolve: {alias: {}}}, {dir}),
+  );
+
+  // The boundary: exactness removes the ancestor case and only that one, so an
+  // exact key at or below a package still routes a real request.
+  const effectiveExact = (label, build) =>
+    it(`stays quiet for an exact alias ${label}`, () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const dir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-exact-ok-')),
+      );
+      try {
+        build(dir, path.join(dir, 'customRoot'));
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(dir, {recursive: true, force: true});
+      }
+    });
+
+  effectiveExact('on the package itself', (dir, target) =>
+    withAstryx().webpack(
+      {resolve: {alias: {'@astryxdesign/core$': target}}},
+      {dir},
+    ),
+  );
+
+  effectiveExact('on the package, array form', (dir, target) =>
+    withAstryx().webpack(
+      {
+        resolve: {
+          alias: [
+            {name: '@astryxdesign/core', onlyModule: true, alias: target},
+          ],
+        },
+      },
+      {dir},
+    ),
+  );
+
+  effectiveExact('on a subpath under the package', (dir, target) =>
+    withAstryx().webpack(
+      {resolve: {alias: {'@astryxdesign/core/Badge$': target}}},
+      {dir},
+    ),
+  );
+
   const scoped = (label, build) =>
     it(`stays quiet for a scope-prefix alias ${label}`, () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/build/src/next.test.mjs
+++ b/packages/build/src/next.test.mjs
@@ -401,18 +401,17 @@ describe('withAstryx alias coverage', () => {
     vi.restoreAllMocks();
   });
 
-  it('warns when no package yields a source entry', () => {
+  it('warns when nothing routes the packages at all', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    // An app directory with no astryx packages installed: every lookup is
-    // skipped, the alias map comes out empty, and that is the pre-0.5.3 config
-    // rather than a partial one.
+    // Nothing installed and no caller alias, so the merged map claims none of
+    // the packages — the pre-0.5.3 config, rather than a partial one.
     const empty = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-none-')),
     );
     try {
       withAstryx().webpack({resolve: {}}, {dir: empty});
       expect(warn).toHaveBeenCalledOnce();
-      expect(warn.mock.calls[0][0]).toMatch(/resolved no `source` entries/);
+      expect(warn.mock.calls[0][0]).toMatch(/produced no alias for/);
     } finally {
       fs.rmSync(empty, {recursive: true, force: true});
     }
@@ -424,5 +423,76 @@ describe('withAstryx alias coverage', () => {
     // lab are absent and skipped. A partial map is the normal case, not a fault.
     resolveConfig();
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet when a caller alias already routes the packages', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Nothing installed, so this helper generates nothing — but the caller has
+    // routed the packages itself, which is a working config with nothing to
+    // warn about. The check is on the merged alias map, not on what we
+    // generated.
+    const empty = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-caller-')),
+    );
+    try {
+      withAstryx().webpack(
+        {
+          resolve: {
+            alias: {'@astryxdesign/core': path.join(empty, 'vendored')},
+          },
+        },
+        {dir: empty},
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(empty, {recursive: true, force: true});
+    }
+  });
+
+  it('stays quiet for an array-shaped caller alias too', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const empty = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-caller-arr-')),
+    );
+    try {
+      withAstryx().webpack(
+        {
+          resolve: {
+            alias: [
+              {
+                name: '@astryxdesign/core',
+                onlyModule: false,
+                alias: path.join(empty, 'vendored'),
+              },
+            ],
+          },
+        },
+        {dir: empty},
+      );
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(empty, {recursive: true, force: true});
+    }
+  });
+
+  it('stays quiet when the caller routes them from its webpack hook', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const empty = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-caller-hook-')),
+    );
+    try {
+      withAstryx({
+        webpack: cfg => {
+          cfg.resolve.alias['@astryxdesign/core'] = path.join(
+            empty,
+            'vendored',
+          );
+          return cfg;
+        },
+      }).webpack({resolve: {alias: {}}}, {dir: empty});
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(empty, {recursive: true, force: true});
+    }
   });
 });


### PR DESCRIPTION
Fixes #5921. Draft while the one compatibility question on that issue is open — see the end.

## Problem

`withAstryx()` installs every alias it needs inside `nextConfig.webpack`, and Turbopack never calls that hook. So `withAstryx()` under Turbopack reinstates exactly the failure #5932 removed: the app resolves `@astryxdesign/*` through `default` to `dist`, whose runtime class names are disjoint from the CSS the PostCSS pass compiles out of source, and the build **succeeds** with an unstyled page and nothing logged.

Next 16 defaults to Turbopack, so a project scaffolded today gets the unstyled page from a *correctly configured* source build. That is why this is separate from #5920 rather than a regression of it.

## Change

**1. Refuse under Turbopack** (`assertWebpack()`, called at config construction). There is no configuration in which the combination does what the author intended, so it throws rather than warning — an unstyled production deploy costs more than a failed build. The message names both ways out: keep the source build and pass `--webpack`, or drop `withAstryx()` and consume the pre-built package.

Detection is `process.env.TURBOPACK`, verified rather than assumed — Next 16.3.4 sets `TURBOPACK=1` for both `next dev --turbopack` and `next build --turbopack`, in the parent process *and* in each build worker, and leaves it unset under `--webpack`.

**2. Report an empty alias map.** `sourceEntryAliases()` skips a package that is not installed, or whose export map ships no `source` condition. Correct per package — an app need not depend on all three. Skipping *every* one of them is not: the result is zero aliases, which is the pre-0.5.3 config, and the app goes back to resolving dist against source-compiled CSS. A `console.warn` rather than a throw, because an install layout this helper cannot walk is not proof the build is wrong.

## Evidence

Unit tests: **6 added, 27 passing** in `packages/build/src/next.test.mjs`, no changes to the existing 21.

End to end against a real Next 16.3.4 app on `0.5.3`, measured on the served HTML and CSS rather than the exit code:

| | before | after |
|---|---|---|
| `next build --turbopack` | exits 0, `/` prerenders, **134 of 141** rendered classes have no matching CSS rule | fails at config load with the message |
| `next build --webpack` | 0 of 141 unmatched | 0 of 141 unmatched, `○ (Static)` |

The harness that produces the unmatched-class count builds each documented setup under both bundlers, serves it, and cross-checks every class on a rendered element against the served stylesheet. Happy to extract it as a standalone repro if useful — it is what turned up #5920.

## The open question

From #5921, and the reason this is a draft: **throw or warn for the Turbopack case?**

A throw is the useful behaviour, but it turns a currently-succeeding build into a failing one — a break for anyone who has `withAstryx()` in a Turbopack config and has not noticed, which is exactly the population this issue is about. This PR implements the throw; switching it to a warn is a one-line change if you would rather not take that in a `0.x` minor.

I have left the changeset off until that is settled, since the category (`fix` vs `breaking`) follows from the answer and drives the bump.

Checked `main` and the open PRs first per `AGENTS.md`: `packages/build/src/next.js` is unchanged since `bea53b23` and no open PR touches it.