### PR TITLE
expand description to take react node

### DIFF
--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -92,7 +92,7 @@ export interface EmptyStateProps extends BaseProps<HTMLDivElement> {
   /**
    * Optional secondary text providing additional context.
    */
-  description?: string;
+  description?: string | ReactNode;
   /**
    * Optional icon or illustration displayed above the title.
    * Rendered as decorative (aria-hidden="true").


### PR DESCRIPTION
Hi there! The implementation of empty state suggests `description` should take react node as types, however the typescript types don't agree. This updates it.