### PR TITLE
fix(BreadcrumbItem): complete Night Watch audit

### DIFF
--- a/.changeset/breadcrumb-item-menu-accessibility.md
+++ b/.changeset/breadcrumb-item-menu-accessibility.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BreadcrumbItem preserves valid outside focus on menu light dismiss and labels menus from rich trigger content
+
+@cixzhang

--- a/apps/storybook/stories/BreadcrumbItem.stories.tsx
+++ b/apps/storybook/stories/BreadcrumbItem.stories.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  BreadcrumbItem,
+  BreadcrumbMenuItem,
+  Breadcrumbs,
+} from '@astryxdesign/core/Breadcrumbs';
+import {Icon} from '@astryxdesign/core/Icon';
+import {VStack} from '@astryxdesign/core/Layout';
+
+const meta: Meta<typeof BreadcrumbItem> = {
+  title: 'Core/BreadcrumbItem',
+  component: BreadcrumbItem,
+  tags: ['autodocs'],
+  parameters: {
+    controls: {disable: true},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BreadcrumbItem>;
+
+/**
+ * Keeps the public rendering branches on one reusable fixture: navigation link,
+ * action button, explicit current item, icon content, and a current menu trigger.
+ * The menu opens so component-scoped accessibility and RTL audits can reach its
+ * popup semantics without creating a story per audit row.
+ */
+export const PublicStates: Story = {
+  name: 'Public States',
+  render: () => (
+    <VStack gap={4}>
+      <Breadcrumbs label="Link, action, and current breadcrumb items">
+        <BreadcrumbItem
+          href="/calendar"
+          startIcon={<Icon icon="calendar" size="sm" />}>
+          Calendar
+        </BreadcrumbItem>
+        <BreadcrumbItem onClick={() => {}}>Refresh</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>
+      <Breadcrumbs label="Current breadcrumb item with a menu">
+        <BreadcrumbItem href="/">Home</BreadcrumbItem>
+        <BreadcrumbItem
+          isCurrent
+          menu={
+            <>
+              <BreadcrumbMenuItem label="Design" />
+              <BreadcrumbMenuItem label="Engineering" />
+            </>
+          }>
+          <span>Teams</span>
+        </BreadcrumbItem>
+      </Breadcrumbs>
+    </VStack>
+  ),
+  play: async ({canvasElement}) => {
+    const trigger = canvasElement.querySelector(
+      '.astryx-breadcrumb-item-menu-trigger',
+    );
+    if (
+      trigger instanceof HTMLButtonElement &&
+      trigger.getAttribute('aria-expanded') === 'false'
+    ) {
+      trigger.click();
+    }
+  },
+};

--- a/apps/storybook/stories/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/Breadcrumbs.stories.tsx
@@ -94,14 +94,12 @@ export const CustomSeparator: Story = {
 export const WithIcons: Story = {
   render: () => (
     <Breadcrumbs>
-      <BreadcrumbItem
-        href="/"
-        startIcon={<HomeIcon width={16} height={16} aria-hidden="true" />}>
+      <BreadcrumbItem href="/" startIcon={<Icon icon={HomeIcon} size="sm" />}>
         Home
       </BreadcrumbItem>
       <BreadcrumbItem
         href="/settings"
-        startIcon={<Cog6ToothIcon width={16} height={16} aria-hidden="true" />}>
+        startIcon={<Icon icon={Cog6ToothIcon} size="sm" />}>
         Settings
       </BreadcrumbItem>
       <BreadcrumbItem isCurrent>Profile</BreadcrumbItem>
@@ -162,14 +160,12 @@ export const SupportingWithIcons: Story = {
   name: 'Supporting Variant with Icons',
   render: () => (
     <Breadcrumbs variant="supporting">
-      <BreadcrumbItem
-        href="/"
-        startIcon={<HomeIcon width={14} height={14} aria-hidden="true" />}>
+      <BreadcrumbItem href="/" startIcon={<Icon icon={HomeIcon} size="xsm" />}>
         Home
       </BreadcrumbItem>
       <BreadcrumbItem
         href="/projects"
-        startIcon={<FolderIcon width={14} height={14} aria-hidden="true" />}>
+        startIcon={<Icon icon={FolderIcon} size="xsm" />}>
         Projects
       </BreadcrumbItem>
       <BreadcrumbItem isCurrent>My Project</BreadcrumbItem>

--- a/packages/cli/assets/templates/blocks/components/BreadcrumbItem/BreadcrumbItemShowcase.tsx
+++ b/packages/cli/assets/templates/blocks/components/BreadcrumbItem/BreadcrumbItemShowcase.tsx
@@ -2,27 +2,11 @@
 
 'use client';
 
-import type {ComponentProps} from 'react';
 import {Breadcrumbs, BreadcrumbItem} from '@astryxdesign/core/Breadcrumbs';
+import {Icon} from '@astryxdesign/core/Icon';
 import {VStack} from '@astryxdesign/core/Layout';
 import {Text} from '@astryxdesign/core/Text';
-
-function HomeIcon(props: ComponentProps<'svg'>) {
-  return (
-    <svg
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth={2}
-      stroke="currentColor"
-      {...props}>
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M3 9.5L12 3l9 6.5V20a1 1 0 01-1 1H4a1 1 0 01-1-1V9.5z"
-      />
-    </svg>
-  );
-}
+import {HomeIcon} from '@heroicons/react/24/outline';
 
 export default function BreadcrumbItemShowcase() {
   return (
@@ -32,7 +16,9 @@ export default function BreadcrumbItemShowcase() {
           With start icon
         </Text>
         <Breadcrumbs>
-          <BreadcrumbItem href="/" startIcon={<HomeIcon />}>
+          <BreadcrumbItem
+            href="/"
+            startIcon={<Icon icon={HomeIcon} size="sm" />}>
             Home
           </BreadcrumbItem>
           <BreadcrumbItem href="/docs">Docs</BreadcrumbItem>

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.doc.mjs
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.doc.mjs
@@ -8,6 +8,10 @@ export const docs = {
   displayName: 'Breadcrumb Item',
   isHiddenFromOverview: true,
   description: 'Individual breadcrumb item that renders as a link when href is provided, or as plain text for the current page.',
+  usage: {
+    description:
+      'BreadcrumbItem represents one destination, action, current location, or sibling-menu trigger inside a Breadcrumbs trail.',
+  },
   props: [
     {
       name: 'children',
@@ -28,8 +32,8 @@ export const docs = {
     {
       name: 'isCurrent',
       type: 'boolean',
-      description: 'Marks this item as the current page, applying aria-current="page".',
-      default: 'false',
+      description:
+        'Marks this item as the current page, applying aria-current="page". When omitted, the last item is auto-detected if no item is explicitly current; pass false to opt out.',
     },
     {
       name: 'startIcon',
@@ -90,8 +94,8 @@ export const docsZh = {
     {
       name: 'isCurrent',
       type: 'boolean',
-      description: '将此项标记为当前页面，应用 aria-current="page"。',
-      default: 'false',
+      description:
+        '将此项标记为当前页面，应用 aria-current="page"。省略时，如果没有显式的当前项，则自动将最后一项标记为当前项；传入 false 可退出自动检测。',
     },
     {
       name: 'startIcon',
@@ -127,7 +131,8 @@ export const docsDense = {
     children: 'label content',
     href: 'link URL; omit for non-navigable items',
     onClick: 'click handler',
-    isCurrent: 'marks current page w/ aria-current="page"',
+    isCurrent:
+      'marks current page w/ aria-current="page"; omitted auto-detects the last item; false opts out',
     startIcon: 'icon before label',
     menu: 'DropdownMenuOption[] | children; opens a menu trigger (aria-haspopup="menu"); reuses the DropdownMenu item API',
     menuSize: "menu item size; defaults from variant (supporting→sm, else md)",

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.spec.md
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.spec.md
@@ -1,0 +1,225 @@
+---
+schema_version: 3
+template_version: 4
+kind: component
+id: component:BreadcrumbItem
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [public-api, behavior, layout, theming, accessibility]
+verified_by:
+  [
+    packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx,
+    apps/storybook/stories/BreadcrumbItem.stories.tsx,
+    packages/core/src/theme/themingTargets.test.ts,
+    scripts/check-knowledge.mjs,
+  ]
+modules: []
+families: [family:navigation-destinations, family:overlay-dismissal]
+design_specs: []
+architecture:
+  [
+    architecture:component-style-authoring,
+    architecture:component-test-sufficiency,
+    architecture:component-theming-surface,
+    architecture:interaction-modality,
+    architecture:layer-runtime,
+    architecture:public-component-api,
+    architecture:react-component-runtime,
+  ]
+contributing: [contributing:api-conventions]
+system_specs: [spec:AST-002, spec:AST-005, spec:AST-029]
+---
+
+# BreadcrumbItem component contract
+
+## Intent
+
+BreadcrumbItem presents one destination, action, current location, or sibling-menu
+trigger inside a Breadcrumbs trail. This observational draft records verified
+released behavior and current shared obligations without changing public API,
+defaults, or the component's visual design.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: additive observational documentation plus bug fixes that
+  preserve the released public surface
+- Controlled/uncontrolled behavior: not applicable
+- Migration decision: none
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The list-item root, the item-content branch selected from current public inputs,
+  and forwarding the documented item ref and `BaseProps` surface to that root.
+- The decorative separator container rendered for its position in the trail.
+- The link-styled action or menu trigger and BreadcrumbItem-specific menu surface,
+  including their current theme targets.
+- Deriving the menu-item size from the parent Breadcrumbs variant when no explicit
+  menu size is supplied.
+
+**Does not own / non-goals**
+
+- The navigation landmark, ordered list, trail label, separator value, or visual
+  variant — owned by `component:Breadcrumbs` through the public parent component.
+- Destination acceptance and custom-router handoff — owned by
+  `family:navigation-destinations` and the shared link owner.
+- Generic top-layer hosting, focus containment, positioning, and light dismissal —
+  owned by `component:Popover` and `architecture:layer-runtime`.
+- Shared Escape/platform-close ordering — owned by
+  `family:overlay-dismissal`.
+- Menu-item data, row semantics, selection, or submenu behavior — delegated to the
+  DropdownMenu item pipeline.
+- Caller-provided icon artwork or arbitrary child content.
+
+## Public concepts
+
+| Concept       | Closed values or states                            | Meaning                                                                                                                         | Availability by variant/orientation/state | Default                                         | Owner                                          | Stability                                       | Invalid-value behavior                                                                     |
+| ------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ----------------------------------------------- | ---------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Item content  | required `ReactNode`                               | Supplies the visible item label and may contain caller-owned content.                                                           | Every item branch                         | Required                                        | `component:BreadcrumbItem`                     | Released                                        | React renders the supplied node.                                                           |
+| Destination   | supplied or absent `href`                          | Selects the shared link path when the item is not explicitly current and has no menu.                                           | Default and supporting variants           | Absent                                          | `family:navigation-destinations`               | Released                                        | Shared link handling decides accepted destinations.                                        |
+| Action        | supplied or absent `onClick`                       | Selects a native link-styled button when no destination or menu is supplied, or augments the link path when `href` is supplied. | Non-current items                         | Absent                                          | `component:BreadcrumbItem`                     | Released                                        | `menu` currently suppresses this input and warns in development.                           |
+| Current page  | `true`, `false`, or omitted                        | `true` explicitly marks the item current; `false` opts it out; omission makes the item an auto-current candidate.               | Every branch, including a menu trigger    | Omitted                                         | `component:BreadcrumbItem`                     | Released observation; intent review pending     | When no item is explicitly current, the omitted final item receives `aria-current="page"`. |
+| Link renderer | per-item `as`, provider renderer, or native anchor | Selects the component that receives an accepted destination.                                                                    | Non-current link path                     | Provider renderer, then native anchor           | `family:navigation-destinations`               | Released                                        | Explicitly current and menu paths do not use it.                                           |
+| Start content | supplied or absent `startIcon`                     | Renders caller content before the item label.                                                                                   | Every item branch                         | Absent                                          | Caller                                         | Released                                        | Caller content remains caller-owned.                                                       |
+| Sibling menu  | data array, composed menu content, or absent       | Replaces the link/action content branch with a menu button and menu surface.                                                    | Current or non-current item               | Absent                                          | `component:BreadcrumbItem`; menu rows delegate | Released observation; precedence review pending | Currently suppresses `href` or `onClick` and warns in development.                         |
+| Menu size     | `sm`, `md`, or `lg`                                | Selects the delegated menu-row size.                                                                                            | Menu branch                               | `sm` for supporting Breadcrumbs; otherwise `md` | `component:BreadcrumbItem`                     | Released                                        | TypeScript rejects unsupported values.                                                     |
+
+## Behavioral and layout contract
+
+Draft requirements identify their basis so observed code is not mistaken for an
+intentional decision.
+
+| ID  | Candidate invariant                                                                                                                                                                                                                   | Basis                                                                                  | Draft review state                                                                                          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| FR1 | The item root MUST remain one `<li>` carrying the public ref, item theme target, variant reflection, styling escape hatches, and neutral DOM pass-throughs.                                                                           | Released types, source, docs, and tests; `architecture:public-component-api`           | Verified current behavior; no API change proposed                                                           |
+| FR2 | A non-current item with `href` and no menu MUST use the shared link renderer; an item with only `onClick` MUST use a native button; an item with neither MUST render text content.                                                    | Released source, docs, and tests                                                       | Verified current behavior                                                                                   |
+| FR3 | Explicit `isCurrent=true` MUST expose `aria-current="page"`; explicit `false` MUST opt out; when every item omits the prop, the final item MUST receive the same current-page state.                                                  | Released source, docs, and tests                                                       | Verified current behavior; whether auto-detection remains the intended long-term default needs owner review |
+| FR4 | Every item MUST render one decorative separator container; the first item hides it. The built-in slash mirrors exactly once in RTL, while caller-provided separators remain caller-owned.                                             | Source, focused tests, and objective bidi behavior                                     | Verified current behavior                                                                                   |
+| FR5 | A menu item MUST expose one named menu button, current expanded state, control relationship, and one named `role="menu"` surface. Click, Enter, Space, and ArrowDown open it and focus its first item; Escape and selection close it. | APG Menu Button pattern, current Popover contract, source, tests, and browser evidence | Settled objective behavior                                                                                  |
+| FR6 | Closing the menu MUST preserve a newly focused outside control. Focus returns to the trigger only when the closing surface would otherwise strand focus.                                                                              | `component:Popover/AR4` and browser focus behavior                                     | Settled objective behavior                                                                                  |
+| FR7 | The menu branch MUST delegate item rendering, selection, typeahead, row focus, and submenu content to the shared DropdownMenu pipeline.                                                                                               | Released source and focused tests                                                      | Verified current behavior; DropdownMenu's draft contract remains context only                               |
+| FR8 | Omitted `menuSize` MUST resolve from the parent variant before entering DropdownMenu context.                                                                                                                                         | Released source and consumer docs                                                      | Verified current behavior                                                                                   |
+| FR9 | The current local targets MUST remain `breadcrumb-item`, `breadcrumb-item-menu-trigger`, and `breadcrumb-menu`, each on its current visible style owner with `variant` reflected where applicable.                                    | Released docs, source, and theming tests                                               | Verified current inventory; no target change proposed                                                       |
+
+### Allowed variation
+
+- **AV1 — Link renderer.** Native anchors and custom router components may differ in
+  DOM implementation while preserving the shared destination contract.
+- **AV2 — Caller content.** Labels and start content may be any renderable React
+  content; the item owns surrounding semantics, not caller artwork or markup.
+- **AV3 — Menu content.** Data-driven and composed content may produce actions,
+  sections, dividers, selectable items, or submenus through the delegated pipeline.
+- **AV4 — Theme.** Current targets and semantic tokens may change paint while item
+  roles, focus ownership, and branch behavior remain stable.
+
+### Representative states
+
+| State            | Required invariant                                                                                            | Allowed variation                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Destination link | Shared link path, visible keyboard focus, and accepted destination behavior remain available.                 | Native or custom router renderer; optional start content.     |
+| Action button    | Native button semantics and supplied click handling remain available.                                         | Default or supporting typography.                             |
+| Explicit current | Current-page state is exposed on the rendered content owner.                                                  | Plain content or menu trigger.                                |
+| Auto-current     | The final omitted item receives current-page state only when no explicit current item exists.                 | Link or text content remains in its released branch.          |
+| Closed menu      | Trigger exposes `aria-haspopup="menu"`, controls the menu, and reports collapsed state.                       | Data-driven or composed rows; current or non-current trigger. |
+| Open menu        | Named menu is top-layer reachable and focus enters its first eligible row.                                    | Row kinds, submenu content, and explicit menu size.           |
+| Dismissed menu   | One dismissal closes the surface; valid outside focus is preserved and stranded focus returns to the trigger. | Escape, selection, Tab, or native light dismiss.              |
+
+### Transformation and precedence order
+
+- **ORD1 — Content branch.** Explicit current is evaluated first; within either
+  current or non-current state, `menu` selects the menu branch. Otherwise `href`
+  selects the link branch, then `onClick` selects the action branch, then plain
+  content remains.
+- **ORD2 — Link renderer.** Per-item `as` wins over LinkProvider, which wins over
+  the native anchor.
+- **ORD3 — Menu size.** Explicit `menuSize` wins; otherwise supporting resolves to
+  `sm` and every other parent variant resolves to `md`.
+
+### Performance and resources
+
+- **PR1 — Delegated layer resources.** BreadcrumbItem creates no independent global
+  listeners or observers; menu lifecycle and focus resources remain delegated to
+  Popover and shared menu hooks.
+- **PR2 — Auto-current reconciliation.** Current source reconciles omitted current
+  state by inspecting the rendered sibling list after render. This is a known
+  runtime-authority gap under `architecture:react-component-runtime`, not an
+  approved implementation requirement.
+
+## Accessibility contract
+
+- **AR1 — Trail semantics.** The parent Breadcrumbs landmark and ordered list own
+  aggregate breadcrumb semantics; each item remains one list item.
+- **AR2 — Current state.** The content owner for a current item exposes
+  `aria-current="page"`; the list-item wrapper does not duplicate it.
+- **AR3 — Native interaction.** Links use link semantics, action-only items use a
+  native button, and menu items use the APG Menu Button relationship.
+- **AR4 — Menu name.** The menu surface is labelled by its trigger, including when
+  the visible item content is a non-string React node.
+- **AR5 — Focus.** Keyboard focus is visible on links and menu/action buttons. Menu
+  entry, containment, Escape return, and outside-focus preservation follow FR5–FR6.
+- **AR6 — Separator.** Separator content is hidden from assistive technology while
+  remaining directionally correct for sighted readers.
+
+## Design relationships
+
+| Anatomy or state       | Design requirement                                                                               | Representation authority                                         | Hierarchy role    | Component contract |
+| ---------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- | ----------------- | ------------------ |
+| Item root              | Carries current typography and the `breadcrumb-item` target.                                     | Current source and public docs                                   | Supporting        | FR1, FR9           |
+| Link or action content | Uses native semantics and the shared focus indicator without introducing another content target. | Current source; `architecture:interaction-modality`              | Supporting        | FR2, AR3, AR5      |
+| Current content        | Uses the released non-color text emphasis alongside current-page semantics.                      | Current source and objective non-color communication             | Prominent         | FR3, AR2           |
+| Separator              | Remains decorative to assistive technology and mirrors by contextual bidi role.                  | Objective bidi behavior                                          | Supporting        | FR4, AR6           |
+| Menu trigger           | Paints the menu-trigger target on the native focus owner.                                        | Current source and public docs                                   | Supporting        | FR5, FR9, AR3–AR5  |
+| Menu surface           | Paints the `breadcrumb-menu` refinement inside Popover's shared layer surface.                   | `component:Popover` plus current BreadcrumbItem target inventory | Prominent         | FR5–FR9            |
+| Start content          | Renders caller content without claiming its artwork or semantics.                                | Caller content; `component:Icon` when composed                   | Context-dependent | AV2                |
+
+## Family and system relationships
+
+- `family:navigation-destinations` owns destination inspection and handoff for
+  native and custom link paths. BreadcrumbItem composes the shared link owner.
+- `family:overlay-dismissal` owns topmost Escape/platform-close routing.
+  BreadcrumbItem participates through Popover.
+- `component:Popover` owns generic menu-surface hosting, focus containment, and
+  stranded-focus return; BreadcrumbItem owns its trigger and refinement target.
+- `architecture:component-theming-surface` owns target qualification, placement,
+  and state reflection.
+- `architecture:public-component-api` and `spec:AST-002` own released API,
+  precedence, invalid-state prevention, and compatibility review.
+
+## Verification map
+
+| Contract         | Verification                                                               | Representative states                                                                      | Mutation or failure expectation                                                                     | Audit section                                 |
+| ---------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| FR1–FR3, AR1–AR3 | `Breadcrumbs.test.tsx` branch, ref, pass-through, and current-state suites | Link, action, explicit current, omitted final, explicit false                              | A branch changes semantic element, loses current state, or moves the public root contract.          | `audit:BreadcrumbItem/api-behavior`           |
+| FR4, AR6         | `Breadcrumbs.test.tsx`, `BreadcrumbItem.stories.tsx`, and RTL audit        | Built-in slash, bidi-mirrored glyph, explicit icon mirror, LTR and RTL                     | A contextual separator fails to mirror exactly once or becomes exposed to AT.                       | `audit:BreadcrumbItem/rtl`                    |
+| FR5–FR8, AR3–AR5 | `Breadcrumbs.test.tsx` plus real-browser story evidence                    | String and ReactNode labels, click/keyboard open, rows, selection, Escape, outside dismiss | A menu loses its name/state, focus enters the wrong owner, or dismissal steals valid outside focus. | `audit:BreadcrumbItem/accessibility-behavior` |
+| FR9              | `themingTargets.test.ts`, source inspection, and rendered theme evidence   | Item, menu trigger, menu surface; default/supporting                                       | A target disappears, moves to non-painting plumbing, or loses variant reflection.                   | `audit:BreadcrumbItem/theming`                |
+| Draft structure  | `scripts/check-knowledge.mjs`                                              | Required schema and current relationship links                                             | Missing sections, stale links, or accidental current authority fail validation.                     | `audit:BreadcrumbItem/knowledge`              |
+
+## Decision log
+
+None. This draft records observed released behavior and objective shared
+requirements; it makes no component-local API, default, compatibility, ownership,
+or visual-design decision.
+
+## Open questions
+
+- **OQ1 — Conflicting interaction props.** Should the released `menu` + `href` or
+  `menu` + `onClick` combinations remain warning-based precedence, or should a
+  compatibility plan make them unrepresentable? (`human-api`)
+- **OQ2 — Auto-current ownership.** Should omitted `isCurrent` remain an
+  auto-detected current candidate, and if so which React-owned mechanism should
+  replace post-render DOM reconciliation? (`human-api`)
+
+## Content boundary
+
+This file does not duplicate the consumer prop table, menu-item API, audit scores,
+run evidence, screenshots, implementation steps, or shared navigation, layer,
+dismissal, and theming rules. It links to their owners.

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -96,8 +96,9 @@ export interface BreadcrumbItemProps extends Omit<
   onClick?: (e: MouseEvent<HTMLElement>) => void;
   /**
    * Marks this item as the current page. Renders as a span with aria-current="page".
-   * If not set on any item, the last item is auto-detected as current.
-   * @default false
+   * When omitted, the last item is auto-detected as current if no item is
+   * explicitly current. Pass `false` to opt this item out of auto-detection.
+   * @default undefined
    */
   isCurrent?: boolean;
   /**
@@ -395,8 +396,7 @@ export function BreadcrumbItem({
             menu={menu}
             menuSize={resolvedMenuSize}
             variant={ctx.variant}
-            isCurrent
-            label={children}>
+            isCurrent>
             {content}
           </BreadcrumbMenuTrigger>
         ) : (
@@ -439,8 +439,7 @@ export function BreadcrumbItem({
           ref={contentRef}
           menu={menu}
           menuSize={resolvedMenuSize}
-          variant={ctx.variant}
-          label={children}>
+          variant={ctx.variant}>
           {content}
         </BreadcrumbMenuTrigger>
       ) : href != null ? (
@@ -493,8 +492,6 @@ interface BreadcrumbMenuTriggerProps {
   ref: React.Ref<HTMLElement>;
   /** The link-styled label content rendered inside the trigger button. */
   children: ReactNode;
-  /** Accessible name for the menu surface (the crumb's label). */
-  label: ReactNode;
   menu: DropdownMenuOption[] | ReactNode;
   menuSize: DropdownMenuSize;
   variant: BreadcrumbsVariant;
@@ -511,20 +508,17 @@ interface BreadcrumbMenuTriggerProps {
 function BreadcrumbMenuTrigger({
   ref,
   children,
-  label,
   menu,
   menuSize,
   variant,
   isCurrent = false,
 }: BreadcrumbMenuTriggerProps) {
   const menuId = useId();
+  const triggerId = useId();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const isSupporting = variant === 'supporting';
 
   const popover = usePopover({
-    onHide: useCallback(() => {
-      buttonRef.current?.focus();
-    }, []),
     hasLightDismiss: true,
     hasCloseButton: false,
     hasAutoFocus: false,
@@ -637,6 +631,7 @@ function BreadcrumbMenuTrigger({
         onClick={handleClick}
         onKeyDown={handleKeyDown}
         {...popover.triggerProps}
+        id={triggerId}
         aria-haspopup="menu"
         aria-controls={menuId}
         aria-current={isCurrent ? 'page' : undefined}
@@ -670,7 +665,7 @@ function BreadcrumbMenuTrigger({
           ref={listRef}
           id={menuId}
           role="menu"
-          aria-label={typeof label === 'string' ? label : undefined}
+          aria-labelledby={triggerId}
           onKeyDown={listKeyDown}
           {...mergeProps(
             themeProps('breadcrumb-menu'),

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -117,8 +117,8 @@ export const docs = {
         {
           name: 'isCurrent',
           type: 'boolean',
-          description: 'Marks this item as the current page, applying aria-current="page".',
-          default: 'false',
+          description:
+            'Marks this item as the current page, applying aria-current="page". When omitted, the last item is auto-detected if no item is explicitly current; pass false to opt out.',
         },
         {
           name: 'startIcon',

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, waitFor, fireEvent} from '@testing-library/react';
+import {render, screen, waitFor, fireEvent, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Breadcrumbs} from './Breadcrumbs';
 import {BreadcrumbItem} from './BreadcrumbItem';
@@ -427,6 +427,24 @@ describe('BreadcrumbItem menu', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('labels the menu from non-string trigger content', async () => {
+    const user = userEvent.setup();
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem menu={items}>
+          <span>Teams</span>
+        </BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Teams'}));
+
+    expect(screen.getByRole('menu', {hidden: true})).toHaveAccessibleName(
+      'Teams',
+    );
+  });
+
   it('portability: a DropdownMenuOption[] renders its items on open', async () => {
     const user = userEvent.setup();
     render(
@@ -437,7 +455,7 @@ describe('BreadcrumbItem menu', () => {
     );
     await user.click(screen.getByRole('button', {name: 'Teams'}));
     const menu = screen.getByRole('menu', {hidden: true});
-    expect(menu).toHaveAttribute('aria-label', 'Teams');
+    expect(menu).toHaveAccessibleName('Teams');
     expect(
       screen.getByRole('menuitem', {name: 'Design', hidden: true}),
     ).toBeInTheDocument();
@@ -576,6 +594,35 @@ describe('BreadcrumbItem menu', () => {
     expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
     await waitFor(() => {
       expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('preserves outside focus after a browser light dismiss', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <Breadcrumbs>
+          <BreadcrumbItem menu={items}>Teams</BreadcrumbItem>
+          <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+        </Breadcrumbs>
+        <button type="button">Outside action</button>
+      </>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Teams'});
+    await user.click(trigger);
+    const menu = screen.getByRole('menu', {hidden: true});
+    const outside = screen.getByRole('button', {name: 'Outside action'});
+
+    outside.focus();
+    expect(outside).toHaveFocus();
+    const popover = menu.closest('[popover]');
+    expect(popover).not.toBeNull();
+    await act(async () => {
+      (popover as HTMLElement).hidePopover();
+    });
+
+    await waitFor(() => {
+      expect(outside).toHaveFocus();
     });
   });
 


### PR DESCRIPTION
## User impact

`BreadcrumbItem` menus now keep a valid outside focus target after light dismiss, and menus remain named when the visible trigger label is rich React content rather than a string.

## Audit result

- Component: `core/BreadcrumbItem`
- Mode: Night Watch (`N`)
- Rubric: `1.16.1`
- Baseline: **71.3 / C**, 5 BLOCKs
- Final: **84.7 / C**, 1 BLOCK
- Sensitivity: resolving the remaining BLOCK without changing anything else projects **89.3 / B**
- Source base: `5447429bacc4baa6b02f70da73dcdb9bb7d6e8ee`
- Frozen head: `e5b33bbbbcdbe632aff7640f4636909aa9a6fca7`
- Landed squash: [`585c4125303a`](https://github.com/facebook/astryx/commit/585c4125303a441f7b2f8c7c490635f32bfac211)
- Final landed ledger: [wiki commit `f5f2723580`](https://github.com/facebook/astryx/wiki/_compare/f5f27235809825f506a3ab28d73dd463f4973a91)

| Section | Baseline | Final |
|---|---:|---:|
| Accessibility | 2.5/5 | 5/5 |
| Theming | 4.5/5 | 4.5/5 |
| Public API | 3/5 | 3/5 |
| Behavior | 4/5 | 4/5 |
| Design — objective | 5/5 | 5/5 |
| Design — rendered | 4.5/5 | 4.5/5 |
| Testing | 3/5 | 4.5/5 |
| Code health | 4/5 | 4/5 |
| Docs | 3/5 | 4/5 |
| i18n & RTL | 4/5 limited | 5/5 limited |
| Responsive & touch | 5/5 limited | 5/5 limited |

Limited-section weights are redistributed per the rubric.

## Changes

- Adds a draft observational `BreadcrumbItem` contract using the current component schema. It records shipped behavior only and remains non-authoritative pending owner approval.
- Fixes two objective accessibility defects with public-seam red → green tests: rich menu labels now name the menu, and native light dismiss no longer steals valid outside focus.
- Adds one reusable component-scoped Storybook fixture so accessibility and RTL tooling can measure `BreadcrumbItem` directly.
- Corrects the documented `isCurrent` omission behavior, adds standalone usage guidance, and routes example glyphs through `Icon`.

## Evidence inventory

Closed: **18/18 rows accounted for** from public exports/types, docs, reachable states, and implementation branches. Evidence includes 42 baseline and 42 exact-head Chromium frames with fail-closed sensor receipts, focused unit coverage, axe, RTL, source checks, and package/Storybook builds. Comparable baseline/exact-head frames are byte-identical except the two icon fixture frames intentionally migrated to the shared `Icon` primitive.

### Rendered evidence

| Baseline | Exact head |
|---|---|
| [Light contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__baseline-light.png) | [Light contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__exact-head-light.png) |
| [Dark contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__baseline-dark.png) | [Dark contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__exact-head-dark.png) |
| [Forced-colors / reduced-motion](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__baseline-special.png) | [Forced-colors / reduced-motion](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__exact-head-special.png) |

The new component-scoped fixture is visible in [light](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__public-states-light.png) and [dark](https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-6206/pr-assets/BreadcrumbItem__public-states-dark.png).

## Needs review

- **P8 / `architecture:public-component-api/INV3` — inherited BLOCK:** `menu` suppresses `href` or `onClick`. Fixing this requires an API and compatibility decision, so this audit leaves it unchanged.
- **C16 / runtime INV1:** omitted `isCurrent` is reconciled after render through DOM inspection. Replacing that mechanism depends on the owner deciding whether the released auto-current default remains.
- **B4 / D13:** pressed link-style items currently look the same as hover. The appropriate link/navigation treatment is a visual-design decision, so this audit does not invent one.
- **T23:** the first-item separator relay still uses the undocumented unprefixed `--separator-display` implementation variable. A direct private rename fails the derived-variable contract, so this needs a proper structural or registered-variable fix rather than a cosmetic rename.

## Validation

- `pnpm vitest run packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx` — 42/42 pass
- `pnpm check:knowledge` — pass
- `pnpm -F @astryxdesign/core typecheck:docs` — pass
- `pnpm -F @astryxdesign/core typecheck` — pass
- `pnpm lint:strict` — pass (87 pre-existing warnings, 0 errors; no changed-file warnings)
- `pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm storybook:build` — pass
- `pnpm a11y:audit -- --components BreadcrumbItem` — 0 issues
- `pnpm rtl:audit -- --filter BreadcrumbItem` — measured; D6 pass, 0 failures, 0 coverage gaps
- `node scripts/check-use-client.mjs` and `node scripts/sync-exports.js --check` — pass
- `pnpm build`, Storybook typecheck, and `node scripts/verify-exports.mjs` — pass after building all workspace packages
- [Exact-head CI run](https://github.com/facebook/astryx/actions/runs/34470950642) — success; all test, build, lint, a11y, RTL, and stable visual jobs passed

## Pre-merge exact-head audit eligibility

```json
{
  "schemaVersion": 1,
  "component": "BreadcrumbItem",
  "package": "core",
  "auditMode": "N",
  "rubricVersion": "1.16.1",
  "heads": {
    "repository": "e5b33bbbbcdbe632aff7640f4636909aa9a6fca7",
    "componentContract": "e5b33bbbbcdbe632aff7640f4636909aa9a6fca7"
  },
  "inventory": {
    "closed": true,
    "gaps": [
      "P8: menu suppresses href/onClick",
      "C16: omitted current state is reconciled after render",
      "B4/D13: pressed treatment requires design judgment",
      "T23: separator relay uses an undocumented unprefixed implementation variable",
      "Standalone consumer guidance remains incomplete",
      "menuSize behavior lacks focused mutation-sensitive coverage"
    ]
  },
  "unresolvedGaps": {
    "objective": [
      "C16 post-render current-state reconciliation",
      "T23 separator implementation variable",
      "standalone documentation completeness",
      "menuSize focused test coverage"
    ],
    "manual": [
      "P8 API and compatibility decision for conflicting menu/navigation inputs",
      "B4/D13 pressed-state representation",
      "exact-head owner approval for the draft observational contract"
    ]
  },
  "remediations": [
    {
      "ruleId": "A1",
      "beforeEvidence": ["non-string trigger content left role=menu unnamed"],
      "afterEvidence": ["public-seam regression test and axe pass"]
    },
    {
      "ruleId": "A5",
      "beforeEvidence": ["native light dismiss moved focus from an outside button back to the trigger"],
      "afterEvidence": ["public-seam regression test and real Chromium outside-focus receipt"]
    },
    {
      "ruleId": "V10/I17",
      "beforeEvidence": ["component-scoped a11y audited zero stories; RTL reported one coverage gap"],
      "afterEvidence": ["component-scoped story; axe 0 issues; RTL measured with D6 pass"]
    },
    {
      "ruleId": "X2/P31",
      "beforeEvidence": ["standalone docs lacked usage.description and claimed isCurrent defaulted to false"],
      "afterEvidence": ["usage guidance and omission/false semantics align with source; docs typecheck passes"]
    },
    {
      "ruleId": "T17",
      "beforeEvidence": ["the BreadcrumbItem showcase rendered a private inline SVG"],
      "afterEvidence": ["the same caller-owned glyph is rendered through Icon"]
    }
  ],
  "approvals": [
    {"name": "component-spec-owner", "state": "pending"},
    {"name": "human-review", "state": "pending"}
  ],
  "checks": [
    {"name": "local-focused", "state": "pass"},
    {"name": "exact-head-ci", "state": "pass"},
    {"name": "audit-eligibility", "state": "unavailable"}
  ],
  "eligibility": {
    "eligible": false,
    "reasons": [
      "spec:AST-029 remains phase: accepted; FR11 activation is absent",
      "the trusted audit-eligibility check is unavailable",
      "one inherited BLOCK remains",
      "manual API, design, and exact-head contract approval are pending"
    ]
  }
}
```

## Post-merge closure

[PR #6206](https://github.com/facebook/astryx/pull/6206) squash-merged as [`585c4125303a`](https://github.com/facebook/astryx/commit/585c4125303a441f7b2f8c7c490635f32bfac211) after exact-head review and green CI. The squash contains exactly the nine reviewed paths: every landed blob and mode is byte-identical to reviewed head `e5b33bbbbcdb`, no intervening main commit touched those paths, and both diffs have stable patch ID `425b2c2de7e0a7591a554862c1e31ab6285e4ac0`.

The final post-merge row is [wiki commit `f5f2723580`](https://github.com/facebook/astryx/wiki/_compare/f5f27235809825f506a3ab28d73dd463f4973a91): **84.7 / C**, one inherited **P8 BLOCK**, mode `N`, rubric `1.16.1`, landed commit `585c4125303a441f7b2f8c7c490635f32bfac211`. Rubric `1.16.2` changed only the recording lifecycle and explicitly preserves score comparability.

Auto-merge remained disabled; this PR landed through the reviewed Night Watch path.

