### PR TITLE
docs(DateInput): deprecate nativePicker shorthands

### DIFF
--- a/.changeset/deprecate-date-native-picker.md
+++ b/.changeset/deprecate-date-native-picker.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Deprecate the DateInput and DateTimeInput `nativePicker` shorthands in favor of `adaptations` (#6239)
+@cixzhang

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -16,21 +16,7 @@ const meta: Meta<typeof DateInput> = {
     docs: {
       description: {
         component:
-          'A date field that fits the pointer it is used with. Every story ' +
-          'below shows the pointer surface — a text input you can type into ' +
-          'with a calendar in a popover — because that is the right answer ' +
-          'for the mouse you are reading this with.\n\n' +
-          'Where the primary pointer is a finger (`pointer: coarse`), the ' +
-          'same component renders a picker built for one instead: a bottom ' +
-          'sheet of months swiped sideways, with month and year wheels ' +
-          'behind the header title, and no text entry (the keyboard would ' +
-          'cover the sheet it is meant to fill in). Same props either way — ' +
-          'there is nothing to opt into.\n\n' +
-          '**Seeing the touch surface:** open any story below on a phone or ' +
-          'tablet, or in a device-emulated tab reporting a coarse pointer. ' +
-          'Every one of them renders it — they are the same stories, and ' +
-          'that is the point. There is no separate touch story because there ' +
-          'is no separate thing to adopt.',
+          'A date field with an exact caller-owned adaptations policy over native, popover, and bottom-sheet surfaces. The policy names the server-rendered default and any ordered width/pointer rules. Without adaptations, the deprecated nativePicker compatibility path keeps its released pointer-driven behavior.',
       },
     },
   },
@@ -112,7 +98,8 @@ const meta: Meta<typeof DateInput> = {
       control: 'radio',
       options: ['touch', 'always', 'never'],
       description:
-        'Whether the browser or Astryx draws the picker for each pointer type',
+        'Deprecated. Use adaptations. At rest, touch maps to default popover plus a coarse-pointer native rule; always maps to constant native; never maps to default popover plus a coarse-pointer bottom-sheet rule. adaptations additionally holds the active tree until idle.',
+      table: {category: 'Deprecated'},
     },
   },
 };
@@ -202,40 +189,6 @@ export const Formats: Story = {
               new Date(iso + 'T00:00'),
             )
           }
-        />
-      </div>
-    );
-  },
-};
-
-export const NativePickerModes: Story = {
-  name: 'Native picker modes',
-  render: () => {
-    const [value, setValue] = useState<ISODateString | undefined>(
-      '2026-03-21' as ISODateString,
-    );
-    return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
-        <DateInput
-          label="nativePicker='touch' (default)"
-          description="Native picker on a coarse pointer; Astryx picker otherwise"
-          value={value}
-          onChange={setValue}
-          nativePicker="touch"
-        />
-        <DateInput
-          label="nativePicker='always'"
-          description="Native picker wherever the browser supports it"
-          value={value}
-          onChange={setValue}
-          nativePicker="always"
-        />
-        <DateInput
-          label="nativePicker='never'"
-          description="Astryx picker on every pointer type"
-          value={value}
-          onChange={setValue}
-          nativePicker="never"
         />
       </div>
     );

--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -14,9 +14,7 @@ const meta: Meta<typeof DateTimeInput> = {
     docs: {
       description: {
         component:
-          'A date-time field that fits the pointer it is used with. On a mouse or trackpad it renders the existing side-by-side date and time inputs: the date half opens a calendar popover, and the time half accepts typed entry plus optional preset times.\n\n' +
-          "Where the primary pointer is a finger (`pointer: coarse`), the closed control still renders separate Date and Time segments; tapping either segment opens a bottom sheet directly to the matching section. A segmented Date/Time pill stays at the top of the sheet for switching; Date reuses Astryx's custom swipable month picker and month/year wheels, its Save date action advances to Time, and Time uses accessible hour/minute/second wheels with the final Save action. The public props are the same on both surfaces.\n\n" +
-          '**Seeing the touch surface:** open any story on a phone/tablet or in device emulation reporting a coarse pointer. No separate story is needed because the same component chooses the surface at runtime.',
+          'A date-time field with an exact caller-owned adaptations policy over native, popover, and bottom-sheet surfaces for both segments. The policy names the server-rendered default and any ordered width/pointer rules. Without adaptations, the deprecated nativePicker compatibility path keeps its released pointer-driven and per-segment fallback behavior.',
       },
     },
   },
@@ -78,7 +76,8 @@ const meta: Meta<typeof DateTimeInput> = {
       control: 'radio',
       options: ['touch', 'always', 'never'],
       description:
-        "Date and time picker surfaces: native browser/OS controls on touch by default, native wherever compatible, or Astryx's surfaces everywhere",
+        'Deprecated. Use adaptations. At rest, touch maps to default popover plus a coarse-pointer native rule; always maps to constant native; never maps to default popover plus a coarse-pointer bottom-sheet rule. adaptations additionally holds the active tree until idle.',
+      table: {category: 'Deprecated'},
     },
     numberOfMonths: {
       control: 'radio',
@@ -135,39 +134,6 @@ export const WithValue: Story = {
   },
   args: {
     label: 'Event time',
-  },
-};
-
-export const NativePickerModes: Story = {
-  render: () => {
-    const [value, setValue] = useState<ISODateTimeString | undefined>(
-      '2026-03-15T14:30' as ISODateTimeString,
-    );
-    return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
-        <DateTimeInput
-          label="nativePicker='touch' (default)"
-          description="Native date and compatible time controls on a coarse primary pointer"
-          value={value}
-          onChange={setValue}
-          nativePicker="touch"
-        />
-        <DateTimeInput
-          label="nativePicker='always'"
-          description="Native date and compatible time controls on every pointer type"
-          value={value}
-          onChange={setValue}
-          nativePicker="always"
-        />
-        <DateTimeInput
-          label="nativePicker='never'"
-          description="Astryx bottom sheet on coarse pointers; calendar popover on fine pointers"
-          value={value}
-          onChange={setValue}
-          nativePicker="never"
-        />
-      </div>
-    );
   },
 };
 

--- a/docs/specs/AST-031/spec.md
+++ b/docs/specs/AST-031/spec.md
@@ -146,12 +146,14 @@ mapping without exposing raw queries or a general conditional-props bag.
   depending directly on the `DefinedTheme.__adaptations` storage field.
 - **FR6 — Adaptation and direct policy are exclusive.** A component's
   `adaptations` prop cannot be combined with the defined direct prop that owns the
-  same choice (`presentation` or `nativePicker`). Selector's existing union can
-  encode `?: never` exclusivity. DateInput and DateTimeInput keep their exported
-  `interface` props extendable, so they add both optional members without converting
-  the interface to a union; a runtime error rejects calls where both values are
-  defined. An explicitly spread `undefined` does not conflict. This preserves
-  interface-extension compatibility while keeping one effective policy.
+  same choice (`presentation` or `nativePicker`). DateInput and DateTimeInput
+  deprecate `nativePicker` in favor of `adaptations` while preserving every legacy
+  call at runtime; Selector's `presentation` remains supported. Selector's existing
+  union can encode `?: never` exclusivity. DateInput and DateTimeInput keep their
+  exported `interface` props extendable, so they add both optional members without
+  converting the interface to a union; a runtime error rejects calls where both
+  values are defined. An explicitly spread `undefined` does not conflict. This
+  preserves interface-extension compatibility while keeping one effective policy.
 - **FR7 — Selector's shorthand migrates deliberately.** Public
   `SelectorAdaptationValue` is an alias of the existing internal
   `ResolvedAdaptivePresentation` (`popover | bottom-sheet`) and is exported from
@@ -175,7 +177,9 @@ mapping without exposing raw queries or a general conditional-props bag.
   `native` renders browser/OS date/time controls, `popover` renders Astryx's pointer
   field and anchored surface, and `bottom-sheet` renders Astryx's touch field and
   modal sheet. These values have the same whole-tree meaning regardless of pointer
-  precision. Existing shorthand maps as follows when `adaptations` is absent:
+  precision. `nativePicker` is deprecated in favor of this exact policy, but its
+  released runtime behavior remains supported. Migrate the shorthand as follows
+  when the field's other props are compatible with every selected exact surface:
 
   | Component                 | Shorthand | Equivalent requested surface policy                           |
   | ------------------------- | --------- | ------------------------------------------------------------- |
@@ -183,13 +187,19 @@ mapping without exposing raw queries or a general conditional-props bag.
   | DateInput / DateTimeInput | `always`  | constant `native`                                             |
   | DateInput / DateTimeInput | `never`   | default `popover`; primary `pointer: coarse` → `bottom-sheet` |
 
+  These mappings select the same initial and idle surface. They are intentionally
+  not interaction-equivalent: `adaptations` holds the active tree through focus or
+  an open picker under FR10, while legacy `touch` and `never` continue switching
+  immediately when the primary pointer changes.
+
   For DateInput with a non-default `numberOfMonths` or explicit `weekStartsOn`,
   legacy `touch`/`always` renders today but has no exact `native` adaptation
   equivalent because those presentation options are not expressible by the OS
   control. For DateTimeInput, `hasSeconds`, non-default `timeIncrement`, or
   `timeOptionInterval` can make legacy `touch`/`always` render a mixed native-date
   plus Astryx-time tree, which likewise has no exact `adaptations` equivalent.
-  Those legacy behaviors remain when `adaptations` is absent.
+  Those legacy behaviors remain when `adaptations` is absent. Their deprecation
+  is advisory only: it emits editor guidance and changes no runtime behavior.
 
 - **FR9 — Exact surfaces validate capabilities eagerly.** If `default` or any rule
   names `native`, DateInput rejects a non-default `numberOfMonths` or explicit
@@ -288,7 +298,8 @@ Selector's exact default 768px boundary is breaking as described by FR7 and must
 released as such. No per-callsite configuration can preserve the single equality
 case; changing the Theme's `md` moves the shared global point and is the only
 threshold migration. Existing nativePicker behavior does not change when the new
-prop is absent.
+prop is absent; the shorthand is deprecated so editors direct new and migrating
+callsites to the exact `adaptations` policy.
 
 This proposal adds no CSS-variable or context layer. Structural presentation is a
 JavaScript decision because it changes DOM identity, ARIA, focus ownership, and
@@ -349,14 +360,21 @@ CSS remains the path for visual values. Adapted policy values can change mounted
 controls, semantics, focus, and native behavior, so neither custom-property reads
 nor duplicate hidden trees provide a correct first-paint implementation.
 
-### DEC-5 — Preserve direct props as compatibility syntax
+### DEC-5 — Deprecate date-field shorthand without changing behavior
 
 **Reference:** `spec:AST-031/DEC-5`
-**Decider:** pending
+**Decider:** `cixzhang`, `2026-09-11`
 
-Selector `presentation` and DateInput/DateTimeInput `nativePicker` retain their
-existing meanings when `adaptations` is absent. The new prop is an explicit advanced
-policy, not a forced migration.
+DateInput and DateTimeInput deprecate `nativePicker` in favor of `adaptations`.
+The shorthand remains accepted and keeps its released runtime meaning so existing
+calls do not break. Consumer docs and editor annotations provide the initial/idle
+mapping for `touch`, `always`, and `never`, call out adaptations' intentional
+active-interaction latching difference, and identify legacy mixed-surface cases
+that have no exact adaptation. Removal is a separate future compatibility decision
+and requires the release process's migration evidence and codemod.
+
+Selector `presentation` remains supported compatibility syntax; this decision does
+not deprecate it.
 
 ### DEC-6 — Adopt AST-012's exclusive `below` edge for Selector
 
@@ -380,8 +398,5 @@ and `adaptations` values.
 
 ## Open questions
 
-- **OQ1 — Should compatibility shorthands be deprecated after migration?**
-  (`human-api`) The first implementation preserves them; removal needs separate
-  evidence and migration.
-- **OQ2 — Should later component value domains admit non-string primitives?**
+- **OQ1 — Should later component value domains admit non-string primitives?**
   (`human-api`) The first consumers use closed string unions only.

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -160,14 +160,14 @@ export const docs = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "Which surface draws the date picker. 'touch' (the default) hands a touch device to the browser/OS: the field becomes an input type=date and the platform draws the picker (the iOS wheel, the Android calendar dialog); 'always' does that wherever the browser supports input type=date; 'never' keeps Astryx's own pickers everywhere (the bottom-sheet picker on a finger, the calendar popover on a mouse). Use 'never' for a field that needs weekStartsOn, numberOfMonths or dateConstraints, none of which a native picker can express. format and placeholder still apply in native mode; min and max are forwarded, but a native picker may not show them (on iOS an out-of-range date can be selected and is refused on commit rather than greyed out). Mutually exclusive with adaptations.",
+        "Deprecated. Use adaptations instead. For the initial render and while the field is idle, map 'touch' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}, 'always' to {default: 'native', rules: []}, and 'never' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}. The policy matches those idle surfaces but intentionally holds an active tree until the field is idle; nativePicker='touch' and nativePicker='never' switch immediately when the pointer changes. Existing calls keep their released behavior. Calls that combine 'touch' or 'always' with numberOfMonths=2 or an explicit weekStartsOn have no exact adaptation because the platform picker cannot draw those options; keep nativePicker until the callsite can choose an exact supported surface. format and placeholder still apply in native mode; min, max, and dateConstraints remain supported and are enforced on commit. Mutually exclusive with adaptations.",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "Environment-conditioned surface policy, for the cases the pointer-driven nativePicker shorthand cannot express. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform control, 'popover' the typable field with the anchored calendar, 'bottom-sheet' the touch field with the month sheet. A policy naming 'native' anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2 or weekStartsOn is set at all, because the platform picker cannot draw either; min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with nativePicker; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
+        "Preferred surface-selection API. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform control, 'popover' the typable field with the anchored calendar, 'bottom-sheet' the touch field with the month sheet. A policy naming 'native' anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2 or weekStartsOn is set at all, because the platform picker cannot draw either; min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with the deprecated nativePicker shorthand; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
     },
     {
       name: 'width',
@@ -228,7 +228,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Reach for adaptations only when the pointer alone is the wrong question — a width point, a policy the server must render, or a surface a rule should pin. nativePicker stays the short spelling, and the two are mutually exclusive.',
+          'Use adaptations for all new surface selection. The deprecated nativePicker shorthand remains supported only for compatibility; migrate with the mapping in its prop description.',
       },
       {
         guidance: false,
@@ -321,7 +321,7 @@ export const docsZh = {
       {
         guidance: true,
         description:
-          'Use adaptations when the surface should follow a width point or a policy the server renders, and nativePicker when the pointer is the whole question. The two props are mutually exclusive.',
+          'Use adaptations for all new surface selection. nativePicker 已弃用，仅为兼容旧代码保留；请按该属性说明中的映射迁移。',
       },
       {
         guidance: false,
@@ -472,14 +472,14 @@ export const docsZh = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "由哪个界面绘制日期选择器。'touch'（默认）在触摸设备上交给浏览器/操作系统：字段变为 input type=date，由平台绘制选择器（iOS 滚轮、Android 日历对话框）；'always' 在所有支持 input type=date 的浏览器上都这样做；'never' 始终使用 Astryx 自带的选择器（触摸设备用底部弹出选择器，鼠标设备用日历弹出层）。需要 weekStartsOn、numberOfMonths 或 dateConstraints 的字段应使用 'never'，原生选择器无法表达这些。原生模式下 format 和 placeholder 仍然生效；min 和 max 会传递给原生控件，但原生选择器可能不会显示这些限制（在 iOS 上仍可选中超出范围的日期，会在提交时被拒绝，而不是变灰）。与 adaptations 互斥。",
+        "已弃用，请改用 adaptations。初始渲染及字段空闲时的映射：'touch' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}；'always' → {default: 'native', rules: []}；'never' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}。adaptations 会将正在使用的界面保持到字段空闲；nativePicker='touch' 和 nativePicker='never' 会在指针变化时立即切换，因此交互中的行为并不完全相同。现有调用保持原有行为。若 'touch' 或 'always' 与 numberOfMonths=2 或显式 weekStartsOn 组合，原生选择器无法绘制这些选项，因此没有完全等价的 adaptations 策略；在调用方能选择明确且受支持的界面前继续使用 nativePicker。与 adaptations 互斥。",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "按环境决定界面的策略，用于 nativePicker 指针快捷方式无法表达的场景。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生控件，'popover' 为可输入字段加锚定日历，'bottom-sheet' 为触摸字段加月份底部弹层。只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2 或任何 weekStartsOn，就会抛出错误，因为原生选择器无法绘制这两者；min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
+        "首选的界面选择 API。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生控件，'popover' 为可输入字段加锚定日历，'bottom-sheet' 为触摸字段加月份底部弹层。只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2 或任何 weekStartsOn，就会抛出错误，因为原生选择器无法绘制这两者；min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
     },
     {
       name: 'xstyle',
@@ -539,7 +539,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'nativePicker = pointer shorthand; adaptations={{default, rules}} = exact surface per width/pointer rule, SSR-safe via default. Mutually exclusive.',
+          'Use adaptations={{default, rules}} for all new surface selection. nativePicker is deprecated compatibility syntax; see its prop description for the exact migration.',
       },
       {
         guidance: false,
@@ -592,9 +592,9 @@ export const docsDense = {
     format:
       "committed-value display: 'date_long' (default, March 21, 2026), 'date' (Mar 21, 2026), 'date_weekday' (Wed, Mar 21, 2026), 'system_date' (2026-03-21), or (iso)=>string; reuses Timestamp vocabulary. Committed value only, not while typing.",
     nativePicker:
-      "which surface draws the picker: 'touch' (default) = browser/OS on a coarse pointer, 'always', 'never' = Astryx's own everywhere. use 'never' for weekStartsOn/numberOfMonths/dateConstraints. format+placeholder still apply; min/max forwarded but not necessarily shown by the OS picker, refused on commit instead. exclusive with adaptations.",
+      'DEPRECATED; use adaptations. idle mapping: touch -> default popover + coarse-pointer native rule; always -> constant native; never -> default popover + coarse-pointer bottom-sheet rule. adaptations holds an active tree until idle; legacy touch/never switch immediately. incompatible native options have no exact mapping; see full docs. exclusive with adaptations.',
     adaptations:
-      "{default, rules} surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer. a 'native' value anywhere throws with numberOfMonths=2 or any weekStartsOn; min/max/dateConstraints still fine. exclusive with nativePicker. held while focused or open.",
+      "{default, rules} preferred surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer. a 'native' value anywhere throws with numberOfMonths=2 or any weekStartsOn; min/max/dateConstraints still fine. exclusive with deprecated nativePicker. held while focused or open.",
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -167,6 +167,9 @@ export type DateInputSize = keyof typeof sizeStyles;
  *   popover on mouse-driven ones
  * - `'always'`: native wherever the browser supports `<input type="date">`
  * - `'never'`: Astryx's own pickers everywhere
+ *
+ * @deprecated Use `adaptations` with `DateInputAdaptationValue`. The closest
+ * policy for each shorthand is documented on `DateInputProps.nativePicker`.
  */
 export type DateInputNativePicker = 'touch' | 'always' | 'never';
 
@@ -408,36 +411,33 @@ export interface DateInputProps extends Omit<
   format?: DateInputFormat | ((value: ISODateString) => string);
 
   /**
-   * When date picking is handed to the browser/OS instead of Astryx's own
-   * surfaces: the field becomes an `<input type="date">` and the platform
-   * draws the picker — the iOS wheel, the Android calendar dialog — with the
-   * OS's own hit areas, momentum scrolling, locale and accessibility
-   * settings.
+   * Deprecated shorthand for choosing a picker surface. Existing calls keep
+   * their released behavior, but new code should use `adaptations` so the
+   * server-rendered surface and every environment rule are explicit.
    *
-   * - `'touch'` (default): native on touch devices (coarse pointer), the text
-   *   field and calendar popover on mouse-driven ones
-   * - `'always'`: native wherever the browser supports `<input type="date">`
-   * - `'never'`: Astryx's own pickers everywhere — the touch picker on a
-   *   finger, the calendar popover on a mouse
+   * For the initial render and while the field is idle, map each value as
+   * follows:
+   * - `'touch'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}`
+   * - `'always'` → `{default: 'native', rules: []}`
+   * - `'never'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}`
    *
-   * `format` and `placeholder` still apply in native mode: DateInput paints
-   * the closed field's text itself, over the control. `numberOfMonths` and
-   * `weekStartsOn` do not — they describe a calendar grid the native picker
-   * does not have — so a field that needs either should pass `'never'`.
+   * The new policy intentionally differs during an active interaction:
+   * `adaptations` holds the current tree until the field is idle, while
+   * `nativePicker="touch"` and `nativePicker="never"` keep their released
+   * immediate pointer-switch behavior.
    *
-   * `min` and `max` are forwarded, but note that a native picker may not
-   * *show* them: on iOS they are constraint-validation flags rather than
-   * clamps, so an out-of-range date can be selected and is refused on commit
-   * (announced to assistive technology) rather than being greyed out in the
-   * picker. `dateConstraints` is enforced the same way, on commit, and is
-   * reason enough to prefer `'never'` on a field that uses it.
+   * `format` and `placeholder` still apply in native mode. `min`, `max`, and
+   * `dateConstraints` remain supported and are enforced on commit. A legacy
+   * call that combines `'touch'` or `'always'` with `numberOfMonths={2}` or an
+   * explicit `weekStartsOn` has no exact `adaptations` equivalent because the
+   * platform picker cannot draw those options; keep the shorthand until that
+   * callsite can choose an exact supported surface.
+   *
+   * Mutually exclusive with `adaptations`.
    *
    * @default 'touch'
-   * @example
-   * ```
-   * // Astryx's own touch picker instead of the platform's
-   * <DateInput label="Event date" value={date} onChange={setDate} nativePicker="never" />
-   * ```
+   * @deprecated Use `adaptations`; the mapping above preserves idle surface
+   * selection when the exact surfaces support the field's other props.
    */
   nativePicker?: DateInputNativePicker;
 
@@ -1057,46 +1057,28 @@ function PointerDateField({
 PointerDateField.displayName = 'PointerDateField';
 
 /**
- * A date picker that fits the pointer it is being used with.
+ * A date picker whose `adaptations` policy selects an exact native, popover, or
+ * bottom-sheet surface for the server and for ordered width/pointer rules.
  *
- * With a mouse or trackpad this is a text input you can type into, with a
- * calendar in a popover — unchanged, and still the surface every existing
- * consumer gets. With a finger it is a picker built for one: a bottom sheet
- * holding one month per screen, swiped sideways, with month and year wheels
- * behind the header title for the far jumps swiping is bad at.
+ * The surfaces share one value contract but use separate trees: the native
+ * browser/OS control, a typable field with an anchored calendar, or a read-only
+ * field opening Astryx's swipe-paged month sheet. The resolved tree is held
+ * while the field is in use so a resize or rotation cannot discard a draft.
  *
- * The props are identical either way — this is one component with two
- * surfaces, not two components — so nothing at the call site changes, and a
- * date typed on a laptop and a date thumbed on a phone are the same value.
- *
- * `adaptations` takes that decision back: an ordered policy over the three
- * exact surfaces (`native`, `popover`, `bottom-sheet`) resolved against the
- * nearest Theme's width points and the primary pointer, replacing the built-in
- * pointer test for the call sites that pass it.
+ * Without `adaptations`, the deprecated `nativePicker` compatibility path keeps
+ * its released pointer-driven behavior.
  *
  * ## Why a runtime switch and not CSS
  *
- * The two surfaces are structurally different — a popover anchored to a text
- * field versus a full-width sheet holding a scroller — so "render both, hide
- * one" would double the DOM, double the tab stops, and mount two calendars.
- * The condition is not layout either: it is *which interaction is faster*,
- * and that depends on the pointer, which CSS cannot hand to JS.
- *
- * They are two components rather than one with a branch inside because the
- * hook lists differ; keeping them separate is what lets each own its own.
+ * The surfaces are structurally different, so rendering all of them and hiding
+ * the inactive ones would duplicate controls, ids, dialogs, effects, and focus
+ * targets. One exact policy value selects the mounted tree instead.
  *
  * ## Hydration
  *
- * `useMediaQuery` reports false during SSR, so server HTML is always the
- * pointer field and the swap happens after hydration. That is deliberately
- * unobservable: both surfaces render the SAME closed field — a bordered input
- * with a calendar icon and the formatted date — and differ only in what
- * opens. Nothing moves; the field just starts opening a sheet.
- *
- * An `adaptations` policy replaces that pointer test with the caller's own
- * rules, and its `default` is the server truth: the server renders `default`,
- * the hydration render matches it, and the browser's real answer arrives on the
- * render after (spec:AST-031 FR3).
+ * `adaptations.default` is the server-rendered and hydration surface. The
+ * browser publishes the last matching rule after hydration, without asking the
+ * server to guess a viewport or pointer (spec:AST-031 FR3).
  *
  * @example
  * ```
@@ -1104,6 +1086,10 @@ PointerDateField.displayName = 'PointerDateField';
  *   label="Event date"
  *   value={date}
  *   onChange={setDate}
+ *   adaptations={{
+ *     default: 'popover',
+ *     rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+ *   }}
  * />
  * ```
  */

--- a/packages/core/src/DateInput/DateInputAdaptations.test.tsx
+++ b/packages/core/src/DateInput/DateInputAdaptations.test.tsx
@@ -5,7 +5,8 @@
  * @input Uses vitest, @testing-library/react, react-dom/server
  * @output Tests DateInput's public surface policy (spec:AST-031)
  * @position Tests; validates the `adaptations` prop — resolution, eager
- *   validation, latching — and the untouched `nativePicker` path beside it.
+ *   validation, latching — and the deprecated `nativePicker` compatibility
+ *   path beside it, including the documented migration mapping.
  *   Behavior that is not surface selection (month geometry, typing, the sheet's
  *   internals) stays in DateInput.test.tsx and DateInputTouch.test.tsx.
  *
@@ -1356,10 +1357,10 @@ describe('latching', () => {
 });
 
 // =============================================================================
-// The released `nativePicker` contract, unchanged beside the new one
+// Deprecated `nativePicker` compatibility and migration
 // =============================================================================
 
-describe('legacy nativePicker parity', () => {
+describe('deprecated nativePicker compatibility', () => {
   it.each([
     ['touch', 'fine', 'popover'],
     ['touch', 'coarse', 'native'],
@@ -1382,6 +1383,47 @@ describe('legacy nativePicker parity', () => {
       );
 
       expect(surfaceIn()).toBe(expected);
+    },
+  );
+
+  it.each(['fine', 'coarse'] as const)(
+    'matches the documented idle adaptations policy on a %s pointer',
+    pointer => {
+      environment.set({
+        pointer,
+        width: pointer === 'coarse' ? 390 : 1280,
+      });
+      const migrations = [
+        [
+          'touch',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+          }),
+        ],
+        ['always', policy({default: 'native', rules: []})],
+        [
+          'never',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+          }),
+        ],
+      ] as const;
+
+      for (const [nativePicker, adaptations] of migrations) {
+        const legacy = render(
+          <DateInput label="Event date" nativePicker={nativePicker} />,
+        );
+        const legacySurface = surfaceIn();
+        legacy.unmount();
+
+        const migrated = render(
+          <DateInput label="Event date" adaptations={adaptations} />,
+        );
+        expect(surfaceIn()).toBe(legacySurface);
+        migrated.unmount();
+      }
     },
   );
 

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -192,14 +192,14 @@ export const docs = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "Which surfaces draw the date and time pickers. 'touch' (the default) uses browser/OS controls on a coarse primary pointer; 'always' uses them wherever input type=date/time are supported; 'never' keeps Astryx's own surfaces everywhere. The native time control is used only for the default minute-precision contract: hasSeconds, non-default timeIncrement, or timeOptionInterval retain Astryx's time field because iOS cannot express them faithfully. Use 'never' when numberOfMonths, weekStartsOn, or visible dateConstraints behavior matters. Constraints are enforced on commit; min/max are forwarded as hints. hourFormat formats the closed time, while the OS picker follows the user's locale. Mutually exclusive with adaptations.",
+        "Deprecated. Use adaptations instead. For the initial render and while the field is idle, map 'touch' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}, 'always' to {default: 'native', rules: []}, and 'never' to {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}. The policy matches those idle surfaces but intentionally holds an active tree until the field is idle; nativePicker='touch' and nativePicker='never' switch immediately when the pointer changes. Existing calls keep their released behavior. Legacy 'touch' and 'always' may retain an Astryx time field for hasSeconds, non-default timeIncrement, or timeOptionInterval, and may ignore numberOfMonths or weekStartsOn on the native date control; those mixed fallbacks have no exact adaptation, so keep nativePicker until the callsite can choose an exact supported surface. min, max, and dateConstraints remain supported and are enforced on commit. Mutually exclusive with adaptations.",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "Environment-conditioned surface policy, for the cases the pointer-driven nativePicker shorthand cannot express. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform date and time controls, 'popover' the typed fields with anchored calendar and time list, 'bottom-sheet' the coordinated Date/Time sheet. Because 'native' means native for both segments with no per-segment fallback, a policy naming it anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2, weekStartsOn is set at all, hasSeconds is on, timeIncrement is non-default, or timeOptionInterval is set. min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with nativePicker; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
+        "Preferred surface-selection API. default is the server-rendered, hydration, and no-match surface; rules are checked in order and the LAST match wins. Width names resolve against the nearest Theme's width points, from is inclusive, below is exclusive, and the fields of one when are ANDed. Each value is exact and holds on any pointer: 'native' is the platform date and time controls, 'popover' the typed fields with anchored calendar and time list, 'bottom-sheet' the coordinated Date/Time sheet. Because 'native' means native for both segments with no per-segment fallback, a policy naming it anywhere — default or any rule, matched today or not — throws when numberOfMonths is 2, weekStartsOn is set at all, hasSeconds is on, timeIncrement is non-default, or timeOptionInterval is set. min, max and dateConstraints stay supported and are enforced on commit. Mutually exclusive with the deprecated nativePicker shorthand; passing both throws. The resolved surface is held while the field has focus or an open picker, so a resize or rotation mid-entry applies only once the field is idle.",
     },
     {
       name: 'width',
@@ -237,7 +237,7 @@ export const docs = {
   },
   usage: {
     description:
-      'DateTimeInput combines date and time selection in one field. With nativePicker="touch" (the default), mouse/trackpad devices use Astryx typed fields and popovers, while coarse-pointer devices use browser/OS date and time controls in the same two-segment field. nativePicker="always" uses both native controls on every pointer; nativePicker="never" keeps Astryx\'s own surfaces — pointer fields on fine pointers and the coordinated Date/Time bottom sheet on coarse pointers. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
+      'DateTimeInput combines date and time selection in one field. Use adaptations to choose exact native, popover, or bottom-sheet surfaces for the server and for ordered width/pointer rules. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
     bestPractices: [
       {
         guidance: true,
@@ -262,7 +262,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Reach for adaptations only when the pointer alone is the wrong question — a width point, a policy the server must render, or a surface a rule should pin. nativePicker stays the short spelling, and the two are mutually exclusive.',
+          'Use adaptations for all new surface selection. The deprecated nativePicker shorthand remains supported only for compatibility; migrate with the mapping in its prop description.',
       },
       {
         guidance: false,
@@ -296,7 +296,7 @@ export const docs = {
         name: 'Date input',
         required: true,
         description:
-          'A typed date field with calendar popover on the fine-pointer Astryx surface, a real input type=date in native modes, or a read-only segment opening the Astryx touch sheet when nativePicker is never on a coarse pointer.',
+          'The active date segment: a typed field with an anchored calendar for popover, a real input type=date for native, or a read-only segment opening the coordinated sheet for bottom-sheet.',
       },
       {
         name: 'Calendar icon',
@@ -308,19 +308,19 @@ export const docs = {
         name: 'Date picker',
         required: false,
         description:
-          'The browser/OS picker in native modes, an Astryx month-grid popover on a fine pointer, or the Date panel of the Astryx bottom sheet on a coarse pointer with nativePicker="never".',
+          'The browser/OS picker for native, an Astryx month-grid popover for popover, or the Date panel of the coordinated sheet for bottom-sheet.',
       },
       {
         name: 'Time input',
         required: true,
         description:
-          'A real input type=time for the default minute-precision native mode, a text/combobox time field when seconds, custom increments, or preset options are requested, or a read-only segment opening accessible time wheels when nativePicker is never on a coarse pointer.',
+          'The active time segment: a real input type=time for native, a text/combobox field for popover, or a read-only segment opening accessible time wheels for bottom-sheet.',
       },
       {
         name: 'Time options popover',
         required: false,
         description:
-          "A list of preset times at the timeOptionInterval cadence. Setting the prop retains Astryx's text/combobox time field even when nativePicker otherwise selects native controls; the Astryx touch sheet uses wheels instead.",
+          'A list of preset times at the timeOptionInterval cadence on the popover surface. The exact native surface rejects this prop because platform pickers have no equivalent list; the bottom-sheet surface uses wheels.',
       },
       {
         name: 'Clear button',
@@ -342,7 +342,7 @@ export const docsZh = {
   displayName: 'Date Time Input',
   usage: {
     description:
-      'DateTimeInput combines date and time selection in one field. With nativePicker="touch" (the default), mouse/trackpad devices use Astryx typed fields and popovers, while coarse-pointer devices use browser/OS date and time controls in the same two-segment field. nativePicker="always" uses both native controls on every pointer; nativePicker="never" keeps Astryx\'s own surfaces — pointer fields on fine pointers and the coordinated Date/Time bottom sheet on coarse pointers. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
+      'DateTimeInput combines date and time selection in one field. Use adaptations to choose exact native, popover, or bottom-sheet surfaces for the server and for ordered width/pointer rules. The closed segments stay side by side when at least 400px is available and wrap into full-width rows below 400px, independent of viewport width. Use it for scheduling, event creation, deadline setting, or any form field that needs a specific datetime.',
     bestPractices: [
       {
         guidance: true,
@@ -367,7 +367,7 @@ export const docsZh = {
       {
         guidance: true,
         description:
-          'Use adaptations when the surfaces should follow a width point or a policy the server renders, and nativePicker when the pointer is the whole question. The two props are mutually exclusive.',
+          'Use adaptations for all new surface selection. nativePicker 已弃用，仅为兼容旧代码保留；请按该属性说明中的映射迁移。',
       },
       {
         guidance: false,
@@ -545,14 +545,14 @@ export const docsZh = {
       name: 'nativePicker',
       type: "'touch' | 'always' | 'never'",
       description:
-        "选择由哪些界面绘制日期和时间选择器。'touch'（默认）在粗略主指针设备上使用浏览器/操作系统的原生控件；'always' 在支持 input type=date/time 的浏览器中始终使用原生控件；'never' 始终使用 Astryx 自带的界面。原生时间控件仅用于默认的分钟精度：hasSeconds、非默认 timeIncrement 或 timeOptionInterval 会保留 Astryx 时间字段，因为 iOS 无法忠实表达这些行为。需要 numberOfMonths、weekStartsOn 或可见 dateConstraints 行为时请使用 'never'。约束会在提交时执行，min/max 作为提示传给原生控件。hourFormat 格式化关闭状态的时间，而操作系统选择器遵循用户区域设置。与 adaptations 互斥。",
+        "已弃用，请改用 adaptations。初始渲染及字段空闲时的映射：'touch' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}；'always' → {default: 'native', rules: []}；'never' → {default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}。adaptations 会将正在使用的界面保持到字段空闲；nativePicker='touch' 和 nativePicker='never' 会在指针变化时立即切换，因此交互中的行为并不完全相同。现有调用保持原有行为。旧的 'touch' 和 'always' 在 hasSeconds、非默认 timeIncrement 或 timeOptionInterval 下可能保留 Astryx 时间字段，也可能让原生日期控件忽略 numberOfMonths 或 weekStartsOn；这些混合回退没有完全等价的 adaptations 策略，在调用方能选择明确且受支持的界面前继续使用 nativePicker。min、max 和 dateConstraints 仍然支持，并在提交时校验。与 adaptations 互斥。",
       default: "'touch'",
     },
     {
       name: 'adaptations',
       type: "{default: 'native' | 'popover' | 'bottom-sheet', rules: Array<{when: {width?: {from?: 'sm' | 'md' | 'lg' | 'xl' | '2xl', below?: 'sm' | 'md' | 'lg' | 'xl' | '2xl'}, pointer?: 'coarse' | 'fine'}, value: 'native' | 'popover' | 'bottom-sheet'}>}",
       description:
-        "按环境决定界面的策略，用于 nativePicker 指针快捷方式无法表达的场景。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生日期与时间控件，'popover' 为可输入字段加锚定日历与时间列表，'bottom-sheet' 为协同的日期/时间底部弹层。由于 'native' 表示两个片段都使用原生控件、没有逐片段回退，只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2、任何 weekStartsOn、hasSeconds、非默认 timeIncrement 或 timeOptionInterval，就会抛出错误。min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
+        "首选的界面选择 API。default 是服务端渲染、注水以及无规则命中时的界面；rules 按顺序检查，最后一条命中的规则获胜。宽度名称按最近的 Theme 宽度断点解析，from 为闭区间、below 为开区间，同一个 when 内的各字段为“与”关系。每个值都是精确的，且与指针无关：'native' 为平台原生日期与时间控件，'popover' 为可输入字段加锚定日历与时间列表，'bottom-sheet' 为协同的日期/时间底部弹层。由于 'native' 表示两个片段都使用原生控件、没有逐片段回退，只要策略中任何位置（default 或任意规则，无论当前是否命中）出现 'native'，同时又设置了 numberOfMonths=2、任何 weekStartsOn、hasSeconds、非默认 timeIncrement 或 timeOptionInterval，就会抛出错误。min、max 和 dateConstraints 仍然支持，并在提交时校验。与 nativePicker 互斥，同时传入两者会抛出错误。字段处于焦点中或选择器打开时，已解析的界面会被锁定，窗口缩放或旋转要等到字段空闲后才生效。",
     },
     {
       name: 'xstyle',
@@ -590,7 +590,7 @@ export const docsDense = {
     'combined date + time picker with calendar popover and time input',
   usage: {
     description:
-      'DateTimeInput combines date and time selection. nativePicker="touch" (default) uses browser/OS date+time controls on coarse pointers and Astryx pointer fields on fine pointers; "always" uses both native controls everywhere; "never" uses Astryx\'s coordinated bottom sheet on coarse pointers and pointer fields on fine pointers. Closed segments stay side by side when at least 400px is available and wrap below 400px.',
+      'DateTimeInput combines date and time selection. Use adaptations to choose exact native, popover, or bottom-sheet surfaces for SSR and ordered width/pointer rules. Closed segments stay side by side when at least 400px is available and wrap below 400px.',
     bestPractices: [
       {
         guidance: true,
@@ -615,7 +615,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'nativePicker = pointer shorthand; adaptations={{default, rules}} = exact surface per width/pointer rule, SSR-safe via default. Mutually exclusive.',
+          'Use adaptations={{default, rules}} for all new surface selection. nativePicker is deprecated compatibility syntax; see its prop description for the exact migration.',
       },
       {
         guidance: false,
@@ -676,9 +676,9 @@ export const docsDense = {
     weekStartsOn:
       'first day of week in Astryx calendars (0=Sunday, or name e.g. "mon"); ignored by native date controls',
     nativePicker:
-      "date+time surfaces: 'touch' (default) = browser/OS controls on a coarse pointer, 'always' = native on every pointer, 'never' = Astryx calendar/time popovers on fine pointers and coordinated bottom sheet on coarse pointers. use 'never' for numberOfMonths/weekStartsOn/visible dateConstraints/timeOptionInterval; native mode enforces constraints on commit and forwards min/max. exclusive with adaptations.",
+      'DEPRECATED; use adaptations. idle mapping: touch -> default popover + coarse-pointer native rule; always -> constant native; never -> default popover + coarse-pointer bottom-sheet rule. adaptations holds an active tree until idle; legacy touch/never switch immediately. mixed native/Astryx fallbacks have no exact mapping; see full docs. exclusive with adaptations.',
     adaptations:
-      "{default, rules} surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer, both segments. a 'native' value anywhere throws with numberOfMonths=2, any weekStartsOn, hasSeconds, non-default timeIncrement, or any timeOptionInterval; min/max/dateConstraints still fine. exclusive with nativePicker. held while focused or open.",
+      "{default, rules} preferred surface policy over 'native' | 'popover' | 'bottom-sheet'; default is the SSR/hydration/no-match value, LAST matching rule wins, width names come from the nearest Theme (from inclusive, below exclusive), when fields ANDed. exact values, any pointer, both segments. a 'native' value anywhere throws with numberOfMonths=2, any weekStartsOn, hasSeconds, non-default timeIncrement, or any timeOptionInterval; min/max/dateConstraints still fine. exclusive with deprecated nativePicker. held while focused or open.",
     xstyle: 'StyleX styles for layout; must be stylex.create() value',
   },
 };

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -114,6 +114,13 @@ export type ISODateTimeString = string & {
   readonly __brand: 'ISODateTimeString';
 };
 
+/**
+ * When DateTimeInput hands date and time picking to the browser/OS instead of
+ * its own surfaces.
+ *
+ * @deprecated Use `adaptations` with `DateTimeInputAdaptationValue`. The closest
+ * policy for each shorthand is documented on `DateTimeInputProps.nativePicker`.
+ */
 export type DateTimeInputNativePicker = 'touch' | 'always' | 'never';
 
 /**
@@ -501,35 +508,35 @@ export interface DateTimeInputProps extends Omit<
   weekStartsOn?: DayOfWeek | DayOfWeekName;
 
   /**
-   * When date and time picking are handed to the browser/OS instead of Astryx's
-   * calendar and time surfaces.
+   * Deprecated shorthand for choosing the date and time surfaces. Existing
+   * calls keep their released behavior, but new code should use `adaptations`
+   * so the server-rendered surface and every environment rule are explicit.
    *
-   * - `'touch'` (default): native date and time inputs on a coarse primary
-   *   pointer; Astryx's typed fields and popovers otherwise
-   * - `'always'`: native date and time inputs wherever the browser supports them
-   * - `'never'`: Astryx's own surfaces everywhere — typed fields on a fine
-   *   pointer and the coordinated Date/Time bottom sheet on a coarse pointer
+   * For the initial render and while the field is idle, map each value as
+   * follows:
+   * - `'touch'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'native'}]}`
+   * - `'always'` → `{default: 'native', rules: []}`
+   * - `'never'` → `{default: 'popover', rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}]}`
    *
-   * Native pickers cannot express `numberOfMonths`, `weekStartsOn`,
-   * `dateConstraints`, or `timeOptionInterval`. Calendar-only options are
-   * ignored in native mode and constraints are enforced on commit. The native
-   * time control is used for the default minute-precision contract; requesting
-   * `hasSeconds`, a non-default `timeIncrement`, or `timeOptionInterval` keeps
-   * Astryx's time field because iOS cannot represent those behaviors faithfully.
-   * `min` / `max` are forwarded to each native control as hints and enforced in
-   * JavaScript. `hourFormat` formats the closed value; the OS picker follows the
-   * user's locale.
+   * The new policy intentionally differs during an active interaction:
+   * `adaptations` holds the current tree until the field is idle, while
+   * `nativePicker="touch"` and `nativePicker="never"` keep their released
+   * immediate pointer-switch behavior.
+   *
+   * Those mappings select the same idle surfaces for fields whose other props
+   * every selected surface can honor. Legacy `'touch'` and `'always'` calls may
+   * instead retain an Astryx time field when `hasSeconds`, a non-default
+   * `timeIncrement`, or `timeOptionInterval` is set, and may ignore
+   * `numberOfMonths` or `weekStartsOn` on the native date control. Those mixed
+   * fallbacks have no exact `adaptations` equivalent; keep the shorthand until
+   * the callsite can choose an exact supported surface. `min`, `max`, and
+   * `dateConstraints` remain supported and are enforced on commit.
+   *
+   * Mutually exclusive with `adaptations`.
    *
    * @default 'touch'
-   * @example
-   * ```
-   * <DateTimeInput
-   *   label="Event time"
-   *   value={dateTime}
-   *   onChange={setDateTime}
-   *   nativePicker="never"
-   * />
-   * ```
+   * @deprecated Use `adaptations`; the mapping above preserves idle surface
+   * selection when the exact surfaces support the field's other props.
    */
   nativePicker?: DateTimeInputNativePicker;
 
@@ -2110,17 +2117,14 @@ function PointerDateTimeField({
 PointerDateTimeField.displayName = 'PointerDateTimeField';
 
 /**
- * A combined date and time picker whose `nativePicker` prop chooses both
- * surfaces. Native modes use OS-owned date and time controls in Astryx field
- * chrome. With `nativePicker="never"`, fine pointers keep the typed fields and
- * popovers while coarse pointers get Astryx's coordinated Date/Time bottom
- * sheet.
+ * A combined date and time picker whose `adaptations` policy selects one exact
+ * surface for both segments: native controls, typed fields with anchored
+ * popovers, or the coordinated Date/Time bottom sheet. `default` owns the
+ * server-rendered and hydration surface; ordered rules may then respond to the
+ * nearest Theme's width points and the primary pointer (spec:AST-031 FR3).
  *
- * `adaptations` replaces that pointer test at the call sites that pass it: an
- * ordered policy over the three exact surfaces (`native`, `popover`,
- * `bottom-sheet`), resolved against the nearest Theme's width points and the
- * primary pointer, with `default` as the server-rendered and hydration value
- * (spec:AST-031 FR3).
+ * Without `adaptations`, the deprecated `nativePicker` compatibility path keeps
+ * its released pointer-driven and per-segment fallback behavior.
  */
 export function DateTimeInput({
   nativePicker,

--- a/packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInputAdaptations.test.tsx
@@ -5,7 +5,8 @@
  * @input Uses vitest, @testing-library/react, react-dom/server
  * @output Tests DateTimeInput's public surface policy (spec:AST-031)
  * @position Tests; validates the `adaptations` prop — resolution, eager
- *   validation, latching — and the untouched `nativePicker` path beside it.
+ *   validation, latching — and the deprecated `nativePicker` compatibility
+ *   path beside it, including the documented migration mapping.
  *   Behavior that is not surface selection (typing, the calendar, the sheet's
  *   panels, the native segments' own commit rules) stays in
  *   DateTimeInput.test.tsx, DateTimeInputTouch.test.tsx and
@@ -1625,10 +1626,10 @@ describe('latching', () => {
 });
 
 // =============================================================================
-// The released `nativePicker` contract, unchanged beside the new one
+// Deprecated `nativePicker` compatibility and migration
 // =============================================================================
 
-describe('legacy nativePicker parity', () => {
+describe('deprecated nativePicker compatibility', () => {
   it.each([
     ['touch', 'fine', 'popover'],
     ['touch', 'coarse', 'native'],
@@ -1653,6 +1654,56 @@ describe('legacy nativePicker parity', () => {
 
       expect(surfaceIn()).toBe(expected);
       expectSegments(expected);
+    },
+  );
+
+  it.each(['fine', 'coarse'] as const)(
+    'matches the documented idle adaptations policy on a %s pointer',
+    pointer => {
+      environment.set({
+        pointer,
+        width: pointer === 'coarse' ? 390 : 1280,
+      });
+      const migrations = [
+        [
+          'touch',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'native'}],
+          }),
+        ],
+        ['always', policy({default: 'native', rules: []})],
+        [
+          'never',
+          policy({
+            default: 'popover',
+            rules: [{when: {pointer: 'coarse'}, value: 'bottom-sheet'}],
+          }),
+        ],
+      ] as const;
+
+      for (const [nativePicker, adaptations] of migrations) {
+        const legacy = render(
+          <DateTimeInput
+            label={LABEL}
+            onChange={noop}
+            nativePicker={nativePicker}
+          />,
+        );
+        const legacySurface = surfaceIn();
+        legacy.unmount();
+
+        const migrated = render(
+          <DateTimeInput
+            label={LABEL}
+            onChange={noop}
+            adaptations={adaptations}
+          />,
+        );
+        expect(surfaceIn()).toBe(legacySurface);
+        expectSegments(legacySurface);
+        migrated.unmount();
+      }
     },
   );
 


### PR DESCRIPTION
## Why

`adaptations` now expresses the full picker-surface policy for `DateInput` and `DateTimeInput`, including SSR and ordered width/pointer rules. Keeping `nativePicker` as a recommended shorthand would leave two public ways to own the same decision.

## What

- mark both `nativePicker` props and their exported value types as deprecated while preserving every existing runtime behavior
- make consumer docs and stories adaptations-first
- document the initial/idle mappings for `touch`, `always`, and `never`, the intentional active-interaction latching difference, and legacy mixed-surface cases that cannot migrate exactly
- record the deprecation decision in the draft AST-031 proposal and add migration-parity coverage
- add a patch changeset attributed to this PR

No codemod is included because no prop is renamed or removed; the release policy requires one when a deprecated prop is removed.

This PR is stacked on #6133 and targets its feature branch. It updates that proposal stack only; #6133 still requires AST-031 approval before it can merge to `main`.

## Risk

Low. Runtime selection code is unchanged. Existing `nativePicker` calls remain supported; consumers receive editor and docs guidance only.

## Testing

- focused DateInput and DateTimeInput adaptation suites
- component-doc and adaptation-story suites
- Core typecheck and build
- repository checks, including knowledge and changeset validation
