### PR TITLE
feat(DateInput): add exact theme-aware picker adaptations

### DIFF
--- a/.changeset/date-picker-adaptations.md
+++ b/.changeset/date-picker-adaptations.md
@@ -1,0 +1,67 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Give `DateInput` and `DateTimeInput` a caller-owned `adaptations` surface policy
+
+Both date fields now accept an ordered, environment-conditioned policy over the
+three surfaces they already have, instead of deciding from the primary pointer
+alone:
+
+```tsx
+<DateInput
+  label="Event date"
+  value={date}
+  onChange={setDate}
+  adaptations={{
+    default: 'popover',
+    rules: [
+      {when: {width: {below: 'md'}, pointer: 'coarse'}, value: 'bottom-sheet'},
+      {when: {width: {below: 'sm'}, pointer: 'coarse'}, value: 'native'},
+    ],
+  }}
+/>
+```
+
+`default` is the server-rendered, hydration, and no-match value, so the server
+picks the whole tree without guessing at a viewport. Rules are checked in author
+order and the LAST match wins; `width` names resolve against the nearest Theme's
+width points, `from` is inclusive, `below` is exclusive, and the fields of one
+`when` are ANDed. An empty `rules` array is valid and always resolves to
+`default`. `DateInputAdaptationValue` and `DateTimeInputAdaptationValue` — both
+`'native' | 'popover' | 'bottom-sheet'` — are exported from `@astryxdesign/core`
+and from `@astryxdesign/core/DateInput` and `@astryxdesign/core/DateTimeInput`.
+
+Each value is EXACT and holds on any pointer, which is what `nativePicker`
+cannot say: `'native'` is the platform control, `'popover'` the typable field
+with the anchored calendar (and, on DateTimeInput, the time list), and
+`'bottom-sheet'` the touch field with its sheet. A policy can therefore pin the
+sheet on a mouse-driven kiosk, keep the typable field on a tablet, or render a
+chosen surface on the server.
+
+`nativePicker` is unchanged and keeps its meaning: with no `adaptations` prop,
+both components run exactly the pointer test they always did, including its
+mid-interaction switch and its quiet fallback for props the platform picker
+cannot draw. The two props are mutually exclusive — passing both defined values
+throws before a surface opens, while an explicitly spread `undefined` is not a
+conflict.
+
+A policy that names `'native'` is validated EAGERLY, across `default` and every
+rule, matched or not: `numberOfMonths={2}` or any explicit `weekStartsOn` throws
+on DateInput, and those plus `hasSeconds`, a non-default `timeIncrement`, or any
+`timeOptionInterval` throw on DateTimeInput, each naming the offending policy
+path. The point is that the failure lands on the author's machine rather than on
+the one device whose width and pointer select that rule, and it throws in
+production as well as development, because a silently dropped week start is a
+wrong calendar rather than a warning. `min`, `max` and `dateConstraints` stay
+supported on the native surface: the bounds are forwarded and every constraint
+is enforced on commit.
+
+The resolved surface is LATCHED while the field is in use. These components
+switch between separate component trees, so publishing a new value mid-entry
+would unmount the focused control and take the uncommitted draft with it — an
+ordinary rotation or window resize, on a field someone is typing into. A policy
+change now applies once the surface has closed and focus has left. The legacy
+`nativePicker` path deliberately keeps its released behavior here too.
+
+@imdreamrunner

--- a/.changeset/deprecate-date-native-picker.md
+++ b/.changeset/deprecate-date-native-picker.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Deprecate the DateInput and DateTimeInput `nativePicker` shorthands in favor of `adaptations` (#6239)
+@cixzhang

--- a/.github/scripts/story-play-guard.js
+++ b/.github/scripts/story-play-guard.js
@@ -56,6 +56,28 @@ const TARGETS = [
       'presentation="bottom-sheet"); what this adds is real-browser evidence ' +
       'for it, since jsdom stubs showModal and never runs the exit',
   },
+  {
+    component: 'DateInput',
+    story: 'core-dateinput--adaptations-fine-bottom-sheet',
+    guards:
+      'a policy-pinned bottom sheet on a fine pointer stays keyboard ' +
+      'operable: Enter opens a genuinely modal <dialog> (:modal, which only ' +
+      'showModal() can make true), focus moves into the sheet, and Escape ' +
+      'closes it through the real exit transition and returns focus to the ' +
+      'field. jsdom stubs showModal and never runs that exit, so the unit ' +
+      'suite can only assert against a simulation of this surface',
+  },
+  {
+    component: 'DateInput',
+    story: 'core-dateinput--adaptations-latched-while-in-use',
+    guards:
+      'the adaptations latch survives a REAL browser focus move: after the ' +
+      "policy flips under a focused field, the browser's own focusout/" +
+      'focusin pair between the input and its calendar toggle must not ' +
+      'release it — the tree stays mounted, the entry survives and the click ' +
+      'lands — and the pending surface arrives once the field goes idle. ' +
+      'jsdom can model that sequence but never dispatch one',
+  },
 ];
 
 const CONTENT_TYPES = {

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {DateInput} from '@astryxdesign/core/DateInput';
+import type {DateInputAdaptationValue} from '@astryxdesign/core/DateInput';
 import type {ISODateString} from '@astryxdesign/core/Calendar';
 import {Layout, LayoutContent} from '@astryxdesign/core/Layout';
 import {Theme, defineTheme} from '@astryxdesign/core/theme';
@@ -237,6 +238,298 @@ export const NativePickerModes: Story = {
           nativePicker="never"
         />
       </div>
+    );
+  },
+};
+
+/**
+ * A caller-owned `adaptations` policy: the surface follows rules you write
+ * rather than the pointer alone.
+ *
+ * This one keeps the typable field and its anchored calendar as the default —
+ * the server renders that, and every mouse keeps it — and hands a touch device
+ * to the platform's own picker at any width. `nativePicker="touch"` would say
+ * something close, but only `adaptations` can add a width point to it, render a
+ * chosen surface on the server, or pin a rule to a surface the pointer would
+ * not have picked.
+ *
+ * Rules are checked in author order and the LAST match wins.
+ */
+export const AdaptationsCoarseNative: Story = {
+  name: 'Adaptations — native on a coarse pointer',
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(
+      '2026-03-21' as ISODateString,
+    );
+    return (
+      <DateInput
+        label="Event date"
+        description="Platform picker on a finger, typable field with a calendar popover on a mouse"
+        value={value}
+        onChange={setValue}
+        adaptations={{
+          default: 'popover',
+          rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+        }}
+      />
+    );
+  },
+};
+
+/**
+ * The touch sheet on a FINE pointer, kept keyboard operable.
+ *
+ * A policy value is exact: `bottom-sheet` means the swipe-paged month sheet on
+ * whatever pointer is reading this, which is the case a pointer test cannot
+ * express at all. It is also the surface with the weakest unit-test evidence —
+ * jsdom stubs `showModal` and never runs an exit transition, so the suite's
+ * focus assertions are made against a simulation of a modal dialog rather than
+ * one.
+ *
+ * The play function below closes that gap in a real browser: the policy picks
+ * the sheet on a mouse, Enter opens a genuinely modal `<dialog>`, focus moves
+ * inside it, and Escape closes it through the real exit transition and hands
+ * focus back to the field. It runs in Chromium under the story play guard,
+ * which is what makes these assertions a required check rather than a demo.
+ */
+export const AdaptationsFineBottomSheet: Story = {
+  name: 'Adaptations — bottom sheet on a fine pointer',
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(
+      '2026-03-21' as ISODateString,
+    );
+    return (
+      <div data-date-sheet-keyboard-fixture>
+        <DateInput
+          label="Event date"
+          description="Policy-pinned touch sheet, on any pointer"
+          value={value}
+          onChange={setValue}
+          min={'2026-02-01' as ISODateString}
+          max={'2026-04-30' as ISODateString}
+          adaptations={{default: 'bottom-sheet', rules: []}}
+        />
+      </div>
+    );
+  },
+  play: async ({canvasElement}) => {
+    const frame = () =>
+      new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+    /** Poll until `check` is true, or fail loudly. Play has no test lib. */
+    const until = async (what: string, check: () => boolean) => {
+      for (let attempt = 0; attempt < 180; attempt++) {
+        if (check()) {
+          return;
+        }
+        await frame();
+      }
+      throw new Error(`Timed out waiting for ${what}`);
+    };
+
+    const press = (target: Element, key: string) => {
+      target.dispatchEvent(
+        new KeyboardEvent('keydown', {key, bubbles: true, cancelable: true}),
+      );
+      target.dispatchEvent(
+        new KeyboardEvent('keyup', {key, bubbles: true, cancelable: true}),
+      );
+    };
+
+    const fixture = canvasElement.querySelector<HTMLElement>(
+      '[data-date-sheet-keyboard-fixture]',
+    );
+    const input = fixture?.querySelector<HTMLInputElement>(
+      'input[role="combobox"]',
+    );
+    if (!input) {
+      throw new Error('Sheet keyboard fixture did not render a field');
+    }
+
+    // The resolved surface, read off the closed field: only the touch field
+    // refuses the virtual keyboard and advertises a dialog.
+    if (
+      input.inputMode !== 'none' ||
+      input.getAttribute('aria-haspopup') !== 'dialog'
+    ) {
+      throw new Error(
+        'A fine pointer did not get the policy-pinned bottom sheet',
+      );
+    }
+
+    input.focus();
+    press(input, 'Enter');
+
+    await until(
+      'the sheet to open',
+      () => document.querySelector('dialog[open]') != null,
+    );
+    const dialog = document.querySelector<HTMLDialogElement>('dialog[open]');
+    if (!dialog) {
+      throw new Error('The sheet never opened');
+    }
+
+    // `:modal` is the assertion jsdom cannot make: it is true only for a
+    // dialog the browser actually put in the top layer via showModal().
+    if (!dialog.matches(':modal')) {
+      throw new Error('The sheet opened, but not as a modal dialog');
+    }
+    await until('focus to move into the sheet', () =>
+      dialog.contains(document.activeElement),
+    );
+
+    press(document.activeElement ?? dialog, 'Escape');
+
+    // The real exit transition runs here — this is the part the unit suite has
+    // to deliver by hand — and focus comes back only after it finishes.
+    await until(
+      'the sheet to close and focus to return to the field',
+      () =>
+        document.querySelector('dialog[open]') == null &&
+        document.activeElement === input,
+    );
+  },
+};
+
+/**
+ * The resolved surface is HELD while the field is in use.
+ *
+ * The policy here flips itself from the typable field to the touch sheet
+ * shortly after the story mounts — standing in for the rotation, window resize
+ * or theme change that moves a real rule boundary. Focus the field before it
+ * flips and nothing moves: the tree you are typing into is the tree you keep,
+ * caret and draft included. Click away and the pending surface arrives.
+ *
+ * That guarantee is the reason the two props differ here: the legacy
+ * `nativePicker` swaps on the pointer whenever the pointer changes, mid-entry
+ * included, and a policy does not.
+ *
+ * The play function is the real-browser half of the evidence. jsdom can model a
+ * focus move but not dispatch one, and the bug this guards against lives in the
+ * dispatch: a browser fires `focusout` on the control you left, drains
+ * microtasks, and only then fires `focusin` on the one you reached. A latch
+ * that decides in that gap sees focus nowhere and lets go — unmounting the tree
+ * under the pointer and eating the click. Here the browser supplies its own
+ * events, its own `relatedTarget`, and its own ordering.
+ */
+export const AdaptationsLatchedWhileInUse: Story = {
+  name: 'Adaptations — surface held while the field is in use',
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>();
+    const [surface, setSurface] = useState<DateInputAdaptationValue>('popover');
+    useEffect(() => {
+      const timer = setTimeout(() => setSurface('bottom-sheet'), 600);
+      return () => clearTimeout(timer);
+    }, []);
+    return (
+      <div data-date-latch-fixture data-policy={surface}>
+        <DateInput
+          label="Event date"
+          description="Focus the field before the policy flips: it keeps the surface until you leave"
+          value={value}
+          onChange={setValue}
+          adaptations={{default: surface, rules: []}}
+        />
+      </div>
+    );
+  },
+  play: async ({canvasElement}) => {
+    const frame = () =>
+      new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+    /** Poll until `check` is true, or fail loudly. Play has no test lib. */
+    const until = async (what: string, check: () => boolean) => {
+      for (let attempt = 0; attempt < 180; attempt++) {
+        if (check()) {
+          return;
+        }
+        await frame();
+      }
+      throw new Error(`Timed out waiting for ${what}`);
+    };
+
+    const fixture = canvasElement.querySelector<HTMLElement>(
+      '[data-date-latch-fixture]',
+    );
+    if (!fixture) {
+      throw new Error('Latch fixture did not render');
+    }
+    const typableField = () =>
+      fixture.querySelector<HTMLInputElement>(
+        'input[role="combobox"]:not([inputmode="none"])',
+      );
+
+    const input = typableField();
+    const toggle = fixture.querySelector<HTMLButtonElement>('button');
+    if (!input || !toggle) {
+      throw new Error('The story did not start on the typable field');
+    }
+
+    input.focus();
+    input.value = '3/2/2026';
+    input.dispatchEvent(new Event('input', {bubbles: true}));
+
+    await until(
+      'the policy to flip under the focused field',
+      () => fixture.dataset.policy === 'bottom-sheet',
+    );
+
+    // Held: the policy now names the sheet, and the field is still the one
+    // being typed into — same element, not a re-render of an equivalent one.
+    if (typableField() !== input) {
+      throw new Error('The focused field was swapped out from under the user');
+    }
+
+    // The gap itself, which is the whole bug. A browser dispatches focusout,
+    // drains microtasks, and only then dispatches focusin — so a latch that
+    // defers its decision decides HERE, with focus nowhere. The focusout is
+    // synthesized because only a user gesture can make the browser split the
+    // pair, but everything it feeds the latch is real: React's own listener,
+    // a real FocusEvent, a real relatedTarget.
+    input.dispatchEvent(
+      new FocusEvent('focusout', {bubbles: true, relatedTarget: toggle}),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    // A frame, so a release that happened in the gap has been committed and
+    // this check reports the gap rather than a later symptom of it.
+    await frame();
+    if (typableField() !== input) {
+      throw new Error(
+        'The latch released between focusout and focusin — the tree was swapped mid-interaction',
+      );
+    }
+
+    // And now the move for real: the browser dispatches its own focusout and
+    // focusin, with its own relatedTarget. Still held, and the click lands.
+    toggle.focus();
+    if (typableField() !== input) {
+      throw new Error('Moving focus to the toggle released the latch');
+    }
+    toggle.click();
+    await until(
+      'the calendar to open',
+      () => input.getAttribute('aria-expanded') === 'true',
+    );
+    if (typableField() !== input) {
+      throw new Error('Opening the calendar released the latch');
+    }
+
+    // Released: the calendar closes and focus leaves the field entirely, so the
+    // surface the policy has been asking for finally arrives.
+    input.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    (document.activeElement as HTMLElement | null)?.blur();
+    await until(
+      'the pending bottom sheet to arrive once the field is idle',
+      () =>
+        fixture.querySelector('input[inputmode="none"]') != null &&
+        typableField() == null,
     );
   },
 };

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -16,21 +16,7 @@ const meta: Meta<typeof DateInput> = {
     docs: {
       description: {
         component:
-          'A date field that fits the pointer it is used with. Every story ' +
-          'below shows the pointer surface — a text input you can type into ' +
-          'with a calendar in a popover — because that is the right answer ' +
-          'for the mouse you are reading this with.\n\n' +
-          'Where the primary pointer is a finger (`pointer: coarse`), the ' +
-          'same component renders a picker built for one instead: a bottom ' +
-          'sheet of months swiped sideways, with month and year wheels ' +
-          'behind the header title, and no text entry (the keyboard would ' +
-          'cover the sheet it is meant to fill in). Same props either way — ' +
-          'there is nothing to opt into.\n\n' +
-          '**Seeing the touch surface:** open any story below on a phone or ' +
-          'tablet, or in a device-emulated tab reporting a coarse pointer. ' +
-          'Every one of them renders it — they are the same stories, and ' +
-          'that is the point. There is no separate touch story because there ' +
-          'is no separate thing to adopt.',
+          'A date field with an exact caller-owned adaptations policy over native, popover, and bottom-sheet surfaces. The policy names the server-rendered default and any ordered width/pointer rules. Without adaptations, the deprecated nativePicker compatibility path keeps its released pointer-driven behavior.',
       },
     },
   },
@@ -112,7 +98,8 @@ const meta: Meta<typeof DateInput> = {
       control: 'radio',
       options: ['touch', 'always', 'never'],
       description:
-        'Whether the browser or Astryx draws the picker for each pointer type',
+        'Deprecated. Use adaptations. At rest, touch maps to default popover plus a coarse-pointer native rule; always maps to constant native; never maps to default popover plus a coarse-pointer bottom-sheet rule. adaptations additionally holds the active tree until idle.',
+      table: {category: 'Deprecated'},
     },
   },
 };
@@ -202,40 +189,6 @@ export const Formats: Story = {
               new Date(iso + 'T00:00'),
             )
           }
-        />
-      </div>
-    );
-  },
-};
-
-export const NativePickerModes: Story = {
-  name: 'Native picker modes',
-  render: () => {
-    const [value, setValue] = useState<ISODateString | undefined>(
-      '2026-03-21' as ISODateString,
-    );
-    return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
-        <DateInput
-          label="nativePicker='touch' (default)"
-          description="Native picker on a coarse pointer; Astryx picker otherwise"
-          value={value}
-          onChange={setValue}
-          nativePicker="touch"
-        />
-        <DateInput
-          label="nativePicker='always'"
-          description="Native picker wherever the browser supports it"
-          value={value}
-          onChange={setValue}
-          nativePicker="always"
-        />
-        <DateInput
-          label="nativePicker='never'"
-          description="Astryx picker on every pointer type"
-          value={value}
-          onChange={setValue}
-          nativePicker="never"
         />
       </div>
     );

--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -14,9 +14,7 @@ const meta: Meta<typeof DateTimeInput> = {
     docs: {
       description: {
         component:
-          'A date-time field that fits the pointer it is used with. On a mouse or trackpad it renders the existing side-by-side date and time inputs: the date half opens a calendar popover, and the time half accepts typed entry plus optional preset times.\n\n' +
-          "Where the primary pointer is a finger (`pointer: coarse`), the closed control still renders separate Date and Time segments; tapping either segment opens a bottom sheet directly to the matching section. A segmented Date/Time pill stays at the top of the sheet for switching; Date reuses Astryx's custom swipable month picker and month/year wheels, its Save date action advances to Time, and Time uses accessible hour/minute/second wheels with the final Save action. The public props are the same on both surfaces.\n\n" +
-          '**Seeing the touch surface:** open any story on a phone/tablet or in device emulation reporting a coarse pointer. No separate story is needed because the same component chooses the surface at runtime.',
+          'A date-time field with an exact caller-owned adaptations policy over native, popover, and bottom-sheet surfaces for both segments. The policy names the server-rendered default and any ordered width/pointer rules. Without adaptations, the deprecated nativePicker compatibility path keeps its released pointer-driven and per-segment fallback behavior.',
       },
     },
   },
@@ -78,7 +76,8 @@ const meta: Meta<typeof DateTimeInput> = {
       control: 'radio',
       options: ['touch', 'always', 'never'],
       description:
-        "Date and time picker surfaces: native browser/OS controls on touch by default, native wherever compatible, or Astryx's surfaces everywhere",
+        'Deprecated. Use adaptations. At rest, touch maps to default popover plus a coarse-pointer native rule; always maps to constant native; never maps to default popover plus a coarse-pointer bottom-sheet rule. adaptations additionally holds the active tree until idle.',
+      table: {category: 'Deprecated'},
     },
     numberOfMonths: {
       control: 'radio',
@@ -135,39 +134,6 @@ export const WithValue: Story = {
   },
   args: {
     label: 'Event time',
-  },
-};
-
-export const NativePickerModes: Story = {
-  render: () => {
-    const [value, setValue] = useState<ISODateTimeString | undefined>(
-      '2026-03-15T14:30' as ISODateTimeString,
-    );
-    return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
-        <DateTimeInput
-          label="nativePicker='touch' (default)"
-          description="Native date and compatible time controls on a coarse primary pointer"
-          value={value}
-          onChange={setValue}
-          nativePicker="touch"
-        />
-        <DateTimeInput
-          label="nativePicker='always'"
-          description="Native date and compatible time controls on every pointer type"
-          value={value}
-          onChange={setValue}
-          nativePicker="always"
-        />
-        <DateTimeInput
-          label="nativePicker='never'"
-          description="Astryx bottom sheet on coarse pointers; calendar popover on fine pointers"
-          value={value}
-          onChange={setValue}
-          nativePicker="never"
-        />
-      </div>
-    );
   },
 };
 

--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -171,6 +171,81 @@ export const NativePickerModes: Story = {
   },
 };
 
+/**
+ * A caller-owned `adaptations` policy: the pair of surfaces follows rules you
+ * write rather than the pointer alone.
+ *
+ * This one defaults to the platform's own date and time controls — including on
+ * the server, which a pointer test cannot decide — and keeps Astryx's typed
+ * fields with their anchored calendar and time list on a touch device, where a
+ * tablet user cross-referencing dates is better served by a visible month grid
+ * than by an OS wheel. That is the opposite of what `nativePicker` can say,
+ * which is the point: a policy value is exact, and holds on whatever pointer is
+ * reading it.
+ *
+ * Note what authoring `native` costs the whole field: because the value is a
+ * promise that BOTH segments are platform controls, the props the OS picker
+ * cannot express — `hasSeconds`, a non-default `timeIncrement`,
+ * `timeOptionInterval`, `weekStartsOn`, `numberOfMonths` — cannot be set on
+ * this field at all, on any pointer. They throw at render, naming the policy
+ * path, rather than being quietly dropped on whichever device selects the
+ * native rule. A field that needs one of them wants a policy over `popover` and
+ * `bottom-sheet`, or the legacy `nativePicker`, whose per-segment fallback
+ * retains an Astryx time field instead.
+ *
+ * Rules are checked in author order and the LAST match wins.
+ */
+export const AdaptationsCoarsePopover: Story = {
+  name: 'Adaptations — Astryx popovers on a coarse pointer',
+  render: () => {
+    const [value, setValue] = useState<ISODateTimeString | undefined>(
+      '2026-03-15T14:30' as ISODateTimeString,
+    );
+    return (
+      <DateTimeInput
+        label="Starts"
+        description="Typed fields with anchored calendar on a finger; platform controls on a mouse"
+        value={value}
+        onChange={setValue}
+        adaptations={{
+          default: 'native',
+          rules: [{when: {pointer: 'coarse'}, value: 'popover'}],
+        }}
+      />
+    );
+  },
+};
+
+/**
+ * The coordinated Date/Time sheet on a FINE pointer.
+ *
+ * `bottom-sheet` names the touch surface exactly, so it renders on the mouse
+ * you are reading this with: two read-only segments that open one sheet with a
+ * Date panel and a Time panel, rather than two independent popovers. Useful on
+ * a kiosk or a stylus-driven screen, where the pointer reports `fine` but the
+ * reach is a whole arm — and impossible to ask for with `nativePicker`.
+ *
+ * `default` with no rules is also the SSR-safe spelling: the server renders
+ * this surface, and hydration matches it.
+ */
+export const AdaptationsFineBottomSheet: Story = {
+  name: 'Adaptations — coordinated sheet on a fine pointer',
+  render: () => {
+    const [value, setValue] = useState<ISODateTimeString | undefined>(
+      '2026-03-15T14:30' as ISODateTimeString,
+    );
+    return (
+      <DateTimeInput
+        label="Starts"
+        description="Policy-pinned Date/Time sheet, on any pointer"
+        value={value}
+        onChange={setValue}
+        adaptations={{default: 'bottom-sheet', rules: []}}
+      />
+    );
+  },
+};
+
 export const TwentyFourHourFormat: Story = {
   render: args => {
     const [value, setValue] = useState<ISODateTimeString | undefined>(

--- a/apps/storybook/stories/adaptationStories.test.tsx
+++ b/apps/storybook/stories/adaptationStories.test.tsx
@@ -1,0 +1,125 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file adaptationStories.test.tsx
+ * @input Uses vitest, @testing-library/react, and the date components' story
+ *   modules
+ * @output Smoke coverage: every story that AUTHORS an adaptations policy
+ *   actually mounts
+ * @position Tests; the gate that catches a story whose policy is rejected at
+ *   render.
+ *
+ * An adaptations policy is validated eagerly, so a story can author one that
+ * throws — a `native` value beside a prop the platform picker cannot express,
+ * for instance. Nothing else here notices. The a11y audit loads each story in a
+ * real browser, but a story that throws renders an empty page, and axe reports
+ * an empty page as zero violations: a broken story passes the gate by being
+ * blank. The visual pass and the docsite reach the same non-conclusion.
+ *
+ * So this asserts the one thing those cannot: the story mounts. It selects
+ * stories by name rather than listing them, so a policy story added later is
+ * covered the day it lands, and it deliberately does NOT render the rest of
+ * each file — those stories authored no policy and have nothing to fail this
+ * way.
+ *
+ * SYNC: When a component gains an adaptations policy and stories for it, add
+ * its story module to STORY_MODULES below.
+ * - /apps/storybook/stories/DateInput.stories.tsx
+ * - /apps/storybook/stories/DateTimeInput.stories.tsx
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
+import {render, cleanup} from '@testing-library/react';
+import type {ReactElement} from 'react';
+import * as DateInputStories from './DateInput.stories';
+import * as DateTimeInputStories from './DateTimeInput.stories';
+
+/** Story modules whose exports may author an adaptations policy. */
+const STORY_MODULES = {
+  DateInput: DateInputStories,
+  DateTimeInput: DateTimeInputStories,
+} as const;
+
+/**
+ * A story object, as far as this test needs to know: something with a `render`
+ * that takes no required arguments. Stories driven by `args` are out of scope —
+ * none of the policy stories use them, and calling one with no args would fail
+ * for a reason that has nothing to do with its policy.
+ */
+interface RenderableStory {
+  name?: string;
+  render?: (...args: never[]) => ReactElement;
+}
+
+function policyStories(
+  module: Record<string, unknown>,
+): Array<[string, RenderableStory]> {
+  return Object.entries(module)
+    .filter(([exportName]) => exportName.startsWith('Adaptations'))
+    .map(([exportName, story]) => [exportName, story as RenderableStory]);
+}
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  Element.prototype.scrollTo = vi.fn();
+  // jsdom implements none of these, and the touch surfaces mount a dialog.
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.open = true;
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.open = true;
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.open = false;
+  });
+});
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+for (const [component, module] of Object.entries(STORY_MODULES)) {
+  describe(`${component} adaptations stories`, () => {
+    const stories = policyStories(module);
+
+    it('has at least one, so a rename cannot empty this suite silently', () => {
+      expect(stories.length).toBeGreaterThan(0);
+    });
+
+    for (const [exportName, story] of stories) {
+      it(`${exportName} mounts`, () => {
+        const {render: renderStory} = story;
+        expect(renderStory).toBeTypeOf('function');
+        // Mounted as a COMPONENT, not invoked: a story's render body calls
+        // hooks (`useState` for the controlled value), which are only legal
+        // while React is rendering it.
+        const Story = renderStory as () => ReactElement;
+        // Throwing here is the whole point: an eagerly-rejected policy — a
+        // `native` value beside a prop the platform cannot express — fails on
+        // the render, naming the offending policy path.
+        expect(() => render(<Story />)).not.toThrow();
+        expect(document.querySelector('input')).not.toBeNull();
+      });
+    }
+  });
+}

--- a/docs/specs/AST-031/spec.md
+++ b/docs/specs/AST-031/spec.md
@@ -146,12 +146,14 @@ mapping without exposing raw queries or a general conditional-props bag.
   depending directly on the `DefinedTheme.__adaptations` storage field.
 - **FR6 — Adaptation and direct policy are exclusive.** A component's
   `adaptations` prop cannot be combined with the defined direct prop that owns the
-  same choice (`presentation` or `nativePicker`). Selector's existing union can
-  encode `?: never` exclusivity. DateInput and DateTimeInput keep their exported
-  `interface` props extendable, so they add both optional members without converting
-  the interface to a union; a runtime error rejects calls where both values are
-  defined. An explicitly spread `undefined` does not conflict. This preserves
-  interface-extension compatibility while keeping one effective policy.
+  same choice (`presentation` or `nativePicker`). DateInput and DateTimeInput
+  deprecate `nativePicker` in favor of `adaptations` while preserving every legacy
+  call at runtime; Selector's `presentation` remains supported. Selector's existing
+  union can encode `?: never` exclusivity. DateInput and DateTimeInput keep their
+  exported `interface` props extendable, so they add both optional members without
+  converting the interface to a union; a runtime error rejects calls where both
+  values are defined. An explicitly spread `undefined` does not conflict. This
+  preserves interface-extension compatibility while keeping one effective policy.
 - **FR7 — Selector's shorthand migrates deliberately.** Public
   `SelectorAdaptationValue` is an alias of the existing internal
   `ResolvedAdaptivePresentation` (`popover | bottom-sheet`) and is exported from
@@ -175,7 +177,9 @@ mapping without exposing raw queries or a general conditional-props bag.
   `native` renders browser/OS date/time controls, `popover` renders Astryx's pointer
   field and anchored surface, and `bottom-sheet` renders Astryx's touch field and
   modal sheet. These values have the same whole-tree meaning regardless of pointer
-  precision. Existing shorthand maps as follows when `adaptations` is absent:
+  precision. `nativePicker` is deprecated in favor of this exact policy, but its
+  released runtime behavior remains supported. Migrate the shorthand as follows
+  when the field's other props are compatible with every selected exact surface:
 
   | Component                 | Shorthand | Equivalent requested surface policy                           |
   | ------------------------- | --------- | ------------------------------------------------------------- |
@@ -183,13 +187,19 @@ mapping without exposing raw queries or a general conditional-props bag.
   | DateInput / DateTimeInput | `always`  | constant `native`                                             |
   | DateInput / DateTimeInput | `never`   | default `popover`; primary `pointer: coarse` → `bottom-sheet` |
 
+  These mappings select the same initial and idle surface. They are intentionally
+  not interaction-equivalent: `adaptations` holds the active tree through focus or
+  an open picker under FR10, while legacy `touch` and `never` continue switching
+  immediately when the primary pointer changes.
+
   For DateInput with a non-default `numberOfMonths` or explicit `weekStartsOn`,
   legacy `touch`/`always` renders today but has no exact `native` adaptation
   equivalent because those presentation options are not expressible by the OS
   control. For DateTimeInput, `hasSeconds`, non-default `timeIncrement`, or
   `timeOptionInterval` can make legacy `touch`/`always` render a mixed native-date
   plus Astryx-time tree, which likewise has no exact `adaptations` equivalent.
-  Those legacy behaviors remain when `adaptations` is absent.
+  Those legacy behaviors remain when `adaptations` is absent. Their deprecation
+  is advisory only: it emits editor guidance and changes no runtime behavior.
 
 - **FR9 — Exact surfaces validate capabilities eagerly.** If `default` or any rule
   names `native`, DateInput rejects a non-default `numberOfMonths` or explicit
@@ -288,7 +298,8 @@ Selector's exact default 768px boundary is breaking as described by FR7 and must
 released as such. No per-callsite configuration can preserve the single equality
 case; changing the Theme's `md` moves the shared global point and is the only
 threshold migration. Existing nativePicker behavior does not change when the new
-prop is absent.
+prop is absent; the shorthand is deprecated so editors direct new and migrating
+callsites to the exact `adaptations` policy.
 
 This proposal adds no CSS-variable or context layer. Structural presentation is a
 JavaScript decision because it changes DOM identity, ARIA, focus ownership, and
@@ -349,14 +360,21 @@ CSS remains the path for visual values. Adapted policy values can change mounted
 controls, semantics, focus, and native behavior, so neither custom-property reads
 nor duplicate hidden trees provide a correct first-paint implementation.
 
-### DEC-5 — Preserve direct props as compatibility syntax
+### DEC-5 — Deprecate date-field shorthand without changing behavior
 
 **Reference:** `spec:AST-031/DEC-5`
-**Decider:** pending
+**Decider:** `cixzhang`, `2026-09-11`
 
-Selector `presentation` and DateInput/DateTimeInput `nativePicker` retain their
-existing meanings when `adaptations` is absent. The new prop is an explicit advanced
-policy, not a forced migration.
+DateInput and DateTimeInput deprecate `nativePicker` in favor of `adaptations`.
+The shorthand remains accepted and keeps its released runtime meaning so existing
+calls do not break. Consumer docs and editor annotations provide the initial/idle
+mapping for `touch`, `always`, and `never`, call out adaptations' intentional
+active-interaction latching difference, and identify legacy mixed-surface cases
+that have no exact adaptation. Removal is a separate future compatibility decision
+and requires the release process's migration evidence and codemod.
+
+Selector `presentation` remains supported compatibility syntax; this decision does
+not deprecate it.
 
 ### DEC-6 — Adopt AST-012's exclusive `below` edge for Selector
 
@@ -380,8 +398,5 @@ and `adaptations` values.
 
 ## Open questions
 
-- **OQ1 — Should compatibility shorthands be deprecated after migration?**
-  (`human-api`) The first implementation preserves them; removal needs separate
-  evidence and migration.
-- **OQ2 — Should later component value domains admit non-string primitives?**
+- **OQ1 — Should later component value domains admit non-string primitives?**
   (`human-api`) The first consumers use closed string unions only.

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -160,8 +160,14 @@ export const docs = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "Which surface draws the date picker. 'touch' (the default) hands a touch device to the browser/OS: the field becomes an input type=date and the platform draws the picker (the iOS wheel, the Android calendar dialog); 'always' does that wherever the browser supports input type=date; 'never' keeps Astryx's own pickers everywhere (the bottom-sheet picker on a finger, the calendar popover on a mouse). Use 'never' for a field that needs weekStartsOn, numberOfMonths or dateConstraints, none of which a native picker can express. format and placeholder still apply in native mode; min and max are forwarded, but a native picker may not show them (on iOS an out-of-range date can be selected and is refused on commit rather than greyed out).",
+        "Which surface draws the date picker. 'touch' (the default) hands a touch device to the browser/OS: the field becomes an input type=date and the platform draws the picker (the iOS wheel, the Android calendar dialog); 'always' does that wherever the browser supports input type=date; 'never' keeps Astryx's own pickers everywhere (the bottom-sheet picker on a finger, the calendar popover on a mouse). Use 'never' for a field that needs weekStartsOn, numberOfMonths or dateConstraints, none of which a native picker can express. format and placeholder still apply in native mode; min and max are forwarded, but a native picker may not show them (on iOS an out-of-range date can be selected and is refused on commit rather than greyed out). Mutually exclusive with adaptations.",
       default: "'touch'",
+    },
+    {
+      name: 'adaptations',
+      type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
+      description:
+        "Environment-conditioned surface policy, for the cases the pointer-driven nativePicker shorthand cannot express. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform control, 'popover' the typable field with the anchored calendar, 'bottom-sheet' the touch field with the month sheet. A policy naming 'native' anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2 or weekStartsOn is set at all, because the platform picker cannot draw either; min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with nativePicker; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
     },
     {
       name: 'width',
@@ -178,9 +184,16 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'astryx-date-input', visualProps: ['size', 'status'], states: ['disabled']},
+      {
+        className: 'astryx-date-input',
+        visualProps: ['size', 'status'],
+        states: ['disabled'],
+      },
       {className: 'astryx-date-input-toggle-icon', states: ['state']},
-      {className: 'astryx-date-input-clear-icon', deprecatedFor: 'input-clear-icon'},
+      {
+        className: 'astryx-date-input-clear-icon',
+        deprecatedFor: 'input-clear-icon',
+      },
     ],
   },
   usage: {
@@ -211,6 +224,11 @@ export const docs = {
         guidance: true,
         description:
           'Use DateInput inside InputGroup when adding a short static prefix or suffix, such as a due-date hint.',
+      },
+      {
+        guidance: true,
+        description:
+          'Reach for adaptations only when the pointer alone is the wrong question — a width point, a policy the server must render, or a surface a rule should pin. nativePicker stays the short spelling, and the two are mutually exclusive.',
       },
       {
         guidance: false,
@@ -299,6 +317,11 @@ export const docsZh = {
         guidance: true,
         description:
           'Show a loading state with changeAction when the date triggers a server-side save.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use adaptations when the surface should follow a width point or a policy the server renders, and nativePicker when the pointer is the whole question. The two props are mutually exclusive.',
       },
       {
         guidance: false,
@@ -434,7 +457,8 @@ export const docsZh = {
     {
       name: 'weekStartsOn',
       type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'",
-      description: '日历弹出层中每周的起始日。可为数字（0=周日……6=周六）或三字母星期缩写。',
+      description:
+        '日历弹出层中每周的起始日。可为数字（0=周日……6=周六）或三字母星期缩写。',
       default: '0',
     },
     {
@@ -448,8 +472,14 @@ export const docsZh = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "由哪个界面绘制日期选择器。'touch'（默认）在触摸设备上交给浏览器/操作系统：字段变为 input type=date，由平台绘制选择器（iOS 滚轮、Android 日历对话框）；'always' 在所有支持 input type=date 的浏览器上都这样做；'never' 始终使用 Astryx 自带的选择器（触摸设备用底部弹出选择器，鼠标设备用日历弹出层）。需要 weekStartsOn、numberOfMonths 或 dateConstraints 的字段应使用 'never'，原生选择器无法表达这些。原生模式下 format 和 placeholder 仍然生效；min 和 max 会传递给原生控件，但原生选择器可能不会显示这些限制（在 iOS 上仍可选中超出范围的日期，会在提交时被拒绝，而不是变灰）。",
+        "由哪个界面绘制日期选择器。'touch'（默认）在触摸设备上交给浏览器/操作系统：字段变为 input type=date，由平台绘制选择器（iOS 滚轮、Android 日历对话框）；'always' 在所有支持 input type=date 的浏览器上都这样做；'never' 始终使用 Astryx 自带的选择器（触摸设备用底部弹出选择器，鼠标设备用日历弹出层）。需要 weekStartsOn、numberOfMonths 或 dateConstraints 的字段应使用 'never'，原生选择器无法表达这些。原生模式下 format 和 placeholder 仍然生效；min 和 max 会传递给原生控件，但原生选择器可能不会显示这些限制（在 iOS 上仍可选中超出范围的日期，会在提交时被拒绝，而不是变灰）。与 adaptations 互斥。",
       default: "'touch'",
+    },
+    {
+      name: 'adaptations',
+      type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
+      description:
+        "按环境决定界面的策略，用于 nativePicker 指针快捷方式无法表达的场景。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生控件，'popover' 为可输入字段加锚定日历，'bottom-sheet' 为触摸字段加月份底部弹层。只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2 或任何 weekStartsOn，就会抛出错误，因为原生选择器无法绘制这两者；min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
     },
     {
       name: 'xstyle',
@@ -466,7 +496,10 @@ export const docsZh = {
         states: ['disabled'],
       },
       {className: 'astryx-date-input-toggle-icon', states: ['state']},
-      {className: 'astryx-date-input-clear-icon', deprecatedFor: 'input-clear-icon'},
+      {
+        className: 'astryx-date-input-clear-icon',
+        deprecatedFor: 'input-clear-icon',
+      },
     ],
   },
 };
@@ -502,6 +535,11 @@ export const docsDense = {
         guidance: true,
         description:
           'Use inside InputGroup for a short static prefix or suffix, such as a due-date hint.',
+      },
+      {
+        guidance: true,
+        description:
+          'nativePicker = pointer shorthand; adaptations={{default, rules}} = exact surface per width/pointer rule, SSR-safe via default. Mutually exclusive.',
       },
       {
         guidance: false,
@@ -544,15 +582,19 @@ export const docsDense = {
     placeholder: 'placeholder text in input',
     size: 'input control size',
     status: 'error/warning/success status w/ message',
-    statusVariant: 'How status message is placed: attached overlaps below input; detached floats below w/ spacing; tooltip hides the box and shows it on the status icon.',
+    statusVariant:
+      'How status message is placed: attached overlaps below input; detached floats below w/ spacing; tooltip hides the box and shows it on the status icon.',
     labelTooltip: 'tooltip text via info icon at label end',
     hasClear: 'Shows clear button when date is set. Clears value on click.',
     numberOfMonths: 'months shown simultaneously in calendar popover',
-    weekStartsOn: 'first day of week in calendar (0=Sunday, or name e.g. "mon")',
+    weekStartsOn:
+      'first day of week in calendar (0=Sunday, or name e.g. "mon")',
     format:
       "committed-value display: 'date_long' (default, March 21, 2026), 'date' (Mar 21, 2026), 'date_weekday' (Wed, Mar 21, 2026), 'system_date' (2026-03-21), or (iso)=>string; reuses Timestamp vocabulary. Committed value only, not while typing.",
     nativePicker:
-      "which surface draws the picker: 'touch' (default) = browser/OS on a coarse pointer, 'always', 'never' = Astryx's own everywhere. use 'never' for weekStartsOn/numberOfMonths/dateConstraints. format+placeholder still apply; min/max forwarded but not necessarily shown by the OS picker, refused on commit instead.",
+      "which surface draws the picker: 'touch' (default) = browser/OS on a coarse pointer, 'always', 'never' = Astryx's own everywhere. use 'never' for weekStartsOn/numberOfMonths/dateConstraints. format+placeholder still apply; min/max forwarded but not necessarily shown by the OS picker, refused on commit instead. exclusive with adaptations.",
+    adaptations:
+      "{default, rules} surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer. a 'native' value anywhere throws with numberOfMonths=2 or any weekStartsOn; min/max/dateConstraints still fine. exclusive with nativePicker. held while focused or open.",
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -160,14 +160,14 @@ export const docs = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "Which surface draws the date picker. 'touch' (the default) hands a touch device to the browser/OS: the field becomes an input type=date and the platform draws the picker (the iOS wheel, the Android calendar dialog); 'always' does that wherever the browser supports input type=date; 'never' keeps Astryx's own pickers everywhere (the bottom-sheet picker on a finger, the calendar popover on a mouse). Use 'never' for a field that needs weekStartsOn, numberOfMonths or dateConstraints, none of which a native picker can express. format and placeholder still apply in native mode; min and max are forwarded, but a native picker may not show them (on iOS an out-of-range date can be selected and is refused on commit rather than greyed out). Mutually exclusive with adaptations.",
+        "Deprecated. Use adaptations instead. For the initial render and while the field is idle, map 'touch' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}, 'always' to {default: 'native', rules: []}, and 'never' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}. The policy matches those idle surfaces but intentionally holds an active tree until the field is idle; nativePicker='touch' and nativePicker='never' switch immediately when the pointer changes. Existing calls keep their released behavior. Calls that combine 'touch' or 'always' with numberOfMonths=2 or an explicit weekStartsOn have no exact adaptation because the platform picker cannot draw those options; keep nativePicker until the callsite can choose an exact supported surface. format and placeholder still apply in native mode; min, max, and dateConstraints remain supported and are enforced on commit. Mutually exclusive with adaptations.",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "Environment-conditioned surface policy, for the cases the pointer-driven nativePicker shorthand cannot express. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform control, 'popover' the typable field with the anchored calendar, 'bottom-sheet' the touch field with the month sheet. A policy naming 'native' anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2 or weekStartsOn is set at all, because the platform picker cannot draw either; min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with nativePicker; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
+        "Preferred surface-selection API. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform control, 'popover' the typable field with the anchored calendar, 'bottom-sheet' the touch field with the month sheet. A policy naming 'native' anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2 or weekStartsOn is set at all, because the platform picker cannot draw either; min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with the deprecated nativePicker shorthand; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
     },
     {
       name: 'width',
@@ -228,7 +228,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Reach for adaptations only when the pointer alone is the wrong question — a width point, a policy the server must render, or a surface a rule should pin. nativePicker stays the short spelling, and the two are mutually exclusive.',
+          'Use adaptations for all new surface selection. The deprecated nativePicker shorthand remains supported only for compatibility; migrate with the mapping in its prop description.',
       },
       {
         guidance: false,
@@ -321,7 +321,7 @@ export const docsZh = {
       {
         guidance: true,
         description:
-          'Use adaptations when the surface should follow a width point or a policy the server renders, and nativePicker when the pointer is the whole question. The two props are mutually exclusive.',
+          'Use adaptations for all new surface selection. nativePicker 已弃用，仅为兼容旧代码保留；请按该属性说明中的映射迁移。',
       },
       {
         guidance: false,
@@ -472,14 +472,14 @@ export const docsZh = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "由哪个界面绘制日期选择器。'touch'（默认）在触摸设备上交给浏览器/操作系统：字段变为 input type=date，由平台绘制选择器（iOS 滚轮、Android 日历对话框）；'always' 在所有支持 input type=date 的浏览器上都这样做；'never' 始终使用 Astryx 自带的选择器（触摸设备用底部弹出选择器，鼠标设备用日历弹出层）。需要 weekStartsOn、numberOfMonths 或 dateConstraints 的字段应使用 'never'，原生选择器无法表达这些。原生模式下 format 和 placeholder 仍然生效；min 和 max 会传递给原生控件，但原生选择器可能不会显示这些限制（在 iOS 上仍可选中超出范围的日期，会在提交时被拒绝，而不是变灰）。与 adaptations 互斥。",
+        "已弃用，请改用 adaptations。初始渲染及字段空闲时的映射：'touch' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}；'always' → {default: 'native', rules: []}；'never' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}。adaptations 会将正在使用的界面保持到字段空闲；nativePicker='touch' 和 nativePicker='never' 会在指针变化时立即切换，因此交互中的行为并不完全相同。现有调用保持原有行为。若 'touch' 或 'always' 与 numberOfMonths=2 或显式 weekStartsOn 组合，原生选择器无法绘制这些选项，因此没有完全等价的 adaptations 策略；在调用方能选择明确且受支持的界面前继续使用 nativePicker。与 adaptations 互斥。",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "按环境决定界面的策略，用于 nativePicker 指针快捷方式无法表达的场景。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生控件，'popover' 为可输入字段加锚定日历，'bottom-sheet' 为触摸字段加月份底部弹层。只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2 或任何 weekStartsOn，就会抛出错误，因为原生选择器无法绘制这两者；min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
+        "首选的界面选择 API。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生控件，'popover' 为可输入字段加锚定日历，'bottom-sheet' 为触摸字段加月份底部弹层。只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2 或任何 weekStartsOn，就会抛出错误，因为原生选择器无法绘制这两者；min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
     },
     {
       name: 'xstyle',
@@ -539,7 +539,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'nativePicker = pointer shorthand; adaptations={{default, rules}} = exact surface per width/pointer rule, SSR-safe via default. Mutually exclusive.',
+          'Use adaptations={{default, rules}} for all new surface selection. nativePicker is deprecated compatibility syntax; see its prop description for the exact migration.',
       },
       {
         guidance: false,
@@ -592,9 +592,9 @@ export const docsDense = {
     format:
       "committed-value display: 'date_long' (default, March 21, 2026), 'date' (Mar 21, 2026), 'date_weekday' (Wed, Mar 21, 2026), 'system_date' (2026-03-21), or (iso)=>string; reuses Timestamp vocabulary. Committed value only, not while typing.",
     nativePicker:
-      "which surface draws the picker: 'touch' (default) = browser/OS on a coarse pointer, 'always', 'never' = Astryx's own everywhere. use 'never' for weekStartsOn/numberOfMonths/dateConstraints. format+placeholder still apply; min/max forwarded but not necessarily shown by the OS picker, refused on commit instead. exclusive with adaptations.",
+      'DEPRECATED; use adaptations. idle mapping: touch -> default popover + coarse-pointer native rule; always -> constant native; never -> default popover + coarse-pointer bottom-sheet rule. adaptations holds an active tree until idle; legacy touch/never switch immediately. incompatible native options have no exact mapping; see full docs. exclusive with adaptations.',
     adaptations:
-      "{default, rules} surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer. a 'native' value anywhere throws with numberOfMonths=2 or any weekStartsOn; min/max/dateConstraints still fine. exclusive with nativePicker. held while focused or open.",
+      "{default, rules} preferred surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer. a 'native' value anywhere throws with numberOfMonths=2 or any weekStartsOn; min/max/dateConstraints still fine. exclusive with deprecated nativePicker. held while focused or open.",
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -167,6 +167,9 @@ export type DateInputSize = keyof typeof sizeStyles;
  *   popover on mouse-driven ones
  * - `'always'`: native wherever the browser supports `<input type="date">`
  * - `'never'`: Astryx's own pickers everywhere
+ *
+ * @deprecated Use `adaptations` with `DateInputAdaptationValue`. The closest
+ * policy for each shorthand is documented on `DateInputProps.nativePicker`.
  */
 export type DateInputNativePicker = 'touch' | 'always' | 'never';
 
@@ -408,36 +411,33 @@ export interface DateInputProps extends Omit<
   format?: DateInputFormat | ((value: ISODateString) => string);
 
   /**
-   * When date picking is handed to the browser/OS instead of Astryx's own
-   * surfaces: the field becomes an `<input type="date">` and the platform
-   * draws the picker — the iOS wheel, the Android calendar dialog — with the
-   * OS's own hit areas, momentum scrolling, locale and accessibility
-   * settings.
+   * Deprecated shorthand for choosing a picker surface. Existing calls keep
+   * their released behavior, but new code should use `adaptations` so the
+   * server-rendered surface and every environment rule are explicit.
    *
-   * - `'touch'` (default): native on touch devices (coarse pointer), the text
-   *   field and calendar popover on mouse-driven ones
-   * - `'always'`: native wherever the browser supports `<input type="date">`
-   * - `'never'`: Astryx's own pickers everywhere — the touch picker on a
-   *   finger, the calendar popover on a mouse
+   * For the initial render and while the field is idle, map each value as
+   * follows:
+   * - `'touch'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}`
+   * - `'always'` → `{default: 'native', rules: []}`
+   * - `'never'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}`
    *
-   * `format` and `placeholder` still apply in native mode: DateInput paints
-   * the closed field's text itself, over the control. `numberOfMonths` and
-   * `weekStartsOn` do not — they describe a calendar grid the native picker
-   * does not have — so a field that needs either should pass `'never'`.
+   * The new policy intentionally differs during an active interaction:
+   * `adaptations` holds the current tree until the field is idle, while
+   * `nativePicker="touch"` and `nativePicker="never"` keep their released
+   * immediate pointer-switch behavior.
    *
-   * `min` and `max` are forwarded, but note that a native picker may not
-   * *show* them: on iOS they are constraint-validation flags rather than
-   * clamps, so an out-of-range date can be selected and is refused on commit
-   * (announced to assistive technology) rather than being greyed out in the
-   * picker. `dateConstraints` is enforced the same way, on commit, and is
-   * reason enough to prefer `'never'` on a field that uses it.
+   * `format` and `placeholder` still apply in native mode. `min`, `max`, and
+   * `dateConstraints` remain supported and are enforced on commit. A legacy
+   * call that combines `'touch'` or `'always'` with `numberOfMonths={2}` or an
+   * explicit `weekStartsOn` has no exact `adaptations` equivalent because the
+   * platform picker cannot draw those options; keep the shorthand until that
+   * callsite can choose an exact supported surface.
+   *
+   * Mutually exclusive with `adaptations`.
    *
    * @default 'touch'
-   * @example
-   * ```
-   * // Astryx's own touch picker instead of the platform's
-   * <DateInput label="Event date" value={date} onChange={setDate} nativePicker="never" />
-   * ```
+   * @deprecated Use `adaptations`; the mapping above preserves idle surface
+   * selection when the exact surfaces support the field's other props.
    */
   nativePicker?: DateInputNativePicker;
 
@@ -1057,46 +1057,28 @@ function PointerDateField({
 PointerDateField.displayName = 'PointerDateField';
 
 /**
- * A date picker that fits the pointer it is being used with.
+ * A date picker whose `adaptations` policy selects an exact native, popover, or
+ * bottom-sheet surface for the server and for ordered width/pointer rules.
  *
- * With a mouse or trackpad this is a text input you can type into, with a
- * calendar in a popover — unchanged, and still the surface every existing
- * consumer gets. With a finger it is a picker built for one: a bottom sheet
- * holding one month per screen, swiped sideways, with month and year wheels
- * behind the header title for the far jumps swiping is bad at.
+ * The surfaces share one value contract but use separate trees: the native
+ * browser/OS control, a typable field with an anchored calendar, or a read-only
+ * field opening Astryx's swipe-paged month sheet. The resolved tree is held
+ * while the field is in use so a resize or rotation cannot discard a draft.
  *
- * The props are identical either way — this is one component with two
- * surfaces, not two components — so nothing at the call site changes, and a
- * date typed on a laptop and a date thumbed on a phone are the same value.
- *
- * `adaptations` takes that decision back: an ordered policy over the three
- * exact surfaces (`native`, `popover`, `bottom-sheet`) resolved against the
- * nearest Theme's width points and the primary pointer, replacing the built-in
- * pointer test for the call sites that pass it.
+ * Without `adaptations`, the deprecated `nativePicker` compatibility path keeps
+ * its released pointer-driven behavior.
  *
  * ## Why a runtime switch and not CSS
  *
- * The two surfaces are structurally different — a popover anchored to a text
- * field versus a full-width sheet holding a scroller — so "render both, hide
- * one" would double the DOM, double the tab stops, and mount two calendars.
- * The condition is not layout either: it is *which interaction is faster*,
- * and that depends on the pointer, which CSS cannot hand to JS.
- *
- * They are two components rather than one with a branch inside because the
- * hook lists differ; keeping them separate is what lets each own its own.
+ * The surfaces are structurally different, so rendering all of them and hiding
+ * the inactive ones would duplicate controls, ids, dialogs, effects, and focus
+ * targets. One exact policy value selects the mounted tree instead.
  *
  * ## Hydration
  *
- * `useMediaQuery` reports false during SSR, so server HTML is always the
- * pointer field and the swap happens after hydration. That is deliberately
- * unobservable: both surfaces render the SAME closed field — a bordered input
- * with a calendar icon and the formatted date — and differ only in what
- * opens. Nothing moves; the field just starts opening a sheet.
- *
- * An `adaptations` policy replaces that pointer test with the caller's own
- * rules, and its `default` is the server truth: the server renders `default`,
- * the hydration render matches it, and the browser's real answer arrives on the
- * render after (spec:AST-031 FR3).
+ * `adaptations.default` is the server-rendered and hydration surface. The
+ * browser publishes the last matching rule after hydration, without asking the
+ * server to guess a viewport or pointer (spec:AST-031 FR3).
  *
  * @example
  * ```
@@ -1104,6 +1086,10 @@ PointerDateField.displayName = 'PointerDateField';
  *   label="Event date"
  *   value={date}
  *   onChange={setDate}
+ *   adaptations={{
+ *     default: 'popover',
+ *     rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+ *   }}
  * />
  * ```
  */

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -11,7 +11,10 @@
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/DateInput/DateInput.doc.mjs (props table, features, implementation notes)
  * - /packages/core/src/DateInput/DateInput.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/DateInput/DateInputAdaptations.test.tsx (surface policy tests)
  * - /packages/core/src/DateInput/index.ts (exports if types change)
+ * - /packages/core/src/hooks/useAdaptationSurfaceLatch.ts (holds a surface mid-interaction)
+ * - /packages/core/src/theme/componentAdaptations.ts (policy shape + compiler)
  * - /apps/storybook/stories/DateInput.stories.tsx (storybook stories)
  * - /packages/cli/assets/templates/blocks/components/DateInput/ (showcase blocks)
  */
@@ -58,9 +61,15 @@ import {
 } from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {useInputStatusIcon} from '../hooks/useInputStatusIcon';
+import {useAdaptationSurfaceLatch} from '../hooks/useAdaptationSurfaceLatch';
 import {useMediaQuery} from '../hooks/useMediaQuery';
 import {useResolvedRequired} from '../hooks/useResolvedRequired';
 import {usePopover} from '../Popover';
+import {
+  forEachAuthoredAdaptationValue,
+  type ComponentAdaptations,
+} from '../theme/componentAdaptations';
+import {useComponentAdaptations} from '../theme/useComponentAdaptations';
 import {NativeDateField} from './NativeDateField';
 import {TouchDateField} from './TouchDateField';
 import {useTooltip} from '../Tooltip';
@@ -160,6 +169,31 @@ export type DateInputSize = keyof typeof sizeStyles;
  * - `'never'`: Astryx's own pickers everywhere
  */
 export type DateInputNativePicker = 'touch' | 'always' | 'never';
+
+/**
+ * The surfaces a resolved DateInput adaptation policy can name.
+ *
+ * The whole domain of `adaptations`, and each value is EXACT — it names one
+ * tree, on any pointer:
+ * - `'native'`: the platform's own control (`<input type="date">`), the surface
+ *   `nativePicker` used to be the only way to ask for
+ * - `'popover'`: the typable field with the calendar in an anchored popover
+ * - `'bottom-sheet'`: the touch field with the swipe-paged month sheet
+ *
+ * Spelled as literals rather than aliased to an internal type, so a consumer's
+ * compiler diagnostics never name something they cannot import.
+ */
+export type DateInputAdaptationValue = 'native' | 'popover' | 'bottom-sheet';
+
+/** Runtime domain for `adaptations`, so an untyped caller is rejected too. */
+const DATE_INPUT_ADAPTATION_VALUES = [
+  'native',
+  'popover',
+  'bottom-sheet',
+] as const satisfies ReadonlyArray<DateInputAdaptationValue>;
+
+/** Diagnostic root for every `adaptations` failure on this component. */
+const ADAPTATIONS_PATH = '<DateInput adaptations>';
 
 export type DateInputFormat = Extract<
   TimestampFormat,
@@ -406,6 +440,139 @@ export interface DateInputProps extends Omit<
    * ```
    */
   nativePicker?: DateInputNativePicker;
+
+  /**
+   * Environment-conditioned surface policy: which of the three pickers this
+   * field renders, decided by rules you write instead of by the pointer alone.
+   *
+   * `default` is the server-rendered, hydration, and no-match value; ordered
+   * `rules` map conditions to the same three values, and the LAST matching rule
+   * wins — condition shape creates no specificity. Width names resolve against
+   * the NEAREST Theme's width points, `from` is inclusive, `below` is
+   * exclusive, and the fields of one `when` are ANDed. An empty `rules` array
+   * is well-formed and pins the field to `default` everywhere.
+   *
+   * Each value is exact and holds on any pointer, which is the difference from
+   * `nativePicker`: `'bottom-sheet'` presents the touch sheet to a mouse if
+   * that is what the policy says, and `'popover'` keeps the typable field on a
+   * phone.
+   *
+   * A policy naming `'native'` anywhere — `default` or ANY rule, matched today
+   * or not — is checked against the props the platform picker cannot express:
+   * `numberOfMonths={2}` and an explicit `weekStartsOn` throw at render, rather
+   * than being silently dropped on whichever device selects that rule. `min`,
+   * `max` and `dateConstraints` stay supported: native mode forwards the bounds
+   * and refuses an out-of-range commit.
+   *
+   * Mutually exclusive with `nativePicker` — the two name the same choice, so
+   * passing both defined values throws before a surface opens. An explicitly
+   * spread `undefined` is not a conflict.
+   *
+   * While the field is in use the resolved surface is held: a rule boundary
+   * crossed during an open picker, or while the field has focus, applies once
+   * the surface has closed and focus has left, so a rotation never swallows a
+   * half-typed date.
+   *
+   * @example
+   * ```
+   * <DateInput
+   *   label="Event date"
+   *   value={date}
+   *   onChange={setDate}
+   *   adaptations={{
+   *     default: 'popover',
+   *     rules: [
+   *       {when: {width: {below: 'md'}, pointer: 'coarse'}, value: 'bottom-sheet'},
+   *       {when: {pointer: 'coarse', width: {below: 'sm'}}, value: 'native'},
+   *     ],
+   *   }}
+   * />
+   * ```
+   */
+  adaptations?: ComponentAdaptations<DateInputAdaptationValue>;
+}
+
+/**
+ * `nativePicker` and `adaptations` name the same choice, so accepting both
+ * would make precedence — not the caller — decide the surface.
+ *
+ * Checked on `undefined`, not on presence: spreading a props bag that carries
+ * an explicit `adaptations: undefined` beside a real `nativePicker` is an
+ * ordinary call, not a conflict (spec:AST-031 FR6).
+ */
+function assertExclusiveSurfaceProps(
+  nativePicker: DateInputNativePicker | undefined,
+  adaptations: ComponentAdaptations<DateInputAdaptationValue> | undefined,
+): void {
+  if (nativePicker !== undefined && adaptations !== undefined) {
+    throw new Error(
+      '<DateInput> received both `nativePicker` and `adaptations`, which select the same surface. Pass `adaptations` for an environment-conditioned policy — its `native` value is what `nativePicker` reaches — or `nativePicker` for the pointer-driven shorthand.',
+    );
+  }
+}
+
+/**
+ * Reject a policy that names a surface it has also made impossible to draw.
+ *
+ * The platform picker has no month grid and no week-start control, so
+ * `numberOfMonths={2}` or an explicit `weekStartsOn` beside a `'native'` value
+ * is a contradiction. Every authored value is checked — `default` and EVERY
+ * rule, including ones today's viewport cannot match — so the failure lands on
+ * the author's machine instead of on the one phone that selects that rule
+ * (spec:AST-031 IR3). It throws in production as well as development: a
+ * silently dropped week start is a wrong calendar, not a warning.
+ *
+ * `weekStartsOn` is rejected on PRESENCE, not on value: `weekStartsOn={0}`
+ * states Sunday, and the platform picker follows the OS locale whatever that
+ * says. `numberOfMonths={1}` is the default shape and passes.
+ *
+ * `min`, `max` and `dateConstraints` are deliberately NOT rejected — native
+ * mode forwards the bounds and enforces every constraint on commit — which is
+ * also why the legacy `nativePicker` path keeps its own quieter fallback: it
+ * predates this policy and drops what it cannot draw.
+ */
+function assertNativeSurfaceIsDrawable(
+  adaptations: ComponentAdaptations<DateInputAdaptationValue>,
+  {numberOfMonths, weekStartsOn}: DateInputProps,
+): void {
+  const conflicts: string[] = [];
+  if (numberOfMonths !== undefined && numberOfMonths !== 1) {
+    conflicts.push(
+      `\`numberOfMonths={${numberOfMonths}}\` (the platform picker has no month grid to widen)`,
+    );
+  }
+  if (weekStartsOn !== undefined) {
+    conflicts.push(
+      `\`weekStartsOn={${JSON.stringify(weekStartsOn)}}\` (the platform picker follows the OS locale's first day of week)`,
+    );
+  }
+  if (conflicts.length === 0) {
+    return;
+  }
+  forEachAuthoredAdaptationValue(
+    adaptations,
+    ADAPTATIONS_PATH,
+    (value, valuePath) => {
+      if (value === 'native') {
+        throw new Error(
+          `${valuePath} is "native", which cannot honor ${conflicts.join(
+            ' or ',
+          )}. Use "popover" or "bottom-sheet" for that value, or drop the prop.`,
+        );
+      }
+    },
+  );
+}
+
+/** Run the latch's focus handler after the caller's own, never instead of it. */
+function composeFocusHandler(
+  callerHandler: React.FocusEventHandler<HTMLElement> | undefined,
+  latchHandler: (event: React.FocusEvent<HTMLElement>) => void,
+): React.FocusEventHandler<HTMLElement> {
+  return event => {
+    callerHandler?.(event);
+    latchHandler(event);
+  };
 }
 
 /**
@@ -902,6 +1069,11 @@ PointerDateField.displayName = 'PointerDateField';
  * surfaces, not two components — so nothing at the call site changes, and a
  * date typed on a laptop and a date thumbed on a phone are the same value.
  *
+ * `adaptations` takes that decision back: an ordered policy over the three
+ * exact surfaces (`native`, `popover`, `bottom-sheet`) resolved against the
+ * nearest Theme's width points and the primary pointer, replacing the built-in
+ * pointer test for the call sites that pass it.
+ *
  * ## Why a runtime switch and not CSS
  *
  * The two surfaces are structurally different — a popover anchored to a text
@@ -921,6 +1093,11 @@ PointerDateField.displayName = 'PointerDateField';
  * with a calendar icon and the formatted date — and differ only in what
  * opens. Nothing moves; the field just starts opening a sheet.
  *
+ * An `adaptations` policy replaces that pointer test with the caller's own
+ * rules, and its `default` is the server truth: the server renders `default`,
+ * the hydration render matches it, and the browser's real answer arrives on the
+ * render after (spec:AST-031 FR3).
+ *
  * @example
  * ```
  * <DateInput
@@ -930,8 +1107,42 @@ PointerDateField.displayName = 'PointerDateField';
  * />
  * ```
  */
-export function DateInput(props: DateInputProps) {
+export function DateInput({adaptations, ...props}: DateInputProps) {
+  // Both props before any hook: a call that names the surface twice is a
+  // mistake to report, not a precedence to resolve.
+  assertExclusiveSurfaceProps(props.nativePicker, adaptations);
+
   const isTouch = useMediaQuery(TOUCH_POINTER_QUERY);
+  // Called unconditionally, with `undefined` for a call site that has no
+  // policy: the resolver then subscribes to nothing and publishes nothing, so
+  // the legacy path below runs exactly the media query it always did.
+  const {value: adaptedSurface} = useComponentAdaptations(adaptations, {
+    path: ADAPTATIONS_PATH,
+    values: DATE_INPUT_ADAPTATION_VALUES,
+  });
+  const {surface, onFocusCapture, onBlurCapture} =
+    useAdaptationSurfaceLatch(adaptedSurface);
+
+  if (adaptations !== undefined) {
+    assertNativeSurfaceIsDrawable(adaptations, props);
+    // The three surfaces are separate trees, so the latch's focus handlers ride
+    // the field root each of them spreads its pass-through props onto.
+    const surfaceProps: DateInputProps = {
+      ...props,
+      onFocusCapture: composeFocusHandler(props.onFocusCapture, onFocusCapture),
+      onBlurCapture: composeFocusHandler(props.onBlurCapture, onBlurCapture),
+    };
+    if (surface === 'native') {
+      return <NativeDateField {...surfaceProps} />;
+    }
+    if (surface === 'bottom-sheet') {
+      return <TouchDateField {...surfaceProps} />;
+    }
+    // 'popover' — and the only other reachable value, since a policy always
+    // resolves to one of its own admitted values.
+    return <PointerDateField {...surfaceProps} />;
+  }
+
   const nativePicker = props.nativePicker ?? 'touch';
 
   // The platform's picker, where the consumer asked for it — see the

--- a/packages/core/src/DateInput/DateInputAdaptations.test.tsx
+++ b/packages/core/src/DateInput/DateInputAdaptations.test.tsx
@@ -5,7 +5,8 @@
  * @input Uses vitest, @testing-library/react, react-dom/server
  * @output Tests DateInput's public surface policy (spec:AST-031)
  * @position Tests; validates the `adaptations` prop — resolution, eager
- *   validation, latching — and the untouched `nativePicker` path beside it.
+ *   validation, latching — and the deprecated `nativePicker` compatibility
+ *   path beside it, including the documented migration mapping.
  *   Behavior that is not surface selection (month geometry, typing, the sheet's
  *   internals) stays in DateInput.test.tsx and DateInputTouch.test.tsx.
  *
@@ -1356,10 +1357,10 @@ describe('latching', () => {
 });
 
 // =============================================================================
-// The released `nativePicker` contract, unchanged beside the new one
+// Deprecated `nativePicker` compatibility and migration
 // =============================================================================
 
-describe('legacy nativePicker parity', () => {
+describe('deprecated nativePicker compatibility', () => {
   it.each([
     ['touch', 'fine', 'popover'],
     ['touch', 'coarse', 'native'],
@@ -1382,6 +1383,47 @@ describe('legacy nativePicker parity', () => {
       );
 
       expect(surfaceIn()).toBe(expected);
+    },
+  );
+
+  it.each(['fine', 'coarse'] as const)(
+    'matches the documented idle adaptations policy on a %s pointer',
+    pointer => {
+      environment.set({
+        pointer,
+        width: pointer === 'coarse' ? 390 : 1280,
+      });
+      const migrations = [
+        [
+          'touch',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+          }),
+        ],
+        ['always', policy({default: 'native', rules: []})],
+        [
+          'never',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+          }),
+        ],
+      ] as const;
+
+      for (const [nativePicker, adaptations] of migrations) {
+        const legacy = render(
+          <DateInput label="Event date" nativePicker={nativePicker} />,
+        );
+        const legacySurface = surfaceIn();
+        legacy.unmount();
+
+        const migrated = render(
+          <DateInput label="Event date" adaptations={adaptations} />,
+        );
+        expect(surfaceIn()).toBe(legacySurface);
+        migrated.unmount();
+      }
     },
   );
 

--- a/packages/core/src/DateInput/DateInputAdaptations.test.tsx
+++ b/packages/core/src/DateInput/DateInputAdaptations.test.tsx
@@ -1,0 +1,1407 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file DateInputAdaptations.test.tsx
+ * @input Uses vitest, @testing-library/react, react-dom/server
+ * @output Tests DateInput's public surface policy (spec:AST-031)
+ * @position Tests; validates the `adaptations` prop — resolution, eager
+ *   validation, latching — and the untouched `nativePicker` path beside it.
+ *   Behavior that is not surface selection (month geometry, typing, the sheet's
+ *   internals) stays in DateInput.test.tsx and DateInputTouch.test.tsx.
+ *
+ * The environment here is a REAL query evaluator rather than a
+ * `query === '<literal>'` stub: an exact-boundary rule (`width < md`) can only
+ * be told apart from an inclusive one by a stub that computes an answer from an
+ * actual viewport width, and a latch test needs listeners that actually fire.
+ *
+ * SYNC: When DateInput's surface policy changes, update these tests.
+ * - /packages/core/src/DateInput/DateInput.tsx
+ * - /packages/core/src/hooks/useAdaptationSurfaceLatch.ts
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, act, fireEvent, waitFor} from '@testing-library/react';
+import {renderToString} from 'react-dom/server';
+import {hydrateRoot} from 'react-dom/client';
+import {useState, type ReactNode} from 'react';
+import {DateInput} from './DateInput';
+import type {DateInputAdaptationValue, DateInputProps} from './DateInput';
+import {Theme} from '../theme/Theme';
+import {defineTheme} from '../theme/defineTheme';
+import {resetThemes} from '../theme/themeRegistry';
+import {
+  getAdaptationStoreCount,
+  resetAdaptationStores,
+} from '../theme/useComponentAdaptations';
+import type {ComponentAdaptations} from '../theme/componentAdaptations';
+import type {ISODateString} from '../utils';
+
+// =============================================================================
+// A viewport, not a query allowlist
+// =============================================================================
+
+interface Viewport {
+  width: number;
+  pointer: 'coarse' | 'fine';
+}
+
+interface FakeMediaQueryList {
+  media: string;
+  matches: boolean;
+  listeners: Set<() => void>;
+}
+
+interface Environment {
+  /** Every distinct query anything asked about. */
+  queries: () => string[];
+  /**
+   * Only the queries a surface policy can produce. Unrelated hooks in the tree
+   * ask about hover and reduced motion, so "subscribed to nothing" has to mean
+   * "asked nothing about the viewport", not "never called matchMedia".
+   */
+  policyQueries: () => string[];
+  /** Move the viewport and notify listeners, as a resize or rotation does. */
+  set: (next: Partial<Viewport>) => void;
+}
+
+/** Matches the repo-wide setup polyfill, so hover-gated behavior still works. */
+const HOVER_CAPABLE = /\(\s*hover\s*:\s*hover\s*\)/;
+
+/**
+ * Evaluate one media query against a viewport.
+ *
+ * Understands the grammars in play: AST-031's compiled range syntax
+ * (`(width < 768px)`), the legacy `(max-width: …)` / `(min-width: …)` forms,
+ * and pointer precision. Anything else falls back to the repo's default
+ * answer so unrelated hooks keep behaving.
+ */
+function evaluate(query: string, viewport: Viewport): boolean {
+  const parts = query.split(' and ').map(part => part.trim());
+  let understood = false;
+  const value = parts.every(part => {
+    const range = /^\(width (<|<=|>|>=) (\d+)px\)$/.exec(part);
+    if (range) {
+      understood = true;
+      const point = Number(range[2]);
+      switch (range[1]) {
+        case '<':
+          return viewport.width < point;
+        case '<=':
+          return viewport.width <= point;
+        case '>':
+          return viewport.width > point;
+        default:
+          return viewport.width >= point;
+      }
+    }
+    const maxWidth = /^\(max-width:\s*(\d+)px\)$/.exec(part);
+    if (maxWidth) {
+      understood = true;
+      return viewport.width <= Number(maxWidth[1]);
+    }
+    const minWidth = /^\(min-width:\s*(\d+)px\)$/.exec(part);
+    if (minWidth) {
+      understood = true;
+      return viewport.width >= Number(minWidth[1]);
+    }
+    const anyPointer = /^\(any-pointer:\s*(coarse|fine)\)$/.exec(part);
+    if (anyPointer) {
+      understood = true;
+      return anyPointer[1] === viewport.pointer;
+    }
+    const pointer = /^\(pointer:\s*(coarse|fine)\)$/.exec(part);
+    if (pointer) {
+      understood = true;
+      return pointer[1] === viewport.pointer;
+    }
+    return false;
+  });
+  return understood ? value : HOVER_CAPABLE.test(query);
+}
+
+function installEnvironment(initial: Viewport): Environment {
+  const viewport: Viewport = {...initial};
+  const lists = new Map<string, FakeMediaQueryList>();
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((media: string) => {
+      let list = lists.get(media);
+      if (!list) {
+        list = {
+          media,
+          matches: evaluate(media, viewport),
+          listeners: new Set(),
+        };
+        lists.set(media, list);
+      }
+      // Re-evaluate on every read: a list created before a `set` must not
+      // report the viewport it was born in.
+      list.matches = evaluate(media, viewport);
+      const handle = list;
+      return {
+        get matches() {
+          return handle.matches;
+        },
+        media,
+        onchange: null,
+        addEventListener: (type: string, listener: () => void) => {
+          if (type === 'change') {
+            handle.listeners.add(listener);
+          }
+        },
+        removeEventListener: (type: string, listener: () => void) => {
+          if (type === 'change') {
+            handle.listeners.delete(listener);
+          }
+        },
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      } as unknown as MediaQueryList;
+    }),
+  );
+
+  return {
+    queries: () => [...lists.keys()],
+    policyQueries: () =>
+      [...lists.keys()].filter(
+        query => query.includes('width') || query.includes('pointer'),
+      ),
+    set(next) {
+      Object.assign(viewport, next);
+      act(() => {
+        for (const list of lists.values()) {
+          const matches = evaluate(list.media, viewport);
+          if (matches === list.matches) {
+            continue;
+          }
+          list.matches = matches;
+          for (const listener of [...list.listeners]) {
+            listener();
+          }
+        }
+      });
+    },
+  };
+}
+
+// =============================================================================
+// jsdom scaffolding (mirrors DateInputTouch.test.tsx)
+// =============================================================================
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+let environment: Environment;
+
+beforeEach(() => {
+  resetThemes();
+  resetAdaptationStores();
+  Element.prototype.scrollTo = vi.fn();
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.open = true;
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.open = true;
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.open = false;
+  });
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
+  environment = installEnvironment({width: 1280, pointer: 'fine'});
+});
+
+afterEach(() => {
+  resetAdaptationStores();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// =============================================================================
+// Reading the resolved surface out of the DOM
+// =============================================================================
+
+type Surface = DateInputAdaptationValue;
+
+/**
+ * Which of the three trees is mounted.
+ *
+ * Each surface has one unmistakable mark: the platform control is a real
+ * `<input type="date">`, the touch field is the combobox that refuses the
+ * keyboard (`inputmode="none"`), and the pointer field is the typable one.
+ */
+function surfaceIn(root: ParentNode = document): Surface {
+  if (root.querySelector('input[type="date"]') != null) {
+    return 'native';
+  }
+  const combobox = root.querySelector('input[role="combobox"]');
+  if (combobox == null) {
+    throw new Error('No DateInput field is mounted.');
+  }
+  return combobox.getAttribute('inputmode') === 'none'
+    ? 'bottom-sheet'
+    : 'popover';
+}
+
+/** The same read against server-rendered markup, before any DOM exists. */
+function surfaceInMarkup(html: string): Surface {
+  if (html.includes('type="date"')) {
+    return 'native';
+  }
+  // React server-renders `inputMode` in its camelCase spelling; the DOM read
+  // above sees the lowercased attribute. Matching case-insensitively keeps the
+  // two readings of the same mark from drifting apart.
+  return /inputmode="none"/i.test(html) ? 'bottom-sheet' : 'popover';
+}
+
+function field(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>(
+    'input[role="combobox"], input[type="date"]',
+  );
+  if (input == null) {
+    throw new Error('No DateInput field is mounted.');
+  }
+  return input;
+}
+
+const policy = (
+  value: ComponentAdaptations<DateInputAdaptationValue>,
+): ComponentAdaptations<DateInputAdaptationValue> => value;
+
+function themeWithMd(name: string, md: number) {
+  return defineTheme({name, adaptations: {widthBreakpoints: {md}}});
+}
+
+function withTheme(theme: ReturnType<typeof defineTheme>) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    return <Theme theme={theme}>{children}</Theme>;
+  };
+}
+
+async function focusField(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.focus();
+  });
+}
+
+async function blurField(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.blur();
+  });
+}
+
+/** Drop focus wherever it currently is — inside an open sheet, for instance. */
+async function blurActiveElement(): Promise<void> {
+  await act(async () => {
+    (document.activeElement as HTMLElement | null)?.blur();
+  });
+}
+
+/**
+ * jsdom never runs the sheet's exit transition, so a closed BottomSheet stays
+ * an open `<dialog>` until the transition is delivered by hand — and that open
+ * dialog is one of the two signals the latch waits on.
+ */
+function finishSheetExit(): void {
+  const panel = document.querySelector<HTMLElement>('.astryx-bottom-sheet');
+  if (panel != null) {
+    fireEvent.transitionEnd(panel, {propertyName: 'transform'});
+  }
+  for (const dialog of document.querySelectorAll('dialog')) {
+    dialog.open = false;
+  }
+}
+
+// =============================================================================
+// FR3 — `default` is server truth
+// =============================================================================
+
+describe('server rendering', () => {
+  it.each([
+    ['popover', 'popover'],
+    ['bottom-sheet', 'bottom-sheet'],
+    ['native', 'native'],
+  ] as const)(
+    'renders the `%s` default without reading matchMedia',
+    (value, expected) => {
+      const html = renderToString(
+        <DateInput
+          label="Event date"
+          adaptations={policy({
+            default: value,
+            rules: [
+              {when: {width: {below: 'md'}}, value: 'bottom-sheet'},
+              {when: {pointer: 'coarse'}, value: 'native'},
+            ],
+          })}
+        />,
+      );
+
+      expect(surfaceInMarkup(html)).toBe(expected);
+      expect(environment.policyQueries()).toEqual([]);
+    },
+  );
+
+  it('leaves the registry empty after a render that never commits', () => {
+    renderToString(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+        })}
+      />,
+    );
+
+    expect(environment.queries()).toEqual([]);
+  });
+
+  it('hydrates the server default, then publishes the browser answer', async () => {
+    const adaptations = policy({
+      default: 'popover',
+      rules: [
+        {
+          when: {width: {below: 'md'}, pointer: 'coarse'},
+          value: 'bottom-sheet',
+        },
+      ],
+    });
+    const tree = <DateInput label="Event date" adaptations={adaptations} />;
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(tree);
+    document.body.appendChild(container);
+    // The client is the phone the rule was written for; the server was not.
+    expect(surfaceIn(container)).toBe('popover');
+    environment.set({width: 390, pointer: 'coarse'});
+
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      errors.push(args);
+    });
+    await act(async () => {
+      hydrateRoot(container, tree);
+    });
+    spy.mockRestore();
+
+    expect(errors).toEqual([]);
+    expect(surfaceIn(container)).toBe('bottom-sheet');
+    container.remove();
+  });
+});
+
+// =============================================================================
+// FR2/FR4 — exact values, on either pointer
+// =============================================================================
+
+describe('exact surfaces', () => {
+  const pointers = ['fine', 'coarse'] as const;
+  const surfaces: ReadonlyArray<Surface> = [
+    'native',
+    'popover',
+    'bottom-sheet',
+  ];
+
+  for (const pointer of pointers) {
+    for (const value of surfaces) {
+      it(`renders ${value} on a ${pointer} pointer`, () => {
+        environment.set({
+          pointer,
+          width: pointer === 'coarse' ? 390 : 1280,
+        });
+        render(
+          <DateInput
+            label="Event date"
+            adaptations={policy({default: value, rules: []})}
+          />,
+        );
+
+        expect(surfaceIn()).toBe(value);
+      });
+    }
+  }
+
+  it('keeps the touch sheet on a mouse when a rule says so', async () => {
+    environment.set({width: 1280, pointer: 'fine'});
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {width: {from: 'lg'}}, value: 'bottom-sheet'}],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+    fireEvent.click(field());
+    await waitFor(() => {
+      expect(document.querySelector('dialog')).not.toBeNull();
+    });
+  });
+
+  it('keeps the anchored popover on a finger when a rule says so', async () => {
+    environment.set({width: 390, pointer: 'coarse'});
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {pointer: 'coarse'}, value: 'popover'}],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('popover');
+    fireEvent.click(
+      screen.getByRole('button', {name: /open calendar|calendar/i}),
+    );
+    await waitFor(() => {
+      expect(field().getAttribute('aria-expanded')).toBe('true');
+    });
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  it('follows the environment while the field is idle', () => {
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [
+            {when: {width: {below: 'md'}}, value: 'bottom-sheet'},
+            {when: {width: {below: 'sm'}, pointer: 'coarse'}, value: 'native'},
+          ],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('popover');
+    environment.set({width: 700});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('native');
+    environment.set({width: 1280, pointer: 'fine'});
+    expect(surfaceIn()).toBe('popover');
+  });
+});
+
+// =============================================================================
+// FR2 — rule order is precedence
+// =============================================================================
+
+describe('rule order', () => {
+  it('lets the LAST matching rule win, not the most specific', () => {
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'bottom-sheet',
+            },
+            {when: {pointer: 'coarse'}, value: 'native'},
+          ],
+        })}
+      />,
+    );
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('native');
+  });
+
+  it('reverses the outcome when the same rules are reordered', () => {
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [
+            {when: {pointer: 'coarse'}, value: 'native'},
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'bottom-sheet',
+            },
+          ],
+        })}
+      />,
+    );
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('resolves an empty rule list to `default` and subscribes to nothing', () => {
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={policy({default: 'bottom-sheet', rules: []})}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+    // No rules, so nothing can change the answer: no shared media connection
+    // is opened at all. (The pointer query still on the list belongs to the
+    // component's own legacy switch, which every call site runs.)
+    expect(getAdaptationStoreCount()).toBe(0);
+    expect(environment.queries().some(query => query.includes('width'))).toBe(
+      false,
+    );
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+});
+
+// =============================================================================
+// FR4/IR4 — the nearest Theme's width points
+// =============================================================================
+
+describe('theme width points', () => {
+  const belowMd = policy({
+    default: 'popover',
+    rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+  });
+
+  it('anchors at exactly the default md point (768px), and swaps 1px below', () => {
+    render(<DateInput label="Event date" adaptations={belowMd} />);
+
+    environment.set({width: 768});
+    expect(surfaceIn()).toBe('popover');
+    environment.set({width: 767});
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it("moves that edge with the theme's md", () => {
+    render(<DateInput label="Event date" adaptations={belowMd} />, {
+      wrapper: withTheme(themeWithMd('wide-md', 900)),
+    });
+
+    environment.set({width: 850});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    environment.set({width: 900});
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('prefers the NEAREST theme when providers nest', () => {
+    render(
+      <Theme theme={themeWithMd('outer-md', 700)}>
+        <Theme theme={themeWithMd('inner-md', 1000)}>
+          <DateInput label="Event date" adaptations={belowMd} />
+        </Theme>
+      </Theme>,
+    );
+
+    // 850 is above the outer point and below the inner one, so the two themes
+    // disagree and only the inner one's answer is visible.
+    environment.set({width: 850});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    environment.set({width: 1100});
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('compiles a range query rather than a max-width query', () => {
+    render(<DateInput label="Event date" adaptations={belowMd} />);
+
+    expect(environment.queries()).toContain('(width < 768px)');
+    expect(
+      environment.queries().some(query => query.includes('max-width')),
+    ).toBe(false);
+  });
+});
+
+// =============================================================================
+// FR6 — the two surface props are exclusive
+// =============================================================================
+
+describe('mutual exclusivity with nativePicker', () => {
+  it('throws when both props are defined', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <DateInput
+          label="Event date"
+          nativePicker="always"
+          adaptations={policy({default: 'popover', rules: []})}
+        />,
+      ),
+    ).toThrow(/received both `nativePicker` and `adaptations`/);
+    spy.mockRestore();
+  });
+
+  it('accepts an explicitly undefined `adaptations` beside a nativePicker', () => {
+    environment.set({width: 1280, pointer: 'fine'});
+    render(
+      <DateInput
+        label="Event date"
+        nativePicker="always"
+        adaptations={undefined}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('native');
+  });
+
+  it('accepts an explicitly undefined `nativePicker` beside a policy', () => {
+    render(
+      <DateInput
+        label="Event date"
+        nativePicker={undefined}
+        adaptations={policy({default: 'bottom-sheet', rules: []})}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+});
+
+// =============================================================================
+// IR3 — invalid policies fail with a path-specific message
+// =============================================================================
+
+describe('policy validation', () => {
+  function expectRenderToThrow(node: ReactNode, message: RegExp) {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(node)).toThrow(message);
+    spy.mockRestore();
+  }
+
+  it('rejects a value outside the admitted three', () => {
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        adaptations={
+          {
+            default: 'inline',
+            rules: [],
+          } as unknown as ComponentAdaptations<DateInputAdaptationValue>
+        }
+      />,
+      /<DateInput adaptations>\.default must be one of native, popover, bottom-sheet; received "inline"\./,
+    );
+  });
+
+  it('names the offending rule, not just the policy', () => {
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        adaptations={
+          {
+            default: 'popover',
+            rules: [
+              {when: {pointer: 'coarse'}, value: 'bottom-sheet'},
+              {when: {pointer: 'fine'}, value: 'adaptive'},
+            ],
+          } as unknown as ComponentAdaptations<DateInputAdaptationValue>
+        }
+      />,
+      /<DateInput adaptations>\.rules\[1\]\.value must be one of native, popover, bottom-sheet/,
+    );
+  });
+
+  it('rejects a missing rule list rather than assuming none', () => {
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        adaptations={
+          {
+            default: 'popover',
+          } as unknown as ComponentAdaptations<DateInputAdaptationValue>
+        }
+      />,
+      /<DateInput adaptations>\.rules is required; pass \[\] for no rules\./,
+    );
+  });
+
+  it('rejects an empty condition', () => {
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {}, value: 'native'}],
+        })}
+      />,
+      /<DateInput adaptations>\.rules\[0\]\.when/,
+    );
+  });
+
+  it.each([null, false, 0, ''])(
+    'rejects the falsy non-object %p instead of treating it as no policy',
+    falsy => {
+      expectRenderToThrow(
+        <DateInput
+          label="Event date"
+          adaptations={
+            falsy as unknown as ComponentAdaptations<DateInputAdaptationValue>
+          }
+        />,
+        /<DateInput adaptations>/,
+      );
+    },
+  );
+
+  it('treats an absent policy as no policy at all', () => {
+    environment.set({width: 1280, pointer: 'fine'});
+    render(<DateInput label="Event date" />);
+
+    expect(surfaceIn()).toBe('popover');
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+});
+
+// =============================================================================
+// IR3 — a `native` value is checked against the props it cannot draw
+// =============================================================================
+
+describe('eager native-surface validation', () => {
+  function expectRenderToThrow(node: ReactNode, message: RegExp) {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(node)).toThrow(message);
+    spy.mockRestore();
+  }
+
+  it('rejects numberOfMonths={2} beside a native default', () => {
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        numberOfMonths={2}
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+      /<DateInput adaptations>\.default is "native", which cannot honor `numberOfMonths=\{2\}`/,
+    );
+  });
+
+  it('rejects an explicit weekStartsOn even when it is falsy', () => {
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        weekStartsOn={0}
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+      /<DateInput adaptations>\.default is "native", which cannot honor `weekStartsOn=\{0\}`/,
+    );
+  });
+
+  it('names every conflicting prop at once', () => {
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        numberOfMonths={2}
+        weekStartsOn="mon"
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+      /`numberOfMonths=\{2\}`.*or.*`weekStartsOn=\{"mon"\}`/s,
+    );
+  });
+
+  it('rejects a native value in a rule the current viewport cannot match', () => {
+    // A wide fine-pointer laptop: the coarse rule is unreachable here, which is
+    // exactly why it has to fail here rather than on the phone that selects it.
+    environment.set({width: 1280, pointer: 'fine'});
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        numberOfMonths={2}
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+        })}
+      />,
+      /<DateInput adaptations>\.rules\[0\]\.value is "native"/,
+    );
+  });
+
+  it('throws in production too, not only in development', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    expectRenderToThrow(
+      <DateInput
+        label="Event date"
+        numberOfMonths={2}
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+      /cannot honor `numberOfMonths=\{2\}`/,
+    );
+  });
+
+  it('accepts the shapes native mode already has', () => {
+    render(
+      <DateInput
+        label="Event date"
+        numberOfMonths={1}
+        adaptations={policy({
+          default: 'native',
+          rules: [{when: {pointer: 'fine'}, value: 'native'}],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('native');
+  });
+
+  it('keeps min, max and dateConstraints supported on the native surface', () => {
+    const noWeekends = vi.fn(
+      (date: Date) => date.getDay() !== 0 && date.getDay() !== 6,
+    );
+    render(
+      <DateInput
+        label="Event date"
+        min="2026-03-01"
+        max="2026-03-31"
+        dateConstraints={[noWeekends]}
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+    );
+
+    const input = field();
+    expect(input.getAttribute('type')).toBe('date');
+    expect(input.getAttribute('min')).toBe('2026-03-01');
+    expect(input.getAttribute('max')).toBe('2026-03-31');
+  });
+
+  it('refuses a constrained date on commit in native mode', async () => {
+    const onChange = vi.fn();
+    render(
+      <DateInput
+        label="Event date"
+        onChange={onChange}
+        min="2026-03-10"
+        max="2026-03-20"
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+    );
+
+    const input = field();
+    fireEvent.change(input, {target: {value: '2026-03-25'}});
+    await waitFor(() => {
+      expect(onChange).not.toHaveBeenCalledWith('2026-03-25');
+    });
+
+    fireEvent.change(input, {target: {value: '2026-03-15'}});
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('2026-03-15');
+    });
+  });
+
+  it('leaves the legacy nativePicker path to its own fallback', () => {
+    // Same incompatible prop, no policy: the released contract drops what the
+    // platform picker cannot draw instead of throwing.
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(() =>
+      render(
+        <DateInput
+          label="Event date"
+          numberOfMonths={2}
+          weekStartsOn="mon"
+          nativePicker="always"
+        />,
+      ),
+    ).not.toThrow();
+    expect(surfaceIn()).toBe('native');
+  });
+});
+
+// =============================================================================
+// FR5 — the resolved surface is latched while the field is in use
+// =============================================================================
+
+describe('latching', () => {
+  const popoverBelowMd = policy({
+    default: 'popover',
+    rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+  });
+
+  /**
+   * A real browser's focus move, in its real order.
+   *
+   * A user's Tab or click dispatches `focusout` on the old control, DRAINS
+   * MICROTASKS, and only then dispatches `focusin` on the new one. Everything
+   * that used to defer the release decision — a microtask, a promise callback —
+   * therefore ran in the gap, saw focus nowhere, and released the latch mid-
+   * interaction. jsdom's own `blur()`/`focus()` pair cannot reproduce that: it
+   * runs both inside one task. So the gap is modelled here explicitly, and
+   * `inTheGap` is where the assertions that matter live.
+   */
+  async function moveFocus(
+    from: HTMLElement,
+    to: HTMLElement | null,
+    inTheGap: () => void,
+  ): Promise<void> {
+    fireEvent.focusOut(from, {relatedTarget: to});
+    // Drain microtasks — the whole width of the gap.
+    await act(async () => {});
+    inTheGap();
+    if (to != null) {
+      fireEvent.focusIn(to, {relatedTarget: from});
+      to.focus();
+      await act(async () => {});
+    }
+  }
+
+  const toggleButton = () => screen.getByRole('button', {name: /calendar/i});
+
+  it('holds from the input to its calendar toggle, across the focusout gap', async () => {
+    function Controlled() {
+      const [value, setValue] = useState<ISODateString | undefined>();
+      return (
+        <DateInput
+          label="Event date"
+          value={value}
+          onChange={setValue}
+          adaptations={popoverBelowMd}
+        />
+      );
+    }
+    render(<Controlled />);
+    const input = field();
+    await focusField(input);
+    // A COMPLETE date, deliberately: blurring the text field commits what was
+    // typed, which is the field's own long-standing contract and nothing to do
+    // with the latch (a partial "3/2" reverts on blur whatever the policy is
+    // doing). What the latch owes this move is that the entry survives it at
+    // all, rather than leaving with an unmounted tree.
+    fireEvent.change(input, {target: {value: '3/2/2026'}});
+    const toggle = toggleButton();
+
+    // The policy now wants the sheet; the field is mid-entry, so it must not
+    // get it — not even for the instant between the two focus events.
+    environment.set({width: 390, pointer: 'coarse'});
+
+    await moveFocus(input, toggle, () => {
+      expect(surfaceIn()).toBe('popover');
+      expect(field()).toBe(input);
+      expect(input.value).toBe('March 2, 2026');
+      // The button the pointer is travelling towards is still the same node:
+      // a swap here would unmount it under the cursor and eat the click.
+      expect(toggleButton()).toBe(toggle);
+    });
+
+    expect(surfaceIn()).toBe('popover');
+    expect(field()).toBe(input);
+    expect(input.value).toBe('March 2, 2026');
+
+    // And the click that started this actually lands on the surface that was
+    // there when the user pressed the pointer down.
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('holds from the input to its clear button, across the focusout gap', async () => {
+    function Controlled() {
+      const [value, setValue] = useState<ISODateString | undefined>(
+        '2026-03-21' as ISODateString,
+      );
+      return (
+        <DateInput
+          label="Event date"
+          hasClear
+          value={value}
+          onChange={setValue}
+          adaptations={popoverBelowMd}
+        />
+      );
+    }
+    render(<Controlled />);
+    const input = field();
+    await focusField(input);
+    const clear = screen.getByRole('button', {name: /clear/i});
+    environment.set({width: 390, pointer: 'coarse'});
+
+    await moveFocus(input, clear, () => {
+      expect(surfaceIn()).toBe('popover');
+      expect(screen.getByRole('button', {name: /clear/i})).toBe(clear);
+    });
+
+    fireEvent.click(clear);
+    await waitFor(() => {
+      expect(field().value).toBe('');
+    });
+    // Clearing unmounts the button, which is a focus change of its own; the
+    // field still holds the surface because focus came back to it.
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('releases when the focusout names a target outside the field', async () => {
+    render(
+      <>
+        <DateInput label="Event date" adaptations={popoverBelowMd} />
+        <button type="button">Elsewhere</button>
+      </>,
+    );
+    const input = field();
+    await focusField(input);
+    environment.set({width: 390, pointer: 'coarse'});
+    const outside = screen.getByRole('button', {name: 'Elsewhere'});
+
+    fireEvent.focusOut(input, {relatedTarget: outside});
+    await act(async () => {});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('releases when the focusout names no target at all', async () => {
+    render(<DateInput label="Event date" adaptations={popoverBelowMd} />);
+    const input = field();
+    await focusField(input);
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // `relatedTarget` is null when focus leaves for the document, another
+    // window, or a target the browser withholds. All of them are "outside".
+    fireEvent.focusOut(input, {relatedTarget: null});
+    await act(async () => {});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('keeps holding on a null focusout while a surface is still open', async () => {
+    render(<DateInput label="Event date" adaptations={popoverBelowMd} />);
+    const input = field();
+    await focusField(input);
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // Focus went nowhere the field can name, but the calendar is still open —
+    // the surface arm is what keeps an anchored popover, portaled out of this
+    // subtree, from being torn out from under itself.
+    fireEvent.focusOut(input, {relatedTarget: null});
+    await act(async () => {});
+
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('holds the focused tree across a viewport change, keeping the draft', async () => {
+    render(<DateInput label="Event date" adaptations={popoverBelowMd} />);
+    const input = field();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: '3/2'}});
+    expect(input.value).toBe('3/2');
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // Same node, same uncommitted text, same focus: nothing was remounted.
+    expect(surfaceIn()).toBe('popover');
+    expect(field()).toBe(input);
+    expect(input.value).toBe('3/2');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('applies the pending surface once focus leaves', async () => {
+    render(<DateInput label="Event date" adaptations={popoverBelowMd} />);
+    const input = field();
+    await focusField(input);
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('popover');
+
+    await blurField(input);
+
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+  });
+
+  it('does not swap while the anchored calendar is open', async () => {
+    render(<DateInput label="Event date" adaptations={popoverBelowMd} />);
+    const input = field();
+    await focusField(input);
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('popover');
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('holds while an open surface outlives focus, then releases when it closes', async () => {
+    render(
+      <>
+        <DateInput label="Event date" adaptations={popoverBelowMd} />
+        <button type="button">Elsewhere</button>
+      </>,
+    );
+    const input = field();
+    await focusField(input);
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('popover');
+
+    // Focus moves to another control with the calendar still open: the
+    // surface, not the caret, is what holds the latch now.
+    await focusField(screen.getByRole('button', {name: 'Elsewhere'}));
+    expect(surfaceIn()).toBe('popover');
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+
+    // Closing it is the release signal on its own — focus never comes back,
+    // so nothing else would tell the latch the field is done.
+    await act(async () => {
+      fireEvent.keyDown(input, {key: 'Escape'});
+    });
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', {name: 'Elsewhere'}),
+    );
+  });
+
+  it('holds the touch sheet through its own lifecycle', async () => {
+    environment.set({width: 390, pointer: 'coarse'});
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+        })}
+      />,
+    );
+    expect(surfaceIn()).toBe('bottom-sheet');
+    const input = field();
+    await focusField(input);
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(document.querySelector('dialog')?.hasAttribute('open')).toBe(true);
+    });
+
+    // A rotation to a wide viewport mid-pick must not pull the sheet out.
+    environment.set({width: 1280, pointer: 'fine'});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    expect(document.querySelector('dialog')).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.keyDown(document.querySelector('dialog')!, {key: 'Escape'});
+    });
+    // Focus is inside the sheet, which jsdom leaves there: it never runs the
+    // exit transition that hands focus back. Dropping focus by hand is the
+    // "focus has left, the surface has not" case.
+    await blurActiveElement();
+    expect(surfaceIn()).toBe('bottom-sheet');
+
+    // Completing the exit is what hands focus back to the field, so the sheet
+    // is still the right tree to be in — the release waits for that focus to
+    // leave as well.
+    await act(async () => {
+      finishSheetExit();
+    });
+    expect(document.activeElement).toBe(field());
+    expect(surfaceIn()).toBe('bottom-sheet');
+
+    await blurField(field());
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('popover');
+    });
+  });
+
+  it('holds across a theme change that moves the boundary', async () => {
+    // 800px sits above the default md point and below the widened one, so the
+    // theme swap alone flips which rule matches.
+    environment.set({width: 800, pointer: 'fine'});
+    function ThemeSwitch() {
+      const [md, setMd] = useState(768);
+      return (
+        <Theme theme={themeWithMd(`md-${md}`, md)}>
+          <DateInput label="Event date" adaptations={popoverBelowMd} />
+          <button type="button" onClick={() => setMd(1000)}>
+            Widen
+          </button>
+        </Theme>
+      );
+    }
+    render(<ThemeSwitch />);
+    expect(surfaceIn()).toBe('popover');
+    const input = field();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: '3/2'}});
+
+    await act(async () => {
+      // Clicking does not move focus in jsdom, so the field stays engaged.
+      screen.getByRole('button', {name: 'Widen'}).click();
+    });
+
+    expect(surfaceIn()).toBe('popover');
+    expect(field()).toBe(input);
+    expect(input.value).toBe('3/2');
+
+    await blurField(input);
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+  });
+
+  it('holds across a policy change, then applies it on release', async () => {
+    function PolicySwitch() {
+      const [value, setValue] = useState<DateInputAdaptationValue>('popover');
+      return (
+        <>
+          <DateInput
+            label="Event date"
+            adaptations={policy({default: value, rules: []})}
+          />
+          <button type="button" onClick={() => setValue('native')}>
+            Go native
+          </button>
+        </>
+      );
+    }
+    render(<PolicySwitch />);
+    const input = field();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: '3/2'}});
+
+    await act(async () => {
+      screen.getByRole('button', {name: 'Go native'}).click();
+    });
+    expect(surfaceIn()).toBe('popover');
+    expect(input.value).toBe('3/2');
+
+    await blurField(input);
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('native');
+    });
+  });
+
+  it('holds the native control while it has focus, and releases on blur', async () => {
+    const nativeUntilMd = policy({
+      default: 'native',
+      rules: [{when: {width: {from: 'md'}}, value: 'popover'}],
+    });
+    environment.set({width: 390, pointer: 'coarse'});
+    render(<DateInput label="Event date" adaptations={nativeUntilMd} />);
+    expect(surfaceIn()).toBe('native');
+
+    const input = field();
+    await focusField(input);
+    environment.set({width: 1280, pointer: 'fine'});
+    expect(surfaceIn()).toBe('native');
+    expect(document.activeElement).toBe(input);
+
+    await blurField(input);
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('popover');
+    });
+  });
+
+  it('swaps immediately when the field was never touched', () => {
+    render(<DateInput label="Event date" adaptations={popoverBelowMd} />);
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('keeps a committed value across a released swap', async () => {
+    function Controlled() {
+      const [value, setValue] = useState<ISODateString | undefined>(
+        '2026-03-21' as ISODateString,
+      );
+      return (
+        <DateInput
+          label="Event date"
+          value={value}
+          onChange={setValue}
+          adaptations={popoverBelowMd}
+        />
+      );
+    }
+    render(<Controlled />);
+    const input = field();
+    expect(input.value).toBe('March 21, 2026');
+
+    await focusField(input);
+    environment.set({width: 390, pointer: 'coarse'});
+    await blurField(input);
+
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+    expect(field().value).toBe('March 21, 2026');
+  });
+
+  it('still runs the caller’s own focus handlers', async () => {
+    const onFocusCapture = vi.fn();
+    const onBlurCapture = vi.fn();
+    render(
+      <DateInput
+        label="Event date"
+        adaptations={popoverBelowMd}
+        onFocusCapture={onFocusCapture}
+        onBlurCapture={onBlurCapture}
+      />,
+    );
+
+    const input = field();
+    await focusField(input);
+    await blurField(input);
+
+    expect(onFocusCapture).toHaveBeenCalled();
+    expect(onBlurCapture).toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// The released `nativePicker` contract, unchanged beside the new one
+// =============================================================================
+
+describe('legacy nativePicker parity', () => {
+  it.each([
+    ['touch', 'fine', 'popover'],
+    ['touch', 'coarse', 'native'],
+    ['always', 'fine', 'native'],
+    ['always', 'coarse', 'native'],
+    ['never', 'fine', 'popover'],
+    ['never', 'coarse', 'bottom-sheet'],
+  ] as const)(
+    'nativePicker="%s" on a %s pointer renders %s',
+    (nativePicker, pointer, expected) => {
+      environment.set({
+        pointer,
+        width: pointer === 'coarse' ? 390 : 1280,
+      });
+      render(
+        <DateInput
+          label="Event date"
+          nativePicker={nativePicker as DateInputProps['nativePicker']}
+        />,
+      );
+
+      expect(surfaceIn()).toBe(expected);
+    },
+  );
+
+  it('asks only the pointer question, never a width one', () => {
+    environment.set({width: 390, pointer: 'coarse'});
+    render(<DateInput label="Event date" nativePicker="never" />);
+
+    expect(environment.policyQueries()).toEqual(['(pointer: coarse)']);
+  });
+
+  it('still follows the pointer with no latch of its own', async () => {
+    render(<DateInput label="Event date" nativePicker="never" />);
+    const input = field();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: '3/2'}});
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // Legacy behavior is deliberately left as it was: the pointer switch wins
+    // mid-interaction, which is the very thing `adaptations` fixes.
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+});

--- a/packages/core/src/DateInput/index.ts
+++ b/packages/core/src/DateInput/index.ts
@@ -11,6 +11,7 @@
 
 export {DateInput} from './DateInput';
 export type {
+  DateInputAdaptationValue,
   DateInputProps,
   DateInputSize,
   DateInputFormat,

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -192,14 +192,14 @@ export const docs = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "Which surfaces draw the date and time pickers. 'touch' (the default) uses browser/OS controls on a coarse primary pointer; 'always' uses them wherever input type=date/time are supported; 'never' keeps Astryx's own surfaces everywhere. The native time control is used only for the default minute-precision contract: hasSeconds, non-default timeIncrement, or timeOptionInterval retain Astryx's time field because iOS cannot express them faithfully. Use 'never' when numberOfMonths, weekStartsOn, or visible dateConstraints behavior matters. Constraints are enforced on commit; min/max are forwarded as hints. hourFormat formats the closed time, while the OS picker follows the user's locale. Mutually exclusive with adaptations.",
+        "Deprecated. Use adaptations instead. For the initial render and while the field is idle, map 'touch' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}, 'always' to {default: 'native', rules: []}, and 'never' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}. The policy matches those idle surfaces but intentionally holds an active tree until the field is idle; nativePicker='touch' and nativePicker='never' switch immediately when the pointer changes. Existing calls keep their released behavior. Legacy 'touch' and 'always' may retain an Astryx time field for hasSeconds, non-default timeIncrement, or timeOptionInterval, and may ignore numberOfMonths or weekStartsOn on the native date control; those mixed fallbacks have no exact adaptation, so keep nativePicker until the callsite can choose an exact supported surface. min, max, and dateConstraints remain supported and are enforced on commit. Mutually exclusive with adaptations.",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "Environment-conditioned surface policy, for the cases the pointer-driven nativePicker shorthand cannot express. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform date and time controls, 'popover' the typed fields with anchored calendar and time list, 'bottom-sheet' the coordinated Date/Time sheet. Because 'native' means native for both segments with no per-segment fallback, a policy naming it anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2, weekStartsOn is set at all, hasSeconds is on, timeIncrement is non-default, or timeOptionInterval is set. min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with nativePicker; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
+        "Preferred surface-selection API. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform date and time controls, 'popover' the typed fields with anchored calendar and time list, 'bottom-sheet' the coordinated Date/Time sheet. Because 'native' means native for both segments with no per-segment fallback, a policy naming it anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2, weekStartsOn is set at all, hasSeconds is on, timeIncrement is non-default, or timeOptionInterval is set. min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with the deprecated nativePicker shorthand; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
     },
     {
       name: 'width',
@@ -237,7 +237,7 @@ export const docs = {
   },
   usage: {
     description:
-      'DateTimeInput combines date and time selection in one field. With nativePicker="touch" (the default), mouse/trackpad devices use Astryx typed fields and popovers, while coarse-pointer devices use browser/OS date and time controls in the same two-segment field. nativePicker="always" uses both native controls on every pointer; nativePicker="never" keeps Astryx\'s own surfaces — pointer fields on fine pointers and the coordinated Date/Time bottom sheet on coarse pointers. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
+      'DateTimeInput combines date and time selection in one field. Use adaptations to choose exact native, popover, or bottom-sheet surfaces for the server and for ordered width/pointer rules. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
     bestPractices: [
       {
         guidance: true,
@@ -262,7 +262,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Reach for adaptations only when the pointer alone is the wrong question — a width point, a policy the server must render, or a surface a rule should pin. nativePicker stays the short spelling, and the two are mutually exclusive.',
+          'Use adaptations for all new surface selection. The deprecated nativePicker shorthand remains supported only for compatibility; migrate with the mapping in its prop description.',
       },
       {
         guidance: false,
@@ -296,7 +296,7 @@ export const docs = {
         name: 'Date input',
         required: true,
         description:
-          'A typed date field with calendar popover on the fine-pointer Astryx surface, a real input type=date in native modes, or a read-only segment opening the Astryx touch sheet when nativePicker is never on a coarse pointer.',
+          'The active date segment: a typed field with an anchored calendar for popover, a real input type=date for native, or a read-only segment opening the coordinated sheet for bottom-sheet.',
       },
       {
         name: 'Calendar icon',
@@ -308,19 +308,19 @@ export const docs = {
         name: 'Date picker',
         required: false,
         description:
-          'The browser/OS picker in native modes, an Astryx month-grid popover on a fine pointer, or the Date panel of the Astryx bottom sheet on a coarse pointer with nativePicker="never".',
+          'The browser/OS picker for native, an Astryx month-grid popover for popover, or the Date panel of the coordinated sheet for bottom-sheet.',
       },
       {
         name: 'Time input',
         required: true,
         description:
-          'A real input type=time for the default minute-precision native mode, a text/combobox time field when seconds, custom increments, or preset options are requested, or a read-only segment opening accessible time wheels when nativePicker is never on a coarse pointer.',
+          'The active time segment: a real input type=time for native, a text/combobox field for popover, or a read-only segment opening accessible time wheels for bottom-sheet.',
       },
       {
         name: 'Time options popover',
         required: false,
         description:
-          "A list of preset times at the timeOptionInterval cadence. Setting the prop retains Astryx's text/combobox time field even when nativePicker otherwise selects native controls; the Astryx touch sheet uses wheels instead.",
+          'A list of preset times at the timeOptionInterval cadence on the popover surface. The exact native surface rejects this prop because platform pickers have no equivalent list; the bottom-sheet surface uses wheels.',
       },
       {
         name: 'Clear button',
@@ -342,7 +342,7 @@ export const docsZh = {
   displayName: 'Date Time Input',
   usage: {
     description:
-      'DateTimeInput combines date and time selection in one field. With nativePicker="touch" (the default), mouse/trackpad devices use Astryx typed fields and popovers, while coarse-pointer devices use browser/OS date and time controls in the same two-segment field. nativePicker="always" uses both native controls on every pointer; nativePicker="never" keeps Astryx\'s own surfaces — pointer fields on fine pointers and the coordinated Date/Time bottom sheet on coarse pointers. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
+      'DateTimeInput combines date and time selection in one field. Use adaptations to choose exact native, popover, or bottom-sheet surfaces for the server and for ordered width/pointer rules. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
     bestPractices: [
       {
         guidance: true,
@@ -367,7 +367,7 @@ export const docsZh = {
       {
         guidance: true,
         description:
-          'Use adaptations when the surfaces should follow a width point or a policy the server renders, and nativePicker when the pointer is the whole question. The two props are mutually exclusive.',
+          'Use adaptations for all new surface selection. nativePicker 已弃用，仅为兼容旧代码保留；请按该属性说明中的映射迁移。',
       },
       {
         guidance: false,
@@ -545,14 +545,14 @@ export const docsZh = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "选择由哪些界面绘制日期和时间选择器。'touch'（默认）在粗略主指针设备上使用浏览器/操作系统的原生控件；'always' 在支持 input type=date/time 的浏览器中始终使用原生控件；'never' 始终使用 Astryx 自带的界面。原生时间控件仅用于默认的分钟精度：hasSeconds、非默认 timeIncrement 或 timeOptionInterval 会保留 Astryx 时间字段，因为 iOS 无法忠实表达这些行为。需要 numberOfMonths、weekStartsOn 或可见 dateConstraints 行为时请使用 'never'。约束会在提交时执行，min/max 作为提示传给原生控件。hourFormat 格式化关闭状态的时间，而操作系统选择器遵循用户区域设置。与 adaptations 互斥。",
+        "已弃用，请改用 adaptations。初始渲染及字段空闲时的映射：'touch' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}；'always' → {default: 'native', rules: []}；'never' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}。adaptations 会将正在使用的界面保持到字段空闲；nativePicker='touch' 和 nativePicker='never' 会在指针变化时立即切换，因此交互中的行为并不完全相同。现有调用保持原有行为。旧的 'touch' 和 'always' 在 hasSeconds、非默认 timeIncrement 或 timeOptionInterval 下可能保留 Astryx 时间字段，也可能让原生日期控件忽略 numberOfMonths 或 weekStartsOn；这些混合回退没有完全等价的 adaptations 策略，在调用方能选择明确且受支持的界面前继续使用 nativePicker。min、max 和 dateConstraints 仍然支持，并在提交时校验。与 adaptations 互斥。",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "按环境决定界面的策略，用于 nativePicker 指针快捷方式无法表达的场景。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生日期与时间控件，'popover' 为可输入字段加锚定日历与时间列表，'bottom-sheet' 为协同的日期/时间底部弹层。由于 'native' 表示两个片段都使用原生控件、没有逐片段回退，只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2、任何 weekStartsOn、hasSeconds、非默认 timeIncrement 或 timeOptionInterval，就会抛出错误。min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
+        "首选的界面选择 API。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生日期与时间控件，'popover' 为可输入字段加锚定日历与时间列表，'bottom-sheet' 为协同的日期/时间底部弹层。由于 'native' 表示两个片段都使用原生控件、没有逐片段回退，只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2、任何 weekStartsOn、hasSeconds、非默认 timeIncrement 或 timeOptionInterval，就会抛出错误。min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
     },
     {
       name: 'xstyle',
@@ -590,7 +590,7 @@ export const docsDense = {
     'combined date + time picker with calendar popover and time input',
   usage: {
     description:
-      'DateTimeInput combines date and time selection. nativePicker="touch" (default) uses browser/OS date+time controls on coarse pointers and Astryx pointer fields on fine pointers; "always" uses both native controls everywhere; "never" uses Astryx\'s coordinated bottom sheet on coarse pointers and pointer fields on fine pointers. Closed segments stay side by side when at least 400px is available and wrap below 400px.',
+      'DateTimeInput combines date and time selection. Use adaptations to choose exact native, popover, or bottom-sheet surfaces for SSR and ordered width/pointer rules. Closed segments stay side by side when at least 400px is available and wrap below 400px.',
     bestPractices: [
       {
         guidance: true,
@@ -615,7 +615,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'nativePicker = pointer shorthand; adaptations={{default, rules}} = exact surface per width/pointer rule, SSR-safe via default. Mutually exclusive.',
+          'Use adaptations={{default, rules}} for all new surface selection. nativePicker is deprecated compatibility syntax; see its prop description for the exact migration.',
       },
       {
         guidance: false,
@@ -676,9 +676,9 @@ export const docsDense = {
     weekStartsOn:
       'first day of week in Astryx calendars (0=Sunday, or name e.g. "mon"); ignored by native date controls',
     nativePicker:
-      "date+time surfaces: 'touch' (default) = browser/OS controls on a coarse pointer, 'always' = native on every pointer, 'never' = Astryx calendar/time popovers on fine pointers and coordinated bottom sheet on coarse pointers. use 'never' for numberOfMonths/weekStartsOn/visible dateConstraints/timeOptionInterval; native mode enforces constraints on commit and forwards min/max. exclusive with adaptations.",
+      'DEPRECATED; use adaptations. idle mapping: touch -> default popover + coarse-pointer native rule; always -> constant native; never -> default popover + coarse-pointer bottom-sheet rule. adaptations holds an active tree until idle; legacy touch/never switch immediately. mixed native/Astryx fallbacks have no exact mapping; see full docs. exclusive with adaptations.',
     adaptations:
-      "{default, rules} surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer, both segments. a 'native' value anywhere throws with numberOfMonths=2, any weekStartsOn, hasSeconds, non-default timeIncrement, or any timeOptionInterval; min/max/dateConstraints still fine. exclusive with nativePicker. held while focused or open.",
+      "{default, rules} preferred surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer, both segments. a 'native' value anywhere throws with numberOfMonths=2, any weekStartsOn, hasSeconds, non-default timeIncrement, or any timeOptionInterval; min/max/dateConstraints still fine. exclusive with deprecated nativePicker. held while focused or open.",
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -121,14 +121,14 @@ export const docs = {
       name: 'timeIncrement',
       type: '1 | 5 | 10 | 15 | 30',
       description:
-        'Minute step for arrow keys in Astryx\'s typed time field. A non-default value keeps the Astryx time field in nativePicker modes because iOS treats native step as validation, not picker cadence. Ignored by the Astryx touch sheet, which uses wheels.',
+        "Minute step for arrow keys in Astryx's typed time field. A non-default value keeps the Astryx time field in nativePicker modes because iOS treats native step as validation, not picker cadence. Ignored by the Astryx touch sheet, which uses wheels.",
       default: '1',
     },
     {
       name: 'timeOptionInterval',
       type: '5 | 10 | 15 | 30 | 60',
       description:
-        'Minute cadence for the preset-time combobox on Astryx\'s fine-pointer time field. Setting it keeps that Astryx time field even in nativePicker modes because the OS picker has no equivalent preset list. The Astryx touch sheet uses wheels.',
+        "Minute cadence for the preset-time combobox on Astryx's fine-pointer time field. Setting it keeps that Astryx time field even in nativePicker modes because the OS picker has no equivalent preset list. The Astryx touch sheet uses wheels.",
     },
     {
       name: 'hasClear',
@@ -192,8 +192,14 @@ export const docs = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "Which surfaces draw the date and time pickers. 'touch' (the default) uses browser/OS controls on a coarse primary pointer; 'always' uses them wherever input type=date/time are supported; 'never' keeps Astryx's own surfaces everywhere. The native time control is used only for the default minute-precision contract: hasSeconds, non-default timeIncrement, or timeOptionInterval retain Astryx's time field because iOS cannot express them faithfully. Use 'never' when numberOfMonths, weekStartsOn, or visible dateConstraints behavior matters. Constraints are enforced on commit; min/max are forwarded as hints. hourFormat formats the closed time, while the OS picker follows the user's locale.",
+        "Which surfaces draw the date and time pickers. 'touch' (the default) uses browser/OS controls on a coarse primary pointer; 'always' uses them wherever input type=date/time are supported; 'never' keeps Astryx's own surfaces everywhere. The native time control is used only for the default minute-precision contract: hasSeconds, non-default timeIncrement, or timeOptionInterval retain Astryx's time field because iOS cannot express them faithfully. Use 'never' when numberOfMonths, weekStartsOn, or visible dateConstraints behavior matters. Constraints are enforced on commit; min/max are forwarded as hints. hourFormat formats the closed time, while the OS picker follows the user's locale. Mutually exclusive with adaptations.",
       default: "'touch'",
+    },
+    {
+      name: 'adaptations',
+      type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
+      description:
+        "Environment-conditioned surface policy, for the cases the pointer-driven nativePicker shorthand cannot express. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform date and time controls, 'popover' the typed fields with anchored calendar and time list, 'bottom-sheet' the coordinated Date/Time sheet. Because 'native' means native for both segments with no per-segment fallback, a policy naming it anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2, weekStartsOn is set at all, hasSeconds is on, timeIncrement is non-default, or timeOptionInterval is set. min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with nativePicker; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
     },
     {
       name: 'width',
@@ -254,6 +260,11 @@ export const docs = {
           "Choose the hour format (12h or 24h) that matches your audience's locale.",
       },
       {
+        guidance: true,
+        description:
+          'Reach for adaptations only when the pointer alone is the wrong question — a width point, a policy the server must render, or a surface a rule should pin. nativePicker stays the short spelling, and the two are mutually exclusive.',
+      },
+      {
         guidance: false,
         description:
           'Use DateTimeInput when only a date is needed; use DateInput instead.',
@@ -309,7 +320,7 @@ export const docs = {
         name: 'Time options popover',
         required: false,
         description:
-          'A list of preset times at the timeOptionInterval cadence. Setting the prop retains Astryx\'s text/combobox time field even when nativePicker otherwise selects native controls; the Astryx touch sheet uses wheels instead.',
+          "A list of preset times at the timeOptionInterval cadence. Setting the prop retains Astryx's text/combobox time field even when nativePicker otherwise selects native controls; the Astryx touch sheet uses wheels instead.",
       },
       {
         name: 'Clear button',
@@ -352,6 +363,11 @@ export const docsZh = {
         guidance: true,
         description:
           "Choose the hour format (12h or 24h) that matches your audience's locale.",
+      },
+      {
+        guidance: true,
+        description:
+          'Use adaptations when the surfaces should follow a width point or a policy the server renders, and nativePicker when the pointer is the whole question. The two props are mutually exclusive.',
       },
       {
         guidance: false,
@@ -529,8 +545,14 @@ export const docsZh = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "选择由哪些界面绘制日期和时间选择器。'touch'（默认）在粗略主指针设备上使用浏览器/操作系统的原生控件；'always' 在支持 input type=date/time 的浏览器中始终使用原生控件；'never' 始终使用 Astryx 自带的界面。原生时间控件仅用于默认的分钟精度：hasSeconds、非默认 timeIncrement 或 timeOptionInterval 会保留 Astryx 时间字段，因为 iOS 无法忠实表达这些行为。需要 numberOfMonths、weekStartsOn 或可见 dateConstraints 行为时请使用 'never'。约束会在提交时执行，min/max 作为提示传给原生控件。hourFormat 格式化关闭状态的时间，而操作系统选择器遵循用户区域设置。",
+        "选择由哪些界面绘制日期和时间选择器。'touch'（默认）在粗略主指针设备上使用浏览器/操作系统的原生控件；'always' 在支持 input type=date/time 的浏览器中始终使用原生控件；'never' 始终使用 Astryx 自带的界面。原生时间控件仅用于默认的分钟精度：hasSeconds、非默认 timeIncrement 或 timeOptionInterval 会保留 Astryx 时间字段，因为 iOS 无法忠实表达这些行为。需要 numberOfMonths、weekStartsOn 或可见 dateConstraints 行为时请使用 'never'。约束会在提交时执行，min/max 作为提示传给原生控件。hourFormat 格式化关闭状态的时间，而操作系统选择器遵循用户区域设置。与 adaptations 互斥。",
       default: "'touch'",
+    },
+    {
+      name: 'adaptations',
+      type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
+      description:
+        "按环境决定界面的策略，用于 nativePicker 指针快捷方式无法表达的场景。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生日期与时间控件，'popover' 为可输入字段加锚定日历与时间列表，'bottom-sheet' 为协同的日期/时间底部弹层。由于 'native' 表示两个片段都使用原生控件、没有逐片段回退，只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2、任何 weekStartsOn、hasSeconds、非默认 timeIncrement 或 timeOptionInterval，就会抛出错误。min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
     },
     {
       name: 'xstyle',
@@ -591,6 +613,11 @@ export const docsDense = {
           "Choose the hour format (12h or 24h) that matches your audience's locale.",
       },
       {
+        guidance: true,
+        description:
+          'nativePicker = pointer shorthand; adaptations={{default, rules}} = exact surface per width/pointer rule, SSR-safe via default. Mutually exclusive.',
+      },
+      {
         guidance: false,
         description:
           'Use DateTimeInput when only a date is needed; use DateInput instead.',
@@ -649,7 +676,9 @@ export const docsDense = {
     weekStartsOn:
       'first day of week in Astryx calendars (0=Sunday, or name e.g. "mon"); ignored by native date controls',
     nativePicker:
-      "date+time surfaces: 'touch' (default) = browser/OS controls on a coarse pointer, 'always' = native on every pointer, 'never' = Astryx calendar/time popovers on fine pointers and coordinated bottom sheet on coarse pointers. use 'never' for numberOfMonths/weekStartsOn/visible dateConstraints/timeOptionInterval; native mode enforces constraints on commit and forwards min/max.",
+      "date+time surfaces: 'touch' (default) = browser/OS controls on a coarse pointer, 'always' = native on every pointer, 'never' = Astryx calendar/time popovers on fine pointers and coordinated bottom sheet on coarse pointers. use 'never' for numberOfMonths/weekStartsOn/visible dateConstraints/timeOptionInterval; native mode enforces constraints on commit and forwards min/max. exclusive with adaptations.",
+    adaptations:
+      "{default, rules} surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer, both segments. a 'native' value anywhere throws with numberOfMonths=2, any weekStartsOn, hasSeconds, non-default timeIncrement, or any timeOptionInterval; min/max/dateConstraints still fine. exclusive with nativePicker. held while focused or open.",
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -114,6 +114,13 @@ export type ISODateTimeString = string & {
   readonly __brand: 'ISODateTimeString';
 };
 
+/**
+ * When DateTimeInput hands date and time picking to the browser/OS instead of
+ * its own surfaces.
+ *
+ * @deprecated Use `adaptations` with `DateTimeInputAdaptationValue`. The closest
+ * policy for each shorthand is documented on `DateTimeInputProps.nativePicker`.
+ */
 export type DateTimeInputNativePicker = 'touch' | 'always' | 'never';
 
 /**
@@ -501,35 +508,35 @@ export interface DateTimeInputProps extends Omit<
   weekStartsOn?: DayOfWeek | DayOfWeekName;
 
   /**
-   * When date and time picking are handed to the browser/OS instead of Astryx's
-   * calendar and time surfaces.
+   * Deprecated shorthand for choosing the date and time surfaces. Existing
+   * calls keep their released behavior, but new code should use `adaptations`
+   * so the server-rendered surface and every environment rule are explicit.
    *
-   * - `'touch'` (default): native date and time inputs on a coarse primary
-   *   pointer; Astryx's typed fields and popovers otherwise
-   * - `'always'`: native date and time inputs wherever the browser supports them
-   * - `'never'`: Astryx's own surfaces everywhere — typed fields on a fine
-   *   pointer and the coordinated Date/Time bottom sheet on a coarse pointer
+   * For the initial render and while the field is idle, map each value as
+   * follows:
+   * - `'touch'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}`
+   * - `'always'` → `{default: 'native', rules: []}`
+   * - `'never'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}`
    *
-   * Native pickers cannot express `numberOfMonths`, `weekStartsOn`,
-   * `dateConstraints`, or `timeOptionInterval`. Calendar-only options are
-   * ignored in native mode and constraints are enforced on commit. The native
-   * time control is used for the default minute-precision contract; requesting
-   * `hasSeconds`, a non-default `timeIncrement`, or `timeOptionInterval` keeps
-   * Astryx's time field because iOS cannot represent those behaviors faithfully.
-   * `min` / `max` are forwarded to each native control as hints and enforced in
-   * JavaScript. `hourFormat` formats the closed value; the OS picker follows the
-   * user's locale.
+   * The new policy intentionally differs during an active interaction:
+   * `adaptations` holds the current tree until the field is idle, while
+   * `nativePicker="touch"` and `nativePicker="never"` keep their released
+   * immediate pointer-switch behavior.
+   *
+   * Those mappings select the same idle surfaces for fields whose other props
+   * every selected surface can honor. Legacy `'touch'` and `'always'` calls may
+   * instead retain an Astryx time field when `hasSeconds`, a non-default
+   * `timeIncrement`, or `timeOptionInterval` is set, and may ignore
+   * `numberOfMonths` or `weekStartsOn` on the native date control. Those mixed
+   * fallbacks have no exact `adaptations` equivalent; keep the shorthand until
+   * the callsite can choose an exact supported surface. `min`, `max`, and
+   * `dateConstraints` remain supported and are enforced on commit.
+   *
+   * Mutually exclusive with `adaptations`.
    *
    * @default 'touch'
-   * @example
-   * ```
-   * <DateTimeInput
-   *   label="Event time"
-   *   value={dateTime}
-   *   onChange={setDateTime}
-   *   nativePicker="never"
-   * />
-   * ```
+   * @deprecated Use `adaptations`; the mapping above preserves idle surface
+   * selection when the exact surfaces support the field's other props.
    */
   nativePicker?: DateTimeInputNativePicker;
 
@@ -2110,17 +2117,14 @@ function PointerDateTimeField({
 PointerDateTimeField.displayName = 'PointerDateTimeField';
 
 /**
- * A combined date and time picker whose `nativePicker` prop chooses both
- * surfaces. Native modes use OS-owned date and time controls in Astryx field
- * chrome. With `nativePicker="never"`, fine pointers keep the typed fields and
- * popovers while coarse pointers get Astryx's coordinated Date/Time bottom
- * sheet.
+ * A combined date and time picker whose `adaptations` policy selects one exact
+ * surface for both segments: native controls, typed fields with anchored
+ * popovers, or the coordinated Date/Time bottom sheet. `default` owns the
+ * server-rendered and hydration surface; ordered rules may then respond to the
+ * nearest Theme's width points and the primary pointer (spec:AST-031 FR3).
  *
- * `adaptations` replaces that pointer test at the call sites that pass it: an
- * ordered policy over the three exact surfaces (`native`, `popover`,
- * `bottom-sheet`), resolved against the nearest Theme's width points and the
- * primary pointer, with `default` as the server-rendered and hydration value
- * (spec:AST-031 FR3).
+ * Without `adaptations`, the deprecated `nativePicker` compatibility path keeps
+ * its released pointer-driven and per-segment fallback behavior.
  */
 export function DateTimeInput({
   nativePicker,

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -15,7 +15,10 @@
  * - /packages/core/src/DateTimeInput/DateTimeInput.doc.mjs (props table, features, implementation notes)
  * - /packages/core/src/DateTimeInput/DateTimeInput.test.tsx (desktop tests for new/changed behavior)
  * - /packages/core/src/DateTimeInput/DateTimeInputTouch.test.tsx (touch-surface tests)
+ * - /packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx (surface policy tests)
  * - /packages/core/src/DateTimeInput/index.ts (exports if types change)
+ * - /packages/core/src/hooks/useAdaptationSurfaceLatch.ts (holds a surface mid-interaction)
+ * - /packages/core/src/theme/componentAdaptations.ts (policy shape + compiler)
  * - /apps/storybook/stories/DateTimeInput.stories.tsx (storybook stories)
  * - /packages/cli/assets/templates/blocks/components/DateTimeInput/ (showcase blocks)
  */
@@ -90,9 +93,15 @@ import {
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useAnnounce} from '../hooks/useAnnounce';
+import {useAdaptationSurfaceLatch} from '../hooks/useAdaptationSurfaceLatch';
 import {useMediaQuery} from '../hooks/useMediaQuery';
 import {useResolvedRequired} from '../hooks/useResolvedRequired';
 import {useSize} from '../SizeContext/SizeContext';
+import {
+  forEachAuthoredAdaptationValue,
+  type ComponentAdaptations,
+} from '../theme/componentAdaptations';
+import {useComponentAdaptations} from '../theme/useComponentAdaptations';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 import {useLocale, useTranslator} from '../i18n';
@@ -106,6 +115,23 @@ export type ISODateTimeString = string & {
 };
 
 export type DateTimeInputNativePicker = 'touch' | 'always' | 'never';
+
+/**
+ * The surfaces a resolved DateTimeInput adaptation policy can name.
+ *
+ * The whole domain of `adaptations`, and each value is EXACT — it names one
+ * tree for BOTH segments, on any pointer:
+ * - `'native'`: the platform's own date and time controls in Astryx chrome
+ * - `'popover'`: the typed fields with the calendar and time list in anchored
+ *   popovers
+ * - `'bottom-sheet'`: the read-only segments opening the coordinated Date/Time
+ *   sheet
+ *
+ * Spelled as literals rather than aliased to an internal type, so a consumer's
+ * compiler diagnostics never name something they cannot import.
+ */
+export type DateTimeInputAdaptationValue =
+  'native' | 'popover' | 'bottom-sheet';
 
 export type DateTimeInputHourFormat = '12h' | '24h';
 
@@ -506,6 +532,180 @@ export interface DateTimeInputProps extends Omit<
    * ```
    */
   nativePicker?: DateTimeInputNativePicker;
+
+  /**
+   * Environment-conditioned surface policy: which pair of pickers this field
+   * renders, decided by rules you write instead of by the pointer alone.
+   *
+   * `default` is the server-rendered, hydration, and no-match value; ordered
+   * `rules` map conditions to the same three values, and the LAST matching rule
+   * wins — condition shape creates no specificity. Width names resolve against
+   * the NEAREST Theme's width points, `from` is inclusive, `below` is
+   * exclusive, and the fields of one `when` are ANDed. An empty `rules` array
+   * is well-formed and pins the field to `default` everywhere.
+   *
+   * Each value is exact and holds on any pointer, which is the difference from
+   * `nativePicker`: `'bottom-sheet'` presents the coordinated sheet to a mouse
+   * if that is what the policy says, and `'popover'` keeps the typed fields on
+   * a phone. `'native'` means native for BOTH segments — there is no
+   * per-segment fallback inside it.
+   *
+   * That exactness is why a policy naming `'native'` anywhere — `default` or
+   * ANY rule, matched today or not — is checked against the props the platform
+   * controls cannot express: `numberOfMonths={2}`, an explicit `weekStartsOn`,
+   * `hasSeconds`, a non-default `timeIncrement`, or any `timeOptionInterval`
+   * throw at render rather than quietly retaining an Astryx field on whichever
+   * device selects that rule. `min`, `max` and `dateConstraints` stay
+   * supported: native mode forwards the bounds and enforces constraints on
+   * commit.
+   *
+   * Mutually exclusive with `nativePicker` — the two name the same choice, so
+   * passing both defined values throws before a surface opens. An explicitly
+   * spread `undefined` is not a conflict.
+   *
+   * While the field is in use the resolved surface is held: a rule boundary
+   * crossed during an open picker, or while the field has focus, applies once
+   * the surface has closed and focus has left, so a rotation never swallows a
+   * half-typed time.
+   *
+   * @example
+   * ```
+   * <DateTimeInput
+   *   label="Starts"
+   *   value={dateTime}
+   *   onChange={setDateTime}
+   *   adaptations={{
+   *     default: 'popover',
+   *     rules: [
+   *       {when: {width: {below: 'md'}}, value: 'bottom-sheet'},
+   *       {when: {width: {below: 'sm'}, pointer: 'coarse'}, value: 'native'},
+   *     ],
+   *   }}
+   * />
+   * ```
+   */
+  adaptations?: ComponentAdaptations<DateTimeInputAdaptationValue>;
+}
+
+/** Runtime domain for `adaptations`, so an untyped caller is rejected too. */
+const DATE_TIME_INPUT_ADAPTATION_VALUES = [
+  'native',
+  'popover',
+  'bottom-sheet',
+] as const satisfies ReadonlyArray<DateTimeInputAdaptationValue>;
+
+/** Diagnostic root for every `adaptations` failure on this component. */
+const ADAPTATIONS_PATH = '<DateTimeInput adaptations>';
+
+/**
+ * `nativePicker` and `adaptations` name the same choice, so accepting both
+ * would make precedence — not the caller — decide the surfaces.
+ *
+ * Checked on `undefined`, not on presence: spreading a props bag that carries
+ * an explicit `adaptations: undefined` beside a real `nativePicker` is an
+ * ordinary call, not a conflict (spec:AST-031 FR6).
+ */
+function assertExclusiveSurfaceProps(
+  nativePicker: DateTimeInputNativePicker | undefined,
+  adaptations: ComponentAdaptations<DateTimeInputAdaptationValue> | undefined,
+): void {
+  if (nativePicker !== undefined && adaptations !== undefined) {
+    throw new Error(
+      '<DateTimeInput> received both `nativePicker` and `adaptations`, which select the same surfaces. Pass `adaptations` for an environment-conditioned policy — its `native` value is what `nativePicker` reaches — or `nativePicker` for the pointer-driven shorthand.',
+    );
+  }
+}
+
+/**
+ * Reject a policy that names a surface it has also made impossible to draw.
+ *
+ * `'native'` is a promise about BOTH segments, so every prop the platform
+ * controls cannot represent is a contradiction with it: the OS picker has no
+ * month grid and no week-start control, iOS has no seconds wheel, its `step` is
+ * validation rather than picker cadence, and it has no preset-time list. Under
+ * the legacy `nativePicker` those props quietly retain an Astryx time field
+ * per segment; a policy that names an exact surface cannot do that without
+ * making the name a lie, so it throws instead — in production as well as
+ * development.
+ *
+ * Every authored value is checked — `default` and EVERY rule, including ones
+ * today's viewport cannot match — so the failure lands on the author's machine
+ * instead of on the one phone that selects that rule (spec:AST-031 IR3).
+ *
+ * Presence versus value matters: `weekStartsOn={0}` and `timeOptionInterval`
+ * are rejected because they were stated at all, while `hasSeconds={false}`,
+ * `timeIncrement={1}` and `numberOfMonths={1}` state the shape native mode
+ * already has and pass. `min`, `max` and `dateConstraints` are never rejected —
+ * native mode forwards the bounds and enforces constraints on commit.
+ */
+function assertNativeSurfaceIsDrawable(
+  adaptations: ComponentAdaptations<DateTimeInputAdaptationValue>,
+  {
+    numberOfMonths,
+    weekStartsOn,
+    hasSeconds,
+    timeIncrement,
+    timeOptionInterval,
+  }: DateTimeInputProps,
+): void {
+  const conflicts: string[] = [];
+  if (numberOfMonths !== undefined && numberOfMonths !== 1) {
+    conflicts.push(
+      `\`numberOfMonths={${numberOfMonths}}\` (the platform picker has no month grid to widen)`,
+    );
+  }
+  if (weekStartsOn !== undefined) {
+    conflicts.push(
+      `\`weekStartsOn={${JSON.stringify(weekStartsOn)}}\` (the platform picker follows the OS locale's first day of week)`,
+    );
+  }
+  if (hasSeconds) {
+    // Truthiness, not `=== true`, because that is how the RENDER reads it:
+    // `usesNativeTimePicker` is gated on `!hasSeconds`, so an untyped caller's
+    // `hasSeconds={1}` retains the Astryx time field. Validating on strict
+    // equality would let exactly that call through a policy promising two
+    // platform controls, and the field would quietly render one.
+    conflicts.push(
+      `\`hasSeconds={${JSON.stringify(hasSeconds)}}\` (iOS has no seconds wheel)`,
+    );
+  }
+  if (timeIncrement !== undefined && timeIncrement !== 1) {
+    conflicts.push(
+      `\`timeIncrement={${timeIncrement}}\` (native \`step\` is validation, not picker cadence)`,
+    );
+  }
+  if (timeOptionInterval !== undefined) {
+    conflicts.push(
+      `\`timeOptionInterval={${timeOptionInterval}}\` (the platform picker has no preset-time list)`,
+    );
+  }
+  if (conflicts.length === 0) {
+    return;
+  }
+  forEachAuthoredAdaptationValue(
+    adaptations,
+    ADAPTATIONS_PATH,
+    (value, valuePath) => {
+      if (value === 'native') {
+        throw new Error(
+          `${valuePath} is "native", which cannot honor ${conflicts.join(
+            ' or ',
+          )}. Use "popover" or "bottom-sheet" for that value, or drop the prop.`,
+        );
+      }
+    },
+  );
+}
+
+/** Run the latch's focus handler after the caller's own, never instead of it. */
+function composeFocusHandler(
+  callerHandler: React.FocusEventHandler<HTMLElement> | undefined,
+  latchHandler: (event: FocusEvent<HTMLElement>) => void,
+): React.FocusEventHandler<HTMLElement> {
+  return event => {
+    callerHandler?.(event);
+    latchHandler(event);
+  };
 }
 
 function splitDateTime(dt: ISODateTimeString | undefined): {
@@ -1915,17 +2115,62 @@ PointerDateTimeField.displayName = 'PointerDateTimeField';
  * chrome. With `nativePicker="never"`, fine pointers keep the typed fields and
  * popovers while coarse pointers get Astryx's coordinated Date/Time bottom
  * sheet.
+ *
+ * `adaptations` replaces that pointer test at the call sites that pass it: an
+ * ordered policy over the three exact surfaces (`native`, `popover`,
+ * `bottom-sheet`), resolved against the nearest Theme's width points and the
+ * primary pointer, with `default` as the server-rendered and hydration value
+ * (spec:AST-031 FR3).
  */
 export function DateTimeInput({
-  nativePicker = 'touch',
+  nativePicker,
+  adaptations,
   ...props
 }: DateTimeInputProps) {
+  // Both props before any hook: a call that names the surfaces twice is a
+  // mistake to report, not a precedence to resolve.
+  assertExclusiveSurfaceProps(nativePicker, adaptations);
+
   const isTouch = useMediaQuery(TOUCH_POINTER_QUERY);
+  // Called unconditionally, with `undefined` for a call site that has no
+  // policy: the resolver then subscribes to nothing and publishes nothing, so
+  // the legacy path below runs exactly the media query it always did.
+  const {value: adaptedSurface} = useComponentAdaptations(adaptations, {
+    path: ADAPTATIONS_PATH,
+    values: DATE_TIME_INPUT_ADAPTATION_VALUES,
+  });
+  const {surface, onFocusCapture, onBlurCapture} =
+    useAdaptationSurfaceLatch(adaptedSurface);
+
+  if (adaptations !== undefined) {
+    assertNativeSurfaceIsDrawable(adaptations, props);
+    // The two surfaces are separate trees, so the latch's focus handlers ride
+    // the field root each of them spreads its pass-through props onto.
+    const surfaceProps: DateTimeInputProps = {
+      ...props,
+      onFocusCapture: composeFocusHandler(props.onFocusCapture, onFocusCapture),
+      onBlurCapture: composeFocusHandler(props.onBlurCapture, onBlurCapture),
+    };
+    if (surface === 'bottom-sheet') {
+      return <TouchDateTimeField {...surfaceProps} />;
+    }
+    // The pointer field draws both native and Astryx segments; the exact value
+    // picks which, on any pointer, rather than letting its own media query.
+    return (
+      <PointerDateTimeField
+        {...surfaceProps}
+        nativePicker={surface === 'native' ? 'always' : 'never'}
+      />
+    );
+  }
+
+  const legacyNativePicker = nativePicker ?? 'touch';
   const usesNativePicker =
-    nativePicker === 'always' || (nativePicker === 'touch' && isTouch);
+    legacyNativePicker === 'always' ||
+    (legacyNativePicker === 'touch' && isTouch);
 
   return usesNativePicker || !isTouch ? (
-    <PointerDateTimeField {...props} nativePicker={nativePicker} />
+    <PointerDateTimeField {...props} nativePicker={legacyNativePicker} />
   ) : (
     <TouchDateTimeField {...props} />
   );

--- a/packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx
@@ -5,7 +5,8 @@
  * @input Uses vitest, @testing-library/react, react-dom/server
  * @output Tests DateTimeInput's public surface policy (spec:AST-031)
  * @position Tests; validates the `adaptations` prop — resolution, eager
- *   validation, latching — and the untouched `nativePicker` path beside it.
+ *   validation, latching — and the deprecated `nativePicker` compatibility
+ *   path beside it, including the documented migration mapping.
  *   Behavior that is not surface selection (typing, the calendar, the sheet's
  *   panels, the native segments' own commit rules) stays in
  *   DateTimeInput.test.tsx, DateTimeInputTouch.test.tsx and
@@ -1625,10 +1626,10 @@ describe('latching', () => {
 });
 
 // =============================================================================
-// The released `nativePicker` contract, unchanged beside the new one
+// Deprecated `nativePicker` compatibility and migration
 // =============================================================================
 
-describe('legacy nativePicker parity', () => {
+describe('deprecated nativePicker compatibility', () => {
   it.each([
     ['touch', 'fine', 'popover'],
     ['touch', 'coarse', 'native'],
@@ -1653,6 +1654,56 @@ describe('legacy nativePicker parity', () => {
 
       expect(surfaceIn()).toBe(expected);
       expectSegments(expected);
+    },
+  );
+
+  it.each(['fine', 'coarse'] as const)(
+    'matches the documented idle adaptations policy on a %s pointer',
+    pointer => {
+      environment.set({
+        pointer,
+        width: pointer === 'coarse' ? 390 : 1280,
+      });
+      const migrations = [
+        [
+          'touch',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+          }),
+        ],
+        ['always', policy({default: 'native', rules: []})],
+        [
+          'never',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+          }),
+        ],
+      ] as const;
+
+      for (const [nativePicker, adaptations] of migrations) {
+        const legacy = render(
+          <DateTimeInput
+            label={LABEL}
+            onChange={noop}
+            nativePicker={nativePicker}
+          />,
+        );
+        const legacySurface = surfaceIn();
+        legacy.unmount();
+
+        const migrated = render(
+          <DateTimeInput
+            label={LABEL}
+            onChange={noop}
+            adaptations={adaptations}
+          />,
+        );
+        expect(surfaceIn()).toBe(legacySurface);
+        expectSegments(legacySurface);
+        migrated.unmount();
+      }
     },
   );
 

--- a/packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx
@@ -1,0 +1,1682 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file DateTimeInputAdaptations.test.tsx
+ * @input Uses vitest, @testing-library/react, react-dom/server
+ * @output Tests DateTimeInput's public surface policy (spec:AST-031)
+ * @position Tests; validates the `adaptations` prop — resolution, eager
+ *   validation, latching — and the untouched `nativePicker` path beside it.
+ *   Behavior that is not surface selection (typing, the calendar, the sheet's
+ *   panels, the native segments' own commit rules) stays in
+ *   DateTimeInput.test.tsx, DateTimeInputTouch.test.tsx and
+ *   NativePickerSegments.test.tsx.
+ *
+ * A policy value here is a promise about BOTH halves of the field, so the
+ * readings below check the date and the time segment together: `native` means
+ * two platform controls, never a native date beside a retained Astryx time.
+ * That per-segment fallback is precisely what the legacy `nativePicker` still
+ * does, and the last describe block pins it in place unchanged.
+ *
+ * The environment is a REAL query evaluator rather than a
+ * `query === '<literal>'` stub: an exact-boundary rule (`width < md`) can only
+ * be told apart from an inclusive one by a stub that computes an answer from an
+ * actual viewport width, and a latch test needs listeners that actually fire.
+ *
+ * SYNC: When DateTimeInput's surface policy changes, update these tests.
+ * - /packages/core/src/DateTimeInput/DateTimeInput.tsx
+ * - /packages/core/src/DateTimeInput/TouchDateTimeField.tsx
+ * - /packages/core/src/hooks/useAdaptationSurfaceLatch.ts
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, act, fireEvent, waitFor} from '@testing-library/react';
+import {renderToString} from 'react-dom/server';
+import {hydrateRoot} from 'react-dom/client';
+import {useState, type ReactNode} from 'react';
+import {DateTimeInput} from './DateTimeInput';
+import type {
+  DateTimeInputAdaptationValue,
+  DateTimeInputProps,
+  ISODateTimeString,
+} from './DateTimeInput';
+import {Theme} from '../theme/Theme';
+import {defineTheme} from '../theme/defineTheme';
+import {resetThemes} from '../theme/themeRegistry';
+import {
+  getAdaptationStoreCount,
+  resetAdaptationStores,
+} from '../theme/useComponentAdaptations';
+import type {ComponentAdaptations} from '../theme/componentAdaptations';
+
+// =============================================================================
+// A viewport, not a query allowlist
+// =============================================================================
+
+interface Viewport {
+  width: number;
+  pointer: 'coarse' | 'fine';
+}
+
+interface FakeMediaQueryList {
+  media: string;
+  matches: boolean;
+  listeners: Set<() => void>;
+}
+
+interface Environment {
+  /** Every distinct query anything asked about. */
+  queries: () => string[];
+  /**
+   * Only the queries a surface policy can produce. Unrelated hooks in the tree
+   * ask about hover and reduced motion, so "subscribed to nothing" has to mean
+   * "asked nothing about the viewport", not "never called matchMedia".
+   */
+  policyQueries: () => string[];
+  /** Move the viewport and notify listeners, as a resize or rotation does. */
+  set: (next: Partial<Viewport>) => void;
+}
+
+/** Matches the repo-wide setup polyfill, so hover-gated behavior still works. */
+const HOVER_CAPABLE = /\(\s*hover\s*:\s*hover\s*\)/;
+
+/**
+ * Evaluate one media query against a viewport.
+ *
+ * Understands the grammars in play: AST-031's compiled range syntax
+ * (`(width < 768px)`), the legacy `(max-width: …)` / `(min-width: …)` forms,
+ * and pointer precision. Anything else falls back to the repo's default
+ * answer so unrelated hooks keep behaving.
+ */
+function evaluate(query: string, viewport: Viewport): boolean {
+  const parts = query.split(' and ').map(part => part.trim());
+  let understood = false;
+  const value = parts.every(part => {
+    const range = /^\(width (<|<=|>|>=) (\d+)px\)$/.exec(part);
+    if (range) {
+      understood = true;
+      const point = Number(range[2]);
+      switch (range[1]) {
+        case '<':
+          return viewport.width < point;
+        case '<=':
+          return viewport.width <= point;
+        case '>':
+          return viewport.width > point;
+        default:
+          return viewport.width >= point;
+      }
+    }
+    const maxWidth = /^\(max-width:\s*(\d+)px\)$/.exec(part);
+    if (maxWidth) {
+      understood = true;
+      return viewport.width <= Number(maxWidth[1]);
+    }
+    const minWidth = /^\(min-width:\s*(\d+)px\)$/.exec(part);
+    if (minWidth) {
+      understood = true;
+      return viewport.width >= Number(minWidth[1]);
+    }
+    const anyPointer = /^\(any-pointer:\s*(coarse|fine)\)$/.exec(part);
+    if (anyPointer) {
+      understood = true;
+      return anyPointer[1] === viewport.pointer;
+    }
+    const pointer = /^\(pointer:\s*(coarse|fine)\)$/.exec(part);
+    if (pointer) {
+      understood = true;
+      return pointer[1] === viewport.pointer;
+    }
+    return false;
+  });
+  return understood ? value : HOVER_CAPABLE.test(query);
+}
+
+function installEnvironment(initial: Viewport): Environment {
+  const viewport: Viewport = {...initial};
+  const lists = new Map<string, FakeMediaQueryList>();
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((media: string) => {
+      let list = lists.get(media);
+      if (!list) {
+        list = {
+          media,
+          matches: evaluate(media, viewport),
+          listeners: new Set(),
+        };
+        lists.set(media, list);
+      }
+      // Re-evaluate on every read: a list created before a `set` must not
+      // report the viewport it was born in.
+      list.matches = evaluate(media, viewport);
+      const handle = list;
+      return {
+        get matches() {
+          return handle.matches;
+        },
+        media,
+        onchange: null,
+        addEventListener: (type: string, listener: () => void) => {
+          if (type === 'change') {
+            handle.listeners.add(listener);
+          }
+        },
+        removeEventListener: (type: string, listener: () => void) => {
+          if (type === 'change') {
+            handle.listeners.delete(listener);
+          }
+        },
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      } as unknown as MediaQueryList;
+    }),
+  );
+
+  return {
+    queries: () => [...lists.keys()],
+    policyQueries: () =>
+      [...lists.keys()].filter(
+        query => query.includes('width') || query.includes('pointer'),
+      ),
+    set(next) {
+      Object.assign(viewport, next);
+      act(() => {
+        for (const list of lists.values()) {
+          const matches = evaluate(list.media, viewport);
+          if (matches === list.matches) {
+            continue;
+          }
+          list.matches = matches;
+          for (const listener of [...list.listeners]) {
+            listener();
+          }
+        }
+      });
+    },
+  };
+}
+
+// =============================================================================
+// jsdom scaffolding (mirrors DateTimeInputTouch.test.tsx)
+// =============================================================================
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+let environment: Environment;
+
+beforeEach(() => {
+  resetThemes();
+  resetAdaptationStores();
+  Element.prototype.scrollTo = vi.fn();
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.open = true;
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.open = true;
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.open = false;
+  });
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
+  environment = installEnvironment({width: 1280, pointer: 'fine'});
+});
+
+afterEach(() => {
+  resetAdaptationStores();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+// =============================================================================
+// Reading the resolved surface out of the DOM
+// =============================================================================
+
+type Surface = DateTimeInputAdaptationValue;
+
+const LABEL = 'Starts';
+/** The time half's accessible name is derived from the field label. */
+const TIME_LABEL = `${LABEL} time`;
+
+const noop = () => {};
+
+/**
+ * Which of the three trees is mounted.
+ *
+ * Each surface has one unmistakable mark on its date half: the platform control
+ * is a real `<input type="date">`, the touch segment is the combobox that
+ * refuses the keyboard (`inputmode="none"`), and the pointer field is the
+ * typable one. `expectSegments` then proves the time half agrees.
+ */
+function surfaceIn(root: ParentNode = document): Surface {
+  if (root.querySelector('input[type="date"]') != null) {
+    return 'native';
+  }
+  const combobox = root.querySelector('input[role="combobox"]');
+  if (combobox == null) {
+    throw new Error('No DateTimeInput field is mounted.');
+  }
+  return combobox.getAttribute('inputmode') === 'none'
+    ? 'bottom-sheet'
+    : 'popover';
+}
+
+/** The same read against server-rendered markup, before any DOM exists. */
+function surfaceInMarkup(html: string): Surface {
+  if (html.includes('type="date"')) {
+    return 'native';
+  }
+  // React server-renders `inputMode` in its camelCase spelling; the DOM read
+  // above sees the lowercased attribute. Matching case-insensitively keeps the
+  // two readings of the same mark from drifting apart.
+  return /inputmode="none"/i.test(html) ? 'bottom-sheet' : 'popover';
+}
+
+/**
+ * The input inside one half of the field.
+ *
+ * Addressed through the segment's stable theme target rather than by role or
+ * label, because those differ per surface: the time half is a combobox only in
+ * the sheet, and the native halves carry no combobox role at all.
+ */
+function segmentInput(half: 'date' | 'time'): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>(
+    `.astryx-date-time-input-${half}-segment input`,
+  );
+  if (input == null) {
+    throw new Error(`No DateTimeInput ${half} segment is mounted.`);
+  }
+  return input;
+}
+
+const dateField = () => segmentInput('date');
+const timeField = () => segmentInput('time');
+
+/**
+ * Both halves belong to the surface the policy named.
+ *
+ * The point of an exact value: `native` is not "native where convenient", and
+ * `bottom-sheet` is not "a sheet on the date half". Each surface's two segments
+ * are asserted together, so a per-segment fallback leaking into the policy path
+ * fails here rather than passing a date-only reading.
+ */
+function expectSegments(value: Surface): void {
+  const date = dateField();
+  const time = timeField();
+  if (value === 'native') {
+    expect(date.type).toBe('date');
+    expect(time.type).toBe('time');
+    return;
+  }
+  expect(date.type).toBe('text');
+  expect(time.type).toBe('text');
+  if (value === 'bottom-sheet') {
+    for (const input of [date, time]) {
+      expect(input).toHaveAttribute('role', 'combobox');
+      expect(input).toHaveAttribute('readonly');
+      expect(input).toHaveAttribute('inputmode', 'none');
+    }
+    return;
+  }
+  // The anchored surface is the typable one: no read-only segment, and no
+  // suppressed on-screen keyboard on either half.
+  for (const input of [date, time]) {
+    expect(input).not.toHaveAttribute('readonly');
+    expect(input).not.toHaveAttribute('inputmode');
+  }
+}
+
+const policy = (
+  value: ComponentAdaptations<DateTimeInputAdaptationValue>,
+): ComponentAdaptations<DateTimeInputAdaptationValue> => value;
+
+function themeWithMd(name: string, md: number) {
+  return defineTheme({name, adaptations: {widthBreakpoints: {md}}});
+}
+
+function withTheme(theme: ReturnType<typeof defineTheme>) {
+  return function Wrapper({children}: {children: ReactNode}) {
+    return <Theme theme={theme}>{children}</Theme>;
+  };
+}
+
+async function focusField(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.focus();
+  });
+}
+
+async function blurField(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.blur();
+  });
+}
+
+/** Drop focus wherever it currently is — inside an open sheet, for instance. */
+async function blurActiveElement(): Promise<void> {
+  await act(async () => {
+    (document.activeElement as HTMLElement | null)?.blur();
+  });
+}
+
+/**
+ * jsdom never runs the sheet's exit transition, so a closed BottomSheet stays
+ * an open `<dialog>` until the transition is delivered by hand — and that open
+ * dialog is one of the two signals the latch waits on.
+ */
+function finishSheetExit(): void {
+  const panel = document.querySelector<HTMLElement>('.astryx-bottom-sheet');
+  if (panel != null) {
+    fireEvent.transitionEnd(panel, {propertyName: 'transform'});
+  }
+  for (const dialog of document.querySelectorAll('dialog')) {
+    dialog.open = false;
+  }
+}
+
+// =============================================================================
+// FR3 — `default` is server truth
+// =============================================================================
+
+describe('server rendering', () => {
+  it.each([
+    ['popover', 'popover'],
+    ['bottom-sheet', 'bottom-sheet'],
+    ['native', 'native'],
+  ] as const)(
+    'renders the `%s` default without reading matchMedia',
+    (value, expected) => {
+      const html = renderToString(
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          adaptations={policy({
+            default: value,
+            rules: [
+              {when: {width: {below: 'md'}}, value: 'bottom-sheet'},
+              {when: {pointer: 'coarse'}, value: 'native'},
+            ],
+          })}
+        />,
+      );
+
+      expect(surfaceInMarkup(html)).toBe(expected);
+      expect(environment.policyQueries()).toEqual([]);
+    },
+  );
+
+  it('server-renders both halves of the native default, not just the date', () => {
+    const html = renderToString(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+    );
+
+    expect(html).toContain('type="date"');
+    expect(html).toContain('type="time"');
+  });
+
+  it('leaves the registry empty after a render that never commits', () => {
+    renderToString(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+        })}
+      />,
+    );
+
+    expect(environment.queries()).toEqual([]);
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+
+  it('hydrates the server default, then publishes the browser answer', async () => {
+    const adaptations = policy({
+      default: 'popover',
+      rules: [
+        {
+          when: {width: {below: 'md'}, pointer: 'coarse'},
+          value: 'bottom-sheet',
+        },
+      ],
+    });
+    const tree = (
+      <DateTimeInput label={LABEL} onChange={noop} adaptations={adaptations} />
+    );
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(tree);
+    document.body.appendChild(container);
+    // The client is the phone the rule was written for; the server was not.
+    expect(surfaceIn(container)).toBe('popover');
+    environment.set({width: 390, pointer: 'coarse'});
+
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      errors.push(args);
+    });
+    await act(async () => {
+      hydrateRoot(container, tree);
+    });
+    spy.mockRestore();
+
+    expect(errors).toEqual([]);
+    expect(surfaceIn(container)).toBe('bottom-sheet');
+    container.remove();
+  });
+});
+
+// =============================================================================
+// FR2/FR4 — exact values, on either pointer
+// =============================================================================
+
+describe('exact surfaces', () => {
+  const pointers = ['fine', 'coarse'] as const;
+  const surfaces: ReadonlyArray<Surface> = [
+    'native',
+    'popover',
+    'bottom-sheet',
+  ];
+
+  for (const pointer of pointers) {
+    for (const value of surfaces) {
+      it(`renders ${value} on a ${pointer} pointer`, () => {
+        environment.set({
+          pointer,
+          width: pointer === 'coarse' ? 390 : 1280,
+        });
+        render(
+          <DateTimeInput
+            label={LABEL}
+            onChange={noop}
+            adaptations={policy({default: value, rules: []})}
+          />,
+        );
+
+        expect(surfaceIn()).toBe(value);
+        expectSegments(value);
+      });
+    }
+  }
+
+  it('keeps the touch sheet on a mouse when a rule says so', async () => {
+    environment.set({width: 1280, pointer: 'fine'});
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {width: {from: 'lg'}}, value: 'bottom-sheet'}],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+    fireEvent.click(dateField());
+    await waitFor(() => {
+      expect(document.querySelector('dialog')).not.toBeNull();
+    });
+  });
+
+  it('keeps the anchored popover on a finger when a rule says so', async () => {
+    environment.set({width: 390, pointer: 'coarse'});
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {pointer: 'coarse'}, value: 'popover'}],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('popover');
+    fireEvent.click(
+      screen.getByRole('button', {name: /open calendar|calendar/i}),
+    );
+    await waitFor(() => {
+      expect(dateField().getAttribute('aria-expanded')).toBe('true');
+    });
+    expect(document.querySelector('dialog')).toBeNull();
+  });
+
+  it('opens the coordinated sheet from the time half too', async () => {
+    environment.set({width: 390, pointer: 'coarse'});
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({default: 'bottom-sheet', rules: []})}
+      />,
+    );
+
+    // Both segments belong to one sheet, so the time half opens the same
+    // dialog the date half does — the value picked a whole tree, not a widget.
+    expect(timeField()).toBe(screen.getByRole('combobox', {name: TIME_LABEL}));
+    fireEvent.click(timeField());
+    await waitFor(() => {
+      expect(document.querySelector('dialog')).not.toBeNull();
+    });
+    expect(timeField()).toHaveAttribute('aria-expanded', 'true');
+    expect(dateField()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('follows the environment while the field is idle', () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({
+          default: 'popover',
+          rules: [
+            {when: {width: {below: 'md'}}, value: 'bottom-sheet'},
+            {when: {width: {below: 'sm'}, pointer: 'coarse'}, value: 'native'},
+          ],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('popover');
+    environment.set({width: 700});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('native');
+    environment.set({width: 1280, pointer: 'fine'});
+    expect(surfaceIn()).toBe('popover');
+  });
+});
+
+// =============================================================================
+// FR2 — rule order is precedence
+// =============================================================================
+
+describe('rule order', () => {
+  it('lets the LAST matching rule win, not the most specific', () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({
+          default: 'popover',
+          rules: [
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'bottom-sheet',
+            },
+            {when: {pointer: 'coarse'}, value: 'native'},
+          ],
+        })}
+      />,
+    );
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('native');
+  });
+
+  it('reverses the outcome when the same rules are reordered', () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({
+          default: 'popover',
+          rules: [
+            {when: {pointer: 'coarse'}, value: 'native'},
+            {
+              when: {width: {below: 'md'}, pointer: 'coarse'},
+              value: 'bottom-sheet',
+            },
+          ],
+        })}
+      />,
+    );
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('resolves an empty rule list to `default` and subscribes to nothing', () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({default: 'bottom-sheet', rules: []})}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+    // No rules, so nothing can change the answer: no shared media connection
+    // is opened at all. (The pointer query still on the list belongs to the
+    // component's own legacy switch, which every call site runs.)
+    expect(getAdaptationStoreCount()).toBe(0);
+    expect(environment.queries().some(query => query.includes('width'))).toBe(
+      false,
+    );
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+});
+
+// =============================================================================
+// FR4/IR4 — the nearest Theme's width points
+// =============================================================================
+
+describe('theme width points', () => {
+  const belowMd = policy({
+    default: 'popover',
+    rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+  });
+
+  it('anchors at exactly the default md point (768px), and swaps 1px below', () => {
+    render(
+      <DateTimeInput label={LABEL} onChange={noop} adaptations={belowMd} />,
+    );
+
+    environment.set({width: 768});
+    expect(surfaceIn()).toBe('popover');
+    environment.set({width: 767});
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it("moves that edge with the theme's md", () => {
+    // 900 sits between sm (640) and lg (1024): `defineTheme` requires strictly
+    // increasing width points, so a moved md has to stay inside its neighbors.
+    render(
+      <DateTimeInput label={LABEL} onChange={noop} adaptations={belowMd} />,
+      {wrapper: withTheme(themeWithMd('wide-md', 900))},
+    );
+
+    environment.set({width: 850});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    environment.set({width: 900});
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('prefers the NEAREST theme when providers nest', () => {
+    render(
+      <Theme theme={themeWithMd('outer-md', 700)}>
+        <Theme theme={themeWithMd('inner-md', 1000)}>
+          <DateTimeInput label={LABEL} onChange={noop} adaptations={belowMd} />
+        </Theme>
+      </Theme>,
+    );
+
+    // 850 is above the outer point and below the inner one, so the two themes
+    // disagree and only the inner one's answer is visible.
+    environment.set({width: 850});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    environment.set({width: 1100});
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('compiles a range query rather than a max-width query', () => {
+    render(
+      <DateTimeInput label={LABEL} onChange={noop} adaptations={belowMd} />,
+    );
+
+    expect(environment.queries()).toContain('(width < 768px)');
+    expect(
+      environment.queries().some(query => query.includes('max-width')),
+    ).toBe(false);
+  });
+});
+
+// =============================================================================
+// FR6 — the two surface props are exclusive
+// =============================================================================
+
+describe('mutual exclusivity with nativePicker', () => {
+  it('throws when both props are defined', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() =>
+      render(
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          nativePicker="always"
+          adaptations={policy({default: 'popover', rules: []})}
+        />,
+      ),
+    ).toThrow(/received both `nativePicker` and `adaptations`/);
+    spy.mockRestore();
+  });
+
+  it('accepts an explicitly undefined `adaptations` beside a nativePicker', () => {
+    environment.set({width: 1280, pointer: 'fine'});
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        nativePicker="always"
+        adaptations={undefined}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('native');
+  });
+
+  it('accepts an explicitly undefined `nativePicker` beside a policy', () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        nativePicker={undefined}
+        adaptations={policy({default: 'bottom-sheet', rules: []})}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+});
+
+// =============================================================================
+// IR3 — invalid policies fail with a path-specific message
+// =============================================================================
+
+describe('policy validation', () => {
+  function expectRenderToThrow(node: ReactNode, message: RegExp) {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(node)).toThrow(message);
+    spy.mockRestore();
+  }
+
+  it('rejects a value outside the admitted three', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={
+          {
+            default: 'inline',
+            rules: [],
+          } as unknown as ComponentAdaptations<DateTimeInputAdaptationValue>
+        }
+      />,
+      /<DateTimeInput adaptations>\.default must be one of native, popover, bottom-sheet; received "inline"\./,
+    );
+  });
+
+  it('names the offending rule, not just the policy', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={
+          {
+            default: 'popover',
+            rules: [
+              {when: {pointer: 'coarse'}, value: 'bottom-sheet'},
+              {when: {pointer: 'fine'}, value: 'adaptive'},
+            ],
+          } as unknown as ComponentAdaptations<DateTimeInputAdaptationValue>
+        }
+      />,
+      /<DateTimeInput adaptations>\.rules\[1\]\.value must be one of native, popover, bottom-sheet/,
+    );
+  });
+
+  it('rejects a missing rule list rather than assuming none', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={
+          {
+            default: 'popover',
+          } as unknown as ComponentAdaptations<DateTimeInputAdaptationValue>
+        }
+      />,
+      /<DateTimeInput adaptations>\.rules is required; pass \[\] for no rules\./,
+    );
+  });
+
+  it('rejects an empty condition', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {}, value: 'native'}],
+        })}
+      />,
+      /<DateTimeInput adaptations>\.rules\[0\]\.when must contain at least one condition\./,
+    );
+  });
+
+  it.each([null, false, 0, ''])(
+    'rejects the falsy non-object %p instead of treating it as no policy',
+    falsy => {
+      expectRenderToThrow(
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          adaptations={
+            falsy as unknown as ComponentAdaptations<DateTimeInputAdaptationValue>
+          }
+        />,
+        /<DateTimeInput adaptations>/,
+      );
+    },
+  );
+
+  it('treats an absent policy as no policy at all', () => {
+    environment.set({width: 1280, pointer: 'fine'});
+    render(<DateTimeInput label={LABEL} onChange={noop} />);
+
+    expect(surfaceIn()).toBe('popover');
+    expect(getAdaptationStoreCount()).toBe(0);
+  });
+});
+
+// =============================================================================
+// IR3 — a `native` value is checked against the props it cannot draw
+// =============================================================================
+
+describe('eager native-surface validation', () => {
+  function expectRenderToThrow(node: ReactNode, message: RegExp) {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(node)).toThrow(message);
+    spy.mockRestore();
+  }
+
+  const nativeDefault = policy({default: 'native', rules: []});
+
+  it('rejects numberOfMonths={2} beside a native default', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        numberOfMonths={2}
+        adaptations={nativeDefault}
+      />,
+      /<DateTimeInput adaptations>\.default is "native", which cannot honor `numberOfMonths=\{2\}`/,
+    );
+  });
+
+  it('rejects an explicit weekStartsOn even when it is falsy', () => {
+    // `weekStartsOn={0}` is Sunday, not "unset": presence is what conflicts, so
+    // a falsy-but-stated value has to be rejected like any other.
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        weekStartsOn={0}
+        adaptations={nativeDefault}
+      />,
+      /<DateTimeInput adaptations>\.default is "native", which cannot honor `weekStartsOn=\{0\}`/,
+    );
+  });
+
+  it('rejects hasSeconds beside a native default', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        hasSeconds
+        adaptations={nativeDefault}
+      />,
+      /<DateTimeInput adaptations>\.default is "native", which cannot honor `hasSeconds=\{true\}`/,
+    );
+  });
+
+  it('rejects a non-default timeIncrement beside a native default', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        timeIncrement={15}
+        adaptations={nativeDefault}
+      />,
+      /<DateTimeInput adaptations>\.default is "native", which cannot honor `timeIncrement=\{15\}`/,
+    );
+  });
+
+  it('rejects any timeOptionInterval beside a native default', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        timeOptionInterval={30}
+        adaptations={nativeDefault}
+      />,
+      /<DateTimeInput adaptations>\.default is "native", which cannot honor `timeOptionInterval=\{30\}`/,
+    );
+  });
+
+  it('names every conflicting prop at once', () => {
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        numberOfMonths={2}
+        weekStartsOn="mon"
+        hasSeconds
+        timeIncrement={5}
+        timeOptionInterval={15}
+        adaptations={nativeDefault}
+      />,
+      /`numberOfMonths=\{2\}`.*or.*`weekStartsOn=\{"mon"\}`.*or.*`hasSeconds=\{true\}`.*or.*`timeIncrement=\{5\}`.*or.*`timeOptionInterval=\{15\}`/s,
+    );
+  });
+
+  it('rejects a native value in a rule the current viewport cannot match', () => {
+    // A wide fine-pointer laptop: the coarse rule is unreachable here, which is
+    // exactly why it has to fail here rather than on the phone that selects it.
+    environment.set({width: 1280, pointer: 'fine'});
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        timeOptionInterval={15}
+        adaptations={policy({
+          default: 'popover',
+          rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+        })}
+      />,
+      /<DateTimeInput adaptations>\.rules\[0\]\.value is "native"/,
+    );
+  });
+
+  it('throws in production too, not only in development', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        hasSeconds
+        adaptations={nativeDefault}
+      />,
+      /cannot honor `hasSeconds=\{true\}`/,
+    );
+  });
+
+  it('rejects a TRUTHY untyped hasSeconds, matching how the render reads it', () => {
+    // `usesNativeTimePicker` is gated on `!hasSeconds`, so an untyped caller's
+    // `hasSeconds={1}` retains the Astryx time field. Validating on `=== true`
+    // would admit exactly that call under a policy promising two platform
+    // controls, and the field would render one of each while claiming
+    // "native" — the silent half-native state this rule exists to prevent.
+    expectRenderToThrow(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        hasSeconds={1 as unknown as boolean}
+        adaptations={policy({default: 'native', rules: []})}
+      />,
+      /<DateTimeInput adaptations>\.default is "native", which cannot honor `hasSeconds=\{1\}`/,
+    );
+  });
+
+  it.each([false, undefined, 0, ''])(
+    'accepts the falsy hasSeconds %p, which leaves the time half native',
+    falsy => {
+      render(
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          hasSeconds={falsy as unknown as boolean}
+          adaptations={policy({default: 'native', rules: []})}
+        />,
+      );
+
+      expect(surfaceIn()).toBe('native');
+      expectSegments('native');
+    },
+  );
+
+  it('accepts the shapes native mode already has', () => {
+    // Each of these states the shape the platform controls already have, so
+    // stating them is agreement, not contradiction.
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        numberOfMonths={1}
+        hasSeconds={false}
+        timeIncrement={1}
+        adaptations={policy({
+          default: 'native',
+          rules: [{when: {pointer: 'fine'}, value: 'native'}],
+        })}
+      />,
+    );
+
+    expect(surfaceIn()).toBe('native');
+    expectSegments('native');
+  });
+
+  it('keeps min and max forwarded to both native halves', () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        value={'2026-03-10T10:00' as ISODateTimeString}
+        min={'2026-03-10T09:00' as ISODateTimeString}
+        max={'2026-03-20T17:00' as ISODateTimeString}
+        adaptations={nativeDefault}
+      />,
+    );
+
+    expect(dateField()).toHaveAttribute('min', '2026-03-10');
+    expect(dateField()).toHaveAttribute('max', '2026-03-20');
+    // The time bound is the one that applies on the selected day: the value is
+    // on the min date, so the earliest allowed time rides the time control.
+    expect(timeField()).toHaveAttribute('min', '09:00');
+  });
+
+  it('keeps dateConstraints enforced on commit in native mode', async () => {
+    const noWeekends = vi.fn(
+      (date: Date) => date.getDay() !== 0 && date.getDay() !== 6,
+    );
+    const onChange = vi.fn();
+    render(
+      <DateTimeInput
+        label={LABEL}
+        value={'2026-03-16T14:30' as ISODateTimeString}
+        onChange={onChange}
+        dateConstraints={[noWeekends]}
+        adaptations={nativeDefault}
+      />,
+    );
+
+    // 2026-03-21 is a Saturday, which the constraint refuses; the platform
+    // control cannot grey it out, so the commit is where it is caught.
+    fireEvent.change(dateField(), {target: {value: '2026-03-21'}});
+    await waitFor(() => {
+      expect(dateField()).toHaveAttribute('aria-invalid', 'true');
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.change(dateField(), {target: {value: '2026-03-20'}});
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('2026-03-20T14:30');
+    });
+  });
+
+  it('leaves the legacy nativePicker path to its own fallback', () => {
+    // The same props with no policy: the released contract quietly retains an
+    // Astryx time field instead of throwing.
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(() =>
+      render(
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          numberOfMonths={2}
+          weekStartsOn="mon"
+          hasSeconds
+          timeIncrement={5}
+          timeOptionInterval={15}
+          nativePicker="always"
+        />,
+      ),
+    ).not.toThrow();
+    expect(dateField().type).toBe('date');
+    expect(timeField().type).toBe('text');
+  });
+});
+
+// =============================================================================
+// FR5 — the resolved surface is latched while the field is in use
+// =============================================================================
+
+describe('latching', () => {
+  const popoverBelowMd = policy({
+    default: 'popover',
+    rules: [{when: {width: {below: 'md'}}, value: 'bottom-sheet'}],
+  });
+
+  /**
+   * A real browser's focus move, in its real order.
+   *
+   * A user's Tab or click dispatches `focusout` on the old control, DRAINS
+   * MICROTASKS, and only then dispatches `focusin` on the new one. A latch that
+   * defers its release decision therefore decides inside that gap, sees focus
+   * nowhere, and lets go in the middle of the interaction. jsdom's own
+   * `blur()`/`focus()` pair runs inside a single task and cannot show it, so
+   * the gap is modelled explicitly here and `inTheGap` holds the assertions
+   * that matter. This field has two halves, which makes the move an ordinary
+   * one: crossing from the date segment to the time segment is not leaving.
+   */
+  async function moveFocus(
+    from: HTMLElement,
+    to: HTMLElement | null,
+    inTheGap: () => void,
+  ): Promise<void> {
+    fireEvent.focusOut(from, {relatedTarget: to});
+    await act(async () => {});
+    inTheGap();
+    if (to != null) {
+      fireEvent.focusIn(to, {relatedTarget: from});
+      to.focus();
+      await act(async () => {});
+    }
+  }
+
+  it('holds from the date half to the time half, across the focusout gap', async () => {
+    function Controlled() {
+      const [value, setValue] = useState<ISODateTimeString | undefined>();
+      return (
+        <DateTimeInput
+          label={LABEL}
+          value={value}
+          onChange={setValue}
+          adaptations={popoverBelowMd}
+        />
+      );
+    }
+    render(<Controlled />);
+    const date = dateField();
+    await focusField(date);
+    // A complete date: blurring commits what was typed, which is the field's
+    // own contract. What the latch owes the move is that the entry survives it.
+    fireEvent.change(date, {target: {value: '3/2/2026'}});
+    const time = timeField();
+
+    // The policy now wants the coordinated sheet, whose halves are different
+    // controls in a different tree. Crossing between the two segments must not
+    // hand the user that tree mid-entry.
+    environment.set({width: 390, pointer: 'coarse'});
+
+    await moveFocus(date, time, () => {
+      expect(surfaceIn()).toBe('popover');
+      expect(dateField()).toBe(date);
+      expect(timeField()).toBe(time);
+      expect(date.value).toBe('March 2, 2026');
+    });
+
+    expect(surfaceIn()).toBe('popover');
+    expect(dateField()).toBe(date);
+    expect(document.activeElement).toBe(time);
+
+    // The time half is still the typable one it was, so the entry the user
+    // crossed over to make actually reaches it.
+    fireEvent.change(time, {target: {value: '2:30 PM'}});
+    expect(time.value).toBe('2:30 PM');
+    expect(surfaceIn()).toBe('popover');
+  });
+
+  it('releases when the focusout names a target outside the field', async () => {
+    render(
+      <>
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          adaptations={popoverBelowMd}
+        />
+        <button type="button">Elsewhere</button>
+      </>,
+    );
+    const date = dateField();
+    await focusField(date);
+    environment.set({width: 390, pointer: 'coarse'});
+
+    fireEvent.focusOut(date, {
+      relatedTarget: screen.getByRole('button', {name: 'Elsewhere'}),
+    });
+    await act(async () => {});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('releases when the focusout names no target at all', async () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+    const date = dateField();
+    await focusField(date);
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // `relatedTarget` is null when focus leaves for the document, another
+    // window, or a target the browser withholds. All of them are "outside".
+    fireEvent.focusOut(date, {relatedTarget: null});
+    await act(async () => {});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('keeps holding on a null focusout while the calendar is still open', async () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+    const date = dateField();
+    await focusField(date);
+    fireEvent.click(date);
+    await waitFor(() => {
+      expect(date.getAttribute('aria-expanded')).toBe('true');
+    });
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // This field's calendar is PORTALED out of the row, so focus moving into it
+    // names a target the field does not contain — the open surface is the only
+    // thing that can say the interaction is still the field's.
+    fireEvent.focusOut(date, {relatedTarget: null});
+    await act(async () => {});
+
+    expect(surfaceIn()).toBe('popover');
+    expect(date.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('holds the focused tree across a viewport change, keeping the draft', async () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+    const input = dateField();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: 'Feb'}});
+    expect(input.value).toBe('Feb');
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // Same node, same uncommitted text, same focus: nothing was remounted.
+    expect(surfaceIn()).toBe('popover');
+    expect(dateField()).toBe(input);
+    expect(input.value).toBe('Feb');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('applies the pending surface once focus leaves', async () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+    const input = dateField();
+    await focusField(input);
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('popover');
+
+    await blurField(input);
+
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+  });
+
+  it('keeps holding while focus moves from the date half to the time half', async () => {
+    // The two halves are one field, so the blur that hands focus across them is
+    // not focus leaving — the deferred re-check is what tells those apart.
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+    const date = dateField();
+    await focusField(date);
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('popover');
+
+    const time = timeField();
+    await focusField(time);
+    expect(surfaceIn()).toBe('popover');
+    expect(document.activeElement).toBe(time);
+    expect(dateField()).toBe(date);
+
+    await blurField(time);
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+  });
+
+  it('does not swap while the anchored calendar is open', async () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+    const input = dateField();
+    await focusField(input);
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('popover');
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('holds while an open surface outlives focus, then releases when it closes', async () => {
+    render(
+      <>
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          adaptations={popoverBelowMd}
+        />
+        <button type="button">Elsewhere</button>
+      </>,
+    );
+    const input = dateField();
+    await focusField(input);
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+    environment.set({width: 390, pointer: 'coarse'});
+    expect(surfaceIn()).toBe('popover');
+
+    // Focus moves to another control with the calendar still open: the
+    // surface, not the caret, is what holds the latch now. The calendar is a
+    // sibling of the row, so focus never bubbles back through the field.
+    await focusField(screen.getByRole('button', {name: 'Elsewhere'}));
+    expect(surfaceIn()).toBe('popover');
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+
+    // Closing it is the release signal on its own — focus never comes back,
+    // so nothing else would tell the latch the field is done.
+    await act(async () => {
+      fireEvent.keyDown(input, {key: 'Escape'});
+    });
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', {name: 'Elsewhere'}),
+    );
+  });
+
+  it('holds the touch sheet through its own lifecycle', async () => {
+    environment.set({width: 390, pointer: 'coarse'});
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+    expect(surfaceIn()).toBe('bottom-sheet');
+    const input = dateField();
+    await focusField(input);
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(document.querySelector('dialog')?.hasAttribute('open')).toBe(true);
+    });
+
+    // A rotation to a wide viewport mid-pick must not pull the sheet out.
+    environment.set({width: 1280, pointer: 'fine'});
+    expect(surfaceIn()).toBe('bottom-sheet');
+    expect(document.querySelector('dialog')).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.keyDown(document.querySelector('dialog')!, {key: 'Escape'});
+    });
+    // Focus is inside the sheet, which jsdom leaves there: it never runs the
+    // exit transition that hands focus back. Dropping focus by hand is the
+    // "focus has left, the surface has not" case.
+    await blurActiveElement();
+    expect(surfaceIn()).toBe('bottom-sheet');
+
+    // Completing the exit is what hands focus back to the segment, so the
+    // sheet is still the right tree to be in — the release waits for that
+    // focus to leave as well.
+    await act(async () => {
+      finishSheetExit();
+    });
+    expect(document.activeElement).toBe(dateField());
+    expect(surfaceIn()).toBe('bottom-sheet');
+
+    await blurField(dateField());
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('popover');
+    });
+  });
+
+  it('holds across a theme change that moves the boundary', async () => {
+    // 800px sits above the default md point and below the widened one, so the
+    // theme swap alone flips which rule matches.
+    environment.set({width: 800, pointer: 'fine'});
+    function ThemeSwitch() {
+      const [md, setMd] = useState(768);
+      return (
+        <Theme theme={themeWithMd(`md-${md}`, md)}>
+          <DateTimeInput
+            label={LABEL}
+            onChange={noop}
+            adaptations={popoverBelowMd}
+          />
+          <button type="button" onClick={() => setMd(1000)}>
+            Widen
+          </button>
+        </Theme>
+      );
+    }
+    render(<ThemeSwitch />);
+    expect(surfaceIn()).toBe('popover');
+    const input = dateField();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: 'Feb'}});
+
+    await act(async () => {
+      // Clicking does not move focus in jsdom, so the field stays engaged.
+      screen.getByRole('button', {name: 'Widen'}).click();
+    });
+
+    expect(surfaceIn()).toBe('popover');
+    expect(dateField()).toBe(input);
+    expect(input.value).toBe('Feb');
+
+    await blurField(input);
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+  });
+
+  it('holds across a policy change, then applies it on release', async () => {
+    function PolicySwitch() {
+      const [value, setValue] =
+        useState<DateTimeInputAdaptationValue>('popover');
+      return (
+        <>
+          <DateTimeInput
+            label={LABEL}
+            onChange={noop}
+            adaptations={policy({default: value, rules: []})}
+          />
+          <button type="button" onClick={() => setValue('native')}>
+            Go native
+          </button>
+        </>
+      );
+    }
+    render(<PolicySwitch />);
+    const input = dateField();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: 'Feb'}});
+
+    await act(async () => {
+      screen.getByRole('button', {name: 'Go native'}).click();
+    });
+    expect(surfaceIn()).toBe('popover');
+    expect(input.value).toBe('Feb');
+
+    await blurField(input);
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('native');
+    });
+  });
+
+  it('holds the native control while it has focus, and releases on blur', async () => {
+    const nativeUntilMd = policy({
+      default: 'native',
+      rules: [{when: {width: {from: 'md'}}, value: 'popover'}],
+    });
+    environment.set({width: 390, pointer: 'coarse'});
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={nativeUntilMd}
+      />,
+    );
+    expect(surfaceIn()).toBe('native');
+
+    // The OS picker draws outside the page and reflects no disclosure state, so
+    // focus is the only signal holding the latch for this surface.
+    const input = dateField();
+    await focusField(input);
+    environment.set({width: 1280, pointer: 'fine'});
+    expect(surfaceIn()).toBe('native');
+    expect(document.activeElement).toBe(input);
+
+    await blurField(input);
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('popover');
+    });
+  });
+
+  it('swaps immediately when the field was never touched', () => {
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+      />,
+    );
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+
+  it('keeps a committed value across a released swap', async () => {
+    function Controlled() {
+      const [value, setValue] = useState<ISODateTimeString | undefined>(
+        '2026-03-21T14:30' as ISODateTimeString,
+      );
+      return (
+        <DateTimeInput
+          label={LABEL}
+          value={value}
+          onChange={setValue}
+          adaptations={popoverBelowMd}
+        />
+      );
+    }
+    render(<Controlled />);
+    expect(dateField().value).toBe('March 21, 2026');
+    expect(timeField().value).toBe('2:30 PM');
+
+    const input = dateField();
+    await focusField(input);
+    environment.set({width: 390, pointer: 'coarse'});
+    await blurField(input);
+
+    await waitFor(() => {
+      expect(surfaceIn()).toBe('bottom-sheet');
+    });
+    // Both halves survive the swap: the value lives above the surface.
+    expect(dateField().value).toBe('March 21, 2026');
+    expect(timeField().value).toBe('2:30 PM');
+  });
+
+  it('still runs the caller’s own focus handlers', async () => {
+    const onFocusCapture = vi.fn();
+    const onBlurCapture = vi.fn();
+    render(
+      <DateTimeInput
+        label={LABEL}
+        onChange={noop}
+        adaptations={popoverBelowMd}
+        onFocusCapture={onFocusCapture}
+        onBlurCapture={onBlurCapture}
+      />,
+    );
+
+    const input = dateField();
+    await focusField(input);
+    await blurField(input);
+
+    expect(onFocusCapture).toHaveBeenCalled();
+    expect(onBlurCapture).toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// The released `nativePicker` contract, unchanged beside the new one
+// =============================================================================
+
+describe('legacy nativePicker parity', () => {
+  it.each([
+    ['touch', 'fine', 'popover'],
+    ['touch', 'coarse', 'native'],
+    ['always', 'fine', 'native'],
+    ['always', 'coarse', 'native'],
+    ['never', 'fine', 'popover'],
+    ['never', 'coarse', 'bottom-sheet'],
+  ] as const)(
+    'nativePicker="%s" on a %s pointer renders %s',
+    (nativePicker, pointer, expected) => {
+      environment.set({
+        pointer,
+        width: pointer === 'coarse' ? 390 : 1280,
+      });
+      render(
+        <DateTimeInput
+          label={LABEL}
+          onChange={noop}
+          nativePicker={nativePicker as DateTimeInputProps['nativePicker']}
+        />,
+      );
+
+      expect(surfaceIn()).toBe(expected);
+      expectSegments(expected);
+    },
+  );
+
+  it('asks only the pointer question, never a width one', () => {
+    environment.set({width: 390, pointer: 'coarse'});
+    render(
+      <DateTimeInput label={LABEL} onChange={noop} nativePicker="never" />,
+    );
+
+    expect(environment.policyQueries()).toEqual(['(pointer: coarse)']);
+  });
+
+  it('still follows the pointer with no latch of its own', async () => {
+    render(
+      <DateTimeInput label={LABEL} onChange={noop} nativePicker="never" />,
+    );
+    const input = dateField();
+    await focusField(input);
+    fireEvent.change(input, {target: {value: 'Feb'}});
+
+    environment.set({width: 390, pointer: 'coarse'});
+
+    // Legacy behavior is deliberately left as it was: the pointer switch wins
+    // mid-interaction, which is the very thing `adaptations` fixes.
+    expect(surfaceIn()).toBe('bottom-sheet');
+  });
+});

--- a/packages/core/src/DateTimeInput/index.ts
+++ b/packages/core/src/DateTimeInput/index.ts
@@ -11,6 +11,7 @@
 
 export {DateTimeInput} from './DateTimeInput';
 export type {
+  DateTimeInputAdaptationValue,
   DateTimeInputProps,
   DateTimeInputSize,
   DateTimeInputHourFormat,

--- a/packages/core/src/hooks/useAdaptationSurfaceLatch.ts
+++ b/packages/core/src/hooks/useAdaptationSurfaceLatch.ts
@@ -1,0 +1,222 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useAdaptationSurfaceLatch.ts
+ * @input The surface an adaptation policy resolves to right now, plus focus
+ *   events from the field rendering it
+ * @output Package-internal latch that holds one resolved surface while the
+ *   field is in use, and the focus handlers that observe that use
+ * @position spec:AST-031 FR5, for the components whose surfaces are SEPARATE
+ *   component trees.
+ *
+ * `DateInput` and `DateTimeInput` choose between whole trees — a native
+ * control, a typable field with an anchored popover, a touch field with a modal
+ * sheet — so publishing a new policy value mid-interaction would unmount the
+ * focused control and take the uncommitted draft, the caret and the open
+ * surface with it. A viewport that crosses a rule boundary while someone is
+ * typing is an ordinary event: a rotated phone, a resized window, a nested
+ * Theme swapped under a policy that reads its width points.
+ *
+ * Selector deliberately does NOT use this: its two surfaces live inside one
+ * component, so `useSelectorPresentation` latches without a tree swap.
+ *
+ * The latch holds while EITHER signal is live and releases only when both are
+ * clear (spec:AST-031 FR5):
+ * - focus is somewhere in the field's tree, decided from the blur event's
+ *   `relatedTarget` — the element focus is moving TO — rather than from a
+ *   deferred re-check;
+ * - the field still owns an open surface, read from the DOM as an expanded
+ *   trigger or a mounted open `<dialog>`. That is the arm that covers a
+ *   DateTimeInput calendar, whose popover is PORTALED out of the field's DOM
+ *   subtree: focus moving into it reports a `relatedTarget` the field does not
+ *   contain, and the open surface is what says that focus is still the field's.
+ *
+ * ## Why `relatedTarget` and not a deferred re-check
+ *
+ * Moving between two controls of one field — the text input to its calendar
+ * toggle, a date segment to its time segment — fires a blur and then a focus,
+ * and the latch must not read the gap between them as focus leaving. The
+ * tempting implementation defers the decision (a microtask, a timeout) and asks
+ * again once the focus has landed. It is wrong, and jsdom hides it: there, a
+ * programmatic `blur()`/`focus()` pair runs inside one task, so a microtask
+ * always observes the landed focus. A real browser dispatches a user's Tab or
+ * click as `focusout`, then drains microtasks, then `focusin` — so the deferred
+ * check runs BETWEEN them, sees focus nowhere, and releases the latch in the
+ * middle of the very interaction it exists to protect: the tree swaps under the
+ * pointer, the draft goes with it, and the click never reaches the button that
+ * was under the cursor.
+ *
+ * `relatedTarget` carries the answer synchronously, in the event that asks the
+ * question, which is why it is the pattern focus-within implementations settle
+ * on. It is `null` when focus leaves for the document, another window, or a
+ * target the browser withholds — all read as "outside", after which the owned
+ * surface still gets its say.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/DateInput/DateInput.tsx
+ * - /packages/core/src/DateTimeInput/DateTimeInput.tsx
+ * - /packages/core/src/DateInput/DateInputAdaptations.test.tsx
+ * - /packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx
+ * - /apps/storybook/stories/DateInput.stories.tsx (the real-browser proof)
+ */
+
+import {useCallback, useEffect, useRef, useState, type FocusEvent} from 'react';
+
+/** Attributes whose change can end an owned surface's lifetime. */
+const SURFACE_STATE_ATTRIBUTES = ['aria-expanded', 'open'];
+
+/**
+ * Whether the field still owns an open surface.
+ *
+ * Two DOM signals, because the surfaces are not alike. Every Astryx trigger
+ * reflects its disclosure state with `aria-expanded`, which covers the anchored
+ * calendar and the touch sheet's segments; a `BottomSheet` then stays mounted
+ * as an open `<dialog>` through its exit transition after that flag clears, and
+ * swapping the tree during the exit would drop the sheet mid-animation and
+ * strand the focus handoff it owes the trigger.
+ *
+ * A native OS picker has neither signal — the browser draws it outside the page
+ * — so for that surface the latch rests on focus, which is exactly what the
+ * platform provides: an `<input type="date">` keeps focus while its picker is
+ * up, and blurs when the picker is dismissed.
+ */
+function hasOpenOwnedSurface(root: HTMLElement | null): boolean {
+  return (
+    root != null &&
+    (root.querySelector('[aria-expanded="true"]') != null ||
+      root.querySelector('dialog[open]') != null)
+  );
+}
+
+/** What the latch publishes back to the component that owns the switch. */
+export interface AdaptationSurfaceLatch<T> {
+  /** The surface to render now: the resolved one, or the held one while busy. */
+  readonly surface: T;
+  /** Spread onto the rendered surface's root, composed with the caller's. */
+  readonly onFocusCapture: (event: FocusEvent<HTMLElement>) => void;
+  readonly onBlurCapture: (event: FocusEvent<HTMLElement>) => void;
+}
+
+/**
+ * Hold `resolved` steady while the field it selects is being used.
+ *
+ * Returns the resolved value unchanged whenever the field is idle — including
+ * every server render, where no focus event has happened and no DOM is read —
+ * so a policy change reaches an untouched field immediately. Once focus enters
+ * the field, the value that was rendered stays rendered until focus leaves AND
+ * every surface it owns has closed; the pending value is applied on that
+ * release, in one re-render.
+ *
+ * @internal
+ */
+export function useAdaptationSurfaceLatch<T>(
+  resolved: T,
+): AdaptationSurfaceLatch<T> {
+  // The surface that was rendered when the field last became busy. Kept in
+  // state rather than a ref because releasing the latch has to re-render.
+  const [rendered, setRendered] = useState<T>(resolved);
+  const resolvedRef = useRef<T>(resolved);
+  resolvedRef.current = resolved;
+
+  // Split deliberately: `isBusyRef` is what render reads, and it stays true
+  // while an owned surface is open with focus elsewhere; `isFocusWithinRef` is
+  // the raw focus signal, so a surface closing later knows whether focus ever
+  // came back.
+  const isBusyRef = useRef(false);
+  const isFocusWithinRef = useRef(false);
+  const rootRef = useRef<HTMLElement | null>(null);
+  const observerRef = useRef<MutationObserver | null>(null);
+
+  const stopObserving = useCallback(() => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+  }, []);
+
+  const release = useCallback(() => {
+    stopObserving();
+    isBusyRef.current = false;
+    // Publishes whatever the policy resolves to now. An unchanged value bails
+    // out of the re-render on its own, so an ordinary blur costs nothing.
+    setRendered(resolvedRef.current);
+  }, [stopObserving]);
+
+  /**
+   * Decide the latch now that focus is not in the field: release, or keep
+   * holding for an owned surface and watch for it to close.
+   *
+   * Also the observer's callback, which is how a surface that outlives focus
+   * releases the latch when it finally closes — there is no later focus event
+   * to carry that news.
+   */
+  const releaseUnlessSurfaceIsOpen = useCallback(() => {
+    if (isFocusWithinRef.current) {
+      stopObserving();
+      return;
+    }
+    if (hasOpenOwnedSurface(rootRef.current)) {
+      if (observerRef.current == null && rootRef.current != null) {
+        const observer = new MutationObserver(() => {
+          releaseUnlessSurfaceIsOpen();
+        });
+        observer.observe(rootRef.current, {
+          attributes: true,
+          attributeFilter: SURFACE_STATE_ATTRIBUTES,
+          subtree: true,
+        });
+        observerRef.current = observer;
+      }
+      return;
+    }
+    release();
+  }, [release, stopObserving]);
+
+  const handleFocusCapture = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      // `currentTarget` is the field root the handler was spread onto, which is
+      // how the latch learns which subtree to read disclosure state from
+      // without a ref of its own — the surfaces forward `ref` to their input.
+      rootRef.current = event.currentTarget;
+      isFocusWithinRef.current = true;
+      isBusyRef.current = true;
+      stopObserving();
+    },
+    [stopObserving],
+  );
+
+  const handleBlurCapture = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      const root = event.currentTarget;
+      rootRef.current = root;
+      const nextFocused = event.relatedTarget as Node | null;
+      if (nextFocused != null && root.contains(nextFocused)) {
+        // Focus moved to another control of this same field — the input to its
+        // calendar toggle, a date segment to its time segment. Nothing has
+        // ended, and deciding it here rather than after the fact is what keeps
+        // a real browser's focusout/focusin gap from reading as a departure.
+        isFocusWithinRef.current = true;
+        return;
+      }
+      isFocusWithinRef.current = false;
+      releaseUnlessSurfaceIsOpen();
+    },
+    [releaseUnlessSurfaceIsOpen],
+  );
+
+  useEffect(() => stopObserving, [stopObserving]);
+
+  // Idle: track the resolved value so the next engagement latches what is
+  // actually on screen. Adjusting state during render is the sanctioned way to
+  // do this — React re-runs this component immediately, before committing, so
+  // no extra pass reaches the child tree.
+  if (!isBusyRef.current && rendered !== resolved) {
+    setRendered(resolved);
+  }
+
+  return {
+    surface: isBusyRef.current ? rendered : resolved,
+    onFocusCapture: handleFocusCapture,
+    onBlurCapture: handleBlurCapture,
+  };
+}

--- a/packages/core/src/theme/componentAdaptations.ts
+++ b/packages/core/src/theme/componentAdaptations.ts
@@ -30,6 +30,8 @@
  * - /packages/core/src/theme/index.ts (re-exports the authoring vocabulary
  *   only; the compiler stays package-internal)
  * - /packages/core/src/Selector/Selector.tsx (first public consumer)
+ * - /packages/core/src/DateInput/DateInput.tsx (public consumer)
+ * - /packages/core/src/DateTimeInput/DateTimeInput.tsx (public consumer)
  * - /packages/core/src/theme/componentAdaptations.test.ts
  */
 
@@ -122,6 +124,43 @@ export interface CompiledComponentAdaptations<T extends string> {
 
 const ADAPTATIONS_KEYS = new Set(['default', 'rules']);
 const RULE_KEYS = new Set(['when', 'value']);
+
+/**
+ * Visit every value a policy AUTHORS — `default` and each rule's — with the
+ * diagnostic path that names it.
+ *
+ * The point is EAGERNESS (spec:AST-031 IR3): a component whose value domain
+ * carries prop-compatibility rules of its own must check the whole policy
+ * before any of it is matched, so an unreachable-today rule fails on the
+ * author's machine rather than on the one device whose width and pointer
+ * select it.
+ *
+ * Deliberately tolerant of a malformed policy: a non-array `rules`, or a rule
+ * that is not an object, is skipped rather than crashing, because the shape
+ * diagnostics belong to `compileComponentAdaptations` and it names them better.
+ *
+ * @internal
+ */
+export function forEachAuthoredAdaptationValue<T extends string>(
+  adaptations: ComponentAdaptations<T>,
+  path: string,
+  visit: (value: T, valuePath: string) => void,
+): void {
+  visit(adaptations.default, `${path}.default`);
+  const rules: unknown = adaptations.rules;
+  if (!Array.isArray(rules)) {
+    return;
+  }
+  rules.forEach((rule: unknown, index) => {
+    if (typeof rule !== 'object' || rule === null) {
+      return;
+    }
+    visit(
+      (rule as ComponentAdaptationRule<T>).value,
+      `${path}.rules[${index}].value`,
+    );
+  });
+}
 
 function assertAdmittedValue<T extends string>(
   value: unknown,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,10 @@
  *   `extends: true`; the `node` project deliberately does NOT extend, so it
  *   runs in a plain node environment without the jsdom/StyleX overhead.
  *
+ *   Storybook is split across BOTH projects on purpose: `.storybook/` config
+ *   invariants are pure assertions about config objects and belong to `node`,
+ *   while a suite about a STORY has to render one and belongs to `ui`.
+ *
  *   (Migrated from the removed `vitest.workspace.ts` for Vitest 4, which
  *   dropped the standalone workspace file in favor of inline `test.projects`.)
  *
@@ -89,9 +93,10 @@ export default defineConfig({
     // Test projects (migrated from vitest.workspace.ts). Partitioning rule
     // (nothing can fall through):
     //   - `ui`   = packages/core + packages/lab + packages/charts + packages/richtext
-    //              + packages/vega — need jsdom, the StyleX babel
-    //              transform, and the jest-dom setup; inherit all of that from
-    //              the root config via `extends: true`.
+    //              + packages/vega + apps/storybook/stories — need jsdom,
+    //              the StyleX babel transform, and the jest-dom setup;
+    //              inherit all of that from the root config via
+    //              `extends: true`.
     //   - `node` = everything else (CLI, build tooling, scripts, internal
     //              utils, and app-level suites that need no DOM) — no DOM, no
     //              StyleX/babel transform, no jest-dom
@@ -123,6 +128,10 @@ export default defineConfig({
             'packages/charts/src/**/*.test.{ts,tsx,mjs}',
             'packages/richtext/src/**/*.test.{ts,tsx,mjs}',
             'packages/vega/src/**/*.test.{ts,tsx,mjs}',
+            // Story-level suites: a story can only be asserted on where it can
+            // be RENDERED, so these belong here rather than in `node` beside
+            // the .storybook config invariants.
+            'apps/storybook/stories/**/*.test.{ts,tsx}',
           ],
         },
       },


### PR DESCRIPTION
## Summary

- add exact `native | popover | bottom-sheet` adaptation values to DateInput and DateTimeInput
- resolve width/pointer rules through the nearest Theme's named breakpoints
- preserve every existing `nativePicker` behavior when `adaptations` is absent
- latch the selected tree through active focus/surface interactions
- reject exact-native policies that cannot represent authored picker features
- leave TimeInput and DateRangeInput unchanged

## Validation

- focused DateInput/DateTimeInput/native-picker/theme suites
- Core and docs typechecks
- browser stories for explicit cross-pointer surfaces
- a11y, keyboard/focus, and visual checks
- repository guardrails and build

This draft is stacked on #6130 → #6127 → #6123 → #5543 and remains blocked on owner approval of AST-031. No spec approval was posted by the agent.
