### PR TITLE
fix(Center): complete Night Watch audit

### DIFF
--- a/.changeset/center-owned-axis.md
+++ b/.changeset/center-owned-axis.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] Center: preserve component-owned axis reflection and correct the horizontal-centering example.
+
+@cixzhang

--- a/.github/scripts/rtl-audit-coverage.test.mjs
+++ b/.github/scripts/rtl-audit-coverage.test.mjs
@@ -10,6 +10,7 @@ import {
   buildAuditedComponentRoster,
   buildComponentCoverage,
   classifyDirectionalDecorationPair,
+  classifyLogicalInlinePair,
   collectDirectionalDecorations,
 } from '../../apps/storybook/rtl-audit/rtl-audit-coverage.mjs';
 
@@ -97,6 +98,139 @@ describe('classifyDirectionalDecorationPair', () => {
         decoration('›', 'auto-bidi', MIRROR),
       ),
     ).toMatchObject({verdict: 'fail'});
+  });
+});
+
+function logicalMeasurement(overrides = {}) {
+  return {
+    count: 1,
+    visible: true,
+    width: 320,
+    height: 120,
+    direction: 'ltr',
+    writingMode: 'horizontal-tb',
+    inlineStart: 8,
+    inlineEnd: 24,
+    top: 4,
+    right: 24,
+    bottom: 12,
+    left: 8,
+    ...overrides,
+  };
+}
+
+describe('classifyLogicalInlinePair', () => {
+  it('passes asymmetric logical edges on a horizontal inline axis', () => {
+    expect(
+      classifyLogicalInlinePair(
+        logicalMeasurement(),
+        logicalMeasurement({direction: 'rtl', left: 24, right: 8}),
+      ),
+    ).toMatchObject({
+      verdict: 'pass',
+      reason:
+        'logical start/end stay stable and resolved left/right sides swap for horizontal-tb',
+    });
+  });
+
+  it('passes asymmetric logical edges on a vertical inline axis', () => {
+    expect(
+      classifyLogicalInlinePair(
+        logicalMeasurement({
+          writingMode: 'vertical-rl',
+          top: 8,
+          right: 4,
+          bottom: 24,
+          left: 12,
+        }),
+        logicalMeasurement({
+          direction: 'rtl',
+          writingMode: 'vertical-rl',
+          top: 24,
+          right: 4,
+          bottom: 8,
+          left: 12,
+        }),
+      ),
+    ).toMatchObject({
+      verdict: 'pass',
+      reason:
+        'logical start/end stay stable and resolved top/bottom sides swap for vertical-rl',
+    });
+  });
+
+  it('fails a hidden zero-size subject even when its values mirror', () => {
+    expect(
+      classifyLogicalInlinePair(
+        logicalMeasurement({visible: false, width: 0, height: 0}),
+        logicalMeasurement({
+          direction: 'rtl',
+          visible: false,
+          width: 0,
+          height: 0,
+          left: 24,
+          right: 8,
+        }),
+      ),
+    ).toMatchObject({
+      verdict: 'fail',
+      reason: 'logical inline-edge subject is not one visible non-zero box',
+    });
+  });
+
+  it('fails horizontal logical edges that stay on physical sides', () => {
+    expect(
+      classifyLogicalInlinePair(
+        logicalMeasurement(),
+        logicalMeasurement({direction: 'rtl'}),
+      ),
+    ).toMatchObject({verdict: 'fail'});
+  });
+
+  it('fails vertical writing that swaps left/right instead of top/bottom', () => {
+    expect(
+      classifyLogicalInlinePair(
+        logicalMeasurement({
+          writingMode: 'vertical-rl',
+          top: 8,
+          right: 4,
+          bottom: 24,
+          left: 12,
+        }),
+        logicalMeasurement({
+          direction: 'rtl',
+          writingMode: 'vertical-rl',
+          top: 8,
+          right: 12,
+          bottom: 24,
+          left: 4,
+        }),
+      ),
+    ).toMatchObject({
+      verdict: 'fail',
+      reason:
+        'logical start/end did not mirror on the top/bottom inline axis for vertical-rl',
+    });
+  });
+
+  it('fails when the writing mode changes between directions', () => {
+    expect(
+      classifyLogicalInlinePair(
+        logicalMeasurement(),
+        logicalMeasurement({
+          direction: 'rtl',
+          writingMode: 'vertical-rl',
+          top: 24,
+          right: 4,
+          bottom: 8,
+          left: 12,
+        }),
+      ),
+    ).toMatchObject({
+      verdict: 'fail',
+      reason:
+        'logical inline-edge writing mode is missing or changed between directions',
+    });
   });
 });
 

--- a/apps/storybook/rtl-audit/README.md
+++ b/apps/storybook/rtl-audit/README.md
@@ -187,7 +187,7 @@ D6 returns **N-A** when a story contains no contextual decoration. The
 applicability layer below decides whether that N-A is explained; D6 itself does
 not turn absence into a pass.
 
-### B. Curated precision — D2 / D3 / D4
+### B. Curated precision — D2 / D3 / D4 / D7 / D8
 
 `targets.json` holds the geometry/behavior dimensions that genuinely need
 hand-written selectors, run **in addition** to auto-discovery:
@@ -197,6 +197,17 @@ hand-written selectors, run **in addition** to auto-discovery:
 - **D3 behavior-flip** — directional behavior inverts, e.g. Carousel's scroll
   axis: "next" makes `scrollLeft` go positive in LTR and negative in RTL.
 - **D4 overlay-side** — a positioned affordance flips side (`boundingBox`).
+- **D7 coarse hit alignment** — each configured native input remains centered
+  under its visible coarse-pointer wrapper and receives a center-point hit.
+- **D8 logical inline-edge mirror** — one configured, visible, non-zero subject
+  carries an intentionally asymmetric logical start/end padding pair whose
+  logical values stay stable while the resolved physical inline-axis sides swap
+  between LTR and RTL: left/right in horizontal writing, top/bottom in vertical
+  or sideways writing. The orthogonal physical edges must remain stable.
+  Missing, duplicate, hidden, zero-size, symmetric, or changing-writing-mode
+  fixtures fail closed because they cannot prove the relationship. Real
+  Chromium startup self-checks prove horizontal and vertical-writing passes plus
+  a hidden-subject failure before any component result is accepted.
 
 D1 and D6 are intentionally **not** in `targets.json`; auto-discovery covers
 them universally.

--- a/apps/storybook/rtl-audit/rtl-audit-coverage.mjs
+++ b/apps/storybook/rtl-audit/rtl-audit-coverage.mjs
@@ -257,6 +257,113 @@ export function evaluateDirectionalDecorations(ltr, rtl) {
   };
 }
 
+/**
+ * Classify one asymmetric inline-edge pair across LTR and RTL.
+ *
+ * Logical start/end values must stay stable while the physical edges for the
+ * computed inline axis swap: left/right in horizontal writing and top/bottom
+ * in vertical or sideways writing. A symmetric fixture cannot prove this
+ * relationship, so it fails closed instead of producing a vacuous pass.
+ */
+export function classifyLogicalInlinePair(ltr, rtl, tolerancePx = 0.5) {
+  const close = (left, right) => Math.abs(left - right) <= tolerancePx;
+  const boxes = [ltr, rtl];
+  if (
+    !boxes.every(
+      measurement =>
+        measurement?.count === 1 &&
+        measurement.visible === true &&
+        Number.isFinite(measurement.width) &&
+        Number.isFinite(measurement.height) &&
+        measurement.width > 0 &&
+        measurement.height > 0,
+    )
+  ) {
+    return {
+      verdict: 'fail',
+      reason: 'logical inline-edge subject is not one visible non-zero box',
+    };
+  }
+
+  const values = boxes.flatMap(measurement => [
+    measurement.inlineStart,
+    measurement.inlineEnd,
+    measurement.top,
+    measurement.right,
+    measurement.bottom,
+    measurement.left,
+  ]);
+  if (!values.every(Number.isFinite)) {
+    return {
+      verdict: 'fail',
+      reason: 'logical inline-edge measurements are incomplete',
+    };
+  }
+  if (ltr.direction !== 'ltr' || rtl.direction !== 'rtl') {
+    return {
+      verdict: 'fail',
+      reason:
+        'logical inline-edge measurements did not use LTR and RTL directions',
+    };
+  }
+  if (
+    typeof ltr.writingMode !== 'string' ||
+    ltr.writingMode !== rtl.writingMode
+  ) {
+    return {
+      verdict: 'fail',
+      reason:
+        'logical inline-edge writing mode is missing or changed between directions',
+    };
+  }
+
+  const writingMode = ltr.writingMode.toLowerCase();
+  const inlineEdges = writingMode.startsWith('horizontal')
+    ? ['left', 'right']
+    : writingMode.startsWith('vertical') || writingMode.startsWith('sideways')
+      ? ['top', 'bottom']
+      : null;
+  if (inlineEdges == null) {
+    return {
+      verdict: 'fail',
+      reason: `unsupported writing mode: ${ltr.writingMode}`,
+    };
+  }
+  if (close(ltr.inlineStart, ltr.inlineEnd)) {
+    return {
+      verdict: 'fail',
+      reason: 'fixture is symmetric and cannot prove inline-edge mirroring',
+    };
+  }
+
+  const [physicalStart, physicalEnd] = inlineEdges;
+  const orthogonalEdges =
+    physicalStart === 'left' ? ['top', 'bottom'] : ['left', 'right'];
+  const logicalStable =
+    close(ltr.inlineStart, rtl.inlineStart) &&
+    close(ltr.inlineEnd, rtl.inlineEnd);
+  const physicalMirrored =
+    close(ltr[physicalStart], rtl[physicalEnd]) &&
+    close(ltr[physicalEnd], rtl[physicalStart]);
+  const orthogonalStable = orthogonalEdges.every(edge =>
+    close(ltr[edge], rtl[edge]),
+  );
+
+  return logicalStable && physicalMirrored && orthogonalStable
+    ? {
+        verdict: 'pass',
+        reason:
+          `logical start/end stay stable and resolved ${physicalStart}/${physicalEnd} ` +
+          `sides swap for ${writingMode}`,
+      }
+    : {
+        verdict: 'fail',
+        reason:
+          `logical start/end did not mirror on the ${physicalStart}/${physicalEnd} ` +
+          `inline axis for ${writingMode}`,
+      };
+}
+
 function resultIsApplicable(result) {
   return result?.verdict === 'pass' || result?.verdict === 'fail';
 }

--- a/apps/storybook/rtl-audit/rtl-audit.mjs
+++ b/apps/storybook/rtl-audit/rtl-audit.mjs
@@ -19,16 +19,17 @@
  *           - D6 (directional-decoration): single-glyph, aria-hidden decorations
  *             in repeated-item or between-sibling contexts mirror exactly once.
  *     (B) CURATED PRECISION — targets.json entries add D2 (order-flip),
- *         D3 (behavior-flip), D4 (overlay-side): the geometry/behavior dims that
+ *         D3 (behavior-flip), D4 (overlay-side), D7 (coarse hit alignment),
+ *         and D8 (logical inline-edge mirroring): the geometry/behavior dims that
  *         genuinely need hand-written selectors.
  *     (C) APPLICABILITY: every component is measured, explicitly verified N/A,
  *         or reported as a coverage gap. An all-N/A result is never called clean.
  * @input --storybook-dir <path> --output <file> [--targets <path>]
  *   [--verified-not-applicable <path>] [--filter <csv>] [--auto-only]
  *   [--curated-only]
- * @output JSON scorecard: D1/D5/D6 auto verdicts, curated D2/D3/D4 results,
- *   and a component coverage rollup. Mirrors the pr-a11y accessibility-audit
- *   harness.
+ * @output JSON scorecard: D1/D5/D6 auto verdicts, curated D2/D3/D4/D7/D8
+ *   results, and a component coverage rollup. Mirrors the pr-a11y accessibility-
+ *   audit harness.
  * @position internal test harness; run by the soft-gated `pr-rtl` CI job and
  *   locally via `pnpm -F @astryxdesign/storybook rtl-audit`.
  *
@@ -50,6 +51,7 @@ import {discoverComponents} from '../../../packages/cli/foundation/discovery/com
 import {
   buildAuditedComponentRoster,
   buildComponentCoverage,
+  classifyLogicalInlinePair,
   collectDirectionalDecorations,
   evaluateDirectionalDecorations,
 } from './rtl-audit-coverage.mjs';
@@ -782,6 +784,82 @@ async function checkD7CoarseHit(page, port, t, card) {
   card.notes.push(`D7 coarse hit-target center: ${results.map(result => `${result.rtl ? 'RTL' : 'LTR'} ${result.size}:${result.centers.map(formatTarget).join(',')}`).join('; ')}`);
 }
 
+async function measureLogicalInlineSubject(page, subject) {
+  const subjects = page.locator(subject);
+  const count = await subjects.count();
+  if (count !== 1) return {count, visible: false};
+  return subjects.first().evaluate(element => {
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    const number = value => Number.parseFloat(value);
+    const visible = typeof element.checkVisibility === 'function'
+      ? element.checkVisibility({checkOpacity: true, checkVisibilityCSS: true})
+      : style.display !== 'none' && style.visibility !== 'hidden' && Number(style.opacity) !== 0;
+    return {
+      count: 1, visible, width: rect.width, height: rect.height,
+      direction: style.direction,
+      writingMode: style.writingMode,
+      inlineStart: number(style.paddingInlineStart),
+      inlineEnd: number(style.paddingInlineEnd),
+      top: number(style.paddingTop), right: number(style.paddingRight),
+      bottom: number(style.paddingBottom), left: number(style.paddingLeft),
+    };
+  }).catch(() => null);
+}
+
+async function verifyD8BrowserContract(page) {
+  await page.setContent(`
+    <div id="d8-horizontal" dir="ltr" style="box-sizing:border-box;width:160px;height:40px;padding-block:4px 12px;padding-inline-start:8px;padding-inline-end:24px">horizontal</div>
+    <div id="d8-vertical" dir="ltr" style="box-sizing:border-box;width:160px;height:80px;writing-mode:vertical-rl;padding-block:4px 12px;padding-inline-start:8px;padding-inline-end:24px">vertical</div>
+  `);
+  const verifyPair = async subject => {
+    const ltr = await measureLogicalInlineSubject(page, subject);
+    await page.locator(subject).evaluate(element => { element.dir = 'rtl'; });
+    const rtl = await measureLogicalInlineSubject(page, subject);
+    return {ltr, rtl, result: classifyLogicalInlinePair(ltr, rtl)};
+  };
+  const horizontal = await verifyPair('#d8-horizontal');
+  const vertical = await verifyPair('#d8-vertical');
+  await page.locator('#d8-horizontal').evaluate(element => { element.style.display = 'none'; });
+  const hidden = await measureLogicalInlineSubject(page, '#d8-horizontal');
+  const hiddenVerdict = classifyLogicalInlinePair(hidden, hidden);
+  if (
+    horizontal.result.verdict !== 'pass' ||
+    vertical.result.verdict !== 'pass' ||
+    hiddenVerdict.verdict !== 'fail'
+  ) {
+    throw new Error(
+      `D8 browser contract failed: ${JSON.stringify({horizontal, vertical, hidden: {measurement: hidden, result: hiddenVerdict}})}`,
+    );
+  }
+  return {
+    horizontal,
+    vertical,
+    hidden: {measurement: hidden, result: hiddenVerdict},
+  };
+}
+
+async function checkD8LogicalInline(page, port, t, card) {
+  const subject = t.selectors?.subject;
+  if (!subject) { card.dims.D8 = 'N-A'; card.notes.push('D8: no subject selector configured'); return; }
+  const run = async rtl => {
+    await page.goto(storyUrl(port, t.storyId, rtl), {waitUntil: 'domcontentloaded'});
+    await settle(page); await doSetup(page, t);
+    return measureLogicalInlineSubject(page, subject);
+  };
+  const ltr = await run(false), rtl = await run(true);
+  if (ltr == null || rtl == null) { card.dims.D8 = 'N-A'; card.notes.push('D8: logical inline-edge subject was not measurable'); return; }
+  const result = classifyLogicalInlinePair(ltr, rtl);
+  card.dims.D8 = result.verdict;
+  const formatPhysical = measurement =>
+    `${measurement.top}/${measurement.right}/${measurement.bottom}/${measurement.left}px`;
+  card.notes.push(
+    `D8 logical inline edges: ${result.reason}; writing-mode ${ltr.writingMode}; ` +
+    `LTR start/end ${ltr.inlineStart}/${ltr.inlineEnd}px T/R/B/L ${formatPhysical(ltr)}; ` +
+    `RTL start/end ${rtl.inlineStart}/${rtl.inlineEnd}px T/R/B/L ${formatPhysical(rtl)}`,
+  );
+}
+
 async function scoreCurated(page, coarsePage, port, t) {
   const card = {component: t.component, storyId: t.storyId, dims: {}, notes: []};
   for (const dim of t.dims) {
@@ -790,6 +868,7 @@ async function scoreCurated(page, coarsePage, port, t) {
       else if (dim === 'D3') await checkD3Scroll(page, port, t, card);
       else if (dim === 'D4') await checkD4(page, port, t, card);
       else if (dim === 'D7') await checkD7CoarseHit(coarsePage, port, t, card);
+      else if (dim === 'D8') await checkD8LogicalInline(page, port, t, card);
       // D1 is handled by auto-discovery; ignore any stray D1 in curated entries.
     } catch (e) {
       card.dims[dim] = 'ERROR';
@@ -843,6 +922,7 @@ async function mapPool(items, pages, fn) {
     ),
   );
   const page = pages[0]; // curated dims run serially on the first page
+  const d8BrowserContract = await verifyD8BrowserContract(page);
   const coarseContext = await browser.newContext({
     viewport: {width: 1100, height: 760},
     deviceScaleFactor: 1,
@@ -1016,6 +1096,7 @@ async function mapPool(items, pages, fn) {
   const report = {
     generatedAt: new Date().toISOString(),
     dist: DIST,
+    selfChecks: {d8LogicalInline: d8BrowserContract},
     autoDiscovery: {
       total: autoResults.length,
       applicable: autoResults.filter(r => r.verdict !== 'N-A').length,

--- a/apps/storybook/rtl-audit/targets.json
+++ b/apps/storybook/rtl-audit/targets.json
@@ -36,6 +36,16 @@
     }
   },
   {
+    "component": "Center",
+    "storyId": "core-center--padding-per-edge",
+    "dims": [
+      "D8"
+    ],
+    "selectors": {
+      "subject": ".astryx-center"
+    }
+  },
+  {
     "component": "CheckboxInput",
     "storyId": "core-checkboxinput--size-comparison",
     "dims": [

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -62,7 +62,8 @@ const meta: Meta<typeof Center> = {
     axis: {
       control: 'select',
       options: ['both', 'horizontal', 'vertical'],
-      description: 'Which direction(s) to center',
+      description:
+        'Center mode. In horizontal writing, the names match physical axes; in vertical writing, current single-axis behavior follows flex main/cross axes.',
     },
     width: {
       control: 'text',
@@ -87,36 +88,36 @@ const meta: Meta<typeof Center> = {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description:
-        'Inline (horizontal) padding; overrides padding on that axis',
+        'Logical inline-axis padding; overrides padding on that axis',
     },
     paddingInlineStart: {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description:
-        'Inline-start (left in LTR) padding; overrides paddingInline/padding on that edge',
+        'Logical inline-start padding; physical edge depends on writing mode and direction',
     },
     paddingInlineEnd: {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description:
-        'Inline-end (right in LTR) padding; overrides paddingInline/padding on that edge',
+        'Logical inline-end padding; physical edge depends on writing mode and direction',
     },
     paddingBlock: {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
-      description: 'Block (vertical) padding; overrides padding on that axis',
+      description: 'Logical block-axis padding; overrides padding on that axis',
     },
     paddingBlockStart: {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description:
-        'Block-start (top) padding; overrides paddingBlock/padding on that edge',
+        'Logical block-start padding; physical edge depends on writing mode',
     },
     paddingBlockEnd: {
       control: 'select',
       options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description:
-        'Block-end (bottom) padding; overrides paddingBlock/padding on that edge',
+        'Logical block-end padding; physical edge depends on writing mode',
     },
   },
 };

--- a/packages/cli/assets/templates/blocks/components/Center/CenterHorizontal.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Center/CenterHorizontal.doc.mjs
@@ -6,8 +6,9 @@ export const doc = {
   exampleFor: 'Center',
   name: 'Center — Horizontal Center',
   displayName: 'Center — Horizontal Center',
-  description: 'An editor toolbar with a document title on the left and formatting actions on the right. This shows axis="horizontal", centering in one direction only. Use when content needs to be horizontally centered while other elements are positioned independently around it.',
+  description:
+    'A formatting control group centered with axis="horizontal" in the default horizontal writing mode. In other writing modes, Center currently follows the flex main axis rather than guaranteeing physical horizontal centering.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Center', 'Card', 'Icon', 'IconButton', 'Layout', 'Text'],
+  componentsUsed: ['Center', 'Card', 'Icon', 'IconButton', 'Layout'],
 };

--- a/packages/cli/assets/templates/blocks/components/Center/CenterHorizontal.tsx
+++ b/packages/cli/assets/templates/blocks/components/Center/CenterHorizontal.tsx
@@ -2,9 +2,9 @@
 
 'use client';
 
+import {Center} from '@astryxdesign/core/Center';
 import {Card} from '@astryxdesign/core/Card';
 import {Stack} from '@astryxdesign/core/Layout';
-import {Heading} from '@astryxdesign/core/Text';
 import {Icon} from '@astryxdesign/core/Icon';
 import {IconButton} from '@astryxdesign/core/IconButton';
 import {
@@ -19,9 +19,8 @@ import {
 export default function CenterHorizontal() {
   return (
     <Card width={520} padding={2}>
-      <Stack direction="horizontal" vAlign="center">
-        <Heading level={2}>Untitled Document</Heading>
-        <Stack direction="horizontal" gap={0} hAlign="end" style={{flex: 1}}>
+      <Center axis="horizontal" width="100%">
+        <Stack direction="horizontal" gap={0} vAlign="center">
           <IconButton
             label="Bold"
             icon={<Icon icon={BoldIcon} />}
@@ -59,7 +58,7 @@ export default function CenterHorizontal() {
             size="sm"
           />
         </Stack>
-      </Stack>
+      </Center>
     </Card>
   );
 }

--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -20,7 +20,8 @@ export const docs = {
     {
       name: 'axis',
       type: "'both' | 'horizontal' | 'vertical'",
-      description: 'Which direction(s) to center.',
+      description:
+        'Which Center mode to use. In horizontal writing, "horizontal" centers the flex main/inline axis and "vertical" centers the cross/block axis. In vertical writing, current single-axis behavior follows those logical flex axes rather than the physical names; "both" still centers both axes.',
       default: "'both'",
     },
     {
@@ -53,37 +54,37 @@ export const docs = {
       name: 'paddingInline',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
-        'Inline (horizontal) padding, using the spacing scale. Overrides padding on the inline axis when both are set.',
+        'Logical inline-axis padding, using the spacing scale. Overrides padding on the inline axis when both are set.',
     },
     {
       name: 'paddingInlineStart',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
-        'Inline-start padding, using the spacing scale (left in LTR, right in RTL). Overrides paddingInline and padding on that edge only.',
+        'Logical inline-start padding, using the spacing scale. Its resolved physical edge depends on writing mode and direction. Overrides paddingInline and padding on that edge only.',
     },
     {
       name: 'paddingInlineEnd',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
-        'Inline-end padding, using the spacing scale (right in LTR, left in RTL). Overrides paddingInline and padding on that edge only.',
+        'Logical inline-end padding, using the spacing scale. Its resolved physical edge depends on writing mode and direction. Overrides paddingInline and padding on that edge only.',
     },
     {
       name: 'paddingBlock',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
-        'Block (vertical) padding, using the spacing scale. Overrides padding on the block axis when both are set.',
+        'Logical block-axis padding, using the spacing scale. Overrides padding on the block axis when both are set.',
     },
     {
       name: 'paddingBlockStart',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
-        'Block-start (top) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+        'Logical block-start padding, using the spacing scale. Its resolved physical edge depends on writing mode. Overrides paddingBlock and padding on that edge only.',
     },
     {
       name: 'paddingBlockEnd',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
-        'Block-end (bottom) padding, using the spacing scale. Overrides paddingBlock and padding on that edge only.',
+        'Logical block-end padding, using the spacing scale. Its resolved physical edge depends on writing mode. Overrides paddingBlock and padding on that edge only.',
     },
     {
       name: 'isInline',
@@ -112,9 +113,10 @@ export const docs = {
     description:
       'Center aligns content to the middle of its container. Use it for empty states, loading screens, login forms, or any content that should sit in the center of the available space.',
     bestPractices: [
-      {guidance: true, description: 'Use axis="horizontal" or axis="vertical" when you only need one direction. Both axes is the default but not always needed.'},
-      {guidance: true, description: 'Set a height when centering vertically. Center needs a defined height to know what space to center within.'},
+      {guidance: true, description: 'Use a single-axis value only in horizontal writing, or after verifying the active writing mode. In vertical writing, the current implementation follows flex main/cross axes rather than the physical prop names.'},
+      {guidance: true, description: 'In horizontal writing, give Center height when using axis="vertical"; centering needs available space on the selected flex axis.'},
       {guidance: true, description: 'Use isInline to center small elements like icons or badges within a line of text without breaking the text flow.'},
+      {guidance: true, description: 'Keep semantic structure and accessible names on the content. Center is a layout-only container and does not add a role or label.'},
       {guidance: false, description: 'Wrap large page sections in Center. Use Layout or AppShell for page-level structure.'},
       {guidance: false, description: 'Use Center for horizontal lists of items. Use Stack with hAlign="center" instead.'},
     ],
@@ -133,15 +135,16 @@ export const docsZh = {
     description:
       'Center aligns content to the middle of its container. Use it for empty states, loading screens, login forms, or any content that should sit in the center of the available space.',
     bestPractices: [
-      {guidance: true, description: 'Use axis="horizontal" or axis="vertical" when you only need one direction. Both axes is the default but not always needed.'},
-      {guidance: true, description: 'Set a height when centering vertically. Center needs a defined height to know what space to center within.'},
+      {guidance: true, description: 'Use a single-axis value only in horizontal writing, or after verifying the active writing mode. In vertical writing, the current implementation follows flex main/cross axes rather than the physical prop names.'},
+      {guidance: true, description: 'In horizontal writing, give Center height when using axis="vertical"; centering needs available space on the selected flex axis.'},
       {guidance: true, description: 'Use isInline to center small elements like icons or badges within a line of text without breaking the text flow.'},
+      {guidance: true, description: 'Keep semantic structure and accessible names on the content. Center is a layout-only container and does not add a role or label.'},
       {guidance: false, description: 'Wrap large page sections in Center. Use Layout or AppShell for page-level structure.'},
       {guidance: false, description: 'Use Center for horizontal lists of items. Use Stack with hAlign="center" instead.'},
     ],
   },
   props: [
-    {name: 'axis', type: "'both' | 'horizontal' | 'vertical'", description: '居中的方向。', default: "'both'"},
+    {name: 'axis', type: "'both' | 'horizontal' | 'vertical'", description: '选择 Center 模式。横向书写时，horizontal 对应 flex 主轴/行内轴，vertical 对应交叉轴/块轴；纵向书写时，当前单轴行为仍跟随这些逻辑 flex 轴，而不是属性名暗示的物理轴。', default: "'both'"},
     {name: 'width', type: 'number | string', description: '容器宽度（px 或 CSS 值）。'},
     {name: 'height', type: 'number | string', description: '容器高度（px 或 CSS 值）。'},
     {
@@ -153,32 +156,32 @@ export const docsZh = {
     {
       name: 'paddingInline',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
-      description: '行内（水平）内边距，使用间距刻度。两者同时设置时在行内轴上覆盖 padding。',
+      description: '逻辑行内轴内边距，使用间距刻度。两者同时设置时在行内轴上覆盖 padding。',
     },
     {
       name: 'paddingInlineStart',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
-      description: '行内起始内边距，使用间距刻度（LTR 中为左侧，RTL 中为右侧）。仅在该边上覆盖 paddingInline 和 padding。',
+      description: '逻辑行内起始内边距，使用间距刻度。解析后的物理边取决于书写模式和方向。仅在该边上覆盖 paddingInline 和 padding。',
     },
     {
       name: 'paddingInlineEnd',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
-      description: '行内结束内边距，使用间距刻度（LTR 中为右侧，RTL 中为左侧）。仅在该边上覆盖 paddingInline 和 padding。',
+      description: '逻辑行内结束内边距，使用间距刻度。解析后的物理边取决于书写模式和方向。仅在该边上覆盖 paddingInline 和 padding。',
     },
     {
       name: 'paddingBlock',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
-      description: '块（垂直）内边距，使用间距刻度。两者同时设置时在块轴上覆盖 padding。',
+      description: '逻辑块轴内边距，使用间距刻度。两者同时设置时在块轴上覆盖 padding。',
     },
     {
       name: 'paddingBlockStart',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
-      description: '块起始（顶部）内边距，使用间距刻度。仅在该边上覆盖 paddingBlock 和 padding。',
+      description: '逻辑块起始内边距，使用间距刻度。解析后的物理边取决于书写模式。仅在该边上覆盖 paddingBlock 和 padding。',
     },
     {
       name: 'paddingBlockEnd',
       type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
-      description: '块结束（底部）内边距，使用间距刻度。仅在该边上覆盖 paddingBlock 和 padding。',
+      description: '逻辑块结束内边距，使用间距刻度。解析后的物理边取决于书写模式。仅在该边上覆盖 paddingBlock 和 padding。',
     },
     {name: 'isInline', type: 'boolean', description: '使用 inline-flex（适用于文本/图标）。', default: 'false'},
     {name: 'children', type: 'ReactNode', description: '要居中的内容。'},
@@ -203,30 +206,31 @@ export const docsZh = {
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
-  description: 'centers content horizontally and/or vertically via flexbox',
+  description: 'centers content on one or both flex axes; single-axis names match physical axes only in horizontal writing',
   usage: {
     description:
       'Center aligns content to the middle of its container. Use for empty states, loading screens, login forms.',
     bestPractices: [
-      {guidance: true, description: 'Use axis="horizontal" or axis="vertical" when you only need one direction. Both axes is the default but not always needed.'},
-      {guidance: true, description: 'Set a height when centering vertically. Center needs a defined height to know what space to center within.'},
+      {guidance: true, description: 'Use a single-axis value only in horizontal writing, or after verifying the active writing mode. In vertical writing, the current implementation follows flex main/cross axes rather than the physical prop names.'},
+      {guidance: true, description: 'In horizontal writing, give Center height when using axis="vertical"; centering needs available space on the selected flex axis.'},
       {guidance: true, description: 'Use isInline to center small elements (icons, badges) within a line of text without breaking text flow.'},
+      {guidance: true, description: 'Keep semantic structure and accessible names on the content; Center adds no role or label.'},
       {guidance: false, description: 'Wrap large page sections in Center. Use Layout or AppShell for page-level structure.'},
       {guidance: false, description: 'Use Center for horizontal lists of items. Use Stack with hAlign="center" instead.'},
     ],
   },
   propDescriptions: {
-    axis: 'centering direction(s)',
+    axis: 'centering mode; outside horizontal writing, single-axis values follow flex main/cross axes',
     width: 'container width (px or CSS)',
     height: 'container height (px or CSS)',
     padding:
       'inner padding on all sides (spacing step: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10)',
-    paddingInline: 'inline (horizontal) padding; overrides padding on that axis',
-    paddingInlineStart: 'inline-start padding (left in LTR); overrides paddingInline/padding on that edge',
-    paddingInlineEnd: 'inline-end padding (right in LTR); overrides paddingInline/padding on that edge',
-    paddingBlock: 'block (vertical) padding; overrides padding on that axis',
-    paddingBlockStart: 'block-start (top) padding; overrides paddingBlock/padding on that edge',
-    paddingBlockEnd: 'block-end (bottom) padding; overrides paddingBlock/padding on that edge',
+    paddingInline: 'logical inline-axis padding; overrides padding on that axis',
+    paddingInlineStart: 'logical inline-start padding; physical edge depends on writing mode and direction',
+    paddingInlineEnd: 'logical inline-end padding; physical edge depends on writing mode and direction',
+    paddingBlock: 'logical block-axis padding; overrides padding on that axis',
+    paddingBlockStart: 'logical block-start padding; physical edge depends on writing mode',
+    paddingBlockEnd: 'logical block-end padding; physical edge depends on writing mode',
     isInline: 'use inline-flex for text/icons',
     children: 'content to center',
     xstyle: 'StyleX styles for layout (margins, positioning, sizing); must be stylex.create() value',

--- a/packages/core/src/Center/Center.spec.md
+++ b/packages/core/src/Center/Center.spec.md
@@ -1,0 +1,225 @@
+---
+schema_version: 3
+template_version: 4
+kind: component
+id: component:Center
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+owners: [cixzhang]
+review_triggers: [public-api, layout, theming, accessibility]
+verified_by:
+  [
+    packages/core/src/Center/Center.test.tsx,
+    packages/core/src/theme/themingTargets.test.ts,
+    apps/storybook/rtl-audit/targets.json,
+    scripts/check-knowledge.mjs,
+  ]
+modules: []
+families: [family:layout-primitives]
+design_specs: []
+architecture:
+  [
+    architecture:knowledge-contracts,
+    architecture:public-component-api,
+    architecture:component-theming-surface,
+    architecture:container-padding,
+  ]
+contributing: []
+system_specs: [spec:AST-002, spec:AST-029]
+---
+
+# Center component contract
+
+## Intent
+
+Center arranges caller-supplied content at the horizontal center, vertical center,
+or both within its own box. This draft records verified released behavior, the
+objective owned-attribute repair in the accompanying audit, and the existing
+vertical-writing mismatch against current family authority. It does not add public
+API, defaults, responsive behavior, container-bleed participation, or product
+meaning.
+
+## Compatibility and migration
+
+- Released default preserved: `yes`
+- Compatibility class: defect repair plus additive observational documentation;
+  public types, defaults, supported values, DOM element, and theme target remain
+  unchanged
+- Controlled/uncontrolled behavior: not applicable
+- Migration decision: none; the inherited vertical-writing mismatch remains
+  unchanged and requires a separate runtime correction with DOM, flow, RSC, and
+  caller-content compatibility evidence
+
+Consumer migration instructions belong in consumer docs and release notes.
+
+## Ownership boundary
+
+**Owns**
+
+- The fixed `div` container and its flex or inline-flex display mode.
+- Centering along the selected public axis or axes.
+- The current box-size inputs and logical padding precedence.
+- The current `center` theme target and its reflected `axis` value.
+
+**Does not own / non-goals**
+
+- The semantics, paint, interaction, intrinsic size, or reading order of caller
+  content.
+- Page or structural-region layout; those remain with Layout, AppShell, and the
+  product callsite.
+- Gap between multiple children, responsive breakpoints, overflow, or automatic
+  sizing on an axis.
+- Container inset publication or descendant bleed behavior. Center padding remains
+  local under `architecture:container-padding`.
+- New visual treatment, public values, or element polymorphism.
+
+## Public concepts
+
+Consumer syntax remains in `Center.doc.mjs`. This table records observable concepts
+rather than duplicating its prop table.
+
+| Concept        | Closed values or states                                         | Meaning                                                                                                               | Availability by variant/orientation/state                                     | Default                                          | Owner                               | Stability                 | Invalid-value behavior                                                                          |
+| -------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------- |
+| Centering axis | `both`, `horizontal`, `vertical`                                | Selects which physical axis or axes align caller content to the center of Center's box.                               | Every render.                                                                 | `both`                                           | `component:Center`                  | Observed released surface | Values rejected by the public type are outside this draft.                                      |
+| Display mode   | flex or inline-flex                                             | Selects a block-level or inline-level flex container without changing centering semantics.                            | Every axis value.                                                             | flex                                             | `component:Center`                  | Observed released surface | The public boolean type admits only enabled or omitted.                                         |
+| Box size       | number or CSS value string for current width/height constraints | Applies the shared `SizeValue` contract to Center's own box.                                                          | Every axis and display mode.                                                  | Intrinsic/containing-layout result when omitted. | `family:layout-primitives`          | Observed released surface | Runtime-invalid CSS follows browser CSS handling; this draft adds no validation.                |
+| Local padding  | Shared spacing step on uniform, axis, or logical edge inputs    | Insets caller content inside Center without publishing container-bleed geometry.                                      | Every axis and display mode; logical edges follow writing mode and direction. | No component padding when omitted.               | `family:layout-primitives`          | Observed released surface | Values rejected by `SpacingStep` are outside this draft.                                        |
+| DOM extension  | Supported BaseProps inputs and ref                              | Supported DOM, ARIA, data, event, class, style, and StyleX inputs reach the current root; the ref reaches that `div`. | Every render.                                                                 | No additional inputs.                            | `architecture:public-component-api` | Observed released surface | Component-owned target reflection remains authoritative when a generic data attribute collides. |
+
+## Behavioral and layout contract
+
+| ID  | Candidate invariant                                                                                                                                                                                                                                                                                                                                                   | Basis                                                                                                   | Draft review state                                                                                                                                                                                            |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FR1 | The current root is one `div`. It renders as flex by default and inline-flex when the current inline flag is enabled.                                                                                                                                                                                                                                                 | Released declarations, source, docs, tests, and browser evidence                                        | Verified released behavior; no element or display change decided                                                                                                                                              |
+| FR2 | `both` centers the physical horizontal and vertical axes. `horizontal` and `vertical` are physical-axis aliases under `family:layout-primitives`, independent of writing mode. The current flex implementation satisfies this in horizontal writing but swaps the one-axis results under vertical writing because it maps the names directly to flex main/cross axes. | Current family contract, source, docs, tests, and Chromium vertical-writing evidence                    | Pre-existing current-authority conformance gap; this audit records the BLOCK and leaves runtime remediation out because a safe fix must preserve DOM, flow, server rendering, and caller content writing mode |
+| FR3 | Current width, height, maximum-width, and minimum-height inputs use `SizeValue`: numbers resolve as CSS pixels and strings pass through as CSS values.                                                                                                                                                                                                                | Current family contract, public declarations, docs, source, and browser evidence                        | Verified released behavior; no sizing API change                                                                                                                                                              |
+| FR4 | Padding resolves independently per logical edge: explicit logical edge, then matching axis, then uniform padding. Inline and block edges resolve from writing mode and direction.                                                                                                                                                                                     | `family:layout-primitives/FR1–FR3`, source, tests, RTL audit, and browser evidence                      | Settled shared behavior; audit coverage completed                                                                                                                                                             |
+| FR5 | Center padding remains local. It does not publish the internal container-padding variables that descendants use for bleed compensation.                                                                                                                                                                                                                               | `family:layout-primitives/FR8` and `architecture:container-padding/INV8`                                | Verified released boundary; no protocol participation added                                                                                                                                                   |
+| FR6 | The root carries the current `center` target and reflects the resolved axis. Supported consumer styling composes on that same element, while a colliding generic `data-axis` value does not replace component-owned target state.                                                                                                                                     | `architecture:public-component-api/INV5–INV6`, current source, docs, target tests, and audit regression | Objective contract restoration in this audit; no target or API addition                                                                                                                                       |
+| FR7 | Center creates no breakpoint, automatic overflow behavior, gap between children, structural region, or content-specific semantic wrapper.                                                                                                                                                                                                                             | `family:layout-primitives/FR4, FR7, AV3–AV5`, source, and docs                                          | Verified released boundary; no new capability inferred                                                                                                                                                        |
+
+### Allowed variation
+
+- **AV1 — Caller content.** Any renderable caller content may appear inside the
+  current root and retains its own semantics, paint, interaction, and theme ownership.
+- **AV2 — Available space.** Parent layout and current size inputs may change the
+  box available for centering without changing the axis contract.
+- **AV3 — Consumer styling.** Supported class, style, and StyleX inputs may alter
+  the root through the documented escape hatches while the component-owned target
+  name and resolved axis reflection remain present.
+
+### Representative states
+
+| State                            | Required invariant                                                                                         | Allowed variation                                                 |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Both axes                        | Physical horizontal and vertical alignment are centered in every writing mode.                             | Caller content and available width/height may vary.               |
+| Horizontal only                  | The physical horizontal axis is centered; Center does not add physical vertical centering.                 | Height and caller-owned vertical placement may vary.              |
+| Vertical only                    | The physical vertical axis is centered; Center does not add physical horizontal centering.                 | Width and caller-owned horizontal placement may vary.             |
+| Vertical writing                 | The physical-axis requirements above remain unchanged. Current source reverses the one-axis outcomes.      | Writing mode and caller content may vary; the violation does not. |
+| Inline                           | The root is inline-flex and retains the selected axis behavior.                                            | Surrounding inline content and caller children may vary.          |
+| Asymmetric logical padding       | Logical start/end values keep their meaning while resolved physical inline-axis edges swap with direction. | Spacing steps, writing mode, and block-edge padding may vary.     |
+| Narrow or coarse-pointer context | The passive container preserves its layout contract without adding a breakpoint or interaction mode.       | Parent width and caller content may wrap or size themselves.      |
+
+### Transformation and precedence order
+
+- **ORD1 — Layout resolution.** Resolve display mode and preserve the public
+  physical-axis meaning across writing modes before applying current box-size inputs.
+  Current source instead maps `horizontal` to flex main-axis alignment and `vertical`
+  to flex cross-axis alignment, producing the FR2 conformance gap in vertical writing.
+- **ORD2 — Padding resolution.** Resolve each edge from edge input to axis input to
+  uniform input, preserving zero as an explicit spacing step.
+- **ORD3 — Root composition.** Combine the `center` target, resolved axis reflection,
+  component styles, and supported consumer styling on one root. Forward remaining
+  supported DOM inputs without allowing them to replace component-owned target state.
+
+### Performance and resources
+
+- Center owns no state, Effect, listener, observer, timer, portal, measurement, or
+  asynchronous resource. Its current render performs only synchronous prop
+  resolution and one DOM render.
+
+## Accessibility contract
+
+- **AR1 — Passive semantics.** Center adds no interactive role, accessible name,
+  state, focus behavior, keyboard handling, or live region. Caller content keeps its
+  own semantic and interaction ownership.
+- **AR2 — Supported DOM semantics.** Supported caller ARIA, role, data, event, and
+  ref inputs reach the current root unless the attribute is component-owned target
+  reflection under FR6.
+- **AR3 — Reading order.** Center renders caller children in caller order and does
+  not visually reorder them.
+
+## Design relationships
+
+| Anatomy or state | Design requirement                                                                                       | Representation authority                             | Hierarchy role    | Component contract |
+| ---------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ----------------- | ------------------ |
+| Container        | Supplies one- or two-axis alignment and optional local inset without adding a visual surface by default. | Current source, docs, and `family:layout-primitives` | Supporting layout | FR1–FR7            |
+| Content          | Retains caller-owned semantics, paint, interaction, and hierarchy inside the container.                  | Caller-owned content                                 | Context-dependent | AV1, AR1, AR3      |
+
+This observational draft records current layout relationships. It does not decide a
+new density, breakpoint, visual treatment, or content hierarchy.
+
+### Theming anatomy
+
+<!-- anatomy-theming:v1 -->
+
+```json
+{
+  "Container": {"target": "center"},
+  "Content": {
+    "none": {
+      "reason": "intentional: Caller-supplied content retains its own theming ownership; Center applies no content target."
+    }
+  }
+}
+```
+
+## Family and system relationships
+
+- `family:layout-primitives` owns the shared `SizeValue`, `SpacingStep`, logical
+  padding, padding precedence, and Center arrangement vocabulary.
+- `architecture:container-padding` records that Center's current padding is local
+  and does not publish descendant bleed geometry.
+- `architecture:component-theming-surface` owns anatomy qualification, target
+  placement, and axis reflection on the current target.
+- `architecture:public-component-api` owns the released subpath, BaseProps
+  passthrough, styling composition, ref reachability, and owned-attribute boundary.
+- `architecture:knowledge-contracts` and `spec:AST-029` keep this observational
+  draft from settling new behavior and require exact-head owner approval.
+- `spec:AST-002` owns admission for any future public or behavioral delta.
+
+## Verification map
+
+| Contract                  | Verification                                                                             | Representative states                                                   | Mutation or failure expectation                                                                                          | Audit section                |
+| ------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| FR1                       | `Center.test.tsx`, `Center.stories.tsx`, and receipted Chromium evidence                 | Block and inline display                                                | Removing a display style changes the public DOM/computed layout and fails focused or browser evidence.                   | `audit:Center/behavior`      |
+| FR2                       | Receipted Chromium geometry in horizontal and `vertical-rl` writing modes                | Both, horizontal, and vertical axes across writing modes                | A one-axis value that centers the opposite physical dimension remains an open BLOCK until runtime behavior conforms.     | `audit:Center/behavior`      |
+| FR3                       | Public declarations, source, focused tests, and browser evidence                         | Numeric and string width/height constraints                             | Changing SizeValue lowering or dropping a size input changes the current root's computed box.                            | `audit:Center/api`           |
+| FR4                       | `Center.test.tsx`, writing-mode-aware `targets.json` D8, and LTR/RTL browser receipts    | Uniform, axis, per-edge, zero, horizontal writing, and vertical writing | Wrong precedence changes functional StyleX output; fixed left/right assumptions fail the vertical-writing D8 self-check. | `audit:Center/layout`        |
+| FR5, FR7                  | Source review against family and container-padding authority                             | Padded and narrow containers                                            | Publishing bleed geometry or adding implicit responsive/overflow behavior contradicts the current boundary.              | `audit:Center/architecture`  |
+| FR6                       | `Center.test.tsx` and `themingTargets.test.ts`                                           | Every axis plus a colliding consumer data attribute                     | Missing target/axis metadata or consumer replacement of component-owned reflection fails focused tests.                  | `audit:Center/theming`       |
+| AR1–AR3                   | Source, passthrough tests, component-scoped axe, and browser inspection                  | Passive content, caller ARIA/role, and multiple children                | Added component semantics, dropped supported semantics, or visual reordering becomes observable.                         | `audit:Center/accessibility` |
+| Documentation and surface | `Center.doc.mjs`, block/docsite checks, export checks, and `scripts/check-knowledge.mjs` | Consumer docs, examples, package entry points, and this draft           | Missing or stale docs, exports, required structure, relationships, or anatomy mapping fails repository checks.           | `audit:Center/docs`          |
+
+Current audit scores, screenshots, eligibility, and per-run receipts remain in their
+existing wiki, pull-request, and trusted-check owners rather than this contract.
+
+## Decision log
+
+None. Current family authority already settles the physical-axis meaning. The
+vertical-writing mismatch is an implementation conformance gap, not an unresolved API
+or design decision; this observational draft neither waives it nor prescribes a risky
+fix.
+
+## Open questions
+
+None.
+
+## Content boundary
+
+This file does not duplicate consumer prop tables or examples, current audit scores or
+screenshots, implementation steps, shared layout vocabulary, container-padding
+mechanics, or system API/theming rules. It links to their owners.

--- a/packages/core/src/Center/Center.test.tsx
+++ b/packages/core/src/Center/Center.test.tsx
@@ -11,6 +11,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
+import {renderToString} from 'react-dom/server';
 import {Center} from './Center';
 
 /**
@@ -39,8 +40,11 @@ describe('Center', () => {
     const element = screen.getByTestId('center');
     expect(screen.getByText('Centered Content')).toBeInTheDocument();
     expect(element).toBeInTheDocument();
-    // Check that it has flex display
-    expect(element).toHaveStyle({display: 'flex'});
+    expect(element).toHaveStyle({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    });
   });
 
   it('centers horizontally only', () => {
@@ -51,7 +55,11 @@ describe('Center', () => {
     );
     const element = screen.getByTestId('center');
     expect(screen.getByText('Horizontal Center')).toBeInTheDocument();
-    expect(element).toHaveStyle({display: 'flex'});
+    expect(element).toHaveStyle({
+      display: 'flex',
+      justifyContent: 'center',
+    });
+    expect(element).not.toHaveStyle({alignItems: 'center'});
   });
 
   it('centers vertically only', () => {
@@ -62,7 +70,11 @@ describe('Center', () => {
     );
     const element = screen.getByTestId('center');
     expect(screen.getByText('Vertical Center')).toBeInTheDocument();
-    expect(element).toHaveStyle({display: 'flex'});
+    expect(element).toHaveStyle({
+      display: 'flex',
+      alignItems: 'center',
+    });
+    expect(element).not.toHaveStyle({justifyContent: 'center'});
   });
 
   it('applies height prop', () => {
@@ -212,6 +224,32 @@ describe('Center', () => {
     );
     const element = screen.getByTestId('center');
     expect(element).toHaveAttribute('aria-label', 'centered container');
+  });
+
+  it('does not let consumer data attributes override the reflected axis', () => {
+    const {container} = render(
+      <Center axis="horizontal" data-axis="vertical">
+        <div>Content</div>
+      </Center>,
+    );
+
+    expect(container.firstElementChild).toHaveAttribute(
+      'data-axis',
+      'horizontal',
+    );
+  });
+
+  it('renders on the server without a client boundary', () => {
+    const html = renderToString(
+      <Center axis="horizontal" paddingInlineStart={2}>
+        Centered content
+      </Center>,
+    );
+
+    expect(html).toContain('<div');
+    expect(html).toContain('astryx-center');
+    expect(html).toContain('data-axis="horizontal"');
+    expect(html).toContain('Centered content');
   });
 
   it('renders as div element', () => {

--- a/packages/core/src/Center/Center.tsx
+++ b/packages/core/src/Center/Center.tsx
@@ -4,10 +4,11 @@
  * @file Center.tsx
  * @input Uses React, StyleX for centering styles, Layout padding.stylex for spacing-scale padding
  * @output Exports Center component and CenterProps
- * @position Center component for centering children horizontally/vertically
+ * @position Center component for one- or two-axis flex centering
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Center/Center.doc.mjs
+ * - /packages/core/src/Center/Center.spec.md
  * - /packages/core/src/Center/Center.test.tsx
  * - /apps/storybook/stories/Center.stories.tsx
  * - /packages/cli/assets/templates/blocks/components/Center/ (showcase blocks)
@@ -62,10 +63,13 @@ export interface CenterProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
-   * Center axis - which direction(s) to center.
-   * - `both`: Center both horizontally and vertically (default)
-   * - `horizontal`: Center horizontally only (justifyContent: center)
-   * - `vertical`: Center vertically only (alignItems: center)
+   * Center mode. In horizontal writing:
+   * - `both`: Center on the flex main and cross axes (default)
+   * - `horizontal`: Center on the flex main/inline axis
+   * - `vertical`: Center on the flex cross/block axis
+   *
+   * In vertical writing, the current single-axis behavior still follows those
+   * logical flex axes rather than the physical names. `both` centers both axes.
    * @default 'both'
    */
   axis?: CenterAxis;
@@ -103,39 +107,41 @@ export interface CenterProps extends BaseProps<HTMLDivElement> {
   padding?: SpacingStep;
 
   /**
-   * Inline (horizontal) padding, using the spacing scale.
+   * Logical inline-axis padding, using the spacing scale.
    * Overrides `padding` on the inline axis when both are set.
    */
   paddingInline?: SpacingStep;
 
   /**
-   * Inline-start padding, using the spacing scale. Logical: the left edge in
-   * LTR, the right edge in RTL.
+   * Logical inline-start padding, using the spacing scale. The resolved
+   * physical edge depends on writing mode and direction.
    * Overrides `paddingInline` and `padding` on that edge only.
    */
   paddingInlineStart?: SpacingStep;
 
   /**
-   * Inline-end padding, using the spacing scale. Logical: the right edge in
-   * LTR, the left edge in RTL.
+   * Logical inline-end padding, using the spacing scale. The resolved
+   * physical edge depends on writing mode and direction.
    * Overrides `paddingInline` and `padding` on that edge only.
    */
   paddingInlineEnd?: SpacingStep;
 
   /**
-   * Block (vertical) padding, using the spacing scale.
+   * Logical block-axis padding, using the spacing scale.
    * Overrides `padding` on the block axis when both are set.
    */
   paddingBlock?: SpacingStep;
 
   /**
-   * Block-start (top) padding, using the spacing scale.
+   * Logical block-start padding, using the spacing scale. The resolved physical
+   * edge depends on writing mode.
    * Overrides `paddingBlock` and `padding` on that edge only.
    */
   paddingBlockStart?: SpacingStep;
 
   /**
-   * Block-end (bottom) padding, using the spacing scale.
+   * Logical block-end padding, using the spacing scale. The resolved physical
+   * edge depends on writing mode.
    * Overrides `paddingBlock` and `padding` on that edge only.
    */
   paddingBlockEnd?: SpacingStep;
@@ -153,10 +159,11 @@ export interface CenterProps extends BaseProps<HTMLDivElement> {
 }
 
 /**
- * Center component for centering children horizontally and/or vertically.
+ * Center component for centering children on one or both flex axes.
  *
- * Uses flexbox for centering. By default, centers on both axes.
- * Use the `axis` prop to center on only one axis.
+ * In horizontal writing, the single-axis names match physical horizontal and
+ * vertical dimensions. In vertical writing, the current single-axis behavior
+ * follows flex main/cross axes; `both` still centers on both axes.
  *
  * @example
  * ```
@@ -222,7 +229,7 @@ export function Center({
   );
 
   return (
-    <div ref={ref} {...stylexProps} {...props}>
+    <div ref={ref} {...props} {...stylexProps}>
       {children}
     </div>
   );


### PR DESCRIPTION
## User impact

Center now keeps its own theme-axis metadata even when a consumer passes a colliding `data-axis`, the public horizontal-centering example actually renders Center, and the shipped logical padding contract has reusable RTL evidence.

## Audit result

- Component: `core/Center`
- Queue reason: first refreshed queue item; never audited
- Mode: Night Watch (`N`)
- Rubric: `1.16.2` (the patch advanced from the task-pinned `1.16.1` during this run; scoring is unchanged)
- Baseline: **73.3 / C**, 3 BLOCKs
- Final: **87.0 / C**, 1 BLOCK
- Sensitivity: fix the 1 open BLOCK and change nothing else → projected **95.0 / A**
- Audit baseline: `5447429bacc4baa6b02f70da73dcdb9bb7d6e8ee`
- Reconciled main: `ae4ad8375d1ce553cdc889e83c79c9bc6dd5756c`
- Frozen head: `55f51a06c6e1f7780eecb078fa6bf10447579956`
- Evidence commit: [`2dce2e5c21f3`](https://github.com/cixzhang/astryx/commit/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422)
- Controlling exact-head review/spec approval: [comment](https://github.com/facebook/astryx/pull/6207#issuecomment-5621768713)
- Tracker: [final landed row `c1021b151f`](https://github.com/facebook/astryx/wiki/_compare/c1021b151f64b0eaffe238a37f89b32ab475b217)

| Section | Baseline | Final |
|---|---:|---:|
| Accessibility | 4/5 limited | 5/5 limited |
| Theming | 5/5 | 5/5 |
| Public API | 3/5 | 4.5/5 |
| Behavior | 3/5 | 3/5 |
| Design — objective | 5/5 limited | 5/5 limited |
| Design — rendered | 5/5 | 5/5 |
| Testing | 3/5 | 4.5/5 |
| Code health | 5/5 limited | 5/5 limited |
| Docs | 3.5/5 | 4.5/5 |
| i18n & RTL | 3/5 limited | 5/5 limited |
| Responsive & touch | 5/5 limited | 5/5 limited |

Limited-section weights are redistributed per the rubric.

## Changes

- Adds a draft observational `Center` contract using the current component schema. It records released behavior only and remains non-authoritative pending owner approval.
- Fixes `architecture:public-component-api/INV5` / P3: a generic `data-axis` can no longer replace Center’s component-owned axis reflection. The public-seam regression was proven red before production changed, then green.
- Adds a mutation-sensitive SSR contract test and exact axis-layout assertions.
- Extends the shared RTL audit with writing-mode-aware D8 coverage: asymmetric logical padding keeps start/end meaning while the resolved physical inline edges swap left/right in horizontal writing or top/bottom in vertical writing. Center reports measured with zero RTL gaps.
- Corrects the `CenterHorizontal` public example so it renders Center and demonstrates horizontal centering rather than an unrelated split toolbar.

## Evidence inventory

Closed: **26/26 rows accounted for**. Each row maps one public surface or reachable branch to source, existing tests, consumer docs, rendered evidence, governing authority, and any surviving gap, as required by `spec:AST-029/FR5`.

[Machine-readable evidence inventory](https://github.com/cixzhang/astryx/blob/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/evidence-inventory.json)

<details>
<summary>Public-surface → evidence receipt</summary>

| ID | Public surface or branch | Source | Existing tests | Consumer docs | Rendered evidence | Authority | Result / gap |
|---|---|---|---|---|---|---|---|
| E01 | @astryxdesign/core/Center package subpath | packages/core/package.json<br>packages/core/src/Center/index.ts | scripts/verify-exports.mjs<br>published @astryxdesign/core@0.5.4 export probe | packages/core/src/Center/Center.doc.mjs | N/A: module reachability is non-rendering; all Center frames import the public subpath | architecture:public-component-api/INV1<br>architecture:public-component-api/INV9<br>architecture:public-component-api/INV12 | pass |
| E02 | Center, CenterProps, and CenterAxis exports | packages/core/src/Center/index.ts<br>packages/core/src/Center/Center.tsx | published @astryxdesign/core@0.5.4 declaration probe<br>core typecheck | packages/core/src/Center/Center.doc.mjs | N/A: value/type export shape is non-visual | architecture:public-component-api/INV1<br>architecture:public-component-api/INV12 | pass |
| E03 | fixed div root and required children | packages/core/src/Center/Center.tsx | renders as div element<br>renders on the server without a client boundary<br>renders and centers children | Center.doc.mjs anatomy and children prop | all component frames | component:Center/FR1<br>component:Center/AV1 | pass |
| E04 | axis omitted or both | Center.tsx default axis='both'<br>styles.alignItemsCenter<br>styles.justifyContentCenter | renders and centers children (both axes by default) | Center.doc.mjs axis default<br>Center.stories.tsx Default and AllAxisModes | neutral-{light,dark}-all-axis-modes<br>matcha-{light,dark}-default | family:layout-primitives/FR5<br>component:Center/FR2 | pass |
| E05 | axis='horizontal' in horizontal writing | Center.tsx justifyContentCenter branch | centers horizontally only | Center.doc.mjs axis caveat<br>Center.stories.tsx HorizontalOnly and AllAxisModes | neutral-{light,dark}-all-axis-modes | family:layout-primitives/FR5<br>component:Center/FR2 | pass in horizontal writing; B15 applies outside horizontal writing; see E07 |
| E06 | axis='vertical' in horizontal writing | Center.tsx alignItemsCenter branch | centers vertically only | Center.doc.mjs axis caveat<br>Center.stories.tsx VerticalOnly and AllAxisModes | neutral-{light,dark}-all-axis-modes | family:layout-primitives/FR5<br>component:Center/FR2 | pass in horizontal writing; B15 applies outside horizontal writing; see E07 |
| E07 | single-axis modes under vertical writing | Center.tsx maps horizontal to justifyContent and vertical to alignItems | no unit assertion can establish physical geometry; browser measurement is authoritative | Center.doc.mjs and CenterHorizontal.doc.mjs explicit caveat<br>component:Center draft FR2 | Center__vertical-writing__{baseline,exact-head}-{light,dark}<br>vertical-writing measurement receipts | family:layout-primitives/FR5<br>component:Center/FR2 | BLOCK; B15: horizontal centers the vertical physical dimension and vertical centers the horizontal physical dimension under vertical-rl |
| E08 | block-level flex display | Center.tsx styles.base | default and one-axis tests assert display:flex | Center.doc.mjs<br>Center.stories.tsx Default | neutral-{light,dark}-all-axis-modes | component:Center/FR1 | pass |
| E09 | isInline=true inline-flex display | Center.tsx styles.inline branch | renders as inline-flex when isInline is true | Center.doc.mjs isInline<br>Center.stories.tsx Inline | neutral-{light,dark}-inline | component:Center/FR1 | pass |
| E10 | numeric width | Center.tsx dynamicStyles.sizing | applies width prop | Center.doc.mjs width<br>Center.stories.tsx AllAxisModes | neutral-{light,dark}-all-axis-modes records 300px boxes | family:layout-primitives/FR1<br>component:Center/FR3 | pass; legacy unit assertion is render-only; covered by Chromium geometry |
| E11 | CSS-value string width | Center.tsx dynamicStyles.sizing | applies both width and height props | Center.doc.mjs width<br>Center.stories.tsx Default and FullSize | default frames record width='100%' resolved inside the story surface | family:layout-primitives/FR1<br>component:Center/FR3 | pass; legacy unit assertion is render-only; covered by Chromium geometry |
| E12 | numeric height | Center.tsx dynamicStyles.sizing | applies both width and height props | Center.doc.mjs height<br>Center.stories.tsx Default, VerticalOnly, and AllAxisModes | default and all-axis frames record the requested 200px and 150px heights | family:layout-primitives/FR1<br>component:Center/FR3 | pass; legacy unit assertion is render-only; covered by Chromium geometry |
| E13 | CSS-value string height | Center.tsx dynamicStyles.sizing | applies height prop with 100% | Center.doc.mjs height | N/A: string acceptance is type/source verified; no distinct visual contract beyond resolved box geometry | family:layout-primitives/FR1<br>component:Center/FR3 | pass with V4 testing debt; height string has only a render-only unit assertion |
| E14 | maxWidth constraint | Center.tsx dynamicStyles.sizing | source/type coverage; browser counterfactual is the mutation-sensitive check | Center.doc.mjs maxWidth | neutral-light-max-width-constraint: width 480 constrained to 240 | family:layout-primitives/FR1<br>component:Center/FR3 | pass |
| E15 | minHeight constraint | Center.tsx dynamicStyles.sizing | source/type coverage; browser counterfactual is the mutation-sensitive check | Center.doc.mjs minHeight | neutral-light-min-height-constraint: height 80 raised to 220 | family:layout-primitives/FR1<br>component:Center/FR3 | pass |
| E16 | uniform padding | Center.tsx padding fallback chain | applies a class when padding is set<br>leaves default output unchanged when omitted | Center.doc.mjs padding<br>Center.stories.tsx Padding | padding-per-edge frames retain uniform padding on non-overridden edges | family:layout-primitives/FR1<br>family:layout-primitives/FR3<br>component:Center/FR4 | pass |
| E17 | paddingInline and paddingBlock axis overrides | Center.tsx per-axis padding resolution | accepts paddingInline and paddingBlock<br>axis override class-set equivalence | Center.doc.mjs logical axis descriptions | padding-per-edge frames exercise the fallback chain on unaffected edges | family:layout-primitives/FR2<br>family:layout-primitives/FR3<br>component:Center/FR4 | pass; some legacy unit assertions are render-only; D8 and browser geometry cover logical resolution |
| E18 | four logical edge overrides and precedence | Center.tsx paddingInlineStartStyles, paddingInlineEndStyles, paddingBlockStartStyles, paddingBlockEndStyles | block-start/end precedence<br>inline-start/end precedence<br>resolves all four edges independently | Center.doc.mjs logical edge props<br>Center.stories.tsx PaddingPerEdge | neutral-{light,dark}-{ltr,rtl}-padding-per-edge | family:layout-primitives/FR2<br>family:layout-primitives/FR3<br>component:Center/FR4 | pass |
| E19 | explicit zero spacing | Center.tsx uses nullish checks so zero is retained | padding={0}<br>paddingBlockEnd={0}<br>paddingInlineEnd={0} | Center.doc.mjs spacing-step unions include 0 | padding-per-edge frames record paddingBottom=0 | family:layout-primitives/FR1<br>family:layout-primitives/FR3<br>component:Center/FR4 | pass |
| E20 | logical padding under direction and writing-mode changes | logical StyleX padding properties<br>D8 measureLogicalInlineSubject | writing-mode-aware classifyLogicalInlinePair tests<br>Chromium horizontal and vertical startup self-checks | Center.doc.mjs logical padding wording<br>rtl-audit README D8 | LTR/RTL padding-per-edge receipts<br>D8 report records writingMode and top/right/bottom/left | family:layout-primitives/FR2<br>component:Center/FR4 | pass |
| E21 | BaseProps DOM/ARIA passthrough and ref | CenterProps extends BaseProps<HTMLDivElement><br>Center.tsx root composition | passes through additional props<br>forwards ref correctly<br>server render | Center.doc.mjs accessibility guidance<br>component:Center/AR1-AR3 | N/A: ref and neutral ARIA/data passthrough are non-visual; collision output is measured separately | architecture:public-component-api/INV5<br>architecture:public-component-api/INV8 | pass |
| E22 | className, style, and xstyle composition | Center.tsx mergeProps and root spread order | public passthrough tests<br>xstyle render-only test | Center.doc.mjs xstyle | Inline and Padding stories apply non-empty xstyle to the Center root | architecture:public-component-api/INV5<br>architecture:public-component-api/INV6 | pass with V4 testing debt; the dedicated xstyle unit case passes undefined; real Storybook compositions supply the behavioral evidence |
| E23 | center theme target and reflected axis | Center.tsx themeProps('center', {axis}) | themingTargets.test.ts<br>owned data-axis red-before-green regression | Center.doc.mjs theming.targets | neutral-light-owned-axis-collision plus matrix measurement | architecture:component-theming-surface<br>architecture:public-component-api/INV5<br>component:Center/FR6 | pass after P3 remediation |
| E24 | public CenterHorizontal example | packages/cli/assets/templates/blocks/components/Center/CenterHorizontal.tsx | docsite generation/test<br>CLI structure and component-reference checks | CenterHorizontal.doc.mjs | CenterHorizontal before/after exact-commit pair | rubric X7<br>component:Center/FR2 | pass after example repair; single-axis vertical-writing caveat is explicit |
| E25 | passive content semantics and reading order | Center.tsx renders children unchanged in one div | children, passthrough, server-render, and axe coverage | Center.doc.mjs accessibility best practice<br>component:Center/AR1-AR3 | all frames retain caller content order; component-scoped axe has zero violations | component:Center/AR1-AR3<br>objective accessibility semantics | pass |
| E26 | absence of implicit gap, breakpoint, overflow, region, and bleed publication | Center.tsx has no such branch or public prop | source branch inventory<br>320px and coarse-pointer browser checks | component:Center/FR5 and FR7<br>Center.doc.mjs scope guidance | neutral-{light,dark}-{narrow,coarse} with no overflow | family:layout-primitives/FR4,FR7,FR8<br>architecture:container-padding/INV8 | pass |

</details>

### Retained finding

- **B15 / `family:layout-primitives` FR5 / Center draft FR2 — BLOCK:** with `writing-mode: vertical-rl`, `axis="horizontal"` centers the child vertically (`Δx=124px`, `Δy=0`) and `axis="vertical"` centers it horizontally (`Δx=0`, `Δy=-89px`). Current family authority defines these as physical axes. The exact-base and exact-head receipted frames reproduce the same defect; this PR records rather than disguises it.

### Rendered evidence

| Baseline | Exact head |
|---|---|
| [Light contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__baseline-light.png) | [Light contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__exact-head-light.png) |
| [Dark contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__baseline-dark.png) | [Dark contact sheet](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__exact-head-dark.png) |
| [Horizontal example before](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/CenterHorizontal__before.png) | [Horizontal example after](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/CenterHorizontal__after.png) |
| [Vertical-writing BLOCK: light](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__vertical-writing__baseline-light.png) · [dark](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__vertical-writing__baseline-dark.png) | [Vertical-writing BLOCK: light](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__vertical-writing__exact-head-light.png) · [dark](https://raw.githubusercontent.com/cixzhang/astryx/2dce2e5c21f3c8eda0b6a66db5a6e6f0546b7422/pr-assets/Center__vertical-writing__exact-head-dark.png) |

All 17 comparable baseline/exact-head component frames and both vertical-writing frames are byte-identical. The intentional example change has its own exact-commit before/after pair. All 20 receipt pairs match on every sensor except Build. The evidence covers both axis/display matrices, the owned-axis collision, independent 480→240 max-width and 80→220 min-height constraints, asymmetric logical padding, vertical writing, 320px, coarse pointer, neutral light/dark, and matcha light/dark.

## Validation

- `pnpm vitest run packages/core/src/Center/Center.test.tsx .github/scripts/rtl-audit-coverage.test.mjs packages/core/src/theme/themingTargets.test.ts packages/core/src/docPropLiterals.test.ts packages/core/src/docPropReferences.test.ts` — 478/478 pass
- `pnpm check:knowledge`, `pnpm check:sync`, `pnpm check:changesets`, `node scripts/check-use-client.mjs`, `node scripts/sync-exports.js --check` — pass
- `pnpm -F @astryxdesign/core typecheck`, `typecheck:docs`, Storybook typecheck — pass
- `pnpm build` — pass
- `node scripts/verify-exports.mjs` — 10 packages, 46 export targets clean
- `pnpm -F @astryxdesign/docsite generate && pnpm -F @astryxdesign/docsite test` — 495/495 pass
- `pnpm lint:strict` — 0 errors; 87 pre-existing warnings, none in changed files
- `pnpm a11y:audit -- --components Center` — 10 stories, 0 violations
- `pnpm rtl:audit -- --filter Center` — D8 pass; horizontal-writing and vertical-writing Chromium self-checks pass; 1 measured, 0 failures, 0 gaps
- [Exact-head CI run 34497134946](https://github.com/facebook/astryx/actions/runs/34497134946) — all required jobs pass
- Real Chromium — 17 baseline + 17 exact-head component frames, two light/dark vertical-writing pairs, and one before/after example pair; all 20 receipt pairs match except Build; visual inspection clean; comparable pixel diff 19/19 identical outside the intentional example correction

## Exact-head audit eligibility

```json
{
  "schemaVersion": 1,
  "component": "Center",
  "package": "core",
  "auditMode": "N",
  "rubricVersion": "1.16.2",
  "heads": {
    "repository": "55f51a06c6e1f7780eecb078fa6bf10447579956",
    "componentContract": "55f51a06c6e1f7780eecb078fa6bf10447579956",
    "base": "5447429bacc4baa6b02f70da73dcdb9bb7d6e8ee"
  },
  "inventory": {
    "closed": true,
    "rows": 26,
    "receipt": "pr-assets/evidence-inventory.json",
    "gaps": [
      "B15 / component:Center/FR2: physical one-axis semantics reverse under vertical writing"
    ]
  },
  "unresolvedGaps": {
    "objective": [
      "B15 / component:Center/FR2: physical one-axis semantics reverse under vertical writing"
    ],
    "manual": [
      "The FR2 runtime correction is intentionally outside this audit because a safe fix must preserve DOM, flow, server rendering, and caller-content writing mode",
      "Exact-head owner approval for the draft observational contract"
    ]
  },
  "remediations": [
    {
      "ruleId": "P3",
      "beforeEvidence": [
        "Public Center accepted data-axis=vertical while axis=horizontal and rendered the spoofed value"
      ],
      "afterEvidence": [
        "The public-seam regression test passes with data-axis=horizontal",
        "The receipted collision matrix records the intended input separately and the reflected output changes from vertical at base to horizontal at head"
      ]
    },
    {
      "ruleId": "V3",
      "beforeEvidence": [
        "Axis tests asserted only display:flex and sizing tests asserted only render success"
      ],
      "afterEvidence": [
        "Axis tests assert the public computed alignment contract",
        "An SSR output test proves the server-safe public seam",
        "Max-width 480→240 and min-height 80→220 browser counterfactuals fail if either constraint is dropped"
      ]
    },
    {
      "ruleId": "I17",
      "beforeEvidence": [
        "The component RTL audit reported zero measured and one coverage gap"
      ],
      "afterEvidence": [
        "D8 records writing mode, direction, logical start/end, and all four physical edges",
        "Real Chromium startup checks pass left/right mirroring in horizontal writing and top/bottom mirroring in vertical writing while rejecting a hidden subject",
        "Center reports one measured component and zero coverage gaps"
      ]
    },
    {
      "ruleId": "X7",
      "beforeEvidence": [
        "CenterHorizontal was attributed to Center but rendered no Center"
      ],
      "afterEvidence": [
        "The example renders Center axis=horizontal around the centered control group",
        "Exact-base and exact-head receipts and measurement summaries name their matching commits"
      ]
    }
  ],
  "approvals": [
    {
      "name": "independent-exact-head-review",
      "state": "pass",
      "evidence": "https://github.com/facebook/astryx/pull/6207#issuecomment-5621768713"
    },
    {
      "name": "component-spec-owner",
      "state": "pass",
      "evidence": "https://github.com/facebook/astryx/pull/6207#issuecomment-5621768713"
    },
    {"name": "human-reviewed-merge", "state": "pass"}
  ],
  "checks": [
    {"name": "local-focused", "state": "pass", "assertions": 478},
    {"name": "local-build", "state": "pass"},
    {"name": "a11y", "state": "pass", "stories": 10, "violations": 0},
    {"name": "rtl", "state": "pass", "measured": 1, "gaps": 0},
    {"name": "exact-head-ci", "state": "pass", "run": 34497134946},
    {"name": "audit-eligibility", "state": "unavailable"}
  ],
  "evidence": {
    "componentFrames": {"baseline": 17, "exactHead": 17, "pixelIdentical": 17},
    "verticalWritingFrames": {"baseline": 2, "exactHead": 2, "pixelIdentical": 2},
    "exampleFrames": {
      "baseline": 1,
      "exactHead": 1,
      "intentionalChange": true,
      "baseHead": "5447429bacc4baa6b02f70da73dcdb9bb7d6e8ee",
      "exactHeadCommit": "55f51a06c6e1f7780eecb078fa6bf10447579956"
    },
    "receiptPairs": 20,
    "receiptPairsMatchExceptBuild": 20
  },
  "postMerge": {
    "landedCommit": "f069c04f454e52a4944b32d22dee91fb6fc6214c",
    "reviewedHead": "55f51a06c6e1f7780eecb078fa6bf10447579956",
    "allReviewedPathsIdentical": true,
    "pathCount": 13,
    "receipt": "pr-assets/landed-byte-verification.json"
  },
  "eligibility": {
    "eligible": false,
    "reasons": [
      "spec:AST-029 remains phase: accepted; FR11 activation is absent",
      "The trusted audit-eligibility check is unavailable",
      "One inherited B15 / component:Center/FR2 BLOCK remains open"
    ]
  }
}
```

Auto-merge is intentionally disabled. This PR must remain open for human review.
