### PR TITLE
fix(ci): use stable fallback for CDN smoke

### DIFF
--- a/.github/scripts/cdn-template-smoke-test.mjs
+++ b/.github/scripts/cdn-template-smoke-test.mjs
@@ -29,6 +29,7 @@ import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {resolvePublishedCdnVersion} from './lib/cdn-version.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const CLI = path.join(ROOT, 'packages/cli/clients/cli/bin/astryx.mjs');
@@ -65,19 +66,18 @@ console.log(`scaffolded ${PAGE} pinned to ${pinned}`);
 // The pin is the version in this checkout, which is unpublished for the whole
 // life of a release PR (`changeset version` bumps package.json before npm has
 // the tarball). Gating every PR on that would make the release PR unmergeable,
-// so on an unpublished pin we re-point the page at the newest published version
-// and still assert the recipe.
-const published = await fetch('https://registry.npmjs.org/@astryxdesign/core')
+// so on an unpublished pin we re-point the page at npm's stable `latest`
+// dist-tag and still assert the recipe. Registry `versions` keys are not a
+// version-ordered API: the final key can be a canary that esm.sh has not built.
+const metadata = await fetch('https://registry.npmjs.org/@astryxdesign/core')
   .then(r => r.json())
-  .then(j => Object.keys(j.versions ?? {}))
-  .catch(() => []);
-if (published.length === 0) {
-  fail('could not reach the npm registry to resolve a published version');
+  .catch(() => null);
+const rendered = resolvePublishedCdnVersion(metadata, pinned);
+if (rendered == null) {
+  fail('could not resolve a published stable version from the npm registry');
   process.exit(1);
 }
-let rendered = pinned;
-if (!published.includes(pinned)) {
-  rendered = published[published.length - 1];
+if (rendered !== pinned) {
   console.log(`  note  ${pinned} is not published yet — rendering against ${rendered}`);
   fs.writeFileSync(
     pagePath,

--- a/.github/scripts/lib/cdn-version.mjs
+++ b/.github/scripts/lib/cdn-version.mjs
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Pick the published package version used to exercise the CDN starter page.
+ *
+ * The package registry's `versions` object is not a version-ordered API. Its
+ * final key may be a canary, so an unpublished release pin must fall back to
+ * the registry's authoritative stable `latest` dist-tag instead.
+ *
+ * @param {unknown} metadata
+ * @param {string} pinned
+ * @returns {string | null}
+ */
+export function resolvePublishedCdnVersion(metadata, pinned) {
+  if (metadata == null || typeof metadata !== 'object') return null;
+
+  const versions = metadata.versions;
+  if (versions == null || typeof versions !== 'object') return null;
+  if (Object.hasOwn(versions, pinned)) return pinned;
+
+  const latest = metadata['dist-tags']?.latest;
+  return typeof latest === 'string' && Object.hasOwn(versions, latest)
+    ? latest
+    : null;
+}

--- a/.github/scripts/lib/cdn-version.test.mjs
+++ b/.github/scripts/lib/cdn-version.test.mjs
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {resolvePublishedCdnVersion} from './cdn-version.mjs';
+
+describe('resolvePublishedCdnVersion', () => {
+  const metadata = {
+    'dist-tags': {latest: '0.5.4', canary: '0.5.4-canary.abc1234'},
+    versions: {
+      '0.5.4': {},
+      '0.5.4-canary.abc1234': {},
+    },
+  };
+
+  it('keeps an exact published pin', () => {
+    expect(resolvePublishedCdnVersion(metadata, '0.5.4-canary.abc1234')).toBe(
+      '0.5.4-canary.abc1234',
+    );
+  });
+
+  it('uses the stable latest tag when the release pin is unpublished', () => {
+    expect(resolvePublishedCdnVersion(metadata, '0.6.0')).toBe('0.5.4');
+  });
+
+  it('does not trust a latest tag that is absent from published versions', () => {
+    expect(
+      resolvePublishedCdnVersion(
+        {...metadata, 'dist-tags': {latest: '0.5.5'}},
+        '0.6.0',
+      ),
+    ).toBeNull();
+  });
+
+  it('fails closed when registry metadata is unavailable', () => {
+    expect(resolvePublishedCdnVersion(null, '0.6.0')).toBeNull();
+    expect(resolvePublishedCdnVersion({}, '0.6.0')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

A Version Packages PR pins an unpublished version. The CDN smoke is supposed to re-point that page at a published version, but it selected the final key in npm registry `versions` metadata. That object is not a semver-ordered API, so the test picked a canary that esm.sh repeatedly returned HTTP 408 for and made every release bump unmergeable.

## What

- keep an exact pin when it is already published
- otherwise use npm’s authoritative stable `latest` dist-tag
- fail closed when registry metadata or the tagged version is inconsistent
- cover exact-pin, stable-fallback, invalid-tag, and unavailable-registry cases

## Validation

- `pnpm exec vitest run .github/scripts/lib/cdn-version.test.mjs --project node --maxWorkers=1`
- `node .github/scripts/cdn-template-smoke-test.mjs` — rendered the button with zero console/page/request failures
- `pnpm check:repo`

No published package behavior changes; no Changeset.