### PR TITLE
fix(Spinner): route the default assistive label through the translation runtime

### DIFF
--- a/.changeset/spinner-loading-label-i18n.md
+++ b/.changeset/spinner-loading-label-i18n.md
@@ -1,0 +1,15 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Spinner: route the default assistive label through the translation runtime (#6214)
+
+A bare `<Spinner />` with no `aria-label` or string `label` announced the
+literal English word "Loading" to assistive technology, even inside a
+localized application. The default now resolves through `useTranslator`
+via a new `@astryx.spinner.loading` catalog key, matching the pattern
+already used for `typeahead.loading`, `commandPalette.loading`, and
+`button.loading`. An explicit `aria-label` or string `label` still wins,
+unchanged.
+
+@HelloOjasMutreja

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1139,6 +1139,10 @@
     "defaultMessage": "{label} submenu",
     "description": "Accessible name for the flyout dialog that opens from a collapsed (icon-only) SideNav item to show its sub-items. {label} is the parent item's label. Example: `Settings submenu`."
   },
+  "@astryx.spinner.loading": {
+    "defaultMessage": "Loading",
+    "description": "Screen-reader-only default accessible name for a bare Spinner with no visible label. Present-progressive form, matching the other loading-state strings (`typeahead.loading`, `commandPalette.loading`, `button.loading`). Used only when the consumer sets neither `aria-label` nor a string `label`."
+  },
   "@astryx.tableFiltering.filterByColumn": {
     "defaultMessage": "Filter {header}",
     "description": "Triple-use string on per-column filter controls: visible label, placeholder, AND aria label. `{header}` is the column header — example: `Filter Name`. Keep short."

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -23,6 +23,7 @@ import type {BaseProps} from '../BaseProps';
 import {Text} from '../Text/Text';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Constants
@@ -484,6 +485,7 @@ export function Spinner({
   const arcLength = circumference * ARC_FRACTION;
   const hasLabel = label != null;
   const labelId = useId();
+  const t = useTranslator();
 
   // When a visible string label renders (and no explicit aria-label is set),
   // name the status element from the visible Text via aria-labelledby instead
@@ -492,9 +494,11 @@ export function Spinner({
   const namedByVisibleLabel =
     hasLabel && typeof label === 'string' && ariaLabel == null;
 
-  // Resolve accessible name: explicit aria-label > string label > "Loading"
+  // Resolve accessible name: explicit aria-label > string label > catalog default
   const resolvedAriaLabel =
-    ariaLabel ?? (typeof label === 'string' ? label : undefined) ?? 'Loading';
+    ariaLabel ??
+    (typeof label === 'string' ? label : undefined) ??
+    t('@astryx.spinner.loading');
 
   const spinner = (
     <span


### PR DESCRIPTION
Fixes #6214.

## Problem

`Spinner` supplied its assistive-technology-facing default label `"Loading"` as a hardcoded literal in component source, instead of resolving it through the Astryx translation runtime. A localized application relying on the default announces the literal English word regardless of the active locale.

## Fix

Added `@astryx.spinner.loading` to `packages/core/locales/en.json` (Spinner had no prior i18n keys at all) and route the fallback through `useTranslator`, matching the established pattern already used for `typeahead.loading`, `commandPalette.loading`, and `button.loading`.

```diff
- ariaLabel ?? (typeof label === 'string' ? label : undefined) ?? 'Loading';
+ ariaLabel ??
+   (typeof label === 'string' ? label : undefined) ??
+   t('@astryx.spinner.loading');
```

An explicit `aria-label` or string `label` still wins over the translated default, unchanged. The `aria-labelledby` path (visible string `label` naming the status element) is also untouched.

## Testing

- `packages/core/src/Spinner` suite: 45/45 passing
- `pnpm check:i18n-catalog`: passes, key resolves, all 29 locales report the new key falling back to `en` as expected for an unreviewed addition
- Typecheck and lint clean