### PR TITLE
fix(Kbd): normalise the esc and return aliases useHotkeys accepts

### DIFF
--- a/.changeset/kbd-esc-return-aliases.md
+++ b/.changeset/kbd-esc-return-aliases.md
@@ -1,0 +1,15 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Kbd: normalise the "esc" and "return" aliases useHotkeys accepts (#5403)
+
+`useHotkeys` and `Kbd` take the same '+'-separated combo string, but `Kbd`
+did not resolve two of the aliases `useHotkeys` accepts for the same keys:
+`esc` and `return` fell through its uppercase fallback and rendered as
+the literal words "ESC" and "RETURN" instead of the existing `Esc`/`↵`
+glyphs and `Escape`/`Enter` accessible names already used for
+`escape`/`enter`. `meta` and `space` are left as-is; per the issue, those
+need a platform/design decision this fix does not make.
+
+@HelloOjasMutreja

--- a/packages/core/src/Kbd/Kbd.doc.mjs
+++ b/packages/core/src/Kbd/Kbd.doc.mjs
@@ -27,7 +27,7 @@ export const docs = {
       name: 'keys',
       type: 'string',
       description:
-        'Keyboard shortcut string. Use "+" to separate keys. Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape, tab, up, down, left, right.',
+        'Keyboard shortcut string. Use "+" to separate keys. Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape, tab, up, down, left, right. Also accepts the "esc" and "return" aliases useHotkeys uses for the same combo string.',
       required: true,
     },
     {
@@ -122,7 +122,7 @@ export const docsDense = {
     ],
   },
   propDescriptions: {
-    keys: 'Shortcut string. "+" separates keys. Special: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape, tab, up, down, left, right.',
+    keys: 'Shortcut string. "+" separates keys. Special: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape, tab, up, down, left, right. Also accepts "esc"/"return" aliases.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
     className: 'CSS class for root element. Prefer xstyle; className for non-StyleX integration.',
     style: 'Inline styles for root element. Prefer xstyle; inline styles bypass StyleX optimization.',

--- a/packages/core/src/Kbd/Kbd.test.tsx
+++ b/packages/core/src/Kbd/Kbd.test.tsx
@@ -72,6 +72,17 @@ describe('Kbd', () => {
     expect(screen.getByText('Esc')).toBeInTheDocument();
   });
 
+  it('normalises the "esc" and "return" aliases useHotkeys accepts (#5403)', () => {
+    const {unmount} = render(<Kbd keys="esc" />);
+    expect(screen.getByText('Esc')).toBeInTheDocument();
+    expect(screen.getByRole('img')).toHaveAttribute('aria-label', 'Escape');
+    unmount();
+
+    render(<Kbd keys="return" />);
+    expect(screen.getByText('↵')).toBeInTheDocument();
+    expect(screen.getByRole('img')).toHaveAttribute('aria-label', 'Enter');
+  });
+
   it('exposes a spoken accessible name and hides the glyphs (obs-1)', () => {
     render(<Kbd keys="mod+shift+k" />);
     // The wrapper carries a screen-reader name built from spoken key labels

--- a/packages/core/src/Kbd/Kbd.tsx
+++ b/packages/core/src/Kbd/Kbd.tsx
@@ -57,6 +57,18 @@ const styles = stylex.create({
 });
 
 /**
+ * Aliases that `useHotkeys` accepts in the same '+'-separated combo string
+ * (its own `KEY_ALIASES`) and that map onto a name `KEY_DISPLAY`/`KEY_LABEL`
+ * already cover below. Narrower than `useHotkeys`' own list on purpose:
+ * `meta` and `space` are a platform/design decision for a maintainer, not a
+ * plain naming gap, so they are left unresolved here (#5403).
+ */
+const KEY_ALIASES: Record<string, string> = {
+  esc: 'escape',
+  return: 'enter',
+};
+
+/**
  * Map of modifier key names to display symbols.
  * Note: `mod` is not in this map — it resolves dynamically via platform
  * detection inside the component.
@@ -85,7 +97,8 @@ function getKeyDisplay(key: string, isMac: boolean): string {
   if (key === 'mod') {
     return isMac ? '\u2318' : 'Ctrl';
   }
-  return KEY_DISPLAY[key] ?? key.toUpperCase();
+  const resolved = KEY_ALIASES[key] ?? key;
+  return KEY_DISPLAY[resolved] ?? resolved.toUpperCase();
 }
 
 /**
@@ -112,7 +125,8 @@ function getKeyLabel(key: string, isMac: boolean): string {
   if (key === 'mod') {
     return isMac ? 'Command' : 'Control';
   }
-  return KEY_LABEL[key] ?? key.toUpperCase();
+  const resolved = KEY_ALIASES[key] ?? key;
+  return KEY_LABEL[resolved] ?? resolved.toUpperCase();
 }
 
 function subscribeToPlatformChanges(): () => void {
@@ -128,6 +142,8 @@ export interface KbdProps extends BaseProps<HTMLSpanElement> {
   /**
    * Keyboard shortcut string. Use "+" to separate keys.
    * Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape.
+   * Also accepts the "esc" and "return" aliases `useHotkeys` uses for the
+   * same combo string, resolved to escape/enter respectively.
    * Use "plus" to render a literal "+" key (e.g. "shift+plus").
    *
    * @example


### PR DESCRIPTION
Fixes #5403.

## Problem

`useHotkeys` and `Kbd` take the same '+'-separated combo string, but each keeps its own key vocabulary. `useHotkeys` resolves `esc`/`return` (among others) through its own `KEY_ALIASES` to `escape`/`enter`. `Kbd` does not run the same step, and its fallback (`key.toUpperCase()`) is written for single letters, so these multi-character aliases render as the literal words "ESC" and "RETURN" instead of the `Esc`/`↵` glyphs and `Escape`/`Enter` accessible names `Kbd` already has for `escape`/`enter`.

As the issue itself notes, this is two different problems:
- `esc`/`return` are a plain naming gap; `KEY_DISPLAY`/`KEY_LABEL` already cover the canonical names.
- `meta`/`space` need a platform/design decision (whether `meta` branches per-platform like `mod`, and whether `space` renders as a glyph or the word "Space") that a contributor shouldn't make unilaterally.

This PR only fixes the first part.

## Fix

Added a narrow, `Kbd`-local `KEY_ALIASES` map (`esc` → `escape`, `return` → `enter` only) resolved inside `getKeyDisplay`/`getKeyLabel` before their existing lookups. `meta` and `space` are untouched.

## Testing

- `packages/core/src/Kbd` suite: 16/16 passing, including a new regression test for both aliases
- Typecheck and lint clean
