### PR TITLE
fix(ci): skip stale post-merge preview reruns

### DIFF
--- a/.github/scripts/lib/pr-preview.mjs
+++ b/.github/scripts/lib/pr-preview.mjs
@@ -182,6 +182,15 @@ export async function resolveWorkflowRunPullRequest({
       // accepted above may reach a privileged mutation.
     }
   }
+  if (
+    matches.length === 0 &&
+    candidates.every(pull => pull?.state !== 'open')
+  ) {
+    // A source run can be rerun after its pull request merges. No privileged
+    // work remains when there is no open candidate, so finish without turning
+    // the trusted default-branch workflow red.
+    return null;
+  }
   if (matches.length !== 1) {
     refuse(
       `expected exactly one current pull request for source run ${run?.id}; found ${matches.length}`,

--- a/.github/scripts/lib/pr-preview.test.mjs
+++ b/.github/scripts/lib/pr-preview.test.mjs
@@ -1,10 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import fs from 'node:fs';
+import {createRequire} from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 
 import {afterEach, describe, expect, it, vi} from 'vitest';
+import yaml from 'yaml';
 
 import {
   PR_ANALYSIS_MARKER,
@@ -20,6 +22,19 @@ const HEAD = 'a'.repeat(40);
 const BASE = 'b'.repeat(40);
 const PAGES = 'c'.repeat(40);
 const INDEX = 'd'.repeat(64);
+const ROOT = path.resolve(import.meta.dirname, '../../..');
+const REQUIRE = createRequire(import.meta.url);
+const ASYNC_FUNCTION = Object.getPrototypeOf(async function () {}).constructor;
+const PR_COMMENT_WORKFLOW = yaml.parse(
+  fs.readFileSync(path.join(ROOT, '.github/workflows/pr-comment.yml'), 'utf8'),
+);
+const RESOLVE_SCRIPT = PR_COMMENT_WORKFLOW.jobs.resolve.steps.find(
+  step => step.name === 'Resolve trusted PR identity',
+).with.script;
+const EXECUTABLE_RESOLVE_SCRIPT = RESOLVE_SCRIPT.replace(
+  /const \{pathToFileURL\} = require\('node:url'\);\nconst \{resolveWorkflowRunPullRequest\} = await import\([\s\S]*?\n\);/,
+  'const resolveWorkflowRunPullRequest = injectedResolve;',
+);
 const roots = [];
 
 function identity(overrides = {}) {
@@ -236,6 +251,109 @@ describe('trusted PR preview identity', () => {
       head: 'cixzhang:fix-failed-ci-preview-links',
       per_page: 100,
     });
+  });
+
+  it('skips a stale rerun when no open pull request remains', async () => {
+    const value = identity();
+    const {github} = githubFixture({value});
+    github.rest.pulls.list.mockResolvedValue({data: []});
+
+    await expect(
+      resolveWorkflowRunPullRequest({
+        github,
+        owner: 'facebook',
+        repo: 'astryx',
+        run: sourceRun(value),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('skips a stale rerun whose directly referenced pull request is closed', async () => {
+    const value = identity();
+    const {github} = githubFixture({value});
+    github.rest.pulls.get.mockResolvedValue({
+      data: {...pull(value), state: 'closed'},
+    });
+    const run = {
+      ...sourceRun(value),
+      pull_requests: [{number: value.prNumber}],
+    };
+
+    await expect(
+      resolveWorkflowRunPullRequest({
+        github,
+        owner: 'facebook',
+        repo: 'astryx',
+        run,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('executes the stale workflow path without classifying or publishing it', async () => {
+    const value = identity();
+    const {github} = githubFixture({value});
+    const resolve = vi.fn(async () => null);
+    const core = {notice: vi.fn(), setOutput: vi.fn()};
+    const previousWorkspace = process.env.GITHUB_WORKSPACE;
+    process.env.GITHUB_WORKSPACE = ROOT;
+
+    try {
+      await new ASYNC_FUNCTION(
+        'require',
+        'context',
+        'github',
+        'core',
+        'injectedResolve',
+        EXECUTABLE_RESOLVE_SCRIPT,
+      )(
+        REQUIRE,
+        {
+          repo: {owner: 'facebook', repo: 'astryx'},
+          payload: {workflow_run: sourceRun(value)},
+        },
+        github,
+        core,
+        resolve,
+      );
+    } finally {
+      if (previousWorkspace === undefined) delete process.env.GITHUB_WORKSPACE;
+      else process.env.GITHUB_WORKSPACE = previousWorkspace;
+    }
+
+    expect(EXECUTABLE_RESOLVE_SCRIPT).not.toBe(RESOLVE_SCRIPT);
+    expect(resolve).toHaveBeenCalledWith({
+      github,
+      owner: 'facebook',
+      repo: 'astryx',
+      run: sourceRun(value),
+    });
+    expect(core.notice).toHaveBeenCalledWith(
+      expect.stringContaining('no open pull request remains'),
+    );
+    expect(core.setOutput).toHaveBeenCalledWith('valid', 'false');
+    expect(github.rest.pulls.get).not.toHaveBeenCalled();
+    expect(github.paginate).not.toHaveBeenCalled();
+  });
+
+  it('keeps every write-capable job behind the valid identity output', () => {
+    const writeCapableJobs = Object.entries(PR_COMMENT_WORKFLOW.jobs)
+      .filter(([, job]) =>
+        Object.values(job.permissions ?? {}).some(value => value === 'write'),
+      )
+      .map(([name]) => name);
+
+    expect(writeCapableJobs).toEqual([
+      'invalidate',
+      'spec-only-visual',
+      'spec-only-reconcile',
+      'deploy-preview',
+      'comment',
+    ]);
+    for (const name of writeCapableJobs) {
+      expect(PR_COMMENT_WORKFLOW.jobs[name].if, name).toContain(
+        "needs.resolve.outputs.valid == 'true'",
+      );
+    }
   });
 
   it.each([

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -75,6 +75,13 @@ jobs:
               ...context.repo,
               run: context.payload.workflow_run,
             });
+            if (identity === null) {
+              core.notice(
+                `Skipping source run ${context.payload.workflow_run.id}: no open pull request remains for this head.`,
+              );
+              core.setOutput('valid', 'false');
+              return;
+            }
             const path = require('node:path');
             const {classifyChanges} = require(path.join(
               process.env.GITHUB_WORKSPACE,


### PR DESCRIPTION
## User impact

Rerunning CI for an already-merged pull request no longer leaves a false-red PR Comment workflow on `main`.

## Change

- Treat a source run as stale only when no open pull request remains for its head.
- Exit the trusted workflow successfully without publishing or mutating preview state.
- Continue failing closed when any open candidate is mismatched or ambiguous.

## Test plan

- `pnpm exec vitest run .github/scripts/lib/pr-preview.test.mjs .github/scripts/ci-tooling-routing.test.mjs`
- `pnpm exec prettier --check .github/scripts/lib/pr-preview.mjs .github/scripts/lib/pr-preview.test.mjs .github/workflows/pr-comment.yml`
- `git diff --check`