### PR TITLE
fix(SideNav): prevent resizable overflow

### DIFF
--- a/.changeset/clip-the-resizable-sidenav-handle-within-the-sid-r265.md
+++ b/.changeset/clip-the-resizable-sidenav-handle-within-the-sid-r265.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Clip the resizable SideNav handle within the sidebar bounds
+@harjothkhara

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -715,6 +715,48 @@ export const ResizableInAppShell: Story = {
       <Text type="body">Drag the sidebar edge to resize the navigation.</Text>
     </AppShell>
   ),
+  play: async ({canvasElement}) => {
+    await document.fonts.ready;
+    await new Promise<void>(resolve =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+
+    const nav = canvasElement.querySelector<HTMLElement>('nav');
+    const panel = nav?.closest<HTMLElement>('.astryx-app-shell-sidenav');
+    const handle = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="astryx-sidenav-resize-handle"]',
+    );
+
+    if (!panel || !handle) {
+      throw new Error('Resizable AppShell fixture did not render as expected');
+    }
+
+    if (panel.scrollWidth !== panel.clientWidth) {
+      throw new Error(
+        `Resizable SideNav overflowed its AppShell panel: clientWidth ${panel.clientWidth}px, scrollWidth ${panel.scrollWidth}px`,
+      );
+    }
+
+    handle.focus();
+    await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+
+    const focusStyle = getComputedStyle(handle);
+    const outlineWidth = Number.parseFloat(focusStyle.outlineWidth);
+    const outlineOffset = Number.parseFloat(focusStyle.outlineOffset);
+    if (
+      canvasElement.ownerDocument.activeElement !== handle ||
+      !handle.matches(':focus-visible') ||
+      focusStyle.outlineStyle === 'none' ||
+      !Number.isFinite(outlineWidth) ||
+      outlineWidth <= 0 ||
+      !Number.isFinite(outlineOffset) ||
+      outlineOffset > -outlineWidth
+    ) {
+      throw new Error(
+        `Resize handle focus ring was not visibly inset: ${outlineWidth}px ${focusStyle.outlineStyle}, offset ${outlineOffset}px`,
+      );
+    }
+  },
 };
 
 // =============================================================================

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
+import {AppShell} from '@astryxdesign/core/AppShell';
 import {
   SideNav,
   SideNavHeading,
@@ -673,6 +674,46 @@ export const CollapsibleSidebar: Story = {
         />
       </SideNavSection>
     </SideNav>
+  ),
+};
+
+// =============================================================================
+// Resizable in AppShell
+// =============================================================================
+
+export const ResizableInAppShell: Story = {
+  name: 'Resizable in AppShell',
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => (
+    <AppShell
+      contentPadding={6}
+      sideNav={
+        <SideNav
+          resizable
+          header={
+            <SideNavHeading
+              icon={
+                <NavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+              }
+              heading="My App"
+            />
+          }>
+          <SideNavSection title="Main">
+            <SideNavItem
+              label="Dashboard"
+              icon={HomeIcon}
+              selectedIcon={HomeIconSolid}
+              isSelected
+            />
+            <SideNavItem label="Projects" icon={FolderIcon} />
+            <SideNavItem label="Analytics" icon={ChartBarIcon} />
+          </SideNavSection>
+        </SideNav>
+      }>
+      <Text type="body">Drag the sidebar edge to resize the navigation.</Text>
+    </AppShell>
   ),
 };
 

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -25,7 +25,7 @@ export const docs = {
       {className: 'astryx-side-nav-section'},
     ],
   },
-  description: 'Container with five zones: header, topContent, children (scrollable), footer, and footerIcons. Supports collapsible mode.',
+  description: 'Container with five zones: header, topContent, children (scrollable), footer, and footerIcons. Supports collapsible and resizable modes.',
   props: [
     {
       name: 'header',

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -989,6 +989,16 @@ describe('SideNav resizable', () => {
     ).toBeInTheDocument();
   });
 
+  it('clips the overlay drag handle within the resizable nav bounds', () => {
+    render(<SideNav resizable>Content</SideNav>);
+    const nav = screen.getByRole('navigation');
+    const container = nav.parentElement;
+    const handle = screen.getByTestId('astryx-sidenav-resize-handle');
+
+    expect(container).toContainElement(handle);
+    expect(getComputedStyle(container!).overflow).toBe('clip');
+  });
+
   it('does not render drag handle without resizable', () => {
     render(<SideNav>Content</SideNav>);
     expect(

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -11,7 +11,8 @@
  * Sidebar navigation container with five zones: header + topContent (sticky together),
  * children (scrollable), footer, and footerIcons (sticky bottom).
  *
- * Supports optional resize via drag handle at the inline-end edge.
+ * Supports optional resize via a drag handle at the inline-end edge. The
+ * resizable wrapper clips handle overflow while keeping its focus ring inside.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/SideNav/SideNav.doc.mjs
@@ -25,7 +26,7 @@ import {useCallback, useImperativeHandle, useRef, type ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {spacingVars} from '../theme/tokens.stylex';
+import {focusVars, spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {
   SideNavCollapseContext,
@@ -241,6 +242,16 @@ const styles = stylex.create({
     display: 'flex',
     flexShrink: 0,
     height: '100%',
+    overflow: 'clip',
+  },
+  resizableHandle: {
+    // Keep the shared ring inside the clipping boundary. The wrapper cannot
+    // use overflow-clip-margin: that paint allowance also contributes the
+    // overlay's half-pixel spill to AppShell's scrollable overflow.
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': `calc(0px - ${focusVars['--focus-outline-width']})`,
+    },
   },
   // Topbar mode — horizontal layout for mobile top bar
   topbar: {
@@ -658,6 +669,7 @@ export function SideNav({
         position="overlay"
         pillPlacement="end"
         isAlwaysVisible={false}
+        xstyle={styles.resizableHandle}
         resizable={resizableHook.props}
         label={t('@astryx.sideNav.resizeSidebar')}
       />


### PR DESCRIPTION
## Summary

Eliminates the horizontal scrollbar created by a resizable `SideNav` inside an `AppShell`, while preserving the resize handle's keyboard focus ring.

## Case

The overlay resize handle extends just beyond the resizable wrapper. In an `AppShell` scrollable panel, that half-pixel spill made a 260px panel report a 261px `scrollWidth`.

## Fix

- Clip the SideNav-owned resizable wrapper at `packages/core/src/SideNav/SideNav.tsx:240`.
- Override the shared focus outline in the same `:focus-visible` priority bucket at `packages/core/src/SideNav/SideNav.tsx:247`, moving it inward by the theme's outline width.
- Cover containment at `packages/core/src/SideNav/SideNav.test.tsx:992` and add the exact AppShell composition at `apps/storybook/stories/SideNav.stories.tsx:684`.

## Scope

This changes only SideNav's internal resizable composition. It does not change the public SideNav, LayoutPanel, or ResizeHandle APIs, and it preserves vertical scrolling plus pointer and keyboard resizing.

## Testing

- `corepack pnpm exec vitest run packages/core/src/SideNav/SideNav.test.tsx` — 200 passed
- `corepack pnpm -F @astryxdesign/core typecheck`
- `corepack pnpm lint:strict` — 0 errors (87 pre-existing warnings)
- `corepack pnpm build`
- `corepack pnpm storybook:build`
- Real Chrome: baseline AppShell panel `clientWidth=260`, `scrollWidth=261`; fixed panel `260/260`. Keyboard traversal matches `:focus-visible` and computes a 2px outline with `outline-offset: -2px`, keeping its outer edge exactly inside the clipped wrapper.
- Full local suite reached 16,229 passing tests; known macOS `cp --reflink` incompatibilities and CLI watch timeouts remain outside the changed paths. The prior production head's complete GitHub test/UI/build/lint/a11y/RTL suite passed; revised-head CI is rerunning.

Storybook: [Resizable in AppShell](https://facebook.github.io/astryx/pr/6196/?path=/story/core-sidenav--resizable-in-app-shell)

Changeset: `@astryxdesign/core` patch.

Fixes #6177
