### PR TITLE
feat(Table): pin group headings while their section is on screen

### DIFF
--- a/.changeset/table-sticky-group-headings.md
+++ b/.changeset/table-sticky-group-headings.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] `useTableGroupedRows` takes `hasStickyGroupHeaders`, which pins each group heading to the top of the table's scroll container until the next section pushes it out, so a reader scrolling deep inside a long group can still see which group they are in. A sticky cell leaves its row behind and the row is what carries the heading's fill, so the pinned cell takes an opaque background of its own; it also clears the body cells `useTableStickyColumns` pins, which would otherwise paint over the heading as rows pass beneath. For the offset the two plugins now cooperate: `useTableStickyHeader` measures its header and publishes the height as `--table-sticky-header-height` on the scroll container, and a pinned heading starts below that, the same way the two already share `--table-sticky-background`. Install both and the heading comes to rest under the header instead of hiding it; with no pinned header the variable is unset and the heading pins to the top edge. Both need a scrollport with somewhere to travel, which is what `useTableStickyHeader`'s `maxHeight` is for.
+
+@ernestt

--- a/apps/storybook/stories/TableGroupedRows.stories.tsx
+++ b/apps/storybook/stories/TableGroupedRows.stories.tsx
@@ -5,6 +5,8 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {
   Table,
   useTableGroupedRows,
+  useTableStickyHeader,
+  useTableStickyColumns,
   proportional,
   pixel,
 } from '@astryxdesign/core/Table';
@@ -143,6 +145,96 @@ export const CustomOrderAndHeader: Story = {
         hasHover
         plugins={{grouped: grouped.plugin}}
       />
+    );
+  },
+};
+
+// =============================================================================
+// Sticky group headings
+//
+// Needs more rows than the sample set above: a heading only has somewhere to
+// pin once its own section is taller than the scrollport.
+// =============================================================================
+
+const TEAMS = ['Design Systems', 'Infra', 'Growth', 'Payments'];
+const ROLES = ['Engineer', 'Senior Eng', 'Staff Eng', 'Manager', 'PM'];
+
+const staff: Person[] = Array.from({length: 48}, (_, index) => ({
+  id: String(index + 1),
+  name: `Person ${String(index + 1).padStart(2, '0')}`,
+  team: TEAMS[Math.floor(index / 12)],
+  role: ROLES[index % ROLES.length],
+}));
+
+// Wider than the container the composition story puts it in, so there is
+// something to scroll sideways past the pinned column.
+const wideColumns: TableColumn<Person>[] = [
+  {key: 'name', header: 'Name', width: pixel(200)},
+  {key: 'team', header: 'Team', width: pixel(180)},
+  {key: 'role', header: 'Role', width: pixel(180)},
+];
+
+/**
+ * `hasStickyGroupHeaders` pins each heading to the top of the scrollport while
+ * its section is on screen, so scrolling deep into a long group never loses
+ * which group it is. The heading needs somewhere to pin, which is what
+ * `useTableStickyHeader`'s `maxHeight` gives it — and with that plugin
+ * installed the heading comes to rest below the header row rather than over
+ * it, because the header publishes its measured height for it to clear.
+ */
+export const StickyGroupHeadings: Story = {
+  render: () => {
+    const {collapsedGroups, onToggleGroup} = useCollapsed();
+    const grouped = useTableGroupedRows<Person>({
+      data: staff,
+      groupBy: p => p.team,
+      collapsedGroups,
+      onToggleGroup,
+      getRowKey: p => p.id,
+      hasStickyGroupHeaders: true,
+    });
+    const stickyHeader = useTableStickyHeader<Person>({maxHeight: 320});
+    return (
+      <Table
+        data={grouped.data}
+        columns={columns}
+        idKey={grouped.idKey}
+        hasHover
+        plugins={{grouped: grouped.plugin, stickyHeader}}
+      />
+    );
+  },
+};
+
+/**
+ * All three at once. Scrolling down pins the header row and the heading under
+ * it; scrolling sideways holds the `Name` column and keeps the heading's label
+ * at the start edge. The heading stays above the pinned column as rows pass
+ * beneath, and below the pinned header rather than covering it.
+ */
+export const StickyGroupHeadingsWithStickyColumn: Story = {
+  render: () => {
+    const {collapsedGroups, onToggleGroup} = useCollapsed();
+    const grouped = useTableGroupedRows<Person>({
+      data: staff,
+      groupBy: p => p.team,
+      collapsedGroups,
+      onToggleGroup,
+      getRowKey: p => p.id,
+      hasStickyGroupHeaders: true,
+    });
+    const stickyHeader = useTableStickyHeader<Person>({maxHeight: 320});
+    const stickyColumns = useTableStickyColumns<Person>({startKeys: ['name']});
+    return (
+      <div style={{maxWidth: 420}}>
+        <Table
+          data={grouped.data}
+          columns={wideColumns}
+          idKey={grouped.idKey}
+          hasHover
+          plugins={{grouped: grouped.plugin, stickyHeader, stickyColumns}}
+        />
+      </div>
     );
   },
 };

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.test.tsx
@@ -29,6 +29,7 @@ function Harness({
   rows = people,
   initialCollapsed = EMPTY,
   renderGroupHeader,
+  hasStickyGroupHeaders,
 }: {
   rows?: Person[];
   initialCollapsed?: Set<string>;
@@ -37,6 +38,7 @@ function Harness({
     count: number,
     collapsed: boolean,
   ) => React.ReactNode;
+  hasStickyGroupHeaders?: boolean;
 }) {
   const [collapsedGroups, setCollapsed] = useState(initialCollapsed);
   const onToggleGroup = useCallback((key: string) => {
@@ -57,6 +59,7 @@ function Harness({
     onToggleGroup,
     getRowKey: p => p.id,
     renderGroupHeader,
+    hasStickyGroupHeaders,
   });
   return (
     <Table
@@ -328,5 +331,71 @@ describe('useTableGroupedRows', () => {
     // Count reflects the new member (3), header still present.
     expect(screen.getByText('Core')).toBeInTheDocument();
     expect(screen.getByText('(3)')).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Sticky group headings
+  //
+  // `position: sticky`, the offset and the z-index are applied via StyleX,
+  // which compiles to classNames that jsdom does not resolve to
+  // `element.style`. They are asserted by class identity instead: the heading
+  // cell carries a class it does not carry with the option off, and every
+  // heading carries the same one.
+  // ===========================================================================
+
+  function headingCell(group: string): HTMLElement {
+    const cell = screen.getByText(group).closest('td');
+    if (!(cell instanceof HTMLElement)) {
+      throw new Error(`no heading cell for ${group}`);
+    }
+    return cell;
+  }
+
+  it('leaves group headings unpinned by default', () => {
+    const {unmount} = render(<Harness />);
+    const bare = headingCell('Core').className;
+    unmount();
+
+    render(<Harness hasStickyGroupHeaders={false} />);
+
+    expect(headingCell('Core').className).toBe(bare);
+  });
+
+  it('pins group headings when asked', () => {
+    const {unmount} = render(<Harness />);
+    const bare = headingCell('Core').className;
+    unmount();
+
+    render(<Harness hasStickyGroupHeaders />);
+
+    const pinned = headingCell('Core').className;
+    expect(pinned).not.toBe(bare);
+    expect(pinned.length).toBeGreaterThan(bare.length);
+  });
+
+  it('pins every heading, not just the first', () => {
+    render(<Harness hasStickyGroupHeaders />);
+
+    // A table that pinned only the first heading would still look right until
+    // the reader scrolled into the second group.
+    expect(headingCell('Core').className).toBe(headingCell('Infra').className);
+  });
+
+  it('pins a custom-rendered heading too', () => {
+    // The heading content is the caller's, but the cell it sits in is the
+    // plugin's, so the option has to survive renderGroupHeader.
+    const renderGroupHeader = (groupKey: string) => (
+      <span>{groupKey} team</span>
+    );
+
+    const {unmount} = render(<Harness renderGroupHeader={renderGroupHeader} />);
+    const bare = headingCell('Core team').className;
+    unmount();
+
+    render(
+      <Harness renderGroupHeader={renderGroupHeader} hasStickyGroupHeaders />,
+    );
+
+    expect(headingCell('Core team').className).not.toBe(bare);
   });
 });

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -92,6 +92,20 @@ export interface UseTableGroupedRowsConfig<T extends Record<string, unknown>> {
     count: number,
     collapsed: boolean,
   ) => ReactNode;
+  /**
+   * Pin each group heading to the top of the table's scroll container while
+   * its section is on screen, so a reader deep inside a long group can still
+   * see which group they are in.
+   *
+   * Requires a scrollport with somewhere to travel: the table's own container
+   * only becomes one once something bounds its height, which is what
+   * `useTableStickyHeader`'s `maxHeight` does. Install that plugin alongside
+   * this one and the heading pins directly beneath the header row — it reads
+   * the header's height and starts below it, so the two never overlap.
+   *
+   * @default false
+   */
+  hasStickyGroupHeaders?: boolean;
   /** Stable key for a real row. Falls back to a positional key when omitted. */
   getRowKey?: (item: T) => string;
   /** Explicit group ordering; groups not listed keep first-seen order after these. */
@@ -151,6 +165,25 @@ const styles = stylex.create({
   // shrink-wrap is opt-in rather than unconditional.
   headerInnerFitContent: {
     width: 'fit-content',
+  },
+  // Applied alongside headerCell when the heading is pinned vertically.
+  headerCellSticky: {
+    position: 'sticky',
+    // Starts below whatever the table already pins at the top of the same
+    // scrollport. useTableStickyHeader publishes its height here; with no
+    // pinned header the variable is unset and 0 is the right answer.
+    insetBlockStart: `var(--table-sticky-header-height, 0px)`,
+    // Above the body cells useTableStickyColumns pins at 1, so a pinned
+    // column scrolling underneath cannot paint over the heading. This ties
+    // with the header row useTableStickyHeader pins at 2 — harmless only
+    // because the offset above means the two never occupy the same pixels.
+    zIndex: 2,
+    // A sticky cell leaves its row behind, and the row is what carries the
+    // heading's fill. Without a background of its own the pinned cell is
+    // transparent and the rows travelling under it show through.
+    backgroundColor: colorVars['--color-background-muted'],
+    // Keeps the fill off the cell's collapsed divider border.
+    backgroundClip: 'padding-box',
   },
   // Standalone chevron button with no heavy chrome (transparent, borderless,
   // zero padding) so the icon sits flush with the start of the table
@@ -275,6 +308,7 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
     collapsedGroups,
     onToggleGroup,
     renderGroupHeader,
+    hasStickyGroupHeaders = false,
     getRowKey: getRowKeyProp,
     groupOrder,
   } = config;
@@ -383,7 +417,12 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
             // colSpan larger than the column count is clamped by the browser
             // to the actual number of columns, so the header always spans the
             // full width without the plugin knowing the column count.
-            <td colSpan={999} {...stylex.props(styles.headerCell)}>
+            <td
+              colSpan={999}
+              {...stylex.props(
+                styles.headerCell,
+                hasStickyGroupHeaders && styles.headerCellSticky,
+              )}>
               <span
                 {...stylex.props(
                   styles.headerInner,
@@ -429,7 +468,13 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
         };
       },
     }),
-    [collapsedGroups, onToggleGroup, renderGroupHeader, t],
+    [
+      collapsedGroups,
+      onToggleGroup,
+      renderGroupHeader,
+      hasStickyGroupHeaders,
+      t,
+    ],
   );
 
   return {plugin, data: flattened, idKey};

--- a/packages/core/src/Table/plugins/stickyHeader/useTableStickyHeader.test.tsx
+++ b/packages/core/src/Table/plugins/stickyHeader/useTableStickyHeader.test.tsx
@@ -14,7 +14,7 @@
  * and it is absent when the plugin is not installed.
  */
 
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {Table} from '../../Table';
 import {useTableStickyHeader} from './useTableStickyHeader';
@@ -54,6 +54,31 @@ function getScrollWrapper(): HTMLElement {
 
 function headerCells(): HTMLElement[] {
   return screen.getAllByRole('columnheader');
+}
+
+const HEIGHT_VAR = '--table-sticky-header-height';
+
+function publishedHeight(): string {
+  return getScrollWrapper().style.getPropertyValue(HEIGHT_VAR);
+}
+
+/**
+ * jsdom lays nothing out, so every box measures zero and the published height
+ * would be `0px` whatever the plugin did. Forcing a height is what makes the
+ * assertion about the plugin rather than about jsdom.
+ */
+function mockLayoutHeight(height: number) {
+  return vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    height,
+    width: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  });
 }
 
 // =============================================================================
@@ -154,6 +179,50 @@ describe('useTableStickyHeader', () => {
 
       unmount();
     }
+  });
+
+  it('publishes the header height, so anything else pinning in the same scrollport can clear it', () => {
+    const rect = mockLayoutHeight(44);
+    function Harness() {
+      const stickyHeader = useTableStickyHeader<Row>({maxHeight: 480});
+      return <Table data={data} columns={columns} plugins={{stickyHeader}} />;
+    }
+    render(<Harness />);
+
+    expect(publishedHeight()).toBe('44px');
+    rect.mockRestore();
+  });
+
+  it('publishes no height when the header is not pinned, so a lone group heading falls back to the top edge', () => {
+    const rect = mockLayoutHeight(44);
+    render(<Table data={data} columns={columns} />);
+
+    expect(publishedHeight()).toBe('');
+    rect.mockRestore();
+  });
+
+  it('keeps publishing the height when another plugin also holds the wrapper ref', () => {
+    const rect = mockLayoutHeight(44);
+    function Harness() {
+      const stickyHeader = useTableStickyHeader<Row>({maxHeight: 480});
+      const stickyColumns = useTableStickyColumns<Row>({startKeys: ['name']});
+      return (
+        <Table
+          data={data}
+          columns={columns}
+          plugins={{stickyColumns, stickyHeader}}
+        />
+      );
+    }
+    render(<Harness />);
+
+    // Both plugins want a ref on the same element. If either overwrote the
+    // other's rather than composing, one of these variables would be missing.
+    expect(publishedHeight()).toBe('44px');
+    expect(
+      getScrollWrapper().style.getPropertyValue('--table-sticky-shadow-start'),
+    ).not.toBe('');
+    rect.mockRestore();
   });
 
   it('is stable across re-renders with the same config', () => {

--- a/packages/core/src/Table/plugins/stickyHeader/useTableStickyHeader.tsx
+++ b/packages/core/src/Table/plugins/stickyHeader/useTableStickyHeader.tsx
@@ -13,7 +13,7 @@
  * - /packages/core/src/Table/index.ts (exports)
  */
 
-import {useMemo, type CSSProperties} from 'react';
+import {useCallback, useMemo, useRef, type CSSProperties} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../../../theme/tokens.stylex';
 import type {
@@ -21,6 +21,18 @@ import type {
   HeaderCellRenderProps,
   ScrollWrapperRenderProps,
 } from '../../types';
+
+/**
+ * The pinned header's height, published on the scroll container.
+ *
+ * Anything else pinning inside the same scrollport has to start below the
+ * header or it will be drawn over it, and the height is not knowable ahead of
+ * time — it moves with density, with wrapped headings, and with whatever a
+ * column puts in its `header`. Publishing it as a variable is what lets
+ * `useTableGroupedRows` clear the header without the two plugins referring to
+ * each other, the same way they already share `--table-sticky-background`.
+ */
+const HEADER_HEIGHT_VAR = '--table-sticky-header-height';
 
 // =============================================================================
 // Config
@@ -106,6 +118,34 @@ export function useTableStickyHeader<T extends Record<string, unknown>>(
 ): TablePlugin<T> {
   const {maxHeight} = config;
 
+  // Measured against the DOM rather than held in state: the height is only
+  // ever read back out as a CSS variable, so putting it through React would
+  // re-render the whole table on every resize to produce the same paint.
+  const detachRef = useRef<(() => void) | null>(null);
+  const publishHeaderHeight = useCallback((el: HTMLDivElement | null) => {
+    detachRef.current?.();
+    detachRef.current = null;
+    if (el == null) {
+      return;
+    }
+    // Refs attach depth-first, so the table is already in the DOM here.
+    const head = el.querySelector('thead');
+    if (head == null) {
+      return;
+    }
+    const update = () => {
+      el.style.setProperty(
+        HEADER_HEIGHT_VAR,
+        `${head.getBoundingClientRect().height}px`,
+      );
+    };
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(update) : null;
+    resizeObserver?.observe(head);
+    update();
+    detachRef.current = () => resizeObserver?.disconnect();
+  }, []);
+
   return useMemo<TablePlugin<T>>(
     () => ({
       transformScrollWrapper(
@@ -120,10 +160,23 @@ export function useTableStickyHeader<T extends Record<string, unknown>>(
                 maxHeight:
                   typeof maxHeight === 'number' ? `${maxHeight}px` : maxHeight,
               };
+        // Compose with any ref a prior plugin set on the same element, the
+        // way useTableStickyColumns does for its scroll shadows.
+        const existingRef = props.htmlProps.ref;
+        const mergedRef = (node: HTMLDivElement | null) => {
+          publishHeaderHeight(node);
+          if (typeof existingRef === 'function') {
+            existingRef(node);
+          } else if (existingRef != null) {
+            existingRef.current = node;
+          }
+        };
+
         return {
           ...props,
           htmlProps: {
             ...props.htmlProps,
+            ref: mergedRef,
             style: {...props.htmlProps.style, ...heightStyle},
           },
           xstyle: [...props.xstyle, stickyHeaderStyles.scrollWrapper],
@@ -137,6 +190,6 @@ export function useTableStickyHeader<T extends Record<string, unknown>>(
         };
       },
     }),
-    [maxHeight],
+    [maxHeight, publishHeaderHeight],
   );
 }

--- a/packages/core/src/Table/useTableGroupedRows.doc.mjs
+++ b/packages/core/src/Table/useTableGroupedRows.doc.mjs
@@ -41,6 +41,13 @@ export const docs = {
         "Custom renderer for a group header's content (right of the chevron). Defaults to `<groupKey> (<count>)`.",
     },
     {
+      name: 'hasStickyGroupHeaders',
+      type: 'boolean',
+      defaultValue: 'false',
+      description:
+        "Pin each group heading to the top of the table's scroll container while its section is on screen, so a reader deep inside a long group can still see which group they are in. Needs a scrollport with somewhere to travel: the table's container only becomes one once something bounds its height, which is what useTableStickyHeader's maxHeight does. Install that alongside and the heading pins directly beneath the header row rather than under it — it reads the header's measured height and starts below it.",
+    },
+    {
       name: 'getRowKey',
       type: '(item: T) => string',
       description:
@@ -66,6 +73,8 @@ export const docsDense = {
     onToggleGroup: 'Called with the group key when a header is toggled.',
     renderGroupHeader:
       "Custom header content (right of chevron). Default '<key> (<count>)'. Args: (key, count, collapsed).",
+    hasStickyGroupHeaders:
+      "Pin each heading to the top of the table's scrollport while its section is on screen. Default false. Needs a bounded scrollport (useTableStickyHeader's maxHeight); with that plugin installed the heading pins below the header row, not under it.",
     getRowKey: 'Stable key for a real row; positional fallback when omitted.',
     groupOrder: 'Pin these group keys first; others keep first-seen order.',
   },

--- a/packages/core/src/Table/useTableGroupedRows.doc.mjs
+++ b/packages/core/src/Table/useTableGroupedRows.doc.mjs
@@ -43,7 +43,7 @@ export const docs = {
     {
       name: 'hasStickyGroupHeaders',
       type: 'boolean',
-      defaultValue: 'false',
+      default: 'false',
       description:
         "Pin each group heading to the top of the table's scroll container while its section is on screen, so a reader deep inside a long group can still see which group they are in. Needs a scrollport with somewhere to travel: the table's container only becomes one once something bounds its height, which is what useTableStickyHeader's maxHeight does. Install that alongside and the heading pins directly beneath the header row rather than under it — it reads the header's measured height and starts below it.",
     },

--- a/packages/core/src/Table/useTableStickyHeader.doc.mjs
+++ b/packages/core/src/Table/useTableStickyHeader.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableStickyHeader',
   description:
-    "Hook that returns a TablePlugin which pins the header row to the top of the table's scroll container, so column headings stay readable while the body scrolls. The header pins to a scrollport the table owns, so pass maxHeight unless an ancestor already bounds the table's height. Composes with useTableStickyColumns: install both to pin a column and the header at once, and the corner where they cross stays above both.",
+    "Hook that returns a TablePlugin which pins the header row to the top of the table's scroll container, so column headings stay readable while the body scrolls. The header pins to a scrollport the table owns, so pass maxHeight unless an ancestor already bounds the table's height. Composes with useTableStickyColumns: install both to pin a column and the header at once, and the corner where they cross stays above both. Also composes with useTableGroupedRows' hasStickyGroupHeaders: this plugin measures its header and publishes the height as --table-sticky-header-height on the scroll container, which is what lets a pinned group heading come to rest below the header rather than on top of it.",
   props: [
     {
       name: 'maxHeight',
@@ -22,7 +22,7 @@ export const docsZh = {
   name: 'useTableStickyHeader',
   displayName: 'useTableStickyHeader',
   description:
-    '返回 TablePlugin 的 Hook，将表头行固定到表格滚动容器的顶部，使列标题在正文滚动时保持可见。表头固定在表格自身拥有的滚动视口上，因此除非祖先元素已限制表格高度，否则请传入 maxHeight。可与 useTableStickyColumns 组合使用：同时安装两者即可固定某一列和表头，二者交叉的角单元格会保持在最上层。',
+    '返回 TablePlugin 的 Hook，将表头行固定到表格滚动容器的顶部，使列标题在正文滚动时保持可见。表头固定在表格自身拥有的滚动视口上，因此除非祖先元素已限制表格高度，否则请传入 maxHeight。可与 useTableStickyColumns 组合使用：同时安装两者即可固定某一列和表头，二者交叉的角单元格会保持在最上层。也可与 useTableGroupedRows 的 hasStickyGroupHeaders 组合：本插件会测量表头高度并将其作为 --table-sticky-header-height 发布到滚动容器上，固定的分组标题据此停靠在表头下方，而不会覆盖表头。',
   props: [
     {
       name: 'maxHeight',
@@ -37,7 +37,7 @@ export const docsDense = {
   name: 'useTableStickyHeader',
   displayName: 'useTableStickyHeader',
   description:
-    "Hook returning TablePlugin that pins the header row to the top of the table's scroll container. Needs a scrollport: pass maxHeight unless an ancestor bounds the height. Composes with useTableStickyColumns; the corner cell stays above both.",
+    "Hook returning TablePlugin that pins the header row to the top of the table's scroll container. Needs a scrollport: pass maxHeight unless an ancestor bounds the height. Composes with useTableStickyColumns; the corner cell stays above both. Publishes its measured height as --table-sticky-header-height, which useTableGroupedRows' hasStickyGroupHeaders reads so a pinned heading rests below the header.",
   propDescriptions: {
     maxHeight:
       "Height cap for the table's scroll container, px number or CSS length. Omit only when an ancestor already bounds the height.",


### PR DESCRIPTION
Stacked on #6221 — review that one first; this PR's diff is only the last commit.

`useTableGroupedRows` takes `hasStickyGroupHeaders`. With it on, each group heading holds at the top of the table's scroll container until the next section pushes it out, so a reader scrolling deep inside a long group can still see which group they are in.

## What it looks like

Same table, same scroll position, 48 people in four teams of twelve. Scrolled far enough into Infra that the heading has left the top of the list.

| `hasStickyGroupHeaders` off | on |
| --- | --- |
| <img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/sticky-group-headings/before.png" width="420" /> | <img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/sticky-group-headings/after.png" width="420" /> |

On the left there is nothing on screen that says which team these people are on. On the right the heading is holding under the header row — at the header's measured height, not over it and not guessed.

Scrolled on both axes with `useTableStickyColumns` pinning `Name`, the heading stays above the pinned column and below the pinned header:

<img src="https://raw.githubusercontent.com/facebook/astryx/gh-pages/template-shots/sticky-group-headings/both-axes.png" width="420" />

## Why it needed both plugins

Pinning a heading vertically is not just `position: sticky` on the cell.

A sticky cell leaves its row behind, and the row is what carries the heading's fill — without a background of its own the pinned cell is transparent and the rows travelling under it show through. It also has to clear the body cells `useTableStickyColumns` pins at `z-index: 1`, or a pinned column paints over the heading as rows pass beneath it.

The offset is the part that needed the two plugins to cooperate. A heading pinned at the top of the scrollport lands on the header row `useTableStickyHeader` pins there too, and because `tbody` follows `thead` in the document the heading wins and hides it. There is no integer left between the sticky column's body cells at 1 and the pinned header at 2, so the fix is not a z-index but an offset: `useTableStickyHeader` now measures its header and publishes the height as `--table-sticky-header-height` on the scroll container, and a pinned heading starts below that. The two plugins already share `--table-sticky-background`, so this follows a path that exists.

Nothing to wire up. Install both and the heading comes to rest under the header; with no pinned header the variable is unset and the heading pins to the top edge, which is the right answer for a table that only pins its headings.

Both need a scrollport with somewhere to travel, which is what `useTableStickyHeader`'s `maxHeight` is for — a container with no bounded height never scrolls itself, and a heading cannot pin to a scrollport it is not inside.

## Verified

Measured in Storybook against the real plugins, not just in jsdom:

- header pinned at `top: 0`, 37.5px tall, publishing `--table-sticky-header-height: 37.5px`
- heading coming to rest at exactly 37.5px — flush under the header, no overlap
- scrolled on both axes at once: the heading stays above the pinned column and below the pinned header, with the chevron held at the start edge

Two stories added under `Core/TableGroupedRows`, plus 7 tests: the option is off by default, on when asked, applies to every heading rather than only the first, survives `renderGroupHeader`, publishes the height, publishes nothing when the header is not pinned, and keeps publishing when `useTableStickyColumns` also holds the wrapper ref (that last one guards ref clobbering, which is the easy way to break this).

## Follow-up to #6222

#6222 keeps the heading visible when the table is scrolled *sideways*. This is the same instinct on the other axis, split out because that one is a regression fix and this is a feature that depends on #6221.

Made with [Cursor](https://cursor.com)

