### PR TITLE
feat(Selector): add theme-aware presentation adaptations

### DIFF
--- a/.changeset/selector-adaptations.md
+++ b/.changeset/selector-adaptations.md
@@ -1,0 +1,71 @@
+---
+'@astryxdesign/core': minor
+---
+
+[breaking] Give `Selector` a caller-owned `adaptations` presentation policy
+
+`Selector` now accepts an ordered, environment-conditioned policy for the one
+choice `presentation` already owned — anchored popover or modal bottom sheet:
+
+```tsx
+<Selector
+  label="Owner"
+  options={owners}
+  adaptations={{
+    default: 'popover',
+    rules: [
+      {when: {width: {below: 'md'}, pointer: 'coarse'}, value: 'bottom-sheet'},
+    ],
+  }}
+/>
+```
+
+`default` is the server-rendered, hydration, and no-match value, so the server
+picks the whole tree without guessing at a viewport. Rules are checked in author
+order and the LAST match wins; `width` names resolve against the nearest Theme's
+width points, `from` is inclusive, `below` is exclusive, and the fields of one
+`when` are ANDed. An empty `rules` array is valid and always resolves to
+`default`. `ComponentAdaptations`, `ComponentAdaptationRule`, and
+`ComponentAdaptationCondition` are exported from `@astryxdesign/core`;
+`SelectorAdaptationValue` (`'popover' | 'bottom-sheet'`) is exported from both
+`@astryxdesign/core` and `@astryxdesign/core/Selector`.
+
+`presentation` keeps its meaning and stays the short spelling. The two props are
+mutually exclusive: TypeScript admits only one, and passing both defined values
+throws before any surface opens. An explicitly spread `undefined` is not a
+conflict.
+
+**Behavior change — an invalid `presentation` now throws.** Its closed set is
+`popover`, `bottom-sheet`, and `adaptive`. A value outside it — one arriving
+from JavaScript, an untyped props bag, config, or a stale `presentation="modal"`
+left by a rename — previously fell through to an anchored popover with no
+warning, so a wrong surface was reported as a correct one. It now throws
+`<Selector presentation> must be one of popover, bottom-sheet, adaptive;
+received "modal".` TypeScript callers are unaffected; a JavaScript call site
+passing a bad value sees a failure where it used to see silence.
+
+**Breaking — the exact 768px edge.** `presentation="adaptive"` is now
+`default: 'popover'` plus a `{width: {below: 'md'}, pointer: 'coarse'}`
+bottom-sheet rule, resolved against the theme's `md` point. The released query
+was `(max-width: 768px) and (pointer: coarse)`, which INCLUDED 768px; `below` is
+exclusive, so at exactly 768px a coarse-pointer Selector now opens an anchored
+popover where it previously presented a bottom sheet. Every other width behaves
+as before. There is no per-callsite migration — the shared grammar has no
+inclusive upper edge. A product that needs the old cutoff moves its theme's `md`
+(global, and it also moves AppShell's default mobile-nav breakpoint); a Selector
+that should always present a sheet uses `presentation="bottom-sheet"`.
+
+`MultiSelector`, `DropdownMenu`, and `ContextMenu` are unchanged and keep the
+released `max-width: 768px` query, so Selector and MultiSelector deliberately
+disagree at exactly that width until they are separately migrated.
+
+One pre-existing limitation is worth knowing when adopting a policy: with
+server rendering, a selector that also sets `isDefaultOpen` comes up CLOSED
+whenever its policy resolves differently on the client — `presentation="adaptive"`
+on a compact touch client, or any rule matching there. The open runs from a
+mount effect holding the server value. It behaves the same on `MultiSelector`,
+which never migrated, and is unchanged by this release. Where a server-rendered
+selector must start open, give it a policy that does not change across
+hydration: `adaptations={{default: 'bottom-sheet', rules: []}}`.
+
+@imdreamrunner

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -45,6 +45,17 @@ const TARGETS = [
       'isFullBleed strip/label geometry incl. clamp far side, and the real ' +
       'LayoutHeader paddingBlockEnd -> TabList isFullBleed dock (#2622)',
   },
+  {
+    component: 'Selector',
+    story: 'core-selector--keyboard-bottom-sheet-policy',
+    guards:
+      'fine-pointer bottom sheet stays keyboard operable: Enter opens the ' +
+      'real modal dialog, focus enters the listbox, arrows move the active ' +
+      'option, Escape closes through the real exit transition and returns ' +
+      'focus to the trigger. The combination is long-standing (plain ' +
+      'presentation="bottom-sheet"); what this adds is real-browser evidence ' +
+      'for it, since jsdom stubs showModal and never runs the exit',
+  },
 ];
 
 const CONTENT_TYPES = {

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -74,7 +74,8 @@ const meta: Meta<typeof Selector> = {
     presentation: {
       control: 'radio',
       options: ['popover', 'bottom-sheet', 'adaptive'],
-      description: 'Popover, bottom sheet, or responsive presentation.',
+      description:
+        "Popover, bottom sheet, or responsive presentation. adaptive presents the sheet below the theme's md width point on coarse-pointer devices; the boundary is exclusive, so exactly md stays anchored. For any other rule, pass an adaptations policy instead — the two props are mutually exclusive.",
     },
     isDisabled: {
       control: 'boolean',
@@ -167,6 +168,165 @@ export const BottomSheetPresentation: Story = {
         presentation="bottom-sheet"
       />
     );
+  },
+};
+
+/**
+ * A caller-owned `adaptations` policy — the non-legacy case the `adaptive`
+ * shorthand cannot express.
+ *
+ * The rule here is pointer-only: a touch device gets the modal sheet at ANY
+ * width, which is right for a workflow whose users are on tablets held in
+ * landscape, where the shorthand's `below: 'md'` width test would keep the
+ * anchored popover. `default` is what the server renders and what a
+ * fine-pointer client keeps.
+ *
+ * Rules are checked in author order and the last match wins; width names,
+ * when a policy uses them, resolve against the nearest Theme.
+ */
+export const AdaptationsPointerPolicy: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | undefined>();
+    return (
+      <Selector
+        label="Assignee"
+        options={['Ada Lovelace', 'Grace Hopper', 'Katherine Johnson']}
+        value={value}
+        onChange={setValue}
+        adaptations={{
+          default: 'popover',
+          rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+        }}
+      />
+    );
+  },
+};
+
+/**
+ * A bottom sheet on a FINE pointer, kept keyboard operable.
+ *
+ * This combination is NOT new: `presentation="bottom-sheet"` has always
+ * rendered the modal sheet whatever the pointer, and `adaptations` only adds
+ * another way to ask for it. What is new is the coverage — a sheet is a modal
+ * dialog, and its keyboard contract had no real-browser evidence.
+ *
+ * That gap matters because jsdom fakes exactly the two things that decide it:
+ * `showModal` is a stub, and the exit transition never runs, so the unit
+ * suite's focus assertions are made against a simulation of the surface
+ * rather than the surface. Here a real `<dialog>`, a real focus trap, and a
+ * real transition are exercised: Enter opens it, focus enters the listbox,
+ * arrows move the active option, and Escape closes it and hands focus back to
+ * the trigger. These play assertions run in Chromium under the story play
+ * guard, which is what makes them a required check rather than a demo.
+ */
+export const KeyboardBottomSheetPolicy: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | undefined>();
+    return (
+      <div data-sheet-keyboard-fixture>
+        <Selector
+          label="Team"
+          options={['Design', 'Engineering', 'Marketing', 'Operations']}
+          value={value}
+          onChange={setValue}
+          adaptations={{default: 'bottom-sheet', rules: []}}
+        />
+      </div>
+    );
+  },
+  play: async ({canvasElement}) => {
+    const frame = () =>
+      new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+    /** Poll until `check` is true, or fail loudly. Play has no test lib. */
+    const until = async (what: string, check: () => boolean) => {
+      for (let attempt = 0; attempt < 120; attempt++) {
+        if (check()) {
+          return;
+        }
+        await frame();
+      }
+      throw new Error(`Timed out waiting for ${what}`);
+    };
+
+    const press = (target: Element, key: string) => {
+      target.dispatchEvent(
+        new KeyboardEvent('keydown', {key, bubbles: true, cancelable: true}),
+      );
+      target.dispatchEvent(
+        new KeyboardEvent('keyup', {key, bubbles: true, cancelable: true}),
+      );
+    };
+
+    const fixture = canvasElement.querySelector<HTMLElement>(
+      '[data-sheet-keyboard-fixture]',
+    );
+    const trigger = fixture?.querySelector<HTMLElement>('[role="combobox"]');
+    if (!trigger) {
+      throw new Error('Sheet keyboard fixture did not render a trigger');
+    }
+
+    // A fine pointer must still be offered the modal sheet when the policy
+    // asks for it — the trigger says so before anything opens.
+    if (trigger.getAttribute('aria-haspopup') !== 'dialog') {
+      throw new Error(
+        `Expected a dialog trigger, got aria-haspopup="${trigger.getAttribute('aria-haspopup')}"`,
+      );
+    }
+
+    trigger.focus();
+    if (document.activeElement !== trigger) {
+      throw new Error('Trigger did not take focus');
+    }
+
+    press(trigger, 'Enter');
+
+    await until(
+      'the modal sheet to open',
+      () => document.querySelector('dialog[open]') != null,
+    );
+    const dialog = document.querySelector('dialog[open]') as HTMLDialogElement;
+
+    // Focus entry: the listbox inside the sheet, not the trigger behind it.
+    // `showModal` first parks focus on the dialog itself and the component
+    // moves it a frame later, so the WAIT has to be for the listbox — waiting
+    // for "anything inside the dialog" resolves on that intermediate state.
+    const sheetListbox = () => dialog.querySelector('[role="listbox"]');
+    await until('focus to reach the sheet listbox', () => {
+      const listbox = sheetListbox();
+      return listbox != null && document.activeElement === listbox;
+    });
+    const listbox = sheetListbox();
+    if (!listbox) {
+      throw new Error('Sheet opened without a listbox');
+    }
+    if (trigger.getAttribute('aria-expanded') !== 'true') {
+      throw new Error('Trigger did not report the sheet as expanded');
+    }
+
+    // Arrow keys move the active option inside the modal surface.
+    const activeOption = () => listbox.getAttribute('aria-activedescendant');
+    const firstActive = activeOption();
+    press(listbox, 'ArrowDown');
+    await until(
+      'the active option to move',
+      () => activeOption() !== firstActive,
+    );
+
+    // Dismissal returns focus to the trigger — through the sheet's real exit
+    // transition, which is the part jsdom cannot run.
+    press(document.activeElement ?? listbox, 'Escape');
+
+    await until(
+      'the sheet to close',
+      () => document.querySelector('dialog[open]') == null,
+    );
+    await until('focus to return to the trigger', () => {
+      return document.activeElement === trigger;
+    });
+    if (trigger.getAttribute('aria-expanded') !== 'false') {
+      throw new Error('Trigger still reports the sheet as expanded');
+    }
   },
 };
 

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -84,7 +84,10 @@ import {groupStyles} from '../InputGroup/groupStyles';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {useTranslator} from '../i18n';
-import type {AdaptivePresentation} from '../hooks/useAdaptivePresentation';
+import {
+  useAdaptivePresentation,
+  type AdaptivePresentation,
+} from '../hooks/useAdaptivePresentation';
 import {SelectorBottomSheet} from '../Selector/SelectorBottomSheet';
 import {useSelectorPresentation} from '../Selector/useSelectorPresentation';
 import {selectorPresentationStyles} from '../Selector/selectorPresentation.stylex';
@@ -992,8 +995,16 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }
   }, [hasSearch, optimisticValue]);
 
+  // The legacy `(max-width: 768px) and (pointer: coarse)` policy, resolved
+  // HERE rather than inside the shared controller. MultiSelector is explicitly
+  // out of scope for spec:AST-031's first migration, so it keeps its released
+  // query — including the inclusive 768px edge — while Selector moves to the
+  // theme's named `md` point. Called immediately before the controller, where
+  // the controller used to call it, so hook order is unchanged.
+  const resolvedPresentation = useAdaptivePresentation(presentation);
+
   const surface = useSelectorPresentation({
-    presentation,
+    presentation: resolvedPresentation,
     onHide: handleLayerHide,
     onShow: handleLayerShow,
     triggerRef,

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -337,8 +337,14 @@ export const docs = {
       name: 'presentation',
       type: "'popover' | 'bottom-sheet' | 'adaptive'",
       description:
-        'How the option list is presented. adaptive uses a bottom sheet on compact touch screens and an anchored popover otherwise.',
+        "How the option list is presented. adaptive uses a bottom sheet below the theme's md width point on coarse-pointer devices, and an anchored popover otherwise; the boundary is exclusive, so a viewport exactly at md stays anchored. Those three values are the whole set: any other value throws rather than falling back to popover. Mutually exclusive with adaptations.",
       default: "'popover'",
+    },
+    {
+      name: 'adaptations',
+      type: "{default: 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'popover' | 'bottom-sheet'}>}",
+      description:
+        "Environment-conditioned presentation policy, for the cases the adaptive shorthand cannot express. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Mutually exclusive with presentation; passing both throws. Known limitation, shared with the adaptive shorthand and with MultiSelector: with server rendering, a policy that resolves differently on the client is not honored by a selector that starts open — it comes up closed, because the open runs from a mount effect holding the server value. Pass a policy that does not change across hydration there, such as {default: 'bottom-sheet', rules: []}.",
     },
     {
       name: 'width',
@@ -405,6 +411,11 @@ export const docs = {
           'Use presentation="adaptive" when the selector should become a bottom sheet on compact touch screens.',
       },
       {
+        guidance: true,
+        description:
+          'Reach for adaptations only when the adaptive shorthand is wrong for the surface — a different width point, a pointer-only rule, or a server-rendered bottom sheet.',
+      },
+      {
         guidance: false,
         description:
           'Use for action menus; use Dropdown Menu for triggering commands or navigation.',
@@ -464,6 +475,11 @@ export const docsZh = {
         guidance: true,
         description:
           'Set a meaningful placeholder that hints at the expected selection (e.g. "Choose a country" not "Select...").',
+      },
+      {
+        guidance: true,
+        description:
+          'Use presentation="adaptive" when the selector should become a bottom sheet on compact touch screens, and adaptations when the rule differs from that shorthand. The two props are mutually exclusive.',
       },
       {
         guidance: false,
@@ -535,6 +551,11 @@ export const docsDense = {
         guidance: true,
         description:
           'Use variant="ghost" in toolbars with ghost buttons; prefer statusVariant="tooltip" for compact validation status.',
+      },
+      {
+        guidance: true,
+        description:
+          'presentation="adaptive" = bottom sheet below the theme md width on a coarse pointer (md itself stays anchored); adaptations={{default, rules}} for any other rule. The two props are mutually exclusive.',
       },
       {
         guidance: false,

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -39,6 +39,17 @@ import {generateThemeCSS} from '../theme/generateThemeRules';
 import {spacingVars} from '../theme/tokens.stylex';
 import {selectorPresentationStyles} from './selectorPresentation.stylex';
 
+/**
+ * What `presentation="adaptive"` compiles to at the default `md` point.
+ *
+ * Selector resolves through the AST-031 grammar now, so its compact-touch
+ * query is `width < 768px` — EXCLUSIVE — where the legacy shared hook (which
+ * MultiSelector and the menus still use) asks for `max-width: 768px`. The
+ * literal is spelled here rather than imported so a silent change to the
+ * compiled query fails these tests instead of following them.
+ */
+const COMPACT_TOUCH_ADAPTATION_QUERY = '(width < 768px) and (pointer: coarse)';
+
 function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
   return [prose, component].filter(Boolean).join('\n\n');
@@ -330,7 +341,7 @@ describe('Selector', () => {
     vi.stubGlobal(
       'matchMedia',
       vi.fn().mockImplementation((query: string) => ({
-        matches: query === '(max-width: 768px) and (pointer: coarse)',
+        matches: query === COMPACT_TOUCH_ADAPTATION_QUERY,
         media: query,
         onchange: null,
         addEventListener: vi.fn(),
@@ -2475,7 +2486,7 @@ describe('Selector', () => {
       vi.mocked(matchMedia).mockImplementation(
         (query: string) =>
           ({
-            matches: query === '(max-width: 768px) and (pointer: coarse)',
+            matches: query === COMPACT_TOUCH_ADAPTATION_QUERY,
             media: query,
             onchange: null,
             addEventListener: vi.fn(),

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -11,8 +11,12 @@
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Selector/Selector.doc.mjs
+ * - /packages/core/src/Selector/Selector.spec.md
  * - /packages/core/src/Selector/Selector.test.tsx
+ * - /packages/core/src/Selector/SelectorAdaptations.test.tsx
+ * - /packages/core/src/Selector/useSelectorPresentation.ts
  * - /packages/core/src/Selector/index.ts
+ * - /packages/core/src/theme/componentAdaptations.ts
  * - /apps/storybook/stories/InputGroup.stories.tsx
  * - /packages/cli/assets/templates/blocks/components/Selector/ (showcase blocks)
  */
@@ -85,7 +89,8 @@ import {groupStyles} from '../InputGroup/groupStyles';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {useTranslator} from '../i18n';
-import type {AdaptivePresentation} from '../hooks/useAdaptivePresentation';
+import type {ComponentAdaptations} from '../theme/componentAdaptations';
+import {useComponentAdaptations} from '../theme/useComponentAdaptations';
 import {SelectorBottomSheet} from './SelectorBottomSheet';
 import {useSelectorPresentation} from './useSelectorPresentation';
 import {selectorPresentationStyles} from './selectorPresentation.stylex';
@@ -464,7 +469,107 @@ export type SelectorSize = 'sm' | 'md' | 'lg';
 
 export type SelectorVariant = 'input' | 'ghost';
 
-export type SelectorPresentation = AdaptivePresentation;
+/**
+ * The surfaces a resolved Selector presentation policy can name.
+ *
+ * The whole domain of `adaptations`: an anchored popover or a modal bottom
+ * sheet. `adaptive` is not a member — it is legacy shorthand for a policy that
+ * resolves to one of these (spec:AST-031 FR7).
+ *
+ * Spelled as literals rather than aliased to the internal
+ * `ResolvedAdaptivePresentation`, so a consumer's hover, error, and `.d.ts`
+ * read `'popover' | 'bottom-sheet'` instead of naming a type they cannot
+ * import. The reverse alias — the internal type pointing here — would put the
+ * shared adaptive hook, which DropdownMenu and ContextMenu also use, behind
+ * one component's public API. `SelectorAdaptations.test.tsx` asserts at
+ * compile time that the two unions stay identical.
+ */
+export type SelectorAdaptationValue = 'popover' | 'bottom-sheet';
+
+export type SelectorPresentation = SelectorAdaptationValue | 'adaptive';
+
+/** Runtime domain for `adaptations`, so an untyped caller is rejected too. */
+const SELECTOR_ADAPTATION_VALUES = [
+  'popover',
+  'bottom-sheet',
+] as const satisfies ReadonlyArray<SelectorAdaptationValue>;
+
+/**
+ * `presentation="adaptive"`, expressed in the shared grammar.
+ *
+ * The width point is the nearest Theme's `md`, and `below` is EXCLUSIVE — the
+ * one behavior difference from the legacy `(max-width: 768px)` query, which
+ * included equality. At the default 768px point a coarse-pointer Selector now
+ * anchors instead of presenting a sheet (spec:AST-031 FR7/DEC-6).
+ */
+const ADAPTIVE_PRESENTATION_POLICY: ComponentAdaptations<SelectorAdaptationValue> =
+  {
+    default: 'popover',
+    rules: [
+      {when: {width: {below: 'md'}, pointer: 'coarse'}, value: 'bottom-sheet'},
+    ],
+  };
+
+/**
+ * Every legacy `presentation` value as a policy.
+ *
+ * A constant presentation is a policy with no rules: it resolves to `default`
+ * everywhere and subscribes to nothing, so the two spellings run through one
+ * resolver instead of a branch that only the shorthand path exercises. Module
+ * scope keeps the objects referentially stable across renders.
+ *
+ * Also the runtime domain of `presentation`: the keys are what a value is
+ * checked against before it is used as one.
+ */
+const PRESENTATION_POLICIES: Readonly<
+  Record<SelectorPresentation, ComponentAdaptations<SelectorAdaptationValue>>
+> = {
+  popover: {default: 'popover', rules: []},
+  'bottom-sheet': {default: 'bottom-sheet', rules: []},
+  adaptive: ADAPTIVE_PRESENTATION_POLICY,
+};
+
+/**
+ * The policy one call site's props select, with both props validated first.
+ *
+ * `presentation` is validated rather than trusted: TypeScript covers a typed
+ * caller, but a value arriving from JavaScript, an untyped props bag, or a
+ * stale `presentation="modal"` would otherwise index the policy map to
+ * `undefined` and resolve to an anchored popover — a wrong surface reported as
+ * a correct one. The failure a caller gets should name the prop, not appear as
+ * a silently different surface (spec:AST-031 IR3).
+ */
+function resolvePresentationPolicy(
+  presentation: SelectorPresentation | undefined,
+  adaptations: ComponentAdaptations<SelectorAdaptationValue> | undefined,
+): ComponentAdaptations<SelectorAdaptationValue> {
+  // Checked on `undefined`, not on presence: spreading a props bag that
+  // carries an explicit `adaptations: undefined` beside a real `presentation`
+  // is an ordinary call, not a conflict (spec:AST-031 FR6).
+  if (presentation !== undefined && adaptations !== undefined) {
+    throw new Error(
+      '<Selector> received both `presentation` and `adaptations`, which select the same surface. Pass `adaptations` for an environment-conditioned policy, or `presentation` for a constant surface or the legacy `adaptive` shorthand.',
+    );
+  }
+  if (adaptations !== undefined) {
+    return adaptations;
+  }
+  if (presentation === undefined) {
+    return PRESENTATION_POLICIES.popover;
+  }
+  // `hasOwnProperty`, not `in`: `presentation="toString"` must not resolve
+  // through Object.prototype to a policy-shaped function.
+  if (
+    !Object.prototype.hasOwnProperty.call(PRESENTATION_POLICIES, presentation)
+  ) {
+    throw new Error(
+      `<Selector presentation> must be one of ${Object.keys(
+        PRESENTATION_POLICIES,
+      ).join(', ')}; received ${JSON.stringify(presentation)}.`,
+    );
+  }
+  return PRESENTATION_POLICIES[presentation];
+}
 
 export type SelectorStatusType = 'warning' | 'error' | 'success';
 
@@ -699,18 +804,22 @@ interface SelectorPropsBase<
    */
   placement?: LayerPlacement;
 
-  /**
-   * How the option list is presented.
-   * - 'popover': anchored to the trigger
-   * - 'bottom-sheet': modal sheet suited to compact touch screens
-   * - 'adaptive': bottom sheet on compact coarse-pointer screens, otherwise popover
-   * @default 'popover'
-   */
-  presentation?: SelectorPresentation;
+  // presentation and adaptations are in the exclusive policy union below
 
   /**
    * Whether the dropdown starts open on mount.
    * Useful for showcases and previews.
+   *
+   * Known limitation, unchanged by `adaptations` and shared with
+   * MultiSelector: under SERVER RENDERING, a policy whose value differs
+   * between server and client — `presentation="adaptive"` on a compact touch
+   * client, or any rule that matches there — comes up CLOSED. The open runs
+   * from a mount effect, which sees the hydration render's value (the server
+   * one), while the render after hydration has already published the
+   * browser's. Client-only rendering is unaffected. A policy that does not
+   * change across hydration opens correctly, which is the workaround:
+   * `adaptations={{default: 'bottom-sheet', rules: []}}`.
+   *
    * @default false
    */
   isDefaultOpen?: boolean;
@@ -727,6 +836,69 @@ interface SelectorPropsBase<
    */
   'data-testid'?: string;
 }
+
+/**
+ * How the option list is presented — exactly one spelling per call site.
+ *
+ * A separate two-arm union, INTERSECTED with the `hasClear` union rather than
+ * folded into it: exclusivity is orthogonal to the value contract, and
+ * spelling it inside `hasClear` would turn two arms into four that each have
+ * to restate `value`/`onChange`/`changeAction`. `?: never` is what makes the
+ * pair exclusive to the compiler while both members stay optional, so an
+ * explicitly spread `undefined` still type-checks (spec:AST-031 FR6).
+ */
+type SelectorPresentationPolicy =
+  | {
+      /**
+       * How the option list is presented.
+       * - 'popover': anchored to the trigger
+       * - 'bottom-sheet': modal sheet suited to compact touch screens
+       * - 'adaptive': bottom sheet on compact coarse-pointer screens,
+       *   otherwise popover. Equivalent to
+       *   `adaptations={{default: 'popover', rules: [{when: {width: {below:
+       *   'md'}, pointer: 'coarse'}, value: 'bottom-sheet'}]}}`, resolved
+       *   against the nearest Theme's `md` point.
+       *
+       * Those three are the whole set; any other value throws rather than
+       * falling back to a popover.
+       *
+       * Mutually exclusive with `adaptations`.
+       * @default 'popover'
+       */
+      presentation?: SelectorPresentation;
+      adaptations?: never;
+    }
+  | {
+      presentation?: never;
+      /**
+       * Environment-conditioned presentation policy.
+       *
+       * `default` is the server-rendered, hydration, and no-match value;
+       * ordered `rules` map conditions to the same two values, and the LAST
+       * matching rule wins. Width points come from the nearest Theme, `from`
+       * is inclusive, `below` is exclusive, and condition fields are ANDed.
+       *
+       * Mutually exclusive with `presentation`.
+       *
+       * @example
+       * ```
+       * <Selector
+       *   label="Fruit"
+       *   options={options}
+       *   adaptations={{
+       *     default: 'popover',
+       *     rules: [
+       *       {
+       *         when: {width: {below: 'md'}, pointer: 'coarse'},
+       *         value: 'bottom-sheet',
+       *       },
+       *     ],
+       *   }}
+       * />
+       * ```
+       */
+      adaptations?: ComponentAdaptations<SelectorAdaptationValue>;
+    };
 
 /**
  * Without `hasClear`, the selector always has a string value (or undefined for placeholder).
@@ -755,8 +927,10 @@ type SelectorPropsClearable<T extends SelectorOptionType = SelectorOptionType> =
     changeAction?: (value: string | null) => void | Promise<void>;
   };
 
-export type SelectorProps<T extends SelectorOptionType = SelectorOptionType> =
-  SelectorPropsNonClearable<T> | SelectorPropsClearable<T>;
+export type SelectorProps<T extends SelectorOptionType = SelectorOptionType> = (
+  SelectorPropsNonClearable<T> | SelectorPropsClearable<T>
+) &
+  SelectorPresentationPolicy;
 
 /**
  * Default option renderer
@@ -848,7 +1022,8 @@ export function Selector<T extends SelectorOptionType>(
     emptyText: emptyTextFromProps,
     emptySearchText: emptySearchTextFromProps,
     placement,
-    presentation = 'popover',
+    presentation: presentationProp,
+    adaptations,
     isDefaultOpen = false,
     'data-testid': testId,
     width,
@@ -859,7 +1034,7 @@ export function Selector<T extends SelectorOptionType>(
     hasClear: hasClearProp,
     id,
     ...rest
-  } = props as SelectorPropsClearable<T>;
+  } = props as SelectorPropsClearable<T> & SelectorPresentationPolicy;
   const isEffectivelyRequired = useResolvedRequired({isRequired, isOptional});
   const placeholder = placeholderFromProps ?? t('@astryx.selector.placeholder');
   const searchPlaceholder =
@@ -1007,8 +1182,20 @@ export function Selector<T extends SelectorOptionType>(
     }
   }, [hasSearch]);
 
+  // One effective policy per call site, both props validated before use.
+  // `presentation` and `adaptations` name the same choice, so accepting both
+  // would make precedence — not the caller — decide the surface.
+  const presentationPolicy = resolvePresentationPolicy(
+    presentationProp,
+    adaptations,
+  );
+  const {value: resolvedPresentation} = useComponentAdaptations(
+    presentationPolicy,
+    {path: '<Selector adaptations>', values: SELECTOR_ADAPTATION_VALUES},
+  );
+
   const surface = useSelectorPresentation({
-    presentation,
+    presentation: resolvedPresentation,
     onHide: handleLayerHide,
     onShow: handleLayerShow,
     triggerRef,
@@ -1030,6 +1217,16 @@ export function Selector<T extends SelectorOptionType>(
   const keepOpenProps = useKeepLayerOpenProps(popover.id, popover.isOpen);
 
   // Open dropdown on mount when isDefaultOpen is true and interaction is allowed.
+  //
+  // Mount-only, so it runs with the HYDRATION render's resolved value — the
+  // server one by spec:AST-031 FR3. A policy that changes across hydration
+  // (`adaptive` on a compact touch client) therefore opens against a value the
+  // next render has already replaced, and the field comes up closed. That
+  // predates this policy — MultiSelector, still on the released adaptive hook,
+  // does the same — and the fix belongs to `isDefaultOpen`'s own contract:
+  // deferring the open past hydration changes when EVERY default-open surface
+  // appears, which is not this migration's call to make. Documented on the
+  // prop, characterized in SelectorAdaptations.test.tsx.
   useEffect(() => {
     if (isDefaultOpen && !isEffectivelyReadOnly) {
       surface.show();

--- a/packages/core/src/Selector/SelectorAdaptations.test.tsx
+++ b/packages/core/src/Selector/SelectorAdaptations.test.tsx
@@ -1,0 +1,1559 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file SelectorAdaptations.test.tsx
+ * @input Uses vitest, @testing-library/react, react-dom/server
+ * @output Tests Selector's public presentation policy (spec:AST-031)
+ * @position Tests; validates the `adaptations` prop, the `presentation`
+ *   shorthand it subsumes, and the isolation between Selector and
+ *   MultiSelector. Behavior that is not policy resolution — geometry,
+ *   selection, search, read-only — stays in Selector.test.tsx.
+ *
+ * The environment here is a REAL query evaluator rather than a
+ * `query === '<literal>'` stub: the boundary this migration changes is
+ * `width < md` versus `max-width: md`, and only a stub that computes an answer
+ * from an actual viewport width can tell those two apart at 768px.
+ *
+ * SYNC: When Selector's presentation policy changes, update these tests.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, act, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {renderToString} from 'react-dom/server';
+import {hydrateRoot} from 'react-dom/client';
+import {createElement, type ReactNode} from 'react';
+import {Selector} from './Selector';
+import type {SelectorAdaptationValue} from './Selector';
+import type {ResolvedAdaptivePresentation} from '../hooks/useAdaptivePresentation';
+import {MultiSelector} from '../MultiSelector';
+import {Theme} from '../theme/Theme';
+import {defineTheme} from '../theme/defineTheme';
+import {resetThemes} from '../theme/themeRegistry';
+import {resetAdaptationStores} from '../theme/useComponentAdaptations';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import {__resetInteractionModalityForTest} from '../utils/interactionModality';
+
+const OPTIONS = ['Apple', 'Banana', 'Cherry'];
+
+/** The one policy `presentation="adaptive"` is shorthand for. */
+const ADAPTIVE_POLICY = {
+  default: 'popover',
+  rules: [
+    {when: {width: {below: 'md'}, pointer: 'coarse'}, value: 'bottom-sheet'},
+  ],
+} as const;
+
+// =============================================================================
+// A viewport, not a query allowlist
+// =============================================================================
+
+interface Viewport {
+  width: number;
+  pointer: 'coarse' | 'fine';
+}
+
+interface FakeMediaQueryList {
+  media: string;
+  matches: boolean;
+  listeners: Set<() => void>;
+}
+
+interface Environment {
+  /** Every distinct query anything asked about. */
+  queries: () => string[];
+  /**
+   * Only the queries an AST-031 or legacy adaptive policy can produce.
+   *
+   * Unrelated hooks in the tree ask about `prefers-reduced-motion` and hover,
+   * so "subscribed to nothing" has to mean "asked nothing about the viewport",
+   * not "called matchMedia zero times".
+   */
+  presentationQueries: () => string[];
+  /** Move the viewport and notify listeners, as a resize does. */
+  set: (next: Partial<Viewport>) => void;
+}
+
+/**
+ * Evaluate one media query against a viewport.
+ *
+ * Understands exactly the two grammars in play: AST-031's compiled range
+ * syntax (`(width < 768px)`, `(width >= 1024px)`) and the legacy shared hook's
+ * `(max-width: 768px)`. Anything else — `(hover: hover)`, `(prefers-*)` — is
+ * reported as not matching rather than throwing, so an unrelated hook asking
+ * about the environment does not fail the test that owns this stub.
+ */
+function evaluate(query: string, viewport: Viewport): boolean {
+  return query.split(' and ').every(rawPart => {
+    const part = rawPart.trim();
+    const range = /^\(width (<|<=|>|>=) (\d+)px\)$/.exec(part);
+    if (range) {
+      const point = Number(range[2]);
+      switch (range[1]) {
+        case '<':
+          return viewport.width < point;
+        case '<=':
+          return viewport.width <= point;
+        case '>':
+          return viewport.width > point;
+        default:
+          return viewport.width >= point;
+      }
+    }
+    const maxWidth = /^\(max-width: (\d+)px\)$/.exec(part);
+    if (maxWidth) {
+      return viewport.width <= Number(maxWidth[1]);
+    }
+    const minWidth = /^\(min-width: (\d+)px\)$/.exec(part);
+    if (minWidth) {
+      return viewport.width >= Number(minWidth[1]);
+    }
+    const pointer = /^\(pointer: (coarse|fine)\)$/.exec(part);
+    if (pointer) {
+      return pointer[1] === viewport.pointer;
+    }
+    return false;
+  });
+}
+
+function installEnvironment(initial: Viewport): Environment {
+  const viewport: Viewport = {...initial};
+  const lists = new Map<string, FakeMediaQueryList>();
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((media: string) => {
+      let list = lists.get(media);
+      if (!list) {
+        list = {
+          media,
+          matches: evaluate(media, viewport),
+          listeners: new Set(),
+        };
+        lists.set(media, list);
+      }
+      // Re-evaluate on every read: a list created before a `set` must not
+      // report the viewport it was born in.
+      list.matches = evaluate(media, viewport);
+      const handle = list;
+      return {
+        get matches() {
+          return handle.matches;
+        },
+        media,
+        onchange: null,
+        addEventListener: (type: string, listener: () => void) => {
+          if (type === 'change') {
+            handle.listeners.add(listener);
+          }
+        },
+        removeEventListener: (type: string, listener: () => void) => {
+          if (type === 'change') {
+            handle.listeners.delete(listener);
+          }
+        },
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      } as unknown as MediaQueryList;
+    }),
+  );
+
+  return {
+    queries: () => [...lists.keys()],
+    presentationQueries: () =>
+      [...lists.keys()].filter(
+        query => query.includes('width') || query.includes('pointer'),
+      ),
+    set(next) {
+      Object.assign(viewport, next);
+      act(() => {
+        for (const list of lists.values()) {
+          const matches = evaluate(list.media, viewport);
+          if (matches === list.matches) {
+            continue;
+          }
+          list.matches = matches;
+          for (const listener of [...list.listeners]) {
+            listener();
+          }
+        }
+      });
+    },
+  };
+}
+
+// =============================================================================
+// jsdom surface stubs (mirrors Selector.test.tsx)
+// =============================================================================
+
+beforeEach(() => {
+  __resetLiveRegionsForTest();
+  __resetInteractionModalityForTest();
+  resetThemes();
+  resetAdaptationStores();
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+  installEnvironment({width: 1280, pointer: 'fine'});
+});
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+  resetAdaptationStores();
+  vi.unstubAllGlobals();
+});
+
+/**
+ * Which surface the closed trigger advertises.
+ *
+ * `aria-haspopup` is the resolved value made observable without opening
+ * anything: `listbox` for the anchored popover, `dialog` for the modal sheet
+ * (component:Selector AR1). Reading it keeps every resolution assertion a
+ * single synchronous render.
+ */
+function advertisedSurface(label = 'Fruit'): string | null {
+  // Exact name match: 'Fruit' and 'Fruits' are both on screen in the
+  // Selector/MultiSelector isolation cases.
+  return screen
+    .getByRole('combobox', {name: label})
+    .getAttribute('aria-haspopup');
+}
+
+function themeWithMd(name: string, md: number) {
+  return defineTheme({name, adaptations: {widthBreakpoints: {md}}});
+}
+
+/**
+ * jsdom never runs the sheet's exit transition, so BottomSheet's final-focus
+ * handoff — the signal Selector waits for before releasing the latched value —
+ * has to be delivered by hand. Mirrors Selector.test.tsx's read-only close.
+ */
+function finishSheetExit(dialog: HTMLElement): void {
+  const panel = dialog.querySelector<HTMLElement>('.astryx-bottom-sheet');
+  expect(panel).not.toBeNull();
+  fireEvent.transitionEnd(panel!, {propertyName: 'transform'});
+}
+
+/** jsdom keeps popover content out of the accessibility tree. */
+const hidden = {hidden: true} as const;
+
+// =============================================================================
+// Injected-CSS inspection (mirrors Field/InputClearButton.test.tsx)
+// =============================================================================
+
+interface InjectedRule {
+  selector: string;
+  text: string;
+  media: string | null;
+}
+
+/**
+ * Every style rule StyleX injected at runtime, flattened out of its at-rule
+ * wrapper and tagged with that wrapper's condition — so a
+ * `@media (pointer: coarse)` declaration stays distinguishable from the
+ * unconditional one. jsdom resolves neither media queries nor pseudo-element
+ * boxes, so this is where a pointer-gated floor is checkable at unit level.
+ */
+function injectedRules(): InjectedRule[] {
+  const walk = (rules: CSSRuleList, condition: string | null): InjectedRule[] =>
+    [...rules].flatMap((rule): InjectedRule[] => {
+      const {selectorText} = rule as CSSStyleRule;
+      if (typeof selectorText === 'string') {
+        return [{selector: selectorText, text: rule.cssText, media: condition}];
+      }
+      const nested = (rule as CSSGroupingRule).cssRules;
+      if (nested == null) {
+        return [];
+      }
+      const own = (rule as CSSMediaRule).media?.mediaText;
+      return walk(nested, own != null && own !== '' ? own : condition);
+    });
+
+  return [...document.styleSheets].flatMap(sheet => walk(sheet.cssRules, null));
+}
+
+/** Declaration lookup scoped to the classes actually on one element. */
+function declarationsFor(element: Element) {
+  const classes = element.className.split(' ').filter(Boolean);
+  const rules = injectedRules().filter(({selector}) =>
+    classes.some(name => selector.includes(`.${name}`)),
+  );
+  // Guards every assertion against passing silently if StyleX's runtime
+  // injection or the class plumbing changes shape.
+  expect(rules.length).toBeGreaterThan(0);
+  return (pattern: RegExp, inMedia?: string) =>
+    rules.some(
+      ({text, media}) =>
+        pattern.test(text) &&
+        (inMedia == null ? media == null : (media ?? '').includes(inMedia)),
+    );
+}
+
+function withTheme(theme: ReturnType<typeof defineTheme>) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    return <Theme theme={theme}>{children}</Theme>;
+  };
+}
+
+// =============================================================================
+// FR3 — default is server truth
+// =============================================================================
+
+describe('server rendering', () => {
+  it('renders `default` and never reads matchMedia', () => {
+    // A viewport the rule matches: if the server consulted it, the markup
+    // would carry the sheet's semantics instead of the default's.
+    installEnvironment({width: 375, pointer: 'coarse'});
+
+    const html = renderToString(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    expect(html).toContain('aria-haspopup="listbox"');
+    expect(html).not.toContain('aria-haspopup="dialog"');
+    expect(matchMedia).not.toHaveBeenCalled();
+  });
+
+  it('renders a `bottom-sheet` default as the sheet trigger', () => {
+    installEnvironment({width: 1600, pointer: 'fine'});
+
+    const html = renderToString(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={{
+          default: 'bottom-sheet',
+          rules: [{when: {width: {from: 'lg'}}, value: 'popover'}],
+        }}
+      />,
+    );
+
+    expect(html).toContain('aria-haspopup="dialog"');
+    expect(matchMedia).not.toHaveBeenCalled();
+  });
+
+  it('does not read matchMedia for the legacy shorthand either', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+
+    const html = renderToString(
+      <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />,
+    );
+
+    expect(html).toContain('aria-haspopup="listbox"');
+    expect(matchMedia).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// FR3/FR4 — client resolution
+// =============================================================================
+
+describe('client resolution', () => {
+  it('publishes the matching rule after hydration', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it('falls back to `default` when no rule matches', () => {
+    installEnvironment({width: 375, pointer: 'fine'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    // Narrow, but a fine pointer: the ANDed condition does not match.
+    expect(advertisedSurface()).toBe('listbox');
+  });
+
+  it('opens the resolved bottom sheet, with modal dialog semantics', async () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(
+      await screen.findByRole('dialog', {name: 'Fruit'}),
+    ).toBeInTheDocument();
+    expect(HTMLElement.prototype.showPopover).not.toHaveBeenCalled();
+  });
+
+  it('opens the resolved popover, anchored', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalledOnce();
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+  });
+
+  it('follows the environment while closed', () => {
+    const environment = installEnvironment({width: 1280, pointer: 'fine'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+    expect(advertisedSurface()).toBe('listbox');
+
+    environment.set({width: 375, pointer: 'coarse'});
+
+    expect(advertisedSurface()).toBe('dialog');
+  });
+});
+
+// =============================================================================
+// FR4 — rule order is precedence
+// =============================================================================
+
+describe('rule order', () => {
+  it('lets the LAST matching rule win, not the most specific', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={{
+          default: 'bottom-sheet',
+          rules: [
+            // Narrower condition first — it still loses to the later match.
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'bottom-sheet',
+            },
+            {when: {width: {below: 'md'}}, value: 'popover'},
+          ],
+        }}
+      />,
+    );
+
+    expect(advertisedSurface()).toBe('listbox');
+  });
+
+  it('reverses the outcome when the same rules are reordered', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={{
+          default: 'bottom-sheet',
+          rules: [
+            {when: {width: {below: 'md'}}, value: 'popover'},
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'bottom-sheet',
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it('resolves an empty rule list to `default` and subscribes to nothing', () => {
+    const environment = installEnvironment({width: 375, pointer: 'coarse'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={{default: 'bottom-sheet', rules: []}}
+      />,
+    );
+
+    expect(advertisedSurface()).toBe('dialog');
+    expect(environment.presentationQueries()).toEqual([]);
+  });
+});
+
+// =============================================================================
+// FR5 — width points come from the nearest Theme
+// =============================================================================
+
+describe('theme width points', () => {
+  it('uses the AST-012 defaults without a theme', () => {
+    installEnvironment({width: 700, pointer: 'coarse'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it("follows the theme's `md` override", () => {
+    installEnvironment({width: 850, pointer: 'coarse'});
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+      {wrapper: withTheme(themeWithMd('selector-adaptations-wide-md', 900))},
+    );
+
+    // 850 is above the default md (768) but below this theme's 900.
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it('prefers the NEAREST theme when providers nest', () => {
+    installEnvironment({width: 850, pointer: 'coarse'});
+    const outer = themeWithMd('selector-adaptations-outer', 900);
+    const inner = themeWithMd('selector-adaptations-inner', 800);
+
+    render(
+      <Theme theme={outer}>
+        <Selector
+          label="Outer"
+          options={OPTIONS}
+          adaptations={ADAPTIVE_POLICY}
+        />
+        <Theme theme={inner}>
+          <Selector
+            label="Inner"
+            options={OPTIONS}
+            adaptations={ADAPTIVE_POLICY}
+          />
+        </Theme>
+      </Theme>,
+    );
+
+    // One viewport, two answers: 850 < 900 but 850 >= 800.
+    expect(advertisedSurface('Outer')).toBe('dialog');
+    expect(advertisedSurface('Inner')).toBe('listbox');
+  });
+
+  it('moves the shorthand boundary with the theme too', () => {
+    installEnvironment({width: 850, pointer: 'coarse'});
+    render(
+      <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />,
+      {
+        wrapper: withTheme(themeWithMd('selector-adaptations-shorthand', 900)),
+      },
+    );
+
+    expect(advertisedSurface()).toBe('dialog');
+  });
+});
+
+// =============================================================================
+// FR7/DEC-6 — the exclusive `below` edge
+// =============================================================================
+
+describe('the exact md boundary', () => {
+  it('anchors at exactly the default md point (768px)', () => {
+    installEnvironment({width: 768, pointer: 'coarse'});
+    render(
+      <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />,
+    );
+
+    // `below` is exclusive. The legacy `max-width: 768px` query included this
+    // width; this single pixel is the reviewed breaking change (AST-031 DEC-6).
+    expect(advertisedSurface()).toBe('listbox');
+  });
+
+  it('presents a sheet one pixel below it (767px)', () => {
+    installEnvironment({width: 767, pointer: 'coarse'});
+    render(
+      <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />,
+    );
+
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it("moves that edge with the theme's md", () => {
+    installEnvironment({width: 768, pointer: 'coarse'});
+    render(
+      <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />,
+      {wrapper: withTheme(themeWithMd('selector-adaptations-edge', 769))},
+    );
+
+    // Restoring the old inclusive behavior at 768 is a global theme change,
+    // not a per-callsite one — exactly what FR7 says the migration costs.
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it('compiles the range query rather than a max-width query', () => {
+    const environment = installEnvironment({width: 767, pointer: 'coarse'});
+    render(
+      <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />,
+    );
+
+    expect(environment.presentationQueries()).toEqual([
+      '(width < 768px) and (pointer: coarse)',
+    ]);
+  });
+});
+
+// =============================================================================
+// FR7/DEC-5 — the legacy shorthand
+// =============================================================================
+
+describe('presentation shorthand', () => {
+  it('defaults to an anchored popover and reads no media query', () => {
+    const environment = installEnvironment({width: 375, pointer: 'coarse'});
+    render(<Selector label="Fruit" options={OPTIONS} />);
+
+    expect(advertisedSurface()).toBe('listbox');
+    expect(environment.presentationQueries()).toEqual([]);
+  });
+
+  it('keeps `bottom-sheet` constant on a wide fine-pointer viewport', () => {
+    const environment = installEnvironment({width: 1600, pointer: 'fine'});
+    render(
+      <Selector label="Fruit" options={OPTIONS} presentation="bottom-sheet" />,
+    );
+
+    expect(advertisedSurface()).toBe('dialog');
+    expect(environment.presentationQueries()).toEqual([]);
+  });
+
+  it('keeps `popover` constant on a compact touch viewport', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    render(<Selector label="Fruit" options={OPTIONS} presentation="popover" />);
+
+    expect(advertisedSurface()).toBe('listbox');
+  });
+
+  it('resolves `adaptive` exactly as the equivalent explicit policy', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    const {unmount} = render(
+      <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />,
+    );
+    const shorthand = advertisedSurface();
+    unmount();
+
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    expect(shorthand).toBe('dialog');
+    expect(advertisedSurface()).toBe(shorthand);
+  });
+});
+
+// =============================================================================
+// FR6 — one policy per call site
+// =============================================================================
+
+describe('mutual exclusivity', () => {
+  it('throws when both props are defined', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() =>
+      render(
+        // @ts-expect-error -- the two props are exclusive at type level too
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          presentation="adaptive"
+          adaptations={ADAPTIVE_POLICY}
+        />,
+      ),
+    ).toThrow(/both `presentation` and `adaptations`/);
+
+    consoleError.mockRestore();
+  });
+
+  it('accepts an explicitly undefined counterpart', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    const spread = {presentation: undefined};
+
+    expect(() =>
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          {...spread}
+          adaptations={ADAPTIVE_POLICY}
+        />,
+      ),
+    ).not.toThrow();
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it('accepts an explicitly undefined `adaptations` beside a presentation', () => {
+    const spread = {adaptations: undefined};
+
+    expect(() =>
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          {...spread}
+          presentation="bottom-sheet"
+        />,
+      ),
+    ).not.toThrow();
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it('rejects an unadmitted value with a path-specific message', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() =>
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          adaptations={{
+            default: 'popover',
+            // @ts-expect-error -- 'native' is DateInput's domain, not Selector's
+            rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+          }}
+        />,
+      ),
+    ).toThrow('<Selector adaptations>.rules[0].value');
+
+    consoleError.mockRestore();
+  });
+
+  it('rejects an empty condition with a path-specific message', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() =>
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          adaptations={{
+            default: 'popover',
+            rules: [{when: {}, value: 'bottom-sheet'}],
+          }}
+        />,
+      ),
+    ).toThrow('<Selector adaptations>.rules[0].when');
+
+    consoleError.mockRestore();
+  });
+});
+
+// =============================================================================
+// The `presentation` value is validated, not trusted
+// =============================================================================
+
+describe('presentation validation', () => {
+  /**
+   * TypeScript covers a typed caller, so every case here is one that reaches
+   * the component anyway: JavaScript, an untyped props bag, a value read from
+   * config, or a stale `presentation="modal"` left behind by a rename. Each
+   * one used to index the policy map to `undefined` and resolve to an anchored
+   * popover — the wrong surface, reported as a correct one.
+   */
+  function renderWithPresentation(presentation: unknown) {
+    const props = {presentation} as {presentation?: never};
+    return render(<Selector label="Fruit" options={OPTIONS} {...props} />);
+  }
+
+  const rejected: ReadonlyArray<[string, unknown]> = [
+    ['an unknown string', 'modal'],
+    ['a stale renamed value', 'sheet'],
+    ['a value differing only in case', 'Popover'],
+    ['a non-string', 3],
+    ['null', null],
+    // `in` would find these on Object.prototype and hand back a function or a
+    // prototype object as though it were a policy.
+    ['a prototype key', 'toString'],
+    ['the constructor key', 'constructor'],
+  ];
+
+  it.each(rejected)(
+    'rejects %s with a path-specific message',
+    (_label, value) => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      expect(() => renderWithPresentation(value)).toThrow(
+        /<Selector presentation> must be one of popover, bottom-sheet, adaptive/,
+      );
+
+      consoleError.mockRestore();
+    },
+  );
+
+  it('names the value it received', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => renderWithPresentation('modal')).toThrow(/received "modal"/);
+
+    consoleError.mockRestore();
+  });
+
+  it('accepts every admitted value, and an absent one', () => {
+    for (const presentation of [
+      undefined,
+      'popover',
+      'bottom-sheet',
+      'adaptive',
+    ] as const) {
+      const {unmount} = render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          presentation={presentation}
+        />,
+      );
+      unmount();
+    }
+  });
+
+  it('does not reject an unknown value that never reaches the prop', () => {
+    // An `adaptations` policy with no `presentation` must not be dragged into
+    // the shorthand's validation path.
+    expect(() =>
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          adaptations={{default: 'bottom-sheet', rules: []}}
+        />,
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('type-level contract', () => {
+  it('keeps the public value union identical to the internal one', () => {
+    // `SelectorAdaptationValue` is spelled as literals so consumer
+    // diagnostics never name an unexported type. This is what keeps that
+    // spelling honest: if the shared adaptive hook's resolved union ever
+    // gains or loses a member, these assignments stop compiling.
+    type Exact<A, B> = [A] extends [B]
+      ? [B] extends [A]
+        ? true
+        : never
+      : never;
+    const publicCoversInternal: Exact<
+      SelectorAdaptationValue,
+      ResolvedAdaptivePresentation
+    > = true;
+    // And the controller still accepts what the public type produces.
+    const passedToController: ResolvedAdaptivePresentation =
+      'bottom-sheet' satisfies SelectorAdaptationValue;
+
+    expect(publicCoversInternal).toBe(true);
+    expect(passedToController).toBe('bottom-sheet');
+  });
+
+  it('keeps the hasClear union usable with either spelling', () => {
+    // Not an assertion about runtime — this block exists so `tsc` checks that
+    // adding the exclusive policy pair did not multiply the value contract.
+    // Both arms of `hasClear` must still compose with both spellings.
+    const clearableWithAdaptations = (
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        hasClear
+        value={null}
+        onChange={(next: string | null) => next}
+        adaptations={ADAPTIVE_POLICY}
+      />
+    );
+    const clearableWithPresentation = (
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        hasClear
+        value={null}
+        onChange={(next: string | null) => next}
+        presentation="adaptive"
+      />
+    );
+    const plainWithAdaptations = (
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Apple"
+        onChange={(next: string) => next}
+        adaptations={ADAPTIVE_POLICY}
+      />
+    );
+
+    expect(clearableWithAdaptations).toBeTruthy();
+    expect(clearableWithPresentation).toBeTruthy();
+    expect(plainWithAdaptations).toBeTruthy();
+  });
+
+  it('rejects `adaptive` and unknown values inside a policy', () => {
+    const bad = (
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={{
+          // @ts-expect-error -- 'adaptive' is shorthand, never a resolved value
+          default: 'adaptive',
+          rules: [],
+        }}
+      />
+    );
+    const worse = (
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={{
+          default: 'popover',
+          // @ts-expect-error -- contrast is CSS-owned, not a component axis
+          rules: [{when: {contrast: 'more'}, value: 'bottom-sheet'}],
+        }}
+      />
+    );
+
+    expect(bad).toBeTruthy();
+    expect(worse).toBeTruthy();
+  });
+});
+
+// =============================================================================
+// Newly reachable combinations: coarse + popover, fine + bottom sheet
+// =============================================================================
+
+describe('coarse pointer with an anchored popover', () => {
+  /**
+   * Before this policy existed, a coarse pointer under `adaptive` below 768px
+   * always got the sheet. A caller can now hold the popover there — at 768px
+   * exactly, by policy, or with `presentation="popover"` — so the popover's
+   * touch affordances have to hold on a coarse pointer.
+   *
+   * They are CSS media rules, not JavaScript: they key off the POINTER, and
+   * nothing in the presentation policy can reach them. That independence is
+   * the invariant these assert.
+   *
+   * Measured in Chromium against the built Storybook, one touch context
+   * (`hasTouch`/`isMobile`, so `(pointer: coarse)` really matches) versus a
+   * desktop one, with the anchored popover open in both:
+   *
+   *   coarse: trigger font-size 16px, clear-button hit area 24x24, option
+   *           rows 32px, surface = anchored popover
+   *   fine:   trigger font-size 14px, clear-button hit area 20x20, option
+   *           rows 32px
+   *
+   * So both pointer-gated floors hold with the popover resolved. Option rows
+   * carry no coarse-pointer floor at all — 32px on either pointer — but that
+   * is presentation-independent and pre-existing: the same rows measure 32px
+   * inside the bottom sheet, on both pointers. Choosing the popover on a
+   * coarse pointer takes nothing away that the sheet was providing.
+   */
+  beforeEach(() => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+  });
+
+  function renderCoarsePopover() {
+    return render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Apple"
+        hasClear
+        onChange={() => {}}
+        adaptations={{default: 'popover', rules: []}}
+      />,
+    );
+  }
+
+  it('styles its trigger identically whichever surface the policy picks', () => {
+    // The structural half of the claim: on ONE coarse-pointer environment, the
+    // trigger's class set must not depend on the resolved surface. Every
+    // pointer-gated rule that reaches the sheet's trigger therefore reaches the
+    // popover's, including the ones jsdom cannot evaluate.
+    const triggerClasses = (policy: 'popover' | 'bottom-sheet') => {
+      const {unmount} = render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          adaptations={{default: policy, rules: []}}
+        />,
+      );
+      const element = screen
+        .getByRole('combobox')
+        .closest('.astryx-selector') as HTMLElement;
+      const classes = element.className.split(' ').filter(Boolean).sort();
+      unmount();
+      return classes;
+    };
+
+    expect(triggerClasses('popover')).toEqual(triggerClasses('bottom-sheet'));
+  });
+
+  it('keeps a coarse-pointer rule attached to the trigger', () => {
+    renderCoarsePopover();
+    const trigger = screen
+      .getByRole('combobox')
+      .closest('.astryx-selector') as HTMLElement;
+    expect(trigger).not.toBeNull();
+
+    const classes = trigger.className.split(' ').filter(Boolean);
+    const coarseRules = injectedRules().filter(
+      ({selector, media}) =>
+        (media ?? '').includes('pointer: coarse') &&
+        classes.some(name => selector.includes(`.${name}`)),
+    );
+
+    // That block is where the trigger's `max(1rem, …)` text floor lives — the
+    // rule that keeps mobile Safari from zooming on focus and never zooming
+    // back. Its VALUE is unassertable here: jsdom's CSS parser drops a
+    // `max()` containing a var(), so the rule arrives with an empty body (the
+    // clear button's floors below survive only because custom properties skip
+    // that parser). What is checkable is that the coarse block still attaches
+    // to this trigger when the policy resolved to a popover.
+    expect(coarseRules.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the clear button at the 24px coarse hit area (WCAG 2.5.8 AA)', () => {
+    renderCoarsePopover();
+    const clear = screen.getByRole('button', {name: /clear/i});
+
+    const declares = declarationsFor(clear);
+    // Same floors InputClearButton.test.tsx owns, asserted here because the
+    // combination that reaches them — coarse pointer, anchored surface — is
+    // what this change made reachable.
+    expect(
+      declares(/--_input-clear-hit-inset\s*:\s*-2px/, 'pointer: coarse'),
+    ).toBe(true);
+    expect(
+      declares(/--_input-clear-hit-content\s*:\s*""/, 'pointer: coarse'),
+    ).toBe(true);
+  });
+
+  it('resolves to the popover and stays operable by touch and by keyboard', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={onChange}
+        adaptations={{default: 'popover', rules: []}}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+
+    await user.click(trigger);
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalledOnce();
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+
+    // The anchored listbox is reachable and selectable, not merely mounted.
+    await user.click(screen.getByRole('option', {name: 'Cherry', ...hidden}));
+    expect(onChange).toHaveBeenCalledWith('Cherry');
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});
+
+describe('fine pointer with a modal bottom sheet', () => {
+  /**
+   * The mirror combination. Reaching it is not new — `presentation="bottom-sheet"`
+   * has always rendered the modal sheet on any pointer — so what these cover is
+   * the keyboard contract on that surface, which a policy can now select and
+   * which had thin coverage: a sheet is a modal dialog, and entry, movement,
+   * dismissal, and restoration are AR2's promise.
+   *
+   * jsdom stubs `showModal` and never runs the exit transition, so these
+   * assert against a simulation. The real-browser half is the
+   * `KeyboardBottomSheetPolicy` story, run in Chromium by the story play
+   * guard.
+   */
+  const SHEET_ON_FINE = {
+    default: 'bottom-sheet',
+    rules: [{when: {pointer: 'fine'}, value: 'bottom-sheet'}],
+  } as const;
+
+  beforeEach(() => {
+    installEnvironment({width: 1440, pointer: 'fine'});
+  });
+
+  it('opens the sheet from the keyboard and moves focus into the listbox', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector label="Fruit" options={OPTIONS} adaptations={SHEET_ON_FINE} />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    trigger.focus();
+    await user.keyboard('{Enter}');
+
+    await screen.findByRole('dialog', {name: 'Fruit'});
+    await waitFor(() => expect(screen.getByRole('listbox')).toHaveFocus());
+  });
+
+  it('selects with the keyboard and restores focus to the trigger', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={onChange}
+        adaptations={SHEET_ON_FINE}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    trigger.focus();
+    await user.keyboard('{Enter}');
+    const dialog = await screen.findByRole('dialog', {name: 'Fruit'});
+    await waitFor(() => expect(screen.getByRole('listbox')).toHaveFocus());
+
+    // The listbox opens with the first option highlighted, so one ArrowDown
+    // moves to the second.
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(onChange).toHaveBeenCalledWith('Banana');
+    await waitFor(() => expect(dialog).toHaveAttribute('inert'));
+    finishSheetExit(dialog);
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('dismisses on Escape and restores focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector label="Fruit" options={OPTIONS} adaptations={SHEET_ON_FINE} />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    trigger.focus();
+    await user.keyboard('{Enter}');
+    const dialog = await screen.findByRole('dialog', {name: 'Fruit'});
+    await waitFor(() => expect(screen.getByRole('listbox')).toHaveFocus());
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(dialog).toHaveAttribute('inert'));
+    finishSheetExit(dialog);
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps the sheet reachable through the search control', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        hasSearch
+        adaptations={SHEET_ON_FINE}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    await screen.findByRole('dialog', {name: 'Fruit'});
+
+    // With search, the sheet owns the combobox and focus lands on it.
+    await waitFor(() =>
+      expect(screen.getByRole('combobox', hidden)).toHaveFocus(),
+    );
+  });
+});
+
+// =============================================================================
+// Known limitation: SSR + `adaptive` + `isDefaultOpen`
+// =============================================================================
+
+describe('server-rendered default-open', () => {
+  /**
+   * A CHARACTERIZATION test, not an endorsement. `isDefaultOpen` opens from a
+   * mount effect, which runs with the hydration render's resolved value — the
+   * server one, by FR3 — while the post-hydration render has already published
+   * the browser's. Under `adaptive` on a compact touch client the two disagree
+   * and the field comes up collapsed.
+   *
+   * This predates AST-031: the released `useAdaptivePresentation` returns its
+   * `serverDefault` during hydration for exactly the same reason, and the
+   * MultiSelector case below — still on that untouched hook — reproduces it.
+   * Fixing it means changing when the default-open effect fires, which is
+   * `isDefaultOpen`'s contract and not this migration's to move.
+   *
+   * The workaround is a policy whose server and client values already agree.
+   */
+  /**
+   * Hydrated roots live outside Testing Library's cleanup, so each one is
+   * tracked and torn down: a container left in `document.body` makes every
+   * later `getByRole('combobox')` ambiguous.
+   */
+  const mounted: {
+    container: HTMLElement;
+    root: ReturnType<typeof hydrateRoot>;
+  }[] = [];
+
+  afterEach(() => {
+    for (const {container, root} of mounted.splice(0)) {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+
+  function hydrate(element: React.ReactElement): HTMLElement {
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(element);
+    document.body.appendChild(container);
+    act(() => {
+      mounted.push({container, root: hydrateRoot(container, element)});
+    });
+    return container;
+  }
+
+  const triggerIn = (container: HTMLElement) =>
+    container.querySelector('[role="combobox"]');
+
+  it('comes up collapsed for hydrated `adaptive` on a compact touch client', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+
+    const container = hydrate(
+      createElement(Selector, {
+        label: 'Fruit',
+        options: OPTIONS,
+        presentation: 'adaptive',
+        isDefaultOpen: true,
+      }),
+    );
+
+    // Documented, not desired: the resolved value is the sheet, but the
+    // default-open effect already ran against the server's popover.
+    expect(triggerIn(container)).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(triggerIn(container)).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('reproduces identically on MultiSelector, which never migrated', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+
+    const container = hydrate(
+      createElement(MultiSelector, {
+        label: 'Fruits',
+        options: OPTIONS,
+        value: [],
+        onChange: () => {},
+        presentation: 'adaptive',
+        isDefaultOpen: true,
+      }),
+    );
+
+    // The control that makes "pre-existing" a measurement rather than a claim:
+    // MultiSelector still runs the legacy adaptive hook.
+    expect(triggerIn(container)).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens correctly with a policy whose server value already agrees', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+
+    const container = hydrate(
+      createElement(Selector, {
+        label: 'Fruit',
+        options: OPTIONS,
+        adaptations: {default: 'bottom-sheet', rules: []},
+        isDefaultOpen: true,
+      }),
+    );
+
+    // The documented workaround: no value changes between server and client,
+    // so the mount effect and the render agree.
+    expect(triggerIn(container)).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(triggerIn(container)).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('is not a defect of default-open itself: a constant popover hydrates open', () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+
+    const container = hydrate(
+      createElement(Selector, {
+        label: 'Fruit',
+        options: OPTIONS,
+        presentation: 'popover',
+        isDefaultOpen: true,
+      }),
+    );
+
+    expect(triggerIn(container)).toHaveAttribute('aria-expanded', 'true');
+  });
+});
+
+// =============================================================================
+// FR10 — an open surface does not switch trees
+// =============================================================================
+
+describe('latching', () => {
+  it('keeps an open sheet mounted when the environment stops matching', async () => {
+    const environment = installEnvironment({width: 375, pointer: 'coarse'});
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const dialog = await screen.findByRole('dialog', {name: 'Fruit'});
+
+    environment.set({width: 1280, pointer: 'fine'});
+
+    expect(dialog).toBeInTheDocument();
+    expect(HTMLElement.prototype.showPopover).not.toHaveBeenCalled();
+    expect(advertisedSurface()).toBe('dialog');
+  });
+
+  it('returns focus to the trigger and adopts the new value on reopen', async () => {
+    const environment = installEnvironment({width: 375, pointer: 'coarse'});
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    const dialog = await screen.findByRole('dialog', {name: 'Fruit'});
+
+    environment.set({width: 1280, pointer: 'fine'});
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(dialog).toHaveAttribute('inert'));
+    finishSheetExit(dialog);
+
+    await waitFor(() => expect(trigger).toHaveFocus());
+    await waitFor(() => expect(advertisedSurface()).toBe('listbox'));
+
+    await user.click(trigger);
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalledOnce();
+  });
+});
+
+// =============================================================================
+// AR1/AR2 — accessibility follows the resolved surface
+// =============================================================================
+
+describe('accessibility', () => {
+  it('moves focus into the sheet listbox and restores it on close', async () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    const dialog = await screen.findByRole('dialog', {name: 'Fruit'});
+
+    await waitFor(() => expect(screen.getByRole('listbox')).toHaveFocus());
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(dialog).toHaveAttribute('inert'));
+    finishSheetExit(dialog);
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps combobox semantics at the trigger for a resolved popover', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('listbox', hidden)).toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('selects a value from the resolved sheet and closes it', async () => {
+    installEnvironment({width: 375, pointer: 'coarse'});
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={onChange}
+        adaptations={ADAPTIVE_POLICY}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    const dialog = await screen.findByRole('dialog', {name: 'Fruit'});
+
+    await user.click(screen.getByRole('option', {name: 'Banana'}));
+
+    expect(onChange).toHaveBeenCalledWith('Banana');
+    await waitFor(() => expect(dialog).toHaveAttribute('inert'));
+    finishSheetExit(dialog);
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+});
+
+// =============================================================================
+// IR5 — Selector's migration does not move MultiSelector
+// =============================================================================
+
+describe('MultiSelector isolation', () => {
+  it('disagrees with Selector at exactly 768px, deliberately', () => {
+    installEnvironment({width: 768, pointer: 'coarse'});
+
+    render(
+      <>
+        <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />
+        <MultiSelector
+          label="Fruits"
+          options={OPTIONS}
+          value={[]}
+          onChange={() => {}}
+          presentation="adaptive"
+        />
+      </>,
+    );
+
+    // Selector resolves `width < md`; MultiSelector keeps the released
+    // `max-width: 768px`, which includes equality. AST-031 accepts the split
+    // until MultiSelector is separately migrated.
+    expect(advertisedSurface('Fruit')).toBe('listbox');
+    expect(advertisedSurface('Fruits')).toBe('dialog');
+  });
+
+  it('agrees below the boundary', () => {
+    installEnvironment({width: 500, pointer: 'coarse'});
+
+    render(
+      <>
+        <Selector label="Fruit" options={OPTIONS} presentation="adaptive" />
+        <MultiSelector
+          label="Fruits"
+          options={OPTIONS}
+          value={[]}
+          onChange={() => {}}
+          presentation="adaptive"
+        />
+      </>,
+    );
+
+    expect(advertisedSurface('Fruit')).toBe('dialog');
+    expect(advertisedSurface('Fruits')).toBe('dialog');
+  });
+
+  it('leaves MultiSelector on the legacy query string', () => {
+    const environment = installEnvironment({width: 500, pointer: 'coarse'});
+
+    render(
+      <MultiSelector
+        label="Fruits"
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+        presentation="adaptive"
+      />,
+    );
+
+    expect(environment.presentationQueries()).toEqual([
+      '(max-width: 768px) and (pointer: coarse)',
+    ]);
+  });
+
+  it('ignores a Theme md override, as the released hook does', () => {
+    installEnvironment({width: 850, pointer: 'coarse'});
+
+    render(
+      <MultiSelector
+        label="Fruits"
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+        presentation="adaptive"
+      />,
+      {wrapper: withTheme(themeWithMd('multi-selector-untouched-md', 900))},
+    );
+
+    // A theme point that moves Selector must not move MultiSelector.
+    expect(advertisedSurface('Fruits')).toBe('listbox');
+  });
+});

--- a/packages/core/src/Selector/index.ts
+++ b/packages/core/src/Selector/index.ts
@@ -11,6 +11,7 @@
 export {
   Selector,
   type SelectorProps,
+  type SelectorAdaptationValue,
   type SelectorPresentation,
   type SelectorSize,
   type SelectorStatus,

--- a/packages/core/src/Selector/useSelectorPresentation.ts
+++ b/packages/core/src/Selector/useSelectorPresentation.ts
@@ -4,9 +4,18 @@
 
 /**
  * @file useSelectorPresentation.ts
- * @input Uses the shared adaptive presentation policy and usePopover
+ * @input An already-resolved presentation value and usePopover
  * @output Coordinates popover and bottom-sheet disclosure state
- * @position Internal presentation controller shared by Selector and MultiSelector
+ * @position Internal presentation controller shared by Selector and
+ *   MultiSelector. Policy resolution is the CALLER's: Selector resolves its
+ *   public `adaptations`/`presentation` policy and MultiSelector runs the
+ *   legacy adaptive hook, so migrating one cannot move the other
+ *   (spec:AST-031 IR5).
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Selector/Selector.tsx (resolves the AST-031 policy)
+ * - /packages/core/src/MultiSelector/MultiSelector.tsx (resolves the legacy
+ *   adaptive policy)
  */
 
 import {
@@ -21,15 +30,16 @@ import {
   type UsePopoverOptions,
   type UsePopoverReturn,
 } from '../Popover/usePopover';
-import {
-  useAdaptivePresentation,
-  type AdaptivePresentation,
-  type ResolvedAdaptivePresentation,
-} from '../hooks/useAdaptivePresentation';
+import type {ResolvedAdaptivePresentation} from '../hooks/useAdaptivePresentation';
 import {useFocusReturnVisibility} from '../hooks/useFocusReturnVisibility';
 
 interface UseSelectorPresentationOptions {
-  presentation: AdaptivePresentation;
+  /**
+   * The surface to open, already resolved to an exact value. This controller
+   * never reads the environment: it owns disclosure state, latching, and the
+   * focus handoff, not which surface a caller's policy selects.
+   */
+  presentation: ResolvedAdaptivePresentation;
   onHide: () => void;
   onShow: () => void;
   popoverOptions: Omit<UsePopoverOptions, 'onHide' | 'onShow'>;
@@ -50,13 +60,12 @@ interface SelectorPresentationController {
 }
 
 export function useSelectorPresentation({
-  presentation,
+  presentation: resolvedPresentation,
   onHide,
   onShow,
   popoverOptions,
   triggerRef,
 }: UseSelectorPresentationOptions): SelectorPresentationController {
-  const resolvedPresentation = useAdaptivePresentation(presentation);
   const activePresentationRef =
     useRef<ResolvedAdaptivePresentation>(resolvedPresentation);
   const [isSheetOpen, setIsSheetOpen] = useState(false);

--- a/packages/core/src/theme/componentAdaptations.test.ts
+++ b/packages/core/src/theme/componentAdaptations.test.ts
@@ -127,9 +127,10 @@ describe('public value shape', () => {
 });
 
 describe('package-internal surface', () => {
-  it('is not reachable from the theme entry point while AST-031 is a draft', () => {
+  it('publishes the authoring vocabulary but no resolver', () => {
     // Types are erased, so the runtime check is the negative one: nothing that
-    // resolves an adaptation is exported (spec:AST-031 IR1/IR2).
+    // RESOLVES an adaptation is exported (spec:AST-031 IR1/IR2). Selector's
+    // public `adaptations` prop admitted the value shape, not the machinery.
     for (const internal of [
       'compileComponentAdaptations',
       'useComponentAdaptations',
@@ -143,15 +144,31 @@ describe('package-internal surface', () => {
     }
 
     // The value TYPES are erased at runtime, so the guard on them is the
-    // barrel source: it must not re-export this module at all.
+    // barrel source: it re-exports exactly the three authoring types a caller
+    // needs to write a policy, and nothing else from this module.
     const barrelSource = fs.readFileSync(
       path.join(path.dirname(fileURLToPath(import.meta.url)), 'index.ts'),
       'utf8',
     );
-    expect(barrelSource).not.toMatch(
-      /^\s*export .*from '\.\/componentAdaptations'/m,
+    const reExport = barrelSource.match(
+      /export type \{([^}]*)\} from '\.\/componentAdaptations';/,
     );
-    expect(barrelSource).not.toContain('ComponentAdaptations,');
+    expect(reExport).not.toBeNull();
+    expect(
+      reExport![1]
+        .split(',')
+        .map(name => name.trim())
+        .filter(Boolean)
+        .sort(),
+    ).toEqual([
+      'ComponentAdaptationCondition',
+      'ComponentAdaptationRule',
+      'ComponentAdaptations',
+    ]);
+    // A value re-export would smuggle the compiler out with the types.
+    expect(barrelSource).not.toMatch(
+      /^\s*export \{[^}]*\} from '\.\/componentAdaptations'/m,
+    );
 
     // The width vocabulary the types refer to is public, and unmoved.
     expect(themeBarrel).toHaveProperty('WIDTH_BREAKPOINT_NAMES');

--- a/packages/core/src/theme/componentAdaptations.ts
+++ b/packages/core/src/theme/componentAdaptations.ts
@@ -3,12 +3,15 @@
 /**
  * @file componentAdaptations.ts
  * @input One component's authored adaptation policy and the effective width map
- * @output Package-internal component-adaptation types plus validation and
- *   media-query compilation for the JavaScript resolver
- * @position spec:AST-031 FR1/FR2/IR1/IR3. Package-internal in every direction:
- *   AST-031 is a draft, so neither these types nor the compiler are exported
- *   from the package entry point. The component PR that admits a public
- *   `adaptations` prop is what makes the value shape public.
+ * @output Public component-adaptation authoring types plus package-internal
+ *   validation and media-query compilation for the JavaScript resolver
+ * @position spec:AST-031 FR1/FR2/IR1/IR3. Split surface: the AUTHORING
+ *   VOCABULARY below (`ComponentAdaptations`, `ComponentAdaptationRule`,
+ *   `ComponentAdaptationCondition`) is exported from the package entry point,
+ *   because Selector's `adaptations` prop is a public policy a caller cannot
+ *   type without it. Everything under "Package-internal compilation" is not:
+ *   components own their public policy props, and the compiler stays behind
+ *   them.
  *
  * A component adaptation is ONE closed policy value, not a bag of conditional
  * props: `default` is the server-rendered, hydration, and no-match value, and
@@ -24,8 +27,9 @@
  * SYNC: When modified, update:
  * - /packages/core/src/theme/adaptationConditions.ts (shared condition grammar)
  * - /packages/core/src/theme/useComponentAdaptations.ts (runtime resolver)
- * - /packages/core/src/theme/index.ts (kept free of these exports while
- *   spec:AST-031 is a draft)
+ * - /packages/core/src/theme/index.ts (re-exports the authoring vocabulary
+ *   only; the compiler stays package-internal)
+ * - /packages/core/src/Selector/Selector.tsx (first public consumer)
  * - /packages/core/src/theme/componentAdaptations.test.ts
  */
 
@@ -40,7 +44,7 @@ import {
 } from './adaptationConditions';
 
 // =============================================================================
-// Authoring vocabulary (package-internal until a component prop admits it)
+// Authoring vocabulary (public; re-exported from the package entry point)
 // =============================================================================
 
 /**

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -63,10 +63,17 @@ export type {
   ThemeAdaptationTypographyConfig,
 } from './themeAdaptations';
 
-// Component adaptations (spec:AST-031) are deliberately NOT exported here. The
-// spec is still a draft, so the value types, the condition compiler, and the
-// resolver hook all stay package-internal until a component's public policy
-// prop is separately accepted; that component's PR adds the export it needs.
+// Component adaptations (spec:AST-031). The AUTHORING VOCABULARY is public as
+// of Selector's `adaptations` prop — a caller cannot write a policy for a
+// public prop without the types that describe it. The condition compiler and
+// the `useComponentAdaptations` resolver stay package-internal: components own
+// their public policy props, and admitting a resolver would publish a second,
+// component-less way to read the environment that no record covers.
+export type {
+  ComponentAdaptations,
+  ComponentAdaptationRule,
+  ComponentAdaptationCondition,
+} from './componentAdaptations';
 
 export type {
   SyntaxTokenName,


### PR DESCRIPTION
## Summary

- add `Selector.adaptations={{default, rules}}` using theme-aware width/pointer conditions
- preserve `presentation` as compatibility syntax; `adaptive` now resolves through the active Theme's `md`
- keep MultiSelector on its existing inclusive 768px legacy policy
- latch the selected surface for the lifetime of an open interaction
- export the shared component-adaptation types and `SelectorAdaptationValue`

## Compatibility

At the default `md = 768`, `presentation="adaptive"` now treats exactly 768px as the wider side, matching AST-012's exclusive `below` edge. Direct `popover` and `bottom-sheet` behavior is unchanged.

## Evidence

- focused Selector/MultiSelector/theme tests
- Core and Storybook typechecks
- real Chromium story play for fine-pointer bottom-sheet keyboard/focus/exit behavior
- coarse-pointer popover measurements: 16px trigger text and 24×24 clear hit target
- Selector a11y, RTL, and modal-close guards
- full build and repository checks

This draft is stacked on #6127 → #6123 → #5543 and remains blocked on owner approval of AST-031. No spec approval was posted by the agent.
