### PR TITLE
docs: make Astryx CLI bootstrap shell-portable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,24 +181,24 @@ Documentation lives in two places:
 <!-- ASTRYX-CLI:START -->
 
 Astryx CLI|Run from repo root. Load agent docs before any component work.
-ASTRYX="node packages/cli/clients/cli/bin/astryx.mjs"
+astryx() { node packages/cli/clients/cli/bin/astryx.mjs "$@"; }
 BOOTSTRAP (run every branch, <500ms):
-$ASTRYX help # discover all commands and options
-$ASTRYX docs # list available doc topics
-$ASTRYX docs principles --dense # design rules, anti-patterns, xstyle, tokens
-$ASTRYX docs tokens --dense # spacing, color, radius, typography, shadow
-$ASTRYX docs theme --dense # theme provider, light/dark, overrides
-$ASTRYX component --list # all components grouped by category
-$ASTRYX template --list # available page templates
+astryx help # discover all commands and options
+astryx docs # list available doc topics
+astryx docs principles --dense # design rules, anti-patterns, xstyle, tokens
+astryx docs tokens --dense # spacing, color, radius, typography, shadow
+astryx docs theme --dense # theme provider, light/dark, overrides
+astryx component --list # all components grouped by category
+astryx template --list # available page templates
 ON DEMAND:
-$ASTRYX component <Name> --dense # props, variants, usage, anatomy for one component
-$ASTRYX template <name> # emit full page source
-$ASTRYX template <name> --skeleton # layout skeleton with spatial annotations
-$ASTRYX swizzle <Name> # eject component source for deep customization
-$ASTRYX upgrade --apply # run version migration codemods
+astryx component <Name> --dense # props, variants, usage, anatomy for one component
+astryx template <name> # emit full page source
+astryx template <name> --skeleton # layout skeleton with spatial annotations
+astryx swizzle <Name> # eject component source for deep customization
+astryx upgrade --apply # run version migration codemods
 OPTIONS: --detail compact|brief less output | --dense token-efficient | --zh Chinese
 RULE: always run bootstrap on each branch — docs reflect the branch's actual API
-RULE: always run $ASTRYX component <Name> --dense before modifying a component
-RULE: after @astryxdesign/core bump, always run $ASTRYX upgrade --apply
+RULE: always run astryx component <Name> --dense before modifying a component
+RULE: after @astryxdesign/core bump, always run astryx upgrade --apply
 
 <!-- ASTRYX-CLI:END -->


### PR DESCRIPTION
## Summary

- replace the scalar `ASTRYX="node …"` command variable with a portable shell function
- update every documented bootstrap/on-demand invocation to call that function

## Why

zsh does not split a scalar variable into command plus arguments, so `$ASTRYX help` attempted to execute a literal file named `node packages/cli/clients/cli/bin/astryx.mjs`. Night Watch hit this during its first test audit.

## Validation

Executed the documented function and both `help` and `component AvatarGroupOverflow --dense` successfully under zsh and Bash.

One file only; no CLI behavior changes.