### PR TITLE
docs(useMediaQuery): document server default snapshot

### DIFF
--- a/packages/core/src/hooks/useMediaQuery.doc.mjs
+++ b/packages/core/src/hooks/useMediaQuery.doc.mjs
@@ -4,7 +4,15 @@
 export const docs = {
   name: 'useMediaQuery',
   displayName: 'useMediaQuery',
-  keywords: ['responsive', 'breakpoint', 'media', 'mobile', 'desktop', 'screen', 'matchmedia'],
+  keywords: [
+    'responsive',
+    'breakpoint',
+    'media',
+    'mobile',
+    'desktop',
+    'screen',
+    'matchmedia',
+  ],
   params: [
     {
       name: 'query',
@@ -12,20 +20,47 @@ export const docs = {
       description: 'CSS media query string to evaluate.',
       required: true,
     },
+    {
+      name: 'serverDefault',
+      type: 'boolean',
+      description:
+        'Snapshot returned during server rendering and hydration before the live matchMedia subscription takes over. Pass a reliable server-side hint when available to avoid a visible mode change.',
+      default: 'false',
+      required: false,
+    },
   ],
   returns: [
     {
       name: 'matches',
       type: 'boolean',
-      description: 'Whether the media query currently matches. Always false on first render (SSR-safe).',
+      description:
+        'Whether the media query matches. During server rendering and hydration this is serverDefault; on the live client it follows matchMedia.',
     },
   ],
   usage: {
-    description: 'SSR-safe media query hook that subscribes to window.matchMedia changes. Returns whether the given media query matches. Always returns false on first render for SSR compatibility.',
+    description:
+      'SSR-safe media query hook that subscribes to window.matchMedia changes. The serverDefault snapshot is used during server rendering and hydration, then the live browser match becomes authoritative.',
     bestPractices: [
-      { guidance: true, description: 'Use for responsive layout switching based on viewport width, color scheme, or motion preferences.' },
-      { guidance: true, description: 'Prefer Astryx responsive tokens and component props over manual breakpoint logic when possible.' },
-      { guidance: false, description: 'Use for server-rendered content that must match on first paint; the hook always returns false initially.' },
+      {
+        guidance: true,
+        description:
+          'Use JavaScript only when semantic structure or behavior must change; use CSS for presentation-only adaptation.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass a reliable server-side hint as serverDefault when the first rendered mode must match before hydration; omission defaults to false.',
+      },
+      {
+        guidance: true,
+        description:
+          'Prefer Astryx responsive tokens and component props over manual breakpoint logic when possible.',
+      },
+      {
+        guidance: false,
+        description:
+          'Assume the hook always returns false initially when a true serverDefault was supplied.',
+      },
     ],
   },
   relatedComponents: [],
@@ -36,19 +71,36 @@ export const docs = {
 
 /** @type {import('@astryxdesign/cli/authoring').HookTranslationDoc} */
 export const docsDense = {
-  description: 'SSR-safe media query hook subscribing to window.matchMedia changes. Returns whether given media query matches. Always returns false on first render for SSR compatibility.',
+  description:
+    'SSR-safe media-query subscription; serverDefault is the server/hydration snapshot, then live matchMedia becomes authoritative',
   paramDescriptions: {
     query: 'CSS media query string to evaluate.',
+    serverDefault:
+      'server-render and hydration snapshot before live matchMedia takes over; defaults to false',
   },
   returnDescriptions: {
-    matches: 'whether media query currently matches. Always false on first render (SSR-safe).',
+    matches:
+      'serverDefault during SSR/hydration, then whether the live browser media query matches',
   },
   usage: {
-    description: 'SSR-safe media query hook subscribing to window.matchMedia changes. Returns whether given media query matches. Always returns false on first render for SSR compatibility.',
+    description:
+      'Use for semantic structure or behavior that must change in JavaScript. Prefer CSS for presentation-only adaptation.',
     bestPractices: [
-      { guidance: true, description: 'Use for responsive layout switching based on viewport width, color scheme, or motion preferences.' },
-      { guidance: true, description: 'Prefer Astryx responsive tokens + component props over manual breakpoint logic when possible.' },
-      { guidance: false, description: 'Use for server-rendered content that must match on first paint; hook always returns false initially.' },
+      {
+        guidance: true,
+        description:
+          'Pass a reliable server-side hint when the first rendered mode must match before hydration.',
+      },
+      {
+        guidance: true,
+        description:
+          'Prefer Astryx responsive tokens + component props over manual breakpoint logic when possible.',
+      },
+      {
+        guidance: false,
+        description:
+          'Assume the first result is always false when serverDefault was supplied.',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary

- documents the shipped optional `serverDefault` parameter
- explains that it supplies the SSR/hydration snapshot before live `matchMedia` becomes authoritative
- corrects the stale claim that the hook always returns `false` initially
- narrows guidance: CSS owns presentation-only adaptation; JavaScript is for semantic structure or behavior

## Authority and audit routing

- Resolves responsive audit row R4's documentation drift only.
- `architecture:component-style-authoring` already owns CSS-first presentation.
- The public `useMediaQuery` source and tests already own `serverDefault = false` and `getServerSnapshot` behavior.
- This PR adds no responsive architecture, API, runtime behavior, test, tooling, or wiki change.

## Overlap receipt

- Searched current authority and all open PRs by `useMediaQuery`, `serverDefault`, responsive swap, AppShell, and affected paths.
- #5543 and the AST-031 stack touch AppShell/adaptation behavior but do not edit this hook doc; this PR does not adopt their draft APIs.
- #5313 has a component-local `defaultIsMobile` path and remains untouched.

## Validation

- Prettier
- `node scripts/check-knowledge.mjs`
- `pnpm check:sync`
- `pnpm check:changesets`
- `git diff --check`
- repository pre-commit suite

No changeset: documentation now matches existing released behavior.