### PR TITLE
fix: preserve Resizable bound migration semantics

### DIFF
--- a/.changeset/fix-resizable-bound-migrations.md
+++ b/.changeset/fix-resizable-bound-migrations.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] Prevented removed Resizable bounds from being silently ignored and kept ambiguous spread migrations behavior-preserving (#6124)
+@cixzhang

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -164,6 +164,16 @@ const regions = resize({regions: {
     expect(output).not.toContain('maxSizePx: 900');
   });
 
+  it('leaves spread-bearing bounds for manual migration', async () => {
+    const input = `import {useResizable} from '@astryxdesign/core/Resizable';
+const legacy = {minSizePx: 160};
+const region = useResizable({minSizePx: 80, ...legacy});`;
+    const output = await apply('rename-resizable-pixel-bounds', input);
+    expect(output).toContain('minSizePx: 80');
+    expect(output).not.toContain('minSize: 80');
+    expect(output).toContain('TODO(astryx upgrade)');
+  });
+
   it('leaves unrelated and dynamic configuration objects alone', async () => {
     const input = `import {useResizable} from '@astryxdesign/core/Resizable';
 const config = {minSizePx: 120};

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -174,6 +174,35 @@ const region = useResizable({minSizePx: 80, ...legacy});`;
     expect(output).toContain('TODO(astryx upgrade)');
   });
 
+  it.each([
+    [
+      'before the alias',
+      `import {useResizable} from '@astryxdesign/core/Resizable';
+const key = 'minSize';
+const region = useResizable({[key]: 160, minSizePx: 80});`,
+    ],
+    [
+      'after the alias',
+      `import {useResizable} from '@astryxdesign/core/Resizable';
+const key = 'minSize';
+const region = useResizable({minSizePx: 80, [key]: 160});`,
+    ],
+    [
+      'inside a region',
+      `import {useResizable} from '@astryxdesign/core/Resizable';
+const key = 'minSize';
+const regions = useResizable({regions: {nav: {[key]: 160, minSizePx: 80}}});`,
+    ],
+  ])(
+    'leaves a computed property %s for manual migration',
+    async (_label, input) => {
+      const output = await apply('rename-resizable-pixel-bounds', input);
+      expect(output).toContain('minSizePx: 80');
+      expect(output).not.toContain('minSize: 80');
+      expect(output).toContain('TODO(astryx upgrade)');
+    },
+  );
+
   it('leaves unrelated and dynamic configuration objects alone', async () => {
     const input = `import {useResizable} from '@astryxdesign/core/Resizable';
 const config = {minSizePx: 120};

--- a/packages/cli/assets/codemods/transforms/next/rename-resizable-pixel-bounds.mjs
+++ b/packages/cli/assets/codemods/transforms/next/rename-resizable-pixel-bounds.mjs
@@ -6,8 +6,8 @@
  * Numbers already mean pixels in minSize/maxSize. This rewrites inline single-
  * and multi-region configurations while preserving shorthand values and the
  * released conflict rule (the unified property wins when both are present).
- * A spread can change property precedence invisibly, so spread-bearing objects
- * stay unchanged and receive a manual-migration TODO instead.
+ * A spread or computed property can change precedence invisibly, so dynamic
+ * objects stay unchanged and receive a manual-migration TODO instead.
  */
 
 export const meta = {
@@ -15,7 +15,7 @@ export const meta = {
   description:
     'Renames deprecated `minSizePx`/`maxSizePx` properties to `minSize`/' +
     '`maxSize` in static inline useResizable configurations and marks ' +
-    'spread-bearing configurations for manual migration.',
+    'objects with spreads or computed properties for manual migration.',
 };
 
 const IMPORT_SOURCES = new Set([
@@ -29,9 +29,9 @@ const RENAMES = new Map([
   ['maxSizePx', 'maxSize'],
 ]);
 const MANUAL_MIGRATION_COMMENT =
-  ' TODO(astryx upgrade): This useResizable configuration contains a spread. ' +
-  'Rename minSizePx/maxSizePx to minSize/maxSize manually without changing ' +
-  'property precedence. ';
+  ' TODO(astryx upgrade): This useResizable configuration contains a spread ' +
+  'or computed property. Rename minSizePx/maxSizePx to minSize/maxSize ' +
+  'manually without changing property precedence. ';
 
 /** @param {any} property */
 function staticPropertyName(property) {
@@ -66,12 +66,13 @@ function migrateObject(j, object) {
   const firstOldProperty = object.properties.find(
     (/** @type {any} */ property) => RENAMES.has(staticPropertyName(property)),
   );
-  const hasSpread = object.properties.some(
+  const hasDynamicProperty = object.properties.some(
     (/** @type {any} */ property) =>
+      property.computed === true ||
       property.type === 'SpreadElement' ||
       property.type === 'ExperimentalSpreadProperty',
   );
-  if (firstOldProperty && hasSpread) {
+  if (firstOldProperty && hasDynamicProperty) {
     firstOldProperty.comments ??= [];
     if (
       !firstOldProperty.comments.some(

--- a/packages/cli/assets/codemods/transforms/next/rename-resizable-pixel-bounds.mjs
+++ b/packages/cli/assets/codemods/transforms/next/rename-resizable-pixel-bounds.mjs
@@ -6,13 +6,16 @@
  * Numbers already mean pixels in minSize/maxSize. This rewrites inline single-
  * and multi-region configurations while preserving shorthand values and the
  * released conflict rule (the unified property wins when both are present).
+ * A spread can change property precedence invisibly, so spread-bearing objects
+ * stay unchanged and receive a manual-migration TODO instead.
  */
 
 export const meta = {
   title: 'Rename useResizable pixel bounds',
   description:
     'Renames deprecated `minSizePx`/`maxSizePx` properties to `minSize`/' +
-    '`maxSize` in inline useResizable configurations.',
+    '`maxSize` in static inline useResizable configurations and marks ' +
+    'spread-bearing configurations for manual migration.',
 };
 
 const IMPORT_SOURCES = new Set([
@@ -25,6 +28,10 @@ const RENAMES = new Map([
   ['minSizePx', 'minSize'],
   ['maxSizePx', 'maxSize'],
 ]);
+const MANUAL_MIGRATION_COMMENT =
+  ' TODO(astryx upgrade): This useResizable configuration contains a spread. ' +
+  'Rename minSizePx/maxSizePx to minSize/maxSize manually without changing ' +
+  'property precedence. ';
 
 /** @param {any} property */
 function staticPropertyName(property) {
@@ -56,6 +63,30 @@ function renameKey(j, property, nextName) {
  * @param {any} object
  */
 function migrateObject(j, object) {
+  const firstOldProperty = object.properties.find(
+    (/** @type {any} */ property) => RENAMES.has(staticPropertyName(property)),
+  );
+  const hasSpread = object.properties.some(
+    (/** @type {any} */ property) =>
+      property.type === 'SpreadElement' ||
+      property.type === 'ExperimentalSpreadProperty',
+  );
+  if (firstOldProperty && hasSpread) {
+    firstOldProperty.comments ??= [];
+    if (
+      !firstOldProperty.comments.some(
+        (/** @type {any} */ comment) =>
+          comment.value === MANUAL_MIGRATION_COMMENT,
+      )
+    ) {
+      firstOldProperty.comments.push(
+        j.commentBlock(MANUAL_MIGRATION_COMMENT, true, false),
+      );
+      return true;
+    }
+    return false;
+  }
+
   let changed = false;
   for (const [oldName, newName] of RENAMES) {
     const hasNew = object.properties.some(

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -1639,6 +1639,17 @@ describe('Resizable size source compatibility (AST-010 API3/API4)', () => {
       // @ts-expect-error maxSizePx was removed in 0.6; use maxSize
       maxSizePx: 500,
     };
+    function useRemovedDynamicBoundsCompileChecks() {
+      const dynamicRemovedMin = {defaultSize: 260, minSizePx: 100};
+      // @ts-expect-error removed aliases must not compile through a variable
+      useResizable(dynamicRemovedMin);
+      const dynamicRemovedMax = {
+        regions: {sidebar: {defaultSize: 260, maxSizePx: 500}},
+      };
+      // @ts-expect-error removed aliases must not compile in dynamic regions
+      useResizable(dynamicRemovedMax);
+    }
+    expect(useRemovedDynamicBoundsCompileChecks).toBeTypeOf('function');
     expect([rem, cssMath, removedMin, removedMax]).toHaveLength(4);
   });
 });

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -1648,6 +1648,11 @@ describe('Resizable size source compatibility (AST-010 API3/API4)', () => {
       };
       // @ts-expect-error removed aliases must not compile in dynamic regions
       useResizable(dynamicRemovedMax);
+      const unionWithRemovedMin = null as unknown as
+        | UseResizableSingleConfig
+        | (UseResizableSingleConfig & {minSizePx: number});
+      // @ts-expect-error every union member must exclude removed aliases
+      useResizable(unionWithRemovedMin);
     }
     expect(useRemovedDynamicBoundsCompileChecks).toBeTypeOf('function');
     expect([rem, cssMath, removedMin, removedMax]).toHaveLength(4);

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -4,7 +4,8 @@
 
 /**
  * @file useResizable.ts
- * @input Resize configuration (defaultSize, minSize, maxSize, snaps) and
+ * @input Resize configuration (defaultSize, minSize, maxSize, snaps), with
+ *   removed pixel-bound aliases rejected even through assembled objects, and
  *   collapse configuration (collapsible,
  *   defaultIsCollapsed, isCollapsed)
  * @output Hook return: size, isCollapsed, collapse/expand/resize methods, props for handle
@@ -1096,9 +1097,30 @@ function useMultiResizable(
 // Public API
 // =============================================================================
 
-export function useResizable(config: UseResizableSingleConfig): ResizableRegion;
-export function useResizable(
-  config: UseResizableMultiConfig,
+/** Removed keys must fail even when a variable bypasses excess-property checks. */
+type RejectRemovedPixelBounds<Config> =
+  Extract<keyof Config, 'minSizePx' | 'maxSizePx'> extends never
+    ? unknown
+    : {
+        [Key in Extract<keyof Config, 'minSizePx' | 'maxSizePx'>]: never;
+      };
+
+type SingleResizableArgument<Config> = 'regions' extends keyof Config
+  ? never
+  : Config & RejectRemovedPixelBounds<Config>;
+
+type MultiResizableArgument<Config extends UseResizableMultiConfig> = Config & {
+  regions: {
+    [Key in keyof Config['regions']]: Config['regions'][Key] &
+      RejectRemovedPixelBounds<Config['regions'][Key]>;
+  };
+};
+
+export function useResizable<const Config extends UseResizableSingleConfig>(
+  config: SingleResizableArgument<Config>,
+): ResizableRegion;
+export function useResizable<const Config extends UseResizableMultiConfig>(
+  config: MultiResizableArgument<Config>,
 ): Record<string, ResizableRegion>;
 export function useResizable(
   config: UseResizableSingleConfig | UseResizableMultiConfig,

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -1098,23 +1098,26 @@ function useMultiResizable(
 // =============================================================================
 
 /** Removed keys must fail even when a variable bypasses excess-property checks. */
-type RejectRemovedPixelBounds<Config> =
-  Extract<keyof Config, 'minSizePx' | 'maxSizePx'> extends never
-    ? unknown
-    : {
-        [Key in Extract<keyof Config, 'minSizePx' | 'maxSizePx'>]: never;
-      };
+type RejectRemovedPixelBounds<Config> = Config extends unknown
+  ? Config & {minSizePx?: never; maxSizePx?: never}
+  : never;
 
-type SingleResizableArgument<Config> = 'regions' extends keyof Config
-  ? never
-  : Config & RejectRemovedPixelBounds<Config>;
+type SingleResizableArgument<Config> = Config extends unknown
+  ? 'regions' extends keyof Config
+    ? never
+    : RejectRemovedPixelBounds<Config>
+  : never;
 
-type MultiResizableArgument<Config extends UseResizableMultiConfig> = Config & {
-  regions: {
-    [Key in keyof Config['regions']]: Config['regions'][Key] &
-      RejectRemovedPixelBounds<Config['regions'][Key]>;
-  };
-};
+type MultiResizableArgument<Config extends UseResizableMultiConfig> =
+  Config extends unknown
+    ? Config & {
+        regions: {
+          [Key in keyof Config['regions']]: RejectRemovedPixelBounds<
+            Config['regions'][Key]
+          >;
+        };
+      }
+    : never;
 
 export function useResizable<const Config extends UseResizableSingleConfig>(
   config: SingleResizableArgument<Config>,


### PR DESCRIPTION
## Why

The 0.6 Resizable cleanup could silently drop deprecated bounds passed through assembled objects, and its codemod could change property precedence when an inline configuration contained dynamic properties.

## What

- Reject removed pixel-bound aliases even when TypeScript excess-property checks or union types would otherwise allow them through variables.
- Leave inline configurations with spreads or computed properties unchanged and add a manual-migration TODO instead of applying a potentially behavior-changing rewrite.

## Risk

Low. Runtime behavior is unchanged; the correction makes unsupported TypeScript inputs fail loudly and makes ambiguous codemod cases explicit.

## Testing

- 157 focused Resizable, ResizeHandle, and next-codemod tests
- Core and strict CLI typechecks
- Core build
- Repository checks and focused lint

The non-required stable visual job cannot plan shots because Resizable has no seeded visual baseline; this PR changes no rendered output.