### PR TITLE
feat(Chat): support whitespace queries via allowSpaces on ChatComposerTrigger

### DIFF
--- a/.changeset/chat-trigger-allow-spaces.md
+++ b/.changeset/chat-trigger-allow-spaces.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Chat: support whitespace-tolerant search queries via opt-in `allowSpaces` on `ChatComposerTrigger` with punctuation boundary and word-cap termination rules.
+
+@Geervan

--- a/apps/storybook/stories/ChatComposerInput.stories.tsx
+++ b/apps/storybook/stories/ChatComposerInput.stories.tsx
@@ -231,6 +231,7 @@ export const MentionTrigger: Story = {
     const mentionTrigger: ChatComposerTrigger = {
       character: '@',
       searchSource: userSource,
+      allowSpaces: true,
       renderItem: item => (
         <TypeaheadItem
           item={item}
@@ -356,6 +357,7 @@ export const MultipleTriggers: Story = {
     const mentionTrigger: ChatComposerTrigger = {
       character: '@',
       searchSource: userSource,
+      allowSpaces: true,
       onSelect: item => ({
         value: `@${item.id}`,
         label: item.label,

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -151,6 +151,12 @@ export type ChatComposerTrigger = {
   loadingText?: string;
   /** Accessible label for the menu. @default 'Suggestions' */
   menuLabel?: string;
+  /**
+   * Whether the search query can contain spaces (e.g. for multi-word mentions like "@Jane Doe"
+   * or candidate browsing with "@ "). When false, the menu closes on the first space.
+   * @default false
+   */
+  allowSpaces?: boolean;
 };
 
 export interface ChatComposerInputProps extends Omit<

--- a/packages/core/src/Chat/useTriggerMenu.test.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.test.tsx
@@ -1,0 +1,364 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useTriggerMenu.test.tsx
+ * @input Uses vitest, @testing-library/react, useTriggerMenu hook
+ * @output Unit tests for trigger detection, whitespace tolerance, and punctuation termination
+ * @position Testing; validates useTriggerMenu.tsx implementation
+ *
+ * SYNC: When useTriggerMenu.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {useTriggerMenu} from './useTriggerMenu';
+import type {ChatComposerTrigger} from './ChatComposerInput';
+import {createStaticSource} from '../Typeahead/createStaticSource';
+import type {SearchableItem} from '../Typeahead/types';
+
+const USERS: SearchableItem[] = [
+  {id: 'cindy', label: 'Cindy Zhang'},
+  {id: 'alex', label: 'Alex Johnson'},
+  {id: 'sam', label: 'Sam Rivera'},
+  {id: 'obrien', label: "O'Brien"},
+  {id: 'jeanluc', label: "Jean-Luc's Task"},
+];
+
+const COMMANDS: SearchableItem[] = [
+  {id: 'summarize', label: 'summarize'},
+  {id: 'translate', label: 'translate'},
+  {id: 'search', label: 'search'},
+];
+
+function createMentionTrigger(
+  overrides?: Partial<ChatComposerTrigger>,
+): ChatComposerTrigger {
+  return {
+    character: '@',
+    searchSource: createStaticSource(USERS),
+    onSelect: item => ({
+      value: `@${item.id}`,
+      label: `@${item.label}`,
+      variant: 'blue' as const,
+    }),
+    allowSpaces: true,
+    ...overrides,
+  };
+}
+
+function createCommandTrigger(
+  overrides?: Partial<ChatComposerTrigger>,
+): ChatComposerTrigger {
+  return {
+    character: '/',
+    searchSource: createStaticSource(COMMANDS),
+    onSelect: item => `/${item.label} `,
+    allowSpaces: false,
+    ...overrides,
+  };
+}
+
+describe('useTriggerMenu', () => {
+  let editable: HTMLDivElement;
+
+  beforeEach(() => {
+    editable = document.createElement('div');
+    editable.contentEditable = 'true';
+    document.body.appendChild(editable);
+  });
+
+  afterEach(() => {
+    editable.remove();
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+  });
+
+  function setCursor(text: string, cursorOffset?: number) {
+    editable.textContent = text;
+    const textNode = editable.firstChild;
+    const offset = cursorOffset ?? text.length;
+
+    const selection = window.getSelection();
+    if (!selection) {
+      return;
+    }
+    selection.removeAllRanges();
+
+    if (textNode) {
+      const range = document.createRange();
+      range.setStart(textNode, offset);
+      range.collapse(true);
+      selection.addRange(range);
+    }
+  }
+
+  function renderTriggerHook(triggers?: ChatComposerTrigger[]) {
+    return renderHook(() =>
+      useTriggerMenu({
+        triggers: triggers ?? [createMentionTrigger(), createCommandTrigger()],
+        editableRef: {current: editable},
+        onInsertToken: vi.fn(),
+        onInsertText: vi.fn(),
+        onEmitChange: vi.fn(),
+        debounceMs: 0,
+      }),
+    );
+  }
+
+  // 1. Single-token / behavior unchanged (own dedicated test, not merged with @ cases)
+  it('1. single-token / command behavior is unchanged and terminates on space', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('/summarize');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('summarize');
+    expect(result.current.state.activeTrigger?.character).toBe('/');
+
+    // Space immediately terminates single-token trigger
+    await act(async () => {
+      setCursor('/summarize ');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+
+    // Further typing after space remains inactive
+    await act(async () => {
+      setCursor('/summarize now');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+  });
+
+  // 2. allowSpaces: true multi-word match (@Project Alpha)
+  it('2. allows multi-word queries when allowSpaces is true', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('@Project');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('Project');
+
+    await act(async () => {
+      setCursor('@Project Alpha');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('Project Alpha');
+  });
+
+  // 3. Trailing-space browse-all (@ )
+  it('3. supports trailing-space browse-all query', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('@ ');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe(' ');
+
+    await act(async () => {
+      setCursor('@Project ');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('Project ');
+  });
+
+  // 4. Punctuation termination, attached and spaced
+  it('4. terminates on punctuation terminators (attached or spaced)', async () => {
+    const {result} = renderTriggerHook();
+    const terminators = ['.', ',', '!', '?', ';', ':'];
+
+    for (const term of terminators) {
+      // Attached punctuation
+      await act(async () => {
+        setCursor(`@Project Alpha${term}`);
+        result.current.handleInput();
+        await Promise.resolve();
+      });
+      expect(result.current.state.isActive).toBe(false);
+
+      // Spaced punctuation
+      await act(async () => {
+        setCursor(`@Project Alpha ${term}`);
+        result.current.handleInput();
+        await Promise.resolve();
+      });
+      expect(result.current.state.isActive).toBe(false);
+    }
+  });
+
+  // 5. Zero-length query + immediate punctuation -> null (dedicated test)
+  it('5. returns null on zero-length query immediately followed by punctuation', async () => {
+    const {result} = renderTriggerHook();
+    const terminators = ['.', ',', '!', '?', ';', ':'];
+
+    for (const term of terminators) {
+      await act(async () => {
+        setCursor(`@${term}`);
+        result.current.handleInput();
+        await Promise.resolve();
+      });
+      expect(result.current.state.isActive).toBe(false);
+      expect(result.current.state.activeTrigger).toBeNull();
+    }
+  });
+
+  // 6. Apostrophe/hyphen preserved (O'Brien, Jean-Luc's Task)
+  it("6. preserves apostrophes and hyphens without terminating (O'Brien, Jean-Luc's Task)", async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor("@O'Brien");
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe("O'Brien");
+
+    await act(async () => {
+      setCursor("@Jean-Luc's Task");
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe("Jean-Luc's Task");
+  });
+
+  // 7. Word cap: 5 words active, 6 closes
+  it('7. enforces 5-word cap (5 words active, 6 words closes)', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('@one two three four five');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('one two three four five');
+
+    await act(async () => {
+      setCursor('@one two three four five six');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+  });
+
+  // 8. Double space does not close or over-count words
+  it('8. tolerates double spaces without closing or over-counting words', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('@Project  Alpha');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('Project  Alpha');
+
+    await act(async () => {
+      setCursor('@one  two  three  four  five');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('one  two  three  four  five');
+  });
+
+  // 9. Backspace past a terminator reactivates statelessly
+  it('9. reactivates statelessly when backspacing past a terminator', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('@Project Alpha,');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+
+    // User backspaces the comma
+    await act(async () => {
+      setCursor('@Project Alpha');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('Project Alpha');
+  });
+
+  // 10. Cursor repositioned into an earlier mention binds correctly
+  it('10. binds correctly to earlier mention when cursor is repositioned', async () => {
+    const {result} = renderTriggerHook();
+    const fullText = 'Hello @First and @Second Name';
+
+    // Reposition cursor right after "@First and" (offset 16)
+    await act(async () => {
+      setCursor(fullText, 16);
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('First and');
+
+    // Reposition cursor at end of fullText
+    await act(async () => {
+      setCursor(fullText, fullText.length);
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(true);
+    expect(result.current.state.query).toBe('Second Name');
+  });
+
+  // 11. Word-boundary gate holds (email@domain.com does not activate)
+  it('11. preserves word-boundary gate (email@domain.com, foo/bar do not activate)', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('email@domain.com');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+
+    await act(async () => {
+      setCursor('foo/bar');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+  });
+
+  // 12. Newline hard-terminates even with allowSpaces: true
+  it('12. terminates on newline even with allowSpaces: true', async () => {
+    const {result} = renderTriggerHook();
+
+    await act(async () => {
+      setCursor('@Project\nAlpha');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+
+    await act(async () => {
+      setCursor('@\n');
+      result.current.handleInput();
+      await Promise.resolve();
+    });
+    expect(result.current.state.isActive).toBe(false);
+  });
+});

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -189,6 +189,9 @@ function getTextBeforeCursor(editable: HTMLDivElement): string | null {
   return null;
 }
 
+const MAX_TRIGGER_WORDS = 5;
+const PUNCTUATION_TERMINATORS = new Set(['.', ',', '!', '?', ';', ':']);
+
 function findActiveTrigger(
   textBeforeCursor: string,
   triggers: ChatComposerTrigger[],
@@ -197,10 +200,16 @@ function findActiveTrigger(
   query: string;
   triggerStart: number;
 } | null {
+  const anyAllowsSpaces = triggers.some(t => t.allowSpaces);
+
   for (let i = textBeforeCursor.length - 1; i >= 0; i--) {
     const char = textBeforeCursor[i];
 
-    if (char === ' ' || char === '\n') {
+    if (char === '\n' || PUNCTUATION_TERMINATORS.has(char)) {
+      return null;
+    }
+
+    if (!anyAllowsSpaces && char === ' ') {
       return null;
     }
 
@@ -209,7 +218,25 @@ function findActiveTrigger(
         const prevChar = i > 0 ? textBeforeCursor[i - 1] : null;
         if (prevChar === null || prevChar === ' ' || prevChar === '\n') {
           const query = textBeforeCursor.slice(i + 1);
-          return {trigger, query, triggerStart: i};
+
+          for (let j = 0; j < query.length; j++) {
+            if (PUNCTUATION_TERMINATORS.has(query[j])) {
+              return null;
+            }
+          }
+
+          if (trigger.allowSpaces) {
+            const words = query.trim().split(/\s+/).filter(Boolean);
+            if (words.length > MAX_TRIGGER_WORDS) {
+              return null;
+            }
+            return {trigger, query, triggerStart: i};
+          } else {
+            if (query.includes(' ')) {
+              return null;
+            }
+            return {trigger, query, triggerStart: i};
+          }
         }
       }
     }
@@ -329,6 +356,15 @@ export function useTriggerMenu(
     removeAnchorSpan();
     popover.hide();
     triggerStartRef.current = -1;
+    setState(prev => ({
+      ...prev,
+      isActive: false,
+      activeTrigger: null,
+      query: '',
+      items: [],
+      highlightedIndex: 0,
+      isLoading: false,
+    }));
   }, [popover, state.activeTrigger, removeAnchorSpan]);
 
   // Anchor the popover to the cursor position (not the entire input).


### PR DESCRIPTION
Fixes #6110
### Summary
Adds opt-in `allowSpaces?: boolean` to `ChatComposerTrigger` in `@astryxdesign/core`, enabling multi-word trigger queries (e.g. `@Cindy Zhang`) and trailing-space candidate browsing (`@ `).

### Scanner & Termination Rules
- **Punctuation boundaries**: `.`, `,`, `!`, `?`, `;`, `:` unconditionally terminate active queries.
- **Word cap**: Maximum 5 words allowed in the active query (6th word closes the menu).
- **Apostrophe & Hyphen**: Preserved (e.g. `@O'Brien`, `@Jean-Luc's Task`).
- **Cursor-relative binding**: Scanning operates on `textBeforeCursor` up to the active selection offset.
- **Zero-length query**: Immediate punctuation (`@,`, `@.`) returns `null` immediately.
- **Single-token triggers**: Triggers with `allowSpaces: false` or unset (such as `/` slash commands) retain strict space-terminating single-token behavior.

### New Test Suite (`useTriggerMenu.test.tsx`)
Added dedicated hook unit test file `packages/core/src/Chat/useTriggerMenu.test.tsx` covering all 12 scanner edge cases:
1. Single-token `/` command behavior unchanged (closes on space).
2. `allowSpaces: true` multi-word query matching (`@Project Alpha`).
3. Trailing-space browse-all query (`@ `).
4. Punctuation termination, attached and spaced (`.`, `,`, `!`, `?`, `;`, `:`).
5. Zero-length query + immediate punctuation returns `null` (`@,`, `@.`).
6. Preserves apostrophes and hyphens (`@O'Brien`, `@Jean-Luc's Task`).
7. 5-word cap enforcement (5 words active, 6 words closes).
8. Double-space tolerance without closing or over-counting words.
9. Stateless reactivation on backspacing past a terminator.
10. Cursor repositioning / cursor-relative binding to earlier mentions.
11. Word-boundary gate preservation (`email@domain.com`, `foo/bar` do not activate).
12. Newline hard-termination.

### Verification
- `packages/core/src/Chat/useTriggerMenu.test.tsx`: 12/12 passed
- `packages/core/src/Chat/`: 263/263 passed across 19 test files
- ESLint: 0 errors
- Changeset check: Passed
