### PR TITLE
fix(Chat): allow trigger menus to opt into whitespace queries (#6110)

### DIFF
--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -107,6 +107,11 @@ export type ChatComposerTrigger = {
   /** Character that activates this trigger menu (e.g. '@', '/') */
   character: string;
   /**
+   * If true, the trigger menu remains open when the user types a space,
+   * allowing multi-word queries. Default is false (single-token only).
+   */
+  allowWhitespace?: boolean;
+  /**
    * Search source providing items for this trigger.
    * Reuses the same SearchSource interface as Typeahead \u2014
    * supports sync/async search, bootstrap, and cancel().

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -200,7 +200,11 @@ function findActiveTrigger(
   for (let i = textBeforeCursor.length - 1; i >= 0; i--) {
     const char = textBeforeCursor[i];
 
-    if (char === ' ' || char === '\n') {
+    if (char === '\n') {
+      return null;
+    }
+
+    if (char === ' ' && !triggers.some(t => t.allowWhitespace)) {
       return null;
     }
 
@@ -209,6 +213,11 @@ function findActiveTrigger(
         const prevChar = i > 0 ? textBeforeCursor[i - 1] : null;
         if (prevChar === null || prevChar === ' ' || prevChar === '\n') {
           const query = textBeforeCursor.slice(i + 1);
+
+          if (query.includes(' ') && !trigger.allowWhitespace) {
+            continue;
+          }
+
           return {trigger, query, triggerStart: i};
         }
       }


### PR DESCRIPTION
Resolves #6110

This adds an `allowWhitespace` property to `ChatComposerTrigger` which opts into continuing the search past space characters. By default, single-token grammar like `/` continues to close the menu instantly when a space is typed. But triggers like `@` mentions can opt-in to remain open to support multi-word search queries.

- `useTriggerMenu.tsx`: The scanner now only aborts on newlines, or spaces when no triggers support whitespace. It verifies the query against `allowWhitespace` for each trigger.
- `ChatComposerInput.tsx`: Exposes the `allowWhitespace?: boolean` property.