### PR TITLE
ci: verify tooling-only routing (temporary)

### DIFF
--- a/scripts/score-ledger.test.mjs
+++ b/scripts/score-ledger.test.mjs
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+// Temporary CI routing canary; this branch will be closed without landing.
+
 /**
  * @file score-ledger.test.mjs
  * Unit tests for the component score ledger — chiefly the ratchet, whose whole


### PR DESCRIPTION
## Temporary CI canary

This draft changes only the admitted score-ledger test path to verify the tooling-only lane that landed in #6113.

Expected matrix:
- run: Node tests, lint/repository guardrails, and the historical `test`, `build`, `docsite-test`, and `lint` contexts
- skip: UI tests, component analysis, Storybook/Sandbox builds, browser/theme/visual/a11y/RTL jobs, and preview publication
- settle: `visual-acceptance` succeeds explicitly without waiting for preview deployment

This PR will be closed without landing after the live workflow evidence is captured.
