### PR TITLE
fix(Timestamp): attach popup semantics to the focusable time

### DIFF
--- a/.changeset/timestamp-focusable-popup-trigger.md
+++ b/.changeset/timestamp-focusable-popup-trigger.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Timestamp exposes its details popup on the focusable time element.
+@jiunshinn

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -1,5 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/**
+ * @file Timestamp.stories.tsx
+ * @input Uses Timestamp, Text, and the Storybook theme decorator
+ * @output Stories for timestamp formats and keyboard-accessible details
+ * @position Storybook examples for Timestamp
+ */
+
 import type {Meta, StoryObj} from '@storybook/react';
 import {Timestamp} from '@astryxdesign/core/Timestamp';
 import {InternationalizationProvider} from '@astryxdesign/core/i18n';
@@ -100,6 +107,14 @@ export const Default: Story = {
 };
 
 export const RelativeFormat: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Tab to a timestamp to reveal its details dialog. The focused time exposes the popup relationship. Tab into the copy button; Escape dismisses its tooltip, then the card, returning focus to the timestamp.',
+      },
+    },
+  },
   render: () => (
     <div
       style={{

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -1,5 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/**
+ * @file Timestamp.doc.mjs
+ * @input Timestamp public props, theming targets, and usage patterns
+ * @output Consumer documentation for formatted times and hover/focus details
+ * @position Timestamp documentation consumed by the CLI and doc site
+ */
+
 /** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
@@ -42,7 +49,7 @@ export const docs = {
       name: 'hasTooltip',
       type: 'boolean',
       description:
-        'Whether to show a copyable hover card with the full date/time on hover. Applies to relative timestamps and to any format once tooltipEntries is configured.',
+        'Whether to show a copyable hover card with the full date/time on hover or keyboard focus. Applies to relative timestamps and to any format once tooltipEntries is configured.',
       default: 'true',
     },
     {
@@ -188,7 +195,7 @@ export const docsDense = {
     value: 'date/time as unix seconds or ISO string',
     format: "display mode: 'relative' (locale-native long wording), 'relative_short' (locale-native narrow wording), 'auto', 'date', 'date_long', 'date_weekday', 'date_time', 'time', 'system_date', 'system_date_time', 'system_time', 'unix_seconds'",
     autoThreshold: 'seconds threshold for auto relative\u2192date_time switch',
-    hasTooltip: 'show copyable full-time hover card on hover (relative mode, or any format with tooltipEntries)',
+    hasTooltip: 'show copyable full-time hover card on hover or keyboard focus (relative mode, or any format with tooltipEntries)',
     tooltipEntries:
       "hover rows across zones/formats: [{timezoneID?, format?, label?}]; timezoneID omitted or 'local' = viewer zone, format defaults to 'full'; the hover surface is always a copy-to-clipboard card, these customize its rows (default: a single full-time row), and configuring entries enables the card on absolute formats",
     isTimezoneShown:

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -1,5 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/**
+ * @file Timestamp.test.tsx
+ * @input Uses Timestamp, Testing Library, and mocked browser APIs
+ * @output Regression coverage for formatting and the focusable details trigger
+ * @position Colocated Timestamp behavior and accessibility tests
+ */
+
 import {
   describe,
   it,
@@ -22,12 +29,7 @@ async function openTimestampHoverCard(): Promise<HTMLElement> {
   if (timestamp == null) {
     throw new Error('Expected Timestamp to render a <time> element');
   }
-  const trigger = timestamp.parentElement;
-  if (trigger == null) {
-    throw new Error('Expected Timestamp to render a hover-card trigger');
-  }
-
-  fireEvent.mouseEnter(trigger);
+  await userEvent.hover(timestamp);
   await waitFor(() => {
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
   });
@@ -740,9 +742,15 @@ describe('Timestamp', () => {
       // installs fake timers, which would stall them).
       vi.useRealTimers();
 
-      // Mock the Popover API, which jsdom does not implement.
-      HTMLElement.prototype.showPopover = vi.fn();
-      HTMLElement.prototype.hidePopover = vi.fn();
+      // Match HoverCard's Popover API mock so dismissal can observe which
+      // layer is actually open, including the copy button's nested tooltip.
+      const openPopovers = new WeakSet<HTMLElement>();
+      HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+        openPopovers.add(this);
+      });
+      HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+        openPopovers.delete(this);
+      });
 
       // jsdom does not derive :focus-visible from keyboard focus for a <time>
       // element; treat the focused element as focus-visible so the card's
@@ -751,6 +759,9 @@ describe('Timestamp', () => {
       (HTMLElement.prototype as any).matches = function (
         selector: string,
       ): boolean {
+        if (selector === ':popover-open') {
+          return openPopovers.has(this);
+        }
         if (selector === ':focus-visible') {
           return this === document.activeElement;
         }
@@ -776,23 +787,36 @@ describe('Timestamp', () => {
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
     });
 
-    it('does not put aria-expanded on the role-less hover-card trigger', async () => {
-      render(
-        <Timestamp
-          value={Date.now() / 1000 - 3600}
-          format="relative"
-          data-testid="ts"
-        />,
-      );
-      const trigger = screen.getByTestId('ts').parentElement;
-      // The trigger is Text's <span>, which has no role, so aria-expanded is
-      // invalid on it (axe aria-allowed-attr, critical). aria-haspopup is
-      // global and still advertises the dialog.
-      await waitFor(() => {
-        expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
-      });
-      expect(trigger).not.toHaveAttribute('aria-expanded');
-    });
+    it.each([
+      ['relative', {format: 'relative'}],
+      ['relative_short', {format: 'relative_short'}],
+      ['auto', {format: 'auto'}],
+      ['configured absolute', {format: 'date_time', tooltipEntries: [{}]}],
+    ] as const)(
+      'advertises the %s details popup on the tab stop',
+      async (_, props) => {
+        render(
+          <Timestamp
+            value={Date.now() / 1000 - 3600}
+            {...props}
+            data-testid="ts"
+          />,
+        );
+        const trigger = screen.getByTestId('ts');
+        await waitFor(() => {
+          expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+        });
+        expect(trigger).toHaveAttribute('tabindex', '0');
+        expect(trigger).not.toHaveAttribute('aria-controls');
+        // A semantic <time> keeps the global popup attributes without an
+        // unsupported expanded state or a role that promises activation.
+        expect(trigger).not.toHaveAttribute('aria-expanded');
+        expect(trigger).not.toHaveAttribute('role');
+        expect(trigger.closest('.astryx-timestamp')).not.toHaveAttribute(
+          'aria-haspopup',
+        );
+      },
+    );
 
     it('shows the hover card when the timestamp receives keyboard focus', async () => {
       const user = userEvent.setup();
@@ -831,6 +855,90 @@ describe('Timestamp', () => {
       });
       const card = screen.getByRole('dialog', {hidden: true});
       expect(normalize(card.textContent ?? '')).toContain(normalize(expected));
+      expect(el).toHaveAttribute('aria-controls', card.id);
+      expect(el).not.toHaveAttribute('aria-expanded');
+
+      // Move into the card before dismissing it: focus must return to the
+      // same semantic timestamp that exposed the popup relationship.
+      const copy = screen.getByRole('button', {name: /^Copy /, hidden: true});
+      act(() => copy.focus());
+      expect(copy).toHaveFocus();
+      // The copy button's own tooltip is the topmost layer on focus.
+      if (screen.queryByRole('tooltip', {hidden: true})) {
+        await user.keyboard('{Escape}');
+      }
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(el).not.toHaveAttribute('aria-controls');
+      });
+      expect(el).toHaveFocus();
+      expect(el).toHaveAttribute('aria-haspopup', 'dialog');
+    });
+
+    it('keeps the ref, caller props, and text styling when a card is attached', async () => {
+      const ref = {current: null as HTMLTimeElement | null};
+      const onFocus = vi.fn();
+      const {rerender} = render(
+        <Timestamp
+          ref={ref}
+          value="2026-02-19T17:00:00Z"
+          format="date_time"
+          tooltipEntries={[{}]}
+          aria-label="Published"
+          aria-controls="related-content"
+          id="published-at"
+          data-source="cms"
+          onFocus={onFocus}
+          type="body"
+          color="primary"
+          weight="bold"
+          className="custom-timestamp"
+          style={{marginInlineStart: 12}}
+          data-testid="ts"
+        />,
+      );
+      await waitFor(() => {
+        expect(ref.current).toHaveAttribute('aria-haspopup', 'dialog');
+      });
+      const time = screen.getByTestId('ts');
+      expect(ref.current).toBe(time);
+      expect(time).toHaveAttribute('aria-label', 'Published');
+      expect(time).toHaveAttribute('id', 'published-at');
+      expect(time).toHaveAttribute('data-source', 'cms');
+      const text = time.closest('.astryx-timestamp');
+      expect(text).toHaveClass('astryx-text', 'custom-timestamp');
+      expect(text).toHaveAttribute('data-type', 'body');
+      expect(text).toHaveAttribute('data-color', 'primary');
+      expect(text).toHaveStyle({marginInlineStart: '12px'});
+
+      act(() => time.focus());
+      const card = await screen.findByRole('dialog', {hidden: true});
+      await waitFor(() => {
+        expect(time).toHaveAttribute(
+          'aria-controls',
+          `related-content ${card.id}`,
+        );
+      });
+      expect(onFocus).toHaveBeenCalledOnce();
+
+      rerender(
+        <Timestamp
+          ref={ref}
+          value="2026-02-19T17:00:00Z"
+          format="date_time"
+          tooltipEntries={[{}]}
+          hasTooltip={false}
+          aria-controls="related-content"
+          data-testid="ts"
+        />,
+      );
+      expect(ref.current).toBe(screen.getByTestId('ts'));
+      expect(ref.current).not.toHaveAttribute('tabindex');
+      expect(ref.current).not.toHaveAttribute('aria-haspopup');
+      expect(ref.current).toHaveAttribute('aria-controls', 'related-content');
+      expect(
+        screen.queryByRole('dialog', {hidden: true}),
+      ).not.toBeInTheDocument();
     });
 
     it('does not add a tab stop when the hover card is disabled', () => {

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -4,9 +4,9 @@
 
 /**
  * @file Timestamp.tsx
- * @input Uses React, Text, provider locale, and Timestamp formatters
+ * @input Uses React, Text, lazy TimestampHoverCard, locale, and formatters
  * @output Exports Timestamp component and related types
- * @position Core implementation; renders formatted timestamps
+ * @position Core implementation; the semantic time element anchors its details card
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Timestamp/formatRelativeTime.ts
@@ -375,6 +375,37 @@ export function Timestamp({
   );
 
   const timeElement = (
+    <time
+      ref={mergedTimeRef}
+      dateTime={isoString}
+      data-testid={testId}
+      {...stylex.props(styles.time)}
+      {...rest}
+      // `ariaLabelText` is '' only for an invalid date, which bails out
+      // before rendering — but keep the guard local: an empty aria-label
+      // must be omitted entirely (not rendered as aria-label="") so AT
+      // falls back to reading the visible <time> content.
+      {...(isRelativeFormat(effectiveFormat) && ariaLabelText !== ''
+        ? {'aria-label': ariaLabelText}
+        : {})}
+      // The hover card is anchored here with focusTrigger="always", which
+      // attaches focus listeners but does not itself make the anchor
+      // focusable. A bare <time> is not focusable, so without a tab stop
+      // sighted keyboard users could never reveal the card (WCAG 1.4.13 /
+      // 2.1.1). Add the tab stop only while a card is actually attached — no
+      // gratuitous tab stops otherwise. The card carries its own
+      // dashed-underline hover indication as the affordance, so the anchor
+      // needs no separate focus outline.
+      {...(showTooltip ? {tabIndex: 0} : {})}>
+      {displayText}
+    </time>
+  );
+
+  // Keep Text outside the lazy card so HoverCard's first element child is
+  // the focusable <time>. Its popup attributes, anchor, and focus return must
+  // all use that same element. Text continues to own typography and theming.
+  // While the overlay chunk loads, the same styled timestamp stays visible.
+  return (
     <Text
       type={type}
       size={size}
@@ -382,57 +413,19 @@ export function Timestamp({
       weight={weight}
       xstyle={xstyle}
       {...timestampProps}>
-      <time
-        ref={mergedTimeRef}
-        dateTime={isoString}
-        data-testid={testId}
-        {...stylex.props(styles.time)}
-        {...rest}
-        // `ariaLabelText` is '' only for an invalid date, which bails out
-        // before rendering — but keep the guard local: an empty aria-label
-        // must be omitted entirely (not rendered as aria-label="") so AT
-        // falls back to reading the visible <time> content.
-        {...(isRelativeFormat(effectiveFormat) && ariaLabelText !== ''
-          ? {'aria-label': ariaLabelText}
-          : {})}
-        // The hover card is anchored here with focusTrigger="always", which
-        // attaches focus listeners but does not itself make the anchor
-        // focusable. A bare <time> is not focusable, so without a tab stop
-        // sighted keyboard users could never reveal the card (WCAG 1.4.13 /
-        // 2.1.1). Add the tab stop only while a card is actually attached — no
-        // gratuitous tab stops otherwise. The card carries its own
-        // dashed-underline hover indication as the affordance, so the anchor
-        // needs no separate focus outline.
-        {...(showTooltip ? {tabIndex: 0} : {})}>
-        {displayText}
-      </time>
+      {showTooltip ? (
+        <Suspense fallback={timeElement}>
+          <LazyTimestampHoverCard
+            lines={lines}
+            label={t('@astryx.timestamp.detailsLabel')}>
+            {timeElement}
+          </LazyTimestampHoverCard>
+        </Suspense>
+      ) : (
+        timeElement
+      )}
     </Text>
   );
-
-  if (showTooltip) {
-    // One surface for every timestamp that shows one: the copyable hover card,
-    // loaded lazily so the default card-less path never bundles it. Each line
-    // becomes a labelled row with its own copy button. With no configured
-    // entries this is a single row carrying the full absolute time, itself
-    // copyable — so hovering a relative timestamp reveals the full time and
-    // lets the reader copy it. Opens on hover and on keyboard focus (the
-    // <time> tab stop above), with the dashed-underline affordance signalling
-    // it is interactive.
-    //
-    // While the chunk loads the bare <time> stays visible (the Suspense
-    // fallback), so nothing disappears — the card simply attaches once ready.
-    return (
-      <Suspense fallback={timeElement}>
-        <LazyTimestampHoverCard
-          lines={lines}
-          label={t('@astryx.timestamp.detailsLabel')}>
-          {timeElement}
-        </LazyTimestampHoverCard>
-      </Suspense>
-    );
-  }
-
-  return timeElement;
 }
 
 Timestamp.displayName = 'Timestamp';


### PR DESCRIPTION
## User impact

Fixes #5497. Timestamp now exposes its details-dialog relationship on the focused `<time>`. Dismissing the card from its copy button also returns keyboard focus to that timestamp.

## Problem and solution fit

HoverCard uses its first element child as the trigger. Timestamp supplied Text, so the popup attributes and anchor landed on a non-focusable `<span>` while keyboard users reached the inner `<time>`. The focused element could not expose the popup relationship, and the shared focus-return behavior targeted the wrong element.

Nest the lazy HoverCard inside Text so the semantic time is the trigger for both behaviors.

## Expected behavior and authority

#5497 documents the mismatch. The named-dialog relationship from #5419 follows [WAI-ARIA aria-haspopup](https://www.w3.org/TR/wai-aria-1.2/#aria-haspopup) and [aria-controls](https://www.w3.org/TR/wai-aria-1.2/#aria-controls); #5501's restriction on unsupported `aria-expanded` remains intact. The current layer-runtime, overlay-dismissal, and component-theming-surface contracts continue to own positioning, dismissal, and theming.

Under [AST-009 FR1–FR3 and FR7–FR8](https://github.com/facebook/astryx/blob/main/docs/specs/AST-009/spec.md), these are browser-exposed semantics and ordinary keyboard-focus claims. DOM, Chromium accessibility-tree, and keyboard evidence prove them. No spoken-output, virtual-cursor, or AT-specific focus claim is made; no real-AT trigger applies.

## Smallest restoration

Only Timestamp's composition changes. Text retains typography, styling props, and its theme target; time retains its ref, semantic attributes, pass-through props, and conditional tab stop. The lazy chunk and styled Suspense fallback remain. HoverCard's shared trigger resolution and lifecycle are unchanged. Tests, consumer documentation, Storybook guidance, and a patch changeset support the fix.

## Evidence

- Reproduction before the change: in `Core/Timestamp` Default with `format=relative`, Tab focuses time, but its DOM and Chromium AX node lack the popup relationship. After entering the copy button and dismissing its tooltip and card, focus falls to body.
- Result after the change: the focused time exposes AX `hasPopup: dialog` and `controls` resolving to the named dialog. `aria-controls` clears on close; no unsupported `aria-expanded` or fabricated role is added. Escape returns focus to time.
- Representative unchanged path: nine Chromium states cover lazy loading, closed/focused/hovered cards, copy focus, Escape, `hasTooltip=false`, absolute formats without a card, and configured absolute entries in Stone/dark/RTL. Time/card geometry, font, and color match before and after. Seven screenshots are pixel-identical; the two states following Escape differ only by the restored time focus indicator. The default time bounds remain `(16, 22, 77.4375, 15)` and the open card `(0, 41, 317.796875, 52)` at 1000×700.
- Regression test or other mutation-sensitive proof: all six targeted cases fail with the original Timestamp source and pass with the fix. Coverage includes relative, short-relative, auto, configured absolute, live `aria-controls`, focus return, ref/caller props, styling, and disabling an attached card.

## Scope

- [x] One defect is restored.
- [x] Separable contradictory or unsettled tagalongs were removed or split.
- [x] No new public API, visual representation, default, or interaction model is hidden under the bug-fix label.
- [x] Public text and artifacts contain no internal Meta context.

## Testing

- `pnpm build` — passed.
- `pnpm lint:strict` — passed, 0 errors and 84 existing warnings.
- `pnpm test packages/core/src/Timestamp packages/core/src/HoverCard --maxWorkers=4` — 187 passed.
- `pnpm test --maxWorkers=4` — 16,976 passed, 50 skipped; two failures and a setup error in the unchanged `setup-workspace.test.mjs` use GNU `cp --reflink=auto`, unsupported by macOS `cp`. The same failures reproduce with the original source. No unrelated tooling changes included.
- Real Chromium 150.0.7871.24 after the build: nine before/after states, keyboard/hover, DOM, AX, screenshots, and settled geometry; no page errors.
- Targeted axe: configured labelled card has zero violations. The default unlabelled card has the same pre-existing `definition-list` finding before and after; its content is unchanged.
