### PR TITLE
feat(theme): add shared component adaptation infrastructure

### DIFF
--- a/packages/core/src/AppShell/AppShell.test.tsx
+++ b/packages/core/src/AppShell/AppShell.test.tsx
@@ -437,6 +437,54 @@ describe('AppShell', () => {
     expect(window.matchMedia).toHaveBeenCalledWith('(width < 1280px)');
   });
 
+  it('resolves the point of the NEAREST Theme when providers nest', () => {
+    const outer = {
+      ...defineTheme({
+        name: 'app-shell-nested-outer',
+        adaptations: {widthBreakpoints: {md: 700}},
+      }),
+      __built: true as const,
+    };
+    const inner = {
+      ...defineTheme({
+        name: 'app-shell-nested-inner',
+        adaptations: {widthBreakpoints: {md: 900}},
+      }),
+      __built: true as const,
+    };
+
+    render(
+      <Theme theme={outer}>
+        <Theme theme={inner}>
+          <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'md'}}>
+            <div>Content</div>
+          </AppShell>
+        </Theme>
+      </Theme>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 900px)');
+    expect(window.matchMedia).not.toHaveBeenCalledWith('(width < 700px)');
+  });
+
+  it('uses the default points for a theme carrying no adaptation metadata', () => {
+    const legacy = {
+      name: 'app-shell-legacy-theme',
+      tokens: {},
+      __built: true as const,
+    } as unknown as ReturnType<typeof defineTheme>;
+
+    render(
+      <Theme theme={legacy}>
+        <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'lg'}}>
+          <div>Content</div>
+        </AppShell>
+      </Theme>,
+    );
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(width < 1024px)');
+  });
+
   it('does not enter mobile mode when mobileNav breakpoint is none', () => {
     render(
       <AppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'none'}}>

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -12,10 +12,15 @@ import React from 'react';
  *   Composes Layout internally to provide header, sideNav, and main content areas.
  *   Use for any app that needs a top nav, side navigation, and scrollable content.
  *
+ *   `mobileNav.breakpoint` names an AST-012 width point; the value comes from
+ *   the shared accessor in /packages/core/src/theme/effectiveBreakpoints.ts, so
+ *   AppShell and component adaptations agree on what `md` is.
+ *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/AppShell/AppShell.doc.mjs
  * - /packages/core/src/AppShell/index.ts
  * - /packages/core/src/AppShell/AppShell.test.tsx
+ * - /packages/core/src/theme/effectiveBreakpoints.ts (named width points)
  * - /apps/storybook/stories/AppShell.stories.tsx
  * - /packages/cli/assets/templates/blocks/components/AppShell/ (showcase blocks)
  */
@@ -56,11 +61,8 @@ import {useMediaQuery} from '../hooks/useMediaQuery';
 import {observeResize} from '../utils/sharedResizeObserver';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
-import {useThemeDefinition} from '../theme/useTheme';
-import {
-  DEFAULT_WIDTH_BREAKPOINTS,
-  type WidthBreakpointName,
-} from '../theme/themeAdaptations';
+import {useEffectiveWidthBreakpoints} from '../theme/effectiveBreakpoints';
+import type {WidthBreakpointName} from '../theme/themeAdaptations';
 import type {AppShellVariantMap} from './index';
 
 import {useMergedRefs} from '../hooks/useMergedRefs';
@@ -468,7 +470,9 @@ export function AppShell({
   ...rest
 }: AppShellProps) {
   const t = useTranslator();
-  const activeTheme = useThemeDefinition();
+  // Named width points resolve through the shared accessor (spec:AST-031 FR5),
+  // never by reading the theme's `__adaptations` storage here.
+  const widthBreakpoints = useEffectiveWidthBreakpoints();
   // =========================================================================
   // Parse mobileNav prop — normalize to config, custom element, or disabled
   // =========================================================================
@@ -504,14 +508,10 @@ export function AppShell({
   // =========================================================================
   // Mobile nav open state (controlled + uncontrolled)
   // =========================================================================
-  const activeWidthBreakpoints = activeTheme?.__adaptations?.widthBreakpoints;
   const breakpointQuery =
     sideNavBreakpoint === 'none'
       ? '(width < 0px)'
-      : `(width < ${
-          activeWidthBreakpoints?.[sideNavBreakpoint] ??
-          DEFAULT_WIDTH_BREAKPOINTS[sideNavBreakpoint]
-        }px)`;
+      : `(width < ${widthBreakpoints[sideNavBreakpoint]}px)`;
   const isBelowBreakpoint = useMediaQuery(
     breakpointQuery,
     sideNavBreakpoint === 'none' ? false : mobileNavConfig?.defaultIsMobile,

--- a/packages/core/src/theme/adaptationConditions.test.ts
+++ b/packages/core/src/theme/adaptationConditions.test.ts
@@ -1,0 +1,208 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file adaptationConditions.test.ts
+ * Tests the shared AST-012 condition grammar (spec:AST-031 IR1): one
+ * normalizer and one compiler serve theme CSS and component adaptations, with
+ * the caller's own diagnostic path and axis set.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {
+  COMPONENT_ADAPTATION_AXES,
+  DEFAULT_WIDTH_BREAKPOINTS,
+  THEME_ADAPTATION_AXES,
+  WIDTH_BREAKPOINT_NAMES,
+  compileAdaptationConditionQuery,
+  normalizeAdaptationCondition,
+  type ThemeAdaptationCondition,
+} from './adaptationConditions';
+import {defineTheme, generateAdaptationCSS} from './index';
+
+const POINTS = DEFAULT_WIDTH_BREAKPOINTS;
+
+function mediaPreludes(css: string): string[] {
+  return [...css.matchAll(/@media ([^{]+) \{/g)].map(match => match[1]);
+}
+
+describe('shared axis vocabulary', () => {
+  it('exposes the theme axes and the component subset', () => {
+    expect(THEME_ADAPTATION_AXES).toEqual([
+      'width',
+      'pointer',
+      'contrast',
+      'motion',
+    ]);
+    expect(COMPONENT_ADAPTATION_AXES).toEqual(['width', 'pointer']);
+    expect(WIDTH_BREAKPOINT_NAMES).toEqual(['sm', 'md', 'lg', 'xl', '2xl']);
+  });
+});
+
+describe('normalizeAdaptationCondition', () => {
+  it('keeps only defined fields and clones the input', () => {
+    const input = {width: {from: 'md' as const}, pointer: undefined};
+    const condition = normalizeAdaptationCondition(input, 'when');
+
+    expect(condition).toEqual({width: {from: 'md'}});
+    expect(condition.width).not.toBe(input.width);
+  });
+
+  it('names the caller path in every diagnostic', () => {
+    expect(() =>
+      normalizeAdaptationCondition(null, '<Selector adaptations>'),
+    ).toThrow('<Selector adaptations> must be an object.');
+    expect(() =>
+      normalizeAdaptationCondition({}, 'theme.rules[2].when'),
+    ).toThrow('theme.rules[2].when must contain at least one condition.');
+    expect(() =>
+      normalizeAdaptationCondition({width: {}}, 'theme.rules[2].when'),
+    ).toThrow(
+      'theme.rules[2].when.width must contain `from`, `below`, or both.',
+    );
+    expect(() =>
+      normalizeAdaptationCondition({width: {from: 'xs'}}, 'p.when'),
+    ).toThrow('p.when.width.from must be one of sm, md, lg, xl, 2xl.');
+  });
+
+  it('restricts the axis set to what the caller admits', () => {
+    const themeCondition = {contrast: 'more' as const};
+    expect(normalizeAdaptationCondition(themeCondition, 'theme.when')).toEqual(
+      themeCondition,
+    );
+
+    expect(() =>
+      normalizeAdaptationCondition(
+        themeCondition,
+        '<Selector adaptations>.rules[0].when',
+        COMPONENT_ADAPTATION_AXES,
+      ),
+    ).toThrow(
+      '<Selector adaptations>.rules[0].when.contrast is not supported.',
+    );
+    expect(() =>
+      normalizeAdaptationCondition(
+        {motion: 'reduce'},
+        'p.when',
+        COMPONENT_ADAPTATION_AXES,
+      ),
+    ).toThrow('p.when.motion is not supported.');
+  });
+
+  it('rejects unknown axes and malformed values for every caller', () => {
+    expect(() => normalizeAdaptationCondition({hover: true}, 'p.when')).toThrow(
+      'p.when.hover is not supported.',
+    );
+    expect(() =>
+      normalizeAdaptationCondition({pointer: 'any'}, 'p.when'),
+    ).toThrow("p.when.pointer must be 'coarse' or 'fine'.");
+    expect(() =>
+      normalizeAdaptationCondition({width: {size: 'md'}}, 'p.when'),
+    ).toThrow('p.when.width.size is not supported.');
+  });
+});
+
+describe('compileAdaptationConditionQuery', () => {
+  it('lowers inclusive from and exclusive below edges', () => {
+    expect(
+      compileAdaptationConditionQuery({width: {below: 'md'}}, POINTS, 'p'),
+    ).toBe('(width < 768px)');
+    expect(
+      compileAdaptationConditionQuery({width: {from: 'lg'}}, POINTS, 'p'),
+    ).toBe('(width >= 1024px)');
+    expect(
+      compileAdaptationConditionQuery(
+        {width: {from: 'lg', below: 'xl'}},
+        POINTS,
+        'p',
+      ),
+    ).toBe('(width >= 1024px) and (width < 1280px)');
+  });
+
+  it('ANDs axes in one stable order', () => {
+    const condition: ThemeAdaptationCondition = {
+      motion: 'reduce',
+      pointer: 'coarse',
+      width: {from: 'md', below: 'xl'},
+      contrast: 'more',
+    };
+
+    expect(compileAdaptationConditionQuery(condition, POINTS, 'p')).toBe(
+      '(width >= 768px) and (width < 1280px) and (pointer: coarse) and (prefers-contrast: more) and (prefers-reduced-motion: reduce)',
+    );
+  });
+
+  it('resolves named points against the supplied map', () => {
+    expect(
+      compileAdaptationConditionQuery(
+        {width: {below: 'md'}},
+        {
+          ...POINTS,
+          md: 900,
+        },
+        'p',
+      ),
+    ).toBe('(width < 900px)');
+  });
+
+  it('rejects a range that does not resolve to from < below', () => {
+    expect(() =>
+      compileAdaptationConditionQuery(
+        {width: {from: 'lg', below: 'md'}},
+        POINTS,
+        '<Selector adaptations>.rules[0].when',
+      ),
+    ).toThrow(
+      '<Selector adaptations>.rules[0].when.width must resolve to `from < below`; lg is 1024px and md is 768px.',
+    );
+  });
+
+  it('rejects an equal-edge range once a theme moves a point', () => {
+    expect(() =>
+      compileAdaptationConditionQuery(
+        {width: {from: 'md', below: 'lg'}},
+        {...POINTS, lg: 768},
+        'p.when',
+      ),
+    ).toThrow('p.when.width must resolve to `from < below`');
+  });
+
+  it('rejects a condition with no concrete part', () => {
+    expect(() => compileAdaptationConditionQuery({}, POINTS, 'p.when')).toThrow(
+      'p.when must contain at least one concrete condition.',
+    );
+  });
+});
+
+describe('theme and component queries cannot diverge', () => {
+  it('compiles the same string the theme CSS compiler emits', () => {
+    const theme = defineTheme({
+      name: 'shared-grammar-parity',
+      adaptations: {
+        widthBreakpoints: {md: 800},
+        rules: [
+          {
+            when: {width: {below: 'md'}, pointer: 'coarse'},
+            value: {tokens: {'--spacing-4': '12px'}},
+          },
+          {
+            when: {width: {from: 'md', below: 'xl'}},
+            value: {tokens: {'--spacing-4': '20px'}},
+          },
+        ],
+      },
+    });
+
+    const points = theme.__adaptations.widthBreakpoints;
+    const compiled = theme.__adaptations.rules.map(rule =>
+      compileAdaptationConditionQuery(rule.when, points, 'p.when'),
+    );
+
+    expect(compiled).toEqual([
+      '(width < 800px) and (pointer: coarse)',
+      '(width >= 800px) and (width < 1280px)',
+    ]);
+    expect(mediaPreludes(generateAdaptationCSS(theme).component)).toEqual(
+      compiled,
+    );
+  });
+});

--- a/packages/core/src/theme/adaptationConditions.ts
+++ b/packages/core/src/theme/adaptationConditions.ts
@@ -1,0 +1,344 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file adaptationConditions.ts
+ * @input Authored adaptation conditions and width-breakpoint maps
+ * @output Package-internal condition vocabulary, normalization, and media-query
+ *   compilation shared by every adaptation consumer
+ * @position Shared owner of AST-012 condition semantics (spec:AST-031 IR1);
+ *   consumed by themeAdaptations (CSS compiler) and componentAdaptations
+ *   (JavaScript resolver). Not re-exported from the package entry point.
+ *
+ * One module owns what a condition means so the theme and component grammars
+ * cannot drift. Callers supply their own diagnostic path — `defineTheme("x")
+ * .adaptations.rules[0].when` or `<Selector adaptations>.rules[0].when` — and
+ * their own allowed axis set, so a component may admit a closed subset of the
+ * theme vocabulary while sharing one normalizer and one compiler.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/theme/adaptationConditions.test.ts
+ * - /packages/core/src/theme/themeAdaptations.ts (theme rules and CSS output)
+ * - /packages/core/src/theme/componentAdaptations.ts (component policy values)
+ * - /packages/core/src/theme/useComponentAdaptations.ts (runtime resolver)
+ */
+
+// =============================================================================
+// Width vocabulary
+// =============================================================================
+
+/** Fixed names for viewport-width tier start points. */
+export const WIDTH_BREAKPOINT_NAMES = ['sm', 'md', 'lg', 'xl', '2xl'] as const;
+
+/** One fixed viewport-width breakpoint name. */
+export type WidthBreakpointName = (typeof WIDTH_BREAKPOINT_NAMES)[number];
+
+/** A complete, validated map of viewport-width tier start points in CSS px. */
+export type WidthBreakpoints = Record<WidthBreakpointName, number>;
+
+/** The default Astryx viewport-width tier start points in CSS px. */
+export const DEFAULT_WIDTH_BREAKPOINTS: Readonly<WidthBreakpoints> =
+  Object.freeze({
+    sm: 640,
+    md: 768,
+    lg: 1024,
+    xl: 1280,
+    '2xl': 1536,
+  });
+
+// =============================================================================
+// Condition vocabulary
+// =============================================================================
+
+/** Inclusive lower and exclusive upper edges for one width condition. */
+export interface ThemeAdaptationWidthCondition {
+  /** Match at and above this named point. */
+  from?: WidthBreakpointName;
+  /** Match strictly below this named point. */
+  below?: WidthBreakpointName;
+}
+
+/** Closed environmental condition vocabulary. Fields are ANDed. */
+export interface ThemeAdaptationCondition {
+  /** Viewport-width range, using named start points. */
+  width?: ThemeAdaptationWidthCondition;
+  /** Primary pointing-device precision. */
+  pointer?: 'coarse' | 'fine';
+  /** User contrast preference. */
+  contrast?: 'more' | 'less' | 'no-preference';
+  /** User reduced-motion preference. */
+  motion?: 'reduce' | 'no-preference';
+}
+
+/** One named environmental axis inside a condition. */
+export type AdaptationConditionAxis = keyof ThemeAdaptationCondition;
+
+const THEME_CONDITION_AXES = [
+  'width',
+  'pointer',
+  'contrast',
+  'motion',
+] as const satisfies ReadonlyArray<AdaptationConditionAxis>;
+type UnhandledConditionAxis = Exclude<
+  AdaptationConditionAxis,
+  (typeof THEME_CONDITION_AXES)[number]
+>;
+
+/**
+ * Every axis a theme rule may use. The conditional type keeps this exhaustive:
+ * adding a field to `ThemeAdaptationCondition` without listing it here fails to
+ * compile rather than silently becoming unsupported.
+ */
+export const THEME_ADAPTATION_AXES: UnhandledConditionAxis extends never
+  ? ReadonlyArray<AdaptationConditionAxis>
+  : never = THEME_CONDITION_AXES;
+
+/**
+ * The closed subset component adaptations admit (spec:AST-031 FR2/DEC-3).
+ * Contrast and motion stay CSS-owned; they never select a component tree.
+ */
+export const COMPONENT_ADAPTATION_AXES = [
+  'width',
+  'pointer',
+] as const satisfies ReadonlyArray<AdaptationConditionAxis>;
+
+// =============================================================================
+// Shared structural helpers
+// =============================================================================
+
+/** Whether a value is a plain object (not null, not an array). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Assert a plain object, naming the caller's diagnostic path. */
+export function assertRecord(
+  value: unknown,
+  path: string,
+): asserts value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object.`);
+  }
+}
+
+/** Reject any key outside the closed set, naming the offending path. */
+export function assertAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      throw new Error(`${path}.${key} is not supported.`);
+    }
+  }
+}
+
+/** Deep-clone plain data so normalized output never aliases caller input. */
+export function cloneData<T>(value: T): T {
+  if (Array.isArray(value)) {
+    const cloned: unknown[] = [];
+    for (const item of value) {
+      cloned.push(cloneData(item));
+    }
+    return cloned as T;
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, cloneData(nested)]),
+    ) as T;
+  }
+  return value;
+}
+
+// =============================================================================
+// Width-breakpoint map validation
+// =============================================================================
+
+const BREAKPOINT_NAMES = new Set<string>(WIDTH_BREAKPOINT_NAMES);
+const WIDTH_CONDITION_KEYS = new Set(['from', 'below']);
+
+/** Validate a partial override map of fixed width points. */
+export function normalizeBreakpointOverrides(
+  value: unknown,
+  path: string,
+): Partial<WidthBreakpoints> {
+  assertRecord(value, path);
+  assertAllowedKeys(value, BREAKPOINT_NAMES, path);
+  const result: Partial<WidthBreakpoints> = {};
+  for (const name of WIDTH_BREAKPOINT_NAMES) {
+    const point = value[name];
+    if (point === undefined) {
+      continue;
+    }
+    if (typeof point !== 'number' || !Number.isFinite(point) || point <= 0) {
+      throw new Error(
+        `${path}.${name} must be a finite positive number of CSS pixels.`,
+      );
+    }
+    result[name] = point;
+  }
+  return result;
+}
+
+/** Validate a map that must already name every fixed width point. */
+export function assertCompleteBreakpoints(
+  value: unknown,
+  path: string,
+): WidthBreakpoints {
+  const overrides = normalizeBreakpointOverrides(value, path);
+  for (const name of WIDTH_BREAKPOINT_NAMES) {
+    if (overrides[name] === undefined) {
+      throw new Error(
+        `${path}.${name} is missing from the effective breakpoint map.`,
+      );
+    }
+  }
+  return overrides as WidthBreakpoints;
+}
+
+/** Reject a width map whose named points are not strictly increasing. */
+export function assertIncreasingBreakpoints(
+  points: WidthBreakpoints,
+  path: string,
+): void {
+  let previous: WidthBreakpointName | undefined;
+  for (const name of WIDTH_BREAKPOINT_NAMES) {
+    if (previous !== undefined && points[name] <= points[previous]) {
+      throw new Error(
+        `${path} must be strictly increasing: ${name} (${points[name]}) is not above ${previous} (${points[previous]}).`,
+      );
+    }
+    previous = name;
+  }
+}
+
+// =============================================================================
+// Condition normalization
+// =============================================================================
+
+/**
+ * Validate one authored condition against a closed axis set.
+ *
+ * `axes` is the caller's admitted vocabulary: theme rules pass every axis,
+ * component adaptations pass width and pointer only, so an unsupported axis
+ * fails with the caller's own path rather than a shared generic message.
+ */
+export function normalizeAdaptationCondition(
+  value: unknown,
+  path: string,
+  axes: ReadonlyArray<AdaptationConditionAxis> = THEME_ADAPTATION_AXES,
+): ThemeAdaptationCondition {
+  assertRecord(value, path);
+  assertAllowedKeys(value, new Set<string>(axes), path);
+  const defined = Object.fromEntries(
+    Object.entries(value).filter(([, nested]) => nested !== undefined),
+  );
+  if (Object.keys(defined).length === 0) {
+    throw new Error(`${path} must contain at least one condition.`);
+  }
+
+  const condition = cloneData(defined) as ThemeAdaptationCondition;
+  if (condition.width !== undefined) {
+    assertRecord(condition.width, `${path}.width`);
+    assertAllowedKeys(condition.width, WIDTH_CONDITION_KEYS, `${path}.width`);
+    if (
+      condition.width.from === undefined &&
+      condition.width.below === undefined
+    ) {
+      throw new Error(
+        `${path}.width must contain \`from\`, \`below\`, or both.`,
+      );
+    }
+    for (const edge of ['from', 'below'] as const) {
+      const name = condition.width[edge];
+      if (
+        name !== undefined &&
+        (typeof name !== 'string' || !BREAKPOINT_NAMES.has(name))
+      ) {
+        throw new Error(
+          `${path}.width.${edge} must be one of ${WIDTH_BREAKPOINT_NAMES.join(', ')}.`,
+        );
+      }
+    }
+  }
+
+  if (
+    condition.pointer !== undefined &&
+    condition.pointer !== 'coarse' &&
+    condition.pointer !== 'fine'
+  ) {
+    throw new Error(`${path}.pointer must be 'coarse' or 'fine'.`);
+  }
+  if (
+    condition.contrast !== undefined &&
+    condition.contrast !== 'more' &&
+    condition.contrast !== 'less' &&
+    condition.contrast !== 'no-preference'
+  ) {
+    throw new Error(
+      `${path}.contrast must be 'more', 'less', or 'no-preference'.`,
+    );
+  }
+  if (
+    condition.motion !== undefined &&
+    condition.motion !== 'reduce' &&
+    condition.motion !== 'no-preference'
+  ) {
+    throw new Error(`${path}.motion must be 'reduce' or 'no-preference'.`);
+  }
+
+  return condition;
+}
+
+// =============================================================================
+// Media-query compilation
+// =============================================================================
+
+/**
+ * Lower one normalized condition to a media-query prelude (no `@media`).
+ *
+ * The part order is stable — width edges, pointer, contrast, motion — and both
+ * the theme CSS compiler and the component resolver call this, so a component
+ * query and its theme equivalent are the same string for the same condition.
+ */
+export function compileAdaptationConditionQuery(
+  condition: ThemeAdaptationCondition,
+  points: WidthBreakpoints,
+  path: string,
+): string {
+  const parts: string[] = [];
+
+  if (condition.width) {
+    const from = condition.width.from;
+    const below = condition.width.below;
+    if (
+      from !== undefined &&
+      below !== undefined &&
+      points[from] >= points[below]
+    ) {
+      throw new Error(
+        `${path}.width must resolve to \`from < below\`; ${from} is ${points[from]}px and ${below} is ${points[below]}px.`,
+      );
+    }
+    if (from !== undefined) {
+      parts.push(`(width >= ${points[from]}px)`);
+    }
+    if (below !== undefined) {
+      parts.push(`(width < ${points[below]}px)`);
+    }
+  }
+  if (condition.pointer !== undefined) {
+    parts.push(`(pointer: ${condition.pointer})`);
+  }
+  if (condition.contrast !== undefined) {
+    parts.push(`(prefers-contrast: ${condition.contrast})`);
+  }
+  if (condition.motion !== undefined) {
+    parts.push(`(prefers-reduced-motion: ${condition.motion})`);
+  }
+
+  if (parts.length === 0) {
+    throw new Error(`${path} must contain at least one concrete condition.`);
+  }
+  return parts.join(' and ');
+}

--- a/packages/core/src/theme/componentAdaptations.test.ts
+++ b/packages/core/src/theme/componentAdaptations.test.ts
@@ -1,0 +1,318 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file componentAdaptations.test.ts
+ * Tests the public component-adaptation value shape (spec:AST-031 FR1/FR2) and
+ * the package-internal compiler's path-specific diagnostics (IR3).
+ */
+
+import {describe, expect, it} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {DEFAULT_WIDTH_BREAKPOINTS} from './adaptationConditions';
+import * as themeBarrel from './index';
+import {
+  compileComponentAdaptations,
+  type ComponentAdaptationCondition,
+  type ComponentAdaptationRule,
+  type ComponentAdaptations,
+  type CompiledComponentAdaptations,
+} from './componentAdaptations';
+import type {ThemeAdaptationCondition} from './themeAdaptations';
+
+type Presentation = 'popover' | 'bottom-sheet';
+const PRESENTATIONS = ['popover', 'bottom-sheet'] as const;
+const POINTS = DEFAULT_WIDTH_BREAKPOINTS;
+const PATH = '<Selector adaptations>';
+
+function compile(
+  adaptations: unknown,
+  admitted?: ReadonlyArray<Presentation>,
+): CompiledComponentAdaptations<Presentation> {
+  return compileComponentAdaptations(
+    adaptations as ComponentAdaptations<Presentation>,
+    POINTS,
+    PATH,
+    admitted,
+  );
+}
+
+describe('public value shape', () => {
+  it('accepts a default plus ordered rules', () => {
+    const adaptations: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      rules: [
+        {
+          when: {width: {below: 'md'}, pointer: 'coarse'},
+          value: 'bottom-sheet',
+        },
+      ],
+    };
+
+    expect(adaptations.default).toBe('popover');
+    expect(adaptations.rules).toHaveLength(1);
+  });
+
+  it('shares the theme condition grammar, narrowed to width and pointer', () => {
+    const condition: ComponentAdaptationCondition = {
+      width: {from: 'md', below: 'lg'},
+      pointer: 'fine',
+    };
+    // The component condition is assignable to the theme condition it is
+    // Pick'd from — the two grammars are one type, not two copies.
+    const themeCondition: ThemeAdaptationCondition = condition;
+    expect(themeCondition).toEqual(condition);
+
+    const invalid: ComponentAdaptationCondition = {
+      // @ts-expect-error contrast is theme-owned; it never selects a tree
+      contrast: 'more',
+    };
+    expect(invalid).toBeDefined();
+  });
+
+  it('requires a default and a rules array', () => {
+    // @ts-expect-error `default` is the server-rendered value and is required
+    const noDefault: ComponentAdaptations<Presentation> = {
+      rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+    };
+    // @ts-expect-error `rules` is required; pass [] rather than omitting it
+    const noRules: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+    };
+    const badValue: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      // @ts-expect-error rule values stay inside the component's value domain
+      rules: [{when: {pointer: 'coarse'}, value: 'modal'}],
+    };
+
+    expect([noDefault, noRules, badValue]).toHaveLength(3);
+  });
+
+  it('accepts an empty rules array', () => {
+    // A computed rule list that matched nothing is well-formed policy, not a
+    // type error at the call site.
+    const empty: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      rules: [],
+    };
+    const candidates: ReadonlyArray<ComponentAdaptationRule<Presentation>> = [
+      {when: {pointer: 'coarse'}, value: 'bottom-sheet'},
+    ];
+    const filtered: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      rules: candidates.filter(() => false),
+    };
+
+    expect(empty.rules).toEqual([]);
+    expect(filtered.rules).toEqual([]);
+  });
+
+  it('is readonly in place', () => {
+    const rule: ComponentAdaptationRule<Presentation> = {
+      when: {pointer: 'coarse'},
+      value: 'bottom-sheet',
+    };
+    const adaptations: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      rules: [rule],
+    };
+
+    // @ts-expect-error the policy is caller-owned data, not resolver state
+    adaptations.default = 'bottom-sheet';
+    // @ts-expect-error rules are read as authored
+    adaptations.rules[0] = rule;
+    expect(adaptations.rules[0].value).toBe('bottom-sheet');
+  });
+});
+
+describe('package-internal surface', () => {
+  it('is not reachable from the theme entry point while AST-031 is a draft', () => {
+    // Types are erased, so the runtime check is the negative one: nothing that
+    // resolves an adaptation is exported (spec:AST-031 IR1/IR2).
+    for (const internal of [
+      'compileComponentAdaptations',
+      'useComponentAdaptations',
+      'normalizeAdaptationCondition',
+      'compileAdaptationConditionQuery',
+      'getEffectiveWidthBreakpoints',
+      'useEffectiveWidthBreakpoints',
+      'COMPONENT_ADAPTATION_AXES',
+    ]) {
+      expect(themeBarrel).not.toHaveProperty(internal);
+    }
+
+    // The value TYPES are erased at runtime, so the guard on them is the
+    // barrel source: it must not re-export this module at all.
+    const barrelSource = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), 'index.ts'),
+      'utf8',
+    );
+    expect(barrelSource).not.toMatch(
+      /^\s*export .*from '\.\/componentAdaptations'/m,
+    );
+    expect(barrelSource).not.toContain('ComponentAdaptations,');
+
+    // The width vocabulary the types refer to is public, and unmoved.
+    expect(themeBarrel).toHaveProperty('WIDTH_BREAKPOINT_NAMES');
+    expect(themeBarrel.DEFAULT_WIDTH_BREAKPOINTS).toBe(
+      DEFAULT_WIDTH_BREAKPOINTS,
+    );
+  });
+});
+
+describe('compileComponentAdaptations', () => {
+  it('lowers every rule in author order', () => {
+    const compiled = compile(
+      {
+        default: 'popover',
+        rules: [
+          {when: {width: {below: 'md'}}, value: 'bottom-sheet'},
+          {when: {pointer: 'fine'}, value: 'popover'},
+        ],
+      },
+      PRESENTATIONS,
+    );
+
+    expect(compiled).toEqual({
+      default: 'popover',
+      queries: ['(width < 768px)', '(pointer: fine)'],
+      values: ['bottom-sheet', 'popover'],
+    });
+  });
+
+  it('resolves named points against the supplied theme map', () => {
+    const compiled = compileComponentAdaptations<Presentation>(
+      {
+        default: 'popover',
+        rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+      },
+      {...POINTS, md: 900},
+      PATH,
+    );
+
+    expect(compiled.queries).toEqual(['(width < 900px)']);
+  });
+
+  it('compiles an empty policy to no queries', () => {
+    const compiled = compile({default: 'popover', rules: []}, PRESENTATIONS);
+
+    expect(compiled).toEqual({
+      default: 'popover',
+      queries: [],
+      values: [],
+    });
+  });
+
+  it.each([
+    [null, `${PATH} must be an object.`],
+    [
+      {rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]},
+      `${PATH}.default is required; it is the server-rendered and no-match value.`,
+    ],
+    [{default: 'popover'}, `${PATH}.rules is required; pass [] for no rules.`],
+    [
+      {default: 'popover', rules: {}},
+      `${PATH}.rules must be an array of {when, value} objects.`,
+    ],
+    [
+      {default: 'popover', rules: [{pointer: 'coarse'}]},
+      `${PATH}.rules[0].pointer is not supported.`,
+    ],
+    [
+      {default: 'popover', rules: [{when: {pointer: 'coarse'}}]},
+      `${PATH}.rules[0].value is required.`,
+    ],
+    [
+      {default: 'popover', rules: [{value: 'bottom-sheet'}]},
+      `${PATH}.rules[0].when is required.`,
+    ],
+    [
+      {default: 'popover', rules: [{when: {}, value: 'bottom-sheet'}]},
+      `${PATH}.rules[0].when must contain at least one condition.`,
+    ],
+    [
+      {
+        default: 'popover',
+        presentation: 'popover',
+        rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+      },
+      `${PATH}.presentation is not supported.`,
+    ],
+  ])('rejects an invalid policy %#', (adaptations, message) => {
+    expect(() => compile(adaptations)).toThrow(message);
+  });
+
+  it('rejects unsupported condition axes with the rule path', () => {
+    expect(() =>
+      compile({
+        default: 'popover',
+        rules: [
+          {when: {pointer: 'coarse'}, value: 'bottom-sheet'},
+          {when: {contrast: 'more'}, value: 'bottom-sheet'},
+        ],
+      }),
+    ).toThrow(`${PATH}.rules[1].when.contrast is not supported.`);
+
+    expect(() =>
+      compile({
+        default: 'popover',
+        rules: [{when: {motion: 'reduce'}, value: 'bottom-sheet'}],
+      }),
+    ).toThrow(`${PATH}.rules[0].when.motion is not supported.`);
+  });
+
+  it('rejects unknown breakpoint names and reversed ranges', () => {
+    expect(() =>
+      compile({
+        default: 'popover',
+        rules: [{when: {width: {below: 'xs'}}, value: 'bottom-sheet'}],
+      }),
+    ).toThrow(
+      `${PATH}.rules[0].when.width.below must be one of sm, md, lg, xl, 2xl.`,
+    );
+
+    expect(() =>
+      compile({
+        default: 'popover',
+        rules: [
+          {when: {width: {from: 'xl', below: 'sm'}}, value: 'bottom-sheet'},
+        ],
+      }),
+    ).toThrow(`${PATH}.rules[0].when.width must resolve to \`from < below\``);
+  });
+
+  it('rejects values outside the component domain when one is given', () => {
+    expect(() =>
+      compile(
+        {
+          default: 'popover',
+          rules: [{when: {pointer: 'coarse'}, value: 'modal'}],
+        },
+        PRESENTATIONS,
+      ),
+    ).toThrow(
+      `${PATH}.rules[0].value must be one of popover, bottom-sheet; received "modal".`,
+    );
+
+    expect(() => compile({default: 'modal', rules: []}, PRESENTATIONS)).toThrow(
+      `${PATH}.default must be one of popover, bottom-sheet; received "modal".`,
+    );
+
+    expect(() =>
+      compile({
+        default: 42,
+        rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+      }),
+    ).toThrow(`${PATH}.default must be a non-empty string value.`);
+  });
+
+  it('accepts any string value when the caller admits no closed domain', () => {
+    const compiled = compile({
+      default: 'anything',
+      rules: [{when: {pointer: 'coarse'}, value: 'else'}],
+    });
+
+    expect(compiled.values).toEqual(['else']);
+  });
+});

--- a/packages/core/src/theme/componentAdaptations.ts
+++ b/packages/core/src/theme/componentAdaptations.ts
@@ -1,0 +1,207 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file componentAdaptations.ts
+ * @input One component's authored adaptation policy and the effective width map
+ * @output Package-internal component-adaptation types plus validation and
+ *   media-query compilation for the JavaScript resolver
+ * @position spec:AST-031 FR1/FR2/IR1/IR3. Package-internal in every direction:
+ *   AST-031 is a draft, so neither these types nor the compiler are exported
+ *   from the package entry point. The component PR that admits a public
+ *   `adaptations` prop is what makes the value shape public.
+ *
+ * A component adaptation is ONE closed policy value, not a bag of conditional
+ * props: `default` is the server-rendered, hydration, and no-match value, and
+ * ordered `rules` map environmental conditions to the same value domain. Rule
+ * order is precedence — the LAST matching rule wins — and condition shape
+ * creates no specificity score. An empty rule list is well-formed and resolves
+ * to `default` everywhere.
+ *
+ * Conditions reuse AST-012's grammar through ./adaptationConditions.ts, closed
+ * to `width` and `pointer`. Contrast and motion stay CSS-owned: they must not
+ * silently become structural switches.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/theme/adaptationConditions.ts (shared condition grammar)
+ * - /packages/core/src/theme/useComponentAdaptations.ts (runtime resolver)
+ * - /packages/core/src/theme/index.ts (kept free of these exports while
+ *   spec:AST-031 is a draft)
+ * - /packages/core/src/theme/componentAdaptations.test.ts
+ */
+
+import {
+  COMPONENT_ADAPTATION_AXES,
+  assertAllowedKeys,
+  assertRecord,
+  compileAdaptationConditionQuery,
+  normalizeAdaptationCondition,
+  type ThemeAdaptationCondition,
+  type WidthBreakpoints,
+} from './adaptationConditions';
+
+// =============================================================================
+// Authoring vocabulary (package-internal until a component prop admits it)
+// =============================================================================
+
+/**
+ * Environmental conditions a component adaptation rule may test.
+ *
+ * A closed subset of the theme condition grammar, so the two cannot drift:
+ * viewport width against the theme's named points, and primary-pointer
+ * precision. Fields are ANDed; `width.from` is inclusive and `width.below` is
+ * exclusive; raw media-query strings are never accepted.
+ */
+export type ComponentAdaptationCondition = Pick<
+  ThemeAdaptationCondition,
+  'width' | 'pointer'
+>;
+
+/**
+ * One ordered condition-to-value rule for a component policy.
+ *
+ * @typeParam T - The component's admitted policy values.
+ */
+export interface ComponentAdaptationRule<T extends string> {
+  /** Environmental fields that must all match. */
+  readonly when: ComponentAdaptationCondition;
+  /** Policy value published while the condition matches. */
+  readonly value: T;
+}
+
+/**
+ * A component's environment-conditioned policy.
+ *
+ * `default` is required: it is the server-rendered value, the hydration value,
+ * and the value used whenever no rule matches. `rules` is required too, and MAY
+ * be empty — an empty policy is well-formed and always resolves to `default`,
+ * which keeps a caller's computed rule list (a `.filter()` that matched
+ * nothing, a feature flag that dropped every rule) from becoming a type or
+ * runtime error at the call site.
+ *
+ * @typeParam T - The component's admitted policy values.
+ *
+ * @example
+ * ```
+ * <Selector
+ *   adaptations={{
+ *     default: 'popover',
+ *     rules: [
+ *       {when: {width: {below: 'md'}, pointer: 'coarse'}, value: 'bottom-sheet'},
+ *     ],
+ *   }}
+ * />
+ * ```
+ */
+export interface ComponentAdaptations<T extends string> {
+  /** Server-rendered, hydration, and no-match value. */
+  readonly default: T;
+  /** Ordered rules; the last matching rule wins. May be empty. */
+  readonly rules: ReadonlyArray<ComponentAdaptationRule<T>>;
+}
+
+// =============================================================================
+// Package-internal compilation
+// =============================================================================
+
+/**
+ * One policy compiled to parallel query and value lists.
+ * @internal
+ */
+export interface CompiledComponentAdaptations<T extends string> {
+  /** No-match value, carried through for the resolver. */
+  readonly default: T;
+  /** Compiled media queries, in authored rule order. */
+  readonly queries: ReadonlyArray<string>;
+  /** Rule values, in authored rule order. */
+  readonly values: ReadonlyArray<T>;
+}
+
+const ADAPTATIONS_KEYS = new Set(['default', 'rules']);
+const RULE_KEYS = new Set(['when', 'value']);
+
+function assertAdmittedValue<T extends string>(
+  value: unknown,
+  path: string,
+  admitted: ReadonlyArray<T> | undefined,
+): T {
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`${path} must be a non-empty string value.`);
+  }
+  if (admitted !== undefined && !admitted.includes(value as T)) {
+    throw new Error(
+      `${path} must be one of ${admitted.join(', ')}; received "${value}".`,
+    );
+  }
+  return value as T;
+}
+
+/**
+ * Validate one component policy and lower every rule to a media query.
+ *
+ * Diagnostics are path-specific (spec:AST-031 IR3): the caller passes the
+ * component and prop it is resolving — `<Selector adaptations>` — and every
+ * message names the offending rule inside it, so an invalid policy fails
+ * before a surface opens rather than at match time.
+ *
+ * @param adaptations - The authored policy, from an untrusted caller.
+ * @param points - The nearest Theme's effective width-breakpoint map.
+ * @param path - Diagnostic root, e.g. `<Selector adaptations>`.
+ * @param admittedValues - The component's closed value domain, when it has one.
+ * @internal
+ */
+export function compileComponentAdaptations<T extends string>(
+  adaptations: ComponentAdaptations<T>,
+  points: WidthBreakpoints,
+  path: string,
+  admittedValues?: ReadonlyArray<T>,
+): CompiledComponentAdaptations<T> {
+  assertRecord(adaptations, path);
+  assertAllowedKeys(adaptations, ADAPTATIONS_KEYS, path);
+
+  if (!Object.prototype.hasOwnProperty.call(adaptations, 'default')) {
+    throw new Error(
+      `${path}.default is required; it is the server-rendered and no-match value.`,
+    );
+  }
+  const defaultValue = assertAdmittedValue(
+    adaptations.default,
+    `${path}.default`,
+    admittedValues,
+  );
+
+  const rules: unknown = adaptations.rules;
+  if (!Object.prototype.hasOwnProperty.call(adaptations, 'rules')) {
+    throw new Error(`${path}.rules is required; pass [] for no rules.`);
+  }
+  if (!Array.isArray(rules)) {
+    throw new Error(`${path}.rules must be an array of {when, value} objects.`);
+  }
+
+  const queries: string[] = [];
+  const values: T[] = [];
+  rules.forEach((rule: unknown, index) => {
+    const rulePath = `${path}.rules[${index}]`;
+    assertRecord(rule, rulePath);
+    assertAllowedKeys(rule, RULE_KEYS, rulePath);
+    if (!Object.prototype.hasOwnProperty.call(rule, 'when')) {
+      throw new Error(`${rulePath}.when is required.`);
+    }
+    if (!Object.prototype.hasOwnProperty.call(rule, 'value')) {
+      throw new Error(`${rulePath}.value is required.`);
+    }
+
+    const condition = normalizeAdaptationCondition(
+      rule.when,
+      `${rulePath}.when`,
+      COMPONENT_ADAPTATION_AXES,
+    );
+    queries.push(
+      compileAdaptationConditionQuery(condition, points, `${rulePath}.when`),
+    );
+    values.push(
+      assertAdmittedValue(rule.value, `${rulePath}.value`, admittedValues),
+    );
+  });
+
+  return {default: defaultValue, queries, values};
+}

--- a/packages/core/src/theme/effectiveBreakpoints.test.tsx
+++ b/packages/core/src/theme/effectiveBreakpoints.test.tsx
@@ -1,0 +1,263 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file effectiveBreakpoints.test.tsx
+ * Tests the package-internal width-point accessor (spec:AST-031 FR5): one
+ * resolution order for every consumer, and no component reaching into
+ * `DefinedTheme.__adaptations` on its own.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {ReactNode} from 'react';
+import {renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {DEFAULT_WIDTH_BREAKPOINTS} from './adaptationConditions';
+import {
+  getEffectiveWidthBreakpoints,
+  useEffectiveWidthBreakpoints,
+} from './effectiveBreakpoints';
+import {Theme} from './Theme';
+import {defineTheme, type DefinedTheme} from './defineTheme';
+import {resetThemes} from './themeRegistry';
+
+function built(input: Parameters<typeof defineTheme>[0]): DefinedTheme {
+  return {...defineTheme(input), __built: true as const};
+}
+
+function themeWrapper(theme: DefinedTheme) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    return <Theme theme={theme}>{children}</Theme>;
+  };
+}
+
+beforeEach(() => {
+  resetThemes();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getEffectiveWidthBreakpoints', () => {
+  it('returns the AST-012 defaults without a theme', () => {
+    expect(getEffectiveWidthBreakpoints(undefined)).toBe(
+      DEFAULT_WIDTH_BREAKPOINTS,
+    );
+    expect(getEffectiveWidthBreakpoints(null)).toEqual({
+      sm: 640,
+      md: 768,
+      lg: 1024,
+      xl: 1280,
+      '2xl': 1536,
+    });
+  });
+
+  it("merges a theme's overrides over the defaults", () => {
+    const theme = built({
+      name: 'accessor-overrides',
+      adaptations: {widthBreakpoints: {md: 800, '2xl': 1800}},
+    });
+
+    expect(getEffectiveWidthBreakpoints(theme)).toEqual({
+      ...DEFAULT_WIDTH_BREAKPOINTS,
+      md: 800,
+      '2xl': 1800,
+    });
+  });
+
+  it('completes a partial map from a built theme, per name', () => {
+    const partial = {
+      ...defineTheme({name: 'accessor-partial'}),
+      __built: true as const,
+      __adaptations: {widthBreakpoints: {md: 700}, rules: []},
+    } as unknown as DefinedTheme;
+
+    expect(getEffectiveWidthBreakpoints(partial)).toEqual({
+      ...DEFAULT_WIDTH_BREAKPOINTS,
+      md: 700,
+    });
+  });
+
+  it('falls back per name when a stored point is explicitly undefined', () => {
+    // A spread-built or hand-assembled map can carry `{md: undefined}`, which
+    // an object spread would let overwrite the default with nothing.
+    const explicitUndefined = {
+      ...defineTheme({name: 'accessor-explicit-undefined'}),
+      __built: true as const,
+      __adaptations: {
+        widthBreakpoints: {
+          sm: 640,
+          md: undefined,
+          lg: 1100,
+          xl: undefined,
+          '2xl': 1536,
+        },
+        rules: [],
+      },
+    } as unknown as DefinedTheme;
+
+    expect(getEffectiveWidthBreakpoints(explicitUndefined)).toEqual({
+      ...DEFAULT_WIDTH_BREAKPOINTS,
+      lg: 1100,
+    });
+    // Every name answers a number — nothing resolves to undefined.
+    for (const point of Object.values(
+      getEffectiveWidthBreakpoints(explicitUndefined),
+    )) {
+      expect(typeof point).toBe('number');
+    }
+  });
+
+  it('answers every named point for a theme with no adaptations', () => {
+    const legacy = {name: 'accessor-legacy', tokens: {}} as DefinedTheme;
+
+    expect(getEffectiveWidthBreakpoints(legacy)).toBe(
+      DEFAULT_WIDTH_BREAKPOINTS,
+    );
+  });
+});
+
+describe('useEffectiveWidthBreakpoints', () => {
+  it('uses the defaults with no provider and no registered root theme', () => {
+    const {result} = renderHook(() => useEffectiveWidthBreakpoints());
+
+    expect(result.current).toEqual(DEFAULT_WIDTH_BREAKPOINTS);
+  });
+
+  it('reads the nearest Theme provider', () => {
+    const theme = built({
+      name: 'accessor-provider',
+      adaptations: {widthBreakpoints: {lg: 1200}},
+    });
+
+    const {result} = renderHook(() => useEffectiveWidthBreakpoints(), {
+      wrapper: themeWrapper(theme),
+    });
+
+    expect(result.current.lg).toBe(1200);
+    expect(result.current.md).toBe(768);
+  });
+
+  it('prefers the NEAREST theme when providers nest', () => {
+    const outer = built({
+      name: 'accessor-outer',
+      adaptations: {widthBreakpoints: {md: 700}},
+    });
+    const inner = built({
+      name: 'accessor-inner',
+      adaptations: {widthBreakpoints: {md: 900}},
+    });
+
+    const {result} = renderHook(() => useEffectiveWidthBreakpoints(), {
+      wrapper: ({children}: {children: ReactNode}) => (
+        <Theme theme={outer}>
+          <Theme theme={inner}>{children}</Theme>
+        </Theme>
+      ),
+    });
+
+    expect(result.current.md).toBe(900);
+  });
+
+  it('follows the registered root theme without provider context', () => {
+    defineTheme({
+      name: 'accessor-root',
+      adaptations: {widthBreakpoints: {md: 720}},
+    });
+    const original = document.documentElement.getAttribute.bind(
+      document.documentElement,
+    );
+    vi.spyOn(document.documentElement, 'getAttribute').mockImplementation(
+      name => (name === 'data-astryx-theme' ? 'accessor-root' : original(name)),
+    );
+
+    const {result} = renderHook(() => useEffectiveWidthBreakpoints());
+
+    expect(result.current.md).toBe(720);
+  });
+
+  it('is referentially stable while the theme is unchanged', () => {
+    const theme = built({
+      name: 'accessor-stable',
+      adaptations: {widthBreakpoints: {md: 800}},
+    });
+    const {result, rerender} = renderHook(
+      () => useEffectiveWidthBreakpoints(),
+      {wrapper: themeWrapper(theme)},
+    );
+    const first = result.current;
+
+    rerender();
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('resolves exactly what the non-hook helper resolves', () => {
+    // The production hook calls the helper, so the two cannot drift; this
+    // pins that they agree for a theme with overrides and for none at all.
+    const theme = built({
+      name: 'accessor-parity',
+      adaptations: {widthBreakpoints: {md: 800, xl: 1400}},
+    });
+
+    const withTheme = renderHook(() => useEffectiveWidthBreakpoints(), {
+      wrapper: themeWrapper(theme),
+    });
+    expect(withTheme.result.current).toEqual(
+      getEffectiveWidthBreakpoints(theme),
+    );
+
+    // Unmount first: a mounted root Theme syncs `<html data-astryx-theme>`,
+    // which the no-provider fallback would otherwise (correctly) follow.
+    withTheme.unmount();
+
+    const {result: bare} = renderHook(() => useEffectiveWidthBreakpoints());
+    expect(bare.current).toBe(getEffectiveWidthBreakpoints(undefined));
+  });
+});
+
+// =============================================================================
+// FR5 — components resolve width points through the accessor, never directly
+// =============================================================================
+
+describe('no direct __adaptations reads outside the theme system', () => {
+  const CORE_SRC = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+  );
+  const THEME_DIR = path.join(CORE_SRC, 'theme');
+
+  function sourceFiles(dir: string): string[] {
+    const found: string[] = [];
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (full === THEME_DIR || entry.name === 'node_modules') {
+          continue;
+        }
+        found.push(...sourceFiles(full));
+        continue;
+      }
+      if (!/\.tsx?$/.test(entry.name) || entry.name.includes('.test.')) {
+        continue;
+      }
+      found.push(full);
+    }
+    return found;
+  }
+
+  it('keeps the storage field private to the theme system', () => {
+    // Matches property ACCESS (`theme.__adaptations`, `theme?.__adaptations`,
+    // `theme['__adaptations']`), so prose that merely names the field — the
+    // reason a component must not touch it — is not itself a violation.
+    const access = /(?:\.|\[\s*['"`])__adaptations/;
+    const offenders = sourceFiles(CORE_SRC).filter(file =>
+      access.test(fs.readFileSync(file, 'utf8')),
+    );
+
+    expect(offenders.map(file => path.relative(CORE_SRC, file))).toEqual([]);
+  });
+});

--- a/packages/core/src/theme/effectiveBreakpoints.ts
+++ b/packages/core/src/theme/effectiveBreakpoints.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file effectiveBreakpoints.ts
+ * @input The nearest Theme (or the registered root theme) and its normalized
+ *   adaptation metadata
+ * @output Package-internal accessors for the effective width-breakpoint map
+ * @position spec:AST-031 FR5. The ONE place a component learns what `md` is.
+ *
+ * Components must not read `DefinedTheme.__adaptations` themselves: that field
+ * is normalized storage for theme extension, may be partial on a built theme,
+ * and is absent entirely without a theme. Reading it directly spreads the
+ * default-merge and the provider/root fallback across call sites. These
+ * accessors resolve all three cases once — nearest Theme context, then the
+ * registered root theme, then the AST-012 defaults.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/theme/adaptationConditions.ts (default width points)
+ * - /packages/core/src/theme/useComponentAdaptations.ts (resolver consumer)
+ * - /packages/core/src/AppShell/AppShell.tsx (mobileNav.breakpoint consumer)
+ * - /packages/core/src/theme/effectiveBreakpoints.test.tsx
+ */
+
+import {useMemo} from 'react';
+import {
+  DEFAULT_WIDTH_BREAKPOINTS,
+  type WidthBreakpoints,
+} from './adaptationConditions';
+import type {DefinedTheme} from './defineTheme';
+import {useThemeDefinition} from './useTheme';
+
+/**
+ * Complete the width map of one theme object.
+ *
+ * Every named point is resolved individually with `??`, so a stored map that is
+ * partial — a built theme, or one carrying an explicit `undefined` for a name —
+ * falls back per name instead of letting that name go missing. The literal is
+ * spelled out rather than spread: the `WidthBreakpoints` annotation then makes
+ * a newly added point a compile error here instead of a silent omission.
+ *
+ * @internal
+ */
+export function getEffectiveWidthBreakpoints(
+  theme: DefinedTheme | null | undefined,
+): Readonly<WidthBreakpoints> {
+  const overrides = theme?.__adaptations?.widthBreakpoints;
+  if (!overrides) {
+    return DEFAULT_WIDTH_BREAKPOINTS;
+  }
+
+  const resolved: WidthBreakpoints = {
+    sm: overrides.sm ?? DEFAULT_WIDTH_BREAKPOINTS.sm,
+    md: overrides.md ?? DEFAULT_WIDTH_BREAKPOINTS.md,
+    lg: overrides.lg ?? DEFAULT_WIDTH_BREAKPOINTS.lg,
+    xl: overrides.xl ?? DEFAULT_WIDTH_BREAKPOINTS.xl,
+    '2xl': overrides['2xl'] ?? DEFAULT_WIDTH_BREAKPOINTS['2xl'],
+  };
+  return resolved;
+}
+
+/**
+ * The effective width points of the nearest active Theme.
+ *
+ * Resolution order matches `architecture:theme-application`: the nearest Theme
+ * provider, then the registered root theme when there is no provider context,
+ * then the AST-012 defaults. The returned map is referentially stable while the
+ * active theme is unchanged, so callers may use it as a hook dependency.
+ *
+ * @internal
+ */
+export function useEffectiveWidthBreakpoints(): Readonly<WidthBreakpoints> {
+  const theme = useThemeDefinition();
+  // One merge implementation, exercised by the hook every render, so the
+  // non-hook helper cannot drift away from what components actually resolve.
+  return useMemo(() => getEffectiveWidthBreakpoints(theme), [theme]);
+}

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -63,6 +63,11 @@ export type {
   ThemeAdaptationTypographyConfig,
 } from './themeAdaptations';
 
+// Component adaptations (spec:AST-031) are deliberately NOT exported here. The
+// spec is still a draft, so the value types, the condition compiler, and the
+// resolver hook all stay package-internal until a component's public policy
+// prop is separately accepted; that component's PR adds the export it needs.
+
 export type {
   SyntaxTokenName,
   DomainTokenName,

--- a/packages/core/src/theme/themeAdaptations.ts
+++ b/packages/core/src/theme/themeAdaptations.ts
@@ -12,7 +12,12 @@
  * matching rule writes after the root theme and later matching writes win. Token
  * cycles are judged only after each reachable ordered cascade is complete.
  *
+ * Condition normalization, media-query compilation, and the width vocabulary
+ * live in ./adaptationConditions.ts so theme CSS and component adaptations
+ * (spec:AST-031) share one grammar; this module owns theme rule VALUES.
+ *
  * SYNC: When modified, update:
+ * - /packages/core/src/theme/adaptationConditions.ts (shared condition grammar)
  * - /packages/core/src/theme/defineTheme.ts (`DefineThemeInput.adaptations`)
  * - /packages/core/src/theme/generateThemeRules.ts (`generateAdaptationCSS`)
  * - /packages/core/src/AppShell/AppShell.tsx (named breakpoint consumption)
@@ -32,49 +37,38 @@ import {
   isReservedThemeLocalTokenName,
   resolveAdaptationLocalTokens,
 } from './localTokens';
+import {
+  DEFAULT_WIDTH_BREAKPOINTS,
+  WIDTH_BREAKPOINT_NAMES,
+  assertAllowedKeys,
+  assertCompleteBreakpoints,
+  assertIncreasingBreakpoints,
+  assertRecord,
+  cloneData,
+  compileAdaptationConditionQuery,
+  isRecord,
+  normalizeAdaptationCondition,
+  normalizeBreakpointOverrides,
+  type ThemeAdaptationCondition,
+  type WidthBreakpoints,
+} from './adaptationConditions';
 
 // =============================================================================
 // Public authoring vocabulary
 // =============================================================================
 
-/** Fixed names for viewport-width tier start points. */
-export const WIDTH_BREAKPOINT_NAMES = ['sm', 'md', 'lg', 'xl', '2xl'] as const;
-
-/** One fixed viewport-width breakpoint name. */
-export type WidthBreakpointName = (typeof WIDTH_BREAKPOINT_NAMES)[number];
-
-/** A complete, validated map of viewport-width tier start points in CSS px. */
-export type WidthBreakpoints = Record<WidthBreakpointName, number>;
-
-/** The default Astryx viewport-width tier start points in CSS px. */
-export const DEFAULT_WIDTH_BREAKPOINTS: Readonly<WidthBreakpoints> =
-  Object.freeze({
-    sm: 640,
-    md: 768,
-    lg: 1024,
-    xl: 1280,
-    '2xl': 1536,
-  });
-
-/** Inclusive lower and exclusive upper edges for one width condition. */
-export interface ThemeAdaptationWidthCondition {
-  /** Match at and above this named point. */
-  from?: WidthBreakpointName;
-  /** Match strictly below this named point. */
-  below?: WidthBreakpointName;
-}
-
-/** Closed environmental condition vocabulary. Fields are ANDed. */
-export interface ThemeAdaptationCondition {
-  /** Viewport-width range, using named start points. */
-  width?: ThemeAdaptationWidthCondition;
-  /** Primary pointing-device precision. */
-  pointer?: 'coarse' | 'fine';
-  /** User contrast preference. */
-  contrast?: 'more' | 'less' | 'no-preference';
-  /** User reduced-motion preference. */
-  motion?: 'reduce' | 'no-preference';
-}
+// The width vocabulary and condition grammar are shared with component
+// adaptations; they are re-exported here so theme consumers keep one import.
+export {
+  DEFAULT_WIDTH_BREAKPOINTS,
+  WIDTH_BREAKPOINT_NAMES,
+} from './adaptationConditions';
+export type {
+  ThemeAdaptationCondition,
+  ThemeAdaptationWidthCondition,
+  WidthBreakpointName,
+  WidthBreakpoints,
+} from './adaptationConditions';
 
 /** Typography overrides inside an adaptation rule. */
 export interface ThemeAdaptationTypographyConfig extends Omit<
@@ -157,64 +151,8 @@ export interface ResolvedThemeAdaptationRule {
 // Structural validation
 // =============================================================================
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function assertRecord(
-  value: unknown,
-  path: string,
-): asserts value is Record<string, unknown> {
-  if (!isRecord(value)) {
-    throw new Error(`${path} must be an object.`);
-  }
-}
-
-function assertAllowedKeys(
-  value: Record<string, unknown>,
-  allowed: ReadonlySet<string>,
-  path: string,
-): void {
-  for (const key of Object.keys(value)) {
-    if (!allowed.has(key)) {
-      throw new Error(`${path}.${key} is not supported.`);
-    }
-  }
-}
-
-function cloneData<T>(value: T): T {
-  if (Array.isArray(value)) {
-    const cloned: unknown[] = [];
-    for (const item of value) {
-      cloned.push(cloneData(item));
-    }
-    return cloned as T;
-  }
-  if (isRecord(value)) {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, nested]) => [key, cloneData(nested)]),
-    ) as T;
-  }
-  return value;
-}
-
-const BREAKPOINT_NAMES = new Set<string>(WIDTH_BREAKPOINT_NAMES);
 const ADAPTATION_KEYS = new Set(['widthBreakpoints', 'rules']);
 const RULE_KEYS = new Set(['when', 'value']);
-const CONDITION_AXES = [
-  'width',
-  'pointer',
-  'contrast',
-  'motion',
-] as const satisfies ReadonlyArray<keyof ThemeAdaptationCondition>;
-type UnhandledConditionAxis = Exclude<
-  keyof ThemeAdaptationCondition,
-  (typeof CONDITION_AXES)[number]
->;
-const CONDITION_KEYS: UnhandledConditionAxis extends never
-  ? ReadonlySet<keyof ThemeAdaptationCondition>
-  : never = new Set(CONDITION_AXES);
-const WIDTH_CONDITION_KEYS = new Set(['from', 'below']);
 const VALUE_KEYS = new Set([
   'typography',
   'color',
@@ -224,124 +162,6 @@ const VALUE_KEYS = new Set([
   'localTokens',
   'components',
 ]);
-
-function normalizeBreakpointOverrides(
-  value: unknown,
-  path: string,
-): Partial<WidthBreakpoints> {
-  assertRecord(value, path);
-  assertAllowedKeys(value, BREAKPOINT_NAMES, path);
-  const result: Partial<WidthBreakpoints> = {};
-  for (const name of WIDTH_BREAKPOINT_NAMES) {
-    const point = value[name];
-    if (point === undefined) {
-      continue;
-    }
-    if (typeof point !== 'number' || !Number.isFinite(point) || point <= 0) {
-      throw new Error(
-        `${path}.${name} must be a finite positive number of CSS pixels.`,
-      );
-    }
-    result[name] = point;
-  }
-  return result;
-}
-
-function assertCompleteBreakpoints(
-  value: unknown,
-  path: string,
-): WidthBreakpoints {
-  const overrides = normalizeBreakpointOverrides(value, path);
-  for (const name of WIDTH_BREAKPOINT_NAMES) {
-    if (overrides[name] === undefined) {
-      throw new Error(
-        `${path}.${name} is missing from the effective breakpoint map.`,
-      );
-    }
-  }
-  return overrides as WidthBreakpoints;
-}
-
-function assertIncreasingBreakpoints(
-  points: WidthBreakpoints,
-  path: string,
-): void {
-  let previous: WidthBreakpointName | undefined;
-  for (const name of WIDTH_BREAKPOINT_NAMES) {
-    if (previous !== undefined && points[name] <= points[previous]) {
-      throw new Error(
-        `${path} must be strictly increasing: ${name} (${points[name]}) is not above ${previous} (${points[previous]}).`,
-      );
-    }
-    previous = name;
-  }
-}
-
-function normalizeCondition(
-  value: unknown,
-  path: string,
-): ThemeAdaptationCondition {
-  assertRecord(value, path);
-  assertAllowedKeys(value, CONDITION_KEYS, path);
-  const defined = Object.fromEntries(
-    Object.entries(value).filter(([, nested]) => nested !== undefined),
-  );
-  if (Object.keys(defined).length === 0) {
-    throw new Error(`${path} must contain at least one condition.`);
-  }
-
-  const condition = cloneData(defined) as ThemeAdaptationCondition;
-  if (condition.width !== undefined) {
-    assertRecord(condition.width, `${path}.width`);
-    assertAllowedKeys(condition.width, WIDTH_CONDITION_KEYS, `${path}.width`);
-    if (
-      condition.width.from === undefined &&
-      condition.width.below === undefined
-    ) {
-      throw new Error(
-        `${path}.width must contain \`from\`, \`below\`, or both.`,
-      );
-    }
-    for (const edge of ['from', 'below'] as const) {
-      const name = condition.width[edge];
-      if (
-        name !== undefined &&
-        (typeof name !== 'string' || !BREAKPOINT_NAMES.has(name))
-      ) {
-        throw new Error(
-          `${path}.width.${edge} must be one of ${WIDTH_BREAKPOINT_NAMES.join(', ')}.`,
-        );
-      }
-    }
-  }
-
-  if (
-    condition.pointer !== undefined &&
-    condition.pointer !== 'coarse' &&
-    condition.pointer !== 'fine'
-  ) {
-    throw new Error(`${path}.pointer must be 'coarse' or 'fine'.`);
-  }
-  if (
-    condition.contrast !== undefined &&
-    condition.contrast !== 'more' &&
-    condition.contrast !== 'less' &&
-    condition.contrast !== 'no-preference'
-  ) {
-    throw new Error(
-      `${path}.contrast must be 'more', 'less', or 'no-preference'.`,
-    );
-  }
-  if (
-    condition.motion !== undefined &&
-    condition.motion !== 'reduce' &&
-    condition.motion !== 'no-preference'
-  ) {
-    throw new Error(`${path}.motion must be 'reduce' or 'no-preference'.`);
-  }
-
-  return condition;
-}
 
 function normalizeValue(value: unknown, path: string): ThemeAdaptationValue {
   assertRecord(value, path);
@@ -365,7 +185,7 @@ function normalizeRule(value: unknown, path: string): ThemeAdaptationRule {
     throw new Error(`${path}.value is required.`);
   }
   return {
-    when: normalizeCondition(value.when, `${path}.when`),
+    when: normalizeAdaptationCondition(value.when, `${path}.when`),
     value: normalizeValue(value.value, `${path}.value`),
   };
 }
@@ -608,42 +428,11 @@ function mediaQueryForCondition(
   condition: ThemeAdaptationCondition,
   points: WidthBreakpoints,
 ): string {
-  const path = `defineTheme("${themeName}").adaptations.rules[${ruleIndex}].when`;
-  const parts: string[] = [];
-
-  if (condition.width) {
-    const from = condition.width.from;
-    const below = condition.width.below;
-    if (
-      from !== undefined &&
-      below !== undefined &&
-      points[from] >= points[below]
-    ) {
-      throw new Error(
-        `${path}.width must resolve to \`from < below\`; ${from} is ${points[from]}px and ${below} is ${points[below]}px.`,
-      );
-    }
-    if (from !== undefined) {
-      parts.push(`(width >= ${points[from]}px)`);
-    }
-    if (below !== undefined) {
-      parts.push(`(width < ${points[below]}px)`);
-    }
-  }
-  if (condition.pointer !== undefined) {
-    parts.push(`(pointer: ${condition.pointer})`);
-  }
-  if (condition.contrast !== undefined) {
-    parts.push(`(prefers-contrast: ${condition.contrast})`);
-  }
-  if (condition.motion !== undefined) {
-    parts.push(`(prefers-reduced-motion: ${condition.motion})`);
-  }
-
-  if (parts.length === 0) {
-    throw new Error(`${path} must contain at least one concrete condition.`);
-  }
-  return parts.join(' and ');
+  return compileAdaptationConditionQuery(
+    condition,
+    points,
+    `defineTheme("${themeName}").adaptations.rules[${ruleIndex}].when`,
+  );
 }
 
 type PointerEnvironment =

--- a/packages/core/src/theme/useComponentAdaptations.test.tsx
+++ b/packages/core/src/theme/useComponentAdaptations.test.tsx
@@ -1,0 +1,1064 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useComponentAdaptations.test.tsx
+ * Tests the shared component-adaptation resolver (spec:AST-031 FR3/FR4/FR5 and
+ * IR2/IR3): server truth, last-matching-rule precedence, nearest-Theme width
+ * points, one shared subscription per compiled query set, and path-specific
+ * runtime validation.
+ */
+
+import {createElement, StrictMode, type ReactNode} from 'react';
+import {createRoot, hydrateRoot} from 'react-dom/client';
+import {renderToString} from 'react-dom/server';
+import {act, render, renderHook, screen, waitFor} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {Theme} from './Theme';
+import {defineTheme} from './defineTheme';
+import {resetThemes} from './themeRegistry';
+import {
+  getAdaptationStoreCount,
+  resetAdaptationStores,
+  useComponentAdaptations,
+} from './useComponentAdaptations';
+import type {ComponentAdaptations} from './componentAdaptations';
+
+type Presentation = 'popover' | 'bottom-sheet';
+const PRESENTATIONS = ['popover', 'bottom-sheet'] as const;
+const OPTIONS = {path: '<Selector adaptations>', values: PRESENTATIONS};
+
+// =============================================================================
+// Controllable matchMedia
+// =============================================================================
+
+interface FakeMediaQueryList {
+  media: string;
+  matches: boolean;
+  listeners: Set<() => void>;
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+}
+
+interface MediaEnvironment {
+  /** Every query passed to matchMedia, in call order. */
+  queries: string[];
+  /** One list per distinct query. */
+  lists: Map<string, FakeMediaQueryList>;
+  matchMedia: ReturnType<typeof vi.fn>;
+  /** Flip one query and notify its listeners, as a real browser does. */
+  setMatches: (query: string, matches: boolean) => void;
+  listenerCount: () => number;
+}
+
+function installMatchMedia(
+  matching: ReadonlyArray<string> = [],
+): MediaEnvironment {
+  const lists = new Map<string, FakeMediaQueryList>();
+  const queries: string[] = [];
+
+  const matchMedia = vi.fn((media: string) => {
+    queries.push(media);
+    let list = lists.get(media);
+    if (!list) {
+      const listeners = new Set<() => void>();
+      list = {
+        media,
+        matches: matching.includes(media),
+        listeners,
+        addEventListener: (type, listener) => {
+          if (type === 'change') {
+            listeners.add(listener);
+          }
+        },
+        removeEventListener: (type, listener) => {
+          if (type === 'change') {
+            listeners.delete(listener);
+          }
+        },
+      };
+      lists.set(media, list);
+    }
+    return list as unknown as MediaQueryList;
+  });
+
+  vi.stubGlobal('matchMedia', matchMedia);
+
+  return {
+    queries,
+    lists,
+    matchMedia,
+    setMatches(query, matches) {
+      const list = lists.get(query);
+      if (!list) {
+        throw new Error(`No MediaQueryList for ${query}`);
+      }
+      act(() => {
+        list.matches = matches;
+        for (const listener of [...list.listeners]) {
+          listener();
+        }
+      });
+    },
+    listenerCount() {
+      let total = 0;
+      for (const list of lists.values()) {
+        total += list.listeners.size;
+      }
+      return total;
+    },
+  };
+}
+
+const COMPACT_TOUCH = '(width < 768px) and (pointer: coarse)';
+const WIDE = '(width >= 1024px)';
+
+function compactTouchPolicy(): ComponentAdaptations<Presentation> {
+  return {
+    default: 'popover',
+    rules: [
+      {when: {width: {below: 'md'}, pointer: 'coarse'}, value: 'bottom-sheet'},
+    ],
+  };
+}
+
+beforeEach(() => {
+  resetThemes();
+  resetAdaptationStores();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetAdaptationStores();
+});
+
+// =============================================================================
+// Resolution
+// =============================================================================
+
+describe('resolution', () => {
+  it('publishes the default and index -1 when no rule matches', () => {
+    installMatchMedia([]);
+
+    const {result} = renderHook(() =>
+      useComponentAdaptations(compactTouchPolicy(), OPTIONS),
+    );
+
+    expect(result.current).toEqual({value: 'popover', matchedRuleIndex: -1});
+  });
+
+  it('publishes the matching rule after hydration', () => {
+    installMatchMedia([COMPACT_TOUCH]);
+
+    const {result} = renderHook(() =>
+      useComponentAdaptations(compactTouchPolicy(), OPTIONS),
+    );
+
+    expect(result.current).toEqual({
+      value: 'bottom-sheet',
+      matchedRuleIndex: 0,
+    });
+  });
+
+  it('lets the LAST matching rule win, whatever the condition shape', () => {
+    installMatchMedia([COMPACT_TOUCH, '(pointer: coarse)']);
+    const policy: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      // The first rule is far more specific; author order still decides.
+      rules: [
+        {
+          when: {width: {below: 'md'}, pointer: 'coarse'},
+          value: 'bottom-sheet',
+        },
+        {when: {pointer: 'coarse'}, value: 'popover'},
+      ],
+    };
+
+    const {result} = renderHook(() => useComponentAdaptations(policy, OPTIONS));
+
+    expect(result.current).toEqual({value: 'popover', matchedRuleIndex: 1});
+  });
+
+  it('reorders behavior when the rules are reordered', () => {
+    installMatchMedia([COMPACT_TOUCH, '(pointer: coarse)']);
+    const policy: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      rules: [
+        {when: {pointer: 'coarse'}, value: 'popover'},
+        {
+          when: {width: {below: 'md'}, pointer: 'coarse'},
+          value: 'bottom-sheet',
+        },
+      ],
+    };
+
+    const {result} = renderHook(() => useComponentAdaptations(policy, OPTIONS));
+
+    expect(result.current).toEqual({
+      value: 'bottom-sheet',
+      matchedRuleIndex: 1,
+    });
+  });
+
+  it('republishes when the environment changes', () => {
+    const media = installMatchMedia([]);
+    const {result} = renderHook(() =>
+      useComponentAdaptations(compactTouchPolicy(), OPTIONS),
+    );
+    expect(result.current.value).toBe('popover');
+
+    media.setMatches(COMPACT_TOUCH, true);
+    expect(result.current).toEqual({
+      value: 'bottom-sheet',
+      matchedRuleIndex: 0,
+    });
+
+    media.setMatches(COMPACT_TOUCH, false);
+    expect(result.current).toEqual({value: 'popover', matchedRuleIndex: -1});
+  });
+
+  it('treats `below` as exclusive at the exact named point', () => {
+    // The compiled query carries the exclusivity; a browser at exactly 768px
+    // reports no match for `(width < 768px)`.
+    const media = installMatchMedia([]);
+    renderHook(() => useComponentAdaptations(compactTouchPolicy(), OPTIONS));
+
+    expect(media.queries).toContain(COMPACT_TOUCH);
+    expect(media.queries.join(' ')).not.toContain('max-width');
+  });
+
+  it('returns undefined without a policy and subscribes to nothing', () => {
+    const media = installMatchMedia([]);
+
+    const {result} = renderHook(() =>
+      useComponentAdaptations(undefined, OPTIONS),
+    );
+
+    expect(result.current).toEqual({value: undefined, matchedRuleIndex: -1});
+    expect(media.matchMedia).not.toHaveBeenCalled();
+  });
+
+  it('resolves an empty policy to the default, subscribing to nothing', () => {
+    const media = installMatchMedia([COMPACT_TOUCH]);
+    const empty: ComponentAdaptations<Presentation> = {
+      default: 'bottom-sheet',
+      rules: [],
+    };
+
+    const {result, rerender} = renderHook(() =>
+      useComponentAdaptations(empty, OPTIONS),
+    );
+
+    expect(result.current).toEqual({
+      value: 'bottom-sheet',
+      matchedRuleIndex: -1,
+    });
+    // Nothing can change the answer, so no MediaQueryList and no shared store.
+    expect(media.matchMedia).not.toHaveBeenCalled();
+    expect(media.listenerCount()).toBe(0);
+    expect(getAdaptationStoreCount()).toBe(0);
+
+    rerender();
+
+    expect(result.current.value).toBe('bottom-sheet');
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('keeps an empty policy on the default when the environment changes', () => {
+    const media = installMatchMedia([]);
+    // A sibling policy owns the only live query; the empty one must not follow
+    // it, and must not be handed that store by the shared registry.
+    renderHook(() => useComponentAdaptations(compactTouchPolicy(), OPTIONS));
+    const {result} = renderHook(() =>
+      useComponentAdaptations(
+        {
+          default: 'popover',
+          rules: [],
+        } satisfies ComponentAdaptations<Presentation>,
+        OPTIONS,
+      ),
+    );
+
+    media.setMatches(COMPACT_TOUCH, true);
+
+    expect(result.current).toEqual({value: 'popover', matchedRuleIndex: -1});
+    expect(getAdaptationStoreCount()).toBe(1);
+  });
+
+  it('renders the default for an empty policy during SSR', () => {
+    const matchMedia = vi.fn();
+    vi.stubGlobal('matchMedia', matchMedia);
+
+    function Probe() {
+      const {value} = useComponentAdaptations(
+        {
+          default: 'popover',
+          rules: [],
+        } satisfies ComponentAdaptations<Presentation>,
+        OPTIONS,
+      );
+      return createElement('output', null, value);
+    }
+
+    expect(renderToString(createElement(Probe))).toContain('popover');
+    expect(matchMedia).not.toHaveBeenCalled();
+  });
+
+  it('drops the subscription when a policy loses its last rule', () => {
+    const media = installMatchMedia([COMPACT_TOUCH]);
+    const withRule = compactTouchPolicy();
+    const {result, rerender} = renderHook(
+      ({policy}: {policy: ComponentAdaptations<Presentation>}) =>
+        useComponentAdaptations(policy, OPTIONS),
+      {initialProps: {policy: withRule}},
+    );
+
+    expect(result.current.value).toBe('bottom-sheet');
+    expect(media.listenerCount()).toBe(1);
+
+    rerender({policy: {default: 'popover', rules: []}});
+
+    expect(result.current).toEqual({value: 'popover', matchedRuleIndex: -1});
+    expect(media.listenerCount()).toBe(0);
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('keeps a stable result object while the match is unchanged', () => {
+    installMatchMedia([]);
+    const {result, rerender} = renderHook(() =>
+      useComponentAdaptations(compactTouchPolicy(), OPTIONS),
+    );
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});
+
+// =============================================================================
+// Server truth (FR3)
+// =============================================================================
+
+describe('server and hydration', () => {
+  it('renders the default during SSR without reading matchMedia', () => {
+    const matchMedia = vi.fn();
+    vi.stubGlobal('matchMedia', matchMedia);
+
+    function Probe() {
+      const {value, matchedRuleIndex} = useComponentAdaptations(
+        compactTouchPolicy(),
+        OPTIONS,
+      );
+      return createElement('output', {'data-index': matchedRuleIndex}, value);
+    }
+
+    const html = renderToString(createElement(Probe));
+
+    expect(html).toContain('popover');
+    expect(html).toContain('data-index="-1"');
+    expect(matchMedia).not.toHaveBeenCalled();
+  });
+
+  it('hydrates with the default, then publishes the browser match', async () => {
+    installMatchMedia([COMPACT_TOUCH]);
+
+    function Probe() {
+      const {value} = useComponentAdaptations(compactTouchPolicy(), OPTIONS);
+      return createElement('output', null, value);
+    }
+
+    const serverHTML = renderToString(createElement(Probe));
+    expect(serverHTML).toContain('popover');
+
+    const container = document.createElement('div');
+    container.innerHTML = serverHTML;
+    document.body.appendChild(container);
+
+    const recoverableErrors: unknown[] = [];
+    let root: ReturnType<typeof hydrateRoot> | undefined;
+    await act(async () => {
+      root = hydrateRoot(container, createElement(Probe), {
+        onRecoverableError: error => recoverableErrors.push(error),
+      });
+    });
+
+    // The hydration render used the server snapshot, so React reconciled the
+    // real match afterwards rather than reporting a mismatch.
+    await waitFor(() =>
+      expect(container.querySelector('output')?.textContent).toBe(
+        'bottom-sheet',
+      ),
+    );
+    expect(recoverableErrors).toEqual([]);
+
+    act(() => root?.unmount());
+    container.remove();
+  });
+
+  it('falls back to the default when matchMedia is unavailable', () => {
+    vi.stubGlobal('matchMedia', undefined);
+
+    const {result} = renderHook(() =>
+      useComponentAdaptations(compactTouchPolicy(), OPTIONS),
+    );
+
+    expect(result.current).toEqual({value: 'popover', matchedRuleIndex: -1});
+  });
+});
+
+// =============================================================================
+// Nearest Theme (FR5)
+// =============================================================================
+
+describe('effective width points', () => {
+  function Probe() {
+    const {value} = useComponentAdaptations(compactTouchPolicy(), OPTIONS);
+    return createElement('output', null, value);
+  }
+
+  function wrapper(theme: ReturnType<typeof defineTheme>) {
+    return function Wrapper({children}: {children: ReactNode}) {
+      return <Theme theme={theme}>{children}</Theme>;
+    };
+  }
+
+  it('uses AST-012 defaults without a theme', () => {
+    const media = installMatchMedia([]);
+
+    renderHook(() => useComponentAdaptations(compactTouchPolicy(), OPTIONS));
+
+    expect(media.queries).toContain('(width < 768px) and (pointer: coarse)');
+  });
+
+  it("uses the nearest Theme's overridden point", () => {
+    const media = installMatchMedia([]);
+    const theme = {
+      ...defineTheme({
+        name: 'adaptation-points',
+        adaptations: {widthBreakpoints: {md: 900}},
+      }),
+      __built: true as const,
+    };
+
+    renderHook(() => useComponentAdaptations(compactTouchPolicy(), OPTIONS), {
+      wrapper: wrapper(theme),
+    });
+
+    expect(media.queries).toContain('(width < 900px) and (pointer: coarse)');
+    expect(media.queries).not.toContain(COMPACT_TOUCH);
+  });
+
+  it('lets a nested Theme select a different value at one viewport width', () => {
+    const media = installMatchMedia(['(width < 900px) and (pointer: coarse)']);
+    const outer = {
+      ...defineTheme({
+        name: 'adaptation-outer',
+        adaptations: {widthBreakpoints: {md: 700}},
+      }),
+      __built: true as const,
+    };
+    const inner = {
+      ...defineTheme({
+        name: 'adaptation-inner',
+        adaptations: {widthBreakpoints: {md: 900}},
+      }),
+      __built: true as const,
+    };
+
+    render(
+      <Theme theme={outer}>
+        <div data-testid="outer">
+          <Probe />
+        </div>
+        <Theme theme={inner}>
+          <div data-testid="inner">
+            <Probe />
+          </div>
+        </Theme>
+      </Theme>,
+    );
+
+    // 700px point does not match, 900px point does — same viewport, two values.
+    expect(screen.getByTestId('outer').textContent).toBe('popover');
+    expect(screen.getByTestId('inner').textContent).toBe('bottom-sheet');
+    expect(media.queries).toContain('(width < 700px) and (pointer: coarse)');
+  });
+
+  it('follows the registered root theme without provider context', () => {
+    const media = installMatchMedia([]);
+    defineTheme({
+      name: 'adaptation-root-fallback',
+      adaptations: {widthBreakpoints: {md: 700}},
+    });
+    const original = document.documentElement.getAttribute.bind(
+      document.documentElement,
+    );
+    vi.spyOn(document.documentElement, 'getAttribute').mockImplementation(
+      name =>
+        name === 'data-astryx-theme'
+          ? 'adaptation-root-fallback'
+          : original(name),
+    );
+
+    renderHook(() => useComponentAdaptations(compactTouchPolicy(), OPTIONS));
+
+    expect(media.queries).toContain('(width < 700px) and (pointer: coarse)');
+  });
+});
+
+// =============================================================================
+// Subscription identity and cleanup (IR2)
+// =============================================================================
+
+describe('subscriptions', () => {
+  it('does not resubscribe when an inline policy literal is re-created', () => {
+    const media = installMatchMedia([]);
+    const {rerender} = renderHook(() =>
+      // A NEW object and a NEW rules array on every render, as documented.
+      useComponentAdaptations(
+        {
+          default: 'popover',
+          rules: [
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'bottom-sheet',
+            },
+          ],
+        } satisfies ComponentAdaptations<Presentation>,
+        OPTIONS,
+      ),
+    );
+
+    const listenersAfterMount = media.listenerCount();
+    const listsAfterMount = media.lists.size;
+    rerender();
+    rerender();
+    rerender();
+
+    expect(listenersAfterMount).toBe(1);
+    expect(media.listenerCount()).toBe(1);
+    expect(media.lists.size).toBe(listsAfterMount);
+    expect(getAdaptationStoreCount()).toBe(1);
+  });
+
+  it('shares one store across components with identical queries', () => {
+    const media = installMatchMedia([]);
+
+    function Probe() {
+      const {value} = useComponentAdaptations(compactTouchPolicy(), OPTIONS);
+      return createElement('output', null, value);
+    }
+
+    const view = render(
+      createElement(
+        'div',
+        null,
+        createElement(Probe),
+        createElement(Probe),
+        createElement(Probe),
+      ),
+    );
+
+    expect(media.lists.size).toBe(1);
+    expect(media.listenerCount()).toBe(1);
+    expect(getAdaptationStoreCount()).toBe(1);
+
+    view.unmount();
+
+    expect(media.listenerCount()).toBe(0);
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('subscribes per distinct compiled query and cleans every listener up', () => {
+    const media = installMatchMedia([]);
+    const policy: ComponentAdaptations<Presentation> = {
+      default: 'popover',
+      rules: [
+        {when: {width: {below: 'md'}}, value: 'bottom-sheet'},
+        {when: {width: {from: 'lg'}}, value: 'popover'},
+      ],
+    };
+
+    const {unmount} = renderHook(() =>
+      useComponentAdaptations(policy, OPTIONS),
+    );
+
+    expect([...media.lists.keys()]).toEqual(['(width < 768px)', WIDE]);
+    expect(media.listenerCount()).toBe(2);
+
+    unmount();
+
+    expect(media.listenerCount()).toBe(0);
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('resubscribes when the compiled queries actually change', () => {
+    const media = installMatchMedia([]);
+    const {rerender} = renderHook(
+      ({below}: {below: 'md' | 'lg'}) =>
+        useComponentAdaptations(
+          {
+            default: 'popover',
+            rules: [{when: {width: {below}}, value: 'bottom-sheet'}],
+          } satisfies ComponentAdaptations<Presentation>,
+          OPTIONS,
+        ),
+      {initialProps: {below: 'md'}},
+    );
+
+    expect([...media.lists.keys()]).toEqual(['(width < 768px)']);
+
+    rerender({below: 'lg'});
+
+    expect([...media.lists.keys()]).toEqual([
+      '(width < 768px)',
+      '(width < 1024px)',
+    ]);
+    // The abandoned query's listener is released, not stranded.
+    expect(media.lists.get('(width < 768px)')?.listeners.size).toBe(0);
+    expect(media.lists.get('(width < 1024px)')?.listeners.size).toBe(1);
+    expect(getAdaptationStoreCount()).toBe(1);
+  });
+
+  it('keeps other subscribers alive when one component unmounts', () => {
+    const media = installMatchMedia([]);
+
+    function Probe() {
+      const {value} = useComponentAdaptations(compactTouchPolicy(), OPTIONS);
+      return createElement('output', null, value);
+    }
+
+    const view = render(
+      createElement(
+        'div',
+        null,
+        createElement(Probe, {key: 'a'}),
+        createElement(Probe, {key: 'b'}),
+      ),
+    );
+    view.rerender(createElement('div', null, createElement(Probe, {key: 'a'})));
+
+    expect(media.listenerCount()).toBe(1);
+
+    media.setMatches(COMPACT_TOUCH, true);
+    expect(screen.getByText('bottom-sheet')).toBeInTheDocument();
+  });
+
+  it('shares one connection between callers with different value domains', () => {
+    const media = installMatchMedia([]);
+
+    // Two components admit different policy values but compile to the SAME
+    // query text, so they share one connection. The connection publishes a
+    // matching-rule INDEX, never a value: each caller maps that index through
+    // its own values array. A connection that cached a resolved value — or
+    // that keyed on anything other than the queries — would leak one
+    // component's vocabulary into the other.
+    type Picker = 'astryx' | 'native';
+    const PICKERS = ['astryx', 'native'] as const;
+
+    function SelectorProbe() {
+      const {value, matchedRuleIndex} = useComponentAdaptations(
+        compactTouchPolicy(),
+        OPTIONS,
+      );
+      return createElement(
+        'output',
+        {'data-testid': 'selector', 'data-index': matchedRuleIndex},
+        value,
+      );
+    }
+
+    function DateProbe() {
+      const {value, matchedRuleIndex} = useComponentAdaptations(
+        {
+          default: 'astryx',
+          rules: [
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'native',
+            },
+          ],
+        } satisfies ComponentAdaptations<Picker>,
+        {path: '<DateInput adaptations>', values: PICKERS},
+      );
+      return createElement(
+        'output',
+        {'data-testid': 'date', 'data-index': matchedRuleIndex},
+        value,
+      );
+    }
+
+    render(
+      createElement(
+        'div',
+        null,
+        createElement(SelectorProbe),
+        createElement(DateProbe),
+      ),
+    );
+
+    // One connection, one MediaQueryList, one listener — for both callers.
+    expect(getAdaptationStoreCount()).toBe(1);
+    expect(media.lists.size).toBe(1);
+    expect(media.listenerCount()).toBe(1);
+
+    // No match: each caller falls back to its OWN default.
+    expect(screen.getByTestId('selector')).toHaveTextContent('popover');
+    expect(screen.getByTestId('date')).toHaveTextContent('astryx');
+    expect(screen.getByTestId('selector')).toHaveAttribute('data-index', '-1');
+    expect(screen.getByTestId('date')).toHaveAttribute('data-index', '-1');
+
+    media.setMatches(COMPACT_TOUCH, true);
+
+    // Same shared index, two different values.
+    expect(screen.getByTestId('selector')).toHaveAttribute('data-index', '0');
+    expect(screen.getByTestId('date')).toHaveAttribute('data-index', '0');
+    expect(screen.getByTestId('selector')).toHaveTextContent('bottom-sheet');
+    expect(screen.getByTestId('date')).toHaveTextContent('native');
+
+    media.setMatches(COMPACT_TOUCH, false);
+
+    expect(screen.getByTestId('selector')).toHaveTextContent('popover');
+    expect(screen.getByTestId('date')).toHaveTextContent('astryx');
+  });
+
+  it('keeps each caller inside its own value domain when rules diverge', () => {
+    // Same shared query set, but the two callers order their values
+    // differently: index 1 must mean each caller's OWN second rule.
+    const media = installMatchMedia([]);
+    const WIDE_QUERY = '(width >= 1024px)';
+
+    function make(
+      testid: string,
+      first: string,
+      second: string,
+      fallback: string,
+    ) {
+      return function Probe() {
+        const {value, matchedRuleIndex} = useComponentAdaptations(
+          {
+            default: fallback,
+            rules: [
+              {when: {width: {below: 'md'}, pointer: 'coarse'}, value: first},
+              {when: {width: {from: 'lg'}}, value: second},
+            ],
+          } satisfies ComponentAdaptations<string>,
+          {path: `<${testid} adaptations>`},
+        );
+        return createElement(
+          'output',
+          {'data-testid': testid, 'data-index': matchedRuleIndex},
+          value,
+        );
+      };
+    }
+
+    const First = make('first', 'sheet', 'anchored', 'anchored');
+    const Second = make('second', 'native', 'astryx', 'astryx');
+
+    render(
+      createElement('div', null, createElement(First), createElement(Second)),
+    );
+
+    expect(getAdaptationStoreCount()).toBe(1);
+    expect(media.listenerCount()).toBe(2);
+
+    media.setMatches(WIDE_QUERY, true);
+
+    expect(screen.getByTestId('first')).toHaveAttribute('data-index', '1');
+    expect(screen.getByTestId('second')).toHaveAttribute('data-index', '1');
+    expect(screen.getByTestId('first')).toHaveTextContent('anchored');
+    expect(screen.getByTestId('second')).toHaveTextContent('astryx');
+  });
+});
+
+// =============================================================================
+// Store lifecycle (IR2) — StrictMode, server renders, late polyfills
+// =============================================================================
+
+describe('connection lifecycle', () => {
+  function Probe() {
+    const {value} = useComponentAdaptations(compactTouchPolicy(), OPTIONS);
+    return createElement('output', null, value);
+  }
+
+  it('re-registers after a StrictMode remount, so later mounts still share', () => {
+    const media = installMatchMedia([]);
+
+    // The first Probe keeps a STABLE position across the rerender below, so it
+    // stays mounted and subscribed; only the second one is new. Otherwise
+    // React remounts everything and any implementation re-registers.
+    const first = render(
+      createElement(
+        StrictMode,
+        null,
+        createElement('div', null, createElement(Probe, {key: 'a'})),
+      ),
+    );
+
+    expect(getAdaptationStoreCount()).toBe(1);
+    expect(media.listenerCount()).toBe(1);
+
+    // A second identical policy mounting AFTERWARDS must join the connection
+    // the surviving subscriber holds. StrictMode's subscribe → unsubscribe →
+    // subscribe closed and reopened it; a design that only registered once,
+    // at creation, leaves the registry empty here and opens a second
+    // connection — two MediaQueryList sets and two listener registrations.
+    first.rerender(
+      createElement(
+        StrictMode,
+        null,
+        createElement(
+          'div',
+          null,
+          createElement(Probe, {key: 'a'}),
+          createElement(Probe, {key: 'b'}),
+        ),
+      ),
+    );
+
+    expect(getAdaptationStoreCount()).toBe(1);
+    expect(media.lists.size).toBe(1);
+    expect(media.listenerCount()).toBe(1);
+
+    // And the shared connection is live for every subscriber.
+    media.setMatches(COMPACT_TOUCH, true);
+    expect(screen.getAllByText('bottom-sheet')).toHaveLength(2);
+
+    first.unmount();
+    expect(getAdaptationStoreCount()).toBe(0);
+    expect(media.listenerCount()).toBe(0);
+  });
+
+  it('leaves the registry empty across repeated server renders', () => {
+    const matchMedia = vi.fn();
+    vi.stubGlobal('matchMedia', matchMedia);
+
+    for (let index = 0; index < 3; index++) {
+      expect(renderToString(createElement(Probe))).toContain('popover');
+    }
+
+    // A render that never commits must register nothing: on a server this map
+    // is process-wide and would grow without bound.
+    expect(getAdaptationStoreCount()).toBe(0);
+    expect(matchMedia).not.toHaveBeenCalled();
+  });
+
+  it('leaves the registry empty when a client render is abandoned', () => {
+    installMatchMedia([]);
+
+    // A concurrent render that is thrown away calls getSnapshot but never
+    // subscribes.
+    renderToString(createElement(Probe));
+
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('attaches listeners when matchMedia only appears after the first subscriber', () => {
+    // First subscriber arrives with no matchMedia at all. It renders inside a
+    // stable container so the rerender below ADDS a sibling rather than
+    // remounting it — a remount would re-attach on any implementation.
+    vi.stubGlobal('matchMedia', undefined);
+    const view = render(
+      createElement('div', null, createElement(Probe, {key: 'early'})),
+    );
+
+    expect(screen.getByText('popover')).toBeInTheDocument();
+    expect(getAdaptationStoreCount()).toBe(1);
+
+    // The polyfill lands, and a second identical subscriber joins the SAME
+    // connection. Attachment must not be inferred from "this is the first
+    // subscriber": the lists did not exist then, so nothing was attached, and
+    // the surviving early subscriber means the count is no longer zero.
+    const media = installMatchMedia([]);
+    view.rerender(
+      createElement(
+        'div',
+        null,
+        createElement(Probe, {key: 'early'}),
+        createElement(Probe, {key: 'late'}),
+      ),
+    );
+
+    expect(media.listenerCount()).toBe(1);
+
+    media.setMatches(COMPACT_TOUCH, true);
+    expect(screen.getAllByText('bottom-sheet')).toHaveLength(2);
+
+    view.unmount();
+    expect(media.listenerCount()).toBe(0);
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+});
+
+// =============================================================================
+// Runtime validation (IR3)
+// =============================================================================
+
+describe('runtime validation', () => {
+  function renderPolicy(policy: unknown) {
+    return renderHook(() =>
+      useComponentAdaptations(
+        policy as ComponentAdaptations<Presentation>,
+        OPTIONS,
+      ),
+    );
+  }
+
+  beforeEach(() => {
+    installMatchMedia([]);
+    // React logs the thrown render error; the assertion is the throw itself.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it.each([
+    [
+      {
+        default: 'popover',
+        rules: [{when: {contrast: 'more'}, value: 'popover'}],
+      },
+      '<Selector adaptations>.rules[0].when.contrast is not supported.',
+    ],
+    [
+      {default: 'popover', rules: [{when: {}, value: 'popover'}]},
+      '<Selector adaptations>.rules[0].when must contain at least one condition.',
+    ],
+    [
+      {
+        default: 'popover',
+        rules: [{when: {width: {below: 'xs'}}, value: 'popover'}],
+      },
+      '<Selector adaptations>.rules[0].when.width.below must be one of sm, md, lg, xl, 2xl.',
+    ],
+    [
+      {
+        default: 'popover',
+        rules: [{when: {width: {from: 'lg', below: 'sm'}}, value: 'popover'}],
+      },
+      '<Selector adaptations>.rules[0].when.width must resolve to `from < below`',
+    ],
+    [
+      {default: 'popover'},
+      '<Selector adaptations>.rules is required; pass [] for no rules.',
+    ],
+    [
+      {
+        default: 'popover',
+        rules: [{when: {pointer: 'coarse'}, value: 'modal'}],
+      },
+      '<Selector adaptations>.rules[0].value must be one of popover, bottom-sheet',
+    ],
+  ])(
+    'rejects an unusable policy before any surface opens %#',
+    (policy, message) => {
+      expect(() => renderPolicy(policy)).toThrow(message);
+    },
+  );
+
+  it.each([
+    ['null', null],
+    ['false', false],
+    ['zero', 0],
+    ['empty string', ''],
+    ['NaN', Number.NaN],
+  ])('rejects the falsy non-undefined policy %s', (_label, policy) => {
+    // Only `undefined` means "no policy". A truthiness guard would treat each
+    // of these as an absent prop and publish `undefined`, hiding an untyped
+    // caller's mistake behind a component that silently never adapts.
+    expect(() => renderPolicy(policy)).toThrow(
+      '<Selector adaptations> must be an object.',
+    );
+  });
+
+  it.each([
+    ['an array', []],
+    ['a string', 'popover'],
+    ['a number', 1],
+    ['true', true],
+  ])('rejects the truthy non-object policy %s', (_label, policy) => {
+    expect(() => renderPolicy(policy)).toThrow(
+      '<Selector adaptations> must be an object.',
+    );
+  });
+
+  it('still treats an explicitly spread undefined as no policy', () => {
+    // The documented escape hatch: `{...maybeAdaptations}` spreading nothing
+    // must stay a no-op, not a thrown render.
+    const props: {adaptations?: ComponentAdaptations<Presentation>} = {
+      adaptations: undefined,
+    };
+
+    const {result} = renderHook(() =>
+      useComponentAdaptations(props.adaptations, OPTIONS),
+    );
+
+    expect(result.current).toEqual({value: undefined, matchedRuleIndex: -1});
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('rejects a falsy policy without leaving a connection behind', () => {
+    expect(() => renderPolicy(null)).toThrow();
+
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('rejects a width edge the active theme cannot order', () => {
+    const theme = {
+      ...defineTheme({
+        name: 'adaptation-equal-edges',
+        // Legal on its own; `{from: 'md', below: 'lg'}` becomes an empty band.
+        adaptations: {widthBreakpoints: {md: 1000, lg: 1001}},
+      }),
+      __built: true as const,
+    };
+
+    expect(() =>
+      renderHook(
+        () =>
+          useComponentAdaptations(
+            {
+              default: 'popover',
+              rules: [
+                {when: {width: {from: 'lg', below: 'md'}}, value: 'popover'},
+              ],
+            } satisfies ComponentAdaptations<Presentation>,
+            OPTIONS,
+          ),
+        {
+          wrapper: ({children}: {children: ReactNode}) => (
+            <Theme theme={theme}>{children}</Theme>
+          ),
+        },
+      ),
+    ).toThrow('must resolve to `from < below`; lg is 1001px and md is 1000px.');
+  });
+});
+
+// =============================================================================
+// No CSS, no new context (IR4)
+// =============================================================================
+
+describe('no CSS emission', () => {
+  it('does not inject a stylesheet for a resolved policy', () => {
+    installMatchMedia([COMPACT_TOUCH]);
+    const before = document.head.querySelectorAll('style').length;
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        createElement(function Probe() {
+          const {value} = useComponentAdaptations(
+            compactTouchPolicy(),
+            OPTIONS,
+          );
+          return createElement('output', null, value);
+        }),
+      );
+    });
+
+    expect(document.head.querySelectorAll('style').length).toBe(before);
+    act(() => root.unmount());
+  });
+});

--- a/packages/core/src/theme/useComponentAdaptations.ts
+++ b/packages/core/src/theme/useComponentAdaptations.ts
@@ -1,0 +1,378 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useComponentAdaptations.ts
+ * @input One component's authored adaptation policy plus the nearest Theme's
+ *   effective width points
+ * @output Package-internal React resolver publishing the current policy value
+ * @position spec:AST-031 FR3/FR4/IR2. Not exported from the package entry
+ *   point: components own their public policy props, this hook resolves them.
+ *
+ * Contract:
+ * - `default` is server truth. `getServerSnapshot` returns the no-match
+ *   sentinel, so `matchMedia` is read during neither server rendering nor the
+ *   hydration render; the browser's real match arrives on the post-hydration
+ *   store read. A policy with no rules resolves to `default` and subscribes to
+ *   nothing.
+ * - Rule order is precedence: the LAST matching rule wins, regardless of how
+ *   specific any condition looks.
+ * - Subscription identity is keyed by the COMPILED QUERY STRINGS, not by the
+ *   caller's object identity, because the documented usage is an inline
+ *   `adaptations={{...}}` literal that is a new object on every render. A
+ *   module-level registry shares one connection — one `MediaQueryList` per
+ *   distinct query, one listener registration — across every component using
+ *   the same queries, and closes it when the last subscriber leaves. Only
+ *   `subscribe` ever registers: a render that never commits, a server render
+ *   included, leaves the registry untouched.
+ *
+ * No CSS is emitted and no context is added: the resolver reads the Theme
+ * metadata that already exists (spec:AST-031 IR4).
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/theme/componentAdaptations.ts (policy shape + compiler)
+ * - /packages/core/src/theme/effectiveBreakpoints.ts (width point resolution)
+ * - /packages/core/src/theme/useComponentAdaptations.test.tsx
+ */
+
+import {useMemo, useSyncExternalStore} from 'react';
+import {
+  compileComponentAdaptations,
+  type ComponentAdaptations,
+} from './componentAdaptations';
+import {useEffectiveWidthBreakpoints} from './effectiveBreakpoints';
+
+/** No rule matched — the server snapshot and the no-match sentinel. */
+const NO_MATCH = -1;
+
+/** Queries never contain NUL, so it cannot collide with query text. */
+const QUERY_SEPARATOR = '\u0000';
+
+// =============================================================================
+// Shared media-query connections
+// =============================================================================
+
+/**
+ * What one render hands to `useSyncExternalStore`.
+ *
+ * A handle is cheap and carries no browser state: it is a stable pair of
+ * `subscribe`/`getSnapshot` identities bound to one query key. All browser
+ * state lives on the CONNECTION, which is created and registered only when a
+ * subscriber actually commits.
+ */
+interface AdaptationQueryStore {
+  /** Joined compiled queries; the registry key. */
+  readonly key: string;
+  readonly subscribe: (onStoreChange: () => void) => () => void;
+  /** Index of the last matching query, or -1. */
+  readonly getSnapshot: () => number;
+}
+
+/**
+ * The live, shared browser state for one query key.
+ *
+ * Exactly one connection exists per key while anything is subscribed, so N
+ * components with identical policies share one set of `MediaQueryList`s and one
+ * `change` registration per query.
+ */
+interface AdaptationQueryConnection {
+  readonly key: string;
+  readonly queries: ReadonlyArray<string>;
+  /**
+   * The handle later renders for this key resolve to, so `subscribe` and
+   * `getSnapshot` identities stay stable across renders and React does not
+   * resubscribe.
+   */
+  handle: AdaptationQueryStore;
+  /** One list per query; empty until `matchMedia` is reachable. */
+  lists: MediaQueryList[];
+  /**
+   * Whether `notify` is attached to `lists`. Tracked explicitly rather than
+   * inferred from the listener count: the first subscriber can arrive before
+   * `matchMedia` exists (a late polyfill, a jsdom suite installing it after
+   * mount), and a later subscriber must then create the lists AND attach —
+   * which a "first subscriber attaches" rule silently skips.
+   */
+  attached: boolean;
+  readonly listeners: Set<() => void>;
+  readonly notify: () => void;
+}
+
+const storeRegistry = new Map<string, AdaptationQueryConnection>();
+
+function canMatchMedia(): boolean {
+  return (
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+  );
+}
+
+function lastMatchingIndex(lists: ReadonlyArray<MediaQueryList>): number {
+  // Author order is precedence: keep scanning so the LAST match wins.
+  let matched = NO_MATCH;
+  for (let index = 0; index < lists.length; index++) {
+    if (lists[index].matches) {
+      matched = index;
+    }
+  }
+  return matched;
+}
+
+/**
+ * Bring a connection as live as the environment allows, idempotently.
+ *
+ * Creates the lists once `matchMedia` is reachable and attaches the shared
+ * listener once, so a connection opened in a matchMedia-less environment
+ * becomes live as soon as anything touches it afterwards.
+ */
+function activate(connection: AdaptationQueryConnection): MediaQueryList[] {
+  if (connection.lists.length === 0 && canMatchMedia()) {
+    connection.lists = connection.queries.map(query =>
+      window.matchMedia(query),
+    );
+  }
+  if (!connection.attached && connection.lists.length > 0) {
+    for (const list of connection.lists) {
+      list.addEventListener('change', connection.notify);
+    }
+    connection.attached = true;
+  }
+  return connection.lists;
+}
+
+function openConnection(
+  key: string,
+  queries: ReadonlyArray<string>,
+  handle: AdaptationQueryStore,
+): AdaptationQueryConnection {
+  const existing = storeRegistry.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const listeners = new Set<() => void>();
+  const connection: AdaptationQueryConnection = {
+    key,
+    queries,
+    handle,
+    lists: [],
+    attached: false,
+    listeners,
+    notify: () => {
+      // Copy first: a listener may unsubscribe while being notified.
+      for (const listener of [...listeners]) {
+        listener();
+      }
+    },
+  };
+  storeRegistry.set(key, connection);
+  return connection;
+}
+
+function closeConnection(connection: AdaptationQueryConnection): void {
+  if (connection.attached) {
+    for (const list of connection.lists) {
+      list.removeEventListener('change', connection.notify);
+    }
+    connection.attached = false;
+  }
+  connection.lists = [];
+  // Drop the shared entry only while it is still this connection, so a
+  // teardown cannot delete a connection someone else already opened.
+  if (storeRegistry.get(connection.key) === connection) {
+    storeRegistry.delete(connection.key);
+  }
+}
+
+function createAdaptationQueryStore(
+  key: string,
+  queries: ReadonlyArray<string>,
+): AdaptationQueryStore {
+  // Snapshot lists for a handle that has no connection yet — a client render
+  // before commit. They carry no listeners and are never registered, so an
+  // abandoned render leaves nothing behind.
+  let probeLists: MediaQueryList[] | null = null;
+
+  const store: AdaptationQueryStore = {
+    key,
+    subscribe(onStoreChange) {
+      const connection = openConnection(key, queries, store);
+      // Re-registration is the point: StrictMode's subscribe → unsubscribe →
+      // subscribe closes the connection and this opens a fresh one under the
+      // same key, so an identical policy mounting afterwards still shares.
+      activate(connection);
+      connection.listeners.add(onStoreChange);
+
+      return () => {
+        connection.listeners.delete(onStoreChange);
+        if (connection.listeners.size === 0) {
+          closeConnection(connection);
+        }
+      };
+    },
+    getSnapshot() {
+      const connection = storeRegistry.get(key);
+      if (connection) {
+        return lastMatchingIndex(activate(connection));
+      }
+      if (!canMatchMedia()) {
+        return NO_MATCH;
+      }
+      probeLists ??= queries.map(query => window.matchMedia(query));
+      return lastMatchingIndex(probeLists);
+    },
+  };
+
+  return store;
+}
+
+/**
+ * The store handle for one compiled query set.
+ *
+ * Called during render and READ-ONLY with respect to the registry: a render
+ * that never commits — a server render, an abandoned concurrent render — must
+ * not leave a connection behind, so only `subscribe` ever registers one. Once a
+ * connection exists, every later render for the same key resolves to the handle
+ * it was opened with, which is what keeps `useSyncExternalStore` from
+ * resubscribing when the caller passes a fresh inline policy literal.
+ */
+function getAdaptationQueryStore(
+  queries: ReadonlyArray<string>,
+): AdaptationQueryStore {
+  const key = queries.join(QUERY_SEPARATOR);
+  return (
+    storeRegistry.get(key)?.handle ?? createAdaptationQueryStore(key, queries)
+  );
+}
+
+/** A component without an adaptations policy, or with no rules, subscribes to nothing. */
+const EMPTY_STORE: AdaptationQueryStore = {
+  key: '',
+  subscribe: () => () => {},
+  getSnapshot: () => NO_MATCH,
+};
+
+function getServerSnapshot(): number {
+  return NO_MATCH;
+}
+
+/**
+ * Live shared-connection count. Test-only; a leaked listener, or a render that
+ * wrongly registered without committing, shows up here.
+ * @internal
+ */
+export function getAdaptationStoreCount(): number {
+  return storeRegistry.size;
+}
+
+/**
+ * Close and drop every shared connection so a suite's stubbed `matchMedia`
+ * cannot be reached through a connection another test opened. Test-only.
+ * @internal
+ */
+export function resetAdaptationStores(): void {
+  for (const connection of [...storeRegistry.values()]) {
+    closeConnection(connection);
+  }
+  storeRegistry.clear();
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/** Options naming the caller for diagnostics and its admitted value domain. */
+export interface UseComponentAdaptationsOptions<T extends string> {
+  /**
+   * Diagnostic root for validation failures, naming the component and prop —
+   * e.g. `<Selector adaptations>`. Rule paths extend it.
+   */
+  readonly path: string;
+  /** The component's closed value domain, rejected against at runtime. */
+  readonly values?: ReadonlyArray<T>;
+}
+
+/** The resolved policy value and which rule produced it. */
+export interface ComponentAdaptationMatch<T> {
+  /** Last matching rule's value; `default` on the server and with no match. */
+  readonly value: T;
+  /** Index of the matching rule, or -1 on the server and with no match. */
+  readonly matchedRuleIndex: number;
+}
+
+export function useComponentAdaptations<T extends string>(
+  adaptations: ComponentAdaptations<T>,
+  options: UseComponentAdaptationsOptions<T>,
+): ComponentAdaptationMatch<T>;
+export function useComponentAdaptations<T extends string>(
+  adaptations: ComponentAdaptations<T> | undefined,
+  options: UseComponentAdaptationsOptions<T>,
+): ComponentAdaptationMatch<T | undefined>;
+/**
+ * Resolve one component adaptation policy against the current environment.
+ *
+ * Returns `default` during server rendering and hydration, then the value of
+ * the last rule whose condition matches. Conditions resolve against the nearest
+ * Theme's effective width points, so a nested Theme can select a different
+ * value at the same viewport width.
+ *
+ * Invalid policies throw with a path-specific message (`<Selector
+ * adaptations>.rules[0].when.contrast is not supported.`) rather than silently
+ * never matching. Only `undefined` means "no policy"; any other non-object
+ * value is rejected.
+ *
+ * @internal
+ */
+export function useComponentAdaptations<T extends string>(
+  adaptations: ComponentAdaptations<T> | undefined,
+  options: UseComponentAdaptationsOptions<T>,
+): ComponentAdaptationMatch<T | undefined> {
+  const points = useEffectiveWidthBreakpoints();
+
+  // Compiling every render is what keys the subscription on query TEXT: the
+  // work is a few string concatenations, and it validates untyped callers on
+  // the render that introduces them.
+  //
+  // The guard tests `!== undefined`, not truthiness: `undefined` is the only
+  // value that means "this component has no policy" (an absent prop, or an
+  // explicitly spread `undefined`). Every other falsy value — null, false, 0,
+  // '', NaN — is an untyped caller's mistake and must reach the compiler's
+  // `assertRecord`, which names the prop, rather than silently publishing
+  // `undefined` as though no policy had been passed.
+  const compiled =
+    adaptations !== undefined
+      ? compileComponentAdaptations(
+          adaptations,
+          points,
+          options.path,
+          options.values,
+        )
+      : undefined;
+
+  const store =
+    compiled !== undefined && compiled.queries.length > 0
+      ? getAdaptationQueryStore(compiled.queries)
+      : // No policy, or a policy with no rules: nothing can change the answer,
+        // so there is nothing to subscribe to and no registry entry to keep.
+        EMPTY_STORE;
+  const snapshotIndex = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    getServerSnapshot,
+  );
+
+  const matchedRuleIndex =
+    compiled !== undefined &&
+    snapshotIndex >= 0 &&
+    snapshotIndex < compiled.values.length
+      ? snapshotIndex
+      : NO_MATCH;
+  const value =
+    compiled !== undefined
+      ? matchedRuleIndex === NO_MATCH
+        ? compiled.default
+        : compiled.values[matchedRuleIndex]
+      : undefined;
+
+  return useMemo(() => ({value, matchedRuleIndex}), [value, matchedRuleIndex]);
+}


### PR DESCRIPTION
## Summary

- add shared `ComponentAdaptations<T>` types and a private theme-aware resolver
- extract one condition compiler used by both theme CSS and component policies
- resolve named width points through the nearest Theme, registered root, or defaults
- use one `useSyncExternalStore` subscription keyed by compiled query strings
- move AppShell behind the same effective-breakpoint accessor without behavior change
- emit no CSS and add no React context

## Validation

- Core/UI/AppShell and resolver suites
- Core typecheck and docs typecheck
- ESLint and repository guardrails
- Core build
- theme/compiler byte-equivalence probe

This is draft infrastructure stacked on #6123, which is stacked on #5543. It does not change a component's public behavior.
