### PR TITLE
fix(CheckboxListItem): name the checkbox from a rich label's visible text

### DIFF
--- a/.changeset/checkbox-list-item-rich-label-name.md
+++ b/.changeset/checkbox-list-item-rich-label-name.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxListItem: a ReactNode `label` now names the checkbox from its visible text through `aria-labelledby`, the way RadioListItem already does, instead of falling back to the generic name "Checkbox". `aria-label` still replaces that name when the visible text is absent or reads badly; the dev-time warning that asked for it is gone.
+
+@Kyujenius

--- a/.changeset/checkbox-list-item-rich-label-name.md
+++ b/.changeset/checkbox-list-item-rich-label-name.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] CheckboxListItem: a ReactNode `label` now names the checkbox from its visible text through `aria-labelledby`, the way RadioListItem already does, instead of falling back to the generic name "Checkbox". `aria-label` still replaces that name when the visible text is absent or reads badly; the dev-time warning that asked for it is gone.
+[fix] CheckboxListItem: a ReactNode `label` now names the checkbox from its visible text through `aria-labelledby`, the way RadioListItem already does, instead of falling back to the generic name "Checkbox". `aria-label` still replaces that name; a rich label with no text at all needs it, as it does for RadioListItem. The dev-time warning that asked for `aria-label` on every rich label is gone.
 
 @Kyujenius

--- a/apps/storybook/stories/CheckboxA11y.stories.tsx
+++ b/apps/storybook/stories/CheckboxA11y.stories.tsx
@@ -59,8 +59,8 @@ export const ListItemUnchecked = storyFor('list-item-unchecked');
 export const ListItemChecked = storyFor('list-item-checked');
 export const ListItemMixed = storyFor('list-item-mixed');
 export const ListItemDescribed = storyFor('list-item-described');
-export const ListItemRichLabelMissingName = storyFor(
-  'list-item-rich-label-missing-name',
+export const ListItemRichLabelVisibleName = storyFor(
+  'list-item-rich-label-visible-name',
 );
 export const ListItemDisabled = storyFor('list-item-disabled');
 export const ListItemLoading = storyFor('list-item-loading');

--- a/apps/storybook/stories/CheckboxList.stories.tsx
+++ b/apps/storybook/stories/CheckboxList.stories.tsx
@@ -109,7 +109,6 @@ export const RichDescriptions: Story = {
               Analytics <Link href="#analytics-details">details</Link>
             </>
           }
-          aria-label="Analytics"
           value="analytics"
           description={
             <>

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -377,7 +377,7 @@
   },
   "@astryx.checkboxList.item.checkbox": {
     "defaultMessage": "Checkbox",
-    "description": "Screen-reader-only last-ditch fallback name for a checkbox inside a list item when no label is provided. Should almost never render — consumers should supply a real label."
+    "description": "Screen-reader-only placeholder text of the hidden label for a checkbox inside a list item whose visible label is rich content. The checkbox normally takes its name from that visible content via aria-labelledby, which outranks this text; it becomes the name only when the rich label has no text and no aria-label."
   },
   "@astryx.commandPalette.emptySearch": {
     "defaultMessage": "No results",

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -377,7 +377,7 @@
   },
   "@astryx.checkboxList.item.checkbox": {
     "defaultMessage": "Checkbox",
-    "description": "Screen-reader-only placeholder text of the hidden label for a checkbox inside a list item whose visible label is rich content. The checkbox normally takes its name from that visible content via aria-labelledby, which outranks this text; it becomes the name only when the rich label has no text and no aria-label."
+    "description": "Localized hidden text used internally when a rich visible label names the checkbox through aria-labelledby. It does not become the computed name; callers must provide aria-label when rich content has no text."
   },
   "@astryx.commandPalette.emptySearch": {
     "defaultMessage": "No results",

--- a/packages/core/src/CheckboxInput/__tests__/Checkbox.a11y.known-failures.ts
+++ b/packages/core/src/CheckboxInput/__tests__/Checkbox.a11y.known-failures.ts
@@ -39,19 +39,6 @@ export const CHECKBOX_KNOWN_FAILURES: ReadonlyArray<KnownFailure> = [
       'This is the accessibility-tree face of the missing relationship recorded above. It is separate because each known failure names exactly one expectation and layer.',
   },
   {
-    expectation: 'checkbox.name.matches-visible-label',
-    binding: 'CheckboxListItem',
-    state: 'list-item-rich-label-missing-name',
-    evidenceLayer: 'accessibility-tree',
-    failureEquals:
-      'the visible label reads "Pro plan" but the browser computes the accessible name as "Checkbox", so speaking the visible label does not reach this control',
-    standardsReference: 'WCAG 2.2 2.5.3 Label in Name (Level A)',
-    userImpact:
-      'The browser exposes every rich-label item without an aria-label under the generic name "Checkbox", so speech input cannot address the item by the visible words.',
-    reason:
-      'The public API permits a ReactNode label without an equivalent plain-text name. The migration records that supported branch without changing the component API.',
-  },
-  {
     expectation: 'checkbox.readonly.declared',
     binding: 'CheckboxInput',
     state: 'input-handlerless-read-only',

--- a/packages/core/src/CheckboxInput/__tests__/Checkbox.a11y.renders.tsx
+++ b/packages/core/src/CheckboxInput/__tests__/Checkbox.a11y.renders.tsx
@@ -281,7 +281,7 @@ export const CHECKBOX_STATE_RENDERS: Record<
       description="Receive notifications by email"
     />
   ),
-  'list-item-rich-label-missing-name': () => (
+  'list-item-rich-label-visible-name': () => (
     <StandaloneListItem initial={false} label="Pro plan" omitAriaLabel />
   ),
   'list-item-disabled': () => (

--- a/packages/core/src/CheckboxInput/__tests__/Checkbox.a11y.states.ts
+++ b/packages/core/src/CheckboxInput/__tests__/Checkbox.a11y.states.ts
@@ -260,14 +260,13 @@ export const CHECKBOX_BINDING_STATES = [
     ],
   },
   {
-    id: 'list-item-rich-label-missing-name',
+    id: 'list-item-rich-label-visible-name',
     binding: 'CheckboxListItem',
-    summary:
-      'a rich-label list item with no equivalent plain-text accessible name',
+    summary: 'a rich-label list item named from its visible text',
     facts: facts(),
     visibleLabel: 'Pro plan',
     visibleLabelSelector: '[data-a11y-visible-label]',
-    storyId: 'a11y-checkbox-pattern--list-item-rich-label-missing-name',
+    storyId: 'a11y-checkbox-pattern--list-item-rich-label-visible-name',
   },
   {
     id: 'list-item-disabled',

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -593,7 +593,7 @@ describe('CheckboxListItem accessible name', () => {
     ).toBeInTheDocument();
   });
 
-  it('names the checkbox from aria-label when the label is a ReactNode', () => {
+  it('names the checkbox from a conforming aria-label when the label is a ReactNode', () => {
     render(
       <CheckboxList label="Plans" value={[]} onChange={() => {}}>
         <CheckboxListItem
@@ -602,13 +602,13 @@ describe('CheckboxListItem accessible name', () => {
               Pro plan <em>(recommended)</em>
             </span>
           }
-          aria-label="Pro plan"
+          aria-label="Pro plan (recommended) option"
           value="pro"
         />
       </CheckboxList>,
     );
     expect(
-      screen.getByRole('checkbox', {name: 'Pro plan'}),
+      screen.getByRole('checkbox', {name: 'Pro plan (recommended) option'}),
     ).toBeInTheDocument();
   });
 

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -640,17 +640,17 @@ describe('CheckboxListItem accessible name', () => {
     );
   });
 
-  it('does not reference the visible label when aria-label is given', () => {
+  it('does not reference the visible label when a conforming aria-label is given', () => {
     render(
       <CheckboxList label="Plans" value={[]} onChange={() => {}}>
         <CheckboxListItem
           label={<span>Pro plan</span>}
-          aria-label="Pro"
+          aria-label="Pro plan option"
           value="pro"
         />
       </CheckboxList>,
     );
-    const checkbox = screen.getByRole('checkbox', {name: 'Pro'});
+    const checkbox = screen.getByRole('checkbox', {name: 'Pro plan option'});
     expect(checkbox).not.toHaveAttribute('aria-labelledby');
   });
 });

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -786,7 +786,7 @@ describe('CheckboxListItem ARIA props', () => {
         <CheckboxListItem
           label="Custom aria"
           aria-describedby="help-text"
-          aria-label="custom label"
+          aria-label="Custom aria label"
         />
       </List>,
     );
@@ -796,7 +796,7 @@ describe('CheckboxListItem ARIA props', () => {
     // ...but aria-label names the checkbox control, not the row.
     expect(item).not.toHaveAttribute('aria-label');
     expect(
-      screen.getByRole('checkbox', {name: 'custom label'}),
+      screen.getByRole('checkbox', {name: 'Custom aria label'}),
     ).toBeInTheDocument();
   });
 

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -614,7 +614,7 @@ describe('CheckboxListItem accessible name', () => {
     ).toBeInTheDocument();
   });
 
-  it('names the checkbox from the visible text of a ReactNode label', () => {
+  it('links a ReactNode label to the checkbox control', () => {
     render(
       <CheckboxList label="Plans" value={[]} onChange={() => {}}>
         <CheckboxListItem
@@ -627,14 +627,7 @@ describe('CheckboxListItem accessible name', () => {
         />
       </CheckboxList>,
     );
-    const checkbox = screen.getByRole('checkbox', {
-      name: 'Pro plan (recommended)',
-    });
-    expect(checkbox).toBeInTheDocument();
-    expect(
-      screen.queryByRole('checkbox', {name: 'Checkbox'}),
-    ).not.toBeInTheDocument();
-    // The name comes from the visible label element itself.
+    const checkbox = screen.getByRole('checkbox');
     const labelledBy = checkbox.getAttribute('aria-labelledby');
     expect(labelledBy).toBeTruthy();
     expect(document.getElementById(labelledBy!)).toHaveTextContent(

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -594,7 +594,6 @@ describe('CheckboxListItem accessible name', () => {
   });
 
   it('names the checkbox from aria-label when the label is a ReactNode', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(
       <CheckboxList label="Plans" value={[]} onChange={() => {}}>
         <CheckboxListItem
@@ -611,9 +610,6 @@ describe('CheckboxListItem accessible name', () => {
     expect(
       screen.getByRole('checkbox', {name: 'Pro plan'}),
     ).toBeInTheDocument();
-    // A named checkbox needs no dev guidance.
-    expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   it('names the checkbox from the visible text of a ReactNode label', () => {

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -616,33 +616,46 @@ describe('CheckboxListItem accessible name', () => {
     warnSpy.mockRestore();
   });
 
-  it('warns once when a ReactNode label has no aria-label', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const richLabel = (
-      <span>
-        Pro plan <em>(recommended)</em>
-      </span>
-    );
-    const {rerender} = render(
+  it('names the checkbox from the visible text of a ReactNode label', () => {
+    render(
       <CheckboxList label="Plans" value={[]} onChange={() => {}}>
-        <CheckboxListItem label={richLabel} value="pro" />
+        <CheckboxListItem
+          label={
+            <span>
+              Pro plan <em>(recommended)</em>
+            </span>
+          }
+          value="pro"
+        />
       </CheckboxList>,
     );
-    // Falls back to the generic name, and tells the developer how to fix it.
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Pro plan (recommended)',
+    });
+    expect(checkbox).toBeInTheDocument();
     expect(
-      screen.getByRole('checkbox', {name: 'Checkbox'}),
-    ).toBeInTheDocument();
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('aria-label');
+      screen.queryByRole('checkbox', {name: 'Checkbox'}),
+    ).not.toBeInTheDocument();
+    // The name comes from the visible label element itself.
+    const labelledBy = checkbox.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)).toHaveTextContent(
+      'Pro plan (recommended)',
+    );
+  });
 
-    // Warn once per item instance — re-renders don't repeat it.
-    rerender(
-      <CheckboxList label="Plans" value={['pro']} onChange={() => {}}>
-        <CheckboxListItem label={richLabel} value="pro" />
+  it('does not reference the visible label when aria-label is given', () => {
+    render(
+      <CheckboxList label="Plans" value={[]} onChange={() => {}}>
+        <CheckboxListItem
+          label={<span>Pro plan</span>}
+          aria-label="Pro"
+          value="pro"
+        />
       </CheckboxList>,
     );
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    warnSpy.mockRestore();
+    const checkbox = screen.getByRole('checkbox', {name: 'Pro'});
+    expect(checkbox).not.toHaveAttribute('aria-labelledby');
   });
 });
 

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -369,12 +369,14 @@ describe('CheckboxList', () => {
               Pro plan <a href="#pricing">pricing details</a>
             </>
           }
-          aria-label="Pro plan"
+          aria-label="Pro plan pricing details"
           value="pro"
         />
       </CheckboxList>,
     );
-    const checkbox = screen.getByRole('checkbox', {name: 'Pro plan'});
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Pro plan pricing details',
+    });
     const link = screen.getByRole('link', {name: 'pricing details'});
     await user.tab();
     expect(checkbox).toHaveFocus();

--- a/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
@@ -14,14 +14,14 @@ export const docs = {
       name: 'label',
       type: 'ReactNode',
       description:
-        'Primary text label for the item. Rich labels may contain links or buttons, which keep their own behavior without toggling the item. A ReactNode label names the checkbox from its visible text; pass aria-label when that text is absent or reads badly.',
+        'Primary text label for the item. Rich labels may contain links or buttons, which keep their own behavior without toggling the item. A ReactNode label names the checkbox from its visible text; pass aria-label only when that text is absent, or include all visible label words in the override.',
       required: true,
     },
     {
       name: 'aria-label',
       type: 'string',
       description:
-        'Plain-text accessible name for the checkbox, replacing the one derived from label. Applied to the checkbox control. Use it when a rich label\'s visible text is absent or reads badly.',
+        'Plain-text accessible name for the checkbox, replacing the one derived from label. Applied to the checkbox control. Use it when a rich label has no visible text; otherwise the value must retain every visible label word.',
     },
     {
       name: 'value',
@@ -100,14 +100,14 @@ export const docsZh = {
       name: 'label',
       type: 'ReactNode',
       description:
-        '选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会切换该选项。ReactNode 标签会以其可见文本为复选框命名；当该文本缺失或不适合朗读时再传入 aria-label。',
+        '选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会切换该选项。ReactNode 标签会以其可见文本为复选框命名；仅当可见文本缺失时使用 aria-label，否则覆盖值必须保留全部可见文字。',
       required: true,
     },
     {
       name: 'aria-label',
       type: 'string',
       description:
-        '复选框的纯文本无障碍名称，会替换由 label 推导出的名称。当富标签的可见文本缺失或不适合朗读时使用。',
+        '复选框的纯文本无障碍名称，会替换由 label 推导出的名称。仅当富标签没有可见文本时才完全替代；否则必须保留全部可见文字。',
     },
     {
       name: 'value',

--- a/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
@@ -14,14 +14,14 @@ export const docs = {
       name: 'label',
       type: 'ReactNode',
       description:
-        'Primary text label for the item. Rich labels may contain links or buttons, which keep their own behavior without toggling the item. Pair a ReactNode label with aria-label so screen readers get a concise checkbox name.',
+        'Primary text label for the item. Rich labels may contain links or buttons, which keep their own behavior without toggling the item. A ReactNode label names the checkbox from its visible text; pass aria-label when that text is absent or reads badly.',
       required: true,
     },
     {
       name: 'aria-label',
       type: 'string',
       description:
-        'Plain-text accessible name for the checkbox when label is a ReactNode. Applied to the checkbox control. Without it, rich-label items all announce as the generic "Checkbox" to screen readers.',
+        'Plain-text accessible name for the checkbox, replacing the one derived from label. Applied to the checkbox control. Use it when a rich label\'s visible text is absent or reads badly.',
     },
     {
       name: 'value',
@@ -100,14 +100,14 @@ export const docsZh = {
       name: 'label',
       type: 'ReactNode',
       description:
-        '选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会切换该选项。ReactNode 标签应同时传入 aria-label，为屏幕阅读器提供简洁的复选框名称。',
+        '选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会切换该选项。ReactNode 标签会以其可见文本为复选框命名；当该文本缺失或不适合朗读时再传入 aria-label。',
       required: true,
     },
     {
       name: 'aria-label',
       type: 'string',
       description:
-        '当 label 是 ReactNode 时，复选框的纯文本无障碍名称。缺少它时，富标签选项都会向屏幕阅读器播报为通用的 "Checkbox"。',
+        '复选框的纯文本无障碍名称，会替换由 label 推导出的名称。当富标签的可见文本缺失或不适合朗读时使用。',
     },
     {
       name: 'value',
@@ -160,7 +160,7 @@ export const docsDense = {
     label:
       'Primary label. String or ReactNode; nested controls keep their behavior.',
     'aria-label':
-      'Plain-text checkbox name when label is a ReactNode. Without it, rich-label items all announce as "Checkbox".',
+      'Plain-text checkbox name replacing the one derived from label. Use when a rich label\'s visible text is absent or reads badly.',
     value: 'Identity key (required inside CheckboxList).',
     description: 'Secondary content below label. String or ReactNode.',
     endContent: 'Content rendered after label area.',

--- a/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
@@ -82,7 +82,7 @@ export const docs = {
       label: 'Rich label with an overriding aria-label',
       code: `<CheckboxListItem
   label={<span>Pro plan <Badge label="Recommended" /></span>}
-  aria-label="Pro plan"
+  aria-label="Pro plan Recommended option"
   value="pro"
 />`,
     },

--- a/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
@@ -79,7 +79,7 @@ export const docs = {
   ],
   examples: [
     {
-      label: 'Rich label with an accessible name',
+      label: 'Rich label with an overriding aria-label',
       code: `<CheckboxListItem
   label={<span>Pro plan <Badge label="Recommended" /></span>}
   aria-label="Pro plan"
@@ -158,7 +158,7 @@ export const docsDense = {
     'Individual checkbox item w/ label, description, end content slot.',
   propDescriptions: {
     label:
-      'Primary label. String or ReactNode; nested controls keep their behavior.',
+      'Primary label. String or ReactNode; nested controls keep their behavior. A ReactNode names the checkbox from its visible text.',
     'aria-label':
       'Plain-text checkbox name replacing the one derived from label. Use when a rich label\'s visible text is absent or reads badly.',
     value: 'Identity key (required inside CheckboxList).',

--- a/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxListItem.doc.mjs
@@ -160,7 +160,7 @@ export const docsDense = {
     label:
       'Primary label. String or ReactNode; nested controls keep their behavior. A ReactNode names the checkbox from its visible text.',
     'aria-label':
-      'Plain-text checkbox name replacing the one derived from label. Use when a rich label\'s visible text is absent or reads badly.',
+      'Plain-text checkbox name replacing the one derived from label. Use when visible text is absent; otherwise retain every visible label word.',
     value: 'Identity key (required inside CheckboxList).',
     description: 'Secondary content below label. String or ReactNode.',
     endContent: 'Content rendered after label area.',

--- a/packages/core/src/CheckboxList/CheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/CheckboxListItem.tsx
@@ -16,12 +16,11 @@
  * - /packages/cli/assets/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {use, useRef, type ReactNode} from 'react';
+import {use, useRef, type ReactNode, useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
-import {useDevWarning} from '../hooks/useDevWarning';
 import {CheckboxInput} from '../CheckboxInput/CheckboxInput';
 import {ListItem} from '../List/ListItem';
 import {ListContext} from '../List/ListContext';
@@ -54,13 +53,14 @@ export interface CheckboxListItemProps extends BaseProps<HTMLLIElement> {
    */
   label: ReactNode;
   /**
-   * Plain-text accessible name for the checkbox when `label` is a ReactNode.
+   * Plain-text accessible name for the checkbox, replacing the one derived
+   * from `label`.
    *
-   * A string `label` names the checkbox automatically. A rich (ReactNode)
-   * `label` cannot, so pass a concise string equivalent via the standard
-   * `aria-label` — otherwise the checkbox falls back to the generic name
-   * "Checkbox" and every rich-label item in a list announces identically to
-   * screen readers. Applied to the checkbox control, not the row.
+   * A string `label` names the checkbox directly, and a rich (ReactNode)
+   * `label` names it from its visible text through `aria-labelledby`. Pass
+   * `aria-label` when that flattened text is absent or reads badly — it
+   * replaces the derived name rather than adding to it. Applied to the
+   * checkbox control, not the row.
    *
    * @example
    * ```
@@ -164,24 +164,17 @@ export function CheckboxListItem({
     );
   }
 
-  // Accessible name for the (visually hidden) checkbox label. A string
-  // `label` names it directly; a rich label needs `aria-label`.
+  // Accessible name for the checkbox. A string `label` (or an explicit
+  // `aria-label`) becomes the text of its visually hidden label. A rich
+  // label instead names the checkbox from the visible label element through
+  // `aria-labelledby`, the same route RadioListItem takes; the hidden label
+  // then only carries the generic word, which `aria-labelledby` outranks.
+  const isRichLabel = typeof label !== 'string';
+  const labelID = useId();
+  const namesFromVisibleLabel = isRichLabel && ariaLabel == null;
   const checkboxLabel =
     ariaLabel ??
-    (typeof label === 'string'
-      ? label
-      : t('@astryx.checkboxList.item.checkbox'));
-
-  // Dev-time guardrail: a rich label without `aria-label` leaves the
-  // checkbox with the generic name "Checkbox".
-  useDevWarning(
-    'CheckboxListItem',
-    '`label` is a ReactNode, so the checkbox falls ' +
-      'back to the generic accessible name "Checkbox". Pass ' +
-      '`aria-label` with a concise string equivalent of the visible ' +
-      'label so screen readers can tell items apart.',
-    typeof label !== 'string' && ariaLabel == null,
-  );
+    (isRichLabel ? t('@astryx.checkboxList.item.checkbox') : label);
 
   // Density from list context for checkbox sizing
   const listCtx = use(ListContext);
@@ -249,7 +242,7 @@ export function CheckboxListItem({
     <ListItem
       {...restProps}
       ref={ref}
-      label={label}
+      label={isRichLabel ? <span id={labelID}>{label}</span> : label}
       description={description}
       endContent={endContent}
       isDisabled={effectiveDisabled}
@@ -275,6 +268,7 @@ export function CheckboxListItem({
         <CheckboxInput
           ref={checkboxRef}
           label={checkboxLabel}
+          aria-labelledby={namesFromVisibleLabel ? labelID : undefined}
           isLabelHidden
           value={resolvedChecked}
           onChange={() => handleToggle()}

--- a/packages/core/src/CheckboxList/CheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/CheckboxListItem.tsx
@@ -52,8 +52,9 @@ export interface CheckboxListItemProps extends BaseProps<HTMLLIElement> {
    * delegate to the checkbox.
    *
    * A string names the checkbox directly. A ReactNode names it from its
-   * visible text through `aria-labelledby`; if that text is absent or reads
-   * badly, pass `aria-label`.
+   * visible text through `aria-labelledby`; if that text is absent, pass
+   * `aria-label`. When visible text is present, an override must retain every
+   * visible word so speech-input users can say what they see.
    */
   label: ReactNode;
   /**
@@ -62,15 +63,16 @@ export interface CheckboxListItemProps extends BaseProps<HTMLLIElement> {
    *
    * A string `label` names the checkbox directly, and a rich (ReactNode)
    * `label` names it from its visible text through `aria-labelledby`. Pass
-   * `aria-label` when that flattened text is absent or reads badly — it
-   * replaces the derived name rather than adding to it. Applied to the
-   * checkbox control, not the row.
+   * `aria-label` when that text is absent. When visible text is present, the
+   * override must retain every visible word so speech-input users can say what
+   * they see. It replaces the derived name and applies to the checkbox control,
+   * not the row.
    *
    * @example
    * ```
    * <CheckboxListItem
    *   label={<span>Pro plan <Badge label="Recommended" /></span>}
-   *   aria-label="Pro plan"
+   *   aria-label="Pro plan Recommended option"
    *   value="pro"
    * />
    * ```

--- a/packages/core/src/CheckboxList/CheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/CheckboxListItem.tsx
@@ -16,7 +16,7 @@
  * - /packages/cli/assets/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {use, useRef, type ReactNode, useId} from 'react';
+import {use, useId, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -50,6 +50,10 @@ export interface CheckboxListItemProps extends BaseProps<HTMLLIElement> {
    * child components control their own text behavior). Links and buttons in
    * the label keep their own behavior; only non-interactive row clicks
    * delegate to the checkbox.
+   *
+   * A string names the checkbox directly. A ReactNode names it from its
+   * visible text through `aria-labelledby`; if that text is absent or reads
+   * badly, pass `aria-label`.
    */
   label: ReactNode;
   /**
@@ -165,10 +169,12 @@ export function CheckboxListItem({
   }
 
   // Accessible name for the checkbox. A string `label` (or an explicit
-  // `aria-label`) becomes the text of its visually hidden label. A rich
-  // label instead names the checkbox from the visible label element through
-  // `aria-labelledby`, the same route RadioListItem takes; the hidden label
-  // then only carries the generic word, which `aria-labelledby` outranks.
+  // `aria-label`) becomes the text of CheckboxInput's visually hidden
+  // `<label>`, which only accepts a string. A rich label instead names the
+  // checkbox from the visible label element through `aria-labelledby`, as
+  // RadioListItem does; the hidden label then carries only the generic word,
+  // which `aria-labelledby` outranks. Strings are left unwrapped on purpose:
+  // Item single-line-truncates a raw string label but not a node.
   const isRichLabel = typeof label !== 'string';
   const labelID = useId();
   const namesFromVisibleLabel = isRichLabel && ariaLabel == null;
@@ -242,7 +248,7 @@ export function CheckboxListItem({
     <ListItem
       {...restProps}
       ref={ref}
-      label={isRichLabel ? <span id={labelID}>{label}</span> : label}
+      label={namesFromVisibleLabel ? <span id={labelID}>{label}</span> : label}
       description={description}
       endContent={endContent}
       isDisabled={effectiveDisabled}

--- a/packages/core/src/RadioList/RadioList.test.tsx
+++ b/packages/core/src/RadioList/RadioList.test.tsx
@@ -705,13 +705,13 @@ describe('RadioList', () => {
             label="Option A"
             value="a"
             data-testid="item-a"
-            aria-label="First option"
+            aria-label="Option A, first option"
           />
         </RadioList>,
       );
       expect(screen.getByTestId('item-a')).not.toHaveAttribute('aria-label');
       expect(
-        screen.getByRole('radio', {name: 'First option'}),
+        screen.getByRole('radio', {name: 'Option A, first option'}),
       ).toBeInTheDocument();
     });
   });
@@ -746,12 +746,14 @@ describe('RadioList', () => {
                 Pro plan <em>(recommended)</em>
               </span>
             }
-            aria-label="Pro plan"
+            aria-label="Pro plan (recommended) option"
             value="pro"
           />
         </RadioList>,
       );
-      expect(screen.getByRole('radio', {name: 'Pro plan'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', {name: 'Pro plan (recommended) option'}),
+      ).toBeInTheDocument();
     });
 
     it('selects the option when a ReactNode label is clicked', async () => {
@@ -777,12 +779,14 @@ describe('RadioList', () => {
                 Pro plan <a href="#pricing">pricing details</a>
               </>
             }
-            aria-label="Pro plan"
+            aria-label="Pro plan pricing details"
             value="pro"
           />
         </RadioList>,
       );
-      const radio = screen.getByRole('radio', {name: 'Pro plan'});
+      const radio = screen.getByRole('radio', {
+        name: 'Pro plan pricing details',
+      });
       const link = screen.getByRole('link', {name: 'pricing details'});
       await user.tab();
       expect(radio).toHaveFocus();

--- a/packages/core/src/RadioList/RadioList.test.tsx
+++ b/packages/core/src/RadioList/RadioList.test.tsx
@@ -731,8 +731,7 @@ describe('RadioList', () => {
         </RadioList>,
       );
       // The radio points at its visible label, so the name is computed from
-      // the rich node's own text — unlike CheckboxListItem, whose control has
-      // a separate hidden label and needs aria-label to say anything useful.
+      // the rich node's own text.
       expect(
         screen.getByRole('radio', {name: 'Pro plan (recommended)'}),
       ).toBeInTheDocument();

--- a/packages/core/src/RadioList/RadioListItem.doc.mjs
+++ b/packages/core/src/RadioList/RadioListItem.doc.mjs
@@ -22,14 +22,14 @@ export const docs = {
       name: 'label',
       type: 'ReactNode',
       description:
-        'Primary label for the radio item. Rich labels may contain links or buttons, which keep their own behavior without selecting the item. The label text names the radio; pair it with aria-label when that text does not read well on its own.',
+        'Primary label for the radio item. Rich labels may contain links or buttons, which keep their own behavior without selecting the item. The label text names the radio; use aria-label only when that text is absent, or retain every visible label word in the override.',
       required: true,
     },
     {
       name: 'aria-label',
       type: 'string',
       description:
-        'Plain-text accessible name for the radio, applied to the control rather than the row. It overrides whatever the label element computes — a plain string label included — so reach for it when a rich label\u2019s own text is absent or reads badly.',
+        'Plain-text accessible name for the radio, applied to the control rather than the row. It overrides the name derived from the label. Use it when a rich label has no visible text; otherwise retain every visible label word.',
     },
     {
       name: 'value',
@@ -96,14 +96,14 @@ export const docsZh = {
       name: 'label',
       type: 'ReactNode',
       description:
-        '单选选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会选中该选项。标签文本用于命名单选框；若朗读效果不佳，请同时传入 aria-label。',
+        '单选选项的主标签。富内容标签可包含链接或按钮，它们保留自身行为且不会选中该选项。标签文本用于命名单选框；仅当可见文本缺失时使用 aria-label，否则覆盖值必须保留全部可见文字。',
       required: true,
     },
     {
       name: 'aria-label',
       type: 'string',
       description:
-        '单选框的纯文本无障碍名称，应用于控件本身而非整行。它会覆盖标签元素计算出的名称（包括纯字符串标签），因此仅在富文本标签自身缺少文本或朗读效果不佳时使用。',
+        '单选框的纯文本无障碍名称，应用于控件本身而非整行。它会覆盖由标签推导出的名称。仅当富标签没有可见文本时才完全替代；否则必须保留全部可见文字。',
     },
     {
       name: 'value',
@@ -144,7 +144,8 @@ export const docsDense = {
   propDescriptions: {
     label:
       'Primary label. String or ReactNode; nested controls keep their behavior.',
-    'aria-label': 'Plain-text radio name; overrides any label.',
+    'aria-label':
+      'Plain-text radio name replacing the derived label. Use when visible text is absent; otherwise retain every visible label word.',
     value: 'Value of this radio item.',
     description: 'Secondary content below label. String or ReactNode.',
     isDisabled: 'Whether this individual radio item disabled.',

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -105,21 +105,23 @@ export interface RadioListItemProps extends BaseProps<HTMLDivElement> {
    * Accepts a plain string or a ReactNode for rich content. Links and buttons
    * in the label keep their own behavior; only non-interactive row clicks
    * delegate to the radio. The radio points at the rendered label for its
-   * accessible name, so a rich label still names it from its own text — pass
-   * `aria-label` when that text is absent or too noisy to announce.
+   * accessible name, so a rich label still names it from its own text. Pass
+   * `aria-label` when that text is absent. When visible text is present, the
+   * override must retain every visible word so speech-input users can say what
+   * they see.
    */
   label: ReactNode;
   /**
    * Plain-text accessible name for the radio, applied to the control rather
-   * than the row. It replaces the name the label would otherwise supply — a
-   * plain string label included — so reach for it when a rich label's own
-   * text is absent or reads badly, not as a routine addition.
+   * than the row. It replaces the name the label would otherwise supply. Use
+   * it when a rich label has no visible text; otherwise the value must retain
+   * every visible word.
    *
    * @example
    * ```
    * <RadioListItem
    *   label={<span>Pro plan <Badge label="Recommended" /></span>}
-   *   aria-label="Pro plan"
+   *   aria-label="Pro plan Recommended option"
    *   value="pro"
    * />
    * ```


### PR DESCRIPTION
## Summary

A `ReactNode` `label` without `aria-label` left the checkbox named "Checkbox", so every rich-label item in a list announced the same (`checkbox.name.matches-visible-label` in the shared [APG checkbox](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/) contract).

The item now wraps a rich label in a `<span id>` and points the checkbox at it with `aria-labelledby` — the route `RadioListItem` already takes — so the accessible name is the visible text. `aria-label` still replaces that name when given (`aria-labelledby` would outrank it, so the two are exclusive). String labels are untouched, and the dev warning that asked for `aria-label` is gone since the name no longer depends on it.

`CheckboxList / Rich Descriptions` drops its `aria-label` to exercise the derived name; because that label contains a link, the checkbox is now named "Analytics details" rather than "Analytics". If `aria-label` replaces the derived name, it must retain every visible label word so speech-input users can say what they see.

## Test Plan

- [x] `pnpm test` — 193 passed; rich-label name and conforming aria-label override cases replace the old warning case
- [x] `pnpm test:a11y-contract` — 185 passed; `list-item-rich-label-visible-name` passes, its known-failure record removed
- [x] Chromium computes the name `"Pro plan"` for that story; `a11y:audit` 0 new
- [x] Chromium against a local `upstream/main` build: `list-item-rich-label-visible-name` name "Checkbox" → "Pro plan"; every other CheckboxList story unchanged (names, tab order, row height, hit-test). `a11y:audit` 0 new, `rtl-audit` 0 gap.

## Related Issues

Closes #6161