### PR TITLE
docs(cli): fix palette authoring types and drop the stale xds command name

### DIFF
--- a/.changeset/palette-type-docs.md
+++ b/.changeset/palette-type-docs.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Correct the palette authoring types. `TonalPaletteCandidate`'s description had landed on `TonalPaletteAnchor`, so the generated `.d.ts` documented the wrong type and left the candidate bare. `TonalPaletteFamilyInput` — the type an author writes by hand — had no property descriptions, and `neutralProfile` never said what its four values do.
+
+[fix] Give the generation receipt a real type. `generationReceipt` was `Record<string, unknown>`; it is now `TonalPaletteGenerationReceipt`, with `TonalPaletteRampDiagnostics`, `TonalPaletteCoordinationDiagnostics`, and `TonalPaletteNormalizedRequest` beside it. The generator's internal typedefs point at the same types, so the compiler holds the documentation true instead of letting it drift.
+
+[docs] Replace the stale `xds` command name with `astryx` across 79 lines of API type docs in 11 files, and realign the invocation tables. Codemods and changelogs that reference the old name are untouched — migrating it is their job.
+
+@josephfarina

--- a/packages/cli/api/build/build.type.mjs
+++ b/packages/cli/api/build/build.type.mjs
@@ -7,7 +7,7 @@
  */
 
 /**
- * xds --json build (no query) — the "how to build a page" playbook signal.
+ * astryx --json build (no query) — the "how to build a page" playbook signal.
  *
  * @typedef {object} BuildHelpResponse
  * @property {'build.help'} type
@@ -16,7 +16,7 @@
  */
 
 /**
- * xds --json build "<idea>" — the composition kit for what you're building.
+ * astryx --json build "<idea>" — the composition kit for what you're building.
  *
  * Entries are raw `SearchResultEntry` objects (no package-manager-prefixed
  * command strings — the CLI adds those); `frame`/`foundation` are static

--- a/packages/cli/api/component/component.type.mjs
+++ b/packages/cli/api/component/component.type.mjs
@@ -11,23 +11,23 @@
  *   --detail compact  Names + 1-line description + import path.
  *   --detail full     Full ComponentDoc per entry (props, theming, examples, etc.).
  *
- * Invocation                                 -> type discriminator
+ * Invocation                                      -> type discriminator
  * ------------------------------------------------------------------
- * xds --json component                      -> component.list (data.detail='names')
- * xds --json component --list               -> component.list (data.detail='names')
- * xds --json component --category Form      -> component.list (filtered)
- * xds --json component --list --detail compact -> component.list (data.detail='compact')
- * xds --json component --list --detail full -> component.list (data.detail='full')
- * xds --json component Button               -> component.detail
- * xds --json component Button --props       -> component.detail.props
- * xds --json component Button --source      -> component.detail.source
- * xds --json component Button --showcase    -> component.detail.showcase
- * xds --json component Button --blocks      -> component.detail.blocks
- * (not found)                               -> CLIError
+ * astryx --json component                         -> component.list (data.detail='names')
+ * astryx --json component --list                  -> component.list (data.detail='names')
+ * astryx --json component --category Form         -> component.list (filtered)
+ * astryx --json component --list --detail compact -> component.list (data.detail='compact')
+ * astryx --json component --list --detail full    -> component.list (data.detail='full')
+ * astryx --json component Button                  -> component.detail
+ * astryx --json component Button --props          -> component.detail.props
+ * astryx --json component Button --source         -> component.detail.source
+ * astryx --json component Button --showcase       -> component.detail.showcase
+ * astryx --json component Button --blocks         -> component.detail.blocks
+ * (not found)                                     -> CLIError
  */
 
 /**
- * xds --json component [--list] [--category X] [--detail names|compact|full]
+ * astryx --json component [--list] [--category X] [--detail names|compact|full]
  *
  * The list view emits ONE `component.list` type across all three detail levels;
  * the depth is carried in `data.detail` and `data.components` holds the grouped
@@ -67,7 +67,7 @@
  */
 
 /**
- * xds --json component <name>
+ * astryx --json component <name>
  * @typedef {object} ComponentDetailResponse
  * @property {'component.detail'} type
  * @property {import('@astryxdesign/cli/authoring').ComponentDoc & ComponentOwnership} data
@@ -84,28 +84,28 @@
  */
 
 /**
- * xds --json component <name> --props
+ * astryx --json component <name> --props
  * @typedef {object} ComponentDetailPropsResponse
  * @property {'component.detail.props'} type
  * @property {import('@astryxdesign/cli/authoring').ComponentPropDoc[]} data
  */
 
 /**
- * xds --json component <name> --source
+ * astryx --json component <name> --source
  * @typedef {object} ComponentDetailSourceResponse
  * @property {'component.detail.source'} type
  * @property {{component: string; source: string}} data
  */
 
 /**
- * xds --json component <name> --showcase
+ * astryx --json component <name> --showcase
  * @typedef {object} ComponentDetailShowcaseResponse
  * @property {'component.detail.showcase'} type
  * @property {{component: string; aspectRatio: number; source: string}} data
  */
 
 /**
- * xds --json component <name> --blocks
+ * astryx --json component <name> --blocks
  * @typedef {object} ComponentDetailBlocksResponse
  * @property {'component.detail.blocks'} type
  * @property {{component: string; showcase: BlockEntry | null; examples: BlockEntry[]; related: BlockEntry[]}} data

--- a/packages/cli/api/discover/discover.type.mjs
+++ b/packages/cli/api/discover/discover.type.mjs
@@ -6,16 +6,16 @@
  *
  * Invocation                                      -> type discriminator
  * ------------------------------------------------------------------
- * xds --json discover                            -> discover.list
- * xds --json discover @scope/name                -> discover.detail
- * xds --json discover @scope/name/Component      -> discover.detail.doc
- * xds --json discover <searchterm> (1 match)     -> discover.detail.doc
- * xds --json discover <searchterm> (N matches)   -> discover.search
- * (not found)                                    -> CLIError
+ * astryx --json discover                          -> discover.list
+ * astryx --json discover @scope/name              -> discover.detail
+ * astryx --json discover @scope/name/Component    -> discover.detail.doc
+ * astryx --json discover <searchterm> (1 match)   -> discover.detail.doc
+ * astryx --json discover <searchterm> (N matches) -> discover.search
+ * (not found)                                     -> CLIError
  */
 
 /**
- * xds --json discover
+ * astryx --json discover
  * @typedef {object} DiscoverListResponse
  * @property {'discover.list'} type
  * @property {DiscoverListEntry[]} data
@@ -35,21 +35,21 @@
  */
 
 /**
- * xds --json discover @scope/name
+ * astryx --json discover @scope/name
  * @typedef {object} DiscoverDetailResponse
  * @property {'discover.detail'} type
  * @property {DiscoverListEntry} data
  */
 
 /**
- * xds --json discover @scope/name/Component
+ * astryx --json discover @scope/name/Component
  * @typedef {object} DiscoverDetailDocResponse
  * @property {'discover.detail.doc'} type
  * @property {import('@astryxdesign/cli/authoring').ComponentDoc} data
  */
 
 /**
- * xds --json discover <searchterm> (multiple matches)
+ * astryx --json discover <searchterm> (multiple matches)
  * @typedef {object} DiscoverSearchResponse
  * @property {'discover.search'} type
  * @property {{query: string, matches: DiscoverSearchEntry[]}} data

--- a/packages/cli/api/docs/docs.type.mjs
+++ b/packages/cli/api/docs/docs.type.mjs
@@ -4,16 +4,16 @@
  * @file Colocated types for the `docs` command — source of truth for the docs
  *   command JSON responses. `types/docs.d.ts` re-exports these.
  *
- *   Invocation                          -> type discriminator
+ *   Invocation                           -> type discriminator
  *   ------------------------------------------------------------
- *   xds --json docs                     -> docs.list
- *   xds --json docs <topic>             -> docs.detail
- *   xds --json docs <topic> <section>   -> docs.detail.section
- *   (unknown topic/section)             -> CLIError
+ *   astryx --json docs                   -> docs.list
+ *   astryx --json docs <topic>           -> docs.detail
+ *   astryx --json docs <topic> <section> -> docs.detail.section
+ *   (unknown topic/section)              -> CLIError
  */
 
 /**
- * xds --json docs
+ * astryx --json docs
  * @typedef {object} DocsListResponse
  * @property {'docs.list'} type
  * @property {DocsListEntry[]} data
@@ -30,14 +30,14 @@
  */
 
 /**
- * xds --json docs <topic>
+ * astryx --json docs <topic>
  * @typedef {object} DocsDetailResponse
  * @property {'docs.detail'} type
  * @property {import('@astryxdesign/cli/authoring').ReferenceDoc} data
  */
 
 /**
- * xds --json docs <topic> <section>
+ * astryx --json docs <topic> <section>
  * @typedef {object} DocsDetailSectionResponse
  * @property {'docs.detail.section'} type
  * @property {import('@astryxdesign/cli/authoring').ReferenceSection} data

--- a/packages/cli/api/doctor/doctor.type.mjs
+++ b/packages/cli/api/doctor/doctor.type.mjs
@@ -32,7 +32,7 @@
  */
 
 /**
- * xds --json doctor
+ * astryx --json doctor
  * @typedef {object} DoctorResponse
  * @property {'doctor'} type
  * @property {object} data

--- a/packages/cli/api/hook/hook.type.mjs
+++ b/packages/cli/api/hook/hook.type.mjs
@@ -11,14 +11,14 @@
  *
  * Invocation                                 -> type discriminator
  * ------------------------------------------------------------------
- * xds --json hook                           -> hook.list (data.detail='names')
- * xds --json hook --list                    -> hook.list (data.detail='names')
- * xds --json hook --category State          -> hook.list (filtered)
- * xds --json hook --list --detail compact   -> hook.list (data.detail='compact')
- * xds --json hook --list --detail full      -> hook.list (data.detail='full')
- * xds --json hook useMediaQuery             -> hook.detail
- * xds --json hook useMediaQuery --params    -> hook.detail.params
- * (not found)                               -> CLIError
+ * astryx --json hook                         -> hook.list (data.detail='names')
+ * astryx --json hook --list                  -> hook.list (data.detail='names')
+ * astryx --json hook --category State        -> hook.list (filtered)
+ * astryx --json hook --list --detail compact -> hook.list (data.detail='compact')
+ * astryx --json hook --list --detail full    -> hook.list (data.detail='full')
+ * astryx --json hook useMediaQuery           -> hook.detail
+ * astryx --json hook useMediaQuery --params  -> hook.detail.params
+ * (not found)                                -> CLIError
  */
 
 // Re-export the authored-doc types from core so the hook leaves reference these
@@ -28,7 +28,7 @@
 /** @typedef {import('@astryxdesign/cli/authoring').HookParamDoc} HookParamDoc */
 
 /**
- * xds --json hook [--list] [--category X] [--detail names|compact|full]
+ * astryx --json hook [--list] [--category X] [--detail names|compact|full]
  *
  * The list view emits ONE `hook.list` type across all three detail levels; the
  * depth is carried in `data.detail` and `data.components` holds the grouped map
@@ -56,14 +56,14 @@
  */
 
 /**
- * xds --json hook <name>
+ * astryx --json hook <name>
  * @typedef {object} HookDetailResponse
  * @property {'hook.detail'} type
  * @property {HookDoc} data
  */
 
 /**
- * xds --json hook <name> --params
+ * astryx --json hook <name> --params
  * @typedef {object} HookDetailParamsResponse
  * @property {'hook.detail.params'} type
  * @property {HookParamDoc[]} data

--- a/packages/cli/api/search/search.type.mjs
+++ b/packages/cli/api/search/search.type.mjs
@@ -28,7 +28,7 @@
  */
 
 /**
- * xds --json search <query>
+ * astryx --json search <query>
  * @typedef {object} SearchResponse
  * @property {'search'} type
  * @property {object} data

--- a/packages/cli/api/swizzle/swizzle.type.mjs
+++ b/packages/cli/api/swizzle/swizzle.type.mjs
@@ -7,7 +7,7 @@
  */
 
 /**
- * xds --json swizzle [--list]
+ * astryx --json swizzle [--list]
  *
  * @typedef {object} SwizzleListResponse
  * @property {'swizzle.list'} type
@@ -23,7 +23,7 @@
  */
 
 /**
- * xds --json swizzle <component>
+ * astryx --json swizzle <component>
  *
  * @typedef {object} SwizzleCopyResponse
  * @property {'swizzle.copy'} type

--- a/packages/cli/api/template/template.type.mjs
+++ b/packages/cli/api/template/template.type.mjs
@@ -6,18 +6,18 @@
  *
  * Each template is exactly two files: page.tsx (code) + template.doc.mjs (metadata).
  *
- * Invocation                                 -> type discriminator
+ * Invocation                               -> type discriminator
  * ------------------------------------------------------------------
- * xds --json template [--list]              -> template.list
- * xds --json template <name>               -> template.show
- * xds --json template <name> --skeleton    -> template.skeleton
- * xds --json template <name> [path]        -> template.copy
- * xds --json template --cdn [path]         -> template.cdn
- * (unknown template)                        -> CLIError
+ * astryx --json template [--list]          -> template.list
+ * astryx --json template <name>            -> template.show
+ * astryx --json template <name> --skeleton -> template.skeleton
+ * astryx --json template <name> [path]     -> template.copy
+ * astryx --json template --cdn [path]      -> template.cdn
+ * (unknown template)                       -> CLIError
  */
 
 /**
- * xds --json template [--list]
+ * astryx --json template [--list]
  * @typedef {object} TemplateListResponse
  * @property {'template.list'} type
  * @property {TemplateListEntry[]} data
@@ -37,7 +37,7 @@
  */
 
 /**
- * xds --json template <name>
+ * astryx --json template <name>
  * @typedef {object} TemplateShowResponse
  * @property {'template.show'} type
  * @property {object} data
@@ -49,7 +49,7 @@
  */
 
 /**
- * xds --json template <name> --skeleton
+ * astryx --json template <name> --skeleton
  * @typedef {object} TemplateSkeletonResponse
  * @property {'template.skeleton'} type
  * @property {object} data
@@ -60,7 +60,7 @@
  */
 
 /**
- * xds --json template <name> [path]
+ * astryx --json template <name> [path]
  * @typedef {object} TemplateCopyResponse
  * @property {'template.copy'} type
  * @property {object} data
@@ -71,7 +71,7 @@
  */
 
 /**
- * xds --json template --cdn [path]
+ * astryx --json template --cdn [path]
  * `written: false` with `reason: 'exists'` is a success: the command is safe to
  * re-run, and an edited page is the consumer's file to keep. `version` is the
  * Astryx version every CDN URL in the file was pinned to.

--- a/packages/cli/api/theme/palette/generate/generate.mjs
+++ b/packages/cli/api/theme/palette/generate/generate.mjs
@@ -98,7 +98,7 @@ function serializeCandidate(candidate, outputPath) {
   );
 }
 
-/** @param {PaletteGenerationResult} result @param {string} candidateText @param {string | null} [previewText] */
+/** @param {PaletteGenerationResult} result @param {string} candidateText @param {string | null} [previewText] @returns {import('../../theme.type.mjs').TonalPaletteGenerationReceipt} */
 function receiptFor(result, candidateText, previewText = null) {
   return {
     schemaVersion: 1,

--- a/packages/cli/api/theme/palette/generate/generator.mjs
+++ b/packages/cli/api/theme/palette/generate/generator.mjs
@@ -12,15 +12,17 @@ import {
 
 /** @typedef {import('../../theme.type.mjs').TonalPaletteAnchor} TonalPaletteAnchor */
 /** @typedef {import('../../theme.type.mjs').TonalPaletteGenerationInput} TonalPaletteGenerationInput */
+/** @typedef {import('../../theme.type.mjs').TonalPaletteRampDiagnostics} TonalPaletteRampDiagnostics */
+/** @typedef {import('../../theme.type.mjs').TonalPaletteCoordinationDiagnostics} TonalPaletteCoordinationDiagnostics */
+/** @typedef {import('../../theme.type.mjs').TonalPaletteNormalizedRequest} NormalizedRequest */
 /** @typedef {[number, number, number]} ColorTriple */
 /** @typedef {'light' | 'dark'} PaletteMode */
 /** @typedef {{lightness: number, chroma: number, hue: number}} PolarColor */
 /** @typedef {TonalPaletteAnchor & {color: string, generatedColor: string, deltaE: number}} AnchorResult */
-/** @typedef {{colors: Record<number, string>, diagnostics: Record<string, unknown>}} GeneratedRamp */
+/** @typedef {{colors: Record<number, string>, diagnostics: TonalPaletteRampDiagnostics}} GeneratedRamp */
 /** @typedef {{id: string, name: string, seed: string, kind: 'chromatic' | 'neutral', anchors: TonalPaletteAnchor[]}} NormalizedFamily */
-/** @typedef {{recipe: typeof PALETTE_RECIPE, vibrancy: number, neutralProfile: string, modeStrategy: string, stops: number[], families: NormalizedFamily[]}} NormalizedRequest */
 /** @typedef {{id: string, name: string, seed: string, light?: GeneratedRamp, dark?: GeneratedRamp}} GeneratedFamily */
-/** @typedef {{recipe: typeof PALETTE_RECIPE, status: 'candidate', request: NormalizedRequest, families: GeneratedFamily[], coordination: Record<string, unknown>[], errors: {familyId: string, message: string}[]}} PaletteGenerationResult */
+/** @typedef {{recipe: typeof PALETTE_RECIPE, status: 'candidate', request: NormalizedRequest, families: GeneratedFamily[], coordination: TonalPaletteCoordinationDiagnostics[], errors: {familyId: string, message: string}[]}} PaletteGenerationResult */
 
 export const PALETTE_RECIPE = 'astryx-oklch-v1';
 export const PALETTE_BLACK = '#000000';
@@ -411,6 +413,7 @@ function buildDiagnostics(colors, stops, sourceHue, gamutMappedStops, anchors) {
   let minimumAdjacentDeltaE = Number.POSITIVE_INFINITY;
   let maximumAdjacentDeltaE = 0;
   let maximumHueDrift = 0;
+  /** @type {TonalPaletteRampDiagnostics['hueIdentityRisk']} */
   let hueIdentityRisk = null;
   for (let index = 0; index < stops.length; index++) {
     const stop = stops[index];
@@ -526,6 +529,7 @@ function buildCoordinationDiagnostics(request, families) {
           chroma: hexToOklch(color).C,
         };
       });
+    /** @type {[string, string] | null} */
     let closestFamilies = null;
     let minimumFamilyDeltaE = Number.POSITIVE_INFINITY;
     for (let index = 0; index < samples.length; index++) {

--- a/packages/cli/api/theme/theme.type.mjs
+++ b/packages/cli/api/theme/theme.type.mjs
@@ -6,23 +6,23 @@
  * directly (functions own their types); the public `@astryxdesign/cli/api`
  * surface re-exports them via types/theme.d.ts, so consumers see the same names.
  *
- * Invocation                                 -> type discriminator
+ * Invocation                                  -> type discriminator
  * ------------------------------------------------------------------
- * xds --json theme build <file>             -> theme.build
- * xds --json theme build <file> --check     -> theme.build.check
- * xds --json theme build <a> <b> …          -> theme.build.batch
- * xds --json theme list                     -> theme.list
- * xds --json theme add <slug>               -> theme.add
- * xds --json theme template                 -> theme.template
- * xds --json theme targets [filter]         -> theme.targets
- * xds --json theme palette generate <file>  -> theme.palette.generate
- * (file not found / parse error)            -> CLIError
+ * astryx --json theme build <file>            -> theme.build
+ * astryx --json theme build <file> --check    -> theme.build.check
+ * astryx --json theme build <a> <b> …         -> theme.build.batch
+ * astryx --json theme list                    -> theme.list
+ * astryx --json theme add <slug>              -> theme.add
+ * astryx --json theme template                -> theme.template
+ * astryx --json theme targets [filter]        -> theme.targets
+ * astryx --json theme palette generate <file> -> theme.palette.generate
+ * (file not found / parse error)              -> CLIError
  *
  * @position api — colocated typedefs for api/theme/{theme,build,add,list,template,targets,_adapter}
  */
 
 /**
- * xds --json theme build <file>
+ * astryx --json theme build <file>
  * @typedef {object} ThemeBuildResponse
  * @property {'theme.build'} type
  * `warnings` are defects the theme author should fix. `notices` are advisories
@@ -32,14 +32,14 @@
  */
 
 /**
- * xds --json theme build <file> --check
+ * astryx --json theme build <file> --check
  * @typedef {object} ThemeBuildCheckResponse
  * @property {'theme.build.check'} type
  * @property {{name: string, upToDate: boolean, stale: Array<{path: string, reason: 'missing' | 'outdated'}>, checked: string[]}} data
  */
 
 /**
- * xds --json theme build <a> <b> … — several themes in one invocation. Each
+ * astryx --json theme build <a> <b> … — several themes in one invocation. Each
  * result carries the file as it was passed and the receipt a single-file build
  * would have returned (null when that theme produced no CSS). One file still
  * returns the bare theme.build / theme.build.check envelope.
@@ -58,21 +58,21 @@
  */
 
 /**
- * xds --json theme list
+ * astryx --json theme list
  * @typedef {object} ThemeListResponse
  * @property {'theme.list'} type
  * @property {ThemeListEntry[]} data
  */
 
 /**
- * xds --json theme add <slug>
+ * astryx --json theme add <slug>
  * @typedef {object} ThemeAddResponse
  * @property {'theme.add'} type
  * @property {{slug: string, displayName: string, maintained: boolean, outputDir: string, entry: string, exportName: string, files: string[]}} data
  */
 
 /**
- * xds --json theme template
+ * astryx --json theme template
  * `written: false` with `reason: 'exists'` is a success: the command is safe to
  * re-run, and an edited template is the consumer's file to keep.
  * @typedef {object} ThemeTemplateResponse
@@ -93,19 +93,18 @@
  */
 
 /**
- * xds --json theme targets [filter]
+ * astryx --json theme targets [filter]
  * @typedef {object} ThemeTargetsResponse
  * @property {'theme.targets'} type
  * @property {{filter: string | null, componentCount: number, targets: ThemeTargetEntry[]}} data
  */
 
 /**
- * A generated palette candidate. The palette is still subject to author review
- * and is not connected to runtime theme values.
+ * A color an author pins at one stop of one mode, constraining generation.
  * @typedef {object} TonalPaletteAnchor
  * @property {'light' | 'dark'} mode Mode containing the anchored stop.
  * @property {number} stop Existing requested stop where the anchor applies.
- * @property {string} color
+ * @property {string} color Six-digit sRGB hex the stop is pulled toward.
  * @property {'exact' | 'bounded' | 'flexible'} policy `exact` preserves the
  * chosen color at that stop; `bounded` permits adjustment within `maxDeltaE`;
  * `flexible` treats the color as guidance and blends toward it.
@@ -114,12 +113,15 @@
  */
 
 /**
+ * One requested family: a seed color and the constraints applied to its ramp.
  * @typedef {object} TonalPaletteFamilyInput
- * @property {string} id
- * @property {string} seed
- * @property {string} [name]
- * @property {'chromatic' | 'neutral'} [kind]
- * @property {TonalPaletteAnchor[]} [anchors]
+ * @property {string} id Lower-kebab-case key for the family in the generated
+ * palette. `black` and `white` are reserved for the standalone values.
+ * @property {string} seed Six-digit sRGB hex the ramp is generated from.
+ * @property {string} [name] Display name for review artifacts; defaults to `id`.
+ * @property {'chromatic' | 'neutral'} [kind] `neutral` derives the ramp from
+ * `neutralProfile` instead of the seed hue; defaults to `chromatic`.
+ * @property {TonalPaletteAnchor[]} [anchors] Colors pinned at specific stops.
  */
 
 /**
@@ -128,6 +130,9 @@
  * @property {number} [vibrancy] Chroma control from 0 (most muted) through 50
  * (default) to 100 (most vivid).
  * @property {'neutral-v1' | 'warm-v1' | 'cool-v1' | 'custom'} [neutralProfile]
+ * Hue treatment for `neutral` families: `neutral-v1` is fully achromatic,
+ * `warm-v1` and `cool-v1` add a slight tint, and `custom` derives the hue from
+ * the family's own seed. Defaults to `neutral-v1`.
  * @property {'light-only' | 'dark-only' | 'light-and-dark'} [modeStrategy]
  * @property {number[]} [stops] Ordered stops shared by every requested family;
  * defaults to 0 through 100 in increments of 5. Decimal stops are supported,
@@ -135,6 +140,8 @@
  */
 
 /**
+ * A generated palette candidate. The palette is still subject to author review
+ * and is not connected to runtime theme values.
  * @typedef {object} TonalPaletteCandidate
  * @property {1} schemaVersion
  * @property {'candidate'} status
@@ -145,10 +152,67 @@
  */
 
 /**
- * xds --json theme palette generate <config>
+ * Per-ramp evidence recorded for one family in one mode.
+ * @typedef {object} TonalPaletteRampDiagnostics
+ * @property {boolean} monotonic Whether luminance rises across every stop.
+ * @property {number} minimumAdjacentDeltaE Smallest perceptual gap between
+ * neighboring stops; a small value means two stops read as one color.
+ * @property {number} maximumAdjacentDeltaE Largest gap between neighboring stops.
+ * @property {number} maximumHueDrift Largest hue distance, in degrees, between
+ * a stop and the family's reference hue.
+ * @property {'blue-to-purple' | 'yellow-to-brown' | null} hueIdentityRisk Named
+ * drift the ramp is at risk of, or `null`.
+ * @property {number[]} gamutMappedStops Stops whose ideal color fell outside
+ * sRGB and was mapped back into it.
+ * @property {Array<TonalPaletteAnchor & {generatedColor: string, deltaE: number}>} anchors
+ * Each anchor with the color generated before correction and the perceptual
+ * distance the correction moved.
+ */
+
+/**
+ * Cross-family evidence for one mode, sampled at the stop nearest 50.
+ * @typedef {object} TonalPaletteCoordinationDiagnostics
+ * @property {'light' | 'dark'} mode Mode these samples come from.
+ * @property {number} stop Sampled stop.
+ * @property {[string, string] | null} closestFamilies The two chromatic
+ * families hardest to tell apart, or `null` with fewer than two.
+ * @property {number | null} minimumFamilyDeltaE Perceptual distance between them.
+ * @property {string | null} strongestFamily Most saturated family at this stop.
+ * @property {string | null} weakestFamily Least saturated family at this stop.
+ * @property {number | null} chromaRatio Strongest chroma over weakest; a large
+ * ratio means the families are unbalanced.
+ */
+
+/**
+ * The request as the generator resolved it, with every default filled in.
+ * @typedef {object} TonalPaletteNormalizedRequest
+ * @property {'astryx-oklch-v1'} recipe
+ * @property {number} vibrancy
+ * @property {'neutral-v1' | 'warm-v1' | 'cool-v1' | 'custom'} neutralProfile
+ * @property {'light-only' | 'dark-only' | 'light-and-dark'} modeStrategy
+ * @property {number[]} stops
+ * @property {Array<{id: string, name: string, seed: string, kind: 'chromatic' | 'neutral', anchors: TonalPaletteAnchor[]}>} families
+ */
+
+/**
+ * The detached receipt written beside a candidate. It records what was asked
+ * for and what the generator observed, so a candidate can be traced back to
+ * its request without rerunning generation.
+ * @typedef {object} TonalPaletteGenerationReceipt
+ * @property {1} schemaVersion
+ * @property {'astryx-oklch-v1'} recipe Recipe that produced the candidate.
+ * @property {string} candidateSha256 SHA-256 over the candidate bytes as written.
+ * @property {{version: string, sha256: string}} [preview] Present only when a
+ * preview was written.
+ * @property {TonalPaletteNormalizedRequest} request
+ * @property {{families: Record<string, {light?: TonalPaletteRampDiagnostics, dark?: TonalPaletteRampDiagnostics}>, coordination: TonalPaletteCoordinationDiagnostics[]}} diagnostics
+ */
+
+/**
+ * astryx --json theme palette generate <config>
  * @typedef {object} ThemePaletteGenerateResponse
  * @property {'theme.palette.generate'} type
- * @property {{recipe: 'astryx-oklch-v1', status: 'candidate', familyCount: number, stopCount: number, modes: string[], output: string | null, receipt: string | null, preview: string | null, written: boolean, reason: 'exists' | null, candidate: TonalPaletteCandidate, generationReceipt: Record<string, unknown>}} data
+ * @property {{recipe: 'astryx-oklch-v1', status: 'candidate', familyCount: number, stopCount: number, modes: string[], output: string | null, receipt: string | null, preview: string | null, written: boolean, reason: 'exists' | null, candidate: TonalPaletteCandidate, generationReceipt: TonalPaletteGenerationReceipt}} data
  */
 
 // Make this a module so the @typedefs above are importable as types via

--- a/packages/cli/api/upgrade/upgrade.type.mjs
+++ b/packages/cli/api/upgrade/upgrade.type.mjs
@@ -4,16 +4,16 @@
  * @file Colocated types for the `upgrade` command — source of truth for the
  * upgrade command JSON responses. Re-exported by `types/upgrade.d.ts`.
  *
- * Invocation                                 -> type discriminator
+ * Invocation                                   -> type discriminator
  * ------------------------------------------------------------------
- * xds --json upgrade --list                 -> upgrade.list
- * xds --json upgrade [--apply]              -> upgrade.run
- * xds --json upgrade (status short-circuit) -> upgrade.status
- * (version detection failure)               -> CLIError
+ * astryx --json upgrade --list                 -> upgrade.list
+ * astryx --json upgrade [--apply]              -> upgrade.run
+ * astryx --json upgrade (status short-circuit) -> upgrade.status
+ * (version detection failure)                  -> CLIError
  */
 
 /**
- * xds --json upgrade --list
+ * astryx --json upgrade --list
  * @typedef {object} UpgradeListResponse
  * @property {'upgrade.list'} type
  * @property {UpgradeListEntry[]} data
@@ -48,7 +48,7 @@
  */
 
 /**
- * xds --json upgrade [--apply]
+ * astryx --json upgrade [--apply]
  * @typedef {object} UpgradeRunResponse
  * @property {'upgrade.run'} type
  * @property {object} data
@@ -64,7 +64,7 @@
  */
 
 /**
- * xds --json upgrade — short-circuit status results.
+ * astryx --json upgrade — short-circuit status results.
  *
  * - `up_to_date`: `--from` is >= installed target and `--force` was not passed.
  * - `no_codemods`: no codemods (core or integration) apply to the range.

--- a/packages/cli/assets/docs/styling-libraries.doc.mjs
+++ b/packages/cli/assets/docs/styling-libraries.doc.mjs
@@ -351,7 +351,7 @@ tokens: {
     },
   },
   shortcuts: {
-    'xds-card': 'bg-surface text-primary border border-border rounded-lg p-4',
+    'astryx-card': 'bg-surface text-primary border border-border rounded-lg p-4',
   },
 });`,
         },

--- a/packages/cli/assets/docs/working-with-ai.doc.mjs
+++ b/packages/cli/assets/docs/working-with-ai.doc.mjs
@@ -181,7 +181,7 @@ astryx docs tokens --dense`,
           label: 'MCP config (same for all tools)',
           code: `{
   "mcpServers": {
-    "xds": {
+    "astryx": {
       "type": "url",
       "url": "https://astryx.atmeta.com/mcp"
     }


### PR DESCRIPTION
Stacked on #5992 — this is docs and types only, no behavior change. Ruby, take or leave any of it; it is meant to save you a round, not add one.

### What is wrong today

**`TonalPaletteCandidate` has no description, and `TonalPaletteAnchor` has the wrong one.** The text "A generated palette candidate. The palette is still subject to author review…" sits above `TonalPaletteAnchor`. It reads as correct in the source and lands wrong in the emitted `.d.ts`, where the anchor type is described as a palette candidate and the candidate has nothing.

**`TonalPaletteFamilyInput` has no property descriptions at all.** `id`, `seed`, `name`, `kind` are bare. It is the type an author writes by hand, so it is the one that most needs them — `id` in particular has a rule (lower-kebab-case, `black`/`white` reserved) that only appears as a thrown error.

**`neutralProfile` lists four values and explains none.** `custom` deriving hue from the family seed is not guessable from the name.

**`generationReceipt` is `Record<string, unknown>`.** The receipt is the artifact that ties a candidate back to its request, and its shape is entirely opaque to a consumer.

**79 lines across 11 files tell readers to run `xds --json …`.** The binary is `astryx`; `xds` has never been a command.

### What this does

Moves the candidate description to the candidate and gives the anchor its own. Describes every property on `TonalPaletteFamilyInput` and all four `neutralProfile` values.

Types the receipt: `TonalPaletteGenerationReceipt`, with `TonalPaletteRampDiagnostics`, `TonalPaletteCoordinationDiagnostics`, and `TonalPaletteNormalizedRequest`. The generator's internal typedefs now point at those same types instead of `Record<string, unknown>`, so **the compiler holds the documentation true**. I wrote the receipt type by hand first and it was wrong twice — `preview.version` is a string, not a number, and `request` is the normalized request with a `recipe` key the input type does not have. Both only surfaced by running the generator and diffing real output against the type, which is the argument for wiring it to the compiler rather than leaving prose.

Two local annotations came with that (`hueIdentityRisk`, `closestFamilies`) so TS keeps the narrow types rather than widening to `string | null` and `string[]`. Those unions are the useful part of the documentation.

Renames `xds` to `astryx` in the API type docs and realigns the invocation tables, whose `->` columns the longer name had knocked out. **Codemods and changelogs that reference `xds` are untouched** — `migrate-xds-module-specifiers`, `drop-xds-prefix-imports` and friends exist to migrate that exact name, so renaming inside them would break them. Two doc examples also carried it: the MCP server key users paste into Cursor/Claude Desktop, and an UnoCSS shortcut named `xds-card`.

### Verification

- `tsc --project tsconfig.api-dts.json` — clean. It failed three times while I wrote this and each failure was a real inaccuracy in my types, not noise.
- `pnpm check:repo` clean, `pnpm lint:strict` 0 errors (90 pre-existing warnings).
- 981 tests pass across the palette, foundation, and theme-neutral suites.
- **All four AST-008 canonical fixtures byte-identical** (3571 / 286 / 233 / 869 bytes, hashes unchanged), so no palette output moves.
- Emitted the `.d.ts` and confirmed the descriptions land on the right types and `Record<string, unknown>` is gone from it.

### Not in scope

The decimal-stop ordering bug from the review on #5992 is not fixed here — that is a behavior change and belongs in yours. The doctor check, the `assets/docs` palette topic, and a palette reader are all still absent.
