### PR TITLE
docs: correct the MCP setup instructions in working-with-ai

### DIFF
--- a/.changeset/mcp-setup-instructions.md
+++ b/.changeset/mcp-setup-instructions.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Fix the MCP setup snippet in working-with-ai — "type": "url" is not a transport type, and Claude Desktop adds remote servers through Connectors
+@Kyujenius

--- a/packages/cli/assets/docs/working-with-ai.doc.mjs
+++ b/packages/cli/assets/docs/working-with-ai.doc.mjs
@@ -173,20 +173,42 @@ astryx docs tokens --dense`,
         },
         {
           type: 'prose',
-          text: 'Add the server to your MCP config file. This works with any MCP-compatible tool: Claude Desktop (claude_desktop_config.json), Cursor (.cursor/mcp.json), Windsurf (.windsurf/mcp.json), Cline, and others.',
+          text: 'Add the server to your MCP config file. The entry is a remote HTTP server, and the exact shape differs per client, so use the snippet for the tool you run. An entry with an unrecognized transport is skipped with a warning rather than an error, which reads as a server that connects but exposes no tools.',
         },
         {
           type: 'code',
           lang: 'json',
-          label: 'MCP config (same for all tools)',
+          label: 'Claude Code (.mcp.json), Windsurf, Cline',
           code: `{
   "mcpServers": {
     "xds": {
-      "type": "url",
+      "type": "http",
       "url": "https://astryx.atmeta.com/mcp"
     }
   }
 }`,
+        },
+        {
+          type: 'code',
+          lang: 'json',
+          label: 'Cursor (.cursor/mcp.json) - remote servers take no type field',
+          code: `{
+  "mcpServers": {
+    "xds": {
+      "url": "https://astryx.atmeta.com/mcp"
+    }
+  }
+}`,
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Claude Code, equivalent to the JSON above',
+          code: `claude mcp add --transport http xds https://astryx.atmeta.com/mcp`,
+        },
+        {
+          type: 'prose',
+          text: 'Claude Desktop is the exception: claude_desktop_config.json holds local stdio servers, so a remote server is added through Settings, then Connectors, then Add custom connector, pasting the URL above.',
         },
         {
           type: 'prose',


### PR DESCRIPTION
## Summary

The MCP Server section of the `working-with-ai` guide documents a config snippet that no MCP client accepts. It uses `"type": "url"`, which is not a transport type, presents one block as valid for every tool when the shape differs per client, and names `claude_desktop_config.json` as the place to add a remote server, which is not how Claude Desktop connects to one.

The failure is silent. Claude Code parses the entry, does not recognise the type, and skips the server with a **warning rather than an error** — so a reader believes Astryx is connected and only notices that the tools never appear.

This reaches two surfaces, since `apps/docsite` generates its docs registry from the same source: `astryx docs working-with-ai`, and the guide published on the docsite. The MCP server itself is healthy, so this is docs-only.

## Reproduction

1. `npx @astryxdesign/cli@0.5.4 docs working-with-ai` — the MCP Server section
   prints the snippet.
2. Save it as `.mcp.json` in any project.
3. `claude mcp list`.

Same file, same directory, only `type` changed:

| `.mcp.json` entry | `claude mcp list` |
| --- | --- |
| `"type": "url"` (as documented) | `Skipped — unknown MCP server type "url"` |
| `url`, no `type` | `Skipped — add "type": "http" (or "sse" / "ws")` |
| `"type": "http"` | `xds: https://astryx.atmeta.com/mcp (HTTP) - ✔ Connected` |

The endpoint is fine: `initialize` returns `astryx 2.0.0` and `tools/list` returns `search` and `get`.

## Why these values

Valid transport types are `http` (alias `streamable-http`), `sse`, `ws`, `stdio` ([Claude Code](https://code.claude.com/docs/en/mcp)). The MCP registry uses `streamable-http` and `sse` for remote entries ([spec](https://modelcontextprotocol.io/registry/remote-servers)). Cursor's documented `.cursor/mcp.json` examples pass a bare `url`, and its schema types that field as `enum: ['http', 'sse']`, defaulting to `http` when a `url` is given ([Cursor](https://cursor.com/docs/mcp)). No client defines `url` as a transport type.

`claude_desktop_config.json` holds stdio servers ([local](https://modelcontextprotocol.io/docs/develop/connect-local-servers)); Claude Desktop adds remote ones through Settings, then Connectors, then Add custom connector
([remote](https://modelcontextprotocol.io/docs/develop/connect-remote-servers)).

## Changes

`packages/cli/assets/docs/working-with-ai.doc.mjs`, MCP Server section:

- Split the single "same for all tools" block into per-client snippets.
- Replace the `claude_desktop_config.json` sentence with the Connectors UI path.
- Add the `claude mcp add --transport http` one-liner, which writes the JSON itself.
- Add a changeset.

`apps/docsite/src/generated/` is gitignored and rebuilt by `pnpm generate`, so no
generated file is committed here.

**After**

```json
// Claude Code (.mcp.json), Windsurf, Cline
{ "mcpServers": { "xds": { "type": "http", "url": "https://astryx.atmeta.com/mcp" } } }
```

```json
// Cursor (.cursor/mcp.json) — remote servers take no type field
{ "mcpServers": { "xds": { "url": "https://astryx.atmeta.com/mcp" } } }
```

```bash
claude mcp add --transport http xds https://astryx.atmeta.com/mcp
```

Claude Desktop: Settings → Connectors → Add custom connector.

## Test Plan

- [ ] `npx @astryxdesign/cli docs working-with-ai` renders the new section cleanly
- [ ] `pnpm lint:strict` (covers `check:changesets`)
- [ ] `pnpm test`, `pnpm build`
- [ ] `pnpm --filter @astryxdesign/docsite generate` and confirm the guide page
      shows the new snippets
- [ ] `claude mcp add --transport http xds <url>` writes the documented snippet

## Notes

Cursor and Claude Desktop behaviour is taken from their official docs linked above, not reproduced locally. The Claude Code rows in the table were measured.