### PR TITLE
fix(ChatTypingIndicator): build the typing status from the i18n catalog and Intl.ListFormat

### DIFF
--- a/.changeset/chat-typing-indicator-i18n.md
+++ b/.changeset/chat-typing-indicator-i18n.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Adds the `@astryx.chatTypingIndicator.*` catalog keys so the lab ChatTypingIndicator can build its typing status from the translation runtime instead of English literals, joining names with `Intl.ListFormat` for the active locale. English output is unchanged.
+
+@Kyujenius

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -431,6 +431,18 @@
     "defaultMessage": "Next",
     "description": "Screen-reader-only label on the right-arrow button in a Lightbox (navigates to next media item). Pairs with `lightbox.previous`."
   },
+  "@astryx.chatTypingIndicator.one": {
+    "defaultMessage": "{name} is typing…",
+    "description": "Politely announced status naming the single person currently typing in a chat. `name` is a display name supplied by the app. Present-progressive form; the trailing ellipsis is the single … character."
+  },
+  "@astryx.chatTypingIndicator.many": {
+    "defaultMessage": "{names} are typing…",
+    "description": "Politely announced status when more than one person is typing in a chat. `names` is already joined for the locale by Intl.ListFormat, so translations must not add their own conjunction — place `{names}` where the joined list belongs."
+  },
+  "@astryx.chatTypingIndicator.others": {
+    "defaultMessage": "{count, number} {count, plural, one {other} other {others}}",
+    "description": "Overflow element for the chat typing status when three or more people type: the first name is shown and the rest collapse into this phrase, which is then joined to the name by Intl.ListFormat. Renders as the last list item, e.g. \"Ana and 2 others\"."
+  },
   "@astryx.listInput.emptyTitle": {
     "defaultMessage": "No {itemName}s yet",
     "description": "EmptyState title shown inside a lab ListInput when its collection has no records. `{itemName}` is the consumer's singular noun for one record (e.g. \"guest\"); the source appends a literal \"s\" to pluralize it, which only works for regular English plurals. If your language cannot pluralize an interpolated noun this way, rephrase around `{itemName}` instead (e.g. \"No {itemName} added yet\")."

--- a/packages/lab/src/Chat/ChatTypingIndicator.doc.mjs
+++ b/packages/lab/src/Chat/ChatTypingIndicator.doc.mjs
@@ -8,12 +8,12 @@ export const docs = {
   group: 'Chat',
   category: 'Chat',
   displayName: 'Chat Typing Indicator',
-  description: 'Animated three-dot typing hint with a grammar-aware label: "Ana is typing...", "Ana and Ben are typing...", or "Ana and 2 others are typing...". Dots bounce with staggered stylex.keyframes delays, disabled under prefers-reduced-motion; the label is announced politely via role="status".',
+  description: 'Animated three-dot typing hint with a localized, grammar-aware label: "Ana is typing...", "Ana and Ben are typing...", or "Ana and 2 others are typing...". Dots bounce with staggered stylex.keyframes delays, disabled under prefers-reduced-motion; the label is announced politely via role="status".',
   props: [
     {
       name: 'names',
       type: 'string[]',
-      description: 'Names of people currently typing. One name renders "is typing", two render both names, more collapse to "and N others". When omitted or empty, only the animated dots render.',
+      description: 'Names of people currently typing. One name renders "is typing", two render both names, more collapse to "and N others". The sentence comes from the i18n catalog and the names are joined with Intl.ListFormat, so the wording and conjunction follow the active locale. When omitted or empty, only the animated dots render.',
     },
   ],
 };
@@ -23,7 +23,7 @@ export const docsZh = {
   displayName: 'Chat Typing Indicator',
   description: '带语法感知标签的三点跳动输入提示："Ana is typing..."、"Ana and Ben are typing..." 或 "Ana and 2 others are typing..."。圆点用 stylex.keyframes 交错跳动，prefers-reduced-motion 下禁用；标签通过 role="status" 礼貌播报。',
   propDescriptions: {
-    names: '正在输入的人名。一个名字渲染 "is typing"，两个渲染双名，更多折叠为 "and N others"。省略或为空时仅渲染动画圆点。',
+    names: '正在输入的人名。一个名字渲染 "is typing"，两个渲染双名，更多折叠为 "and N others"。语句取自 i18n 词条，人名由 Intl.ListFormat 按当前语言拼接，因此措辞与连接词随语言而变。省略或为空时仅渲染动画圆点。',
   },
 };
 
@@ -32,6 +32,7 @@ export const docsDense = {
   displayName: 'Chat Typing Indicator',
   description: 'bouncing three-dot typing hint; label grammar 1/2/N names; reduced-motion safe keyframes; role=status polite announce; dots-only when names empty',
   propDescriptions: {
-    names: "string[]; 1='X is typing', 2='X and Y', 3+='X and N others'; empty=dots only",
+    names:
+      "string[]; 1='X is typing', 2='X and Y', 3+='X and N others'; phrases from i18n catalog, names joined by Intl.ListFormat; empty=dots only",
   },
 };

--- a/packages/lab/src/Chat/ChatTypingIndicator.test.tsx
+++ b/packages/lab/src/Chat/ChatTypingIndicator.test.tsx
@@ -3,6 +3,7 @@
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {ChatTypingIndicator} from './ChatTypingIndicator';
+import {InternationalizationProvider} from '@astryxdesign/core/i18n';
 
 describe('ChatTypingIndicator', () => {
   it('renders "X is typing…" for one name', () => {
@@ -18,6 +19,51 @@ describe('ChatTypingIndicator', () => {
   it('collapses three or more names to "and N others"', () => {
     render(<ChatTypingIndicator names={['Ana', 'Ben', 'Casey']} />);
     expect(screen.getByText('Ana and 2 others are typing…')).toBeTruthy();
+  });
+
+  it('localizes the one-name sentence through the i18n catalog', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {
+            '@astryx.chatTypingIndicator.one': '{name} est en train d’écrire…',
+          },
+        }}>
+        <ChatTypingIndicator names={['Ana']} />
+      </InternationalizationProvider>,
+    );
+    expect(screen.getByText('Ana est en train d’écrire…')).toBeTruthy();
+  });
+
+  it('joins two names with the locale list format', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {'@astryx.chatTypingIndicator.many': '{names} écrivent…'},
+        }}>
+        <ChatTypingIndicator names={['Ana', 'Ben']} />
+      </InternationalizationProvider>,
+    );
+    // Intl.ListFormat('fr') joins with "et", not the English "and".
+    expect(screen.getByText('Ana et Ben écrivent…')).toBeTruthy();
+  });
+
+  it('localizes the collapsed overflow sentence', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {
+            '@astryx.chatTypingIndicator.others': '{count, number} autres',
+            '@astryx.chatTypingIndicator.many': '{names} écrivent…',
+          },
+        }}>
+        <ChatTypingIndicator names={['Ana', 'Ben', 'Casey']} />
+      </InternationalizationProvider>,
+    );
+    expect(screen.getByText('Ana et 2 autres écrivent…')).toBeTruthy();
   });
 
   it('renders dots only when names is empty', () => {

--- a/packages/lab/src/Chat/ChatTypingIndicator.tsx
+++ b/packages/lab/src/Chat/ChatTypingIndicator.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file ChatTypingIndicator.tsx
- * @input Uses React, StyleX (keyframes), theme tokens
+ * @input Uses React, i18n (useTranslator/useLocale), StyleX (keyframes), theme tokens
  * @output Exports ChatTypingIndicator component and ChatTypingIndicatorProps
  * @position Animated "X is typing…" hint above a chat composer
  *
@@ -19,6 +19,7 @@
  * - /apps/storybook/stories/ChatAdditions.stories.tsx (examples)
  */
 
+import {useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -31,6 +32,8 @@ import {
 import type {BaseProps} from '@astryxdesign/core';
 import {mergeProps} from '@astryxdesign/core/utils';
 import {themeProps} from '@astryxdesign/core/utils';
+import {useLocale, useTranslator} from '@astryxdesign/core/i18n';
+import type {TranslatorFn} from '@astryxdesign/core/i18n';
 
 export interface ChatTypingIndicatorProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -94,17 +97,36 @@ const styles = stylex.create({
   },
 });
 
-function typingLabel(names: string[] | undefined): string | null {
+/**
+ * Builds the status sentence for the people currently typing.
+ *
+ * Every phrase comes from the translation catalog, and the names themselves are
+ * joined by `Intl.ListFormat` for the active locale rather than an English
+ * "and". Three or more people collapse to the first name plus a translated
+ * overflow phrase, which is then joined the same way — so the conjunction, the
+ * separator, and their order all follow the locale instead of this file.
+ */
+function typingLabel(
+  names: string[] | undefined,
+  t: TranslatorFn,
+  listFormat: Intl.ListFormat,
+): string | null {
   if (names == null || names.length === 0) {
     return null;
   }
   if (names.length === 1) {
-    return `${names[0]} is typing…`;
+    return t('@astryx.chatTypingIndicator.one', {name: names[0]});
   }
-  if (names.length === 2) {
-    return `${names[0]} and ${names[1]} are typing…`;
-  }
-  return `${names[0]} and ${names.length - 1} others are typing…`;
+  const parts =
+    names.length === 2
+      ? [names[0], names[1]]
+      : [
+          names[0],
+          t('@astryx.chatTypingIndicator.others', {count: names.length - 1}),
+        ];
+  return t('@astryx.chatTypingIndicator.many', {
+    names: listFormat.format(parts),
+  });
 }
 
 // =============================================================================
@@ -132,7 +154,13 @@ export function ChatTypingIndicator({
   'data-testid': testId,
   ref,
 }: ChatTypingIndicatorProps) {
-  const label = typingLabel(names);
+  const t = useTranslator();
+  const locale = useLocale();
+  const listFormat = useMemo(
+    () => new Intl.ListFormat(locale, {style: 'long', type: 'conjunction'}),
+    [locale],
+  );
+  const label = typingLabel(names, t, listFormat);
   return (
     <div
       ref={ref}


### PR DESCRIPTION
## Summary

`ChatTypingIndicator` built its typing sentences from literals in component source and joined names with an English "and", so a localized app could not translate the status. The phrases now come from the catalog (`@astryx.chatTypingIndicator.one` / `.many` / `.others`) and the names are joined with `Intl.ListFormat` for the active locale, so the conjunction, separator, and order follow the locale rather than this file. English output is unchanged.

The issue also lists `"Several people are typing…"`. That string is not in the component, the repository, or its history (`git log --all -S`), so there was nothing to move; the component builds three sentences and all three are covered.

## Test Plan

- [x] `pnpm test` — three new cases in a French locale, including `Intl.ListFormat` joining with "et" rather than "and"; each fails with the literal restored. The three existing English assertions are unchanged and still pass
- [x] `pnpm check:i18n-catalog` — 365 keys, 29 locales consistent
- [x] `Lab/ChatAdditions → Typing And Unread` renders the same sentence as before (`"Ana and 2 others are typing…"`), verified against the story's exact input

## Related Issues

Closes #6215
