### PR TITLE
fix(docsite): render dashboard templates in gallery and playground

### DIFF
--- a/.changeset/visible-dashboard-templates.md
+++ b/.changeset/visible-dashboard-templates.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Show all seven dashboard page templates in the templates gallery and playground.
+
+@kentonquatman

--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -40,6 +40,7 @@
     "prettier": "catalog:",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "recharts": "^3.9.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/docsite/scripts/generate-playground-types.mjs
+++ b/apps/docsite/scripts/generate-playground-types.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-
 /**
- * Generates a JSON bundle of all @astryxdesign/core .d.ts files for the playground's
- * Monaco editor. Output: public/playground-types.json
+ * Generates a JSON bundle of @astryxdesign/core, React, StyleX, icon, and
+ * Recharts declarations for the playground's Monaco editor.
+ * Output: public/playground-types.json
  *
  * Structure: { "@astryxdesign/core": { "Button/index.d.ts": "...", ... } }
  *
@@ -12,7 +12,14 @@
  * Also runs as part of the prebuild/predev scripts.
  */
 
-import {readdirSync, readFileSync, statSync, writeFileSync, existsSync, mkdirSync} from 'node:fs';
+import {
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+} from 'node:fs';
 import {join, dirname, relative} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -41,7 +48,9 @@ function collectDts(dir, base = dir) {
 console.log(`Scanning ${distDir} for .d.ts files...`);
 
 if (!existsSync(distDir)) {
-  console.log('dist/ not found — skipping playground types generation (run pnpm build first)');
+  console.log(
+    'dist/ not found — skipping playground types generation (run pnpm build first)',
+  );
   // Write an empty placeholder so the app doesn't 404
   writeFileSync(join(outDir, 'playground-types.json'), '{}');
   process.exit(0);
@@ -151,7 +160,14 @@ declare module '@stylexjs/stylex' {
 // index.d.ts so the set stays accurate (e.g. 16/solid ships fewer icons).
 function buildHeroiconTypes() {
   const variants = ['16/solid', '20/solid', '24/outline', '24/solid'];
-  const heroRoot = join(root, '..', '..', 'node_modules', '@heroicons', 'react');
+  const heroRoot = join(
+    root,
+    '..',
+    '..',
+    'node_modules',
+    '@heroicons',
+    'react',
+  );
   const iconType =
     'React.ComponentType<React.SVGProps<SVGSVGElement> & ' +
     '{title?: string; titleId?: string}>';
@@ -162,9 +178,9 @@ function buildHeroiconTypes() {
     if (!existsSync(indexPath)) continue;
 
     const src = readFileSync(indexPath, 'utf-8');
-    const names = [
-      ...src.matchAll(/export \{ default as (\w+) \}/g),
-    ].map(m => m[1]);
+    const names = [...src.matchAll(/export \{ default as (\w+) \}/g)].map(
+      m => m[1],
+    );
     if (names.length === 0) continue;
 
     const exports = names.map(n => `  export const ${n}: HeroIcon;`).join('\n');
@@ -177,9 +193,48 @@ function buildHeroiconTypes() {
   return files;
 }
 
+function buildRechartsTypes() {
+  const indexPath = join(
+    root,
+    '..',
+    '..',
+    'node_modules',
+    'recharts',
+    'types',
+    'index.d.ts',
+  );
+  if (!existsSync(indexPath)) return {};
+
+  const source = readFileSync(indexPath, 'utf-8');
+  const names = new Set();
+  for (const match of source.matchAll(/^export \{([^}]+)\} from/gm)) {
+    for (const binding of match[1].split(',')) {
+      const name = binding
+        .trim()
+        .split(/\s+as\s+/)
+        .pop();
+      if (/^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
+    }
+  }
+
+  return {
+    'index.d.ts':
+      `declare module 'recharts' {\n` +
+      [...names]
+        .sort()
+        .map(name => `  export const ${name}: any;`)
+        .join('\n') +
+      '\n}',
+  };
+}
+
 const heroiconTypes = buildHeroiconTypes();
+const rechartsTypes = buildRechartsTypes();
 console.log(
   `Generated heroicon types: ${Object.keys(heroiconTypes).length} variants`,
+);
+console.log(
+  `Generated Recharts types: ${Object.keys(rechartsTypes).length} declaration file`,
 );
 
 const output = {
@@ -187,8 +242,11 @@ const output = {
   react: {'index.d.ts': reactTypes, 'jsx-runtime.d.ts': reactJsxRuntimeTypes},
   '@stylexjs/stylex': {'index.d.ts': stylexTypes},
   '@heroicons/react': heroiconTypes,
+  recharts: rechartsTypes,
 };
 
 const json = JSON.stringify(output);
 writeFileSync(join(outDir, 'playground-types.json'), json);
-console.log(`Generated playground-types.json: ${fileCount} Astryx type files, ${(json.length / 1024).toFixed(0)}KB`);
+console.log(
+  `Generated playground-types.json: ${fileCount} Astryx type files, ${(json.length / 1024).toFixed(0)}KB`,
+);

--- a/apps/docsite/scripts/generate-scope.mjs
+++ b/apps/docsite/scripts/generate-scope.mjs
@@ -28,15 +28,16 @@ const HEADER = `// Copyright (c) Meta Platforms, Inc. and affiliates.
 const corePkg = JSON.parse(readFileSync(CORE_PKG, 'utf-8'));
 const exportKeys = Object.keys(corePkg.exports ?? {});
 
-const SKIP = /\.(css|stylex)$|\/utils$|^\.\/theme|^\.\/hooks|^\.\/utils|^\.\/syntax|^\.\/docs|^\.\/groups|^\.$|^\.\/reset/;
+const SKIP =
+  /\.(css|stylex)$|\/utils$|^\.\/theme|^\.\/hooks|^\.\/utils|^\.\/syntax|^\.\/docs|^\.\/groups|^\.$|^\.\/reset/;
 
 const components = exportKeys
-  .filter((k) => {
+  .filter(k => {
     if (SKIP.test(k)) return false;
     const name = k.replace('./', '');
     return /^[A-Z]/.test(name);
   })
-  .map((k) => k.replace('./', ''));
+  .map(k => k.replace('./', ''));
 
 // Themes — add new themes here as they become available
 const SCOPE_THEMES = [
@@ -55,12 +56,13 @@ const HEROICON_VARIANTS = [
   {path: '24/solid', alias: 'Heroicons24Solid'},
 ];
 
-
 // Build output — matches the structure of the previously committed scope.ts
 const lines = [HEADER, ''];
 
 // ── React ──────────────────────────────────────────────────────────────
-lines.push("import React, {useState, useCallback, useMemo, useEffect, useRef} from 'react';");
+lines.push(
+  "import React, {useState, useCallback, useMemo, useEffect, useRef} from 'react';",
+);
 lines.push('');
 
 // ── StyleX mock ────────────────────────────────────────────────────────
@@ -207,7 +209,9 @@ lines.push('');
 lines.push("import {Theme} from '@astryxdesign/core/theme';");
 lines.push("import type {DefinedTheme} from '@astryxdesign/core/theme';");
 lines.push("import {createElement, type ComponentProps} from 'react';");
-lines.push("import * as astryxTokens from '@astryxdesign/core/theme/tokens.stylex';");
+lines.push(
+  "import * as astryxTokens from '@astryxdesign/core/theme/tokens.stylex';",
+);
 lines.push('');
 
 // ── Hooks ──────────────────────────────────────────────────────────────
@@ -216,11 +220,16 @@ lines.push('');
 lines.push("import * as Hooks from '@astryxdesign/core/hooks';");
 lines.push('');
 
-// ── Icon libraries ─────────────────────────────────────────────────────
+// ── Icon and chart libraries ───────────────────────────────────────────
 lines.push("import * as LucideIcons from 'lucide-react';");
-lines.push('// Heroicons kept available in the playground scope alongside Lucide');
-lines.push("// so template / example code that still imports from");
-lines.push("// '@heroicons/react/*' continues to render. New docsite code authors");
+lines.push("import * as Recharts from 'recharts';");
+lines.push(
+  '// Heroicons kept available in the playground scope alongside Lucide',
+);
+lines.push('// so template / example code that still imports from');
+lines.push(
+  "// '@heroicons/react/*' continues to render. New docsite code authors",
+);
 lines.push('// against Lucide; these entries are purely for backwards compat.');
 for (const h of HEROICON_VARIANTS) {
   lines.push(`import * as ${h.alias} from '@heroicons/react/${h.path}';`);
@@ -229,7 +238,7 @@ lines.push('');
 
 // ── ControlledTheme wrapper ─────────────────────────────────────────
 const themeEntries = SCOPE_THEMES.map(
-  (t) => `  ${t.name.replace('Theme', '').toLowerCase()}: ${t.name},`,
+  t => `  ${t.name.replace('Theme', '').toLowerCase()}: ${t.name},`,
 ).join('\n');
 
 lines.push(`const SCOPE_THEMES: Record<string, DefinedTheme> = {
@@ -265,7 +274,10 @@ lines.push(`  react: {
 
 // stylex
 lines.push("  '@stylexjs/stylex': {default: stylexMock, ...stylexMock},");
-lines.push("  stylex: {default: stylexMock, ...stylexMock},");
+lines.push('  stylex: {default: stylexMock, ...stylexMock},');
+
+// Recharts comes before Astryx so Astryx components win global name collisions.
+lines.push('  recharts: Recharts,');
 
 // themes
 for (const t of SCOPE_THEMES) {
@@ -288,7 +300,7 @@ for (const name of components) {
 }
 
 // Barrel export — all components spread
-const spreads = components.map((n) => `    ...${n},`).join('\n');
+const spreads = components.map(n => `    ...${n},`).join('\n');
 lines.push(`  '@astryxdesign/core': {
 ${spreads}
   },`);
@@ -314,4 +326,6 @@ writeFileSync(OUT, lines.join('\n'));
 console.log(`✓ Generated ${OUT}`);
 console.log(`  ${components.length} components`);
 console.log(`  ${SCOPE_THEMES.length} themes`);
-console.log(`  lucide-react icons + ${HEROICON_VARIANTS.length} heroicon variants`);
+console.log(
+  `  lucide-react icons + ${HEROICON_VARIANTS.length} heroicon variants`,
+);

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -24,6 +24,7 @@ import {docTopics, docsCount} from '../generated/docsRegistry';
 import {showcaseRegistry} from '../generated/showcaseRegistry';
 import {externalComponentPreviews} from '../generated/componentPreviewRegistry';
 import {eagerShowcases} from '../components/eagerShowcases';
+import {TEMPLATE_COMPONENTS} from '../components/templateComponents';
 import {exampleRegistry} from '../generated/exampleRegistry';
 import {normalizeComponentCategory} from '../lib/componentCategories';
 
@@ -988,6 +989,27 @@ describe('templateRegistry', () => {
     const slugs = templates.map(t => t.slug);
     expect(slugs).toContain('dashboard');
     expect(slugs).toContain('settings');
+  });
+
+  it('surfaces all dashboard templates with live previews', () => {
+    const dashboards = templates.filter(template =>
+      template.category.startsWith('Dashboard'),
+    );
+
+    expect(dashboards.map(template => template.slug).sort()).toEqual([
+      'dashboard',
+      'dashboard-alert-rail',
+      'dashboard-cohort-funnel',
+      'dashboard-comparison',
+      'dashboard-composition',
+      'dashboard-progress',
+      'dashboard-scorecard',
+    ]);
+    for (const template of dashboards) {
+      expect(template.isReady).toBe(true);
+      expect(template.isHiddenFromOverview).toBe(false);
+      expect(TEMPLATE_COMPONENTS[template.slug]).toBeDefined();
+    }
   });
 
   it('no duplicate template slugs', () => {

--- a/apps/docsite/src/__tests__/playground-scope.test.ts
+++ b/apps/docsite/src/__tests__/playground-scope.test.ts
@@ -5,7 +5,7 @@
  *
  * Validates that the generated playground scope includes every public
  * component exported from @astryxdesign/core/package.json, plus the expected
- * non-component scope entries (themes, icons, stylex, react, next/image).
+ * non-component scope entries and editor declarations used by page templates.
  *
  * This test reads the generated file as text (rather than importing it)
  * because the scope imports @astryxdesign/core/* which requires a prior build step.
@@ -21,6 +21,15 @@ import {describe, it, expect, beforeAll} from 'vitest';
 const GENERATED_SCOPE_PATH = path.resolve(
   __dirname,
   '../generated/playground-scope.ts',
+);
+
+const PLAYGROUND_TYPES_PATH = path.resolve(
+  __dirname,
+  '../../public/playground-types.json',
+);
+const MONACO_SETUP_PATH = path.resolve(
+  __dirname,
+  '../app/playground/monacoSetup.ts',
 );
 
 const CORE_PKG_PATH = path.resolve(
@@ -140,6 +149,24 @@ describe('playground-scope', () => {
     expect(scopeContent).toContain("'lucide-react': LucideIcons,");
     expect(scopeContent).toContain(
       "import * as LucideIcons from 'lucide-react';",
+    );
+  });
+
+  it('includes Recharts for template previews', () => {
+    expect(scopeContent).toContain("import * as Recharts from 'recharts';");
+    expect(scopeContent).toContain('recharts: Recharts,');
+
+    const playgroundTypes = JSON.parse(
+      fs.readFileSync(PLAYGROUND_TYPES_PATH, 'utf-8'),
+    );
+    expect(playgroundTypes.recharts['index.d.ts']).toContain(
+      "declare module 'recharts'",
+    );
+    expect(playgroundTypes.recharts['index.d.ts']).toContain(
+      'export const LineChart: any;',
+    );
+    expect(fs.readFileSync(MONACO_SETUP_PATH, 'utf-8')).toContain(
+      'packages.recharts',
     );
   });
 

--- a/apps/docsite/src/app/playground/monacoSetup.ts
+++ b/apps/docsite/src/app/playground/monacoSetup.ts
@@ -9,7 +9,8 @@
  *
  * Configures Monaco's TypeScript service with real Astryx type definitions loaded
  * from a pre-built JSON bundle (generated at build time), so the editor offers
- * accurate autocomplete and diagnostics for @astryxdesign/core, React, StyleX, and icons.
+ * accurate autocomplete and diagnostics for @astryxdesign/core, React, StyleX,
+ * icons, and Recharts.
  *
  * Also registers Prettier (see ./formatCode) as the document formatter, which is
  * what powers both the "Format code" toolbar button and Monaco's built-in
@@ -150,6 +151,11 @@ export function configureMonaco(
           content,
           `file:///node_modules/@heroicons/react/${variant}/index.d.ts`,
         );
+      }
+
+      const rechartsFiles = packages.recharts ?? {};
+      for (const [fileName, content] of Object.entries(rechartsFiles)) {
+        ts.addExtraLib(content, `file:///node_modules/recharts/${fileName}`);
       }
 
       const coreFiles = packages['@astryxdesign/core'] ?? {};

--- a/apps/docsite/src/components/templateComponents.ts
+++ b/apps/docsite/src/components/templateComponents.ts
@@ -50,9 +50,29 @@ export const TEMPLATE_COMPONENTS: Record<
     () =>
       import('../../../../packages/cli/assets/templates/pages/dashboard/page'),
   ),
+  'dashboard-alert-rail': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/dashboard-alert-rail/page'),
+  ),
+  'dashboard-cohort-funnel': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/dashboard-cohort-funnel/page'),
+  ),
+  'dashboard-comparison': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/dashboard-comparison/page'),
+  ),
   'dashboard-composition': lazy(
     () =>
       import('../../../../packages/cli/assets/templates/pages/dashboard-composition/page'),
+  ),
+  'dashboard-progress': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/dashboard-progress/page'),
+  ),
+  'dashboard-scorecard': lazy(
+    () =>
+      import('../../../../packages/cli/assets/templates/pages/dashboard-scorecard/page'),
   ),
   'detail-page': lazy(
     () =>

--- a/packages/cli/assets/templates/pages/dashboard-alert-rail/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-alert-rail/template.doc.mjs
@@ -5,7 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Service Monitoring Dashboard',
   displayName: 'Service Monitoring Dashboard',
-  description: 'Always-on analytics with a triage rail: status-colored tiles with sparklines, multi-series time charts over a switchable window, and an independently scrolling alert column that folds into the content when narrow. Monitoring, uptime, health, latency, alerting, incidents, or observability.',
-  isReady: false,
+  description:
+    'Always-on analytics with a triage rail: status-colored tiles with sparklines, multi-series time charts over a switchable window, and an independently scrolling alert column that folds into the content when narrow. Monitoring, uptime, health, latency, alerting, incidents, or observability.',
+  isReady: true,
   category: 'Dashboard - Monitoring',
 };

--- a/packages/cli/assets/templates/pages/dashboard-cohort-funnel/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-cohort-funnel/template.doc.mjs
@@ -5,7 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Funnel & Cohort Dashboard',
   displayName: 'Funnel & Cohort Dashboard',
-  description: 'Analytics for sequence and retention questions, pairing two shapes a plain dashboard cannot hold: a staged funnel where each step reads as drop-off against the one before, and a two-axis cohort matrix rendered as a heatmap. Conversion, drop-off, activation, churn, or retention reporting.',
-  isReady: false,
+  description:
+    'Analytics for sequence and retention questions, pairing two shapes a plain dashboard cannot hold: a staged funnel where each step reads as drop-off against the one before, and a two-axis cohort matrix rendered as a heatmap. Conversion, drop-off, activation, churn, or retention reporting.',
+  isReady: true,
   category: 'Dashboard - Funnel & Cohort',
 };

--- a/packages/cli/assets/templates/pages/dashboard-comparison/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-comparison/template.doc.mjs
@@ -5,8 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Data Dashboard',
   displayName: 'Data Dashboard',
-  description: 'Comparison-heavy analytics behind a persistent filter bar: tiles that each carry an inline sparkline and several period-over-period deltas, then segmented breakdowns underneath. Every number is shown against another number. Dashboard, metrics, stats, analytics, trends, or reporting.',
-  isReady: false,
+  description:
+    'Comparison-heavy analytics behind a persistent filter bar: tiles that each carry an inline sparkline and several period-over-period deltas, then segmented breakdowns underneath. Every number is shown against another number. Dashboard, metrics, stats, analytics, trends, or reporting.',
+  isReady: true,
   category: 'Dashboard - Comparison',
-  isHiddenFromOverview: true,
 };

--- a/packages/cli/assets/templates/pages/dashboard-composition/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-composition/template.doc.mjs
@@ -5,8 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Portfolio Dashboard',
   displayName: 'Portfolio Dashboard',
-  description: 'Analytics for a value-over-time question: balance and change tiles above a stacked area chart of composition through time, closing on a ranked table of the largest contributors. Portfolio, holdings, positions, returns, allocation, investments, or performance reporting.',
+  description:
+    'Analytics for a value-over-time question: balance and change tiles above a stacked area chart of composition through time, closing on a ranked table of the largest contributors. Portfolio, holdings, positions, returns, allocation, investments, or performance reporting.',
   isReady: true,
   category: 'Dashboard - Portfolio',
-  isHiddenFromOverview: true,
 };

--- a/packages/cli/assets/templates/pages/dashboard-progress/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-progress/template.doc.mjs
@@ -5,8 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Project Status Dashboard',
   displayName: 'Project Status Dashboard',
-  description: 'Status analytics mixing progress and time-axis shapes: a completion donut, a horizontal timeline of dated bars against a today marker, a per-owner table with progress and status, an at-risk list, and a burndown. Project, program, milestone, roadmap, launch, or delivery status.',
+  description:
+    'Status analytics mixing progress and time-axis shapes: a completion donut, a horizontal timeline of dated bars against a today marker, a per-owner table with progress and status, an at-risk list, and a burndown. Project, program, milestone, roadmap, launch, or delivery status.',
   isReady: true,
   category: 'Dashboard - Project Status',
-  isHiddenFromOverview: true,
 };

--- a/packages/cli/assets/templates/pages/dashboard-scorecard/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard-scorecard/template.doc.mjs
@@ -5,8 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Executive Summary Dashboard',
   displayName: 'Executive Summary Dashboard',
-  description: 'Report-shaped analytics with a prose rail beside the charts: a scorecard of headline numbers with period deltas and status coloring, goal-attainment bars, a trend grid, and a written commentary column that folds beneath the content when narrow. Executive summary, business review, readout, or reporting.',
+  description:
+    'Report-shaped analytics with a prose rail beside the charts: a scorecard of headline numbers with period deltas and status coloring, goal-attainment bars, a trend grid, and a written commentary column that folds beneath the content when narrow. Executive summary, business review, readout, or reporting.',
   isReady: true,
   category: 'Dashboard - Scorecard',
-  isHiddenFromOverview: true,
 };

--- a/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
+++ b/packages/cli/assets/templates/pages/dashboard/template.doc.mjs
@@ -5,8 +5,8 @@ export const doc = {
   type: 'page',
   name: 'Analytics Dashboard',
   displayName: 'Analytics Dashboard',
-  description: 'Three-band analytics: a row of headline tiles, then charts, then supporting tables, all re-reading from one global filter bar. Breadth over depth, a summary surface rather than a drill-down. Dashboard, overview, metrics, stats, analytics, reporting, or insights.',
+  description:
+    'Three-band analytics: a row of headline tiles, then charts, then supporting tables, all re-reading from one global filter bar. Breadth over depth, a summary surface rather than a drill-down. Dashboard, overview, metrics, stats, analytics, reporting, or insights.',
   isReady: true,
   category: 'Dashboard - Analytics',
-  isHiddenFromOverview: true,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      recharts:
+        specifier: ^3.9.2
+        version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1)
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
## User need

Builders need all seven dashboard page templates to be discoverable and runnable from the templates gallery and playground. Five carried overview-hidden metadata, while three also remained `isReady: false`; the docsite did not fully provide the Recharts runtime, editor declarations, or live-preview loaders the family requires.

## Current specification

[`spec:AST-033`](https://github.com/facebook/astryx/blob/main/docs/specs/AST-033/spec.md) defines upstream template metadata as the visibility/readiness owner and requires gallery, preview, and playground projections to preserve those facts consistently.

## Public delta

- Makes all seven dashboard page templates ready and visible:
  - Analytics Dashboard
  - Service Monitoring Dashboard
  - Funnel & Cohort Dashboard
  - Data Dashboard
  - Portfolio Dashboard
  - Project Status Dashboard
  - Executive Summary Dashboard
- Adds every dashboard to the templates gallery and playground menu.
- Adds live-preview loaders for every dashboard.
- Adds Recharts as an explicit docsite dependency and playground runtime module.
- Adds generated Recharts editor declarations so dashboard source does not produce missing-module diagnostics in Monaco.
- Adds exact regression coverage for the seven-template inventory, readiness, visibility, and preview availability.

No public component API changes.

## Design and alternatives

The docsite consumes Recharts directly because the canonical page-template source imports it directly. The playground scope registers Recharts before Astryx modules so Astryx components continue to win global-name collisions while explicit `recharts` imports resolve normally. A generated ambient declaration keeps editor support small and synchronized with the installed Recharts runtime exports.

## Evidence

- The generated registry contains exactly seven dashboard templates, all ready and visible.
- All seven have live-preview loaders.
- The production docsite build succeeds and statically generates all 52 template routes.
- The full docsite suite and targeted template API suite pass.

## Scope

- [x] One capability is added.
- [x] Unrelated fixes, cleanup, and policy changes were removed or split.
- [x] Consumer docs, focused tests, and migration evidence ship with the feature.
- [x] Public text and artifacts contain no internal Meta context.

## Testing

- `pnpm -F @astryxdesign/docsite test` — 498 tests passed
- `pnpm -F @astryxdesign/docsite typecheck`
- `pnpm exec vitest run packages/cli/authoring/doctypes/template packages/cli/api/template` — 73 tests passed
- `pnpm exec eslint apps/docsite/src/__tests__/data-extraction.test.ts apps/docsite/src/components/templateComponents.ts`
- `pnpm check:knowledge`
- `pnpm check:changesets`
- `pnpm -F @astryxdesign/docsite build`
