### PR TITLE
fix(docsite): tighten template gallery columns

### DIFF
--- a/apps/docsite/src/app/(site)/templates/page.tsx
+++ b/apps/docsite/src/app/(site)/templates/page.tsx
@@ -255,7 +255,7 @@ function TemplatesGallery() {
         </VStack>
 
         {/* Body */}
-        <Grid columns={{minWidth: isMobile ? 280 : 420}} gap={4} width="100%">
+        <Grid columns={{minWidth: isMobile ? 280 : 360}} gap={4} width="100%">
           {filteredItems.map(item => {
             const templateContent = <TemplateThumbnail slug={item.slug} />;
 


### PR DESCRIPTION
## User impact

The desktop template gallery can fit more cards per row by reducing each card's minimum grid width from 420px to 360px. The existing 280px mobile minimum is unchanged.

## Visual authority

This is the requested adjustment to the gallery's existing explicit grid sizing; it does not introduce a new component or interaction pattern.

## Before and after

- Before: desktop template cards use a 420px minimum width.
- After: desktop template cards use a 360px minimum width.

## State matrix

- Desktop gallery: updated to 360px minimum columns.
- Mobile gallery: unchanged at 280px.
- Themes, color modes, LTR/RTL, and interaction states: unchanged.

## Scope

- [x] Appearance is the primary intent.
- [x] Behavior, API, and interaction model are unchanged.
- [x] Public text contains no internal context.

## Testing

- `pnpm -F @astryxdesign/docsite typecheck`
- `pnpm -F @astryxdesign/docsite test` — 498 tests passed
- `pnpm -F @astryxdesign/docsite build`
- Pre-commit repository checks
