### PR TITLE
fix(Table): keep the grouped-rows chevron pinned under a custom header

### DIFF
--- a/.changeset/grouped-rows-sticky-chevron.md
+++ b/.changeset/grouped-rows-sticky-chevron.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `useTableGroupedRows` kept its collapse chevron pinned only when the group header used the built-in heading. The shrink-wrap that makes the sticky header work was gated behind `!renderGroupHeader`, on the reasoning that a custom heading may want the full column width — but a sticky box is confined to its containing block, so a wrapper already spanning the cell (and the cell spans every column) has no slack to take up and never moves. Any table combining `renderGroupHeader` with `useTableStickyColumns` therefore lost its collapse toggle off-screen as soon as it was scrolled sideways, with no way for userland to reach the control and pin it. The wrapper is now shrink-wrapped unconditionally.
+@ernestt

--- a/.changeset/grouped-rows-sticky-chevron.md
+++ b/.changeset/grouped-rows-sticky-chevron.md
@@ -3,4 +3,6 @@
 ---
 
 [fix] `useTableGroupedRows` kept its collapse chevron pinned only when the group header used the built-in heading. The shrink-wrap that makes the sticky header work was gated behind `!renderGroupHeader`, on the reasoning that a custom heading may want the full column width — but a sticky box is confined to its containing block, so a wrapper already spanning the cell (and the cell spans every column) has no slack to take up and never moves. Any table combining `renderGroupHeader` with `useTableStickyColumns` therefore lost its collapse toggle off-screen as soon as it was scrolled sideways, with no way for userland to reach the control and pin it. The wrapper is now shrink-wrapped unconditionally.
+
+The same chevron also grows from 12px to 16px. It is the control for an entire section and sits beside a heading, so at 12 it read as decoration on the label rather than as the thing you press, and it was the smallest hit target in the table. Row height is unchanged: the heading's line box is taller than either size, so the row was never measuring the chevron.
 @ernestt

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
@@ -167,6 +167,28 @@ describe('useTableGroupedRows', () => {
     expect(screen.getByText('Infra::1::open')).toBeInTheDocument();
   });
 
+  it('shrink-wraps the group header the same way with and without renderGroupHeader', () => {
+    // The chevron only stays pinned on a sideways-scrolled table if its
+    // wrapper is narrower than the cell it sits in — a sticky box confined to
+    // a containing block it already fills has no slack to travel. The wrapper
+    // used to be shrink-wrapped only for the built-in heading, which stranded
+    // the collapse toggle off-screen for anyone passing renderGroupHeader.
+    const wrapperClass = (container: HTMLElement) => {
+      const toggle = within(container).getAllByRole('button')[0];
+      return toggle.parentElement?.className;
+    };
+
+    const builtIn = render(<Harness />);
+    const builtInClass = wrapperClass(builtIn.container);
+    builtIn.unmount();
+
+    const custom = render(
+      <Harness renderGroupHeader={key => <span>{key}</span>} />,
+    );
+
+    expect(wrapperClass(custom.container)).toBe(builtInClass);
+  });
+
   it('renders nothing (no group headers) for empty data', () => {
     render(<Harness rows={[]} />);
     // Column header row still renders; no group header rows.

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -145,11 +145,13 @@ const styles = stylex.create({
     // No inline start padding on the cell, so the chevron aligns with the
     // table's leading edge (Ernest review #1).
     paddingInlineStart: spacingVars['--spacing-1'],
-  },
-  // Applied alongside headerInner when using the built-in default heading.
-  // A custom `renderGroupHeader` may need the full column width, so the
-  // shrink-wrap is opt-in rather than unconditional.
-  headerInnerFitContent: {
+    // Shrink-wrapped so the sticky above has somewhere to travel. A sticky box
+    // is confined to its containing block, so one that already spans the cell —
+    // and the cell spans every column — has no slack to take up and never
+    // moves. This applies to a custom `renderGroupHeader` too: the chevron is
+    // the plugin's, and userland can pin its own heading but cannot reach the
+    // control, so leaving the wrapper full width stranded the collapse toggle
+    // off-screen on any table scrolled sideways.
     width: 'fit-content',
   },
   // Standalone chevron button with no heavy chrome (transparent, borderless,
@@ -384,11 +386,7 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
             // to the actual number of columns, so the header always spans the
             // full width without the plugin knowing the column count.
             <td colSpan={999} {...stylex.props(styles.headerCell)}>
-              <span
-                {...stylex.props(
-                  styles.headerInner,
-                  !renderGroupHeader && styles.headerInnerFitContent,
-                )}>
+              <span {...stylex.props(styles.headerInner)}>
                 {/* Standalone chevron button, flush with the table's start
                     edge (no heavy button chrome) — the keyboard control. */}
                 <button

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -408,7 +408,12 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
                   aria-expanded={!collapsed}>
                   <Icon
                     icon="chevronRight"
-                    size="xsm"
+                    // 16px, not the 12px this started at. The chevron is the
+                    // control for the whole section and sits beside a heading,
+                    // so at 12 it read as decoration on the label rather than
+                    // the thing you press, and it was the smallest hit target
+                    // in the table.
+                    size="sm"
                     // The rotation rides on the glyph rather than a wrapper
                     // span so the theme target below reaches both the mark and
                     // its open/closed transform.


### PR DESCRIPTION
`useTableGroupedRows` loses its collapse chevron off the left edge as soon as a table is scrolled sideways — but only for callers who pass `renderGroupHeader`.

## What was wrong

The group header's inner wrapper is `position: sticky` so the chevron and label ride along as the table scrolls horizontally. That only works if the wrapper is narrower than the cell it sits in: a sticky box is confined to its containing block, so one that already spans the cell — and the group header cell spans every column — has no slack to take up and never moves.

The shrink-wrap that provides that slack was gated behind `!renderGroupHeader`, on the reasoning that a custom heading might want the full column width. The cost of that choice wasn't visible at the time: it silently disabled the pinning it was paired with.

Both shots scroll the same table to its right edge. The group labels are drawn by a custom `renderGroupHeader`, which pins itself, so the label survives either way — it's the chevron that goes missing.

| before — chevron gone | after — chevron pinned |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/grouped-chevron/before.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/grouped-chevron/after.png) |

Look at "Overview" and "Pricing": before, the labels are there and the toggles are not. The chevron in the after shot is also bigger than the one that went missing — that is the second commit, below.

## Why userland can't work around it

The chevron belongs to the plugin. A caller can pin whatever they render inside `renderGroupHeader`, but they have no handle on the control, so there is no way to keep the toggle on screen from outside. That's what makes this a fix rather than a default worth debating: the gate protected a width choice for custom content while taking away the only interactive element in the row.

The affected combination is `renderGroupHeader` + `useTableStickyColumns`, which is what any wide comparison or spend table reaches for.

## The change

`width: fit-content` moves onto `headerInner` unconditionally and `headerInnerFitContent` goes away. Net −4 lines plus comments.

A custom header that genuinely wants the full column width still lays out normally inside the shrink-wrapped span for any content that fills the visible cell; what it no longer gets is a wrapper wider than the viewport, which was never useful — that width existed off-screen.

## Also: the chevron was 12px

Second commit. The chevron is the control for the whole section and it sits beside a heading, so at `xsm` it read as decoration on the label rather than the thing you press, and it was the smallest hit target in the table. `sm` — 16px — is what `Collapsible` uses for the same job.

| before — 12px | after — 16px |
|---|---|
| <img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/grouped-chevron/size-before.png" width="380" /> | <img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/grouped-chevron/size-after.png" width="380" /> |

Row height is unchanged: the heading's line box is taller than either size, so the row was never measuring the chevron.

## Tests

One regression test, asserting the wrapper carries the same class with and without `renderGroupHeader`. Verified it fails against `main` (`expected 'useTableGroupedRows__styles.headerInn…' to be …`) and passes here.

`packages/core/src/Table` is green: 552 tests, 27 files.

