### PR TITLE
docs(Banner): approve frame theme target

### DIFF
--- a/packages/core/src/Banner/Banner.spec.md
+++ b/packages/core/src/Banner/Banner.spec.md
@@ -34,18 +34,18 @@ system_specs: []
 ## Intent
 
 Banner presents a persistent status message at the top of a page or section.
-This draft records the current painted surfaces and theming ownership so the
-outer-surface question can be reviewed against explicit facts. It documents the
-existing outer frame as anatomy, but does not choose a new target or change
-runtime behavior.
+This contract records the current painted surfaces and admits the Banner frame as
+a separately targetable surface. Runtime implementation follows in a separate
+change; the existing status and content targets remain unchanged.
 
 ## Compatibility and migration
 
 - Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, and public API remain unchanged
+- Compatibility class: additive public theming target; no existing target,
+  runtime default, DOM, prop, or behavior changes
 - Controlled/uncontrolled behavior: unchanged
-- Migration decision: none
+- Migration decision: none; new themes use `banner-frame` for frame-specific
+  overrides
 
 Consumer migration instructions belong in consumer docs and release notes.
 
@@ -61,41 +61,40 @@ Consumer migration instructions belong in consumer docs and release notes.
 **Does not own / non-goals**
 
 - Painting for action and dismiss controls — delegated to `component:Button`.
-- A public theming target for the Banner frame — no such target exists today,
-  and this draft does not decide whether to add one.
 - A new theme property, prop, variant, or DOM element.
 
 ## Public concepts
 
-No new public concept is introduced. Consumer props, defaults, and usage remain
-documented in `Banner.doc.mjs`.
+The Banner frame is a stable public theming concept. Its target is
+`banner-frame`, and it reflects the existing `container` and `elevation` axes.
+The existing `banner` target remains on the Status surface and continues to
+reflect `container` and `status`.
 
-The current `status`, `container`, and `elevation` props continue to select the
-existing presentation. This draft does not change which axes are extensible or
-which values themes may add.
+Consumer props, defaults, and usage remain documented in `Banner.doc.mjs`. No
+prop vocabulary or extensibility rule changes.
 
 ## Behavioral and layout contract
 
-Draft requirements identify their basis so observed code is not mistaken for an
-intentional decision.
+The requirements below distinguish current implementation from the approved
+additive target contract.
 
-| ID  | Candidate invariant                                                                                                                                                                          | Basis                                      | Draft review state                                           |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------------------------------------------ |
-| FR1 | The current render places `banner` on the colored status surface, which is Banner's primary painted surface and reflects `container` and `status`.                                           | Current source, public docs, and tests     | Verified current behavior; no target change decided          |
-| FR2 | The Banner frame receives the public ref, role, supported DOM props, `xstyle`, `className`, and `style`; it also paints the selected `boxShadow`.                                            | Current source and tests                   | Verified current behavior; future ownership remains open     |
-| FR3 | An elevated `card` frame also paints the whole-banner radius. A `section` frame remains square. A non-elevated frame does not receive the frame-radius style.                                | Current source and elevation tests         | Verified current behavior; future ownership remains open     |
-| FR4 | Card shape is split across surface owners: the status surface owns all corners without visible content or the top corners with visible content; the content surface owns the bottom corners. | Current source                             | Verified current behavior; no DOM or clipping change decided |
-| FR5 | Theme-authored `borderRadius` on `banner` currently expands to the private `--_banner-radius` variable used by the status surface, content surface, and elevated card frame.                 | Current component docs and theme compiler  | Verified current routing; private variable stays private     |
-| FR6 | The Banner frame has no public theming target and reflects neither `container` nor `elevation` through `themeProps`. `elevation` is not reflected on any current Banner target.              | Current source and public target inventory | Verified current absence; admission is a human decision      |
-| FR7 | The current public targets are `banner`, `banner-icon`, `banner-description`, and `banner-content`; their exact anatomy ownership is recorded below.                                         | Current public docs and source             | Verified current behavior; no target added or removed        |
+| ID  | Invariant                                                                                                                                                                                                                                                            | Basis                                          | Contract state                           |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------- |
+| FR1 | The current render places `banner` on the colored status surface, which is Banner's primary painted surface and reflects `container` and `status`.                                                                                                                   | Current source, public docs, and tests         | Current behavior                         |
+| FR2 | The Banner frame receives the public ref, role, supported DOM props, `xstyle`, `className`, and `style`; it also paints the selected `boxShadow`.                                                                                                                    | Current source and tests                       | Current behavior                         |
+| FR3 | An elevated `card` frame also paints the whole-banner radius. A `section` frame remains square. A non-elevated frame does not receive the frame-radius style.                                                                                                        | Current source and elevation tests             | Current behavior                         |
+| FR4 | Card shape is split across surface owners: the status surface owns all corners without visible content or the top corners with visible content; the content surface owns the bottom corners.                                                                         | Current source                                 | Current behavior                         |
+| FR5 | Theme-authored `borderRadius` on `banner` currently writes the private `--_banner-radius` variable on the Status surface only. CSS inheritance does not carry that value upward to the frame or sideways to the Content surface, so both keep their fallback radius. | Current compiler output and CSS inheritance    | Current reachability gap                 |
+| FR6 | The Banner frame MUST expose `banner-frame` and reflect `container` and `elevation`. The existing `banner` target MUST remain on the Status surface rather than move to the outermost DOM element.                                                                   | Owner decision; `component:Banner/DEC-1`       | Current contract; implementation pending |
+| FR7 | `banner-frame` is additive. The existing `banner`, `banner-icon`, `banner-description`, and `banner-content` targets and their current axes MUST remain unchanged.                                                                                                   | Current target inventory; compatibility policy | Current contract; implementation pending |
 
 ### Allowed variation
 
 - **AV1 — Content presence.** The content surface may be absent, collapsed,
   expanded, or always visible under the existing `collapsible` contract.
-- **AV2 — Current theme overrides.** Themes may use the four current targets and
-  the existing derived radius route without gaining a selector for the Banner
-  frame.
+- **AV2 — Target scope.** Themes use `banner-frame` for the whole Banner
+  silhouette and elevation, `banner` for the primary Status surface, and the
+  existing child targets for their owned parts.
 
 ### Representative states
 
@@ -104,7 +103,7 @@ intentional decision.
 | Flat card, no visible content  | Status surface is the full rounded painted surface; frame shadow is `none` and frame radius styling is absent.      | Status, text, controls, and theme paint |
 | Elevated card, visible content | Frame paints the whole shadow and radius; status surface paints top corners; content surface paints bottom corners. | Elevation tier and content              |
 | Elevated section               | Frame paints the whole shadow without card radius; status and content surfaces remain square.                       | Elevation tier and content              |
-| Custom radius theme            | `banner` border-radius authoring routes through the private radius variable to each current surface owner.          | Authored radius value                   |
+| Custom radius on `banner`      | Status surface receives the private radius value; frame and Content surface keep their fallback radius.             | Authored radius value                   |
 
 ### Transformation and precedence order
 
@@ -112,19 +111,20 @@ intentional decision.
   content; apply whole-banner elevation and any elevated-card radius to the
   Banner frame; then render the targeted status and optional targeted content
   surfaces.
-- **ORD2 — Radius routing.** Theme compilation turns `borderRadius` authored on
-  `banner` into the private radius variable before the current surface owners
-  consume it. Consumers do not author the private variable directly.
+- **ORD2 — Current radius routing.** Theme compilation writes a
+  `borderRadius` authored on `banner` to the private radius variable on the
+  Status surface. That value does not inherit to the ancestor frame or sibling
+  Content surface. Consumers do not author the private variable directly.
 
 ### Performance and resources
 
-This draft introduces no new measurement, observer, listener, render pass, or
+This contract introduces no new measurement, observer, listener, render pass, or
 runtime work.
 
 ## Accessibility contract
 
-This draft does not change Banner's current status roles, announcements, focus
-handoff, disclosure controls, or accessible control names.
+This contract does not change Banner's current status roles, announcements,
+focus handoff, disclosure controls, or accessible control names.
 
 ## Design relationships
 
@@ -135,8 +135,9 @@ handoff, disclosure controls, or accessible control names.
 | Content surface         | Carries optional supporting detail below the status surface.                                       | Current source and public docs | Supporting     | FR4, FR7           |
 | Action/dismiss controls | Keep their own Button painting and target ownership.                                               | Current composition            | Supporting     | FR7                |
 
-The Banner frame is stable anatomy and a current surface owner. Its separate
-public theme ownership remains undecided.
+The Banner frame is stable anatomy and owns the additive `banner-frame` target.
+The Status surface remains Banner's primary painted surface and keeps the
+unqualified `banner` target.
 
 ### Theming anatomy
 
@@ -146,7 +147,7 @@ public theme ownership remains undecided.
 {
   "Banner frame": {
     "none": {
-      "reason": "unsettled: The current frame owns whole-banner elevation and the elevated-card silhouette, but whether it needs separate public theme ownership is undecided."
+      "reason": "reachability-gap: The approved banner-frame target is not yet emitted or documented by the runtime implementation."
     }
   },
   "Status surface": {"target": "banner"},
@@ -163,43 +164,52 @@ public theme ownership remains undecided.
 }
 ```
 
-This map records current consumer anatomy and current targets. `banner` belongs
-to the primary Status surface rather than the outermost DOM element. The Banner
-frame is named anatomy because it owns the visible whole-banner silhouette; its
-`none` disposition records that no current target reaches it without deciding
-whether a future target should.
+This map records current runtime reachability. `banner` belongs to the primary
+Status surface rather than the outermost DOM element. DEC-1 admits the Banner
+frame under `banner-frame`; its temporary `none` disposition is therefore a
+reachability gap that the implementation change must close.
 
 ## Family and system relationships
 
 - `architecture:component-theming-surface` owns target qualification, anatomy
   mapping, and the requirement that public targets sit on stable painted parts.
-- `architecture:public-component-api` owns admission and compatibility for a new
-  public theming seam.
+- `architecture:public-component-api` governs compatibility for the additive
+  target admitted by DEC-1.
 - `architecture:theme-compilation` owns the private derived-variable route that
   currently carries Banner radius across its painters.
 
 ## Verification map
 
-| Contract            | Verification                                                      | Representative states                                    | Mutation or failure expectation                                                                      | Audit section           |
-| ------------------- | ----------------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------- |
-| FR1, FR6, FR7       | `Banner.test.tsx` and `themingTargets.test.ts`                    | Status surface, content surface, all current target axes | Moving, adding, or removing a target changes current class/data-attribute assertions.                | `audit:Banner/theming`  |
-| FR2, FR3, FR4       | `Banner.test.tsx` plus current source inspection                  | Flat/elevated card and elevated section                  | Frame, status surface, content surface, shadow, or radius ownership changes from the recorded state. | `audit:Banner/surfaces` |
-| FR5                 | Component docs, derived registry checks, and theme compiler tests | Card with and without content; elevated card             | Radius authoring stops reaching one of the current surface owners or exposes the private var.        | `audit:Banner/radius`   |
-| Theming anatomy map | `scripts/check-knowledge.mjs`                                     | Eight anatomy entries and four current targets           | Missing, extra, prefixed, stale, or unclaimed mappings fail validation.                              | `audit:Banner/theming`  |
+| Contract            | Verification                                                   | Representative states                                    | Mutation or failure expectation                                                                                  | Audit section           |
+| ------------------- | -------------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| FR1, FR7            | `Banner.test.tsx` and `themingTargets.test.ts`                 | Status surface, content surface, current target axes     | Moving, removing, or changing an existing target breaks current assertions.                                      | `audit:Banner/theming`  |
+| FR2, FR3, FR4       | `Banner.test.tsx` plus current source inspection               | Flat/elevated card and elevated section                  | Frame, status surface, content surface, shadow, or radius ownership changes from the recorded state.             | `audit:Banner/surfaces` |
+| FR5                 | Compiler output plus browser/computed-style evidence           | Card with and without content; elevated card             | `banner.borderRadius` unexpectedly reaches the frame/content, or docs claim that the current route already does. | `audit:Banner/radius`   |
+| FR6, FR7            | Implementation PR target, compiler, probe, and component tests | Card/section across none, low, med, and high elevation   | `banner-frame` is absent, uses another name, misses an axis, or moves the existing `banner` target.              | `audit:Banner/theming`  |
+| Theming anatomy map | `scripts/check-knowledge.mjs`                                  | Eight anatomy entries and four currently emitted targets | Missing, extra, prefixed, stale, or unclaimed current mappings fail validation.                                  | `audit:Banner/theming`  |
 
 ## Decision log
 
-None. This draft records current facts and introduces no component-local design
-or public-API decision.
+### DEC-1 — The Banner frame has separate public theme ownership
+
+**Reference:** `component:Banner/DEC-1`
+
+**Decider:** cixzhang, 2026-09-07
+
+The Banner frame is stable visible anatomy that owns whole-banner elevation and
+the elevated-card silhouette across the Status and optional Content surfaces.
+It receives the additive `banner-frame` target with `container` and `elevation`
+selector axes. The existing `banner` target remains on the primary Status
+surface.
+
+`frame` names the public visual role. `root` is rejected because it describes DOM
+placement and would imply that the target must remain on the outermost element.
 
 ## Open questions
 
-- **OQ1 — Should the Banner frame receive separate public theme ownership for
-  whole-banner elevation and silhouette, or should the existing `banner` target
-  continue to route supported frame paint internally? If separate, what
-  role-based target name should it use?** (`human-api`)
+None.
 
 ## Content boundary
 
-This file does not duplicate consumer prop tables or examples, choose the
-outer-target outcome, add implementation steps, or restate system theming rules.
+This file does not duplicate consumer prop tables or examples, implementation
+steps, or system theming rules.


### PR DESCRIPTION
## Why

[facebook/astryx#6116](https://github.com/facebook/astryx/pull/6116) established Banner’s frame, status surface, and content surface, but its merged contract still left frame theme ownership unresolved. The owner decision is now explicit: the frame is independently targetable, and its public name follows the visual role rather than DOM placement.

## What

- admit `banner-frame` as the additive target for the Banner frame
- assign `container` and `elevation` as its selector axes
- preserve `banner` on the primary Status surface and preserve every existing child target
- record the current missing runtime target as an implementation reachability gap
- record the current `banner.borderRadius` reachability gap: it affects the Status surface but not the ancestor frame or sibling Content surface
- reject `root` naming because it would promise outermost-DOM placement rather than stable anatomy

## Risk

Specification-only. Runtime implementation remains in [facebook/astryx#6007](https://github.com/facebook/astryx/pull/6007).

## Testing

- `node scripts/check-knowledge.mjs`
- `pnpm exec vitest run packages/core/src/theme/themingTargets.test.ts`
- repository pre-commit checks
