### PR TITLE
feat(cli): let integrations replace Core templates

### DIFF
--- a/.changeset/integration-template-replacements.md
+++ b/.changeset/integration-template-replacements.md
@@ -1,0 +1,35 @@
+---
+'@astryxdesign/cli': minor
+---
+
+[breaking] Let integration templates replace Core templates by id.
+
+Integration manifests can map their own template ids to Core ids with
+`templateReplacements`. Unqualified template lookup and discovery surfaces use a
+valid replacement, while `--package @astryxdesign/core` still selects the
+original. Missing targets, type mismatches, and duplicate declarations fail
+closed and are reported by `astryx doctor integration templates`. When separate
+configured packages replace one target, the package configured later wins with
+a warning. Explicitly configured packages always precede autolinked ones. When
+only autolinked packages conflict, the dependency listed later in package.json
+wins with a warning and the CLI recommends explicit configuration.
+
+Invalid contribution kinds remain reportable without hiding other valid kinds.
+Invalid template or component files do not hide valid siblings. CLIs from 0.5.3
+onward ignore `templateReplacements` when it is unknown and preserve understood
+contributions. Versions 0.5.2 and earlier reject unknown manifest keys and drop
+the entire integration. Replacement selection starts in 0.7.0.
+
+Migration for integration authors: require `@astryxdesign/cli >=0.7.0` when your
+package depends on replacement selection. Use `@astryxdesign/cli >=0.5.3` only
+when graceful degradation to the integration template's own id is acceptable.
+Do not support 0.5.2 or earlier with a manifest that declares this field.
+
+Migration for JSON consumers: `template.list` entries can now include optional
+`replaces`, and a winning replacement removes its Core target from the default
+list. Select `@astryxdesign/core` explicitly when you need the original. Every
+`IntegrationTemplateConflict` now has required `relationship` and can have
+`severity: 'info'`; update exhaustive shape or severity handling before
+upgrading.
+
+@josephfarina

--- a/docs/architecture/cli-surface.md
+++ b/docs/architecture/cli-surface.md
@@ -76,11 +76,15 @@ goes through the `Project` seam in `foundation/config`, which resolves the
 integrations named in `astryx.config` and then autolinks any DECLARED dependency
 that ships a root `astryx.integration.*` manifest — a config entry is how a
 project pins an integration, not how the CLI finds one. Each integration is
-loaded independently, so one broken package degrades that package's
-contribution and never fails the run.
+loaded independently. A manifest load failure withdraws that package. An error
+in one contribution kind does not hide other valid kinds, and invalid template
+or component files do not hide valid siblings.
 
 AST-017 DEC-4 owns stable response-entry fields and requires their complete type,
-test, applicable text, and consumer-documentation projections.
+test, applicable text, and consumer-documentation projections. A `template.list`
+entry can carry optional `replaces`, naming the Core id that a winning
+integration template supersedes; the Core entry is omitted from the default list
+and remains available through explicit Core package selection.
 
 ## Boundaries and invariants
 
@@ -152,11 +156,13 @@ test, applicable text, and consumer-documentation projections.
   compares the required file inventory with the actual tarball, extracts that
   tarball into a scratch consumer, reruns contribution discovery, and verifies
   advertised component and template imports through Node's package resolver.
-- **INV18 — Integration diagnostics are read-only and package-specific.** Doctor
-  validation reports malformed or unreachable roots and contribution conflicts
-  without rewriting the package. Everyday discovery skips a broken integration
-  and records its issue; a package-scoped theme lookup surfaces that package's
-  blocking catalog error instead of misreporting the theme as unknown.
+- **INV18 — Integration diagnostics are read-only and contribution-specific.**
+  Doctor reports malformed or unreachable roots and contribution conflicts
+  without rewriting the package. A manifest load failure withdraws the package.
+  A contribution-kind error remains visible without hiding other valid kinds.
+  Invalid template and component files do not hide valid siblings. A
+  package-scoped theme lookup still surfaces that package's blocking catalog
+  error instead of misreporting the theme as unknown.
 - **INV19 — Integration themes are packaged editable source.** The manifest's
   `themes` root contains a versioned catalog. Each entry names its slug, source
   entry, named runtime export, and complete file list. Discovery parses the entry

--- a/docs/specs/AST-035/spec.md
+++ b/docs/specs/AST-035/spec.md
@@ -1,0 +1,158 @@
+---
+schema_version: 1
+template_version: 1
+kind: system-spec
+id: spec:AST-035
+authority: draft
+archive_reason: null
+superseded_by: null
+approved_by: null
+approved_at: null
+phase: proposed
+owners: [josephfarina, cixzhang]
+affects_architecture: [architecture:cli-surface]
+affects_families: []
+affects_contributing: [contributing:templates, contributing:api-conventions]
+affects_consumer_docs: [cli-integrations]
+---
+
+# Integration template replacement system spec
+
+## Intent
+
+Let an installed integration provide the project-specific implementation of a Core
+template without making the common lookup ambiguous or removing access to the Core
+original.
+
+## Non-goals
+
+- Replacing integration components or reference-doc topics. Those surfaces own their
+  own contracts.
+- Rewriting template source that a consumer already copied into an app.
+- Making an integration template available when its source or metadata is invalid.
+- Selecting an integration that the project neither configures nor autolinks.
+
+## Requirements
+
+- **FR1 — Integrations declare replacement intent in the manifest.** An integration
+  MAY provide `templateReplacements` as a map from one of its template ids to an
+  existing Core template id. The declaration is separate from the strict template
+  metadata object. CLIs from 0.5.3 onward can ignore an unknown manifest field
+  while retaining contributions they understand. Versions 0.5.2 and earlier reject
+  unknown manifest keys and therefore require the integration to declare a
+  compatible CLI floor.
+- **FR2 — A valid replacement owns default discovery.** When one valid declaration
+  applies, unqualified template lookup and default template projections MUST use the
+  integration template for the Core id. The integration template MUST remain
+  addressable by its own id. List, search, build suggestions, Project discovery, and
+  block-layout lookup MUST project the same winner.
+- **FR3 — Explicit package selection preserves alternatives.** Selecting
+  `@astryxdesign/core` MUST address the original Core template. Selecting an
+  integration package MUST retain access to its shadowed or rejected template by its
+  own id.
+- **FR4 — Invalid declarations fail closed.** A missing local template, missing Core
+  target, template-kind mismatch, or more than one declaration for one target inside
+  a package MUST be an error. An invalid set MUST NOT replace Core. Valid integration
+  templates remain available by their own ids when replacement metadata alone is
+  invalid.
+- **FR5 — Precedence is deterministic.** When multiple explicitly configured
+  integrations validly replace one target, the integration configured later wins and
+  the CLI reports a warning. An explicitly configured replacement MUST win over an
+  autolinked replacement. When only autolinked integrations validly replace one
+  target, the dependency listed later in package.json wins with a warning; naming
+  the intended package in `astryx.config` makes precedence explicit. Invalid
+  autolinked declarations remain reportable but MUST NOT disable a valid explicit
+  replacement.
+- **FR6 — Omission preserves selection behavior for valid integrations.** Without
+  `templateReplacements`, valid template selection and package-aware ambiguity remain
+  unchanged. FR9 intentionally changes failure isolation with or without the field.
+- **FR7 — Diagnostics are complete and stable.** `astryx doctor integration templates`
+  MUST report intentional replacements, missing targets, missing local templates,
+  kind mismatches, and same-package ambiguity. Error findings MUST produce exit code
+  1 and MUST NOT be followed by a false success message.
+- **FR8 — Public schema projection is complete.** Effective `template.list` entries
+  MAY include optional `replaces`. The response type, generated inventory, terminal
+  projection, consumer documentation, and tests MUST describe that field and the
+  expanded integration-template diagnostic behavior together.
+- **FR9 — Failure isolation preserves valid contributions.** An error in one
+  contribution kind MUST remain reportable without removing the integration's other
+  valid contribution kinds. Within template and component discovery, one unusable file
+  MUST NOT remove valid siblings. Other kinds keep their existing per-kind atomicity. A
+  manifest load failure still withdraws the integration because no contribution roots
+  are trustworthy. This rule applies whether or not `templateReplacements` is present.
+
+### Platform support
+
+- Compatibility floor for preserving understood contributions when this field is
+  unknown: `@astryxdesign/cli >=0.5.3`. Versions 0.5.3 onward ignore the unknown
+  manifest key. Versions 0.5.2 and earlier use strict manifest parsing, reject the
+  unknown key, and drop the integration.
+- Replacement selection itself starts in `@astryxdesign/cli 0.7.0`, the release
+  produced by this breaking minor changeset.
+- Browser evidence: not applicable to catalog selection. A generated consumer app
+  MUST still build or run when its selected template renders integration-owned
+  navigation.
+
+## Current-state impact
+
+The integration manifest type and parser gain one optional map. Shared template
+resolution becomes the owner for replacement validation, precedence, aliases, and the
+default discovery view. Template commands, search/build, Project, layout, Doctor,
+response documentation, and the integration-authoring guide project that result.
+Project reports invalid contributions while retaining other valid contribution kinds
+and valid template or component siblings.
+
+The manifest field is optional, and valid manifests keep their selection behavior
+when it is absent. The overall release is breaking: a winning replacement removes its
+Core target from the default `template.list` response, every
+`IntegrationTemplateConflict` gains required `relationship`, and its `severity` can
+now be `info`. The changeset uses a minor bump under 0.x and includes migration
+instructions as required by `spec:AST-017/FR8`. Optional `replaces` is projected
+across every public response surface under `spec:AST-017/FR13`.
+
+## Verification
+
+| Contract | Verification                                                            | Representative states                                                          | Mutation or failure expectation                                                       |
+| -------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| FR1, FR6 | Manifest parser tests plus an unmodified-base CLI consumer run          | field present, field absent, old CLI                                           | a new field makes an older CLI drop the integration                                   |
+| FR2, FR3 | Template API/CLI and real consumer-app tests                            | target id, own id, Core package, integration package                           | lookup becomes ambiguous or the Core original is unreachable                          |
+| FR4, FR7 | Doctor and discovery tests                                              | missing local/source, missing target, wrong kind, duplicate, same-id rejection | invalid metadata activates a replacement or Doctor reports success                    |
+| FR5      | Multi-integration and autolink tests                                    | configured order, explicit versus autolinked, invalid loser                    | file/display order chooses the winner or invalid autolinking disables explicit intent |
+| FR2, FR8 | List, search/build, Project, layout, response, and generated-doc checks | alias plus undeclared exact-id collision, page and block                       | two projections disagree or a public field is undocumented                            |
+| FR9      | Project discovery and issue-order tests                                 | invalid component/template siblings, valid contribution kinds and siblings     | one bad contribution removes unrelated valid output                                   |
+
+## Decision log
+
+### DEC-1 — Replacement declarations live on the integration manifest
+
+**Reference:** `spec:AST-035/DEC-1`
+**Proposed by:** `josephfarina`, `2026-09-11`
+
+Use `templateReplacements: Record<integrationTemplateId, coreTemplateId>` on the
+integration manifest. This makes intent explicit. CLIs from 0.5.3 onward ignore the
+field when it is unknown without rejecting understood contributions; integrations
+that use it must not claim compatibility with 0.5.2 or earlier. Replacement selection
+starts in 0.7.0.
+
+Rejected: adding `replaces` directly to `TemplateDoc`. A CLI released before that
+field would reject the strict metadata object and make the integration template
+unavailable instead of degrading cleanly.
+
+### DEC-2 — Explicit project configuration owns replacement precedence
+
+**Reference:** `spec:AST-035/DEC-2`
+**Proposed by:** `josephfarina`, `2026-09-11`
+
+Use configuration order when more than one explicitly configured package replaces a
+target, and prefer any explicit replacement over autolinking. This keeps the
+consumer-authored config authoritative while making valid conflicts deterministic and
+visible.
+
+Rejected: making every cross-package replacement ambiguous. That would prevent a
+consumer from intentionally composing integrations in a declared order. Also
+rejected: letting autolinking override explicit config merely because it is appended
+to discovery later.
+
+## Open questions
+
+- **OQ1 — Should the current CLI/system owner accept the replacement/default/fallback/precedence and failure-isolation contract above?** (`human-api`)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -401,7 +401,7 @@ Every response has a `type` discriminant. The full set is below (generated from 
 | `component.detail.source`         | One component's source file, as {component, source}.                                                                                                                                                                                                                                          |
 | `component.detail.showcase`       | One component's showcase example, as {component, aspectRatio, source}.                                                                                                                                                                                                                        |
 | `component.detail.blocks`         | One component's example blocks, as {component, showcase, examples, related} of BlockEntry.                                                                                                                                                                                                    |
-| `docs.list`                       | All reference-doc topics as DocsListEntry[] ({topic, description}), in discovery order.                                                                                                                                                                                                       |
+| `docs.list`                       | All reference-doc topics as DocsListEntry[] ({topic, description, package, replaces?}), in read order.                                                                                                                                                                                        |
 | `docs.detail`                     | One topic's full ReferenceDoc, with token-ref blocks inlined.                                                                                                                                                                                                                                 |
 | `docs.detail.section`             | A single ReferenceSection of a topic: the first whose title contains the section query.                                                                                                                                                                                                       |
 | `blog.list`                       | The feed URL plus every post parsed from the RSS feed, each with slug, title, description, date, type, authors, link, and plaintext URL.                                                                                                                                                      |
@@ -417,7 +417,7 @@ Every response has a `type` discriminant. The full set is below (generated from 
 | `swizzle.copy`                    | An eject receipt: component name, owning package, output directory, files-copied count, the written file names, whether any file uses StyleX, and an optional maintainer note.                                                                                                                |
 | `gap-report.categories`           | The fixed gap category values and human-readable labels.                                                                                                                                                                                                                                      |
 | `gap-report.file`                 | An aggregate receipt with overall status, the selected package and issues URL, ordered per-handler deliveries, and filedCount/routedOnlyCount totals.                                                                                                                                         |
-| `template.list`                   | Every discovered template (page + block); each entry carries id, name, description, kind, owning package, optional category and componentsUsed, and readiness flags.                                                                                                                          |
+| `template.list`                   | The effective discovered TemplateListEntry[] for pages and blocks. A winning replacement entry includes optional `replaces`, naming the Core id omitted from the default list.                                                                                                                |
 | `template.show`                   | The resolved template's raw source plus its description, kind, and the component names it composes.                                                                                                                                                                                           |
 | `template.skeleton`               | A layout skeleton (structural tags with spatial annotations) plus the template's description and the components it composes.                                                                                                                                                                  |
 | `template.copy`                   | A scaffold receipt: template id, output directory, written file name, and file count.                                                                                                                                                                                                         |
@@ -441,9 +441,9 @@ Every response has a `type` discriminant. The full set is below (generated from 
 | `integration.add`                 | A contribution-writer receipt: kind, name, optional root {path, created}, integration-manifest path, every affected project-relative path, written, and dryRun.                                                                                                                               |
 | `integration.pack-check`          | The packed-package check: package identity, tarball facts, local and packed contribution inventories, and issues.                                                                                                                                                                             |
 | `integration.validate`            | The validation result: the package name and version (both null when no local manifest is found) plus issues, an AstryxIntegrationIssue[] of {code, severity: warning \| error, message}.                                                                                                      |
-| `integration.template-conflicts`  | The integration identity, structural issues, and non-blocking conflicts where an integration template id is also owned by Core; each conflict includes the exact package-qualified command.                                                                                                   |
+| `integration.template-conflicts`  | The integration identity, issues, and conflicts as {severity: info \| warning, relationship: replaces \| accidental, replaces?, command}.                                                                                                                                                     |
 | `integration.component-conflicts` | The integration identity, structural issues, and non-blocking conflicts where an integration component name is also owned by Core; each conflict includes the exact package-qualified command.                                                                                                |
-| `integration.doc-conflicts`       | The integration identity, structural issues, and Core doc overlaps classified as intentional replacements, intentional extensions, or accidental same-name conflicts.                                                                                                                         |
+| `integration.doc-conflicts`       | The integration identity, structural issues, and Core doc overlaps. Each finding includes `severity` (`info` \| `error`) and `relationship` (`replaces` \| `extends` \| `accidental`).                                                                                                        |
 | `layout.expand`                   | The expansion: parsed form, generated TSX code, componentsUsed, states (count of useState hooks scaffolded), todos, blocksReferenced (each {name, mode}), warnings, and written (the output path, or null when nothing was written).                                                          |
 | `layout.check`                    | The validation result: a valid flag, the detected form, errors (each with line/col, message, formatted text, and suggestions), warnings, and the expression re-printed in both canonical surfaces (compact and outline).                                                                      |
 | `layout.grammar`                  | The XLE/XLO grammar cheatsheet: a text field with the full reference plus an aliases map (short name → canonical component) generated from this install's registry.                                                                                                                           |
@@ -604,18 +604,22 @@ version) comes from `package.json`, not the manifest.
 export default {
   components: './components',
   templates: './templates',
+  templateReplacements: {
+    'acme-app-shell': 'shell-side-nav',
+  },
   codemods: './codemods',
   issuesUrl: 'https://github.com/acme/widgets/issues',
 };
 ```
 
-| Field        | Type     | Purpose                                                                           |
-| ------------ | -------- | --------------------------------------------------------------------------------- |
-| `components` | `string` | Directory holding the package's components and their `.doc.*` files.              |
-| `templates`  | `string` | Directory holding the package's page/block templates.                             |
-| `codemods`   | `string` | Directory holding upgrade codemods run by `astryx upgrade`.                       |
-| `docs`       | `string` | Directory of reference docs; each `{topic}.doc.*` becomes a topic the CLI serves. |
-| `issuesUrl`  | `string` | Where "report an issue" links for this package's contributions point.             |
+| Field                  | Type                     | Purpose                                                                           |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------------------- |
+| `components`           | `string`                 | Directory holding the package's components and their `.doc.*` files.              |
+| `templates`            | `string`                 | Directory holding the package's page/block templates.                             |
+| `templateReplacements` | `Record<string, string>` | Maps integration template ids to the Core ids they replace.                       |
+| `codemods`             | `string`                 | Directory holding upgrade codemods run by `astryx upgrade`.                       |
+| `docs`                 | `string`                 | Directory of reference docs; each `{topic}.doc.*` becomes a topic the CLI serves. |
+| `issuesUrl`            | `string`                 | Where "report an issue" links for this package's contributions point.             |
 
 Every field is optional; declare only the roots the package ships. There is no
 factory: write a plain object, and annotate it with the `AstryxIntegration` type
@@ -631,9 +635,10 @@ wrong type fails there; a field this CLI does not know is ignored with a
 warning naming it, so a manifest written against a newer CLI still contributes
 everything this one understands.
 
-Discovery is resilient: a broken or misconfigured integration is skipped with a
-one-line warning on stderr instead of crashing the CLI, and it never corrupts a
-`--json` envelope. To inspect problems, run
+Discovery is resilient. A manifest load failure skips that package with a warning.
+An invalid contribution kind remains reportable without hiding other valid kinds,
+and invalid template or component metadata is omitted without hiding valid siblings.
+Warnings go to stderr and never corrupt a `--json` envelope. To inspect problems, run
 `astryx doctor integration validate <package>` for structure, then use `templates`,
 `components`, or `docs` under the same `astryx doctor integration` group to check
 Core identity overlaps before publishing. Bare `astryx doctor` checks overall

--- a/packages/cli/api/component/_adapter.mjs
+++ b/packages/cli/api/component/_adapter.mjs
@@ -32,16 +32,15 @@ import {
   resolveIntegrationImportPath as resolveIntegrationImport,
 } from '../../foundation/discovery/component-discovery.mjs';
 import {Project} from '../../foundation/config/project.mjs';
-import {loadDocs} from '../../foundation/discovery/component-loader.mjs';
+import {loadComponentDoc as loadValidatedComponentDoc} from '../../foundation/discovery/component-loader.mjs';
 import {searchComponents} from '../../foundation/text/string-utils.mjs';
 import {AstryxError} from '../error.mjs';
 
 export {CORE_PACKAGE};
 
 /**
- * A loaded component doc. `loadDocs` returns the authored `.doc.mjs` shape,
- * which is either a single-component or multi-component doc; this loose view
- * captures the fields the API reads across both forms.
+ * A loaded component doc. The shared validated loader accepts stamped and legacy
+ * component docs; this loose view captures the fields the API reads across both.
  * @typedef {object} LoadedComponentDoc
  * @property {string} [name]
  * @property {string} [description]
@@ -53,9 +52,7 @@ export {CORE_PACKAGE};
  */
 
 /**
- * Options object for `loadDocs`, matching its declared parameter shape (used
- * as a cast target so `lang` (which the API may hold as `string|null`) type
- * checks against `loadDocs`'s `lang?: string`).
+ * Options object for the shared component-doc loader.
  * @typedef {{zh?: boolean, dense?: boolean, lang?: string}} LoadDocsOpts
  */
 
@@ -345,9 +342,22 @@ export async function resolveUnscopedDoc(dirName, {coreDir, cwd, name}) {
  */
 export async function loadComponentDoc(docPath, opts = {}) {
   const {zh = false, dense = false, lang = null} = opts;
-  return /** @type {LoadedComponentDoc} */ (
-    await loadDocs(docPath, /** @type {LoadDocsOpts} */ ({zh, dense, lang}))
-  );
+  try {
+    return /** @type {LoadedComponentDoc} */ (
+      await loadValidatedComponentDoc(
+        docPath,
+        /** @type {LoadDocsOpts} */ ({zh, dense, lang}),
+      )
+    );
+  } catch (err) {
+    throw new AstryxError(
+      `Cannot load component metadata: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      undefined,
+      ERROR_CODES.ERR_INVALID_DOC,
+    );
+  }
 }
 
 /**

--- a/packages/cli/api/component/component.mjs
+++ b/packages/cli/api/component/component.mjs
@@ -121,14 +121,20 @@ export async function component(name, options = {}) {
   // Searches that package first — critical for names that exist in both core
   // and an external package (AppShell, Button, SideNav).
   if (packageScope) {
-    const scoped = classifyScope(packageScope, {owners, loadedIntegrations, cwd, name});
+    const scoped = classifyScope(packageScope, {
+      owners,
+      loadedIntegrations,
+      cwd,
+      name,
+    });
 
     if (scoped.kind === 'core' || scoped.kind === 'integration') {
       const owner = scoped.owner;
       if (source) {
         return componentDetailSource(dirName, owner.sourcePath, {
           name,
-          notFoundInPackage: scoped.kind === 'integration' ? packageScope : null,
+          notFoundInPackage:
+            scoped.kind === 'integration' ? packageScope : null,
         });
       }
       // showcase/blocks were previously dropped on the scoped path — a
@@ -158,17 +164,48 @@ export async function component(name, options = {}) {
     if (extDocPath) {
       const docs = await loadComponentDoc(extDocPath, docOpts);
       if (props) return componentDetailProps(docs);
-      return componentDetail(docs, {package: scoped.ext.name, sourcePath: null}, dirName, coreDir);
+      return componentDetail(
+        docs,
+        {package: scoped.ext.name, sourcePath: null},
+        dirName,
+        coreDir,
+      );
     }
-    throw new AstryxError(`No component "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_UNKNOWN_COMPONENT);
+    throw new AstryxError(
+      `No component "${name}" in package "${packageScope}"`,
+      undefined,
+      ERROR_CODES.ERR_UNKNOWN_COMPONENT,
+    );
   }
 
-  // ── Ambiguity: owned by MORE THAN ONE package, no --package ─────
-  assertUnambiguousOwners(owners, dirName);
+  // Invalid integration metadata does not create ambiguity against a valid
+  // owner. Keep raw owners only when no doc owner is valid, so an integration-
+  // only component still exposes its source and returns ERR_INVALID_DOC for
+  // detail instead of degrading to an unrelated unknown-component error.
+  const validOwners = [];
+  for (const owner of owners) {
+    if (owner.package === CORE_PACKAGE) {
+      validOwners.push(owner);
+      continue;
+    }
+    try {
+      await loadComponentDoc(owner.docPath);
+      validOwners.push(owner);
+    } catch {
+      // Project/Doctor report invalid metadata; it is not an effective owner.
+    }
+  }
+  const effectiveOwners = validOwners.length > 0 ? validOwners : owners;
+
+  // ── Ambiguity: owned by MORE THAN ONE valid package, no --package ──
+  assertUnambiguousOwners(effectiveOwners, dirName);
 
   // ── Single non-core owner (an integration provides it, core does not) ──
-  if (owners.length === 1 && owners[0].package !== CORE_PACKAGE) {
-    const owner = owners[0];
+  if (
+    effectiveOwners.length === 1 &&
+    effectiveOwners[0].package !== CORE_PACKAGE
+  ) {
+    const owner = effectiveOwners[0];
     if (source) {
       return componentDetailSource(dirName, owner.sourcePath, {name});
     }
@@ -184,7 +221,11 @@ export async function component(name, options = {}) {
   // ── No-scope core path ─────────────────────────────────────────
   // `--source` reads core directly (no external/fuzzy fallback).
   if (source) {
-    return componentDetailSource(dirName, resolveCoreSourcePath(coreDir, dirName), {name});
+    return componentDetailSource(
+      dirName,
+      resolveCoreSourcePath(coreDir, dirName),
+      {name},
+    );
   }
   if (showcase) {
     return componentDetailShowcase(dirName, {cwd, name});
@@ -203,10 +244,14 @@ export async function component(name, options = {}) {
   // scope the response to just the matching sub-component.
   const sub = scopeSubComponent(docs, dirName, coreDir);
   if (sub) {
-    if (props) return componentDetailProps({props: sub.matchingComponent.props});
+    if (props)
+      return componentDetailProps({props: sub.matchingComponent.props});
     return componentDetail(
       sub.scoped,
-      {package: resolved.resolvedOwnerPackage, sourcePath: resolved.resolvedSourcePath},
+      {
+        package: resolved.resolvedOwnerPackage,
+        sourcePath: resolved.resolvedSourcePath,
+      },
       dirName,
       coreDir,
     );
@@ -215,7 +260,10 @@ export async function component(name, options = {}) {
   if (props) return componentDetailProps(docs);
   return componentDetail(
     docs,
-    {package: resolved.resolvedOwnerPackage, sourcePath: resolved.resolvedSourcePath},
+    {
+      package: resolved.resolvedOwnerPackage,
+      sourcePath: resolved.resolvedSourcePath,
+    },
     resolved.resolvedName,
     coreDir,
   );

--- a/packages/cli/api/component/list/list.mjs
+++ b/packages/cli/api/component/list/list.mjs
@@ -15,7 +15,7 @@ import {
   CORE_PACKAGE,
   discoverComponents,
   discoverExternalComponentsGrouped,
-  discoverIntegrationComponents,
+  discoverValidIntegrationComponents,
   findComponentReadme,
   resolveImportPath,
 } from '../../../foundation/discovery/component-discovery.mjs';
@@ -162,7 +162,8 @@ export async function componentList(coreDir, {cwd, category, detail, zh, dense, 
   const seenIntegration = new Set();
   for (const integration of loadedIntegrations) {
     seenIntegration.add(integration.name);
-    const owned = discoverIntegrationComponents(integration);
+    const {components: owned} =
+      await discoverValidIntegrationComponents(integration);
     // Group integration components by their doc `group`, falling back to the
     // package name. Keys are package-qualified so they never collide with
     // core groups or each other.

--- a/packages/cli/api/doctor/doctor.mjs
+++ b/packages/cli/api/doctor/doctor.mjs
@@ -55,6 +55,8 @@ const _require = createRequire(import.meta.url);
  * @property {import('../../foundation/integrations/integrations.mjs').LoadedIntegration[]|null} [integrations]
  *   Every integration the project loaded, or null when the project could not be
  *   read at all.
+ * @property {Array<{package: string, code: string, severity: 'warning'|'error', message: string}>|null} [integrationIssues]
+ *   Combined project-level integration issues, including cross-package template replacement warnings.
  * @property {Error|null} [configError] - Error thrown while resolving the config
  *   path (e.g. multiple config files present), surfaced by checkConfig as a FAIL.
  */
@@ -582,7 +584,43 @@ export function checkPeerDeps(ctx) {
 }
 
 /**
- * Check 9 — report the detected package manager, and say so when the project's
+ * Summarize the combined integration graph, including cross-package warnings.
+ * @param {DoctorContext} ctx
+ * @returns {DoctorCheck}
+ */
+export function checkIntegrationIssues(ctx) {
+  const issues = ctx.integrationIssues;
+  if (issues == null) {
+    return {
+      id: 'integration-issues',
+      label: 'Integration contributions',
+      status: 'info',
+      message: 'Skipped — the project integration graph could not be loaded.',
+    };
+  }
+  if (issues.length === 0) {
+    return {
+      id: 'integration-issues',
+      label: 'Integration contributions',
+      status: 'pass',
+      message: 'Integration contributions and cross-package relationships are valid.',
+    };
+  }
+  const errors = issues.filter(issue => issue.severity === 'error').length;
+  const details = issues
+    .map(issue => `${issue.package}: ${issue.message}`)
+    .join(' | ');
+  return {
+    id: 'integration-issues',
+    label: 'Integration contributions',
+    status: errors > 0 ? 'fail' : 'warn',
+    message: `${issues.length} integration issue(s): ${details}`,
+    fix: 'Run `astryx doctor integration` for package-specific diagnostics and resolve cross-package precedence in astryx.config.',
+  };
+}
+
+/**
+ * Check 10 — report the detected package manager, and say so when the project's
  * own declaration disagrees with what is on disk.
  *
  * Two states are worth surfacing rather than guessing past, because in both the
@@ -649,6 +687,7 @@ export const SYNC_CHECKS = [
   checkVersionAlignment,
   checkThemes,
   checkImplicitIntegrations,
+  checkIntegrationIssues,
   checkAgentDocs,
   checkPeerDeps,
   checkPackageManager,
@@ -680,11 +719,14 @@ export async function runChecks(options = {}) {
   let configTheme = null;
   /** @type {import('../../foundation/integrations/integrations.mjs').LoadedIntegration[]|null} */
   let integrations = null;
+  /** @type {Array<{package: string, code: string, severity: 'warning'|'error', message: string}>|null} */
+  let integrationIssues = null;
   try {
     const project = await Project.load(cwd);
     configTheme =
       /** @type {{theme?: string}} */ (project.config ?? {}).theme ?? null;
     integrations = project.loadedIntegrations;
+    integrationIssues = await project.issues();
   } catch {
     // Best-effort: a missing/invalid config leaves configTheme null.
   }
@@ -697,6 +739,7 @@ export async function runChecks(options = {}) {
     configPath,
     configTheme,
     integrations,
+    integrationIssues,
     configError,
   };
 

--- a/packages/cli/api/doctor/doctor.test.mjs
+++ b/packages/cli/api/doctor/doctor.test.mjs
@@ -14,6 +14,7 @@ import {fileURLToPath} from 'node:url';
 import {
   doctor,
   checkImplicitIntegrations,
+  checkIntegrationIssues,
   checkVersionAlignment,
   checkPackageManager,
 } from './doctor.mjs';
@@ -70,6 +71,27 @@ describe('doctor leaf', () => {
     expect(ids).toContain('node-version');
     expect(ids).toContain('core-installed');
   }, SLOW);
+});
+
+describe('integration issue check', () => {
+  it('surfaces cross-package replacement warnings', () => {
+    const check = checkIntegrationIssues({
+      integrationIssues: [
+        {
+          package: '@acme/later',
+          code: 'ambiguous_template_replacement',
+          severity: 'warning',
+          message: 'Later configured replacement wins.',
+        },
+      ],
+    });
+
+    expect(check).toMatchObject({
+      id: 'integration-issues',
+      status: 'warn',
+      message: expect.stringContaining('Later configured replacement wins.'),
+    });
+  });
 });
 
 describe('doctor leaf — degradation & error paths', () => {

--- a/packages/cli/api/integration/authoring-checks.mjs
+++ b/packages/cli/api/integration/authoring-checks.mjs
@@ -3,10 +3,9 @@
 /**
  * @file Integration authoring diagnostics against the built-in Core catalog.
  *
- * Components and templates may intentionally share a Core identity, but
- * unqualified lookup then fails closed and callers must select the package.
- * Docs have explicit `replaces` / `extends` relationships, so the check can
- * distinguish intentional ownership from an accidental same-name shadow.
+ * Templates may intentionally replace Core identities; undeclared same-id
+ * overlaps stay fail-closed and require package selection. Docs have explicit
+ * `replaces` / `extends` relationships with parallel validation semantics.
  */
 
 import {getCliInvocation} from '../../foundation/env/package-manager.mjs';
@@ -20,6 +19,7 @@ import {
   discoverIntegrationDocs,
 } from '../../foundation/discovery/docs-discovery.mjs';
 import {
+  applyTemplateReplacements,
   discoverCoreTemplates,
   discoverIntegrationTemplatesForOne,
 } from '../../foundation/discovery/template-adapter.mjs';
@@ -48,16 +48,27 @@ async function resolveIntegration(pkg, cwd) {
 /**
  * Add discovery errors once to an issue list.
  * @param {Array<{code: string, severity: 'warning' | 'error', message: string}>} issues
- * @param {Array<{message: string} | Error>} errors
+ * @param {Array<{message: string, code?: string, severity?: 'warning' | 'error'} | Error>} errors
  * @param {string} code
  */
 function addErrors(issues, errors, code) {
   for (const error of errors) {
     const message = error.message;
-    if (issues.some(issue => issue.code === code && issue.message === message)) {
+    const issueCode =
+      'code' in error && typeof error.code === 'string' ? error.code : code;
+    const severity =
+      'severity' in error &&
+      (error.severity === 'warning' || error.severity === 'error')
+        ? error.severity
+        : 'error';
+    if (
+      issues.some(
+        issue => issue.code === issueCode && issue.message === message,
+      )
+    ) {
       continue;
     }
-    issues.push({code, severity: 'error', message});
+    issues.push({code: issueCode, severity, message});
   }
 }
 
@@ -74,7 +85,7 @@ export async function integrationTemplateConflicts(pkg, options = {}) {
   const version = resolved.found ? (resolved.version ?? null) : null;
   const issues = [...resolved.issues];
 
-  if (!resolved.integration?.templates || name == null) {
+  if (!resolved.integration || name == null) {
     return {
       type: 'integration.template-conflicts',
       data: {name, version, conflicts: [], issues},
@@ -86,6 +97,31 @@ export async function integrationTemplateConflicts(pkg, options = {}) {
     discoverCoreTemplates(),
   ]);
   addErrors(issues, errors, 'invalid_template');
+
+  const replacementResolution = applyTemplateReplacements(
+    [...coreTemplates, ...templates],
+    errors.filter(error => error.replacementTarget != null),
+  );
+  for (const error of replacementResolution.errors) {
+    if (
+      !issues.some(
+        issue => issue.code === error.code && issue.message === error.message,
+      )
+    ) {
+      issues.push({
+        code: error.code,
+        severity: error.severity,
+        message: error.message,
+      });
+    }
+  }
+  const activeReplacementIds = new Set(
+    replacementResolution.templates
+      .filter(
+        template => template.package === name && template.replaces != null,
+      )
+      .map(template => template.dirName),
+  );
 
   /** @type {Map<string, Array<{type: 'page' | 'block', name: string}>>} */
   const coreById = new Map();
@@ -101,30 +137,57 @@ export async function integrationTemplateConflicts(pkg, options = {}) {
   }
 
   const run = getCliInvocation(cwd);
-  const conflicts = templates
-    .flatMap(template => {
-      const coreMatches = coreById.get(template.dirName);
-      if (!coreMatches) return [];
-      const command = `${run} template ${shellArg(template.dirName)} --package ${shellArg(name)}`;
-      const coreKinds = coreMatches
+  /** @type {import('./authoring-checks.type.mjs').IntegrationTemplateConflict[]} */
+  const conflicts = [];
+  for (const template of templates) {
+    const sameIdCore = coreById.get(template.dirName);
+    const replacementIsActive = activeReplacementIds.has(template.dirName);
+
+    if (replacementIsActive && template.replaces != null) {
+      conflicts.push({
+        id: template.dirName,
+        severity: 'info',
+        relationship: 'replaces',
+        replaces: template.replaces,
+        integrationPackage: name,
+        integrationType: template.type,
+        integrationName: template.name,
+        coreMatches: coreById.get(template.replaces) ?? [],
+        message:
+          `Intentional replacement: "${template.dirName}" replaces the Core template ` +
+          `"${template.replaces}" for unqualified lookup.`,
+        command: `${run} template ${shellArg(template.replaces)} --package ${shellArg('@astryxdesign/core')}`,
+      });
+    }
+
+    if (
+      sameIdCore &&
+      !(replacementIsActive && template.replaces === template.dirName)
+    ) {
+      const coreKinds = sameIdCore
         .map(match => `${match.type} "${match.name}"`)
         .join(', ');
-      return [
-        {
-          id: template.dirName,
-          severity: /** @type {const} */ ('warning'),
-          integrationPackage: name,
-          integrationType: template.type,
-          integrationName: template.name,
-          coreMatches,
-          message:
-            `Template id "${template.dirName}" conflicts with Core (${coreKinds}). ` +
-            'Consider renaming the integration template. If you keep it, always select it with --package.',
-          command,
-        },
-      ];
-    })
-    .sort((a, b) => a.id.localeCompare(b.id));
+      const compatibleKind = sameIdCore.some(
+        match => match.type === template.type,
+      );
+      conflicts.push({
+        id: template.dirName,
+        severity: 'warning',
+        relationship: 'accidental',
+        integrationPackage: name,
+        integrationType: template.type,
+        integrationName: template.name,
+        coreMatches: sameIdCore,
+        message: compatibleKind
+          ? `Template id "${template.dirName}" conflicts with Core (${coreKinds}). Consider renaming it or declare templateReplacements: {${JSON.stringify(template.dirName)}: ${JSON.stringify(template.dirName)}} to replace it.`
+          : `Template id "${template.dirName}" conflicts with Core (${coreKinds}), but a ${template.type} template cannot replace a different template kind. Rename the integration template.`,
+        command: `${run} template ${shellArg(template.dirName)} --package ${shellArg(name)}`,
+      });
+    }
+  }
+  conflicts.sort((a, b) =>
+    `${a.id}:${a.relationship}`.localeCompare(`${b.id}:${b.relationship}`),
+  );
 
   return {
     type: 'integration.template-conflicts',

--- a/packages/cli/api/integration/authoring-checks.test.mjs
+++ b/packages/cli/api/integration/authoring-checks.test.mjs
@@ -20,7 +20,13 @@ import {
 
 let tmpDir;
 
-function writeIntegration({id, name, type = 'block', root = tmpDir}) {
+function writeIntegration({
+  id,
+  name,
+  type = 'block',
+  root = tmpDir,
+  replacements,
+}) {
   fs.mkdirSync(root, {recursive: true});
   fs.writeFileSync(
     path.join(root, 'package.json'),
@@ -28,7 +34,7 @@ function writeIntegration({id, name, type = 'block', root = tmpDir}) {
   );
   fs.writeFileSync(
     path.join(root, 'astryx.integration.mjs'),
-    `export default {templates: './templates'};\n`,
+    `export default {templates: './templates'${replacements == null ? '' : `, templateReplacements: ${JSON.stringify(replacements)}`}};\n`,
   );
   const stem = path.join(root, 'templates', id);
   fs.mkdirSync(path.dirname(stem), {recursive: true});
@@ -158,6 +164,158 @@ describe('integrationTemplateConflicts', () => {
     );
   });
 
+  it('classifies a valid replacement and points to the Core original', async () => {
+    const core = (await discoverCoreTemplates()).find(
+      template => template.type === 'page',
+    );
+    expect(core).toBeDefined();
+    writeIntegration({
+      id: 'acme-app-shell',
+      name: 'Acme app shell',
+      type: core.type,
+      replacements: {'acme-app-shell': core.dirName},
+    });
+
+    const result = await integrationTemplateConflicts(undefined, {cwd: tmpDir});
+
+    expect(result.data.issues).toEqual([]);
+    expect(result.data.conflicts).toEqual([
+      expect.objectContaining({
+        id: 'acme-app-shell',
+        severity: 'info',
+        relationship: 'replaces',
+        replaces: core.dirName,
+      }),
+    ]);
+    expect(result.data.conflicts[0].command).toContain(
+      `template ${core.dirName} --package @astryxdesign/core`,
+    );
+  });
+
+  it('reports a replacement target that Core does not provide', async () => {
+    writeIntegration({
+      id: 'acme-app-shell',
+      name: 'Acme app shell',
+      type: 'page',
+      replacements: {'acme-app-shell': 'missing-core-shell'},
+    });
+
+    const result = await integrationTemplateConflicts(undefined, {cwd: tmpDir});
+
+    expect(result.data.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'missing_template_replacement_target',
+          severity: 'error',
+        }),
+      ]),
+    );
+  });
+
+  it('reports a replacement declaration for a template the integration does not provide', async () => {
+    const [core] = await discoverCoreTemplates();
+    expect(core).toBeDefined();
+    writeIntegration({
+      id: 'provided-template',
+      name: 'Provided template',
+      type: core.type,
+      replacements: {'missing-template': core.dirName},
+    });
+
+    const result = await integrationTemplateConflicts(undefined, {cwd: tmpDir});
+
+    expect(result.data.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid_template_replacement',
+          severity: 'error',
+          message: expect.stringContaining('contributes no usable template'),
+        }),
+      ]),
+    );
+  });
+
+  it('reports two templates that replace the same Core target as ambiguous', async () => {
+    const [core] = await discoverCoreTemplates();
+    expect(core).toBeDefined();
+    const replacements = {
+      'acme-app-shell-a': core.dirName,
+      'acme-app-shell-b': core.dirName,
+    };
+    writeIntegration({
+      id: 'acme-app-shell-a',
+      name: 'Acme app shell A',
+      type: core.type,
+      replacements,
+    });
+    writeIntegration({
+      id: 'acme-app-shell-b',
+      name: 'Acme app shell B',
+      type: core.type,
+      replacements,
+    });
+
+    const result = await integrationTemplateConflicts(undefined, {cwd: tmpDir});
+
+    expect(result.data.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'ambiguous_template_replacement',
+          severity: 'error',
+        }),
+      ]),
+    );
+  });
+
+  it('reports a replacement whose template kind differs from Core', async () => {
+    const corePage = (await discoverCoreTemplates()).find(
+      template => template.type === 'page',
+    );
+    expect(corePage).toBeDefined();
+    writeIntegration({
+      id: 'acme-app-shell',
+      name: 'Acme app shell',
+      type: 'block',
+      replacements: {'acme-app-shell': corePage.dirName},
+    });
+
+    const result = await integrationTemplateConflicts(undefined, {cwd: tmpDir});
+
+    expect(result.data.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid_template_replacement',
+          severity: 'error',
+          message: expect.stringContaining('same type'),
+        }),
+      ]),
+    );
+  });
+
+  it('does not recommend an impossible replacement for a different Core kind', async () => {
+    const corePage = (await discoverCoreTemplates()).find(
+      template => template.type === 'page',
+    );
+    expect(corePage).toBeDefined();
+    writeIntegration({
+      id: corePage.dirName,
+      name: 'Acme block with a page id',
+      type: 'block',
+    });
+
+    const result = await integrationTemplateConflicts(undefined, {cwd: tmpDir});
+    const conflict = result.data.conflicts.find(
+      item => item.id === corePage.dirName,
+    );
+
+    expect(conflict?.relationship).toBe('accidental');
+    expect(conflict?.message).toContain(
+      'cannot replace a different template kind',
+    );
+    expect(conflict?.message).toContain('Rename');
+    expect(conflict?.message).not.toContain('templateReplacements');
+  });
+
   it('shell-quotes unusual ids instead of allowing command substitution', () => {
     expect(shellArg('safe/id')).toBe('safe/id');
     expect(shellArg('my$thing')).toBe("'my$thing'");
@@ -221,7 +379,9 @@ describe('integrationComponentConflicts', () => {
     expect(core).toBeDefined();
     writeComponentIntegration(core.name);
 
-    const result = await integrationComponentConflicts(undefined, {cwd: tmpDir});
+    const result = await integrationComponentConflicts(undefined, {
+      cwd: tmpDir,
+    });
 
     expect(result.type).toBe('integration.component-conflicts');
     expect(result.data.issues).toEqual([]);
@@ -240,7 +400,9 @@ describe('integrationComponentConflicts', () => {
   it('does not flag an integration-only component name', async () => {
     writeComponentIntegration('AcmeOnlyWidget');
 
-    const result = await integrationComponentConflicts(undefined, {cwd: tmpDir});
+    const result = await integrationComponentConflicts(undefined, {
+      cwd: tmpDir,
+    });
 
     expect(result.data.conflicts).toEqual([]);
     expect(result.data.issues).toEqual([]);

--- a/packages/cli/api/integration/authoring-checks.type.mjs
+++ b/packages/cli/api/integration/authoring-checks.type.mjs
@@ -16,7 +16,9 @@
 /**
  * @typedef {object} IntegrationTemplateConflict
  * @property {string} id
- * @property {'warning'} severity
+ * @property {'info' | 'warning'} severity
+ * @property {'replaces' | 'accidental'} relationship
+ * @property {string} [replaces]
  * @property {string} integrationPackage
  * @property {'page' | 'block'} integrationType
  * @property {string} integrationName

--- a/packages/cli/api/integration/integrationTemplateConflicts.doc.mjs
+++ b/packages/cli/api/integration/integrationTemplateConflicts.doc.mjs
@@ -10,11 +10,12 @@ export const doc = {
   kind: 'api',
   name: 'integrationTemplateConflicts',
   displayName: 'integrationTemplateConflicts()',
-  summary: 'Find integration template ids that also exist in Core.',
+  summary: 'Validate integration template replacements and Core id overlaps.',
   description:
-    'Loads one local or installed integration, compares its template ids with the ' +
-    'built-in Core page and block templates, and returns non-blocking conflicts with ' +
-    'the exact package-qualified CLI command required to keep an intentional overlap.',
+    'Loads one local or installed integration, validates its template replacement ' +
+    'declarations against the built-in Core page and block templates, and reports ' +
+    'intentional replacements, missing targets, ambiguous declarations, type ' +
+    'mismatches, and undeclared same-id conflicts.',
   importPath: '@astryxdesign/cli/api',
   signature:
     'integrationTemplateConflicts(pkg?: string, options?: IntegrationAuthoringOptions): Promise<IntegrationTemplateConflictResponse>',
@@ -37,7 +38,7 @@ export const doc = {
     {
       type: 'integration.template-conflicts',
       description:
-        'The integration identity, structural issues, and every Core template-id conflict with a package-qualified command.',
+        'The integration identity, structural and replacement-declaration issues, intentional Core replacements, and undeclared same-id conflicts.',
     },
   ],
   examples: [

--- a/packages/cli/api/integration/pack-check.test.mjs
+++ b/packages/cli/api/integration/pack-check.test.mjs
@@ -310,6 +310,41 @@ describe('integrationPackCheck', () => {
     expect(result.data.packable).toBe(true);
   });
 
+  it('detects a lifecycle script that changes packed template replacements', async () => {
+    const script = [
+      "const fs=require('fs')",
+      "const p='astryx.integration.mjs'",
+      "const s=fs.readFileSync(p,'utf8')",
+      "fs.writeFileSync(p,s.replace('shell-side-nav','shell-top-nav'))",
+    ].join(';');
+    writePackage({
+      manifest:
+        "export default {templates: './templates', templateReplacements: {'acme-shell': 'shell-side-nav'}};\n",
+      files: ['astryx.integration.mjs', 'templates'],
+      themes: false,
+      scripts: {prepack: `node -e "${script}"`},
+    });
+    fs.mkdirSync(path.join(tmpDir, 'templates'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'templates', 'acme-shell.template.mjs'),
+      "export default {type: 'page', name: 'Acme shell', description: 'Fixture.'};\n",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'templates', 'acme-shell.tsx'),
+      'export default function AcmeShell() { return null; }\n',
+    );
+
+    const result = await integrationPackCheck({cwd: tmpDir});
+
+    expect(result.data.packable).toBe(false);
+    expect(result.data.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'identity_mismatch',
+        message: expect.stringContaining('acme-shell'),
+      }),
+    );
+  });
+
   it('detects a lifecycle script that changes the packed identity', async () => {
     const script = [
       "const fs=require('fs')",

--- a/packages/cli/api/integration/pack-check.type.mjs
+++ b/packages/cli/api/integration/pack-check.type.mjs
@@ -18,13 +18,27 @@
 /** @typedef {IntegrationPackCheckResponse} PackCheckResponse */
 
 /**
+ * Public contribution inventory returned by pack-check. Kept here rather than
+ * importing the runtime inventory module so the type-only `/json` surface does
+ * not pull implementation dependencies into downstream type checking.
+ * @typedef {object} PackCheckContributionIdentities
+ * @property {{slug: string, exportName: string}[]} themes
+ * @property {string[]} components
+ * @property {{id: string, type: string, name: string}[]} templates
+ * @property {{template: string, target: string}[]} templateReplacements
+ * @property {{version: string, id: string}[]} codemods
+ * @property {string[]} docs
+ * @property {string[]} agentDocsAppend
+ */
+
+/**
  * @typedef {object} PackCheckData
  * @property {string|null} name
  * @property {string|null} version
  * @property {boolean} packable — true when zero error-severity issues
  * @property {PackCheckTarball|null} tarball
  * @property {PackCheckInventory} inventory
- * @property {{local: import('../../foundation/integrations/contribution-inventory.mjs').ContributionIdentities|null, packed: import('../../foundation/integrations/contribution-inventory.mjs').ContributionIdentities|null}} contributions
+ * @property {{local: PackCheckContributionIdentities|null, packed: PackCheckContributionIdentities|null}} contributions
  * @property {import('../../foundation/integrations/issue').AstryxIntegrationIssue[]} issues
  */
 

--- a/packages/cli/api/integration/validate-integration.mjs
+++ b/packages/cli/api/integration/validate-integration.mjs
@@ -350,6 +350,7 @@ async function validateAtPackageDir(
     version: identity.version,
     components: resolveRoot(manifest.components),
     templates: resolveRoot(manifest.templates),
+    templateReplacements: manifest.templateReplacements,
     codemods: resolveRoot(manifest.codemods),
     docs: resolveRoot(manifest.docs),
     themes: resolveRoot(manifest.themes),

--- a/packages/cli/api/integration/validate-integration.test.mjs
+++ b/packages/cli/api/integration/validate-integration.test.mjs
@@ -130,6 +130,22 @@ describe('validate-integration API', () => {
     expect(byCode(result.issues, 'multiple_manifests')).toHaveLength(1);
   });
 
+  it('rejects template replacements without a templates root', async () => {
+    const pkgDir = path.join(tmpDir, 'pkg');
+    writePackage(pkgDir, {
+      manifest: `export default {templateReplacements: {'acme-app-shell': 'shell-side-nav'}};\n`,
+    });
+
+    const result = await validateLocalIntegration(pkgDir);
+
+    expect(byCode(result.issues, 'invalid_template_replacement')).toEqual([
+      expect.objectContaining({
+        severity: 'error',
+        message: expect.stringContaining('no available templates root'),
+      }),
+    ]);
+  });
+
   it('returns found:false (guidance) when no manifest is present', async () => {
     const pkgDir = path.join(tmpDir, 'pkg');
     fs.mkdirSync(pkgDir, {recursive: true});
@@ -154,7 +170,7 @@ describe('validate-integration API', () => {
     fs.mkdirSync(componentsDir);
     fs.writeFileSync(
       path.join(componentsDir, 'Widget.doc.mjs'),
-      `export default {name: 'Widget'};\n`,
+      `export default {name: 'Widget', props: []};\n`,
     );
     fs.writeFileSync(
       path.join(componentsDir, 'Widget.tsx'),
@@ -417,7 +433,7 @@ describe('validate-integration API', () => {
     fs.mkdirSync(cDir, {recursive: true});
     fs.writeFileSync(
       path.join(cDir, 'Widget.doc.mjs'),
-      `export default { name: 'Widget' };\n`,
+      `export default { type: 'component', name: 'Widget', props: [] };\n`,
     );
     fs.writeFileSync(
       path.join(cDir, 'Widget.tsx'),
@@ -439,7 +455,7 @@ describe('validate-integration API', () => {
     // Doc with no sibling Widget.tsx.
     fs.writeFileSync(
       path.join(cDir, 'Widget.doc.mjs'),
-      `export default { name: 'Widget' };\n`,
+      `export default { type: 'component', name: 'Widget', props: [] };\n`,
     );
 
     const result = await validateLocalIntegration(pkgDir);

--- a/packages/cli/api/integration/validate-integration.type.mjs
+++ b/packages/cli/api/integration/validate-integration.type.mjs
@@ -15,6 +15,7 @@
  * @property {string} [version]
  * @property {string} [components]
  * @property {string} [templates]
+ * @property {Record<string, string>} [templateReplacements]
  * @property {string} [codemods]
  * @property {string} [docs]
  * @property {string} [issuesUrl]

--- a/packages/cli/api/json/index.ts
+++ b/packages/cli/api/json/index.ts
@@ -28,6 +28,8 @@ export type * from '../init/init.type.mjs';
 export type * from '../doctor/doctor.type.mjs';
 export type * from '../layout/layout.type.mjs';
 export type * from '../integration/validate-integration.type.mjs';
+export type * from '../integration/authoring-checks.type.mjs';
+export type * from '../integration/pack-check.type.mjs';
 export type * from '../../foundation/response/base';
 export type * from '../../foundation/response/error-codes';
 export type * from '../../clients/cli/lib/manifest';

--- a/packages/cli/api/layout/_adapter.mjs
+++ b/packages/cli/api/layout/_adapter.mjs
@@ -50,7 +50,18 @@ async function loadBlocks(cwd) {
   const blocks = [];
   try {
     const all = await discoverTemplates(cwd);
-    for (const t of all) if (t.type === 'block') blocks.push({...t, kind: 'template'});
+    const templates = all.filter(template => template.type === 'block');
+    /** @type {Map<string, import('../../foundation/discovery/template-adapter.mjs').DiscoveredTemplate>} */
+    const byId = new Map();
+    // Exact ids are the fallback. Active replacement aliases override them in a
+    // second pass, matching template() regardless of discovery/display order.
+    for (const template of templates) byId.set(template.dirName, template);
+    for (const template of templates) {
+      if (template.replaces != null) byId.set(template.replaces, template);
+    }
+    for (const [id, template] of byId) {
+      blocks.push({...template, dirName: id, kind: 'template'});
+    }
   } catch {
     // discovery is best-effort
   }
@@ -91,7 +102,10 @@ export function formatIssue(issue) {
  * @param {string} expression
  * @param {{form?: 'compact'|'outline'|'auto', loose?: boolean, cwd?: string}} [options]
  */
-export async function analyze(expression, {form = 'auto', loose = false, cwd = process.cwd()} = {}) {
+export async function analyze(
+  expression,
+  {form = 'auto', loose = false, cwd = process.cwd()} = {},
+) {
   // Validate inputs in the API (not just the CLI): an empty expression or an
   // unknown --form must error, not silently parse as an empty/compact layout.
   if (typeof expression !== 'string' || expression.trim() === '') {
@@ -108,9 +122,10 @@ export async function analyze(expression, {form = 'auto', loose = false, cwd = p
       ERROR_CODES.ERR_INVALID_OPTION,
     );
   }
-  const registry = /** @type {import('../../foundation/xle/xle-ast').Registry} */ (
-    /** @type {unknown} */ (await buildRegistry({cwd}))
-  );
+  const registry =
+    /** @type {import('../../foundation/xle/xle-ast').Registry} */ (
+      /** @type {unknown} */ (await buildRegistry({cwd}))
+    );
   const blocks = await loadBlocks(cwd);
 
   /** @type {import('../../foundation/xle/xle-ast').XLEDoc} */

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -54,15 +54,19 @@ import {pathToFileURL} from 'node:url';
 import {findCoreDir} from '../../foundation/fs/paths.mjs';
 import {
   discoverComponents,
-  discoverIntegrationComponents,
+  discoverValidIntegrationComponents,
   findComponentReadme,
   resolveImportPath,
   resolveIntegrationImportPath,
 } from '../../foundation/discovery/component-discovery.mjs';
-import {discoverHooks, findHookDoc} from '../../foundation/discovery/hook-discovery.mjs';
+import {
+  discoverHooks,
+  findHookDoc,
+} from '../../foundation/discovery/hook-discovery.mjs';
 import {loadIntegrationsSafely} from '../component/_adapter.mjs';
 import {levenshteinDistance} from '../../foundation/text/string-utils.mjs';
 import {discoverTemplates, extractComponents} from '../template/template.mjs';
+import {templateLookupIds} from '../../foundation/discovery/template-adapter.mjs';
 import {loadDocsCatalog, loadTopicDoc} from '../docs/_adapter.mjs';
 import {AstryxError} from '../error.mjs';
 import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
@@ -83,6 +87,8 @@ import {setResultCoverage} from './coverage.mjs';
  * @property {string} [_title]
  * @property {string} [_displayName]
  * @property {'page'|'block'} [_kind]
+ * @property {string} [_resultName]
+ * @property {string} [_commandName]
  */
 
 /**
@@ -92,7 +98,17 @@ import {setResultCoverage} from './coverage.mjs';
  * and its siblings). Lowercase, single words or short phrases.
  */
 const SYNONYMS = {
-  dashboard: ['overview', 'analytics', 'kpi', 'kpis', 'metrics', 'stats', 'reporting', 'insights', 'control'],
+  dashboard: [
+    'overview',
+    'analytics',
+    'kpi',
+    'kpis',
+    'metrics',
+    'stats',
+    'reporting',
+    'insights',
+    'control',
+  ],
   login: ['signin', 'auth', 'authentication', 'sso', 'credentials', 'account'],
   signup: ['register', 'registration', 'onboarding'],
   payment: ['checkout', 'billing', 'card', 'pay', 'purchase', 'order'],
@@ -153,7 +169,6 @@ export function stem(w) {
   return s;
 }
 
-
 /** Valid domain filters for `--type`. */
 export const SEARCH_DOMAINS = ['component', 'hook', 'doc', 'template'];
 
@@ -162,12 +177,66 @@ export const SEARCH_DOMAINS = ['component', 'hook', 'doc', 'template'];
  * ("a page where you can see business stats") ranks on its content words.
  */
 const STOPWORDS = new Set([
-  'a', 'an', 'the', 'of', 'for', 'to', 'with', 'and', 'or', 'in', 'on', 'at',
-  'by', 'that', 'this', 'my', 'your', 'our', 'their', 'is', 'are', 'be', 'it',
-  'its', 'as', 'from', 'page', 'screen', 'app', 'application', 'view', 'where',
-  'you', 'can', 'some', 'like', 'just', 'basically', 'kinda', 'want', 'wants',
-  'need', 'needs', 'something', 'thing', 'things', 'build', 'make', 'create',
-  'i', 'me', 'we', 'us', 'so', 'up', 'out', 'over', 'side', 'one', 'big',
+  'a',
+  'an',
+  'the',
+  'of',
+  'for',
+  'to',
+  'with',
+  'and',
+  'or',
+  'in',
+  'on',
+  'at',
+  'by',
+  'that',
+  'this',
+  'my',
+  'your',
+  'our',
+  'their',
+  'is',
+  'are',
+  'be',
+  'it',
+  'its',
+  'as',
+  'from',
+  'page',
+  'screen',
+  'app',
+  'application',
+  'view',
+  'where',
+  'you',
+  'can',
+  'some',
+  'like',
+  'just',
+  'basically',
+  'kinda',
+  'want',
+  'wants',
+  'need',
+  'needs',
+  'something',
+  'thing',
+  'things',
+  'build',
+  'make',
+  'create',
+  'i',
+  'me',
+  'we',
+  'us',
+  'so',
+  'up',
+  'out',
+  'over',
+  'side',
+  'one',
+  'big',
 ]);
 
 /**
@@ -178,12 +247,14 @@ const STOPWORDS = new Set([
  * @returns {string[]}
  */
 export function tokenizeQuery(term) {
-  return term
-    .split(/\s+/)
-    // Strip only leading/trailing punctuation; keep joined identifiers intact
-    // (e.g. "foo_bar" stays one token) so gibberish stays gibberish.
-    .map(t => t.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ''))
-    .filter(t => t.length >= 2 && !STOPWORDS.has(t));
+  return (
+    term
+      .split(/\s+/)
+      // Strip only leading/trailing punctuation; keep joined identifiers intact
+      // (e.g. "foo_bar" stays one token) so gibberish stays gibberish.
+      .map(t => t.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ''))
+      .filter(t => t.length >= 2 && !STOPWORDS.has(t))
+  );
 }
 
 /**
@@ -227,7 +298,8 @@ function bestForToken(tok, candidate) {
       const h = scoreCandidate(s, candidate);
       if (h) {
         const score = Math.round(h.score * 0.85);
-        if (!best || score > best.score) best = {score, reason: `${h.reason} (~${tok})`};
+        if (!best || score > best.score)
+          best = {score, reason: `${h.reason} (~${tok})`};
       }
     }
   }
@@ -259,7 +331,8 @@ export function scoreQuery(term, tokens, candidate) {
   // single words), but if stopwords left exactly one DIFFERENT token (e.g.
   // "pricing page" → "pricing"), score that token too and take the stronger.
   if (tokens.length <= 1) {
-    const single = tokens.length === 1 ? bestForToken(tokens[0], candidate) : null;
+    const single =
+      tokens.length === 1 ? bestForToken(tokens[0], candidate) : null;
     if (full && (!single || full.score >= single.score)) return asFull(full);
     return single ? asFull(single) : null;
   }
@@ -313,7 +386,9 @@ export function scoreQuery(term, tokens, candidate) {
   // terms can never score lower, since every term of the expression is
   // non-decreasing in the set of matched tokens.
   const coverage = matched / tokens.length;
-  const tokenScore = Math.round(strongest + Math.min(matched - 1, 3) * 12 + coverage * 15);
+  const tokenScore = Math.round(
+    strongest + Math.min(matched - 1, 3) * 12 + coverage * 15,
+  );
 
   if (full && full.score >= tokenScore) return asFull(full);
   return {
@@ -341,7 +416,14 @@ export function scoreQuery(term, tokens, candidate) {
  */
 export function scoreCandidate(
   term,
-  {name, keywords = [], weakKeywords = [], description = '', prose = [], guidance = []},
+  {
+    name,
+    keywords = [],
+    weakKeywords = [],
+    description = '',
+    prose = [],
+    guidance = [],
+  },
 ) {
   let best = 0;
   let reason = '';
@@ -365,7 +447,11 @@ export function scoreCandidate(
     // Substring (both directions), min 4 chars, >=50% coverage.
     const shorter = term.length < nameLower.length ? term : nameLower;
     const longer = term.length < nameLower.length ? nameLower : term;
-    if (shorter.length >= 4 && longer.includes(shorter) && shorter.length / longer.length >= 0.5) {
+    if (
+      shorter.length >= 4 &&
+      longer.includes(shorter) &&
+      shorter.length / longer.length >= 0.5
+    ) {
       consider(60, `name contains "${shorter}"`);
     }
     const dist = levenshteinDistance(term, nameLower);
@@ -480,12 +566,20 @@ async function loadModuleDoc(docPath, exportName = 'docs') {
 function guidanceFrom(doc) {
   if (!doc) return [];
   const features = Array.isArray(doc.features) ? doc.features : [];
-  const practices = Array.isArray(doc.usage?.bestPractices) ? doc.usage.bestPractices : [];
+  const practices = Array.isArray(doc.usage?.bestPractices)
+    ? doc.usage.bestPractices
+    : [];
   return [...features, ...practices]
     .map(entry =>
       typeof entry === 'string'
         ? entry
-        : [entry?.title, entry?.text, entry?.description, entry?.do, entry?.dont]
+        : [
+            entry?.title,
+            entry?.text,
+            entry?.description,
+            entry?.do,
+            entry?.dont,
+          ]
             .filter(Boolean)
             .join(' '),
     )
@@ -545,7 +639,8 @@ async function gatherIntegrationComponents(cwd) {
   /** @type {Candidate[]} */
   const candidates = [];
   for (const integration of loadedIntegrations) {
-    for (const rec of discoverIntegrationComponents(integration)) {
+    const {components} = await discoverValidIntegrationComponents(integration);
+    for (const rec of components) {
       const doc = await loadModuleDoc(rec.docPath);
       candidates.push({
         domain: 'component',
@@ -692,6 +787,13 @@ async function gatherTemplates(cwd) {
     return [];
   }
   return templates.map(t => {
+    // A replacement's target is its canonical unqualified lookup id. Keep the
+    // integration-owned id as a keyword and response label, but score and print
+    // commands against the id that `template()` resolves back to this entry.
+    // This matters for replacement chains: one replacement's own id can be the
+    // target of another, so using that shadowed id as the command would select
+    // the other template.
+    const commandName = t.replaces ?? t.dirName;
     // Blocks ship an authored componentsUsed; page templates don't, so derive
     // them from the source. Category words (e.g. "Dashboard - Analytics") are
     // strong intent signal for pages, which otherwise only index on name +
@@ -701,7 +803,10 @@ async function gatherTemplates(cwd) {
     // category words are a deliberate statement of what the template is for,
     // while scraped JSX tags only say what it happens to render. See the
     // scoring table at the top of this file for why the derived set is capped.
-    const keywords = Array.isArray(t.componentsUsed) ? [...t.componentsUsed] : [];
+    const keywords = Array.isArray(t.componentsUsed)
+      ? [...t.componentsUsed]
+      : [];
+    keywords.push(...templateLookupIds(t).filter(id => id !== commandName));
     /** @type {string[]} */
     let weakKeywords = [];
     if (t.type === 'page') {
@@ -712,16 +817,19 @@ async function gatherTemplates(cwd) {
           // Best-effort: skip keyword enrichment if the source can't be read.
         }
       }
-      if (t.category) keywords.push(...t.category.split(/[^A-Za-z0-9]+/).filter(Boolean));
+      if (t.category)
+        keywords.push(...t.category.split(/[^A-Za-z0-9]+/).filter(Boolean));
     }
     return {
       domain: 'template',
-      name: t.dirName,
+      name: commandName,
       keywords,
       weakKeywords,
       description: t.description || '',
       _displayName: t.name,
       _kind: t.type, // 'page' | 'block'
+      _resultName: t.dirName,
+      _commandName: commandName,
     };
   });
 }
@@ -740,7 +848,7 @@ async function gatherTemplates(cwd) {
 function toResult(c, score, reason, matchedTerms, queryTerms) {
   const base = {
     domain: c.domain,
-    name: c.name,
+    name: c._resultName ?? c.name,
     score,
     reason,
     description: c.description || '',
@@ -773,7 +881,7 @@ function toResult(c, score, reason, matchedTerms, queryTerms) {
         ...base,
         displayName: c._displayName,
         kind: c._kind,
-        command: `astryx template ${c.name}`,
+        command: `astryx template ${c._commandName ?? c.name} --type ${c._kind}`,
       };
       break;
     default:
@@ -814,10 +922,7 @@ export async function search(query, options = {}) {
   // Validate limit here (not just in the CLI) so direct API callers get the same
   // contract: a non-positive or non-integer limit is an error, never a silent
   // "return everything". (Previously `limit <= 0` fell through to the full set.)
-  if (
-    limit != null &&
-    (!Number.isInteger(limit) || limit <= 0)
-  ) {
+  if (limit != null && (!Number.isInteger(limit) || limit <= 0)) {
     throw new AstryxError(
       `Invalid limit "${limit}". Must be a positive integer.`,
       undefined,
@@ -852,7 +957,10 @@ export async function search(query, options = {}) {
   const scored = [];
   for (const candidate of all) {
     const hit = scoreQuery(term, tokens, candidate);
-    if (hit) scored.push(toResult(candidate, hit.score, hit.reason, hit.matched, hit.total));
+    if (hit)
+      scored.push(
+        toResult(candidate, hit.score, hit.reason, hit.matched, hit.total),
+      );
   }
 
   // Sort by score desc, then domain (stable order), then name.

--- a/packages/cli/api/search/search.test.mjs
+++ b/packages/cli/api/search/search.test.mjs
@@ -213,11 +213,17 @@ describe('search leaf — integration components', () => {
     );
     fs.writeFileSync(
       path.join(widgetsDir, 'components', 'FancyGizmo.doc.mjs'),
-      `export const docs = {
+      `export default {
+        type: 'component',
         name: 'FancyGizmo',
         keywords: ['gizmo', 'widget'],
         usage: {description: 'A fancy gizmo widget.'},
+        props: [],
       };\n`,
+    );
+    fs.writeFileSync(
+      path.join(widgetsDir, 'components', 'FancyGizmo.tsx'),
+      `export function FancyGizmo() { return null; }\n`,
     );
 
     return dir;

--- a/packages/cli/api/template/list/list.mjs
+++ b/packages/cli/api/template/list/list.mjs
@@ -32,6 +32,7 @@ export function templateList(templates, options = {}) {
       description: t.description,
       type: t.type,
       package: pkgOf(t),
+      replaces: t.replaces,
       category: t.category || undefined,
       componentsUsed: t.componentsUsed ?? undefined,
       aspectRatio: t.aspectRatio,

--- a/packages/cli/api/template/template-integration.test.mjs
+++ b/packages/cli/api/template/template-integration.test.mjs
@@ -12,7 +12,15 @@
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {template} from './template.mjs';
+import {
+  discoverAllWithErrors,
+  discoverCoreTemplates,
+  template,
+} from './template.mjs';
+import {search} from '../search/search.mjs';
+import {build} from '../build/build.mjs';
+import {layoutExpand} from '../layout/layout.mjs';
+import {runCli} from '../../test-utils/run-cli.mjs';
 
 let tmpDir;
 let originalCwd;
@@ -50,7 +58,7 @@ function installWidgets(consumerDir) {
 }
 
 /** Write a template doc + same-stem source under the templates root. */
-function writeTemplate(pkgDir, id, {kind, body, withSource = true}) {
+function writeTemplate(pkgDir, id, {kind, body, source, withSource = true}) {
   const docPath = path.join(pkgDir, 'templates', `${id}.doc.mjs`);
   fs.mkdirSync(path.dirname(docPath), {recursive: true});
   fs.writeFileSync(
@@ -61,9 +69,17 @@ function writeTemplate(pkgDir, id, {kind, body, withSource = true}) {
   if (withSource) {
     fs.writeFileSync(
       path.join(pkgDir, 'templates', `${id}.tsx`),
-      `export default function ${id.replace(/[^a-zA-Z0-9]/g, '')}() { return null; }\n`,
+      source ??
+        `export default function ${id.replace(/[^a-zA-Z0-9]/g, '')}() { return null; }\n`,
     );
   }
+}
+
+function declareTemplateReplacements(pkgDir, replacements) {
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default {templates: './templates', templateReplacements: ${JSON.stringify(replacements)}};\n`,
+  );
 }
 
 beforeEach(() => {
@@ -178,6 +194,27 @@ describe('integration template discovery', () => {
     expect(result.data.find(t => t.id === 'untyped')).toBeUndefined();
   });
 
+  it('does not read Object prototype keys as replacement declarations', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    for (const id of ['constructor', 'toString', '__proto__']) {
+      writeTemplate(pkgDir, id, {kind: 'page'});
+    }
+    declareTemplateReplacements(pkgDir, {});
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(
+      discovered.errors.filter(error => error.replacementTarget != null),
+    ).toEqual([]);
+    for (const id of ['constructor', 'toString', '__proto__']) {
+      const entry = discovered.templates.find(
+        template =>
+          template.dirName === id && template.package === '@acme/widgets',
+      );
+      expect(entry).toBeDefined();
+      expect(entry?.replaces).toBeUndefined();
+    }
+  });
+
   it('errors with candidates when an id is ambiguous across type/package', async () => {
     const pkgDir = installWidgets(tmpDir);
     // Same id "hero" as both a page and a block within the integration.
@@ -237,6 +274,887 @@ describe('integration template discovery', () => {
     expect(result.type).toBe('template.copy');
     expect(result.data.fileName).toBe('page.tsx');
     expect(fs.existsSync(path.join(tmpDir, 'dest', 'page.tsx'))).toBe(true);
+  });
+
+  it('uses a declared integration replacement by default and keeps the Core original addressable', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell', {
+      kind: 'page',
+      source:
+        'export default function AcmeAppShell() { return <nav>AcmeSideNav + AcmeTopNav</nav>; }\n',
+    });
+    declareTemplateReplacements(pkgDir, {
+      'acme-app-shell': 'shell-side-nav',
+    });
+
+    const listed = await template(undefined, {list: true, cwd: tmpDir});
+    expect(
+      listed.data.find(entry => entry.id === 'acme-app-shell'),
+    ).toMatchObject({
+      package: '@acme/widgets',
+      replaces: 'shell-side-nav',
+    });
+    expect(
+      listed.data.find(
+        entry =>
+          entry.id === 'shell-side-nav' &&
+          entry.package === '@astryxdesign/core',
+      ),
+    ).toBeUndefined();
+
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('acme-app-shell');
+    expect(selected.data.source).toContain('AcmeSideNav + AcmeTopNav');
+
+    const searched = await search('shell-side-nav', {
+      type: 'template',
+      cwd: tmpDir,
+    });
+    expect(searched.data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: 'acme-app-shell'}),
+      ]),
+    );
+
+    const original = await template('shell-side-nav', {
+      package: '@astryxdesign/core',
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(original.data.template).toBe('shell-side-nav');
+    expect(original.data.source).toContain('@astryxdesign/core/SideNav');
+    expect(original.data.source).not.toContain('AcmeSideNav + AcmeTopNav');
+  });
+
+  it('uses canonical replacement resolution for copy collisions', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell', {kind: 'page'});
+    declareTemplateReplacements(pkgDir, {
+      'acme-app-shell': 'shell-side-nav',
+    });
+    const target = path.join(tmpDir, 'existing');
+    fs.mkdirSync(target);
+    fs.writeFileSync(path.join(target, 'page.tsx'), '// keep me\n');
+
+    const result = await runCli(
+      ['template', 'shell-side-nav', 'existing'],
+      tmpDir,
+    );
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain(
+      'Refusing to overwrite existing file',
+    );
+    expect(fs.readFileSync(path.join(target, 'page.tsx'), 'utf-8')).toBe(
+      '// keep me\n',
+    );
+  });
+
+  it('keeps package-scoped lookup exact when one package also owns the Core id', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell', {
+      kind: 'page',
+      source:
+        "export default function AcmeAppShell() { return 'active replacement'; }\n",
+    });
+    writeTemplate(pkgDir, 'shell-side-nav', {
+      kind: 'page',
+      source:
+        "export default function PackageShellSideNav() { return 'package exact id'; }\n",
+    });
+    declareTemplateReplacements(pkgDir, {
+      'acme-app-shell': 'shell-side-nav',
+    });
+
+    const unqualified = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(unqualified.data.template).toBe('acme-app-shell');
+    expect(unqualified.data.source).toContain('active replacement');
+
+    const packageExact = await template('shell-side-nav', {
+      package: '@acme/widgets',
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(packageExact.data.template).toBe('shell-side-nav');
+    expect(packageExact.data.source).toContain('package exact id');
+
+    const packageOwnId = await template('acme-app-shell', {
+      package: '@acme/widgets',
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(packageOwnId.data.template).toBe('acme-app-shell');
+    expect(packageOwnId.data.source).toContain('active replacement');
+  });
+
+  it('preserves an active replacement whose own id is another active target', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'shell-top-nav', {
+      kind: 'page',
+      source:
+        "export default function FirstReplacement() { return 'first replacement'; }\n",
+    });
+    writeTemplate(pkgDir, 'acme-second-shell', {
+      kind: 'page',
+      source:
+        "export default function SecondReplacement() { return 'second replacement'; }\n",
+    });
+    declareTemplateReplacements(pkgDir, {
+      'shell-top-nav': 'shell-side-nav',
+      'acme-second-shell': 'shell-top-nav',
+    });
+
+    const first = await template('shell-side-nav', {show: true, cwd: tmpDir});
+    expect(first.data.template).toBe('shell-top-nav');
+    expect(first.data.source).toContain('first replacement');
+
+    const second = await template('shell-top-nav', {show: true, cwd: tmpDir});
+    expect(second.data.template).toBe('acme-second-shell');
+    expect(second.data.source).toContain('second replacement');
+
+    const firstSearch = await search('shell-side-nav', {
+      type: 'template',
+      cwd: tmpDir,
+    });
+    expect(firstSearch.data.results[0]).toMatchObject({
+      name: 'shell-top-nav',
+      command: 'astryx template shell-side-nav --type page',
+    });
+
+    const secondSearch = await search('shell-top-nav', {
+      type: 'template',
+      cwd: tmpDir,
+    });
+    expect(secondSearch.data.results[0]).toMatchObject({
+      name: 'acme-second-shell',
+      command: 'astryx template shell-top-nav --type page',
+    });
+
+    const renderedBuild = await runCli(['build', 'shell-side-nav'], tmpDir);
+    expect(renderedBuild.status).toBe(0);
+    expect(renderedBuild.stdout).toContain(
+      'template shell-side-nav --type page <path>',
+    );
+    expect(renderedBuild.stdout).not.toContain('template shell-top-nav <path>');
+
+    const listed = await template(undefined, {list: true, cwd: tmpDir});
+    expect(listed.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'shell-top-nav',
+          replaces: 'shell-side-nav',
+          package: '@acme/widgets',
+        }),
+        expect.objectContaining({
+          id: 'acme-second-shell',
+          replaces: 'shell-top-nav',
+          package: '@acme/widgets',
+        }),
+      ]),
+    );
+  });
+
+  it('keeps an active replacement ahead of an undeclared exact-id template in search', async () => {
+    const active = installWidgets(tmpDir);
+    writeTemplate(active, 'active-shell', {
+      kind: 'page',
+      body: `export default {type: 'page', name: 'ZZZ active shell', description: 'replacement'};\n`,
+    });
+    declareTemplateReplacements(active, {'active-shell': 'shell-side-nav'});
+
+    const accidental = path.join(tmpDir, 'node_modules', '@acme', 'extra');
+    fs.mkdirSync(path.join(accidental, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(accidental, 'package.json'),
+      JSON.stringify({name: '@acme/extra', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(accidental, 'astryx.integration.mjs'),
+      `export default {templates: './templates'};\n`,
+    );
+    writeTemplate(accidental, 'shell-side-nav', {
+      kind: 'page',
+      body: `export default {type: 'page', name: 'AAA accidental shell', description: 'collision'};\n`,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `export default { integrations: ['@acme/widgets', '@acme/extra'] };\n`,
+    );
+
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('active-shell');
+    const searched = await search('shell-side-nav', {
+      type: 'template',
+      cwd: tmpDir,
+    });
+    expect(searched.data.results[0]).toMatchObject({
+      name: 'active-shell',
+      command: 'astryx template shell-side-nav --type page',
+    });
+  });
+
+  it('resolves a replacement block through the layout alias', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-card-callout', {
+      kind: 'block',
+      source:
+        'export default function AcmeCardCallout() { return <span>Acme replacement block</span>; }\n',
+    });
+    declareTemplateReplacements(pkgDir, {
+      'acme-card-callout': 'CardCallout',
+    });
+
+    const accidental = path.join(tmpDir, 'node_modules', '@acme', 'extra');
+    fs.mkdirSync(path.join(accidental, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(accidental, 'package.json'),
+      JSON.stringify({name: '@acme/extra', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(accidental, 'astryx.integration.mjs'),
+      `export default {templates: './templates'};\n`,
+    );
+    writeTemplate(accidental, 'CardCallout', {
+      kind: 'block',
+      body: `export default {type: 'block', name: 'ZZZ accidental block', description: 'collision'};\n`,
+      source:
+        'export default function Accidental() { return <span>Accidental block</span>; }\n',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `export default { integrations: ['@acme/widgets', '@acme/extra'] };\n`,
+    );
+
+    const result = await layoutExpand('C{card-callout}', {
+      name: 'ReplacementLayout',
+      cwd: tmpDir,
+    });
+
+    expect(result.data.code).toContain('Acme replacement block');
+    expect(result.data.code).not.toContain('Accidental block');
+    expect(result.data.blocksReferenced).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({name: 'CardCallout', mode: 'splice'}),
+      ]),
+    );
+  }, 30_000);
+
+  it('resolves chained block aliases consistently in template and layout', async () => {
+    const [firstTarget, secondTarget] = (await discoverCoreTemplates()).filter(
+      candidate => candidate.type === 'block',
+    );
+    expect(firstTarget).toBeDefined();
+    expect(secondTarget).toBeDefined();
+
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, secondTarget.dirName, {
+      kind: 'block',
+      source:
+        'export default function FirstReplacement() { return <span>First chain replacement</span>; }\n',
+    });
+    writeTemplate(pkgDir, 'acme-final-block', {
+      kind: 'block',
+      source:
+        'export default function FinalReplacement() { return <span>Final chain replacement</span>; }\n',
+    });
+    declareTemplateReplacements(pkgDir, {
+      [secondTarget.dirName]: firstTarget.dirName,
+      'acme-final-block': secondTarget.dirName,
+    });
+
+    const firstTemplate = await template(firstTarget.dirName, {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(firstTemplate.data.source).toContain('First chain replacement');
+    const layoutId = id =>
+      id.replace(/([a-z0-9])([A-Z])/gu, '$1-$2').toLowerCase();
+    const firstLayout = await layoutExpand(
+      `C{${layoutId(firstTarget.dirName)}}`,
+      {
+        cwd: tmpDir,
+      },
+    );
+    expect(firstLayout.data.code).toContain('First chain replacement');
+    expect(firstLayout.data.code).not.toContain('Final chain replacement');
+
+    const secondTemplate = await template(secondTarget.dirName, {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(secondTemplate.data.source).toContain('Final chain replacement');
+    const secondLayout = await layoutExpand(
+      `C{${layoutId(secondTarget.dirName)}}`,
+      {
+        cwd: tmpDir,
+      },
+    );
+    expect(secondLayout.data.code).toContain('Final chain replacement');
+  }, 30_000);
+
+  it('keeps the old discovery behavior when no replacement is declared', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell', {kind: 'page'});
+
+    const core = await template('shell-side-nav', {show: true, cwd: tmpDir});
+    expect(core.data.template).toBe('shell-side-nav');
+    const integration = await template('acme-app-shell', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(integration.data.template).toBe('acme-app-shell');
+  });
+
+  it('fails an ambiguous replacement closed and reports every declaration', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell-a', {kind: 'page'});
+    writeTemplate(pkgDir, 'acme-app-shell-b', {kind: 'page'});
+    declareTemplateReplacements(pkgDir, {
+      'acme-app-shell-a': 'shell-side-nav',
+      'acme-app-shell-b': 'shell-side-nav',
+    });
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(
+      discovered.errors.filter(
+        error => error.code === 'ambiguous_template_replacement',
+      ),
+    ).toHaveLength(2);
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('shell-side-nav');
+    expect(
+      discovered.templates.filter(template =>
+        template.dirName.startsWith('acme-app-shell-'),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('does not activate a replacement when the same package also declares a missing template', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell', {kind: 'page'});
+    writeTemplate(pkgDir, 'missing-app-shell', {
+      kind: 'page',
+      withSource: false,
+    });
+    declareTemplateReplacements(pkgDir, {
+      'acme-app-shell': 'shell-side-nav',
+      'missing-app-shell': 'shell-side-nav',
+    });
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid_template_replacement',
+          template: 'missing-app-shell',
+        }),
+      ]),
+    );
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('shell-side-nav');
+    const own = await template('acme-app-shell', {show: true, cwd: tmpDir});
+    expect(own.data.template).toBe('acme-app-shell');
+  });
+
+  it('lets the later configured package win a shared replacement target with a warning', async () => {
+    const first = installWidgets(tmpDir);
+    writeTemplate(first, 'acme-app-shell-a', {
+      kind: 'page',
+      source:
+        "export default function AcmeAppShellA() { return 'first replacement'; }\n",
+    });
+    declareTemplateReplacements(first, {
+      'acme-app-shell-a': 'shell-side-nav',
+    });
+
+    const second = path.join(tmpDir, 'node_modules', '@acme', 'extra');
+    fs.mkdirSync(path.join(second, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(second, 'package.json'),
+      JSON.stringify({name: '@acme/extra', version: '1.0.0'}),
+    );
+    writeTemplate(second, 'acme-app-shell-b', {
+      kind: 'page',
+      source:
+        "export default function AcmeAppShellB() { return 'later replacement'; }\n",
+    });
+    declareTemplateReplacements(second, {
+      'acme-app-shell-b': 'shell-side-nav',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `export default { integrations: ['@acme/widgets', '@acme/extra'] };\n`,
+    );
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'ambiguous_template_replacement',
+          severity: 'warning',
+          package: '@acme/extra',
+        }),
+      ]),
+    );
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('acme-app-shell-b');
+    expect(selected.data.source).toContain('later replacement');
+
+    const command = await runCli(['template', 'shell-side-nav'], tmpDir);
+    expect(command.status).toBe(0);
+    expect(command.stderr).toContain('@acme/extra has 1 integration issue');
+    expect(command.stderr).toContain('astryx doctor');
+
+    const doctor = await runCli(['doctor'], tmpDir);
+    expect(doctor.status).toBe(0);
+    expect(doctor.stdout).toContain('configured later');
+  });
+
+  it('keeps an explicitly configured replacement ahead of an autolinked one', async () => {
+    const explicit = installWidgets(tmpDir);
+    writeTemplate(explicit, 'explicit-shell', {
+      kind: 'page',
+      source:
+        "export default function ExplicitShell() { return 'explicit replacement'; }\n",
+    });
+    declareTemplateReplacements(explicit, {
+      'explicit-shell': 'shell-side-nav',
+    });
+
+    const implicit = path.join(tmpDir, 'node_modules', '@acme', 'implicit');
+    fs.mkdirSync(path.join(implicit, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(implicit, 'package.json'),
+      JSON.stringify({name: '@acme/implicit', version: '1.0.0'}),
+    );
+    writeTemplate(implicit, 'implicit-shell', {
+      kind: 'page',
+      source:
+        "export default function ImplicitShell() { return 'implicit replacement'; }\n",
+    });
+    declareTemplateReplacements(implicit, {
+      'implicit-shell': 'shell-side-nav',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        dependencies: {
+          '@acme/widgets': '1.0.0',
+          '@acme/implicit': '1.0.0',
+        },
+      }),
+    );
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'ambiguous_template_replacement',
+          severity: 'warning',
+          package: '@acme/widgets',
+          message: expect.stringContaining('explicitly configured'),
+        }),
+      ]),
+    );
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('explicit-shell');
+    expect(selected.data.source).toContain('explicit replacement');
+  });
+
+  it('describes precedence truthfully when only autolinked packages conflict', async () => {
+    const first = installWidgets(tmpDir);
+    writeTemplate(first, 'first-shell', {kind: 'page'});
+    declareTemplateReplacements(first, {
+      'first-shell': 'shell-side-nav',
+    });
+
+    const second = path.join(tmpDir, 'node_modules', '@acme', 'implicit');
+    fs.mkdirSync(path.join(second, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(second, 'package.json'),
+      JSON.stringify({name: '@acme/implicit', version: '1.0.0'}),
+    );
+    writeTemplate(second, 'second-shell', {kind: 'page'});
+    declareTemplateReplacements(second, {
+      'second-shell': 'shell-side-nav',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      'export default {};\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        dependencies: {
+          '@acme/widgets': '1.0.0',
+          '@acme/implicit': '1.0.0',
+        },
+      }),
+    );
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    const warning = discovered.errors.find(
+      error => error.code === 'ambiguous_template_replacement',
+    );
+
+    expect(warning?.package).toBe('@acme/implicit');
+    expect(warning?.message).toContain(
+      'listed later in package.json dependencies',
+    );
+    expect(warning?.message).toContain('astryx.config');
+    expect(warning?.message).not.toContain('configured later');
+  });
+
+  it('does not let an invalid autolinked declaration disable an explicit replacement', async () => {
+    const explicit = installWidgets(tmpDir);
+    writeTemplate(explicit, 'explicit-shell', {
+      kind: 'page',
+      source:
+        "export default function ExplicitShell() { return 'explicit replacement'; }\n",
+    });
+    declareTemplateReplacements(explicit, {
+      'explicit-shell': 'shell-side-nav',
+    });
+
+    const implicit = path.join(tmpDir, 'node_modules', '@acme', 'implicit');
+    fs.mkdirSync(path.join(implicit, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(implicit, 'package.json'),
+      JSON.stringify({name: '@acme/implicit', version: '1.0.0'}),
+    );
+    writeTemplate(implicit, 'wrong-kind-shell', {kind: 'block'});
+    declareTemplateReplacements(implicit, {
+      'wrong-kind-shell': 'shell-side-nav',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'consumer',
+        dependencies: {
+          '@acme/widgets': '1.0.0',
+          '@acme/implicit': '1.0.0',
+        },
+      }),
+    );
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid_template_replacement',
+          package: '@acme/implicit',
+        }),
+      ]),
+    );
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('explicit-shell');
+  });
+
+  it('fails closed when an earlier package has an invalid replacement for the winning target', async () => {
+    const first = installWidgets(tmpDir);
+    writeTemplate(first, 'wrong-kind-shell', {kind: 'block'});
+    declareTemplateReplacements(first, {
+      'wrong-kind-shell': 'shell-side-nav',
+    });
+
+    const second = path.join(tmpDir, 'node_modules', '@acme', 'extra');
+    fs.mkdirSync(path.join(second, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(second, 'package.json'),
+      JSON.stringify({name: '@acme/extra', version: '1.0.0'}),
+    );
+    writeTemplate(second, 'valid-shell', {kind: 'page'});
+    declareTemplateReplacements(second, {
+      'valid-shell': 'shell-side-nav',
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `export default { integrations: ['@acme/widgets', '@acme/extra'] };\n`,
+    );
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid_template_replacement',
+          package: '@acme/widgets',
+        }),
+      ]),
+    );
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('shell-side-nav');
+  });
+
+  it('reports a missing Core target and leaves the integration template available by its own id', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell', {kind: 'page'});
+    declareTemplateReplacements(pkgDir, {
+      'acme-app-shell': 'missing-core-shell',
+    });
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'missing_template_replacement_target',
+          template: 'acme-app-shell',
+        }),
+      ]),
+    );
+    const integration = await template('acme-app-shell', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(integration.data.template).toBe('acme-app-shell');
+    const listed = await template(undefined, {
+      list: true,
+      package: '@acme/widgets',
+      cwd: tmpDir,
+    });
+    expect(
+      listed.data.find(entry => entry.id === 'acme-app-shell')?.replaces,
+    ).toBeUndefined();
+  });
+
+  it('reports a missing self-id target without hiding the integration template', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'ghost-shell', {kind: 'page'});
+    declareTemplateReplacements(pkgDir, {
+      'ghost-shell': 'ghost-shell',
+    });
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'missing_template_replacement_target',
+          template: 'ghost-shell',
+          replacementTarget: 'ghost-shell',
+        }),
+      ]),
+    );
+    expect(
+      discovered.templates.find(
+        candidate =>
+          candidate.dirName === 'ghost-shell' &&
+          candidate.package === '@acme/widgets',
+      ),
+    ).toBeDefined();
+
+    const selected = await template('ghost-shell', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('ghost-shell');
+    expect(selected.data.source).toContain('ghostshell');
+  });
+
+  it('reports a replacement whose kind does not match Core', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-app-shell', {kind: 'block'});
+    declareTemplateReplacements(pkgDir, {
+      'acme-app-shell': 'shell-side-nav',
+    });
+
+    const discovered = await discoverAllWithErrors(tmpDir);
+    expect(discovered.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid_template_replacement',
+          template: 'acme-app-shell',
+        }),
+      ]),
+    );
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('shell-side-nav');
+  });
+
+  it('falls back to Core for a rejected same-id replacement while package lookup keeps the integration template', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'shell-side-nav', {kind: 'block'});
+    declareTemplateReplacements(pkgDir, {
+      'shell-side-nav': 'shell-side-nav',
+    });
+
+    const selected = await template('shell-side-nav', {
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(selected.data.template).toBe('shell-side-nav');
+    expect(selected.data.type).toBe('page');
+
+    const integration = await template('shell-side-nav', {
+      package: '@acme/widgets',
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(integration.data.template).toBe('shell-side-nav');
+    expect(integration.data.type).toBe('block');
+
+    const block = await template('shell-side-nav', {
+      type: 'block',
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(block.data.template).toBe('shell-side-nav');
+    expect(block.data.type).toBe('block');
+
+    const listedBlocks = await template(undefined, {
+      list: true,
+      type: 'block',
+      cwd: tmpDir,
+    });
+    expect(listedBlocks.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'shell-side-nav',
+          type: 'block',
+          package: '@acme/widgets',
+        }),
+      ]),
+    );
+
+    const searched = await search('shell-side-nav', {
+      type: 'template',
+      limit: 100,
+      cwd: tmpDir,
+    });
+    const sameId = searched.data.results.filter(
+      result => result.name === 'shell-side-nav',
+    );
+    expect(sameId).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'page',
+          command: 'astryx template shell-side-nav --type page',
+        }),
+        expect.objectContaining({
+          kind: 'block',
+          command: 'astryx template shell-side-nav --type block',
+        }),
+      ]),
+    );
+
+    const kit = await build('shell-side-nav', {
+      type: 'template',
+      limit: 100,
+      cwd: tmpDir,
+    });
+    expect(kit.type).toBe('build.kit');
+    if (kit.type !== 'build.kit') throw new Error('expected build.kit');
+    expect(kit.data.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'shell-side-nav',
+          command: 'astryx template shell-side-nav --type block',
+        }),
+      ]),
+    );
+  });
+
+  it('round-trips both kinds when a block replacement shadows a page with the same id', async () => {
+    const pkgDir = installWidgets(tmpDir);
+    writeTemplate(pkgDir, 'acme-callout', {
+      kind: 'block',
+      source:
+        "export default function AcmeCallout() { return 'replacement block'; }\n",
+    });
+    writeTemplate(pkgDir, 'CardCallout', {
+      kind: 'page',
+      source:
+        "export default function CardCalloutPage() { return 'ordinary page'; }\n",
+    });
+    declareTemplateReplacements(pkgDir, {
+      'acme-callout': 'CardCallout',
+    });
+
+    const bare = await template('CardCallout', {show: true, cwd: tmpDir});
+    expect(bare.data.template).toBe('acme-callout');
+    expect(bare.data.type).toBe('block');
+
+    const page = await template('CardCallout', {
+      type: 'page',
+      show: true,
+      cwd: tmpDir,
+    });
+    expect(page.data.template).toBe('CardCallout');
+    expect(page.data.type).toBe('page');
+
+    const searched = await search('CardCallout', {
+      type: 'template',
+      limit: 100,
+      cwd: tmpDir,
+    });
+    expect(searched.data.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'CardCallout',
+          kind: 'page',
+          command: 'astryx template CardCallout --type page',
+        }),
+        expect.objectContaining({
+          name: 'acme-callout',
+          kind: 'block',
+          command: 'astryx template CardCallout --type block',
+        }),
+      ]),
+    );
+
+    const kit = await build('CardCallout', {
+      type: 'template',
+      limit: 100,
+      cwd: tmpDir,
+    });
+    expect(kit.type).toBe('build.kit');
+    if (kit.type !== 'build.kit') throw new Error('expected build.kit');
+    expect(kit.data.pages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'CardCallout',
+          command: 'astryx template CardCallout --type page',
+        }),
+      ]),
+    );
+    expect(kit.data.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'acme-callout',
+          command: 'astryx template CardCallout --type block',
+        }),
+      ]),
+    );
   });
 
   it('copies a block template into a directory as <id-basename>.tsx', async () => {

--- a/packages/cli/api/template/template.doc.mjs
+++ b/packages/cli/api/template/template.doc.mjs
@@ -16,15 +16,27 @@ export const doc = {
   description:
     'One entry point for the template family: with no name it lists the discovered ' +
     "templates; with a name it returns that template's source, a layout skeleton, or " +
-    'scaffolds it into the project. Templates are discovered across core, external ' +
-    'packages, and integrations, so the same id can appear in more than one place; ' +
-    'narrow an ambiguous name with type and/or package. The cdn option writes the ' +
-    'annotated no-build-step CDN starter page, which ships as an asset rather than as ' +
+    'scaffolds it into the project. A configured integration may replace a Core ' +
+    'template id for unqualified discovery and lookup; package selection still ' +
+    'addresses the Core original. Other duplicate ids remain ambiguous and can be ' +
+    'narrowed by type and/or package. The cdn option writes the annotated ' +
+    'no-build-step CDN starter page, which ships as an asset rather than as ' +
     'a discovered template.',
   importPath: '@astryxdesign/cli/api',
   signature:
     'template(name?: string, options?: TemplateOptions): Promise<TemplateListResponse | TemplateShowResponse | TemplateSkeletonResponse | TemplateCopyResponse | TemplateCdnResponse>',
-  keywords: ['template', 'scaffold', 'page', 'block', 'skeleton', 'starter', 'cdn', 'esm', 'importmap', 'no-build'],
+  keywords: [
+    'template',
+    'scaffold',
+    'page',
+    'block',
+    'skeleton',
+    'starter',
+    'cdn',
+    'esm',
+    'importmap',
+    'no-build',
+  ],
   params: [
     {
       name: 'name',
@@ -69,7 +81,7 @@ export const doc = {
       name: 'options.package',
       type: 'string',
       description:
-        'Narrow lookups to templates from a specific owning package (core templates report @astryxdesign/core).',
+        'Narrow lookups to templates from a specific owning package. Without it, a valid integration replacement is selected for the Core id; use @astryxdesign/core to select the original.',
     },
     {
       name: 'options.targetPath',
@@ -94,7 +106,7 @@ export const doc = {
     {
       type: 'template.list',
       description:
-        'Every discovered template (page + block); each entry carries id, name, description, kind, owning package, optional category and componentsUsed, and readiness flags. Filtered by type/package when provided.',
+        'The effective templates (page + block); a valid integration replacement takes the place of its Core target and carries `replaces`. Pass `package` to list one package, including replaced Core originals.',
     },
     {
       type: 'template.show',
@@ -141,7 +153,15 @@ export const doc = {
   ],
   examples: [
     {label: 'List templates', code: 'const {data} = await template();'},
+    {
+      label: 'List exact Core ids',
+      code: "await template(undefined, {list: true, package: '@astryxdesign/core'});",
+    },
     {label: 'Show source', code: "await template('dashboard');"},
+    {
+      label: 'Select a replaced Core original',
+      code: "await template('shell-side-nav', {package: '@astryxdesign/core'});",
+    },
     {
       label: 'Layout skeleton',
       code: "await template('dashboard', {skeleton: true});",

--- a/packages/cli/api/template/template.mjs
+++ b/packages/cli/api/template/template.mjs
@@ -15,7 +15,13 @@
  *   ./list, ./show, ./skeleton, ./copy, ./cdn and shared discovery in foundation/discovery.
  */
 
-import {discoverAll, pkgOf} from '../../foundation/discovery/template-adapter.mjs';
+import {
+  discoverAll,
+  discoverAllResolved,
+  discoverAllUnresolved,
+  pkgOf,
+  templateLookupIds,
+} from '../../foundation/discovery/template-adapter.mjs';
 import {AstryxError} from '../error.mjs';
 import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
 import {templateList} from './list/list.mjs';
@@ -88,18 +94,48 @@ export async function template(name, options = {}) {
     });
   }
 
-  const templates = await discoverAll(cwd);
+  const templates =
+    packageFilter === '@astryxdesign/core'
+      ? await discoverAllUnresolved(cwd)
+      : packageFilter
+        ? await discoverAllResolved(cwd)
+        : await discoverAll(cwd);
 
   if (list || (!name && !skeleton)) {
     return templateList(templates, {type, package: packageFilter});
   }
 
-  // Resolve `name` to a single template. The same id can appear across types
-  // and/or packages (e.g. a core "hero" page and an integration "hero"
-  // block); narrow with --type / --package.
-  let candidates = templates.filter(t => t.dirName === name);
-  if (type) candidates = candidates.filter(t => t.type === type);
-  if (packageFilter) candidates = candidates.filter(t => pkgOf(t) === packageFilter);
+  // Resolve `name` to a single template. Without an explicit package, an active
+  // integration replacement owns the Core id it names. Package-qualified lookup
+  // stays exact, which keeps the original addressable as
+  // `--package @astryxdesign/core`.
+  let pool = templates;
+  if (type) pool = pool.filter(t => t.type === type);
+  if (packageFilter) pool = pool.filter(t => pkgOf(t) === packageFilter);
+  const replacements = packageFilter
+    ? []
+    : pool.filter(t => t.replaces === name);
+  let candidates = packageFilter
+    ? pool.filter(t => t.dirName === (name ?? ''))
+    : replacements.length > 0
+      ? replacements
+      : pool.filter(t => templateLookupIds(t).includes(name ?? ''));
+
+  // A rejected same-id declaration must not displace Core for the bare command,
+  // but a different-kind integration template remains reachable with --type.
+  if (!packageFilter && !type && candidates.length > 1) {
+    const core = candidates.filter(t => pkgOf(t) === '@astryxdesign/core');
+    const rejected = candidates.filter(t => pkgOf(t) !== '@astryxdesign/core');
+    if (
+      core.length === 1 &&
+      rejected.length === candidates.length - 1 &&
+      rejected.every(
+        t => t.replacementRejected && t.replacementTarget === (name ?? ''),
+      )
+    ) {
+      candidates = core;
+    }
+  }
 
   if (name && candidates.length === 0) {
     throw new AstryxError(

--- a/packages/cli/api/template/template.type.mjs
+++ b/packages/cli/api/template/template.type.mjs
@@ -31,6 +31,7 @@
  * @property {string} description
  * @property {'page' | 'block'} type
  * @property {string} package - Owning package; core (built-in) templates report '@astryxdesign/core'.
+ * @property {string} [replaces] - Core template id this integration template replaces by default.
  * @property {string} [category] - Optional grouping/category label.
  * @property {string[]} [componentsUsed] - Component display names the template composes.
  * @property {number} [aspectRatio] - Block preview width/height ratio.
@@ -93,8 +94,8 @@
  * @property {boolean} [skeleton]
  * @property {boolean} [show]
  * @property {boolean | string} [cdn] Write the no-build-step CDN starter page instead of resolving a template. A string is used as the destination path.
- * @property {'page' | 'block'} [type] Filter templates by kind: 'page' or 'block'. Only applies to list views.
- * @property {string} [package] Narrow to templates from a specific package (id-only lookups across packages are ambiguous).
+ * @property {'page' | 'block'} [type] Filter templates by kind: 'page' or 'block'. Narrows both list and direct lookup.
+ * @property {string} [package] Narrow to templates from a specific package. Without it, a valid integration replacement is selected for the Core id; @astryxdesign/core explicitly selects the original.
  * @property {string} [targetPath]
  * @property {boolean} [overwrite] Overwrite an existing target file instead of erroring (ERR_FILE_EXISTS).
  * @property {string} [cwd]

--- a/packages/cli/assets/docs/cli-integrations.doc.mjs
+++ b/packages/cli/assets/docs/cli-integrations.doc.mjs
@@ -152,16 +152,37 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'A template id is its source-relative path with the metadata suffix removed; the display `name` is not its identity and may repeat. If an integration id matches a Core id, unqualified lookup fails closed instead of choosing one. Run `astryx doctor integration templates <package>` before publishing: it recommends renaming, but an intentional overlap is allowed when callers always pass `--package <package>`.',
+          text: "A template id is its exact source-relative path with the metadata suffix removed; the display `name` is not its identity and may repeat. Run `astryx --json template --list --package @astryxdesign/core` and copy the Core entry's `id` exactly. In `templateReplacements`, each key is the integration template's exact id and each value is the exact Core id it replaces. Generate the source/metadata pair with `integration add template`, then add this explicit replacement policy to the manifest.",
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          label: 'Create the integration template',
+          code: 'astryx integration add template acme-app-shell --type page',
         },
         {
           type: 'code',
           lang: 'typescript',
-          code: "// AcmeLandingPage.template.ts\nexport default {\n  type: 'page',\n  // name, description, preview, ...\n};",
+          label: 'Declare the replacement',
+          code: "// astryx.integration.ts\nexport default {\n  templates: './templates',\n  templateReplacements: {\n    'acme-app-shell': 'shell-side-nav',\n  },\n};\n\n// templates/acme-app-shell.template.mjs\nexport default {\n  type: 'page',\n  name: 'Acme App Shell',\n  description: 'An app shell with Acme navigation.',\n};",
+        },
+        {
+          type: 'code',
+          lang: 'typescript',
+          label: 'Use product navigation in the replacement source',
+          code: "// templates/acme-app-shell.tsx\nimport {AppShell} from '@astryxdesign/core/AppShell';\nimport {Card} from '@astryxdesign/core/Card';\nimport {AcmeSideNav, AcmeTopNav} from '@acme/navigation';\n\nexport default function AcmeAppShell() {\n  return (\n    <AppShell\n      sideNav={<AcmeSideNav />}\n      topNav={<AcmeTopNav />}>\n      <Card>Product content</Card>\n    </AppShell>\n  );\n}",
         },
         {
           type: 'prose',
-          text: 'The CLI needs both files at consume time. `integration add` includes the templates root when package.json already has a files allowlist. It never creates an exports map, because doing that can make previously-open deep imports private; when a map already exists, it adds the generated source subpath without replacing author-owned entries. `integration pack --check` proves the source and metadata survive the tarball and verifies every component through the public import its metadata advertises.',
+          text: 'With that declaration, `astryx template shell-side-nav` selects `acme-app-shell`; template listing, search, build suggestions, and block-layout lookup use the same effective identity. `astryx template shell-side-nav --package @astryxdesign/core` still selects the original, and `astryx template acme-app-shell --package @acme/navigation` explicitly selects the integration template. In the `template.list` JSON response, a winning replacement entry carries `replaces` naming the Core id it supersedes, and the Core entry is omitted from the default listing. A page can replace only a Core page, and a block can replace only a Core block. Missing Core targets, type mismatches, declarations for templates the package does not provide, and more than one replacement from one package fail closed: Core stays the default and `astryx doctor integration templates <package>` reports the error. If multiple explicitly configured packages each replace the target, the package configured later wins with a warning. An explicitly configured replacement always wins over an autolinked one. If only autolinked packages conflict, the package listed later in package.json dependencies wins with a warning; add the intended package to `astryx.config` to make the choice explicit. Without `templateReplacements`, valid template selection keeps the existing package-aware ambiguity behavior; contribution failure isolation still follows the rules below.',
+        },
+        {
+          type: 'prose',
+          text: "The replacement map is part of the integration manifest rather than the strict per-template metadata object. CLIs from 0.5.3 onward ignore an unknown manifest key with a warning, preserve contributions they understand, and leave templates addressable by their own ids. Versions 0.5.2 and earlier reject unknown manifest keys and drop the entire integration. Replacement selection starts in 0.7.0. Integration authors who require replacement behavior should declare `@astryxdesign/cli >=0.7.0`; use `@astryxdesign/cli >=0.5.3` only when fallback to own-id access is acceptable. `__proto__` is unsupported and reserved as a `templateReplacements` map key. An ordinary `{'__proto__': 'shell-side-nav'}` literal uses JavaScript's special prototype-setter form; because the string value is neither an object nor null, it does not change the prototype, creates no own key, and disappears before validation. Observable own keys created with computed-property syntax or deserialization are rejected. As a template directory id it remains discoverable, but choose another kebab-case id.",
+        },
+        {
+          type: 'prose',
+          text: 'The CLI needs both files at consume time. `integration add` includes the templates root when package.json already has a files allowlist. It never creates an exports map, because doing that can make previously-open deep imports private; when a map already exists, it adds the generated source subpath without replacing author-owned entries. `integration pack --check` proves the source, metadata, and replacement map survive the tarball and verifies every component through the public import its metadata advertises.',
         },
       ],
     },
@@ -355,7 +376,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Discovery is resilient. A broken or misconfigured integration is skipped with a single non-blocking warning on stderr instead of crashing the CLI, and it never corrupts a `--json` stdout envelope. Everyday commands keep working with the remaining valid contributions.',
+          text: "Discovery is resilient. A manifest that fails to load is skipped because none of its roots are trustworthy. An error in one contribution kind is reported without hiding the integration's other valid kinds. Invalid template and component files are omitted without hiding valid siblings; other kinds keep their existing all-or-nothing behavior. Everyday commands keep working with the remaining valid contributions, warnings go to stderr, and `--json` stdout stays clean.",
         },
         {
           type: 'prose',

--- a/packages/cli/assets/docs/cli-integrations.test.mjs
+++ b/packages/cli/assets/docs/cli-integrations.test.mjs
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {docs as integrationGuide} from './cli-integrations.doc.mjs';
+import {doc as integrationSchema} from '../../authoring/integration/integration.doc.mjs';
+
+function guideText() {
+  return integrationGuide.sections
+    .flatMap(section => section.content)
+    .flatMap(block => {
+      if (block.type === 'prose') return [block.text];
+      if (block.type === 'code') return [block.label ?? '', block.code];
+      if (block.type === 'list') return block.items;
+      return [];
+    })
+    .join('\n');
+}
+
+describe('integration template replacement docs', () => {
+  it('documents the complete author and consumer contract', () => {
+    const text = guideText();
+
+    for (const required of [
+      'templateReplacements',
+      'acme-app-shell',
+      'shell-side-nav',
+      'astryx --json template --list --package @astryxdesign/core',
+      'astryx template shell-side-nav --package @astryxdesign/core',
+      'astryx template acme-app-shell --package @acme/navigation',
+      'templates/acme-app-shell.template.mjs',
+      'AcmeSideNav',
+      'AcmeTopNav',
+      '<Card>Product content</Card>',
+      'fail closed',
+      'configured later wins',
+      'wins over an autolinked one',
+      'listed later in package.json dependencies',
+      'valid siblings',
+      'Without `templateReplacements`',
+      '@astryxdesign/cli >=0.5.3',
+      '@astryxdesign/cli >=0.7.0',
+      '`template.list` JSON response',
+      '`__proto__` is unsupported and reserved',
+      "`{'__proto__': 'shell-side-nav'}` literal",
+      'special prototype-setter form',
+      'does not change the prototype',
+      'creates no own key',
+      'computed-property syntax or deserialization are rejected',
+    ]) {
+      expect(text, required).toContain(required);
+    }
+  });
+
+  it('keeps the generated schema doc aligned with the public type', () => {
+    const field = integrationSchema.fields.find(
+      candidate => candidate.name === 'templateReplacements',
+    );
+
+    expect(field).toMatchObject({
+      type: 'Record<string, string>',
+      example: "{'acme-app-shell': 'shell-side-nav'}",
+    });
+    expect(field.description).toContain('exact integration template id');
+    expect(field.description).toContain('--package @astryxdesign/core');
+    expect(field.description).toContain('fail closed');
+    expect(field.description).toContain(
+      'explicit configuration wins over autolinking',
+    );
+    expect(field.description).toContain('CLIs from 0.5.3 onward');
+    expect(field.description).toContain('Versions 0.5.2 and earlier');
+    expect(field.description).toContain(
+      'Replacement selection starts in 0.7.0',
+    );
+    expect(field.description).toContain('`__proto__` is unsupported');
+    expect(field.description).toContain('special prototype-setter form');
+    expect(field.description).toContain('does not change the prototype');
+    expect(field.description).toContain('creates no own key');
+    expect(field.description).toContain(
+      'computed-property syntax or deserialization are rejected',
+    );
+  });
+});

--- a/packages/cli/authoring/integration/integration.doc.mjs
+++ b/packages/cli/authoring/integration/integration.doc.mjs
@@ -15,8 +15,8 @@ export const doc = {
   description:
     'The astryx.integration.* manifest that sits beside an integration ' +
     "package's package.json. Points the CLI at the package's components, " +
-    'templates, codemods, doc topics, source themes, and managed agent guidance, ' +
-    'and where to file issues. Every field is optional.',
+    'templates, template replacements, codemods, doc topics, source themes, and ' +
+    'managed agent guidance, and where to file issues. Every field is optional.',
   appliesTo: 'astryx.integration.{ts,mjs,js}',
   fields: [
     {
@@ -32,6 +32,13 @@ export const doc = {
       description:
         'Relative path to the templates root (resolved to absolute).',
       example: "'./src/templates'",
+    },
+    {
+      name: 'templateReplacements',
+      type: 'Record<string, string>',
+      description:
+        "Maps each exact integration template id to the exact Core template id it replaces. Find Core ids with `astryx --json template --list --package @astryxdesign/core`. Unqualified lookup selects a valid replacement; use `--package @astryxdesign/core` for the original. Invalid declarations fail closed, later explicitly configured packages win with a warning, and explicit configuration wins over autolinking. If only autolinked packages conflict, the dependency listed later in package.json wins with a warning. CLIs from 0.5.3 onward ignore this field when unknown and preserve understood contributions; Versions 0.5.2 and earlier reject unknown manifest keys and drop the integration. Replacement selection starts in 0.7.0. `__proto__` is unsupported and reserved as a `templateReplacements` map key. An ordinary `{'__proto__': 'shell-side-nav'}` literal uses JavaScript's special prototype-setter form; because the string value is neither an object nor null, it does not change the prototype, creates no own key, and disappears before validation. Observable own keys created with computed-property syntax or deserialization are rejected. Template discovery otherwise accepts that directory id.",
+      example: "{'acme-app-shell': 'shell-side-nav'}",
     },
     {
       name: 'codemods',
@@ -73,6 +80,9 @@ export const doc = {
       code: `export default {
   components: './src/components',
   templates: './src/templates',
+  templateReplacements: {
+    'acme-app-shell': 'shell-side-nav',
+  },
   codemods: './codemods',
   docs: './docs',
   themes: './themes',

--- a/packages/cli/authoring/integration/parse.mjs
+++ b/packages/cli/authoring/integration/parse.mjs
@@ -12,7 +12,7 @@
  */
 
 import {formatZodError} from '../_shared/errors.mjs';
-import {integrationSchema} from './schema.mjs';
+import {assertSafeIntegrationKeys, integrationSchema} from './schema.mjs';
 
 /** @typedef {import('./type').AstryxIntegration} AstryxIntegration */
 
@@ -28,6 +28,7 @@ import {integrationSchema} from './schema.mjs';
  * @returns {AstryxIntegration}
  */
 export function parseIntegration(input, label = 'astryx.integration') {
+  assertSafeIntegrationKeys(input, label);
   const result = integrationSchema.safeParse(input);
   if (!result.success) {
     throw new Error(formatZodError(label, result.error));

--- a/packages/cli/authoring/integration/parse.test.mjs
+++ b/packages/cli/authoring/integration/parse.test.mjs
@@ -31,6 +31,15 @@ describe('parseIntegration (load boundary)', () => {
     expect(parseIntegration({themes: './themes'})).toEqual({
       themes: './themes',
     });
+    expect(
+      parseIntegration({
+        templates: './templates',
+        templateReplacements: {'acme-app-shell': 'shell-side-nav'},
+      }),
+    ).toEqual({
+      templates: './templates',
+      templateReplacements: {'acme-app-shell': 'shell-side-nav'},
+    });
     expect(() =>
       parseIntegration({components: './c', issuesUrl: 'https://example.com/i'}),
     ).not.toThrow();
@@ -66,7 +75,9 @@ describe('parseIntegration (load boundary)', () => {
           ? 'https://example.com/issues'
           : key === 'agentDocs'
             ? {}
-            : './x',
+            : key === 'templateReplacements'
+              ? {'acme-app-shell': 'shell-side-nav'}
+              : './x',
       ]),
     );
     expect(unknownIntegrationKeys(everyKnownKey)).toEqual([]);
@@ -80,6 +91,26 @@ describe('parseIntegration (load boundary)', () => {
 
   it('rejects a non-URL issuesUrl', () => {
     expect(reason({issuesUrl: 'nope'})).toContain('issuesUrl');
+  });
+
+  it('rejects an invalid template replacement declaration', () => {
+    expect(reason({templateReplacements: {'acme-app-shell': 42}})).toContain(
+      'templateReplacements',
+    );
+    expect(reason({templateReplacements: {'': 'shell-side-nav'}})).toContain(
+      'templateReplacements',
+    );
+    expect(reason({templateReplacements: {'acme-app-shell': ''}})).toContain(
+      'templateReplacements',
+    );
+  });
+
+  it('rejects an own __proto__ replacement key before parsing can drop it', () => {
+    const templateReplacements = JSON.parse('{"__proto__":"shell-side-nav"}');
+    expect(Object.hasOwn(templateReplacements, '__proto__')).toBe(true);
+    expect(reason({templateReplacements})).toContain(
+      'reserved key "__proto__"',
+    );
   });
 
   it('accepts an optional append array as manifest data', () => {

--- a/packages/cli/authoring/integration/schema.mjs
+++ b/packages/cli/authoring/integration/schema.mjs
@@ -68,6 +68,9 @@ export const agentDocsSchema = z.object({
 export const integrationBaseSchema = z.object({
   components: z.string().optional(),
   templates: z.string().optional(),
+  templateReplacements: z
+    .record(z.string().min(1), z.string().min(1))
+    .optional(),
   codemods: z.string().optional(),
   docs: z.string().optional(),
   themes: z.string().optional(),
@@ -88,6 +91,28 @@ export const integrationSchema = integrationBaseSchema.extend({
 });
 
 /**
+ * Reject manifest map keys that JavaScript object assignment treats specially.
+ * @param {unknown} input
+ * @param {string} label
+ */
+export function assertSafeIntegrationKeys(input, label) {
+  if (input == null || typeof input !== 'object' || Array.isArray(input))
+    return;
+  const replacements = /** @type {{templateReplacements?: unknown}} */ (input)
+    .templateReplacements;
+  if (
+    replacements != null &&
+    typeof replacements === 'object' &&
+    !Array.isArray(replacements) &&
+    Object.hasOwn(replacements, '__proto__')
+  ) {
+    throw new Error(
+      `${label} field "templateReplacements" must not declare the reserved key "__proto__".`,
+    );
+  }
+}
+
+/**
  * Parse every default-manifest field except the independently isolated
  * `agentDocs` contribution.
  * @param {unknown} input
@@ -95,6 +120,7 @@ export const integrationSchema = integrationBaseSchema.extend({
  * @returns {Omit<AstryxIntegration, 'agentDocs'>}
  */
 export function parseIntegrationBase(input, label) {
+  assertSafeIntegrationKeys(input, label);
   const result = integrationBaseSchema.safeParse(input);
   if (!result.success) throw new Error(formatZodError(label, result.error));
   return result.data;

--- a/packages/cli/authoring/integration/type.ts
+++ b/packages/cli/authoring/integration/type.ts
@@ -17,6 +17,26 @@ export interface AstryxIntegration {
   components?: string;
   /** Relative path to the templates root (resolved to absolute). */
   templates?: string;
+  /** Maps exact integration template ids to exact Core template ids. Find Core
+   *  ids with `astryx --json template --list --package @astryxdesign/core`.
+   *  A valid replacement owns unqualified lookup and every default discovery
+   *  surface; package-qualified lookup still selects the Core original or the
+   *  integration's own id. Invalid declarations fail closed. Later explicitly
+   *  configured integrations win valid conflicts with a warning, and explicit
+   *  configuration wins over autolinking. When only autolinked packages
+   *  conflict, the dependency listed later in package.json wins with a warning.
+   *  CLIs from 0.5.3 onward ignore this key when it is unknown and preserve
+   *  understood contributions. Versions 0.5.2 and earlier reject unknown
+   *  manifest keys and drop the whole integration. Replacement selection starts in
+   *  0.7.0. `__proto__` is unsupported and reserved as a
+   *  `templateReplacements` map key. An ordinary
+   *  `{'__proto__': 'shell-side-nav'}` literal uses JavaScript's special
+   *  prototype-setter form; because the string value is neither an object nor
+   *  null, it does not change the prototype, creates no own key, and disappears
+   *  before validation. Observable own keys created with computed-property
+   *  syntax or deserialization are rejected. Template discovery otherwise
+   *  accepts that directory id. */
+  templateReplacements?: Record<string, string>;
   /** Relative path to the codemods root (resolved to absolute). */
   codemods?: string;
   /** Relative path to the reference-docs (topics) root (resolved to

--- a/packages/cli/clients/cli/commands/build-theme.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.mjs
@@ -190,7 +190,7 @@ async function warnOnThemeIntegrationIssues(json) {
   try {
     const project = await Project.load(process.cwd());
     await project.themes();
-    await warnOnIntegrationIssues(project.loadedIntegrations, {json});
+    await warnOnIntegrationIssues(project, {json});
   } catch {
     // Never let the nudge break the command.
   }

--- a/packages/cli/clients/cli/commands/build.mjs
+++ b/packages/cli/clients/cli/commands/build.mjs
@@ -187,10 +187,13 @@ export function registerBuild(program) {
       // `template <name> <path>` scaffolds into your project; <path> is the file
       // (or folder) to write it to — a placeholder, since we can't know your
       // layout. `--skeleton` and `component <Name>` just print, so no path.
+      const pageCommand = pages.length
+        ? formatCliCommand(pages[0].command)
+        : null;
       const startCmd = directMatch
-        ? `${run} template ${pages[0].name} <path>`
+        ? `${pageCommand} <path>`
         : pages.length
-          ? `${run} template ${pages[0].name} --skeleton`
+          ? pageCommand
           : `${run} component AppShell`;
       const startNote = directMatch
         ? `This \`${pages[0].name}\` page template appears to be the closest to what you want, so we recommend scaffolding it into your project — replace \`<path>\` with the file (or folder) to write it to — then adapting. Otherwise, browse PAGE TEMPLATES first, then BLOCKS and DOMAIN COMPONENTS below.`

--- a/packages/cli/clients/cli/commands/component-ownership.test.mjs
+++ b/packages/cli/clients/cli/commands/component-ownership.test.mjs
@@ -71,7 +71,7 @@ function createFixture({
   );
   fs.writeFileSync(
     path.join(compDir, 'MetaAppShell.doc.mjs'),
-    `export const docs = {\n  name: 'MetaAppShell',\n  usage: { description: 'Meta-flavored app shell.' },\n  props: [{ name: 'title', type: 'string', description: 'Header title' }],\n};\n`,
+    `export default {\n  type: 'component',\n  name: 'MetaAppShell',\n  usage: { description: 'Meta-flavored app shell.' },\n  props: [{ name: 'title', type: 'string', description: 'Header title' }],\n};\n`,
   );
   if (withSource) {
     fs.writeFileSync(
@@ -82,7 +82,7 @@ function createFixture({
   if (extraComponent) {
     fs.writeFileSync(
       path.join(compDir, `${extraComponent}.doc.mjs`),
-      `export const docs = {\n  name: '${extraComponent}',\n  usage: { description: '${extraComponent} from meta.' },\n};\n`,
+      `export default {\n  type: 'component',\n  name: '${extraComponent}',\n  usage: { description: '${extraComponent} from meta.' },\n  props: [],\n};\n`,
     );
     fs.writeFileSync(
       path.join(compDir, `${extraComponent}.tsx`),
@@ -100,7 +100,7 @@ function createFixture({
       : '';
     fs.writeFileSync(
       path.join(entryDir, `${entryPoint.component}.doc.mjs`),
-      `export const docs = {\n  name: '${entryPoint.component}',${ownSpecifier}\n  usage: { description: '${entryPoint.component} from an entry point.' },\n};\n`,
+      `export default {\n  type: 'component',\n  name: '${entryPoint.component}',${ownSpecifier}\n  usage: { description: '${entryPoint.component} from an entry point.' },\n  props: [],\n};\n`,
     );
   }
 

--- a/packages/cli/clients/cli/commands/component/index.mjs
+++ b/packages/cli/clients/cli/commands/component/index.mjs
@@ -112,7 +112,7 @@ export function registerComponent(program) {
       // doctor integration validate. Best-effort; suppressed in --json mode.
       try {
         const project = await Project.load(process.cwd());
-        await warnOnIntegrationIssues(project.loadedIntegrations, {json});
+        await warnOnIntegrationIssues(project, {json});
       } catch {
         // Never let the nudge break the command.
       }

--- a/packages/cli/clients/cli/commands/discover.broken-integration.test.mjs
+++ b/packages/cli/clients/cli/commands/discover.broken-integration.test.mjs
@@ -69,11 +69,12 @@ describe('astryx discover with a manifest that fails to load', () => {
 
     expect(status).toBe(0);
     expect(stderr).toContain(
-      'Warning: @test/broken has 1 integration issue(s). ' +
-        'Run: astryx doctor integration validate @test/broken',
+      'Warning: @test/broken has 1 integration issue(s). Run: astryx doctor',
     );
     expect(stdout).not.toContain('No integrations configured.');
-    expect(stdout).toContain('No external components found in configured integrations.');
+    expect(stdout).toContain(
+      'No external components found in configured integrations.',
+    );
   });
 
   it('reports meta.configured=true in --json, with the nudge suppressed', async () => {
@@ -101,8 +102,7 @@ describe('astryx search with a manifest that fails to load', () => {
 
     expect(status).toBe(0);
     expect(stderr).toContain(
-      'Warning: @test/broken has 1 integration issue(s). ' +
-        'Run: astryx doctor integration validate @test/broken',
+      'Warning: @test/broken has 1 integration issue(s). Run: astryx doctor',
     );
 
     const asJson = await runCli(['search', 'button', '--json'], {cwd: project});

--- a/packages/cli/clients/cli/commands/discover.mjs
+++ b/packages/cli/clients/cli/commands/discover.mjs
@@ -83,7 +83,7 @@ export function registerDiscover(program) {
       // doctor integration validate. Best-effort; suppressed in --json mode.
       try {
         const project = await Project.load(process.cwd());
-        await warnOnIntegrationIssues(project.loadedIntegrations, {json});
+        await warnOnIntegrationIssues(project, {json});
       } catch {
         // Never let the nudge break the command.
       }

--- a/packages/cli/clients/cli/commands/doctor-integration-templates.doc.mjs
+++ b/packages/cli/clients/cli/commands/doctor-integration-templates.doc.mjs
@@ -10,12 +10,13 @@ export const doc = {
   name: 'doctor integration templates',
   displayName: 'astryx doctor integration templates',
   namespace: 'cli',
-  summary: 'Warn when integration template ids conflict with Core',
+  summary: 'Validate integration template replacements and Core id overlaps',
   description:
-    'Compares one local or installed integration with the built-in Core page and ' +
-    'block template ids. A conflict is allowed and exits successfully, but the ' +
-    'report recommends renaming and gives the exact --package command required ' +
-    'to select the integration template when the overlap is intentional.',
+    'Validates one local or installed integration against the built-in Core page ' +
+    'and block template ids. Intentional replacements are informational and name ' +
+    'the command for selecting the Core original. Missing targets, ambiguous ' +
+    'replacements, and invalid declarations are errors; undeclared same-id overlaps ' +
+    'remain warnings that require package selection.',
   fn: 'integrationTemplateConflicts',
   args: [
     {
@@ -37,8 +38,14 @@ export const doc = {
     },
   ],
   exitCodes: [
-    {code: 0, when: 'the check completed; template conflicts are warnings'},
-    {code: 1, when: 'the integration or one of its templates is invalid'},
+    {
+      code: 0,
+      when: 'replacement declarations are valid; undeclared id conflicts are warnings',
+    },
+    {
+      code: 1,
+      when: 'the integration, a template, or a replacement declaration is invalid',
+    },
   ],
   related: ['doctor integration validate', 'template'],
 };

--- a/packages/cli/clients/cli/commands/doctor-integration.test.mjs
+++ b/packages/cli/clients/cli/commands/doctor-integration.test.mjs
@@ -31,6 +31,8 @@ function writeIntegration({
   id,
   name = 'Integration template',
   missingRoot = false,
+  replacements,
+  type = 'page',
 }) {
   fs.writeFileSync(
     path.join(tmpDir, 'package.json'),
@@ -38,14 +40,14 @@ function writeIntegration({
   );
   fs.writeFileSync(
     path.join(tmpDir, 'astryx.integration.mjs'),
-    `export default {templates: '${missingRoot ? './missing' : './templates'}'};\n`,
+    `export default {templates: '${missingRoot ? './missing' : './templates'}'${replacements == null ? '' : `, templateReplacements: ${JSON.stringify(replacements)}`}};\n`,
   );
   if (missingRoot || id == null) return;
   const stem = path.join(tmpDir, 'templates', id);
   fs.mkdirSync(path.dirname(stem), {recursive: true});
   fs.writeFileSync(
     `${stem}.template.mjs`,
-    `export default {type: 'page', name: ${JSON.stringify(name)}, description: 'fixture'};\n`,
+    `export default {type: '${type}', name: ${JSON.stringify(name)}, description: 'fixture'};\n`,
   );
   fs.writeFileSync(
     `${stem}.tsx`,
@@ -124,7 +126,12 @@ describe('doctor integration — command', () => {
       return true;
     });
 
-    await createProgram().parseAsync(['node', 'astryx', 'doctor', 'integration']);
+    await createProgram().parseAsync([
+      'node',
+      'astryx',
+      'doctor',
+      'integration',
+    ]);
 
     const output = writes.join('');
     expect(output).toContain('validate [package]');
@@ -136,7 +143,9 @@ describe('doctor integration — command', () => {
 
   it('explains the optional package argument in every leaf help', () => {
     const program = createProgram();
-    const doctor = program.commands.find(command => command.name() === 'doctor');
+    const doctor = program.commands.find(
+      command => command.name() === 'doctor',
+    );
     const integration = doctor?.commands.find(
       command => command.name() === 'integration',
     );
@@ -152,7 +161,10 @@ describe('doctor integration — command', () => {
   });
 
   it('templates explains how to check an installed package when no local manifest exists', async () => {
-    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({name: 'plain'}));
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: 'plain'}),
+    );
     process.chdir(tmpDir);
 
     await createProgram().parseAsync([
@@ -239,6 +251,97 @@ describe('doctor integration — command', () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it('templates reports an intentional replacement and the Core-original command', async () => {
+    const core = (await discoverCoreTemplates()).find(
+      template => template.type === 'page',
+    );
+    expect(core).toBeDefined();
+    writeIntegration({
+      id: 'acme-app-shell',
+      type: core.type,
+      replacements: {'acme-app-shell': core.dirName},
+    });
+    process.chdir(tmpDir);
+
+    await createProgram().parseAsync([
+      'node',
+      'astryx',
+      '--json',
+      'doctor',
+      'integration',
+      'templates',
+    ]);
+
+    const parsed = JSON.parse(logCalls.join('\n'));
+    expect(parsed.data.issues).toEqual([]);
+    expect(parsed.data.conflicts).toEqual([
+      expect.objectContaining({
+        id: 'acme-app-shell',
+        relationship: 'replaces',
+        replaces: core.dirName,
+        severity: 'info',
+      }),
+    ]);
+    expect(parsed.data.conflicts[0].command).toContain(
+      `--package @astryxdesign/core`,
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('templates exits 1 for a missing replacement target', async () => {
+    writeIntegration({
+      id: 'acme-app-shell',
+      replacements: {'acme-app-shell': 'missing-core-shell'},
+    });
+    process.chdir(tmpDir);
+
+    await createProgram().parseAsync([
+      'node',
+      'astryx',
+      '--json',
+      'doctor',
+      'integration',
+      'templates',
+    ]);
+
+    const parsed = JSON.parse(logCalls.join('\n'));
+    expect(parsed.data.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'missing_template_replacement_target',
+          severity: 'error',
+        }),
+      ]),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('templates rejects replacement declarations when no templates root exists', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: '@acme/widgets', version: '1.2.3'}),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      `export default {templateReplacements: {'ghost-shell': 'shell-side-nav'}};\n`,
+    );
+    process.chdir(tmpDir);
+
+    await createProgram().parseAsync([
+      'node',
+      'astryx',
+      'doctor',
+      'integration',
+      'templates',
+    ]);
+
+    const output = logCalls.join('\n');
+    expect(output).toContain('[fail]');
+    expect(output).toContain('no available templates root');
+    expect(output).not.toContain('[ok]');
+    expect(process.exitCode).toBe(1);
+  });
+
   it('templates exits 1 when structural errors prevent a trustworthy check', async () => {
     writeIntegration({missingRoot: true});
     process.chdir(tmpDir);
@@ -278,9 +381,7 @@ describe('doctor integration — command', () => {
     const output = logCalls.join('\n');
     expect(output).toContain('[warn]');
     expect(output).toContain(core.name);
-    expect(output).toContain(
-      `component ${core.name} --package @acme/widgets`,
-    );
+    expect(output).toContain(`component ${core.name} --package @acme/widgets`);
     expect(process.exitCode).toBeUndefined();
   });
 

--- a/packages/cli/clients/cli/commands/doctor.mjs
+++ b/packages/cli/clients/cli/commands/doctor.mjs
@@ -128,14 +128,18 @@ function printTemplateConflicts(data) {
     ),
     ...issueBlocks(data.issues),
   ];
-  if (data.conflicts.length === 0) {
-    output.push(text('[ok] No template ids conflict with Core.'));
-  } else {
+  if (data.conflicts.length === 0 && data.issues.length === 0) {
+    output.push(
+      text('[ok] No template replacements or id conflicts with Core.'),
+    );
+  } else if (data.conflicts.length > 0) {
     output.push(
       records(data.conflicts, {
         fields: [
           'severity',
+          'relationship',
           'id',
+          'replaces',
           'integrationPackage',
           'integrationType',
           'integrationName',
@@ -144,10 +148,7 @@ function printTemplateConflicts(data) {
         ],
         format: {severity: statusToken},
       }),
-      text(
-        `${data.conflicts.length} Core template conflict(s). ` +
-          'Renaming is recommended but optional; keep the package-qualified command if the overlap is intentional.',
-      ),
+      text(`${data.conflicts.length} Core template relationship(s).`),
     );
   }
   emit(...output);
@@ -168,7 +169,13 @@ function printComponentConflicts(data) {
   } else {
     output.push(
       records(data.conflicts, {
-        fields: ['severity', 'name', 'integrationPackage', 'message', 'command'],
+        fields: [
+          'severity',
+          'name',
+          'integrationPackage',
+          'message',
+          'command',
+        ],
         format: {severity: statusToken},
       }),
       text(
@@ -275,7 +282,8 @@ async function runAuthoringCheck(program, pkg, kind) {
   const structuralErrors = summarizeIssues(result.data.issues).errors;
   const docErrors =
     result.type === 'integration.doc-conflicts'
-      ? result.data.findings.filter(finding => finding.severity === 'error').length
+      ? result.data.findings.filter(finding => finding.severity === 'error')
+          .length
       : 0;
   if (structuralErrors > 0 || docErrors > 0) process.exitCode = 1;
   return NO_RESULT_SET;

--- a/packages/cli/clients/cli/commands/search.mjs
+++ b/packages/cli/clients/cli/commands/search.mjs
@@ -49,7 +49,7 @@ export function registerSearch(program) {
 
       try {
         const project = await Project.load(process.cwd());
-        await warnOnIntegrationIssues(project.loadedIntegrations, {json});
+        await warnOnIntegrationIssues(project, {json});
       } catch {
         // Never let the nudge break the command.
       }

--- a/packages/cli/clients/cli/commands/template.doc.mjs
+++ b/packages/cli/clients/cli/commands/template.doc.mjs
@@ -18,16 +18,22 @@ export const doc = {
   description:
     'One entry point for the template family: with no name it lists the discovered ' +
     'templates; with a name it shows the source or a layout skeleton, or scaffolds it ' +
-    'into the project at a target path. Narrow an ambiguous name with --type and/or --package. ' +
-    '--cdn writes the no-build-step CDN starter page, which ships as an asset rather than as ' +
-    'a discovered template.',
+    'into the project at a target path. A configured integration replacement is the ' +
+    'default for its Core id; use --package @astryxdesign/core for the original. ' +
+    'Narrow other ambiguous names with --type and/or --package. --cdn writes the ' +
+    'no-build-step CDN starter page, which ships as an asset rather than as a ' +
+    'discovered template.',
   fn: 'template',
   args: [
     {name: 'name', param: 'name', required: false},
     {name: 'path', param: 'options.targetPath', required: false},
   ],
   options: [
-    {flag: '--list', param: 'options.list', description: 'List available templates'},
+    {
+      flag: '--list',
+      param: 'options.list',
+      description: 'List available templates',
+    },
     {
       flag: '--type <type>',
       param: 'options.type',
@@ -37,7 +43,8 @@ export const doc = {
     {
       flag: '--package <pkg>',
       param: 'options.package',
-      description: 'Narrow to templates from a specific package',
+      description:
+        'Narrow to templates from a specific package. Use @astryxdesign/core to select an original hidden by an integration replacement.',
     },
     {
       flag: '--skeleton',
@@ -60,14 +67,28 @@ export const doc = {
   examples: [
     {label: 'List templates', cli: 'astryx template --json'},
     {
+      label: 'List exact Core ids',
+      cli: 'astryx --json template --list --package @astryxdesign/core',
+    },
+    {
       label: 'Scaffold into the app',
       cli: 'astryx template dashboard ./src/app',
     },
+    {
+      label: 'Select a replaced Core original',
+      cli: 'astryx template shell-side-nav ./src/app --package @astryxdesign/core',
+    },
     {label: 'CDN starter page', cli: 'astryx template --cdn'},
-    {label: 'CDN starter page, elsewhere', cli: 'astryx template --cdn public/demo.html'},
+    {
+      label: 'CDN starter page, elsewhere',
+      cli: 'astryx template --cdn public/demo.html',
+    },
   ],
   exitCodes: [
-    {code: 0, when: 'success, including a CDN page left untouched because it already exists'},
+    {
+      code: 0,
+      when: 'success, including a CDN page left untouched because it already exists',
+    },
     {
       code: 1,
       when: 'unknown or ambiguous template, no source, a path escape, or an existing target without --overwrite',

--- a/packages/cli/clients/cli/commands/template.mjs
+++ b/packages/cli/clients/cli/commands/template.mjs
@@ -4,12 +4,9 @@
  * @file template command — thin CLI wrapper around api/template.mjs
  */
 
-import * as path from 'node:path';
-import * as fs from 'node:fs';
 import {jsonOut} from '../../../foundation/response/json.mjs';
 import {emit, section, text, records, code} from '../formatters/index.mjs';
 import {cliError} from '../lib/cli-error.mjs';
-import {ERROR_CODES} from '../../../foundation/response/error-codes.mjs';
 import {template as templateApi} from '../../../api/template/template.mjs';
 import {Project} from '../../../foundation/config/project.mjs';
 import {warnOnIntegrationIssues} from '../../../foundation/integrations/integration-warnings.mjs';
@@ -20,18 +17,6 @@ import {doc as templateCommand} from './template.doc.mjs';
 import {doc as templateFn} from '../../../api/template/template.doc.mjs';
 
 export {discoverTemplates, listTemplates} from '../../../api/template/template.mjs';
-
-/**
- * A template entry as produced by the discover* helpers in api/template.mjs.
- * The api layer returns these as `object[]`; this local shape captures the
- * fields the command consumes. Remove once api/template.mjs exports a precise
- * type for its discovered templates.
- * @typedef {object} DiscoveredTemplate
- * @property {'page' | 'block'} type
- * @property {string} dirName
- * @property {string} name
- * @property {string} filePath
- */
 
 /**
  * The discriminated response returned by the template API. The api layer
@@ -89,34 +74,9 @@ export function registerTemplate(program) {
       // doctor integration validate. Best-effort; suppressed in --json mode.
       try {
         const project = await Project.load(process.cwd());
-        await warnOnIntegrationIssues(
-          /** @type {Array<import('../../../foundation/integrations/integrations.mjs').LoadedIntegration>} */ (
-            project.loadedIntegrations
-          ),
-          {json},
-        );
+        await warnOnIntegrationIssues(project, {json});
       } catch {
         // Never let the nudge break the command.
-      }
-
-      // Pre-flight overwrite check (only when we'd actually copy a file).
-      // The API resolves the destination; we need to mirror its logic
-      // narrowly enough to detect collisions before invoking it.
-      if (
-        name &&
-        targetPath &&
-        !options.list &&
-        !options.skeleton &&
-        !options.cdn
-      ) {
-        const collision = await detectTemplateCollision(name, targetPath);
-        if (collision && !options.overwrite) {
-          const rel = path.relative(process.cwd(), collision) || collision;
-          const msg =
-            `Refusing to overwrite existing file ${rel}. ` +
-            `Re-run with --overwrite (or -f) to replace it.`;
-          return cliError(msg, {code: ERROR_CODES.ERR_FILE_EXISTS});
-        }
       }
 
       /** @type {TemplateResponse} */
@@ -156,12 +116,14 @@ export function registerTemplate(program) {
           // isn't the built-in core package.
           /** @param {import('../../../api/template/template.type.mjs').TemplateListEntry} t */
           const toRow = t => ({
+            id: t.id,
             name: t.isReady ? t.name : `${t.name} (WIP)`,
             description: t.description,
             package:
               t.package && t.package !== '@astryxdesign/core' ? t.package : '',
+            replaces: t.replaces ?? '',
           });
-          const fields = ['name', 'description', 'package'];
+          const fields = ['id', 'name', 'description', 'package', 'replaces'];
           emit(
             pages.length > 0 && section('Page Templates'),
             pages.length > 0 && records(pages.map(toRow), {fields}),
@@ -228,53 +190,4 @@ export function registerTemplate(program) {
       return answered;
     },
   });
-}
-
-/**
- * Mirror the destination-resolution logic in api/template.mjs so we can
- * detect a clobber before invoking the API.
- *
- * Returns the absolute destination file path if it already exists, or
- * `null` otherwise (template missing, no collision, or list/skeleton mode).
- *
- * Path-safety enforcement happens inside the API; here we only need
- * enough precision to check existence — a false negative just means the
- * API will catch the issue and abort.
- *
- * @param {string} name
- * @param {string} targetPath
- * @returns {Promise<string | null>}
- */
-async function detectTemplateCollision(name, targetPath) {
-  const {discoverTemplates} = await import('../../../api/template/template.mjs');
-  /** @type {DiscoveredTemplate[]} */
-  let templates;
-  try {
-    templates = /** @type {DiscoveredTemplate[]} */ (
-      await discoverTemplates(process.cwd())
-    );
-  } catch {
-    return null;
-  }
-  const match = templates.find(t => t.dirName === name);
-  if (!match) return null;
-
-  // Resolve target as the API will. We can't call assertWithin here
-  // because the API does it itself; we just need to know "is there a
-  // file at the destination?".
-  const resolved = path.resolve(process.cwd(), targetPath);
-
-  // File-arg branch: targetPath looks like `./foo.tsx`.
-  const {isFilePathArg} = await import('../../../foundation/fs/path-safety.mjs');
-  let dest;
-  if (isFilePathArg(targetPath)) {
-    dest = resolved;
-  } else {
-    const fileName = match.type === 'block'
-      ? path.basename(match.filePath)
-      : 'page.tsx';
-    dest = path.join(resolved, fileName);
-  }
-
-  return fs.existsSync(dest) ? dest : null;
 }

--- a/packages/cli/foundation/config/project.mjs
+++ b/packages/cli/foundation/config/project.mjs
@@ -19,10 +19,10 @@
  *   - Discovery methods (components/templates/codemods/docs/themes) are MEMOIZED per
  *     instance (via the pluggable cache) and orchestrate the EXISTING discovery
  *     functions — Project never reimplements discovery.
- *   - SKIP + WARN policy: as a discovery method runs, per-integration work is
- *     guarded so one broken integration never throws out of discovery. Any
- *     AstryxIntegrationIssue encountered is collected into a private set and
- *     that integration's contributions are skipped.
+ *   - SKIP + WARN policy: discovery records each integration issue. Other valid
+ *     contribution kinds remain available; invalid template and component files
+ *     do not hide valid siblings. A manifest load failure still withdraws the
+ *     package because its roots cannot be trusted.
  *   - `issues()` returns the deduped accumulated set, and (when called
  *     directly) fills in validation for any configured integration not yet
  *     visited by a discovery call, so it is always complete on demand.
@@ -48,11 +48,13 @@ import {
 import {
   CORE_PACKAGE,
   discoverOwnedComponents,
-  discoverIntegrationComponents,
+  discoverValidIntegrationComponents,
 } from '../discovery/component-discovery.mjs';
 import {findCoreDir} from '../fs/paths.mjs';
 import {
-  discoverAll as discoverTemplates,
+  applyTemplateReplacements,
+  effectiveTemplateDiscovery,
+  discoverAllUnresolved as discoverTemplates,
   discoverIntegrationTemplatesForOne,
 } from '../discovery/template-adapter.mjs';
 import {
@@ -68,10 +70,7 @@ import {
   discoverIntegrationCodemods,
   selectIntegrationCodemods,
 } from '../../assets/codemods/integration-discovery.mjs';
-import {
-  INVALID_AGENT_DOCS,
-  validateLoadedIntegration,
-} from '../integrations/validate-contributions.mjs';
+import {validateLoadedIntegration} from '../integrations/validate-contributions.mjs';
 import {
   InMemoryConfigCache,
   cacheKey,
@@ -209,6 +208,8 @@ export class Project {
    * @type {Set<string>}
    */
   #visitedIssues = new Set();
+  /** @type {Promise<Array<object>> | null} */
+  #templatesPromise = null;
 
   /**
    * @param {object} init
@@ -440,22 +441,6 @@ export class Project {
   }
 
   /**
-   * Whether this package has an error that invalidates its regular manifest
-   * contributions. Invalid `agentDocs` blocks agent-doc writes only; it must not
-   * withdraw components, templates, docs, or codemods.
-   * @param {string} pkg
-   * @returns {boolean}
-   */
-  #hasBlockingContributionIssue(pkg) {
-    return this.#issues.some(
-      issue =>
-        issue.package === pkg &&
-        issue.severity === 'error' &&
-        issue.code !== INVALID_AGENT_DOCS,
-    );
-  }
-
-  /**
    * Validate one loaded integration and collect any issues. Marks the
    * integration visited so issues() won't redo the work. Best-effort: a
    * validator throwing is itself recorded as an issue, never propagated.
@@ -491,9 +476,9 @@ export class Project {
   /**
    * Core + integration component ownership records. Wraps
    * discoverOwnedComponents for core and discoverIntegrationComponents (via
-   * discoverOwnedComponents) for integrations, but applies the skip+warn
-   * policy per integration: a broken integration's components are skipped and
-   * its issues collected, never thrown. Memoized per instance.
+   * discoverOwnedComponents) for integrations. Invalid component records are
+   * omitted and reported; valid component siblings and other contribution kinds
+   * remain available. Memoized per instance.
    *
    * @returns {Promise<Array<{name: string, package: string, group: string|null, docPath: string|null, sourcePath: string|null, issuesUrl: string|undefined}>>}
    */
@@ -513,18 +498,22 @@ export class Project {
         }
       }
 
-      // Each integration in isolation so one broken integration is skipped.
+      // Each integration is discovered independently. Invalid records are
+      // omitted below without hiding valid siblings or other contribution kinds.
       for (const integration of this.#loadedIntegrations) {
         await this.#collectIssues(integration);
         const pkg = this.#pkgLabel(integration);
-        if (this.#hasBlockingContributionIssue(pkg)) continue;
         try {
-          // discoverOwnedComponents owns the core+integration record shape;
-          // here we add only this integration's records (core is handled
-          // above) so a single broken integration can be skipped in isolation.
-          for (const rec of discoverIntegrationComponents(integration)) {
-            records.push(rec);
+          const {components, errors} =
+            await discoverValidIntegrationComponents(integration);
+          for (const error of errors) {
+            this.#pushIssue(pkg, {
+              code: 'invalid_component',
+              severity: 'error',
+              message: error.message,
+            });
           }
+          records.push(...components);
         } catch (err) {
           this.#pushIssue(pkg, {
             code: 'invalid_component',
@@ -539,17 +528,21 @@ export class Project {
   }
 
   /**
-   * Core + integration templates, type-tagged. Wraps discoverTemplates (core +
-   * external blocks) and discoverIntegrationTemplatesForOne per integration so
-   * a broken integration's templates are skipped and its issues collected.
-   * Memoized per instance.
+   * Core + integration templates, type-tagged, with valid integration
+   * replacements projected over their Core targets. Wraps raw template discovery
+   * (Core + external blocks) and discoverIntegrationTemplatesForOne per integration
+   * so unusable template files are reported and omitted while valid siblings
+   * remain available. Memoized per instance.
    *
    * @returns {Promise<Array<object>>}
    */
   async templates() {
-    return this.#memo('templates', async () => {
+    if (this.#templatesPromise) return this.#templatesPromise;
+    this.#templatesPromise = (async () => {
       /** @type {any[]} */
       const templates = [];
+      /** @type {import('../discovery/template-adapter.mjs').TemplateDiscoveryError[]} */
+      const replacementErrors = [];
 
       // Core + external-package templates (discoverTemplates internally also
       // loads integration templates via loadConfig today; we intentionally
@@ -570,20 +563,24 @@ export class Project {
       for (const integration of this.#loadedIntegrations) {
         await this.#collectIssues(integration);
         const pkg = this.#pkgLabel(integration);
-        if (this.#hasBlockingContributionIssue(pkg)) continue;
+        // Template discovery already isolates invalid template files and returns
+        // every valid sibling. Do not withdraw templates because another
+        // contribution kind in this package is broken.
         try {
           const {templates: ts, errors} =
             await discoverIntegrationTemplatesForOne(integration);
           for (const e of errors) {
             this.#pushIssue(pkg, {
-              code: 'invalid_template',
-              severity: 'error',
+              code: e.code ?? 'invalid_template',
+              severity: e.severity ?? 'error',
               message: e.message,
             });
+            if (e.replacementTarget != null) replacementErrors.push(e);
           }
-          // Only contribute templates when the integration had no per-template
-          // errors (skip the whole integration's templates on any error).
-          if (errors.length === 0) templates.push(...ts);
+          // Discovery already omits each unusable template from `ts`. Keep all
+          // valid siblings, while the collected errors remain visible through
+          // issues() and replacement errors disable only their own targets.
+          templates.push(...ts);
         } catch (err) {
           this.#pushIssue(pkg, {
             code: 'invalid_template',
@@ -593,15 +590,24 @@ export class Project {
         }
       }
 
-      return templates.sort((a, b) => a.name.localeCompare(b.name));
-    });
+      const resolved = applyTemplateReplacements(templates, replacementErrors);
+      for (const error of resolved.errors) {
+        this.#pushIssue(error.package, {
+          code: error.code,
+          severity: error.severity,
+          message: error.message,
+        });
+      }
+      return effectiveTemplateDiscovery(resolved.templates);
+    })();
+    return this.#templatesPromise;
   }
 
   /**
    * Bundled source themes plus themes contributed by installed integrations.
    * Each record keeps its package owner and source directory so callers can
-   * both list and copy it without reconstructing paths. A broken integration's
-   * themes are skipped under the same issue policy as every other kind.
+   * both list and copy it without reconstructing paths. A broken theme
+   * contribution is reported without hiding the package's other valid kinds.
    *
    * @returns {Promise<import('../discovery/theme-discovery.mjs').DiscoveredTheme[]>}
    */
@@ -612,7 +618,6 @@ export class Project {
       for (const integration of this.#loadedIntegrations) {
         await this.#collectIssues(integration);
         const pkg = this.#pkgLabel(integration);
-        if (this.#hasBlockingContributionIssue(pkg)) continue;
         if (!integration?.themes) continue;
         try {
           themes.push(...(await discoverIntegrationThemes(integration)));
@@ -650,7 +655,6 @@ export class Project {
       for (const integration of this.#loadedIntegrations) {
         await this.#collectIssues(integration);
         const pkg = this.#pkgLabel(integration);
-        if (this.#hasBlockingContributionIssue(pkg)) continue;
         if (!integration?.docs) continue;
         try {
           const {records, errors} = await discoverIntegrationDocs(integration);
@@ -686,8 +690,8 @@ export class Project {
   /**
    * Core registry transforms + integration codemods for an upgrade range.
    * Wraps getTransformsBetween (core) and discoverIntegrationCodemods /
-   * selectIntegrationCodemods (integrations). A broken integration's codemods
-   * are skipped (issue collected) rather than failing the whole resolution.
+   * selectIntegrationCodemods (integrations). An invalid codemod contribution
+   * is reported and omitted without hiding other valid contribution kinds.
    * Memoized per (from, to) key.
    *
    * @param {string} fromVersion exclusive lower bound
@@ -705,7 +709,6 @@ export class Project {
       for (const integration of this.#loadedIntegrations) {
         await this.#collectIssues(integration);
         const pkg = this.#pkgLabel(integration);
-        if (this.#hasBlockingContributionIssue(pkg)) continue;
         if (!integration?.codemods) continue;
         try {
           // Validate this integration's codemods discover cleanly in
@@ -760,6 +763,10 @@ export class Project {
    * @returns {Promise<ProjectIntegrationIssue[]>}
    */
   async issues() {
+    // Template replacement validity depends on the combined Core + integration
+    // catalog. Resolve it first so issue results never depend on which discovery
+    // method the caller happened to invoke earlier.
+    await this.templates();
     for (const integration of this.#loadedIntegrations) {
       await this.#collectIssues(integration);
     }

--- a/packages/cli/foundation/config/project.test.mjs
+++ b/packages/cli/foundation/config/project.test.mjs
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import {Project, DEFAULT_ISSUES_URL, findConfigPath} from './project.mjs';
 import {InMemoryConfigCache} from './config-cache.mjs';
 import * as componentDiscovery from '../discovery/component-discovery.mjs';
+import {discoverCoreTemplates} from '../discovery/template-adapter.mjs';
 
 let tmpDir;
 let originalCwd;
@@ -21,6 +22,9 @@ function scaffold({
   issuesUrl,
   withComponents = true,
   withTemplates = true,
+  templateId = 'hero',
+  templateType = 'block',
+  templateReplacements = null,
   withCodemods = true,
   brokenComponent = false,
   brokenCodemod = false,
@@ -50,6 +54,9 @@ function scaffold({
   const manifest = {};
   if (withComponents) manifest.components = './components';
   if (withTemplates) manifest.templates = './templates';
+  if (templateReplacements) {
+    manifest.templateReplacements = templateReplacements;
+  }
   if (withCodemods) manifest.codemods = './codemods';
   if (docs) manifest.docs = './docs';
   if (agentDocs != null) manifest.agentDocs = agentDocs;
@@ -65,7 +72,7 @@ function scaffold({
     fs.mkdirSync(compDir, {recursive: true});
     fs.writeFileSync(
       path.join(compDir, 'Widget.doc.mjs'),
-      `export const docs = { name: 'Widget', usage: {description: 'A widget'} };\n`,
+      `export const docs = { name: 'Widget', usage: {description: 'A widget'}, props: [] };\n`,
     );
     if (!brokenComponent) {
       fs.writeFileSync(
@@ -80,12 +87,12 @@ function scaffold({
     const tDir = path.join(pkgDir, 'templates');
     fs.mkdirSync(tDir, {recursive: true});
     fs.writeFileSync(
-      path.join(tDir, 'hero.doc.mjs'),
-      `export default { type: 'block', name: 'Hero', description: 'A hero' };\n`,
+      path.join(tDir, `${templateId}.doc.mjs`),
+      `export default { type: '${templateType}', name: 'Fixture template', description: 'A fixture template' };\n`,
     );
     fs.writeFileSync(
-      path.join(tDir, 'hero.tsx'),
-      `export default function Hero() { return null; }\n`,
+      path.join(tDir, `${templateId}.tsx`),
+      `export default function FixtureTemplate() { return null; }\n`,
     );
   }
 
@@ -337,6 +344,91 @@ describe('Project discovery', () => {
     expect(hero.type).toBe('block');
   });
 
+  it('templates() projects a valid integration replacement instead of its Core target', async () => {
+    const corePage = (await discoverCoreTemplates()).find(
+      template => template.type === 'page',
+    );
+    expect(corePage).toBeDefined();
+    scaffold({
+      templateId: 'acme-app-shell',
+      templateType: 'page',
+      templateReplacements: {'acme-app-shell': corePage.dirName},
+    });
+    const project = await Project.load(tmpDir);
+
+    const templates = await project.templates();
+
+    expect(
+      templates.find(template => template.dirName === 'acme-app-shell'),
+    ).toMatchObject({
+      package: '@acme/widgets',
+      replaces: corePage.dirName,
+    });
+    expect(
+      templates.find(
+        template =>
+          template.dirName === corePage.dirName &&
+          template.package !== '@acme/widgets',
+      ),
+    ).toBeUndefined();
+    expect(await project.issues()).toEqual([]);
+  });
+
+  it('reports replacement issues regardless of discovery call order without hiding other contributions', async () => {
+    scaffold({
+      templateReplacements: {hero: 'missing-core-template'},
+    });
+
+    const componentsFirst = await Project.load(tmpDir);
+    expect(
+      (await componentsFirst.components()).some(
+        component => component.package === '@acme/widgets',
+      ),
+    ).toBe(true);
+    expect(await componentsFirst.issues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'missing_template_replacement_target',
+          package: '@acme/widgets',
+        }),
+      ]),
+    );
+
+    const issuesFirst = await Project.load(tmpDir, {fresh: true});
+    expect(await issuesFirst.issues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'missing_template_replacement_target',
+          package: '@acme/widgets',
+        }),
+      ]),
+    );
+    expect(
+      (await issuesFirst.components()).some(
+        component => component.package === '@acme/widgets',
+      ),
+    ).toBe(true);
+    const ownTemplate = (await issuesFirst.templates()).find(
+      template =>
+        template.package === '@acme/widgets' && template.dirName === 'hero',
+    );
+    expect(ownTemplate).toBeDefined();
+    expect(ownTemplate).not.toHaveProperty('replaces');
+
+    const sharedCache = new InMemoryConfigCache();
+    const warm = await Project.load(tmpDir, {cache: sharedCache});
+    await warm.templates();
+    const cached = await Project.load(tmpDir, {cache: sharedCache});
+    expect(await cached.issues()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'missing_template_replacement_target',
+          package: '@acme/widgets',
+        }),
+      ]),
+    );
+  });
+
   it('codemods() returns core registry groups + integration groups', async () => {
     scaffold();
     const project = await Project.load(tmpDir);
@@ -479,6 +571,53 @@ describe('Project issues (skip + warn)', () => {
     const issues = await project.issues();
     expect(issues.length).toBeGreaterThan(0);
     expect(issues.some(i => i.package === '@acme/widgets')).toBe(true);
+  });
+
+  it('keeps valid contribution kinds and siblings when others are broken', async () => {
+    const pkgDir = scaffold({brokenComponent: true});
+    fs.writeFileSync(
+      path.join(pkgDir, 'templates', 'broken.template.mjs'),
+      `export default {type: 'block', name: 'Broken', description: 'Missing source'};\n`,
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, 'components', 'ValidWidget.doc.mjs'),
+      `export default {type: 'component', name: 'ValidWidget', props: []};\n`,
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, 'components', 'ValidWidget.tsx'),
+      `export function ValidWidget() { return null; }\n`,
+    );
+    const project = await Project.load(tmpDir);
+
+    const templates = await project.templates();
+    const components = await project.components();
+    const issues = await project.issues();
+
+    expect(
+      templates.find(
+        template =>
+          template.dirName === 'hero' && template.package === '@acme/widgets',
+      ),
+    ).toBeDefined();
+    expect(
+      components.find(
+        component =>
+          component.name === 'ValidWidget' &&
+          component.package === '@acme/widgets',
+      ),
+    ).toBeDefined();
+    expect(
+      components.find(
+        component =>
+          component.name === 'Widget' && component.package === '@acme/widgets',
+      ),
+    ).toBeUndefined();
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({code: 'invalid_component'}),
+        expect.objectContaining({code: 'invalid_template'}),
+      ]),
+    );
   });
 
   it('does not throw when an integration codemod is broken', async () => {

--- a/packages/cli/foundation/discovery/component-discovery.mjs
+++ b/packages/cli/foundation/discovery/component-discovery.mjs
@@ -7,6 +7,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {existsCaseExact} from '../fs/paths.mjs';
+import {loadComponentDoc} from './component-loader.mjs';
 
 const SKIP_DIRS = new Set(['hooks', 'utils', '__tests__', 'node_modules']);
 
@@ -673,6 +674,53 @@ export function discoverIntegrationComponents(integration) {
 
   scanDir(componentsDir);
   return [...byName.values()];
+}
+
+/**
+ * Load and validate every discovered integration component independently.
+ * Invalid metadata or a missing same-stem source removes only that component;
+ * callers can report the returned errors while retaining valid siblings.
+ *
+ * @param {{name: string, components?: string, issuesUrl?: string}} integration
+ * @returns {Promise<{
+ *   components: Array<{name: string, package: string, docPath: string, sourcePath: string, issuesUrl: string|undefined, group: string|null}>,
+ *   discovered: Array<{name: string, package: string, docPath: string, sourcePath: string|null, issuesUrl: string|undefined, group: string|null}>,
+ *   errors: Array<{name: string, message: string}>,
+ * }>}
+ */
+export async function discoverValidIntegrationComponents(integration) {
+  const discovered = discoverIntegrationComponents(integration);
+  /** @type {Array<{name: string, package: string, docPath: string, sourcePath: string, issuesUrl: string|undefined, group: string|null}>} */
+  const components = [];
+  /** @type {Array<{name: string, message: string}>} */
+  const errors = [];
+
+  for (const record of discovered) {
+    if (record.sourcePath == null) {
+      errors.push({
+        name: record.name,
+        message: `Component "${record.name}" is missing its same-stem source file ${record.name}.tsx.`,
+      });
+      continue;
+    }
+    try {
+      await loadComponentDoc(record.docPath);
+      components.push(
+        /** @type {{name: string, package: string, docPath: string, sourcePath: string, issuesUrl: string|undefined, group: string|null}} */ (
+          record
+        ),
+      );
+    } catch (err) {
+      errors.push({
+        name: record.name,
+        message: `Component "${record.name}" has invalid metadata: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
+    }
+  }
+
+  return {components, discovered, errors};
 }
 
 /**

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -43,6 +43,53 @@ export function pkgOf(t) {
 }
 
 /**
+ * Every id that should resolve to a discovered template. Replacements keep
+ * their own integration id and also own the Core id they replace.
+ * @param {{dirName: string, replaces?: string}} template
+ * @returns {string[]}
+ */
+export function templateLookupIds(template) {
+  if (template.replaces && template.replaces !== template.dirName) {
+    return [template.dirName, template.replaces];
+  }
+  return [template.dirName];
+}
+
+/**
+ * Remove entries shadowed in the default discovery view while retaining them in
+ * package-scoped views. An active replacement owns its target id. A rejected
+ * same-id declaration falls back to Core when a Core template of the same kind
+ * owns that id; otherwise the integration template remains available by kind.
+ * @param {DiscoveredTemplate[]} templates
+ * @returns {DiscoveredTemplate[]}
+ */
+export function effectiveTemplateDiscovery(templates) {
+  const activeTargets = new Set(
+    templates
+      .filter(template => template.replaces != null)
+      .map(template => `${template.type}:${template.replaces}`),
+  );
+  const coreIds = new Set(
+    templates
+      .filter(template => pkgOf(template) === CORE_PACKAGE)
+      .map(template => `${template.type}:${template.dirName}`),
+  );
+  return templates.filter(template => {
+    if (
+      template.replacementRejected &&
+      template.replacementTarget === template.dirName &&
+      coreIds.has(`${template.type}:${template.dirName}`)
+    ) {
+      return false;
+    }
+    return (
+      !activeTargets.has(`${template.type}:${template.dirName}`) ||
+      template.replaces != null
+    );
+  });
+}
+
+/**
  * A discovered template (page or block), normalized across core, external, and
  * integration sources. Not every source populates every field, so
  * source-specific extras (`aspectRatio`, `isShowcase`, `package`) are optional.
@@ -64,6 +111,11 @@ export function pkgOf(t) {
  * @property {string} filePath
  * @property {string} docPath
  * @property {string} [package]
+ * @property {boolean} [autolinked] whether the owning integration was discovered
+ *   from package.json rather than named in astryx.config
+ * @property {string} [replaces] active Core template id this integration template replaces
+ * @property {boolean} [replacementRejected] whether an invalid declaration was disabled
+ * @property {string} [replacementTarget] disabled declaration target
  */
 
 /**
@@ -72,6 +124,15 @@ export function pkgOf(t) {
  * @property {string} package
  * @property {string} [template]
  * @property {string} message
+ * @property {string} [code]
+ * @property {'warning' | 'error'} [severity]
+ * @property {string} [replacementTarget] Core target whose replacement set is invalid
+ * @property {boolean} [autolinked] whether the declaration came from an autolinked integration
+ */
+
+/**
+ * A semantic error in an integration template replacement declaration.
+ * @typedef {TemplateDiscoveryError & {code: 'missing_template_replacement_target' | 'ambiguous_template_replacement' | 'invalid_template_replacement', severity: 'warning' | 'error'}} TemplateReplacementError
  */
 
 /**
@@ -436,38 +497,291 @@ export async function discoverCoreTemplates() {
 }
 
 /**
- * @param {string} [cwd]
- * @returns {Promise<DiscoveredTemplate[]>}
+ * Apply valid integration replacements to a raw template set.
+ *
+ * One declaration owns its Core target. When different configured packages
+ * replace the same target, the later package wins and discovery returns a
+ * warning, matching integration-doc replacement order. Multiple declarations
+ * inside one package are invalid and fail closed. Missing targets and kind
+ * mismatches also fail closed: Core stays selected and every integration
+ * template remains addressable by its own id.
+ *
+ * @param {DiscoveredTemplate[]} templates
+ * @param {TemplateDiscoveryError[]} [declarationErrors]
+ * @returns {{templates: DiscoveredTemplate[], errors: TemplateReplacementError[]}}
  */
-export async function discoverAll(cwd = process.cwd()) {
+export function applyTemplateReplacements(templates, declarationErrors = []) {
+  /** @type {Map<string, DiscoveredTemplate[]>} */
+  const coreById = new Map();
+  /** @type {Map<string, DiscoveredTemplate[]>} */
+  const replacementsByTarget = new Map();
+
+  for (const template of templates) {
+    if (pkgOf(template) === CORE_PACKAGE) {
+      const matches = coreById.get(template.dirName) ?? [];
+      matches.push(template);
+      coreById.set(template.dirName, matches);
+    }
+    if (template.replaces != null) {
+      const replacements = replacementsByTarget.get(template.replaces) ?? [];
+      replacements.push(template);
+      replacementsByTarget.set(template.replaces, replacements);
+    }
+  }
+
+  const activeReplacements = new Set();
+  const replacedCore = new Set();
+  /** @type {TemplateReplacementError[]} */
+  const errors = declarationErrors.map(error => ({
+    ...error,
+    code: /** @type {TemplateReplacementError['code']} */ (
+      error.code ?? 'invalid_template_replacement'
+    ),
+    severity: error.severity ?? 'error',
+  }));
+  /** @param {TemplateReplacementError} error */
+  const pushError = error => {
+    if (
+      errors.some(
+        existing =>
+          existing.code === error.code &&
+          existing.package === error.package &&
+          existing.template === error.template &&
+          existing.message === error.message,
+      )
+    ) {
+      return;
+    }
+    errors.push(error);
+  };
+  for (const [target, replacements] of replacementsByTarget) {
+    const targetErrors = errors.filter(
+      error => error.replacementTarget === target,
+    );
+    const hasExplicitIntent =
+      replacements.some(replacement => !replacement.autolinked) ||
+      targetErrors.some(error => !error.autolinked);
+    const contenders = hasExplicitIntent
+      ? replacements.filter(replacement => !replacement.autolinked)
+      : replacements;
+    let targetInvalid = targetErrors.some(
+      error =>
+        error.severity === 'error' && (!hasExplicitIntent || !error.autolinked),
+    );
+
+    /** @type {Map<string, DiscoveredTemplate[]>} */
+    const byPackage = new Map();
+    for (const replacement of replacements) {
+      const pkg = pkgOf(replacement);
+      const fromPackage = byPackage.get(pkg) ?? [];
+      fromPackage.push(replacement);
+      byPackage.set(pkg, fromPackage);
+    }
+    for (const [pkg, declarations] of byPackage) {
+      if (declarations.length < 2) continue;
+      if (!hasExplicitIntent || !declarations[0].autolinked) {
+        targetInvalid = true;
+      }
+      const message =
+        `${pkg} declares ${declarations.length} templates as replacements for Core ` +
+        `template "${target}" (${declarations.map(template => template.dirName).join(', ')}). ` +
+        'One package must declare at most one replacement for a Core target.';
+      for (const declaration of declarations) {
+        pushError({
+          code: 'ambiguous_template_replacement',
+          severity: 'error',
+          package: pkg,
+          template: declaration.dirName,
+          replacementTarget: target,
+          autolinked: declaration.autolinked,
+          message,
+        });
+      }
+    }
+
+    const coreMatches = coreById.get(target) ?? [];
+    /** @type {Map<DiscoveredTemplate, DiscoveredTemplate>} */
+    const coreMatchByReplacement = new Map();
+    for (const replacement of replacements) {
+      const invalidAffectsTarget =
+        !hasExplicitIntent || !replacement.autolinked;
+      if (coreMatches.length === 0) {
+        if (invalidAffectsTarget) targetInvalid = true;
+        pushError({
+          code: 'missing_template_replacement_target',
+          severity: 'error',
+          package: pkgOf(replacement),
+          template: replacement.dirName,
+          replacementTarget: target,
+          autolinked: replacement.autolinked,
+          message: `Template "${replacement.dirName}" replaces "${target}", which is not a Core template id.`,
+        });
+        continue;
+      }
+      const sameType = coreMatches.filter(
+        core => core.type === replacement.type,
+      );
+      if (sameType.length !== 1) {
+        if (invalidAffectsTarget) targetInvalid = true;
+        const kinds = coreMatches.map(core => core.type).join(', ');
+        pushError({
+          code: 'invalid_template_replacement',
+          severity: 'error',
+          package: pkgOf(replacement),
+          template: replacement.dirName,
+          replacementTarget: target,
+          autolinked: replacement.autolinked,
+          message:
+            `Template "${replacement.dirName}" is a ${replacement.type} template, but Core ` +
+            `template "${target}" is ${kinds || 'not available'}. A replacement must have the same type.`,
+        });
+        continue;
+      }
+      coreMatchByReplacement.set(replacement, sameType[0]);
+    }
+
+    const validContenders = contenders.filter(replacement =>
+      coreMatchByReplacement.has(replacement),
+    );
+    if (targetInvalid || validContenders.length === 0) continue;
+
+    const replacement = validContenders[validContenders.length - 1];
+    const validReplacements = replacements.filter(candidate =>
+      coreMatchByReplacement.has(candidate),
+    );
+    if (validReplacements.length > 1) {
+      const autolinkedLost =
+        hasExplicitIntent &&
+        validReplacements.some(candidate => candidate.autolinked);
+      const allAutolinked = validReplacements.every(
+        candidate => candidate.autolinked,
+      );
+      pushError({
+        code: 'ambiguous_template_replacement',
+        severity: 'warning',
+        package: pkgOf(replacement),
+        template: replacement.dirName,
+        replacementTarget: target,
+        autolinked: replacement.autolinked,
+        message: autolinkedLost
+          ? `Core template "${target}" is replaced by ${validReplacements.map(candidate => pkgOf(candidate)).join(', ')}. ${pkgOf(replacement)} is explicitly configured, so it wins over autolinked integrations.`
+          : allAutolinked
+            ? `Core template "${target}" is replaced by autolinked dependencies ${validReplacements.map(candidate => pkgOf(candidate)).join(', ')}. ${pkgOf(replacement)} is listed later in package.json dependencies, so it wins. Add the intended package to astryx.config integrations to make precedence explicit.`
+            : `Core template "${target}" is replaced by ${validReplacements.map(candidate => pkgOf(candidate)).join(', ')}. ${pkgOf(replacement)} is configured later, so it wins.`,
+      });
+    }
+
+    activeReplacements.add(replacement);
+    const coreMatch = coreMatchByReplacement.get(replacement);
+    if (coreMatch) replacedCore.add(coreMatch);
+  }
+
+  const effective = templates.flatMap(template => {
+    if (replacedCore.has(template)) return [];
+    if (template.replaces != null && !activeReplacements.has(template)) {
+      const fallback = {
+        ...template,
+        replacementRejected: true,
+        replacementTarget: template.replaces,
+      };
+      delete fallback.replaces;
+      return [fallback];
+    }
+    return [template];
+  });
+
+  return {
+    templates: effective.sort((a, b) => a.name.localeCompare(b.name)),
+    errors,
+  };
+}
+
+/**
+ * Discover the raw Core, external, and integration template set before
+ * replacement declarations are applied.
+ * @param {string} [cwd]
+ * @returns {Promise<{templates: DiscoveredTemplate[], errors: TemplateDiscoveryError[]}>}
+ */
+async function discoverAllSources(cwd = process.cwd()) {
   const [core, external, integration] = await Promise.all([
     discoverCoreTemplates(),
     discoverExternalBlocks(cwd),
     discoverIntegrationTemplates(cwd),
   ]);
-  return [...core, ...external, ...integration.templates].sort((a, b) =>
+  return {
+    templates: [...core, ...external, ...integration.templates],
+    errors: integration.errors,
+  };
+}
+
+/**
+ * Discover every template without hiding replaced Core originals. Internal
+ * package-qualified selection uses this view.
+ * @param {string} [cwd]
+ * @returns {Promise<DiscoveredTemplate[]>}
+ */
+export async function discoverAllUnresolved(cwd = process.cwd()) {
+  return (await discoverAllSources(cwd)).templates.sort((a, b) =>
     a.name.localeCompare(b.name),
   );
 }
 
 /**
- * Like {@link discoverAll} but also returns integration-template discovery
- * errors (missing same-stem source, missing `type`, load failure). Use this
- * when the caller wants to warn about malformed integration templates.
+ * Resolve replacement declarations while retaining package-addressable entries
+ * that are shadowed or rejected in the default discovery view.
+ * @param {string} [cwd]
+ * @returns {Promise<{templates: DiscoveredTemplate[], errors: Array<TemplateDiscoveryError | TemplateReplacementError>}>}
+ */
+async function resolveAllSources(cwd = process.cwd()) {
+  const discovered = await discoverAllSources(cwd);
+  const replacementErrors = discovered.errors.filter(
+    error => error.replacementTarget != null,
+  );
+  const resolved = applyTemplateReplacements(
+    discovered.templates,
+    replacementErrors,
+  );
+  return {
+    templates: resolved.templates,
+    errors: [
+      ...discovered.errors.filter(error => error.replacementTarget == null),
+      ...resolved.errors,
+    ],
+  };
+}
+
+/**
+ * Discover the resolved catalog before default-view shadowing. Internal
+ * package-qualified selection uses this view.
+ * @param {string} [cwd]
+ * @returns {Promise<DiscoveredTemplate[]>}
+ */
+export async function discoverAllResolved(cwd = process.cwd()) {
+  return (await resolveAllSources(cwd)).templates;
+}
+
+/**
+ * @param {string} [cwd]
+ * @returns {Promise<DiscoveredTemplate[]>}
+ */
+export async function discoverAll(cwd = process.cwd()) {
+  return effectiveTemplateDiscovery(await discoverAllResolved(cwd));
+}
+
+/**
+ * Like {@link discoverAll} but also returns integration-template discovery and
+ * replacement-declaration errors. Use this when the caller wants to warn about
+ * malformed integration templates or inactive replacement declarations.
  *
  * @param {string} [cwd]
- * @returns {Promise<{templates: DiscoveredTemplate[], errors: TemplateDiscoveryError[]}>}
+ * @returns {Promise<{templates: DiscoveredTemplate[], errors: Array<TemplateDiscoveryError | TemplateReplacementError>}>}
  */
 export async function discoverAllWithErrors(cwd = process.cwd()) {
-  const [pages, blocks, integration] = await Promise.all([
-    discoverPages(),
-    discoverAllBlocks(cwd),
-    discoverIntegrationTemplates(cwd),
-  ]);
-  const templates = [...pages, ...blocks, ...integration.templates].sort(
-    (a, b) => a.name.localeCompare(b.name),
-  );
-  return {templates, errors: integration.errors};
+  const resolved = await resolveAllSources(cwd);
+  return {
+    templates: effectiveTemplateDiscovery(resolved.templates),
+    errors: resolved.errors,
+  };
 }
 
 /**
@@ -553,12 +867,89 @@ async function discoverIntegrationTemplates(cwd = process.cwd()) {
 }
 
 /**
+ * Validate manifest replacement declarations against one integration's usable
+ * template set before cross-package precedence is considered.
+ * @param {{name?: string, __spec?: string, __autolinked?: boolean, templates?: string, templateReplacements?: Record<string, string>}} integration
+ * @param {DiscoveredTemplate[]} templates
+ * @param {TemplateDiscoveryError[]} errors
+ * @param {boolean} rootAvailable
+ */
+function validateTemplateReplacementDeclarations(
+  integration,
+  templates,
+  errors,
+  rootAvailable,
+) {
+  const pkg = integration.name ?? integration.__spec ?? 'integration';
+  const declarations = Object.entries(integration.templateReplacements ?? {});
+  if (declarations.length === 0) return;
+
+  if (!rootAvailable) {
+    for (const [template, target] of declarations) {
+      errors.push({
+        code: 'invalid_template_replacement',
+        severity: 'error',
+        package: pkg,
+        autolinked: integration.__autolinked,
+        template,
+        replacementTarget: target,
+        message:
+          `templateReplacements declares "${template}" -> "${target}", but ` +
+          'the integration has no available templates root.',
+      });
+    }
+    return;
+  }
+
+  const discoveredIds = new Set(templates.map(template => template.dirName));
+  /** @type {Map<string, string[]>} */
+  const idsByTarget = new Map();
+  for (const [template, target] of declarations) {
+    const ids = idsByTarget.get(target) ?? [];
+    ids.push(template);
+    idsByTarget.set(target, ids);
+    if (!discoveredIds.has(template)) {
+      errors.push({
+        code: 'invalid_template_replacement',
+        severity: 'error',
+        package: pkg,
+        autolinked: integration.__autolinked,
+        template,
+        replacementTarget: target,
+        message:
+          `templateReplacements declares "${template}" -> "${target}", but ` +
+          `this integration contributes no usable template with id "${template}".`,
+      });
+    }
+  }
+
+  for (const [target, ids] of idsByTarget) {
+    if (ids.length < 2) continue;
+    const message =
+      `${pkg} declares ${ids.length} templates as replacements for Core template ` +
+      `"${target}" (${ids.join(', ')}). One package must declare at most one ` +
+      'replacement for a Core target.';
+    for (const template of ids) {
+      errors.push({
+        code: 'ambiguous_template_replacement',
+        severity: 'error',
+        package: pkg,
+        autolinked: integration.__autolinked,
+        template,
+        replacementTarget: target,
+        message,
+      });
+    }
+  }
+}
+
+/**
  * Discover the templates contributed by a SINGLE integration. Same per-template
  * rules as {@link discoverIntegrationTemplates} (same-stem source required,
  * page|block type required); broken templates are recorded in `errors` rather
  * than thrown. Exposed for `doctor integration validate` and template authoring checks.
  *
- * @param {{name?: string, __spec?: string, templates?: string}} integration
+ * @param {{name?: string, __spec?: string, __autolinked?: boolean, templates?: string, templateReplacements?: Record<string, string>}} integration
  * @returns {Promise<{templates: DiscoveredTemplate[], errors: TemplateDiscoveryError[]}>}
  */
 export async function discoverIntegrationTemplatesForOne(integration) {
@@ -569,7 +960,15 @@ export async function discoverIntegrationTemplatesForOne(integration) {
 
   const root = integration?.templates;
   const pkgLabel = integration?.name ?? integration?.__spec ?? 'integration';
-  if (!root || !fs.existsSync(root)) return {templates, errors};
+  if (!root || !fs.existsSync(root)) {
+    validateTemplateReplacementDeclarations(
+      integration,
+      templates,
+      errors,
+      false,
+    );
+    return {templates, errors};
+  }
 
   for (const docPath of findIntegrationDocFiles(root)) {
     const suffix = matchedTemplateSuffix(docPath);
@@ -639,9 +1038,16 @@ export async function discoverIntegrationTemplatesForOne(integration) {
       filePath: sourcePath,
       docPath,
       package: pkgLabel,
+      autolinked: integration.__autolinked,
+      replaces:
+        integration.templateReplacements != null &&
+        Object.hasOwn(integration.templateReplacements, id)
+          ? integration.templateReplacements[id]
+          : undefined,
     });
   }
 
+  validateTemplateReplacementDeclarations(integration, templates, errors, true);
   return {templates, errors};
 }
 

--- a/packages/cli/foundation/discovery/template-adapter.test.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.test.mjs
@@ -17,6 +17,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {
+  effectiveTemplateDiscovery,
   extractComponents,
   stripTemplateAssetRefs,
 } from './template-adapter.mjs';
@@ -162,5 +163,46 @@ describe('stripTemplateAssetRefs', () => {
     ).toThrow(
       /Unrecognized template asset format bin for \/template-assets\/clip\.bin/,
     );
+  });
+});
+
+describe('effectiveTemplateDiscovery', () => {
+  it('shadows only the matching template kind', () => {
+    const pageReplacement = {
+      type: 'page',
+      dirName: 'acme-dashboard',
+      name: 'Acme dashboard',
+      description: '',
+      filePath: '/acme-dashboard.tsx',
+      docPath: '/acme-dashboard.template.mjs',
+      package: '@acme/widgets',
+      replaces: 'dashboard',
+    };
+    const corePage = {
+      type: 'page',
+      dirName: 'dashboard',
+      name: 'Dashboard page',
+      description: '',
+      filePath: '/dashboard-page.tsx',
+      docPath: '/dashboard-page.template.mjs',
+    };
+    const coreBlock = {
+      type: 'block',
+      dirName: 'dashboard',
+      name: 'Dashboard block',
+      description: '',
+      filePath: '/dashboard-block.tsx',
+      docPath: '/dashboard-block.template.mjs',
+    };
+
+    const effective = effectiveTemplateDiscovery([
+      corePage,
+      coreBlock,
+      pageReplacement,
+    ]);
+
+    expect(effective).toContain(pageReplacement);
+    expect(effective).toContain(coreBlock);
+    expect(effective).not.toContain(corePage);
   });
 });

--- a/packages/cli/foundation/integrations/autolink.test.mjs
+++ b/packages/cli/foundation/integrations/autolink.test.mjs
@@ -87,7 +87,7 @@ function installPackage(
     fs.mkdirSync(componentsDir, {recursive: true});
     fs.writeFileSync(
       path.join(componentsDir, `${componentName}.doc.mjs`),
-      `export const docs = {name: '${componentName}', usage: {description: 'A widget'}};\n`,
+      `export default {type: 'component', name: '${componentName}', usage: {description: 'A widget'}, props: []};\n`,
     );
     fs.writeFileSync(
       path.join(componentsDir, `${componentName}.tsx`),

--- a/packages/cli/foundation/integrations/contribution-inventory.mjs
+++ b/packages/cli/foundation/integrations/contribution-inventory.mjs
@@ -193,6 +193,7 @@ export function computeRequiredFiles(loaded) {
  * @property {{slug: string, exportName: string}[]} themes
  * @property {string[]} components
  * @property {{id: string, type: string, name: string}[]} templates
+ * @property {{template: string, target: string}[]} templateReplacements
  * @property {{version: string, id: string}[]} codemods
  * @property {string[]} docs
  * @property {string[]} agentDocsAppend
@@ -205,6 +206,7 @@ export function computeRequiredFiles(loaded) {
  * @property {string} [themes]
  * @property {string} [components]
  * @property {string} [templates]
+ * @property {Record<string, string>} [templateReplacements]
  * @property {string} [codemods]
  * @property {string} [docs]
  * @property {{append?: readonly string[]}} [agentDocs]
@@ -223,6 +225,9 @@ export async function collectIdentities(loaded) {
     themes: [],
     components: [],
     templates: [],
+    templateReplacements: Object.entries(loaded.templateReplacements ?? {})
+      .map(([template, target]) => ({template, target}))
+      .sort((a, b) => a.template.localeCompare(b.template)),
     codemods: [],
     docs: [],
     agentDocsAppend: loaded.agentDocs?.append
@@ -443,6 +448,12 @@ export function compareIdentities(local, packed) {
   compareKind('Theme', local.themes, packed.themes, item => item.slug);
   compareKind('Component', local.components, packed.components, item => item);
   compareKind('Template', local.templates, packed.templates, item => item.id);
+  compareKind(
+    'Template replacement',
+    local.templateReplacements,
+    packed.templateReplacements,
+    item => item.template,
+  );
   compareKind(
     'Codemod',
     local.codemods,

--- a/packages/cli/foundation/integrations/contribution-inventory.test.mjs
+++ b/packages/cli/foundation/integrations/contribution-inventory.test.mjs
@@ -205,6 +205,7 @@ describe('compareIdentities', () => {
     themes: [],
     components: [],
     templates: [],
+    templateReplacements: [],
     codemods: [],
     docs: [],
     agentDocsAppend: [],
@@ -262,6 +263,26 @@ describe('compareIdentities', () => {
     const issues = compareIdentities(local, packed);
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toContain('dash');
+  });
+
+  it('errors when a packed template replacement target differs', () => {
+    const local = {
+      ...base(),
+      templateReplacements: [
+        {template: 'acme-shell', target: 'shell-side-nav'},
+      ],
+    };
+    const packed = {
+      ...base(),
+      templateReplacements: [{template: 'acme-shell', target: 'shell-top-nav'}],
+    };
+
+    expect(compareIdentities(local, packed)).toEqual([
+      expect.objectContaining({
+        code: 'identity_mismatch',
+        message: expect.stringContaining('acme-shell'),
+      }),
+    ]);
   });
 
   it('errors when a codemod is missing from packed', () => {

--- a/packages/cli/foundation/integrations/integration-warnings.mjs
+++ b/packages/cli/foundation/integrations/integration-warnings.mjs
@@ -10,8 +10,9 @@
  * contributions or spamming per-contribution diagnostics.
  *
  * Design constraints (all enforced here):
- *   - Reuses the Doctor integration validators (validateLoadedIntegration);
- *     no validation logic is duplicated.
+ *   - Reuses Project.issues() when a Project is available, so cross-package
+ *     replacement warnings are visible; accepts loaded integrations for legacy
+ *     internal callers and tests.
  *   - Writes to STDERR only, so it never corrupts a --json stdout envelope.
  *   - Suppressed entirely in --json mode.
  *   - Best-effort: never throws, never changes the exit code. Broken
@@ -28,32 +29,50 @@ import {validateLoadedIntegration} from './validate-contributions.mjs';
  *
  *   Warning: <pkg> has N integration issue(s). Run: astryx doctor integration validate <pkg>
  *
- * @param {Array<import('./integrations.mjs').LoadedIntegration>} loadedIntegrations the Project's loaded integrations
+ * @param {Array<import('./integrations.mjs').LoadedIntegration> | {issues: () => Promise<Array<{package: string, code: string, severity: string, message: string}>>}} source loaded integrations or their Project owner
  * @param {{json?: boolean}} [options]
  * @returns {Promise<void>}
  */
-export async function warnOnIntegrationIssues(loadedIntegrations, {json = false} = {}) {
+export async function warnOnIntegrationIssues(source, {json = false} = {}) {
   try {
-    // Cheap guard: only do work when integrations are actually configured.
     if (json) return;
-    if (!Array.isArray(loadedIntegrations) || loadedIntegrations.length === 0) {
-      return;
-    }
-    for (const integration of loadedIntegrations) {
-      if (!integration || typeof integration !== 'object') continue;
-      let issues;
-      try {
-        issues = await validateLoadedIntegration(integration);
-      } catch {
-        // Best-effort: a validator throwing must not break the host command.
-        continue;
+
+    /** @type {Map<string, number>} */
+    const issueCounts = new Map();
+    const fromProject =
+      source != null &&
+      !Array.isArray(source) &&
+      typeof source.issues === 'function';
+
+    if (fromProject) {
+      const issues = await source.issues();
+      for (const issue of issues) {
+        issueCounts.set(
+          issue.package,
+          (issueCounts.get(issue.package) ?? 0) + 1,
+        );
       }
-      if (!Array.isArray(issues) || issues.length === 0) continue;
-      const pkg = integration.name ?? integration.__spec ?? '(integration)';
-      // Stderr only — keeps stdout (and any --json envelope) clean.
+    } else if (Array.isArray(source)) {
+      for (const integration of source) {
+        if (!integration || typeof integration !== 'object') continue;
+        let issues;
+        try {
+          issues = await validateLoadedIntegration(integration);
+        } catch {
+          continue;
+        }
+        if (!Array.isArray(issues) || issues.length === 0) continue;
+        const pkg = integration.name ?? integration.__spec ?? '(integration)';
+        issueCounts.set(pkg, issues.length);
+      }
+    }
+
+    for (const [pkg, count] of issueCounts) {
+      const command = fromProject
+        ? 'astryx doctor'
+        : `astryx doctor integration validate ${pkg}`;
       console.error(
-        `Warning: ${pkg} has ${issues.length} integration issue(s). ` +
-          `Run: astryx doctor integration validate ${pkg}`,
+        `Warning: ${pkg} has ${count} integration issue(s). Run: ${command}`,
       );
     }
   } catch {

--- a/packages/cli/foundation/integrations/integration-warnings.test.mjs
+++ b/packages/cli/foundation/integrations/integration-warnings.test.mjs
@@ -37,7 +37,12 @@ afterEach(() => {
  * Build a loaded-integration-shaped object. Roots are absolute (mirrors
  * loadIntegrations' resolveRoot).
  */
-function loaded({name = '@acme/widgets', components, templates, codemods} = {}) {
+function loaded({
+  name = '@acme/widgets',
+  components,
+  templates,
+  codemods,
+} = {}) {
   return {
     name,
     version: '1.0.0',
@@ -60,6 +65,25 @@ describe('warnOnIntegrationIssues', () => {
       'Warning: @acme/widgets has 1 integration issue(s). ' +
         'Run: astryx doctor integration validate @acme/widgets',
     );
+  });
+
+  it('surfaces cross-package issues collected by Project', async () => {
+    const project = {
+      issues: async () => [
+        {
+          package: '@acme/later',
+          code: 'ambiguous_template_replacement',
+          severity: 'warning',
+          message: 'Later configured replacement wins.',
+        },
+      ],
+    };
+
+    await warnOnIntegrationIssues(project, {json: false});
+
+    expect(errLines).toEqual([
+      'Warning: @acme/later has 1 integration issue(s). Run: astryx doctor',
+    ]);
   });
 
   it('emits nothing in --json mode (keeps stdout/JSON clean)', async () => {

--- a/packages/cli/foundation/integrations/integrations.mjs
+++ b/packages/cli/foundation/integrations/integrations.mjs
@@ -27,13 +27,16 @@ import {parseGapReportHandler} from '../../authoring/gap-report/parse.mjs';
 /**
  * A fully-resolved, loaded integration. Identity (`name`, `version`) comes from
  * the package's package.json; the `components`/`templates`/`codemods`/`docs`/
- * `themes` roots are absolute paths resolved from the manifest. The `__`-prefixed fields
- * are internal bookkeeping used by Doctor integration validation and Project.
+ * `themes` roots are absolute paths resolved from the manifest, while
+ * `templateReplacements` maps integration ids to Core ids. The `__`-prefixed
+ * fields are internal bookkeeping used by Doctor integration validation and
+ * Project.
  * @typedef {object} LoadedIntegration
  * @property {string} name
  * @property {string} [version]
  * @property {string} [components]
  * @property {string} [templates]
+ * @property {Record<string, string>} [templateReplacements]
  * @property {string} [codemods]
  * @property {string} [docs]
  * @property {string} [themes]
@@ -323,6 +326,7 @@ export async function loadLocalIntegration(packageDir, {fresh = false} = {}) {
     version: pkg.version,
     components: resolveRoot(manifest.components),
     templates: resolveRoot(manifest.templates),
+    templateReplacements: manifest.templateReplacements,
     codemods: resolveRoot(manifest.codemods),
     docs: resolveRoot(manifest.docs),
     themes: resolveRoot(manifest.themes),
@@ -424,6 +428,7 @@ export async function loadIntegrations(
       version: pkg.version,
       components: resolveRoot(manifest.components),
       templates: resolveRoot(manifest.templates),
+      templateReplacements: manifest.templateReplacements,
       codemods: resolveRoot(manifest.codemods),
       docs: resolveRoot(manifest.docs),
       themes: resolveRoot(manifest.themes),

--- a/packages/cli/foundation/integrations/integrations.test.mjs
+++ b/packages/cli/foundation/integrations/integrations.test.mjs
@@ -208,6 +208,52 @@ describe('configured integrations', () => {
 });
 
 describe('local integration self-resolution', () => {
+  it('preserves template replacement declarations for local discovery', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: '@acme/local', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      `export default {
+  templates: './templates',
+  templateReplacements: {'acme-app-shell': 'shell-side-nav'},
+};
+`,
+    );
+    fs.mkdirSync(path.join(tmpDir, 'templates'));
+
+    const loaded = await loadLocalIntegration(tmpDir, {fresh: true});
+
+    expect(loaded).toMatchObject({
+      name: '@acme/local',
+      templates: path.join(tmpDir, 'templates'),
+      templateReplacements: {'acme-app-shell': 'shell-side-nav'},
+      __local: true,
+    });
+  });
+
+  it('documents that an ordinary __proto__ literal vanishes before parsing', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({name: '@acme/local', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      `export default {
+  templateReplacements: {'__proto__': 'shell-side-nav'},
+};
+`,
+    );
+
+    const loaded = await loadLocalIntegration(tmpDir, {fresh: true});
+
+    expect(loaded?.templateReplacements).toEqual({});
+    expect(Object.hasOwn(loaded?.templateReplacements ?? {}, '__proto__')).toBe(
+      false,
+    );
+  });
+
   it('preserves a valid gapReport named export', async () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),

--- a/packages/cli/foundation/integrations/validate-contributions.mjs
+++ b/packages/cli/foundation/integrations/validate-contributions.mjs
@@ -162,11 +162,17 @@ async function checkCodemods(integration, issues) {
  * @param {Issue[]} issues
  */
 async function checkTemplates(integration, issues) {
-  if (!integration.templates || !fs.existsSync(integration.templates)) return;
+  const replacements = Object.keys(integration.templateReplacements ?? {});
+  if (!integration.templates && replacements.length === 0) return;
+  if (integration.templates && !fs.existsSync(integration.templates)) return;
   try {
     const {errors} = await discoverIntegrationTemplatesForOne(integration);
     for (const e of errors) {
-      issues.push(issueError('invalid_template', e.message));
+      issues.push({
+        code: e.code ?? 'invalid_template',
+        severity: e.severity ?? 'error',
+        message: e.message,
+      });
     }
   } catch (err) {
     issues.push(
@@ -176,36 +182,24 @@ async function checkTemplates(integration, issues) {
 }
 
 /**
- * Validate the integration's components via the landed ownership discovery.
- * Feature-detected: if the component-ownership export isn't present in this
- * build (sibling PR not yet merged), component validation is skipped rather
- * than hard-failing.
- *
- * `discoverIntegrationComponents` returns ownership records and does not throw
- * on a missing same-stem source — it records `sourcePath: null`. We surface
- * each such record as an `invalid_component` error.
+ * Validate the integration's components through the same load-and-parse boundary
+ * that component detail uses. Missing source and invalid metadata are reported
+ * per component so valid siblings remain available.
  * @param {LoadedIntegration} integration loaded-integration-shaped object
  * @param {Issue[]} issues
  */
 async function checkComponents(integration, issues) {
   if (!integration.components || !fs.existsSync(integration.components)) return;
-  const discover = componentDiscovery.discoverIntegrationComponents;
+  const discover = componentDiscovery.discoverValidIntegrationComponents;
   if (typeof discover !== 'function') return; // feature not present yet
   try {
-    const records = (await discover(integration)) ?? [];
-    for (const record of records) {
-      if (record?.sourcePath == null) {
-        issues.push(
-          issueError(
-            'invalid_component',
-            `Component "${record?.name}" is missing its same-stem source file ${record?.name}.tsx.`,
-          ),
-        );
-      }
+    const {discovered, errors} = await discover(integration);
+    for (const error of errors) {
+      issues.push(issueError('invalid_component', error.message));
     }
     for (const name of findSourceOnlyCandidates(
       integration.components,
-      records.map(record => record.name),
+      discovered.map(record => record.name),
     )) {
       issues.push(
         issueWarning(

--- a/packages/cli/foundation/response/response-types.doc.mjs
+++ b/packages/cli/foundation/response/response-types.doc.mjs
@@ -61,7 +61,7 @@ export const doc = {
     {
       value: 'docs.list',
       description:
-        'All reference-doc topics as DocsListEntry[] ({topic, description}), in discovery order.',
+        'All reference-doc topics as DocsListEntry[] ({topic, description, package, replaces?}), in read order.',
     },
     {
       value: 'docs.detail',
@@ -153,7 +153,7 @@ export const doc = {
     {
       value: 'template.list',
       description:
-        'Every discovered template (page + block); each entry carries id, name, description, kind, owning package, optional category and componentsUsed, and readiness flags.',
+        'The effective discovered TemplateListEntry[] for pages and blocks. A winning replacement entry includes optional `replaces`, naming the Core id omitted from the default list.',
     },
     {
       value: 'template.show',
@@ -281,7 +281,7 @@ export const doc = {
     {
       value: 'integration.template-conflicts',
       description:
-        'The integration identity, structural issues, and non-blocking conflicts where an integration template id is also owned by Core; each conflict includes the exact package-qualified command.',
+        'The integration identity, issues, and conflicts as {severity: info | warning, relationship: replaces | accidental, replaces?, command}.',
     },
     {
       value: 'integration.component-conflicts',
@@ -291,7 +291,7 @@ export const doc = {
     {
       value: 'integration.doc-conflicts',
       description:
-        'The integration identity, structural issues, and Core doc overlaps classified as intentional replacements, intentional extensions, or accidental same-name conflicts.',
+        'The integration identity, structural issues, and Core doc overlaps. Each finding includes `severity` (`info` | `error`) and `relationship` (`replaces` | `extends` | `accidental`).',
     },
 
     // layout (XLE/XLO)

--- a/packages/cli/foundation/xle/expand.mjs
+++ b/packages/cli/foundation/xle/expand.mjs
@@ -544,7 +544,7 @@ class Emitter {
       const flags = hint.flags.length > 0 ? ` (+${hint.flags.join(' +')})` : '';
       const arg = hint.arg ? `:${hint.arg}` : '';
       return [
-        `${pad}{/* TODO(xle): content block '${hint.block.name}'${flags}${arg} — scaffold it with: astryx template ${hint.block.name} */}`,
+        `${pad}{/* TODO(xle): content block '${hint.block.name}'${flags}${arg} — scaffold it with: astryx template ${hint.block.name} --type block */}`,
       ];
     }
     this.todos.push(`unresolved hint {${hint.name}}`);

--- a/packages/cli/foundation/xle/xle.test.mjs
+++ b/packages/cli/foundation/xle/xle.test.mjs
@@ -10,6 +10,7 @@ import {describe, it, expect} from 'vitest';
 import {parse, parseCompact, parseOutline, detectForm, XLEParseError} from './parse.mjs';
 import {toCompact, toOutline} from './print.mjs';
 import {validate} from './validate.mjs';
+import {expand} from './expand.mjs';
 import {parseEnumValues, SPACING_STEPS} from './registry.mjs';
 
 // ─── parser: compact ───────────────────────────────────────────────────────
@@ -307,6 +308,18 @@ describe('validate', () => {
     const doc = parse('Bx{card-callout}');
     expect(validate(doc, registry, BLOCKS).errors).toEqual([]);
     expect(doc.roots[0].hint.block.name).toBe('CardCallout');
+  });
+
+  it('includes --type block when a known block source is unavailable', () => {
+    const doc = parse('Bx{card-callout}');
+    expect(validate(doc, registry, BLOCKS).errors).toEqual([]);
+    const result = expand(doc, registry, {
+      componentName: 'Demo',
+      blockModules: new Map(),
+    });
+    expect(result.code).toContain(
+      'astryx template CardCallout --type block',
+    );
   });
 
   it('enforces structural pairings', () => {

--- a/packages/cli/test/invalid-component-metadata.regression.test.mjs
+++ b/packages/cli/test/invalid-component-metadata.regression.test.mjs
@@ -1,0 +1,362 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Regression shapes for PR #6265 — syntax-invalid component metadata.
+ *
+ * These tests pin the FR9 contract for component discovery when an
+ * integration contributes a doc file that cannot be imported (syntax error,
+ * runtime error, or missing export). They cover every surface that reads
+ * component records: Project.components(), Project.issues(), the component
+ * CLI (list, detail, source), search, build, and Doctor.
+ *
+ * Fixture: @acme/widgets with two components:
+ *   - FooWidget: valid source (.tsx), INVALID doc (.doc.mjs has syntax error)
+ *   - BarWidget: valid source (.tsx), valid doc (.doc.mjs)
+ *   - Button: valid Core component plus invalid integration owner
+ *
+ * Expected behavior per FR9 (AST-035):
+ *   - FooWidget is OMITTED from every component result
+ *   - FooWidget's invalidity is REPORTED as an issue
+ *   - BarWidget (valid sibling) REMAINS in every result
+ *   - Other contribution kinds (templates, themes) REMAIN unaffected
+ *   - Doctor reports integration-issues as FAIL
+ *   - component detail for FooWidget throws a coded error, not a raw SyntaxError
+ *
+ * @position packages/cli/test (regression — cross-surface FR9 pin)
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ── Test subjects ──────────────────────────────────────────────────
+import {Project} from '../foundation/config/project.mjs';
+import {component} from '../api/component/component.mjs';
+import {search} from '../api/search/search.mjs';
+import {build} from '../api/build/build.mjs';
+import {doctor} from '../api/doctor/doctor.mjs';
+
+// ── Fixture ────────────────────────────────────────────────────────
+
+let tmpDir;
+let originalCwd;
+
+/**
+ * Scaffold a consumer with @acme/widgets contributing:
+ *   - FooWidget: valid source, broken doc (syntax error)
+ *   - BarWidget: valid source, valid doc
+ *   - One valid template (hero block)
+ *
+ * @returns {string} pkgDir — the integration package directory
+ */
+function scaffoldInvalidDoc() {
+  // Consumer
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'astryx.config.mjs'),
+    `export default { integrations: ['@acme/widgets'] };\n`,
+  );
+
+  // Integration package
+  const pkgDir = path.join(tmpDir, 'node_modules', '@acme', 'widgets');
+  fs.mkdirSync(pkgDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({name: '@acme/widgets', version: '1.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default { components: './components', templates: './templates' };\n`,
+  );
+
+  // ── Components ────────────────────────────────────────────────────
+
+  const compDir = path.join(pkgDir, 'components');
+
+  // FooWidget: valid source, BROKEN doc
+  const fooDir = path.join(compDir, 'FooWidget');
+  fs.mkdirSync(fooDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(fooDir, 'FooWidget.tsx'),
+    `export const FooWidget = () => null;\n`,
+  );
+  // Syntax-invalid: missing commas, unclosed brace
+  fs.writeFileSync(
+    path.join(fooDir, 'FooWidget.doc.mjs'),
+    [
+      `export const docs = {`,
+      `  type: 'component',`,
+      `  name: 'FooWidget',`,
+      `  category: 'Data'`, // ← missing comma
+      `  group: 'Widgets'`, // ← SyntaxError: Unexpected identifier 'group'
+      `  keywords: ['foo' 'widget'],`,
+      `  usage: { description: 'A foo widget.' }`,
+      ``, // ← unclosed brace
+    ].join('\n'),
+  );
+
+  // Button: valid integration source, broken doc, colliding with valid Core.
+  const buttonDir = path.join(compDir, 'Button');
+  fs.mkdirSync(buttonDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(buttonDir, 'Button.tsx'),
+    `export function Button() { return 'BrokenIntegrationButton'; }\n`,
+  );
+  fs.writeFileSync(
+    path.join(buttonDir, 'Button.doc.mjs'),
+    `export default {type: 'component', name: 'Button', props: [};\n`,
+  );
+
+  // BarWidget: valid source, valid doc
+  const barDir = path.join(compDir, 'BarWidget');
+  fs.mkdirSync(barDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(barDir, 'BarWidget.tsx'),
+    `export const BarWidget = () => null;\n`,
+  );
+  fs.writeFileSync(
+    path.join(barDir, 'BarWidget.doc.mjs'),
+    `export const docs = {
+      type: 'component',
+      name: 'BarWidget',
+      category: 'Data',
+      group: 'Widgets',
+      keywords: ['bar', 'widget'],
+      usage: { description: 'A valid bar widget.' },
+      props: [{ name: 'value', type: 'number', description: 'The value.' }],
+    };\n`,
+  );
+
+  // ── Templates (valid, other contribution kind) ────────────────────
+
+  const tDir = path.join(pkgDir, 'templates');
+  fs.mkdirSync(tDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(tDir, 'hero.doc.mjs'),
+    `export default { type: 'block', name: 'Hero', description: 'A hero section' };\n`,
+  );
+  fs.writeFileSync(
+    path.join(tDir, 'hero.tsx'),
+    `export default function Hero() { return null; }\n`,
+  );
+
+  return pkgDir;
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-fr9-invalid-doc-'));
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+// ── A. Project ─────────────────────────────────────────────────────
+
+describe('Project — invalid component metadata (FR9)', () => {
+  it('omits a component whose doc.mjs has a syntax error', async () => {
+    scaffoldInvalidDoc();
+    const project = await Project.load(tmpDir);
+    const comps = await project.components();
+
+    expect(comps.find(c => c.name === 'FooWidget')).toBeUndefined();
+  });
+
+  it('retains a valid sibling in the same integration', async () => {
+    scaffoldInvalidDoc();
+    const project = await Project.load(tmpDir);
+    const comps = await project.components();
+
+    expect(
+      comps.find(c => c.name === 'BarWidget' && c.package === '@acme/widgets'),
+    ).toBeDefined();
+  });
+
+  it('reports the invalid doc as an invalid_component issue', async () => {
+    scaffoldInvalidDoc();
+    const project = await Project.load(tmpDir);
+    await project.components(); // trigger discovery
+    const issues = await project.issues();
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          package: '@acme/widgets',
+          code: 'invalid_component',
+          severity: 'error',
+        }),
+      ]),
+    );
+  });
+
+  it('preserves other contribution kinds from the same integration', async () => {
+    scaffoldInvalidDoc();
+    const project = await Project.load(tmpDir);
+
+    const templates = await project.templates();
+    expect(templates.find(t => t.package === '@acme/widgets')).toBeDefined();
+
+    const comps = await project.components();
+    expect(comps.find(c => c.name === 'FooWidget')).toBeUndefined();
+    expect(
+      comps.find(c => c.name === 'BarWidget' && c.package === '@acme/widgets'),
+    ).toBeDefined();
+  });
+});
+
+// ── B. CLI component --list ────────────────────────────────────────
+
+describe('component --list — invalid component metadata (FR9)', () => {
+  it('does not list a component whose doc.mjs has a syntax error', async () => {
+    scaffoldInvalidDoc();
+    const r = await component(undefined, {cwd: tmpDir, list: true});
+    const allNames = Object.values(r.data.components)
+      .flat()
+      .map(c => c.name);
+
+    expect(allNames).not.toContain('FooWidget');
+  });
+
+  it('lists the valid sibling', async () => {
+    scaffoldInvalidDoc();
+    const r = await component(undefined, {cwd: tmpDir, list: true});
+    const allNames = Object.values(r.data.components)
+      .flat()
+      .map(c => c.name);
+
+    expect(allNames).toContain('BarWidget');
+  });
+});
+
+// ── C. Search ──────────────────────────────────────────────────────
+
+describe('search — invalid component metadata (FR9)', () => {
+  it('does not return a component with invalid metadata', async () => {
+    scaffoldInvalidDoc();
+    const r = await search('FooWidget', {cwd: tmpDir, type: 'component'});
+
+    expect(r.data.results.find(x => x.name === 'FooWidget')).toBeUndefined();
+  });
+
+  it('returns the valid sibling', async () => {
+    scaffoldInvalidDoc();
+    const r = await search('BarWidget', {cwd: tmpDir, type: 'component'});
+
+    expect(r.data.results.find(x => x.name === 'BarWidget')).toBeDefined();
+  });
+});
+
+describe('build — invalid component metadata (FR9)', () => {
+  it('omits the invalid component and retains its valid sibling', async () => {
+    scaffoldInvalidDoc();
+    const invalid = await build('FooWidget', {
+      cwd: tmpDir,
+      type: 'component',
+    });
+    const valid = await build('BarWidget', {
+      cwd: tmpDir,
+      type: 'component',
+    });
+    if (invalid.type !== 'build.kit' || valid.type !== 'build.kit') {
+      throw new Error('expected build.kit');
+    }
+
+    expect(invalid.data.domain.some(entry => entry.name === 'FooWidget')).toBe(
+      false,
+    );
+    expect(valid.data.domain.some(entry => entry.name === 'BarWidget')).toBe(
+      true,
+    );
+  });
+});
+
+// ── D. Doctor ──────────────────────────────────────────────────────
+
+describe('doctor — invalid component metadata (FR9)', () => {
+  it('reports integration-issues as fail when a component doc is invalid', async () => {
+    scaffoldInvalidDoc();
+    const report = await doctor({cwd: tmpDir});
+    const check = report.data.checks.find(c => c.id === 'integration-issues');
+
+    expect(check.status).toBe('fail');
+    expect(check.message).toMatch(
+      /invalid_component|FooWidget|invalid metadata/i,
+    );
+  });
+});
+
+// ── E. Detail ──────────────────────────────────────────────────────
+
+describe('component detail — invalid component metadata (FR9)', () => {
+  it('throws a descriptive error for a component with invalid metadata', async () => {
+    scaffoldInvalidDoc();
+
+    await expect(component('FooWidget', {cwd: tmpDir})).rejects.toThrow(
+      /Cannot load|invalid metadata|FooWidget/i,
+    );
+  });
+
+  it('does not throw a raw SyntaxError (must be wrapped)', async () => {
+    scaffoldInvalidDoc();
+
+    try {
+      await component('FooWidget', {cwd: tmpDir});
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      // A raw SyntaxError from import() is the current broken behavior.
+      // The fix wraps it with context.
+      expect(e.constructor.name).not.toBe('SyntaxError');
+    }
+  });
+
+  it('ignores an invalid integration owner when Core has a valid component', async () => {
+    scaffoldInvalidDoc();
+
+    const detail = await component('Button', {cwd: tmpDir});
+    expect(detail.type).toBe('component.detail');
+    expect(detail.data.package).toBe('@astryxdesign/core');
+
+    const source = await component('Button', {cwd: tmpDir, source: true});
+    expect(source.type).toBe('component.detail.source');
+    expect(source.data.source).not.toContain('BrokenIntegrationButton');
+  });
+
+  it('keeps explicit access to an invalid integration owner diagnostic and source', async () => {
+    scaffoldInvalidDoc();
+
+    await expect(
+      component('Button', {cwd: tmpDir, package: '@acme/widgets'}),
+    ).rejects.toMatchObject({code: 'ERR_INVALID_DOC'});
+
+    const source = await component('Button', {
+      cwd: tmpDir,
+      package: '@acme/widgets',
+      source: true,
+    });
+    expect(source.type).toBe('component.detail.source');
+    expect(source.data.source).toContain('BrokenIntegrationButton');
+  });
+
+  it('loads a valid sibling without error', async () => {
+    scaffoldInvalidDoc();
+    const r = await component('BarWidget', {cwd: tmpDir});
+
+    expect(r.type).toBe('component.detail');
+    expect(r.data.name).toBe('BarWidget');
+    expect(r.data.package).toBe('@acme/widgets');
+  });
+
+  it('returns source for a component with invalid metadata (source is valid)', async () => {
+    scaffoldInvalidDoc();
+    const r = await component('FooWidget', {cwd: tmpDir, source: true});
+
+    expect(r.type).toBe('component.detail.source');
+    expect(r.data.source).toContain('FooWidget');
+  });
+});


### PR DESCRIPTION
## User need

Integration packages can provide a product-specific version of a Core template, but a same-id collision currently makes unqualified lookup ambiguous. Consumers need the installed integration to become the default without losing access to the Core original.

## Current specification

`spec:AST-017` owns published compatibility and complete CLI response projection. The exact replacement/default/precedence proposal is recorded in draft `spec:AST-035` so the current CLI/system owner can approve the durable policy in this PR. The behavior follows the existing integration-doc `replaces` model while keeping the template-specific compatibility boundary explicit.

## Public delta

Integration manifests can now declare:

```js
export default {
  templates: './templates',
  templateReplacements: {
    'acme-app-shell': 'shell-side-nav',
  },
};
```

- `astryx template shell-side-nav` and default discovery surfaces use `acme-app-shell`.
- `astryx template shell-side-nav --package @astryxdesign/core` still selects Core.
- `astryx template acme-app-shell --package @acme/astryx-navigation` selects the integration by its own id.
- Missing targets, wrong template kinds, missing local templates, and duplicate declarations in one package fail closed and are errors.
- Later explicitly configured packages win valid cross-package replacements with a warning. Explicit configuration wins over autolinking.
- CLIs from 0.5.3 onward ignore this key when unknown and preserve understood contributions. Versions 0.5.2 and earlier reject the manifest and drop the integration. Replacement selection starts in 0.7.0.

## Design and alternatives

I kept the map on the integration manifest instead of adding `replaces` to `TemplateDoc`. Existing template metadata parsing is strict, so a new per-template field would make older CLIs reject the template. Integration manifests already ignore unknown fields while preserving known contributions.

Replacement resolution lives in the shared template catalog. Template lookup, list, search, build suggestions, Project discovery, and block-layout lookup now use the same priority rules. Package-scoped views retain shadowed or rejected integration templates for explicit access.

## Evidence

I built the repository, linked the modified CLI and Core packages into a separate Vite/React consumer, and installed a local `@acme/astryx-navigation` integration. Its replacement template renders `AcmeSideNav` and `AcmeTopNav`.

The public CLI selected the replacement for `shell-side-nav`, and the generated app built as a production bundle. Explicit Core selection produced the original Core imports. Removing only `templateReplacements` restored Core as the default while the integration template stayed available by its own id. Published 0.5.3, 0.5.4, and 0.6.0 ignored the unknown key and still listed the integration template; 0.5.2 returned no integration templates because its strict parser dropped the manifest.

Independent review rounds found concrete defects across invalid declarations, call order, package and kind scoping, search/build/layout projection, autolinking, diagnostics, Project isolation, copy collisions, packing, public JSON types, compatibility, and documentation. Each concrete finding was reproduced before fixing. Focused mutation tests now cover those states, including rejected self-id fallback, reverse cross-kind page/block command round trips with explicit `--type`, syntax-invalid metadata across Project/list/search/build/Doctor/detail/source, and invalid integration ownership colliding with valid Core. Draft `spec:AST-035` records the exact public policy for the required current-owner decision, including FR9 for retaining valid contribution kinds and valid template or component siblings. This PR does not self-promote it.

The integration-author guide now covers exact id discovery, declaration syntax, selection and precedence, explicit Core access, validation and failure isolation, absent metadata, the 0.5.3 degradation floor, the 0.7.0 selection floor, and a full AppShell example that composes integration-owned `AcmeSideNav` and `AcmeTopNav`. The SchemaDoc, public `AstryxIntegration` type, command/function docs, generated README, and a focused documentation-contract test carry the same contract.

## Scope

- [x] One capability is added.
- [x] Unrelated fixes, cleanup, and policy changes were removed or split.
- [x] Consumer docs, focused tests, and migration evidence ship with the feature.
- [x] Public text and artifacts contain no internal Meta context.

## Testing

Repository gates:

```sh
pnpm -F @astryxdesign/cli exec tsc --project tsconfig.api-dts.json
pnpm -F @astryxdesign/cli typecheck:authoring
pnpm -F @astryxdesign/cli typecheck:json-api
pnpm -F @astryxdesign/cli readme:check
pnpm check:repo
ASTRYX_STRICT_LINT=1 pnpm exec eslint --no-cache --no-warn-ignored \
  $(git diff --name-only origin/main...HEAD | grep -E '\\.(mjs|ts|tsx)$')
npx --no-install vitest run packages/cli --reporter=dot
pnpm build
```

Results: all commands passed on the latest-main rebased head. The serialized CLI suite passed 254 files and 4,000 tests. `astryx docs cli-integrations` rendered the replacement declaration, Core-id lookup command, explicit original command, and AppShell navigation example from the built CLI docs surface.

Separate consumer app:

```sh
# In the integration package
pnpm exec astryx --json integration pack --check
npm pack

# In a separate Vite consumer, with the packed tarball installed
pnpm install --no-frozen-lockfile
pnpm exec astryx --json doctor integration templates @acme/astryx-navigation
pnpm exec astryx --json template shell-side-nav src/App.tsx
pnpm build
grep -R -o 'Replacement navigation is running\|AcmeSideNav\|AcmeTopNav' dist/assets
```

Results: `pack --check` returned `packable: true`, zero issues, five packed files, and identical local/packed replacement maps. Doctor returned one `info` replacement and zero issues. The copy response selected `acme-app-shell`. Vite transformed 160 modules and built in 1.46 seconds. The production bundle contained all three markers.

Explicit original:

```sh
pnpm exec astryx --json template shell-side-nav proof/original --package @astryxdesign/core
grep -n '@astryxdesign/core/AppShell\|@astryxdesign/core/SideNav' proof/original/page.tsx
```

Result: the response selected `shell-side-nav`; the generated file imported Core `AppShell` and `SideNav` and contained no integration navigation.

After deleting only `templateReplacements` from the installed manifest:

```sh
pnpm exec astryx --json template shell-side-nav proof/fallback
pnpm exec astryx --json template acme-app-shell proof/integration-own
```

Result: the first command selected Core `shell-side-nav`; the second still selected `acme-app-shell`.

Published compatibility floor against the same packed integration manifest:

```sh
node /tmp/probe-v0.5.2/node_modules/@astryxdesign/cli/clients/cli/bin/astryx.mjs --json template --list
node /tmp/probe-v0.5.3/node_modules/@astryxdesign/cli/clients/cli/bin/astryx.mjs --json template --list
node /tmp/probe-v0.5.4/node_modules/@astryxdesign/cli/clients/cli/bin/astryx.mjs --json template --list
node /tmp/probe-v0.6.0/node_modules/@astryxdesign/cli/clients/cli/bin/astryx.mjs --json template --list
```

Result: 0.5.2 returned no integration-owned templates because its strict manifest parser drops the integration on an unknown key. 0.5.3, 0.5.4, and 0.6.0 each listed the integration template by its own id while Core remained the default. The guide, SchemaDoc, public type, changeset, and draft spec now state `@astryxdesign/cli >=0.5.3` as the degradation floor and 0.7.0 as the replacement-selection floor.

Local integration self-resolution:

```sh
node packages/cli/clients/cli/bin/astryx.mjs --json template shell-side-nav proof/default
node packages/cli/clients/cli/bin/astryx.mjs --json template acme-app-shell proof/own --package @acme/local-nav
node packages/cli/clients/cli/bin/astryx.mjs --json template shell-side-nav proof/core --package @astryxdesign/core
```

Result: the first two commands selected the local `acme-app-shell` source and its proof marker. The third selected Core `shell-side-nav` and imported Core `AppShell`. This covers the local-package self-resolution path as well as the installed-consumer path above.





