### PR TITLE
fix(cli): let autolinking be switched off without a release

### DIFF
--- a/.changeset/autolink-kill-switch.md
+++ b/.changeset/autolink-kill-switch.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Autolinking can be switched off without a release: `{"astryx": {"autolink": false}}` in a project's package.json, or `ASTRYX_NO_AUTOLINK` in the environment. Neither affects an integration the project names in its config. Separately, test and fixture files under a codemod version folder are no longer loaded as codemods — one colocated test used to fail validation and take every codemod in that version with it, while `upgrade` reported success.
+@josephfarina

--- a/docs/architecture/cli-surface.md
+++ b/docs/architecture/cli-surface.md
@@ -127,6 +127,12 @@ test, applicable text, and consumer-documentation projections.
   alias or a non-semver protocol resolves like any other. A config entry keeps
   precedence over the same package autolinked, and a dependency whose manifest
   fails to load is dropped rather than raised as the consuming project's issue.
+  Two switches turn it off without touching a declaration:
+  `{"astryx": {"autolink": false}}` in package.json for a project that wants only
+  what it names, and `ASTRYX_NO_AUTOLINK` in the environment for the case a
+  release cannot serve — consumers resolve the CLI from their own lockfiles, so
+  a fix that ships in a version reaches them on their schedule, not ours. Neither
+  switch touches a CONFIGURED integration: naming one is asking for it.
 
 ## Change coupling
 

--- a/packages/cli/assets/codemods/integration-discovery.mjs
+++ b/packages/cli/assets/codemods/integration-discovery.mjs
@@ -33,6 +33,35 @@ import {semverCompare} from '../../foundation/env/semver.mjs';
 const CODEMOD_EXTENSIONS = ['.ts', '.mjs', '.js'];
 
 /**
+ * Directories never walked for codemods: a test directory beside a transform is
+ * the natural place to put its test, and every file found here is loaded and
+ * validated as a codemod.
+ */
+const SKIP_DIRS = new Set(['node_modules', '.git', '__tests__', '__fixtures__']);
+
+/**
+ * Whether a file name is a test or fixture rather than a codemod.
+ *
+ * The trap this closes: EVERY `.ts`/`.mjs`/`.js` under a version folder used to
+ * be loaded as a codemod, so a test file colocated with its transform failed
+ * validation and — because a definition error is a hard error — took every
+ * codemod in that package's version with it. `astryx upgrade` then applied no
+ * transforms and reported success, which is the worst shape a failure can take.
+ *
+ * Core's own codemods never hit this: they are enumerated in a registry, and
+ * their colocated tests are simply not in it. Only integrations are discovered
+ * by walking a directory, so only integrations carry the landmine — which is why
+ * this is a loader fix and not a documentation one. It protects the integrations
+ * that already exist, which no authoring tool can reach.
+ *
+ * @param {string} name a file's base name
+ * @returns {boolean}
+ */
+function isTestFile(name) {
+  return /\.(test|spec)\.[^.]+$/.test(name) || /\.fixture\.[^.]+$/.test(name);
+}
+
+/**
  * Recursively collect codemod module files under a version folder. Returns
  * entries of {id, file} where id is the extension-less relative path
  * (POSIX-style) under `versionDir`.
@@ -49,12 +78,13 @@ function collectCodemodFiles(versionDir) {
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'node_modules' || entry.name === '.git') continue;
+        if (SKIP_DIRS.has(entry.name)) continue;
         walk(full);
         continue;
       }
       const ext = path.extname(entry.name);
       if (!CODEMOD_EXTENSIONS.includes(ext)) continue;
+      if (isTestFile(entry.name)) continue;
       const rel = path.relative(versionDir, full);
       const id = rel.slice(0, rel.length - ext.length).split(path.sep).join('/');
       out.push({id, file: full});

--- a/packages/cli/assets/codemods/integration-discovery.test.mjs
+++ b/packages/cli/assets/codemods/integration-discovery.test.mjs
@@ -221,3 +221,61 @@ describe('integration codemod discovery', () => {
     ).rejects.toThrow(/across versions/i);
   });
 });
+
+describe('test files beside a codemod', () => {
+  // The incident this closes: every .ts/.mjs/.js under a version folder was
+  // loaded AND VALIDATED as a codemod, so a test file colocated with its
+  // transform failed validation — and because a definition error is a hard
+  // error, it took every codemod in that version with it. `astryx upgrade`
+  // then applied nothing and reported success. Core is immune because its own
+  // codemods are enumerated in a registry rather than discovered by walking a
+  // directory, so its colocated tests are simply never visited. Only
+  // integrations carry the landmine.
+  const TRANSFORM = `
+    export default {
+      type: 'code',
+      title: 'Drop foo',
+      transform: (file) => file.source.replace(/foo/g, 'bar'),
+    };
+  `;
+  // Not a codemod: no default export of the right shape. Loading it throws.
+  const A_TEST = `
+    import {describe, it, expect} from 'vitest';
+    describe('drop-foo', () => {
+      it('drops foo', () => expect(1).toBe(1));
+    });
+  `;
+
+  it.each([
+    ['a .test. sibling', '0.2.0/drop-foo.test.mjs'],
+    ['a .spec. sibling', '0.2.0/drop-foo.spec.mjs'],
+    ['a fixture sibling', '0.2.0/drop-foo.fixture.mjs'],
+    ['a __tests__ directory', '0.2.0/__tests__/drop-foo.mjs'],
+    ['a __fixtures__ directory', '0.2.0/__fixtures__/input.mjs'],
+  ])('ignores %s and still discovers the codemod', async (_label, testPath) => {
+    scaffold({'0.2.0/drop-foo.mjs': TRANSFORM, [testPath]: A_TEST});
+
+    const project = await Project.load(tmpDir);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+
+    expect([...byVersion.keys()]).toEqual(['0.2.0']);
+    expect(byVersion.get('0.2.0').map(entry => entry.id)).toEqual(['drop-foo']);
+  });
+
+  it('a nested helper directory is still walked', async () => {
+    // Only test and fixture names are skipped. A package that organises its
+    // transforms into subdirectories keeps working.
+    scaffold({'0.2.0/imports/drop-foo.mjs': TRANSFORM});
+
+    const project = await Project.load(tmpDir);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+
+    expect(byVersion.get('0.2.0').map(entry => entry.id)).toEqual([
+      'imports/drop-foo',
+    ]);
+  });
+});

--- a/packages/cli/foundation/config/project.mjs
+++ b/packages/cli/foundation/config/project.mjs
@@ -122,6 +122,45 @@ function findPackageRoot(startDir) {
 }
 
 /**
+ * Whether autolinking is switched off for this run.
+ *
+ * Two switches, because they answer two different emergencies.
+ *
+ *   - `ASTRYX_NO_AUTOLINK=1` in the environment. The only control that needs no
+ *     change to a repo, which is what a fleet-wide stop requires: consumers
+ *     resolve the CLI from their own lockfiles, so a fix that ships in a release
+ *     reaches them on their upgrade schedule, not ours. Any non-empty value
+ *     other than `0` or `false` counts — an operator reaching for this is not in
+ *     a mood to read a spelling rule.
+ *   - `{"astryx": {"autolink": false}}` in the project's package.json. The
+ *     durable, per-project answer, for a project that wants only what it names.
+ *
+ * package.json rather than astryx.config, for the reason
+ * {@link inheritsIntegrationDebug} gives: an unknown config key is a hard config
+ * error on an older CLI, while `astryx` in package.json is inert to every
+ * version that does not look for it. Only `false` opts out; a missing file or a
+ * malformed one is not an opt-out.
+ *
+ * This never disables a CONFIGURED integration. A project that named an
+ * integration asked for it, and this switch is about the ones it did not name.
+ *
+ * @param {string} projectDir
+ * @returns {boolean}
+ */
+function autolinkDisabled(projectDir) {
+  const env = process.env.ASTRYX_NO_AUTOLINK;
+  if (env != null && env !== '' && env !== '0' && env !== 'false') return true;
+  try {
+    const pkgPath = path.join(projectDir, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    return pkg?.astryx?.autolink === false;
+  } catch {
+    // No package.json, or unreadable/malformed — not an opt-out.
+    return false;
+  }
+}
+
+/**
  * Whether this project accepts `debug` handlers contributed by the
  * integrations it loads.
  *
@@ -282,11 +321,13 @@ export class Project {
     // precedence in every discovery order.
     loadedIntegrations = [
       ...loadedIntegrations,
-      ...(await autolinkIntegrations({
-        projectDir,
-        loaded: loadedIntegrations,
-        fresh,
-      })),
+      ...(autolinkDisabled(projectDir)
+        ? []
+        : await autolinkIntegrations({
+            projectDir,
+            loaded: loadedIntegrations,
+            fresh,
+          })),
     ];
 
     // The debug recorder resolves its settings synchronously, long before any

--- a/packages/cli/foundation/integrations/autolink.test.mjs
+++ b/packages/cli/foundation/integrations/autolink.test.mjs
@@ -428,3 +428,81 @@ describe('Project.load with autolink', () => {
     expect(await project.issues()).toEqual([]);
   });
 });
+
+describe('the autolink kill switch', () => {
+  const ENV = 'ASTRYX_NO_AUTOLINK';
+  let saved;
+
+  beforeEach(() => {
+    saved = process.env[ENV];
+    delete process.env[ENV];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env[ENV];
+    else process.env[ENV] = saved;
+  });
+
+  /** A project whose sole integration arrives by autolink, not by config. */
+  function scaffoldAutolinked(fields = {}) {
+    writeProject(tmpDir, {dependencies: {'@acme/widgets': '^1.0.0'}, ...fields});
+    installPackage(tmpDir, {installAs: '@acme/widgets'});
+  }
+
+  it('loads the autolinked integration when nothing switches it off', async () => {
+    scaffoldAutolinked();
+    const project = await Project.load(tmpDir);
+    expect(project.loadedIntegrations.map(i => i.name)).toEqual(['@acme/widgets']);
+  });
+
+  it('loads nothing when the environment switch is set', async () => {
+    scaffoldAutolinked();
+    process.env[ENV] = '1';
+    const project = await Project.load(tmpDir);
+    expect(project.loadedIntegrations).toEqual([]);
+  });
+
+  it.each(['1', 'true', 'yes', 'please'])(
+    'treats %o as off — an operator reaching for this is not reading a spelling rule',
+    async value => {
+      scaffoldAutolinked();
+      process.env[ENV] = value;
+      const project = await Project.load(tmpDir);
+      expect(project.loadedIntegrations).toEqual([]);
+    },
+  );
+
+  it.each(['', '0', 'false'])('treats %o as not set', async value => {
+    scaffoldAutolinked();
+    process.env[ENV] = value;
+    const project = await Project.load(tmpDir);
+    expect(project.loadedIntegrations.map(i => i.name)).toEqual(['@acme/widgets']);
+  });
+
+  it('loads nothing when package.json opts out', async () => {
+    scaffoldAutolinked({astryx: {autolink: false}});
+    const project = await Project.load(tmpDir);
+    expect(project.loadedIntegrations).toEqual([]);
+  });
+
+  it('opts out only on false, not on any other value', async () => {
+    scaffoldAutolinked({astryx: {autolink: true}});
+    const project = await Project.load(tmpDir);
+    expect(project.loadedIntegrations.map(i => i.name)).toEqual(['@acme/widgets']);
+  });
+
+  it('still loads an integration the config NAMES', async () => {
+    // The switch governs what a project did not ask for. Naming an integration
+    // is asking for it, and no kill switch should silently drop a declaration.
+    writeProject(tmpDir, {
+      dependencies: {'@acme/widgets': '^1.0.0'},
+      astryx: {autolink: false},
+    });
+    installPackage(tmpDir, {installAs: '@acme/widgets'});
+    writeConfig(tmpDir, ['@acme/widgets']);
+    process.env[ENV] = '1';
+
+    const project = await Project.load(tmpDir);
+    expect(project.loadedIntegrations.map(i => i.name)).toEqual(['@acme/widgets']);
+  });
+});


### PR DESCRIPTION
## What

Autolinking (#6202, merged this morning) loads an installed integration a project never named. That is the point — it fixes the ~3,700 apps that have the dependency and no config. But there is currently **no way to stop it**, and a consumer resolves the CLI from its own lockfile, so a fix that ships in a release reaches the fleet on each app's upgrade schedule rather than ours.

Two switches, for two different emergencies:

| | |
|---|---|
| `ASTRYX_NO_AUTOLINK=1` | Needs no change to any repo — what a fleet-wide stop requires. Any non-empty value other than `0`/`false` counts. |
| `{"astryx": {"autolink": false}}` | The durable per-project answer, for a project that wants only what it names. |

In package.json rather than `astryx.config`, for the reason `astryx.inheritDebug` already documents: an unknown config key is a hard error on an older CLI, while an `astryx` block in package.json is inert to every version that does not look for it.

**Neither switch touches a CONFIGURED integration.** Naming one is asking for it, and a kill switch that silently dropped a declaration would be a second silent failure in a system that already has too many. There is a test for exactly that.

## Also: test files under a codemod version folder

Every `.ts`/`.mjs`/`.js` file under `codemods/<version>/` was loaded **and validated** as a codemod. A test colocated with its transform therefore failed validation, and because a definition error is a hard error, it took every codemod in that version with it — while `astryx upgrade` applied nothing and **reported success**.

Core never hit this: its own codemods are enumerated in a registry rather than found by walking a directory, so its colocated tests are simply never visited. The trap is an accident of two different loading strategies, and only integrations carry it.

This is a **loader** fix on purpose. It protects the integrations that already exist, which no amount of authoring tooling or documentation can reach.

## Verification

- `vitest run packages/cli` — **238 files, 3,671 tests, all passing**
- `tsc --project packages/cli/tsconfig.api-dts.json` — clean
- `eslint` on all four changed files — clean

Both fixes were mutation-tested rather than assumed:

- removing the kill-switch call → **6 tests fail**
- removing the test-file skip → **5 tests fail**

## What I checked before writing anything

The original ask included restricting autolink to depth-1 declared dependencies. **That is already how it works** — `#6202` reads dependency keys from the project's own package.json and never walks `node_modules`, with a test named *"ignores a transitive dependency that ships a manifest"*. No change was needed, and none is here.