### PR TITLE
Fix integration component docs and import hints

### DIFF
--- a/.changeset/fix-default-export-component-loader.md
+++ b/.changeset/fix-default-export-component-loader.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Component loader now reads default-export `.doc.mjs` files (the shape `integration add component` writes), fixing a crash where `component` and `search` could not load generated docs. Human `component` detail and list views now use the API-resolved import specifier instead of recomputing from core, so integration components report their package-authored import. `pack --check` now reports an error when a component doc cannot be loaded instead of silently approving.
+@josephfarina

--- a/packages/cli/api/component/component.type.mjs
+++ b/packages/cli/api/component/component.type.mjs
@@ -52,10 +52,13 @@
 /**
  * A single entry in a `component.list` group at `detail: 'names'`. Pre-1.0 the
  * list moved from bare strings to package-qualified objects so consumers can
- * disambiguate ownership (core vs. an integration package).
+ * disambiguate ownership (core vs. an integration package). Integration entries
+ * carry `import` — the package-authored specifier; core entries omit it (the
+ * specifier is derived from the component name by the renderer).
  * @typedef {object} ComponentListEntry
  * @property {string} name
  * @property {string} package - Owner package, e.g. '@astryxdesign/core' or '@acme/astryx-meta'.
+ * @property {string} [import] - Import specifier; present for integration components, absent for core.
  */
 
 /**

--- a/packages/cli/api/component/integration-import-agreement.test.mjs
+++ b/packages/cli/api/component/integration-import-agreement.test.mjs
@@ -316,3 +316,120 @@ describe('integration component import specifiers', () => {
     ).toBe('@acme/widgets');
   });
 });
+
+/**
+ * Scaffold a default-export component doc (the shape `integration add component`
+ * generates). This is a separate function because the existing scaffold writes
+ * a named `export const docs`, and we need to test both.
+ */
+function scaffoldDefaultExport({exports: exportsMap, docImport} = {}) {
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'consumer', version: '1.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'astryx.config.mjs'),
+    "export default {integrations: ['@acme/widgets']};\n",
+  );
+
+  const pkgDir = path.join(tmpDir, 'node_modules', '@acme', 'widgets');
+  const componentDir = path.join(pkgDir, 'src', 'Carousel');
+  fs.mkdirSync(componentDir, {recursive: true});
+
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({
+      name: '@acme/widgets',
+      version: '1.0.0',
+      ...(exportsMap ? {exports: exportsMap} : {}),
+    }),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    "export default {components: './src'};\n",
+  );
+  fs.writeFileSync(
+    path.join(componentDir, 'AcmeCarousel.tsx'),
+    'export const AcmeCarousel = () => null;\n',
+  );
+  // Default export — the shape integration add component writes
+  fs.writeFileSync(
+    path.join(componentDir, 'AcmeCarousel.doc.mjs'),
+    `export default ${JSON.stringify(
+      {
+        type: 'component',
+        name: 'AcmeCarousel',
+        displayName: 'Acme Carousel',
+        keywords: ['carousel', 'slides'],
+        usage: {description: 'A carousel that cycles through slides.'},
+        props: [],
+        ...(docImport ? {import: docImport} : {}),
+      },
+      null,
+      2,
+    )};\n`,
+  );
+}
+
+describe('default-export component doc agreement', () => {
+  it(
+    'component detail loads a default-export doc without crashing',
+    async () => {
+      scaffoldDefaultExport({exports: SUBPATH_EXPORTS});
+      const result = await component('AcmeCarousel', {cwd: tmpDir});
+      expect(result.type).toBe('component.detail');
+      expect(result.data.name).toBe('AcmeCarousel');
+      expect(result.data.import).toBe('@acme/widgets/Carousel');
+      expect(result.data.package).toBe('@acme/widgets');
+    },
+    SLOW,
+  );
+
+  it(
+    'a doc-authored import in a default export wins over the resolved subpath',
+    async () => {
+      scaffoldDefaultExport({exports: SUBPATH_EXPORTS, docImport: '@acme/widgets/Alias'});
+      const result = await component('AcmeCarousel', {cwd: tmpDir});
+      expect(result.data.import).toBe('@acme/widgets/Alias');
+    },
+    SLOW,
+  );
+
+  it(
+    'search finds a default-export component with the correct import',
+    async () => {
+      scaffoldDefaultExport({exports: SUBPATH_EXPORTS});
+      const found = await search('carousel', {cwd: tmpDir});
+      const hit = searchImportFor(found, 'AcmeCarousel');
+      expect(hit).toBe('@acme/widgets/Carousel');
+    },
+    SLOW,
+  );
+
+  it(
+    'component and search agree on a default-export component',
+    async () => {
+      scaffoldDefaultExport({exports: SUBPATH_EXPORTS});
+      const {detail, found} = await bothSurfaces();
+      expect(detail).toBe('@acme/widgets/Carousel');
+      expect(found).toBe(detail);
+    },
+    SLOW,
+  );
+
+  it(
+    'list includes the integration import for a default-export component',
+    async () => {
+      scaffoldDefaultExport({exports: SUBPATH_EXPORTS});
+      const result = await component(undefined, {cwd: tmpDir, list: true});
+      expect(result.type).toBe('component.list');
+      const allEntries = Object.values(result.data.components).flat();
+      const entry = allEntries.find(e => e.name === 'AcmeCarousel');
+      expect(entry).toBeDefined();
+      expect(entry.package).toBe('@acme/widgets');
+      // The import must be the integration subpath, not a core path.
+      expect(/** @type {any} */ (entry).import).toBe('@acme/widgets/Carousel');
+    },
+    SLOW,
+  );
+});

--- a/packages/cli/api/component/list/list.mjs
+++ b/packages/cli/api/component/list/list.mjs
@@ -18,6 +18,7 @@ import {
   discoverIntegrationComponents,
   findComponentReadme,
   resolveImportPath,
+  resolveIntegrationImportPath,
 } from '../../../foundation/discovery/component-discovery.mjs';
 import {discoverExternalPackages} from '../../../foundation/fs/paths.mjs';
 import {ERROR_CODES} from '../../../foundation/response/error-codes.mjs';
@@ -166,13 +167,24 @@ export async function componentList(coreDir, {cwd, category, detail, zh, dense, 
     // Group integration components by their doc `group`, falling back to the
     // package name. Keys are package-qualified so they never collide with
     // core groups or each other.
-    /** @type {Map<string, Array<{name: string, package: string}>>} */
+    /** @type {Map<string, Array<{name: string, package: string, import?: string}>>} */
     const byGroup = new Map();
     for (const rec of owned) {
       const groupLabel = rec.group ?? integration.name;
       const key = `${groupLabel} (${integration.name})`;
       if (!byGroup.has(key)) byGroup.set(key, []);
-      byGroup.get(key)?.push({name: rec.name, package: integration.name});
+      // Resolve the import specifier so list views (both JSON and human)
+      // report the package-authored path instead of a core import.
+      const importPath = resolveIntegrationImportPath(
+        {
+          exportsMap: integration.__packageExports,
+          packageDir: integration.__packageDir,
+          docPath: rec.docPath,
+          packageName: integration.name,
+        },
+        rec.name,
+      );
+      byGroup.get(key)?.push({name: rec.name, package: integration.name, import: importPath});
     }
     for (const [key, members] of byGroup) {
       members.sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/cli/api/integration/pack-check.mjs
+++ b/packages/cli/api/integration/pack-check.mjs
@@ -353,13 +353,21 @@ function resolveConsumerSpecifiers(specifiers, scratchBase) {
  */
 async function validatePackedComponentExports(integration, scratchBase) {
   const records = discoverIntegrationComponents(integration);
+  /** @type {Issue[]} */
+  const issues = [];
   /** @type {Array<{name: string, specifier: string}>} */
   const components = [];
   for (const record of records) {
     let docs;
     try {
       docs = await loadComponentDoc(record.docPath);
-    } catch {
+    } catch (err) {
+      issues.push(
+        error(
+          'component_doc_unloadable',
+          `Component "${record.name}" doc at "${record.docPath}" could not be loaded: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
       continue;
     }
     const specifier =
@@ -380,8 +388,6 @@ async function validatePackedComponentExports(integration, scratchBase) {
     components.map(component => component.specifier),
     scratchBase,
   );
-  /** @type {Issue[]} */
-  const issues = [];
   for (const {name, specifier} of components) {
     const result = resolved.get(specifier);
     if (!result?.url || result.error) {

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -453,7 +453,8 @@ export function scoreCandidate(
 async function loadModuleDoc(docPath, exportName = 'docs') {
   try {
     const mod = await import(pathToFileURL(docPath).href);
-    return mod[exportName] ?? null;
+    // Support both the stamped default export and the legacy named export.
+    return mod?.default ?? mod[exportName] ?? null;
   } catch {
     return null;
   }

--- a/packages/cli/clients/cli/commands/component/index.mjs
+++ b/packages/cli/clients/cli/commands/component/index.mjs
@@ -205,7 +205,10 @@ export function registerComponent(program) {
           }
           /** @param {import('../../../../api/component/component.type.mjs').ComponentListEntry} item */
           const importCell = item => {
-            const importPath = resolveImportPath(coreDir, item.name);
+            // Use a precomputed import when the API supplies one (integration
+            // components carry it); only fall back to the core resolver for
+            // core components.
+            const importPath = item.import ?? resolveImportPath(coreDir, item.name);
             const qualify =
               item.package !== CORE_PKG || (nameCounts.get(item.name)?.size ?? 0) > 1;
             return qualify ? `${importPath}  [${item.package}]` : importPath;
@@ -231,7 +234,11 @@ export function registerComponent(program) {
 
         case 'component.detail': {
           const resolvedName = (name || '').replace(/^XDS/, '');
-          const importHint = resolveImportPath(coreDir, resolvedName);
+          // Use the import the API already resolved (which honors integration
+          // packages and doc-authored specifiers) rather than recomputing from
+          // core, which silently reports the wrong path for every integration
+          // component.
+          const importHint = result.data.import ?? resolveImportPath(coreDir, resolvedName);
           const doc =
             detail === 'brief'
               ? code(formatBrief(result.data, resolvedName, importHint, {themeData}))

--- a/packages/cli/foundation/discovery/__fixtures__/component-both-exports.doc.mjs
+++ b/packages/cli/foundation/discovery/__fixtures__/component-both-exports.doc.mjs
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Fixture: a component doc that has BOTH a default export and a named `docs`
+ * export. The default export must win (same precedence as loadComponentDoc).
+ */
+export default {
+  type: 'component',
+  name: 'DefaultWinsCard',
+  description: 'From the default export.',
+  props: [{name: 'priority', type: 'number', description: 'Priority level.'}],
+};
+
+export const docs = {
+  type: 'component',
+  name: 'NamedLosesCard',
+  description: 'From the named export — must NOT be returned.',
+  props: [],
+};

--- a/packages/cli/foundation/discovery/__fixtures__/component-default-export.doc.mjs
+++ b/packages/cli/foundation/discovery/__fixtures__/component-default-export.doc.mjs
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Fixture: a component doc using the stamped default export convention
+ * (what `integration add component` generates). loadDocs must read this
+ * shape identically to the legacy named `export const docs` form.
+ */
+export default {
+  type: 'component',
+  name: 'DefaultExportCard',
+  description: 'A card written with default export.',
+  props: [{name: 'title', type: 'string', description: 'Card title.'}],
+};

--- a/packages/cli/foundation/discovery/__fixtures__/component-named-export.doc.mjs
+++ b/packages/cli/foundation/discovery/__fixtures__/component-named-export.doc.mjs
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Fixture: a component doc using the legacy named export convention.
+ */
+export const docs = {
+  type: 'component',
+  name: 'NamedExportCard',
+  description: 'A card written with named export.',
+  props: [{name: 'title', type: 'string', description: 'Card title.'}],
+};

--- a/packages/cli/foundation/discovery/component-loader.mjs
+++ b/packages/cli/foundation/discovery/component-loader.mjs
@@ -140,7 +140,10 @@ export function mergeTranslation(docs, translation) {
  */
 export async function loadDocs(readmePath, {zh = false, dense = false, lang} = {}) {
   const mod = await import(pathToFileURL(readmePath).href);
-  const docs = mod.docs;
+  // Support both the new stamped default export (`export default {type: 'component', …}`)
+  // and the legacy named export (`export const docs = {…}`). Default wins when both
+  // are present, matching loadComponentDoc's precedence.
+  const docs = mod?.default ?? mod.docs;
 
   // Resolve which translation to use (--lang takes priority over legacy flags)
   const locale = lang || (dense ? 'dense' : zh ? 'zh' : null);

--- a/packages/cli/foundation/discovery/component-loader.test.mjs
+++ b/packages/cli/foundation/discovery/component-loader.test.mjs
@@ -107,6 +107,54 @@ describe('mergeTranslation — component prop descriptions (regression)', () => 
   });
 });
 
+describe('loadDocs — default vs named export resolution', () => {
+  const fixtureDir = path.join(import.meta.dirname, '__fixtures__');
+
+  it('reads a default-export .doc.mjs (the shape integration add component writes)', async () => {
+    const docs = await loadDocs(path.join(fixtureDir, 'component-default-export.doc.mjs'));
+    expect(docs).toBeDefined();
+    expect(docs.name).toBe('DefaultExportCard');
+    expect(docs.description).toBe('A card written with default export.');
+    expect(docs.props).toHaveLength(1);
+    expect(docs.props[0].name).toBe('title');
+  });
+
+  it('still reads a named-export .doc.mjs (legacy shape)', async () => {
+    const docs = await loadDocs(path.join(fixtureDir, 'component-named-export.doc.mjs'));
+    expect(docs).toBeDefined();
+    expect(docs.name).toBe('NamedExportCard');
+    expect(docs.props).toHaveLength(1);
+  });
+
+  it('default export agrees with loadComponentDoc', async () => {
+    const docPath = path.join(fixtureDir, 'component-default-export.doc.mjs');
+    const fromLoadDocs = await loadDocs(docPath);
+    const fromLoadComponentDoc = await loadComponentDoc(docPath);
+    expect(fromLoadDocs).toEqual(fromLoadComponentDoc);
+  });
+
+  it('named export agrees with loadComponentDoc', async () => {
+    const docPath = path.join(fixtureDir, 'component-named-export.doc.mjs');
+    const fromLoadDocs = await loadDocs(docPath);
+    const fromLoadComponentDoc = await loadComponentDoc(docPath);
+    expect(fromLoadDocs).toEqual(fromLoadComponentDoc);
+  });
+
+  it('default export wins when both default and named exports are present', async () => {
+    const docPath = path.join(fixtureDir, 'component-both-exports.doc.mjs');
+    const fromLoadDocs = await loadDocs(docPath);
+    const fromLoadComponentDoc = await loadComponentDoc(docPath);
+
+    // Default export must win at both loaders
+    expect(fromLoadDocs.name).toBe('DefaultWinsCard');
+    expect(fromLoadDocs.description).toBe('From the default export.');
+    expect(fromLoadDocs.props).toHaveLength(1);
+    expect(fromLoadComponentDoc.name).toBe('DefaultWinsCard');
+    // And the two must agree
+    expect(fromLoadDocs).toEqual(fromLoadComponentDoc);
+  });
+});
+
 describe('loadComponentDoc — full localized doc overlays', () => {
   it('inherits canonical anatomy when docsZh omits it and matches loadDocs', async () => {
     const docPath = path.join(


### PR DESCRIPTION
Replaced by #6291.

The integration writer creates default-export component docs, but the detail loader only read the legacy named export. That made generated components crash in `astryx component` while list and pack still passed.

This also makes human list/detail output use the API-resolved integration import instead of recomputing a Core import, and makes pack-check fail closed on unloadable docs.

Tests:
- API DTS typecheck
- strict lint and repo checks
- full CLI suite, 3,948 tests
- default-only, named-only, and dual-export mutation cases
- JSON/human/list/search import agreement

