### PR TITLE
docs(Avatar): list supported numeric sizes

### DIFF
--- a/.changeset/avatar-size-docs.md
+++ b/.changeset/avatar-size-docs.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Correct Avatar size documentation to list the supported numeric pixel sizes instead of unrestricted numbers.
+@korkt-kim

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -67,8 +67,8 @@ export const docs = {
     },
     {
       name: 'size',
-      type: "'xsm' | 'sm' | 'md' | 'lg' | 'xl' | number",
-      description: "Avatar size. Use a named size ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or a numeric pixel value. Avatar shares Icon's abbreviated scale, but its tiers are larger because avatars align with media rather than glyphs. Inside an AvatarGroup the group's size wins and this prop is ignored.",
+      type: "'xsm' | 'sm' | 'md' | 'lg' | 'xl' | 16 | 20 | 24 | 32 | 36 | 40 | 48 | 60 | 64 | 72 | 96 | 128 | 144 | 180",
+      description: "Avatar size. Use a named size ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or one of the listed numeric pixel sizes. Avatar shares Icon's abbreviated scale, but its tiers are larger because avatars align with media rather than glyphs. Inside an AvatarGroup the group's size wins and this prop is ignored.",
       default: "'md'",
     },
     {
@@ -169,7 +169,7 @@ export const docsDense = {
     fallbackSrc: 'fallback image when primary fails',
     name: 'user name for initials and alt text',
     alt: 'alt text; falls back to name',
-    size: "avatar size. Named ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or numeric px. An AvatarGroup's size overrides it.",
+    size: "avatar size. Named ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or listed numeric px values only. An AvatarGroup's size overrides it.",
     status:
       'corner content for status indicators; AvatarStatusDot reports its `label`, composed into the avatar accessible name ("Jane Doe, Online"), at any nesting depth',
     tooltip:


### PR DESCRIPTION
## Summary

- list the supported numeric pixel sizes instead of unrestricted `number`
- clarify the numeric restriction in the normal and dense descriptions
- keep named-size mappings, the default, and AvatarGroup precedence unchanged

## Motivation

Avatar documents `size` as accepting any number, but [`AvatarSize`](https://github.com/facebook/astryx/blob/47ba5526fa93f2bbcb7c0c26ab0a49d86cf37825/packages/core/src/Avatar/Avatar.tsx#L87-L98) only accepts named sizes and a fixed numeric list. For example, `size={33}` is rejected by TypeScript while `size={32}` is valid.

I considered allowing arbitrary numeric sizes. The current default sizing logic in `AvatarStatusDot` selects 10px, 20px, or 32px rather than scaling continuously. This PR only aligns the documentation with the existing type, leaving broader sizing support and its theme interactions for a separate discussion.

## Scope

Avatar size documentation and a `[docs]` changeset only. No public API or runtime changes.

## Test plan

- `pnpm -F @astryxdesign/core typecheck:docs` — passed
- `pnpm check:repo` — passed through the pre-commit hook
- `pnpm lint:strict` — passed with existing warnings
- `pnpm test --maxWorkers=8` — 16,961 passed, 44 skipped
- `pnpm build` — passed

CLI output was checked in normal, dense, Chinese, and dense Chinese modes.
