### PR TITLE
fix(SideNav): clip the resize handle's overlay hit area to its container

### DIFF
--- a/.changeset/sidenav-resizable-horizontal-scrollbar.md
+++ b/.changeset/sidenav-resizable-horizontal-scrollbar.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: stop a resizable nav's handle from creating a horizontal scrollbar in AppShell (#6177)
+
+`ResizeHandle`'s overlay mode positions an intentionally oversized hit area with a transform offset that can extend a fraction of a pixel past the nav's own width. The wrapper `SideNav` renders around the nav and handle didn't clip that bleed itself, so it reached AppShell's scrollable `LayoutPanel` and surfaced as a real 1px horizontal scrollbar. Adds `overflow: 'clip'` to that wrapper, matching what `ResizeHandle`'s own overlay-mode documentation already expects of its parent.
+
+@HelloOjasMutreja

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -989,6 +989,18 @@ describe('SideNav resizable', () => {
     ).toBeInTheDocument();
   });
 
+  it('clips the resize handle overlay hit area to its own container (#6177)', () => {
+    // ResizeHandle's overlay mode positions its (deliberately oversized) hit
+    // area with a transform offset that can extend a fraction of a pixel
+    // past the nav's own width. The immediate wrapper around the handle
+    // must clip that bleed itself, since it sits directly inside the
+    // AppShell's scrollable LayoutPanel and would otherwise turn into a
+    // visible horizontal scrollbar there.
+    render(<SideNav resizable>Content</SideNav>);
+    const handle = screen.getByTestId('astryx-sidenav-resize-handle');
+    expect(getComputedStyle(handle.parentElement!).overflow).toBe('clip');
+  });
+
   it('does not render drag handle without resizable', () => {
     render(<SideNav>Content</SideNav>);
     expect(

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -241,6 +241,10 @@ const styles = stylex.create({
     display: 'flex',
     flexShrink: 0,
     height: '100%',
+    // ResizeHandle's overlay mode expects its parent to clip, so its wider
+    // hit-area target (offset past the visible bar for easier grabbing)
+    // doesn't bleed into an ancestor's scrollable overflow (#6177).
+    overflow: 'clip',
   },
   // Topbar mode — horizontal layout for mobile top bar
   topbar: {


### PR DESCRIPTION
Fixes #6177.

## Root cause

`ResizeHandle`'s `position="overlay"` mode places an intentionally oversized hit area (`hitArea`) inside the visible resize bar so it is easier to grab. That hit area is positioned with a transform offset, and on the SideNav's default 260px width that offset lands it a fraction of a pixel past the nav's own right edge.

`SideNav`'s own wrapper around the nav and the handle (`resizableContainer`) never set `overflow`, so nothing contained that sub-pixel bleed. It reached the next ancestor up, `AppShell`'s `LayoutPanel` (`astryx-app-shell-sidenav`), which does set `overflow: auto` (via its `isScrollable` prop), and the browser rounded the bleed up to a full 1px scrollable overflow there, producing the reported `clientWidth: 260` / `scrollWidth: 261` and a visible horizontal scrollbar.

`ResizeHandle`'s own overlay-mode doc comment already says: "useful when the parent has `overflow: clip`." `SideNav`'s `resizableContainer` is exactly that parent, but was missing the `overflow: clip` it was implicitly relying on.

## Fix

Adds `overflow: 'clip'` to `resizableContainer` in `packages/core/src/SideNav/SideNav.tsx`.

## Verification

- Reproduced empirically in a real browser (temporary Storybook story matching the issue's exact repro, removed before opening this PR): before the fix, `.astryx-app-shell-sidenav` measured `clientWidth: 260` / `scrollWidth: 261`; after the fix, both are `260`.
- Confirmed the visible resize handle bar itself is unaffected (`left/right/width` unchanged, `16px` wide, fully inside the panel); only the invisible sub-pixel hit-area bleed is clipped.
- Added a jsdom regression test in `SideNav.test.tsx` asserting the computed `overflow` on the handle's immediate wrapper is `clip`.
- `pnpm typecheck`, `pnpm lint`, and the full `SideNav.test.tsx` suite (200 tests) all pass.
- Changeset added.