### PR TITLE
fix(docsite): keep the template preview header inside the dialog

### DIFF
--- a/apps/docsite/src/components/TemplatePreviewDialog.tsx
+++ b/apps/docsite/src/components/TemplatePreviewDialog.tsx
@@ -15,7 +15,10 @@
  * The header surfaces template metadata (name, description) on
  * the left. All controls cluster on the right of the header: a
  * copy-to-clipboard CLI scaffold command, an Open in Playground action,
- * and the close button.
+ * and the close button. The row wraps when the controls no longer fit
+ * beside the title, and the fullscreen (phone) variant stacks the commands
+ * and the primary action full width, with the close button pinned to the
+ * top-inline-end corner — the header must never widen the dialog.
  *
  * The preview sits in a padded, framed (border + radius) surface below the
  * header. The prev/next arrows are position:fixed inside the top-layer
@@ -93,6 +96,11 @@ const styles = stylex.create({
   },
   headerRow: {
     width: '100%',
+    // The header never widens the dialog: a long command or a wide action row
+    // shrinks or truncates instead. Without this the fullscreen dialog's
+    // clipped body can be scrolled sideways by focus and never scrolled back.
+    maxWidth: '100%',
+    minWidth: 0,
     position: 'relative' as const,
   },
   dialogHeader: {
@@ -105,7 +113,12 @@ const styles = stylex.create({
     insetInlineEnd: 0,
   },
   desktopHeaderMeta: {
-    flex: 1,
+    // Grow into the free space, but keep a readable floor: when the actions
+    // no longer fit beside a 240px title block the header wraps instead of
+    // squeezing the title to nothing.
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: '240px',
     minWidth: 0,
   },
   mobileHeaderMeta: {
@@ -116,10 +129,26 @@ const styles = stylex.create({
     width: '100%',
     minWidth: 0,
   },
+  // Standard (desktop) header: the action cluster shares one line with the
+  // title, so it has to be allowed to shrink — otherwise a narrow window
+  // pushes "Open in Playground" past the dialog edge.
+  actionsGroup: {
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  // Command rows and the primary action stack on the fullscreen (mobile)
+  // header, so each one gets the full width instead of competing for it.
+  commandStack: {
+    flexShrink: 1,
+    minWidth: 0,
+  },
   // The CLI command shrinks before the buttons do, and stays on one line.
   commandGroup: {
     flexShrink: 1,
     minWidth: 0,
+  },
+  commandLabel: {
+    flexShrink: 0,
   },
   commandCode: {
     flexShrink: 1,
@@ -194,9 +223,9 @@ function TemplatePreviewHeader({
   );
 
   const copyButton = (
-    <VStack gap={1}>
+    <VStack gap={1} xstyle={styles.commandStack}>
       <HStack gap={2} vAlign="center" xstyle={styles.commandGroup}>
-        <Text type="supporting" color="secondary">
+        <Text type="supporting" color="secondary" xstyle={styles.commandLabel}>
           Astryx CLI
         </Text>
         <Code
@@ -220,7 +249,10 @@ function TemplatePreviewHeader({
       </HStack>
       {CURRENT_TARGET === 'canary' && (
         <HStack gap={2} vAlign="center" xstyle={styles.commandGroup}>
-          <Text type="supporting" color="secondary">
+          <Text
+            type="supporting"
+            color="secondary"
+            xstyle={styles.commandLabel}>
             {shadcnRegistryIsPreview ? 'shadcn preview (expires)' : 'shadcn'}
           </Text>
           <Code xstyle={styles.commandCode}>
@@ -258,6 +290,7 @@ function TemplatePreviewHeader({
       variant="primary"
       size="lg"
       href={playgroundHref}
+      width={isFullscreen ? '100%' : undefined}
       onClick={() => {
         trackOpenPlayground({
           page: 'templates',
@@ -281,14 +314,19 @@ function TemplatePreviewHeader({
     />
   );
 
-  const actions = (
-    <HStack
-      gap={2}
-      vAlign="center"
-      xstyle={isFullscreen ? styles.actionsRow : undefined}>
+  // Fullscreen (mobile) stacks the actions: a phone cannot fit the command
+  // rows and the primary action on one line, and squeezing them there is what
+  // pushed the header past the viewport.
+  const actions = isFullscreen ? (
+    <VStack gap={2} xstyle={styles.actionsRow}>
       {copyButton}
       {playgroundButton}
-      {!isFullscreen && closeButton}
+    </VStack>
+  ) : (
+    <HStack gap={2} vAlign="center" xstyle={styles.actionsGroup}>
+      {copyButton}
+      {playgroundButton}
+      {closeButton}
     </HStack>
   );
 
@@ -299,7 +337,7 @@ function TemplatePreviewHeader({
       {closeButton}
     </VStack>
   ) : (
-    <HStack gap={4} vAlign="start" xstyle={styles.headerRow}>
+    <HStack gap={4} vAlign="start" wrap="wrap" xstyle={styles.headerRow}>
       {metadata}
       {actions}
     </HStack>


### PR DESCRIPTION
## User impact

Anyone opening a template preview from `/templates` on a phone gets an unusable
dialog: the preview surface and the whole header (title, install commands, Open
in Playground, close) are pushed sideways out of view, and nothing scrolls them
back — the only way out is Escape or a reload.

Repro: load the templates gallery at 393 x 660 CSS px (iPhone 14 Pro), tap any
card. The dialog opens already scrolled ~295px to the side.

## Expected behavior and authority

The gallery passes `variant="fullscreen"` on mobile precisely so the preview is
edge-to-edge and self-contained; a fullscreen dialog's own chrome must stay
inside the viewport it fills. The file header for this component already states
the intent ("Dialog variant — pass 'fullscreen' on mobile for edge-to-edge
preview"), and Dialog's fullscreen variant sizes itself to the dynamic viewport.

## Smallest restoration

The header laid the command rows and the primary action on a single line. Its
min-content width is ~976px at the canary target (two command rows), far wider
than a phone, so the header — not the template — pushed the dialog body past the
viewport. The body is clipped with `overflow: hidden`, which is still
programmatically scrollable: initial focus landed on a control inside the
overflowing area, the browser scrolled it into view, and the clipped box stayed
scrolled with no user-reachable scrollbar to undo it.

The fix makes the header fit rather than overflow:

- fullscreen (phone) stacks the command rows and a full-width primary action;
  the close button stays pinned to the top-inline-end corner;
- the standard header wraps when the actions no longer fit beside a 240px title
  block — the same overflow reproduced at tablet width (834px), where the
  actions previously ran ~250px past the dialog edge;
- command rows shrink and truncate before the buttons do, and the header row is
  capped at 100% width so it can never widen the dialog again.

No new API, no new affordance, no change to what the header offers.

## Evidence

Measured in Chromium via Playwright, reading live geometry inside the open
dialog (elements rendered outside the viewport, and clipped containers left with
`scrollLeft > 0`).

Reproduction before the change — 393 x 660, Grouped Table:

```
dialog        = 393px wide
body          = 976px scrollWidth inside it
clipped body  = scrollLeft 295  (unreachable; overflow: hidden)
offscreen     = 19 elements, e.g. header row at left -295, title at left -271
```

Result after the change — same page, same template:

```
dialog        = 393px wide
offscreen     = 0 elements
scrolled      = 0 clipped containers
```

Also clean at 320 x 568 and 393 x 660 across Analytics Dashboard, Grouped Table,
Settings Panels, AI Chat Conversation, Product Gallery, Documentation Technical,
IDE and Kanban Board; and at 834, 1024 and 1440 CSS px.

Representative unchanged path: at 1440 x 900 the standard dialog is unchanged —
1400px wide, title left, command rows centre, Open in Playground and close
right, nothing offscreen, nothing scrolled. At 834px the actions now wrap onto a
second row instead of colliding with the title.

Regression-sensitive proof: the probe fails if any element inside the dialog
renders outside the viewport or any clipped container is left scrolled;
reverting the header changes reproduces the 976px min-content width and the
scrolled clipped body.

## Scope

- [x] One defect is restored.
- [x] Separable contradictory or unsettled tagalongs were removed or split.
- [x] No new public API, visual representation, default, or interaction model is hidden under the bug-fix label.
- [x] Public text and artifacts contain no internal Meta context.

## Testing

- `tsc --noEmit` (apps/docsite) and `eslint` on the changed file — clean.
- Real-browser states: dialog open at 320, 393, 834, 1024, 1440 CSS px; initial
  focus on open (the state that triggered the scroll); command truncation; close
  button reachable; Open in Playground reachable and full width on phones.

## Follow-up (not in this PR)

`Dialog`'s inner body uses `overflow: hidden`, which stays programmatically
scrollable — that is what turned "content too wide" into "content permanently
off-screen". `LayoutContent` already uses `overflow: clip` for its
non-scrollable case. Switching Dialog's inner wrapper to `clip` would contain
this class of bug for every dialog, but it touches core and belongs in its own
change.
