### PR TITLE
fix(ProgressBar): keep focusable marks outside progressbar subtree

### DIFF
--- a/.changeset/progressbar-mark-accessibility.md
+++ b/.changeset/progressbar-mark-accessibility.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Move focusable ProgressBar target marks outside the `progressbar` subtree (#6248)
+@korkt-kim

--- a/packages/core/src/FieldStatus/__tests__/StatusMessage.a11y.states.ts
+++ b/packages/core/src/FieldStatus/__tests__/StatusMessage.a11y.states.ts
@@ -256,7 +256,7 @@ export const CORE_STATUS_MESSAGE_BINDING_STATES = [
       minValue: 0,
       maxValue: 100,
     },
-    focusSelector: '[role="progressbar"] [tabindex="0"]',
+    focusSelector: '[tabindex="0"]',
     storyId: 'a11y-status-message-pattern--progress-mark-focused-update',
   },
 ] as const satisfies ReadonlyArray<CoreStatusMessageBindingDefinition>;

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -1,5 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/**
+ * @file ProgressBar.test.tsx
+ * @input Uses Vitest, Testing Library, and ProgressBar
+ * @output DOM regressions for values, labels, themes, and external mark triggers
+ * @position Colocated unit tests; mark geometry is checked in Storybook
+ */
+
 import {describe, it, expect, beforeAll} from 'vitest';
 import {render, screen, waitFor} from '@testing-library/react';
 import {ProgressBar} from './ProgressBar';
@@ -558,6 +565,21 @@ describe('ProgressBar', () => {
       expect(styleClasses(accentMarks[1])).toBe(styleClasses(errorMarks[1]));
     });
 
+    it('keeps tabbable target marks outside the progressbar subtree', () => {
+      const {container} = render(
+        <ProgressBar
+          value={50}
+          label="Progress"
+          marks={[{value: 80, label: 'Goal'}]}
+        />,
+      );
+      const progressbar = screen.getByRole('progressbar', {name: 'Progress'});
+      const mark = container.querySelector(MARK)!;
+      expect(mark).toHaveAttribute('tabindex', '0');
+      expect(progressbar.querySelector('[tabindex="0"]')).toBeNull();
+      expect(mark.closest('[role="progressbar"]')).toBeNull();
+    });
+
     it('renders every mark as a focusable trigger (label is required, never decorative)', () => {
       const {container} = render(
         <ProgressBar
@@ -605,10 +627,8 @@ describe('ProgressBar', () => {
     });
 
     it('keeps the progressbar element free of role="img"/aria-label children', () => {
-      // Marks are children of role="progressbar" (unchanged DOM), but a
-      // mark uses a Tooltip (aria-describedby) rather than a
-      // role="img"+aria-label child, so nothing muddies what SRs announce for
-      // the bar.
+      // Marks stay outside the progressbar's presentational subtree; their
+      // Tooltip descriptions must not change the bar's own semantics.
       const {container} = render(
         <ProgressBar
           value={50}
@@ -617,9 +637,7 @@ describe('ProgressBar', () => {
         />,
       );
       const progressbar = screen.getByRole('progressbar');
-      // Mark is a child of the progressbar (DOM unchanged from main).
-      expect(progressbar.querySelector(MARK)).not.toBeNull();
-      // But it is not a labeled graphic that pollutes the a11y subtree.
+      expect(progressbar.querySelector(MARK)).toBeNull();
       expect(progressbar.querySelector('[role="img"]')).toBeNull();
       expect(progressbar.querySelector('[aria-label]')).toBeNull();
       expect(container.querySelectorAll(MARK)).toHaveLength(1);
@@ -637,9 +655,9 @@ describe('ProgressBar', () => {
       expect(progressbar.getAttribute('aria-valuetext')).toBe('50%');
     });
 
-    it('renders marks as children of the progressbar (unchanged DOM)', () => {
-      // Marks stay children of role="progressbar", after the fill — the same
-      // shape as main. The fill remains the first child.
+    it('preserves the fill inside the progressbar when marks are rendered outside it', () => {
+      // Only the fill belongs to the semantic track; the focusable marks
+      // remain independently available outside its presentational subtree.
       const {container} = render(
         <ProgressBar
           value={50}
@@ -652,7 +670,7 @@ describe('ProgressBar', () => {
       expect(fill.style.width).toBe('50%');
       expect(fill.classList.contains('astryx-progressbar-mark')).toBe(false);
       const mark = container.querySelector<HTMLElement>(MARK)!;
-      expect(mark.closest('[role="progressbar"]')).toBe(progressbar);
+      expect(progressbar).not.toContainElement(mark);
       expect(container.querySelectorAll(MARK)).toHaveLength(1);
     });
 

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -215,26 +215,23 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     borderWidth: 0,
   },
-  // The `role="progressbar"` element. In determinate mode it does NOT clip its
-  // content (`overflow` stays visible) so a themed mark taller than the bar can
-  // overhang it; the determinate fill rounds its own corners via `border-radius`
-  // (see `fill`) and is always inside the track box, so dropping the clip does
-  // not change its appearance at any progress. Indeterminate mode re-adds the
-  // clip via `trackClipped` (see below) — its sliding fill travels outside the
-  // track and must be clipped, and marks are ignored while indeterminate, so
-  // there is nothing to overhang.
-  track: {
+  // The in-flow track determines this containing block's actual height.
+  // Marks share its geometry without depending on the label row's height or
+  // entering the progressbar's presentational subtree. Keep it unclipped so
+  // themed tall marks can overhang the track symmetrically.
+  trackContainer: {
     position: 'relative',
+    width: '100%',
+  },
+  // The semantic rail holds only the fill, which rounds its own corners.
+  track: {
     width: '100%',
     height: '8px',
     backgroundColor: colorVars['--color-background-muted'],
     borderRadius: radiusVars['--radius-full'],
   },
-  // Indeterminate-only clip. The indeterminate fill slides from translateX
-  // -100% to 250%, so it deliberately overshoots the track on both sides and
-  // relies on the track clipping it to the visible window. Applied only when
-  // `isIndeterminate` (marks are suppressed then, so nothing needs to overhang)
-  // so it never re-clips a themed tall mark in determinate mode.
+  // The indeterminate fill overshoots the track on both sides and must be
+  // clipped to the visible rail. Marks are suppressed in this mode.
   trackClipped: {
     overflow: 'hidden',
   },
@@ -260,11 +257,10 @@ const styles = stylex.create({
     animationTimingFunction: 'ease-in-out',
     animationIterationCount: 'infinite',
   },
-  // A mark is a vertical tick centered on the track, a child of the
-  // `role="progressbar"` element (unchanged DOM). The track no longer clips, so
-  // its height — 8px by default — may exceed the bar and overhang; the centering
-  // translate keeps any overhang symmetric. Positioned horizontally via
-  // `insetInlineStart`; the translate mirrors under RTL.
+  // A mark is a vertical tick centered on the track via their shared positioning container.
+  // It stays outside role="progressbar" so it remains independently focusable.
+  // The centering translate keeps themed overhang symmetric;
+  // insetInlineStart and the mirrored translate preserve RTL.
   //
   // The dimensions read private vars rather than being plain declarations: a
   // theme writes `width`/`height` on the `progressbar-mark` target as usual and
@@ -518,59 +514,50 @@ export function ProgressBar({
         <VisuallyHidden id={labelId}>{label}</VisuallyHidden>
       )}
 
-      {/* Progress track — the `role="progressbar"` element, holding the fill
-          and marks as its children (unchanged DOM shape). It no longer clips
-          (`overflow` is visible), so a themed taller mark can overhang it;
-          the fill preserves its rounded shape via its own `border-radius`. */}
-      <div
-        role="progressbar"
-        aria-valuenow={isIndeterminate ? undefined : clampedValue}
-        aria-valuemin={isIndeterminate ? undefined : 0}
-        aria-valuemax={isIndeterminate ? undefined : safeMax}
-        aria-labelledby={labelId}
-        aria-valuetext={isIndeterminate ? undefined : valueText}
-        {...mergeProps(
-          themeProps('progress-bar-track', undefined, {
-            legacyNames: ['progressbar-track'],
-          }),
-          stylex.props(styles.track, isIndeterminate && styles.trackClipped),
-        )}>
-        {isIndeterminate ? (
-          <div
-            {...mergeProps(
-              themeProps(
-                'progress-bar-fill',
-                {variant: fillVariant},
-                {legacyNames: ['progressbar-fill']},
-              ),
-              stylex.props(
-                styles.indeterminateFill,
-                variantStyles[fillVariant],
-              ),
-            )}
-          />
-        ) : (
-          <div
-            {...mergeProps(
-              themeProps(
-                'progress-bar-fill',
-                {variant: fillVariant},
-                {legacyNames: ['progressbar-fill']},
-              ),
-              stylex.props(styles.fill, variantStyles[fillVariant]),
-            )}
-            style={{width: `${percentage}%`}}
-          />
-        )}
-        {/* Target marks — children of the progressbar element (unchanged),
-            layered above the fill so they show whether progress is below or
-            past them. A mark's color follows what it sits on: inside the fill
-            it uses the fill variant's on-color, out on the bare track it uses
-            the emphasized divider color. Each mark is labeled, so it is a
-            focusable Tooltip trigger: the label is visible on hover/focus and
-            names the mark for assistive tech via the Tooltip's
-            aria-describedby, without adding a labeled child to the
-            progressbar's own a11y subtree. */}
+      <div {...stylex.props(styles.trackContainer)}>
+        <div
+          role="progressbar"
+          aria-valuenow={isIndeterminate ? undefined : clampedValue}
+          aria-valuemin={isIndeterminate ? undefined : 0}
+          aria-valuemax={isIndeterminate ? undefined : safeMax}
+          aria-labelledby={labelId}
+          aria-valuetext={isIndeterminate ? undefined : valueText}
+          {...mergeProps(
+            themeProps('progress-bar-track', undefined, {
+              legacyNames: ['progressbar-track'],
+            }),
+            stylex.props(styles.track, isIndeterminate && styles.trackClipped),
+          )}>
+          {isIndeterminate ? (
+            <div
+              {...mergeProps(
+                themeProps(
+                  'progress-bar-fill',
+                  {variant: fillVariant},
+                  {legacyNames: ['progressbar-fill']},
+                ),
+                stylex.props(
+                  styles.indeterminateFill,
+                  variantStyles[fillVariant],
+                ),
+              )}
+            />
+          ) : (
+            <div
+              {...mergeProps(
+                themeProps(
+                  'progress-bar-fill',
+                  {variant: fillVariant},
+                  {legacyNames: ['progressbar-fill']},
+                ),
+                stylex.props(styles.fill, variantStyles[fillVariant]),
+              )}
+              style={{width: `${percentage}%`}}
+            />
+          )}
+        </div>
+        {/* Marks overlay the fill but live outside the semantic progressbar.
+          Their Tooltip descriptions remain independently reachable on focus. */}
         {resolvedMarks.map(mark => {
           // The tick element. It is both the Tooltip's anchor and the Suspense
           // fallback shown while the lazy Tooltip chunk loads, so the tick is


### PR DESCRIPTION
## Summary

- move focusable target marks outside the `role="progressbar"` subtree
- position the track and marks within a shared container
- keep existing public props and mark tooltips unchanged
- add regression coverage for mark placement and progressbar semantics

## Motivation

WAI-ARIA defines progressbar descendants as presentational, but ProgressBar currently places focusable Tooltip triggers inside that subtree. Keyboard users can reach the marks while assistive technology may flatten or omit them.

## Scope

ProgressBar markup, positioning, and unit tests only. No public API changes.

Fixes #6219.

## Test plan

- `pnpm exec vitest run packages/core/src/ProgressBar` — 52 tests passed
- `pnpm check:repo` — passed through the pre-commit hook

Browser accessibility-tree and visual checks were not run.
