### PR TITLE
Generate TypeScript-safe integration imports

### DIFF
--- a/.changeset/extensionless-integration-imports.md
+++ b/.changeset/extensionless-integration-imports.md
@@ -1,0 +1,20 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Use extensionless subpath specifiers for generated integration imports
+
+`integrationAddComponent` and `integrationAddTemplate` now emit extensionless
+public import specifiers (`@pkg/components/MyWidget` instead of
+`@pkg/components/MyWidget.tsx`) and map them to source files through the
+package `exports` field. This makes the generated contract resolvable under
+TypeScript's `moduleResolution: "node16"` (and `"bundler"`) without requiring
+the consumer to enable `allowImportingTsExtensions`.
+
+`integrationPackCheck` now validates TypeScript-consumer resolvability
+unconditionally — including packages without an exports map, which previously
+false-greened. It rejects specifiers ending in `.tsx`/`.ts` and uses
+TypeScript's `resolveModuleName` API under `node16` resolution to confirm that
+extensionless subpaths resolve through the exports map.
+
+@josephfarina

--- a/packages/cli/api/integration/add-contribution.mjs
+++ b/packages/cli/api/integration/add-contribution.mjs
@@ -250,7 +250,8 @@ async function addComponent(name, options) {
   }
 
   const sourcePath = projectPath(path.relative(packageDir, sourceFile));
-  const importSpecifier = `${owner}/${sourcePath}`;
+  const extensionlessPath = sourcePath.replace(/\.tsx?$/u, '');
+  const importSpecifier = `${owner}/${extensionlessPath}`;
   const docContents = `export default {\n  type: 'component',\n  name: '${name}',\n  import: ${JSON.stringify(importSpecifier)},\n  description: '${name} component.',\n  props: [],\n};\n`;
   const sourceContents = `export function ${name}() {\n  return <div>${name}</div>;\n}\n`;
 
@@ -263,7 +264,7 @@ async function addComponent(name, options) {
     packageFile,
     rootPath,
     path.basename(manifestFile),
-    [{subpath: sourcePath, target: sourcePath}],
+    [{subpath: extensionlessPath, target: sourcePath}],
   );
   if (pkgUpdate != null) {
     plans.push({
@@ -576,6 +577,7 @@ async function addTemplate(name, options) {
 
   const pascalName = kebabToPascal(name);
   const sourcePath = projectPath(path.relative(packageDir, sourceFile));
+  const extensionlessPath = sourcePath.replace(/\.tsx?$/u, '');
   const specContents = `export default {\n  type: '${templateType}',\n  name: '${name}',\n  description: '${kebabToTitle(name)} template.',\n};\n`;
   const sourceContents = `export default function ${pascalName}() {\n  return <div>${kebabToTitle(name)}</div>;\n}\n`;
 
@@ -588,7 +590,7 @@ async function addTemplate(name, options) {
     packageFile,
     rootPath,
     path.basename(manifestFile),
-    [{subpath: sourcePath, target: sourcePath}],
+    [{subpath: extensionlessPath, target: sourcePath}],
   );
   if (pkgUpdate != null) {
     plans.push({

--- a/packages/cli/api/integration/add-contribution.test.mjs
+++ b/packages/cli/api/integration/add-contribution.test.mjs
@@ -118,14 +118,14 @@ describe('integrationAdd component', () => {
     );
     expect(pkg.exports).toEqual({
       '.': './index.mjs',
-      './components/MyWidget.tsx': './components/MyWidget.tsx',
+      './components/MyWidget': './components/MyWidget.tsx',
     });
     expect(
       fs.readFileSync(
         path.join(tmpDir, 'components/MyWidget.doc.mjs'),
         'utf-8',
       ),
-    ).toContain('import: "@acme/integration/components/MyWidget.tsx"');
+    ).toContain('import: "@acme/integration/components/MyWidget"');
   });
 
   it('does not create exports when the package has no exports map', async () => {
@@ -143,7 +143,7 @@ describe('integrationAdd component', () => {
     setup({
       exports: {
         '.': './index.mjs',
-        './components/MyWidget.tsx': './different.tsx',
+        './components/MyWidget': './different.tsx',
       },
     });
 
@@ -421,7 +421,7 @@ describe('integrationAdd template', () => {
     );
     expect(pkg.exports).toEqual({
       '.': './index.mjs',
-      './templates/my-widget.tsx': './templates/my-widget.tsx',
+      './templates/my-widget': './templates/my-widget.tsx',
     });
   });
 

--- a/packages/cli/api/integration/pack-check.mjs
+++ b/packages/cli/api/integration/pack-check.mjs
@@ -421,13 +421,17 @@ async function validatePackedComponentExports(integration, scratchBase) {
  */
 async function validatePackedTemplateExports(integration, scratchBase) {
   const {templates} = await discoverIntegrationTemplatesForOne(integration);
-  const entries = templates.map(template => ({
-    id: template.dirName,
-    specifier: `${integration.name}/${path
+  const entries = templates.map(template => {
+    const relPath = path
       .relative(integration.__packageDir, template.filePath)
       .split(path.sep)
-      .join('/')}`,
-  }));
+      .join('/');
+    const extensionless = relPath.replace(/\.tsx?$/u, '');
+    return {
+      id: template.dirName,
+      specifier: `${integration.name}/${extensionless}`,
+    };
+  });
   const resolved = resolveConsumerSpecifiers(
     entries.map(entry => entry.specifier),
     scratchBase,
@@ -461,6 +465,135 @@ async function validatePackedTemplateExports(integration, scratchBase) {
     }
   }
   return issues;
+}
+
+const TS_EXTENSION_RE = /\.tsx?$/u;
+
+/**
+ * Reject specifiers that end in a TypeScript extension — they fail under
+ * default `moduleResolution` with TS5097/TS2307 unless the consumer enables
+ * `allowImportingTsExtensions`.
+ *
+ * @param {Array<{label: string, specifier: string}>} entries
+ * @returns {Issue[]}
+ */
+function validateSpecifierExtensions(entries) {
+  /** @type {Issue[]} */
+  const issues = [];
+  for (const {label, specifier} of entries) {
+    if (TS_EXTENSION_RE.test(specifier)) {
+      issues.push(
+        error(
+          'typescript_extension_in_specifier',
+          `${label} advertises import "${specifier}", which ends in a TypeScript extension. A consumer with default moduleResolution will reject it (TS5097). Use an extensionless specifier mapped through the package exports.`,
+        ),
+      );
+    }
+  }
+  return issues;
+}
+
+/**
+ * Verify that specifiers resolve under TypeScript's `moduleResolution: "node16"`
+ * using TypeScript's own resolver API. This avoids full compilation (which would
+ * need JSX config and React types) while proving that the specifier is
+ * resolvable through the package exports map.
+ *
+ * Falls back to {@link validateSpecifierExtensions} when TypeScript is not
+ * available in the project's node_modules.
+ *
+ * @param {Array<{label: string, specifier: string, exportName: string}>} entries
+ * @param {string} scratchBase
+ * @returns {Issue[]}
+ */
+function validateTypeScriptConsumer(entries, scratchBase) {
+  if (entries.length === 0) return [];
+
+  // Always check specifier extensions first — .tsx/.ts imports are unconditionally
+  // invalid under default TypeScript settings regardless of resolution.
+  const extensionIssues = validateSpecifierExtensions(entries);
+
+  // Find tsc to locate the TypeScript module
+  const tscBin = findTscBinary(scratchBase);
+  if (!tscBin) {
+    return extensionIssues;
+  }
+
+  // Use TypeScript's module resolution API (not full compilation) to verify
+  // that each specifier resolves through the package exports map.
+  const tsDir = path.dirname(path.dirname(tscBin));
+  const resolver = path.join(scratchBase, '.astryx-ts-resolve.mjs');
+  const source = [
+    `import {createRequire} from 'node:module';`,
+    `const require = createRequire(${JSON.stringify(path.join(tsDir, 'package.json'))});`,
+    `const ts = require(${JSON.stringify(tsDir)});`,
+    `const specs = JSON.parse(process.argv[2]);`,
+    `const opts = {moduleResolution: ts.ModuleResolutionKind.Node16, module: ts.ModuleKind.Node16};`,
+    `const host = ts.createCompilerHost(opts);`,
+    `const fromFile = ${JSON.stringify(path.join(scratchBase, 'check.ts'))};`,
+    `const out = {};`,
+    `for (const s of specs) {`,
+    `  const r = ts.resolveModuleName(s, fromFile, opts, host);`,
+    `  out[s] = r.resolvedModule ? {file: r.resolvedModule.resolvedFileName} : {error: 'not resolved'};`,
+    `}`,
+    `console.log(JSON.stringify(out));`,
+  ].join('\n');
+
+  fs.writeFileSync(resolver, source, {flag: 'wx'});
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [resolver, JSON.stringify([...new Set(entries.map(e => e.specifier))])],
+      {cwd: scratchBase, encoding: 'utf-8', timeout: 30_000},
+    );
+
+    if (result.error || result.status !== 0) {
+      // TypeScript resolver failed to run — fall back to extension check only
+      return extensionIssues;
+    }
+
+    /** @type {Record<string, {file?: string, error?: string}>} */
+    let parsed;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      return extensionIssues;
+    }
+
+    /** @type {Issue[]} */
+    const resolverIssues = [];
+    for (const {label, specifier} of entries) {
+      const entry = parsed[specifier];
+      if (!entry?.file) {
+        resolverIssues.push(
+          error(
+            'typescript_consumer_unresolvable',
+            `${label} import "${specifier}" cannot be resolved by TypeScript under moduleResolution:node16. Ensure the package exports map maps an extensionless subpath to the source file.`,
+          ),
+        );
+      }
+    }
+    return [...extensionIssues, ...resolverIssues];
+  } finally {
+    fs.rmSync(resolver, {force: true});
+  }
+}
+
+/**
+ * Walk up from `startDir` looking for `node_modules/typescript/bin/tsc`.
+ * @param {string} startDir
+ * @returns {string|null}
+ */
+function findTscBinary(startDir) {
+  let dir = path.resolve(startDir);
+  for (let depth = 0; depth < 30; depth++) {
+    const candidate = path.join(dir, 'node_modules', 'typescript', 'bin', 'tsc');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
 }
 
 /**
@@ -715,6 +848,59 @@ export async function integrationPackCheck(options = {}) {
         scratchBase,
       )),
     );
+
+    // ── Phase 4: TypeScript consumer resolution ──
+    // Collect every public specifier and verify a TypeScript consumer with
+    // default moduleResolution can resolve them. This runs UNCONDITIONALLY —
+    // a package without an exports map still publishes a .tsx doc import
+    // that a default TS consumer rejects (TS5097/TS2307).
+    /** @type {Array<{label: string, specifier: string, exportName: string}>} */
+    const tsEntries = [];
+    const componentRecords = discoverIntegrationComponents(
+      packedResult.integration,
+    );
+    for (const record of componentRecords) {
+      let docs;
+      try {
+        docs = await loadComponentDoc(record.docPath);
+      } catch {
+        continue;
+      }
+      const specifier =
+        /** @type {{import?: string}} */ (docs).import ??
+        resolveIntegrationImportPath(
+          {
+            exportsMap: packedResult.integration.__packageExports,
+            packageDir: packedResult.integration.__packageDir,
+            docPath: record.docPath,
+            packageName: packedResult.integration.name,
+          },
+          record.name,
+        );
+      tsEntries.push({
+        label: `Component "${record.name}"`,
+        specifier,
+        exportName: record.name,
+      });
+    }
+    const {templates: packedTemplates} =
+      await discoverIntegrationTemplatesForOne(packedResult.integration);
+    for (const template of packedTemplates) {
+      const relPath = path
+        .relative(
+          packedResult.integration.__packageDir,
+          template.filePath,
+        )
+        .split(path.sep)
+        .join('/');
+      const extensionless = relPath.replace(/\.tsx?$/u, '');
+      tsEntries.push({
+        label: `Template "${template.dirName}"`,
+        specifier: `${packedResult.integration.name}/${extensionless}`,
+        exportName: 'default',
+      });
+    }
+    issues.push(...validateTypeScriptConsumer(tsEntries, scratchBase));
 
     return buildReceipt(
       pkgName,

--- a/packages/cli/api/integration/pack-check.test.mjs
+++ b/packages/cli/api/integration/pack-check.test.mjs
@@ -567,3 +567,230 @@ describe('pack-check mutation tests', () => {
     }
   });
 });
+
+describe('extensionless subpath resolution', () => {
+  it('rejects .tsx specifiers that a TypeScript consumer cannot resolve', async () => {
+    // Manually construct a package with OLD-style .tsx exports keys
+    writePackage({
+      manifest: "export default {components: './components'};\n",
+      files: ['astryx.integration.mjs', 'components', 'index.mjs'],
+      themes: false,
+    });
+    const pkgFile = path.join(tmpDir, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgFile, 'utf-8'));
+    pkg.exports = {
+      '.': './index.mjs',
+      './components/AcmeWidget.tsx': './components/AcmeWidget.tsx',
+    };
+    fs.writeFileSync(pkgFile, `${JSON.stringify(pkg, null, 2)}\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, 'index.mjs'),
+      'export const existing = 1;\n',
+    );
+    fs.mkdirSync(path.join(tmpDir, 'components'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'components', 'AcmeWidget.doc.mjs'),
+      `export default {type: 'component', name: 'AcmeWidget', import: '@acme/widgets/components/AcmeWidget.tsx', description: 'Widget.', props: []};\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'components', 'AcmeWidget.tsx'),
+      'export function AcmeWidget() { return null; }\n',
+    );
+
+    const result = await integrationPackCheck({cwd: tmpDir});
+
+    // The .tsx extension in the specifier must be caught
+    expect(result.data.packable).toBe(false);
+    expect(result.data.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'typescript_extension_in_specifier',
+        message: expect.stringContaining('.tsx'),
+      }),
+    );
+  });
+
+  it('generated extensionless component specifier resolves through exports map', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      `${JSON.stringify({
+        name: '@acme/widgets',
+        version: '1.0.0',
+        files: ['index.mjs'],
+        exports: {'.': './index.mjs'},
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'index.mjs'),
+      'export const existing = 1;\n',
+    );
+    await integrationAddComponent('AcmeWidget', {cwd: tmpDir});
+
+    // Verify the exports map has extensionless key → .tsx target
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8'),
+    );
+    expect(pkg.exports['./components/AcmeWidget']).toBe(
+      './components/AcmeWidget.tsx',
+    );
+    expect(pkg.exports['./components/AcmeWidget.tsx']).toBeUndefined();
+
+    const result = await integrationPackCheck({cwd: tmpDir});
+
+    expect(result.data.packable).toBe(true);
+    expect(result.data.issues).not.toContainEqual(
+      expect.objectContaining({code: 'typescript_extension_in_specifier'}),
+    );
+    expect(result.data.issues).not.toContainEqual(
+      expect.objectContaining({code: 'typescript_consumer_unresolvable'}),
+    );
+    expect(result.data.issues).not.toContainEqual(
+      expect.objectContaining({code: 'component_import_unresolvable'}),
+    );
+  });
+
+  it('generated extensionless template specifiers resolve for page and block types', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      `${JSON.stringify({
+        name: '@acme/widgets',
+        version: '1.0.0',
+        files: ['index.mjs'],
+        exports: {'.': './index.mjs'},
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'index.mjs'),
+      'export const existing = 1;\n',
+    );
+    await integrationAddTemplate('account-page', {cwd: tmpDir, type: 'page'});
+    await integrationAddTemplate('info-card', {cwd: tmpDir, type: 'block'});
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8'),
+    );
+    expect(pkg.exports['./templates/account-page']).toBe(
+      './templates/account-page.tsx',
+    );
+    expect(pkg.exports['./templates/info-card']).toBe(
+      './templates/info-card.tsx',
+    );
+
+    const result = await integrationPackCheck({cwd: tmpDir});
+
+    expect(result.data.packable).toBe(true);
+    expect(result.data.issues).not.toContainEqual(
+      expect.objectContaining({code: 'template_import_unresolvable'}),
+    );
+    expect(result.data.issues).not.toContainEqual(
+      expect.objectContaining({code: 'typescript_extension_in_specifier'}),
+    );
+  });
+
+  it('preserves condition-style exports sugar without creating a map', async () => {
+    // Package with condition-only exports (sugar, no subpaths)
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      `${JSON.stringify({
+        name: '@acme/widgets',
+        version: '1.0.0',
+        files: ['index.mjs'],
+        exports: {import: './index.mjs', require: './index.cjs'},
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'index.mjs'),
+      'export const existing = 1;\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'index.cjs'),
+      'exports.existing = 1;\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      'export default {};\n',
+    );
+
+    await integrationAddComponent('AcmeWidget', {cwd: tmpDir});
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8'),
+    );
+    // Condition sugar wrapped into subpath map with the component added
+    expect(pkg.exports['.']).toEqual({
+      import: './index.mjs',
+      require: './index.cjs',
+    });
+    expect(pkg.exports['./components/AcmeWidget']).toBe(
+      './components/AcmeWidget.tsx',
+    );
+  });
+
+  it('no-map: pack-check fails when generated component has no exports map', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      `${JSON.stringify({
+        name: '@acme/widgets',
+        version: '1.0.0',
+        files: ['dist'],
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      'export default {};\n',
+    );
+
+    await integrationAddComponent('AcmeWidget', {cwd: tmpDir});
+    await integrationAddTemplate('hero-page', {cwd: tmpDir, type: 'page'});
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8'),
+    );
+    // No exports map created
+    expect(pkg.exports).toBeUndefined();
+
+    const result = await integrationPackCheck({cwd: tmpDir});
+
+    // The extensionless import cannot resolve without an exports map —
+    // pack-check must fail closed, not false-green.
+    expect(result.data.packable).toBe(false);
+    expect(result.data.issues).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        message: expect.stringContaining('AcmeWidget'),
+      }),
+    );
+  });
+
+  it('idempotent when extensionless export already exists', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      `${JSON.stringify({
+        name: '@acme/widgets',
+        version: '1.0.0',
+        files: ['index.mjs'],
+        exports: {
+          '.': './index.mjs',
+          './components/AcmeWidget': './components/AcmeWidget.tsx',
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'index.mjs'),
+      'export const existing = 1;\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.integration.mjs'),
+      'export default {};\n',
+    );
+
+    await integrationAddComponent('AcmeWidget', {cwd: tmpDir});
+
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8'),
+    );
+    // Export preserved, no duplicate
+    expect(Object.keys(pkg.exports).filter(k => k.includes('AcmeWidget'))).toEqual([
+      './components/AcmeWidget',
+    ]);
+  });
+});

--- a/packages/cli/clients/cli/commands/integration-authoring.test.mjs
+++ b/packages/cli/clients/cli/commands/integration-authoring.test.mjs
@@ -120,7 +120,7 @@ describe('integration authoring CLI', () => {
     );
   });
 
-  it('packs the generated contribution and proves the consumer inventory', async () => {
+  it('pack-check rejects a generated component without an exports map (no-map false green)', async () => {
     const added = await runCli(
       ['integration', 'add', 'component', 'AcmeWidget', '--json'],
       tmpDir,
@@ -131,19 +131,23 @@ describe('integration authoring CLI', () => {
       ['integration', 'pack', '--check', '--json'],
       tmpDir,
     );
-    expect(checked.status).toBe(0);
-    expect(parseEnvelope(checked.stdout)).toMatchObject({
+    // Without an exports map, the extensionless import cannot resolve —
+    // pack-check must fail, not false-green.
+    expect(checked.status).not.toBe(0);
+    const envelope = parseEnvelope(checked.stdout);
+    expect(envelope).toMatchObject({
       type: 'integration.pack-check',
       data: {
         name: '@acme/widgets',
-        version: '1.0.0',
-        packable: true,
-        contributions: {
-          local: {components: ['AcmeWidget']},
-          packed: {components: ['AcmeWidget']},
-        },
+        packable: false,
       },
     });
+    expect(envelope.data.issues).toContainEqual(
+      expect.objectContaining({
+        severity: 'error',
+        message: expect.stringContaining('AcmeWidget'),
+      }),
+    );
   });
 
   it('requires the explicit --check gate on pack', async () => {


### PR DESCRIPTION
Replaced by #6288.

Generated component and template imports included `.tsx`. Pack-check could approve them even though a default TypeScript or Next consumer rejected the public specifier.

This generates extensionless subpaths, maps them to source files through package exports, and validates every packed public import with TypeScript's Node16 resolver. Packages without a usable public export now fail closed.

Tests:
- API DTS typecheck
- strict lint and repo checks
- full CLI suite, 3,944 tests
- component, page, and block tarball consumers
- no-map and legacy `.ts`/`.tsx` mutation cases
- condition-sugar and idempotency cases

