### PR TITLE
fix(core): preserve keyboard focus at navigation boundaries

### DIFF
--- a/.changeset/fix-edge-navigation-focus.md
+++ b/.changeset/fix-edge-navigation-focus.md
@@ -1,0 +1,7 @@
+---
+"@astryxdesign/core": patch
+---
+
+[fix] Keep keyboard focus inside Pagination, Calendar, Lightbox and the touch DateInput picker when a navigation button becomes disabled at a boundary.
+
+@jiunshinn

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
       {guidance: false, description: 'Disable large blocks of dates without context. The user should understand why dates are unavailable.'},
     ],
     anatomy: [
-      {name: 'Month header', required: true, description: 'The month name and year with navigation arrows to move between months. The arrows mirror automatically under dir="rtl".'},
+      {name: 'Month header', required: true, description: 'The month name and year with navigation arrows to move between months. The arrows mirror automatically under dir="rtl". At a boundary, a keyboard-focused arrow hands focus to the available opposite arrow, or to the day grid when neither arrow is available.'},
       {name: 'Day grid', required: true, description: 'A 7-column grid of days with column headers for the day names.'},
       {name: 'Selected day', required: false, description: 'The currently selected date, highlighted. In range mode, the start and end dates plus the days between them.'},
       {name: 'Today marker', required: false, description: 'A subtle indicator on the current date for orientation.'},

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file Calendar.test.tsx
  * @input Uses vitest, @testing-library/react
- * @output Test suite for Calendar component
+ * @output Calendar selection, rendering and navigation-focus regression tests
  * @position Tests for Calendar.tsx
  *
  * SYNC: When Calendar.tsx changes, update tests accordingly
@@ -1542,5 +1542,66 @@ describe('forced colors (WCAG 1.4.11)', () => {
     // A <button> keeps the native ButtonFace surface and ignores the authored
     // Highlight fill unless it opts out of UA remapping.
     expect(getAllInjectedCss()).toContain('forced-color-adjust: none;');
+  });
+});
+
+describe('Calendar boundary focus', () => {
+  it.each([1, 2] as const)(
+    'keeps focus on an available header control with %s visible months',
+    async numberOfMonths => {
+      render(
+        <Calendar
+          numberOfMonths={numberOfMonths}
+          focusDate="2026-01-01"
+          min="2026-01-01"
+          max={numberOfMonths === 1 ? '2026-02-28' : '2026-03-31'}
+        />,
+      );
+      const user = userEvent.setup();
+      const next = screen.getByRole('button', {name: 'Next month'});
+      const previous = screen.getByRole('button', {name: 'Previous month'});
+      next.focus();
+      await user.keyboard('{Enter}');
+      expect(next).toBeDisabled();
+      expect(previous).toHaveFocus();
+      await user.keyboard(' ');
+      expect(previous).toBeDisabled();
+      expect(next).toHaveFocus();
+    },
+  );
+
+  it('waits for a controlled month change to be accepted', async () => {
+    const onFocusDateChange = vi.fn();
+    const view = (focusDate: ISODateString) => (
+      <Calendar
+        focusDate={focusDate}
+        onFocusDateChange={onFocusDateChange}
+        min="2026-01-01"
+        max="2026-02-28"
+      />
+    );
+    const {rerender} = render(view('2026-01-01'));
+    const next = screen.getByRole('button', {name: 'Next month'});
+    next.focus();
+    await userEvent.setup().keyboard('{Enter}');
+    expect(onFocusDateChange).toHaveBeenCalledWith('2026-02-01');
+    expect(next).toHaveFocus();
+    rerender(view('2026-02-01'));
+    expect(screen.getByRole('button', {name: 'Previous month'})).toHaveFocus();
+  });
+
+  it('falls back to the existing day tab stop when new bounds disable both arrows', () => {
+    const ref = vi.fn();
+    const view = (max: ISODateString) => (
+      <Calendar ref={ref} focusDate="2026-01-01" min="2026-01-01" max={max} />
+    );
+    const {rerender} = render(view('2026-02-28'));
+    screen.getByRole('button', {name: 'Next month'}).focus();
+    rerender(view('2026-01-31'));
+    const day = screen.getByRole('grid').querySelector('button[tabindex="0"]');
+    expect(day).toHaveFocus();
+    expect(ref).toHaveBeenCalledWith(
+      screen.getByRole('grid').closest('.astryx-calendar'),
+    );
   });
 });

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Calendar.tsx
- * @input Uses React useState, useMemo, useCallback, hooks
+ * @input Uses React, calendar hooks and committed navigation focus recovery
  * @output Exports Calendar component and related types
  * @position Core implementation; forwards DOM ref and exposes navigation via
  *   handleRef
@@ -30,7 +30,8 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {Button} from '../Button';
 import {Icon} from '../Icon';
-import {useAnnounce, useGridFocus} from '../hooks';
+import {useAnnounce, useGridFocus, useMergedRefs} from '../hooks';
+import {useDisabledFocusRecovery} from '../hooks/useDisabledFocusRecovery';
 import {
   useCalendarDays,
   useCalendarConstraints,
@@ -228,6 +229,10 @@ export type CalendarProps = CalendarSingleProps | CalendarRangeProps;
 export function Calendar({ref, ...props}: CalendarProps) {
   const t = useTranslator();
   const locale = useLocale();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const mergedRef = useMergedRefs(ref, rootRef);
+  const previousRef = useRef<HTMLButtonElement>(null);
+  const nextRef = useRef<HTMLButtonElement>(null);
   const {
     handleRef,
     mode = 'single',
@@ -387,6 +392,26 @@ export function Calendar({ref, ...props}: CalendarProps) {
     );
   }, [max, baseMonth, numberOfMonths]);
 
+  // Reuse the day grid's existing roving tab stop if changed bounds leave
+  // neither header arrow available. Grid keyboard navigation keeps its owner.
+  const gridReceiver = () =>
+    rootRef.current?.querySelector<HTMLElement>(
+      '[role="grid"] button[tabindex="0"]',
+    ) ?? null;
+  const previousFocus = useDisabledFocusRecovery(
+    !canNavigatePrevious,
+    previousRef,
+    () =>
+      nextRef.current != null && !nextRef.current.disabled
+        ? nextRef.current
+        : gridReceiver(),
+  );
+  const nextFocus = useDisabledFocusRecovery(!canNavigateNext, nextRef, () =>
+    previousRef.current != null && !previousRef.current.disabled
+      ? previousRef.current
+      : gridReceiver(),
+  );
+
   // Navigation handlers
   const navigateMonth = useCallback(
     (delta: number, focusedDate?: ISODateString, offset?: number) => {
@@ -509,7 +534,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
 
   return (
     <div
-      ref={ref}
+      ref={mergedRef}
       {...rest}
       {...mergeProps(
         themeProps('calendar', {mode}),
@@ -535,6 +560,8 @@ export function Calendar({ref, ...props}: CalendarProps) {
               <Icon icon="chevronLeft" size="sm" color="inherit" />
             </span>
           }
+          ref={previousRef}
+          {...previousFocus}
           onClick={() => navigateMonth(-1)}
           isDisabled={!canNavigatePrevious}
           isIconOnly
@@ -556,6 +583,8 @@ export function Calendar({ref, ...props}: CalendarProps) {
               <Icon icon="chevronRight" size="sm" color="inherit" />
             </span>
           }
+          ref={nextRef}
+          {...nextFocus}
           onClick={() => navigateMonth(1)}
           isDisabled={!canNavigateNext}
           isIconOnly

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -255,7 +255,7 @@ export const docs = {
         name: 'Calendar popover',
         required: false,
         description:
-          'A month grid that appears when the icon is clicked or the input is focused.',
+          'A month grid that appears when the icon is clicked or the input is focused. In the touch picker, a keyboard-focused month arrow that reaches the date boundary hands focus to the month/year title.',
       },
       {
         name: 'Clear button',

--- a/packages/core/src/DateInput/DateInputTouch.test.tsx
+++ b/packages/core/src/DateInput/DateInputTouch.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file DateInputTouch.test.tsx
  * @input Uses vitest, @testing-library/react, DateInput and its helpers
- * @output Behavior coverage for the responsive date picker
+ * @output Responsive date-picker behavior, including boundary navigation focus
  * @position Test file for /packages/core/src/DateInput/
  *
  * What jsdom can and cannot see here matters, and the split is deliberate:
@@ -662,6 +662,31 @@ describe('DateInput — field parity', () => {
 // ---------------------------------------------------------------------------
 
 describe('DateInput — calendar surface', () => {
+  it.each([
+    ['Previous month', '2026-02-01', '2026-03-31', 'February 2026'],
+    ['Next month', '2026-03-01', '2026-04-30', 'April 2026'],
+  ])(
+    'hands %s focus to the title when the arrow reaches its boundary',
+    (name, min, max, month) => {
+      renderAndOpen(
+        <Controlled
+          initial="2026-03-21"
+          min={min as ISODateString}
+          max={max as ISODateString}
+        />,
+      );
+      const arrow = screen.getByRole('button', {name});
+      arrow.focus();
+      fireEvent.click(arrow);
+      expect(arrow).toBeDisabled();
+      const title = document.querySelector('[data-title="month-year"]');
+      expect(title).toHaveTextContent(month);
+      expect(title).toHaveFocus();
+      fireEvent.click(title!);
+      expect(title).toHaveAttribute('aria-expanded', 'true');
+    },
+  );
+
   it('opens on the selected month', () => {
     renderAndOpen();
     expect(pane('March 2026')).toBeInTheDocument();

--- a/packages/core/src/DateInput/TouchDateField.tsx
+++ b/packages/core/src/DateInput/TouchDateField.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file TouchDateField.tsx
- * @input Uses React, Field, BottomSheet, Button, Icon, Calendar hooks, MonthScroller, MonthYearWheels
+ * @input Uses React, Field, BottomSheet, Calendar hooks, month navigation and focus recovery
  * @output Exports TouchDateField — the touch surface behind DateInput
  * @position Internal component; consumed by DateInput.tsx
  *
@@ -73,6 +73,7 @@ import {
 } from '../Field';
 import {useInputStatusIcon, useMergedRefs} from '../hooks';
 import {useResolvedRequired} from '../hooks/useResolvedRequired';
+import {useDisabledFocusRecovery} from '../hooks/useDisabledFocusRecovery';
 import {Icon} from '../Icon';
 import {IconButton} from '../IconButton';
 import {useLocale, useTranslator} from '../i18n';
@@ -822,6 +823,21 @@ export function TouchDateField({
   // available. A greyed chevron sitting there permanently reads as broken.
   const canStepBack = monthIndex > minMonthIndex;
   const canStepForward = monthIndex < maxMonthIndex;
+  const titleRef = useRef<HTMLButtonElement>(null);
+  const previousRef = useRef<HTMLButtonElement>(null);
+  const nextRef = useRef<HTMLButtonElement>(null);
+  const monthReceiver = () =>
+    isSheetOpen && !isWheelOpen ? titleRef.current : null;
+  const previousFocus = useDisabledFocusRecovery(
+    !canStepBack,
+    previousRef,
+    monthReceiver,
+  );
+  const nextFocus = useDisabledFocusRecovery(
+    !canStepForward,
+    nextRef,
+    monthReceiver,
+  );
 
   // One month either way, clamped to the reachable range. Goes through the
   // same scrollToMonth the swipe settles on, so the arrows and the gesture
@@ -949,6 +965,7 @@ export function TouchDateField({
           // toggle icon are the documented targets, and nothing has asked to
           // restyle the header button. Adding a target later is additive;
           // withdrawing one is not.
+          ref={titleRef}
           data-title="month-year"
           {...stylex.props(
             styles.title,
@@ -994,6 +1011,8 @@ export function TouchDateField({
               !canStepBack && styles.monthArrowUnavailable,
             ]}
             isDisabled={!canStepBack}
+            ref={previousRef}
+            {...previousFocus}
             onClick={() => stepMonth(-1)}
             label={t('@astryx.calendar.previousMonth')}
             icon={
@@ -1010,6 +1029,8 @@ export function TouchDateField({
               !canStepForward && styles.monthArrowUnavailable,
             ]}
             isDisabled={!canStepForward}
+            ref={nextRef}
+            {...nextFocus}
             onClick={() => stepMonth(1)}
             label={t('@astryx.calendar.nextMonth')}
             icon={

--- a/packages/core/src/Lightbox/Lightbox.doc.mjs
+++ b/packages/core/src/Lightbox/Lightbox.doc.mjs
@@ -21,7 +21,7 @@ const anatomy = [
   {
     name: 'Previous button',
     required: false,
-    description: 'Gallery button that moves to the previous media item.',
+    description: 'Gallery button that moves to the previous media item. A keyboard-focused gallery button that becomes disabled hands focus to the available opposite button, or to Close when no gallery direction remains.',
   },
   {
     name: 'Next button',

--- a/packages/core/src/Lightbox/Lightbox.test.tsx
+++ b/packages/core/src/Lightbox/Lightbox.test.tsx
@@ -1,8 +1,16 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/**
+ * @file Lightbox.test.tsx
+ * @input Vitest, Testing Library and the Lightbox component
+ * @output Media, dismissal and bounded gallery-focus regression coverage
+ * @position Tests for Lightbox.tsx
+ */
+
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {Lightbox} from './Lightbox';
+import userEvent from '@testing-library/user-event';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {InternationalizationProvider} from '../i18n';
 
@@ -674,5 +682,67 @@ describe('Lightbox', () => {
       fireEvent.click(screen.getByRole('img', {hidden: true}));
       expect(onOpenChange).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('Lightbox boundary focus', () => {
+  const media = [
+    {src: '/one.jpg', alt: 'One'},
+    {src: '/two.jpg', alt: 'Two'},
+  ];
+
+  it('moves to the newly available opposite button in both directions', async () => {
+    render(<Lightbox isOpen onOpenChange={() => {}} media={media} />);
+    const user = userEvent.setup();
+    const next = screen.getByRole('button', {name: 'Next'});
+    const previous = screen.getByRole('button', {name: 'Previous'});
+    next.focus();
+    await user.keyboard('{Enter}');
+    expect(next).toBeDisabled();
+    expect(previous).toHaveFocus();
+    await user.keyboard(' ');
+    expect(previous).toBeDisabled();
+    expect(next).toHaveFocus();
+  });
+
+  it('keeps focus while a controlled owner ignores an index request', async () => {
+    const onIndexChange = vi.fn();
+    render(
+      <Lightbox
+        isOpen
+        onOpenChange={() => {}}
+        media={media}
+        index={0}
+        onIndexChange={onIndexChange}
+      />,
+    );
+    const next = screen.getByRole('button', {name: 'Next'});
+    next.focus();
+    await userEvent.setup().keyboard('{Enter}');
+    expect(onIndexChange).toHaveBeenCalledWith(1);
+    expect(next).toHaveFocus();
+    expect(next).not.toBeDisabled();
+  });
+
+  it('does not move focus away from Close after a delayed index change', () => {
+    const view = (index: number) => (
+      <Lightbox isOpen onOpenChange={() => {}} media={media} index={index} />
+    );
+    const {rerender} = render(view(0));
+    screen.getByRole('button', {name: 'Next'}).focus();
+    const close = screen.getByRole('button', {name: 'Close'});
+    close.focus();
+    rerender(view(1));
+    expect(close).toHaveFocus();
+  });
+
+  it('keeps focus on Close if a gallery shrinks to a single item', () => {
+    const view = (items: typeof media) => (
+      <Lightbox isOpen onOpenChange={() => {}} media={items} />
+    );
+    const {rerender} = render(view(media));
+    screen.getByRole('button', {name: 'Next'}).focus();
+    rerender(view(media.slice(0, 1)));
+    expect(screen.getByRole('button', {name: 'Close'})).toHaveFocus();
   });
 });

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Lightbox.tsx
- * @input Uses React, native dialog, StyleX, IconButton, theme tokens
+ * @input Uses React, native dialog, StyleX, IconButton and navigation focus recovery
  * @output Exports Lightbox component, LightboxProps, LightboxMedia
  * @position Core implementation; consumed by index.ts
  *
@@ -31,6 +31,7 @@ import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {Icon} from '../Icon';
 import {IconButton} from '../IconButton';
 import {useAnnounce} from '../hooks/useAnnounce';
+import {useDisabledFocusRecovery} from '../hooks/useDisabledFocusRecovery';
 import {useScrollLock} from '../hooks/useScrollLock';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {mergeProps, rtlStyles} from '../utils';
@@ -321,6 +322,9 @@ export function Lightbox({
   const dialogRef = useRef<HTMLDialogElement>(null);
   const mergedDialogRef = useMergedRefs(ref, dialogRef);
   const containerRef = useRef<HTMLDivElement>(null);
+  const previousRef = useRef<HTMLButtonElement>(null);
+  const nextRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
   const imageWrapperRef = useRef<HTMLDivElement>(null);
   const triggerElementRef = useRef<Element | null>(null);
 
@@ -359,6 +363,21 @@ export function Lightbox({
   const isVideo = currentType === 'video';
   const canPrev = isGallery && index > 0;
   const canNext = isGallery && index < mediaArray.length - 1;
+
+  const previousFocus = useDisabledFocusRecovery(!canPrev, previousRef, () =>
+    isOpen
+      ? nextRef.current != null && !nextRef.current.disabled
+        ? nextRef.current
+        : closeRef.current
+      : null,
+  );
+  const nextFocus = useDisabledFocusRecovery(!canNext, nextRef, () =>
+    isOpen
+      ? previousRef.current != null && !previousRef.current.disabled
+        ? previousRef.current
+        : closeRef.current
+      : null,
+  );
 
   // Scroll lock
   useScrollLock(isOpen);
@@ -628,13 +647,13 @@ export function Lightbox({
             icon={<Icon icon="close" size="sm" color="inherit" />}
             label={t('@astryx.lightbox.close')}
             variant="ghost"
+            ref={closeRef}
             onClick={handleClose}
             xstyle={[styles.closeButton, styles.controlButton]}
           />
 
-          {/* Gallery nav: prev — stays mounted and is disabled at the start of
-            the range so pressing/arrowing to the boundary doesn't unmount the
-            focused control and drop focus to <body>. */}
+          {/* Keep gallery controls mounted; committed disablement transfers
+            their focus to the opposite control when a boundary is reached. */}
           {isGallery && (
             <IconButton
               icon={
@@ -648,6 +667,8 @@ export function Lightbox({
               label={t('@astryx.lightbox.previous')}
               variant="ghost"
               isDisabled={!canPrev}
+              ref={previousRef}
+              {...previousFocus}
               onClick={goToPrev}
               xstyle={[styles.navButton, styles.navPrev, styles.controlButton]}
             />
@@ -716,6 +737,8 @@ export function Lightbox({
               label={t('@astryx.lightbox.next')}
               variant="ghost"
               isDisabled={!canNext}
+              ref={nextRef}
+              {...nextFocus}
               onClick={goToNext}
               xstyle={[styles.navButton, styles.navNext, styles.controlButton]}
             />

--- a/packages/core/src/Pagination/Pagination.doc.mjs
+++ b/packages/core/src/Pagination/Pagination.doc.mjs
@@ -23,7 +23,7 @@ const anatomy = [
     name: 'Previous/next buttons',
     required: true,
     description:
-      'Button controls that move backward or forward through the pages.',
+      'Button controls that move backward or forward through the pages. When a keyboard-focused navigation control reaches a boundary, focus moves to the available opposite control; if neither direction is available, it remains on the Pagination landmark.',
   },
   {
     name: 'Page number button',

--- a/packages/core/src/Pagination/Pagination.test.tsx
+++ b/packages/core/src/Pagination/Pagination.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file Pagination.test.tsx
  * @input Uses vitest, @testing-library/react, Pagination component
- * @output Unit tests for Pagination component behavior
+ * @output Unit tests for Pagination behavior and boundary focus ownership
  * @position Testing; validates Pagination.tsx implementation
  *
  * SYNC: When Pagination.tsx changes, update tests to match new behavior
@@ -19,6 +19,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {useState} from 'react';
 import {Pagination, generatePageRange} from './Pagination';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
@@ -1504,5 +1505,129 @@ describe('Pagination', () => {
       expect(nav).toHaveAttribute('id', 'pager-1');
       expect(nav).toHaveAttribute('aria-describedby', 'hint');
     });
+  });
+});
+
+describe('Pagination boundary focus', () => {
+  it.each([
+    ['Go to next page', 1, 'Go to previous page'],
+    ['Go to previous page', 2, 'Go to next page'],
+    ['Go to last page', 1, 'Go to previous page'],
+    ['Go to first page', 2, 'Go to next page'],
+  ])(
+    'keeps %s activation in the component at a two-page boundary',
+    async (name, initial, receiver) => {
+      function Controlled() {
+        const [page, setPage] = useState(initial);
+        return (
+          <Pagination
+            page={page}
+            onChange={setPage}
+            totalPages={2}
+            variant="input"
+          />
+        );
+      }
+      render(<Controlled />);
+      const user = userEvent.setup();
+      const button = screen.getByRole('button', {name});
+      button.focus();
+      await user.keyboard('{Enter}');
+      expect(button).toBeDisabled();
+      expect(screen.getByRole('button', {name: receiver})).toHaveFocus();
+    },
+  );
+
+  it('uses the rendered cursor boundary after a delayed result, without requiring a total', async () => {
+    const onChange = vi.fn();
+    const {rerender} = render(
+      <Pagination page={2} onChange={onChange} hasMore variant="none" />,
+    );
+    const next = screen.getByRole('button', {name: 'Go to next page'});
+    next.focus();
+    await userEvent.setup().keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith(3);
+    expect(next).toHaveFocus();
+    rerender(
+      <Pagination
+        page={3}
+        onChange={onChange}
+        hasMore={false}
+        variant="none"
+      />,
+    );
+    expect(
+      screen.getByRole('button', {name: 'Go to previous page'}),
+    ).toHaveFocus();
+  });
+
+  it('does not reclaim focus when a delayed cursor result follows a newer focus move', () => {
+    const view = (hasMore: boolean) => (
+      <>
+        <Pagination page={2} onChange={() => {}} hasMore={hasMore} />
+        <button type="button">Other action</button>
+      </>
+    );
+    const {rerender} = render(view(true));
+    screen.getByRole('button', {name: 'Go to next page'}).focus();
+    const other = screen.getByRole('button', {name: 'Other action'});
+    other.focus();
+    rerender(view(false));
+    expect(other).toHaveFocus();
+  });
+
+  it('uses the labelled root if both directions become unavailable and preserves its ref and props', () => {
+    const ref = vi.fn();
+    const view = (isDisabled: boolean) => (
+      <Pagination
+        page={2}
+        onChange={() => {}}
+        totalPages={3}
+        isDisabled={isDisabled}
+        ref={ref}
+        label="Search pages"
+        className="consumer"
+        data-owner="consumer"
+      />
+    );
+    const {rerender} = render(view(false));
+    const nav = screen.getByRole('navigation', {name: 'Search pages'});
+    screen.getByRole('button', {name: 'Go to next page'}).focus();
+    rerender(view(true));
+    expect(nav).toHaveFocus();
+    expect(nav).toHaveAttribute('tabindex', '-1');
+    expect(nav).toHaveClass('astryx-pagination', 'consumer');
+    expect(nav).toHaveAttribute('data-owner', 'consumer');
+    expect(ref).toHaveBeenCalledWith(nav);
+  });
+
+  it('keeps the accepted edge focus when a pending Action settles', async () => {
+    let finish!: () => void;
+    const pending = new Promise<void>(resolve => {
+      finish = resolve;
+    });
+    function Controlled() {
+      const [page, setPage] = useState(1);
+      return (
+        <Pagination
+          page={page}
+          onChange={setPage}
+          totalPages={2}
+          changeAction={async () => {
+            await pending;
+          }}
+        />
+      );
+    }
+    render(<Controlled />);
+    screen.getByRole('button', {name: 'Go to next page'}).focus();
+    await userEvent.setup().keyboard('{Enter}');
+    const previous = screen.getByRole('button', {name: 'Go to previous page'});
+    expect(previous).toHaveFocus();
+    await act(async () => {
+      finish();
+      await pending;
+    });
+    expect(previous).toHaveFocus();
   });
 });

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -7,7 +7,7 @@
  * @input Uses React, StyleX, Button, Icon, Selector, Text; page number buttons delegate to Button.
  *   Prev/next and first/last chevrons mirror under RTL via the shared rtlStyles.mirror
  *   (CSS scaleX), not a JS direction read. The input variant uses the chevronsLeft/chevronsRight
- *   (first/last) icons.
+ *   (first/last) icons. Disabled navigation hands focus to an available local control.
  * @output Exports Pagination component, PaginationProps, PaginationVariant, PaginationSize types
  * @position Core implementation; consumed by index.ts, tested by Pagination.test.tsx
  *
@@ -22,7 +22,9 @@
  *   hasFirstLast, step, siblingCount, size, isDisabled, label, data-testid, xstyle
  */
 
-import {useOptimistic, useTransition} from 'react';
+import {useOptimistic, useRef, useTransition} from 'react';
+import {useMergedRefs} from '../hooks/useMergedRefs';
+import {useDisabledFocusRecovery} from '../hooks/useDisabledFocusRecovery';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -383,6 +385,12 @@ export function Pagination({
   ...rest
 }: PaginationProps) {
   const [, startTransition] = useTransition();
+  const rootRef = useRef<HTMLElement>(null);
+  const mergedRef = useMergedRefs(ref, rootRef);
+  const previousRef = useRef<HTMLButtonElement>(null);
+  const nextRef = useRef<HTMLButtonElement>(null);
+  const firstRef = useRef<HTMLButtonElement>(null);
+  const lastRef = useRef<HTMLButtonElement>(null);
 
   // Resolve system strings once per render. Prop overrides win.
   const t = useTranslator();
@@ -454,6 +462,35 @@ export function Pagination({
     computedTotalPages != null
       ? optimisticPage < computedTotalPages
       : (hasMore ?? false);
+
+  const previousReceiver = () =>
+    nextRef.current != null && !nextRef.current.disabled
+      ? nextRef.current
+      : rootRef.current;
+  const nextReceiver = () =>
+    previousRef.current != null && !previousRef.current.disabled
+      ? previousRef.current
+      : rootRef.current;
+  const previousFocus = useDisabledFocusRecovery(
+    isDisabled || !hasPrevious,
+    previousRef,
+    previousReceiver,
+  );
+  const nextFocus = useDisabledFocusRecovery(
+    isDisabled || !hasNext,
+    nextRef,
+    nextReceiver,
+  );
+  const firstFocus = useDisabledFocusRecovery(
+    isDisabled || !hasPrevious,
+    firstRef,
+    previousReceiver,
+  );
+  const lastFocus = useDisabledFocusRecovery(
+    isDisabled || !hasNext,
+    lastRef,
+    nextReceiver,
+  );
 
   if (totalItems != null && totalItems <= 0) {
     return null;
@@ -775,10 +812,11 @@ export function Pagination({
 
   return (
     <nav
-      ref={ref}
+      ref={mergedRef}
+      tabIndex={-1}
       {...mergeProps(
         themeProps('pagination', {variant, size}),
-        stylex.props(styles.root, xstyle),
+        focusOutlineProps.focusVisible(styles.root, xstyle),
         className,
         style,
       )}
@@ -816,6 +854,8 @@ export function Pagination({
                 xstyle={rtlStyles.mirror}
               />
             }
+            ref={firstRef}
+            {...firstFocus}
             onClick={handleFirst}
             isDisabled={isDisabled || !hasPrevious}
             isIconOnly
@@ -834,6 +874,8 @@ export function Pagination({
               xstyle={rtlStyles.mirror}
             />
           }
+          ref={previousRef}
+          {...previousFocus}
           onClick={handlePrevious}
           isDisabled={isDisabled || !hasPrevious}
           isIconOnly
@@ -853,6 +895,8 @@ export function Pagination({
               xstyle={rtlStyles.mirror}
             />
           }
+          ref={nextRef}
+          {...nextFocus}
           onClick={handleNext}
           isDisabled={isDisabled || !hasNext}
           isIconOnly
@@ -871,6 +915,8 @@ export function Pagination({
                 xstyle={rtlStyles.mirror}
               />
             }
+            ref={lastRef}
+            {...lastFocus}
             onClick={handleLast}
             isDisabled={isDisabled || !hasNext}
             isIconOnly

--- a/packages/core/src/hooks/useDisabledFocusRecovery.test.tsx
+++ b/packages/core/src/hooks/useDisabledFocusRecovery.test.tsx
@@ -1,0 +1,166 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useDisabledFocusRecovery.test.tsx
+ * @input React, Testing Library and private disabled-focus recovery
+ * @output Regression coverage for focus ownership across committed disablement
+ * @position Tests for useDisabledFocusRecovery.ts
+ */
+
+import {StrictMode, useRef} from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {__resetInteractionModalityForTest} from '../utils/interactionModality';
+
+afterEach(__resetInteractionModalityForTest);
+import {useDisabledFocusRecovery} from './useDisabledFocusRecovery';
+
+function Fixture({
+  disabled = false,
+  nodeKey = 'original',
+  hasReceiver = true,
+}: {
+  disabled?: boolean;
+  nodeKey?: string;
+  hasReceiver?: boolean;
+}) {
+  const sourceRef = useRef<HTMLButtonElement>(null);
+  const receiverRef = useRef<HTMLButtonElement>(null);
+  const focus = useDisabledFocusRecovery(
+    disabled,
+    sourceRef,
+    () => receiverRef.current,
+  );
+  return (
+    <>
+      <button
+        type="button"
+        key={nodeKey}
+        ref={sourceRef}
+        disabled={disabled}
+        {...focus}>
+        Next
+      </button>
+      {hasReceiver && (
+        <button type="button" ref={receiverRef}>
+          Previous
+        </button>
+      )}
+      <button type="button">Outside</button>
+    </>
+  );
+}
+
+describe('useDisabledFocusRecovery', () => {
+  it('moves once, without scrolling, only when the focused button becomes disabled', () => {
+    const {rerender} = render(
+      <StrictMode>
+        <Fixture />
+      </StrictMode>,
+    );
+    const next = screen.getByRole('button', {name: 'Next'});
+    const previous = screen.getByRole('button', {name: 'Previous'});
+    const focus = vi.spyOn(previous, 'focus');
+    next.focus();
+    rerender(
+      <StrictMode>
+        <Fixture disabled />
+      </StrictMode>,
+    );
+    expect(previous).toHaveFocus();
+    expect(focus).toHaveBeenCalledExactlyOnceWith({preventScroll: true});
+    rerender(
+      <StrictMode>
+        <Fixture disabled />
+      </StrictMode>,
+    );
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not move focus for an unchanged enabled state or an ignored request', () => {
+    const {rerender} = render(<Fixture />);
+    const next = screen.getByRole('button', {name: 'Next'});
+    next.focus();
+    fireEvent.click(next);
+    rerender(<Fixture />);
+    expect(next).toHaveFocus();
+  });
+
+  it('retains ownership through the native blur caused by disablement', () => {
+    const {rerender} = render(<Fixture />);
+    const next = screen.getByRole('button', {
+      name: 'Next',
+    });
+    next.focus();
+    // jsdom does not blur a natively disabled button. Dispatch the browser's
+    // blur event explicitly; real-browser runs cover the body focus outcome.
+    next.disabled = true;
+    fireEvent.blur(next, {relatedTarget: null});
+    rerender(<Fixture disabled />);
+    expect(screen.getByRole('button', {name: 'Previous'})).toHaveFocus();
+  });
+
+  it('does not reclaim focus after the user explicitly blurs to the document', () => {
+    const {rerender} = render(<Fixture />);
+    const next = screen.getByRole('button', {name: 'Next'});
+    next.focus();
+    next.blur();
+    rerender(<Fixture disabled />);
+    expect(document.body).toHaveFocus();
+  });
+
+  it('does not reclaim focus from a newer target', () => {
+    const {rerender} = render(<Fixture />);
+    screen.getByRole('button', {name: 'Next'}).focus();
+    const outside = screen.getByRole('button', {name: 'Outside'});
+    outside.focus();
+    rerender(<Fixture disabled />);
+    expect(outside).toHaveFocus();
+  });
+
+  it('preserves native pointer focus behavior after keyboard input', () => {
+    const {rerender} = render(<Fixture />);
+    const next = screen.getByRole('button', {name: 'Next'});
+    fireEvent.keyDown(next, {key: 'Tab'});
+    next.focus();
+    fireEvent.pointerDown(next, {pointerType: 'mouse'});
+    const previous = screen.getByRole('button', {name: 'Previous'});
+    const focus = vi.spyOn(previous, 'focus');
+    rerender(<Fixture disabled />);
+    expect(focus).not.toHaveBeenCalled();
+    rerender(<Fixture />);
+    const outside = screen.getByRole('button', {name: 'Outside'});
+    outside.focus();
+    fireEvent.keyDown(outside, {key: 'Tab'});
+    next.focus();
+    rerender(<Fixture disabled />);
+    expect(previous).toHaveFocus();
+    expect(focus).toHaveBeenCalledExactlyOnceWith({preventScroll: true});
+  });
+
+  it('does not transfer stale ownership to a replacement node', () => {
+    const {rerender} = render(<Fixture />);
+    screen.getByRole('button', {name: 'Next'}).focus();
+    const previous = screen.getByRole('button', {name: 'Previous'});
+    const focus = vi.spyOn(previous, 'focus');
+    rerender(<Fixture disabled nodeKey="replacement" />);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it('does not replay a consumed transition when a receiver mounts later', () => {
+    const {rerender} = render(<Fixture hasReceiver={false} />);
+    screen.getByRole('button', {name: 'Next'}).focus();
+    rerender(<Fixture disabled hasReceiver={false} />);
+    rerender(<Fixture disabled />);
+    expect(screen.getByRole('button', {name: 'Previous'})).not.toHaveFocus();
+  });
+
+  it('does not move focus on an initially disabled mount or unmount', () => {
+    const {unmount} = render(<Fixture disabled />);
+    const outside = screen.getByRole('button', {name: 'Outside'});
+    const focus = vi.spyOn(outside, 'focus');
+    expect(document.body).toHaveFocus();
+    unmount();
+    expect(focus).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/hooks/useDisabledFocusRecovery.ts
+++ b/packages/core/src/hooks/useDisabledFocusRecovery.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useDisabledFocusRecovery.ts
+ * @input A navigation button's committed disabled state, ref and local receiver
+ * @output Focus/blur handlers that retain focus ownership across disablement
+ * @position Private Core hook; shared by bounded navigation controls
+ */
+
+import {useRef, type FocusEvent, type RefObject} from 'react';
+import {useIsomorphicLayoutEffect} from './useIsomorphicLayoutEffect';
+import {
+  getInteractionModality,
+  useInteractionModalityTracking,
+} from '../utils/interactionModality';
+
+/** Recover only the focus lost by a newly disabled, still-owned button. */
+export function useDisabledFocusRecovery(
+  isDisabled: boolean,
+  buttonRef: RefObject<HTMLButtonElement | null>,
+  getReceiver: () => HTMLElement | null,
+) {
+  useInteractionModalityTracking();
+  const wasDisabledRef = useRef(isDisabled);
+  const focusedButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  // Synchronize native browser focus with committed availability. A navigation
+  // request cannot predict this transition: controlled owners may ignore/defer
+  // it, and cursor results or bounds can change independently of a press. After
+  // commit the opposite control is also enabled, even in a two-item range.
+  useIsomorphicLayoutEffect(() => {
+    const wasDisabled = wasDisabledRef.current;
+    wasDisabledRef.current = isDisabled;
+    if (wasDisabled || !isDisabled) {
+      return;
+    }
+
+    const button = focusedButtonRef.current;
+    // Consume once, before focus dispatches another event or React replays work.
+    focusedButtonRef.current = null;
+    if (
+      button == null ||
+      (buttonRef.current != null && button !== buttonRef.current)
+    ) {
+      return;
+    }
+    const {activeElement, body} = button.ownerDocument;
+    if (activeElement !== button && activeElement !== body) {
+      return;
+    }
+    // This repairs keyboard navigation. Pointer presses keep the browser's
+    // existing focus behavior, including browsers that do not focus buttons
+    // on click; moving their focus here can inherit an old keyboard ring.
+    if (getInteractionModality() !== 'keyboard') {
+      return;
+    }
+    const receiver = getReceiver();
+    if (receiver?.isConnected) {
+      receiver.focus({preventScroll: true});
+    }
+  }, [isDisabled, buttonRef, getReceiver]);
+
+  return {
+    onFocus: (event: FocusEvent<HTMLButtonElement>) => {
+      focusedButtonRef.current = event.currentTarget;
+    },
+    onBlur: (event: FocusEvent<HTMLButtonElement>) => {
+      // Native disablement blurs to body during the commit. Explicit blur/Tab
+      // while enabled, or a move to another target, relinquishes ownership.
+      if (!event.currentTarget.disabled || event.relatedTarget != null) {
+        focusedButtonRef.current = null;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## User impact

Keyboard users navigating to the first or last page, month, or gallery item lose their place when the focused navigation button becomes disabled. Pagination, Calendar, Lightbox and DateInput's custom touch picker now keep keyboard focus on an available control in the same component.

Closes #5602.

## Problem and solution fit

Native disablement removes focus from the active button. The user loses their position in the page and must find the component again before continuing. A private helper synchronizes browser focus with the committed availability transition, then moves focus once with `preventScroll: true`.

The committed transition matters for controlled owners that ignore or defer requests, cursor results that change `hasMore`, and updated bounds. An enabled blur or a newer active target releases ownership. Pointer navigation retains native focus behavior, including browsers that do not focus clicked buttons.

## Expected behavior and authority

[Interaction modality INV1, INV5, INV7 and INV8](https://github.com/facebook/astryx/blob/main/docs/architecture/interaction-modality.md) require consistent modality, disabled semantics, reachable actions and newer-intent precedence. [React component runtime INV2–INV3](https://github.com/facebook/astryx/blob/main/docs/architecture/react-component-runtime.md) distinguish requested actions from committed external-system synchronization. [WCAG 2.2 SC 2.4.3](https://www.w3.org/TR/WCAG22/#focus-order) supplies the focus-order outcome.

This claim concerns browser focus, keyboard operation and focus-ring visibility. It makes no spoken-output or assistive-technology mode claim; [AST-009 FR2/FR7](https://github.com/facebook/astryx/blob/main/docs/specs/AST-009/spec.md) therefore use browser and DOM evidence here.

## Smallest restoration

- Pagination and Calendar use the available opposite arrow. Pagination falls back to its labelled landmark, made programmatically focusable with the existing shared outline. Calendar falls back to its existing day-grid tab stop when both arrows become unavailable.
- Lightbox uses the opposite gallery control, or Close if the gallery becomes a single item. Its already-fixed intermediate navigation remains unchanged.
- The touch DateInput picker uses its existing month/year title control.
- The shared helper remains private; native disabled semantics, controlled/optimistic state, callbacks, public refs, theme targets, layouts and grid/dot keyboard navigation retain their owners.

## Evidence

- Reproduction before the change: Chromium keyboard activation reached `<body>` after 9 Pagination Next presses, 2 Calendar Next presses, 3 Lightbox Next presses, and 1 Previous-month press in the custom touch DateInput picker with a two-month bound. Lightbox's intermediate item already retained focus on current `main`.
- Result after the change: Chromium and WebKit pass 40 combinations covering both boundaries, light/dark, LTR/RTL, keyboard use with coarse-pointer emulation, pointer input after keyboard input, and subsequent native Tab navigation. Keyboard focus lands on the named receiver with the existing outline; pointer navigation introduces no outline.
- Representative unchanged path: intermediate navigation retains its button, native dialog/browser-chrome Tab handling is preserved, dot arrow-key selection remains operable, and pointers keep their native focus behavior.
- Regression test or other mutation-sensitive proof: focused tests cover two-item ranges, all four Pagination arrows, delayed cursor/controlled updates, pending Action settlement, ignored requests, newer focus, native disablement blur, node replacement, initial disablement, StrictMode replay, gallery shrinkage, two-month Calendars, and keyboard → pointer → keyboard transitions.

## Scope

- [x] One defect is restored.
- [x] Separable contradictory or unsettled tagalongs were removed or split.
- [x] No new public API, visual representation, default, or interaction model is hidden under the bug-fix label.
- [x] Public text and artifacts contain no internal Meta context.

## Testing

- `pnpm lint:strict` — passes; 84 existing warnings, no errors.
- `pnpm build` — passes after the final runtime change.
- Focused Vitest component/helper suites — 627 tests pass.
- `pnpm test --maxWorkers=4` — 16,999 passed, 50 skipped; the two failing GNU `cp --reflink=auto` cases in `internal/vibe-tests/setup-test/setup-workspace.test.mjs` also fail on clean `main` on macOS. All changed component/helper tests pass.
- Real Chromium and WebKit runtime: 56 passing cases — the 40-case matrix above, plus 16 Pagination count/compact/none/dots/input/stride cases and return from pointer input to keyboard input. WebKit uses its Option-Tab path for all-control keyboard navigation; a native browser-chrome stop is distinguished from document focus.
