### PR TITLE
fix(docsite): alphabetize the all templates view

### DIFF
--- a/apps/docsite/src/__tests__/template-gallery-order.test.tsx
+++ b/apps/docsite/src/__tests__/template-gallery-order.test.tsx
@@ -1,0 +1,105 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// @vitest-environment jsdom
+
+import type {ReactNode} from 'react';
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/templates',
+  useRouter: () => ({replace: vi.fn()}),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock('@stylexjs/stylex', () => ({
+  create: <T,>(styles: T) => styles,
+  props: () => ({}),
+}));
+vi.mock('@astryxdesign/core/AppShell', () => ({
+  useAppShellMobile: () => ({isMobile: true}),
+}));
+vi.mock('@astryxdesign/core/Text', () => ({
+  Heading: ({children}: {children: ReactNode}) => <h2>{children}</h2>,
+  Text: ({children}: {children: ReactNode}) => <span>{children}</span>,
+}));
+vi.mock('@astryxdesign/core/Layout', () => ({
+  VStack: ({children}: {children: ReactNode}) => <div>{children}</div>,
+  HStack: ({children}: {children: ReactNode}) => <div>{children}</div>,
+}));
+vi.mock('@astryxdesign/core/Section', () => ({
+  Section: ({children}: {children: ReactNode}) => <section>{children}</section>,
+}));
+vi.mock('@astryxdesign/core/Grid', () => ({
+  Grid: ({children}: {children: ReactNode}) => <div>{children}</div>,
+}));
+vi.mock('@astryxdesign/core/ClickableCard', () => ({
+  ClickableCard: ({label, children}: {label: string; children: ReactNode}) => (
+    <button aria-label={label}>{children}</button>
+  ),
+}));
+vi.mock('@astryxdesign/core/Button', () => ({
+  Button: ({label}: {label: string}) => <span>{label}</span>,
+}));
+vi.mock('@astryxdesign/core/Overlay', () => ({
+  Overlay: ({children}: {children: ReactNode}) => <>{children}</>,
+}));
+vi.mock('@astryxdesign/core/ToggleButton', () => ({
+  ToggleButtonGroup: ({children}: {children: ReactNode}) => (
+    <div>{children}</div>
+  ),
+  ToggleButton: ({label}: {label: string}) => <span>{label}</span>,
+}));
+vi.mock('../generated/templateMetadataRegistry', () => ({
+  templateMetadata: [
+    {
+      name: 'Metrics dashboard',
+      slug: 'metrics',
+      category: 'Dashboard',
+      description: '',
+      isReady: true,
+      isHiddenFromOverview: false,
+    },
+    {
+      name: 'AI chat',
+      slug: 'ai-chat',
+      category: 'AI Chat',
+      description: '',
+      isReady: true,
+      isHiddenFromOverview: false,
+    },
+    {
+      name: 'Settings',
+      slug: 'settings',
+      category: 'Settings',
+      description: '',
+      isReady: true,
+      isHiddenFromOverview: false,
+    },
+  ],
+}));
+vi.mock('../components/TemplateThumbnail', () => ({
+  TemplateThumbnail: ({slug}: {slug: string}) => <span>{slug}</span>,
+}));
+vi.mock('../lib/analytics', () => ({
+  trackOpenPlayground: vi.fn(),
+  trackView: vi.fn(),
+}));
+vi.mock('../layout.stylex', () => ({layout: {contentMaxWidth: '1200px'}}));
+
+import TemplatesPage from '../app/(site)/templates/page';
+
+describe('TemplatesGallery order', () => {
+  it('renders the All view alphabetically by title', () => {
+    render(<TemplatesPage />);
+
+    expect(
+      screen
+        .getAllByRole('button', {name: /^Preview /})
+        .map(button => button.getAttribute('aria-label')),
+    ).toEqual([
+      'Preview AI chat',
+      'Preview Metrics dashboard',
+      'Preview Settings',
+    ]);
+  });
+});

--- a/apps/docsite/src/app/(site)/templates/page.tsx
+++ b/apps/docsite/src/app/(site)/templates/page.tsx
@@ -26,6 +26,7 @@ import {templateMetadata as templates} from '../../../generated/templateMetadata
 import {TemplateThumbnail} from '../../../components/TemplateThumbnail';
 import {buildTemplatePlaygroundHref} from '../../../components/playgroundLink';
 import {buildTemplatePreviewHref} from '../../../components/templatePreviewUrl';
+import {sortTemplatesByTitle} from '../../../components/templateGalleryOrder';
 import type {TemplatePreviewItem} from '../../../components/TemplatePreviewDialog';
 import {trackOpenPlayground, trackView} from '../../../lib/analytics';
 import {layout} from '../../../layout.stylex';
@@ -177,13 +178,13 @@ function TemplatesGallery() {
     return ['All', ...present];
   }, [items]);
 
-  const filteredItems = useMemo(
-    () =>
+  const filteredItems = useMemo(() => {
+    const visibleItems =
       activeCategory === 'All'
         ? items
-        : items.filter(i => groupOf(i.category) === activeCategory),
-    [items, activeCategory],
-  );
+        : items.filter(i => groupOf(i.category) === activeCategory);
+    return sortTemplatesByTitle(visibleItems);
+  }, [items, activeCategory]);
 
   // Flattened display-order list backing the preview dialog's prev/next
   // navigation, plus a slug -> index lookup for opening at a given card.

--- a/apps/docsite/src/components/templateGalleryOrder.ts
+++ b/apps/docsite/src/components/templateGalleryOrder.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+export function sortTemplatesByTitle<T extends {name: string}>(
+  templates: readonly T[],
+): T[] {
+  return [...templates].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+}


### PR DESCRIPTION
## Summary

Sort the **All templates** view alphabetically by template title, as requested. This is stacked on #6275 so the performance-only PR keeps its existing group-first ordering.

Category-specific views are also sorted alphabetically by title.

## Regression coverage

A rendered-route test supplies templates whose category order conflicts with title order, renders the actual `/templates` page, and asserts the card labels are emitted alphabetically. This fails if the route stops using the ordering helper.

## Testing

- `pnpm -F @astryxdesign/docsite test` — 512 tests passed
- `pnpm -F @astryxdesign/docsite typecheck`
- Targeted ESLint and Prettier checks
