### PR TITLE
fix(Layout): give LayoutFooter's Properties preview a working component

### DIFF
--- a/packages/core/src/Layout/LayoutFooter.doc.mjs
+++ b/packages/core/src/Layout/LayoutFooter.doc.mjs
@@ -8,6 +8,15 @@ export const docs = {
   displayName: 'Layout Footer',
   isHiddenFromOverview: true,
   description: 'Bottom bar for action bars, pagination, and status bars.',
+  playground: {
+    defaults: {
+      children: 'Footer Content',
+      hasDivider: true,
+    },
+    wrapper: {
+      component: 'Layout',
+    },
+  },
   props: [
     {
       name: 'children',


### PR DESCRIPTION
Fixes #5895.

## Problem

`LayoutFooter.doc.mjs` had no `playground` block, so its standalone Properties preview rendered the component with empty `children` and no `Layout` scaffold around it, an empty stage with nothing to see or exercise.

## Fix

Mirrors `LayoutHeader.doc.mjs`'s existing, working `playground` block exactly (same shape, no `slotProp` needed since footer is a top-level named slot like header):

```js
playground: {
  defaults: {
    children: 'Footer Content',
    hasDivider: true,
  },
  wrapper: {
    component: 'Layout',
  },
},
```

## Verification

Verified the doc value against the CLI's own `parseDoc` schema loader directly (`packages/cli/authoring/doctypes/parse.mjs`); it parses successfully with no schema errors.

I could not get a live docsite preview running in this environment to confirm the rendered pixels: `pnpm dev` fails during its own `generate` step on an unrelated pre-existing ShadCN route-lock mismatch (`checkShadcnRouteLock` in `generate-data.mjs`), reproducible on a clean checkout with no changes at all. Opening as a draft and flagging this rather than claiming a visual check I couldn't actually run; happy for a maintainer (or CI's own screenshot job) to confirm the rendered preview before this is marked ready.

## Testing

- `node --check` on the changed file
- Schema validation via `parseDoc` (passes)
- `packages/core/tsconfig.json` typecheck (clean, no output)