### PR TITLE
fix(a11y): keep resizable demo content keyboard-reachable

### DIFF
--- a/apps/storybook/.storybook/useResizableStory.test.mjs
+++ b/apps/storybook/.storybook/useResizableStory.test.mjs
@@ -1,0 +1,78 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useResizableStory.test.mjs
+ * @input The StructuredPercentSizing Storybook fixture source.
+ * @output Mutation-sensitive contract that its scrollable content is keyboard-reachable.
+ * @position Focused source guard paired with the real Chromium/axe story check.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import {describe, expect, it} from 'vitest';
+
+const STORY_PATH = path.resolve(
+  import.meta.dirname,
+  '../stories/useResizable.stories.tsx',
+);
+
+function jsxAttributes(tagName) {
+  const source = ts.createSourceFile(
+    STORY_PATH,
+    fs.readFileSync(STORY_PATH, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const matches = [];
+  const visit = node => {
+    if (
+      ts.isJsxElement(node) &&
+      node.openingElement.tagName.getText(source) === tagName
+    ) {
+      matches.push(node.openingElement.attributes.properties);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return matches;
+}
+
+describe('StructuredPercentSizing story', () => {
+  it('gates a named scroll region on effective overflow', () => {
+    const sourceText = fs.readFileSync(STORY_PATH, 'utf8');
+    const [attributes] = jsxAttributes('LayoutContent');
+    expect(attributes).toBeDefined();
+
+    const attribute = name =>
+      attributes.find(
+        candidate =>
+          ts.isJsxAttribute(candidate) && candidate.name.getText() === name,
+      );
+    expect(attribute('tabIndex')?.initializer?.getText()).toBe(
+      '{isContentScrollable ? 0 : -1}',
+    );
+    expect(attribute('role')?.initializer?.getText()).toBe(
+      "{isContentScrollable ? 'region' : undefined}",
+    );
+    expect(attribute('label')?.initializer?.getText()).toContain(
+      'isContentScrollable',
+    );
+    expect(attribute('data-testid')?.initializer?.getText()).toContain(
+      'structured-percent-${kind}-content',
+    );
+    const [panelAttributes] = jsxAttributes('LayoutPanel');
+    const panelScrollable = panelAttributes.find(
+      candidate =>
+        ts.isJsxAttribute(candidate) &&
+        candidate.name.getText() === 'isScrollable',
+    );
+    expect(panelScrollable?.initializer?.getText()).toBe('{false}');
+
+    expect(sourceText).toContain('observeResize(content, measureContentOverflow)');
+    expect(sourceText).toContain(
+      'content.scrollHeight > content.clientHeight + 1',
+    );
+  });
+});

--- a/apps/storybook/stories/useResizable.stories.tsx
+++ b/apps/storybook/stories/useResizable.stories.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -11,6 +11,7 @@ import {
 import {useResizable, ResizeHandle} from '@astryxdesign/core/Resizable';
 import {percent, pixel} from '@astryxdesign/core/Resizable/utils';
 import {Layout, LayoutContent, LayoutPanel} from '@astryxdesign/core/Layout';
+import {observeResize} from '@astryxdesign/core/utils';
 
 const s = stylex.create({
   shell: {
@@ -51,6 +52,8 @@ function StructuredPercentProbe({
   width: number;
 }) {
   const frameRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isContentScrollable, setIsContentScrollable] = useState(false);
   const isDefault = kind.startsWith('default');
   const isMinimum = kind === 'minimum';
   const storageKey = `storybook-structured-percent-${kind}`;
@@ -74,6 +77,26 @@ function StructuredPercentProbe({
     : isMinimum
       ? `minSize: percent(40, {min: pixel(333)})`
       : `maxSize: percent(10, {max: pixel(400)})`;
+  const measureContentOverflow = useCallback(() => {
+    const content = contentRef.current;
+    if (content == null) {
+      return;
+    }
+    const overflowY = getComputedStyle(content).overflowY;
+    const isScrollable =
+      ['auto', 'scroll', 'overlay'].includes(overflowY) &&
+      content.scrollHeight > content.clientHeight + 1;
+    setIsContentScrollable(current =>
+      current === isScrollable ? current : isScrollable,
+    );
+  }, []);
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (content == null) {
+      return;
+    }
+    return observeResize(content, measureContentOverflow);
+  }, [measureContentOverflow]);
 
   return (
     <div
@@ -107,6 +130,7 @@ function StructuredPercentProbe({
               <LayoutPanel
                 width={region.size}
                 hasDivider={false}
+                isScrollable={false}
                 data-testid={`structured-percent-${kind}-panel`}>
                 {Math.round(region.size)}px
               </LayoutPanel>
@@ -119,7 +143,16 @@ function StructuredPercentProbe({
             </>
           }
           content={
-            <LayoutContent>
+            <LayoutContent
+              ref={contentRef}
+              data-testid={`structured-percent-${kind}-content`}
+              role={isContentScrollable ? 'region' : undefined}
+              label={
+                isContentScrollable
+                  ? `Structured percent ${kind.replaceAll('-', ' ')} details`
+                  : undefined
+              }
+              tabIndex={isContentScrollable ? 0 : -1}>
               {isDefault
                 ? 'Later basis changes do not rescale this selected pixel size.'
                 : 'The percentage bound follows later basis changes.'}


### PR DESCRIPTION
## Problem

Keyboard users could not focus genuinely scrollable content in the structured `useResizable` percentage-sizing story. Making every region focusable would create unexplained stops for content that fits, so focusability must follow effective overflow.

## Changes

- Measure each story content viewport with Astryx's shared resize observer.
- Add `tabIndex=0`, `role="region"`, and an accessible name only while block-axis overflow is effective; use `tabIndex=-1` when content fits so losing overflow does not blur current focus.
- Disable incidental scrolling on the narrow size-only `LayoutPanel`.
- Add a focused mutation-sensitive regression for the overflow predicate and conditional keyboard/semantic props.

## Test plan

```bash
pnpm exec vitest run --project node apps/storybook/.storybook/useResizableStory.test.mjs
pnpm exec eslint apps/storybook/stories/useResizable.stories.tsx --max-warnings 0
pnpm -F @astryxdesign/storybook typecheck
pnpm -F @astryxdesign/storybook build
```

## Browser proof

Exact-head Chromium proves both basis states:

- initial: 2/4 regions effectively scroll and only those 2 are named tab stops;
- after **Change bases**: 1/4 effectively scrolls and only that region is a named tab stop;
- `PageDown` moves the focused overflowing region;
- focus remains on the same region when it stops overflowing and changes to `tabIndex=-1`;
- Axe `scrollable-region-focusable`: **0 violations before and after**.
