### PR TITLE
fix(Layout): keep content scrollbar at the outer edge

### DIFF
--- a/.changeset/layout-content-full-width-scrollport.md
+++ b/.changeset/layout-content-full-width-scrollport.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Layout: keep content scrollbars at the content area's outer edge when `contentWidth` is set.
+
+Without panels, `LayoutContent` spans the available Layout width and aligns its children to `contentWidth` internally. With exactly one panel, the panel stays aligned to the `contentWidth` frame while content extends across the opposite open area. A two-panel layout keeps the complete composition constrained.
+
+@kentonquatman

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -125,6 +125,12 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-container'],
     overflow: 'hidden',
   },
+  cwContainerMatrix: {
+    height: 240,
+  },
+  scrollbarProbeContent: {
+    scrollbarGutter: 'stable',
+  },
   cwContainer900: {
     width: 900,
   },
@@ -156,6 +162,25 @@ const NavItem = ({
   <div {...stylex.props(styles.navItem, active && styles.navItemActive)}>
     {children}
   </div>
+);
+
+const ScrollbarProbeContent = ({id, label}: {id: string; label: string}) => (
+  <LayoutContent
+    data-scrollbar-case={id}
+    label={`${label} content`}
+    role="region"
+    tabIndex={0}
+    xstyle={styles.scrollbarProbeContent}>
+    <p {...stylex.props(styles.bodyText)}>
+      Scroll this content to confirm its scrollbar stays on the outer edge of
+      the content area.
+    </p>
+    {Array.from({length: 8}, (_, index) => (
+      <div key={index} {...stylex.props(styles.placeholder)}>
+        {label} content block {index + 1}
+      </div>
+    ))}
+  </LayoutContent>
 );
 
 const meta: Meta<typeof Layout> = {
@@ -986,8 +1011,8 @@ export const ContentWidthWithStartPanel: Story = {
   render: () => (
     <VStack gap={4} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>
-        contentWidth=640 with a 200px start panel: the middle row (panel +
-        content) is constrained
+        contentWidth=640 with a 200px start panel: the panel stays aligned while
+        content extends to the open end edge
       </p>
       <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
         <Layout
@@ -1011,8 +1036,8 @@ export const ContentWidthWithStartPanel: Story = {
               <h4 {...stylex.props(styles.subheading)}>General Settings</h4>
               <br />
               <p {...stylex.props(styles.bodyText)}>
-                The start panel and content area together are constrained to
-                640px and centered within the container.
+                The start panel stays inside the centered 640px frame while the
+                content area extends to the container&apos;s open end edge.
               </p>
             </LayoutContent>
           }
@@ -1080,6 +1105,93 @@ export const ContentWidthWithBothPanels: Story = {
       </div>
     </VStack>
   ),
+};
+
+export const ContentWidthScrollbarPlacement: Story = {
+  name: 'Content Width — Scrollbar Placement',
+  tags: ['visual-baseline'],
+  render: () => {
+    const cases = [
+      {
+        id: 'none',
+        label: 'No panels',
+        start: undefined,
+        end: undefined,
+      },
+      {
+        id: 'start',
+        label: 'Start panel only',
+        start: (
+          <LayoutPanel width={160} hasDivider>
+            <NavItem active>Nav</NavItem>
+          </LayoutPanel>
+        ),
+        end: undefined,
+      },
+      {
+        id: 'both',
+        label: 'Start and end panels',
+        start: (
+          <LayoutPanel width={160} hasDivider>
+            <NavItem active>Nav</NavItem>
+          </LayoutPanel>
+        ),
+        end: (
+          <LayoutPanel width={160} hasDivider>
+            <p {...stylex.props(styles.bodyText)}>Details</p>
+          </LayoutPanel>
+        ),
+      },
+      {
+        id: 'end',
+        label: 'End panel only',
+        start: undefined,
+        end: (
+          <LayoutPanel width={160} hasDivider>
+            <p {...stylex.props(styles.bodyText)}>Details</p>
+          </LayoutPanel>
+        ),
+      },
+    ];
+
+    return (
+      <VStack gap={6} xstyle={styles.storySection}>
+        <p {...stylex.props(styles.sectionLabel)}>
+          contentWidth=640 in a 900px container. With no panels, content spans
+          the container and aligns internally. With exactly one panel, content
+          extends through the opposite open area. The two-panel layout remains
+          constrained. Header markers expose both alignment edges.
+        </p>
+        {cases.map(({id, label, start, end}) => (
+          <VStack key={id} gap={2}>
+            <p {...stylex.props(styles.subheading)}>{label}</p>
+            <div
+              data-scrollbar-layout={id}
+              {...stylex.props(
+                styles.cwContainer,
+                styles.cwContainer900,
+                styles.cwContainerMatrix,
+              )}>
+              <Layout
+                contentWidth={640}
+                header={
+                  <LayoutHeader hasDivider>
+                    <HStack hAlign="between">
+                      <span data-header-edge="start">Header start</span>
+                      <span data-header-edge="end">Header end</span>
+                    </HStack>
+                  </LayoutHeader>
+                }
+                start={start}
+                content={<ScrollbarProbeContent id={id} label={label} />}
+                end={end}
+              />
+            </div>
+          </VStack>
+        ))}
+      </VStack>
+    );
+  },
 };
 
 export const ContentWidthNoDividers: Story = {

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -135,7 +135,7 @@ export const docs = {
       name: 'contentWidth',
       type: 'SizeValue',
       description:
-        'Maximum width of the content within each slot (header, content, footer, panels), centered when narrower than the available space. Dividers stay full-bleed. Numbers are treated as pixels, strings are used as-is (e.g. `60ch`). Common page widths: 640 for forms, settings, and text-focused pages; 960 for content pages and wider layouts.',
+        'Maximum width of the aligned content within each slot (header, content, footer, panels), centered when narrower than the available space. Without panels, LayoutContent spans the available width so its scrollbar stays at the outer edge while its children align internally to contentWidth. With exactly one panel, the panel stays aligned to the contentWidth frame while LayoutContent extends to the opposite open edge. With both panels, contentWidth includes the complete middle composition. Percentage widths—including percentage-bearing calc(), min(), max(), and clamp() values—and intrinsic widths, plus bare var(...) values, retain the constrained composition; use calc(var(...)) for a variable guaranteed to resolve to a length. Dividers stay full-bleed. Numbers are treated as pixels, strings are used as-is (e.g. `60ch`). Common page widths: 640 for forms, settings, and text-focused pages; 960 for content pages and wider layouts.',
     },
     {
       name: 'padding',

--- a/packages/core/src/Layout/Layout.spec.md
+++ b/packages/core/src/Layout/Layout.spec.md
@@ -39,15 +39,16 @@ system_specs: []
 Layout is a general layout primitive that arranges five optional named slots:
 Header, logical-start Panel, Content area, logical-end Panel, and Footer. It can
 structure regions within a page or bounded container, while AppShell owns the
-page shell. This draft records the current aggregate consumer anatomy and
-theming ownership without changing runtime behavior, DOM, styling, targets, or
-public API.
+page shell. This draft records the aggregate consumer anatomy, theming ownership,
+and content-width behavior without adding a public API or changing internal
+parent/child communication.
 
 ## Compatibility and migration
 
 - Released default preserved: `yes`
-- Compatibility class: additive documentation only; runtime, DOM, styling,
-  targets, aliases, and public API remain unchanged
+- Compatibility class: bug fix; LayoutContent keeps the same root, direct-child
+  DOM, props, overflow behavior, padding ownership, and default. Context-aware
+  inline insets align content while the root scrollport stays full width.
 - Controlled/uncontrolled behavior: not applicable
 - Migration decision: none
 
@@ -77,7 +78,8 @@ Consumer migration instructions belong in consumer docs and release notes.
 - Correcting current container-padding publication mismatches or preventing two
   adjacent divider owners from both painting; those remain current gaps and
   caller obligations recorded below.
-- New runtime behavior, API, target, alias, or region wrapper.
+- New public API, target, alias, slot-level region wrapper, or parent-to-child
+  context communication.
 
 ## Public concepts
 
@@ -97,14 +99,15 @@ the broader container system shared with Section, Table, Toolbar, and Divider.
 
 ## Behavioral and layout contract
 
-| ID  | Candidate invariant                                                                                                                                                                                                                                              | Basis                                     | Draft review state                                 |
-| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------- |
-| FR1 | Layout renders one general Layout container carrying the current `layout` target and places arbitrary caller-provided ReactNode content in the `header`, `start`, `content`, `end`, and `footer` slots. Slot placement alone adds no region component or target. | Current source, docs, and tests           | Verified current behavior; no new behavior decided |
-| FR2 | When the caller supplies LayoutHeader, LayoutContent, or LayoutFooter, that component carries its current `layout-header`, `layout-content`, or `layout-footer` target; Layout does not add those targets to arbitrary slot content.                             | Current source and target metadata        | Verified current inventory; no target change       |
-| FR3 | LayoutPanel instances supplied to logical start or end share one aggregate Panel anatomy part and the current `layout-panel` target; slot position does not create a second anatomy part or target.                                                              | Current source, docs, tests, and family   | Verified current ownership; no API change          |
-| FR4 | `Layout.doc.mjs` is the canonical aggregate consumer document for the five current `layout*` targets and maps each target once; region subcomponent docs continue to document their own props and usage.                                                         | Current documentation organization        | Verified current ownership                         |
-| FR5 | LayoutContent and LayoutPanel retain their shipped automatic container-padding publication behavior, including the mismatches recorded by `architecture:container-padding`; this documentation does not claim exact parity.                                      | Current source and architecture record    | Current conformance gap; not fixed here            |
-| FR6 | When an adjacent ResizeHandle owns a panel divider, the caller must keep `LayoutPanel hasDivider={false}`; current composition does not prevent both components from painting the same boundary.                                                                 | Current source, docs, and family contract | Current caller obligation; not fixed here          |
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Basis                                        | Draft review state                                 |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------- |
+| FR1 | Layout renders one general Layout container carrying the current `layout` target and places arbitrary caller-provided ReactNode content in the `header`, `start`, `content`, `end`, and `footer` slots. Slot placement alone adds no region component or target.                                                                                                                                                                                                                                                                                                                                                                                                          | Current source, docs, and tests              | Verified current behavior; no new behavior decided |
+| FR2 | When the caller supplies LayoutHeader, LayoutContent, or LayoutFooter, that component carries its current `layout-header`, `layout-content`, or `layout-footer` target; Layout does not add those targets to arbitrary slot content.                                                                                                                                                                                                                                                                                                                                                                                                                                      | Current source and target metadata           | Verified current inventory; no target change       |
+| FR3 | LayoutPanel instances supplied to logical start or end share one aggregate Panel anatomy part and the current `layout-panel` target; slot position does not create a second anatomy part or target.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Current source, docs, tests, and family      | Verified current ownership; no API change          |
+| FR4 | `Layout.doc.mjs` is the canonical aggregate consumer document for the five current `layout*` targets and maps each target once; region subcomponent docs continue to document their own props and usage.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | Current documentation organization           | Verified current ownership                         |
+| FR5 | LayoutContent and LayoutPanel retain their shipped automatic container-padding publication behavior, including the mismatches recorded by `architecture:container-padding`; this documentation does not claim exact parity.                                                                                                                                                                                                                                                                                                                                                                                                                                               | Current source and architecture record       | Current conformance gap; not fixed here            |
+| FR6 | When an adjacent ResizeHandle owns a panel divider, the caller must keep `LayoutPanel hasDivider={false}`; current composition does not prevent both components from painting the same boundary.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Current source, docs, and family contract    | Current caller obligation; not fixed here          |
+| FR7 | When `contentWidth` is set without panels, LayoutContent spans the available middle area and aligns its direct children through context-aware inline insets. With exactly one panel, the panel stays aligned while LayoutContent extends through the opposite open side; logical start and end mirror. With both panels, or a percentage (including percentage-bearing CSS math), intrinsic, or bare-variable width that cannot safely share one CSS arithmetic basis, the complete middle composition remains constrained. A guaranteed length-valued variable uses `calc(var(...))`. LayoutContent's root remains the scroll, padding, styling, and direct-child owner. | Current family contract and browser evidence | Proposed bug fix; no API or context change         |
 
 ### Current evidence and gaps
 
@@ -134,18 +137,26 @@ the broader container system shared with Section, Table, Toolbar, and Divider.
 
 ### Representative states
 
-| State                          | Required invariant                                                                         | Allowed variation                                      |
-| ------------------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
-| Arbitrary content only         | Layout container carries `layout`; arbitrary content gains no region target from its slot. | Caller content and current height/width configuration. |
-| Composed header/content/footer | Supplied Layout region components retain their own anatomy and targets.                    | Any region may instead be absent or arbitrary content. |
-| Start or end LayoutPanel       | Either logical position uses the one Panel anatomy part and `layout-panel` target.         | Position, width, scrolling, padding, and caller role.  |
-| Two LayoutPanels               | Both instances remain repetitions of the same Panel anatomy part and target.               | Independent content, width, and local configuration.   |
-| ResizeHandle-adjacent          | Divider ownership follows the current caller obligation in FR6.                            | Resize state remains owned by the resize components.   |
+| State                          | Required invariant                                                                         | Allowed variation                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Arbitrary content only         | Layout container carries `layout`; arbitrary content gains no region target from its slot. | Caller content and current height/width configuration.                              |
+| Composed header/content/footer | Supplied Layout region components retain their own anatomy and targets.                    | Without panels, contentWidth aligns inside the full-width LayoutContent scrollport. |
+| Start or end LayoutPanel       | Either logical position uses the one Panel anatomy part and `layout-panel` target.         | Position, width, scrolling, padding, caller role, and content-area edge scrolling.  |
+| Two LayoutPanels               | Both instances remain repetitions of the same Panel anatomy part and target.               | The constrained content scrollbar remains between the two panels.                   |
+| ResizeHandle-adjacent          | Divider ownership follows the current caller obligation in FR6.                            | Resize state remains owned by the resize components.                                |
 
 ### Transformation and precedence order
 
-- No new slot, padding, content-width, divider, scrolling, sizing, or styling
-  precedence rule is introduced.
+- `contentWidth` keeps LayoutContent's root scrollport full width without panels.
+  With exactly one panel, the root extends through the opposite open side; the
+  panel and LayoutContent's direct children stay aligned through inline insets.
+  Start and end mirror. With both panels, or with a percentage (including
+  percentage-bearing CSS math), intrinsic, or bare variable that cannot safely
+  share one CSS arithmetic basis, the complete middle composition stays constrained. A guaranteed length-valued variable
+  uses `calc(var(...))`. Layout does not add a context field or inspect/mutate
+  the child.
+- No new slot, padding, divider, scrolling, sizing, or public styling precedence
+  rule is introduced.
 
 ### Performance and resources
 
@@ -210,6 +221,7 @@ end, or both. It does not map the `start` and `end` slots themselves.
 | FR4           | `scripts/check-knowledge.mjs`                                                                  | Canonical aggregate doc and exact five-target map                                  | Missing, extra, prefixed, or stale target mappings fail repository validation.                                                                                                    | `audit:Layout/theming`       |
 | FR5           | Source inspection plus `architecture:container-padding` verification evidence                  | Automatic outer-edge Content area and Panel paths                                  | This draft adds no parity assertion; a runtime correction requires separate compatibility evidence.                                                                               | `audit:Layout/layout`        |
 | FR6           | LayoutPanel source/docs plus `family:layout-regions` verification evidence                     | Panel beside a divider-owning ResizeHandle                                         | This draft adds no prevention assertion; changing ownership requires separate runtime coverage.                                                                                   | `audit:Layout/layout`        |
+| FR7           | `contentWidth.test.tsx` plus the Storybook scrollbar-placement matrix                          | No panels, start only, start and end, end only                                     | Removing the full-width no-panel content scrollport or moving any scrollbar away from its content-area edge fails focused structure or browser geometry checks.                   | `audit:Layout/layout`        |
 | Accessibility | `LayoutSlots.test.tsx` landmark assertions                                                     | Header, Content area, Footer, and Panel roles                                      | Supplied role or label no longer reaches the region element.                                                                                                                      | `audit:Layout/accessibility` |
 
 ## Decision log

--- a/packages/core/src/Layout/Layout.tsx
+++ b/packages/core/src/Layout/Layout.tsx
@@ -40,6 +40,29 @@ import {
  */
 export type LayoutHeight = 'fill' | 'auto';
 
+/**
+ * Internal alignment subtracts contentWidth in CSS. Intrinsic values and bare
+ * variables cannot participate in that arithmetic, so they keep the released
+ * constrained-composition path.
+ */
+function supportsInternalContentWidthAlignment(
+  width: SizeValue | undefined,
+): boolean {
+  if (width == null || typeof width === 'number') {
+    return true;
+  }
+
+  const value = width.trim().toLowerCase();
+  if (value.includes('%')) {
+    return false;
+  }
+  return (
+    value === '0' ||
+    /^-?(?:\d+(?:\.\d+)?|\.\d+)[a-z]+$/.test(value) ||
+    /^(?:calc|min|max|clamp)\(/.test(value)
+  );
+}
+
 const styles = stylex.create({
   // Outer wrapper uses negative margin to escape container padding
   layoutOuter: {
@@ -54,6 +77,10 @@ const styles = stylex.create({
     '--container-padding-inline-end': '0px',
     '--container-padding-block-start': '0px',
     '--container-padding-block-end': '0px',
+    // Reset inherited width so nested Layouts without contentWidth keep their
+    // released padding. An explicit contentWidth overrides this on the same node.
+    '--layout-content-width': '100cqi',
+    '--layout-alignment-width': '100cqi',
   },
   fill: {
     // Add 2x container block padding to compensate for negative block margins
@@ -68,6 +95,51 @@ const styles = stylex.create({
     flex: 1,
     minHeight: 0,
   },
+  middleQuery: {
+    containerType: {
+      default: null,
+      ':has(> div > .astryx-layout-content)': 'inline-size',
+    },
+  },
+  // Without side panels, LayoutContent owns the full-width scrollport and
+  // aligns its children internally. Arbitrary content keeps the existing
+  // constrained-lane behavior.
+  singleColumnContent: {
+    width: '100%',
+    maxWidth: {
+      default: 'var(--layout-content-width, none)',
+      ':has(> .astryx-layout-content)': 'none',
+    },
+    marginInline: 'auto',
+  },
+  // With one side panel, keep that panel aligned to the content-width frame
+  // while allowing LayoutContent to occupy the opposite open side.
+  singlePanelMiddle: {
+    boxSizing: 'border-box',
+    width: '100%',
+    maxWidth: {
+      default: 'var(--layout-content-width, none)',
+      ':has(> div > .astryx-layout-content)': 'none',
+    },
+    marginInline: {
+      default: 'auto',
+      ':has(> div > .astryx-layout-content)': 0,
+    },
+  },
+  singleStartPanel: {
+    paddingInlineStart: {
+      default: null,
+      ':has(> div > .astryx-layout-content)':
+        'max(0px, calc((100% - var(--layout-content-width)) / 2))',
+    },
+  },
+  singleEndPanel: {
+    paddingInlineEnd: {
+      default: null,
+      ':has(> div > .astryx-layout-content)':
+        'max(0px, calc((100% - var(--layout-content-width)) / 2))',
+    },
+  },
   // When full bleed, set outer padding variables to 0 so child components touch container edges
   fullBleed: {
     '--layout-padding-outer-x': '0px',
@@ -78,6 +150,10 @@ const styles = stylex.create({
 const dynamicStyles = stylex.create({
   contentWidthVar: (width: SizeValue) => ({
     '--layout-content-width': typeof width === 'number' ? `${width}px` : width,
+  }),
+  contentAlignmentWidthVar: (width: SizeValue) => ({
+    '--layout-alignment-width':
+      typeof width === 'number' ? `${width}px` : width,
   }),
   contentWidth: (width: SizeValue) => ({
     width: '100%',
@@ -98,9 +174,23 @@ export interface LayoutProps extends Omit<BaseProps, 'content'> {
   content?: ReactNode;
 
   /**
-   * Maximum width of the content within each slot (header, content, footer,
-   * panels). Dividers remain full-bleed. Content is centered with
+   * Maximum width of the aligned content within each slot (header, content,
+   * footer, panels). Dividers remain full-bleed. Content is centered with
    * `margin-inline: auto` when narrower than the available space.
+   *
+   * In a layout without start or end panels, LayoutContent spans the available
+   * width so its scrollbar stays at the outer edge, while its children align
+   * internally to `contentWidth`. With exactly one panel, that panel remains
+   * aligned to the `contentWidth` frame while LayoutContent extends to the
+   * opposite open edge. With both panels, `contentWidth` includes the complete
+   * start + content + end composition. Intrinsic widths such as `fit-content`
+   * retain the constrained composition because they cannot participate in the
+   * internal alignment arithmetic. Percentage widths, including
+   * percentage-bearing `calc()`, `min()`, `max()`, and `clamp()` values, use the
+   * constrained fallback because they cannot share one arithmetic basis. Bare
+   * `var(...)` values also use that fallback because their resolved value may be
+   * intrinsic; wrap a variable guaranteed to resolve to a length in `calc(...)`
+   * to opt into edge scrolling.
    *
    * Numbers are treated as pixels, strings are used as-is (e.g., '60ch').
    * Common page widths:
@@ -253,6 +343,10 @@ export function Layout({
   const hasFooter = footer != null;
   const hasStart = start != null;
   const hasEnd = end != null;
+  const hasBothPanels = hasStart && hasEnd;
+  const hasSinglePanel = hasStart !== hasEnd;
+  const usesInternalContentWidth =
+    contentWidth != null && supportsInternalContentWidthAlignment(contentWidth);
   const slotsValue = useMemo<LayoutSlots>(
     () => ({hasHeader, hasFooter, hasStart, hasEnd}),
     [hasHeader, hasFooter, hasStart, hasEnd],
@@ -282,16 +376,39 @@ export function Layout({
             padding != null && layoutPaddingOuterXVarStyles[padding],
             padding != null && layoutPaddingOuterYVarStyles[padding],
             contentWidth != null && dynamicStyles.contentWidthVar(contentWidth),
+            usesInternalContentWidth &&
+              dynamicStyles.contentAlignmentWidthVar(contentWidth),
           )}>
           <AreaProvider area="header">{header}</AreaProvider>
           <div
             {...stylex.props(
               ...stack({direction: 'horizontal'}),
               styles.middle,
-              contentWidth != null && dynamicStyles.contentWidth(contentWidth),
+              contentWidth != null &&
+                (!usesInternalContentWidth || hasBothPanels) &&
+                dynamicStyles.contentWidth(contentWidth),
+              usesInternalContentWidth && !hasBothPanels && styles.middleQuery,
+              usesInternalContentWidth &&
+                hasSinglePanel &&
+                styles.singlePanelMiddle,
+              usesInternalContentWidth &&
+                hasStart &&
+                !hasEnd &&
+                styles.singleStartPanel,
+              usesInternalContentWidth &&
+                !hasStart &&
+                hasEnd &&
+                styles.singleEndPanel,
             )}>
             <AreaProvider area="start">{start}</AreaProvider>
-            <div {...stylex.props(...stackItem({size: 'fill'}))}>
+            <div
+              {...stylex.props(
+                ...stackItem({size: 'fill'}),
+                usesInternalContentWidth &&
+                  !hasStart &&
+                  !hasEnd &&
+                  styles.singleColumnContent,
+              )}>
               <AreaProvider area="content">{resolvedContent}</AreaProvider>
             </div>
             <AreaProvider area="end">{end}</AreaProvider>

--- a/packages/core/src/Layout/LayoutContent.doc.mjs
+++ b/packages/core/src/Layout/LayoutContent.doc.mjs
@@ -23,7 +23,8 @@ export const docs = {
     {
       name: 'isScrollable',
       type: 'boolean',
-      description: 'Enable scrollable overflow.',
+      description:
+        'Enable scrollable overflow. With arithmetic contentWidth values, the scrollport spans through every open side while context-aware insets keep children aligned.',
       default: 'true',
     },
     {
@@ -58,7 +59,8 @@ export const docsZh = {
     {
       name: 'isScrollable',
       type: 'boolean',
-      description: '启用可滚动溢出。',
+      description:
+        '启用可滚动溢出。设置可参与算术计算的 contentWidth 时，滚动区域会延伸到所有未被面板占用的边缘，同时根据上下文调整内边距以保持子内容对齐。',
       default: 'true',
     },
     {
@@ -82,7 +84,8 @@ export const docsDense = {
   propDescriptions: {
     children: 'Content.',
     padding: 'Internal padding on spacing scale. Overrides layout container default.',
-    isScrollable: 'Enable scrollable overflow.',
+    isScrollable:
+      'Enable scrollable overflow. With arithmetic contentWidth values, the scrollport reaches open sides while context-aware insets align children.',
     label: 'Accessible label for landmark element.',
     role: 'ARIA landmark role.',
   },

--- a/packages/core/src/Layout/LayoutContent.tsx
+++ b/packages/core/src/Layout/LayoutContent.tsx
@@ -84,6 +84,26 @@ const styles = stylex.create({
   scrollable: {
     overflow: 'auto',
   },
+  // Keep LayoutContent as the scroll and padding owner. These styles only add
+  // the gutter needed to align its direct children to contentWidth.
+  constrainedNoPanelsStart: {
+    paddingInlineStart:
+      'max(var(--container-padding-inline-start, 0px), calc((100cqi - var(--layout-alignment-width)) / 2 + var(--container-padding-inline-start, 0px)))',
+  },
+  constrainedNoPanelsEnd: {
+    paddingInlineEnd:
+      'max(var(--container-padding-inline-end, 0px), calc((100cqi - var(--layout-alignment-width)) / 2 + var(--container-padding-inline-end, 0px)))',
+  },
+  // A one-panel middle query box excludes the panel-side centered gutter, so
+  // its full difference from contentWidth is the missing opposite-side gutter.
+  constrainedSingleStartPanel: {
+    paddingInlineEnd:
+      'max(var(--container-padding-inline-end, 0px), calc(100cqi - var(--layout-alignment-width) + var(--container-padding-inline-end, 0px)))',
+  },
+  constrainedSingleEndPanel: {
+    paddingInlineStart:
+      'max(var(--container-padding-inline-start, 0px), calc(100cqi - var(--layout-alignment-width) + var(--container-padding-inline-start, 0px)))',
+  },
   fullBleed: {
     paddingInlineStart: 0,
     paddingInlineEnd: 0,
@@ -135,8 +155,8 @@ export interface LayoutContentProps extends BaseProps<HTMLDivElement> {
  * Scrollable main content area for Layout. Wraps the primary body content
  * with automatic scroll containment and context-aware padding.
  *
- * Already provides its own padding and scroll — don't add padding or
- * overflow to children. Use `padding={0}` if you need edge-to-edge content.
+ * Already provides its own padding and scroll — don't add padding or overflow
+ * to children. Use `padding={0}` if you need edge-to-edge content.
  *
  * @example
  * ```
@@ -202,6 +222,22 @@ export function LayoutContent({
           padding != null && containerPaddingInlineVarStyles[padding],
           padding != null && containerPaddingBlockStartVarStyles[padding],
           padding != null && containerPaddingBlockEndVarStyles[padding],
+          !hasStart &&
+            !hasEnd &&
+            !isZeroPadding &&
+            styles.constrainedNoPanelsStart,
+          !hasStart &&
+            !hasEnd &&
+            !isZeroPadding &&
+            styles.constrainedNoPanelsEnd,
+          hasStart &&
+            !hasEnd &&
+            !isZeroPadding &&
+            styles.constrainedSingleStartPanel,
+          !hasStart &&
+            hasEnd &&
+            !isZeroPadding &&
+            styles.constrainedSingleEndPanel,
           xstyle,
         ),
         className,

--- a/packages/core/src/Layout/LayoutSlots.test.tsx
+++ b/packages/core/src/Layout/LayoutSlots.test.tsx
@@ -208,6 +208,18 @@ describe('LayoutContent', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps the public root as the scroll and direct-child owner', () => {
+    const {container} = render(<LayoutContent>Body</LayoutContent>);
+    const root = container.querySelector(
+      '.astryx-layout-content',
+    ) as HTMLElement;
+
+    expect(getComputedStyle(root).overflow).toBe('auto');
+    expect(root).toHaveTextContent('Body');
+    expect(root.childNodes).toHaveLength(1);
+    expect(root.querySelector('[data-layout-content-inner]')).toBeNull();
+  });
+
   it('exposes the main landmark role with an accessible name', () => {
     render(
       <LayoutContent role="main" label="Main content">

--- a/packages/core/src/Layout/__tests__/contentWidth.test.tsx
+++ b/packages/core/src/Layout/__tests__/contentWidth.test.tsx
@@ -12,25 +12,199 @@ import {Layout} from '../Layout';
 import {LayoutHeader} from '../LayoutHeader';
 import {LayoutFooter} from '../LayoutFooter';
 import {LayoutContent} from '../LayoutContent';
+import {LayoutPanel} from '../LayoutPanel';
 
 describe('Layout contentWidth', () => {
   describe('Layout', () => {
-    it('applies max-width constraint to the middle row', () => {
-      render(
+    it('keeps panel-free LayoutContent full width and constrains its content internally', () => {
+      const {rerender} = render(
         <Layout
           contentWidth={640}
           content={
-            <LayoutContent>
+            <LayoutContent data-testid="content-region">
               <span data-testid="body">Body</span>
             </LayoutContent>
           }
         />,
       );
-      const bodyEl = screen.getByTestId('body');
-      const contentDiv = bodyEl.parentElement!;
-      const stackItemDiv = contentDiv.parentElement!;
-      const middleRow = stackItemDiv.parentElement!;
-      expect(middleRow.className).toBeTruthy();
+
+      const contentRegion = screen.getByTestId('content-region');
+      const contentLane = contentRegion.parentElement!;
+      const middleRow = contentLane.parentElement!;
+      const constrainedLaneClassName = contentLane.className;
+      const constrainedContentClassName = contentRegion.className;
+
+      expect(getComputedStyle(contentRegion).overflow).toBe('auto');
+      expect(screen.getByTestId('body').parentElement).toBe(contentRegion);
+      expect(middleRow.getAttribute('style') ?? '').not.toContain('640px');
+
+      rerender(
+        <Layout
+          content={
+            <LayoutContent data-testid="content-region">
+              <span data-testid="body">Body</span>
+            </LayoutContent>
+          }
+        />,
+      );
+
+      expect(
+        screen.getByTestId('content-region').parentElement!.className,
+      ).not.toBe(constrainedLaneClassName);
+      expect(screen.getByTestId('content-region').className).toBe(
+        constrainedContentClassName,
+      );
+    });
+
+    it.each([
+      {
+        name: 'start',
+        start: <LayoutPanel>Navigation</LayoutPanel>,
+        end: undefined,
+        openPadding: 'paddingInlineEnd',
+      },
+      {
+        name: 'end',
+        start: undefined,
+        end: <LayoutPanel>Details</LayoutPanel>,
+        openPadding: 'paddingInlineStart',
+      },
+    ] as const)(
+      'lets $name-only content span to the opposite open edge',
+      ({start, end, openPadding}) => {
+        render(
+          <Layout
+            contentWidth={640}
+            start={start}
+            content={
+              <LayoutContent data-testid="content-region">Body</LayoutContent>
+            }
+            end={end}
+          />,
+        );
+
+        const contentRegion = screen.getByTestId('content-region');
+        const middleRow = contentRegion.parentElement!.parentElement!;
+
+        expect(getComputedStyle(contentRegion).overflow).toBe('auto');
+        expect(middleRow.getAttribute('style') ?? '').not.toContain('640px');
+        expect(getComputedStyle(contentRegion)[openPadding]).toContain(
+          '100cqi',
+        );
+      },
+    );
+
+    it('keeps the complete middle composition constrained with both panels', () => {
+      render(
+        <Layout
+          contentWidth={640}
+          start={<LayoutPanel>Navigation</LayoutPanel>}
+          content={
+            <LayoutContent data-testid="content-region">Body</LayoutContent>
+          }
+          end={<LayoutPanel>Details</LayoutPanel>}
+        />,
+      );
+
+      const contentRegion = screen.getByTestId('content-region');
+      const middleRow = contentRegion.parentElement!.parentElement!;
+
+      expect(getComputedStyle(contentRegion).overflow).toBe('auto');
+      expect(middleRow.getAttribute('style') ?? '').toContain('640px');
+    });
+
+    it('keeps zero padding full-bleed with arithmetic contentWidth', () => {
+      render(
+        <Layout
+          contentWidth={640}
+          content={
+            <LayoutContent padding={0} data-testid="content-region">
+              Body
+            </LayoutContent>
+          }
+        />,
+      );
+
+      const contentRegion = screen.getByTestId('content-region');
+      expect(getComputedStyle(contentRegion).paddingInlineStart).toContain(
+        '--spacing-0',
+      );
+      expect(getComputedStyle(contentRegion).paddingInlineEnd).toContain(
+        '--spacing-0',
+      );
+    });
+
+    it.each([
+      '50%',
+      'calc(50%)',
+      'min(400px, 80%)',
+      'fit-content',
+      'var(--probe-width)',
+    ])('keeps %s on the constrained composition path', contentWidth => {
+      render(
+        <>
+          <Layout
+            contentWidth={contentWidth}
+            content={
+              <LayoutContent data-testid="content-region">Body</LayoutContent>
+            }
+          />
+          <Layout
+            contentWidth={contentWidth}
+            content={<div data-testid="arbitrary-region">Body</div>}
+          />
+        </>,
+      );
+
+      const regionMiddle =
+        screen.getByTestId('content-region').parentElement!.parentElement!;
+      const arbitraryMiddle =
+        screen.getByTestId('arbitrary-region').parentElement!.parentElement!;
+      expect(regionMiddle.className).toBe(arbitraryMiddle.className);
+    });
+
+    it('resets inherited contentWidth for a nested Layout without one', () => {
+      const {container} = render(
+        <Layout
+          contentWidth={640}
+          content={
+            <LayoutContent>
+              <Layout
+                content={
+                  <LayoutContent data-testid="nested-content">
+                    Nested
+                  </LayoutContent>
+                }
+              />
+            </LayoutContent>
+          }
+        />,
+      );
+
+      const nestedRoot = screen
+        .getByTestId('nested-content')
+        .closest('.astryx-layout') as HTMLElement;
+      const nestedInner = nestedRoot.firstElementChild as HTMLElement;
+      expect(
+        getComputedStyle(nestedInner).getPropertyValue(
+          '--layout-content-width',
+        ),
+      ).toBe('100cqi');
+      expect(container).toHaveTextContent('Nested');
+    });
+
+    it('keeps arbitrary panel-free content constrained', () => {
+      const {rerender} = render(
+        <Layout contentWidth={640} content={<div>Body</div>} />,
+      );
+      const constrainedClassName =
+        screen.getByText('Body').parentElement!.className;
+
+      rerender(<Layout content={<div>Body</div>} />);
+
+      expect(screen.getByText('Body').parentElement!.className).not.toBe(
+        constrainedClassName,
+      );
     });
 
     it('does not crash when contentWidth is not set', () => {


### PR DESCRIPTION
## Summary

`contentWidth` should align content without pulling its scrollbar inward.

- when no side panels are present, `LayoutContent` spans the full available middle area and applies `contentWidth` internally
- with exactly one panel, the panel stays aligned to the `contentWidth` frame while `LayoutContent` extends through the opposite open area
- with both panels, `contentWidth` constrains the complete panel-and-content composition
- `LayoutContent` keeps its root as the scroll, padding, styling, and direct-child owner; context-aware insets provide alignment
- percentage widths—including percentage-bearing CSS math—plus intrinsic and ambiguous bare-variable widths retain the constrained composition; `calc(var(...))` opts a guaranteed length into edge scrolling
- `padding={0}` remains full bleed
- governing contract landed first in PR 6204; no current-spec change remains in this implementation PR
- adds one visual-acceptance Storybook matrix with header edge markers for no panels, start only, both panels, and end only

## Risk

This is a focused geometry change to `Layout` and `LayoutContent`. The two-panel composition keeps its released width behavior; arbitrary content still uses the constrained lane.

## Testing

- 105 focused Layout tests
- core build
- Storybook build
- knowledge and repository checks
- headed Chromium with forced classic scrollbars in LTR and RTL across all four panel states
