### PR TITLE
fix(cli): reject symlink escapes when copying themes

### DIFF
--- a/.changeset/theme-copy-and-codemod-proof.md
+++ b/.changeset/theme-copy-and-codemod-proof.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Keep copied integration theme files inside the target project.
+
+@josephfarina

--- a/packages/cli/api/theme/add/add.mjs
+++ b/packages/cli/api/theme/add/add.mjs
@@ -78,11 +78,25 @@ export async function themeAdd(slug, options = {}) {
     throw err;
   }
 
-  const writes = match.files.map(name => ({
-    name,
-    src: path.join(themeSrcDir, name),
-    dest: path.join(resolvedDir, name),
-  }));
+  let writes;
+  try {
+    writes = match.files.map(name => ({
+      name,
+      src: path.join(themeSrcDir, name),
+      dest: assertWithin(name, resolvedDir, {
+        label: `theme destination for ${name}`,
+      }),
+    }));
+  } catch (err) {
+    if (err instanceof PathSafetyError) {
+      throw new AstryxError(
+        err.message,
+        undefined,
+        ERROR_CODES.ERR_PATH_TRAVERSAL,
+      );
+    }
+    throw err;
+  }
   for (const w of writes) {
     if (!fs.existsSync(w.src)) {
       throw new AstryxError(
@@ -116,11 +130,14 @@ export async function themeAdd(slug, options = {}) {
   try {
     fs.mkdirSync(resolvedDir, {recursive: true});
     for (const w of writes) {
-      fs.mkdirSync(path.dirname(w.dest), {recursive: true});
-      const tmp = `${w.dest}.${process.pid}.tmp`;
+      const dest = assertWithin(w.name, resolvedDir, {
+        label: `theme destination for ${w.name}`,
+      });
+      fs.mkdirSync(path.dirname(dest), {recursive: true});
+      const tmp = `${dest}.${process.pid}.tmp`;
       const contents = stripCopyrightHeader(fs.readFileSync(w.src, 'utf-8'));
       fs.writeFileSync(tmp, contents);
-      staged.push({tmp, dest: w.dest});
+      staged.push({tmp, dest});
     }
     for (const s of staged) {
       fs.renameSync(s.tmp, s.dest);
@@ -132,6 +149,13 @@ export async function themeAdd(slug, options = {}) {
       } catch {
         /* best-effort */
       }
+    }
+    if (err instanceof PathSafetyError) {
+      throw new AstryxError(
+        err.message,
+        undefined,
+        ERROR_CODES.ERR_PATH_TRAVERSAL,
+      );
     }
     throw new AstryxError(
       `Failed to write theme files: ${/** @type {any} */ (err).message}`,

--- a/packages/cli/api/theme/integration-themes.test.mjs
+++ b/packages/cli/api/theme/integration-themes.test.mjs
@@ -104,6 +104,35 @@ describe('themeAdd with integration themes', () => {
     ).toContain('oceanBlue');
   });
 
+  it('rejects a nested destination symlink that escapes the project', async () => {
+    installThemeIntegration(
+      '@acme/themes',
+      'ocean',
+      "import {oceanBlue} from './tokens/colors';\nexport const oceanTheme = {oceanBlue};\n",
+      {'tokens/colors.ts': "export const oceanBlue = '#0064e0';\n"},
+    );
+    const outsideDir = fs.mkdtempSync(
+      path.join(process.cwd(), '.astryx-theme-outside-'),
+    );
+    try {
+      const targetDir = path.join(tmpDir, 'src', 'themes', 'ocean');
+      fs.mkdirSync(targetDir, {recursive: true});
+      fs.symlinkSync(
+        outsideDir,
+        path.join(targetDir, 'tokens'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+
+      await expect(themeAdd('ocean', {cwd: tmpDir})).rejects.toMatchObject({
+        code: 'ERR_PATH_TRAVERSAL',
+      });
+      expect(fs.existsSync(path.join(outsideDir, 'colors.ts'))).toBe(false);
+      expect(fs.existsSync(path.join(targetDir, 'oceanTheme.ts'))).toBe(false);
+    } finally {
+      fs.rmSync(outsideDir, {recursive: true, force: true});
+    }
+  });
+
   it('fails closed on a duplicate slug and resolves it with package scope', async () => {
     installThemeIntegration('@acme/themes', 'neutral');
 


### PR DESCRIPTION
## User impact

An integration theme with a nested file can write outside the requested project when a destination subdirectory is a symlink.

## Expected behavior and authority

`theme add` already confines its target to the project and reports `ERR_PATH_TRAVERSAL` for paths outside it. Every catalog file must stay inside that target too.

## Smallest restoration

Validate each destination before overwrite checks and again immediately before staging. Normal nested theme copies are unchanged.

## Evidence

- Reproduction before the change: a `tokens` symlink redirected `tokens/colors.ts` outside the project.
- Result after the change: the copy returns `ERR_PATH_TRAVERSAL` and writes no outside or partial file.
- Representative unchanged path: a normal nested `tokens/colors.ts` file still copies.
- Regression test or other mutation-sensitive proof: `integration-themes.test.mjs` creates the real escaping symlink and checks both destinations.

## Scope

- [x] One defect is restored.
- [x] Separable contradictory or unsettled tagalongs were removed or split.
- [x] No new public API, visual representation, default, or interaction model is hidden under the bug-fix label.
- [x] Public text and artifacts contain no internal Meta context.

## Testing

- `npx vitest run packages/cli/api/theme/add/add.test.mjs packages/cli/api/theme/integration-themes.test.mjs --root .`
- `pnpm -F @astryxdesign/cli exec tsc --project tsconfig.api-dts.json`
- strict ESLint on the changed files
- `pnpm check:repo`
- `npx vitest run packages/cli` (3,854 tests)
