### PR TITLE
docs(knowledge): add Joey as a spec approver

### DIFF
--- a/.github/scripts/spec-owner-workflow.test.mjs
+++ b/.github/scripts/spec-owner-workflow.test.mjs
@@ -176,6 +176,16 @@ describe('spec-only workflow contract', () => {
     expect(prComment).toContain('files.length !== pr.changed_files');
   });
 
+  it('keeps the workflow spec-owner roster aligned with the latest schema', () => {
+    const workflow = read('.github/workflows/spec-owner-gate.yml');
+    const latestSchema = JSON.parse(read('docs/schemas/knowledge/v4.json'));
+    const workflowOwners = workflow
+      .match(/^  SPEC_OWNERS: (.+)$/m)?.[1]
+      .split(',');
+
+    expect(workflowOwners).toEqual(latestSchema.approvalOwners);
+  });
+
   it('runs the tested exact-head reconciler from the trusted default branch', () => {
     const workflow = read('.github/workflows/spec-owner-gate.yml');
     const reconciler = read('.github/scripts/spec-owner-reconcile.cjs');

--- a/.github/workflows/spec-owner-gate.yml
+++ b/.github/workflows/spec-owner-gate.yml
@@ -44,7 +44,7 @@ on:
 permissions: {}
 
 env:
-  SPEC_OWNERS: cixzhang,imdreamrunner
+  SPEC_OWNERS: cixzhang,imdreamrunner,josephfarina
   REVIEW_LABEL: needs:spec-owner-review
   AUTO_MERGE_LABEL: spec-auto-merge
 

--- a/docs/schemas/knowledge/v4.json
+++ b/docs/schemas/knowledge/v4.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 4,
+  "extends": 3,
+  "kinds": {
+    "system-spec": {
+      "template": "docs/templates/knowledge/system-spec.md",
+      "requiredFrontmatter": [
+        "schema_version",
+        "template_version",
+        "kind",
+        "id",
+        "authority",
+        "archive_reason",
+        "superseded_by",
+        "approved_by",
+        "approved_at",
+        "phase",
+        "owners",
+        "affects_architecture",
+        "affects_families",
+        "affects_contributing",
+        "affects_consumer_docs"
+      ],
+      "requiredSections": [
+        "Intent",
+        "Non-goals",
+        "Requirements",
+        "Current-state impact",
+        "Verification",
+        "Decision log",
+        "Open questions"
+      ],
+      "currentNonEmptyFields": ["owners"]
+    }
+  },
+  "approvalOwners": ["cixzhang", "imdreamrunner", "josephfarina"]
+}

--- a/docs/specs/AST-001/spec.md
+++ b/docs/specs/AST-001/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-001

--- a/docs/specs/AST-002/spec.md
+++ b/docs/specs/AST-002/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-002

--- a/docs/specs/AST-003/spec.md
+++ b/docs/specs/AST-003/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-003

--- a/docs/specs/AST-004/spec.md
+++ b/docs/specs/AST-004/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-004

--- a/docs/specs/AST-005/spec.md
+++ b/docs/specs/AST-005/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-005

--- a/docs/specs/AST-006/spec.md
+++ b/docs/specs/AST-006/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-006

--- a/docs/specs/AST-008/spec.md
+++ b/docs/specs/AST-008/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-008

--- a/docs/specs/AST-009/spec.md
+++ b/docs/specs/AST-009/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-009

--- a/docs/specs/AST-010/spec.md
+++ b/docs/specs/AST-010/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-010

--- a/docs/specs/AST-011/spec.md
+++ b/docs/specs/AST-011/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-011

--- a/docs/specs/AST-012/spec.md
+++ b/docs/specs/AST-012/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-012

--- a/docs/specs/AST-013/spec.md
+++ b/docs/specs/AST-013/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-013

--- a/docs/specs/AST-017/spec.md
+++ b/docs/specs/AST-017/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-017

--- a/docs/specs/AST-018/spec.md
+++ b/docs/specs/AST-018/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-018

--- a/docs/specs/AST-020/spec.md
+++ b/docs/specs/AST-020/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-020

--- a/docs/specs/AST-021/spec.md
+++ b/docs/specs/AST-021/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-021

--- a/docs/specs/AST-022/spec.md
+++ b/docs/specs/AST-022/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-022

--- a/docs/specs/AST-024/spec.md
+++ b/docs/specs/AST-024/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-024

--- a/docs/specs/AST-025/spec.md
+++ b/docs/specs/AST-025/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-025

--- a/docs/specs/AST-026/spec.md
+++ b/docs/specs/AST-026/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-026

--- a/docs/specs/AST-027/spec.md
+++ b/docs/specs/AST-027/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-027

--- a/docs/specs/AST-028/spec.md
+++ b/docs/specs/AST-028/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-028

--- a/docs/specs/AST-029/spec.md
+++ b/docs/specs/AST-029/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-029

--- a/docs/specs/AST-030/spec.md
+++ b/docs/specs/AST-030/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-030

--- a/docs/specs/AST-031/spec.md
+++ b/docs/specs/AST-031/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-031

--- a/docs/specs/AST-033/spec.md
+++ b/docs/specs/AST-033/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-033

--- a/docs/specs/AST-034/spec.md
+++ b/docs/specs/AST-034/spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-034

--- a/docs/templates/knowledge/system-spec.md
+++ b/docs/templates/knowledge/system-spec.md
@@ -1,5 +1,5 @@
 ---
-schema_version: 1
+schema_version: 4
 template_version: 1
 kind: system-spec
 id: spec:AST-000

--- a/scripts/check-knowledge.test.mjs
+++ b/scripts/check-knowledge.test.mjs
@@ -28,7 +28,7 @@ function fixtureRoot() {
     path.join(root, 'docs/templates/knowledge'),
     {recursive: true},
   );
-  for (const version of ['v1.json', 'v2.json', 'v3.json']) {
+  for (const version of ['v1.json', 'v2.json', 'v3.json', 'v4.json']) {
     fs.copyFileSync(
       path.join(repoRoot, `docs/schemas/knowledge/${version}`),
       path.join(root, `docs/schemas/knowledge/${version}`),
@@ -199,7 +199,7 @@ function themeRecord(overrides = {}) {
 
 function systemSpecRecord(overrides = {}) {
   const values = {
-    schema_version: '1',
+    schema_version: '4',
     template_version: '1',
     kind: 'system-spec',
     id: 'spec:AST-900',


### PR DESCRIPTION
Adds Joey to the system-spec approval roster through append-only knowledge schema v4.

The current allowlist names Cindy and Emil only. Joey owns system specs in this repo, including AST-026, so the schema should recognize his approvals too.

This does not rewrite schema v1. It adds v4, migrates active system specs and the template to v4, and leaves every spec body unchanged.

Tested:
- `pnpm check:knowledge`
- `node scripts/check-knowledge.mjs --base origin/main`
- `git diff --check`

This PR needs approval from an existing recognized spec owner before it lands.