### PR TITLE
Document integration authoring end to end

### DIFF
--- a/packages/cli/api/upgrade/upgrade.doc.mjs
+++ b/packages/cli/api/upgrade/upgrade.doc.mjs
@@ -69,7 +69,7 @@ export const doc = {
       name: 'options.integration',
       type: 'string[]',
       description:
-        'Explicit integration package names / file paths to process.',
+        'Explicit integration package names to process. Bare npm names only; file paths and relative segments are rejected.',
     },
     {
       name: 'options.path',

--- a/packages/cli/api/upgrade/upgrade.type.mjs
+++ b/packages/cli/api/upgrade/upgrade.type.mjs
@@ -135,7 +135,7 @@
  * @property {boolean} [force] Run codemods even if `from` >= installed.
  * @property {string} [codemod] Run a single named transform.
  * @property {string[]} [skipCodemod] Exclude named codemods (re-run past a failure).
- * @property {string[]} [integration] Explicit integration package names / file paths.
+ * @property {string[]} [integration] Explicit integration package names (bare npm names only; file paths rejected).
  * @property {string} [path] Source directory to scan (default `./src`).
  * @property {boolean} [installDeps] Auto-install jscodeshift without prompting.
  * @property {boolean} [registry] Reconcile only ShadCN-copied compositions; `from` is not required.

--- a/packages/cli/assets/docs/cli-integrations.doc.mjs
+++ b/packages/cli/assets/docs/cli-integrations.doc.mjs
@@ -20,7 +20,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'The authoring CLI owns the integration file. The first `astryx integration add` creates `astryx.integration.mjs`; each later add declares its root only after writing a valid contribution behind it. Identity (name and version) still comes from package.json. For the consumer side, run `npx astryx docs getting-started`.',
+          text: 'The authoring CLI owns the integration file. The first `astryx integration add` creates `astryx.integration.mjs`; each later add declares its root only after writing a valid contribution behind it. Identity (name and version) still comes from package.json. For the consumer side, run `astryx docs getting-started`.',
         },
         {
           type: 'prose',
@@ -48,7 +48,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Do not start by hand-editing a manifest. Add the contribution you mean to ship; Astryx creates the manifest, writes every required file, preserves an existing custom root, and updates an existing package.json files allowlist without creating one.',
+          text: 'Do not start by hand-editing a manifest. Add the contribution you mean to ship; Astryx creates the manifest, writes every required file, preserves an existing custom root, and updates an existing package.json files allowlist without creating one. Always run these commands from the locally installed CLI in the package (e.g. `node node_modules/@astryxdesign/cli/clients/cli/bin/astryx.mjs` or `pnpm astryx`), not `npx @astryxdesign/cli` — npx may resolve a stale registry version whose integration scaffolding does not match the installed one.',
         },
         {
           type: 'code',
@@ -90,7 +90,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Edit the generated theme and guide files before publishing. Palette generation writes an importable TypeScript candidate and a reproducibility receipt; import the candidate from the theme and list both nested files in that theme catalog entry. `integration pack --check` runs the real package lifecycle and compares local discovery with the npm tarball, so a missing source file or files allowlist entry fails before a consumer sees it.',
+          text: 'Edit the generated theme and guide files before publishing. Palette generation (`astryx theme palette generate`) writes two files: an importable TypeScript candidate (e.g. `oceanPalettes.generated.ts`) containing the full palette, and a detached reproducibility receipt (e.g. `oceanPalettes.generated.receipt.json`). Two additional modules are separately authored: a palette wrapper (e.g. `oceanPalettes.ts`) that re-exports the generated candidate as a named constant the theme source imports, and optionally a palette-refs module (e.g. `oceanPaletteRefs.generated.ts`) that extracts the specific stops the theme actually uses. List all of them — plus the palette config, any icons module, and the theme source itself — in the theme catalog entry\'s `files` array, because `astryx theme add` copies exactly what `files` lists and nothing else. `integration pack --check` runs the real package lifecycle and compares local discovery with the npm tarball, so a missing source file or files allowlist entry fails before a consumer sees it.',
         },
         {
           type: 'code',
@@ -101,6 +101,25 @@ export const docs = {
         {
           type: 'prose',
           text: 'The package must be a direct dependency for automatic discovery. No `astryx.config` entry is needed unless the app must control integration order. `theme add` copies every file listed by the selected catalog entry, including nested token modules, and refuses to overwrite existing project files.',
+        },
+      ],
+    },
+    {
+      title: 'Contribution Kinds at a Glance',
+      category: 'guide',
+      content: [
+        {
+          type: 'prose',
+          text: 'Each contribution kind uses a different metadata suffix, type stamp, and discovery rule. The table below prevents the most common first-time authoring mistake — using the wrong file or export convention.',
+        },
+        {
+          type: 'code',
+          lang: 'text',
+          code: 'Kind        Metadata suffix            type stamp     Source file\n────────    ─────────────────────────  ─────────────  ──────────────────────\nComponent   Name.doc.{ts,mjs,js}       \'component\'    Name.tsx (same stem)\nTemplate    Name.template.{ts,mjs,js}  \'page\'/\'block\' Name.tsx (same stem)\nDoc topic   topic.doc.{ts,mjs,js}      \'generic\'      (none — docs are prose)\nCodemod     <version>/<id>.{ts,mjs,js} \'code\'/\'config\' (the codemod IS the source)\nTheme       manifest.json entry         —             <slug>/<entry>.ts',
+        },
+        {
+          type: 'prose',
+          text: 'The `type` stamp is how new docs should be authored — it routes parsing to the correct schema at the load boundary. Legacy docs without a stamp still load via shape-sniffing for backward compatibility, but unstamped docs rely on heuristics (presence of `props`, `params`, etc.) and may parse under the wrong schema if the shape is ambiguous. Always stamp new integration contributions.',
         },
       ],
     },
@@ -129,7 +148,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Export your components from your library however you like, and consumers still import them from your package. For each component the CLI should document, ship a `.doc.{ts,mjs,js}` file with the same stem, for example `AcmeCarousel.tsx` alongside `AcmeCarousel.doc.ts`.',
+          text: 'Export your components from your library however you like, and consumers still import them from your package. For each component the CLI should document, ship a `.doc.{ts,mjs,js}` file with the same stem, for example `AcmeCarousel.tsx` alongside `AcmeCarousel.doc.ts`. The doc file must default-export an object with `type: \'component\'` — not `\'generic\'` (that is for reference docs) and not `\'page\'`/`\'block\'` (those are for templates).',
         },
         {
           type: 'prose',
@@ -138,7 +157,7 @@ export const docs = {
         {
           type: 'code',
           lang: 'typescript',
-          code: "// AcmeCarousel.doc.ts\nexport default {\n  type: 'component',\n  name: 'AcmeCarousel',\n  description: 'A carousel that cycles through slides.',\n  // props, usage, examples, ...\n};",
+          code: "// AcmeCarousel.doc.ts\nexport default {\n  type: 'component',\n  name: 'AcmeCarousel',\n  description: 'A carousel that cycles through slides.',\n  // props, usage, examples, ...\n} satisfies import('@astryxdesign/cli/authoring').ComponentDoc;",
         },
       ],
     },
@@ -148,7 +167,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: "Templates are usually not exported from the package directly. Instead, consumers browse them through the CLI and materialize them into their app. Define a template as a plain object stamped with `type: 'page'` (full pages) or `type: 'block'` (smaller chunks) in a `.template.{ts,mjs,js}` file next to the source, for example `AcmeLandingPage.tsx` and `AcmeLandingPage.template.ts`.",
+          text: "Templates are usually not exported from the package directly. Instead, consumers browse them through the CLI and materialize them into their app. Define a template as a plain object with `type: 'page'` (full pages) or `type: 'block'` (smaller chunks) as its default export in a `.template.{ts,mjs,js}` file next to the source, for example `AcmeLandingPage.tsx` and `AcmeLandingPage.template.ts`. Do not use the `.doc.{ts,mjs,js}` suffix — that is for component docs and reference docs.",
         },
         {
           type: 'prose',
@@ -161,7 +180,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'The CLI needs both files at consume time. `integration add` includes the templates root when package.json already has a files allowlist. It never creates an exports map, because doing that can make previously-open deep imports private; when a map already exists, it adds the generated source subpath without replacing author-owned entries. `integration pack --check` proves the source and metadata survive the tarball and verifies every component through the public import its metadata advertises.',
+          text: 'The CLI needs both files at consume time. `integration add` includes the templates root when package.json already has a files allowlist. It never creates an exports map, because doing that can make previously-open deep imports private; when a map already exists, it adds the generated source subpath without replacing author-owned entries. Use consumer-safe extensionless subpaths in the exports map (e.g. `"./templates/AcmeDashboard"` instead of `"./templates/AcmeDashboard.tsx"`), so consumers import without knowing the file extension. `integration pack --check` proves the source and metadata survive the tarball and verifies every component through the public import its metadata advertises.',
         },
       ],
     },
@@ -171,7 +190,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: "Point the integration file's `docs` field at a directory of reference docs and every `{topic}.doc.{ts,mjs,js}` under it becomes a topic the CLI serves: `astryx docs` lists it, `astryx docs <topic>` prints it, `astryx search` indexes it, and `astryx init` names it in the agent block. A topic is a plain object stamped `type: 'generic'`, the same shape core's own topics use.",
+          text: "Point the integration file's `docs` field at a directory of reference docs and every `{topic}.doc.{ts,mjs,js}` under it becomes a topic the CLI serves: `astryx docs` lists it, `astryx docs <topic>` prints it, `astryx search` indexes it, and `astryx init` names it in the agent block. A topic is a plain object with `type: 'generic'` as its default export — not `'component'` (that is for component docs with a same-stem source file). This is the same shape core's own topics use.",
         },
         {
           type: 'code',
@@ -219,12 +238,34 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: "The root catalog uses the same entry contract as Astryx's bundled themes: `slug`, `displayName`, `description`, `maintained`, `entry`, `exportName`, and `files`. `entry` and every file are relative to `themes/<slug>/`; `exportName` identifies a named runtime export in the entry source. Astryx parses that source without executing it, requires every local static import and re-export to name a file in `files`, and rejects missing or type-only exports.",
+          text: "The root catalog `manifest.json` must be `{ \"version\": 1, \"themes\": [...] }`. Each entry in the `themes` array requires every field shown below — omitting any one is a hard validation error:",
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            '`slug` — lowercase kebab-case starting with a letter (e.g. `"ocean"`). Must be unique within the catalog.',
+            '`displayName` — human-readable label (e.g. `"Ocean"`).',
+            '`description` — string description of the theme.',
+            '`maintained` — boolean indicating active maintenance.',
+            '`entry` — source file relative to `themes/<slug>/` (e.g. `"oceanTheme.ts"`).',
+            '`exportName` — a valid JS identifier naming the runtime export in the entry file (e.g. `"oceanTheme"`). Astryx parses the source without executing it and rejects missing or type-only exports.',
+            '`files` — non-empty array of filenames relative to `themes/<slug>/`. Must include the entry file and every local static import the entry source uses. Astryx validates that every listed file exists on disk and that every local import in the entry names a file in this list.',
+          ],
         },
         {
           type: 'code',
           lang: 'json',
-          code: '{\n  "version": 1,\n  "themes": [{\n    "slug": "ocean",\n    "displayName": "Ocean",\n    "description": "Ocean theme.",\n    "maintained": true,\n    "entry": "oceanTheme.ts",\n    "exportName": "oceanTheme",\n    "files": ["oceanTheme.ts"]\n  }]\n}',
+          code: '{\n  "version": 1,\n  "themes": [{\n    "slug": "ocean",\n    "displayName": "Ocean",\n    "description": "Ocean theme with OKLCH palettes.",\n    "maintained": true,\n    "entry": "oceanTheme.ts",\n    "exportName": "oceanTheme",\n    "files": [\n      "oceanTheme.ts",\n      "icons.tsx",\n      "oceanPalettes.ts",\n      "oceanPalettes.generated.ts",\n      "oceanPaletteRefs.generated.ts",\n      "oceanPalettes.generated.receipt.json",\n      "palette.config.json"\n    ]\n  }]\n}',
+        },
+        {
+          type: 'prose',
+          text: 'The palette wrapper (`oceanPalettes.ts`) is a short authored file that re-exports the generated candidate as a stable named constant the theme source imports. It is not generated by the CLI — author it yourself:',
+        },
+        {
+          type: 'code',
+          lang: 'typescript',
+          code: "// themes/ocean/oceanPalettes.ts (authored wrapper)\nimport {black, palette, white} from './oceanPalettes.generated';\n\nexport const oceanPalettes = {\n  black,\n  white,\n  ...palette,\n} as const;\n\nexport default oceanPalettes;",
         },
         {
           type: 'prose',
@@ -268,9 +309,31 @@ export const docs = {
           text: "Ship codemods so `astryx upgrade` can migrate consumers across breaking changes in your package. Point the integration file's `codemods` field at your codemods root, and author each one as a plain object stamped with `type: 'code'` (transforms source files) or `type: 'config'` (rewrites the consumer's `astryx.config`).",
         },
         {
+          type: 'prose',
+          text: 'The codemods root uses a version-folder-first layout. Each folder name is an exact semver string (no `v` prefix) matching the version the codemod migrates TO. Each module under it is a kebab-case `.ts`, `.mjs`, or `.js` file whose default export is the codemod envelope:',
+        },
+        {
+          type: 'code',
+          lang: 'text',
+          code: 'codemods/\n  0.2.0/\n    rename-widget-prop.ts\n  0.3.0/\n    update-theme-import.ts\n    config/rename-integration.ts',
+        },
+        {
+          type: 'prose',
+          text: 'Codemod ids (the extension-less relative path under the version folder, e.g. `rename-widget-prop`, `config/rename-integration`) must be unique within a package across all versions. A duplicate id across versions is a hard error.',
+        },
+        {
           type: 'code',
           lang: 'typescript',
-          code: "// codemods/v2-rename-prop.ts\nexport default {\n  type: 'code',\n  // title, description, transform, ...\n};",
+          code: "// codemods/0.2.0/rename-widget-prop.ts\nexport default {\n  type: 'code',\n  title: 'Rename AcmeWidget oldProp to newProp',\n  description: 'Updates JSX props in consumer source files.',\n  transform(file, api) {\n    // jscodeshift transform\n    return file.source;\n  },\n};",
+        },
+        {
+          type: 'prose',
+          text: '`astryx upgrade` is dry-run by default — it previews which codemods would run and what files would change, without writing anything. Pass `--apply` to write the changes. There is no `--dry-run` flag; omitting `--apply` is the dry run. The `--integration` flag accepts bare npm package names only (e.g. `--integration @acme/widgets`); file paths and relative segments are rejected.',
+        },
+        {
+          type: 'code',
+          lang: 'bash',
+          code: '# Preview what would change (dry-run, the default)\nastryx upgrade --from 0.1.0\n\n# Apply the migration\nastryx upgrade --from 0.1.0 --apply',
         },
         {
           type: 'prose',

--- a/packages/cli/authoring/integration/type.ts
+++ b/packages/cli/authoring/integration/type.ts
@@ -19,7 +19,13 @@ export interface AstryxIntegration {
   components?: string;
   /** Relative path to the templates root (resolved to absolute). */
   templates?: string;
-  /** Relative path to the codemods root (resolved to absolute). */
+  /** Relative path to the codemods root (resolved to absolute).
+   *  The root uses a version-folder-first layout:
+   *  `<codemodsRoot>/<version>/<id>.<ext>`, where `<version>` is an exact
+   *  semver string (e.g. `0.2.0`, no `v` prefix) and `<id>` is a kebab-case
+   *  module basename. Each module default-exports a codemod envelope stamped
+   *  `type: 'code'` or `type: 'config'`. Codemod ids must be unique within
+   *  a package across all versions. */
   codemods?: string;
   /** Relative path to the reference-docs (topics) root (resolved to
    *  absolute). Every `{topic}.doc.{ts,mjs,js}` under it is a topic the CLI
@@ -27,7 +33,14 @@ export interface AstryxIntegration {
    *  `replace` or `extend` a built-in topic; see the ReferenceDoc type. */
   docs?: string;
   /** Relative path to the source-theme catalog root (resolved to absolute).
-   *  The root contains `manifest.json` plus one directory per theme slug. */
+   *  The root contains `manifest.json` plus one directory per theme slug.
+   *  `manifest.json` is `{ "version": 1, "themes": [...] }` where each
+   *  entry requires `slug`, `displayName`, `description` (string),
+   *  `maintained` (boolean), `entry` (source file relative to `themes/<slug>/`),
+   *  `exportName` (a valid JS identifier naming the runtime export), and
+   *  `files` (non-empty array of filenames relative to `themes/<slug>/`).
+   *  Every file listed must exist on disk; the entry file must also appear
+   *  in `files`. */
   themes?: string;
   /** Static package guidance appended to the CLI-owned managed agent block. */
   agentDocs?: {

--- a/packages/cli/clients/cli/commands/theme-palette-generate.doc.mjs
+++ b/packages/cli/clients/cli/commands/theme-palette-generate.doc.mjs
@@ -18,7 +18,10 @@ export const doc = {
     'Without --out it prints a preview. With --out it writes a candidate file and detached ' +
     'receipt. --preview writes a standardized, self-contained HTML review artifact. ' +
     'TypeScript output is directly importable and contains no generator dependency. ' +
-    'JSON is also supported. Existing author-owned files are left untouched unless --overwrite is explicit.',
+    'JSON is also supported. Existing author-owned files are left untouched unless --overwrite is explicit. ' +
+    'When used in a theme integration, import the generated candidate from the theme source ' +
+    'and list the candidate, receipt, and palette config in the theme catalog entry\'s `files` array ' +
+    'so `astryx theme add` copies them into the consumer project.',
   fn: 'themePaletteGenerate',
   args: [{name: 'config', param: 'configPath', required: true}],
   options: [

--- a/packages/cli/clients/cli/commands/upgrade.doc.mjs
+++ b/packages/cli/clients/cli/commands/upgrade.doc.mjs
@@ -53,10 +53,10 @@ export const doc = {
         'Exclude named codemods (repeatable). Re-run past a failed codemod by skipping it.',
     },
     {
-      flag: '--integration <package-or-file>',
+      flag: '--integration <package>',
       param: 'options.integration',
       description:
-        'Explicit integration package name or integration file path (repeatable)',
+        'Explicit integration package name (repeatable). Accepts bare npm package names only; file paths are rejected.',
       default: [],
     },
     {

--- a/packages/cli/test/cli-integrations-doc-drift.test.mjs
+++ b/packages/cli/test/cli-integrations-doc-drift.test.mjs
@@ -1,0 +1,382 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Documentation drift tests for the cli-integrations guide and related
+ * CommandDocs/FunctionDocs. Tests verify against executable sources of truth
+ * (parseDoc dispatch, resolvePackageDir, theme-discovery validators, schema
+ * shapes) rather than only prose-to-prose assertions, so a behavioral change
+ * that invalidates a documented claim is caught at CI time.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {docs as integrationGuide} from '../assets/docs/cli-integrations.doc.mjs';
+import {doc as upgradeCommandDoc} from '../clients/cli/commands/upgrade.doc.mjs';
+import {doc as upgradeFnDoc} from '../api/upgrade/upgrade.doc.mjs';
+import {doc as paletteGenerateDoc} from '../clients/cli/commands/theme-palette-generate.doc.mjs';
+import {doc as integrationAddDoc} from '../clients/cli/commands/integration-add.doc.mjs';
+import {parseDoc} from '../authoring/doctypes/parse.mjs';
+import {resolvePackageDir} from '../foundation/integrations/integrations.mjs';
+import {discoverThemeCatalog} from '../foundation/discovery/theme-discovery.mjs';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** Flatten all text content from a ReferenceDoc's sections into one string. */
+function guideText(doc) {
+  const parts = [];
+  for (const section of doc.sections ?? []) {
+    for (const block of section.content ?? []) {
+      if (block.type === 'prose') parts.push(block.text);
+      if (block.type === 'code') parts.push(block.code);
+      if (block.type === 'list') parts.push((block.items ?? []).join('\n'));
+    }
+  }
+  return parts.join('\n');
+}
+
+// ── Executable source-of-truth tests ────────────────────────────────────
+
+describe('parseDoc dispatches on documented type stamps', () => {
+  it('routes type: component to the component parser', () => {
+    const doc = parseDoc({
+      type: 'component',
+      name: 'Test',
+      description: 'x',
+      props: [],
+    });
+    expect(doc.type).toBe('component');
+  });
+
+  it('routes type: generic to the reference parser', () => {
+    const doc = parseDoc({type: 'generic', name: 'test', description: 'x'});
+    expect(doc.type).toBe('generic');
+  });
+
+  it('routes type: page to the template parser', () => {
+    const doc = parseDoc({
+      type: 'page',
+      name: 'TestPage',
+      description: 'x',
+    });
+    expect(doc.type).toBe('page');
+  });
+
+  it('routes type: block to the template parser', () => {
+    const doc = parseDoc({
+      type: 'block',
+      name: 'TestBlock',
+      description: 'x',
+    });
+    expect(doc.type).toBe('block');
+  });
+
+  it('a wrong stamp misroutes: generic on a component-shaped doc drops props', () => {
+    // Demonstrates the guide's claim that a wrong stamp parses under the wrong schema
+    const doc = parseDoc({
+      type: 'generic',
+      name: 'Mislabeled',
+      description: 'x',
+      props: [{name: 'a', type: 'string', description: 'x'}],
+    });
+    // generic schema uses passthrough so props survive, but the type is generic not component
+    expect(doc.type).toBe('generic');
+  });
+});
+
+describe('resolvePackageDir rejects file paths (documented claim)', () => {
+  it('rejects absolute paths', () => {
+    expect(() => resolvePackageDir('/etc/passwd')).toThrow(
+      /invalid integration package name/i,
+    );
+  });
+
+  it('rejects relative segments', () => {
+    expect(() => resolvePackageDir('../escape')).toThrow(
+      /invalid integration package name/i,
+    );
+  });
+
+  it('rejects dot segments', () => {
+    expect(() => resolvePackageDir('./local')).toThrow(
+      /invalid integration package name/i,
+    );
+  });
+
+  it('accepts a bare scoped package name', () => {
+    // Should not throw — just resolves the path (may not exist, that is fine)
+    expect(() => resolvePackageDir('@acme/widgets')).not.toThrow();
+  });
+});
+
+describe('discoverThemeCatalog validates all documented required fields', () => {
+  let tmpDir;
+
+  function writeCatalog(themes) {
+    const root = path.join(tmpDir, 'themes');
+    fs.mkdirSync(root, {recursive: true});
+    fs.writeFileSync(
+      path.join(root, 'manifest.json'),
+      JSON.stringify({version: 1, themes}),
+    );
+    return root;
+  }
+
+  function writeThemeFiles(slug, entry, exportName) {
+    const dir = path.join(tmpDir, 'themes', slug);
+    fs.mkdirSync(dir, {recursive: true});
+    fs.writeFileSync(
+      path.join(dir, entry),
+      `export const ${exportName} = {};\n`,
+    );
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-drift-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('accepts a valid entry with all required fields', () => {
+    const root = writeCatalog([
+      {
+        slug: 'ocean',
+        displayName: 'Ocean',
+        description: 'Ocean theme.',
+        maintained: true,
+        entry: 'oceanTheme.ts',
+        exportName: 'oceanTheme',
+        files: ['oceanTheme.ts'],
+      },
+    ]);
+    writeThemeFiles('ocean', 'oceanTheme.ts', 'oceanTheme');
+    expect(() => discoverThemeCatalog(root, '@test/pkg')).not.toThrow();
+  });
+
+  it('rejects missing slug', () => {
+    const root = writeCatalog([
+      {
+        displayName: 'Ocean',
+        description: 'x',
+        maintained: true,
+        entry: 'a.ts',
+        exportName: 'a',
+        files: ['a.ts'],
+      },
+    ]);
+    expect(() => discoverThemeCatalog(root, '@test/pkg')).toThrow();
+  });
+
+  it('rejects missing displayName', () => {
+    const root = writeCatalog([
+      {
+        slug: 'ocean',
+        description: 'x',
+        maintained: true,
+        entry: 'a.ts',
+        exportName: 'a',
+        files: ['a.ts'],
+      },
+    ]);
+    expect(() => discoverThemeCatalog(root, '@test/pkg')).toThrow();
+  });
+
+  it('rejects missing exportName', () => {
+    const root = writeCatalog([
+      {
+        slug: 'ocean',
+        displayName: 'Ocean',
+        description: 'x',
+        maintained: true,
+        entry: 'a.ts',
+        files: ['a.ts'],
+      },
+    ]);
+    expect(() => discoverThemeCatalog(root, '@test/pkg')).toThrow();
+  });
+
+  it('rejects empty files array', () => {
+    const root = writeCatalog([
+      {
+        slug: 'ocean',
+        displayName: 'Ocean',
+        description: 'x',
+        maintained: true,
+        entry: 'a.ts',
+        exportName: 'a',
+        files: [],
+      },
+    ]);
+    expect(() => discoverThemeCatalog(root, '@test/pkg')).toThrow();
+  });
+
+  it('rejects missing maintained boolean', () => {
+    const root = writeCatalog([
+      {
+        slug: 'ocean',
+        displayName: 'Ocean',
+        description: 'x',
+        entry: 'a.ts',
+        exportName: 'a',
+        files: ['a.ts'],
+      },
+    ]);
+    expect(() => discoverThemeCatalog(root, '@test/pkg')).toThrow();
+  });
+
+  it('requires version: 1 in the catalog root', () => {
+    const root = path.join(tmpDir, 'themes');
+    fs.mkdirSync(root, {recursive: true});
+    fs.writeFileSync(
+      path.join(root, 'manifest.json'),
+      JSON.stringify({version: 2, themes: []}),
+    );
+    expect(() => discoverThemeCatalog(root, '@test/pkg')).toThrow(/version 1/);
+  });
+});
+
+// ── Guide prose content tests (verified against the executable tests above) ──
+
+describe('cli-integrations guide required content', () => {
+  const text = guideText(integrationGuide);
+
+  it('documents all six type stamp values used by parseDoc', () => {
+    // These must match the switch cases in parseDoc
+    for (const stamp of [
+      "'component'",
+      "'generic'",
+      "'page'",
+      "'block'",
+      "'code'",
+      "'config'",
+    ]) {
+      expect(text).toContain(stamp);
+    }
+  });
+
+  it('contrasts component, doc, and template metadata suffixes', () => {
+    expect(text).toContain('.doc.{ts,mjs,js}');
+    expect(text).toContain('.template.{ts,mjs,js}');
+  });
+
+  it('documents the codemod version-directory layout', () => {
+    expect(text).toMatch(/version-folder/i);
+    expect(text).toMatch(/no `v` prefix/i);
+    expect(text).toContain('0.2.0/');
+  });
+
+  it('documents that upgrade is dry-run by default with no --dry-run flag', () => {
+    expect(text).toMatch(/dry-run by default/i);
+    expect(text).toContain('--apply');
+    expect(text).toMatch(/no `--dry-run` flag/i);
+  });
+
+  it('documents all required theme catalog manifest.json fields', () => {
+    for (const field of [
+      '`slug`',
+      '`displayName`',
+      '`description`',
+      '`maintained`',
+      '`entry`',
+      '`exportName`',
+      '`files`',
+    ]) {
+      expect(text).toContain(field);
+    }
+    expect(text).toContain('"version": 1');
+  });
+
+  it('documents palette wrapper as separately authored', () => {
+    expect(text).toMatch(/separately authored/i);
+    expect(text).toMatch(/wrapper/i);
+    expect(text).toContain('oceanPalettes.ts');
+  });
+
+  it('documents extensionless package export subpaths', () => {
+    expect(text).toMatch(/extensionless/i);
+  });
+
+  it('warns against npx for integration authoring', () => {
+    expect(text).toMatch(/not.*npx/i);
+  });
+
+  it('documents that --integration accepts package names only', () => {
+    expect(text).toMatch(/package names only/i);
+  });
+
+  it('documents integration pack --check', () => {
+    expect(text).toContain('integration pack --check');
+  });
+
+  it('explains type stamp as required for new docs with legacy fallback', () => {
+    expect(text).toMatch(/legacy.*stamp.*load/i);
+  });
+});
+
+// ── CommandDoc / FunctionDoc consistency ─────────────────────────────────
+
+describe('upgrade CommandDoc --integration flag', () => {
+  const integrationOpt = upgradeCommandDoc.options.find(
+    o => o.flag.includes('--integration'),
+  );
+
+  it('exists', () => {
+    expect(integrationOpt).toBeDefined();
+  });
+
+  it('states that file paths are rejected', () => {
+    expect(integrationOpt.description).toMatch(/file paths are rejected/i);
+  });
+
+  it('says package names only', () => {
+    expect(integrationOpt.description).toMatch(/package name/i);
+  });
+
+  it('flag placeholder does not say package-or-file', () => {
+    expect(integrationOpt.flag).not.toContain('package-or-file');
+  });
+});
+
+describe('upgrade FunctionDoc --integration param', () => {
+  const integrationParam = upgradeFnDoc.params.find(
+    p => p.name === 'options.integration',
+  );
+
+  it('exists', () => {
+    expect(integrationParam).toBeDefined();
+  });
+
+  it('says package names only', () => {
+    expect(integrationParam.description).toMatch(/package name/i);
+  });
+
+  it('does not claim file paths work', () => {
+    expect(integrationParam.description).not.toMatch(
+      /file paths to process/i,
+    );
+  });
+});
+
+describe('palette generate doc mentions catalog connection', () => {
+  it('description references theme catalog files array', () => {
+    expect(paletteGenerateDoc.description).toMatch(/catalog/i);
+    expect(paletteGenerateDoc.description).toMatch(/files.*array/i);
+  });
+});
+
+describe('integration add doc has all contribution kinds', () => {
+  const kindsArg = integrationAddDoc.args.find(a => a.name === 'kind');
+
+  it('lists component, doc, template, codemod, agent-doc, and theme', () => {
+    for (const kind of [
+      'component',
+      'doc',
+      'template',
+      'codemod',
+      'agent-doc',
+      'theme',
+    ]) {
+      expect(kindsArg.description).toContain(kind);
+    }
+  });
+});


### PR DESCRIPTION
Replaced by #6290.

First-time integration authors repeatedly hit the same gaps. This documents each contribution shape, codemod layout, complete theme catalog, palette wiring, extensionless exports, upgrade dry-run behavior, package-only `--integration`, and local CLI usage.

It also adds executable drift tests against the parsers, package resolver, and theme catalog validator.

Tests:
- README check
- knowledge and repo checks
- strict lint
- full CLI suite, 3,974 tests
- 36 authoring-contract drift assertions

