### PR TITLE
ci: add positive tooling-only lane

### DIFF
--- a/.github/scripts/change-scope.cjs
+++ b/.github/scripts/change-scope.cjs
@@ -30,6 +30,28 @@ const SURFACES = Object.freeze({
   SHARED_OR_UNKNOWN: 'shared-or-unknown',
 });
 
+const RUNTIME_PACKAGE_SURFACES = Object.freeze([
+  ['packages/core/', 'runtime:core'],
+  ['packages/lab/', 'runtime:lab'],
+  ['packages/charts/', 'runtime:charts'],
+  ['packages/richtext/', 'runtime:richtext'],
+  ['packages/vega/', 'runtime:vega'],
+  ['packages/cli/', 'runtime:cli'],
+  ['packages/build/', 'runtime:build'],
+]);
+
+const STORYBOOK_VISUAL_PATTERNS = [
+  /^apps\/storybook\//,
+  /^\.github\/scripts\/(?:accessibility-audit|story-play-guard|visual-scope)\./,
+  /^\.github\/scripts\/visual-gate\//,
+];
+
+const THEME_BUILD_PATTERNS = [
+  /^packages\/themes\//,
+  /^packages\/build\//,
+  /^packages\/core\/src\/theme\//,
+];
+
 // Tooling admission is exact and dependency-reviewed. Do not widen this to all
 // of scripts/: that directory also owns generated public artifacts, package
 // builds, releases, and other shared infrastructure.
@@ -84,11 +106,23 @@ function isNodeToolingPath(filePath) {
   return NODE_TOOLING_PATHS.has(filePath);
 }
 
-function surfaceForPath(filePath) {
-  if (isSpecRecordPath(filePath)) return SURFACES.KNOWLEDGE;
-  if (filePath.startsWith('apps/docsite/')) return SURFACES.DOCSITE;
-  if (isNodeToolingPath(filePath)) return SURFACES.NODE_TOOLING;
-  return SURFACES.SHARED_OR_UNKNOWN;
+function surfacesForPath(filePath) {
+  if (isSpecRecordPath(filePath)) return [SURFACES.KNOWLEDGE];
+  if (filePath.startsWith('apps/docsite/')) return [SURFACES.DOCSITE];
+  if (isNodeToolingPath(filePath)) return [SURFACES.NODE_TOOLING];
+
+  const surfaces = [];
+  const runtimePackage = RUNTIME_PACKAGE_SURFACES.find(([root]) =>
+    filePath.startsWith(root),
+  );
+  if (runtimePackage) surfaces.push(runtimePackage[1]);
+  if (THEME_BUILD_PATTERNS.some(pattern => pattern.test(filePath))) {
+    surfaces.push('theme-build');
+  }
+  if (STORYBOOK_VISUAL_PATTERNS.some(pattern => pattern.test(filePath))) {
+    surfaces.push('storybook-visual');
+  }
+  return surfaces.length > 0 ? surfaces : [SURFACES.SHARED_OR_UNKNOWN];
 }
 
 function normalizeChange(change) {
@@ -127,7 +161,7 @@ function classifyChanges(changes, {expectedCount} = {}) {
       : [change.filename],
   );
   const surfaces = [
-    ...new Set(allPaths.map(surfaceForPath)),
+    ...new Set(allPaths.flatMap(surfacesForPath)),
     ...(!complete ? [SURFACES.SHARED_OR_UNKNOWN] : []),
   ].sort();
   const touchesKnowledgeRecords =
@@ -142,11 +176,11 @@ function classifyChanges(changes, {expectedCount} = {}) {
   const hasPackageReleaseChange = allPaths.some(isPackageReleasePath);
   const specChangesetConflict =
     complete && hasSpecRecord && hasChangeset && !hasPackageReleaseChange;
-  const specOnly = complete && allPaths.every(isSpecRecordPath);
-  const docsiteOnly =
-    complete &&
-    allPaths.every(filePath => filePath.startsWith('apps/docsite/'));
-  const toolingOnly = complete && allPaths.every(isNodeToolingPath);
+  const exactSurface = surface =>
+    complete && surfaces.length === 1 && surfaces[0] === surface;
+  const specOnly = exactSurface(SURFACES.KNOWLEDGE);
+  const docsiteOnly = exactSurface(SURFACES.DOCSITE);
+  const toolingOnly = exactSurface(SURFACES.NODE_TOOLING);
   return {
     specOnly,
     toolingOnly,

--- a/.github/scripts/change-scope.cjs
+++ b/.github/scripts/change-scope.cjs
@@ -23,6 +23,21 @@ const SPEC_RECORD_PATTERNS = [
 
 const CHANGESET_PATTERN = /^\.changeset\/(?!README\.md$)[^/]+\.md$/;
 
+const SURFACES = Object.freeze({
+  KNOWLEDGE: 'knowledge',
+  DOCSITE: 'docsite',
+  NODE_TOOLING: 'node-tooling',
+  SHARED_OR_UNKNOWN: 'shared-or-unknown',
+});
+
+// Tooling admission is exact and dependency-reviewed. Do not widen this to all
+// of scripts/: that directory also owns generated public artifacts, package
+// builds, releases, and other shared infrastructure.
+const NODE_TOOLING_PATHS = new Set([
+  'scripts/score-ledger.mjs',
+  'scripts/score-ledger.test.mjs',
+]);
+
 const THEME_DOC_CANDIDATE = /^docs\/themes\/(?!README\.md$)[^/]+\.md$/;
 const THEME_PACKAGE_CANDIDATE =
   /^packages\/themes\/[^/]+\/(?:.*\/)?[^/]+\.spec\.md$/;
@@ -65,6 +80,17 @@ function isKnowledgeRecordPath(filePath) {
   );
 }
 
+function isNodeToolingPath(filePath) {
+  return NODE_TOOLING_PATHS.has(filePath);
+}
+
+function surfaceForPath(filePath) {
+  if (isSpecRecordPath(filePath)) return SURFACES.KNOWLEDGE;
+  if (filePath.startsWith('apps/docsite/')) return SURFACES.DOCSITE;
+  if (isNodeToolingPath(filePath)) return SURFACES.NODE_TOOLING;
+  return SURFACES.SHARED_OR_UNKNOWN;
+}
+
 function normalizeChange(change) {
   if (typeof change === 'string') {
     return {filename: change, previous_filename: null};
@@ -83,10 +109,12 @@ function classifyChanges(changes, {expectedCount} = {}) {
     const complete = expectedCount == null || expectedCount === 0;
     return {
       specOnly: false,
+      toolingOnly: false,
       touchesKnowledgeRecords: !complete,
       touchesDesignAssets: false,
       specChangesetConflict: false,
       docsiteOnly: false,
+      surfaces: complete ? [] : [SURFACES.SHARED_OR_UNKNOWN],
       complete,
       reason: complete ? 'no changed files' : 'changed-file list is incomplete',
     };
@@ -98,6 +126,10 @@ function classifyChanges(changes, {expectedCount} = {}) {
       ? [change.filename, change.previous_filename]
       : [change.filename],
   );
+  const surfaces = [
+    ...new Set(allPaths.map(surfaceForPath)),
+    ...(!complete ? [SURFACES.SHARED_OR_UNKNOWN] : []),
+  ].sort();
   const touchesKnowledgeRecords =
     !complete || allPaths.some(isKnowledgeRecordPath);
   const touchesDesignAssets = allPaths.some(filePath =>
@@ -111,15 +143,18 @@ function classifyChanges(changes, {expectedCount} = {}) {
   const specChangesetConflict =
     complete && hasSpecRecord && hasChangeset && !hasPackageReleaseChange;
   const specOnly = complete && allPaths.every(isSpecRecordPath);
-  const docsiteOnly = allPaths.every(filePath =>
-    filePath.startsWith('apps/docsite/'),
-  );
+  const docsiteOnly =
+    complete &&
+    allPaths.every(filePath => filePath.startsWith('apps/docsite/'));
+  const toolingOnly = complete && allPaths.every(isNodeToolingPath);
   return {
     specOnly,
+    toolingOnly,
     touchesKnowledgeRecords,
     touchesDesignAssets,
     specChangesetConflict,
     docsiteOnly,
+    surfaces,
     complete,
     reason: !complete
       ? 'changed-file list is incomplete'
@@ -127,7 +162,9 @@ function classifyChanges(changes, {expectedCount} = {}) {
         ? 'only spec records changed'
         : docsiteOnly
           ? 'only docsite files changed'
-          : 'changes include another surface',
+          : toolingOnly
+            ? 'only admitted Node tooling changed'
+            : 'changes include another surface',
   };
 }
 
@@ -163,7 +200,7 @@ if (require.main === module) {
       throw new Error('GITHUB_OUTPUT is required with --github-output.');
     fs.appendFileSync(
       outputPath,
-      `spec_only=${result.specOnly}\ndocsite_only=${result.docsiteOnly}\n`,
+      `spec_only=${result.specOnly}\ndocsite_only=${result.docsiteOnly}\ntooling_only=${result.toolingOnly}\n`,
     );
   } else {
     process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -171,8 +208,11 @@ if (require.main === module) {
 }
 
 module.exports = {
+  NODE_TOOLING_PATHS,
+  SURFACES,
   classifyChanges,
   isKnowledgeRecordPath,
+  isNodeToolingPath,
   isSpecRecordPath,
   parseNameStatus,
 };

--- a/.github/scripts/change-scope.test.mjs
+++ b/.github/scripts/change-scope.test.mjs
@@ -4,7 +4,11 @@ import {createRequire} from 'node:module';
 import {describe, expect, it} from 'vitest';
 
 const require = createRequire(import.meta.url);
-const {classifyChanges, parseNameStatus} = require('./change-scope.cjs');
+const {
+  SURFACES,
+  classifyChanges,
+  parseNameStatus,
+} = require('./change-scope.cjs');
 
 describe('spec-only change scope', () => {
   it('accepts system, family, design, theme, component, and plan records', () => {
@@ -173,5 +177,110 @@ describe('spec-only change scope', () => {
       {filename: 'docs/specs/AST-001-x/spec.md'},
       {filename: 'packages/core/src/X/X.spec.md', previous_filename: 'old.ts'},
     ]);
+  });
+});
+
+describe('positive CI surfaces', () => {
+  const scoreLedger = 'scripts/score-ledger.mjs';
+  const scoreLedgerTest = 'scripts/score-ledger.test.mjs';
+
+  it('admits only the complete score-ledger tooling group', () => {
+    const result = classifyChanges([
+      {filename: scoreLedger},
+      {filename: scoreLedgerTest},
+    ]);
+    expect(result.toolingOnly).toBe(true);
+    expect(result.surfaces).toEqual([SURFACES.NODE_TOOLING]);
+  });
+
+  it('keeps pure specification records in the knowledge singleton', () => {
+    const result = classifyChanges([
+      {filename: 'packages/core/src/Button/Button.spec.md'},
+    ]);
+    expect(result.specOnly).toBe(true);
+    expect(result.toolingOnly).toBe(false);
+    expect(result.surfaces).toEqual([SURFACES.KNOWLEDGE]);
+  });
+
+  it.each([
+    {
+      name: 'component spec plus component code',
+      files: [
+        'packages/core/src/Button/Button.spec.md',
+        'packages/core/src/Button/Button.tsx',
+      ],
+    },
+    {
+      name: 'module spec plus Table plugin code',
+      files: [
+        'packages/core/src/Table/plugins/rowStatus/useTableRowStatus.spec.md',
+        'packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx',
+      ],
+    },
+    {
+      name: 'tooling plus component code',
+      files: [scoreLedger, 'packages/core/src/Button/Button.tsx'],
+    },
+    {
+      name: 'workflow self-change',
+      files: ['.github/workflows/ci.yml'],
+    },
+    {
+      name: 'classifier self-change',
+      files: ['.github/scripts/change-scope.cjs'],
+    },
+    {
+      name: 'unknown path',
+      files: ['new-surface/unknown.file'],
+    },
+    {
+      name: 'shared infrastructure',
+      files: ['pnpm-lock.yaml'],
+    },
+  ])('fails closed for $name', ({files}) => {
+    const result = classifyChanges(files.map(filename => ({filename})));
+    expect(result.toolingOnly).toBe(false);
+    expect(result.surfaces).toContain(SURFACES.SHARED_OR_UNKNOWN);
+  });
+
+  it.each([
+    'packages/core/src/Button/Button.tsx',
+    'packages/lab/src/TransferList/TransferList.tsx',
+    'packages/charts/src/Chart.tsx',
+    'packages/richtext/src/RichTextView.tsx',
+    'packages/vega/src/VegaChart.tsx',
+  ])('routes public package surface %s through broad CI', filename => {
+    const result = classifyChanges([{filename}]);
+    expect(result.toolingOnly).toBe(false);
+    expect(result.surfaces).toEqual([SURFACES.SHARED_OR_UNKNOWN]);
+  });
+
+  it('fails closed when a tooling path was renamed from an unknown path', () => {
+    const result = classifyChanges([
+      {
+        filename: scoreLedger,
+        previous_filename: 'scripts/legacy-score-tool.mjs',
+      },
+    ]);
+    expect(result.toolingOnly).toBe(false);
+    expect(result.surfaces).toEqual([
+      SURFACES.NODE_TOOLING,
+      SURFACES.SHARED_OR_UNKNOWN,
+    ]);
+  });
+
+  it('fails every specialized lane when the changed-file list is incomplete', () => {
+    for (const filename of [
+      scoreLedger,
+      'apps/docsite/src/app/page.tsx',
+      'docs/specs/AST-030/spec.md',
+    ]) {
+      const result = classifyChanges([{filename}], {expectedCount: 2});
+      expect(result.complete).toBe(false);
+      expect(result.toolingOnly).toBe(false);
+      expect(result.docsiteOnly).toBe(false);
+      expect(result.specOnly).toBe(false);
+      expect(result.surfaces).toContain(SURFACES.SHARED_OR_UNKNOWN);
+    }
   });
 });

--- a/.github/scripts/change-scope.test.mjs
+++ b/.github/scripts/change-scope.test.mjs
@@ -209,6 +209,7 @@ describe('positive CI surfaces', () => {
         'packages/core/src/Button/Button.spec.md',
         'packages/core/src/Button/Button.tsx',
       ],
+      surfaces: [SURFACES.KNOWLEDGE, 'runtime:core'],
     },
     {
       name: 'module spec plus Table plugin code',
@@ -216,10 +217,12 @@ describe('positive CI surfaces', () => {
         'packages/core/src/Table/plugins/rowStatus/useTableRowStatus.spec.md',
         'packages/core/src/Table/plugins/rowStatus/useTableRowStatus.tsx',
       ],
+      surfaces: [SURFACES.KNOWLEDGE, 'runtime:core'],
     },
     {
       name: 'tooling plus component code',
       files: [scoreLedger, 'packages/core/src/Button/Button.tsx'],
+      surfaces: [SURFACES.NODE_TOOLING, 'runtime:core'],
     },
     {
       name: 'workflow self-change',
@@ -237,22 +240,30 @@ describe('positive CI surfaces', () => {
       name: 'shared infrastructure',
       files: ['pnpm-lock.yaml'],
     },
-  ])('fails closed for $name', ({files}) => {
+  ])('fails closed for $name', ({files, surfaces}) => {
     const result = classifyChanges(files.map(filename => ({filename})));
     expect(result.toolingOnly).toBe(false);
-    expect(result.surfaces).toContain(SURFACES.SHARED_OR_UNKNOWN);
+    if (surfaces) {
+      expect(result.surfaces).toEqual(surfaces);
+    } else {
+      expect(result.surfaces).toContain(SURFACES.SHARED_OR_UNKNOWN);
+    }
   });
 
   it.each([
-    'packages/core/src/Button/Button.tsx',
-    'packages/lab/src/TransferList/TransferList.tsx',
-    'packages/charts/src/Chart.tsx',
-    'packages/richtext/src/RichTextView.tsx',
-    'packages/vega/src/VegaChart.tsx',
-  ])('routes public package surface %s through broad CI', filename => {
+    ['packages/core/src/Button/Button.tsx', ['runtime:core']],
+    ['packages/lab/src/TransferList/TransferList.tsx', ['runtime:lab']],
+    ['packages/charts/src/Chart.tsx', ['runtime:charts']],
+    ['packages/richtext/src/RichTextView.tsx', ['runtime:richtext']],
+    ['packages/vega/src/VegaChart.tsx', ['runtime:vega']],
+    ['packages/cli/api/build/build.mjs', ['runtime:cli']],
+    ['packages/build/src/vite.ts', ['runtime:build', 'theme-build']],
+    ['packages/themes/neutral/src/neutralTheme.ts', ['theme-build']],
+    ['apps/storybook/stories/Button.stories.tsx', ['storybook-visual']],
+  ])('routes public surface %s through broad CI', (filename, surfaces) => {
     const result = classifyChanges([{filename}]);
     expect(result.toolingOnly).toBe(false);
-    expect(result.surfaces).toEqual([SURFACES.SHARED_OR_UNKNOWN]);
+    expect(result.surfaces).toEqual(surfaces);
   });
 
   it('fails closed when a tooling path was renamed from an unknown path', () => {

--- a/.github/scripts/ci-tooling-routing.test.mjs
+++ b/.github/scripts/ci-tooling-routing.test.mjs
@@ -21,6 +21,7 @@ const read = relative => fs.readFileSync(path.join(root, relative), 'utf8');
 const load = relative => yaml.parse(read(relative));
 const ci = load('.github/workflows/ci.yml');
 const lint = load('.github/workflows/lint.yml');
+const prComment = load('.github/workflows/pr-comment.yml');
 const TOOLING_FALSE = "needs.check-scope.outputs.tooling_only != 'true'";
 const TOOLING_TRUE = "needs.check-scope.outputs.tooling_only == 'true'";
 
@@ -124,5 +125,21 @@ describe('Node-tooling CI routing', () => {
     ).run;
     expect(buildJoin).toContain('needs.build-storybook.result');
     expect(buildJoin).toContain('needs.build-sandbox.result');
+  });
+
+  it('keeps privileged preview publication off the tooling lane', () => {
+    expect(prComment.jobs.resolve.outputs.tooling_only).toContain(
+      'steps.identity.outputs.tooling_only',
+    );
+    for (const name of ['invalidate', 'deploy-preview', 'comment']) {
+      expect(prComment.jobs[name].if, name).toContain(
+        "needs.resolve.outputs.tooling_only != 'true'",
+      );
+    }
+    for (const name of ['spec-only-visual', 'spec-only-reconcile']) {
+      expect(prComment.jobs[name].if, name).toContain(
+        "needs.resolve.outputs.tooling_only == 'true'",
+      );
+    }
   });
 });

--- a/.github/scripts/ci-tooling-routing.test.mjs
+++ b/.github/scripts/ci-tooling-routing.test.mjs
@@ -31,19 +31,28 @@ function step(job, name) {
 
 describe('Node-tooling CI routing', () => {
   it('publishes the tooling output from the trusted-base classifier', () => {
-    const source = read('.github/workflows/ci.yml');
     expect(ci.jobs['check-scope'].outputs.tooling_only).toContain(
       'steps.scope.outputs.tooling_only',
     );
-    expect(source).toContain(
-      'git show "origin/${{ github.base_ref }}:.github/scripts/change-scope.cjs"',
-    );
-    expect(source).toContain(
-      'git show "origin/${{ github.base_ref }}:.github/scripts/knowledge-paths.cjs"',
-    );
-    expect(source).toContain(
-      'git show "origin/${{ github.base_ref }}:scripts/component-packages.cjs"',
-    );
+    for (const workflow of [
+      '.github/workflows/ci.yml',
+      '.github/workflows/lint.yml',
+    ]) {
+      const source = read(workflow);
+      expect(source).toContain(
+        'git show "origin/${{ github.base_ref }}:.github/scripts/change-scope.cjs"',
+      );
+      expect(source).toContain(
+        'git show "origin/${{ github.base_ref }}:.github/scripts/knowledge-paths.cjs"',
+      );
+      expect(source).toContain(
+        'git show "origin/${{ github.base_ref }}:scripts/component-packages.cjs"',
+      );
+      expect(source).toContain('| node "$CLASSIFIER" --github-output');
+      expect(source).not.toContain(
+        '| node .github/scripts/change-scope.cjs --github-output',
+      );
+    }
   });
 
   it('grants no specialized lane without a merge base or trusted dependency', () => {

--- a/.github/scripts/ci-tooling-routing.test.mjs
+++ b/.github/scripts/ci-tooling-routing.test.mjs
@@ -1,0 +1,128 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file ci-tooling-routing.test.mjs
+ * @description Pins the first positive CI surface lane: admitted score-ledger
+ *   tooling runs Node and lint owners while unrelated UI/browser/build work skips.
+ * @input CI and lint workflow YAML.
+ * @output Mutation-sensitive assertions for trusted classification, owned work,
+ *   fail-closed fallbacks, and historical join jobs.
+ * @position Workflow contract for spec:AST-030's first implementation slice.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {describe, expect, it} from 'vitest';
+import yaml from 'yaml';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const read = relative => fs.readFileSync(path.join(root, relative), 'utf8');
+const load = relative => yaml.parse(read(relative));
+const ci = load('.github/workflows/ci.yml');
+const lint = load('.github/workflows/lint.yml');
+const TOOLING_FALSE = "needs.check-scope.outputs.tooling_only != 'true'";
+const TOOLING_TRUE = "needs.check-scope.outputs.tooling_only == 'true'";
+
+function step(job, name) {
+  return job.steps.find(candidate => candidate.name === name);
+}
+
+describe('Node-tooling CI routing', () => {
+  it('publishes the tooling output from the trusted-base classifier', () => {
+    const source = read('.github/workflows/ci.yml');
+    expect(ci.jobs['check-scope'].outputs.tooling_only).toContain(
+      'steps.scope.outputs.tooling_only',
+    );
+    expect(source).toContain(
+      'git show "origin/${{ github.base_ref }}:.github/scripts/change-scope.cjs"',
+    );
+    expect(source).toContain(
+      'git show "origin/${{ github.base_ref }}:.github/scripts/knowledge-paths.cjs"',
+    );
+    expect(source).toContain(
+      'git show "origin/${{ github.base_ref }}:scripts/component-packages.cjs"',
+    );
+  });
+
+  it('grants no specialized lane without a merge base or trusted dependency', () => {
+    for (const workflow of [
+      '.github/workflows/ci.yml',
+      '.github/workflows/lint.yml',
+    ]) {
+      const source = read(workflow);
+      expect(source).toContain(
+        'docsite_only=false\\nspec_only=false\\ntooling_only=false',
+      );
+      expect(source).not.toContain('NON_DOCSITE=');
+    }
+  });
+
+  it('runs the Node project and required lint owners for tooling', () => {
+    const nodeSuite = ci.jobs['test-node'].steps.find(candidate =>
+      candidate.run?.includes('--project node'),
+    );
+    expect(nodeSuite.if).not.toContain('tooling_only');
+    expect(
+      ci.jobs['test-node'].steps.find(candidate =>
+        candidate.uses?.includes('.github/actions/setup'),
+      ).if,
+    ).not.toContain('tooling_only');
+
+    for (const name of ['Check repository guardrails', 'Run ESLint']) {
+      expect(step(lint.jobs.lint, name).if).not.toContain('tooling_only');
+    }
+  });
+
+  it('skips the UI project and component/browser owners for tooling', () => {
+    const uiSuite = ci.jobs['test-ui'].steps.find(candidate =>
+      candidate.run?.includes('--project ui'),
+    );
+    expect(uiSuite.if).toContain(TOOLING_FALSE);
+    expect(ci.jobs['check-components'].if).toContain(TOOLING_FALSE);
+    expect(ci.jobs['theme-layers'].if).toContain(TOOLING_FALSE);
+    expect(ci.jobs['fixture-contrast'].if).toContain(TOOLING_FALSE);
+  });
+
+  it('keeps required build and docsite contexts green without their heavy work', () => {
+    expect(
+      step(ci.jobs['docsite-test'], 'Skip docsite work for Node tooling').if,
+    ).toContain(TOOLING_TRUE);
+    for (const name of [
+      'Build core package',
+      'Build canary component packages',
+      'Generate and test docsite data',
+    ]) {
+      expect(step(ci.jobs['docsite-test'], name).if).toContain(TOOLING_FALSE);
+    }
+
+    expect(ci.jobs['build-sandbox'].if).toContain(TOOLING_FALSE);
+    for (const candidate of ci.jobs['build-storybook'].steps) {
+      if (
+        candidate.name === 'Require successful scope classification' ||
+        candidate.name === 'Skip heavy work for a specialized lane'
+      ) {
+        continue;
+      }
+      if (candidate.run || candidate.uses) {
+        expect(candidate.if, candidate.name ?? candidate.run).toContain(
+          TOOLING_FALSE,
+        );
+      }
+    }
+  });
+
+  it('preserves the historical joins and fails them on owned-lane failure', () => {
+    expect(ci.jobs.test.needs).toEqual(['test-ui', 'test-node']);
+    expect(ci.jobs.build.needs).toEqual(['build-storybook', 'build-sandbox']);
+    const testJoin = step(ci.jobs.test, 'Assert both test lanes succeeded').run;
+    expect(testJoin).toContain('needs.test-node.result');
+    expect(testJoin).toContain('needs.test-ui.result');
+    const buildJoin = step(
+      ci.jobs.build,
+      'Assert parallel builds succeeded',
+    ).run;
+    expect(buildJoin).toContain('needs.build-storybook.result');
+    expect(buildJoin).toContain('needs.build-sandbox.result');
+  });
+});

--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -79,7 +79,7 @@ describe('spec-only workflow contract', () => {
       );
       expect(result.status, result.stderr).toBe(0);
       expect(fs.readFileSync(output, 'utf8')).toBe(
-        'spec_only=true\ndocsite_only=false\n',
+        'spec_only=true\ndocsite_only=false\ntooling_only=false\n',
       );
 
       fs.rmSync(path.join(classifierDir, 'knowledge-paths.cjs'));
@@ -134,7 +134,12 @@ describe('spec-only workflow contract', () => {
     expect(validate).toBeGreaterThan(setup);
     expect(build).toBeGreaterThan(validate);
     expect(generate).toBeGreaterThan(build);
-    expect(docsiteJob.slice(setup, validate)).not.toContain('\n        if:');
+    expect(docsiteJob.slice(setup, validate)).toContain(
+      "if: needs.check-scope.outputs.tooling_only != 'true'",
+    );
+    expect(docsiteJob.slice(setup, validate)).not.toContain(
+      "needs.check-scope.outputs.spec_only != 'true'",
+    );
     expect(docsiteJob.slice(build, generate)).toContain(
       "if: needs.check-scope.outputs.spec_only != 'true'",
     );

--- a/.github/scripts/tooling-surface-contract.test.mjs
+++ b/.github/scripts/tooling-surface-contract.test.mjs
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file tooling-surface-contract.test.mjs
+ * @description Pins the Node-only contract between the admitted score-ledger
+ *   tooling surface and the Sandbox projection that consumes its exports.
+ * @input The score-ledger module and the generator's named import list.
+ * @output Fails when an admitted tooling change breaks the operational consumer
+ *   that the tooling-only lane intentionally validates without a Sandbox build.
+ * @position Safety contract for the first positive CI tooling surface.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {describe, expect, it} from 'vitest';
+
+import * as scoreLedger from '../../scripts/score-ledger.mjs';
+
+const root = path.resolve(import.meta.dirname, '../..');
+const generatorPath = path.join(
+  root,
+  'apps/sandbox/scripts/generate-score-ledger.mjs',
+);
+
+function consumedScoreLedgerExports() {
+  const source = fs.readFileSync(generatorPath, 'utf8');
+  const match = source.match(
+    /import\s*{([^}]*)}\s*from\s*['"]\.\.\/\.\.\/\.\.\/scripts\/score-ledger\.mjs['"]/,
+  );
+  if (!match) throw new Error('Sandbox score-ledger import was not found');
+  return match[1]
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean);
+}
+
+describe('score-ledger tooling surface', () => {
+  it('keeps every Sandbox projection import available', () => {
+    const consumed = consumedScoreLedgerExports();
+    expect(consumed.length).toBeGreaterThan(0);
+    for (const name of consumed) {
+      expect(scoreLedger, `missing Sandbox export ${name}`).toHaveProperty(
+        name,
+      );
+    }
+  });
+
+  it('keeps projected values in the shapes the generated module emits', () => {
+    expect(scoreLedger.AUDIT_PROMPT).toEqual(expect.any(String));
+    expect(scoreLedger.AUDIT_PROMPT.length).toBeGreaterThan(0);
+    expect(scoreLedger.DEFAULT_LEDGER_URL).toMatch(/^https:\/\//);
+    expect(scoreLedger.DEFAULT_REPO).toEqual(expect.any(String));
+    expect(scoreLedger.LEDGER_FETCH_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(scoreLedger.SECTION_TITLES).toEqual(expect.any(Object));
+    expect(scoreLedger.SECTION_WEIGHTS).toEqual(expect.any(Object));
+    expect(scoreLedger.isBlocksShape).toEqual(expect.any(Function));
+    expect(scoreLedger.isEvidenceItem).toEqual(expect.any(Function));
+    expect(scoreLedger.listComponents).toEqual(expect.any(Function));
+  });
+});

--- a/.github/scripts/tooling-surface-contract.test.mjs
+++ b/.github/scripts/tooling-surface-contract.test.mjs
@@ -73,7 +73,8 @@ describe('score-ledger tooling surface', () => {
   it('keeps every serialized value in the exact generated-module shape', () => {
     expect(typeof scoreLedger.AUDIT_PROMPT).toBe('string');
     expect(scoreLedger.AUDIT_PROMPT.length).toBeGreaterThan(0);
-    expect(() => new URL(scoreLedger.DEFAULT_LEDGER_URL)).not.toThrow();
+    const ledgerUrl = new URL(scoreLedger.DEFAULT_LEDGER_URL);
+    expect(ledgerUrl.protocol).toBe('https:');
     expect(scoreLedger.DEFAULT_REPO).toMatch(/^[^/]+\/[^/]+$/);
     expect(Number.isInteger(scoreLedger.LEDGER_FETCH_TIMEOUT_MS)).toBe(true);
     expect(scoreLedger.LEDGER_FETCH_TIMEOUT_MS).toBeGreaterThan(0);

--- a/.github/scripts/tooling-surface-contract.test.mjs
+++ b/.github/scripts/tooling-surface-contract.test.mjs
@@ -35,10 +35,34 @@ function consumedScoreLedgerExports() {
     .filter(Boolean);
 }
 
+const EXPECTED_CONSUMED_EXPORTS = [
+  'AUDIT_PROMPT',
+  'DEFAULT_LEDGER_URL',
+  'DEFAULT_REPO',
+  'LEDGER_FETCH_TIMEOUT_MS',
+  'SECTION_TITLES',
+  'SECTION_WEIGHTS',
+  'isBlocksShape',
+  'isEvidenceItem',
+  'listComponents',
+];
+
+function expectRecord(value, predicate) {
+  expect(value).not.toBeNull();
+  expect(Array.isArray(value)).toBe(false);
+  expect(typeof value).toBe('object');
+  for (const [key, entry] of Object.entries(value)) {
+    expect(key.length).toBeGreaterThan(0);
+    expect(predicate(entry), `${key} has an invalid projected value`).toBe(
+      true,
+    );
+  }
+}
+
 describe('score-ledger tooling surface', () => {
-  it('keeps every Sandbox projection import available', () => {
-    const consumed = consumedScoreLedgerExports();
-    expect(consumed.length).toBeGreaterThan(0);
+  it('keeps the Sandbox projection import list explicit and available', () => {
+    const consumed = consumedScoreLedgerExports().sort();
+    expect(consumed).toEqual([...EXPECTED_CONSUMED_EXPORTS].sort());
     for (const name of consumed) {
       expect(scoreLedger, `missing Sandbox export ${name}`).toHaveProperty(
         name,
@@ -46,16 +70,41 @@ describe('score-ledger tooling surface', () => {
     }
   });
 
-  it('keeps projected values in the shapes the generated module emits', () => {
-    expect(scoreLedger.AUDIT_PROMPT).toEqual(expect.any(String));
+  it('keeps every serialized value in the exact generated-module shape', () => {
+    expect(typeof scoreLedger.AUDIT_PROMPT).toBe('string');
     expect(scoreLedger.AUDIT_PROMPT.length).toBeGreaterThan(0);
-    expect(scoreLedger.DEFAULT_LEDGER_URL).toMatch(/^https:\/\//);
-    expect(scoreLedger.DEFAULT_REPO).toEqual(expect.any(String));
+    expect(() => new URL(scoreLedger.DEFAULT_LEDGER_URL)).not.toThrow();
+    expect(scoreLedger.DEFAULT_REPO).toMatch(/^[^/]+\/[^/]+$/);
+    expect(Number.isInteger(scoreLedger.LEDGER_FETCH_TIMEOUT_MS)).toBe(true);
     expect(scoreLedger.LEDGER_FETCH_TIMEOUT_MS).toBeGreaterThan(0);
-    expect(scoreLedger.SECTION_TITLES).toEqual(expect.any(Object));
-    expect(scoreLedger.SECTION_WEIGHTS).toEqual(expect.any(Object));
+
+    expectRecord(
+      scoreLedger.SECTION_TITLES,
+      value => typeof value === 'string',
+    );
+    expectRecord(
+      scoreLedger.SECTION_WEIGHTS,
+      value => typeof value === 'number' && Number.isFinite(value),
+    );
+    expect(Object.keys(scoreLedger.SECTION_TITLES).sort()).toEqual(
+      Object.keys(scoreLedger.SECTION_WEIGHTS).sort(),
+    );
+
+    const components = scoreLedger.listComponents();
+    expect(Array.isArray(components)).toBe(true);
+    expect(components.length).toBeGreaterThan(0);
+    for (const component of components) {
+      expect(component).toEqual({
+        component: expect.any(String),
+        package: expect.any(String),
+      });
+      expect(component.component.length).toBeGreaterThan(0);
+      expect(component.package.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps generator-only validators callable', () => {
     expect(scoreLedger.isBlocksShape).toEqual(expect.any(Function));
     expect(scoreLedger.isEvidenceItem).toEqual(expect.any(Function));
-    expect(scoreLedger.listComponents).toEqual(expect.any(Function));
   });
 });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       docsite_only: ${{ steps.scope.outputs.docsite_only }}
       spec_only: ${{ steps.scope.outputs.spec_only }}
+      tooling_only: ${{ steps.scope.outputs.tooling_only }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -40,12 +41,12 @@ jobs:
         id: scope
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            printf 'docsite_only=false\nspec_only=false\n' >> "$GITHUB_OUTPUT"
+            printf 'docsite_only=false\nspec_only=false\ntooling_only=false\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           MERGE_BASE=$(git merge-base HEAD origin/${{ github.base_ref }} 2>/dev/null || echo "")
           if [ -z "$MERGE_BASE" ]; then
-            printf 'docsite_only=false\nspec_only=false\n' >> "$GITHUB_OUTPUT"
+            printf 'docsite_only=false\nspec_only=false\ntooling_only=false\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           CLASSIFIER_ROOT="$RUNNER_TEMP/change-scope"
@@ -61,12 +62,9 @@ jobs:
             git diff --name-status "$MERGE_BASE"...HEAD \
               | node "$CLASSIFIER" --github-output
           else
-            # Bootstrap fallback: before the trusted classifier exists on main,
-            # no PR can receive the spec-only fast path.
-            CHANGED=$(git diff --name-only "$MERGE_BASE"...HEAD)
-            NON_DOCSITE=$(printf '%s\n' "$CHANGED" | grep -v '^apps/docsite/' | head -1)
-            printf 'docsite_only=%s\nspec_only=false\n' \
-              "$( [ -z "$NON_DOCSITE" ] && echo true || echo false )" \
+            # Missing trusted policy or dependencies cannot grant a specialized
+            # lane. Run broad CI until the base branch supplies the full classifier.
+            printf 'docsite_only=false\nspec_only=false\ntooling_only=false\n' \
               >> "$GITHUB_OUTPUT"
           fi
   # Docsite data extraction tests — always runs, fast (~2s)
@@ -83,11 +81,16 @@ jobs:
           echo "Change scope could not be classified; refusing to skip required work."
           exit 1
 
+      - name: Skip docsite work for Node tooling
+        if: needs.check-scope.outputs.tooling_only == 'true'
+        run: echo "Node-tooling PR — docsite generation is not an owned check"
+
       - uses: actions/checkout@v7
 
       # Spec validation imports the canonical CLI discovery path, so the
       # lightweight docs path needs workspace dependencies too.
       - uses: ./.github/actions/setup
+        if: needs.check-scope.outputs.tooling_only != 'true'
 
       - name: Validate spec records
         if: needs.check-scope.outputs.spec_only == 'true'
@@ -97,14 +100,14 @@ jobs:
       # @astryxdesign/core/theme entry (dist/theme/index.js). Build core first so that
       # entry exists — otherwise generate fails with "Cannot find module".
       - name: Build core package
-        if: needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/core build
 
       # The generated preview registry imports every configured canary component
       # package. Build those exports so Vitest exercises the same graph as the
       # canary deployment.
       - name: Build canary component packages
-        if: needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: |
           pnpm -F @astryxdesign/lab build
           pnpm -F @astryxdesign/charts build
@@ -112,7 +115,7 @@ jobs:
           pnpm -F @astryxdesign/vega build
 
       - name: Generate and test docsite data
-        if: needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/docsite generate && pnpm -F @astryxdesign/docsite test
 
   # Lightweight check — does the PR touch any published components?
@@ -125,7 +128,7 @@ jobs:
   # job learned about packages/lab/src.
   check-components:
     needs: [check-scope]
-    if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+    if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -201,49 +204,50 @@ jobs:
           echo "Change scope could not be classified; refusing to skip required work."
           exit 1
 
-      - name: Skip heavy work for lightweight docs
-        if: needs.check-scope.outputs.docsite_only == 'true' || needs.check-scope.outputs.spec_only == 'true'
-        run: echo "Lightweight documentation PR — skipping full test suite"
+      - name: Skip heavy work for a specialized lane
+        if: needs.check-scope.outputs.docsite_only == 'true' || needs.check-scope.outputs.spec_only == 'true' || needs.check-scope.outputs.tooling_only == 'true'
+        run: echo "Specialized PR lane — skipping unrelated test suite"
 
       - uses: actions/checkout@v7
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
 
       - uses: ./.github/actions/setup
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
 
       - name: Check knowledge schema history
         if: >-
           github.event_name == 'pull_request' &&
           needs.check-scope.outputs.docsite_only != 'true' &&
-          needs.check-scope.outputs.spec_only != 'true'
+          needs.check-scope.outputs.spec_only != 'true' &&
+          needs.check-scope.outputs.tooling_only != 'true'
         run: |
           git fetch origin "${{ github.event.pull_request.base.sha }}" --depth=1
           node scripts/check-knowledge.mjs --base "${{ github.event.pull_request.base.sha }}"
 
       - name: Check copyright headers
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: ./scripts/add-copyright.sh --check
 
       - name: Check package.json exports are in sync
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: node scripts/sync-exports.js --check
 
       - name: Verify the published CLI ./api type surface
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: node .github/scripts/cli-api-types-verify.mjs
 
       - name: Check token docs are in sync
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: node scripts/generate-token-docs.mjs --check
 
       # Fails when the lab readiness manifest claims a check the source tree
       # contradicts — the report is derived, never hand-maintained.
       - name: Check lab readiness manifest is current
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm lab:readiness:check
 
       - run: pnpm vitest run --project ui
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
 
   test-node:
     needs: [check-scope]
@@ -258,9 +262,9 @@ jobs:
           echo "Change scope could not be classified; refusing to skip required work."
           exit 1
 
-      - name: Skip heavy work for lightweight docs
+      - name: Skip heavy work for a specialized lane
         if: needs.check-scope.outputs.docsite_only == 'true' || needs.check-scope.outputs.spec_only == 'true'
-        run: echo "Lightweight documentation PR — skipping full test suite"
+        run: echo "Specialized PR lane — skipping unrelated test suite"
 
       - uses: actions/checkout@v7
         if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
@@ -311,12 +315,12 @@ jobs:
           echo "Change scope could not be classified; refusing to skip required work."
           exit 1
 
-      - name: Skip heavy work for lightweight docs
-        if: needs.check-scope.outputs.docsite_only == 'true' || needs.check-scope.outputs.spec_only == 'true'
-        run: echo "Lightweight documentation PR — skipping full build"
+      - name: Skip heavy work for a specialized lane
+        if: needs.check-scope.outputs.docsite_only == 'true' || needs.check-scope.outputs.spec_only == 'true' || needs.check-scope.outputs.tooling_only == 'true'
+        run: echo "Specialized PR lane — skipping unrelated build"
 
       - name: Checkout
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         uses: actions/checkout@v7
         with:
           # Depth 50 (same as check-scope) so analyze-pr.js's three-dot diff
@@ -325,66 +329,66 @@ jobs:
           fetch-depth: 50
 
       - name: Fetch base branch for PR analysis
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && github.event_name == 'pull_request'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true' && github.event_name == 'pull_request'
         run: git fetch origin ${{ github.base_ref }} --depth=50
 
       - name: Setup Node and pnpm
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         uses: ./.github/actions/setup
 
       - name: Build core package
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm build
 
       - name: Verify package exports
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: node scripts/verify-exports.mjs
 
       - name: Typecheck component docs
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/core typecheck:docs
 
       - name: Typecheck lab docs
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/lab typecheck:docs
 
       - name: Typecheck charts docs
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/charts typecheck:docs
 
       - name: Typecheck rich text docs
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/richtext typecheck:docs
 
       - name: Typecheck Vega docs
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/vega typecheck:docs
 
       - name: Typecheck template docs
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/cli typecheck:template-docs
 
       # Full-package strict checkJs over the CLI (src, bin, scripts, docs, and
       # the emitted templates). Requires the `pnpm build` above so the template
       # .tsx sources can resolve the built @astryxdesign/{core,charts,lab} types.
       - name: Typecheck CLI (strict)
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/cli typecheck:strict
 
       - name: Typecheck storybook
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/storybook typecheck
 
       - name: Typecheck core (including tests)
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/core typecheck
 
       - name: Build Storybook
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
         run: pnpm -F @astryxdesign/storybook build
 
       - name: Compute PR preview path
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && github.event_name == 'pull_request'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true' && github.event_name == 'pull_request'
         id: urls
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -399,7 +403,7 @@ jobs:
           echo "sandbox_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/sandbox/" >> $GITHUB_OUTPUT
 
       - name: Upload Storybook artifact
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && github.event_name == 'pull_request'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: storybook-${{ steps.urls.outputs.short_hash }}
@@ -418,7 +422,7 @@ jobs:
       # Two paths, so the artifact is rooted at their common ancestor
       # (packages/) — the download below unpacks it there.
       - name: Upload built themes and core
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && github.event_name == 'pull_request'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: dists-${{ steps.urls.outputs.short_hash }}
@@ -428,7 +432,7 @@ jobs:
           retention-days: 1
 
       - name: Analyze components
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && github.event_name == 'pull_request'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true' && github.event_name == 'pull_request'
         run: |
           node .github/scripts/analyze-pr.js \
             --base origin/${{ github.base_ref }} \
@@ -436,7 +440,7 @@ jobs:
             --output analysis.json
 
       - name: Write PR comment metadata
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && github.event_name == 'pull_request'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true' && github.event_name == 'pull_request'
         run: |
           # The pr-comment and deploy-preview workflows run on workflow_run
           # (privileged token), so they can comment on and deploy previews for
@@ -460,7 +464,7 @@ jobs:
           EOF
 
       - name: Upload analysis artifact
-        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && github.event_name == 'pull_request'
+        if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: pr-analysis
@@ -475,7 +479,7 @@ jobs:
   # preview builds entirely.
   build-sandbox:
     needs: [check-scope]
-    if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+    if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
     runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
@@ -675,7 +679,7 @@ jobs:
   # that can break it. Gated like `test` instead: everything but docsite-only.
   theme-layers:
     needs: [check-scope]
-    if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+    if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
     runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
@@ -700,7 +704,7 @@ jobs:
   # which custom properties paint the portaled surfaces.
   fixture-contrast:
     needs: [check-scope]
-    if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true'
+    if: needs.check-scope.outputs.docsite_only != 'true' && needs.check-scope.outputs.spec_only != 'true' && needs.check-scope.outputs.tooling_only != 'true'
     runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
           git fetch origin ${{ github.base_ref }} --depth=50
           MERGE_BASE=$(git merge-base HEAD origin/${{ github.base_ref }} 2>/dev/null || echo "")
           if [ -z "$MERGE_BASE" ]; then
-            printf 'docsite_only=false\nspec_only=false\n' >> "$GITHUB_OUTPUT"
+            printf 'docsite_only=false\nspec_only=false\ntooling_only=false\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
           CLASSIFIER_ROOT="$RUNNER_TEMP/change-scope"
@@ -42,12 +42,9 @@ jobs:
             git diff --name-status "$MERGE_BASE"...HEAD \
               | node "$CLASSIFIER" --github-output
           else
-            # Bootstrap fallback: before the trusted classifier exists on main,
-            # no PR can receive the spec-only fast path.
-            CHANGED=$(git diff --name-only "$MERGE_BASE"...HEAD)
-            NON_DOCSITE=$(printf '%s\n' "$CHANGED" | grep -v '^apps/docsite/' | head -1)
-            printf 'docsite_only=%s\nspec_only=false\n' \
-              "$( [ -z "$NON_DOCSITE" ] && echo true || echo false )" \
+            # Missing trusted policy or dependencies cannot grant a specialized
+            # lane. Run full lint until the base branch supplies the classifier.
+            printf 'docsite_only=false\nspec_only=false\ntooling_only=false\n' \
               >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -53,6 +53,7 @@ jobs:
       run_attempt: ${{ steps.identity.outputs.run_attempt }}
       source_conclusion: ${{ steps.identity.outputs.source_conclusion }}
       spec_only: ${{ steps.identity.outputs.spec_only }}
+      tooling_only: ${{ steps.identity.outputs.tooling_only }}
     steps:
       - name: Checkout trusted default-branch code
         uses: actions/checkout@v7
@@ -103,13 +104,15 @@ jobs:
             core.setOutput('run_attempt', String(identity.sourceRunAttempt));
             core.setOutput('source_conclusion', identity.sourceConclusion);
             core.setOutput('spec_only', String(changeScope.specOnly));
+            core.setOutput('tooling_only', String(changeScope.toolingOnly));
 
   invalidate:
     needs: resolve
     if: >-
       (github.event.action == 'requested' || github.event.action == 'in_progress') &&
       needs.resolve.outputs.valid == 'true' &&
-      needs.resolve.outputs.spec_only != 'true'
+      needs.resolve.outputs.spec_only != 'true' &&
+      needs.resolve.outputs.tooling_only != 'true'
     runs-on: ubuntu-slim
     permissions:
       pull-requests: write
@@ -145,7 +148,8 @@ jobs:
     if: >-
       github.event.action == 'completed' &&
       needs.resolve.outputs.valid == 'true' &&
-      needs.resolve.outputs.spec_only == 'true'
+      (needs.resolve.outputs.spec_only == 'true' ||
+      needs.resolve.outputs.tooling_only == 'true')
     runs-on: ubuntu-slim
     permissions:
       statuses: write
@@ -161,7 +165,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: process.env.HEAD_SHA,
               context: 'visual-acceptance', state: 'success',
-              description: 'Spec-only change — no visual scope.',
+              description: 'Classified change — no visual scope.',
             });
 
   spec-only-reconcile:
@@ -169,7 +173,8 @@ jobs:
     if: >-
       github.event.action == 'completed' &&
       needs.resolve.outputs.valid == 'true' &&
-      needs.resolve.outputs.spec_only == 'true'
+      (needs.resolve.outputs.spec_only == 'true' ||
+      needs.resolve.outputs.tooling_only == 'true')
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -219,7 +224,7 @@ jobs:
               },
               createIfMissing: false,
               fallbackMessage:
-                'The current change only updates durable specifications. Preview links are not shown.',
+                'The current change has no preview-producing surface. Preview links are not shown.',
             });
 
   deploy-preview:
@@ -227,7 +232,8 @@ jobs:
     if: >-
       github.event.action == 'completed' &&
       needs.resolve.outputs.valid == 'true' &&
-      needs.resolve.outputs.spec_only != 'true'
+      needs.resolve.outputs.spec_only != 'true' &&
+      needs.resolve.outputs.tooling_only != 'true'
     permissions:
       actions: read
       contents: write
@@ -253,7 +259,8 @@ jobs:
       always() &&
       github.event.action == 'completed' &&
       needs.resolve.outputs.valid == 'true' &&
-      needs.resolve.outputs.spec_only != 'true'
+      needs.resolve.outputs.spec_only != 'true' &&
+      needs.resolve.outputs.tooling_only != 'true'
     runs-on: 2-core-ubuntu-arm
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Why

A score-ledger-only change currently waits for the full UI suite, Storybook and Sandbox builds, browser guards, and unrelated docsite generation. Those checks do not own this operational Node surface.

Builds on the positive surface/check-ownership contract landed in [#6112](https://github.com/facebook/astryx/pull/6112).

## What

- classify every changed path into a positive surface set, including package-specific runtime, theme/build, Storybook/visual, and shared/unknown surfaces
- derive every specialized lane only from exact surface-set equality using the trusted base-branch classifier
- admit only `scripts/score-ledger.mjs` and its test as the first Node-tooling group
- run Node Vitest plus the existing required lint/guardrail workflow
- keep `test`, `build`, `docsite-test`, and `lint` reporting under their historical names while skipping unrelated UI, browser, Storybook, Sandbox, theme, visual, a11y, and RTL work
- bypass preview publication for tooling while explicitly settling visual status and removing stale preview links
- fail closed for missing classifier dependencies, incomplete input, renames from unknown paths, mixed scope, workflow/classifier changes, shared infrastructure, and package runtime paths
- pin the exact trusted-classifier invocation and the full serialized shape consumed by the Sandbox score-ledger projection

## Risk

The allowlist is intentionally two files. Every other unsupported or mixed path still takes broad CI. This PR changes its own workflow/classifier, so trusted-base classification makes this PR run broad CI; the new lane becomes active only after landing.

## Validation

- 126 focused routing, workflow, and consumer-contract tests passed
- repository pre-commit guardrails passed on every commit
- exact-head CI runs broad by design because this PR changes the classifier/workflows
- independent review challenged and verified the positive-set authority, trusted invocation, and Sandbox projection boundary
